### PR TITLE
feat: Use pinned content for AI agent suggestions

### DIFF
--- a/packages/backend/src/ee/controllers/aiAgentController.test.ts
+++ b/packages/backend/src/ee/controllers/aiAgentController.test.ts
@@ -1,0 +1,74 @@
+import {
+    ParameterError,
+    type AiAgentSuggestionContext,
+    type SessionUser,
+} from '@lightdash/common';
+import { type Request } from 'express';
+import { type ServiceRepository } from '../../services/ServiceRepository';
+import { type AiAgentService } from '../services/AiAgentService/AiAgentService';
+import { AiAgentController } from './aiAgentController';
+
+describe('AiAgentController getAgentSuggestions', () => {
+    const getAgentSuggestions = vi.fn<AiAgentService['getAgentSuggestions']>(
+        async () => ({ chips: [] }),
+    );
+    const controller = new AiAgentController({
+        getAiAgentService: () => ({ getAgentSuggestions }),
+    } as unknown as ServiceRepository);
+    const request = {
+        account: {
+            user: { type: 'registered', id: 'user-1' },
+            organization: {
+                organizationUuid: 'org-1',
+                name: 'Org',
+                createdAt: new Date('2024-01-01'),
+            },
+            authentication: { type: 'session' },
+        },
+    } as unknown as Request;
+
+    it.each<AiAgentSuggestionContext>([
+        { type: 'chart', chartUuid: 'chart-1' },
+        { type: 'dashboard', dashboardUuid: 'dashboard-1' },
+    ])('forwards $type context to the service', async (context) => {
+        await controller.getAgentSuggestions(
+            request,
+            'project-1',
+            'agent-1',
+            undefined,
+            undefined,
+            false,
+            JSON.stringify(context),
+        );
+
+        expect(getAgentSuggestions).toHaveBeenCalledWith(
+            expect.anything() as SessionUser,
+            {
+                projectUuid: 'project-1',
+                agentUuid: 'agent-1',
+                threadUuid: undefined,
+                afterMessageUuid: undefined,
+                enableSqlMode: false,
+                context,
+            },
+        );
+    });
+
+    it('rejects malformed context before calling the service', async () => {
+        getAgentSuggestions.mockClear();
+
+        await expect(
+            controller.getAgentSuggestions(
+                request,
+                'project-1',
+                'agent-1',
+                undefined,
+                undefined,
+                false,
+                JSON.stringify({ type: 'chart' }),
+            ),
+        ).rejects.toThrow(ParameterError);
+
+        expect(getAgentSuggestions).not.toHaveBeenCalled();
+    });
+});

--- a/packages/backend/src/ee/controllers/aiAgentController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentController.ts
@@ -1,5 +1,6 @@
 import {
     AgentAsCode,
+    aiAgentSuggestionContextSchema,
     AiAgentThreadFilters,
     AiArtifactTSOACompat,
     AiClonedThreadCreatedFrom,
@@ -103,6 +104,15 @@ import Logger from '../../logging/logger';
 import { type AiAgentCoderService } from '../services/AiAgentCoderService/AiAgentCoderService';
 import { type AiAgentMemoryService } from '../services/AiAgentMemoryService/AiAgentMemoryService';
 import { type AiAgentService } from '../services/AiAgentService/AiAgentService';
+
+const parseSuggestionContext = (context: string | undefined) => {
+    if (!context) return undefined;
+    try {
+        return aiAgentSuggestionContextSchema.parse(JSON.parse(context));
+    } catch {
+        throw new ParameterError('Invalid agent suggestion context');
+    }
+};
 
 @Route('/api/v1/projects/{projectUuid}/aiAgents')
 @Response<ApiErrorPayload>('default', 'Error')
@@ -688,6 +698,7 @@ export class AiAgentController extends BaseController {
         @Query() threadUuid?: string,
         @Query() afterMessageUuid?: string,
         @Query() enableSqlMode?: boolean,
+        @Query() context?: string,
     ): Promise<ApiAgentSuggestionsResponse> {
         this.setStatus(200);
 
@@ -713,6 +724,7 @@ export class AiAgentController extends BaseController {
                 threadUuid,
                 afterMessageUuid,
                 enableSqlMode,
+                context: parseSuggestionContext(context),
             },
         );
         return {

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -11,6 +11,7 @@ import {
     AiAgentProjectThreadSummary,
     AiAgentReviewClassifierEventType,
     AiAgentReviewRemediationRunJobPayload,
+    AiAgentSuggestionContext,
     AiAgentSummary,
     AiAgentThread,
     AiAgentThreadFilters,
@@ -91,6 +92,7 @@ import {
     isAiMergeChartArtifactConfig,
     isAiSqlChartArtifactConfig,
     isAiWritebackRunInProgress,
+    isDashboardChartTileType,
     isGithubMcpServerUrl,
     isGitProjectType,
     isSlackMessageTooLongError,
@@ -426,6 +428,11 @@ import {
     filterSuggestionsByEnabledTools,
     getEnabledSuggestionTools,
 } from './suggestionAccess';
+import {
+    buildChartSuggestionContext,
+    buildDashboardSuggestionContext,
+    getPinnedSuggestionContextInput,
+} from './suggestionPinnedContext';
 
 type ThreadMessageContext = Array<
     Required<Pick<MessageElement, 'text' | 'user' | 'ts'>>
@@ -433,6 +440,10 @@ type ThreadMessageContext = Array<
 
 type ThreadCompaction = NonNullable<
     Awaited<ReturnType<AiAgentModel['findLatestThreadCompaction']>>
+>;
+
+type SuggestionThreadMessages = Awaited<
+    ReturnType<AiAgentModel['findThreadMessages']>
 >;
 
 type AgentConversationContext = {
@@ -1904,12 +1915,14 @@ export class AiAgentService extends BaseService {
             threadUuid,
             afterMessageUuid,
             enableSqlMode = false,
+            context,
         }: {
             projectUuid: string;
             agentUuid: string;
             threadUuid?: string;
             afterMessageUuid?: string;
             enableSqlMode?: boolean;
+            context?: AiAgentSuggestionContext;
         },
     ): Promise<{ chips: AgentSuggestion[] }> {
         const { organizationUuid } = user;
@@ -1934,6 +1947,21 @@ export class AiAgentService extends BaseService {
                 return { chips: [] };
             }
         }
+
+        const threadMessages = threadUuid
+            ? await this.aiAgentModel.findThreadMessages({
+                  organizationUuid,
+                  threadUuid,
+              })
+            : undefined;
+        const contextInput = context
+            ? [context]
+            : getPinnedSuggestionContextInput(threadMessages);
+        const validatedContext = await this.validatePromptContextAccess(
+            user,
+            agent,
+            contextInput,
+        );
 
         const auditedAbility = this.createAuditedAbility(user);
         const canRunSql =
@@ -2013,22 +2041,30 @@ export class AiAgentService extends BaseService {
             projectUuid,
         );
 
-        const recentUserConversations = threadUuid
-            ? undefined
-            : await this.fetchSuggestionsRecentConversations({
-                  organizationUuid,
-                  agentUuid,
-                  userUuid: user.userUuid,
-              });
+        const recentUserConversations =
+            threadUuid || validatedContext
+                ? undefined
+                : await this.fetchSuggestionsRecentConversations({
+                      organizationUuid,
+                      agentUuid,
+                      userUuid: user.userUuid,
+                  });
 
-        const threadContext = threadUuid
-            ? await this.buildSuggestionsThreadContext({
-                  organizationUuid,
-                  threadUuid,
+        const threadContext = threadMessages
+            ? this.buildSuggestionsThreadContext({
+                  messages: threadMessages,
                   afterMessageUuid,
                   availableExplores,
               })
             : null;
+        const pinnedContext = validatedContext
+            ? await this.buildSuggestionsPinnedContext({
+                  user,
+                  projectUuid,
+                  context: validatedContext,
+                  availableExplores,
+              })
+            : undefined;
 
         const validationCatalog: SuggestionValidationCatalog = {
             exploreNames: new Set(availableExplores.map((e) => e.name)),
@@ -2068,6 +2104,7 @@ export class AiAgentService extends BaseService {
                     verifiedQuestions,
                     verifiedContentTags: agent.tags ?? [],
                     verifiedContent,
+                    pinnedContext,
                     recentUserConversations,
                     thread: threadContext ?? undefined,
                 },
@@ -2254,21 +2291,15 @@ export class AiAgentService extends BaseService {
         }
     }
 
-    private async buildSuggestionsThreadContext({
-        organizationUuid,
-        threadUuid,
+    private buildSuggestionsThreadContext({
+        messages,
         afterMessageUuid,
         availableExplores,
     }: {
-        organizationUuid: string;
-        threadUuid: string;
+        messages: SuggestionThreadMessages;
         afterMessageUuid?: string;
         availableExplores: Explore[];
-    }): Promise<NonNullable<SuggestionPromptContext['thread']> | null> {
-        const messages = await this.aiAgentModel.findThreadMessages({
-            organizationUuid,
-            threadUuid,
-        });
+    }): NonNullable<SuggestionPromptContext['thread']> | null {
         if (messages.length === 0) return null;
 
         // Pick the target assistant message: the one named by afterMessageUuid
@@ -2311,6 +2342,75 @@ export class AiAgentService extends BaseService {
                 latestQueryExplore,
             },
         };
+    }
+
+    private async buildSuggestionsPinnedContext({
+        user,
+        projectUuid,
+        context,
+        availableExplores,
+    }: {
+        user: SessionUser;
+        projectUuid: string;
+        context: AiPromptContextInput;
+        availableExplores: Explore[];
+    }): Promise<SuggestionPromptContext['pinnedContext']> {
+        return Promise.all(
+            context.flatMap((item) => {
+                if (item.type === 'chart') {
+                    return [
+                        (async () => {
+                            const chart = await this.savedChartService.get(
+                                item.chartUuid,
+                                fromSession(user),
+                                { projectUuid },
+                            );
+                            return buildChartSuggestionContext(
+                                chart,
+                                availableExplores,
+                                item.runtimeOverrides,
+                            );
+                        })(),
+                    ];
+                }
+                if (item.type === 'dashboard') {
+                    return [
+                        (async () => {
+                            const dashboard =
+                                await this.dashboardService.getByIdOrSlug(
+                                    user,
+                                    item.dashboardUuid,
+                                    { projectUuid },
+                                );
+                            const chartUuids = dashboard.tiles
+                                .filter(isDashboardChartTileType)
+                                .flatMap((tile) =>
+                                    tile.properties.savedChartUuid
+                                        ? [tile.properties.savedChartUuid]
+                                        : [],
+                                )
+                                .slice(0, 12);
+                            const charts = await Promise.all(
+                                chartUuids.map((chartUuid) =>
+                                    this.savedChartService.get(
+                                        chartUuid,
+                                        fromSession(user),
+                                        { projectUuid },
+                                    ),
+                                ),
+                            );
+                            return buildDashboardSuggestionContext(
+                                dashboard,
+                                charts,
+                                availableExplores,
+                                item.runtimeOverrides,
+                            );
+                        })(),
+                    ];
+                }
+                return [];
+            }),
+        );
     }
 
     private async fetchSuggestionsRecentConversations({

--- a/packages/backend/src/ee/services/AiAgentService/agentSuggestions.service.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/agentSuggestions.service.test.ts
@@ -1,0 +1,42 @@
+import {
+    ForbiddenError,
+    type AiAgent,
+    type SessionUser,
+} from '@lightdash/common';
+import { type SavedChartService } from '../../../services/SavedChartsService/SavedChartService';
+import { AiAgentService } from './AiAgentService';
+
+describe('AiAgentService getAgentSuggestions', () => {
+    it('applies prompt-context chart access checks before loading suggestion metadata', async () => {
+        const hasAccess = vi.fn<SavedChartService['hasAccess']>(async () => {
+            throw new ForbiddenError('Chart is not visible');
+        });
+        const get = vi.fn<SavedChartService['get']>();
+        const service = new AiAgentService({
+            savedChartService: { hasAccess, get },
+        } as unknown as ConstructorParameters<typeof AiAgentService>[0]);
+        vi.spyOn(service, 'getAgent').mockResolvedValue({
+            projectUuid: 'project-1',
+            organizationUuid: 'org-1',
+        } as AiAgent);
+        const user = {
+            userUuid: 'user-1',
+            organizationUuid: 'org-1',
+        } as SessionUser;
+
+        await expect(
+            service.getAgentSuggestions(user, {
+                projectUuid: 'project-1',
+                agentUuid: 'agent-1',
+                context: { type: 'chart', chartUuid: 'chart-1' },
+            }),
+        ).rejects.toThrow('Chart is not visible');
+
+        expect(hasAccess).toHaveBeenCalledWith(
+            'view',
+            { user, projectUuid: 'project-1' },
+            { savedChartUuid: 'chart-1' },
+        );
+        expect(get).not.toHaveBeenCalled();
+    });
+});

--- a/packages/backend/src/ee/services/AiAgentService/suggestionPinnedContext.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/suggestionPinnedContext.test.ts
@@ -1,0 +1,139 @@
+import {
+    ChartType,
+    type AiPromptContext,
+    type Explore,
+    type SavedChart,
+} from '@lightdash/common';
+import {
+    buildChartSuggestionContext,
+    buildDashboardSuggestionContext,
+    getPinnedSuggestionContextInput,
+} from './suggestionPinnedContext';
+
+const chart = {
+    name: 'Revenue by status',
+    description: 'Revenue split by order status',
+    chartConfig: { type: ChartType.CARTESIAN },
+    metricQuery: {
+        exploreName: 'orders',
+        dimensions: ['orders_status'],
+        metrics: ['orders_total_revenue'],
+        filters: {},
+        sorts: [],
+        limit: 500,
+        tableCalculations: [],
+    },
+} satisfies Pick<
+    SavedChart,
+    'name' | 'description' | 'chartConfig' | 'metricQuery'
+>;
+
+const explores = [
+    {
+        name: 'orders',
+        tables: {
+            orders: {
+                dimensions: {
+                    status: {
+                        name: 'status',
+                        table: 'orders',
+                        label: 'Order status',
+                    },
+                },
+                metrics: {
+                    totalRevenue: {
+                        name: 'total_revenue',
+                        table: 'orders',
+                        label: 'Total revenue',
+                    },
+                },
+            },
+        },
+    },
+] as unknown as Explore[];
+
+describe('suggestion pinned context', () => {
+    it('builds chart context from saved fields and metadata', () => {
+        expect(buildChartSuggestionContext(chart, explores)).toEqual({
+            type: 'chart',
+            name: 'Revenue by status',
+            description: 'Revenue split by order status',
+            fields: [
+                {
+                    id: 'orders_status',
+                    label: 'Order status',
+                    kind: 'dimension',
+                },
+                {
+                    id: 'orders_total_revenue',
+                    label: 'Total revenue',
+                    kind: 'metric',
+                },
+            ],
+            metadata: {
+                chartType: ChartType.CARTESIAN,
+                exploreName: 'orders',
+                runtimeOverrides: null,
+            },
+        });
+    });
+
+    it('aggregates dashboard chart fields and metadata', () => {
+        const result = buildDashboardSuggestionContext(
+            {
+                name: 'Revenue overview',
+                description: 'Commercial performance',
+                tabs: [{ name: 'Summary' }],
+            } as Parameters<typeof buildDashboardSuggestionContext>[0],
+            [chart],
+            explores,
+        );
+
+        expect(result).toMatchObject({
+            type: 'dashboard',
+            name: 'Revenue overview',
+            fields: [
+                { id: 'orders_status', label: 'Order status' },
+                { id: 'orders_total_revenue', label: 'Total revenue' },
+            ],
+            metadata: {
+                chartNames: ['Revenue by status'],
+                chartTypes: [ChartType.CARTESIAN],
+                exploreNames: ['orders'],
+                tabNames: ['Summary'],
+            },
+        });
+    });
+
+    it('reuses the latest persisted chart or dashboard pin from a thread', () => {
+        const oldContext: AiPromptContext = [
+            {
+                type: 'chart',
+                chartUuid: 'chart-1',
+                chartSlug: 'old-chart',
+                pinnedVersionUuid: null,
+                displayName: 'Old chart',
+                runtimeOverrides: null,
+                chartKind: null,
+            },
+        ];
+        const latestContext: AiPromptContext = [
+            {
+                type: 'dashboard',
+                dashboardUuid: 'dashboard-1',
+                dashboardSlug: 'latest-dashboard',
+                pinnedVersionUuid: null,
+                displayName: 'Latest dashboard',
+                runtimeOverrides: null,
+            },
+        ];
+
+        expect(
+            getPinnedSuggestionContextInput([
+                { role: 'user', context: oldContext },
+                { role: 'assistant' },
+                { role: 'user', context: latestContext },
+            ]),
+        ).toEqual([{ type: 'dashboard', dashboardUuid: 'dashboard-1' }]);
+    });
+});

--- a/packages/backend/src/ee/services/AiAgentService/suggestionPinnedContext.ts
+++ b/packages/backend/src/ee/services/AiAgentService/suggestionPinnedContext.ts
@@ -1,0 +1,152 @@
+import {
+    getItemId,
+    type AiChartRuntimeOverrides,
+    type AiDashboardRuntimeOverrides,
+    type AiPromptContext,
+    type AiPromptContextInput,
+    type Dashboard,
+    type Explore,
+    type SavedChart,
+} from '@lightdash/common';
+import type { SuggestionPinnedContext } from '../ai/agents/suggestionGenerator';
+
+type SuggestionContextMessage =
+    | { role: 'user'; context: AiPromptContext }
+    | { role: 'assistant' };
+
+type SuggestionChartSource = Pick<
+    SavedChart,
+    'name' | 'description' | 'chartConfig' | 'metricQuery'
+>;
+
+type SuggestionDashboardSource = Pick<
+    Dashboard,
+    'name' | 'description' | 'tabs'
+>;
+
+export const getPinnedSuggestionContextInput = (
+    messages: SuggestionContextMessage[] | undefined,
+): AiPromptContextInput | undefined => {
+    if (!messages) return undefined;
+
+    for (let index = messages.length - 1; index >= 0; index -= 1) {
+        const message = messages[index];
+        if (message.role === 'user') {
+            const context: AiPromptContextInput = [];
+            message.context.forEach((item) => {
+                if (item.type === 'chart') {
+                    context.push({
+                        type: 'chart',
+                        chartUuid: item.chartUuid,
+                        runtimeOverrides: item.runtimeOverrides ?? undefined,
+                    });
+                }
+                if (item.type === 'dashboard') {
+                    context.push({
+                        type: 'dashboard',
+                        dashboardUuid: item.dashboardUuid,
+                        runtimeOverrides: item.runtimeOverrides ?? undefined,
+                    });
+                }
+            });
+            if (context.length > 0) return context;
+        }
+    }
+
+    return undefined;
+};
+
+const getChartFields = (
+    chart: SuggestionChartSource,
+    availableExplores: Explore[],
+): SuggestionPinnedContext['fields'] => {
+    const explore = availableExplores.find(
+        ({ name }) => name === chart.metricQuery.exploreName,
+    );
+    const fields = new Map<
+        string,
+        { id: string; label: string; kind: 'dimension' | 'metric' }
+    >();
+
+    if (explore) {
+        Object.values(explore.tables).forEach((table) => {
+            Object.values(table.dimensions).forEach((field) => {
+                const id = getItemId(field);
+                fields.set(id, {
+                    id,
+                    label: field.label,
+                    kind: 'dimension',
+                });
+            });
+            Object.values(table.metrics).forEach((field) => {
+                const id = getItemId(field);
+                fields.set(id, { id, label: field.label, kind: 'metric' });
+            });
+        });
+    }
+
+    return [
+        ...chart.metricQuery.dimensions.map((id) => ({
+            id,
+            label: fields.get(id)?.label ?? id,
+            kind: 'dimension' as const,
+        })),
+        ...chart.metricQuery.metrics.map((id) => ({
+            id,
+            label: fields.get(id)?.label ?? id,
+            kind: 'metric' as const,
+        })),
+    ];
+};
+
+export const buildChartSuggestionContext = (
+    chart: SuggestionChartSource,
+    availableExplores: Explore[],
+    runtimeOverrides?: AiChartRuntimeOverrides,
+): SuggestionPinnedContext => ({
+    type: 'chart',
+    name: chart.name,
+    description: chart.description ?? null,
+    fields: getChartFields(chart, availableExplores),
+    metadata: {
+        chartType: chart.chartConfig.type,
+        exploreName: chart.metricQuery.exploreName,
+        runtimeOverrides: runtimeOverrides ?? null,
+    },
+});
+
+export const buildDashboardSuggestionContext = (
+    dashboard: SuggestionDashboardSource,
+    charts: SuggestionChartSource[],
+    availableExplores: Explore[],
+    runtimeOverrides?: AiDashboardRuntimeOverrides,
+): SuggestionPinnedContext => {
+    const chartContexts = charts.map((chart) =>
+        buildChartSuggestionContext(chart, availableExplores),
+    );
+    const fields = new Map(
+        chartContexts.flatMap((chart) =>
+            chart.fields.map((field) => [field.id, field] as const),
+        ),
+    );
+
+    return {
+        type: 'dashboard',
+        name: dashboard.name,
+        description: dashboard.description ?? null,
+        fields: [...fields.values()],
+        metadata: {
+            chartNames: charts.map(({ name }) => name),
+            chartTypes: [
+                ...new Set(charts.map(({ chartConfig }) => chartConfig.type)),
+            ],
+            exploreNames: [
+                ...new Set(
+                    charts.map(({ metricQuery }) => metricQuery.exploreName),
+                ),
+            ],
+            tabNames: dashboard.tabs.map(({ name }) => name),
+            runtimeOverrides: runtimeOverrides ?? null,
+        },
+    };
+};

--- a/packages/backend/src/ee/services/ai/agents/suggestionGenerator.test.ts
+++ b/packages/backend/src/ee/services/ai/agents/suggestionGenerator.test.ts
@@ -43,4 +43,18 @@ describe('buildSuggestionSystemPrompt', () => {
         expect(postResponse).toContain('AFTER the agent has just replied');
         expect(emptyState).toContain('starter "chips"');
     });
+
+    it('prioritizes pinned content in both suggestion modes', () => {
+        const postResponse = buildSuggestionSystemPrompt({
+            isPostResponse: true,
+            canManageContent: true,
+        });
+        const emptyState = buildSuggestionSystemPrompt({
+            isPostResponse: false,
+            canManageContent: true,
+        });
+
+        expect(postResponse).toContain('<pinnedContext>');
+        expect(emptyState).toContain('pinnedContext: PRIMARY SIGNAL');
+    });
 });

--- a/packages/backend/src/ee/services/ai/agents/suggestionGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/suggestionGenerator.ts
@@ -3,6 +3,8 @@ import {
     agentSuggestionsModelSchema,
     type AgentSuggestion,
     type AgentSuggestionsModelObject,
+    type AiChartRuntimeOverrides,
+    type AiDashboardRuntimeOverrides,
 } from '@lightdash/common';
 import { generateObject } from 'ai';
 import {
@@ -33,6 +35,7 @@ FORBIDDEN PROMPT-CHIP PATTERNS — these read like commands the agent cannot ful
 - "Open the {chart}" / "Show me the {dashboard}" — there is no deep-link to verified content; if the user wants to see something, propose a PROMPT chip that asks the agent to find/rebuild it (use the findContent tool).
 
 How to use the context (PROMPT chips):
+- pinnedContext: PRIMARY SIGNAL. When present, every chip must ask a useful question about the pinned chart or dashboard. Use its real field labels and metadata to propose drill-downs, comparisons, explanations, or related analyses. Do not emit navigate chips when pinnedContext is present.
 - recentUserConversations: TOPIC SIGNAL. If the user has been digging into "product events", propose a NEW angle as a prompt chip ("Compare conversion rate across product surfaces"). For resumption, emit a navigate chip instead.
 - verifiedContent: TOPIC SIGNAL. If there's a "Revenue Summary" verified chart, propose a fresh angle on revenue ("Break down revenue by month").
 - verifiedQuestions: these ARE complete prompts. Use them verbatim as prompt chips when they fit — they're the highest-quality chip you can produce.
@@ -55,14 +58,15 @@ Two modes:
 
 1. ANSWER mode — when <thread.latestAssistantTurn.askedClarifyingQuestion> is true, the chips ARE the user's likely answers to the agent's question. Pull options from the choices the agent presented in its reply. 5-40 chars typically.
 
-2. CONTINUE mode — natural next prompts (drill-in, refinement, comparison, follow-up). Use ONLY field labels visible in <thread.latestAssistantTurn.latestQueryExplore> (preferred — these are the fields the agent JUST used), or in <thread.latestAssistantTurn.text>, or in <explores>. Never invent terms — if a concept doesn't appear in the data, do not propose it. In defaults.dimensions and defaults.metrics, use field IDs from the catalogue, not labels.
+2. CONTINUE mode — natural next prompts (drill-in, refinement, comparison, follow-up). Use ONLY field labels visible in <pinnedContext>, <thread.latestAssistantTurn.latestQueryExplore> (preferred — these are the fields the agent JUST used), <thread.latestAssistantTurn.text>, or <explores>. Never invent terms — if a concept doesn't appear in the data, do not propose it. In defaults.dimensions and defaults.metrics, use field IDs from the catalogue, not labels.
 
 PREFERRED CONTEXT:
+- When <pinnedContext> is present, keep suggestions grounded in the pinned chart or dashboard and its fields unless the latest assistant turn clearly moved elsewhere.
 - When <thread.latestAssistantTurn.latestQueryExplore> is present, lean on its dimensions and metrics first. These are the fields the agent just touched — the user is almost certainly thinking in that explore's frame.
 - defaults.explore for CONTINUE chips SHOULD match latestQueryExplore.name unless you are deliberately pivoting.
 
 HARD RULES:
-- Never reference a field name, segment, tier, or metric that does not appear in <thread.latestAssistantTurn.latestQueryExplore>, <explores>, <thread.latestAssistantTurn.text>, or <verifiedContent>. This is the #1 failure mode.
+- Never reference a field name, segment, tier, or metric that does not appear in <pinnedContext>, <thread.latestAssistantTurn.latestQueryExplore>, <explores>, <thread.latestAssistantTurn.text>, or <verifiedContent>. This is the #1 failure mode.
 - If <thread.latestAssistantTurn.refused> is true (the agent just said it couldn't do something): do NOT repeat the refused line. Pivot — propose a different explore, a related verified question, or an adjacent angle the data actually supports.
 - 3 chips is ideal. 5 is the maximum.
 - Verified questions, verified content, and content tags reflect the user's curated workflow — prefer them when they fit the next-step slot. A chip that points at a verified chart ("Find the {name} chart") via \`findContent\` is often stronger than a new query.
@@ -155,6 +159,36 @@ type SuggestionFieldContext = {
     label: string;
 };
 
+type SuggestionPinnedFieldContext = SuggestionFieldContext & {
+    kind: 'dimension' | 'metric';
+};
+
+export type SuggestionPinnedContext =
+    | {
+          type: 'chart';
+          name: string;
+          description: string | null;
+          fields: SuggestionPinnedFieldContext[];
+          metadata: {
+              chartType: string;
+              exploreName: string;
+              runtimeOverrides: AiChartRuntimeOverrides | null;
+          };
+      }
+    | {
+          type: 'dashboard';
+          name: string;
+          description: string | null;
+          fields: SuggestionPinnedFieldContext[];
+          metadata: {
+              chartNames: string[];
+              chartTypes: string[];
+              exploreNames: string[];
+              tabNames: string[];
+              runtimeOverrides: AiDashboardRuntimeOverrides | null;
+          };
+      };
+
 export type SuggestionPromptContext = {
     agentName: string;
     agentInstruction: string | null;
@@ -172,6 +206,7 @@ export type SuggestionPromptContext = {
     verifiedQuestions: string[];
     verifiedContentTags: string[];
     verifiedContent: VerifiedContentItem[];
+    pinnedContext?: SuggestionPinnedContext[];
     // Fully-qualified `database.schema.table` names — only set for
     // semantic-layer-less projects with no explores, to ground chips via runSql.
     warehouseTables?: string[];
@@ -225,6 +260,7 @@ export async function generateAgentSuggestions(
             verifiedQuestions: context.verifiedQuestions,
             verifiedContentTags: context.verifiedContentTags,
             verifiedContent: context.verifiedContent,
+            pinnedContext: context.pinnedContext ?? null,
             recentUserConversations: recentForLLM ?? null,
             thread: context.thread ?? null,
         },

--- a/packages/common/src/ee/AiAgent/schemas/agentSuggestions.ts
+++ b/packages/common/src/ee/AiAgent/schemas/agentSuggestions.ts
@@ -2,6 +2,21 @@ import { z } from 'zod';
 import { type ApiSuccess } from '../../../types/api/success';
 import { AGENT_SUGGESTION_TOOLS, type AgentSuggestion } from '../types';
 
+export const aiAgentSuggestionContextSchema = z.discriminatedUnion('type', [
+    z.object({
+        type: z.literal('chart'),
+        chartUuid: z.string().min(1),
+    }),
+    z.object({
+        type: z.literal('dashboard'),
+        dashboardUuid: z.string().min(1),
+    }),
+]);
+
+export type AiAgentSuggestionContext = z.infer<
+    typeof aiAgentSuggestionContextSchema
+>;
+
 const promptChipModelSchema = z.object({
     kind: z.literal('prompt'),
     label: z


### PR DESCRIPTION
People who pin a chart or dashboard before they start a chat see generic prompts. The suggestions now use the pinned item, so the first prompts match the content the person chose.

## How it works

- Accept an optional JSON-encoded `context` query parameter with either `{ "type": "chart", "chartUuid": "..." }` or `{ "type": "dashboard", "dashboardUuid": "..." }`.
- Load the pinned item's name, description, fields, and chart or dashboard metadata for suggestion generation.
- Recover the latest saved chart or dashboard context when suggestions are requested with `threadUuid`.
- Keep the response shape and the no-context path unchanged.

## Authorization

The suggestions service passes both new query context and saved thread context through the same `validatePromptContextAccess` method used by thread creation. This calls the existing chart or dashboard `view` access check before any metadata is loaded.

## First-step findings

VERIFIED: `threadUuid` suggestions previously used recent messages and the latest queried explore, but did not read pinned prompt context.

VERIFIED: thread creation already validated and stored chart and dashboard context on the first user prompt.

INFERRED: the safest shared path is to reuse the thread-create access validator, then build one field-aware suggestion context for both pre-thread query context and saved thread context.

## Verification

- 532 backend test files passed, with 8,406 tests passed and 1 skipped.
- Common and backend typechecks passed.
- Touched backend and common lint passed.
- API and schema generation passed.

Linear: SPK-1598
