### PR TITLE
refactor(backend): make items map keying an invariant assertion, not accidental matching

### DIFF
--- a/docs/composer-viz-plan/01-design.md
+++ b/docs/composer-viz-plan/01-design.md
@@ -337,6 +337,40 @@ knowing the engine. Remaining work, with tickets:
 | Pivoted value columns hardcode `type: NUMBER` — lies for MAX-of-timestamp / boolean ANY | `getPivotedColumns` via `convertItemTypeToDimensionType`; behavior change, staged alone | PROD-10690 |
 | SQL columns bare by accident, rule never made explicit | §3 SQL-path rule as deliberate code | PROD-9832 |
 
+### 2026-08-28 — provenance is provable lineage, not name matching
+
+Implemented as PROD-10772 and PROD-10773 (follow-ups to PR #28241). The rule
+"an item contributes result-column metadata only when it is a genuine
+semantic field behind the column" was enforced by an accidental string
+mismatch: `SqlQueryComposer` keys its virtual-view items
+`${virtualViewName}_${column}` while raw-SQL result columns are bare names,
+so lookups missed — plus a defensive `getItemId(item) !== fieldId` guard
+duplicated across `resultColumns.ts` and `getPivotedColumns.ts`. Now
+explicit:
+
+- **`SqlQueryComposer.getFields()` returns `{}`.** The virtual view is SQL
+  generation machinery (typed dashboard-filter compilation, the pivot seam
+  via `compile().fields`) and its dimensions never reach the results seam.
+- **The id comparison is an invariant assertion.** Items maps are keyed by
+  `getItemId` (`getItemMap`, `compileMetricQuery`, `buildMergeItems`), so a
+  resolved item whose own field id differs from its key is a producer bug
+  and throws instead of silently dropping a real field's metadata.
+- **One shared rule.** `getResultColumnSourceItem` (resultColumns.ts)
+  resolves the source item for `getUnpivotedColumns`, `getPivotedColumns`,
+  and the compose-merge column builder, so metadata and pivoted-column type
+  derivation cannot diverge.
+- **`query_history.fields` stays empty on SQL and compose paths.** The
+  shared prepare/execute seam persists the composer's (now empty) fields
+  map, and the shared DuckDB execution tail (`runDuckdbQuery`) no longer
+  overwrites the row with the synthetic map. Reader audit: the page formatter, pivot value formatting,
+  export items maps, and AI/GSheets consumers all key lookups by bare
+  column references, which never matched the prefixed synthetic keys — no
+  behavior change. Two deliberate exceptions: pivot-export row caps divide
+  by the fields count, so they fall back to the column order when the map
+  is empty; and a merge result source backed by a SQL/compose row is now
+  refused at compile ("carries no field metadata to merge on") instead of
+  compiling against fake fields and failing inside DuckDB at run time.
+
 ### Revised sequencing
 
 Population must not re-land ahead of the parameters prerequisite — columns

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -4360,6 +4360,68 @@ describe('AsyncQueryService', () => {
             expect(disconnect).toHaveBeenCalledOnce();
         });
 
+        it('persists an empty fields map, not the virtual-view items', async () => {
+            // The SqlQueryComposer virtual view serves SQL generation only.
+            // Its synthetic items map must not reach query_history.fields,
+            // where consumers would read it as semantic field metadata.
+            const service = getMockedAsyncQueryService(lightdashConfigMock);
+
+            service.warehouseClients = {};
+            service.findResultsCache = vi.fn().mockResolvedValue({
+                cacheHit: false,
+                updatedAt: undefined,
+                expiresAt: undefined,
+            } satisfies MissCacheResult);
+
+            (
+                service.queryHistoryModel.create as import('vitest').Mock
+            ).mockResolvedValue({
+                queryUuid: 'test-query-uuid',
+            });
+
+            vi.spyOn(service, 'runAsyncWarehouseQuery').mockResolvedValue(
+                undefined,
+            );
+
+            service.getUserAttributes = vi.fn(async () => ({
+                userAttributes: {},
+                intrinsicUserAttributes: { email: 'test@example.com' },
+            }));
+
+            const mockWarehouseClient = {
+                ...warehouseClientMock,
+                streamQuery: vi.fn(async (_sql, callback) => {
+                    await callback({
+                        fields: {
+                            test_col: { type: DimensionType.STRING },
+                        },
+                        rows: [],
+                    });
+                }),
+            };
+
+            service._getWarehouseClient = vi.fn(async () => ({
+                warehouseClient: mockWarehouseClient,
+                sshTunnel: mockSshTunnel,
+                tunnelConnectMs: null,
+            }));
+
+            await service.executeAsyncSqlQuery({
+                account: sessionAccount,
+                projectUuid,
+                sql: 'SELECT 1',
+                context: QueryExecutionContext.SQL_RUNNER,
+            });
+
+            expect(service.queryHistoryModel.create).toHaveBeenCalledWith(
+                sessionAccount,
+                expect.objectContaining({ fields: {} }),
+            );
+            expect(service.runAsyncWarehouseQuery).toHaveBeenCalledWith(
+                expect.objectContaining({ fieldsMap: {} }),
+            );
+        });
+
         describe('cache invalidation', () => {
             it('skips cache when invalidateCache is true', async () => {
                 const service = getMockedAsyncQueryService({
@@ -5739,9 +5801,8 @@ describe('runDuckdbQuery', () => {
         expect(executed.originalColumns).toEqual({
             one: { reference: 'one', type: DimensionType.NUMBER, label: 'One' },
         });
-        expect(Object.keys(executed.fieldsMap)).toEqual([
-            'sql_query_explorer_one',
-        ]);
+        // The composer's virtual-view items never reach the results seam
+        expect(executed.fieldsMap).toEqual({});
         expect(executed.pivotConfiguration).toBeUndefined();
         expect(executed.warehouseClientOverride).toBe(warehouseClient);
         expect(update).toHaveBeenCalledWith(
@@ -5749,7 +5810,6 @@ describe('runDuckdbQuery', () => {
             projectUuid,
             {
                 compiled_sql: executed.query,
-                fields: executed.fieldsMap,
                 original_columns: executed.originalColumns,
             },
             expect.anything(),
@@ -5831,7 +5891,6 @@ describe('runDuckdbQuery', () => {
             projectUuid,
             {
                 compiled_sql: executed.query,
-                fields: fieldsMap,
                 original_columns: originalColumns,
             },
             expect.anything(),

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -1471,7 +1471,11 @@ export class AsyncQueryService extends ProjectService {
                 warehouseType:
                     queryHistory?.warehouseQueryMetadata?.type ?? null,
                 page,
-                columnsCount: Object.keys(queryHistory.fields).length,
+                // SQL and compose rows persist no fields map; count their
+                // stored result columns instead.
+                columnsCount:
+                    Object.keys(queryHistory.fields).length ||
+                    Object.keys(columns ?? {}).length,
                 totalRowCount: totalRowCount ?? 0,
                 totalPageCount: pageCount,
                 resultsPageSize: rows.length,
@@ -7604,7 +7608,6 @@ export class AsyncQueryService extends ProjectService {
                 projectUuid,
                 {
                     compiled_sql: storedCompiledSql ?? execution.query,
-                    fields: execution.fieldsMap,
                     original_columns: execution.originalColumns,
                 },
                 account,
@@ -7815,6 +7818,9 @@ export class AsyncQueryService extends ProjectService {
             query: composer.getSql({
                 columnLimit: this.lightdashConfig.pivotTable.maxColumnLimit,
             }),
+            // Empty by contract: a compose node outputs a result set and
+            // nothing more, so its history row keeps the empty fields map it
+            // was created with rather than the composer's virtual-view items.
             fieldsMap: composer.getFields(),
             usedParameters: composer.getUsedParameters(),
             originalColumns,

--- a/packages/backend/src/services/AsyncQueryService/getPivotedColumns.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/getPivotedColumns.test.ts
@@ -169,6 +169,23 @@ describe('getPivotedColumns', () => {
         );
     });
 
+    test('an items map keyed by anything but getItemId throws', () => {
+        // Metadata and the type derivation resolve their source item through
+        // the same shared rule, so a mis-keyed producer map fails loudly
+        // instead of silently dropping the metric's format and provenance.
+        const misKeyedItemsMap: ItemsMap = {
+            orders_revenue: { ...revenueMetric, name: 'other_revenue' },
+        };
+        expect(() =>
+            getPivotedColumns(
+                unpivotedColumns,
+                pivotConfiguration,
+                pivotValuesColumns,
+                misKeyedItemsMap,
+            ),
+        ).toThrow('must be keyed by getItemId');
+    });
+
     test('value columns without an items map get a reference-derived label and no provenance', () => {
         const columns = getPivotedColumns(
             unpivotedColumns,

--- a/packages/backend/src/services/AsyncQueryService/getPivotedColumns.ts
+++ b/packages/backend/src/services/AsyncQueryService/getPivotedColumns.ts
@@ -2,8 +2,8 @@ import {
     assertUnreachable,
     convertItemTypeToDimensionType,
     DimensionType,
-    getItemId,
     getResultColumnMetadataFromItem,
+    getResultColumnSourceItem,
     isMetric,
     MetricType,
     normalizeIndexColumns,
@@ -96,15 +96,12 @@ export function getPivotedColumns(
         ...indexColumnsResult,
         ...passthroughColumnsResult,
         ...pivotValuesColumns.reduce<ResultColumns>((acc, valueColumn) => {
-            // An item contributes metadata and a type only when the column
-            // reference is the item's own field id — the same identity rule
-            // that getResultColumnMetadataFromItem applies internally.
-            const lookedUpItem = itemsMap?.[valueColumn.referenceField];
-            const sourceItem =
-                lookedUpItem &&
-                getItemId(lookedUpItem) === valueColumn.referenceField
-                    ? lookedUpItem
-                    : undefined;
+            // Shared resolution rule: metadata and the type derivation must
+            // read the same source item, or they diverge.
+            const sourceItem = getResultColumnSourceItem(
+                itemsMap,
+                valueColumn.referenceField,
+            );
             const metadata = getResultColumnMetadataFromItem(
                 sourceItem,
                 valueColumn.referenceField,

--- a/packages/backend/src/services/AsyncQueryService/getUnpivotedColumns.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/getUnpivotedColumns.test.ts
@@ -70,18 +70,11 @@ describe('getUnpivotedColumns', () => {
         });
     });
 
-    test('raw SQL columns get no metadata from virtual-view items', () => {
-        // SqlQueryComposer keys its items map `${table}_${column}` while raw
-        // SQL warehouse columns use unprefixed names. Even a map keyed by
-        // unprefixed names must not contribute provenance, because the item's
-        // field id is not the column reference.
-        const virtualViewItemsMap: ItemsMap = {
+    test('items stored under other field ids never contribute metadata', () => {
+        // An items map keyed `${table}_${column}` cannot match a bare column
+        // reference, so the column falls back to a reference-derived label.
+        const prefixedItemsMap: ItemsMap = {
             sql_query_explorer_payment_method: {
-                ...statusDimension,
-                name: 'payment_method',
-                table: 'sql_query_explorer',
-            },
-            payment_method: {
                 ...statusDimension,
                 name: 'payment_method',
                 table: 'sql_query_explorer',
@@ -90,13 +83,33 @@ describe('getUnpivotedColumns', () => {
         const columns = getUnpivotedColumns(
             {},
             { payment_method: { type: DimensionType.STRING } },
-            virtualViewItemsMap,
+            prefixedItemsMap,
         );
         expect(columns.payment_method).toEqual({
             reference: 'payment_method',
             type: DimensionType.STRING,
             label: 'Payment method',
         });
+    });
+
+    test('an items map keyed by anything but getItemId throws', () => {
+        // A matching key whose item belongs to a different field id means the
+        // producer keyed its map wrong; failing loudly beats silently losing
+        // the field's metadata.
+        const misKeyedItemsMap: ItemsMap = {
+            payment_method: {
+                ...statusDimension,
+                name: 'payment_method',
+                table: 'sql_query_explorer',
+            },
+        };
+        expect(() =>
+            getUnpivotedColumns(
+                {},
+                { payment_method: { type: DimensionType.STRING } },
+                misKeyedItemsMap,
+            ),
+        ).toThrow('must be keyed by getItemId');
     });
 
     test('parameter placeholders interpolate against used parameter values', () => {

--- a/packages/backend/src/services/AsyncQueryService/getUnpivotedColumns.ts
+++ b/packages/backend/src/services/AsyncQueryService/getUnpivotedColumns.ts
@@ -1,5 +1,6 @@
 import {
     getResultColumnMetadataFromItem,
+    getResultColumnSourceItem,
     ItemsMap,
     ParametersValuesMap,
     ResultColumns,
@@ -17,14 +18,14 @@ export function getUnpivotedColumns(
             (acc, [key, value]) => {
                 // For metric queries the warehouse column name is the field id,
                 // so the item lookup enriches the column with display metadata.
-                // Raw SQL columns never match an item (SqlQueryComposer keys
-                // its virtual-view items `${table}_${column}`) and get only a
-                // label derived from the column reference.
+                // Raw SQL columns have no item (SqlQueryComposer exposes no
+                // items at the results seam) and get only a label derived
+                // from the column reference.
                 acc[key] = {
                     reference: key,
                     type: value.type,
                     ...getResultColumnMetadataFromItem(
-                        itemsMap?.[key],
+                        getResultColumnSourceItem(itemsMap, key),
                         key,
                         usedParameters,
                     ),

--- a/packages/backend/src/services/AsyncQueryService/mergeQueryExecution.ts
+++ b/packages/backend/src/services/AsyncQueryService/mergeQueryExecution.ts
@@ -1,6 +1,7 @@
 import {
     getMergeSourceTableLabel,
     getResultColumnMetadataFromItem,
+    getResultColumnSourceItem,
     isField,
     isMergeMetricSource,
     type ItemsMap,
@@ -34,7 +35,7 @@ export const buildComposeMergeOriginalColumns = ({
     Object.fromEntries(
         typedColumns.map((column) => {
             const metadata = getResultColumnMetadataFromItem(
-                itemsMap[column.reference],
+                getResultColumnSourceItem(itemsMap, column.reference),
                 column.reference,
                 usedParametersValues,
             );

--- a/packages/backend/src/services/ExcelService/ExcelService.ts
+++ b/packages/backend/src/services/ExcelService/ExcelService.ts
@@ -778,7 +778,11 @@ export class ExcelService {
         const readStream =
             await resultsStorageClient.getDownloadStream(resultsFileName);
 
-        const fieldCount = Object.keys(fields).length;
+        // SQL and compose rows persist no fields map, so fall back to the
+        // column order (derived from the results file when the request
+        // carries none) to keep the cell-based row cap finite.
+        const fieldCount =
+            Object.keys(fields).length || options.columnOrder.length || 1;
         const cellsLimit =
             csvCellsLimit ?? lightdashConfig.query?.csvCellsLimit ?? 100000;
 

--- a/packages/backend/src/services/PivotTableService/PivotTableService.ts
+++ b/packages/backend/src/services/PivotTableService/PivotTableService.ts
@@ -153,7 +153,11 @@ export class PivotTableService extends BaseService {
         const readStream =
             await storageClient.getDownloadStream(resultsFileName);
 
-        const fieldCount = Object.keys(fields).length;
+        // SQL and compose rows persist no fields map, so fall back to the
+        // column order (derived from the results file when the request
+        // carries none) to keep the cell-based row cap finite.
+        const fieldCount =
+            Object.keys(fields).length || options.columnOrder.length || 1;
         const { csvCellsLimit: cellsLimit } =
             await resolveOrganizationExportLimits(
                 this.organizationSettingsModel,

--- a/packages/backend/src/utils/QueryBuilder/SqlQueryComposer.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/SqlQueryComposer.test.ts
@@ -69,6 +69,22 @@ describe('SqlQueryComposer', () => {
         expect(composer.getExplore().name).toBe(SQL_QUERY_MOCK_EXPLORER_NAME);
     });
 
+    it('exposes no items at the results seam', () => {
+        // The virtual view's dimensions serve SQL generation only. Exposing
+        // them through getFields() would persist fake semantic fields to
+        // query_history.fields on every SQL and compose execution.
+        const composer = new SqlQueryComposer({
+            ...baseArgs,
+            pivotConfiguration: undefined,
+        });
+
+        expect(composer.getFields()).toEqual({});
+        // SQL generation still reads the virtual-view items internally.
+        expect(Object.keys(composer.compile().fields)).toContain(
+            `${SQL_QUERY_MOCK_EXPLORER_NAME}_category`,
+        );
+    });
+
     it('wraps the base query with the pivot query when a pivot is set', () => {
         const composer = new SqlQueryComposer({
             ...baseArgs,

--- a/packages/backend/src/utils/QueryBuilder/SqlQueryComposer.ts
+++ b/packages/backend/src/utils/QueryBuilder/SqlQueryComposer.ts
@@ -8,6 +8,7 @@ import {
     type DashboardFilters,
     type DimensionType,
     type Explore,
+    type ItemsMap,
     type MetricQuery,
     type ParametersValuesMap,
     type PivotConfiguration,
@@ -95,6 +96,18 @@ export class SqlQueryComposer extends QueryComposer {
     /** Dashboard filters actually applied to the SQL, for the response echo. */
     getAppliedDashboardFilters(): DashboardFilters | undefined {
         return this.appliedDashboardFilters;
+    }
+
+    /**
+     * SQL charts expose no items at the results seam. The virtual view's
+     * dimensions are packaging around the user's SQL, not semantic fields:
+     * exposing them here would persist a fields map of fake semantic fields
+     * to query history for downstream consumers to trust. SQL generation
+     * still reads them through `compile().fields` (typed dashboard-filter
+     * compilation, the pivot seam).
+     */
+    getFields(): ItemsMap {
+        return {};
     }
 
     private static build(args: SqlQueryComposerArguments): {

--- a/packages/common/src/utils/resultColumns.test.ts
+++ b/packages/common/src/utils/resultColumns.test.ts
@@ -11,7 +11,10 @@ import {
     type TableCalculation,
 } from '../types/field';
 import { TimeFrames } from '../types/timeFrames';
-import { getResultColumnMetadataFromItem } from './resultColumns';
+import {
+    getResultColumnMetadataFromItem,
+    getResultColumnSourceItem,
+} from './resultColumns';
 
 const dimension: Dimension = {
     fieldType: FieldType.DIMENSION,
@@ -43,6 +46,32 @@ const tableCalculation: TableCalculation = {
     sql: '${orders.revenue} * 2',
 };
 
+describe('getResultColumnSourceItem', () => {
+    test('resolves the item stored under the field id', () => {
+        const itemsMap = { orders_status: dimension };
+        expect(getResultColumnSourceItem(itemsMap, 'orders_status')).toBe(
+            dimension,
+        );
+    });
+
+    test('returns undefined without an items map or a matching entry', () => {
+        expect(
+            getResultColumnSourceItem(undefined, 'orders_status'),
+        ).toBeUndefined();
+        expect(getResultColumnSourceItem({}, 'orders_status')).toBeUndefined();
+    });
+
+    test('throws when an entry is keyed by anything but its field id', () => {
+        // A producer keying by raw column name instead of getItemId (for
+        // example a field whose name contains dots) must fail loudly instead
+        // of silently losing the field's metadata.
+        const itemsMap = { status: dimension };
+        expect(() => getResultColumnSourceItem(itemsMap, 'status')).toThrow(
+            'must be keyed by getItemId',
+        );
+    });
+});
+
 describe('getResultColumnMetadataFromItem', () => {
     test('returns only a label derived from the reference when there is no item', () => {
         expect(
@@ -50,20 +79,19 @@ describe('getResultColumnMetadataFromItem', () => {
         ).toEqual({ label: 'Payment method' });
     });
 
-    test('returns no metadata from an item whose field id differs from the column reference', () => {
-        // SqlQueryComposer keys virtual-view items `${table}_${column}` while
-        // raw SQL warehouse columns use unprefixed names. Even if a lookup
-        // matches, an item with a different field id must not contribute
-        // provenance, because its synthesized dimension is not a semantic
-        // field.
+    test('throws when the item field id differs from the column reference', () => {
+        // Items maps are keyed by getItemId, so a resolved item whose own
+        // field id differs from the column reference means the producer keyed
+        // its map some other way. Silently skipping the item would drop a
+        // real field's metadata with no error.
         const virtualViewDimension: Dimension = {
             ...dimension,
             name: 'status',
             table: 'sql_query_explorer',
         };
-        expect(
+        expect(() =>
             getResultColumnMetadataFromItem(virtualViewDimension, 'status'),
-        ).toEqual({ label: 'Status' });
+        ).toThrow('must be keyed by getItemId');
     });
 
     test('null format keys on an item do not produce a format expression', () => {

--- a/packages/common/src/utils/resultColumns.ts
+++ b/packages/common/src/utils/resultColumns.ts
@@ -1,9 +1,11 @@
 import { isValidFormat } from 'numfmt';
+import { UnexpectedServerError } from '../types/errors';
 import {
     friendlyName,
     isDimension,
     isTableCalculation,
     type Item,
+    type ItemsMap,
 } from '../types/field';
 import { type ParametersValuesMap } from '../types/parameters';
 import { type ResultColumn } from '../types/results';
@@ -21,22 +23,60 @@ import { getItemId, getItemLabel } from './item';
 
 type ResultColumnMetadata = Omit<ResultColumn, 'reference' | 'type'>;
 
+function assertItemMatchesFieldId(item: Item, fieldId: string): void {
+    const itemId = getItemId(item);
+    if (itemId !== fieldId) {
+        throw new UnexpectedServerError(
+            `Result column lookup for "${fieldId}" returned the item ` +
+                `"${itemId}". Items maps must be keyed by getItemId; a map ` +
+                `keyed any other way silently drops column metadata.`,
+        );
+    }
+}
+
+/**
+ * Resolves the semantic item behind a result column from the query's items
+ * map. Returns undefined when the map has no entry for the field id —
+ * computed and raw SQL columns have no item, and consumers fall back to a
+ * reference-derived label.
+ *
+ * Every well-behaved producer keys its items map by `getItemId`
+ * (`getItemMap`, `compileMetricQuery`, `buildMergeItems`), so an entry whose
+ * own field id differs from its key breaks that invariant and throws.
+ * Failing loudly is the point: a silent skip would drop a real field's
+ * label, format, and provenance with no error, and a silent accept would
+ * stamp another field's metadata onto the column.
+ */
+export function getResultColumnSourceItem(
+    itemsMap: ItemsMap | undefined,
+    fieldId: string,
+): Item | undefined {
+    const item = itemsMap?.[fieldId];
+    if (item === undefined) {
+        return undefined;
+    }
+    assertItemMatchesFieldId(item, fieldId);
+    return item;
+}
+
 /**
  * The display/format metadata a semantic item contributes to its result
  * column, resolved once at query-write time (docs/composer-viz-plan/01-design.md §3).
  *
- * An item contributes metadata only when its field id matches the column
- * reference. Unmatched columns get only a display label derived from the
+ * Columns without an item get only a display label derived from the
  * reference with `friendlyName`; they never get provenance or a format.
+ * Resolve the item with `getResultColumnSourceItem`: an item whose field id
+ * differs from the column reference is a producer bug and throws.
  */
 export function getResultColumnMetadataFromItem(
     item: Item | undefined,
     fieldId: string,
     parameters?: ParametersValuesMap | null,
 ): ResultColumnMetadata {
-    if (!item || getItemId(item) !== fieldId) {
+    if (!item) {
         return { label: friendlyName(fieldId) };
     }
+    assertItemMatchesFieldId(item, fieldId);
 
     const metadata: ResultColumnMetadata = {
         label: getItemLabel(item),


### PR DESCRIPTION
Closes: PROD-10772, PROD-10773

### Description:

This PR makes the rule "an item contributes result-column metadata only when it is a genuine semantic field behind the column" explicit and enforceable, rather than relying on accidental string mismatches.

**Key changes:**

1. **`SqlQueryComposer.getFields()` now returns `{}`** — The virtual view's dimensions are SQL generation machinery, not semantic fields. Exposing them at the results seam would persist fake field metadata to `query_history.fields` for downstream consumers to trust. SQL generation still reads them internally via `compile().fields`.

2. **Items map keying is now an invariant assertion** — All well-behaved producers key their items maps by `getItemId` (`getItemMap`, `compileMetricQuery`, `buildMergeItems`). A resolved item whose own field id differs from its key is a producer bug and now throws instead of silently dropping a real field's metadata or stamping another field's metadata onto the column.

3. **Shared resolution rule via `getResultColumnSourceItem()`** — This new function in `resultColumns.ts` is the single point where items maps are resolved for metadata and pivoted-column type derivation, preventing divergence between the two paths.

4. **Fallback for empty fields maps** — `query_history.fields` stays empty on SQL and compose paths. Export and pivot services now fall back to the column order when the fields map is empty, keeping cell-based row caps finite.

5. **Merge compile-time validation** — A merge result source backed by a SQL/compose row (which carries no field metadata) is now refused at compile time with a clear error, instead of compiling against fake fields and failing inside DuckDB at run time.

### Risk assessment:

- [x] This is a high-risk change

**Rationale:** This change affects the contract between query composers and result consumers across multiple code paths (SQL, compose, merge, pivot, export). While the behavior is more correct (explicit invariants instead of accidental matching), it introduces new validation that could surface producer bugs or edge cases in existing code paths. The fallback logic for empty fields maps is defensive, but export/pivot row caps now depend on column order when fields are absent.

**Mitigations:**
- Comprehensive test coverage added for the new assertion and fallback paths
- Shared resolution rule prevents divergence between metadata and type derivation
- Compile-time validation for merge sources prevents runtime failures
- Existing consumers (page formatter, pivot value formatting, export items maps, AI/GSheets) all key lookups by bare column references, which never matched the prefixed synthetic keys — no behavior change for them

https://claude.ai/code/session_01WrCjvtAkPTVXyrAJuYJVkU