### PR TITLE
chore(frontend): stop excluding @lightdash/common from dep optimization

### DIFF
--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -55,7 +55,6 @@ export default defineConfig({
         }),
     ],
     optimizeDeps: {
-        exclude: ['@lightdash/common'],
         include: ['react-vega'],
     },
     resolve: {


### PR DESCRIPTION
### Description:

Dev-only change. Deletes one line from `packages/frontend/vite.config.ts`:

```diff
     optimizeDeps: {
-        exclude: ['@lightdash/common'],
         include: ['react-vega'],
     },
```

**The problem.** `optimizeDeps.exclude` made Vite's dependency scanner treat `@lightdash/common` as external and stop crawling into it. But the dev alias points `@lightdash/common` at `../common/src/index.ts` — a 1,210-line barrel with 321 `export *` lines reaching 455 source modules and 33 third-party packages. None of those were visible to the first-pass scan, so they were only discovered once the browser requested them, triggering a second optimize pass and a forced full page reload on every cold start:

```
✨ new dependencies optimized: @babel/parser, @mastra/schema-compat,
@sidvind/better-ajv-errors, ajv-errors, ajv-formats, ajv, company-email-validator,
dependency-graph, handlebars, liquidjs, lodash/*, moment-timezone, moment,
numfmt, sanitize-html, sql-formatter, yaml, zod-to-json-schema  (37 total)
✨ optimized dependencies changed. reloading
```

All 37 arrive via `@lightdash/common`; none is a direct frontend dependency.

**The fix.** Removing the exclude lets the scanner find them up front. First-pass deps go from 157 to 194, with no re-optimization and no reload.

Adding the 37 packages to `optimizeDeps.include` would also work, but it re-breaks whenever `common` gains an import.

### Measurements

Cold clone, Vite 8.0.5, initial load of the dev module graph:

| | Cold load | Warm |
|---|---|---|
| Before | 25.4s + forced reload | 3.5s |
| After | 9.0s, no reload | 3.0s |

`@lightdash/common` is still served as individual source modules (471 both before and after), so HMR on the package is unchanged — the exclude was only blinding the scanner.

### No production impact

`optimizeDeps` is dev-only: Vite's own types state deps optimization during build was removed in Vite 5.1, and the source alias is gated on `NODE_ENV=development`, so production resolves the built package (verified — the resolved build config carries no `@lightdash/common` alias).

Verified empirically with three full production builds:

- **A** — with exclude
- **A2** — control rerun, identical config
- **B** — without exclude

`A == A2` confirms the build is deterministic, so a real difference would have surfaced. `A == B` byte-for-byte across all 1,102 output files (excluding `.map`/`.gzip`).

`pnpm -F frontend lint` (0 warnings, 0 errors) and `pnpm -F frontend typecheck` both pass.

### Follow-ups (not in this PR)

- 185 of the 471 `common` modules loaded on first paint are the `ee/` AI-agent/MCP subtree, pulled in by `export * from './ee'`. Splitting that barrel is the largest remaining dev-load win.
- Worth checking separately whether that subtree is tree-shaken out of the production bundle — `McpSchemaCompatLayer.ts` runs `new McpSchemaCompatLayer()` at module top level, which can defeat tree-shaking.

### Risk assessment:

- [ ] This is a high-risk change

Dev-tooling only, with production output proven byte-identical.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Knu1wi8j7CetuhJpaPCbEj)_