### PR TITLE
feat: add Live Activity push delivery

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -3389,6 +3389,63 @@ export type FeatureFlagCheckedAggregatedEvent = BaseTrack & {
     };
 };
 
+export type MobilePushNotificationEvent =
+    | (BaseTrack & {
+          event: 'mobile_push.installation_registered';
+          userId: string;
+          properties: {
+              organizationId: string;
+              installationId: string;
+              environment: 'sandbox' | 'production';
+          };
+      })
+    | (BaseTrack & {
+          event: 'mobile_push.live_activity_registered';
+          userId: string;
+          properties: {
+              organizationId: string;
+              projectId: string;
+              agentId: string;
+              threadId: string;
+              promptId: string;
+              installationId: string;
+              liveActivityId: string;
+              environment: 'sandbox' | 'production';
+          };
+      })
+    | (BaseTrack & {
+          event: 'mobile_push.live_activity_delivery';
+          userId: string;
+          properties: {
+              organizationId: string;
+              projectId: string;
+              agentId: string;
+              threadId: string;
+              promptId: string;
+              installationId: string;
+              liveActivityId: string;
+              environment: 'sandbox' | 'production';
+              state: 'working' | 'waiting_for_you' | 'idle';
+              activityEvent: 'update' | 'end';
+              outcome: 'sent' | 'invalid_token' | 'retryable' | 'failed';
+          };
+      })
+    | (BaseTrack & {
+          event: 'mobile_push.completion_alert_delivery';
+          userId: string;
+          properties: {
+              organizationId: string;
+              projectId: string;
+              agentId: string;
+              threadId: string;
+              promptId: string;
+              installationId: string;
+              liveActivityId: string;
+              environment: 'sandbox' | 'production';
+              outcome: 'sent' | 'invalid_token' | 'retryable' | 'failed';
+          };
+      });
+
 type TypedEvent =
     | TrackSimpleEvent
     | CreateUserEvent
@@ -3561,6 +3618,7 @@ type TypedEvent =
     | ImpersonationEvent
     | PromptFetchedEvent
     | FeatureFlagCheckedAggregatedEvent
+    | MobilePushNotificationEvent
     | PersistentFileGenerationRequestedEvent
     | PersistentFileGenerationCompletedEvent
     | PersistentFileUrlRequestedEvent

--- a/packages/backend/src/clients/Apns/ApnsClient.test.ts
+++ b/packages/backend/src/clients/Apns/ApnsClient.test.ts
@@ -158,6 +158,10 @@ describe('ApnsClient.sendAlert', () => {
                     body: 'Approved body',
                 },
             },
+            projectUuid: 'project-uuid',
+            agentUuid: 'agent-uuid',
+            threadUuid: 'thread-uuid',
+            promptUuid: 'prompt-uuid',
         };
 
         await expect(

--- a/packages/backend/src/clients/Apns/ApnsClient.test.ts
+++ b/packages/backend/src/clients/Apns/ApnsClient.test.ts
@@ -1,0 +1,239 @@
+import { type MobilePushNotificationsConfig } from '../../config/parseConfig';
+import {
+    ApnsClient,
+    buildLiveActivityPayload,
+    type ApnsHttpTransport,
+    type ApnsProviderTokenSource,
+} from './ApnsClient';
+
+const config: MobilePushNotificationsConfig = {
+    enabled: true,
+    bundleId: 'com.lightdash.mobile',
+    teamId: 'TEAMID',
+    sandbox: { keyId: 'SANDBOX', privateKey: 'sandbox-private-key' },
+    production: { keyId: 'PRODUCTION', privateKey: 'production-private-key' },
+};
+
+const createClient = (response: { status: number; body?: string }) => {
+    const transport = {
+        send: vi.fn(async () => response),
+    } satisfies ApnsHttpTransport;
+    const providerTokenSource = {
+        getToken: vi.fn(async () => 'provider-token'),
+    } satisfies ApnsProviderTokenSource;
+
+    return {
+        client: new ApnsClient({ config, transport, providerTokenSource }),
+        transport,
+        providerTokenSource,
+    };
+};
+
+describe('ApnsClient.sendLiveActivity', () => {
+    it('sends a sandbox Live Activity request with exact APNs headers', async () => {
+        const { client, transport, providerTokenSource } = createClient({
+            status: 200,
+        });
+        const payload = { aps: { timestamp: 1, event: 'update' as const } };
+
+        await expect(
+            client.sendLiveActivity({
+                environment: 'sandbox',
+                pushToken: 'activity-token',
+                payload,
+            }),
+        ).resolves.toEqual({ status: 'sent' });
+
+        expect(providerTokenSource.getToken).toHaveBeenCalledWith({
+            environment: 'sandbox',
+            teamId: 'TEAMID',
+            keyId: 'SANDBOX',
+            privateKey: 'sandbox-private-key',
+        });
+        expect(transport.send).toHaveBeenCalledWith({
+            origin: 'https://api.sandbox.push.apple.com',
+            headers: {
+                ':method': 'POST',
+                ':path': '/3/device/activity-token',
+                authorization: 'bearer provider-token',
+                'apns-priority': '10',
+                'apns-push-type': 'liveactivity',
+                'apns-topic': 'com.lightdash.mobile.push-type.liveactivity',
+            },
+            body: JSON.stringify(payload),
+        });
+    });
+
+    it('uses the production APNs origin and credential', async () => {
+        const { client, transport, providerTokenSource } = createClient({
+            status: 200,
+        });
+
+        await client.sendLiveActivity({
+            environment: 'production',
+            pushToken: 'activity-token',
+            payload: { aps: { timestamp: 1, event: 'update' } },
+        });
+
+        expect(providerTokenSource.getToken).toHaveBeenCalledWith(
+            expect.objectContaining({
+                environment: 'production',
+                keyId: 'PRODUCTION',
+            }),
+        );
+        expect(transport.send).toHaveBeenCalledWith(
+            expect.objectContaining({
+                origin: 'https://api.push.apple.com',
+            }),
+        );
+    });
+
+    it.each([
+        { status: 410, body: '{"reason":"Unregistered"}' },
+        { status: 400, body: '{"reason":"BadDeviceToken"}' },
+        { status: 400, body: '{"reason":"DeviceTokenNotForTopic"}' },
+    ])('classifies stale activity tokens as invalid', async (response) => {
+        const { client } = createClient(response);
+
+        await expect(
+            client.sendLiveActivity({
+                environment: 'sandbox',
+                pushToken: 'activity-token',
+                payload: { aps: { timestamp: 1, event: 'update' } },
+            }),
+        ).resolves.toEqual({
+            status: 'invalid_token',
+            reason: JSON.parse(response.body).reason,
+        });
+    });
+
+    it.each([429, 500, 503])(
+        'classifies APNs status %s as retryable',
+        async (status) => {
+            const { client } = createClient({ status });
+
+            await expect(
+                client.sendLiveActivity({
+                    environment: 'sandbox',
+                    pushToken: 'activity-token',
+                    payload: { aps: { timestamp: 1, event: 'update' } },
+                }),
+            ).resolves.toEqual({ status: 'retryable', reason: undefined });
+        },
+    );
+
+    it('does not expose a push token from a transport error', async () => {
+        const transport = {
+            send: vi.fn(async () => {
+                throw new Error('request /3/device/activity-token failed');
+            }),
+        } satisfies ApnsHttpTransport;
+        const providerTokenSource = {
+            getToken: vi.fn(async () => 'provider-token'),
+        } satisfies ApnsProviderTokenSource;
+        const client = new ApnsClient({
+            config,
+            transport,
+            providerTokenSource,
+        });
+
+        const result = await client.sendLiveActivity({
+            environment: 'sandbox',
+            pushToken: 'activity-token',
+            payload: { aps: { timestamp: 1, event: 'update' } },
+        });
+
+        expect(result).toEqual({ status: 'retryable', reason: 'Error' });
+        expect(JSON.stringify(result)).not.toContain('activity-token');
+    });
+});
+
+describe('ApnsClient.sendAlert', () => {
+    it('sends a device alert with the app topic and a stable collapse ID', async () => {
+        const { client, transport } = createClient({ status: 200 });
+        const payload = {
+            aps: {
+                alert: {
+                    title: 'Approved title',
+                    body: 'Approved body',
+                },
+            },
+        };
+
+        await expect(
+            client.sendAlert({
+                environment: 'production',
+                deviceToken: 'device-token',
+                collapseId: 'activity-uuid',
+                payload,
+            }),
+        ).resolves.toEqual({ status: 'sent' });
+
+        expect(transport.send).toHaveBeenCalledWith({
+            origin: 'https://api.push.apple.com',
+            headers: {
+                ':method': 'POST',
+                ':path': '/3/device/device-token',
+                authorization: 'bearer provider-token',
+                'apns-collapse-id': 'activity-uuid',
+                'apns-priority': '10',
+                'apns-push-type': 'alert',
+                'apns-topic': 'com.lightdash.mobile',
+            },
+            body: JSON.stringify(payload),
+        });
+    });
+});
+
+describe('buildLiveActivityPayload', () => {
+    it('contains state and opaque identifiers without user content', () => {
+        const payload = buildLiveActivityPayload({
+            state: 'waiting_for_you',
+            timestamp: new Date('2026-08-30T12:00:00.000Z'),
+            staleAt: new Date('2026-08-30T12:05:00.000Z'),
+            event: 'update',
+            projectUuid: 'project-uuid',
+            agentUuid: 'agent-uuid',
+            threadUuid: 'thread-uuid',
+            promptUuid: 'prompt-uuid',
+        });
+
+        expect(payload).toEqual({
+            aps: {
+                timestamp: 1788091200,
+                event: 'update',
+                'stale-date': 1788091500,
+                'content-state': {
+                    state: 'waiting_for_you',
+                    projectUuid: 'project-uuid',
+                    agentUuid: 'agent-uuid',
+                    threadUuid: 'thread-uuid',
+                    promptUuid: 'prompt-uuid',
+                },
+            },
+        });
+        expect(JSON.stringify(payload)).not.toMatch(
+            /question|answer|projectName|organization|title|body/i,
+        );
+    });
+
+    it('ends and dismisses an idle activity without an alert body', () => {
+        const payload = buildLiveActivityPayload({
+            state: 'idle',
+            timestamp: new Date('2026-08-30T12:00:00.000Z'),
+            staleAt: new Date('2026-08-30T12:00:00.000Z'),
+            dismissalAt: new Date('2026-08-30T12:01:00.000Z'),
+            event: 'end',
+            projectUuid: 'project-uuid',
+            agentUuid: 'agent-uuid',
+            threadUuid: 'thread-uuid',
+            promptUuid: 'prompt-uuid',
+        });
+
+        expect(payload.aps).toMatchObject({
+            event: 'end',
+            'dismissal-date': 1788091260,
+        });
+        expect(payload.aps).not.toHaveProperty('alert');
+    });
+});

--- a/packages/backend/src/clients/Apns/ApnsClient.ts
+++ b/packages/backend/src/clients/Apns/ApnsClient.ts
@@ -30,6 +30,10 @@ export type AlertPayload = {
             body: string;
         };
     };
+    projectUuid: string;
+    agentUuid: string;
+    threadUuid: string;
+    promptUuid: string;
 };
 
 export type ApnsDeliveryResult =

--- a/packages/backend/src/clients/Apns/ApnsClient.ts
+++ b/packages/backend/src/clients/Apns/ApnsClient.ts
@@ -1,0 +1,305 @@
+import http2, {
+    type ClientHttp2Session,
+    type IncomingHttpHeaders,
+    type OutgoingHttpHeaders,
+} from 'http2';
+import { importPKCS8, SignJWT } from 'jose';
+import { type MobilePushNotificationsConfig } from '../../config/parseConfig';
+import { type MobilePushEnvironment } from '../../ee/database/entities/mobilePushNotifications';
+
+export type LiveActivityPayload = {
+    aps: {
+        timestamp: number;
+        event: 'update' | 'end';
+        'content-state'?: {
+            state: 'working' | 'waiting_for_you' | 'idle';
+            projectUuid: string;
+            agentUuid: string;
+            threadUuid: string;
+            promptUuid: string;
+        };
+        'stale-date'?: number;
+        'dismissal-date'?: number;
+    };
+};
+
+export type AlertPayload = {
+    aps: {
+        alert: {
+            title: string;
+            body: string;
+        };
+    };
+};
+
+export type ApnsDeliveryResult =
+    | { status: 'sent' }
+    | { status: 'invalid_token'; reason: string | undefined }
+    | { status: 'retryable'; reason: string | undefined }
+    | { status: 'failed'; reason: string | undefined };
+
+type ApnsHttpRequest = {
+    origin: string;
+    headers: OutgoingHttpHeaders;
+    body: string;
+};
+
+export type ApnsHttpTransport = {
+    send(request: ApnsHttpRequest): Promise<{ status: number; body?: string }>;
+};
+
+type ProviderTokenRequest = {
+    environment: MobilePushEnvironment;
+    teamId: string;
+    keyId: string;
+    privateKey: string;
+};
+
+export type ApnsProviderTokenSource = {
+    getToken(request: ProviderTokenRequest): Promise<string>;
+};
+
+type ApnsClientDependencies = {
+    config: MobilePushNotificationsConfig;
+    transport?: ApnsHttpTransport;
+    providerTokenSource?: ApnsProviderTokenSource;
+};
+
+const INVALID_TOKEN_REASONS = new Set([
+    'BadDeviceToken',
+    'DeviceTokenNotForTopic',
+    'Unregistered',
+]);
+
+const parseReason = (body: string | undefined): string | undefined => {
+    if (body === undefined) return undefined;
+    try {
+        const parsed: unknown = JSON.parse(body);
+        if (
+            typeof parsed === 'object' &&
+            parsed !== null &&
+            'reason' in parsed &&
+            typeof parsed.reason === 'string'
+        ) {
+            return parsed.reason;
+        }
+    } catch {
+        return undefined;
+    }
+    return undefined;
+};
+
+export const buildLiveActivityPayload = (args: {
+    state: 'working' | 'waiting_for_you' | 'idle';
+    timestamp: Date;
+    staleAt: Date;
+    dismissalAt?: Date;
+    event: 'update' | 'end';
+    projectUuid: string;
+    agentUuid: string;
+    threadUuid: string;
+    promptUuid: string;
+}): LiveActivityPayload => ({
+    aps: {
+        timestamp: Math.floor(args.timestamp.getTime() / 1000),
+        event: args.event,
+        'stale-date': Math.floor(args.staleAt.getTime() / 1000),
+        'content-state': {
+            state: args.state,
+            projectUuid: args.projectUuid,
+            agentUuid: args.agentUuid,
+            threadUuid: args.threadUuid,
+            promptUuid: args.promptUuid,
+        },
+        ...(args.dismissalAt === undefined
+            ? {}
+            : {
+                  'dismissal-date': Math.floor(
+                      args.dismissalAt.getTime() / 1000,
+                  ),
+              }),
+    },
+});
+
+export class JoseApnsProviderTokenSource implements ApnsProviderTokenSource {
+    private readonly cache = new Map<
+        string,
+        { token: string; createdAt: number }
+    >();
+
+    async getToken(request: ProviderTokenRequest): Promise<string> {
+        const cacheKey = `${request.environment}:${request.keyId}`;
+        const cached = this.cache.get(cacheKey);
+        const now = Date.now();
+        if (cached !== undefined && now - cached.createdAt < 50 * 60 * 1000) {
+            return cached.token;
+        }
+
+        const privateKey = await importPKCS8(
+            request.privateKey.replace(/\\n/g, '\n'),
+            'ES256',
+        );
+        const token = await new SignJWT({})
+            .setProtectedHeader({ alg: 'ES256', kid: request.keyId })
+            .setIssuer(request.teamId)
+            .setIssuedAt(Math.floor(now / 1000))
+            .sign(privateKey);
+        this.cache.set(cacheKey, { token, createdAt: now });
+        return token;
+    }
+}
+
+export class NodeApnsHttpTransport implements ApnsHttpTransport {
+    private readonly sessions = new Map<string, ClientHttp2Session>();
+
+    private getSession(origin: string): ClientHttp2Session {
+        const existing = this.sessions.get(origin);
+        if (existing !== undefined && !existing.closed && !existing.destroyed) {
+            return existing;
+        }
+
+        const session = http2.connect(origin);
+        session.on('close', () => this.sessions.delete(origin));
+        session.on('error', () => this.sessions.delete(origin));
+        this.sessions.set(origin, session);
+        return session;
+    }
+
+    async send(request: ApnsHttpRequest): Promise<{
+        status: number;
+        body?: string;
+    }> {
+        return new Promise((resolve, reject) => {
+            const stream = this.getSession(request.origin).request(
+                request.headers,
+            );
+            let status = 0;
+            let responseBody = '';
+            stream.setEncoding('utf8');
+            stream.on('response', (headers: IncomingHttpHeaders) => {
+                status = Number(headers[':status'] ?? 0);
+            });
+            stream.on('data', (chunk: string) => {
+                responseBody += chunk;
+            });
+            stream.on('end', () =>
+                resolve({
+                    status,
+                    ...(responseBody.length === 0
+                        ? {}
+                        : { body: responseBody }),
+                }),
+            );
+            stream.on('error', reject);
+            stream.end(request.body);
+        });
+    }
+}
+
+export class ApnsClient {
+    private readonly config: MobilePushNotificationsConfig;
+
+    private readonly transport: ApnsHttpTransport;
+
+    private readonly providerTokenSource: ApnsProviderTokenSource;
+
+    constructor(dependencies: ApnsClientDependencies) {
+        this.config = dependencies.config;
+        this.transport = dependencies.transport ?? new NodeApnsHttpTransport();
+        this.providerTokenSource =
+            dependencies.providerTokenSource ??
+            new JoseApnsProviderTokenSource();
+    }
+
+    private async send(args: {
+        environment: MobilePushEnvironment;
+        token: string;
+        payload: LiveActivityPayload | AlertPayload;
+        headers: OutgoingHttpHeaders;
+    }): Promise<ApnsDeliveryResult> {
+        const credential = this.config[args.environment];
+        if (
+            !this.config.enabled ||
+            this.config.teamId === undefined ||
+            credential === undefined
+        ) {
+            return { status: 'failed', reason: 'environment_not_configured' };
+        }
+
+        try {
+            const providerToken = await this.providerTokenSource.getToken({
+                environment: args.environment,
+                teamId: this.config.teamId,
+                keyId: credential.keyId,
+                privateKey: credential.privateKey,
+            });
+            const response = await this.transport.send({
+                origin:
+                    args.environment === 'sandbox'
+                        ? 'https://api.sandbox.push.apple.com'
+                        : 'https://api.push.apple.com',
+                headers: {
+                    ':method': 'POST',
+                    ':path': `/3/device/${args.token}`,
+                    authorization: `bearer ${providerToken}`,
+                    ...args.headers,
+                },
+                body: JSON.stringify(args.payload),
+            });
+            const reason = parseReason(response.body);
+
+            if (response.status === 200) return { status: 'sent' };
+            if (
+                response.status === 410 ||
+                (reason !== undefined && INVALID_TOKEN_REASONS.has(reason))
+            ) {
+                return { status: 'invalid_token', reason };
+            }
+            if (response.status === 429 || response.status >= 500) {
+                return { status: 'retryable', reason };
+            }
+            return { status: 'failed', reason };
+        } catch (error) {
+            return {
+                status: 'retryable',
+                reason: error instanceof Error ? error.name : undefined,
+            };
+        }
+    }
+
+    async sendLiveActivity(args: {
+        environment: MobilePushEnvironment;
+        pushToken: string;
+        payload: LiveActivityPayload;
+    }): Promise<ApnsDeliveryResult> {
+        return this.send({
+            environment: args.environment,
+            token: args.pushToken,
+            payload: args.payload,
+            headers: {
+                'apns-priority': '10',
+                'apns-push-type': 'liveactivity',
+                'apns-topic': `${this.config.bundleId}.push-type.liveactivity`,
+            },
+        });
+    }
+
+    async sendAlert(args: {
+        environment: MobilePushEnvironment;
+        deviceToken: string;
+        collapseId: string;
+        payload: AlertPayload;
+    }): Promise<ApnsDeliveryResult> {
+        return this.send({
+            environment: args.environment,
+            token: args.deviceToken,
+            payload: args.payload,
+            headers: {
+                'apns-collapse-id': args.collapseId,
+                'apns-priority': '10',
+                'apns-push-type': 'alert',
+                'apns-topic': this.config.bundleId,
+            },
+        });
+    }
+}

--- a/packages/backend/src/clients/ClientRepository.ts
+++ b/packages/backend/src/clients/ClientRepository.ts
@@ -1,6 +1,7 @@
 import { ModelRepository } from '../models/ModelRepository';
 import { SchedulerClient } from '../scheduler/SchedulerClient';
 import { type OperationContext } from '../services/ServiceRepository';
+import { ApnsClient } from './Apns/ApnsClient';
 import { S3CacheClient } from './Aws/S3CacheClient';
 import { S3Client } from './Aws/S3Client';
 import EmailClient from './EmailClient/EmailClient';
@@ -18,6 +19,7 @@ import { SlackClient } from './Slack/SlackClient';
  */
 
 export interface ClientManifest {
+    apnsClient: ApnsClient;
     natsClient: NatsClient;
     emailClient: EmailClient;
     googleDriveClient: GoogleDriveClient;
@@ -118,6 +120,17 @@ export class ClientRepository
      * Holds memoized instances of clients after their initial instantiation:
      */
     protected clientInstances: Partial<ClientManifest> = {};
+
+    public getApnsClient(): ApnsClient {
+        return this.getClient(
+            'apnsClient',
+            () =>
+                new ApnsClient({
+                    config: this.context.lightdashConfig
+                        .mobilePushNotifications,
+                }),
+        );
+    }
 
     public getNatsClient(): NatsClient {
         return this.getClient(

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -236,6 +236,13 @@ export const lightdashConfigMock: LightdashConfig = {
             ios: null,
         },
     },
+    mobilePushNotifications: {
+        enabled: false,
+        bundleId: 'com.lightdash.mobile',
+        teamId: undefined,
+        sandbox: undefined,
+        production: undefined,
+    },
     license: {
         licenseKey: null,
         licenseCertificate: null,

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -51,6 +51,64 @@ describe('mobile login config', () => {
     });
 });
 
+describe('mobile push notification config', () => {
+    it('is disabled when APNs credentials are absent', () => {
+        expect(parseConfig().mobilePushNotifications).toEqual({
+            enabled: false,
+            bundleId: 'com.lightdash.mobile',
+            teamId: undefined,
+            sandbox: undefined,
+            production: undefined,
+        });
+    });
+
+    it('enables a complete sandbox credential on Lightdash Cloud', () => {
+        process.env.LIGHTDASH_CLOUD_INSTANCE = 'cloud-instance';
+        process.env.MOBILE_PUSH_NOTIFICATIONS_APNS_TEAM_ID = 'TEAMID';
+        process.env.MOBILE_PUSH_NOTIFICATIONS_APNS_SANDBOX_KEY_ID = 'KEYID';
+        process.env.MOBILE_PUSH_NOTIFICATIONS_APNS_SANDBOX_PRIVATE_KEY =
+            'private-key';
+
+        expect(parseConfig().mobilePushNotifications).toEqual({
+            enabled: true,
+            bundleId: 'com.lightdash.mobile',
+            teamId: 'TEAMID',
+            sandbox: { keyId: 'KEYID', privateKey: 'private-key' },
+            production: undefined,
+        });
+    });
+
+    it('stays disabled outside Lightdash Cloud', () => {
+        process.env.MOBILE_PUSH_NOTIFICATIONS_APNS_TEAM_ID = 'TEAMID';
+        process.env.MOBILE_PUSH_NOTIFICATIONS_APNS_PRODUCTION_KEY_ID = 'KEYID';
+        process.env.MOBILE_PUSH_NOTIFICATIONS_APNS_PRODUCTION_PRIVATE_KEY =
+            'private-key';
+
+        expect(parseConfig().mobilePushNotifications.enabled).toBe(false);
+    });
+
+    it('rejects a partial environment credential', () => {
+        process.env.LIGHTDASH_CLOUD_INSTANCE = 'cloud-instance';
+        process.env.MOBILE_PUSH_NOTIFICATIONS_APNS_TEAM_ID = 'TEAMID';
+        process.env.MOBILE_PUSH_NOTIFICATIONS_APNS_SANDBOX_KEY_ID = 'KEYID';
+
+        expect(() => parseConfig()).toThrow(
+            'MOBILE_PUSH_NOTIFICATIONS_APNS_SANDBOX_KEY_ID and MOBILE_PUSH_NOTIFICATIONS_APNS_SANDBOX_PRIVATE_KEY must be set together',
+        );
+    });
+
+    it('requires a team ID when an environment credential is present', () => {
+        process.env.LIGHTDASH_CLOUD_INSTANCE = 'cloud-instance';
+        process.env.MOBILE_PUSH_NOTIFICATIONS_APNS_PRODUCTION_KEY_ID = 'KEYID';
+        process.env.MOBILE_PUSH_NOTIFICATIONS_APNS_PRODUCTION_PRIVATE_KEY =
+            'private-key';
+
+        expect(() => parseConfig()).toThrow(
+            'MOBILE_PUSH_NOTIFICATIONS_APNS_TEAM_ID is required when APNs credentials are set',
+        );
+    });
+});
+
 describe('license config', () => {
     it('supports an offline license file with a license key', () => {
         process.env.LIGHTDASH_LICENSE_KEY = 'license-key';

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1423,6 +1423,24 @@ export type LightdashSecrets = {
     readonly all: readonly string[];
 };
 
+export type MobilePushNotificationsConfig = {
+    enabled: boolean;
+    bundleId: string;
+    teamId: string | undefined;
+    sandbox:
+        | {
+              keyId: string;
+              privateKey: string;
+          }
+        | undefined;
+    production:
+        | {
+              keyId: string;
+              privateKey: string;
+          }
+        | undefined;
+};
+
 export type LightdashConfig = {
     /** Always equals `lightdashSecrets.active`; kept for compatibility */
     lightdashSecret: string;
@@ -1449,6 +1467,7 @@ export type LightdashConfig = {
     rudder: RudderConfig;
     mode: LightdashMode;
     mobile: HealthState['mobile'];
+    mobilePushNotifications: MobilePushNotificationsConfig;
     license: {
         licenseKey: string | null;
         licenseCertificate: string | null;
@@ -2559,6 +2578,28 @@ const LEGACY_DISABLE_ENV_VARS: ReadonlyArray<
     // Add per migration; truthy env value disables the flag.
 ];
 
+const parseMobilePushCredential = (
+    environment: 'SANDBOX' | 'PRODUCTION',
+): MobilePushNotificationsConfig['sandbox'] => {
+    const keyIdVariable =
+        `MOBILE_PUSH_NOTIFICATIONS_APNS_${environment}_KEY_ID` as const;
+    const privateKeyVariable =
+        `MOBILE_PUSH_NOTIFICATIONS_APNS_${environment}_PRIVATE_KEY` as const;
+    const keyId = process.env[keyIdVariable];
+    const privateKey = process.env[privateKeyVariable];
+
+    if ((keyId === undefined) !== (privateKey === undefined)) {
+        throw new ParseError(
+            `${keyIdVariable} and ${privateKeyVariable} must be set together`,
+            {},
+        );
+    }
+
+    return keyId === undefined || privateKey === undefined
+        ? undefined
+        : { keyId, privateKey };
+};
+
 export const parseConfig = (): LightdashConfig => {
     const lightdashSecret = process.env.LIGHTDASH_SECRET;
     if (!lightdashSecret) {
@@ -2688,6 +2729,19 @@ export const parseConfig = (): LightdashConfig => {
     const natsWorkerQueueTimeoutMs =
         getIntegerFromEnvironmentVariable('NATS_QUEUE_TIMEOUT_MS') ?? 180000;
     const lightdashCloudInstance = process.env.LIGHTDASH_CLOUD_INSTANCE;
+    const mobilePushSandbox = parseMobilePushCredential('SANDBOX');
+    const mobilePushProduction = parseMobilePushCredential('PRODUCTION');
+    const mobilePushTeamId = process.env.MOBILE_PUSH_NOTIFICATIONS_APNS_TEAM_ID;
+    if (
+        (mobilePushSandbox !== undefined ||
+            mobilePushProduction !== undefined) &&
+        mobilePushTeamId === undefined
+    ) {
+        throw new ParseError(
+            'MOBILE_PUSH_NOTIFICATIONS_APNS_TEAM_ID is required when APNs credentials are set',
+            {},
+        );
+    }
     const motherduckInstanceCache = {
         enabled: process.env.MOTHERDUCK_INSTANCE_CACHE_ENABLED === 'true',
         projectUuids: getArrayFromCommaSeparatedList(
@@ -2755,6 +2809,19 @@ export const parseConfig = (): LightdashConfig => {
                     'LIGHTDASH_MOBILE_MINIMUM_IOS_VERSION',
                 ),
             },
+        },
+        mobilePushNotifications: {
+            enabled:
+                lightdashCloudInstance !== undefined &&
+                mobilePushTeamId !== undefined &&
+                (mobilePushSandbox !== undefined ||
+                    mobilePushProduction !== undefined),
+            bundleId:
+                process.env.MOBILE_PUSH_NOTIFICATIONS_APNS_BUNDLE_ID ??
+                'com.lightdash.mobile',
+            teamId: mobilePushTeamId,
+            sandbox: mobilePushSandbox,
+            production: mobilePushProduction,
         },
         cookieSameSite: iframeEmbeddingEnabled ? 'none' : 'lax',
         license: {

--- a/packages/backend/src/ee/controllers/aiAgentLiveActivityController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentLiveActivityController.ts
@@ -1,0 +1,91 @@
+import {
+    assertRegisteredAccount,
+    type ApiErrorPayload,
+    type ApiMobilePushLiveActivityRequest,
+    type ApiMobilePushLiveActivityResponse,
+} from '@lightdash/common';
+import {
+    Body,
+    Delete,
+    Middlewares,
+    OperationId,
+    Path,
+    Put,
+    Query,
+    Request,
+    Response,
+    Route,
+    SuccessResponse,
+    Tags,
+} from '@tsoa/runtime';
+import express from 'express';
+import { toSessionUser } from '../../auth/account';
+import {
+    allowApiKeyAuthentication,
+    isAuthenticated,
+} from '../../controllers/authentication';
+import { BaseController } from '../../controllers/baseController';
+import { type MobilePushNotificationService } from '../services/MobilePushNotificationService/MobilePushNotificationService';
+
+@Route(
+    '/api/v1/projects/{projectUuid}/aiAgents/{agentUuid}/threads/{threadUuid}/live-activities',
+)
+@Response<ApiErrorPayload>('default', 'Error')
+@Tags('AI agent Live Activities')
+export class AiAgentLiveActivityController extends BaseController {
+    private getMobilePushNotificationService(): MobilePushNotificationService {
+        return this.services.getMobilePushNotificationService<MobilePushNotificationService>();
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Put('/{liveActivityUuid}')
+    @OperationId('registerAiAgentLiveActivity')
+    async registerLiveActivity(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() agentUuid: string,
+        @Path() threadUuid: string,
+        @Path() liveActivityUuid: string,
+        @Body() body: ApiMobilePushLiveActivityRequest,
+    ): Promise<ApiMobilePushLiveActivityResponse> {
+        assertRegisteredAccount(req.account);
+        await this.getMobilePushNotificationService().registerLiveActivity({
+            user: toSessionUser(req.account),
+            projectUuid,
+            agentUuid,
+            threadUuid,
+            liveActivityUuid,
+            installationUuid: body.installationUuid,
+            promptUuid: body.promptUuid,
+            pushToken: body.pushToken,
+        });
+        this.setStatus(200);
+        return { status: 'ok', results: undefined };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Delete('/{liveActivityUuid}')
+    @OperationId('revokeAiAgentLiveActivity')
+    async revokeLiveActivity(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() agentUuid: string,
+        @Path() threadUuid: string,
+        @Path() liveActivityUuid: string,
+        @Query() installationUuid: string,
+    ): Promise<ApiMobilePushLiveActivityResponse> {
+        assertRegisteredAccount(req.account);
+        await this.getMobilePushNotificationService().revokeLiveActivity({
+            user: toSessionUser(req.account),
+            installationUuid,
+            projectUuid,
+            agentUuid,
+            threadUuid,
+            liveActivityUuid,
+        });
+        this.setStatus(200);
+        return { status: 'ok', results: undefined };
+    }
+}

--- a/packages/backend/src/ee/controllers/mobilePushNotificationController.ts
+++ b/packages/backend/src/ee/controllers/mobilePushNotificationController.ts
@@ -1,0 +1,90 @@
+import {
+    assertRegisteredAccount,
+    type ApiErrorPayload,
+    type ApiMobilePushInstallationRequest,
+    type ApiMobilePushInstallationResponse,
+    type ApiMobilePushNotificationStatusResponse,
+} from '@lightdash/common';
+import {
+    Body,
+    Delete,
+    Get,
+    Middlewares,
+    OperationId,
+    Path,
+    Put,
+    Request,
+    Response,
+    Route,
+    SuccessResponse,
+    Tags,
+} from '@tsoa/runtime';
+import express from 'express';
+import { toSessionUser } from '../../auth/account';
+import {
+    allowApiKeyAuthentication,
+    isAuthenticated,
+} from '../../controllers/authentication';
+import { BaseController } from '../../controllers/baseController';
+import { type MobilePushNotificationService } from '../services/MobilePushNotificationService/MobilePushNotificationService';
+
+@Route('/api/v1/mobile/push-notifications')
+@Response<ApiErrorPayload>('default', 'Error')
+@Tags('Mobile push notifications')
+export class MobilePushNotificationController extends BaseController {
+    private getMobilePushNotificationService(): MobilePushNotificationService {
+        return this.services.getMobilePushNotificationService<MobilePushNotificationService>();
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/status')
+    @OperationId('getMobilePushNotificationStatus')
+    async getMobilePushNotificationStatus(
+        @Request() req: express.Request,
+    ): Promise<ApiMobilePushNotificationStatusResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: this.getMobilePushNotificationService().getStatus(),
+        };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Put('/installations/{installationUuid}')
+    @OperationId('registerMobilePushInstallation')
+    async registerInstallation(
+        @Request() req: express.Request,
+        @Path() installationUuid: string,
+        @Body() body: ApiMobilePushInstallationRequest,
+    ): Promise<ApiMobilePushInstallationResponse> {
+        assertRegisteredAccount(req.account);
+        await this.getMobilePushNotificationService().registerInstallation({
+            user: toSessionUser(req.account),
+            installationUuid,
+            environment: body.environment,
+            deviceToken: body.deviceToken,
+        });
+        this.setStatus(200);
+        return { status: 'ok', results: undefined };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Delete('/installations/{installationUuid}')
+    @OperationId('revokeMobilePushInstallation')
+    async revokeInstallation(
+        @Request() req: express.Request,
+        @Path() installationUuid: string,
+    ): Promise<ApiMobilePushInstallationResponse> {
+        assertRegisteredAccount(req.account);
+        await this.getMobilePushNotificationService().revokeInstallation({
+            user: toSessionUser(req.account),
+            installationUuid,
+        });
+        this.setStatus(200);
+        return { status: 'ok', results: undefined };
+    }
+}

--- a/packages/backend/src/ee/database/entities/mobilePushNotifications.ts
+++ b/packages/backend/src/ee/database/entities/mobilePushNotifications.ts
@@ -1,0 +1,81 @@
+import { type AiAgentThreadLiveStatus } from '@lightdash/common';
+import { Knex } from 'knex';
+
+export const MobilePushInstallationsTableName = 'mobile_push_installations';
+export const AiAgentLiveActivitiesTableName = 'ai_agent_live_activities';
+
+export type MobilePushEnvironment = 'sandbox' | 'production';
+
+export type DbMobilePushInstallation = {
+    mobile_push_installation_uuid: string;
+    installation_uuid: string;
+    organization_uuid: string;
+    user_uuid: string;
+    environment: MobilePushEnvironment;
+    encrypted_device_token: Buffer;
+    device_token_fingerprint: string;
+    created_at: Date;
+    updated_at: Date;
+};
+
+export type MobilePushInstallationTable = Knex.CompositeTableType<
+    DbMobilePushInstallation,
+    Omit<
+        DbMobilePushInstallation,
+        'mobile_push_installation_uuid' | 'created_at' | 'updated_at'
+    >,
+    Partial<
+        Omit<
+            DbMobilePushInstallation,
+            'mobile_push_installation_uuid' | 'created_at'
+        >
+    >
+>;
+
+export type DbAiAgentLiveActivity = {
+    live_activity_uuid: string;
+    mobile_push_installation_uuid: string;
+    organization_uuid: string;
+    user_uuid: string;
+    project_uuid: string;
+    agent_uuid: string;
+    thread_uuid: string;
+    prompt_uuid: string;
+    encrypted_push_token: Buffer;
+    push_token_fingerprint: string;
+    last_delivered_state: AiAgentThreadLiveStatus['state'] | null;
+    last_delivered_state_changed_at: Date | null;
+    last_delivered_at: Date | null;
+    stale_at: Date | null;
+    ended_at: Date | null;
+    completion_alert_completed_at: Date | null;
+    created_at: Date;
+    updated_at: Date;
+};
+
+export type AiAgentLiveActivityTable = Knex.CompositeTableType<
+    DbAiAgentLiveActivity,
+    Omit<
+        DbAiAgentLiveActivity,
+        | 'last_delivered_state'
+        | 'last_delivered_state_changed_at'
+        | 'last_delivered_at'
+        | 'stale_at'
+        | 'ended_at'
+        | 'completion_alert_completed_at'
+        | 'created_at'
+        | 'updated_at'
+    > &
+        Partial<
+            Pick<
+                DbAiAgentLiveActivity,
+                | 'last_delivered_state'
+                | 'last_delivered_state_changed_at'
+                | 'last_delivered_at'
+                | 'stale_at'
+                | 'ended_at'
+                | 'completion_alert_completed_at'
+            >
+        >,
+    Partial<Omit<DbAiAgentLiveActivity, 'live_activity_uuid' | 'created_at'>>
+>;

--- a/packages/backend/src/ee/database/migrations/20260830170000_create_mobile_push_notification_tables.ts
+++ b/packages/backend/src/ee/database/migrations/20260830170000_create_mobile_push_notification_tables.ts
@@ -1,0 +1,134 @@
+import type { Knex } from 'knex';
+
+export const classification = {
+    kind: 'safe',
+    reason: 'Creates two new empty mobile push notification tables',
+} as const;
+
+const installationsTable = 'mobile_push_installations';
+const liveActivitiesTable = 'ai_agent_live_activities';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '5s'`);
+
+    await knex.schema.createTable(installationsTable, (table) => {
+        table
+            .uuid('mobile_push_installation_uuid')
+            .primary()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+        table.uuid('installation_uuid').notNullable().unique();
+        table
+            .uuid('organization_uuid')
+            .notNullable()
+            .references('organization_uuid')
+            .inTable('organizations')
+            .onDelete('CASCADE')
+            .index();
+        table
+            .uuid('user_uuid')
+            .notNullable()
+            .references('user_uuid')
+            .inTable('users')
+            .onDelete('CASCADE')
+            .index();
+        table
+            .text('environment')
+            .notNullable()
+            .checkIn(['sandbox', 'production']);
+        table.binary('encrypted_device_token').notNullable();
+        table.string('device_token_fingerprint', 64).notNullable();
+        table
+            .timestamp('created_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+        table
+            .timestamp('updated_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+
+        table.unique(['environment', 'device_token_fingerprint']);
+        table.index(['organization_uuid', 'user_uuid']);
+    });
+
+    await knex.schema.createTable(liveActivitiesTable, (table) => {
+        table.uuid('live_activity_uuid').primary();
+        table
+            .uuid('mobile_push_installation_uuid')
+            .notNullable()
+            .references('mobile_push_installation_uuid')
+            .inTable(installationsTable)
+            .onDelete('CASCADE')
+            .index();
+        table
+            .uuid('organization_uuid')
+            .notNullable()
+            .references('organization_uuid')
+            .inTable('organizations')
+            .onDelete('CASCADE')
+            .index();
+        table
+            .uuid('user_uuid')
+            .notNullable()
+            .references('user_uuid')
+            .inTable('users')
+            .onDelete('CASCADE')
+            .index();
+        table
+            .uuid('project_uuid')
+            .notNullable()
+            .references('project_uuid')
+            .inTable('projects')
+            .onDelete('CASCADE');
+        table
+            .uuid('agent_uuid')
+            .notNullable()
+            .references('ai_agent_uuid')
+            .inTable('ai_agent')
+            .onDelete('CASCADE');
+        table
+            .uuid('thread_uuid')
+            .notNullable()
+            .references('ai_thread_uuid')
+            .inTable('ai_thread')
+            .onDelete('CASCADE')
+            .index();
+        table
+            .uuid('prompt_uuid')
+            .notNullable()
+            .references('ai_prompt_uuid')
+            .inTable('ai_prompt')
+            .onDelete('CASCADE');
+        table.binary('encrypted_push_token').notNullable();
+        table.string('push_token_fingerprint', 64).notNullable().unique();
+        table
+            .text('last_delivered_state')
+            .nullable()
+            .checkIn(['working', 'waiting_for_you', 'idle']);
+        table
+            .timestamp('last_delivered_state_changed_at', { useTz: false })
+            .nullable();
+        table.timestamp('last_delivered_at', { useTz: false }).nullable();
+        table.timestamp('stale_at', { useTz: false }).nullable();
+        table.timestamp('ended_at', { useTz: false }).nullable();
+        table
+            .timestamp('completion_alert_completed_at', { useTz: false })
+            .nullable();
+        table
+            .timestamp('created_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+        table
+            .timestamp('updated_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+
+        table.index(['organization_uuid', 'user_uuid']);
+        table.index(['thread_uuid', 'ended_at']);
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '5s'`);
+    await knex.schema.dropTableIfExists(liveActivitiesTable);
+    await knex.schema.dropTableIfExists(installationsTable);
+}

--- a/packages/backend/src/ee/database/migrations/__tests__/20260830170000_create_mobile_push_notification_tables.test.ts
+++ b/packages/backend/src/ee/database/migrations/__tests__/20260830170000_create_mobile_push_notification_tables.test.ts
@@ -1,0 +1,63 @@
+import knex from 'knex';
+import { getTracker, MockClient, type Tracker } from 'knex-mock-client';
+import {
+    down,
+    up,
+} from '../20260830170000_create_mobile_push_notification_tables';
+
+describe('mobile push notification tables migration', () => {
+    const database = knex({ client: MockClient, dialect: 'pg' });
+    let tracker: Tracker;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    afterEach(() => {
+        tracker.reset();
+    });
+
+    it('creates encrypted installation and Live Activity token tables', async () => {
+        tracker.on.any(() => true).response({});
+
+        await up(database);
+
+        const statements = tracker.history.all.map(({ sql }) => sql);
+        const installationSql = statements.find((sql) =>
+            sql.includes('create table "mobile_push_installations"'),
+        );
+        const liveActivitySql = statements.find((sql) =>
+            sql.includes('create table "ai_agent_live_activities"'),
+        );
+        const migrationSql = statements.join('\n');
+
+        expect(installationSql).toContain(
+            '"encrypted_device_token" bytea not null',
+        );
+        expect(migrationSql).toContain(
+            'unique ("environment", "device_token_fingerprint")',
+        );
+        expect(liveActivitySql).toContain(
+            '"encrypted_push_token" bytea not null',
+        );
+        expect(liveActivitySql).toContain(
+            '"push_token_fingerprint" varchar(64) not null',
+        );
+        expect(liveActivitySql).toContain(
+            '"completion_alert_completed_at" timestamp null',
+        );
+        expect(migrationSql).toContain('on delete CASCADE');
+    });
+
+    it('drops Live Activities before installations', async () => {
+        tracker.on.any(() => true).response({});
+
+        await down(database);
+
+        expect(tracker.history.all.map(({ sql }) => sql)).toEqual([
+            "SET LOCAL lock_timeout = '5s'",
+            'drop table if exists "ai_agent_live_activities"',
+            'drop table if exists "mobile_push_installations"',
+        ]);
+    });
+});

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -50,6 +50,7 @@ import { ExternalSourceModel } from './models/ExternalSourceModel';
 import { HomepageRecommendedActionSkipsModel } from './models/HomepageRecommendedActionSkipsModel';
 import { ManagedAgentModel } from './models/ManagedAgentModel';
 import { McpToolCallModel } from './models/McpToolCallModel';
+import { MobilePushNotificationModel } from './models/MobilePushNotificationModel';
 import { ProjectCiStatusModel } from './models/ProjectCiStatusModel';
 import { ProjectContextModel } from './models/ProjectContextModel';
 import { ProjectHomepageModel } from './models/ProjectHomepageModel';
@@ -96,6 +97,8 @@ import { HomepageRecommendedActionSkipsService } from './services/HomepageRecomm
 import { EnterpriseLicenseService } from './services/LicenseService/LicenseService';
 import { ManagedAgentService } from './services/ManagedAgentService/ManagedAgentService';
 import { McpService } from './services/McpService/McpService';
+import { MobilePushNotificationReconciler } from './services/MobilePushNotificationService/MobilePushNotificationReconciler';
+import { MobilePushNotificationService } from './services/MobilePushNotificationService/MobilePushNotificationService';
 import { OnboardingAgentService } from './services/OnboardingAgentService/OnboardingAgentService';
 import { provisionOnboardingOrgFlags } from './services/OrganizationService/provisionOnboardingOrgFlags';
 import { OrganizationWarehouseCredentialsService } from './services/OrganizationWarehouseCredentialsService';
@@ -162,6 +165,30 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                 new EnterpriseLicenseService({
                     licenseKey: lightdashConfig.license.licenseKey,
                 }),
+            mobilePushNotificationService: ({ models, clients, context }) => {
+                const notificationStore =
+                    models.getMobilePushNotificationModel<MobilePushNotificationModel>();
+                const threadStore = models.getAiAgentModel<AiAgentModel>();
+                const scheduler =
+                    clients.getSchedulerClient() as CommercialSchedulerClient;
+                const reconciler = new MobilePushNotificationReconciler({
+                    notificationStore,
+                    threadStore,
+                    apnsClient: clients.getApnsClient(),
+                    scheduler,
+                    analytics: context.lightdashAnalytics,
+                    completionAlert: undefined,
+                });
+                return new MobilePushNotificationService({
+                    mobilePushNotificationStore: notificationStore,
+                    threadStore,
+                    mobilePushNotificationsConfig:
+                        context.lightdashConfig.mobilePushNotifications,
+                    scheduler,
+                    reconciler,
+                    analytics: context.lightdashAnalytics,
+                });
+            },
             linearAppService: ({ models, context }) => {
                 const aiAgentReviewNotificationModel =
                     models.getAiAgentReviewNotificationModel<AiAgentReviewNotificationModel>();
@@ -631,6 +658,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         models.getAiAgentReviewClassifierModel<AiAgentReviewClassifierModel>(),
                     aiAgentReviewNotificationModel:
                         models.getAiAgentReviewNotificationModel<AiAgentReviewNotificationModel>(),
+                    mobilePushNotificationService:
+                        repository.getMobilePushNotificationService<MobilePushNotificationService>(),
                     prometheusMetrics,
                 }),
             aiAgentAdminService: ({ models, repository, context, clients }) =>
@@ -1286,6 +1315,11 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     database,
                     encryptionUtil: utils.getEncryptionUtil(),
                 }),
+            mobilePushNotificationModel: ({ database, utils }) =>
+                new MobilePushNotificationModel({
+                    database,
+                    encryptionUtil: utils.getEncryptionUtil(),
+                }),
             featureFlagModel: ({ database }) =>
                 new CommercialFeatureFlagModel({ database, lightdashConfig }),
         },
@@ -1380,6 +1414,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     context.serviceRepository.getProjectHomepageService<ProjectHomepageService>(),
                 externalSourceService:
                     context.serviceRepository.getExternalSourceService<ExternalSourceService>(),
+                mobilePushNotificationService:
+                    context.serviceRepository.getMobilePushNotificationService<MobilePushNotificationService>(),
                 prometheusMetrics: context.prometheusMetrics,
             }),
         clientProviders: {

--- a/packages/backend/src/ee/models/MobilePushNotificationModel.test.ts
+++ b/packages/backend/src/ee/models/MobilePushNotificationModel.test.ts
@@ -1,0 +1,136 @@
+import knex, { type Knex } from 'knex';
+import { getTracker, MockClient, type Tracker } from 'knex-mock-client';
+import { EncryptionUtil } from '../../utils/EncryptionUtil/EncryptionUtil';
+import {
+    AiAgentLiveActivitiesTableName,
+    MobilePushInstallationsTableName,
+} from '../database/entities/mobilePushNotifications';
+import { MobilePushNotificationModel } from './MobilePushNotificationModel';
+
+const encryptionUtil = {
+    encrypt: (value: string): Buffer => Buffer.from(`encrypted:${value}`),
+    decrypt: (value: Buffer): string =>
+        value.toString('utf8').replace(/^encrypted:/, ''),
+} as unknown as EncryptionUtil;
+
+const database = knex({ client: MockClient, dialect: 'pg' });
+const model = new MobilePushNotificationModel({
+    database: database as unknown as Knex,
+    encryptionUtil,
+});
+
+let tracker: Tracker;
+
+beforeAll(() => {
+    tracker = getTracker();
+});
+
+afterEach(() => {
+    tracker.reset();
+});
+
+describe('MobilePushNotificationModel', () => {
+    it('encrypts and fingerprints a rotating device token', async () => {
+        tracker.on.select(MobilePushInstallationsTableName).responseOnce([]);
+        tracker.on.delete(MobilePushInstallationsTableName).responseOnce([]);
+        tracker.on.insert(MobilePushInstallationsTableName).responseOnce([
+            {
+                mobile_push_installation_uuid: 'stored-installation-uuid',
+                installation_uuid: 'installation-uuid',
+                organization_uuid: 'organization-uuid',
+                user_uuid: 'user-uuid',
+                environment: 'sandbox',
+            },
+        ]);
+
+        await model.upsertInstallation({
+            installationUuid: 'installation-uuid',
+            organizationUuid: 'organization-uuid',
+            userUuid: 'user-uuid',
+            environment: 'sandbox',
+            deviceToken: 'device-token',
+        });
+
+        const insert = tracker.history.insert.find((query) =>
+            query.sql.includes(MobilePushInstallationsTableName),
+        );
+        expect(insert?.sql).toContain(
+            'on conflict ("installation_uuid") do update',
+        );
+        expect(
+            insert?.bindings.some(
+                (binding) =>
+                    Buffer.isBuffer(binding) &&
+                    binding.toString('utf8') === 'encrypted:device-token',
+            ),
+        ).toBe(true);
+        expect(insert?.bindings).not.toContain('device-token');
+        expect(insert?.bindings).toEqual(
+            expect.arrayContaining([expect.stringMatching(/^[a-f0-9]{64}$/)]),
+        );
+    });
+
+    it('encrypts and fingerprints a rotating Live Activity token', async () => {
+        tracker.on.delete(AiAgentLiveActivitiesTableName).responseOnce([]);
+        tracker.on.insert(AiAgentLiveActivitiesTableName).responseOnce([]);
+
+        await model.upsertLiveActivity({
+            liveActivityUuid: 'activity-uuid',
+            mobilePushInstallationUuid: 'installation-uuid',
+            organizationUuid: 'organization-uuid',
+            userUuid: 'user-uuid',
+            projectUuid: 'project-uuid',
+            agentUuid: 'agent-uuid',
+            threadUuid: 'thread-uuid',
+            promptUuid: 'prompt-uuid',
+            pushToken: 'activity-token',
+        });
+
+        const insert = tracker.history.insert.find((query) =>
+            query.sql.includes(AiAgentLiveActivitiesTableName),
+        );
+        expect(insert?.sql).toContain(
+            'on conflict ("live_activity_uuid") do update',
+        );
+        expect(
+            insert?.bindings.some(
+                (binding) =>
+                    Buffer.isBuffer(binding) &&
+                    binding.toString('utf8') === 'encrypted:activity-token',
+            ),
+        ).toBe(true);
+        expect(insert?.bindings).not.toContain('activity-token');
+        expect(insert?.sql).toContain('"ended_at" =');
+    });
+
+    it('decrypts the delivery token without returning ciphertext', async () => {
+        tracker.on.select(AiAgentLiveActivitiesTableName).responseOnce([
+            {
+                liveActivityUuid: 'activity-uuid',
+                mobilePushInstallationUuid: 'installation-uuid',
+                installationUuid: 'public-installation-uuid',
+                organizationUuid: 'organization-uuid',
+                userUuid: 'user-uuid',
+                projectUuid: 'project-uuid',
+                agentUuid: 'agent-uuid',
+                threadUuid: 'thread-uuid',
+                promptUuid: 'prompt-uuid',
+                environment: 'sandbox',
+                encryptedDeviceToken: Buffer.from('encrypted:device-token'),
+                encryptedPushToken: Buffer.from('encrypted:activity-token'),
+                lastDeliveredState: null,
+                lastDeliveredStateChangedAt: null,
+                staleAt: null,
+                endedAt: null,
+                completionAlertCompletedAt: null,
+            },
+        ]);
+
+        const result = await model.findLiveActivity('activity-uuid');
+
+        expect(result?.pushToken).toBe('activity-token');
+        expect(result?.deviceToken).toBe('device-token');
+        expect(result).not.toHaveProperty('encryptedPushToken');
+        expect(result).not.toHaveProperty('encryptedDeviceToken');
+    });
+});

--- a/packages/backend/src/ee/models/MobilePushNotificationModel.ts
+++ b/packages/backend/src/ee/models/MobilePushNotificationModel.ts
@@ -1,0 +1,450 @@
+import { createHash } from 'crypto';
+import { Knex } from 'knex';
+import { type EncryptionUtil } from '../../utils/EncryptionUtil/EncryptionUtil';
+import {
+    AiAgentLiveActivitiesTableName,
+    MobilePushInstallationsTableName,
+    type DbAiAgentLiveActivity,
+    type DbMobilePushInstallation,
+    type MobilePushEnvironment,
+} from '../database/entities/mobilePushNotifications';
+
+type MobilePushNotificationModelDependencies = {
+    database: Knex;
+    encryptionUtil: EncryptionUtil;
+};
+
+export type MobilePushInstallation = {
+    mobilePushInstallationUuid: string;
+    installationUuid: string;
+    organizationUuid: string;
+    userUuid: string;
+    environment: MobilePushEnvironment;
+};
+
+export type AiAgentLiveActivity = {
+    liveActivityUuid: string;
+    mobilePushInstallationUuid: string;
+    installationUuid: string;
+    organizationUuid: string;
+    userUuid: string;
+    projectUuid: string;
+    agentUuid: string;
+    threadUuid: string;
+    promptUuid: string;
+    environment: MobilePushEnvironment;
+    deviceToken: string;
+    pushToken: string;
+    lastDeliveredState: DbAiAgentLiveActivity['last_delivered_state'];
+    lastDeliveredStateChangedAt: Date | null;
+    staleAt: Date | null;
+    endedAt: Date | null;
+    completionAlertCompletedAt: Date | null;
+};
+
+const tokenFingerprint = (token: string): string =>
+    createHash('sha256').update(token).digest('hex');
+
+export class MobilePushNotificationModel {
+    private readonly database: Knex;
+
+    private readonly encryptionUtil: EncryptionUtil;
+
+    constructor(dependencies: MobilePushNotificationModelDependencies) {
+        this.database = dependencies.database;
+        this.encryptionUtil = dependencies.encryptionUtil;
+    }
+
+    async findInstallation(
+        installationUuid: string,
+    ): Promise<MobilePushInstallation | undefined> {
+        return this.database<DbMobilePushInstallation>(
+            MobilePushInstallationsTableName,
+        )
+            .select({
+                mobilePushInstallationUuid: 'mobile_push_installation_uuid',
+                installationUuid: 'installation_uuid',
+                organizationUuid: 'organization_uuid',
+                userUuid: 'user_uuid',
+                environment: 'environment',
+            })
+            .where('installation_uuid', installationUuid)
+            .first();
+    }
+
+    async upsertInstallation(args: {
+        installationUuid: string;
+        organizationUuid: string;
+        userUuid: string;
+        environment: MobilePushEnvironment;
+        deviceToken: string;
+    }): Promise<MobilePushInstallation> {
+        const fingerprint = tokenFingerprint(args.deviceToken);
+        const encryptedDeviceToken = this.encryptionUtil.encrypt(
+            args.deviceToken,
+        );
+
+        return this.database.transaction(async (trx) => {
+            const existing = await trx<DbMobilePushInstallation>(
+                MobilePushInstallationsTableName,
+            )
+                .select(
+                    'mobile_push_installation_uuid',
+                    'organization_uuid',
+                    'user_uuid',
+                )
+                .where('installation_uuid', args.installationUuid)
+                .first();
+
+            if (
+                existing !== undefined &&
+                (existing.organization_uuid !== args.organizationUuid ||
+                    existing.user_uuid !== args.userUuid)
+            ) {
+                await trx<DbAiAgentLiveActivity>(AiAgentLiveActivitiesTableName)
+                    .where(
+                        'mobile_push_installation_uuid',
+                        existing.mobile_push_installation_uuid,
+                    )
+                    .delete();
+            }
+
+            await trx<DbMobilePushInstallation>(
+                MobilePushInstallationsTableName,
+            )
+                .where({
+                    environment: args.environment,
+                    device_token_fingerprint: fingerprint,
+                })
+                .whereNot('installation_uuid', args.installationUuid)
+                .delete();
+
+            const [row] = await trx<DbMobilePushInstallation>(
+                MobilePushInstallationsTableName,
+            )
+                .insert({
+                    installation_uuid: args.installationUuid,
+                    organization_uuid: args.organizationUuid,
+                    user_uuid: args.userUuid,
+                    environment: args.environment,
+                    encrypted_device_token: encryptedDeviceToken,
+                    device_token_fingerprint: fingerprint,
+                })
+                .onConflict('installation_uuid')
+                .merge({
+                    organization_uuid: args.organizationUuid,
+                    user_uuid: args.userUuid,
+                    environment: args.environment,
+                    encrypted_device_token: encryptedDeviceToken,
+                    device_token_fingerprint: fingerprint,
+                    updated_at: new Date(),
+                })
+                .returning([
+                    'mobile_push_installation_uuid',
+                    'installation_uuid',
+                    'organization_uuid',
+                    'user_uuid',
+                    'environment',
+                ]);
+
+            return {
+                mobilePushInstallationUuid: row.mobile_push_installation_uuid,
+                installationUuid: row.installation_uuid,
+                organizationUuid: row.organization_uuid,
+                userUuid: row.user_uuid,
+                environment: row.environment,
+            };
+        });
+    }
+
+    async deleteInstallation(args: {
+        installationUuid: string;
+        organizationUuid: string;
+        userUuid: string;
+    }): Promise<void> {
+        await this.database<DbMobilePushInstallation>(
+            MobilePushInstallationsTableName,
+        )
+            .where({
+                installation_uuid: args.installationUuid,
+                organization_uuid: args.organizationUuid,
+                user_uuid: args.userUuid,
+            })
+            .delete();
+    }
+
+    async upsertLiveActivity(args: {
+        liveActivityUuid: string;
+        mobilePushInstallationUuid: string;
+        organizationUuid: string;
+        userUuid: string;
+        projectUuid: string;
+        agentUuid: string;
+        threadUuid: string;
+        promptUuid: string;
+        pushToken: string;
+    }): Promise<void> {
+        const fingerprint = tokenFingerprint(args.pushToken);
+        const encryptedPushToken = this.encryptionUtil.encrypt(args.pushToken);
+
+        await this.database.transaction(async (trx) => {
+            await trx<DbAiAgentLiveActivity>(AiAgentLiveActivitiesTableName)
+                .where('push_token_fingerprint', fingerprint)
+                .whereNot('live_activity_uuid', args.liveActivityUuid)
+                .delete();
+
+            await trx<DbAiAgentLiveActivity>(AiAgentLiveActivitiesTableName)
+                .insert({
+                    live_activity_uuid: args.liveActivityUuid,
+                    mobile_push_installation_uuid:
+                        args.mobilePushInstallationUuid,
+                    organization_uuid: args.organizationUuid,
+                    user_uuid: args.userUuid,
+                    project_uuid: args.projectUuid,
+                    agent_uuid: args.agentUuid,
+                    thread_uuid: args.threadUuid,
+                    prompt_uuid: args.promptUuid,
+                    encrypted_push_token: encryptedPushToken,
+                    push_token_fingerprint: fingerprint,
+                })
+                .onConflict('live_activity_uuid')
+                .merge({
+                    mobile_push_installation_uuid:
+                        args.mobilePushInstallationUuid,
+                    organization_uuid: args.organizationUuid,
+                    user_uuid: args.userUuid,
+                    project_uuid: args.projectUuid,
+                    agent_uuid: args.agentUuid,
+                    thread_uuid: args.threadUuid,
+                    prompt_uuid: args.promptUuid,
+                    encrypted_push_token: encryptedPushToken,
+                    push_token_fingerprint: fingerprint,
+                    ended_at: null,
+                    completion_alert_completed_at: null,
+                    updated_at: new Date(),
+                });
+        });
+    }
+
+    async findLiveActivityOwner(liveActivityUuid: string): Promise<
+        | {
+              liveActivityUuid: string;
+              mobilePushInstallationUuid: string;
+              organizationUuid: string;
+              userUuid: string;
+              projectUuid: string;
+              agentUuid: string;
+              threadUuid: string;
+              promptUuid: string;
+          }
+        | undefined
+    > {
+        return this.database<DbAiAgentLiveActivity>(
+            AiAgentLiveActivitiesTableName,
+        )
+            .select({
+                liveActivityUuid: 'live_activity_uuid',
+                mobilePushInstallationUuid: 'mobile_push_installation_uuid',
+                organizationUuid: 'organization_uuid',
+                userUuid: 'user_uuid',
+                projectUuid: 'project_uuid',
+                agentUuid: 'agent_uuid',
+                threadUuid: 'thread_uuid',
+                promptUuid: 'prompt_uuid',
+            })
+            .where('live_activity_uuid', liveActivityUuid)
+            .first();
+    }
+
+    async findLiveActivity(
+        liveActivityUuid: string,
+    ): Promise<AiAgentLiveActivity | undefined> {
+        const row = await this.database<DbAiAgentLiveActivity>(
+            AiAgentLiveActivitiesTableName,
+        )
+            .join<DbMobilePushInstallation>(
+                MobilePushInstallationsTableName,
+                `${AiAgentLiveActivitiesTableName}.mobile_push_installation_uuid`,
+                `${MobilePushInstallationsTableName}.mobile_push_installation_uuid`,
+            )
+            .select({
+                liveActivityUuid: `${AiAgentLiveActivitiesTableName}.live_activity_uuid`,
+                mobilePushInstallationUuid: `${AiAgentLiveActivitiesTableName}.mobile_push_installation_uuid`,
+                installationUuid: `${MobilePushInstallationsTableName}.installation_uuid`,
+                organizationUuid: `${AiAgentLiveActivitiesTableName}.organization_uuid`,
+                userUuid: `${AiAgentLiveActivitiesTableName}.user_uuid`,
+                projectUuid: `${AiAgentLiveActivitiesTableName}.project_uuid`,
+                agentUuid: `${AiAgentLiveActivitiesTableName}.agent_uuid`,
+                threadUuid: `${AiAgentLiveActivitiesTableName}.thread_uuid`,
+                promptUuid: `${AiAgentLiveActivitiesTableName}.prompt_uuid`,
+                environment: `${MobilePushInstallationsTableName}.environment`,
+                encryptedDeviceToken: `${MobilePushInstallationsTableName}.encrypted_device_token`,
+                encryptedPushToken: `${AiAgentLiveActivitiesTableName}.encrypted_push_token`,
+                lastDeliveredState: `${AiAgentLiveActivitiesTableName}.last_delivered_state`,
+                lastDeliveredStateChangedAt: `${AiAgentLiveActivitiesTableName}.last_delivered_state_changed_at`,
+                staleAt: `${AiAgentLiveActivitiesTableName}.stale_at`,
+                endedAt: `${AiAgentLiveActivitiesTableName}.ended_at`,
+                completionAlertCompletedAt: `${AiAgentLiveActivitiesTableName}.completion_alert_completed_at`,
+            })
+            .where(
+                `${AiAgentLiveActivitiesTableName}.live_activity_uuid`,
+                liveActivityUuid,
+            )
+            .first();
+
+        if (row === undefined) return undefined;
+        return {
+            liveActivityUuid: row.liveActivityUuid,
+            mobilePushInstallationUuid: row.mobilePushInstallationUuid,
+            installationUuid: row.installationUuid,
+            organizationUuid: row.organizationUuid,
+            userUuid: row.userUuid,
+            projectUuid: row.projectUuid,
+            agentUuid: row.agentUuid,
+            threadUuid: row.threadUuid,
+            promptUuid: row.promptUuid,
+            environment: row.environment,
+            deviceToken: this.encryptionUtil.decrypt(row.encryptedDeviceToken),
+            pushToken: this.encryptionUtil.decrypt(row.encryptedPushToken),
+            lastDeliveredState: row.lastDeliveredState,
+            lastDeliveredStateChangedAt: row.lastDeliveredStateChangedAt,
+            staleAt: row.staleAt,
+            endedAt: row.endedAt,
+            completionAlertCompletedAt: row.completionAlertCompletedAt,
+        };
+    }
+
+    async findActiveLiveActivitiesForThread(
+        threadUuid: string,
+    ): Promise<AiAgentLiveActivity[]> {
+        const rows = await this.database<DbAiAgentLiveActivity>(
+            AiAgentLiveActivitiesTableName,
+        )
+            .join<DbMobilePushInstallation>(
+                MobilePushInstallationsTableName,
+                `${AiAgentLiveActivitiesTableName}.mobile_push_installation_uuid`,
+                `${MobilePushInstallationsTableName}.mobile_push_installation_uuid`,
+            )
+            .select({
+                liveActivityUuid: `${AiAgentLiveActivitiesTableName}.live_activity_uuid`,
+            })
+            .where(`${AiAgentLiveActivitiesTableName}.thread_uuid`, threadUuid)
+            .whereNull(`${AiAgentLiveActivitiesTableName}.ended_at`);
+
+        const activities = await Promise.all(
+            rows.map(({ liveActivityUuid }) =>
+                this.findLiveActivity(liveActivityUuid),
+            ),
+        );
+        return activities.filter(
+            (activity): activity is AiAgentLiveActivity =>
+                activity !== undefined,
+        );
+    }
+
+    async findLiveActivitiesDueForReconciliation(
+        dueBefore: Date,
+        limit: number,
+    ): Promise<
+        {
+            liveActivityUuid: string;
+            organizationUuid: string;
+            projectUuid: string;
+            userUuid: string;
+        }[]
+    > {
+        return this.database<DbAiAgentLiveActivity>(
+            AiAgentLiveActivitiesTableName,
+        )
+            .select({
+                liveActivityUuid: 'live_activity_uuid',
+                organizationUuid: 'organization_uuid',
+                projectUuid: 'project_uuid',
+                userUuid: 'user_uuid',
+            })
+            .whereNull('ended_at')
+            .andWhere((query) =>
+                query
+                    .whereNull('stale_at')
+                    .orWhere('stale_at', '<=', dueBefore),
+            )
+            .orderBy('stale_at', 'asc', 'first')
+            .limit(limit);
+    }
+
+    async markLiveActivityDelivered(args: {
+        liveActivityUuid: string;
+        state: NonNullable<DbAiAgentLiveActivity['last_delivered_state']>;
+        stateChangedAt: Date;
+        staleAt: Date;
+        endedAt: Date | null;
+    }): Promise<void> {
+        await this.database<DbAiAgentLiveActivity>(
+            AiAgentLiveActivitiesTableName,
+        )
+            .where('live_activity_uuid', args.liveActivityUuid)
+            .update({
+                last_delivered_state: args.state,
+                last_delivered_state_changed_at: args.stateChangedAt,
+                last_delivered_at: new Date(),
+                stale_at: args.staleAt,
+                ended_at: args.endedAt,
+                updated_at: new Date(),
+            });
+    }
+
+    async markCompletionAlertCompleted(
+        liveActivityUuid: string,
+    ): Promise<void> {
+        await this.database<DbAiAgentLiveActivity>(
+            AiAgentLiveActivitiesTableName,
+        )
+            .where('live_activity_uuid', liveActivityUuid)
+            .update({
+                completion_alert_completed_at: new Date(),
+                updated_at: new Date(),
+            });
+    }
+
+    async deleteLiveActivity(args: {
+        liveActivityUuid: string;
+        installationUuid?: string;
+        organizationUuid?: string;
+        userUuid?: string;
+        projectUuid?: string;
+        agentUuid?: string;
+        threadUuid?: string;
+    }): Promise<void> {
+        const query = this.database<DbAiAgentLiveActivity>(
+            AiAgentLiveActivitiesTableName,
+        ).where('live_activity_uuid', args.liveActivityUuid);
+
+        if (args.organizationUuid !== undefined) {
+            query.where('organization_uuid', args.organizationUuid);
+        }
+        if (args.userUuid !== undefined) {
+            query.where('user_uuid', args.userUuid);
+        }
+        if (args.projectUuid !== undefined) {
+            query.where('project_uuid', args.projectUuid);
+        }
+        if (args.agentUuid !== undefined) {
+            query.where('agent_uuid', args.agentUuid);
+        }
+        if (args.threadUuid !== undefined) {
+            query.where('thread_uuid', args.threadUuid);
+        }
+        if (args.installationUuid !== undefined) {
+            query.whereIn(
+                'mobile_push_installation_uuid',
+                this.database<DbMobilePushInstallation>(
+                    MobilePushInstallationsTableName,
+                )
+                    .select('mobile_push_installation_uuid')
+                    .where('installation_uuid', args.installationUuid),
+            );
+        }
+
+        await query.delete();
+    }
+}

--- a/packages/backend/src/ee/scheduler/SchedulerClient.test.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerClient.test.ts
@@ -218,3 +218,33 @@ describe('CommercialSchedulerClient.aiAgentMemoryConsolidatePartition', () => {
         );
     });
 });
+
+describe('CommercialSchedulerClient.mobilePushLiveActivity', () => {
+    it('keeps one replaceable reconciliation job per activity', async () => {
+        const addJob = vi.fn().mockResolvedValue({ id: 'job-1' });
+        const client = Object.create(
+            CommercialSchedulerClient.prototype,
+        ) as CommercialSchedulerClient;
+        client.graphileUtils = Promise.resolve({ addJob } as AnyType);
+        const payload = {
+            liveActivityUuid: 'activity-1',
+            organizationUuid: 'organization-1',
+            projectUuid: 'project-1',
+            userUuid: 'user-1',
+        };
+        const runAt = new Date('2026-08-30T12:04:00.000Z');
+
+        await client.mobilePushLiveActivity(payload, runAt);
+
+        expect(addJob).toHaveBeenCalledWith(
+            EE_SCHEDULER_TASKS.MOBILE_PUSH_LIVE_ACTIVITY,
+            payload,
+            {
+                runAt,
+                maxAttempts: 5,
+                jobKey: 'mobile-push-live-activity:activity-1',
+                priority: JobPriority.MEDIUM,
+            },
+        );
+    });
+});

--- a/packages/backend/src/ee/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerClient.ts
@@ -18,6 +18,7 @@ import {
     GenerateArtifactQuestionJobPayload,
     IngestExternalSourceJobPayload,
     JobPriority,
+    MobilePushLiveActivityJobPayload,
     PublishAnnouncementPayload,
     SlackPromptJobPayload,
 } from '@lightdash/common';
@@ -57,6 +58,24 @@ export const aiAgentMemoryDistillEventRunAt = (now: Date): Date =>
     new Date(now.getTime() + MEMORY_DISTILL_EVENT_DEBOUNCE_MS);
 
 export class CommercialSchedulerClient extends SchedulerClient {
+    async mobilePushLiveActivity(
+        payload: MobilePushLiveActivityJobPayload,
+        runAt: Date = new Date(),
+    ) {
+        const graphileClient = await this.graphileUtils;
+        const { id: jobId } = await graphileClient.addJob(
+            EE_SCHEDULER_TASKS.MOBILE_PUSH_LIVE_ACTIVITY,
+            payload,
+            {
+                runAt,
+                maxAttempts: 5,
+                jobKey: `mobile-push-live-activity:${payload.liveActivityUuid}`,
+                priority: JobPriority.MEDIUM,
+            },
+        );
+        return { jobId };
+    }
+
     /**
      * One pending publish per announcement: the stable jobKey (default
      * jobKeyMode `replace`) makes rescheduling an in-place move of `runAt`.

--- a/packages/backend/src/ee/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.ts
@@ -36,6 +36,7 @@ import { AppGenerateService } from '../services/AppGenerateService/AppGenerateSe
 import type { EmbedService } from '../services/EmbedService/EmbedService';
 import type { ExternalSourceService } from '../services/ExternalSourceService/ExternalSourceService';
 import { ManagedAgentService } from '../services/ManagedAgentService/ManagedAgentService';
+import { type MobilePushNotificationService } from '../services/MobilePushNotificationService/MobilePushNotificationService';
 import { type OnboardingAgentService } from '../services/OnboardingAgentService/OnboardingAgentService';
 import { ProjectContextService } from '../services/ProjectContextService/ProjectContextService';
 import type { ProjectHomepageService } from '../services/ProjectHomepageService';
@@ -133,6 +134,10 @@ type CommercialSchedulerWorkerArguments = SchedulerWorkerArguments & {
         ExternalSourceService,
         'runIngest' | 'markIngestError' | 'maintain'
     >;
+    mobilePushNotificationService: Pick<
+        MobilePushNotificationService,
+        'reconcileLiveActivity' | 'sweepLiveActivities'
+    >;
 };
 
 export class CommercialSchedulerWorker extends SchedulerWorker {
@@ -178,6 +183,8 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
 
     protected readonly externalSourceService: CommercialSchedulerWorkerArguments['externalSourceService'];
 
+    protected readonly mobilePushNotificationService: CommercialSchedulerWorkerArguments['mobilePushNotificationService'];
+
     private readonly cleanupMetrics: PrometheusMetrics | null;
 
     constructor(args: CommercialSchedulerWorkerArguments) {
@@ -206,6 +213,7 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
         this.mcpToolCallModel = args.mcpToolCallModel;
         this.projectHomepageService = args.projectHomepageService;
         this.externalSourceService = args.externalSourceService;
+        this.mobilePushNotificationService = args.mobilePushNotificationService;
         this.cleanupMetrics = args.prometheusMetrics ?? null;
     }
 
@@ -259,6 +267,14 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                 pattern: '0 */3 * * *',
                 options: {
                     backfillPeriod: 6 * 60 * 60 * 1000,
+                    maxAttempts: 1,
+                },
+            },
+            {
+                task: EE_SCHEDULER_TASKS.SWEEP_MOBILE_PUSH_LIVE_ACTIVITIES,
+                pattern: '*/2 * * * *',
+                options: {
+                    backfillPeriod: 5 * 60 * 1000,
                     maxAttempts: 1,
                 },
             },
@@ -830,6 +846,26 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
             [EE_SCHEDULER_TASKS.SWEEP_DUE_ANNOUNCEMENTS]: async () => {
                 await this.projectHomepageService.sweepDueAnnouncements();
             },
+            [EE_SCHEDULER_TASKS.MOBILE_PUSH_LIVE_ACTIVITY]: async (
+                payload,
+                helpers,
+            ) => {
+                await SchedulerClient.processJob(
+                    EE_SCHEDULER_TASKS.MOBILE_PUSH_LIVE_ACTIVITY,
+                    helpers.job.id,
+                    helpers.job.run_at,
+                    payload,
+                    async () => {
+                        await this.mobilePushNotificationService.reconcileLiveActivity(
+                            payload.liveActivityUuid,
+                        );
+                    },
+                );
+            },
+            [EE_SCHEDULER_TASKS.SWEEP_MOBILE_PUSH_LIVE_ACTIVITIES]:
+                async () => {
+                    await this.mobilePushNotificationService.sweepLiveActivities();
+                },
             [EE_SCHEDULER_TASKS.SWEEP_STALE_AI_WRITEBACK_RUNS]: async () => {
                 const swept = await this.aiWritebackService.sweepStaleRuns();
                 // A chat run's card reflects the tool-result row, not the run

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.promptInputClassification.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.promptInputClassification.test.ts
@@ -43,8 +43,12 @@ describe('AiAgentService prompt input classification persistence', () => {
 
     const buildService = (classifierEnabled = true) => {
         const updateModelResponse = vi.fn().mockResolvedValue(true);
+        const enqueueThreadReconciliation = vi
+            .fn()
+            .mockResolvedValue(undefined);
         const instance = new AiAgentService({
             aiAgentModel: { updateModelResponse },
+            mobilePushNotificationService: { enqueueThreadReconciliation },
             lightdashConfig: {
                 ...lightdashConfigMock,
                 ai: {
@@ -59,6 +63,7 @@ describe('AiAgentService prompt input classification persistence', () => {
         return {
             service: instance as unknown as ServiceHarness,
             updateModelResponse: vi.mocked(updateModelResponse),
+            enqueueThreadReconciliation,
         };
     };
 
@@ -123,7 +128,8 @@ describe('AiAgentService prompt input classification persistence', () => {
     });
 
     it('does not classify a final update blocked by an existing error', async () => {
-        const { service, updateModelResponse } = buildService();
+        const { service, updateModelResponse, enqueueThreadReconciliation } =
+            buildService();
         updateModelResponse.mockResolvedValueOnce(false);
         const classifyPromptInputRequestAfterResponse = vi
             .spyOn(service, 'classifyPromptInputRequestAfterResponse')
@@ -138,6 +144,30 @@ describe('AiAgentService prompt input classification persistence', () => {
             onlyIfUnfinalized: true,
         });
         expect(classifyPromptInputRequestAfterResponse).not.toHaveBeenCalled();
+        expect(enqueueThreadReconciliation).not.toHaveBeenCalled();
+    });
+
+    it('enqueues reconciliation after each persisted state update', async () => {
+        const { service, enqueueThreadReconciliation } = buildService();
+        vi.spyOn(
+            service,
+            'classifyPromptInputRequestAfterResponse',
+        ).mockImplementation(() => undefined);
+
+        await service.persistTrackedPromptUpdate(
+            {
+                promptUuid: 'prompt-uuid',
+                response: 'Intermediate response',
+            },
+            classificationContext,
+        );
+        await service.persistTrackedPromptUpdate(
+            terminalUpdate,
+            classificationContext,
+        );
+
+        expect(enqueueThreadReconciliation).toHaveBeenCalledTimes(2);
+        expect(enqueueThreadReconciliation).toHaveBeenCalledWith('thread-uuid');
     });
 
     it('keeps the pending guard for a terminal response when classification is disabled', async () => {

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -413,6 +413,7 @@ import { AiWritebackService } from '../AiWritebackService/AiWritebackService';
 import { WritebackThreadPrClosedError } from '../AiWritebackService/errors';
 import type { AiWritebackSource } from '../AiWritebackService/types';
 import { type WritebackPreviewService } from '../AiWritebackService/WritebackPreviewService';
+import { type MobilePushNotificationService } from '../MobilePushNotificationService/MobilePushNotificationService';
 import { PreviewDeploySetupService } from '../PreviewDeploySetupService/PreviewDeploySetupService';
 import { ProjectContextService } from '../ProjectContextService/ProjectContextService';
 import {
@@ -626,6 +627,10 @@ type AiAgentServiceDependencies = {
         'recordClicked'
     >;
     prometheusMetrics?: PrometheusMetrics;
+    mobilePushNotificationService?: Pick<
+        MobilePushNotificationService,
+        'enqueueThreadReconciliation'
+    >;
 };
 
 export type RelevantVerifiedAnswer = {
@@ -979,6 +984,8 @@ export class AiAgentService extends BaseService {
 
     private readonly aiAgentMcpRuntimeClient: AiAgentMcpRuntimeClient;
 
+    private readonly mobilePushNotificationService: AiAgentServiceDependencies['mobilePushNotificationService'];
+
     private static getPinnedContextAnalyticsProperties(
         context: AiPromptContextInput | undefined,
     ): Pick<
@@ -1310,6 +1317,8 @@ export class AiAgentService extends BaseService {
             dependencies.aiAgentReviewClassifierModel;
         this.aiAgentReviewNotificationModel =
             dependencies.aiAgentReviewNotificationModel;
+        this.mobilePushNotificationService =
+            dependencies.mobilePushNotificationService;
         this.aiAgentMcpRuntimeClient = new AiAgentMcpRuntimeClient({
             aiAgentModel: this.aiAgentModel,
             lightdashConfig: this.lightdashConfig,
@@ -1430,12 +1439,27 @@ export class AiAgentService extends BaseService {
             instanceCopilotConfig: this.lightdashConfig.ai.copilot,
             aiAgentModel: this.aiAgentModel,
             analytics: this.analytics,
-        }).catch((error) => {
-            Logger.error(
-                'Failed to persist AI agent prompt input request classification',
-                error,
-            );
-        });
+        })
+            .then(() =>
+                this.enqueueMobilePushThreadReconciliation(args.threadUuid),
+            )
+            .catch((error) => {
+                Logger.error(
+                    'Failed to persist AI agent prompt input request classification',
+                    error,
+                );
+            });
+    }
+
+    private enqueueMobilePushThreadReconciliation(threadUuid: string): void {
+        void this.mobilePushNotificationService
+            ?.enqueueThreadReconciliation(threadUuid)
+            .catch((error) => {
+                Logger.error(
+                    'Failed to enqueue mobile push Live Activity reconciliation',
+                    error,
+                );
+            });
     }
 
     /**
@@ -3302,6 +3326,7 @@ export class AiAgentService extends BaseService {
             decision,
             user.userUuid,
         );
+        this.enqueueMobilePushThreadReconciliation(threadUuid);
         if (!recorded) {
             // A decision was already in place for this tool call — likely a
             // double-click or a race between Slack and the web UI. First
@@ -3479,6 +3504,7 @@ export class AiAgentService extends BaseService {
                 context,
                 modelConfig,
             });
+            this.enqueueMobilePushThreadReconciliation(threadUuid);
 
             this.analytics.track<AiAgentPromptCreatedEvent>({
                 event: 'ai_agent_prompt.created',
@@ -3618,6 +3644,7 @@ export class AiAgentService extends BaseService {
             modelConfig: body.modelConfig,
             hidden: body.hidden,
         });
+        this.enqueueMobilePushThreadReconciliation(threadUuid);
 
         this.analytics.track<AiAgentPromptCreatedEvent>({
             event: 'ai_agent_prompt.created',
@@ -6122,6 +6149,11 @@ export class AiAgentService extends BaseService {
                 : { onlyIfPending: isTerminalStreamUpdate },
         );
         const persistedUpdatePromise = modelUpdatePromise.then((persisted) => {
+            if (persisted && classificationContext !== undefined) {
+                this.enqueueMobilePushThreadReconciliation(
+                    classificationContext.threadUuid,
+                );
+            }
             if (
                 persisted &&
                 isClassifiableTerminalUpdate &&
@@ -6437,6 +6469,7 @@ export class AiAgentService extends BaseService {
             promptUuid: messageUuid,
             createdByUserUuid: user.userUuid,
         });
+        this.enqueueMobilePushThreadReconciliation(threadUuid);
     }
 
     async createAgentThreadMessageSteer(
@@ -9773,6 +9806,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 },
                 () => this.aiAgentModel.createToolCall(args),
             );
+            this.enqueueMobilePushThreadReconciliation(prompt.threadUuid);
         };
 
         const storeToolCallError: StoreToolCallErrorFn = async (args) => {
@@ -9797,6 +9831,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 })),
                 () => this.aiAgentModel.createToolResults(args),
             );
+            this.enqueueMobilePushThreadReconciliation(prompt.threadUuid);
         };
 
         const storeReasoning: StoreReasoningFn = async (
@@ -11141,20 +11176,13 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             updatePrompt: (
                 update: UpdateSlackResponse | UpdateWebAppResponse,
             ) => {
-                const completedResponse = update.response;
-                const updatePromise = this.persistTrackedPromptUpdate(
-                    update,
-                    completedResponse !== undefined &&
-                        shouldClassifyPromptInputRequestForUpdate(update)
-                        ? {
-                              organizationUuid: agentSettings.organizationUuid,
-                              projectUuid: prompt.projectUuid,
-                              agentUuid: agentSettings.uuid,
-                              threadUuid: prompt.threadUuid,
-                              userUuid: user.userUuid,
-                          }
-                        : undefined,
-                );
+                const updatePromise = this.persistTrackedPromptUpdate(update, {
+                    organizationUuid: agentSettings.organizationUuid,
+                    projectUuid: prompt.projectUuid,
+                    agentUuid: agentSettings.uuid,
+                    threadUuid: prompt.threadUuid,
+                    userUuid: user.userUuid,
+                });
                 if (!updatePromise) {
                     return Promise.resolve();
                 }

--- a/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationReconciler.test.ts
+++ b/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationReconciler.test.ts
@@ -1,0 +1,439 @@
+import {
+    MobilePushNotificationReconciler,
+    type AiAgentThreadLiveStateSignals,
+    type MobilePushApnsClient,
+    type MobilePushReconciliationStore,
+    type MobilePushReconciliationThreadStore,
+    type ReconciliationActivity,
+} from './MobilePushNotificationReconciler';
+
+const now = new Date('2026-08-30T12:01:00.000Z');
+const activity: ReconciliationActivity = {
+    liveActivityUuid: 'activity-uuid',
+    mobilePushInstallationUuid: 'installation-uuid',
+    installationUuid: 'public-installation-uuid',
+    organizationUuid: 'organization-uuid',
+    userUuid: 'user-uuid',
+    projectUuid: 'project-uuid',
+    agentUuid: 'agent-uuid',
+    threadUuid: 'thread-uuid',
+    promptUuid: 'prompt-uuid',
+    environment: 'sandbox' as const,
+    deviceToken: 'device-token',
+    pushToken: 'activity-token',
+    lastDeliveredState: null,
+    lastDeliveredStateChangedAt: null,
+    staleAt: null,
+    endedAt: null,
+    completionAlertCompletedAt: null,
+};
+
+const workingSignals = (): AiAgentThreadLiveStateSignals => ({
+    threadUuid: activity.threadUuid,
+    threadCreatedAt: new Date('2026-08-30T12:00:00.000Z'),
+    latestPrompt: {
+        createdAt: new Date('2026-08-30T12:00:00.000Z'),
+        retriedAt: null,
+        respondedAt: null,
+        response: null,
+        errorMessage: null,
+        interruptedAt: null,
+        needsUserInput: null,
+    },
+    runSqlToolCalls: [],
+    pendingWritebackCreatedAt: null,
+    activeDeepResearchRun: null,
+});
+
+const createDependencies = () => {
+    const notificationStore = {
+        findLiveActivity: vi.fn(async () => activity),
+        markLiveActivityDelivered: vi.fn(async () => undefined),
+        markCompletionAlertCompleted: vi.fn(async () => undefined),
+        deleteLiveActivity: vi.fn(async () => undefined),
+        deleteInstallation: vi.fn(async () => undefined),
+    } satisfies MobilePushReconciliationStore;
+    const threadStore = {
+        findThreadOwnership: vi.fn(async () => ({
+            threadUuid: activity.threadUuid,
+            projectUuid: activity.projectUuid,
+            agentUuid: activity.agentUuid,
+            ownerUserUuid: activity.userUuid,
+            createdFrom: 'web_app',
+            ownerIsServiceAccount: false,
+        })),
+        findThreadLiveStateSignals: vi.fn(async () => [workingSignals()]),
+    } satisfies MobilePushReconciliationThreadStore;
+    const apnsClient = {
+        sendLiveActivity: vi.fn<MobilePushApnsClient['sendLiveActivity']>(
+            async () => ({ status: 'sent' }),
+        ),
+        sendAlert: vi.fn<MobilePushApnsClient['sendAlert']>(async () => ({
+            status: 'sent',
+        })),
+    };
+    const scheduler = {
+        mobilePushLiveActivity: vi.fn(async () => ({ jobId: 'job-uuid' })),
+    };
+    const analytics = {
+        track: vi.fn(),
+    };
+    const completionAlert: { title: string; body: string } | undefined =
+        undefined;
+
+    return {
+        notificationStore,
+        threadStore,
+        apnsClient,
+        scheduler,
+        analytics,
+        completionAlert,
+        now: () => now,
+    };
+};
+
+describe('MobilePushNotificationReconciler.reconcileLiveActivity', () => {
+    it('delivers the canonical working state with a five-minute stale date', async () => {
+        const dependencies = createDependencies();
+        const reconciler = new MobilePushNotificationReconciler(dependencies);
+
+        await reconciler.reconcileLiveActivity(activity.liveActivityUuid);
+
+        expect(dependencies.apnsClient.sendLiveActivity).toHaveBeenCalledWith({
+            environment: 'sandbox',
+            pushToken: 'activity-token',
+            payload: {
+                aps: {
+                    timestamp: 1788091260,
+                    event: 'update',
+                    'stale-date': 1788091560,
+                    'content-state': {
+                        state: 'working',
+                        projectUuid: 'project-uuid',
+                        agentUuid: 'agent-uuid',
+                        threadUuid: 'thread-uuid',
+                        promptUuid: 'prompt-uuid',
+                    },
+                },
+            },
+        });
+        expect(
+            dependencies.notificationStore.markLiveActivityDelivered,
+        ).toHaveBeenCalledWith({
+            liveActivityUuid: 'activity-uuid',
+            state: 'working',
+            stateChangedAt: new Date('2026-08-30T12:00:00.000Z'),
+            staleAt: new Date('2026-08-30T12:06:00.000Z'),
+            endedAt: null,
+        });
+        expect(
+            dependencies.scheduler.mobilePushLiveActivity,
+        ).toHaveBeenCalledWith(
+            {
+                liveActivityUuid: 'activity-uuid',
+                organizationUuid: 'organization-uuid',
+                projectUuid: 'project-uuid',
+                userUuid: 'user-uuid',
+            },
+            new Date('2026-08-30T12:05:00.000Z'),
+        );
+        expect(dependencies.analytics.track).toHaveBeenCalledWith({
+            event: 'mobile_push.live_activity_delivery',
+            userId: 'user-uuid',
+            properties: {
+                organizationId: 'organization-uuid',
+                projectId: 'project-uuid',
+                agentId: 'agent-uuid',
+                threadId: 'thread-uuid',
+                promptId: 'prompt-uuid',
+                installationId: 'public-installation-uuid',
+                liveActivityId: 'activity-uuid',
+                environment: 'sandbox',
+                state: 'working',
+                activityEvent: 'update',
+                outcome: 'sent',
+            },
+        });
+        expect(
+            JSON.stringify(dependencies.analytics.track.mock.calls),
+        ).not.toContain('activity-token');
+    });
+
+    it('ends an idle activity and dismisses it after one minute', async () => {
+        const dependencies = createDependencies();
+        dependencies.threadStore.findThreadLiveStateSignals.mockResolvedValue([
+            {
+                ...workingSignals(),
+                latestPrompt: {
+                    ...workingSignals().latestPrompt!,
+                    respondedAt: new Date('2026-08-30T12:00:30.000Z'),
+                    response: 'stored only in the database',
+                },
+            },
+        ]);
+        const reconciler = new MobilePushNotificationReconciler(dependencies);
+
+        await reconciler.reconcileLiveActivity(activity.liveActivityUuid);
+
+        expect(dependencies.apnsClient.sendLiveActivity).toHaveBeenCalledWith(
+            expect.objectContaining({
+                payload: expect.objectContaining({
+                    aps: expect.objectContaining({
+                        event: 'end',
+                        'dismissal-date': 1788091320,
+                        'content-state': expect.objectContaining({
+                            state: 'idle',
+                        }),
+                    }),
+                }),
+            }),
+        );
+        expect(
+            dependencies.notificationStore.markLiveActivityDelivered,
+        ).toHaveBeenCalledWith(
+            expect.objectContaining({ state: 'idle', endedAt: now }),
+        );
+        expect(
+            dependencies.scheduler.mobilePushLiveActivity,
+        ).not.toHaveBeenCalled();
+        expect(dependencies.apnsClient.sendAlert).not.toHaveBeenCalled();
+    });
+
+    it('sends configured completion copy after ending an idle activity', async () => {
+        const dependencies = {
+            ...createDependencies(),
+            completionAlert: {
+                title: 'Approved title',
+                body: 'Approved body',
+            },
+        };
+        dependencies.threadStore.findThreadLiveStateSignals.mockResolvedValue([
+            {
+                ...workingSignals(),
+                latestPrompt: {
+                    ...workingSignals().latestPrompt!,
+                    respondedAt: new Date('2026-08-30T12:00:30.000Z'),
+                    response: 'stored only in the database',
+                },
+            },
+        ]);
+        const reconciler = new MobilePushNotificationReconciler(dependencies);
+
+        await reconciler.reconcileLiveActivity(activity.liveActivityUuid);
+
+        expect(dependencies.apnsClient.sendAlert).toHaveBeenCalledWith({
+            environment: 'sandbox',
+            deviceToken: 'device-token',
+            collapseId: 'activity-uuid',
+            payload: {
+                aps: {
+                    alert: {
+                        title: 'Approved title',
+                        body: 'Approved body',
+                    },
+                },
+            },
+        });
+        expect(
+            dependencies.notificationStore.markCompletionAlertCompleted,
+        ).toHaveBeenCalledWith('activity-uuid');
+        expect(
+            JSON.stringify(dependencies.analytics.track.mock.calls),
+        ).not.toMatch(/Approved title|Approved body/);
+    });
+
+    it('deletes the exact installation when its device token is invalid', async () => {
+        const dependencies = {
+            ...createDependencies(),
+            completionAlert: {
+                title: 'Approved title',
+                body: 'Approved body',
+            },
+        };
+        dependencies.notificationStore.findLiveActivity.mockResolvedValue({
+            ...activity,
+            lastDeliveredState: 'idle',
+            endedAt: now,
+        });
+        dependencies.apnsClient.sendAlert.mockResolvedValue({
+            status: 'invalid_token',
+            reason: 'BadDeviceToken',
+        });
+        const reconciler = new MobilePushNotificationReconciler(dependencies);
+
+        await reconciler.reconcileLiveActivity(activity.liveActivityUuid);
+
+        expect(
+            dependencies.notificationStore.deleteInstallation,
+        ).toHaveBeenCalledWith({
+            installationUuid: 'public-installation-uuid',
+            organizationUuid: 'organization-uuid',
+            userUuid: 'user-uuid',
+        });
+        expect(
+            dependencies.notificationStore.markCompletionAlertCompleted,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('retries an unfinished alert without redelivering an ended activity', async () => {
+        const dependencies = {
+            ...createDependencies(),
+            completionAlert: {
+                title: 'Approved title',
+                body: 'Approved body',
+            },
+        };
+        dependencies.notificationStore.findLiveActivity.mockResolvedValue({
+            ...activity,
+            lastDeliveredState: 'idle',
+            endedAt: now,
+        });
+        dependencies.apnsClient.sendAlert.mockResolvedValue({
+            status: 'retryable',
+            reason: 'ServiceUnavailable',
+        });
+        const reconciler = new MobilePushNotificationReconciler(dependencies);
+
+        await expect(
+            reconciler.reconcileLiveActivity(activity.liveActivityUuid),
+        ).rejects.toThrow('APNs alert delivery is retryable');
+
+        expect(dependencies.apnsClient.sendLiveActivity).not.toHaveBeenCalled();
+        expect(
+            dependencies.notificationStore.markLiveActivityDelivered,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('still sends a completion alert when the Activity token is invalid', async () => {
+        const dependencies = {
+            ...createDependencies(),
+            completionAlert: {
+                title: 'Approved title',
+                body: 'Approved body',
+            },
+        };
+        dependencies.threadStore.findThreadLiveStateSignals.mockResolvedValue([
+            {
+                ...workingSignals(),
+                latestPrompt: {
+                    ...workingSignals().latestPrompt!,
+                    respondedAt: new Date('2026-08-30T12:00:30.000Z'),
+                    response: 'stored only in the database',
+                },
+            },
+        ]);
+        dependencies.apnsClient.sendLiveActivity.mockResolvedValue({
+            status: 'invalid_token',
+            reason: 'Unregistered',
+        });
+        const reconciler = new MobilePushNotificationReconciler(dependencies);
+
+        await reconciler.reconcileLiveActivity(activity.liveActivityUuid);
+
+        expect(dependencies.apnsClient.sendAlert).toHaveBeenCalledOnce();
+        expect(
+            dependencies.notificationStore.deleteLiveActivity,
+        ).toHaveBeenCalledWith({ liveActivityUuid: 'activity-uuid' });
+    });
+
+    it('does not redeliver an unchanged state', async () => {
+        const dependencies = createDependencies();
+        dependencies.notificationStore.findLiveActivity.mockResolvedValue({
+            ...activity,
+            lastDeliveredState: 'working',
+            staleAt: new Date('2026-08-30T12:06:00.000Z'),
+        });
+        const reconciler = new MobilePushNotificationReconciler(dependencies);
+
+        await reconciler.reconcileLiveActivity(activity.liveActivityUuid);
+
+        expect(dependencies.apnsClient.sendLiveActivity).not.toHaveBeenCalled();
+    });
+
+    it('deletes an invalid ActivityKit token without retrying', async () => {
+        const dependencies = createDependencies();
+        dependencies.apnsClient.sendLiveActivity.mockResolvedValue({
+            status: 'invalid_token',
+            reason: 'Unregistered',
+        });
+        const reconciler = new MobilePushNotificationReconciler(dependencies);
+
+        await reconciler.reconcileLiveActivity(activity.liveActivityUuid);
+
+        expect(
+            dependencies.notificationStore.deleteLiveActivity,
+        ).toHaveBeenCalledWith({ liveActivityUuid: 'activity-uuid' });
+        expect(
+            dependencies.notificationStore.markLiveActivityDelivered,
+        ).not.toHaveBeenCalled();
+        expect(dependencies.analytics.track).toHaveBeenCalledWith(
+            expect.objectContaining({
+                properties: expect.objectContaining({
+                    outcome: 'invalid_token',
+                }),
+            }),
+        );
+    });
+
+    it('surfaces a retryable APNs failure to the job runner', async () => {
+        const dependencies = createDependencies();
+        dependencies.apnsClient.sendLiveActivity.mockResolvedValue({
+            status: 'retryable',
+            reason: 'ServiceUnavailable',
+        });
+        const reconciler = new MobilePushNotificationReconciler(dependencies);
+
+        await expect(
+            reconciler.reconcileLiveActivity(activity.liveActivityUuid),
+        ).rejects.toThrow('APNs delivery is retryable: ServiceUnavailable');
+        expect(
+            dependencies.notificationStore.markLiveActivityDelivered,
+        ).not.toHaveBeenCalled();
+        expect(dependencies.analytics.track).toHaveBeenCalledWith(
+            expect.objectContaining({
+                properties: expect.objectContaining({ outcome: 'retryable' }),
+            }),
+        );
+    });
+
+    it('preserves a registration after a non-token APNs rejection', async () => {
+        const dependencies = createDependencies();
+        dependencies.apnsClient.sendLiveActivity.mockResolvedValue({
+            status: 'failed',
+            reason: 'BadTopic',
+        });
+        const reconciler = new MobilePushNotificationReconciler(dependencies);
+
+        await reconciler.reconcileLiveActivity(activity.liveActivityUuid);
+
+        expect(
+            dependencies.notificationStore.deleteLiveActivity,
+        ).not.toHaveBeenCalled();
+        expect(
+            dependencies.notificationStore.deleteInstallation,
+        ).not.toHaveBeenCalled();
+        expect(
+            dependencies.notificationStore.markLiveActivityDelivered,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('deletes a registration when ownership no longer matches', async () => {
+        const dependencies = createDependencies();
+        dependencies.threadStore.findThreadOwnership.mockResolvedValue({
+            threadUuid: activity.threadUuid,
+            projectUuid: activity.projectUuid,
+            agentUuid: activity.agentUuid,
+            ownerUserUuid: 'another-user',
+            createdFrom: 'web_app',
+            ownerIsServiceAccount: false,
+        });
+        const reconciler = new MobilePushNotificationReconciler(dependencies);
+
+        await reconciler.reconcileLiveActivity(activity.liveActivityUuid);
+
+        expect(
+            dependencies.notificationStore.deleteLiveActivity,
+        ).toHaveBeenCalledWith({ liveActivityUuid: 'activity-uuid' });
+        expect(dependencies.apnsClient.sendLiveActivity).not.toHaveBeenCalled();
+    });
+});

--- a/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationReconciler.test.ts
+++ b/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationReconciler.test.ts
@@ -232,6 +232,10 @@ describe('MobilePushNotificationReconciler.reconcileLiveActivity', () => {
                         body: 'Approved body',
                     },
                 },
+                projectUuid: 'project-uuid',
+                agentUuid: 'agent-uuid',
+                threadUuid: 'thread-uuid',
+                promptUuid: 'prompt-uuid',
             },
         });
         expect(

--- a/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationReconciler.ts
+++ b/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationReconciler.ts
@@ -181,7 +181,13 @@ export class MobilePushNotificationReconciler {
             environment: activity.environment,
             deviceToken: activity.deviceToken,
             collapseId: activity.liveActivityUuid,
-            payload: { aps: { alert: this.completionAlert } },
+            payload: {
+                aps: { alert: this.completionAlert },
+                projectUuid: activity.projectUuid,
+                agentUuid: activity.agentUuid,
+                threadUuid: activity.threadUuid,
+                promptUuid: activity.promptUuid,
+            },
         });
         this.track({
             event: 'mobile_push.completion_alert_delivery',

--- a/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationReconciler.ts
+++ b/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationReconciler.ts
@@ -1,0 +1,367 @@
+import {
+    type LightdashAnalytics,
+    type MobilePushNotificationEvent,
+} from '../../../analytics/LightdashAnalytics';
+import {
+    buildLiveActivityPayload,
+    type AlertPayload,
+    type ApnsDeliveryResult,
+    type LiveActivityPayload,
+} from '../../../clients/Apns/ApnsClient';
+import Logger from '../../../logging/logger';
+import { type MobilePushEnvironment } from '../../database/entities/mobilePushNotifications';
+import { deriveAiAgentThreadLiveStatus } from '../AiAgentService/aiAgentThreadLiveStatus';
+import { type AiAgentThreadLiveStateSignals } from '../AiAgentService/aiAgentThreadLiveStatus';
+
+export type { AiAgentThreadLiveStateSignals };
+
+export type ReconciliationActivity = {
+    liveActivityUuid: string;
+    mobilePushInstallationUuid: string;
+    installationUuid: string;
+    organizationUuid: string;
+    userUuid: string;
+    projectUuid: string;
+    agentUuid: string;
+    threadUuid: string;
+    promptUuid: string;
+    environment: MobilePushEnvironment;
+    deviceToken: string;
+    pushToken: string;
+    lastDeliveredState: 'working' | 'waiting_for_you' | 'idle' | null;
+    lastDeliveredStateChangedAt: Date | null;
+    staleAt: Date | null;
+    endedAt: Date | null;
+    completionAlertCompletedAt: Date | null;
+};
+
+export type MobilePushReconciliationStore = {
+    findLiveActivity(
+        liveActivityUuid: string,
+    ): Promise<ReconciliationActivity | undefined>;
+    markLiveActivityDelivered(args: {
+        liveActivityUuid: string;
+        state: 'working' | 'waiting_for_you' | 'idle';
+        stateChangedAt: Date;
+        staleAt: Date;
+        endedAt: Date | null;
+    }): Promise<void>;
+    markCompletionAlertCompleted(liveActivityUuid: string): Promise<void>;
+    deleteInstallation(args: {
+        installationUuid: string;
+        organizationUuid: string;
+        userUuid: string;
+    }): Promise<void>;
+    deleteLiveActivity(args: { liveActivityUuid: string }): Promise<void>;
+};
+
+type ReconciliationThreadOwnership = {
+    threadUuid: string;
+    projectUuid: string;
+    agentUuid: string | null;
+    ownerUserUuid: string | null;
+    createdFrom: string;
+    ownerIsServiceAccount: boolean;
+};
+
+export type MobilePushReconciliationThreadStore = {
+    findThreadOwnership(args: {
+        organizationUuid: string;
+        threadUuid: string;
+    }): Promise<ReconciliationThreadOwnership | undefined>;
+    findThreadLiveStateSignals(args: {
+        organizationUuid: string;
+        threadUuids: string[];
+        projectUuid: string | null;
+        userUuid: string | null;
+        agentUuids: string[] | null;
+    }): Promise<AiAgentThreadLiveStateSignals[]>;
+};
+
+export type MobilePushApnsClient = {
+    sendLiveActivity(args: {
+        environment: MobilePushEnvironment;
+        pushToken: string;
+        payload: LiveActivityPayload;
+    }): Promise<ApnsDeliveryResult>;
+    sendAlert(args: {
+        environment: MobilePushEnvironment;
+        deviceToken: string;
+        collapseId: string;
+        payload: AlertPayload;
+    }): Promise<ApnsDeliveryResult>;
+};
+
+type ReconcilerDependencies = {
+    notificationStore: MobilePushReconciliationStore;
+    threadStore: MobilePushReconciliationThreadStore;
+    apnsClient: MobilePushApnsClient;
+    scheduler: {
+        mobilePushLiveActivity(
+            payload: {
+                liveActivityUuid: string;
+                organizationUuid: string;
+                projectUuid: string;
+                userUuid: string;
+            },
+            runAt: Date,
+        ): Promise<unknown>;
+    };
+    analytics: Pick<LightdashAnalytics, 'track'>;
+    completionAlert?: AlertPayload['aps']['alert'];
+    now?: () => Date;
+};
+
+const LIVE_ACTIVITY_STALE_AFTER_MS = 5 * 60 * 1000;
+const LIVE_ACTIVITY_DISMISS_AFTER_MS = 60 * 1000;
+const LIVE_ACTIVITY_REFRESH_WINDOW_MS = 60 * 1000;
+
+export class MobilePushNotificationReconciler {
+    private readonly notificationStore: MobilePushReconciliationStore;
+
+    private readonly threadStore: MobilePushReconciliationThreadStore;
+
+    private readonly apnsClient: MobilePushApnsClient;
+
+    private readonly scheduler: ReconcilerDependencies['scheduler'];
+
+    private readonly analytics: ReconcilerDependencies['analytics'];
+
+    private readonly completionAlert: ReconcilerDependencies['completionAlert'];
+
+    private readonly now: () => Date;
+
+    constructor(dependencies: ReconcilerDependencies) {
+        this.notificationStore = dependencies.notificationStore;
+        this.threadStore = dependencies.threadStore;
+        this.apnsClient = dependencies.apnsClient;
+        this.scheduler = dependencies.scheduler;
+        this.analytics = dependencies.analytics;
+        this.completionAlert = dependencies.completionAlert;
+        this.now = dependencies.now ?? (() => new Date());
+    }
+
+    private track(event: MobilePushNotificationEvent): void {
+        try {
+            this.analytics.track(event);
+        } catch (error) {
+            Logger.warn('Unable to track mobile push analytics', {
+                event: event.event,
+                error,
+            });
+        }
+    }
+
+    private async scheduleRefresh(
+        activity: ReconciliationActivity,
+        staleAt: Date,
+    ): Promise<void> {
+        await this.scheduler.mobilePushLiveActivity(
+            {
+                liveActivityUuid: activity.liveActivityUuid,
+                organizationUuid: activity.organizationUuid,
+                projectUuid: activity.projectUuid,
+                userUuid: activity.userUuid,
+            },
+            new Date(staleAt.getTime() - LIVE_ACTIVITY_REFRESH_WINDOW_MS),
+        );
+    }
+
+    private async deliverCompletionAlert(
+        activity: ReconciliationActivity,
+    ): Promise<'completed' | 'installation_deleted'> {
+        if (
+            this.completionAlert === undefined ||
+            activity.completionAlertCompletedAt !== null
+        ) {
+            return 'completed';
+        }
+
+        const result = await this.apnsClient.sendAlert({
+            environment: activity.environment,
+            deviceToken: activity.deviceToken,
+            collapseId: activity.liveActivityUuid,
+            payload: { aps: { alert: this.completionAlert } },
+        });
+        this.track({
+            event: 'mobile_push.completion_alert_delivery',
+            userId: activity.userUuid,
+            properties: {
+                organizationId: activity.organizationUuid,
+                projectId: activity.projectUuid,
+                agentId: activity.agentUuid,
+                threadId: activity.threadUuid,
+                promptId: activity.promptUuid,
+                installationId: activity.installationUuid,
+                liveActivityId: activity.liveActivityUuid,
+                environment: activity.environment,
+                outcome: result.status,
+            },
+        });
+
+        if (result.status === 'invalid_token') {
+            await this.notificationStore.deleteInstallation({
+                installationUuid: activity.installationUuid,
+                organizationUuid: activity.organizationUuid,
+                userUuid: activity.userUuid,
+            });
+            return 'installation_deleted';
+        }
+        if (result.status === 'retryable') {
+            throw new Error(
+                `APNs alert delivery is retryable: ${result.reason ?? 'unknown'}`,
+            );
+        }
+
+        await this.notificationStore.markCompletionAlertCompleted(
+            activity.liveActivityUuid,
+        );
+        return 'completed';
+    }
+
+    async reconcileLiveActivity(liveActivityUuid: string): Promise<void> {
+        const activity =
+            await this.notificationStore.findLiveActivity(liveActivityUuid);
+        if (activity === undefined) return;
+
+        const ownership = await this.threadStore.findThreadOwnership({
+            organizationUuid: activity.organizationUuid,
+            threadUuid: activity.threadUuid,
+        });
+        if (
+            ownership?.threadUuid !== activity.threadUuid ||
+            ownership.projectUuid !== activity.projectUuid ||
+            ownership.agentUuid !== activity.agentUuid ||
+            ownership.ownerUserUuid !== activity.userUuid ||
+            ownership.createdFrom !== 'web_app' ||
+            ownership.ownerIsServiceAccount
+        ) {
+            await this.notificationStore.deleteLiveActivity({
+                liveActivityUuid,
+            });
+            return;
+        }
+
+        if (activity.endedAt !== null) {
+            await this.deliverCompletionAlert(activity);
+            return;
+        }
+
+        const signals = await this.threadStore.findThreadLiveStateSignals({
+            organizationUuid: activity.organizationUuid,
+            threadUuids: [activity.threadUuid],
+            projectUuid: activity.projectUuid,
+            userUuid: activity.userUuid,
+            agentUuids: [activity.agentUuid],
+        });
+        const threadSignals = signals[0];
+        if (threadSignals === undefined) {
+            await this.notificationStore.deleteLiveActivity({
+                liveActivityUuid,
+            });
+            return;
+        }
+
+        const deliveryTime = this.now();
+        const liveStatus = deriveAiAgentThreadLiveStatus(
+            threadSignals,
+            deliveryTime,
+        );
+        if (
+            activity.lastDeliveredState === liveStatus.state &&
+            activity.staleAt !== null &&
+            activity.staleAt.getTime() - deliveryTime.getTime() >
+                LIVE_ACTIVITY_REFRESH_WINDOW_MS
+        ) {
+            await this.scheduleRefresh(activity, activity.staleAt);
+            return;
+        }
+
+        const staleAt =
+            liveStatus.state === 'idle'
+                ? deliveryTime
+                : new Date(
+                      deliveryTime.getTime() + LIVE_ACTIVITY_STALE_AFTER_MS,
+                  );
+        const endedAt = liveStatus.state === 'idle' ? deliveryTime : null;
+        const dismissalAt =
+            endedAt === null
+                ? undefined
+                : new Date(
+                      deliveryTime.getTime() + LIVE_ACTIVITY_DISMISS_AFTER_MS,
+                  );
+        const stateChangedAt =
+            liveStatus.stateChangedAt === null
+                ? deliveryTime
+                : new Date(liveStatus.stateChangedAt);
+        const payload = buildLiveActivityPayload({
+            state: liveStatus.state,
+            timestamp: deliveryTime,
+            staleAt,
+            dismissalAt,
+            event: liveStatus.state === 'idle' ? 'end' : 'update',
+            projectUuid: activity.projectUuid,
+            agentUuid: activity.agentUuid,
+            threadUuid: activity.threadUuid,
+            promptUuid: activity.promptUuid,
+        });
+        const result = await this.apnsClient.sendLiveActivity({
+            environment: activity.environment,
+            pushToken: activity.pushToken,
+            payload,
+        });
+        this.track({
+            event: 'mobile_push.live_activity_delivery',
+            userId: activity.userUuid,
+            properties: {
+                organizationId: activity.organizationUuid,
+                projectId: activity.projectUuid,
+                agentId: activity.agentUuid,
+                threadId: activity.threadUuid,
+                promptId: activity.promptUuid,
+                installationId: activity.installationUuid,
+                liveActivityId: activity.liveActivityUuid,
+                environment: activity.environment,
+                state: liveStatus.state,
+                activityEvent: payload.aps.event,
+                outcome: result.status,
+            },
+        });
+
+        if (result.status === 'invalid_token') {
+            if (liveStatus.state === 'idle') {
+                const alertResult = await this.deliverCompletionAlert(activity);
+                if (alertResult === 'installation_deleted') return;
+            }
+            await this.notificationStore.deleteLiveActivity({
+                liveActivityUuid,
+            });
+            return;
+        }
+        if (result.status === 'retryable') {
+            throw new Error(
+                `APNs delivery is retryable: ${result.reason ?? 'unknown'}`,
+            );
+        }
+        if (result.status === 'failed') {
+            if (liveStatus.state === 'idle') {
+                const alertResult = await this.deliverCompletionAlert(activity);
+                if (alertResult === 'installation_deleted') return;
+            }
+            return;
+        }
+
+        await this.notificationStore.markLiveActivityDelivered({
+            liveActivityUuid,
+            state: liveStatus.state,
+            stateChangedAt,
+            staleAt,
+            endedAt,
+        });
+        if (endedAt === null) {
+            await this.scheduleRefresh(activity, staleAt);
+        } else {
+            await this.deliverCompletionAlert(activity);
+        }
+    }
+}

--- a/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationService.test.ts
+++ b/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationService.test.ts
@@ -1,0 +1,455 @@
+import { NotFoundError, ParameterError } from '@lightdash/common';
+import {
+    MobilePushNotificationService,
+    type MobilePushNotificationStore,
+    type MobilePushThreadStore,
+} from './MobilePushNotificationService';
+
+const organizationUuid = '00000000-0000-0000-0000-000000000001';
+const userUuid = '00000000-0000-0000-0000-000000000002';
+const installationUuid = '00000000-0000-0000-0000-000000000003';
+const projectUuid = '00000000-0000-0000-0000-000000000004';
+const agentUuid = '00000000-0000-0000-0000-000000000005';
+const threadUuid = '00000000-0000-0000-0000-000000000006';
+const promptUuid = '00000000-0000-0000-0000-000000000007';
+const liveActivityUuid = '00000000-0000-0000-0000-000000000008';
+
+const installation = {
+    mobilePushInstallationUuid: installationUuid,
+    installationUuid,
+    organizationUuid,
+    userUuid,
+    environment: 'sandbox' as const,
+};
+
+const threadOwnership = {
+    threadUuid,
+    projectUuid,
+    agentUuid,
+    ownerUserUuid: userUuid,
+    createdFrom: 'web_app' as const,
+    ownerIsServiceAccount: false,
+};
+
+const prompt = {
+    organizationUuid,
+    projectUuid,
+    promptUuid,
+    threadUuid,
+    agentUuid,
+    createdByUserUuid: userUuid,
+};
+
+const createDependencies = () => {
+    const mobilePushNotificationStore = {
+        findInstallation: vi.fn(async () => installation),
+        findLiveActivityOwner: vi.fn<
+            MobilePushNotificationStore['findLiveActivityOwner']
+        >(async () => undefined),
+        upsertInstallation: vi.fn(async () => installation),
+        deleteInstallation: vi.fn(async () => undefined),
+        upsertLiveActivity: vi.fn(async () => undefined),
+        deleteLiveActivity: vi.fn(async () => undefined),
+        findActiveLiveActivitiesForThread: vi.fn<
+            MobilePushNotificationStore['findActiveLiveActivitiesForThread']
+        >(async () => []),
+        findLiveActivitiesDueForReconciliation: vi.fn<
+            MobilePushNotificationStore['findLiveActivitiesDueForReconciliation']
+        >(async () => []),
+    } satisfies MobilePushNotificationStore;
+    const threadStore = {
+        findThreadOwnership: vi.fn<
+            MobilePushThreadStore['findThreadOwnership']
+        >(async () => threadOwnership),
+        findWebAppPrompt: vi.fn<MobilePushThreadStore['findWebAppPrompt']>(
+            async () => prompt,
+        ),
+    } satisfies MobilePushThreadStore;
+
+    return {
+        mobilePushNotificationStore,
+        threadStore,
+        mobilePushNotificationsConfig: {
+            enabled: true,
+            bundleId: 'com.lightdash.mobile',
+            teamId: 'TEAMID',
+            sandbox: { keyId: 'KEYID', privateKey: 'private-key' },
+            production: undefined,
+        },
+        scheduler: {
+            mobilePushLiveActivity: vi.fn(async () => ({
+                jobId: 'job-uuid',
+            })),
+        },
+        reconciler: {
+            reconcileLiveActivity: vi.fn(async () => undefined),
+        },
+        analytics: {
+            track: vi.fn(),
+        },
+    };
+};
+
+const register = (
+    service: MobilePushNotificationService,
+    overrides: Partial<Parameters<typeof service.registerLiveActivity>[0]> = {},
+) =>
+    service.registerLiveActivity({
+        user: { userUuid, organizationUuid },
+        projectUuid,
+        agentUuid,
+        threadUuid,
+        liveActivityUuid,
+        installationUuid,
+        promptUuid,
+        pushToken: 'activity-token',
+        ...overrides,
+    });
+
+describe('MobilePushNotificationService.registerLiveActivity', () => {
+    it('registers an activity for the exact owned installation and prompt chain', async () => {
+        const dependencies = createDependencies();
+        const service = new MobilePushNotificationService(dependencies);
+
+        await register(service);
+
+        expect(
+            dependencies.mobilePushNotificationStore.upsertLiveActivity,
+        ).toHaveBeenCalledWith({
+            liveActivityUuid,
+            mobilePushInstallationUuid: installationUuid,
+            organizationUuid,
+            userUuid,
+            projectUuid,
+            agentUuid,
+            threadUuid,
+            promptUuid,
+            pushToken: 'activity-token',
+        });
+        expect(
+            dependencies.scheduler.mobilePushLiveActivity,
+        ).toHaveBeenCalledWith({
+            liveActivityUuid,
+            organizationUuid,
+            projectUuid,
+            userUuid,
+        });
+        expect(dependencies.analytics.track).toHaveBeenCalledWith({
+            event: 'mobile_push.live_activity_registered',
+            userId: userUuid,
+            properties: {
+                organizationId: organizationUuid,
+                projectId: projectUuid,
+                agentId: agentUuid,
+                threadId: threadUuid,
+                promptId: promptUuid,
+                installationId: installationUuid,
+                liveActivityId: liveActivityUuid,
+                environment: 'sandbox',
+            },
+        });
+        expect(
+            JSON.stringify(dependencies.analytics.track.mock.calls),
+        ).not.toContain('activity-token');
+    });
+
+    it('denies an installation registered to another user', async () => {
+        const dependencies = createDependencies();
+        dependencies.mobilePushNotificationStore.findInstallation.mockResolvedValue(
+            { ...installation, userUuid: 'another-user' },
+        );
+        const service = new MobilePushNotificationService(dependencies);
+
+        await expect(register(service)).rejects.toBeInstanceOf(NotFoundError);
+        expect(
+            dependencies.mobilePushNotificationStore.upsertLiveActivity,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('denies replacing an existing activity owned by another user', async () => {
+        const dependencies = createDependencies();
+        dependencies.mobilePushNotificationStore.findLiveActivityOwner.mockResolvedValue(
+            {
+                liveActivityUuid,
+                mobilePushInstallationUuid: installationUuid,
+                organizationUuid,
+                userUuid: 'another-user',
+                projectUuid,
+                agentUuid,
+                threadUuid,
+                promptUuid,
+            },
+        );
+        const service = new MobilePushNotificationService(dependencies);
+
+        await expect(register(service)).rejects.toBeInstanceOf(NotFoundError);
+        expect(
+            dependencies.mobilePushNotificationStore.upsertLiveActivity,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('denies an installation registered to another organization', async () => {
+        const dependencies = createDependencies();
+        dependencies.mobilePushNotificationStore.findInstallation.mockResolvedValue(
+            { ...installation, organizationUuid: 'another-organization' },
+        );
+        const service = new MobilePushNotificationService(dependencies);
+
+        await expect(register(service)).rejects.toBeInstanceOf(NotFoundError);
+        expect(
+            dependencies.mobilePushNotificationStore.upsertLiveActivity,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('denies a thread owned by another user', async () => {
+        const dependencies = createDependencies();
+        dependencies.threadStore.findThreadOwnership.mockResolvedValue({
+            ...threadOwnership,
+            ownerUserUuid: 'another-user',
+        });
+        const service = new MobilePushNotificationService(dependencies);
+
+        await expect(register(service)).rejects.toBeInstanceOf(NotFoundError);
+        expect(
+            dependencies.mobilePushNotificationStore.upsertLiveActivity,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('denies a thread from another organization', async () => {
+        const dependencies = createDependencies();
+        dependencies.threadStore.findThreadOwnership.mockResolvedValue(
+            undefined,
+        );
+        const service = new MobilePushNotificationService(dependencies);
+
+        await expect(register(service)).rejects.toBeInstanceOf(NotFoundError);
+        expect(
+            dependencies.mobilePushNotificationStore.upsertLiveActivity,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('denies a thread from another project', async () => {
+        const dependencies = createDependencies();
+        dependencies.threadStore.findThreadOwnership.mockResolvedValue({
+            ...threadOwnership,
+            projectUuid: 'another-project',
+        });
+        const service = new MobilePushNotificationService(dependencies);
+
+        await expect(register(service)).rejects.toBeInstanceOf(NotFoundError);
+        expect(
+            dependencies.mobilePushNotificationStore.upsertLiveActivity,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('denies a thread from another agent', async () => {
+        const dependencies = createDependencies();
+        dependencies.threadStore.findThreadOwnership.mockResolvedValue({
+            ...threadOwnership,
+            agentUuid: 'another-agent',
+        });
+        const service = new MobilePushNotificationService(dependencies);
+
+        await expect(register(service)).rejects.toBeInstanceOf(NotFoundError);
+        expect(
+            dependencies.mobilePushNotificationStore.upsertLiveActivity,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('denies a prompt from another thread', async () => {
+        const dependencies = createDependencies();
+        dependencies.threadStore.findWebAppPrompt.mockResolvedValue({
+            ...prompt,
+            threadUuid: 'another-thread',
+        });
+        const service = new MobilePushNotificationService(dependencies);
+
+        await expect(register(service)).rejects.toBeInstanceOf(NotFoundError);
+        expect(
+            dependencies.mobilePushNotificationStore.upsertLiveActivity,
+        ).not.toHaveBeenCalled();
+    });
+
+    it.each(['', 'x'.repeat(4097)])(
+        'rejects an invalid Live Activity token before ownership lookup',
+        async (pushToken) => {
+            const dependencies = createDependencies();
+            const service = new MobilePushNotificationService(dependencies);
+
+            await expect(
+                register(service, { pushToken }),
+            ).rejects.toBeInstanceOf(ParameterError);
+            expect(
+                dependencies.threadStore.findThreadOwnership,
+            ).not.toHaveBeenCalled();
+            expect(
+                dependencies.mobilePushNotificationStore.upsertLiveActivity,
+            ).not.toHaveBeenCalled();
+        },
+    );
+});
+
+describe('MobilePushNotificationService reconciliation scheduling', () => {
+    it('enqueues every active activity for a changed thread', async () => {
+        const dependencies = createDependencies();
+        dependencies.mobilePushNotificationStore.findActiveLiveActivitiesForThread.mockResolvedValue(
+            [
+                {
+                    liveActivityUuid,
+                    organizationUuid,
+                    projectUuid,
+                    userUuid,
+                },
+            ],
+        );
+        const service = new MobilePushNotificationService(dependencies);
+
+        await service.enqueueThreadReconciliation(threadUuid);
+
+        expect(
+            dependencies.scheduler.mobilePushLiveActivity,
+        ).toHaveBeenCalledWith({
+            liveActivityUuid,
+            organizationUuid,
+            projectUuid,
+            userUuid,
+        });
+    });
+
+    it('delegates a worker job to the canonical reconciler', async () => {
+        const dependencies = createDependencies();
+        const service = new MobilePushNotificationService(dependencies);
+
+        await service.reconcileLiveActivity(liveActivityUuid);
+
+        expect(
+            dependencies.reconciler.reconcileLiveActivity,
+        ).toHaveBeenCalledWith(liveActivityUuid);
+    });
+});
+
+describe('MobilePushNotificationService installation lifecycle', () => {
+    it('reports only availability and configured environments', () => {
+        const service = new MobilePushNotificationService(createDependencies());
+
+        expect(service.getStatus()).toEqual({
+            enabled: true,
+            environments: ['sandbox'],
+        });
+    });
+
+    it('registers a rotating device token for the current account', async () => {
+        const dependencies = createDependencies();
+        const service = new MobilePushNotificationService(dependencies);
+
+        await service.registerInstallation({
+            user: { userUuid, organizationUuid },
+            installationUuid,
+            environment: 'sandbox',
+            deviceToken: 'device-token',
+        });
+
+        expect(
+            dependencies.mobilePushNotificationStore.upsertInstallation,
+        ).toHaveBeenCalledWith({
+            installationUuid,
+            organizationUuid,
+            userUuid,
+            environment: 'sandbox',
+            deviceToken: 'device-token',
+        });
+        expect(dependencies.analytics.track).toHaveBeenCalledWith({
+            event: 'mobile_push.installation_registered',
+            userId: userUuid,
+            properties: {
+                organizationId: organizationUuid,
+                installationId: installationUuid,
+                environment: 'sandbox',
+            },
+        });
+        expect(
+            JSON.stringify(dependencies.analytics.track.mock.calls),
+        ).not.toContain('device-token');
+    });
+
+    it.each(['', 'x'.repeat(4097)])(
+        'rejects an invalid device token before storage',
+        async (deviceToken) => {
+            const dependencies = createDependencies();
+            const service = new MobilePushNotificationService(dependencies);
+
+            await expect(
+                service.registerInstallation({
+                    user: { userUuid, organizationUuid },
+                    installationUuid,
+                    environment: 'sandbox',
+                    deviceToken,
+                }),
+            ).rejects.toBeInstanceOf(ParameterError);
+            expect(
+                dependencies.mobilePushNotificationStore.upsertInstallation,
+            ).not.toHaveBeenCalled();
+        },
+    );
+
+    it('does not retain a token when mobile push is unavailable', async () => {
+        const dependencies = createDependencies();
+        dependencies.mobilePushNotificationsConfig.enabled = false;
+        const service = new MobilePushNotificationService(dependencies);
+
+        await service.registerInstallation({
+            user: { userUuid, organizationUuid },
+            installationUuid,
+            environment: 'sandbox',
+            deviceToken: 'device-token',
+        });
+
+        expect(
+            dependencies.mobilePushNotificationStore.upsertInstallation,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('revokes only the current account installation on sign-out', async () => {
+        const dependencies = createDependencies();
+        const service = new MobilePushNotificationService(dependencies);
+
+        await service.revokeInstallation({
+            user: { userUuid, organizationUuid },
+            installationUuid,
+        });
+
+        expect(
+            dependencies.mobilePushNotificationStore.deleteInstallation,
+        ).toHaveBeenCalledWith({
+            installationUuid,
+            organizationUuid,
+            userUuid,
+        });
+    });
+
+    it('revokes only the current account activity tuple', async () => {
+        const dependencies = createDependencies();
+        const service = new MobilePushNotificationService(dependencies);
+
+        await service.revokeLiveActivity({
+            user: { userUuid, organizationUuid },
+            installationUuid,
+            projectUuid,
+            agentUuid,
+            threadUuid,
+            liveActivityUuid,
+        });
+
+        expect(
+            dependencies.mobilePushNotificationStore.deleteLiveActivity,
+        ).toHaveBeenCalledWith({
+            installationUuid,
+            organizationUuid,
+            userUuid,
+            projectUuid,
+            agentUuid,
+            threadUuid,
+            liveActivityUuid,
+        });
+    });
+});

--- a/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationService.ts
+++ b/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationService.ts
@@ -1,0 +1,374 @@
+import { NotFoundError, ParameterError } from '@lightdash/common';
+import {
+    type LightdashAnalytics,
+    type MobilePushNotificationEvent,
+} from '../../../analytics/LightdashAnalytics';
+import { type MobilePushNotificationsConfig } from '../../../config/parseConfig';
+import Logger from '../../../logging/logger';
+import { type MobilePushEnvironment } from '../../database/entities/mobilePushNotifications';
+
+type MobilePushUser = {
+    userUuid: string;
+    organizationUuid?: string | null;
+};
+
+type MobilePushInstallation = {
+    mobilePushInstallationUuid: string;
+    installationUuid: string;
+    organizationUuid: string;
+    userUuid: string;
+    environment: MobilePushEnvironment;
+};
+
+type MobilePushThreadOwnership = {
+    threadUuid: string;
+    projectUuid: string;
+    agentUuid: string | null;
+    ownerUserUuid: string | null;
+    createdFrom: string;
+    ownerIsServiceAccount: boolean;
+};
+
+type MobilePushPrompt = {
+    organizationUuid: string;
+    projectUuid: string;
+    promptUuid: string;
+    threadUuid: string;
+    agentUuid: string | null;
+    createdByUserUuid: string;
+};
+
+type UpsertLiveActivity = {
+    liveActivityUuid: string;
+    mobilePushInstallationUuid: string;
+    organizationUuid: string;
+    userUuid: string;
+    projectUuid: string;
+    agentUuid: string;
+    threadUuid: string;
+    promptUuid: string;
+    pushToken: string;
+};
+
+type LiveActivityOwner = Omit<UpsertLiveActivity, 'pushToken'>;
+
+type SchedulableLiveActivity = {
+    liveActivityUuid: string;
+    organizationUuid: string;
+    projectUuid: string;
+    userUuid: string;
+};
+
+export type MobilePushNotificationStore = {
+    findInstallation(
+        installationUuid: string,
+    ): Promise<MobilePushInstallation | undefined>;
+    findLiveActivityOwner(
+        liveActivityUuid: string,
+    ): Promise<LiveActivityOwner | undefined>;
+    upsertInstallation(args: {
+        installationUuid: string;
+        organizationUuid: string;
+        userUuid: string;
+        environment: MobilePushEnvironment;
+        deviceToken: string;
+    }): Promise<MobilePushInstallation>;
+    deleteInstallation(args: {
+        installationUuid: string;
+        organizationUuid: string;
+        userUuid: string;
+    }): Promise<void>;
+    upsertLiveActivity(activity: UpsertLiveActivity): Promise<void>;
+    deleteLiveActivity(args: {
+        liveActivityUuid: string;
+        installationUuid?: string;
+        organizationUuid?: string;
+        userUuid?: string;
+        projectUuid?: string;
+        agentUuid?: string;
+        threadUuid?: string;
+    }): Promise<void>;
+    findActiveLiveActivitiesForThread(
+        threadUuid: string,
+    ): Promise<SchedulableLiveActivity[]>;
+    findLiveActivitiesDueForReconciliation(
+        dueBefore: Date,
+        limit: number,
+    ): Promise<SchedulableLiveActivity[]>;
+};
+
+export type MobilePushThreadStore = {
+    findThreadOwnership(args: {
+        organizationUuid: string;
+        threadUuid: string;
+    }): Promise<MobilePushThreadOwnership | undefined>;
+    findWebAppPrompt(promptUuid: string): Promise<MobilePushPrompt | undefined>;
+};
+
+type MobilePushNotificationServiceDependencies = {
+    mobilePushNotificationStore: MobilePushNotificationStore;
+    threadStore: MobilePushThreadStore;
+    mobilePushNotificationsConfig: MobilePushNotificationsConfig;
+    scheduler: {
+        mobilePushLiveActivity(
+            payload: SchedulableLiveActivity,
+            runAt?: Date,
+        ): Promise<unknown>;
+    };
+    reconciler: {
+        reconcileLiveActivity(liveActivityUuid: string): Promise<void>;
+    };
+    analytics: Pick<LightdashAnalytics, 'track'>;
+};
+
+type RegisterLiveActivity = {
+    user: MobilePushUser;
+    projectUuid: string;
+    agentUuid: string;
+    threadUuid: string;
+    liveActivityUuid: string;
+    installationUuid: string;
+    promptUuid: string;
+    pushToken: string;
+};
+
+const validatePushToken = (pushToken: string): void => {
+    if (pushToken.trim().length === 0 || pushToken.length > 4096) {
+        throw new ParameterError('Push token is invalid');
+    }
+};
+
+export class MobilePushNotificationService {
+    private readonly mobilePushNotificationStore: MobilePushNotificationStore;
+
+    private readonly threadStore: MobilePushThreadStore;
+
+    private readonly config: MobilePushNotificationsConfig;
+
+    private readonly scheduler: MobilePushNotificationServiceDependencies['scheduler'];
+
+    private readonly reconciler: MobilePushNotificationServiceDependencies['reconciler'];
+
+    private readonly analytics: MobilePushNotificationServiceDependencies['analytics'];
+
+    constructor(dependencies: MobilePushNotificationServiceDependencies) {
+        this.mobilePushNotificationStore =
+            dependencies.mobilePushNotificationStore;
+        this.threadStore = dependencies.threadStore;
+        this.config = dependencies.mobilePushNotificationsConfig;
+        this.scheduler = dependencies.scheduler;
+        this.reconciler = dependencies.reconciler;
+        this.analytics = dependencies.analytics;
+    }
+
+    private track(event: MobilePushNotificationEvent): void {
+        try {
+            this.analytics.track(event);
+        } catch (error) {
+            Logger.warn('Unable to track mobile push analytics', {
+                event: event.event,
+                error,
+            });
+        }
+    }
+
+    getStatus(): {
+        enabled: boolean;
+        environments: MobilePushEnvironment[];
+    } {
+        const environments: MobilePushEnvironment[] = [];
+        if (this.config.sandbox !== undefined) environments.push('sandbox');
+        if (this.config.production !== undefined)
+            environments.push('production');
+
+        return {
+            enabled: this.config.enabled,
+            environments: this.config.enabled ? environments : [],
+        };
+    }
+
+    async registerInstallation(args: {
+        user: MobilePushUser;
+        installationUuid: string;
+        environment: MobilePushEnvironment;
+        deviceToken: string;
+    }): Promise<void> {
+        if (!this.config.enabled) return;
+        validatePushToken(args.deviceToken);
+        const { organizationUuid } = args.user;
+        if (
+            organizationUuid == null ||
+            this.config[args.environment] === undefined
+        ) {
+            throw new NotFoundError('Mobile push registration not found');
+        }
+
+        await this.mobilePushNotificationStore.upsertInstallation({
+            installationUuid: args.installationUuid,
+            organizationUuid,
+            userUuid: args.user.userUuid,
+            environment: args.environment,
+            deviceToken: args.deviceToken,
+        });
+        this.track({
+            event: 'mobile_push.installation_registered',
+            userId: args.user.userUuid,
+            properties: {
+                organizationId: organizationUuid,
+                installationId: args.installationUuid,
+                environment: args.environment,
+            },
+        });
+    }
+
+    async revokeInstallation(args: {
+        user: MobilePushUser;
+        installationUuid: string;
+    }): Promise<void> {
+        const { organizationUuid } = args.user;
+        if (organizationUuid == null) return;
+
+        await this.mobilePushNotificationStore.deleteInstallation({
+            installationUuid: args.installationUuid,
+            organizationUuid,
+            userUuid: args.user.userUuid,
+        });
+    }
+
+    async revokeLiveActivity(args: {
+        user: MobilePushUser;
+        installationUuid: string;
+        projectUuid: string;
+        agentUuid: string;
+        threadUuid: string;
+        liveActivityUuid: string;
+    }): Promise<void> {
+        const { organizationUuid } = args.user;
+        if (organizationUuid == null) return;
+
+        await this.mobilePushNotificationStore.deleteLiveActivity({
+            installationUuid: args.installationUuid,
+            organizationUuid,
+            userUuid: args.user.userUuid,
+            projectUuid: args.projectUuid,
+            agentUuid: args.agentUuid,
+            threadUuid: args.threadUuid,
+            liveActivityUuid: args.liveActivityUuid,
+        });
+    }
+
+    async enqueueThreadReconciliation(threadUuid: string): Promise<void> {
+        if (!this.config.enabled) return;
+        const activities =
+            await this.mobilePushNotificationStore.findActiveLiveActivitiesForThread(
+                threadUuid,
+            );
+        await Promise.all(
+            activities.map((activity) =>
+                this.scheduler.mobilePushLiveActivity(activity),
+            ),
+        );
+    }
+
+    async sweepLiveActivities(now: Date = new Date()): Promise<void> {
+        if (!this.config.enabled) return;
+        const activities =
+            await this.mobilePushNotificationStore.findLiveActivitiesDueForReconciliation(
+                new Date(now.getTime() + 60 * 1000),
+                500,
+            );
+        await Promise.all(
+            activities.map((activity) =>
+                this.scheduler.mobilePushLiveActivity(activity),
+            ),
+        );
+    }
+
+    async reconcileLiveActivity(liveActivityUuid: string): Promise<void> {
+        if (!this.config.enabled) return;
+        await this.reconciler.reconcileLiveActivity(liveActivityUuid);
+    }
+
+    async registerLiveActivity(args: RegisterLiveActivity): Promise<void> {
+        if (!this.config.enabled) return;
+        validatePushToken(args.pushToken);
+        const { organizationUuid } = args.user;
+        if (organizationUuid == null) {
+            throw new NotFoundError('Mobile push registration not found');
+        }
+
+        const [installation, existingActivity, ownership, prompt] =
+            await Promise.all([
+                this.mobilePushNotificationStore.findInstallation(
+                    args.installationUuid,
+                ),
+                this.mobilePushNotificationStore.findLiveActivityOwner(
+                    args.liveActivityUuid,
+                ),
+                this.threadStore.findThreadOwnership({
+                    organizationUuid,
+                    threadUuid: args.threadUuid,
+                }),
+                this.threadStore.findWebAppPrompt(args.promptUuid),
+            ]);
+
+        if (
+            installation?.organizationUuid !== organizationUuid ||
+            installation.userUuid !== args.user.userUuid ||
+            (existingActivity !== undefined &&
+                (existingActivity.mobilePushInstallationUuid !==
+                    installation.mobilePushInstallationUuid ||
+                    existingActivity.organizationUuid !== organizationUuid ||
+                    existingActivity.userUuid !== args.user.userUuid ||
+                    existingActivity.projectUuid !== args.projectUuid ||
+                    existingActivity.agentUuid !== args.agentUuid ||
+                    existingActivity.threadUuid !== args.threadUuid ||
+                    existingActivity.promptUuid !== args.promptUuid)) ||
+            ownership?.projectUuid !== args.projectUuid ||
+            ownership.agentUuid !== args.agentUuid ||
+            ownership.ownerUserUuid !== args.user.userUuid ||
+            ownership.threadUuid !== args.threadUuid ||
+            ownership.createdFrom !== 'web_app' ||
+            ownership.ownerIsServiceAccount ||
+            prompt?.organizationUuid !== organizationUuid ||
+            prompt.projectUuid !== args.projectUuid ||
+            prompt.agentUuid !== args.agentUuid ||
+            prompt.threadUuid !== args.threadUuid ||
+            prompt.createdByUserUuid !== args.user.userUuid
+        ) {
+            throw new NotFoundError('Mobile push registration not found');
+        }
+
+        await this.mobilePushNotificationStore.upsertLiveActivity({
+            liveActivityUuid: args.liveActivityUuid,
+            mobilePushInstallationUuid: installation.mobilePushInstallationUuid,
+            organizationUuid,
+            userUuid: args.user.userUuid,
+            projectUuid: args.projectUuid,
+            agentUuid: args.agentUuid,
+            threadUuid: args.threadUuid,
+            promptUuid: args.promptUuid,
+            pushToken: args.pushToken,
+        });
+        this.track({
+            event: 'mobile_push.live_activity_registered',
+            userId: args.user.userUuid,
+            properties: {
+                organizationId: organizationUuid,
+                projectId: args.projectUuid,
+                agentId: args.agentUuid,
+                threadId: args.threadUuid,
+                promptId: args.promptUuid,
+                installationId: args.installationUuid,
+                liveActivityId: args.liveActivityUuid,
+                environment: installation.environment,
+            },
+        });
+        await this.scheduler.mobilePushLiveActivity({
+            liveActivityUuid: args.liveActivityUuid,
+            organizationUuid,
+            projectUuid: args.projectUuid,
+            userUuid: args.user.userUuid,
+        });
+    }
+}

--- a/packages/backend/src/models/ModelRepository.ts
+++ b/packages/backend/src/models/ModelRepository.ts
@@ -190,6 +190,7 @@ export type ModelManifest = {
     aiRouterModel: unknown;
     mcpToolCallModel: unknown;
     managedAgentModel: unknown;
+    mobilePushNotificationModel: unknown;
     aiOrganizationSettingsModel: unknown;
     embedModel: unknown;
     serviceAccountModel: unknown;
@@ -930,6 +931,10 @@ export class ModelRepository
 
     public getAiAgentModel<ModelImplT>(): ModelImplT {
         return this.getModel('aiAgentModel');
+    }
+
+    public getMobilePushNotificationModel<ModelImplT>(): ModelImplT {
+        return this.getModel('mobilePushNotificationModel');
     }
 
     public getAiAgentMemoryModel<ModelImplT>(): ModelImplT {

--- a/packages/backend/src/scheduler/SchedulerTaskTracer.ts
+++ b/packages/backend/src/scheduler/SchedulerTaskTracer.ts
@@ -278,6 +278,13 @@ const getTagsForTask: {
     [SCHEDULER_TASKS.SWEEP_STALE_AI_WRITEBACK_RUNS]: () => ({}),
     [SCHEDULER_TASKS.SWEEP_STALE_AI_DEEP_RESEARCH_RUNS]: () => ({}),
     [SCHEDULER_TASKS.SWEEP_AI_AGENT_MEMORY_THREADS]: () => ({}),
+    [SCHEDULER_TASKS.MOBILE_PUSH_LIVE_ACTIVITY]: (payload) => ({
+        'organization.uuid': payload.organizationUuid,
+        'project.uuid': payload.projectUuid,
+        'user.uuid': payload.userUuid,
+        'mobile_push.live_activity_uuid': payload.liveActivityUuid,
+    }),
+    [SCHEDULER_TASKS.SWEEP_MOBILE_PUSH_LIVE_ACTIVITIES]: () => ({}),
     [SCHEDULER_TASKS.AI_AGENT_MEMORY_DISTILL]: (payload) => ({
         'organization.uuid': payload.organizationUuid,
         'project.uuid': payload.projectUuid,

--- a/packages/backend/src/scripts/rotate-lightdash-secret/registry.ts
+++ b/packages/backend/src/scripts/rotate-lightdash-secret/registry.ts
@@ -102,6 +102,16 @@ export const CIPHERTEXT_REGISTRY: CiphertextRegistryEntry[] = [
         column: 'service_account_token',
     },
     {
+        table: 'mobile_push_installations',
+        primaryKeyColumn: 'mobile_push_installation_uuid',
+        column: 'encrypted_device_token',
+    },
+    {
+        table: 'ai_agent_live_activities',
+        primaryKeyColumn: 'live_activity_uuid',
+        column: 'encrypted_push_token',
+    },
+    {
         table: 'ai_mcp_server_credential',
         primaryKeyColumn: 'ai_mcp_server_credential_uuid',
         column: 'encrypted_credentials',

--- a/packages/backend/src/scripts/rotate-lightdash-secret/rotation.test.ts
+++ b/packages/backend/src/scripts/rotate-lightdash-secret/rotation.test.ts
@@ -49,7 +49,7 @@ afterEach(() => {
 });
 
 describe('ciphertext registry', () => {
-    test('contains the full 22-field inventory', () => {
+    test('contains the full 24-field inventory', () => {
         expect(
             CIPHERTEXT_REGISTRY.map((e) => `${e.table}.${e.column}`),
         ).toEqual([
@@ -71,6 +71,8 @@ describe('ciphertext registry', () => {
             'organization_sso_configurations.config',
             'embedding.encoded_secret',
             'managed_agent_settings.service_account_token',
+            'mobile_push_installations.encrypted_device_token',
+            'ai_agent_live_activities.encrypted_push_token',
             'ai_mcp_server_credential.encrypted_credentials',
             'ai_organization_settings.encrypted_provider_api_keys',
             'external_connection_secrets.encrypted_payload',

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -199,6 +199,7 @@ interface ServiceManifest {
     externalConnectionCoderService: unknown;
     instanceConfigurationService: unknown;
     managedAgentService: unknown;
+    mobilePushNotificationService: unknown;
     mcpService: unknown;
     rolesService: RolesService;
     slackService: SlackService;
@@ -1730,6 +1731,25 @@ export class ServiceRepository
         ManagedAgentServiceImplT,
     >(): ManagedAgentServiceImplT {
         return this.getService('managedAgentService');
+    }
+
+    public getMobilePushNotificationService<
+        MobilePushNotificationServiceImplT,
+    >(): MobilePushNotificationServiceImplT {
+        return this.getService(
+            'mobilePushNotificationService',
+            () =>
+                ({
+                    getStatus: () => ({ enabled: false, environments: [] }),
+                    registerInstallation: async () => undefined,
+                    revokeInstallation: async () => undefined,
+                    registerLiveActivity: async () => undefined,
+                    revokeLiveActivity: async () => undefined,
+                    enqueueThreadReconciliation: async () => undefined,
+                    sweepLiveActivities: async () => undefined,
+                    reconcileLiveActivity: async () => undefined,
+                }) as MobilePushNotificationServiceImplT,
+        );
     }
 
     public getMcpService<McpServiceImplT>(): McpServiceImplT {

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -105,6 +105,7 @@ export * from './types/any';
 export * from './types/api';
 export * from './types/api/comments';
 export * from './types/api/errors';
+export * from './types/api/mobilePushNotifications';
 export * from './types/api/notifications';
 export * from './types/api/paginatedQuery';
 export * from './types/api/parameters';

--- a/packages/common/src/types/api/mobilePushNotifications.ts
+++ b/packages/common/src/types/api/mobilePushNotifications.ts
@@ -1,0 +1,24 @@
+import { type ApiSuccess, type ApiSuccessEmpty } from './success';
+import { type UUID } from './uuid';
+
+export type MobilePushEnvironment = 'sandbox' | 'production';
+
+export type ApiMobilePushNotificationStatusResponse = ApiSuccess<{
+    enabled: boolean;
+    environments: MobilePushEnvironment[];
+}>;
+
+export type ApiMobilePushInstallationRequest = {
+    environment: MobilePushEnvironment;
+    deviceToken: string;
+};
+
+export type ApiMobilePushInstallationResponse = ApiSuccessEmpty;
+
+export type ApiMobilePushLiveActivityRequest = {
+    installationUuid: UUID;
+    promptUuid: UUID;
+    pushToken: string;
+};
+
+export type ApiMobilePushLiveActivityResponse = ApiSuccessEmpty;

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -159,6 +159,10 @@ export type AiAgentMemoryConsolidatePartitionJobPayload = TraceTaskBase & {
     ownerUserUuid: UUID;
 };
 
+export type MobilePushLiveActivityJobPayload = TraceTaskBase & {
+    liveActivityUuid: UUID;
+};
+
 export const EE_SCHEDULER_TASKS = {
     SLACK_AI_PROMPT: 'slackAiPrompt',
     AI_AGENT_EVAL_RESULT: 'aiAgentEvalResult',
@@ -192,6 +196,8 @@ export const EE_SCHEDULER_TASKS = {
     INGEST_EXTERNAL_SOURCE: 'ingestExternalSource',
     INGEST_EXTERNAL_SOURCE_ATTACHMENT: 'ingestExternalSourceAttachment',
     MAINTAIN_EXTERNAL_SOURCES: 'maintainExternalSources',
+    MOBILE_PUSH_LIVE_ACTIVITY: 'mobilePushLiveActivity',
+    SWEEP_MOBILE_PUSH_LIVE_ACTIVITIES: 'sweepMobilePushLiveActivities',
 } as const;
 
 export const SCHEDULER_TASKS = {
@@ -309,6 +315,8 @@ export interface TaskPayloadMap {
     [SCHEDULER_TASKS.INGEST_EXTERNAL_SOURCE]: IngestExternalSourceJobPayload;
     [SCHEDULER_TASKS.INGEST_EXTERNAL_SOURCE_ATTACHMENT]: IngestExternalSourceJobPayload;
     [SCHEDULER_TASKS.MAINTAIN_EXTERNAL_SOURCES]: Record<string, never>;
+    [SCHEDULER_TASKS.MOBILE_PUSH_LIVE_ACTIVITY]: MobilePushLiveActivityJobPayload;
+    [SCHEDULER_TASKS.SWEEP_MOBILE_PUSH_LIVE_ACTIVITIES]: Record<string, never>;
     [SCHEDULER_TASKS.AI_WRITEBACK_PIPELINE]: AiWritebackPipelineJobPayload;
     [SCHEDULER_TASKS.AI_DEEP_RESEARCH]: AiDeepResearchPipelineJobPayload;
     [SCHEDULER_TASKS.AGENT_ONBOARDING_RUN]: AgentOnboardingPipelineJobPayload;
@@ -348,6 +356,11 @@ export interface EETaskPayloadMap {
     [EE_SCHEDULER_TASKS.INGEST_EXTERNAL_SOURCE]: IngestExternalSourceJobPayload;
     [EE_SCHEDULER_TASKS.INGEST_EXTERNAL_SOURCE_ATTACHMENT]: IngestExternalSourceJobPayload;
     [EE_SCHEDULER_TASKS.MAINTAIN_EXTERNAL_SOURCES]: Record<string, never>;
+    [EE_SCHEDULER_TASKS.MOBILE_PUSH_LIVE_ACTIVITY]: MobilePushLiveActivityJobPayload;
+    [EE_SCHEDULER_TASKS.SWEEP_MOBILE_PUSH_LIVE_ACTIVITIES]: Record<
+        string,
+        never
+    >;
 }
 
 export type SchedulerTaskName =


### PR DESCRIPTION
## What changes

- Register iOS installations and Live Activity push tokens.
- Reconcile the existing agent thread state through APNs.
- End stale activities and remove rejected tokens.
- Keep completion alert delivery disabled until the approved copy is set.

## Safety

- Enable push delivery only on Lightdash Cloud with configured APNs credentials.
- Return an unavailable status and no-op on self-hosted instances.
- Encrypt device and Live Activity tokens at rest.
- Recheck the installation, organisation, user, project, agent, thread, and prompt ownership chain before registration and delivery.
- Send only state and opaque identifiers in Live Activity payloads.
- Record only identifiers, state, environment, and delivery outcome in analytics.

## Verification

- `pnpm -F backend test` (537 files, 8,459 passed, 1 skipped)
- `pnpm -F backend typecheck`
- `pnpm -F common typecheck`
- Touched backend and common lint checks
- TSOA route and OpenAPI generation
- Focused tests deny cross-user, cross-organisation, cross-project, cross-agent, cross-thread, and cross-prompt registration.

Linear: SPK-1654

## Rollout follow-up

[SPK-1684](https://linear.app/lightdash/issue/SPK-1684/enable-apns-for-live-activities-and-verify-device-delivery) tracks Apple capability setup, APNs credentials, distribution signing, and real-device delivery.

## Security review

DeepSec triage: HIGH. The deferred review is tracked in [SPK-1678](https://linear.app/lightdash/issue/SPK-1678/ios-run-the-deferred-security-scans-from-the-30-august-queue).
