### PR TITLE
fix(ai): remove unused filter arity

### DIFF
--- a/packages/common/src/ee/AiAgent/schemas/filterExpressions/operators.test.ts
+++ b/packages/common/src/ee/AiAgent/schemas/filterExpressions/operators.test.ts
@@ -1,0 +1,25 @@
+import { expect, expectTypeOf, it } from 'vitest';
+import {
+    filterExpressionOperatorDefinitions,
+    type FilterExpressionArgumentCount,
+} from './operators';
+
+it('keeps expected arities aligned with canonical operators', () => {
+    expectTypeOf<3>().not.toExtend<FilterExpressionArgumentCount>();
+
+    const argumentCounts = filterExpressionOperatorDefinitions.flatMap(
+        ({ argumentCountByFilterType }) =>
+            Object.values(argumentCountByFilterType).filter(
+                (argumentCount) => argumentCount !== null,
+            ),
+    );
+
+    const expectedArgumentCounts = [
+        0,
+        1,
+        2,
+        'oneOrMore',
+    ] satisfies FilterExpressionArgumentCount[];
+
+    expect(new Set(argumentCounts)).toEqual(new Set(expectedArgumentCounts));
+});

--- a/packages/common/src/ee/AiAgent/schemas/filterExpressions/operators.ts
+++ b/packages/common/src/ee/AiAgent/schemas/filterExpressions/operators.ts
@@ -1,6 +1,6 @@
 import { FilterOperator, FilterType } from '../../../../types/filter';
 
-export type FilterExpressionArgumentCount = 0 | 1 | 2 | 3 | 'oneOrMore';
+export type FilterExpressionArgumentCount = 0 | 1 | 2 | 'oneOrMore';
 
 export type FilterExpressionOperatorDefinition = {
     operator: FilterOperator;


### PR DESCRIPTION
Closes: ZAP-963
Closes: ZAP-920
Closes: #28262

Removes unsupported `3` from the valid filter-expression argument count (arity). No operator accepts exactly three values.

Adds type-level coverage excluding `3` and a runtime assertion that canonical operators use only the supported counts.

Risk: low — narrows an internal type to values already used at runtime; query behavior and contracts are unchanged.

Verification:
- 71 filter-expression tests
- common typecheck, lint, and format
- signed commit
