### PR TITLE
feat(ai-agent): generateDataApp brief carries thread analysis; unknown slugs are agent errors, not incidents

### DIFF
--- a/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.test.ts
@@ -3050,4 +3050,75 @@ describe('AiAgentToolsService generateDataApp', () => {
         ).rejects.toThrow('generateDataApp requires a prompt');
         expect(appGenerateService.generateApp).not.toHaveBeenCalled();
     });
+
+    it.each([
+        ['pdf', 'pdf'],
+        [null, undefined],
+    ] as const)(
+        'starts the build with template %s → %s',
+        async (template, expected) => {
+            const appGenerateService = makeAppGenerateService();
+            const service = makeService({ appGenerateService });
+
+            await runGenerate(
+                service,
+                makeRuntimeContext({ promptUuid: 'prompt-uuid' }),
+                { template },
+            );
+
+            const [, , , , , , , builderTemplate] =
+                appGenerateService.generateApp.mock.calls[0];
+            expect(builderTemplate).toBe(expected);
+        },
+    );
+
+    it('names an unknown dashboard slug and starts no build', async () => {
+        const appGenerateService = makeAppGenerateService();
+        const service = makeService({
+            appGenerateService,
+            dashboardService: {
+                getByIdOrSlug: vi
+                    .fn()
+                    .mockRejectedValue(
+                        new NotFoundError('Dashboard not found'),
+                    ),
+            },
+        });
+
+        await expect(
+            runGenerate(
+                service,
+                makeRuntimeContext({ promptUuid: 'prompt-uuid' }),
+                { dashboardSlug: 'no-such-dashboard' },
+            ),
+        ).rejects.toThrow('Dashboard "no-such-dashboard" was not found');
+        expect(appGenerateService.generateApp).not.toHaveBeenCalled();
+    });
+
+    it('names the unknown chart slug among known ones and starts no build', async () => {
+        const appGenerateService = makeAppGenerateService();
+        const service = makeService({
+            appGenerateService,
+            savedChartService: {
+                get: vi.fn().mockImplementation(async (slug: string) => {
+                    if (slug === 'revenue') {
+                        return {
+                            uuid: 'chart-uuid',
+                            spaceUuid: 'sales-space-uuid',
+                        };
+                    }
+                    throw new NotFoundError('Saved chart not found');
+                }),
+            },
+        });
+
+        await expect(
+            runGenerate(
+                service,
+                makeRuntimeContext({ promptUuid: 'prompt-uuid' }),
+                { chartSlugs: ['revenue', 'no-such-chart'] },
+            ),
+        ).rejects.toThrow('Chart "no-such-chart" was not found');
+        expect(appGenerateService.generateApp).not.toHaveBeenCalled();
+    });
 });

--- a/packages/backend/src/ee/services/ai/prompts/systemV2.test.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2.test.ts
@@ -709,3 +709,28 @@ describe('getSystemPromptV2 repo-fs code search caveat', () => {
         );
     });
 });
+
+describe('getSystemPromptV2 data apps', () => {
+    test('teaches generateDataApp when enabled', () => {
+        const content = promptText({
+            availableExplores: [],
+            enableContentTools: true,
+            enableGenerateDataApp: true,
+        });
+        expect(content).toContain('## Data apps');
+        expect(content).toContain('generateDataApp');
+        expect(content).toContain('dashboardSlug');
+        expect(content).toContain('chartSlugs');
+        expect(content).not.toContain('{{generate_data_app_section}}');
+    });
+
+    test('omits the data apps section when the tool is absent', () => {
+        const content = promptText({
+            availableExplores: [],
+            enableContentTools: true,
+        });
+        expect(content).not.toContain('## Data apps');
+        expect(content).not.toContain('generateDataApp');
+        expect(content).not.toContain('{{generate_data_app_section}}');
+    });
+});

--- a/packages/backend/src/ee/services/ai/prompts/systemV2DataApps.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2DataApps.ts
@@ -1,9 +1,14 @@
+import { DATA_APP_VIZ_LINE_FORMAT } from '@lightdash/common';
+
 export const GENERATE_DATA_APP_SECTION = `
 ## Data apps
 
-- When the user asks you to build a data app (an interactive app, a slide show, or a PDF report), use the generateDataApp tool. It starts the build and returns immediately; the build itself runs in the background for several minutes.
-  - Write the prompt as a self-contained brief for the coding agent, which sees the semantic layer but not this conversation. Fold in the analysis done here: for each visualization the app should include, add a line like \`[viz name][metric query]\` describing the explore, metrics, dimensions, filters and sort.
-  - To generate from an existing dashboard or saved charts, pass their slugs (from findContent) as dashboardSlug / chartSlugs.
-  - After the call, tell the user the build has started and will take a few minutes, then end your turn. Do not wait, poll, or call generateDataApp again for the same request.
-- When the user later asks about the app ("where's that app?", "is it done?"), read the outcome from the earlier generateDataApp tool result in this conversation: "success" carries the app name and a builder link (href) to share; "error" carries the failure message; "pending" means it is still building. Do not start another build unless the user asks for a new one.
-- Data apps cannot be created or edited with the content tools; readContent (type data_app) reads a finished app.`;
+generateDataApp starts a data app build — an interactive app, a slide show, or a PDF report — from a brief. The build runs in the background for several minutes; the call returns as soon as it has started.
+
+- The brief is for the coding agent, which sees the semantic layer but not this conversation. Make it self-contained: what the app shows, for whom, and how it behaves.
+- Carry this thread's analysis into the brief as a collection of visualizations. For each one the app should include, write its title, a one-line description, and a metric query line — \`${DATA_APP_VIZ_LINE_FORMAT}\` — so the coding agent rebuilds the same query from the semantic layer.
+- Generate from existing content by slug (from findContent): dashboardSlug for a dashboard's layout and charts, chartSlugs for saved charts to build on. The source content stays unchanged. An unknown slug returns an error naming it and creates no app: look the content up with findContent and retry with the right slug, or ask the user which one they meant.
+- Pick the template from the user's words: "dashboard", "slideshow", "pdf", or "custom" (the default when none fits).
+- One request, one call: once it returns, tell the user the build has started and will take a few minutes, then end your turn. The outcome lands on this call's result for a later turn.
+- When the user later asks about the app, read the outcome from the earlier generateDataApp result: "success" carries the app name and the builder link (href) to share; "error" carries the failure message; "pending" means still building. Start a new build only when the user asks for another app.
+- readContent (type data_app) reads a finished app; the content tools create and edit charts and dashboards, never data apps.`;

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -3860,7 +3860,7 @@ Parameters:
     },
   },
   {
-    "description": "Start building a data app — an interactive application generated from a prompt on top of this project's semantic layer. Use it ONLY when the user asks to build, make, or generate a data app (or an app, slide show, or PDF report). Do NOT use it for questions, charts, dashboards, or other saved content. The build runs in the background for several minutes, so the call returns as soon as it has started (status: "pending"). Tell the user the build has started and that you will be able to link them to the app afterwards, then end your turn. Never wait, poll, or call this tool again for the same request: one request, one call. A later turn sees the outcome on this call's result: "success" carries the app name and the builder link (href) to share; "error" carries the failure message.",
+    "description": "Start building a data app — an interactive application generated from a brief on top of this project's semantic layer. Use it when the user asks to build, make, or generate a data app (or an app, slide show, or PDF report); questions, charts, dashboards, and other saved content have their own tools. The build runs in the background for several minutes, so the call returns as soon as it has started (status: "pending"). One request, one call: tell the user the build has started and that you will link them to the app afterwards, then end your turn — never wait, poll, or call this tool again for the same request. A later turn sees the outcome on this call's result: "success" carries the app name and the builder link (href) to share; "error" carries the failure message.",
     "inputSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": false,
@@ -3877,17 +3877,19 @@ Parameters:
               "type": "null",
             },
           ],
-          "description": "Saved charts (slugs from findContent) whose queries the app should be built on. Null when not building on saved charts.",
+          "default": null,
+          "description": "Saved charts (slugs from findContent) whose queries the app is built on; the charts themselves stay unchanged. Omit when not building on saved charts.",
         },
         "dashboardSlug": {
-          "description": "Generate from an existing dashboard: its slug (from findContent). The app starts from the dashboard's layout and charts. Null when not generating from a dashboard.",
+          "default": null,
+          "description": "Generate from an existing dashboard: its slug (from findContent). The app starts from the dashboard's layout and charts; the dashboard itself stays unchanged. Omit when not generating from a dashboard.",
           "type": [
             "string",
             "null",
           ],
         },
         "prompt": {
-          "description": "A self-contained brief for the coding agent that builds the app: what the app shows, for whom, and how it should behave. Fold in what this thread found — for each visualization the app should include, add a line like \`[viz name][metric query]\` with the explore, metrics, dimensions, filters and sort. The coding agent sees the semantic layer but not this conversation, so include every detail it needs.",
+          "description": "A self-contained brief for the coding agent that builds the app: what the app shows, for whom, and how it behaves. Carry this thread's analysis in as a collection of visualizations — for each one, its title, a one-line description, and a metric query line \`[viz title][explore; metrics; dimensions; filters; sort]\`. The coding agent sees the semantic layer but not this conversation, so include every detail it needs.",
           "type": "string",
         },
         "template": {
@@ -3905,14 +3907,12 @@ Parameters:
               "type": "null",
             },
           ],
-          "description": "Starting template: "dashboard" for a dashboard-style app, "slideshow" for a slide show, "pdf" for a PDF report, "custom" (or null) for anything else.",
+          "default": null,
+          "description": "Starter template the builder would use: "dashboard" for a dashboard-style app, "slideshow" for a slide show, "pdf" for a PDF report, "custom" for anything else. Omit when the user did not ask for one.",
         },
       },
       "required": [
         "prompt",
-        "template",
-        "dashboardSlug",
-        "chartSlugs",
       ],
       "type": "object",
     },

--- a/packages/backend/src/ee/services/ai/tools/generateDataApp.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/generateDataApp.test.ts
@@ -1,4 +1,17 @@
+import { NotFoundError } from '@lightdash/common';
+import * as Sentry from '@sentry/node';
 import { getGenerateDataApp } from './generateDataApp';
+
+vi.mock('@sentry/node', () => ({
+    captureException: vi.fn(),
+}));
+
+vi.mock('../../../../logging/logger', () => ({
+    __esModule: true,
+    default: { error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+const captureException = Sentry.captureException as import('vitest').Mock;
 
 type GenerateDataAppTool = ReturnType<typeof getGenerateDataApp>;
 type GenerateDataAppOutput = {
@@ -23,6 +36,10 @@ const executeGenerateDataApp = (tool: GenerateDataAppTool) =>
     ) as Promise<GenerateDataAppOutput>;
 
 describe('getGenerateDataApp', () => {
+    beforeEach(() => {
+        captureException.mockClear();
+    });
+
     it('forwards the args and the tool call id, returning a pending result', async () => {
         const generateDataApp = vi
             .fn()
@@ -61,5 +78,26 @@ describe('getGenerateDataApp', () => {
             reason: 'failed',
             message: 'Data apps are not enabled',
         });
+    });
+
+    it('reports an unknown slug as an error naming it, without paging Sentry', async () => {
+        const generateDataApp = vi
+            .fn()
+            .mockRejectedValue(
+                new NotFoundError('Chart "no-such-chart" was not found'),
+            );
+
+        const output = await executeGenerateDataApp(
+            getGenerateDataApp({ generateDataApp }),
+        );
+
+        expect(output.metadata).toEqual({
+            status: 'error',
+            appUuid: null,
+            reason: 'failed',
+            message: 'Chart "no-such-chart" was not found',
+        });
+        expect(output.result).toContain('No app was created');
+        expect(captureException).not.toHaveBeenCalled();
     });
 });

--- a/packages/backend/src/ee/services/ai/tools/generateDataApp.ts
+++ b/packages/backend/src/ee/services/ai/tools/generateDataApp.ts
@@ -1,6 +1,7 @@
 import {
     generateDataAppToolDefinition,
     getErrorMessage,
+    NotFoundError,
 } from '@lightdash/common';
 import { tool } from 'ai';
 import type { GenerateDataAppFn } from '../types/aiAgentDependencies';
@@ -42,6 +43,8 @@ export const getGenerateDataApp = ({ generateDataApp }: Dependencies) =>
                     result: toolErrorHandler(
                         error,
                         'Error starting the data app build. No app was created.',
+                        // An unknown slug is the agent's mistake, not an incident.
+                        { captureToSentry: !(error instanceof NotFoundError) },
                     ),
                     metadata: {
                         status: 'error' as const,

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolGenerateDataAppArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolGenerateDataAppArgs.ts
@@ -3,23 +3,29 @@ import {
     APP_VERSION_CANCELLED_BY_USER,
     isAppVersionInProgress,
     type AppVersionStatus,
+    type DataAppTemplate,
 } from '../../../apps/types';
 
 /** Builds run minutes, not seconds: a pending result older than this is stale. */
 export const AI_DATA_APP_BUILD_PENDING_GRACE_MS = 30 * 60 * 1000;
 
+/** Builder starter templates the AI agent may pick; the viz renderer template is internal. */
 export const DATA_APP_BUILD_TEMPLATES = [
     'dashboard',
     'slideshow',
     'pdf',
     'custom',
-] as const;
+] as const satisfies readonly DataAppTemplate[];
 export type DataAppBuildTemplate = (typeof DATA_APP_BUILD_TEMPLATES)[number];
 
+/** How a prior visualization's query travels in the brief; shared with the system prompt. */
+export const DATA_APP_VIZ_LINE_FORMAT =
+    '[viz title][explore; metrics; dimensions; filters; sort]';
+
 export const TOOL_GENERATE_DATA_APP_DESCRIPTION = [
-    "Start building a data app — an interactive application generated from a prompt on top of this project's semantic layer.",
-    'Use it ONLY when the user asks to build, make, or generate a data app (or an app, slide show, or PDF report). Do NOT use it for questions, charts, dashboards, or other saved content.',
-    'The build runs in the background for several minutes, so the call returns as soon as it has started (status: "pending"). Tell the user the build has started and that you will be able to link them to the app afterwards, then end your turn. Never wait, poll, or call this tool again for the same request: one request, one call.',
+    "Start building a data app — an interactive application generated from a brief on top of this project's semantic layer.",
+    'Use it when the user asks to build, make, or generate a data app (or an app, slide show, or PDF report); questions, charts, dashboards, and other saved content have their own tools.',
+    'The build runs in the background for several minutes, so the call returns as soon as it has started (status: "pending"). One request, one call: tell the user the build has started and that you will link them to the app afterwards, then end your turn — never wait, poll, or call this tool again for the same request.',
     'A later turn sees the outcome on this call\'s result: "success" carries the app name and the builder link (href) to share; "error" carries the failure message.',
 ].join(' ');
 
@@ -27,25 +33,28 @@ export const toolGenerateDataAppArgsSchema = z.object({
     prompt: z
         .string()
         .describe(
-            'A self-contained brief for the coding agent that builds the app: what the app shows, for whom, and how it should behave. Fold in what this thread found — for each visualization the app should include, add a line like `[viz name][metric query]` with the explore, metrics, dimensions, filters and sort. The coding agent sees the semantic layer but not this conversation, so include every detail it needs.',
+            `A self-contained brief for the coding agent that builds the app: what the app shows, for whom, and how it behaves. Carry this thread's analysis in as a collection of visualizations — for each one, its title, a one-line description, and a metric query line \`${DATA_APP_VIZ_LINE_FORMAT}\`. The coding agent sees the semantic layer but not this conversation, so include every detail it needs.`,
         ),
     template: z
         .enum(DATA_APP_BUILD_TEMPLATES)
-        .nullable()
+        .nullish()
+        .default(null)
         .describe(
-            'Starting template: "dashboard" for a dashboard-style app, "slideshow" for a slide show, "pdf" for a PDF report, "custom" (or null) for anything else.',
+            'Starter template the builder would use: "dashboard" for a dashboard-style app, "slideshow" for a slide show, "pdf" for a PDF report, "custom" for anything else. Omit when the user did not ask for one.',
         ),
     dashboardSlug: z
         .string()
-        .nullable()
+        .nullish()
+        .default(null)
         .describe(
-            "Generate from an existing dashboard: its slug (from findContent). The app starts from the dashboard's layout and charts. Null when not generating from a dashboard.",
+            "Generate from an existing dashboard: its slug (from findContent). The app starts from the dashboard's layout and charts; the dashboard itself stays unchanged. Omit when not generating from a dashboard.",
         ),
     chartSlugs: z
         .array(z.string())
-        .nullable()
+        .nullish()
+        .default(null)
         .describe(
-            'Saved charts (slugs from findContent) whose queries the app should be built on. Null when not building on saved charts.',
+            'Saved charts (slugs from findContent) whose queries the app is built on; the charts themselves stay unchanged. Omit when not building on saved charts.',
         ),
 });
 


### PR DESCRIPTION
Completes ZAP-959 on top of #28261 / #28255, which shipped the generateDataApp mechanics (slug→uuid resolution, template pass-through, not-found errors naming the slug). This PR adds the remaining pieces:

- **Brief carries the thread's analysis** — system prompt and tool schema instruct the agent to fold prior visualizations into the brief as a title, a one-line description, and a metric query line; the line format is a single shared constant (`DATA_APP_VIZ_LINE_FORMAT`) so prompt and schema can't drift. `dashboardSlug`/`chartSlugs` are documented as leaving the source content unchanged; `template` picks the builder starter. `DATA_APP_BUILD_TEMPLATES` now `satisfies readonly DataAppTemplate[]`.
- **Unknown slugs are agent errors, not incidents** — a `NotFoundError` from slug resolution no longer pages Sentry from the tool error path; the agent gets the named slug back and can retry via findContent or ask the user.
- **Tests** — template mapping (incl. `null → undefined`), unknown dashboard / unknown chart slug names the offender and starts no build, data-apps prompt section present/absent, tool-level not-found result without Sentry capture; contract snapshot updated.

Verified end-to-end locally: a real agent call built a ready dashboard-template app from a dashboard slug + chart slug + thread-analysis brief (resolved uuids persisted on resources, source versions unchanged), and an unknown-slug call returned the named error with no app created.

Closes: ZAP-959
