### PR TITLE
test: remove flaky catalog attribute tests

### DIFF
--- a/packages/api-tests/tests/catalog.test.ts
+++ b/packages/api-tests/tests/catalog.test.ts
@@ -324,24 +324,6 @@ describe('Lightdash catalog search', () => {
         );
     });
 
-    it('Should filter fields with required attributes (age)', async () => {
-        const projectUuid = SEED_PROJECT.project_uuid;
-        const resp = await admin.get<{ results: unknown[] }>(
-            `${apiUrl}/projects/${projectUuid}/dataCatalog?search=average_age`,
-        );
-        expect(resp.status).toBe(200);
-        expect(resp.body.results).toHaveLength(0);
-    });
-
-    it('Should filter table with required attributes (memberships)', async () => {
-        const projectUuid = SEED_PROJECT.project_uuid;
-        const resp = await admin.get<{ results: unknown[] }>(
-            `${apiUrl}/projects/${projectUuid}/dataCatalog?search=memberships`,
-        );
-        expect(resp.status).toBe(200);
-        expect(resp.body.results).toHaveLength(0);
-    });
-
     describe('user attributes', () => {
         const projectUuid = SEED_PROJECT.project_uuid;
         const requiredAttributeName = 'ua_required';


### PR DESCRIPTION
## Summary

- remove two flaky catalog required-attribute assertions
- preserve newer isolated user-attribute coverage
- failures reproduced across 10 unrelated CI branches during Aug 24–28

## Testing

- `SITE_URL=http://localhost:8082 pnpm -F api-tests exec vitest run --config vitest.config.ts tests/catalog.test.ts`
- `pnpm -F api-tests exec oxfmt tests/catalog.test.ts --check`
- `pnpm -F api-tests exec oxlint -c .oxlintrc.json tests/catalog.test.ts`