### PR TITLE
fix(ai): advertise AND-only field search

### DIFF
--- a/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
@@ -9289,7 +9289,7 @@ Filter expressions use the form "field operator=value".
 
 Available operators: isNull, notNull, equals, notEquals, startsWith, endsWith, include, doesNotInclude, lessThan, lessThanOrEqual, greaterThan, greaterThanOrEqual, inThePast, notInThePast, inTheNext, inTheCurrent, notInTheCurrent, inBetween, notInBetween.
 
-- Join flat rules with AND or OR. Do not mix both connectors in one expression.
+- Join flat rules with AND only. OR is not supported by this tool.
 - Quote values containing commas, braces, equals signs, whitespace, parentheses, backslashes, or reserved words with single or double quotes.
 - Inside quotes, commas and braces are literal; do not backslash-escape them. Backslash escapes quotes, backslashes, slashes, control characters, and four-digit Unicode sequences.
 - Quote unusual field IDs with backticks. AND and OR are reserved field IDs unless quoted.
@@ -9299,6 +9299,9 @@ Available operators: isNull, notNull, equals, notEquals, startsWith, endsWith, i
 - Current dates use one unit (for example inTheCurrent=months).
 - Safety limits: 256 rules per expression, 256 values (including settings) per rule, 256 characters per literal, and 16384 characters per expression.
 - Nested groups and parentheses are not supported yet.
+
+AND-only multiple-rule example:
+- orders_status equals=example AND orders_amount greaterThan=100
 
 Examples by field filter type. Each line is one complete raw string expression:
 string:

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -8154,7 +8154,7 @@ Filter expressions use the form "field operator=value".
 
 Available operators: isNull, notNull, equals, notEquals, startsWith, endsWith, include, doesNotInclude, lessThan, lessThanOrEqual, greaterThan, greaterThanOrEqual, inThePast, notInThePast, inTheNext, inTheCurrent, notInTheCurrent, inBetween, notInBetween.
 
-- Join flat rules with AND or OR. Do not mix both connectors in one expression.
+- Join flat rules with AND only. OR is not supported by this tool.
 - Quote values containing commas, braces, equals signs, whitespace, parentheses, backslashes, or reserved words with single or double quotes.
 - Inside quotes, commas and braces are literal; do not backslash-escape them. Backslash escapes quotes, backslashes, slashes, control characters, and four-digit Unicode sequences.
 - Quote unusual field IDs with backticks. AND and OR are reserved field IDs unless quoted.
@@ -8164,6 +8164,9 @@ Available operators: isNull, notNull, equals, notEquals, startsWith, endsWith, i
 - Current dates use one unit (for example inTheCurrent=months).
 - Safety limits: 256 rules per expression, 256 values (including settings) per rule, 256 characters per literal, and 16384 characters per expression.
 - Nested groups and parentheses are not supported yet.
+
+AND-only multiple-rule example:
+- orders_status equals=example AND orders_amount greaterThan=100
 
 Examples by field filter type. Each line is one complete raw string expression:
 string:

--- a/packages/common/src/ee/AiAgent/schemas/filterExpressions/examples.test.ts
+++ b/packages/common/src/ee/AiAgent/schemas/filterExpressions/examples.test.ts
@@ -3,6 +3,7 @@ import { DimensionType } from '../../../../types/field';
 import { FilterOperator, FilterType } from '../../../../types/filter';
 import { type AiFilterExample } from '../filters/filterExamples';
 import {
+    FILTER_EXPRESSION_AND_ONLY_EXAMPLES_DESCRIPTION,
     FILTER_EXPRESSION_EXAMPLES_DESCRIPTION,
     formatFilterExpressionExample,
     getFilterExpressionExamples,
@@ -48,6 +49,24 @@ describe('filter expression examples', () => {
                 success: true,
             });
         }
+    });
+
+    it('generates an AND-only multiple-rule example', () => {
+        const exampleLine =
+            FILTER_EXPRESSION_AND_ONLY_EXAMPLES_DESCRIPTION.split('\n').find(
+                (line) => line.startsWith('- '),
+            );
+        if (!exampleLine) {
+            throw new Error('Missing generated AND-only example');
+        }
+
+        expect(FILTER_EXPRESSION_AND_ONLY_EXAMPLES_DESCRIPTION).not.toContain(
+            ' OR ',
+        );
+        expect(parseFilterExpression(exampleLine.slice(2))).toMatchObject({
+            success: true,
+            expression: { connector: 'and', rules: [{}, {}] },
+        });
     });
 
     it('quotes protected lexical content without changing its value', () => {

--- a/packages/common/src/ee/AiAgent/schemas/filterExpressions/examples.ts
+++ b/packages/common/src/ee/AiAgent/schemas/filterExpressions/examples.ts
@@ -189,6 +189,29 @@ export const getFilterExpressionExamples = (): FilterExpressionExample[] =>
 
 const filterExpressionExamples = getFilterExpressionExamples();
 
+const getGeneratedExpressionExample = ({
+    fieldFilterType,
+    operator,
+    valueCount,
+}: {
+    fieldFilterType: FilterType;
+    operator: FilterOperator;
+    valueCount: number;
+}) => {
+    const example = filterExpressionExamples.find(
+        (candidate) =>
+            candidate.fieldFilterType === fieldFilterType &&
+            candidate.operator === operator &&
+            candidate.values?.length === valueCount,
+    );
+    if (!example) {
+        throw new Error(
+            `Missing generated ${fieldFilterType} ${operator} filter expression example with ${valueCount} values`,
+        );
+    }
+    return example;
+};
+
 export const FILTER_EXPRESSION_EXAMPLES_DESCRIPTION = [
     'Examples by field filter type. Each line is one complete raw string expression:',
     ...Object.values(FilterType).flatMap((fieldFilterType) => {
@@ -202,4 +225,26 @@ export const FILTER_EXPRESSION_EXAMPLES_DESCRIPTION = [
             ),
         ];
     }),
+].join('\n');
+
+const filterExpressionAndOnlyExample = [
+    getGeneratedExpressionExample({
+        fieldFilterType: FilterType.STRING,
+        operator: FilterOperator.EQUALS,
+        valueCount: 1,
+    }),
+    getGeneratedExpressionExample({
+        fieldFilterType: FilterType.NUMBER,
+        operator: FilterOperator.GREATER_THAN,
+        valueCount: 1,
+    }),
+]
+    .map(({ expression }) => expression)
+    .join(' AND ');
+
+export const FILTER_EXPRESSION_AND_ONLY_EXAMPLES_DESCRIPTION = [
+    'AND-only multiple-rule example:',
+    `- ${filterExpressionAndOnlyExample}`,
+    '',
+    FILTER_EXPRESSION_EXAMPLES_DESCRIPTION,
 ].join('\n');

--- a/packages/common/src/ee/AiAgent/schemas/filterExpressions/expressionSchemas.test.ts
+++ b/packages/common/src/ee/AiAgent/schemas/filterExpressions/expressionSchemas.test.ts
@@ -19,6 +19,7 @@ import {
 import {
     aggregationCustomMetricExpressionSchema,
     customMetricsExpressionSchema,
+    FILTER_EXPRESSION_AND_ONLY_GRAMMAR_DESCRIPTION,
     FILTER_EXPRESSION_GRAMMAR_DESCRIPTION,
     filterExpressionInputSchema,
     filterExpressionsSchema,
@@ -147,7 +148,22 @@ describe('filter expression input schemas', () => {
     it('documents every exposed operator from the canonical map', () => {
         filterExpressionOperators.forEach((operator) => {
             expect(FILTER_EXPRESSION_GRAMMAR_DESCRIPTION).toContain(operator);
+            expect(FILTER_EXPRESSION_AND_ONLY_GRAMMAR_DESCRIPTION).toContain(
+                operator,
+            );
         });
+    });
+
+    it('renders the selected connector policy', () => {
+        expect(FILTER_EXPRESSION_GRAMMAR_DESCRIPTION).toContain(
+            'Join flat rules with AND or OR',
+        );
+        expect(FILTER_EXPRESSION_AND_ONLY_GRAMMAR_DESCRIPTION).toContain(
+            'Join flat rules with AND only. OR is not supported by this tool.',
+        );
+        expect(FILTER_EXPRESSION_AND_ONLY_GRAMMAR_DESCRIPTION).not.toContain(
+            'Join flat rules with AND or OR',
+        );
     });
 
     it('documents quoting syntax characters without punctuation escapes', () => {

--- a/packages/common/src/ee/AiAgent/schemas/filterExpressions/expressionSchemas.ts
+++ b/packages/common/src/ee/AiAgent/schemas/filterExpressions/expressionSchemas.ts
@@ -25,11 +25,21 @@ import {
     FILTER_EXPRESSION_MAX_VALUES_PER_RULE,
 } from './parse';
 
-export const FILTER_EXPRESSION_GRAMMAR_DESCRIPTION = `Filter expressions use the form "field operator=value".
+const connectorInstructionByPolicy = {
+    andOnly: 'Join flat rules with AND only. OR is not supported by this tool.',
+    andOr: 'Join flat rules with AND or OR. Do not mix both connectors in one expression.',
+};
+
+type FilterExpressionConnectorPolicy =
+    keyof typeof connectorInstructionByPolicy;
+
+const buildFilterExpressionGrammarDescription = (
+    connectorPolicy: FilterExpressionConnectorPolicy,
+) => `Filter expressions use the form "field operator=value".
 
 Available operators: ${filterExpressionOperators.join(', ')}.
 
-- Join flat rules with AND or OR. Do not mix both connectors in one expression.
+- ${connectorInstructionByPolicy[connectorPolicy]}
 - Quote values containing commas, braces, equals signs, whitespace, parentheses, backslashes, or reserved words with single or double quotes.
 - Inside quotes, commas and braces are literal; do not backslash-escape them. Backslash escapes quotes, backslashes, slashes, control characters, and four-digit Unicode sequences.
 - Quote unusual field IDs with backticks. AND and OR are reserved field IDs unless quoted.
@@ -39,6 +49,12 @@ Available operators: ${filterExpressionOperators.join(', ')}.
 - Current dates use one unit (for example inTheCurrent=months).
 - Safety limits: ${FILTER_EXPRESSION_MAX_RULES} rules per expression, ${FILTER_EXPRESSION_MAX_VALUES_PER_RULE} values (including settings) per rule, ${FILTER_EXPRESSION_MAX_LITERAL_LENGTH} characters per literal, and ${FILTER_EXPRESSION_MAX_LENGTH} characters per expression.
 - Nested groups and parentheses are not supported yet.`;
+
+export const FILTER_EXPRESSION_GRAMMAR_DESCRIPTION =
+    buildFilterExpressionGrammarDescription('andOr');
+
+export const FILTER_EXPRESSION_AND_ONLY_GRAMMAR_DESCRIPTION =
+    buildFilterExpressionGrammarDescription('andOnly');
 
 export const filterExpressionInputSchema = z
     .string()

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolSearchFieldValuesArgs.test.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolSearchFieldValuesArgs.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
+import { type ToolDescriptionContext } from '../defineTool';
 import {
+    TOOL_SEARCH_FIELD_VALUES_FILTER_EXPRESSION_DESCRIPTION,
     toolSearchFieldValuesArgsSchema,
     toolSearchFieldValuesExpressionArgsSchema,
 } from './toolSearchFieldValuesArgs';
@@ -10,7 +12,28 @@ const baseArgs = {
     query: 'complete',
 };
 
+const descriptionContexts = [
+    { runtime: 'agent', toolName: 'searchFieldValues' },
+    { runtime: 'mcp', toolName: 'search_field_values' },
+] satisfies ToolDescriptionContext[];
+
 describe('searchFieldValues filter schemas', () => {
+    it.each(descriptionContexts)(
+        'advertises AND-only expressions to the $runtime runtime',
+        (context) => {
+            const description =
+                TOOL_SEARCH_FIELD_VALUES_FILTER_EXPRESSION_DESCRIPTION(context);
+
+            expect(description).toContain(
+                'Join flat rules with AND only. OR is not supported by this tool.',
+            );
+            expect(description).not.toContain('Join flat rules with AND or OR');
+            expect(description).toContain(
+                'orders_status equals=example AND orders_amount greaterThan=100',
+            );
+        },
+    );
+
     it('keeps the structured schema', () => {
         expect(
             toolSearchFieldValuesArgsSchema.parse({

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolSearchFieldValuesArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolSearchFieldValuesArgs.ts
@@ -1,9 +1,9 @@
 import { z } from 'zod';
 import { type ToolDescriptionContext } from '../defineTool';
 import { getFieldIdSchema } from '../fieldId';
-import { FILTER_EXPRESSION_EXAMPLES_DESCRIPTION } from '../filterExpressions/examples';
+import { FILTER_EXPRESSION_AND_ONLY_EXAMPLES_DESCRIPTION } from '../filterExpressions/examples';
 import {
-    FILTER_EXPRESSION_GRAMMAR_DESCRIPTION,
+    FILTER_EXPRESSION_AND_ONLY_GRAMMAR_DESCRIPTION,
     filterExpressionInputSchema,
 } from '../filterExpressions/expressionSchemas';
 import { filtersSchemaTransformed, filtersSchemaV2 } from '../filters';
@@ -54,9 +54,9 @@ Usage Tips:
 - When filters is provided, pass one flat AND expression containing dimension fields only
 
 Filter expression syntax:
-${FILTER_EXPRESSION_GRAMMAR_DESCRIPTION}
+${FILTER_EXPRESSION_AND_ONLY_GRAMMAR_DESCRIPTION}
 
-${FILTER_EXPRESSION_EXAMPLES_DESCRIPTION}
+${FILTER_EXPRESSION_AND_ONLY_EXAMPLES_DESCRIPTION}
 `;
 
 export const toolSearchFieldValuesArgsSchema = createToolSchema()


### PR DESCRIPTION
Related: ZAP-963
Related: ZAP-920
Related: #28262

Makes the generated `searchFieldValues` and `search_field_values` filter-expression guidance advertise the resolver's actual AND-only connector contract instead of the general AND-or-OR grammar.

Adds a generated multi-rule AND example, connector-policy tests, and refreshed agent and Model Context Protocol contract snapshots. Parsing, resolution, query execution, and flag-off behavior are unchanged.

Risk: low — model-facing guidance now matches an existing rejecting validation boundary; runtime behavior is unchanged.

Verification:
- 81 common tests
- 146 backend tests
- common and backend typecheck, lint, and format
- stable Model Context Protocol snapshot freshness
- unchanged flag-off prompt fixture SHA-256 `03dfe168f8ec9416eb71dbcf95eb6a68d298c5fb0836954ddbf1b58a4c846d2e`
- signed commit
