### PR TITLE
fix: allow service accounts to build data apps

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.buildFromSource.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.buildFromSource.test.ts
@@ -1,6 +1,10 @@
+import { Ability } from '@casl/ability';
 import {
+    ProjectType,
     type AppBuildFromSourceJobPayload,
     type AppVersionDependencies,
+    type ServiceAccount,
+    type SessionUser,
 } from '@lightdash/common';
 import { AppGenerateService } from './AppGenerateService';
 
@@ -68,10 +72,45 @@ const CUSTOM_DEPS: AppVersionDependencies = {
     lockfileHash: 'abc123',
 };
 
+type ServiceAccountLookup = Pick<
+    ServiceAccount,
+    'uuid' | 'description' | 'scopes' | 'organizationUuid' | 'expiresAt'
+>;
+
+const SERVICE_ACCOUNT: ServiceAccountLookup = {
+    uuid: 'service-account-uuid',
+    description: 'CI',
+    scopes: [],
+    organizationUuid: 'org-uuid-1',
+    expiresAt: null,
+};
+
+const makeServiceAccountUser = (): SessionUser => {
+    const ability = new Ability([{ action: 'manage', subject: 'DataApp' }]);
+    return {
+        userUuid: 'user-uuid-1',
+        organizationUuid: 'org-uuid-1',
+        isActive: false,
+        ability,
+        abilityRules: ability.rules,
+    } as unknown as SessionUser;
+};
+
 function buildService(
     versionDependencies: AppVersionDependencies | null = null,
+    authorization?: {
+        user: SessionUser;
+        serviceAccount: ServiceAccountLookup | undefined;
+    },
 ) {
     const appModel = {
+        getApp: vi.fn().mockResolvedValue({
+            app_id: 'app-uuid-1',
+            project_uuid: 'proj-uuid-1',
+            organization_uuid: 'org-uuid-1',
+            space_uuid: null,
+            created_by_user_uuid: 'user-uuid-1',
+        }),
         updateVersionStatusIfInProgress: vi.fn().mockResolvedValue(true),
         updateSandboxUuid: vi.fn().mockResolvedValue(undefined),
         updateStatusMessage: vi.fn().mockResolvedValue(undefined),
@@ -84,6 +123,14 @@ function buildService(
                     : null,
             ),
     };
+    const userModel = {
+        findSessionUserAndOrgByUuid: vi
+            .fn()
+            .mockResolvedValue(authorization?.user),
+        findServiceAccountByUserUuid: vi
+            .fn<() => Promise<ServiceAccountLookup | undefined>>()
+            .mockResolvedValue(authorization?.serviceAccount),
+    };
 
     const raw = new AppGenerateService({
         lightdashConfig: {
@@ -95,20 +142,36 @@ function buildService(
         analytics: {} as never,
         analyticsModel: {} as never,
         catalogModel: {} as never,
-        userModel: {} as never,
+        userModel: userModel as never,
         appModel: appModel as never,
         featureFlagModel: {
             get: vi.fn().mockResolvedValue({ enabled: true }),
         } as never,
         organizationDesignModel: {} as never,
         pinnedListModel: {} as never,
-        projectModel: {} as never,
+        projectModel: {
+            getSummary: vi.fn().mockResolvedValue({
+                organizationUuid: 'org-uuid-1',
+                type: ProjectType.DEFAULT,
+                createdByUserUuid: 'user-uuid-1',
+                upstreamProjectUuid: null,
+            }),
+        } as never,
         projectParametersModel: {} as never,
         spaceModel: {} as never,
         savedChartModel: {} as never,
         schedulerClient: {} as never,
         savedChartService: {} as never,
-        spacePermissionService: {} as never,
+        spacePermissionService: {
+            resolveAccess: vi.fn().mockResolvedValue({
+                organizationUuid: 'org-uuid-1',
+                projectUuid: 'proj-uuid-1',
+                inheritsFromOrgOrProject: false,
+                admins: [],
+                access: [],
+                directOnly: false,
+            }),
+        } as never,
         coderService: {} as never,
         dashboardService: {} as never,
         projectService: {} as never,
@@ -141,9 +204,11 @@ function buildService(
     service.uploadToS3 = vi.fn().mockResolvedValue(100);
     service.suspendSandbox = vi.fn().mockResolvedValue(undefined);
     service.markError = vi.fn().mockResolvedValue(true);
-    service.authorizePipelineExecution = vi.fn().mockResolvedValue({});
+    if (authorization === undefined) {
+        service.authorizePipelineExecution = vi.fn().mockResolvedValue({});
+    }
 
-    return { service, appModel };
+    return { service, appModel, userModel };
 }
 
 describe('AppGenerateService.runBuildFromSourcePipeline', () => {
@@ -170,6 +235,40 @@ describe('AppGenerateService.runBuildFromSourcePipeline', () => {
         expect(service.getS3Client).not.toHaveBeenCalled();
         expect(service.createSandbox).not.toHaveBeenCalled();
         expect(service.runBuild).not.toHaveBeenCalled();
+    });
+
+    it('builds when queued by a valid service account', async () => {
+        const { service } = buildService(null, {
+            user: makeServiceAccountUser(),
+            serviceAccount: SERVICE_ACCOUNT,
+        });
+        service.runBuild = vi
+            .fn()
+            .mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' });
+
+        await service.runBuildFromSourcePipeline(makePayload());
+
+        expect(service.markError).not.toHaveBeenCalled();
+        expect(service.createSandbox).toHaveBeenCalledOnce();
+    });
+
+    it.each([
+        ['deleted', undefined],
+        ['expired', { ...SERVICE_ACCOUNT, expiresAt: new Date('2020-01-01') }],
+        [
+            'cross-organization',
+            { ...SERVICE_ACCOUNT, organizationUuid: 'other-organization' },
+        ],
+    ])('rejects a %s service account', async (_name, serviceAccount) => {
+        const { service } = buildService(null, {
+            user: makeServiceAccountUser(),
+            serviceAccount,
+        });
+
+        await service.runBuildFromSourcePipeline(makePayload());
+
+        expect(service.markError).toHaveBeenCalledOnce();
+        expect(service.createSandbox).not.toHaveBeenCalled();
     });
 
     it('happy path: advances sandbox→building→packaging→ready, uploads, no markError', async () => {

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -350,7 +350,10 @@ type AppGenerateServiceDeps = {
     projectModel: ProjectModel;
     projectParametersModel: ProjectParametersModel;
     spaceModel: SpaceModel;
-    userModel: Pick<UserModel, 'findSessionUserAndOrgByUuid'>;
+    userModel: Pick<
+        UserModel,
+        'findSessionUserAndOrgByUuid' | 'findServiceAccountByUserUuid'
+    >;
     savedChartModel: SavedChartModel;
     schedulerClient: CommercialSchedulerClient;
     savedChartService: SavedChartService;
@@ -556,7 +559,10 @@ export class AppGenerateService extends BaseService {
 
     private readonly spaceModel: SpaceModel;
 
-    private readonly userModel: Pick<UserModel, 'findSessionUserAndOrgByUuid'>;
+    private readonly userModel: Pick<
+        UserModel,
+        'findSessionUserAndOrgByUuid' | 'findServiceAccountByUserUuid'
+    >;
 
     private readonly savedChartModel: SavedChartModel;
 
@@ -869,9 +875,20 @@ export class AppGenerateService extends BaseService {
             payload.organizationUuid,
         );
         if (!user.isActive) {
-            throw new ForbiddenError(
-                'The recorded data app principal is no longer active',
-            );
+            const serviceAccount =
+                await this.userModel.findServiceAccountByUserUuid(
+                    payload.userUuid,
+                );
+            if (
+                serviceAccount === undefined ||
+                serviceAccount.organizationUuid !== payload.organizationUuid ||
+                (serviceAccount.expiresAt !== null &&
+                    serviceAccount.expiresAt < new Date())
+            ) {
+                throw new ForbiddenError(
+                    'The recorded data app principal is no longer active',
+                );
+            }
         }
         await this.assertDataAppsEnabled(user);
 

--- a/packages/backend/src/models/UserModel.test.ts
+++ b/packages/backend/src/models/UserModel.test.ts
@@ -51,18 +51,7 @@ type TestableUserModel = {
         organizationId: number,
         trx?: Knex,
     ) => Promise<string[]>;
-    findServiceAccountByUserUuid: (
-        userUuid: string,
-        options?: { trx?: Knex },
-    ) => Promise<
-        | {
-              uuid: string;
-              description: string;
-              scopes: ServiceAccountScope[];
-              organizationUuid: string;
-          }
-        | undefined
-    >;
+    findServiceAccountByUserUuid: UserModel['findServiceAccountByUserUuid'];
     customRoleScopes: (
         roleUuids: string[],
         trx?: Knex,
@@ -135,6 +124,7 @@ const createUserModel = (): TestableUserModel => {
         description: 'Service account',
         scopes: [ServiceAccountScope.SYSTEM_MEMBER],
         organizationUuid: 'org-1',
+        expiresAt: null,
     }));
     model.customRoleScopes = vi.fn(async () => ({
         'custom-role': ['view:Dashboard'],

--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -32,6 +32,7 @@ import {
     ProjectType,
     Role,
     RoleWithScopes,
+    ServiceAccount,
     ServiceAccountScope,
     SessionUser,
     UpdateUserArgs,
@@ -1229,12 +1230,14 @@ export class UserModel {
         userUuid: string,
         { trx = this.database }: { trx?: Knex } = {},
     ): Promise<
-        | {
-              uuid: string;
-              description: string;
-              scopes: ServiceAccountScope[];
-              organizationUuid: string;
-          }
+        | Pick<
+              ServiceAccount,
+              | 'uuid'
+              | 'description'
+              | 'scopes'
+              | 'organizationUuid'
+              | 'expiresAt'
+          >
         | undefined
     > {
         const row = await trx('service_accounts')
@@ -1245,12 +1248,14 @@ export class UserModel {
                     description: string;
                     scopes: string[];
                     organization_uuid: string;
+                    expires_at: Date | null;
                 }[]
             >(
                 'service_account_uuid',
                 'description',
                 'scopes',
                 'organization_uuid',
+                'expires_at',
             )
             .first();
         if (!row) {
@@ -1261,6 +1266,7 @@ export class UserModel {
             description: row.description,
             scopes: row.scopes as ServiceAccountScope[],
             organizationUuid: row.organization_uuid,
+            expiresAt: row.expires_at,
         };
     }
 


### PR DESCRIPTION
## Summary

- reauthorize queued Data App builds against the live service account
- reject deleted, expired, or cross-organization service accounts
- cover the real source-build worker authorization path

## Tests

- 5 focused backend test files, 246 tests passed
- backend typecheck
- targeted backend lint and formatting

Closes: PROD-10778
Closes: #28325
