### PR TITLE
chore: fix watcher restart storm

### DIFF
--- a/.claude/commands/docker-dev.md
+++ b/.claude/commands/docker-dev.md
@@ -552,10 +552,10 @@ LDPAT=ldpat_deadbeefdeadbeefdeadbeefdeadbeef
 # in dev — without it, POST /api/v1/user 403s once the seed org exists.
 ALLOW_MULTIPLE_ORGS=true
 
-# Restart PM2 tsc watchers above this memory cap — they hold memory after big
-# rebuilds (branch switches), and multiple instances can exhaust the machine.
-# See ecosystem.config.js. Uncomment on smaller (e.g. 16GB) machines:
-# LD_WATCHER_MEMORY_CAP=1500M
+# tsc watchers run with a soft Go memory cap (GOMEMLIMIT, default 1500MiB;
+# override with LD_WATCHER_GOMEMLIMIT). Optional hard backstop below — keep it
+# well above the soft cap or it kill-loops mid-rebuild. See ecosystem.config.js:
+# LD_WATCHER_MEMORY_CAP=4G
 EOF
 echo "DBT_DEMO_DIR=$(pwd)/examples/full-jaffle-shop-demo" >> .env.development.local
 ```

--- a/.env.development
+++ b/.env.development
@@ -79,9 +79,11 @@ INTERCOM_APP_ID=zppxyjpp
 # LIGHTDASH_LICENSE_KEY=
 # LIGHTDASH_LICENSE_CERTIFICATE=
 
-# Restart PM2 tsc watchers when their memory exceeds this cap — they hold
-# memory after big rebuilds (e.g. branch switches). Recommended on 16GB
-# machines, especially with multiple checkouts: 1500M
+# The tsc watchers (tsgo) run with a soft Go memory cap (default 1500MiB) so
+# big rebuilds can't balloon RSS; override the limit, or disable with 'off':
+# LD_WATCHER_GOMEMLIMIT=
+# Optional hard backstop: PM2 restarts a watcher above this RSS. Keep it well
+# above the soft cap (e.g. 4G) — below the rebuild peak it kill-loops:
 # LD_WATCHER_MEMORY_CAP=
 # Users who run Lightdash with Docker should use the following settings
 HEADLESS_BROWSER_HOST=headless-browser

--- a/agent-harness/ecosystem.agent.template.cjs
+++ b/agent-harness/ecosystem.agent.template.cjs
@@ -34,8 +34,19 @@ module.exports = {
                 HEADLESS: 'true',
                 NODE_ENV: 'development',
             },
-            watch: ['src'],
-            ignore_watch: ['src/generated/swagger.json'],
+            // Restart when common's CJS build completes (single sentinel
+            // file) rather than on every emitted dist file.
+            watch: ['src', '../common/dist/cjs/.tsbuildinfo'],
+            // Setting ignore_watch replaces chokidar's default node_modules
+            // ignore; without the explicit entries + followSymlinks:false,
+            // mcp-chart-app/node_modules (a symlink back into packages/common)
+            // turns every common rebuild into thousands of API restarts.
+            ignore_watch: [
+                'src/generated/swagger.json',
+                '**/node_modules',
+                '**/node_modules/**',
+            ],
+            watch_options: { followSymlinks: false },
             watch_delay: 500,
             autorestart: true,
             kill_timeout: 5000,
@@ -82,6 +93,8 @@ module.exports = {
             args: '--build --watch --preserveWatchOutput --incremental tsconfig.build.json',
             interpreter: 'none',
             cwd: path.join(__dirname, 'packages/common'),
+            // tsgo is a Go binary: soft cap so rebuilds return memory to the OS
+            env: { GOMEMLIMIT: '1500MiB' },
             watch: false,
             autorestart: false,
             kill_timeout: 3000,
@@ -96,6 +109,7 @@ module.exports = {
             args: '--build --watch --preserveWatchOutput tsconfig.json',
             interpreter: 'none',
             cwd: path.join(__dirname, 'packages/warehouses'),
+            env: { GOMEMLIMIT: '1500MiB' },
             watch: false,
             autorestart: false,
             kill_timeout: 3000,

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -100,15 +100,26 @@ if (!mapleBin) {
 
 const frontendArgs = fePort ? `--port ${fePort}` : undefined;
 
-// Opt-in via LD_WATCHER_MEMORY_CAP (e.g. 1500M in .env.development.local):
-// bounce a tsc watcher whose RSS exceeds the cap. Watchers recompile the
-// world on branch switches and never release the memory; the post-restart
-// incremental rebuild is cheap. Unset = no cap, today's behavior.
+// Opt-in via LD_WATCHER_MEMORY_CAP (e.g. 4G in .env.development.local): hard
+// backstop that bounces a runaway tsc watcher. Keep it well above GOMEMLIMIT —
+// a cap below the full-rebuild peak kills tsc mid-build and loops on cold
+// rebuilds. Unset = no cap.
 const watcherMemoryCap =
     process.env.LD_WATCHER_MEMORY_CAP ?? env.LD_WATCHER_MEMORY_CAP;
 const watcherMemoryCapConfig = watcherMemoryCap
     ? { max_memory_restart: watcherMemoryCap }
     : {};
+
+// tsgo (TS7 native) is a Go binary: GOMEMLIMIT is a soft cap its GC works to
+// stay under, releasing freed memory back to the OS, so branch-switch rebuilds
+// can't balloon to multi-GB peaks. LD_WATCHER_GOMEMLIMIT overrides ('off'
+// disables).
+const watcherGoMemLimit =
+    process.env.LD_WATCHER_GOMEMLIMIT ??
+    env.LD_WATCHER_GOMEMLIMIT ??
+    '1500MiB';
+const watcherEnv =
+    watcherGoMemLimit === 'off' ? {} : { GOMEMLIMIT: watcherGoMemLimit };
 
 module.exports = {
     apps: [
@@ -128,8 +139,19 @@ module.exports = {
                 OTEL_SERVICE_NAME: instanceId,
                 PORT: apiPort,
             },
-            watch: ['src'],
-            ignore_watch: ['src/generated/swagger.json'],
+            // Restart when common's CJS build completes (single sentinel
+            // file) rather than on every emitted dist file.
+            watch: ['src', '../common/dist/cjs/.tsbuildinfo'],
+            // Setting ignore_watch replaces chokidar's default node_modules
+            // ignore; without the explicit entries + followSymlinks:false,
+            // mcp-chart-app/node_modules (a symlink back into packages/common)
+            // turns every common rebuild into thousands of API restarts.
+            ignore_watch: [
+                'src/generated/swagger.json',
+                '**/node_modules',
+                '**/node_modules/**',
+            ],
+            watch_options: { followSymlinks: false },
             watch_delay: 500,
             autorestart: true,
             kill_timeout: 5000,
@@ -199,6 +221,7 @@ module.exports = {
             args: '--build --watch --preserveWatchOutput --incremental tsconfig.build.json',
             interpreter: 'none',
             cwd: path.join(__dirname, 'packages/common'),
+            env: watcherEnv,
             watch: false,
             autorestart: false,
             ...watcherMemoryCapConfig,
@@ -214,6 +237,7 @@ module.exports = {
             args: '--build --watch --preserveWatchOutput tsconfig.json',
             interpreter: 'none',
             cwd: path.join(__dirname, 'packages/formula'),
+            env: watcherEnv,
             watch: false,
             autorestart: false,
             ...watcherMemoryCapConfig,
@@ -229,6 +253,7 @@ module.exports = {
             args: '--build --watch --preserveWatchOutput tsconfig.json',
             interpreter: 'none',
             cwd: path.join(__dirname, 'packages/warehouses'),
+            env: watcherEnv,
             watch: false,
             autorestart: false,
             ...watcherMemoryCapConfig,

--- a/packages/backend/src/devHarnessConfig.test.ts
+++ b/packages/backend/src/devHarnessConfig.test.ts
@@ -11,6 +11,7 @@ type Pm2App = {
     autorestart?: boolean;
     watch?: string[];
     ignore_watch?: string[];
+    watch_options?: { followSymlinks?: boolean };
 };
 
 type Pm2Config = {
@@ -37,8 +38,16 @@ const expectApiReloadContract = (config: Pm2Config) => {
         interpreter: 'node',
         node_args: expect.stringContaining('--import tsx'),
         autorestart: true,
-        watch: ['src'],
-        ignore_watch: ['src/generated/swagger.json'],
+        watch: ['src', '../common/dist/cjs/.tsbuildinfo'],
+        // ignore_watch replaces chokidar's default node_modules ignore, so the
+        // explicit entries + followSymlinks:false guard against restart storms
+        // via symlinked node_modules inside src (e.g. mcp-chart-app).
+        ignore_watch: [
+            'src/generated/swagger.json',
+            '**/node_modules',
+            '**/node_modules/**',
+        ],
+        watch_options: { followSymlinks: false },
     });
     expect(routeWatcher).toMatchObject({
         script: 'pnpm',


### PR DESCRIPTION
### Description:
added ignore_watch to the api app, which replaces chokidar's default node_modules ignore. Since pnpm install creates a symlink under `backend/src/.../mcp-chart-app/node_modules/@lightdash/common` back into packages/common, every common rebuild turned into thousands of API restarts.

#### Changes (ecosystem.config.js):
- api: explicit **/node_modules ignores + followSymlinks: false; additionally watch ../common/dist/cjs/.tsbuildinfo so the API restarts exactly once per completed common build (backend consumes dist/cjs).
- tsc watchers: GOMEMLIMIT=1500MiB (tsc 7 is a Go binary) — a soft cap so branch-switch rebuilds return memory to the OS instead of ballooning to multi-GB peaks. Override with LD_WATCHER_GOMEMLIMIT (off disables).
- .env.development / docker-dev docs: LD_WATCHER_MEMORY_CAP is now documented as a hard backstop — keep it well above the soft cap (e.g. 4G) or unset; at/below the rebuild peak it kill-loops the watcher mid-build.

### Risk assessment:
<!-- High-risk changes could cause unauthorized access, customer data exposure or loss, a widespread production outage,
weaken security or change-control safeguards, or have another material impact that would be difficult to detect, contain,
or reverse. Routine, tested, reversible, or backwards-compatible changes are normally low risk. -->

- [ ] This is a high-risk change

High-risk changes require approval from a reviewer other than the author before merging.
