### PR TITLE
feat(ai-agent): Slack thread gets the data app build's outcome

### DIFF
--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -8076,6 +8076,27 @@ export class AiAgentModel {
             });
     }
 
+    // Terminal-once transition: updates only while the stored result is still
+    // pending, so racing terminal writers (job timeout vs late pipeline exit)
+    // resolve to exactly one winner. Returns whether this call won.
+    async updateToolResultIfPending(
+        promptUuid: string,
+        toolCallId: string,
+        data: { result: string; metadata: AgentToolOutput['metadata'] },
+    ): Promise<boolean> {
+        const updated = await this.database(AiAgentToolResultTableName)
+            .where({
+                ai_prompt_uuid: promptUuid,
+                tool_call_id: toolCallId,
+            })
+            .whereRaw(`metadata->>'status' = ?`, ['pending'])
+            .update({
+                result: data.result,
+                metadata: data.metadata,
+            });
+        return updated > 0;
+    }
+
     async hasToolResult(
         promptUuid: string,
         toolCallId: string,

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -146,6 +146,7 @@ import {
     type PivotConfiguration,
     type SessionUser,
     type SuggestionValidationCatalog,
+    type ToolGenerateDataAppTerminalResult,
     type ToolRunQueryArgsTransformed,
     type VerifiedContentListItem,
 } from '@lightdash/common';
@@ -9159,8 +9160,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 metadata: { status: 'error', errorCode },
             });
             if (isSlackPrompt(prompt)) {
-                await this.postWritebackOutcomeToSlack(
-                    user,
+                await this.postOutcomeToSlack(
                     prompt,
                     getMarkdownBlocks(`:x: ${toolResult}`),
                     toolResult,
@@ -9300,8 +9300,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 const prCardBlocks =
                     getModernPullRequestCardBlocks(finalToolResults);
                 if (prCardBlocks.length > 0) {
-                    await this.postWritebackOutcomeToSlack(
-                        user,
+                    await this.postOutcomeToSlack(
                         prompt,
                         prCardBlocks,
                         'Your pull request is ready.',
@@ -9386,6 +9385,10 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 aiAgentToolCall.toolCallId,
                 outcome,
             );
+            await this.postDataAppBuildOutcomeToSlack(
+                aiAgentToolCall.promptUuid,
+                outcome,
+            );
         } catch (error) {
             // Never fail the build job over the tool result.
             Logger.error(
@@ -9406,15 +9409,14 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
     }
 
     /**
-     * Post the writeback outcome as a follow-up message in the Slack thread. The
-     * agent's turn ends ~1s after the editDbtProject tool starts — long before
-     * the async pipeline resolves — so its final message carries no result. This
-     * delivers the PR card (or the failure) once the pipeline actually finishes,
-     * mirroring what the web chat card shows. Best-effort: a Slack failure must
-     * never fail the run.
+     * Post an async pipeline's outcome (dbt writeback, data app build) as a
+     * follow-up message in the Slack thread. The agent's turn ends long before
+     * the pipeline resolves, so its final message carries no result. This
+     * delivers the outcome once the pipeline actually finishes, mirroring what
+     * the web chat card shows. Best-effort: a Slack failure must never fail
+     * the run.
      */
-    private async postWritebackOutcomeToSlack(
-        user: SessionUser,
+    private async postOutcomeToSlack(
         prompt: SlackPrompt,
         blocks: (Block | KnownBlock)[],
         text: string,
@@ -9422,7 +9424,16 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         try {
             let agentName: string | undefined;
             try {
-                agentName = (await this.getAgentSettings(user, prompt)).name;
+                const agent = prompt.agentUuid
+                    ? await this.aiAgentModel.getAgent({
+                          organizationUuid: prompt.organizationUuid,
+                          agentUuid: prompt.agentUuid,
+                      })
+                    : await this.aiAgentModel.getAgentBySlackChannelId({
+                          organizationUuid: prompt.organizationUuid,
+                          slackChannelId: prompt.slackChannelId,
+                      });
+                agentName = agent.name;
             } catch {
                 // Fall back to the app's default name.
             }
@@ -9436,11 +9447,38 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 unfurl_links: false,
             });
         } catch (error) {
-            Logger.error(
-                'Failed to post AI writeback outcome to Slack:',
-                error,
-            );
+            Logger.error('Failed to post AI outcome to Slack:', error);
         }
+    }
+
+    // In Slack there is no build card, so a Slack-originated build gets its
+    // outcome as a follow-up message in the thread. Web prompts resolve to
+    // nothing here and post nothing.
+    private async postDataAppBuildOutcomeToSlack(
+        promptUuid: string,
+        outcome: ToolGenerateDataAppTerminalResult,
+    ): Promise<void> {
+        const prompt = await this.aiAgentModel.findSlackPrompt(promptUuid);
+        if (!prompt) {
+            return;
+        }
+        const { metadata } = outcome;
+        if (metadata.status === 'success') {
+            await this.postOutcomeToSlack(
+                prompt,
+                getMarkdownBlocks(
+                    `:white_check_mark: Your data app **${metadata.name}** is ready — [Open it in the builder](${metadata.href})`,
+                ),
+                `Your data app "${metadata.name}" is ready: ${metadata.href}`,
+            );
+            return;
+        }
+        const text = `The data app build did not finish: ${metadata.message}`;
+        await this.postOutcomeToSlack(
+            prompt,
+            getMarkdownBlocks(`:x: ${text}`),
+            text,
+        );
     }
 
     /**

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -8068,19 +8068,25 @@ export class AiAgentService extends BaseService {
         if (!user.organizationUuid) {
             throw new Error('Organization not found');
         }
+        return this.getAgentForPrompt(user.organizationUuid, prompt);
+    }
 
-        // Priority: Use agentUuid if available (set by multi-agent channel selection or web app)
-        // Fallback: Get agent by slack channel ID for single-agent channels
+    // Priority: agentUuid if available (set by multi-agent channel selection or
+    // web app), falling back to the slack channel's agent for single-agent channels.
+    private async getAgentForPrompt(
+        organizationUuid: string,
+        prompt: SlackPrompt | AiWebAppPrompt,
+    ): Promise<AiAgent> {
         if (prompt.agentUuid) {
             return this.aiAgentModel.getAgent({
-                organizationUuid: user.organizationUuid,
+                organizationUuid,
                 agentUuid: prompt.agentUuid,
             });
         }
 
         if ('slackChannelId' in prompt) {
             return this.aiAgentModel.getAgentBySlackChannelId({
-                organizationUuid: user.organizationUuid,
+                organizationUuid,
                 slackChannelId: prompt.slackChannelId,
             });
         }
@@ -9380,15 +9386,19 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 aiAgentToolCall.promptUuid,
                 aiAgentToolCall.toolCallId,
             );
-            await this.aiAgentModel.updateToolResult(
+            // A job timeout and a late pipeline exit both land here; only the
+            // call that flips pending → terminal posts to Slack.
+            const won = await this.aiAgentModel.updateToolResultIfPending(
                 aiAgentToolCall.promptUuid,
                 aiAgentToolCall.toolCallId,
                 outcome,
             );
-            await this.postDataAppBuildOutcomeToSlack(
-                aiAgentToolCall.promptUuid,
-                outcome,
-            );
+            if (won) {
+                await this.postDataAppBuildOutcomeToSlack(
+                    aiAgentToolCall.promptUuid,
+                    outcome,
+                );
+            }
         } catch (error) {
             // Never fail the build job over the tool result.
             Logger.error(
@@ -9424,16 +9434,12 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         try {
             let agentName: string | undefined;
             try {
-                const agent = prompt.agentUuid
-                    ? await this.aiAgentModel.getAgent({
-                          organizationUuid: prompt.organizationUuid,
-                          agentUuid: prompt.agentUuid,
-                      })
-                    : await this.aiAgentModel.getAgentBySlackChannelId({
-                          organizationUuid: prompt.organizationUuid,
-                          slackChannelId: prompt.slackChannelId,
-                      });
-                agentName = agent.name;
+                agentName = (
+                    await this.getAgentForPrompt(
+                        prompt.organizationUuid,
+                        prompt,
+                    )
+                ).name;
             } catch {
                 // Fall back to the app's default name.
             }

--- a/packages/backend/src/ee/services/AiAgentService/recordDataAppBuildOutcome.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/recordDataAppBuildOutcome.test.ts
@@ -35,25 +35,25 @@ const buildService = (
         error?: string | null;
         status_message?: string | null;
     },
-    options?: { isSlack?: boolean },
+    options?: { isSlack?: boolean; alreadyResolved?: boolean },
 ) => {
-    const updateToolResult = vi.fn().mockResolvedValue(undefined);
+    const updateToolResultIfPending = vi
+        .fn()
+        .mockResolvedValue(options?.alreadyResolved !== true);
     const hasToolResult = vi.fn().mockResolvedValue(true);
     const postMessage = vi.fn().mockResolvedValue(undefined);
     const service = new AiAgentService({
         lightdashConfig: { siteUrl: 'https://ld.example.com' },
         aiAgentModel: {
-            updateToolResult,
+            updateToolResultIfPending,
             hasToolResult,
             findSlackPrompt: vi
                 .fn()
                 .mockResolvedValue(options?.isSlack ? SLACK_PROMPT : undefined),
-            getAgentBySlackChannelId: vi
-                .fn()
-                .mockResolvedValue({
-                    uuid: 'agent-1',
-                    name: 'Analytics Agent',
-                }),
+            getAgentBySlackChannelId: vi.fn().mockResolvedValue({
+                uuid: 'agent-1',
+                name: 'Analytics Agent',
+            }),
         },
         appModel: {
             findAppByUuid: vi.fn().mockResolvedValue({ name: 'Revenue app' }),
@@ -66,12 +66,12 @@ const buildService = (
         slackClient: { postMessage },
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any);
-    return { service, updateToolResult, postMessage };
+    return { service, updateToolResultIfPending, postMessage };
 };
 
 describe('AiAgentService.recordDataAppBuildOutcome', () => {
     it('does nothing for a build the AI agent did not start', async () => {
-        const { service, updateToolResult } = buildService({
+        const { service, updateToolResultIfPending } = buildService({
             status: 'ready',
         });
 
@@ -80,17 +80,17 @@ describe('AiAgentService.recordDataAppBuildOutcome', () => {
             aiAgentToolCall: undefined,
         });
 
-        expect(updateToolResult).not.toHaveBeenCalled();
+        expect(updateToolResultIfPending).not.toHaveBeenCalled();
     });
 
     it('patches a ready build to success with the builder link', async () => {
-        const { service, updateToolResult } = buildService({
+        const { service, updateToolResultIfPending } = buildService({
             status: 'ready',
         });
 
         await service.recordDataAppBuildOutcome(PAYLOAD);
 
-        expect(updateToolResult).toHaveBeenCalledWith(
+        expect(updateToolResultIfPending).toHaveBeenCalledWith(
             'prompt-1',
             'tool-call-1',
             expect.objectContaining({
@@ -106,13 +106,13 @@ describe('AiAgentService.recordDataAppBuildOutcome', () => {
     });
 
     it('leaves the result pending while the version is still building', async () => {
-        const { service, updateToolResult } = buildService({
+        const { service, updateToolResultIfPending } = buildService({
             status: 'building',
         });
 
         await service.recordDataAppBuildOutcome(PAYLOAD);
 
-        expect(updateToolResult).not.toHaveBeenCalled();
+        expect(updateToolResultIfPending).not.toHaveBeenCalled();
     });
 
     it('posts the builder link to the Slack thread when a Slack-originated build is ready', async () => {
@@ -193,6 +193,17 @@ describe('AiAgentService.recordDataAppBuildOutcome', () => {
 
     it('posts nothing to Slack for a web-originated build', async () => {
         const { service, postMessage } = buildService({ status: 'ready' });
+
+        await service.recordDataAppBuildOutcome(PAYLOAD);
+
+        expect(postMessage).not.toHaveBeenCalled();
+    });
+
+    it('does not post again when the tool result was already resolved by a racing terminal writer', async () => {
+        const { service, postMessage } = buildService(
+            { status: 'error', error: 'Build timed out.' },
+            { isSlack: true, alreadyResolved: true },
+        );
 
         await service.recordDataAppBuildOutcome(PAYLOAD);
 

--- a/packages/backend/src/ee/services/AiAgentService/recordDataAppBuildOutcome.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/recordDataAppBuildOutcome.test.ts
@@ -20,16 +20,41 @@ const PAYLOAD = {
     aiAgentToolCall: { promptUuid: 'prompt-1', toolCallId: 'tool-call-1' },
 };
 
-const buildService = (version: {
-    status: string;
-    error?: string | null;
-    status_message?: string | null;
-}) => {
+const SLACK_PROMPT = {
+    promptUuid: 'prompt-1',
+    threadUuid: 'thread-1',
+    organizationUuid: 'org-1',
+    projectUuid: 'proj-1',
+    slackChannelId: 'C123',
+    promptSlackTs: '111.222',
+};
+
+const buildService = (
+    version: {
+        status: string;
+        error?: string | null;
+        status_message?: string | null;
+    },
+    options?: { isSlack?: boolean },
+) => {
     const updateToolResult = vi.fn().mockResolvedValue(undefined);
     const hasToolResult = vi.fn().mockResolvedValue(true);
+    const postMessage = vi.fn().mockResolvedValue(undefined);
     const service = new AiAgentService({
         lightdashConfig: { siteUrl: 'https://ld.example.com' },
-        aiAgentModel: { updateToolResult, hasToolResult },
+        aiAgentModel: {
+            updateToolResult,
+            hasToolResult,
+            findSlackPrompt: vi
+                .fn()
+                .mockResolvedValue(options?.isSlack ? SLACK_PROMPT : undefined),
+            getAgentBySlackChannelId: vi
+                .fn()
+                .mockResolvedValue({
+                    uuid: 'agent-1',
+                    name: 'Analytics Agent',
+                }),
+        },
         appModel: {
             findAppByUuid: vi.fn().mockResolvedValue({ name: 'Revenue app' }),
             getVersion: vi.fn().mockResolvedValue({
@@ -38,9 +63,10 @@ const buildService = (version: {
                 ...version,
             }),
         },
+        slackClient: { postMessage },
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any);
-    return { service, updateToolResult };
+    return { service, updateToolResult, postMessage };
 };
 
 describe('AiAgentService.recordDataAppBuildOutcome', () => {
@@ -87,5 +113,89 @@ describe('AiAgentService.recordDataAppBuildOutcome', () => {
         await service.recordDataAppBuildOutcome(PAYLOAD);
 
         expect(updateToolResult).not.toHaveBeenCalled();
+    });
+
+    it('posts the builder link to the Slack thread when a Slack-originated build is ready', async () => {
+        const { service, postMessage } = buildService(
+            { status: 'ready' },
+            { isSlack: true },
+        );
+
+        await service.recordDataAppBuildOutcome(PAYLOAD);
+
+        expect(postMessage).toHaveBeenCalledWith(
+            expect.objectContaining({
+                organizationUuid: 'org-1',
+                channel: 'C123',
+                thread_ts: '111.222',
+                username: 'Analytics Agent',
+                blocks: [
+                    expect.objectContaining({
+                        text: expect.stringContaining(
+                            '[Open it in the builder](https://ld.example.com/projects/proj-1/apps/app-1)',
+                        ),
+                    }),
+                ],
+                text: expect.stringContaining('Revenue app'),
+            }),
+        );
+    });
+
+    it('posts the failure message to the Slack thread when the build fails', async () => {
+        const { service, postMessage } = buildService(
+            {
+                status: 'error',
+                error: 'sandbox exploded',
+                status_message: 'The coding agent hit an error.',
+            },
+            { isSlack: true },
+        );
+
+        await service.recordDataAppBuildOutcome(PAYLOAD);
+
+        expect(postMessage).toHaveBeenCalledWith(
+            expect.objectContaining({
+                channel: 'C123',
+                thread_ts: '111.222',
+                blocks: [
+                    expect.objectContaining({
+                        text: expect.stringContaining(
+                            'The coding agent hit an error.',
+                        ),
+                    }),
+                ],
+            }),
+        );
+    });
+
+    it('posts the cancelled message to the Slack thread when the build is cancelled', async () => {
+        const { service, postMessage } = buildService(
+            { status: 'error', error: 'Cancelled by user' },
+            { isSlack: true },
+        );
+
+        await service.recordDataAppBuildOutcome(PAYLOAD);
+
+        expect(postMessage).toHaveBeenCalledWith(
+            expect.objectContaining({
+                channel: 'C123',
+                thread_ts: '111.222',
+                blocks: [
+                    expect.objectContaining({
+                        text: expect.stringContaining(
+                            'The build was cancelled.',
+                        ),
+                    }),
+                ],
+            }),
+        );
+    });
+
+    it('posts nothing to Slack for a web-originated build', async () => {
+        const { service, postMessage } = buildService({ status: 'ready' });
+
+        await service.recordDataAppBuildOutcome(PAYLOAD);
+
+        expect(postMessage).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
When an AI-agent data app build started from a Slack thread reaches a terminal state, the thread now gets a follow-up message — ready → app name + builder link, error/cancelled → failure message. Web-originated builds post nothing. Modelled on the dbt write-back outcome post; link only in v1.

- `recordDataAppBuildOutcome` (single terminal hook, incl. the timeout path) posts the follow-up when `findSlackPrompt` resolves the prompt as Slack-originated.
- New `AiAgentModel.updateToolResultIfPending`: atomic pending → terminal transition, so racing terminal writers (job timeout vs late pipeline exit) post exactly once.
- Generalized the write-back Slack outcome post into `postOutcomeToSlack` (agent name resolved from the prompt via shared `getAgentForPrompt`; no `SessionUser` needed in worker context).
- Tests per terminal state (ready/failed/cancelled), web-origin negative, and duplicate-post race negative, in the write-back outcome test style.

Verified live end-to-end (Slack thread → build → follow-up per terminal state; web negative confirmed via DB + trace).

Closes: ZAP-958

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KMnnM4XNfBPdGiKJdsCQTA
