### PR TITLE
feat(data-apps): allow image-only external connections

### DIFF
--- a/packages/backend/src/ee/services/ExternalConnectionService/externalConnectionConfigValidation.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/externalConnectionConfigValidation.test.ts
@@ -43,17 +43,17 @@ describe('validateExternalConnectionConfig', () => {
             ).toThrow(/only available for no-auth/);
         });
 
-        it('requires GET', () => {
+        it('accepts an image-only connection', () => {
             expect(() =>
                 validateExternalConnectionConfig(
                     {
                         ...base,
-                        allowedMethods: ['POST'],
+                        allowedMethods: [],
                         allowBrowserImages: true,
                     },
                     false,
                 ),
-            ).toThrow(/requires GET/);
+            ).not.toThrow();
         });
     });
 

--- a/packages/backend/src/ee/services/ExternalConnectionService/externalConnectionConfigValidation.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/externalConnectionConfigValidation.ts
@@ -157,8 +157,9 @@ export function validateExternalConnectionConfig(
         }
     });
 
-    // --- methods: non-empty, supported only ---
-    if (config.allowedMethods.length === 0) {
+    // Browser images are loaded directly, so an image-only connection does not
+    // need to allow any methods through the external-fetch proxy.
+    if (config.allowedMethods.length === 0 && !config.allowBrowserImages) {
         throw new ParameterError('At least one allowed method is required');
     }
     config.allowedMethods.forEach((method) => {
@@ -171,11 +172,6 @@ export function validateExternalConnectionConfig(
         if (config.type !== 'none') {
             throw new ParameterError(
                 'Browser image loading is only available for no-auth connections',
-            );
-        }
-        if (!config.allowedMethods.includes('GET')) {
-            throw new ParameterError(
-                'Browser image loading requires GET to be allowed',
             );
         }
     }

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/AddConnectionWizard.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/AddConnectionWizard.tsx
@@ -389,14 +389,13 @@ export const AddConnectionWizard: FC<Props> = ({
                     : 'Use a valid header or query parameter name';
             },
             customHeaders: validateCustomHeaderRows,
-            allowedMethods: (value) =>
-                value.length === 0 ? 'Select at least one method' : null,
+            allowedMethods: (value, values) =>
+                value.length === 0 && !values.allowBrowserImages
+                    ? 'Select at least one method or allow public images'
+                    : null,
             allowBrowserImages: (value, values) => {
                 if (value && values.type !== 'none') {
                     return 'Public browser images require no authentication';
-                }
-                if (value && !values.allowedMethods.includes('GET')) {
-                    return 'Public browser images require GET';
                 }
                 return null;
             },

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionsTable.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionsTable.tsx
@@ -34,6 +34,16 @@ const authLabel = (type: ExternalConnection['type']): string => {
     }
 };
 
+const accessLabel = (connection: ExternalConnection): string => {
+    const methods = connection.allowedMethods.join(', ');
+
+    if (connection.allowBrowserImages) {
+        return methods ? `${methods} + public images` : 'Public images only';
+    }
+
+    return methods || '—';
+};
+
 const ConnectionRow: FC<
     { connection: ExternalConnectionListItem } & Pick<
         Props,
@@ -56,7 +66,7 @@ const ConnectionRow: FC<
         </Table.Td>
         <Table.Td>
             <Text fz="sm" c="ldGray.6">
-                {connection.allowedMethods.join(', ')}
+                {accessLabel(connection)}
             </Text>
         </Table.Td>
         <Table.Td>
@@ -126,7 +136,7 @@ export const ConnectionsTable: FC<Props> = ({
                         <Table.Th w={300}>Name</Table.Th>
                         <Table.Th>Origin</Table.Th>
                         <Table.Th>Auth</Table.Th>
-                        <Table.Th>Methods</Table.Th>
+                        <Table.Th>Access</Table.Th>
                         <Table.Th>Linked apps</Table.Th>
                         <Table.Th>Builder linking</Table.Th>
                         <Table.Th></Table.Th>

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/EditConnectionModal.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/EditConnectionModal.tsx
@@ -91,14 +91,13 @@ const EditConnectionModalContent: FC<Props> = ({
                     : null;
             },
             customHeaders: validateCustomHeaderRows,
-            allowedMethods: (value) =>
-                value.length === 0 ? 'Select at least one method' : null,
+            allowedMethods: (value, values) =>
+                value.length === 0 && !values.allowBrowserImages
+                    ? 'Select at least one method or allow public images'
+                    : null,
             allowBrowserImages: (value, values) => {
                 if (value && values.type !== 'none') {
                     return 'Public browser images require no authentication';
-                }
-                if (value && !values.allowedMethods.includes('GET')) {
-                    return 'Public browser images require GET';
                 }
                 return null;
             },

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/WizardTestStep.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/WizardTestStep.tsx
@@ -69,6 +69,17 @@ export const WizardTestStep: FC<Props> = ({
         }
     })();
 
+    if (allowedMethods.length === 0) {
+        return (
+            <Stack gap="md" mt="xl">
+                <Text c="ldGray.6" fz="sm">
+                    This image-only connection does not allow proxied requests,
+                    so there is nothing to test here.
+                </Text>
+            </Stack>
+        );
+    }
+
     const handleTest = async () => {
         let parsedBody: unknown;
         if (method !== 'GET' && body.trim()) {


### PR DESCRIPTION
## Summary

- allow external connections with no proxied HTTP methods when public browser images are enabled
- align create and edit validation, and explain why the optional proxy test is unavailable for image-only connections
- show effective access in the settings table, including Public images only and mixed method/image policies

## Testing

- `pnpm -F backend test src/ee/services/ExternalConnectionService/externalConnectionConfigValidation.test.ts` (36 tests)
- `pnpm -F backend typecheck`
- `pnpm -F frontend typecheck`
- targeted frontend Oxlint on the four changed components
- Oxfmt check on all six changed files
- `git diff --check origin/main...HEAD`
- browser-tested the create and edit flows at `http://localhost:3000`; verified empty methods remain invalid without image access, image-only reaches the final step, and the Access table labels render correctly

## Issue

[GLITCH-710](https://linear.app/lightdash/issue/GLITCH-710/allow-an-external-connections-with-image-only)