### PR TITLE
fix: close SSH tunnel after failed column discovery

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -4101,6 +4101,37 @@ describe('AsyncQueryService', () => {
             ).rejects.toThrow(ForbiddenError);
         });
 
+        it('disconnects the SSH tunnel when column discovery fails', async () => {
+            const service = getMockedAsyncQueryService(lightdashConfigMock);
+            const disconnect = vi.fn();
+            const discoveryError = new Error('Column discovery failed');
+
+            service.getUserAttributes = vi.fn(async () => ({
+                userAttributes: {},
+                intrinsicUserAttributes: { email: 'test@example.com' },
+            }));
+            service._getWarehouseClient = vi.fn(async () => ({
+                warehouseClient: {
+                    ...warehouseClientMock,
+                    streamQuery: vi.fn().mockRejectedValue(discoveryError),
+                },
+                sshTunnel: {
+                    disconnect,
+                } as unknown as SshTunnel<CreateWarehouseCredentials>,
+                tunnelConnectMs: null,
+            }));
+
+            await expect(
+                service.executeAsyncSqlQuery({
+                    account: sessionAccount,
+                    projectUuid,
+                    sql: 'SELECT 1',
+                    context: QueryExecutionContext.SQL_RUNNER,
+                }),
+            ).rejects.toBe(discoveryError);
+            expect(disconnect).toHaveBeenCalledOnce();
+        });
+
         describe('cache invalidation', () => {
             it('skips cache when invalidateCache is true', async () => {
                 const service = getMockedAsyncQueryService({

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -8545,6 +8545,7 @@ export class AsyncQueryService extends ProjectService {
                 errorMessage: getErrorMessage(e),
                 ...queryTags,
             });
+            await warehouseConnection.sshTunnel.disconnect();
             throw e;
         }
         const durationColumnDiscovery =


### PR DESCRIPTION
## Summary

SQL chart column discovery can open an SSH tunnel for PostgreSQL and Redshift projects. When the discovery query rejects, `prepareSqlChartAsyncQueryArgs` throws before returning the connection, so its callers cannot run their normal cleanup. Repeated failures can therefore accumulate open SSH sessions.

Disconnect the tunnel in the column-discovery error path before preserving and rethrowing the original warehouse error. Successful discovery keeps its existing cleanup path unchanged.

## Testing

- Focused `AsyncQueryService` regression test
- Backend TypeScript check
- Backend formatter and linter on touched files

Closes: PROD-10783
Closes: #28334
Relates: PROD-10784
