### PR TITLE
chore: gate dev-resources session-start hook behind opt-in env var

### DIFF
--- a/.claude/commands/docker-dev.md
+++ b/.claude/commands/docker-dev.md
@@ -935,7 +935,7 @@ Restart Claude Code to load the new `statusLine` command. If there's no command-
 
 The `SessionStart` hook runs `./scripts/dev-resources.sh hook-start` to report Docker-dev resource use across all claimed instances. It summarises PM2 memory, running containers, and `ld-*` volumes, and flags unclaimed processes or containers as cleanup candidates.
 
-The hook is silent when no Docker-dev resources are present. When it does report, relay the result in 1–2 lines and offer to clean up specific instances with `stop`, `destroy`, `stop-all`, or `gc`.
+The hook is opt-in: it no-ops unless `LIGHTDASH_DEV_RESOURCES_HOOK` is set. It is also silent when no Docker-dev resources are present. When it does report, relay the result in 1–2 lines and offer to clean up specific instances with `stop`, `destroy`, `stop-all`, or `gc`.
 
 Run the report at any time with:
 

--- a/scripts/dev-resources.sh
+++ b/scripts/dev-resources.sh
@@ -11,6 +11,11 @@ case "$MODE" in
         ;;
 esac
 
+# Hook mode is opt-in, like the other agent hooks gate on their env vars.
+if [ "$MODE" = "hook-start" ] && [ -z "${LIGHTDASH_DEV_RESOURCES_HOOK:-}" ]; then
+    exit 0
+fi
+
 if ! command -v python3 >/dev/null 2>&1; then
     [ "$MODE" = "hook-start" ] && exit 0
     echo "python3: unavailable"


### PR DESCRIPTION
The `SessionStart` hook ran `scripts/dev-resources.sh hook-start` (Docker-dev resource report) unconditionally, unlike the okteto/exedev hooks which gate on their env vars. This made it impossible to opt out of the report without `disableAllHooks`, which also kills the statusline.

Now `hook-start` no-ops unless `LIGHTDASH_DEV_RESOURCES_HOOK` is set, mirroring the other agent hooks. `report` mode is unchanged. Updated `.claude/commands/docker-dev.md` accordingly.

No ticket.
