### PR TITLE
fix(data-apps): test connection examples with draft settings

### DIFF
--- a/packages/backend/src/ee/controllers/externalConnectionController.ts
+++ b/packages/backend/src/ee/controllers/externalConnectionController.ts
@@ -374,6 +374,7 @@ export class ExternalConnectionController extends BaseController {
                 path: body.path,
                 query: body.query,
                 body: body.body,
+                config: body.config,
             },
         );
         return { status: 'ok', results };

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.test.ts
@@ -551,6 +551,112 @@ describe('ExternalConnectionService.testConnection', () => {
         expect(result).toEqual(fetchResponse);
     });
 
+    it('tests unsaved policy changes with the stored secret without persisting them', async () => {
+        const { service, model } = buildService({});
+        mockAbility(service, true);
+
+        executeSpy = vi
+            .spyOn(
+                service as unknown as {
+                    executeExternalFetch: (...a: unknown[]) => Promise<unknown>;
+                },
+                'executeExternalFetch',
+            )
+            .mockResolvedValue({
+                response: fetchResponse,
+                requestBytes: 0,
+                responseBytes: 0,
+            });
+
+        await service.testConnection(
+            adminAccount,
+            projectUuid,
+            connectionUuid,
+            {
+                method: 'POST',
+                path: '/v2/items',
+                config: {
+                    allowedMethods: ['POST'],
+                    allowedPathPrefixes: ['/v2/'],
+                    customHeaders: { 'x-api-version': '2' },
+                },
+            },
+        );
+
+        expect(model.getDecryptedSecret).toHaveBeenCalledWith(connectionUuid);
+        expect(model.update).not.toHaveBeenCalled();
+        expect(executeSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                allowedMethods: ['POST'],
+                allowedPathPrefixes: ['/v2/'],
+                customHeaders: { 'x-api-version': '2' },
+            }),
+            's3cr3t',
+            expect.objectContaining({ method: 'POST', path: '/v2/items' }),
+        );
+    });
+
+    it('rejects testing an unsaved origin with the old stored secret', async () => {
+        const { service, model } = buildService({});
+        mockAbility(service, true);
+        const executeExternalFetchSpy = vi.spyOn(
+            service as unknown as {
+                executeExternalFetch: (...a: unknown[]) => Promise<unknown>;
+            },
+            'executeExternalFetch',
+        );
+
+        await expect(
+            service.testConnection(adminAccount, projectUuid, connectionUuid, {
+                method: 'GET',
+                path: '/v1/current',
+                config: { origin: 'https://other.example.com' },
+            }),
+        ).rejects.toThrow('type "bearer_token" requires a secret');
+
+        expect(model.getDecryptedSecret).not.toHaveBeenCalled();
+        expect(executeExternalFetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('uses a replacement secret when testing an unsaved origin', async () => {
+        const { service, model } = buildService({});
+        mockAbility(service, true);
+
+        executeSpy = vi
+            .spyOn(
+                service as unknown as {
+                    executeExternalFetch: (...a: unknown[]) => Promise<unknown>;
+                },
+                'executeExternalFetch',
+            )
+            .mockResolvedValue({
+                response: fetchResponse,
+                requestBytes: 0,
+                responseBytes: 0,
+            });
+
+        await service.testConnection(
+            adminAccount,
+            projectUuid,
+            connectionUuid,
+            {
+                method: 'GET',
+                path: '/v1/current',
+                config: {
+                    origin: 'https://other.example.com',
+                    secret: 'replacement-secret',
+                },
+            },
+        );
+
+        expect(model.getDecryptedSecret).not.toHaveBeenCalled();
+        expect(executeSpy).toHaveBeenCalledWith(
+            expect.objectContaining({ origin: 'https://other.example.com' }),
+            'replacement-secret',
+            expect.objectContaining({ method: 'GET', path: '/v1/current' }),
+        );
+    });
+
     it('defaults method to GET when omitted', async () => {
         const { service } = buildService({});
         mockAbility(service, true);

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
@@ -338,17 +338,10 @@ export class ExternalConnectionService extends BaseService {
         return this.getViewableConnection(account, projectUuid, connectionUuid);
     }
 
-    async update(
-        account: RegisteredAccount,
-        projectUuid: string,
-        connectionUuid: string,
+    private static resolveConnectionUpdate(
+        existing: ExternalConnection,
         data: UpdateExternalConnection,
-    ): Promise<ExternalConnection> {
-        const existing = await this.getOwnedConnection(
-            account,
-            projectUuid,
-            connectionUuid,
-        );
+    ): ExternalConnection {
         const resultingType = data.type ?? existing.type;
         const typeChanged =
             data.type !== undefined && data.type !== existing.type;
@@ -369,10 +362,8 @@ export class ExternalConnectionService extends BaseService {
                 !typeChanged && !originChanged && existing.hasSecret;
         }
 
-        // Resolve a field that belongs only to the resulting auth type: use the
-        // patch value if provided, else keep the existing value — but a type
-        // change never carries the previous type's values forward, and fields
-        // foreign to the resulting type are always cleared.
+        // Type-specific fields never carry across auth type changes and are
+        // cleared when they do not belong to the resulting type.
         const resolveTypeField = <T>(
             belongsToResultingType: boolean,
             patchValue: T | undefined,
@@ -382,63 +373,84 @@ export class ExternalConnectionService extends BaseService {
             if (patchValue !== undefined) return patchValue;
             return typeChanged ? null : existingValue;
         };
-        const resolvedApiKeyName = resolveTypeField(
+        const apiKeyName = resolveTypeField(
             resultingType === 'api_key',
             data.apiKeyName,
             existing.apiKeyName,
         );
-        const resolvedApiKeyLocation = resolveTypeField(
+        const apiKeyLocation = resolveTypeField(
             resultingType === 'api_key',
             data.apiKeyLocation,
             existing.apiKeyLocation,
         );
-        const resolvedOauthScopes = resolveTypeField(
+        const oauthScopes = resolveTypeField(
             resultingType === 'google_service_account',
             data.oauthScopes,
             existing.oauthScopes,
         );
 
-        // Validate the resulting (merged) config so a partial update can't
-        // leave the connection in an invalid or unsafe state.
-        validateExternalConnectionConfig(
-            {
-                type: resultingType,
-                origin: data.origin ?? existing.origin,
-                allowBrowserImages:
-                    data.allowBrowserImages ?? existing.allowBrowserImages,
-                instructions:
-                    data.instructions !== undefined
-                        ? data.instructions
-                        : existing.instructions,
-                allowedPathPrefixes:
-                    data.allowedPathPrefixes ?? existing.allowedPathPrefixes,
-                allowedMethods: data.allowedMethods ?? existing.allowedMethods,
-                allowedContentTypes:
-                    data.allowedContentTypes ?? existing.allowedContentTypes,
-                responseMaxBytes:
-                    data.responseMaxBytes ?? existing.responseMaxBytes,
-                requestMaxBytes:
-                    data.requestMaxBytes ?? existing.requestMaxBytes,
-                timeoutMs: data.timeoutMs ?? existing.timeoutMs,
-                rateLimitPerMinute:
-                    data.rateLimitPerMinute !== undefined
-                        ? data.rateLimitPerMinute
-                        : existing.rateLimitPerMinute,
-                apiKeyName: resolvedApiKeyName,
-                apiKeyLocation: resolvedApiKeyLocation,
-                oauthScopes: resolvedOauthScopes,
-                customHeaders:
-                    data.customHeaders !== undefined
-                        ? data.customHeaders
-                        : existing.customHeaders,
-            },
-            hasSecretAfter,
-        );
-        // Validate the keyfile only when a new secret is supplied — a secret-less
-        // (same-type) update keeps the already-validated stored keyfile.
+        const resolved: ExternalConnection = {
+            ...existing,
+            name: data.name ?? existing.name,
+            type: resultingType,
+            origin: data.origin ?? existing.origin,
+            allowBrowserImages:
+                data.allowBrowserImages ?? existing.allowBrowserImages,
+            allowDataAppBuilderLinking:
+                data.allowDataAppBuilderLinking ??
+                existing.allowDataAppBuilderLinking,
+            instructions:
+                data.instructions !== undefined
+                    ? data.instructions
+                    : existing.instructions,
+            allowedPathPrefixes:
+                data.allowedPathPrefixes ?? existing.allowedPathPrefixes,
+            allowedMethods: data.allowedMethods ?? existing.allowedMethods,
+            allowedContentTypes:
+                data.allowedContentTypes ?? existing.allowedContentTypes,
+            responseMaxBytes:
+                data.responseMaxBytes ?? existing.responseMaxBytes,
+            requestMaxBytes: data.requestMaxBytes ?? existing.requestMaxBytes,
+            timeoutMs: data.timeoutMs ?? existing.timeoutMs,
+            rateLimitPerMinute:
+                data.rateLimitPerMinute !== undefined
+                    ? data.rateLimitPerMinute
+                    : existing.rateLimitPerMinute,
+            apiKeyName,
+            apiKeyLocation,
+            oauthScopes,
+            customHeaders:
+                data.customHeaders !== undefined
+                    ? data.customHeaders
+                    : existing.customHeaders,
+            hasSecret: hasSecretAfter,
+        };
+
+        validateExternalConnectionConfig(resolved, hasSecretAfter);
+        // A secret-less same-type update keeps the already-validated stored
+        // keyfile; only a replacement keyfile needs parsing again.
         if (resultingType === 'google_service_account' && data.secret) {
             validateServiceAccountKeyfile(data.secret);
         }
+
+        return resolved;
+    }
+
+    async update(
+        account: RegisteredAccount,
+        projectUuid: string,
+        connectionUuid: string,
+        data: UpdateExternalConnection,
+    ): Promise<ExternalConnection> {
+        const existing = await this.getOwnedConnection(
+            account,
+            projectUuid,
+            connectionUuid,
+        );
+        const resolved = ExternalConnectionService.resolveConnectionUpdate(
+            existing,
+            data,
+        );
         // Persist the resolved type-specific fields so foreign fields (and the
         // stale scopes/api-key config) are cleared when the type changes.
         const updated = await this.externalConnectionModel.update(
@@ -446,9 +458,9 @@ export class ExternalConnectionService extends BaseService {
             account.user.id,
             {
                 ...data,
-                apiKeyName: resolvedApiKeyName,
-                apiKeyLocation: resolvedApiKeyLocation,
-                oauthScopes: resolvedOauthScopes,
+                apiKeyName: resolved.apiKeyName,
+                apiKeyLocation: resolved.apiKeyLocation,
+                oauthScopes: resolved.oauthScopes,
             },
         );
         this.analytics.track({
@@ -1204,31 +1216,43 @@ export class ExternalConnectionService extends BaseService {
             path: string;
             query?: Record<string, string>;
             body?: unknown;
+            config?: UpdateExternalConnection;
         },
     ): Promise<ExternalFetchResponse> {
-        const conn = await this.loadConnectionForProject(
+        const storedConnection = await this.loadConnectionForProject(
             connectionUuid,
             projectUuid,
         );
-        this.assertCanManage(account, conn.projectUuid, conn.organizationUuid);
+        this.assertCanManage(
+            account,
+            storedConnection.projectUuid,
+            storedConnection.organizationUuid,
+        );
+        const connection = req.config
+            ? ExternalConnectionService.resolveConnectionUpdate(
+                  storedConnection,
+                  req.config,
+              )
+            : storedConnection;
 
         // Method allowlist — mirror the runtime proxy so a test rejects a
         // disallowed method instead of silently sending it.
         const method: ExternalConnectionMethod = req.method ?? 'GET';
-        if (!conn.allowedMethods.includes(method)) {
+        if (!connection.allowedMethods.includes(method)) {
             throw new ParameterError(
                 `Method ${method} is not allowed by this connection`,
             );
         }
 
         const secret =
-            conn.type === 'none'
+            connection.type === 'none'
                 ? null
-                : await this.externalConnectionModel.getDecryptedSecret(
+                : req.config?.secret ||
+                  (await this.externalConnectionModel.getDecryptedSecret(
                       connectionUuid,
-                  );
+                  ));
 
-        return this.executeTestFetch(conn, secret, {
+        return this.executeTestFetch(connection, secret, {
             method,
             path: req.path,
             query: req.query,

--- a/packages/common/src/ee/externalConnections/types.ts
+++ b/packages/common/src/ee/externalConnections/types.ts
@@ -157,6 +157,9 @@ export type ApiTestExternalConnectionRequest = {
     path: string;
     query?: Record<string, string>;
     body?: unknown;
+    /** Optional unsaved edit values to test against the stored connection.
+     *  Blank/omitted secret keeps the stored credential when it is still valid. */
+    config?: UpdateExternalConnection;
 };
 
 /** Test an unsaved connection config (incl. plaintext secret) before creating

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionExamplesPanel.test.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionExamplesPanel.test.tsx
@@ -1,0 +1,176 @@
+import {
+    type ExternalConnection,
+    type ExternalFetchResponse,
+} from '@lightdash/common';
+import { MantineProvider } from '@mantine/core';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ConnectionExamplesPanel } from './ConnectionExamplesPanel';
+
+const mocks = vi.hoisted(() => ({
+    test: vi.fn(),
+    resetTest: vi.fn(),
+    saveSample: vi.fn(),
+    testResult: undefined as ExternalFetchResponse | undefined,
+}));
+
+vi.mock(
+    '../../../features/externalConnections/hooks/useConnectionSamples',
+    () => ({ useConnectionSamples: () => ({ data: [] }) }),
+);
+vi.mock(
+    '../../../features/externalConnections/hooks/useDeleteConnectionSample',
+    () => ({
+        useDeleteConnectionSample: () => ({
+            mutate: vi.fn(),
+            isLoading: false,
+        }),
+    }),
+);
+vi.mock(
+    '../../../features/externalConnections/hooks/useSaveConnectionSample',
+    () => ({
+        useSaveConnectionSample: () => ({
+            mutate: mocks.saveSample,
+            isLoading: false,
+        }),
+    }),
+);
+vi.mock(
+    '../../../features/externalConnections/hooks/useTestConnection',
+    () => ({
+        useTestConnection: () => ({
+            mutate: mocks.test,
+            reset: mocks.resetTest,
+            isLoading: false,
+            data: mocks.testResult,
+        }),
+    }),
+);
+
+const connection: ExternalConnection = {
+    externalConnectionUuid: 'connection-uuid',
+    projectUuid: 'project-uuid',
+    organizationUuid: 'organization-uuid',
+    name: 'Example API',
+    slug: 'example-api',
+    type: 'none',
+    origin: 'https://api.example.com',
+    allowBrowserImages: false,
+    allowDataAppBuilderLinking: false,
+    instructions: null,
+    allowedPathPrefixes: ['/'],
+    allowedMethods: ['GET'],
+    allowedContentTypes: ['application/json'],
+    responseMaxBytes: 1_048_576,
+    requestMaxBytes: 262_144,
+    timeoutMs: 10_000,
+    rateLimitPerMinute: null,
+    apiKeyName: null,
+    apiKeyLocation: null,
+    oauthScopes: null,
+    customHeaders: null,
+    hasSecret: false,
+    createdByUserUuid: 'user-uuid',
+    updatedByUserUuid: 'user-uuid',
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-01T00:00:00Z'),
+};
+
+const renderPanel = (
+    allowedMethods: ExternalConnection['allowedMethods'],
+    onQueueSample = vi.fn(),
+) => {
+    render(
+        <MantineProvider env="test">
+            <ConnectionExamplesPanel
+                projectUuid="project-uuid"
+                connection={connection}
+                config={{ allowedMethods }}
+                hasUnsavedChanges
+                isSampleQueued={false}
+                onQueueSample={onQueueSample}
+                onClearQueuedSample={vi.fn()}
+            />
+        </MantineProvider>,
+    );
+    return { onQueueSample };
+};
+
+describe('ConnectionExamplesPanel draft config', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.testResult = undefined;
+    });
+
+    it('only offers methods allowed by the draft config', () => {
+        renderPanel(['GET']);
+
+        fireEvent.click(screen.getByRole('textbox', { name: 'Method' }));
+
+        expect(screen.getByRole('option', { name: 'GET' })).toBeInTheDocument();
+        expect(
+            screen.queryByRole('option', { name: 'POST' }),
+        ).not.toBeInTheDocument();
+    });
+
+    it('clamps the request method and sends the unsaved config', () => {
+        renderPanel(['POST']);
+
+        expect(screen.getByRole('textbox', { name: 'Method' })).toHaveValue(
+            'POST',
+        );
+        fireEvent.click(
+            screen.getByRole('button', { name: 'Send test request' }),
+        );
+
+        expect(mocks.test).toHaveBeenCalledWith(
+            expect.objectContaining({
+                projectUuid: 'project-uuid',
+                connectionUuid: 'connection-uuid',
+                config: { allowedMethods: ['POST'] },
+                method: 'POST',
+                path: '/',
+            }),
+        );
+    });
+
+    it('does not render a request runner for an image-only draft', () => {
+        renderPanel([]);
+
+        expect(
+            screen.getByText(
+                'This image-only connection does not allow proxied requests, so there is nothing to test here.',
+            ),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByRole('textbox', { name: 'Method' }),
+        ).not.toBeInTheDocument();
+        expect(screen.getByText('Saved samples')).toBeInTheDocument();
+    });
+
+    it('queues a successful draft-based sample instead of saving it immediately', () => {
+        mocks.testResult = {
+            status: 200,
+            contentType: 'application/json',
+            body: { id: 1 },
+            truncated: false,
+        };
+        const onQueueSample = vi.fn();
+        renderPanel(['GET'], onQueueSample);
+
+        fireEvent.click(
+            screen.getByRole('button', { name: 'Send test request' }),
+        );
+        fireEvent.click(
+            screen.getByRole('button', { name: 'Save with connection' }),
+        );
+
+        expect(onQueueSample).toHaveBeenCalledWith({
+            label: null,
+            request: { method: 'GET', path: '/', query: undefined },
+            response: { id: 1 },
+        });
+        expect(mocks.saveSample).not.toHaveBeenCalled();
+    });
+});

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionExamplesPanel.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionExamplesPanel.tsx
@@ -1,10 +1,12 @@
 import {
     EXTERNAL_CONNECTION_METHODS,
+    type ApiSaveExternalConnectionSampleRequest,
     type ExternalConnection,
     type ExternalConnectionMethod,
     type ExternalConnectionSample,
     type ExternalConnectionSampleRequest,
     type ExternalFetchResponse,
+    type UpdateExternalConnection,
 } from '@lightdash/common';
 import {
     ActionIcon,
@@ -193,11 +195,21 @@ const SampleRow: FC<SampleRowProps> = ({
 type Props = {
     projectUuid: string;
     connection: ExternalConnection;
+    config: UpdateExternalConnection;
+    hasUnsavedChanges: boolean;
+    isSampleQueued: boolean;
+    onQueueSample: (sample: ApiSaveExternalConnectionSampleRequest) => void;
+    onClearQueuedSample: () => void;
 };
 
 export const ConnectionExamplesPanel: FC<Props> = ({
     projectUuid,
     connection,
+    config,
+    hasUnsavedChanges,
+    isSampleQueued,
+    onQueueSample,
+    onClearQueuedSample,
 }) => {
     const form = useForm<ExampleFormValues>({
         initialValues: {
@@ -222,6 +234,13 @@ export const ConnectionExamplesPanel: FC<Props> = ({
         projectUuid,
         connection.externalConnectionUuid,
     );
+    const allowedMethods = config.allowedMethods ?? connection.allowedMethods;
+    const methodOptions = EXTERNAL_CONNECTION_METHODS.filter((method) =>
+        allowedMethods.includes(method),
+    );
+    const method = methodOptions.includes(form.values.method)
+        ? form.values.method
+        : (methodOptions[0] ?? 'GET');
 
     // Pasting a URL (or path) with a query string splits the query out into the
     // key/value rows instead of leaving it stuck in the path. The pasted URL is
@@ -242,11 +261,11 @@ export const ConnectionExamplesPanel: FC<Props> = ({
     const handleTest = () => {
         form.onSubmit((values) => {
             const request: ExternalConnectionSampleRequest = {
-                method: values.method,
+                method,
                 path: values.path,
                 query: buildQuery(values.queryParams),
                 body:
-                    values.method !== 'GET'
+                    method !== 'GET'
                         ? parseJson(values.requestBody)
                         : undefined,
             };
@@ -254,6 +273,7 @@ export const ConnectionExamplesPanel: FC<Props> = ({
             testMutation.mutate({
                 projectUuid,
                 connectionUuid: connection.externalConnectionUuid,
+                config,
                 ...request,
             });
         })();
@@ -264,13 +284,20 @@ export const ConnectionExamplesPanel: FC<Props> = ({
         // response — not the current (possibly edited) form state.
         if (!testedRequest) return;
 
-        saveSampleMutation.mutate({
-            projectUuid,
-            connectionUuid: connection.externalConnectionUuid,
+        const sample: ApiSaveExternalConnectionSampleRequest = {
             label: form.values.sampleLabel.trim() || null,
             request: testedRequest,
             response: data.body,
-        });
+        };
+        if (hasUnsavedChanges) {
+            onQueueSample(sample);
+        } else {
+            saveSampleMutation.mutate({
+                projectUuid,
+                connectionUuid: connection.externalConnectionUuid,
+                ...sample,
+            });
+        }
         form.setFieldValue('sampleLabel', '');
     };
 
@@ -284,86 +311,116 @@ export const ConnectionExamplesPanel: FC<Props> = ({
                     Send a real request through this connection and optionally
                     save it as a sample for app generation.
                 </Text>
-            </Stack>
-
-            <Group align="flex-end" gap="xs">
-                <Select
-                    label="Method"
-                    w={110}
-                    allowDeselect={false}
-                    value={form.values.method}
-                    onChange={(v) => {
-                        if (!v) return;
-                        form.setFieldValue(
-                            'method',
-                            v as ExternalConnectionMethod,
-                        );
-                        testMutation.reset();
-                    }}
-                    data={[...EXTERNAL_CONNECTION_METHODS]}
-                />
-                <TextInput
-                    label="Path"
-                    placeholder="/v1/endpoint"
-                    style={{ flexGrow: 1 }}
-                    onPaste={handlePathPaste}
-                    {...form.getInputProps('path')}
-                />
-            </Group>
-
-            <Stack gap={4}>
-                <Text fz="sm" fw={500}>
-                    Query params
-                </Text>
-                <Text c="ldGray.6" fz="xs">
-                    Sent as URL query params. Tip: paste a URL with a query
-                    string into the path field to fill these in automatically.
-                </Text>
-                {form.values.queryParams.map((param, index) => (
-                    <Group key={param.uuid} gap="xs" wrap="nowrap">
-                        <TextInput
-                            size="xs"
-                            placeholder="key"
-                            style={{ flex: 1 }}
-                            {...form.getInputProps(`queryParams.${index}.key`)}
-                        />
-                        <TextInput
-                            size="xs"
-                            placeholder="value"
-                            style={{ flex: 1 }}
-                            {...form.getInputProps(
-                                `queryParams.${index}.value`,
-                            )}
-                        />
-                        <ActionIcon
+                {isSampleQueued && (
+                    <Group gap="xs">
+                        <Text c="ldGray.6" fz="xs">
+                            A tested sample is queued and will be added when you
+                            save the connection.
+                        </Text>
+                        <Button
+                            type="button"
                             variant="subtle"
-                            color="red"
-                            onClick={() =>
-                                form.removeListItem('queryParams', index)
-                            }
+                            size="compact-xs"
+                            onClick={onClearQueuedSample}
                         >
-                            <MantineIcon icon={IconTrash} />
-                        </ActionIcon>
+                            Remove
+                        </Button>
                     </Group>
-                ))}
-                <Button
-                    variant="subtle"
-                    size="compact-sm"
-                    leftSection={<MantineIcon icon={IconPlus} />}
-                    style={{ alignSelf: 'flex-start' }}
-                    onClick={() =>
-                        form.insertListItem('queryParams', {
-                            uuid: uuidv4(),
-                            key: '',
-                            value: '',
-                        })
-                    }
-                >
-                    Add query param
-                </Button>
+                )}
             </Stack>
 
-            {form.values.method !== 'GET' && (
+            {methodOptions.length === 0 && (
+                <Text c="ldGray.6" fz="sm">
+                    This image-only connection does not allow proxied requests,
+                    so there is nothing to test here.
+                </Text>
+            )}
+
+            {methodOptions.length > 0 && (
+                <Group align="flex-end" gap="xs">
+                    <Select
+                        label="Method"
+                        w={110}
+                        allowDeselect={false}
+                        value={method}
+                        onChange={(v) => {
+                            if (!v) return;
+                            form.setFieldValue(
+                                'method',
+                                v as ExternalConnectionMethod,
+                            );
+                            testMutation.reset();
+                        }}
+                        data={methodOptions}
+                    />
+                    <TextInput
+                        label="Path"
+                        placeholder="/v1/endpoint"
+                        style={{ flexGrow: 1 }}
+                        onPaste={handlePathPaste}
+                        {...form.getInputProps('path')}
+                    />
+                </Group>
+            )}
+
+            {methodOptions.length > 0 && (
+                <Stack gap={4}>
+                    <Text fz="sm" fw={500}>
+                        Query params
+                    </Text>
+                    <Text c="ldGray.6" fz="xs">
+                        Sent as URL query params. Tip: paste a URL with a query
+                        string into the path field to fill these in
+                        automatically.
+                    </Text>
+                    {form.values.queryParams.map((param, index) => (
+                        <Group key={param.uuid} gap="xs" wrap="nowrap">
+                            <TextInput
+                                size="xs"
+                                placeholder="key"
+                                style={{ flex: 1 }}
+                                {...form.getInputProps(
+                                    `queryParams.${index}.key`,
+                                )}
+                            />
+                            <TextInput
+                                size="xs"
+                                placeholder="value"
+                                style={{ flex: 1 }}
+                                {...form.getInputProps(
+                                    `queryParams.${index}.value`,
+                                )}
+                            />
+                            <ActionIcon
+                                variant="subtle"
+                                color="red"
+                                onClick={() =>
+                                    form.removeListItem('queryParams', index)
+                                }
+                            >
+                                <MantineIcon icon={IconTrash} />
+                            </ActionIcon>
+                        </Group>
+                    ))}
+                    <Button
+                        variant="subtle"
+                        size="compact-sm"
+                        leftSection={<MantineIcon icon={IconPlus} />}
+                        style={{ alignSelf: 'flex-start' }}
+                        onClick={() =>
+                            form.insertListItem('queryParams', {
+                                uuid: uuidv4(),
+                                key: '',
+                                value: '',
+                            })
+                        }
+                    >
+                        Add query param
+                    </Button>
+                </Stack>
+            )}
+
+            {methodOptions.length > 0 && method !== 'GET' && (
                 <Textarea
                     label="Request body (JSON)"
                     placeholder='{"key": "value"}'
@@ -373,18 +430,20 @@ export const ConnectionExamplesPanel: FC<Props> = ({
                 />
             )}
 
-            <Group>
-                <Button
-                    type="button"
-                    size="xs"
-                    onClick={handleTest}
-                    loading={testMutation.isLoading}
-                >
-                    Send test request
-                </Button>
-            </Group>
+            {methodOptions.length > 0 && (
+                <Group>
+                    <Button
+                        type="button"
+                        size="xs"
+                        onClick={handleTest}
+                        loading={testMutation.isLoading}
+                    >
+                        Send test request
+                    </Button>
+                </Group>
+            )}
 
-            {testMutation.data && (
+            {methodOptions.length > 0 && testMutation.data && (
                 <Stack gap="xs">
                     <ConnectionTestResult response={testMutation.data} />
 
@@ -407,11 +466,14 @@ export const ConnectionExamplesPanel: FC<Props> = ({
                                     }
                                     loading={saveSampleMutation.isLoading}
                                 >
-                                    Save as sample
+                                    {hasUnsavedChanges
+                                        ? 'Save with connection'
+                                        : 'Save as sample'}
                                 </Button>
                                 <Text fz="xs" c="ldGray.6">
-                                    Saved samples ground Claude in the
-                                    API&apos;s response shape.
+                                    {hasUnsavedChanges
+                                        ? 'The sample will be added after you save the connection.'
+                                        : 'Saved samples ground Claude in the API response shape.'}
                                 </Text>
                             </Group>
                         </>
@@ -441,7 +503,9 @@ export const ConnectionExamplesPanel: FC<Props> = ({
                     </Stack>
                 ) : (
                     <Text fz="xs" c="ldGray.6">
-                        No saved samples yet — run a test above and save it.
+                        {methodOptions.length === 0
+                            ? 'No saved samples yet.'
+                            : 'No saved samples yet — run a test above and save it.'}
                     </Text>
                 )}
             </Stack>

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/EditConnectionModal.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/EditConnectionModal.tsx
@@ -6,7 +6,7 @@ import {
 import { Button, Stack, Tabs, Text, Textarea } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { IconPencil } from '@tabler/icons-react';
-import { type FC, useEffect, useState } from 'react';
+import { type FC, useState } from 'react';
 import { isValidOAuthScope } from '../../../features/externalConnections/constants';
 import { useSaveConnectionSample } from '../../../features/externalConnections/hooks/useSaveConnectionSample';
 import { useUpdateExternalConnection } from '../../../features/externalConnections/hooks/useUpdateExternalConnection';
@@ -158,16 +158,11 @@ const EditConnectionModalContent: FC<Props> = ({
 
     const draftConfig = toUpdateExternalConnection(form.values);
     const draftConfigFingerprint = JSON.stringify(draftConfig);
+    const validPendingSample =
+        pendingSample?.configFingerprint === draftConfigFingerprint
+            ? pendingSample
+            : null;
     const isSaving = isUpdating || isSavingSample;
-
-    useEffect(() => {
-        if (
-            pendingSample &&
-            pendingSample.configFingerprint !== draftConfigFingerprint
-        ) {
-            setPendingSample(null);
-        }
-    }, [draftConfigFingerprint, pendingSample]);
 
     const handleSubmit = async (values: ExternalConnectionFormValues) => {
         const data = toUpdateExternalConnection(values);
@@ -178,11 +173,11 @@ const EditConnectionModalContent: FC<Props> = ({
             data,
         });
         if (
-            pendingSample &&
-            pendingSample.configFingerprint === submittedConfigFingerprint
+            validPendingSample &&
+            validPendingSample.configFingerprint === submittedConfigFingerprint
         ) {
             const { configFingerprint: _configFingerprint, ...sample } =
-                pendingSample;
+                validPendingSample;
             await saveSample({
                 projectUuid,
                 connectionUuid: connection.externalConnectionUuid,
@@ -255,10 +250,7 @@ const EditConnectionModalContent: FC<Props> = ({
                             connection={connection}
                             config={draftConfig}
                             hasUnsavedChanges={form.isDirty()}
-                            isSampleQueued={
-                                pendingSample?.configFingerprint ===
-                                draftConfigFingerprint
-                            }
+                            isSampleQueued={validPendingSample !== null}
                             onQueueSample={(sample) =>
                                 setPendingSample({
                                     ...sample,

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/EditConnectionModal.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/EditConnectionModal.tsx
@@ -1,12 +1,14 @@
 import {
+    type ApiSaveExternalConnectionSampleRequest,
     type ExternalConnection,
     type UpdateExternalConnection,
 } from '@lightdash/common';
 import { Button, Stack, Tabs, Text, Textarea } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { IconPencil } from '@tabler/icons-react';
-import { type FC } from 'react';
+import { type FC, useEffect, useState } from 'react';
 import { isValidOAuthScope } from '../../../features/externalConnections/constants';
+import { useSaveConnectionSample } from '../../../features/externalConnections/hooks/useSaveConnectionSample';
 import { useUpdateExternalConnection } from '../../../features/externalConnections/hooks/useUpdateExternalConnection';
 import {
     customHeaderRowsToRecord,
@@ -28,6 +30,41 @@ import {
 
 const FORM_ID = 'edit-external-connection-form';
 
+const toUpdateExternalConnection = (
+    values: ExternalConnectionFormValues,
+): UpdateExternalConnection => ({
+    name: values.name,
+    origin: values.origin,
+    instructions: values.instructions.trim() || null,
+    type: values.type,
+    allowBrowserImages: values.allowBrowserImages,
+    allowDataAppBuilderLinking: values.allowDataAppBuilderLinking,
+    allowedMethods: values.allowedMethods,
+    allowedPathPrefixes: resolvePathPrefixes(
+        values.pathMode,
+        values.allowedPathPrefixes,
+    ),
+    allowedContentTypes: values.allowedContentTypes,
+    responseMaxBytes: values.responseMaxBytes,
+    requestMaxBytes: values.requestMaxBytes,
+    timeoutMs: values.timeoutMs,
+    rateLimitPerMinute: values.rateLimitPerMinute,
+    apiKeyName: values.type === 'api_key' ? values.apiKeyName : null,
+    apiKeyLocation: values.type === 'api_key' ? values.apiKeyLocation : null,
+    oauthScopes:
+        values.type === 'google_service_account' ? values.oauthScopes : null,
+    customHeaders: customHeaderRowsToRecord(values.customHeaders),
+    // Blank => omit so the stored secret is unchanged. A non-blank value on a
+    // non-"none" type is used for both testing and credential rotation.
+    ...(values.type !== 'none' && values.secret
+        ? { secret: values.secret }
+        : {}),
+});
+
+type PendingSample = ApiSaveExternalConnectionSampleRequest & {
+    configFingerprint: string;
+};
+
 type Props = Pick<MantineModalProps, 'opened' | 'onClose'> & {
     projectUuid: string;
     connection: ExternalConnection;
@@ -39,7 +76,13 @@ const EditConnectionModalContent: FC<Props> = ({
     projectUuid,
     connection,
 }) => {
-    const { mutateAsync, isLoading: isSaving } = useUpdateExternalConnection();
+    const { mutateAsync, isLoading: isUpdating } =
+        useUpdateExternalConnection();
+    const { mutateAsync: saveSample, isLoading: isSavingSample } =
+        useSaveConnectionSample();
+    const [pendingSample, setPendingSample] = useState<PendingSample | null>(
+        null,
+    );
     const pathRules = derivePathRules(connection.allowedPathPrefixes);
     const form = useForm<ExternalConnectionFormValues>({
         initialValues: {
@@ -113,43 +156,39 @@ const EditConnectionModalContent: FC<Props> = ({
         },
     });
 
+    const draftConfig = toUpdateExternalConnection(form.values);
+    const draftConfigFingerprint = JSON.stringify(draftConfig);
+    const isSaving = isUpdating || isSavingSample;
+
+    useEffect(() => {
+        if (
+            pendingSample &&
+            pendingSample.configFingerprint !== draftConfigFingerprint
+        ) {
+            setPendingSample(null);
+        }
+    }, [draftConfigFingerprint, pendingSample]);
+
     const handleSubmit = async (values: ExternalConnectionFormValues) => {
-        const data: UpdateExternalConnection = {
-            name: values.name,
-            origin: values.origin,
-            instructions: values.instructions.trim() || null,
-            type: values.type,
-            allowBrowserImages: values.allowBrowserImages,
-            allowDataAppBuilderLinking: values.allowDataAppBuilderLinking,
-            allowedMethods: values.allowedMethods,
-            allowedPathPrefixes: resolvePathPrefixes(
-                values.pathMode,
-                values.allowedPathPrefixes,
-            ),
-            allowedContentTypes: values.allowedContentTypes,
-            responseMaxBytes: values.responseMaxBytes,
-            requestMaxBytes: values.requestMaxBytes,
-            timeoutMs: values.timeoutMs,
-            rateLimitPerMinute: values.rateLimitPerMinute,
-            apiKeyName: values.type === 'api_key' ? values.apiKeyName : null,
-            apiKeyLocation:
-                values.type === 'api_key' ? values.apiKeyLocation : null,
-            oauthScopes:
-                values.type === 'google_service_account'
-                    ? values.oauthScopes
-                    : null,
-            customHeaders: customHeaderRowsToRecord(values.customHeaders),
-            // Blank => omit so the stored secret is unchanged. A non-blank
-            // value on a non-"none" type rotates it via PATCH.
-            ...(values.type !== 'none' && values.secret
-                ? { secret: values.secret }
-                : {}),
-        };
+        const data = toUpdateExternalConnection(values);
+        const submittedConfigFingerprint = JSON.stringify(data);
         await mutateAsync({
             projectUuid,
             connectionUuid: connection.externalConnectionUuid,
             data,
         });
+        if (
+            pendingSample &&
+            pendingSample.configFingerprint === submittedConfigFingerprint
+        ) {
+            const { configFingerprint: _configFingerprint, ...sample } =
+                pendingSample;
+            await saveSample({
+                projectUuid,
+                connectionUuid: connection.externalConnectionUuid,
+                ...sample,
+            });
+        }
         onClose();
     };
 
@@ -214,6 +253,19 @@ const EditConnectionModalContent: FC<Props> = ({
                         <ConnectionExamplesPanel
                             projectUuid={projectUuid}
                             connection={connection}
+                            config={draftConfig}
+                            hasUnsavedChanges={form.isDirty()}
+                            isSampleQueued={
+                                pendingSample?.configFingerprint ===
+                                draftConfigFingerprint
+                            }
+                            onQueueSample={(sample) =>
+                                setPendingSample({
+                                    ...sample,
+                                    configFingerprint: draftConfigFingerprint,
+                                })
+                            }
+                            onClearQueuedSample={() => setPendingSample(null)}
                         />
                     </Tabs.Panel>
                 </Tabs>

--- a/packages/frontend/src/features/externalConnections/hooks/useTestConnection.ts
+++ b/packages/frontend/src/features/externalConnections/hooks/useTestConnection.ts
@@ -21,6 +21,7 @@ const testConnection = async ({
         method: 'POST',
         url: `/ee/projects/${projectUuid}/external-connections/${connectionUuid}/test`,
         body: JSON.stringify(body),
+        sensitive: true,
     });
 
 export const useTestConnection = () => {

--- a/packages/frontend/src/hooks/sensitiveApiRequests.test.tsx
+++ b/packages/frontend/src/hooks/sensitiveApiRequests.test.tsx
@@ -30,6 +30,7 @@ vi.mock('../providers/Tracking/useTracking', () => ({
 
 import { lightdashApi } from '../api';
 import { useServiceAccounts } from '../ee/features/serviceAccounts/useServiceAccounts';
+import { useTestConnection } from '../features/externalConnections/hooks/useTestConnection';
 import { useTestConnectionConfig } from '../features/externalConnections/hooks/useTestConnectionConfig';
 import { useLoginWithEmailMutation } from '../features/users/hooks/useLogin';
 import { getGdriveAccessToken } from './gdrive/useGdrive';
@@ -272,6 +273,27 @@ describe('credential-bearing requests are marked sensitive', () => {
         expect(mockApi).toHaveBeenCalledWith(
             expect.objectContaining({
                 url: '/ee/projects/project-uuid/external-connections/test-config',
+                method: 'POST',
+                sensitive: true,
+            }),
+        );
+    });
+
+    it('existing external connection test', async () => {
+        const { result } = renderHook(() => useTestConnection(), {
+            wrapper: createWrapper(),
+        });
+
+        await result.current.mutateAsync({
+            projectUuid: 'project-uuid',
+            connectionUuid: 'connection-uuid',
+            config: { secret: 'replacement-secret' },
+            path: '/',
+        });
+
+        expect(mockApi).toHaveBeenCalledWith(
+            expect.objectContaining({
+                url: '/ee/projects/project-uuid/external-connections/connection-uuid/test',
                 method: 'POST',
                 sensitive: true,
             }),


### PR DESCRIPTION
Closes: [GLITCH-711](https://linear.app/lightdash/issue/GLITCH-711/running-examples-from-the-edit-modal-doesnt-restrict-methods)
Closes: [GLITCH-712](https://linear.app/lightdash/issue/GLITCH-712/running-examples-from-the-edit-modal-should-reflect-un-saved-changes)

### Description:

- Restrict the edit-modal example runner to methods allowed by the current form draft, including an image-only state with no request runner.
- Send unsaved edit values through the existing admin-only test endpoint and resolve them in memory without persisting changes.
- Reuse stored credentials only when the draft keeps a compatible auth type and origin; replacement secrets are handled as sensitive request data.
- Queue samples produced from draft settings and persist them only after the connection update succeeds.

### Validation:

- 69 focused frontend/backend tests passed.
- Common, backend, and frontend typechecks passed.
- Targeted Oxlint, formatting, pre-commit hooks, API generation, and git diff checks passed.
- Live-tested on localhost:3000 with GET-only, POST-only draft, unsaved-origin, and image-only connections. All form changes were canceled and nothing was persisted.
- Stored/replacement credential behavior is covered by backend tests; authenticated credential rotation was not exercised live.

### Risk assessment:

- [ ] This is a high-risk change

The endpoint remains manage-only, draft changes are not persisted during tests, and secrets are excluded from request logging.