### PR TITLE
refactor: replace promoteApp change-detector tests with sandbox fake

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -450,6 +450,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         featureFlagService: repository.getFeatureFlagService(),
                         aiModelCatalog,
                     }),
+                    sandboxManager: null,
+                    appRuntimeS3: null,
                 }),
             roadmapService: ({ context, repository }) =>
                 new RoadmapService({

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.appCode.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.appCode.test.ts
@@ -233,6 +233,8 @@ function buildService(
         externalConnectionModel: externalConnectionModel as never,
         sandboxRegistryModel: {} as never,
         orgAiCopilotConfigResolver: {} as never,
+        sandboxManager: null,
+        appRuntimeS3: null,
     });
 
     // Stub ability checks to allow everything

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.buildFromSource.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.buildFromSource.test.ts
@@ -181,6 +181,8 @@ function buildService(
         orgAiCopilotConfigResolver: {
             getClaudeCodeConfig: vi.fn().mockResolvedValue(COPILOT_CONFIG),
         } as never,
+        sandboxManager: null,
+        appRuntimeS3: null,
     });
 
     const service = raw as unknown as ServiceWithPrivates;

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.clarifyApp.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.clarifyApp.test.ts
@@ -104,6 +104,8 @@ function buildService() {
                 .mockResolvedValue({ defaultProvider: 'openai' }),
             resolveFastModel,
         } as never,
+        sandboxManager: null,
+        appRuntimeS3: null,
     });
     // Bypass real CASL — the prompt/context selection is what these tests cover.
     (

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppPreviewScope.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppPreviewScope.test.ts
@@ -129,6 +129,8 @@ const buildService = () =>
         externalConnectionModel: {} as never,
         sandboxRegistryModel: {} as never,
         orgAiCopilotConfigResolver: {} as never,
+        sandboxManager: null,
+        appRuntimeS3: null,
     });
 
 const buildAssert = (): AssertFn => {

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizGeneration.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizGeneration.test.ts
@@ -96,6 +96,8 @@ function buildService(
             // the org has no Data App model restrictions.
             getDataAppModelVisibility: async () => null,
         } as never,
+        sandboxManager: null,
+        appRuntimeS3: null,
     });
     // Bypass real CASL — the mapping/flow is what these tests cover.
     (

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
@@ -113,6 +113,8 @@ function buildService(
         } as never,
         sandboxRegistryModel: {} as never,
         orgAiCopilotConfigResolver: {} as never,
+        sandboxManager: null,
+        appRuntimeS3: null,
     });
     // Bypass real CASL — the mapping/flow is what these tests cover.
     (

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.directAccess.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.directAccess.test.ts
@@ -168,6 +168,8 @@ const buildService = (role: SpaceMemberRole) => {
         } as never,
         sandboxRegistryModel: {} as never,
         orgAiCopilotConfigResolver: {} as never,
+        sandboxManager: null,
+        appRuntimeS3: null,
     });
     return { appModel, service, spacePermissionService, userModel };
 };

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.externalSamples.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.externalSamples.test.ts
@@ -82,6 +82,8 @@ function buildService() {
             externalConnectionModel: {} as never,
             sandboxRegistryModel: {} as never,
             orgAiCopilotConfigResolver: {} as never,
+            sandboxManager: null,
+            appRuntimeS3: null,
         }) as unknown as PrivateWithSamples,
         featureFlagModel,
     };

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.getAppCode.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.getAppCode.test.ts
@@ -231,6 +231,8 @@ function buildService(overrides: {
         externalConnectionModel: fullExternalConnectionModel as never,
         sandboxRegistryModel: {} as never,
         orgAiCopilotConfigResolver: {} as never,
+        sandboxManager: null,
+        appRuntimeS3: null,
     });
 
     vi.spyOn(

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.promoteApp.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.promoteApp.test.ts
@@ -1,3 +1,21 @@
+import {
+    CopyObjectCommand,
+    GetObjectCommand,
+    ListObjectsV2Command,
+} from '@aws-sdk/client-s3';
+import { Ability } from '@casl/ability';
+import {
+    assertUnreachable,
+    ProjectType,
+    type AppGeneratePipelineJobPayload,
+    type SessionUser,
+} from '@lightdash/common';
+import { Readable } from 'node:stream';
+import { pack } from 'tar-stream';
+import {
+    MockSandbox,
+    MockSandboxManager,
+} from '../SandboxRuntime/SandboxRuntime.mock';
 import { AppGenerateService } from './AppGenerateService';
 
 vi.mock('e2b', () => ({
@@ -14,90 +32,307 @@ const USER_UUID = 'user';
 const PREVIEW_APP_UUID = 'preview-app';
 const PRODUCTION_APP_UUID = 'production-app';
 const STALE_SANDBOX_UUID = 'stale-sandbox';
+const PROMOTED_SOURCE = 'export const state = "promoted";';
+const STALE_SOURCE = 'export const state = "stale";';
+const SOURCE_PATH = '/app/src/App.tsx';
 
-const previewApp = {
-    app_id: PREVIEW_APP_UUID,
-    project_uuid: PREVIEW_PROJECT_UUID,
-    organization_uuid: ORGANIZATION_UUID,
-    space_uuid: null,
-    design_uuid: null,
-    sandbox_id: 'preview-sandbox',
-    upstream_app_uuid: PRODUCTION_APP_UUID,
-    template: 'data_app',
-    name: 'Revenue app',
-    slug: 'revenue-app',
-    description: null,
-    created_by_user_uuid: USER_UUID,
-    deleted_at: null,
-    deleted_by_user_uuid: null,
+type AppRow = {
+    app_id: string;
+    project_uuid: string;
+    organization_uuid: string;
+    space_uuid: null;
+    design_uuid: null;
+    sandbox_id: string | null;
+    upstream_app_uuid: string | null;
+    template: 'data_app';
+    name: string;
+    slug: string;
+    description: null;
+    created_by_user_uuid: string;
+    deleted_at: null;
+    deleted_by_user_uuid: null;
 };
 
-const sourceVersion = {
-    app_version_id: 'preview-version',
-    app_id: PREVIEW_APP_UUID,
-    version: 3,
-    prompt: 'Fix currency formatting',
-    status: 'ready' as const,
-    error: null,
-    resources: null,
-    dependencies: null,
-    viz_schema: null,
-    data_references: null,
+type VersionRow = {
+    app_version_id: string;
+    app_id: string;
+    version: number;
+    prompt: string;
+    status: 'ready' | 'pending' | 'sandbox';
+    created_at: Date;
+    error: null;
+    resources: null;
+    dependencies: null;
+    viz_schema: null;
+    data_references: null;
 };
 
-function buildService(destroy: () => Promise<void>) {
-    const productionApp = {
+type S3Command = ListObjectsV2Command | CopyObjectCommand | GetObjectCommand;
+
+const makeSourceTar = (source: string): Promise<Buffer> =>
+    new Promise((resolve, reject) => {
+        const archive = pack();
+        const chunks: Buffer[] = [];
+        archive.on('data', (chunk: Buffer) => chunks.push(chunk));
+        archive.on('end', () => resolve(Buffer.concat(chunks)));
+        archive.on('error', reject);
+        archive.entry({ name: 'src/App.tsx' }, source, (error) => {
+            if (error) reject(error);
+            else archive.finalize();
+        });
+    });
+
+const makeUser = (): SessionUser => {
+    const ability = new Ability([{ action: 'manage', subject: 'DataApp' }]);
+    return {
+        userUuid: USER_UUID,
+        organizationUuid: ORGANIZATION_UUID,
+        isActive: true,
+        ability,
+        abilityRules: ability.rules,
+    } as SessionUser;
+};
+
+async function buildScenario() {
+    const previewApp: AppRow = {
+        app_id: PREVIEW_APP_UUID,
+        project_uuid: PREVIEW_PROJECT_UUID,
+        organization_uuid: ORGANIZATION_UUID,
+        space_uuid: null,
+        design_uuid: null,
+        sandbox_id: 'preview-sandbox',
+        upstream_app_uuid: PRODUCTION_APP_UUID,
+        template: 'data_app',
+        name: 'Revenue app',
+        slug: 'revenue-app',
+        description: null,
+        created_by_user_uuid: USER_UUID,
+        deleted_at: null,
+        deleted_by_user_uuid: null,
+    };
+    const productionApp: AppRow = {
         ...previewApp,
         app_id: PRODUCTION_APP_UUID,
         project_uuid: PRODUCTION_PROJECT_UUID,
-        sandbox_id: STALE_SANDBOX_UUID as string | null,
+        sandbox_id: STALE_SANDBOX_UUID,
+        upstream_app_uuid: null,
+    };
+    const apps = new Map([
+        [PREVIEW_APP_UUID, previewApp],
+        [PRODUCTION_APP_UUID, productionApp],
+    ]);
+    const versions = new Map<string, VersionRow[]>([
+        [
+            PREVIEW_APP_UUID,
+            [
+                {
+                    app_version_id: 'preview-version-3',
+                    app_id: PREVIEW_APP_UUID,
+                    version: 3,
+                    prompt: 'Fix currency formatting',
+                    status: 'ready',
+                    created_at: new Date(),
+                    error: null,
+                    resources: null,
+                    dependencies: null,
+                    viz_schema: null,
+                    data_references: null,
+                },
+            ],
+        ],
+        [
+            PRODUCTION_APP_UUID,
+            [
+                {
+                    app_version_id: 'production-version-6',
+                    app_id: PRODUCTION_APP_UUID,
+                    version: 6,
+                    prompt: 'Old prompt',
+                    status: 'ready',
+                    created_at: new Date(),
+                    error: null,
+                    resources: null,
+                    dependencies: null,
+                    viz_schema: null,
+                    data_references: null,
+                },
+            ],
+        ],
+    ]);
+    const objects = new Map<string, Buffer>([
+        [
+            `apps/${PREVIEW_APP_UUID}/versions/3/source.tar`,
+            await makeSourceTar(PROMOTED_SOURCE),
+        ],
+        [
+            `apps/${PRODUCTION_APP_UUID}/versions/6/source.tar`,
+            await makeSourceTar(STALE_SOURCE),
+        ],
+    ]);
+    const s3Client = {
+        send: async (command: S3Command) => {
+            if (command instanceof ListObjectsV2Command) {
+                const prefix = command.input.Prefix ?? '';
+                return {
+                    Contents: [...objects.keys()]
+                        .filter((key) => key.startsWith(prefix))
+                        .map((Key) => ({ Key })),
+                };
+            }
+            if (command instanceof CopyObjectCommand) {
+                const source = decodeURIComponent(
+                    (command.input.CopySource ?? '').replace(
+                        '/test-bucket/',
+                        '',
+                    ),
+                );
+                const value = objects.get(source);
+                if (!value || !command.input.Key) {
+                    throw new Error('Missing copy source');
+                }
+                objects.set(command.input.Key, value);
+                return {};
+            }
+            if (command instanceof GetObjectCommand) {
+                const value = objects.get(command.input.Key ?? '');
+                if (!value) throw new Error('Missing object');
+                return { Body: Readable.from([value]) };
+            }
+            return assertUnreachable(command, 'Unexpected S3 command');
+        },
     };
     const appModel = {
-        getApp: vi.fn().mockResolvedValue(previewApp),
-        getLatestReadyVersion: vi.fn().mockResolvedValue(sourceVersion),
-        getLatestVersion: vi.fn().mockResolvedValue({ version: 6 }),
-        createVersion: vi.fn().mockResolvedValue({ version: 7 }),
-        syncPromotedApp: vi.fn().mockResolvedValue(undefined),
-        updateStatusMessage: vi.fn().mockResolvedValue(undefined),
-        updateVersionDataReferences: vi.fn().mockResolvedValue(undefined),
-        updateSandboxUuid: vi
-            .fn()
-            .mockImplementation(
-                async (_appUuid: string, sandboxUuid: string | null) => {
-                    productionApp.sandbox_id = sandboxUuid;
-                },
-            ),
+        getApp: async (appUuid: string, projectUuid: string) => {
+            const app = apps.get(appUuid);
+            if (!app || app.project_uuid !== projectUuid) {
+                throw new Error('App not found');
+            }
+            return app;
+        },
+        findAppByUuid: async (appUuid: string) => apps.get(appUuid),
+        getLatestReadyVersion: async (appUuid: string) =>
+            versions
+                .get(appUuid)
+                ?.findLast((version) => version.status === 'ready'),
+        getLatestVersion: async (appUuid: string) =>
+            versions.get(appUuid)?.at(-1),
+        getVersion: async (appUuid: string, version: number) =>
+            versions.get(appUuid)?.find((row) => row.version === version),
+        getVersionStatus: async (appUuid: string, version: number) =>
+            versions.get(appUuid)?.find((row) => row.version === version)
+                ?.status,
+        createVersion: async (
+            appUuid: string,
+            input: { version: number; prompt: string },
+            status: VersionRow['status'],
+        ) => {
+            const row: VersionRow = {
+                app_version_id: `${appUuid}-version-${input.version}`,
+                app_id: appUuid,
+                version: input.version,
+                prompt: input.prompt,
+                status,
+                created_at: new Date(),
+                error: null,
+                resources: null,
+                dependencies: null,
+                viz_schema: null,
+                data_references: null,
+            };
+            versions.get(appUuid)?.push(row);
+            return row;
+        },
+        updateVersionStatusIfInProgress: async (
+            appUuid: string,
+            version: number,
+            status: VersionRow['status'] | 'catalog',
+        ) => {
+            const row = versions
+                .get(appUuid)
+                ?.find((item) => item.version === version);
+            if (!row || status === 'catalog') return false;
+            row.status = status;
+            return true;
+        },
+        updateSandboxUuid: async (
+            appUuid: string,
+            sandboxUuid: string | null,
+        ) => {
+            const app = apps.get(appUuid);
+            if (!app) throw new Error('App not found');
+            app.sandbox_id = sandboxUuid;
+        },
+        syncPromotedApp: async () => undefined,
+        updateStatusMessage: async () => undefined,
+        touchVersionIfInProgress: async () => undefined,
     };
-    const manager = { destroy: vi.fn(destroy) };
+    let pipelinePayload: AppGeneratePipelineJobPayload | undefined;
+    const sandboxManager = new MockSandboxManager({
+        sandboxUuid: STALE_SANDBOX_UUID,
+        sandbox: new MockSandbox('stale-provider', {
+            [SOURCE_PATH]: STALE_SOURCE,
+        }),
+    });
     const service = new AppGenerateService({
-        lightdashConfig: { appRuntime: {} } as never,
-        analytics: { track: vi.fn() } as never,
+        lightdashConfig: {
+            appRuntime: {
+                dataAppCodingAgent: 'claude',
+                dependencyRegistryHosts: [],
+                e2bTemplateName: 'test-template',
+                e2bTemplateTag: 'latest',
+                otel: { enabled: false },
+                sampleDataEnabled: false,
+            },
+        } as never,
+        analytics: { track: () => undefined } as never,
         analyticsModel: {} as never,
         catalogModel: {} as never,
-        userModel: {} as never,
-        appModel: appModel as never,
-        featureFlagModel: {
-            get: vi.fn().mockResolvedValue({ enabled: true }),
+        userModel: {
+            findSessionUserAndOrgByUuid: async () => makeUser(),
+            findServiceAccountByUserUuid: async () => undefined,
         } as never,
+        appModel: appModel as never,
+        featureFlagModel: { get: async () => ({ enabled: true }) } as never,
         organizationDesignModel: {
-            findInOrganization: vi.fn().mockResolvedValue(null),
+            findInOrganization: async () => null,
         } as never,
         pinnedListModel: {} as never,
         projectModel: {
-            getSummary: vi.fn().mockResolvedValue({
-                organizationUuid: ORGANIZATION_UUID,
-                projectUuid: PREVIEW_PROJECT_UUID,
-            }),
+            getSummary: async (projectUuid: string) =>
+                projectUuid === PREVIEW_PROJECT_UUID
+                    ? {
+                          projectUuid,
+                          organizationUuid: ORGANIZATION_UUID,
+                          name: 'Preview',
+                          type: ProjectType.PREVIEW,
+                          createdByUserUuid: USER_UUID,
+                          upstreamProjectUuid: PRODUCTION_PROJECT_UUID,
+                      }
+                    : {
+                          projectUuid,
+                          organizationUuid: ORGANIZATION_UUID,
+                          name: 'Production',
+                          type: ProjectType.DEFAULT,
+                          createdByUserUuid: USER_UUID,
+                          upstreamProjectUuid: null,
+                      },
         } as never,
         projectParametersModel: {} as never,
         spaceModel: {} as never,
         savedChartModel: {} as never,
-        schedulerClient: {} as never,
+        schedulerClient: {
+            appGeneratePipeline: async (
+                payload: AppGeneratePipelineJobPayload,
+            ) => {
+                pipelinePayload = payload;
+                return { jobId: 'job' };
+            },
+        } as never,
         savedChartService: {} as never,
         spacePermissionService: {
-            resolveAccess: vi.fn().mockResolvedValue({
+            resolveAccess: async () => ({
                 organizationUuid: ORGANIZATION_UUID,
-                projectUuid: PREVIEW_PROJECT_UUID,
+                projectUuid: PRODUCTION_PROJECT_UUID,
                 inheritsFromOrgOrProject: false,
                 access: [],
                 admins: [],
@@ -109,93 +344,70 @@ function buildService(destroy: () => Promise<void>) {
         projectService: {} as never,
         promoteService: {} as never,
         externalConnectionModel: {
-            listAppLinks: vi.fn().mockResolvedValue([]),
-            replaceAppLinks: vi.fn().mockResolvedValue(undefined),
+            listAppLinks: async () => [],
+            replaceAppLinks: async () => undefined,
         } as never,
         sandboxRegistryModel: {} as never,
-        orgAiCopilotConfigResolver: {} as never,
+        orgAiCopilotConfigResolver: {
+            getDataAppModelVisibility: async () => null,
+            getClaudeCodeConfig: async () => ({
+                defaultProvider: 'anthropic',
+                providers: { anthropic: { apiKey: 'test-key' } },
+                selfManagedProviders: [],
+                byoProviders: [],
+            }),
+        } as never,
+        sandboxManager,
+        appRuntimeS3: { client: s3Client as never, bucket: 'test-bucket' },
     });
 
-    vi.spyOn(
-        service as unknown as { createAuditedAbility: () => unknown },
-        'createAuditedAbility',
-    ).mockReturnValue({ can: () => true, cannot: () => false });
-    vi.spyOn(
-        service as unknown as {
-            getUpstreamProjectForPromotion: () => Promise<unknown>;
-        },
-        'getUpstreamProjectForPromotion',
-    ).mockResolvedValue({
-        upstreamProjectUuid: PRODUCTION_PROJECT_UUID,
-        upstreamProjectName: 'Production',
-        upstreamOrganizationUuid: ORGANIZATION_UUID,
-    });
-    vi.spyOn(
-        service as unknown as {
-            findLinkedUpstreamApp: () => Promise<unknown>;
-        },
-        'findLinkedUpstreamApp',
-    ).mockResolvedValue(productionApp);
-    vi.spyOn(
-        service as unknown as { getS3Client: () => unknown },
-        'getS3Client',
-    ).mockReturnValue({
-        client: { send: vi.fn().mockResolvedValue({}) },
-        bucket: 'test-bucket',
-    });
-    vi.spyOn(
-        AppGenerateService as unknown as {
-            copyVersionS3Prefix: () => Promise<string[]>;
-        },
-        'copyVersionS3Prefix',
-    ).mockResolvedValue([]);
-    vi.spyOn(
-        service as unknown as { getSandboxManager: () => unknown },
-        'getSandboxManager',
-    ).mockReturnValue(manager);
-
-    return { service, productionApp, manager };
+    return {
+        service,
+        apps,
+        getPipelinePayload: () => pipelinePayload,
+        sandboxManager,
+    };
 }
 
-describe('promoteApp sandbox state', () => {
-    beforeEach(() => {
-        vi.restoreAllMocks();
-    });
+describe('AppGenerateService promotion', () => {
+    it('cold-starts the first production iteration from promoted source', async () => {
+        const { service, apps, getPipelinePayload, sandboxManager } =
+            await buildScenario();
+        const user = makeUser();
 
-    it('invalidates the existing production sandbox', async () => {
-        const { service, productionApp, manager } = buildService(
-            async () => {},
+        await service.promoteApp(user, PREVIEW_PROJECT_UUID, PREVIEW_APP_UUID);
+
+        expect(apps.get(PRODUCTION_APP_UUID)?.sandbox_id).toBeNull();
+        expect(sandboxManager.has(STALE_SANDBOX_UUID)).toBe(false);
+
+        await service.iterateApp(
+            user,
+            PRODUCTION_PROJECT_UUID,
+            PRODUCTION_APP_UUID,
+            'Add a total',
+            [],
         );
 
+        const payload = getPipelinePayload();
+        expect(payload).toBeDefined();
+        await service.runPipeline(payload!, 0);
+
+        const source = await sandboxManager
+            .getActiveSandbox()
+            .files.read(SOURCE_PATH);
+        expect(source).toBe(PROMOTED_SOURCE);
+    });
+
+    it('clears production sandbox state when provider cleanup fails', async () => {
+        const { service, apps, sandboxManager } = await buildScenario();
+        sandboxManager.destroyError = new Error('provider unavailable');
+
         await service.promoteApp(
-            {
-                userUuid: USER_UUID,
-                organizationUuid: ORGANIZATION_UUID,
-            } as never,
+            makeUser(),
             PREVIEW_PROJECT_UUID,
             PREVIEW_APP_UUID,
         );
 
-        expect(productionApp.sandbox_id).toBeNull();
-        expect(manager.destroy).toHaveBeenCalledWith({
-            sandboxUuid: STALE_SANDBOX_UUID,
-        });
-    });
-
-    it('clears sandbox state when provider cleanup fails', async () => {
-        const { service, productionApp } = buildService(async () => {
-            throw new Error('provider unavailable');
-        });
-
-        await service.promoteApp(
-            {
-                userUuid: USER_UUID,
-                organizationUuid: ORGANIZATION_UUID,
-            } as never,
-            PREVIEW_PROJECT_UUID,
-            PREVIEW_APP_UUID,
-        );
-
-        expect(productionApp.sandbox_id).toBeNull();
+        expect(apps.get(PRODUCTION_APP_UUID)?.sandbox_id).toBeNull();
     });
 });

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.readDataApp.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.readDataApp.test.ts
@@ -119,6 +119,8 @@ function buildService(appModel: Record<string, unknown>): AppGenerateService {
         } as never,
         sandboxRegistryModel: {} as never,
         orgAiCopilotConfigResolver: {} as never,
+        sandboxManager: null,
+        appRuntimeS3: null,
     });
     vi.spyOn(
         svc as unknown as { createAuditedAbility: () => unknown },

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -195,11 +195,11 @@ import {
     createSandboxManager,
     S3SnapshotStore,
     SandboxCommandError,
-    SandboxManager,
     type AzureSandboxesConfig,
     type CloudRunSandboxesConfig,
     type PersistentWorkspace,
     type SandboxHandle,
+    type SandboxManagerPort,
     type SandboxSpec,
 } from '../SandboxRuntime';
 import {
@@ -338,6 +338,8 @@ type AppExternalConnectionDoc = {
     samples: ExternalConnectionSample[];
 };
 
+type AppRuntimeS3 = { client: S3Client; bucket: string };
+
 type AppGenerateServiceDeps = {
     lightdashConfig: LightdashConfig;
     analytics: LightdashAnalytics;
@@ -365,6 +367,9 @@ type AppGenerateServiceDeps = {
     externalConnectionModel: ExternalConnectionModel;
     sandboxRegistryModel: SandboxRegistryModel;
     orgAiCopilotConfigResolver: OrgAiCopilotConfigResolver;
+    /** Test seams: null in production, where both are built from config. */
+    sandboxManager: SandboxManagerPort | null;
+    appRuntimeS3: AppRuntimeS3 | null;
 };
 
 // Inputs for the AI agent's code-free data app read: manifest fields, the
@@ -586,8 +591,9 @@ export class AppGenerateService extends BaseService {
 
     private readonly orgAiCopilotConfigResolver: OrgAiCopilotConfigResolver;
 
-    // Lazily built from config on first use; memoized for the service lifetime.
-    private sandboxManager: SandboxManager | undefined;
+    private readonly appRuntimeS3: AppRuntimeS3 | null;
+
+    private sandboxManager: SandboxManagerPort | undefined;
 
     private readonly dataReferenceRefreshes = new Map<
         string,
@@ -618,6 +624,8 @@ export class AppGenerateService extends BaseService {
         externalConnectionModel,
         sandboxRegistryModel,
         orgAiCopilotConfigResolver,
+        sandboxManager,
+        appRuntimeS3,
     }: AppGenerateServiceDeps) {
         super();
         this.lightdashConfig = lightdashConfig;
@@ -643,6 +651,8 @@ export class AppGenerateService extends BaseService {
         this.externalConnectionModel = externalConnectionModel;
         this.sandboxRegistryModel = sandboxRegistryModel;
         this.orgAiCopilotConfigResolver = orgAiCopilotConfigResolver;
+        this.sandboxManager = sandboxManager ?? undefined;
+        this.appRuntimeS3 = appRuntimeS3;
     }
 
     private async getDataAppProjectContext(
@@ -1003,12 +1013,12 @@ export class AppGenerateService extends BaseService {
 
     /**
      * The sandbox manager over the provider selected by `SANDBOX_PROVIDER`
-     * (e2b | docker). Memoized — the feature talks only to the manager for
-     * lifecycle (acquire/resume/suspend/destroy via the stable `sandbox_uuid`)
-     * and to the returned {@link SandboxHandle} for the data plane.
+     * (e2b | docker). The feature talks only to the manager for lifecycle
+     * (acquire/resume/suspend/destroy via the stable `sandbox_uuid`) and to
+     * the returned {@link SandboxHandle} for the data plane.
      * See docs/sandbox-runtime.md.
      */
-    private getSandboxManager(): SandboxManager {
+    private getSandboxManager(): SandboxManagerPort {
         if (!this.sandboxManager) {
             const { sandboxProvider } = this.lightdashConfig.appRuntime;
             this.sandboxManager = createSandboxManager({
@@ -1153,7 +1163,9 @@ export class AppGenerateService extends BaseService {
         };
     }
 
-    private getS3Client(): { client: S3Client; bucket: string } {
+    private getS3Client(): AppRuntimeS3 {
+        if (this.appRuntimeS3) return this.appRuntimeS3;
+
         const s3Config = this.lightdashConfig.appRuntime.s3;
         if (!s3Config) {
             throw new MissingConfigError(

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.upgrade.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.upgrade.test.ts
@@ -136,6 +136,8 @@ function buildService(
         externalConnectionModel: {} as never,
         sandboxRegistryModel: {} as never,
         orgAiCopilotConfigResolver: {} as never,
+        sandboxManager: null,
+        appRuntimeS3: null,
     });
 
     const canManage = opts.canManage ?? true;

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.vizSchemaCopy.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.vizSchemaCopy.test.ts
@@ -175,6 +175,8 @@ function buildService() {
         externalConnectionModel: externalConnectionModel as never,
         sandboxRegistryModel: {} as never,
         orgAiCopilotConfigResolver: {} as never,
+        sandboxManager: null,
+        appRuntimeS3: null,
     });
 
     vi.spyOn(

--- a/packages/backend/src/ee/services/SandboxRuntime/SandboxManager.ts
+++ b/packages/backend/src/ee/services/SandboxRuntime/SandboxManager.ts
@@ -57,6 +57,12 @@ export interface SandboxManagerDeps {
     logger: SandboxLogger;
 }
 
+/** The lifecycle subset feature services depend on; satisfied by test fakes. */
+export type SandboxManagerPort = Pick<
+    SandboxManager,
+    'acquire' | 'resume' | 'suspend' | 'suspendByUuid' | 'destroy'
+>;
+
 /**
  * Layer 1 — the only sandbox lifecycle surface feature code talks to. Wraps a
  * {@link SandboxProvider} with a registry (stable `sandbox_uuid`) and the

--- a/packages/backend/src/ee/services/SandboxRuntime/SandboxRuntime.mock.ts
+++ b/packages/backend/src/ee/services/SandboxRuntime/SandboxRuntime.mock.ts
@@ -1,0 +1,147 @@
+import { extract } from 'tar-stream';
+import { type SandboxManager, type SandboxManagerPort } from './SandboxManager';
+import { type SandboxGit, type SandboxHandle } from './types';
+
+const extractTar = (
+    archive: Buffer,
+    destination: string,
+    files: Map<string, Buffer>,
+): Promise<void> =>
+    new Promise((resolve, reject) => {
+        const unpack = extract();
+        unpack.on('entry', (header, stream, next) => {
+            const chunks: Buffer[] = [];
+            stream.on('data', (chunk: Buffer) => chunks.push(chunk));
+            stream.on('end', () => {
+                files.set(
+                    `${destination}/${header.name}`,
+                    Buffer.concat(chunks),
+                );
+                next();
+            });
+            stream.on('error', reject);
+            stream.resume();
+        });
+        unpack.on('finish', resolve);
+        unpack.on('error', reject);
+        unpack.end(archive);
+    });
+
+const unsupportedGit =
+    (method: keyof SandboxGit) => async (): Promise<never> => {
+        throw new Error(`MockSandbox does not support git.${method}`);
+    };
+
+export class MockSandbox implements SandboxHandle {
+    readonly contents: Map<string, Buffer>;
+
+    readonly files: SandboxHandle['files'];
+
+    readonly commands: SandboxHandle['commands'];
+
+    readonly git: SandboxGit = {
+        clone: unsupportedGit('clone'),
+        status: unsupportedGit('status'),
+        createBranch: unsupportedGit('createBranch'),
+        add: unsupportedGit('add'),
+        commit: unsupportedGit('commit'),
+        push: unsupportedGit('push'),
+    };
+
+    constructor(
+        readonly sandboxId: string,
+        initialFiles: Record<string, string> = {},
+    ) {
+        this.contents = new Map([
+            ['/app/skill.md', Buffer.from('test skill')],
+            ...Object.entries(initialFiles).map(
+                ([path, value]) => [path, Buffer.from(value)] as const,
+            ),
+        ]);
+        this.files = {
+            read: async (path) => {
+                const value = this.contents.get(path);
+                if (!value) throw new Error(`Missing file: ${path}`);
+                return value.toString();
+            },
+            readBytes: async (path) => {
+                const value = this.contents.get(path);
+                if (!value) throw new Error(`Missing file: ${path}`);
+                return value;
+            },
+            write: async (path, value) => {
+                this.contents.set(path, Buffer.from(value));
+            },
+            remove: async (path) => {
+                this.contents.delete(path);
+            },
+        };
+        this.commands = {
+            run: async (command) => {
+                const extractMatch = command.match(/^tar -xf (\S+) -C (\S+)$/);
+                if (extractMatch) {
+                    const [, archivePath, destination] = extractMatch;
+                    const archive = this.contents.get(archivePath);
+                    if (!archive) {
+                        throw new Error(`Missing archive: ${archivePath}`);
+                    }
+                    await extractTar(archive, destination, this.contents);
+                }
+                return { exitCode: 0, stdout: '', stderr: '' };
+            },
+        };
+    }
+}
+
+export class MockSandboxManager implements SandboxManagerPort {
+    private readonly sandboxes = new Map<string, MockSandbox>();
+
+    private activeSandbox: MockSandbox | undefined;
+
+    destroyError: Error | null = null;
+
+    constructor(
+        resumable: { sandboxUuid: string; sandbox: MockSandbox } | null = null,
+    ) {
+        if (resumable) {
+            this.sandboxes.set(resumable.sandboxUuid, resumable.sandbox);
+        }
+    }
+
+    async acquire(): ReturnType<SandboxManager['acquire']> {
+        const sandboxUuid = 'fresh-sandbox';
+        const sandbox = new MockSandbox('fresh-provider');
+        this.sandboxes.set(sandboxUuid, sandbox);
+        this.activeSandbox = sandbox;
+        return { sandboxUuid, handle: sandbox };
+    }
+
+    async resume(
+        input: Parameters<SandboxManager['resume']>[0],
+    ): ReturnType<SandboxManager['resume']> {
+        const sandbox = this.sandboxes.get(input.sandboxUuid);
+        if (!sandbox) throw new Error(`Missing sandbox: ${input.sandboxUuid}`);
+        this.activeSandbox = sandbox;
+        return sandbox;
+    }
+
+    async suspend(): ReturnType<SandboxManager['suspend']> {}
+
+    async suspendByUuid(): ReturnType<SandboxManager['suspendByUuid']> {}
+
+    async destroy(
+        input: Parameters<SandboxManager['destroy']>[0],
+    ): ReturnType<SandboxManager['destroy']> {
+        if (this.destroyError) throw this.destroyError;
+        this.sandboxes.delete(input.sandboxUuid);
+    }
+
+    has(sandboxUuid: string): boolean {
+        return this.sandboxes.has(sandboxUuid);
+    }
+
+    getActiveSandbox(): MockSandbox {
+        if (!this.activeSandbox) throw new Error('Sandbox was not acquired');
+        return this.activeSandbox;
+    }
+}


### PR DESCRIPTION
## Summary

Refactor per `CODING_STANDARDS.md` (change-detector tests): the promoteApp tests spied on five private `AppGenerateService` methods and asserted call sequences. Now they drive the public surface (`promoteApp` → `iterateApp` → `runPipeline`) against in-memory fakes and assert observable outcomes.

- New `SandboxRuntime.mock.ts` (`MockSandbox`/`MockSandboxManager`) beside its subject, sharing the exported `SandboxManagerPort` with the service. Typed throwing `git` stubs, generic `tar -xf` parsing, `destroyError` toggle for failure-path tests.
- `AppGenerateService` gains two explicit test seams (`sandboxManager`, `appRuntimeS3`), required `| null` deps wired as `null` in `ee/index.ts` (hence the 2-line change in each sibling test).
- Tests now cover: cold-start of first production iteration from promoted source (stale sandbox actually destroyed, `sandbox_id` cleared), and `sandbox_id` cleared even when provider cleanup throws.

No behaviour change in production code paths.

No Linear ticket — standalone test refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KK2uWryPEcC7xaJnXeoKrC