### PR TITLE
fix(data-apps): configure image origins in AI onboarding

### DIFF
--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.test.ts
@@ -1161,6 +1161,7 @@ describe('ExternalConnectionService proposeConfig', () => {
         name: 'Example API',
         origin: 'https://api.example.com',
         type: 'bearer_token',
+        allowBrowserImages: false,
         apiKeyName: null,
         apiKeyLocation: null,
         oauthScopes: null,

--- a/packages/backend/src/ee/services/ai/agents/externalConnectionConfigGenerator.test.ts
+++ b/packages/backend/src/ee/services/ai/agents/externalConnectionConfigGenerator.test.ts
@@ -30,6 +30,7 @@ const rawProposal = (
         name: string;
         origin: string | null;
         type: ExternalConnectionAuthType;
+        allowBrowserImages: boolean;
         apiKeyName: string | null;
         apiKeyLocation: 'header' | 'query' | null;
         oauthScopes: string[] | null;
@@ -47,6 +48,7 @@ const rawProposal = (
         name: 'Example API',
         origin: 'https://api.example.com',
         type: 'bearer_token' as ExternalConnectionAuthType,
+        allowBrowserImages: false,
         apiKeyName: null,
         apiKeyLocation: null,
         oauthScopes: null,
@@ -75,9 +77,12 @@ const mockGenerateObject = (objects: unknown[]) => {
 describe('buildProposalSystemPrompt', () => {
     it('contains the security guardrails', () => {
         const prompt = buildProposalSystemPrompt();
-        expect(prompt).toContain('official documented API host');
+        expect(prompt).toContain(
+            'official documented API or public image host',
+        );
         expect(prompt).toContain('confident=false');
         expect(prompt).toContain('Least privilege');
+        expect(prompt).toContain('allowBrowserImages=true');
         expect(prompt).toContain(
             'NEVER include, invent, or placeholder any credential value',
         );
@@ -142,6 +147,18 @@ describe('normalizeProposal', () => {
         expect(result.allowedPathPrefixes).toEqual(['/v1/messages']);
     });
 
+    it('preserves image-only access without adding proxy methods', () => {
+        const result = normalizeProposal(
+            rawProposal({
+                type: 'none',
+                allowBrowserImages: true,
+                allowedMethods: [],
+            }),
+        );
+        expect(result.allowBrowserImages).toBe(true);
+        expect(result.allowedMethods).toEqual([]);
+    });
+
     it('strips trailing slash from origin and rejects non-https docs urls', () => {
         const result = normalizeProposal(
             rawProposal({
@@ -199,6 +216,27 @@ describe('generateExternalConnectionConfigProposal', () => {
                 }),
             ]),
         );
+    });
+
+    it('repairs browser image access that requires authentication', async () => {
+        const invalid = rawProposal({ allowBrowserImages: true });
+        const repaired = rawProposal({
+            type: 'none',
+            allowBrowserImages: true,
+            allowedMethods: [],
+            credentialGuide: null,
+        });
+        const mock = mockGenerateObject([invalid, repaired]);
+
+        const result = await generateExternalConnectionConfigProposal(
+            modelOptions,
+            'use public images from this host',
+        );
+
+        expect(result.type).toBe('none');
+        expect(result.allowBrowserImages).toBe(true);
+        expect(result.allowedMethods).toEqual([]);
+        expect(mock).toHaveBeenCalledTimes(2);
     });
 
     it('gives up after a failed repair round', async () => {

--- a/packages/backend/src/ee/services/ai/agents/externalConnectionConfigGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/externalConnectionConfigGenerator.ts
@@ -24,13 +24,18 @@ const MAX_PATH_PREFIXES = 20;
 const MAX_CUSTOM_HEADERS = 20;
 const MAX_OAUTH_SCOPES = 10;
 
-// The wizard hides content types and always creates JSON connections; the
-// proposal validates against the same default so what the user saves is what
-// was checked here.
+// The wizard hides content types. Keep these defaults in sync with its create
+// payload so the proposal is validated as the config the user will save.
 const PROPOSAL_ALLOWED_CONTENT_TYPES = ['application/json'];
+const PROPOSAL_BROWSER_IMAGE_CONTENT_TYPES = [
+    'image/png',
+    'image/jpeg',
+    'image/webp',
+    'image/gif',
+];
 
 const NOT_CONFIDENT_MESSAGE =
-    'Couldn\'t identify which API to connect to. Try naming the provider explicitly, e.g. "the Google Sheets API".';
+    "Couldn't identify which API or image host to connect to. Try naming the provider or domain explicitly.";
 
 // No `.max()` on arrays (Anthropic structured output rejects maxItems) and no
 // z.record (it emits additionalProperties) — caps live in the prompt and are
@@ -39,7 +44,7 @@ const ProposalSchema = z.object({
     confident: z
         .boolean()
         .describe(
-            'False when no specific API service could be identified from the description',
+            'False when no specific API service or public image host could be identified from the description',
         ),
     name: z
         .string()
@@ -48,11 +53,16 @@ const ProposalSchema = z.object({
         .string()
         .nullable()
         .describe(
-            'Official https base URL of the API host with no path, e.g. https://sheets.googleapis.com. Null when not confident.',
+            'Official https base URL of the API or public image host with no path, e.g. https://sheets.googleapis.com. Null when not confident.',
         ),
     type: z
         .enum(['none', 'api_key', 'bearer_token', 'google_service_account'])
         .describe('How the API authenticates requests'),
+    allowBrowserImages: z
+        .boolean()
+        .describe(
+            'Whether linked apps may load public images directly from this origin in the browser',
+        ),
     apiKeyName: z
         .string()
         .nullable()
@@ -112,16 +122,17 @@ const ProposalSchema = z.object({
 type RawProposal = z.infer<typeof ProposalSchema>;
 
 export const buildProposalSystemPrompt = (): string =>
-    `You configure outbound HTTP connections ("external connections") for Lightdash data apps. A connection is an egress allowlist plus auth config enforced by a server-side proxy. Propose exactly one connection config for the user's described integration.
+    `You configure outbound HTTP connections ("external connections") for Lightdash data apps. A connection is an egress allowlist plus auth config enforced by a server-side proxy and can separately allow direct browser image loading. Propose exactly one connection config for the user's described integration.
 
 FIELD SEMANTICS:
-- origin: the https base URL of the API host — bare host, no path or query (e.g. https://sheets.googleapis.com).
+- origin: the https base URL of the API or public image host — bare host, no path or query (e.g. https://sheets.googleapis.com).
 - allowedPathPrefixes: absolute path prefixes (starting with /) the proxy allows, matched on whole path segments.
 - allowedMethods: HTTP methods the proxy allows.
 - type api_key: credential sent as a header or query parameter — set apiKeyName and apiKeyLocation.
 - type bearer_token: credential sent as "Authorization: Bearer <token>".
 - type google_service_account: service-account keyfile JSON with least-privilege oauthScopes.
 - type none: public API, no credential.
+- allowBrowserImages: whether linked apps may load public images directly from this origin in image tags, CSS, or map tile layers. This bypasses the server-side proxy and is only valid with type none.
 - customHeaders: static NON-SECRET headers sent on every request (e.g. version headers like anthropic-version). Never put credentials here — credential-shaped header names are rejected.
 - instructions: guidance for the AI that later builds data apps on this connection — key endpoints, request/response shapes, pagination, quirks. At most ~1500 characters.
 - credentialGuide: numbered markdown steps the user follows in the provider's console to create or find the credential, using the least-privilege role/scope, ending with a link to the relevant docs page. Null only for type none.
@@ -129,8 +140,9 @@ FIELD SEMANTICS:
 - notes: short caveats the user must double-check (e.g. region-specific hosts, plan requirements). Null when none.
 
 RULES:
-- The origin MUST be the provider's official documented API host. Never guess lookalike domains or regional variants you are unsure about. If you cannot confidently identify a specific service, set confident=false and origin=null instead of guessing.
+- The origin MUST be the provider's official documented API or public image host. Never guess lookalike domains or regional variants you are unsure about. If you cannot confidently identify a specific service or image host, set confident=false and origin=null instead of guessing.
 - Least privilege: propose the narrowest allowedPathPrefixes and allowedMethods that serve the described use case. GET-only unless the use case clearly needs writes. Use ["/"] only when the API genuinely requires broad path access.
+- Set allowBrowserImages=true only when the user explicitly wants to render public images or map tiles from the origin. For an image-only connection, use type=none and allowedMethods=[] because no proxy access is needed. Otherwise set allowBrowserImages=false.
 - NEVER include, invent, or placeholder any credential value anywhere in the config.
 - For Google-hosted APIs prefer type google_service_account with minimal scopes, and make credentialGuide mention sharing the target resource with the service account's client_email.
 - At most ${MAX_PATH_PREFIXES} allowedPathPrefixes, ${MAX_CUSTOM_HEADERS} customHeaders, and ${MAX_OAUTH_SCOPES} oauthScopes.`;
@@ -153,11 +165,12 @@ const normalizeOrigin = (origin: string): string => {
 
 const normalizeMethods = (
     methods: ExternalConnectionMethod[],
+    allowBrowserImages: boolean,
 ): ExternalConnectionMethod[] => {
     const unique = EXTERNAL_CONNECTION_METHODS.filter((method) =>
         methods.includes(method),
     );
-    return unique.length > 0 ? unique : ['GET'];
+    return unique.length > 0 || allowBrowserImages ? unique : ['GET'];
 };
 
 const normalizePathPrefixes = (prefixes: string[]): string[] => {
@@ -214,11 +227,15 @@ export const normalizeProposal = (
         name,
         origin,
         type: raw.type,
+        allowBrowserImages: raw.allowBrowserImages,
         apiKeyName: isApiKey ? normalizeString(raw.apiKeyName) : null,
         apiKeyLocation: isApiKey ? (raw.apiKeyLocation ?? 'header') : null,
         oauthScopes,
         customHeaders: normalizeCustomHeaders(raw.customHeaders),
-        allowedMethods: normalizeMethods(raw.allowedMethods),
+        allowedMethods: normalizeMethods(
+            raw.allowedMethods,
+            raw.allowBrowserImages,
+        ),
         allowedPathPrefixes: normalizePathPrefixes(raw.allowedPathPrefixes),
         instructions: normalizeString(raw.instructions),
         credentialGuide:
@@ -233,10 +250,16 @@ const toValidatableConfig = (
 ): ValidatableExternalConnectionConfig => ({
     type: proposal.type,
     origin: proposal.origin,
+    allowBrowserImages: proposal.allowBrowserImages,
     instructions: proposal.instructions,
     allowedPathPrefixes: proposal.allowedPathPrefixes,
     allowedMethods: proposal.allowedMethods,
-    allowedContentTypes: PROPOSAL_ALLOWED_CONTENT_TYPES,
+    allowedContentTypes: proposal.allowBrowserImages
+        ? [
+              ...PROPOSAL_ALLOWED_CONTENT_TYPES,
+              ...PROPOSAL_BROWSER_IMAGE_CONTENT_TYPES,
+          ]
+        : PROPOSAL_ALLOWED_CONTENT_TYPES,
     apiKeyName: proposal.apiKeyName,
     apiKeyLocation: proposal.apiKeyLocation,
     oauthScopes: proposal.oauthScopes,

--- a/packages/common/src/ee/externalConnections/types.ts
+++ b/packages/common/src/ee/externalConnections/types.ts
@@ -189,6 +189,7 @@ export type ExternalConnectionConfigProposal = {
     name: string;
     origin: string;
     type: ExternalConnectionAuthType;
+    allowBrowserImages: boolean;
     apiKeyName: string | null;
     apiKeyLocation: ApiKeyLocation | null;
     oauthScopes: string[] | null;

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/wizardValues.test.ts
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/wizardValues.test.ts
@@ -11,6 +11,7 @@ const proposal = (
     name: 'Google Sheets',
     origin: 'https://sheets.googleapis.com',
     type: 'google_service_account',
+    allowBrowserImages: false,
     apiKeyName: null,
     apiKeyLocation: null,
     oauthScopes: ['https://www.googleapis.com/auth/spreadsheets.readonly'],
@@ -47,6 +48,18 @@ describe('applyProposalToWizardValues', () => {
         expect(values.allowedPathPrefixes.map((p) => p.value)).toEqual([
             '/v4/spreadsheets',
         ]);
+    });
+
+    it('applies browser image access from the proposal', () => {
+        const values = applyProposalToWizardValues(
+            proposal({
+                type: 'none',
+                allowBrowserImages: true,
+                allowedMethods: [],
+            }),
+        );
+        expect(values.allowBrowserImages).toBe(true);
+        expect(values.allowedMethods).toEqual([]);
     });
 
     it('derives allow-all path mode from a root prefix', () => {

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/wizardValues.ts
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/wizardValues.ts
@@ -74,7 +74,7 @@ export const applyProposalToWizardValues = (
         name: proposal.name,
         origin: proposal.origin,
         type: proposal.type,
-        allowBrowserImages: false,
+        allowBrowserImages: proposal.allowBrowserImages,
         allowDataAppBuilderLinking: false,
         secret: '',
         apiKeyName: proposal.apiKeyName ?? '',


### PR DESCRIPTION
Closes: [GLITCH-709](https://linear.app/lightdash/issue/GLITCH-709/ai-onboarding-for-image-origins)

### Description:

```diff
Describe a public image origin to AI
- prefill a regular GET connection with browser images disabled
+ prefill an image-only connection with browser images enabled
```

- Adds browser-image intent to the AI proposal contract and prompt.
- Keeps image-only connections least-privileged with no proxy methods enabled.
- Applies the proposed image setting in the wizard instead of resetting it to off.
- Reuses backend connection validation so browser image access remains limited to no-auth connections; invalid AI proposals get one repair attempt.
- Persists nothing during proposal generation; the admin still reviews every step and explicitly creates the connection.

Validation:

- Backend generator tests: 12 passed
- Backend external connection service tests: 51 passed
- Frontend wizard value tests: 9 passed
- `pnpm -F common typecheck`
- `pnpm -F backend typecheck`
- `pnpm -F frontend typecheck`
- Focused Oxlint and Oxfmt checks
- `pnpm generate-api` (generated artifacts excluded per repository convention)
- `git diff --check`
- Live browser repro on `localhost:3000` using `I want to use images from https://media.formula1.com`: image toggle checked, no proxy methods enabled, and no connection/test data persisted

### Risk assessment:

- [ ] This is a high-risk change

Low risk. This only changes automatic connection proposal prefilling. Manual setup is unchanged, every generated proposal remains reviewable before persistence, and existing backend validation prevents authenticated connections from enabling direct browser image access.
