### PR TITLE
feat: translate user-defined dashboard filter labels via language map

### DIFF
--- a/packages/common/src/utils/i18n/abstract.ts
+++ b/packages/common/src/utils/i18n/abstract.ts
@@ -15,15 +15,16 @@ type AllowedAsCode =
 export abstract class AsCodeInternalization<
     T extends AllowedAsCode,
     Z extends z.AnyZodObject,
+    // Language map entry: mirrors the content shape by default, but an
+    // implementation may substitute its own shape for parts that are not
+    // positionally addressable (e.g. dashboard filter labels)
+    MapEntry = PartialDeep<T['content'], { recurseIntoArrays: true }>,
 > {
     protected abstract schema: Z;
 
     public abstract getLanguageMap(asCode: T['content']): {
         [typeKey in T['type']]: {
-            [slugKey in T['content']['slug']]: PartialDeep<
-                T['content'],
-                { recurseIntoArrays: true }
-            >;
+            [slugKey in T['content']['slug']]: MapEntry;
         };
     };
 

--- a/packages/common/src/utils/i18n/dashboardAsCode.test.ts
+++ b/packages/common/src/utils/i18n/dashboardAsCode.test.ts
@@ -1,0 +1,161 @@
+import { type DashboardAsCode } from '../../types/coder';
+import { DashboardTileTypes } from '../../types/dashboard';
+import { FilterOperator } from '../../types/filter';
+import { DashboardAsCodeInternalization } from './dashboardAsCode';
+
+const dashboardAsCode: DashboardAsCode = {
+    name: 'Sales overview',
+    description: undefined,
+    slug: 'sales-overview',
+    spaceSlug: 'shared',
+    version: 1,
+    tabs: [],
+    tiles: [
+        {
+            uuid: undefined,
+            tileSlug: undefined,
+            type: DashboardTileTypes.MARKDOWN,
+            x: 0,
+            y: 0,
+            h: 3,
+            w: 9,
+            properties: { title: 'Notes', content: 'Some content' },
+        },
+    ],
+    filters: {
+        dimensions: [
+            {
+                label: 'Regio klant',
+                target: {
+                    fieldId: 'customers_region',
+                    tableName: 'customers',
+                },
+                operator: FilterOperator.EQUALS,
+                values: [],
+                tileTargets: {},
+            },
+            {
+                label: undefined,
+                target: { fieldId: 'orders_status', tableName: 'orders' },
+                operator: FilterOperator.EQUALS,
+                values: [],
+                tileTargets: {},
+            },
+        ],
+        metrics: [
+            {
+                id: 'metric-filter-1',
+                label: 'Totale omzet',
+                target: { fieldId: 'orders_total', tableName: 'orders' },
+                operator: FilterOperator.GREATER_THAN,
+                values: [0],
+                tileTargets: {},
+            },
+        ],
+        tableCalculations: [],
+    },
+};
+
+describe('DashboardAsCodeInternalization', () => {
+    describe('getLanguageMap', () => {
+        it('should emit user-defined filter labels keyed by source label', () => {
+            const languageMap =
+                new DashboardAsCodeInternalization().getLanguageMap(
+                    dashboardAsCode,
+                ).dashboard[dashboardAsCode.slug];
+
+            expect(languageMap.name).toBe('Sales overview');
+            expect(languageMap.filters).toEqual({
+                labels: {
+                    'Regio klant': 'Regio klant',
+                    'Totale omzet': 'Totale omzet',
+                },
+            });
+        });
+
+        it('should handle a dashboard without filters', () => {
+            const { filters, ...dashboardWithoutFilters } = dashboardAsCode;
+
+            const languageMap =
+                new DashboardAsCodeInternalization().getLanguageMap(
+                    dashboardWithoutFilters,
+                ).dashboard[dashboardAsCode.slug];
+
+            expect(languageMap.filters).toBeUndefined();
+        });
+
+        it('should omit filters when no rule has a user-defined label', () => {
+            const languageMap =
+                new DashboardAsCodeInternalization().getLanguageMap({
+                    ...dashboardAsCode,
+                    filters: {
+                        dimensions: [
+                            {
+                                ...dashboardAsCode.filters!.dimensions![0],
+                                label: undefined,
+                            },
+                        ],
+                        metrics: [],
+                        tableCalculations: [],
+                    },
+                }).dashboard[dashboardAsCode.slug];
+
+            expect(languageMap.filters).toBeUndefined();
+        });
+    });
+
+    describe('merge', () => {
+        it('should translate filter labels by source label without touching other rule fields', () => {
+            const merged = new DashboardAsCodeInternalization().merge(
+                {
+                    filters: {
+                        labels: {
+                            'Regio klant': 'Région client',
+                            'Totale omzet': "Chiffre d'affaires",
+                        },
+                    },
+                },
+                structuredClone(dashboardAsCode),
+            );
+
+            expect(merged.filters?.dimensions?.[0]).toMatchObject({
+                label: 'Région client',
+                operator: FilterOperator.EQUALS,
+                target: {
+                    fieldId: 'customers_region',
+                    tableName: 'customers',
+                },
+            });
+            expect(merged.filters?.dimensions?.[1]?.label).toBeUndefined();
+            expect(merged.filters?.metrics?.[0]).toMatchObject({
+                id: 'metric-filter-1',
+                label: "Chiffre d'affaires",
+            });
+        });
+
+        it('should leave labels without a translation entry untouched', () => {
+            const merged = new DashboardAsCodeInternalization().merge(
+                { filters: { labels: { 'Some other label': 'Autre' } } },
+                structuredClone(dashboardAsCode),
+            );
+
+            expect(merged.filters?.dimensions?.[0]?.label).toBe('Regio klant');
+            expect(merged.filters?.metrics?.[0]?.label).toBe('Totale omzet');
+        });
+
+        it('should still merge non-filter content alongside filter labels', () => {
+            const merged = new DashboardAsCodeInternalization().merge(
+                {
+                    name: 'Aperçu des ventes',
+                    filters: { labels: { 'Regio klant': 'Région client' } },
+                },
+                structuredClone(dashboardAsCode),
+            );
+
+            expect(merged.name).toBe('Aperçu des ventes');
+            expect(merged.filters?.dimensions?.[0]?.label).toBe(
+                'Région client',
+            );
+        });
+    });
+});

--- a/packages/common/src/utils/i18n/dashboardAsCode.ts
+++ b/packages/common/src/utils/i18n/dashboardAsCode.ts
@@ -1,3 +1,4 @@
+import { type PartialDeep } from 'type-fest';
 import { z } from 'zod';
 import { type DashboardAsCode } from '../../types/coder';
 import { DashboardTileTypes } from '../../types/dashboard';
@@ -52,24 +53,86 @@ const dashboardAsCodeSchema = z.object({
     ),
 });
 
+/**
+ * Source (untranslated) filter label -> translated label. Keyed by label
+ * rather than array position so translations survive filter reordering,
+ * insertion, and deletion; renaming a label invalidates its translation
+ * (the pill falls back to the source label). Deliberately an
+ * index-signature literal, not `Record` — see DashboardTileTargets.
+ */
+export type DashboardFilterLabelTranslations = {
+    [sourceLabel: string]: string;
+};
+
+export const getFilterLabelTranslation = (
+    labels: DashboardFilterLabelTranslations,
+    sourceLabel: string | undefined,
+): string | undefined => {
+    if (!sourceLabel) return undefined;
+    const translated = labels[sourceLabel];
+    return typeof translated === 'string' && translated.length > 0
+        ? translated
+        : undefined;
+};
+
+export const translateFilterRuleLabels = <
+    T extends { label: string | undefined },
+>(
+    rules: T[],
+    labels: DashboardFilterLabelTranslations,
+): T[] =>
+    rules.map((rule) => {
+        const translated = getFilterLabelTranslation(labels, rule.label);
+        return translated ? { ...rule, label: translated } : rule;
+    });
+
+const getFilterLabels = (
+    filters: DashboardAsCode['filters'],
+): DashboardFilterLabelTranslations | undefined => {
+    const labels = [
+        ...(filters?.dimensions ?? []),
+        ...(filters?.metrics ?? []),
+        ...(filters?.tableCalculations ?? []),
+    ]
+        .map((rule) => rule.label)
+        .filter(
+            (label): label is string =>
+                typeof label === 'string' && label.length > 0,
+        );
+    return labels.length > 0
+        ? Object.fromEntries(labels.map((label) => [label, label]))
+        : undefined;
+};
+
+type DashboardLanguageMapEntry = PartialDeep<
+    Omit<DashboardAsCode, 'filters'>,
+    { recurseIntoArrays: true }
+> & {
+    filters: { labels: DashboardFilterLabelTranslations } | undefined;
+};
+
 export class DashboardAsCodeInternalization extends AsCodeInternalization<
     {
         type: 'dashboard';
         content: DashboardAsCode;
     },
-    typeof dashboardAsCodeSchema
+    typeof dashboardAsCodeSchema,
+    DashboardLanguageMapEntry
 > {
     constructor(protected schema = dashboardAsCodeSchema) {
         super();
     }
 
     public getLanguageMap(dashboardAsCode: DashboardAsCode) {
+        const filterLabels = getFilterLabels(dashboardAsCode.filters);
         return {
             dashboard: {
-                [dashboardAsCode.slug]: this.schema
-                    .deepPartial()
-                    .strip()
-                    .parse(dashboardAsCode),
+                [dashboardAsCode.slug]: {
+                    ...this.schema.deepPartial().strip().parse(dashboardAsCode),
+                    filters: filterLabels
+                        ? { labels: filterLabels }
+                        : undefined,
+                },
             },
         };
     }
@@ -81,7 +144,31 @@ export class DashboardAsCodeInternalization extends AsCodeInternalization<
         >['dashboard'][string],
         content: DashboardAsCode,
     ) {
-        return mergeExisting(content, internalizationMap);
+        const { filters: filterOverrides, ...contentOverrides } =
+            internalizationMap;
+        const merged = mergeExisting(
+            content,
+            contentOverrides,
+        ) as DashboardAsCode;
+        const labels = filterOverrides?.labels;
+        if (labels && merged.filters) {
+            merged.filters = {
+                ...merged.filters,
+                dimensions: translateFilterRuleLabels(
+                    merged.filters.dimensions ?? [],
+                    labels,
+                ),
+                metrics: translateFilterRuleLabels(
+                    merged.filters.metrics ?? [],
+                    labels,
+                ),
+                tableCalculations: translateFilterRuleLabels(
+                    merged.filters.tableCalculations ?? [],
+                    labels,
+                ),
+            };
+        }
+        return merged;
     }
 }
 

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboard.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboard.tsx
@@ -44,6 +44,10 @@ import { type EmbedExploreOptions } from '../../../../providers/Embed/types';
 import useEmbed from '../../../../providers/Embed/useEmbed';
 import { useEmbedDashboardTabChange } from '../../hooks/useEmbedDashboardTabChange';
 import { embedContractClass } from '../../styles/embedClassContract';
+import {
+    applyFilterLabelOverrides,
+    restoreFilterLabelOverrides,
+} from '../filterLabelOverrides';
 import { useEmbedDashboard } from '../hooks';
 import { canUseEmbeddedChartBuilder } from '../utils';
 import EmbedDashboardChartEditorModal from './EmbedDashboardChartEditorModal';
@@ -330,6 +334,7 @@ const EmbedDashboard: FC<{
         content,
         embedToken,
         embedWriteContext,
+        languageMap,
         mode,
         onExplore,
         paletteUuid,
@@ -422,12 +427,34 @@ const EmbedDashboard: FC<{
         setDraftDashboardName(dashboard.name);
     }, [dashboard, isEditMode]);
 
+    const filterLabelOverrides = useMemo(
+        () =>
+            dashboard
+                ? languageMap?.dashboard?.[dashboard.slug]?.filters
+                : undefined,
+        [dashboard, languageMap],
+    );
+
+    // Translated filter labels are applied before the dashboard seeds the
+    // provider so every viewer surface (pills, guided setup, popovers) sees
+    // them; handleSaveDashboard restores the untranslated labels.
+    const translatedDashboard = useMemo(() => {
+        if (!dashboard || !filterLabelOverrides) return dashboard;
+        return {
+            ...dashboard,
+            filters: applyFilterLabelOverrides(
+                dashboard.filters,
+                filterLabelOverrides,
+            ),
+        };
+    }, [dashboard, filterLabelOverrides]);
+
     const setEmbedDashboard = useDashboardContext((c) => c.setEmbedDashboard);
     useEffect(() => {
-        if (dashboard) {
-            setEmbedDashboard(dashboard);
+        if (translatedDashboard) {
+            setEmbedDashboard(translatedDashboard);
         }
-    }, [dashboard, setEmbedDashboard]);
+    }, [translatedDashboard, setEmbedDashboard]);
     const unmetFilterRequirements = useDashboardContext(
         (c) => c.unmetFilterRequirements,
     );
@@ -692,20 +719,24 @@ const EmbedDashboard: FC<{
 
         updateDashboard({
             tiles: currentDashboardTiles,
-            filters: {
-                dimensions: [
-                    ...dashboardFilters.dimensions,
-                    ...dashboardTemporaryFilters.dimensions,
-                ],
-                metrics: [
-                    ...dashboardFilters.metrics,
-                    ...dashboardTemporaryFilters.metrics,
-                ],
-                tableCalculations: [
-                    ...dashboardFilters.tableCalculations,
-                    ...dashboardTemporaryFilters.tableCalculations,
-                ],
-            },
+            filters: restoreFilterLabelOverrides(
+                {
+                    dimensions: [
+                        ...dashboardFilters.dimensions,
+                        ...dashboardTemporaryFilters.dimensions,
+                    ],
+                    metrics: [
+                        ...dashboardFilters.metrics,
+                        ...dashboardTemporaryFilters.metrics,
+                    ],
+                    tableCalculations: [
+                        ...dashboardFilters.tableCalculations,
+                        ...dashboardTemporaryFilters.tableCalculations,
+                    ],
+                },
+                dashboard.filters,
+                filterLabelOverrides,
+            ),
             name: draftDashboardName.trim() || dashboard.name,
             tabs: dashboardTabs,
             config: dashboard.config,
@@ -718,6 +749,7 @@ const EmbedDashboard: FC<{
         dashboardTemporaryFilters,
         draftDashboardName,
         currentDashboardTiles,
+        filterLabelOverrides,
         updateDashboard,
     ]);
 

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/filterLabelOverrides.test.ts
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/filterLabelOverrides.test.ts
@@ -1,0 +1,180 @@
+import {
+    FilterOperator,
+    type DashboardFilterRule,
+    type DashboardFilters,
+} from '@lightdash/common';
+import {
+    applyFilterLabelOverrides,
+    restoreFilterLabelOverrides,
+} from './filterLabelOverrides';
+
+const dimensionRule = (
+    id: string,
+    label: string | undefined,
+): DashboardFilterRule => ({
+    id,
+    label,
+    operator: FilterOperator.EQUALS,
+    target: { fieldId: 'customers_region', tableName: 'customers' },
+    values: ['EU'],
+    tileTargets: {},
+});
+
+const savedFilters: DashboardFilters = {
+    dimensions: [
+        dimensionRule('rule-a', 'Region'),
+        dimensionRule('rule-b', undefined),
+        dimensionRule('rule-c', 'Date range'),
+    ],
+    metrics: [dimensionRule('rule-m', 'Revenue')],
+    tableCalculations: [],
+};
+
+const overrides = {
+    labels: {
+        Region: 'Región',
+        'Date range': 'Rango de fechas',
+        Revenue: 'Ingresos',
+    },
+};
+
+describe('applyFilterLabelOverrides', () => {
+    it('translates labels by source label and leaves other rule fields untouched', () => {
+        const result = applyFilterLabelOverrides(savedFilters, overrides);
+
+        expect(result.dimensions[0]).toEqual({
+            ...savedFilters.dimensions[0],
+            label: 'Región',
+        });
+        expect(result.dimensions[1]).toEqual(savedFilters.dimensions[1]);
+        expect(result.dimensions[2].label).toBe('Rango de fechas');
+        expect(result.metrics[0].label).toBe('Ingresos');
+    });
+
+    it('still translates correctly after filters are reordered post-download', () => {
+        const reordered: DashboardFilters = {
+            ...savedFilters,
+            dimensions: [
+                savedFilters.dimensions[2],
+                savedFilters.dimensions[0],
+                savedFilters.dimensions[1],
+            ],
+        };
+
+        const result = applyFilterLabelOverrides(reordered, overrides);
+
+        expect(result.dimensions[0].label).toBe('Rango de fechas');
+        expect(result.dimensions[1].label).toBe('Región');
+        expect(result.dimensions[2].label).toBeUndefined();
+    });
+
+    it('leaves labels without a translation entry untouched', () => {
+        const result = applyFilterLabelOverrides(savedFilters, {
+            labels: { 'Some other label': 'Autre' },
+        });
+
+        expect(result.dimensions[0].label).toBe('Region');
+    });
+
+    it('returns filters unchanged when there are no overrides', () => {
+        expect(applyFilterLabelOverrides(savedFilters, undefined)).toBe(
+            savedFilters,
+        );
+    });
+
+    it('ignores empty-string translations', () => {
+        const result = applyFilterLabelOverrides(savedFilters, {
+            labels: { Region: '' },
+        });
+
+        expect(result.dimensions[0].label).toBe('Region');
+    });
+
+    it('only applies string translation values', () => {
+        const result = applyFilterLabelOverrides(savedFilters, {
+            // A host could hand us anything through contentOverrides
+            labels: { Region: 42 as unknown as string },
+        });
+
+        expect(result.dimensions[0].label).toBe('Region');
+    });
+});
+
+describe('restoreFilterLabelOverrides', () => {
+    const translated = applyFilterLabelOverrides(savedFilters, overrides);
+
+    it('restores original labels for rules still showing the translation', () => {
+        const result = restoreFilterLabelOverrides(
+            translated,
+            savedFilters,
+            overrides,
+        );
+
+        expect(result.dimensions[0].label).toBe('Region');
+        expect(result.dimensions[1].label).toBeUndefined();
+        expect(result.dimensions[2].label).toBe('Date range');
+        expect(result.metrics[0].label).toBe('Revenue');
+    });
+
+    it('restores correctly even when the rules were reordered in the embed', () => {
+        const reordered: DashboardFilters = {
+            ...translated,
+            dimensions: [
+                translated.dimensions[2],
+                translated.dimensions[0],
+                translated.dimensions[1],
+            ],
+        };
+
+        const result = restoreFilterLabelOverrides(
+            reordered,
+            savedFilters,
+            overrides,
+        );
+
+        expect(result.dimensions[0].label).toBe('Date range');
+        expect(result.dimensions[1].label).toBe('Region');
+    });
+
+    it('keeps a label renamed in the embed editor', () => {
+        const renamed: DashboardFilters = {
+            ...translated,
+            dimensions: [
+                { ...translated.dimensions[0], label: 'Customer region' },
+                ...translated.dimensions.slice(1),
+            ],
+        };
+
+        const result = restoreFilterLabelOverrides(
+            renamed,
+            savedFilters,
+            overrides,
+        );
+
+        expect(result.dimensions[0].label).toBe('Customer region');
+    });
+
+    it('keeps rules added in the embed that are not in the saved dashboard', () => {
+        const withNewRule: DashboardFilters = {
+            ...translated,
+            dimensions: [
+                ...translated.dimensions,
+                dimensionRule('rule-new', 'Añadido'),
+            ],
+        };
+
+        const result = restoreFilterLabelOverrides(
+            withNewRule,
+            savedFilters,
+            overrides,
+        );
+
+        expect(result.dimensions[3].label).toBe('Añadido');
+    });
+
+    it('returns filters unchanged when there are no overrides', () => {
+        expect(
+            restoreFilterLabelOverrides(translated, savedFilters, undefined),
+        ).toBe(translated);
+    });
+});

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/filterLabelOverrides.ts
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/filterLabelOverrides.ts
@@ -1,0 +1,63 @@
+import {
+    getFilterLabelTranslation,
+    translateFilterRuleLabels,
+    type DashboardAsCodeLanguageMap,
+    type DashboardFilterRule,
+    type DashboardFilters,
+} from '@lightdash/common';
+
+export type DashboardFilterLabelOverrides =
+    DashboardAsCodeLanguageMap['dashboard'][string]['filters'];
+
+type FilterKind = keyof DashboardFilters;
+
+export const applyFilterLabelOverrides = (
+    filters: DashboardFilters,
+    overrides: DashboardFilterLabelOverrides,
+): DashboardFilters => {
+    const labels = overrides?.labels;
+    if (!labels) return filters;
+
+    return {
+        dimensions: translateFilterRuleLabels(filters.dimensions, labels),
+        metrics: translateFilterRuleLabels(filters.metrics, labels),
+        tableCalculations: translateFilterRuleLabels(
+            filters.tableCalculations,
+            labels,
+        ),
+    };
+};
+
+// Saving an embedded dashboard persists the provider's filter state, which has
+// translated labels applied. Rules still showing the translation of their
+// saved label get that saved label back; anything else (editor renames, rules
+// added in the embed) is kept as-is.
+export const restoreFilterLabelOverrides = (
+    filters: DashboardFilters,
+    savedFilters: DashboardFilters,
+    overrides: DashboardFilterLabelOverrides,
+): DashboardFilters => {
+    const labels = overrides?.labels;
+    if (!labels) return filters;
+
+    const restoreKind = (kind: FilterKind): DashboardFilterRule[] => {
+        const savedLabelByRuleId = new Map(
+            savedFilters[kind].map((rule) => [rule.id, rule.label]),
+        );
+
+        return filters[kind].map((rule) => {
+            const savedLabel = savedLabelByRuleId.get(rule.id);
+            const appliedLabel = getFilterLabelTranslation(labels, savedLabel);
+            if (!appliedLabel || rule.label !== appliedLabel) {
+                return rule;
+            }
+            return { ...rule, label: savedLabel };
+        });
+    };
+
+    return {
+        dimensions: restoreKind('dimensions'),
+        metrics: restoreKind('metrics'),
+        tableCalculations: restoreKind('tableCalculations'),
+    };
+};

--- a/packages/sdk-test-app/generate-embed-token.ts
+++ b/packages/sdk-test-app/generate-embed-token.ts
@@ -205,7 +205,9 @@ async function main() {
                 dashboardUuid,
                 dashboardFiltersInteractivity: {
                     enabled: 'all',
-                    hidden: true,
+                    // Visible so the filter bar (uiOverrides chrome + language
+                    // map filter labels) can be exercised in the test app
+                    hidden: false,
                 },
                 canExportCsv: false,
                 canExportImages: false,

--- a/packages/sdk-test-app/public/locales/en/translation.json
+++ b/packages/sdk-test-app/public/locales/en/translation.json
@@ -2,6 +2,12 @@
     "dashboard": {
         "jaffle-dashboard": {
             "name": "Jaffle dashboard",
+            "filters": {
+                "labels": {
+                    "Completed orders": "Completed orders",
+                    "Order period": "Order period"
+                }
+            },
             "tiles": [
                 {
                     "type": "loom",

--- a/packages/sdk-test-app/public/locales/es/translation.json
+++ b/packages/sdk-test-app/public/locales/es/translation.json
@@ -2,6 +2,12 @@
     "dashboard": {
         "jaffle-dashboard": {
             "name": "Tablero de Jaffle",
+            "filters": {
+                "labels": {
+                    "Completed orders": "Pedidos completados",
+                    "Order period": "Período del pedido"
+                }
+            },
             "tiles": [
                 {
                     "type": "loom",

--- a/packages/sdk-test-app/public/locales/ka/translation.json
+++ b/packages/sdk-test-app/public/locales/ka/translation.json
@@ -2,6 +2,12 @@
     "dashboard": {
         "jaffle-dashboard": {
             "name": "Jaffle-ის დაფა",
+            "filters": {
+                "labels": {
+                    "Completed orders": "დასრულებული შეკვეთები",
+                    "Order period": "შეკვეთის პერიოდი"
+                }
+            },
             "tiles": [
                 {
                     "type": "loom",


### PR DESCRIPTION
## Summary

Customers translating embedded dashboards via the SDK `contentOverrides` / language map reported one remaining gap: user-defined dashboard filter labels (the custom name an author gives a filter, `DashboardFilterRule.label`) were not part of the language map, so filter pills stayed untranslated.

This adds them to the dashboard language map, end to end:

- **Download** (`packages/common`): `DashboardAsCodeInternalization.getLanguageMap` now emits `filters.labels`, a record of `source label → translation` seeded with identity pairs. `GET /projects/:uuid/code/dashboards?languageMap=true` (and `lightdash download --language-map`) includes every user-defined filter label across dimensions/metrics/table calculations.
- **Apply** (embed frontend): `applyFilterLabelOverrides` merges the labels into the dashboard before it seeds the dashboard provider, so every viewer surface translates from one seam — filter pills, the filter popover header, and the required-filters guided setup. Only non-empty string values are applied, so a malformed `contentOverrides` value can never alter filter operators/values.
- **Save-guard**: embedded edit-mode saves persist provider filter state, which would have written translated labels back to the saved dashboard. `restoreFilterLabelOverrides` puts the original label back for any rule still showing its translation (matched by rule id), while keeping genuine renames and filters added in the embed.

## Keyed by source label, not position

Unlike tiles (positional), filter labels are keyed by their untranslated label text. Filter pills are drag-reorderable and deletable as routine edit actions, so positional keys would silently rotate translations onto the wrong pills. Label keys survive reorder/insert/delete, and renaming a label fails safe: the translation no longer matches and the pill falls back to the source label — correct, since a renamed label is a new string needing a new translation. The `AsCodeInternalization` abstract gained an optional `MapEntry` generic so the dashboard map can diverge from the pure content mirror for this one field; charts are unchanged.

## Sample

A downloaded language map emits identity pairs for translators to fill in:

```yaml
dashboard:
  jaffle-dashboard:
    name: Tablero de Jaffle
    filters:
      labels:
        Completed orders: Pedidos completados
        Order period: Período del pedido
```

The sdk-test-app locale bundles (`en`/`es`/`ka`) include working samples of the new `filters.labels` key, keeping them at full coverage for the i18n example page.

Also flips the sdk-test-app token generator to `dashboardFiltersInteractivity.hidden: false` — with `hidden: true` the embed filter bar never rendered, so neither the filter chrome from the `uiOverrides` stack (#28017) nor these labels could be exercised in the test app.

## Testing

- TDD: 6 `@lightdash/common` tests (`getLanguageMap` emits the label record / omits it when nothing is labeled, `merge` translates by source label without touching other rule fields, unknown labels untouched, non-filter content still merges) and 11 frontend tests for apply/restore, including reorder-robustness both ways, empty/non-string values ignored, and editor renames / embed-added rules surviving restore.
- Verified end to end against a local instance with the sdk-test-app i18n example: pills render "Pedidos completados es Verdadero" / "დასრულებული შეკვეთები არის ჭეშმარიტი", composing with the translated operator chrome; the filter popover header translates too. Language-map download verified via the coder API.
- `common`/`frontend` lint + typecheck green.

## Notes

- Field-name pills (filters without a user-defined label, showing explore field labels) are schema content and remain out of scope — tracked in PROD-10554.
- Two filters sharing the same label share one translation entry — which is also the translation they'd want.

Closes: #24690
Closes: PROD-8478

🤖 Generated with [Claude Code](https://claude.com/claude-code)
