### PR TITLE
refactor(permissions): read the PAT delegation footprint off the built ability

### DIFF
--- a/packages/backend/src/services/OrganizationService/OrganizationService.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.ts
@@ -779,13 +779,7 @@ export class OrganizationService extends BaseService {
             await validateOrganizationScopesCanBeGranted({
                 user: authenticatedUser,
                 organizationUuid,
-                grantedScopes: getOrganizationSystemRoleScopes(data.role, {
-                    includePersonalAccessToken:
-                        this.lightdashConfig.auth?.pat?.enabled === true &&
-                        this.lightdashConfig.auth.pat.allowedOrgRoles.includes(
-                            data.role,
-                        ),
-                }),
+                grantedScopes: getOrganizationSystemRoleScopes(data.role),
                 rolesModel: this.rolesModel,
             });
             const organization =

--- a/packages/backend/src/services/RolesService/RolesService.ts
+++ b/packages/backend/src/services/RolesService/RolesService.ts
@@ -1218,16 +1218,7 @@ export class RolesService extends BaseService {
         let ownerType: Role['ownerType'] = 'system';
         let roleScopes = isCustomRole
             ? []
-            : getOrganizationSystemRoleScopes(
-                  roleId as OrganizationMemberRole,
-                  {
-                      includePersonalAccessToken:
-                          this.lightdashConfig.auth?.pat?.enabled === true &&
-                          this.lightdashConfig.auth.pat.allowedOrgRoles.includes(
-                              roleId as OrganizationMemberRole,
-                          ),
-                  },
-              );
+            : getOrganizationSystemRoleScopes(roleId as OrganizationMemberRole);
 
         if (isCustomRole) {
             const role = await this.rolesModel.getRoleWithScopesByUuid(roleId);
@@ -1829,14 +1820,7 @@ export class RolesService extends BaseService {
             organizationUuid: orgUuid,
             grantedScopes: [
                 ...(roleSet.systemRole
-                    ? getOrganizationSystemRoleScopes(roleSet.systemRole, {
-                          includePersonalAccessToken:
-                              this.lightdashConfig.auth?.pat?.enabled ===
-                                  true &&
-                              this.lightdashConfig.auth.pat.allowedOrgRoles.includes(
-                                  roleSet.systemRole,
-                              ),
-                      })
+                    ? getOrganizationSystemRoleScopes(roleSet.systemRole)
                     : []),
                 ...customRoles.flatMap((role) => role.scopes),
             ],

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -793,13 +793,7 @@ export class UserService extends BaseService {
         await validateOrganizationScopesCanBeGranted({
             user,
             organizationUuid,
-            grantedScopes: getOrganizationSystemRoleScopes(userRole, {
-                includePersonalAccessToken:
-                    this.lightdashConfig.auth?.pat?.enabled === true &&
-                    this.lightdashConfig.auth.pat.allowedOrgRoles.includes(
-                        userRole,
-                    ),
-            }),
+            grantedScopes: getOrganizationSystemRoleScopes(userRole),
             rolesModel: this.rolesModel,
         });
 

--- a/packages/backend/src/utils/organizationRolePermissions.test.ts
+++ b/packages/backend/src/utils/organizationRolePermissions.test.ts
@@ -71,7 +71,6 @@ describe('validateOrganizationScopesCanBeGranted', () => {
                 organizationUuid: ORG,
                 grantedScopes: getOrganizationSystemRoleScopes(
                     OrganizationMemberRole.MEMBER,
-                    { includePersonalAccessToken: true },
                 ),
                 rolesModel: rolesModelWithScopes(managerScopes),
             }),
@@ -87,7 +86,6 @@ describe('validateOrganizationScopesCanBeGranted', () => {
                 organizationUuid: ORG,
                 grantedScopes: getOrganizationSystemRoleScopes(
                     OrganizationMemberRole.ADMIN,
-                    { includePersonalAccessToken: true },
                 ),
                 rolesModel: rolesModelWithScopes(managerScopes),
             }),
@@ -139,5 +137,22 @@ describe('validateOrganizationScopesCanBeGranted', () => {
                 rolesModel: rolesModelWithScopes(managerScopes),
             }),
         ).rejects.toThrow('Cannot grant permissions exceeding your own');
+    });
+
+    it('lets a token-restricted caller grant a system role', async () => {
+        // A system role takes token access from deployment config, not from the
+        // grant, so it must not block a caller whose own role denies tokens.
+        await expect(
+            validateOrganizationScopesCanBeGranted({
+                user: customRoleCaller({
+                    canManagePersonalAccessToken: false,
+                }),
+                organizationUuid: ORG,
+                grantedScopes: getOrganizationSystemRoleScopes(
+                    OrganizationMemberRole.MEMBER,
+                ),
+                rolesModel: rolesModelWithScopes(managerScopes),
+            }),
+        ).resolves.toBeUndefined();
     });
 });

--- a/packages/backend/src/utils/organizationRolePermissions.ts
+++ b/packages/backend/src/utils/organizationRolePermissions.ts
@@ -10,13 +10,7 @@ import { RolesModel } from '../models/RolesModel';
 
 export const getOrganizationSystemRoleScopes = (
     role: OrganizationMemberRole,
-    { includePersonalAccessToken = false } = {},
-): string[] => {
-    const permissions = getOrganizationMemberRolePermissions(role);
-    return includePersonalAccessToken
-        ? [...permissions, 'manage:PersonalAccessToken']
-        : permissions;
-};
+): string[] => getOrganizationMemberRolePermissions(role);
 
 const getCallerOrganizationScopes = async (
     user: SessionUser,
@@ -28,13 +22,6 @@ const getCallerOrganizationScopes = async (
     if (!user.role || user.organizationUuid !== organizationUuid) {
         throw new ForbiddenError('You do not have permission');
     }
-
-    // Custom roles never list this scope, but the ability builder still grants
-    // it from the PAT config, so it is part of the caller's real footprint.
-    const canManagePersonalAccessToken = user.ability.can(
-        'manage',
-        'PersonalAccessToken',
-    );
 
     // The caller's runtime ability is the union of the slot (system role or
     // custom role from the session) and any extra custom roles they hold.
@@ -59,11 +46,13 @@ const getCallerOrganizationScopes = async (
         throw new ForbiddenError('You do not have permission');
     }
 
+    // A system role takes token access from deployment config, not its scope
+    // list, so it's read off the built ability instead.
     const scopes = [
         ...(user.roleUuid ? [] : getOrganizationSystemRoleScopes(user.role)),
         ...customRoles.flatMap((role) => role.scopes),
     ];
-    return canManagePersonalAccessToken
+    return user.ability.can('manage', 'PersonalAccessToken')
         ? [...scopes, 'manage:PersonalAccessToken']
         : scopes;
 };


### PR DESCRIPTION
PR 1 of 4 in the PROD-8879 stack (see #28356 for the feature summary). Independently mergeable: no other PR in the stack is needed for this to be correct on main.

## Change

System-role scope lists stop carrying a synthetic `manage:PersonalAccessToken` entry, and the delegation ceiling reads the caller's token footprint off their built CASL ability instead:

- `getOrganizationSystemRoleScopes` loses its `{ includePersonalAccessToken }` options bag; the four call sites (`UserService`, `OrganizationService`, `RolesService` ×2) drop the option and its `lightdashConfig.auth.pat` condition expressions.
- `getCallerOrganizationScopes` reads `user.ability.can('manage', 'PersonalAccessToken')` inline — a system role takes token access from deployment config, never from its scope list.

## Behavior note (deliberate, disclosed)

This is behavior-preserving in the common case, with one narrow loosening: on a deployment with a restrictive `PAT_ALLOWED_ORG_ROLES`, a caller whose own org role is outside the allowlist could previously not grant a system role inside it (the synthetic scope tripped the ceiling). Now they can — which is the correct semantic: a system role's token access is derived from deployment config, not delegated by the caller, so the caller's own token eligibility is irrelevant to the grant. Pinned by a new test ("lets a token-restricted caller grant a system role"). The ceiling still applies to custom-role grants that explicitly list the scope.

## Testing

- `organizationRolePermissions.test.ts` — ceiling invariants, incl. the new case above.
- `UserService.test.ts` 178/178; backend typecheck clean.

Part of PROD-8879 / #25543 (closed by #28356).