### PR TITLE
feat(permissions): add opt-in pat-scope-authoritative flag

### DIFF
--- a/packages/common/src/ee/commercialFeatureFlags.ts
+++ b/packages/common/src/ee/commercialFeatureFlags.ts
@@ -7,4 +7,9 @@ export enum CommercialFeatureFlags {
     CustomRoles = 'custom-roles',
     DirectAccess = 'direct-access',
     HomepageBuilder = 'homepage-builder',
+    /**
+     * Org opt-in: the primary-slot org custom role's scope list fully decides
+     * `manage:PersonalAccessToken` instead of inheriting the deployment default.
+     */
+    PatScopeAuthoritative = 'pat-scope-authoritative',
 }

--- a/packages/common/src/featureFlags/previewFeatureFlags.ts
+++ b/packages/common/src/featureFlags/previewFeatureFlags.ts
@@ -33,6 +33,9 @@ const PREVIEW_EXCLUDED_FEATURE_FLAGS: ReadonlySet<string> = new Set<string>([
     // Derived from instance configuration: left to their config handler so a
     // preview never advertises a feature whose backend isn't configured.
     CommercialFeatureFlags.AiCopilot,
+    // Changes permission semantics per org: makes the org custom role's PAT
+    // scope authoritative. Opt-in only; QA enables via feature_flag_overrides.
+    CommercialFeatureFlags.PatScopeAuthoritative,
     FeatureFlags.ResultsCacheEnabled,
     FeatureFlags.EnableTimezoneSupport,
 ]);


### PR DESCRIPTION
PR 1 of 4 in the PROD-8879 stack (see #28356 for the feature summary). Independently mergeable and completely inert: nothing consumes the flag until #28356.

## Change

- New `CommercialFeatureFlags.PatScopeAuthoritative = 'pat-scope-authoritative'` — an org opt-in that (once consumed, #28355/#28356) makes the primary-slot org custom role's scope list fully decide `manage:PersonalAccessToken` instead of inheriting the deployment default.
- Added to `PREVIEW_EXCLUDED_FEATURE_FLAGS`: preview environments force-enable every flag not listed there, and this one changes permission semantics — "default off" must hold in previews too. QA can still enable it per-org with a `feature_flag_overrides` row.

With no per-flag config handler, the flag resolves through the DB (user override > org override > flag default), i.e. off everywhere until deliberately enabled for an org.

Part of PROD-8879 / #25543 (closed by #28356).