### PR TITLE
perf: fetch active Live Activities in one query

### DIFF
--- a/packages/backend/src/ee/models/MobilePushNotificationModel.test.ts
+++ b/packages/backend/src/ee/models/MobilePushNotificationModel.test.ts
@@ -133,4 +133,45 @@ describe('MobilePushNotificationModel', () => {
         expect(result).not.toHaveProperty('encryptedPushToken');
         expect(result).not.toHaveProperty('encryptedDeviceToken');
     });
+
+    it('returns all active Live Activities for a thread in one query', async () => {
+        tracker.on.select(AiAgentLiveActivitiesTableName).responseOnce([
+            {
+                liveActivityUuid: 'first-activity-uuid',
+                organizationUuid: 'first-organization-uuid',
+                projectUuid: 'first-project-uuid',
+                userUuid: 'first-user-uuid',
+            },
+            {
+                liveActivityUuid: 'second-activity-uuid',
+                organizationUuid: 'second-organization-uuid',
+                projectUuid: 'second-project-uuid',
+                userUuid: 'second-user-uuid',
+            },
+        ]);
+
+        const result =
+            await model.findActiveLiveActivitiesForThread('thread-uuid');
+
+        expect(result).toEqual([
+            {
+                liveActivityUuid: 'first-activity-uuid',
+                organizationUuid: 'first-organization-uuid',
+                projectUuid: 'first-project-uuid',
+                userUuid: 'first-user-uuid',
+            },
+            {
+                liveActivityUuid: 'second-activity-uuid',
+                organizationUuid: 'second-organization-uuid',
+                projectUuid: 'second-project-uuid',
+                userUuid: 'second-user-uuid',
+            },
+        ]);
+        expect(tracker.history.all).toHaveLength(1);
+        expect(tracker.history.select).toHaveLength(1);
+        expect(tracker.history.select[0].sql).toBe(
+            'select "live_activity_uuid" as "liveActivityUuid", "organization_uuid" as "organizationUuid", "project_uuid" as "projectUuid", "user_uuid" as "userUuid" from "ai_agent_live_activities" where "thread_uuid" = $1 and "ended_at" is null',
+        );
+        expect(tracker.history.select[0].bindings).toEqual(['thread-uuid']);
+    });
 });

--- a/packages/backend/src/ee/models/MobilePushNotificationModel.ts
+++ b/packages/backend/src/ee/models/MobilePushNotificationModel.ts
@@ -314,32 +314,25 @@ export class MobilePushNotificationModel {
         };
     }
 
-    async findActiveLiveActivitiesForThread(
-        threadUuid: string,
-    ): Promise<AiAgentLiveActivity[]> {
-        const rows = await this.database<DbAiAgentLiveActivity>(
+    async findActiveLiveActivitiesForThread(threadUuid: string): Promise<
+        {
+            liveActivityUuid: string;
+            organizationUuid: string;
+            projectUuid: string;
+            userUuid: string;
+        }[]
+    > {
+        return this.database<DbAiAgentLiveActivity>(
             AiAgentLiveActivitiesTableName,
         )
-            .join<DbMobilePushInstallation>(
-                MobilePushInstallationsTableName,
-                `${AiAgentLiveActivitiesTableName}.mobile_push_installation_uuid`,
-                `${MobilePushInstallationsTableName}.mobile_push_installation_uuid`,
-            )
             .select({
-                liveActivityUuid: `${AiAgentLiveActivitiesTableName}.live_activity_uuid`,
+                liveActivityUuid: 'live_activity_uuid',
+                organizationUuid: 'organization_uuid',
+                projectUuid: 'project_uuid',
+                userUuid: 'user_uuid',
             })
-            .where(`${AiAgentLiveActivitiesTableName}.thread_uuid`, threadUuid)
-            .whereNull(`${AiAgentLiveActivitiesTableName}.ended_at`);
-
-        const activities = await Promise.all(
-            rows.map(({ liveActivityUuid }) =>
-                this.findLiveActivity(liveActivityUuid),
-            ),
-        );
-        return activities.filter(
-            (activity): activity is AiAgentLiveActivity =>
-                activity !== undefined,
-        );
+            .where('thread_uuid', threadUuid)
+            .whereNull('ended_at');
     }
 
     async findLiveActivitiesDueForReconciliation(


### PR DESCRIPTION
Linear: SPK-1687

## What changed

- Fetch every active Live Activity for a thread in one database query.
- Select only the four fields needed to schedule reconciliation.
- Add a two-row regression that checks filters, projection, bindings, and total query count.

## Why

The merged implementation first listed activity IDs, then loaded and decrypted each activity separately. This created an N+1 query and did cryptographic work that the scheduler does not need.

## Verification

- Passed the focused model suite: 4 tests.
- Passed touched-file backend lint.
- Passed `git diff --check`.
- Local full backend typecheck was blocked by stale built workspace dependencies from another checkout. CI runs it in a clean dependency graph.

## Security

LOW. The change reduces the selected data and avoids loading encrypted delivery tokens in a scheduling-only path. It does not change authorization, request inputs, or credential handling. No DeepSec scan is needed.

## Context

Follow-up to #28316.