### PR TITLE
feat(permissions): gate PAT scope authority behind the org opt-in

### DIFF
--- a/packages/common/src/authorization/AGENTS.md
+++ b/packages/common/src/authorization/AGENTS.md
@@ -48,6 +48,7 @@ Treat each scope in `scopes.ts` as a user-facing permission contract:
 - `roleToScopeMapping.ts` must stay aligned with system-role abilities so duplicated system roles and parity tests keep working.
 - A role's `level` (`'project' | 'organization'`) gates which scopes it may hold and where it can be assigned: org-level roles may only contain org-assignable scopes (`getOrgAssignableScopes` / `isScopeAssignableAtLevel`) and build org-level conditions with `{ organizationUuid }`; project-level roles build project-level conditions with `{ projectUuid }`. This applies to both human-user and service-account custom roles.
 - Org-level grants are deliberately hard to restrict with project-level custom roles because layers are additive.
+- `manage:PersonalAccessToken` becomes authoritative on the organization primary slot only for orgs opted in via `CommercialFeatureFlags.PatScopeAuthoritative` on a licensed deployment (`patScopeAuthoritative` in `index.ts`): the role emits no token rule unless it lists the scope, downstream scope sets have the scope stripped, and the deployment config (`DISABLE_PAT`, `PAT_ALLOWED_ORG_ROLES`) still caps it. Without the opt-in, every scope set keeps inheriting token access from the config, as always.
 
 ## Role Types
 

--- a/packages/common/src/authorization/getUserAbilityBuilder.test.ts
+++ b/packages/common/src/authorization/getUserAbilityBuilder.test.ts
@@ -601,7 +601,9 @@ describe('getUserAbilityBuilder — role sets (extra custom roles)', () => {
 });
 
 describe('getUserAbilityBuilder — personal access tokens', () => {
+    const PROJECT_UUID = 'test-project-uuid';
     const PAT_ROLE_UUID = '33333333-3333-4333-a333-333333333333';
+    const OTHER_ROLE_UUID = '44444444-4444-4444-a444-444444444444';
     const PAT_SCOPE = 'manage:PersonalAccessToken';
 
     const patAllowed = {
@@ -610,6 +612,7 @@ describe('getUserAbilityBuilder — personal access tokens', () => {
             allowedOrgRoles: Object.values(OrganizationMemberRole),
         },
     };
+    const patDisabled = { pat: { enabled: false, allowedOrgRoles: [] } };
 
     // Mirrors PersonalAccessTokenService, which checks `create` on the subject
     // carrying the caller's organization.
@@ -621,16 +624,146 @@ describe('getUserAbilityBuilder — personal access tokens', () => {
                 subject('PersonalAccessToken', { organizationUuid: ORG_UUID }),
             );
 
-    const buildWithOrgCustomRole = (
-        scopes: string[],
-        permissionsConfig: {
-            pat: {
-                enabled: boolean;
-                allowedOrgRoles: OrganizationMemberRole[];
-            };
-        },
-    ) =>
+    const buildFor = ({
+        roleUuid,
+        scopes,
+        permissionsConfig = patAllowed,
+        projectProfiles = [],
+        patScopeAuthoritative = true,
+    }: {
+        roleUuid?: string;
+        scopes?: string[];
+        permissionsConfig?: typeof patAllowed | typeof patDisabled;
+        projectProfiles?: Parameters<
+            typeof getUserAbilityBuilder
+        >[0]['projectProfiles'];
+        patScopeAuthoritative?: boolean;
+    }) =>
         getUserAbilityBuilder({
+            user: {
+                role: OrganizationMemberRole.MEMBER,
+                organizationUuid: ORG_UUID,
+                userUuid: USER_UUID,
+                roleUuid,
+            },
+            projectProfiles,
+            permissionsConfig,
+            customRoleScopes: scopes ? { [PAT_ROLE_UUID]: scopes } : undefined,
+            customRolesEnabled: true,
+            isEnterprise: true,
+            patScopeAuthoritative,
+        }).builder;
+
+    describe('an org-level custom role in the primary slot is authoritative', () => {
+        it('denies PAT when the role omits the scope, even though the deployment allows it', () => {
+            const builder = buildFor({
+                roleUuid: PAT_ROLE_UUID,
+                scopes: ['view:Dashboard'],
+            });
+            expect(canCreatePat(builder)).toBe(false);
+        });
+
+        it('grants PAT when the role lists the scope', () => {
+            const builder = buildFor({
+                roleUuid: PAT_ROLE_UUID,
+                scopes: ['view:Dashboard', PAT_SCOPE],
+            });
+            expect(canCreatePat(builder)).toBe(true);
+        });
+
+        it('still denies PAT when the role lists the scope but the deployment disabled PATs', () => {
+            const builder = buildFor({
+                roleUuid: PAT_ROLE_UUID,
+                scopes: [PAT_SCOPE],
+                permissionsConfig: patDisabled,
+            });
+            expect(canCreatePat(builder)).toBe(false);
+        });
+
+        // Regression: the fallback used to run for every scope set, reading
+        // the primary slot's deliberate refusal as an omission to repair.
+        it('stays denied when the user also holds a project custom role', () => {
+            const builder = buildFor({
+                roleUuid: PAT_ROLE_UUID,
+                scopes: ['view:Dashboard'],
+                projectProfiles: [
+                    {
+                        projectUuid: PROJECT_UUID,
+                        role: ProjectMemberRole.VIEWER,
+                        userUuid: USER_UUID,
+                        roleUuid: OTHER_ROLE_UUID,
+                    },
+                ],
+            });
+            expect(canCreatePat(builder)).toBe(false);
+        });
+
+        it('stays denied when the user also holds an extra org custom role', () => {
+            const { builder } = getUserAbilityBuilder({
+                user: {
+                    role: OrganizationMemberRole.MEMBER,
+                    organizationUuid: ORG_UUID,
+                    userUuid: USER_UUID,
+                    roleUuid: PAT_ROLE_UUID,
+                },
+                orgExtraRoleUuids: [OTHER_ROLE_UUID],
+                projectProfiles: [],
+                permissionsConfig: patAllowed,
+                customRoleScopes: {
+                    [PAT_ROLE_UUID]: ['view:Dashboard'],
+                    [OTHER_ROLE_UUID]: ['view:Dashboard'],
+                },
+                customRolesEnabled: true,
+                isEnterprise: true,
+                patScopeAuthoritative: true,
+            });
+            expect(canCreatePat(builder)).toBe(false);
+        });
+
+        it('stays denied when the user also holds a project system role', () => {
+            const builder = buildFor({
+                roleUuid: PAT_ROLE_UUID,
+                scopes: ['view:Dashboard'],
+                projectProfiles: [
+                    {
+                        projectUuid: PROJECT_UUID,
+                        role: ProjectMemberRole.VIEWER,
+                        userUuid: USER_UUID,
+                        roleUuid: undefined,
+                    },
+                ],
+            });
+            expect(canCreatePat(builder)).toBe(false);
+        });
+
+        it('denies PAT when the role lists the scope but the org role is outside allowedOrgRoles', () => {
+            const { builder } = getUserAbilityBuilder({
+                user: {
+                    role: OrganizationMemberRole.MEMBER,
+                    organizationUuid: ORG_UUID,
+                    userUuid: USER_UUID,
+                    roleUuid: PAT_ROLE_UUID,
+                },
+                projectProfiles: [],
+                permissionsConfig: {
+                    pat: {
+                        enabled: true,
+                        allowedOrgRoles: [OrganizationMemberRole.ADMIN],
+                    },
+                },
+                customRoleScopes: { [PAT_ROLE_UUID]: [PAT_SCOPE] },
+                customRolesEnabled: true,
+                isEnterprise: true,
+                patScopeAuthoritative: true,
+            });
+            expect(canCreatePat(builder)).toBe(false);
+        });
+    });
+
+    it('keeps inheriting tokens on an unlicensed deployment', () => {
+        // Proves the license guard beats the flag: without a license the
+        // scope is absent from the vocabulary, so no role could list it.
+        const { builder, invalidScopes } = getUserAbilityBuilder({
             user: {
                 role: OrganizationMemberRole.MEMBER,
                 organizationUuid: ORG_UUID,
@@ -638,56 +771,22 @@ describe('getUserAbilityBuilder — personal access tokens', () => {
                 roleUuid: PAT_ROLE_UUID,
             },
             projectProfiles: [],
-            permissionsConfig,
-            customRoleScopes: { [PAT_ROLE_UUID]: scopes },
+            permissionsConfig: patAllowed,
+            customRoleScopes: { [PAT_ROLE_UUID]: [PAT_SCOPE] },
             customRolesEnabled: true,
-            isEnterprise: true,
-        }).builder;
-
-    describe('deployment config caps a listed scope', () => {
-        it('grants when the deployment allows tokens', () => {
-            expect(
-                canCreatePat(buildWithOrgCustomRole([PAT_SCOPE], patAllowed)),
-            ).toBe(true);
+            isEnterprise: false,
+            patScopeAuthoritative: true,
         });
-
-        it('denies when the deployment disabled tokens', () => {
-            expect(
-                canCreatePat(
-                    buildWithOrgCustomRole([PAT_SCOPE], {
-                        pat: { enabled: false, allowedOrgRoles: [] },
-                    }),
-                ),
-            ).toBe(false);
-        });
-
-        it('denies when the org role is outside allowedOrgRoles', () => {
-            expect(
-                canCreatePat(
-                    buildWithOrgCustomRole([PAT_SCOPE], {
-                        pat: {
-                            enabled: true,
-                            allowedOrgRoles: [OrganizationMemberRole.ADMIN],
-                        },
-                    }),
-                ),
-            ).toBe(false);
-        });
+        expect(invalidScopes).toContain(PAT_SCOPE);
+        expect(canCreatePat(builder)).toBe(true);
     });
 
-    it('still inherits tokens when a role omits the scope', () => {
-        // The config fallback stays on for every scope set until the
-        // organization-role backfill has landed everywhere.
-        expect(
-            canCreatePat(
-                buildWithOrgCustomRole(['view:Dashboard'], patAllowed),
-            ),
-        ).toBe(true);
-    });
-
-    it.each([OrganizationMemberRole.MEMBER, OrganizationMemberRole.ADMIN])(
-        'system role %s keeps the deployment default',
-        (role) => {
+    describe('system org roles are unchanged', () => {
+        it.each([
+            OrganizationMemberRole.MEMBER,
+            OrganizationMemberRole.VIEWER,
+            OrganizationMemberRole.ADMIN,
+        ])('%s keeps the deployment default', (role) => {
             const { builder } = getUserAbilityBuilder({
                 user: {
                     role,
@@ -701,6 +800,150 @@ describe('getUserAbilityBuilder — personal access tokens', () => {
                 isEnterprise: true,
             });
             expect(canCreatePat(builder)).toBe(true);
-        },
-    );
+        });
+
+        it('a project-level custom role cannot take PAT away from a system org role', () => {
+            const builder = buildFor({
+                scopes: ['view:Dashboard'],
+                projectProfiles: [
+                    {
+                        projectUuid: PROJECT_UUID,
+                        role: ProjectMemberRole.VIEWER,
+                        userUuid: USER_UUID,
+                        roleUuid: PAT_ROLE_UUID,
+                    },
+                ],
+            });
+            expect(canCreatePat(builder)).toBe(true);
+        });
+
+        it('an extra org custom role cannot take PAT away from a system org role', () => {
+            const { builder } = getUserAbilityBuilder({
+                user: {
+                    role: OrganizationMemberRole.VIEWER,
+                    organizationUuid: ORG_UUID,
+                    userUuid: USER_UUID,
+                    roleUuid: undefined,
+                },
+                orgExtraRoleUuids: [PAT_ROLE_UUID],
+                projectProfiles: [],
+                permissionsConfig: patAllowed,
+                customRoleScopes: { [PAT_ROLE_UUID]: ['view:Dashboard'] },
+                customRolesEnabled: true,
+                isEnterprise: true,
+            });
+            expect(canCreatePat(builder)).toBe(true);
+        });
+    });
+
+    describe('explicitly-listed downstream PAT scopes are suppressed while authoritative', () => {
+        it('an extra org custom role listing the scope does not restore tokens', () => {
+            const { builder } = getUserAbilityBuilder({
+                user: {
+                    role: OrganizationMemberRole.MEMBER,
+                    organizationUuid: ORG_UUID,
+                    userUuid: USER_UUID,
+                    roleUuid: PAT_ROLE_UUID,
+                },
+                orgExtraRoleUuids: [OTHER_ROLE_UUID],
+                projectProfiles: [],
+                permissionsConfig: patAllowed,
+                customRoleScopes: {
+                    [PAT_ROLE_UUID]: ['view:Dashboard'],
+                    [OTHER_ROLE_UUID]: ['view:Dashboard', PAT_SCOPE],
+                },
+                customRolesEnabled: true,
+                isEnterprise: true,
+                patScopeAuthoritative: true,
+            });
+            expect(canCreatePat(builder)).toBe(false);
+        });
+
+        it('a project custom role listing the scope does not restore tokens', () => {
+            const { builder } = getUserAbilityBuilder({
+                user: {
+                    role: OrganizationMemberRole.MEMBER,
+                    organizationUuid: ORG_UUID,
+                    userUuid: USER_UUID,
+                    roleUuid: PAT_ROLE_UUID,
+                },
+                projectProfiles: [
+                    {
+                        projectUuid: PROJECT_UUID,
+                        role: ProjectMemberRole.VIEWER,
+                        userUuid: USER_UUID,
+                        roleUuid: OTHER_ROLE_UUID,
+                    },
+                ],
+                permissionsConfig: patAllowed,
+                customRoleScopes: {
+                    [PAT_ROLE_UUID]: ['view:Dashboard'],
+                    [OTHER_ROLE_UUID]: ['view:Dashboard', PAT_SCOPE],
+                },
+                customRolesEnabled: true,
+                isEnterprise: true,
+                patScopeAuthoritative: true,
+            });
+            expect(canCreatePat(builder)).toBe(false);
+        });
+
+        it('the primary org slot keeps its own listed scope', () => {
+            const builder = buildFor({
+                roleUuid: PAT_ROLE_UUID,
+                scopes: ['view:Dashboard', PAT_SCOPE],
+            });
+            expect(canCreatePat(builder)).toBe(true);
+        });
+    });
+
+    describe('without the org opt-in, behavior is unchanged', () => {
+        it('an org custom role omitting the scope still inherits tokens from the deployment config', () => {
+            const builder = buildFor({
+                roleUuid: PAT_ROLE_UUID,
+                scopes: ['view:Dashboard'],
+                patScopeAuthoritative: false,
+            });
+            expect(canCreatePat(builder)).toBe(true);
+        });
+
+        it('still denies when the deployment disables PATs', () => {
+            const builder = buildFor({
+                roleUuid: PAT_ROLE_UUID,
+                scopes: ['view:Dashboard'],
+                permissionsConfig: patDisabled,
+                patScopeAuthoritative: false,
+            });
+            expect(canCreatePat(builder)).toBe(false);
+        });
+
+        it('a downstream role explicitly listing the scope grants it, as today', () => {
+            const { builder } = getUserAbilityBuilder({
+                user: {
+                    role: OrganizationMemberRole.MEMBER,
+                    organizationUuid: ORG_UUID,
+                    userUuid: USER_UUID,
+                    roleUuid: PAT_ROLE_UUID,
+                },
+                orgExtraRoleUuids: [OTHER_ROLE_UUID],
+                projectProfiles: [],
+                permissionsConfig: patAllowed,
+                customRoleScopes: {
+                    [PAT_ROLE_UUID]: ['view:Dashboard'],
+                    [OTHER_ROLE_UUID]: ['view:Dashboard', PAT_SCOPE],
+                },
+                customRolesEnabled: true,
+                isEnterprise: true,
+                patScopeAuthoritative: false,
+            });
+            expect(canCreatePat(builder)).toBe(true);
+        });
+    });
+
+    it('emits no inverted rules (collapse stays sound)', () => {
+        const builder = buildFor({
+            roleUuid: PAT_ROLE_UUID,
+            scopes: ['view:Dashboard'],
+        });
+        expect(builder.rules.some((r) => r.inverted)).toBe(false);
+    });
 });

--- a/packages/common/src/authorization/index.ts
+++ b/packages/common/src/authorization/index.ts
@@ -8,6 +8,7 @@ import { collapseAbilityRules } from './collapseAbilityRules';
 import applyOrganizationMemberAbilities, {
     type OrganizationMemberAbilitiesArgs,
 } from './organizationMemberAbility';
+import { normalizeScopeName } from './parseScopes';
 import { projectMemberAbilities } from './projectMemberAbility';
 import { buildAbilityFromScopes } from './scopeAbilityBuilder';
 import { type MemberAbility } from './types';
@@ -38,6 +39,11 @@ type UserAbilityBuilderArgs = {
     customRoleScopes?: Record<Role['roleUuid'], RoleWithScopes['scopes']>;
     customRolesEnabled?: boolean;
     isEnterprise?: boolean;
+    /**
+     * Org opt-in (PatScopeAuthoritative flag): the primary-slot org custom
+     * role's scope list fully decides token access.
+     */
+    patScopeAuthoritative?: boolean;
 };
 
 export const JWT_HEADER_NAME = 'lightdash-embed-token';
@@ -55,9 +61,26 @@ export const getUserAbilityBuilder = ({
     customRoleScopes,
     customRolesEnabled,
     isEnterprise,
+    patScopeAuthoritative,
 }: UserAbilityBuilderArgs): UserAbilityBuilderResult => {
     const builder = new AbilityBuilder<MemberAbility>(Ability);
     const invalidScopes: string[] = [];
+    // Authoritative only when the org opted in AND the deployment is
+    // licensed — unlicensed orgs keep inheriting the deployment default.
+    const patScopeIsAuthoritative = Boolean(
+        isEnterprise && patScopeAuthoritative,
+    );
+    const applyPatConfigFallback = !patScopeIsAuthoritative;
+    // Only the org primary slot may speak for the scope while authoritative;
+    // downstream sets listing it would silently restore what it withheld.
+    const withoutDownstreamPatScope = (scopes: string[]) =>
+        patScopeIsAuthoritative
+            ? scopes.filter(
+                  (scope) =>
+                      normalizeScopeName(scope) !==
+                      'manage:PersonalAccessToken',
+              )
+            : scopes;
     // Extra custom roles are unioned on top of the slot; unknown uuids are
     // skipped (logged) rather than granting anything.
     const applyExtraRoles = (
@@ -100,6 +123,9 @@ export const getUserAbilityBuilder = ({
                         isEnterprise,
                         organizationRole: user.role,
                         permissionsConfig,
+                        // While the org's PAT opt-in is authoritative, the primary slot alone
+                        // decides token access; downstream sets are stripped and declined.
+                        applyPatConfigFallback,
                     },
                     builder,
                 ),
@@ -120,10 +146,11 @@ export const getUserAbilityBuilder = ({
                 {
                     organizationUuid: user.organizationUuid as string,
                     userUuid: user.userUuid,
-                    scopes,
+                    scopes: withoutDownstreamPatScope(scopes),
                     isEnterprise,
                     organizationRole: user.role,
                     permissionsConfig,
+                    applyPatConfigFallback,
                 },
                 builder,
             ),
@@ -154,10 +181,11 @@ export const getUserAbilityBuilder = ({
                             projectCreatedByUserUuid:
                                 projectProfile.projectCreatedByUserUuid,
                             userUuid: user.userUuid,
-                            scopes,
+                            scopes: withoutDownstreamPatScope(scopes),
                             isEnterprise,
                             organizationRole: user.role,
                             permissionsConfig,
+                            applyPatConfigFallback,
                         },
                         builder,
                     ),
@@ -176,10 +204,11 @@ export const getUserAbilityBuilder = ({
                         projectCreatedByUserUuid:
                             projectProfile.projectCreatedByUserUuid,
                         userUuid: user.userUuid,
-                        scopes,
+                        scopes: withoutDownstreamPatScope(scopes),
                         isEnterprise,
                         organizationRole: user.role,
                         permissionsConfig,
+                        applyPatConfigFallback,
                     },
                     builder,
                 ),

--- a/packages/common/src/authorization/scopeAbilityBuilder.ts
+++ b/packages/common/src/authorization/scopeAbilityBuilder.ts
@@ -5,6 +5,10 @@ import { parseScope, parseScopes } from './parseScopes';
 import { getAllScopeMap } from './scopes';
 import { type MemberAbility } from './types';
 
+/**
+ * Compatibility grant so a scope set doesn't strip already-granted PAT access.
+ * Skipped for every set while the org's PAT opt-in is authoritative, applied otherwise.
+ */
 const handlePatConfigApplication = (
     context: ScopeContext,
     builder: AbilityBuilder<MemberAbility>,
@@ -34,6 +38,7 @@ const handlePatConfigApplication = (
 const applyScopeAbilities = (
     context: ScopeContext,
     builder: AbilityBuilder<MemberAbility>,
+    applyPatConfigFallback: boolean,
 ): void => {
     const scopeMap = getAllScopeMap({ isEnterprise: context.isEnterprise });
 
@@ -60,7 +65,9 @@ const applyScopeAbilities = (
         }
     });
 
-    handlePatConfigApplication(context, builder);
+    if (applyPatConfigFallback) {
+        handlePatConfigApplication(context, builder);
+    }
 };
 
 type OptionalIdContext =
@@ -88,6 +95,11 @@ type BuilderOptions = {
             allowedOrgRoles: string[];
         };
     };
+    /**
+     * Whether an omitted `manage:PersonalAccessToken` still inherits from config.
+     * False for every set when the org opted into authoritative PAT scopes, true otherwise.
+     */
+    applyPatConfigFallback?: boolean;
 } & OptionalIdContext;
 
 /**
@@ -101,18 +113,19 @@ export const buildAbilityFromScopes = (
     context: BuilderOptions,
     builder: AbilityBuilder<MemberAbility>,
 ): string[] => {
+    const { applyPatConfigFallback = true, ...scopeContext } = context;
     const isEnterprise = context.isEnterprise ?? false;
     const { valid, invalid } = parseScopes({
         scopes: context.scopes,
         isEnterprise,
     });
     const parsedContext = {
-        ...context,
+        ...scopeContext,
         scopes: valid,
         isEnterprise,
     };
 
-    applyScopeAbilities(parsedContext, builder);
+    applyScopeAbilities(parsedContext, builder, applyPatConfigFallback);
 
     return invalid;
 };


### PR DESCRIPTION
PR 2 of 4 in the PROD-8879 stack (see #28356 for the feature summary). Independently mergeable and runtime-inert: no backend caller passes the new arg yet, and the flag-off test matrix asserts today's behavior bit-for-bit.

## Problem

`manage:PersonalAccessToken` is a no-op in a custom role: `handlePatConfigApplication` re-grants token access to any scope-built ability whenever the deployment config allows the org role, so unticking the scope in the role builder changes nothing.

## Change

`getUserAbilityBuilder` gains `patScopeAuthoritative?: boolean` (default `false`). When `isEnterprise && patScopeAuthoritative`:

- the PAT config fallback is declined for **every** scope set a human user holds (its "no token rule yet" guard cannot tell a deliberate refusal from an omission, so any one set falling back would repair the primary slot's denial);
- downstream scope sets (org extra roles, project custom-role primary, project extra roles) additionally have an explicitly-listed `manage:PersonalAccessToken` **stripped** (compared via `normalizeScopeName`) — scope parsing has no level filtering, so a downstream set listing it would silently restore what the primary slot withheld;
- the org **primary** slot's scope list is never stripped: it is the single authority. List the scope → tokens (still capped by `DISABLE_PAT` / `PAT_ALLOWED_ORG_ROLES`); omit it → no tokens.

Without the opt-in (or without an enterprise license, where the scope is absent from the vocabulary and could never be granted back), every scope set keeps inheriting token access from the deployment config, exactly as today. No `cannot` rules are emitted — `collapseAbilityRules` stays sound (asserted in a test).

## Testing

`getUserAbilityBuilder.test.ts` (39 tests): authoritative matrix (deny on omission, primary keeps its listed scope, extra-org suppression, project-role suppression, license guard, `DISABLE_PAT`, `allowedOrgRoles` exclusion, no inverted rules) plus a flag-off matrix asserting unchanged legacy behavior, including a downstream role explicitly listing the scope still granting. Full `src/authorization` suite green; common typecheck clean.

Part of PROD-8879 / #25543 (closed by #28356).