### PR TITLE
feat(permissions): resolve the PAT scope opt-in at ability build

### DIFF
--- a/docs/authentication-and-roles.md
+++ b/docs/authentication-and-roles.md
@@ -229,6 +229,27 @@ This means the **same custom role** behaves differently:
 | Bound to `organization_memberships.role_uuid` (e.g. an SA token) | Can deploy any project + manage org members |
 | Bound to `project_memberships.role_uuid` for project A | Can deploy project A + content-as-code on project A; **silently cannot** manage org members |
 
+### Personal access tokens are the exception
+
+`manage:PersonalAccessToken` can be the one scope where the organization
+primary slot has the final say — for organizations that opt in via the
+`pat-scope-authoritative` feature flag on a licensed (enterprise)
+deployment. For everyone else, every scope set inherits token access from
+the deployment config (`DISABLE_PAT`, `PAT_ALLOWED_ORG_ROLES`) when it
+doesn't list the scope, exactly as before.
+
+While the opt-in is active, a custom role in
+`organization_memberships.role_uuid` is read literally: omit the scope and
+its users cannot create tokens; list it and they can, still capped by the
+deployment config, which can deny but never grant. Downstream scope sets
+(project roles, extra roles) can neither inherit the scope from config nor
+restore it by listing it explicitly — the org primary slot alone decides.
+
+That makes an org-level custom role (plus the flag) the supported way to
+deny tokens to a set of users. A project-level role cannot do it, by
+design. System organization roles are unaffected either way: their token
+access always comes from the deployment config.
+
 ### What `BASE_ROLE_SCOPES` returns when you duplicate "Admin"
 
 When an operator clicks **Duplicate role** on a system role, the new

--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -1067,16 +1067,25 @@ export class UserModel {
                 ...(role.extraRoleUuids ?? []),
             ]),
         ].filter((roleUuid): roleUuid is string => Boolean(roleUuid));
-        const [customRoleScopes, customRolesFlag] = await Promise.all([
-            this.customRoleScopes(customRoleUuids, trx),
-            this.featureFlagModel.get(
-                {
-                    user: lightdashUser,
-                    featureFlagId: CommercialFeatureFlags.CustomRoles,
-                },
-                { trx },
-            ),
-        ]);
+        const [customRoleScopes, customRolesFlag, patScopeAuthoritativeFlag] =
+            await Promise.all([
+                this.customRoleScopes(customRoleUuids, trx),
+                this.featureFlagModel.get(
+                    {
+                        user: lightdashUser,
+                        featureFlagId: CommercialFeatureFlags.CustomRoles,
+                    },
+                    { trx },
+                ),
+                this.featureFlagModel.get(
+                    {
+                        user: lightdashUser,
+                        featureFlagId:
+                            CommercialFeatureFlags.PatScopeAuthoritative,
+                    },
+                    { trx },
+                ),
+            ]);
         const { builder: abilityBuilder, invalidScopes } =
             getUserAbilityBuilder({
                 user: lightdashUser,
@@ -1091,6 +1100,7 @@ export class UserModel {
                     customRolesFlag.enabled,
                 isEnterprise:
                     this.lightdashConfig.license.licenseKey !== undefined,
+                patScopeAuthoritative: patScopeAuthoritativeFlag.enabled,
             });
 
         if (invalidScopes.length > 0) {


### PR DESCRIPTION
PR 3 of 4 — the activation point of the PROD-8879 stack (#28353 ✓ → #28355 ✓ → this → #28359). Merging still changes nothing for any org: behavior only changes for orgs that opt in via the `pat-scope-authoritative` feature flag. Do not enable the flag for any org before #28359 is also merged (it closes an empty-role bypass of the denial).

## Feature summary (whole stack)

Enterprise customers building restrictive org custom roles for external users want unticking `manage:PersonalAccessToken` to actually deny personal access tokens. Today the scope is a no-op — the ability builder re-grants token access from deployment config. With the org-level opt-in flag enabled, the primary-slot org custom role's scope list becomes authoritative: omit the scope and its users cannot create, manage, or **use** PATs; list it and they can, still capped by `DISABLE_PAT` / `PAT_ALLOWED_ORG_ROLES`. System org roles, service accounts, embed/JWT, and every org without the flag are untouched. The delegation ceiling is unchanged in both flag states: granting a role that carries token access still requires the caller to hold it (#26771 invariant).

This replaces the earlier unconditional approach (#28200) — inverting the default removes the backfill migration and its silent-token-stripping upgrade risk entirely. Rollback is turning the flag off.

## Change

- `UserModel` resolves `CommercialFeatureFlags.PatScopeAuthoritative` inside the existing `Promise.all` before ability build and passes `patScopeAuthoritative` to the single human-user `getUserAbilityBuilder` call site. Service-account paths keep the default (`false`) by construction.
- Docs: new "Personal access tokens are the exception" section in `docs/authentication-and-roles.md`.

## Rollout notes (per-org enablement)

- Merge #28359 first; then enable the flag for an org via the internal feature-flag console; then the org admin unticks the scope on the custom role (or builds a new org custom role without it) and assigns it in place of the system role.
- Flipping the flag makes **pre-existing** org custom roles authoritative immediately — before enabling, tick the scope on any org custom role whose users should keep tokens.
- A custom manager role that invites or assigns system roles must itself hold `manage:PersonalAccessToken` while the deployment config grants tokens to system roles (strict delegation ceiling).
- Denial is complete: PAT login itself checks `view PersonalAccessToken` on the built ability, so **existing tokens of affected users stop authenticating within ~30 seconds** (the PAT session cache TTL). Revoking outstanding tokens is useful cleanup, not required for enforcement.

## Testing

Backend typecheck clean; `UserService.test.ts` 178/178 (no mock changes needed — the flag resolves to disabled by default in tests, matching production flag-off).

Closes #25543