### PR TITLE
fix: keep optional APNs config from blocking startup

### DIFF
--- a/packages/backend/src/clients/Apns/ApnsClient.test.ts
+++ b/packages/backend/src/clients/Apns/ApnsClient.test.ts
@@ -30,6 +30,40 @@ const createClient = (response: { status: number; body?: string }) => {
 };
 
 describe('ApnsClient.sendLiveActivity', () => {
+    it.each<MobilePushNotificationsConfig>([
+        { ...config, enabled: false },
+        { ...config, teamId: undefined },
+        { ...config, sandbox: undefined },
+    ])(
+        'does not attempt delivery with incomplete configuration',
+        async (incompleteConfig) => {
+            const transport = {
+                send: vi.fn(async () => ({ status: 200 })),
+            } satisfies ApnsHttpTransport;
+            const providerTokenSource = {
+                getToken: vi.fn(async () => 'provider-token'),
+            } satisfies ApnsProviderTokenSource;
+            const client = new ApnsClient({
+                config: incompleteConfig,
+                transport,
+                providerTokenSource,
+            });
+
+            await expect(
+                client.sendLiveActivity({
+                    environment: 'sandbox',
+                    pushToken: 'activity-token',
+                    payload: { aps: { timestamp: 1, event: 'update' } },
+                }),
+            ).resolves.toEqual({
+                status: 'failed',
+                reason: 'environment_not_configured',
+            });
+            expect(providerTokenSource.getToken).not.toHaveBeenCalled();
+            expect(transport.send).not.toHaveBeenCalled();
+        },
+    );
+
     it('sends a sandbox Live Activity request with exact APNs headers', async () => {
         const { client, transport, providerTokenSource } = createClient({
             status: 200,

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -78,6 +78,22 @@ describe('mobile push notification config', () => {
         });
     });
 
+    it('enables a complete production credential on Lightdash Cloud', () => {
+        process.env.LIGHTDASH_CLOUD_INSTANCE = 'cloud-instance';
+        process.env.MOBILE_PUSH_NOTIFICATIONS_APNS_TEAM_ID = 'TEAMID';
+        process.env.MOBILE_PUSH_NOTIFICATIONS_APNS_PRODUCTION_KEY_ID = 'KEYID';
+        process.env.MOBILE_PUSH_NOTIFICATIONS_APNS_PRODUCTION_PRIVATE_KEY =
+            'private-key';
+
+        expect(parseConfig().mobilePushNotifications).toEqual({
+            enabled: true,
+            bundleId: 'com.lightdash.mobile',
+            teamId: 'TEAMID',
+            sandbox: undefined,
+            production: { keyId: 'KEYID', privateKey: 'private-key' },
+        });
+    });
+
     it('stays disabled outside Lightdash Cloud', () => {
         process.env.MOBILE_PUSH_NOTIFICATIONS_APNS_TEAM_ID = 'TEAMID';
         process.env.MOBILE_PUSH_NOTIFICATIONS_APNS_PRODUCTION_KEY_ID = 'KEYID';
@@ -87,25 +103,53 @@ describe('mobile push notification config', () => {
         expect(parseConfig().mobilePushNotifications.enabled).toBe(false);
     });
 
-    it('rejects a partial environment credential', () => {
+    it.each([
+        {
+            key: 'MOBILE_PUSH_NOTIFICATIONS_APNS_SANDBOX_KEY_ID' as const,
+            value: 'KEYID',
+        },
+        {
+            key: 'MOBILE_PUSH_NOTIFICATIONS_APNS_PRODUCTION_PRIVATE_KEY' as const,
+            value: 'private-key',
+        },
+    ])('is disabled when only $key is set', ({ key, value }) => {
         process.env.LIGHTDASH_CLOUD_INSTANCE = 'cloud-instance';
         process.env.MOBILE_PUSH_NOTIFICATIONS_APNS_TEAM_ID = 'TEAMID';
-        process.env.MOBILE_PUSH_NOTIFICATIONS_APNS_SANDBOX_KEY_ID = 'KEYID';
+        process.env[key] = value;
 
-        expect(() => parseConfig()).toThrow(
-            'MOBILE_PUSH_NOTIFICATIONS_APNS_SANDBOX_KEY_ID and MOBILE_PUSH_NOTIFICATIONS_APNS_SANDBOX_PRIVATE_KEY must be set together',
-        );
+        expect(parseConfig().mobilePushNotifications).toEqual({
+            enabled: false,
+            bundleId: 'com.lightdash.mobile',
+            teamId: 'TEAMID',
+            sandbox: undefined,
+            production: undefined,
+        });
     });
 
-    it('requires a team ID when an environment credential is present', () => {
+    it('is disabled when an environment credential has no team ID', () => {
         process.env.LIGHTDASH_CLOUD_INSTANCE = 'cloud-instance';
         process.env.MOBILE_PUSH_NOTIFICATIONS_APNS_PRODUCTION_KEY_ID = 'KEYID';
         process.env.MOBILE_PUSH_NOTIFICATIONS_APNS_PRODUCTION_PRIVATE_KEY =
             'private-key';
 
-        expect(() => parseConfig()).toThrow(
-            'MOBILE_PUSH_NOTIFICATIONS_APNS_TEAM_ID is required when APNs credentials are set',
-        );
+        expect(parseConfig().mobilePushNotifications).toEqual({
+            enabled: false,
+            bundleId: 'com.lightdash.mobile',
+            teamId: undefined,
+            sandbox: undefined,
+            production: { keyId: 'KEYID', privateKey: 'private-key' },
+        });
+    });
+
+    it('allows the global config singleton to load with partial credentials', async () => {
+        process.env.LIGHTDASH_CLOUD_INSTANCE = 'cloud-instance';
+        process.env.MOBILE_PUSH_NOTIFICATIONS_APNS_TEAM_ID = 'TEAMID';
+        process.env.MOBILE_PUSH_NOTIFICATIONS_APNS_SANDBOX_KEY_ID = 'KEYID';
+        vi.resetModules();
+
+        const { lightdashConfig } = await import('./lightdashConfig');
+
+        expect(lightdashConfig.mobilePushNotifications.enabled).toBe(false);
     });
 });
 

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -2588,13 +2588,6 @@ const parseMobilePushCredential = (
     const keyId = process.env[keyIdVariable];
     const privateKey = process.env[privateKeyVariable];
 
-    if ((keyId === undefined) !== (privateKey === undefined)) {
-        throw new ParseError(
-            `${keyIdVariable} and ${privateKeyVariable} must be set together`,
-            {},
-        );
-    }
-
     return keyId === undefined || privateKey === undefined
         ? undefined
         : { keyId, privateKey };
@@ -2732,16 +2725,6 @@ export const parseConfig = (): LightdashConfig => {
     const mobilePushSandbox = parseMobilePushCredential('SANDBOX');
     const mobilePushProduction = parseMobilePushCredential('PRODUCTION');
     const mobilePushTeamId = process.env.MOBILE_PUSH_NOTIFICATIONS_APNS_TEAM_ID;
-    if (
-        (mobilePushSandbox !== undefined ||
-            mobilePushProduction !== undefined) &&
-        mobilePushTeamId === undefined
-    ) {
-        throw new ParseError(
-            'MOBILE_PUSH_NOTIFICATIONS_APNS_TEAM_ID is required when APNs credentials are set',
-            {},
-        );
-    }
     const motherduckInstanceCache = {
         enabled: process.env.MOTHERDUCK_INSTANCE_CACHE_ENABLED === 'true',
         projectUuids: getArrayFromCommaSeparatedList(


### PR DESCRIPTION
Linear: SPK-1688

## What changed

- Treat incomplete APNs credential pairs as unavailable instead of a global parse error.
- Keep mobile push disabled until a team ID and one complete environment credential exist.
- Verify the APNs client stops before token generation or network access when configuration is incomplete.
- Add global-config import coverage for migration and command startup.

## Why

Mobile push is optional. A partial APNs environment must not stop Lightdash web, workers, schedulers, or migration commands when the iOS integration is not in use.

## Verification

- Passed 232 focused parser and APNs client tests.
- Passed formatting on all three touched files.
- Passed `git diff --check`.
- Local full backend typecheck and lint were blocked by the dedicated worktree dependency graph. CI runs both in a clean checkout.

## Security

MEDIUM. This changes optional credential enablement semantics. Delivery remains fail-closed and tests prove that incomplete configuration cannot generate provider tokens or send a request. The DeepSec scan is deferred under SPK-1678 per the current merge queue decision.

## Context

Follow-up to #28316.