### PR TITLE
fix(data-apps): allow editors to unlink external connections

### DIFF
--- a/packages/frontend/src/features/apps/AppResourcePicker.test.tsx
+++ b/packages/frontend/src/features/apps/AppResourcePicker.test.tsx
@@ -3,6 +3,7 @@ import { MantineProvider } from '@mantine/core';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { vi } from 'vitest';
 import {
+    AttachButton,
     ConnectionAttachButton,
     ConnectionPickerView,
     SelectedQuerySection,
@@ -43,12 +44,32 @@ vi.mock('../externalConnections/hooks/useAppExternalConnections', () => ({
             ? [
                   {
                       alias: 'linked_api',
-                      connection: { externalConnectionUuid: 'c-linked' },
+                      connection: {
+                          externalConnectionUuid: 'c-linked',
+                          name: 'Linked API',
+                          origin: 'https://c-linked.example.com',
+                      },
                   },
                   {
                       alias: 'selected_api',
-                      connection: { externalConnectionUuid: 'c-selected' },
+                      connection: {
+                          externalConnectionUuid: 'c-selected',
+                          name: 'Selected API',
+                          origin: 'https://c-selected.example.com',
+                      },
                   },
+                  ...(appUuid === 'app-with-admin-only-link'
+                      ? [
+                            {
+                                alias: 'admin_only_api',
+                                connection: {
+                                    externalConnectionUuid: 'c-admin-only',
+                                    name: 'Admin-only API',
+                                    origin: 'https://admin-only.example.com',
+                                },
+                            },
+                        ]
+                      : []),
               ]
             : undefined,
     }),
@@ -178,6 +199,7 @@ it('counts linked and newly selected connections together, without double counti
 });
 
 it('shows linked connections as checked, and unlinks them on click', () => {
+    unlink.mockClear();
     const onSelect = vi.fn();
     const onDeselect = vi.fn();
     render(
@@ -213,6 +235,49 @@ it('shows linked connections as checked, and unlinks them on click', () => {
     expect(onSelect).toHaveBeenCalledWith(
         expect.objectContaining({ externalConnectionUuid: 'c-plain' }),
     );
+});
+
+it('lets an app unlink a connection that is no longer available for linking', () => {
+    unlink.mockClear();
+    const onDeselectConnection = vi.fn();
+    render(
+        <MantineProvider env="test">
+            <AttachButton
+                selectedCharts={[]}
+                onSelectChart={() => undefined}
+                onDeselectChart={() => undefined}
+                selectedDashboard={null}
+                onSelectDashboard={() => undefined}
+                onDeselectDashboard={() => undefined}
+                selectedConnections={[]}
+                onSelectConnection={() => undefined}
+                onDeselectConnection={onDeselectConnection}
+                onAddFiles={() => undefined}
+                disabled={false}
+                filesDisabled={false}
+                linkedAppUuid="app-with-admin-only-link"
+            />
+        </MantineProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Attach resources' }));
+    fireEvent.click(
+        screen.getByRole('button', { name: /External connections/ }),
+    );
+
+    const linkedRow = screen.getByRole('checkbox', {
+        name: /Admin-only API/,
+    });
+    expect(linkedRow).toBeChecked();
+
+    fireEvent.click(linkedRow);
+    expect(unlink).toHaveBeenCalledWith({
+        projectUuid: 'project-1',
+        appUuid: 'app-with-admin-only-link',
+        alias: 'admin_only_api',
+        name: 'Admin-only API',
+    });
+    expect(onDeselectConnection).toHaveBeenCalledWith('c-admin-only');
 });
 
 it('never unlinks before a first build exists', () => {

--- a/packages/frontend/src/features/apps/AppResourcePicker.test.tsx
+++ b/packages/frontend/src/features/apps/AppResourcePicker.test.tsx
@@ -198,7 +198,7 @@ it('counts linked and newly selected connections together, without double counti
     expect(screen.getByText('3')).toBeInTheDocument();
 });
 
-it('shows linked connections as checked, and unlinks them on click', () => {
+it('confirms before unlinking a checked connection', () => {
     unlink.mockClear();
     const onSelect = vi.fn();
     const onDeselect = vi.fn();
@@ -222,6 +222,15 @@ it('shows linked connections as checked, and unlinks them on click', () => {
     ).not.toBeChecked();
 
     fireEvent.click(linkedRow);
+    expect(unlink).not.toHaveBeenCalled();
+    expect(
+        screen.getByText(
+            'You may not be able to link it again without help from a project admin.',
+            { exact: false },
+        ),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Unlink connection' }));
     expect(unlink).toHaveBeenCalledWith({
         projectUuid: 'project-1',
         appUuid: 'app-1',
@@ -237,7 +246,7 @@ it('shows linked connections as checked, and unlinks them on click', () => {
     );
 });
 
-it('lets an app unlink a connection that is no longer available for linking', () => {
+it('lets an app keep a connection that is no longer available for linking', () => {
     unlink.mockClear();
     const onDeselectConnection = vi.fn();
     render(
@@ -271,13 +280,12 @@ it('lets an app unlink a connection that is no longer available for linking', ()
     expect(linkedRow).toBeChecked();
 
     fireEvent.click(linkedRow);
-    expect(unlink).toHaveBeenCalledWith({
-        projectUuid: 'project-1',
-        appUuid: 'app-with-admin-only-link',
-        alias: 'admin_only_api',
-        name: 'Admin-only API',
-    });
-    expect(onDeselectConnection).toHaveBeenCalledWith('c-admin-only');
+    expect(unlink).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Keep connection' }));
+    expect(unlink).not.toHaveBeenCalled();
+    expect(onDeselectConnection).not.toHaveBeenCalled();
+    expect(linkedRow).toBeChecked();
 });
 
 it('never unlinks before a first build exists', () => {

--- a/packages/frontend/src/features/apps/AppResourcePicker.test.tsx
+++ b/packages/frontend/src/features/apps/AppResourcePicker.test.tsx
@@ -204,15 +204,21 @@ it('confirms before unlinking a checked connection', () => {
     const onDeselect = vi.fn();
     render(
         <MantineProvider env="test">
-            <ConnectionPickerView
+            <ConnectionAttachButton
                 selectedConnections={[]}
                 onSelect={onSelect}
                 onDeselect={onDeselect}
-                onDone={() => undefined}
-                enabled
+                disabled={false}
+                description="Choose connections"
                 linkedAppUuid="app-1"
             />
         </MantineProvider>,
+    );
+
+    fireEvent.click(
+        screen.getByRole('button', {
+            name: '2 external connections attached',
+        }),
     );
 
     const linkedRow = screen.getByRole('checkbox', { name: /Linked API/ });
@@ -230,7 +236,11 @@ it('confirms before unlinking a checked connection', () => {
         ),
     ).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Unlink connection' }));
+    const confirmButton = screen.getByRole('button', {
+        name: 'Unlink connection',
+    });
+    fireEvent.mouseDown(confirmButton);
+    fireEvent.click(confirmButton);
     expect(unlink).toHaveBeenCalledWith({
         projectUuid: 'project-1',
         appUuid: 'app-1',
@@ -246,7 +256,7 @@ it('confirms before unlinking a checked connection', () => {
     );
 });
 
-it('lets an app keep a connection that is no longer available for linking', () => {
+it('keeps the app picker mounted until an unlink confirmation completes', () => {
     unlink.mockClear();
     const onDeselectConnection = vi.fn();
     render(
@@ -282,10 +292,29 @@ it('lets an app keep a connection that is no longer available for linking', () =
     fireEvent.click(linkedRow);
     expect(unlink).not.toHaveBeenCalled();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Keep connection' }));
+    const keepButton = screen.getByRole('button', { name: 'Keep connection' });
+    fireEvent.mouseDown(keepButton);
+    fireEvent.click(keepButton);
     expect(unlink).not.toHaveBeenCalled();
     expect(onDeselectConnection).not.toHaveBeenCalled();
-    expect(linkedRow).toBeChecked();
+    expect(
+        screen.getByRole('checkbox', { name: /Admin-only API/ }),
+    ).toBeChecked();
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /Admin-only API/ }));
+    const confirmButton = screen.getByRole('button', {
+        name: 'Unlink connection',
+    });
+    fireEvent.mouseDown(confirmButton);
+    fireEvent.click(confirmButton);
+
+    expect(unlink).toHaveBeenCalledWith({
+        projectUuid: 'project-1',
+        appUuid: 'app-with-admin-only-link',
+        alias: 'admin_only_api',
+        name: 'Admin-only API',
+    });
+    expect(onDeselectConnection).toHaveBeenCalledWith('c-admin-only');
 });
 
 it('never unlinks before a first build exists', () => {

--- a/packages/frontend/src/features/apps/AppResourcePicker.tsx
+++ b/packages/frontend/src/features/apps/AppResourcePicker.tsx
@@ -965,6 +965,20 @@ export const ConnectionPickerView: FC<{
         enabled ? projectUuid : undefined,
         linkedAppUuid,
     );
+    const visibleConnections = useMemo(() => {
+        const byUuid = new Map(
+            (existingLinks ?? []).map((link) => [
+                link.connection.externalConnectionUuid,
+                link.connection,
+            ]),
+        );
+
+        for (const connection of connections ?? []) {
+            byUuid.set(connection.externalConnectionUuid, connection);
+        }
+
+        return [...byUuid.values()];
+    }, [connections, existingLinks]);
     const linkedAliases = useMemo(
         () =>
             new Map(
@@ -1002,16 +1016,15 @@ export const ConnectionPickerView: FC<{
 
     const filtered = useMemo(() => {
         const q = searchQuery.trim().toLowerCase();
-        const list = connections ?? [];
-        if (!q) return list;
-        return list.filter(
+        if (!q) return visibleConnections;
+        return visibleConnections.filter(
             (c) =>
                 c.name.toLowerCase().includes(q) ||
                 c.origin.toLowerCase().includes(q),
         );
-    }, [connections, searchQuery]);
+    }, [searchQuery, visibleConnections]);
 
-    const hasConnections = (connections?.length ?? 0) > 0;
+    const hasConnections = visibleConnections.length > 0;
     let emptyMessage = 'No connections match your search';
     if (!hasConnections) {
         emptyMessage = canManageConnections
@@ -1177,6 +1190,7 @@ export const AttachButton: FC<{
     onAddFiles: () => void;
     disabled: boolean;
     filesDisabled: boolean;
+    linkedAppUuid?: string;
 }> = ({
     selectedCharts,
     onSelectChart,
@@ -1190,6 +1204,7 @@ export const AttachButton: FC<{
     onAddFiles,
     disabled,
     filesDisabled,
+    linkedAppUuid,
 }) => {
     const projectUuid = useProjectUuid();
     const [opened, setOpened] = useState(false);
@@ -1377,6 +1392,7 @@ export const AttachButton: FC<{
                                     setView('menu');
                                 }}
                                 enabled={opened}
+                                linkedAppUuid={linkedAppUuid}
                             />
                         ) : (
                             <DashboardPickerView

--- a/packages/frontend/src/features/apps/AppResourcePicker.tsx
+++ b/packages/frontend/src/features/apps/AppResourcePicker.tsx
@@ -949,6 +949,7 @@ export const ConnectionPickerView: FC<{
     /** App whose existing links show as checked rows that unlink on click;
      *  omit before a first build, when nothing can be linked yet. */
     linkedAppUuid?: string;
+    onUnlinkConfirmationChange?: (opened: boolean) => void;
 }> = ({
     selectedConnections,
     onSelect,
@@ -956,6 +957,7 @@ export const ConnectionPickerView: FC<{
     onDone,
     enabled,
     linkedAppUuid,
+    onUnlinkConfirmationChange,
 }) => {
     const projectUuid = useProjectUuid();
     const [searchQuery, setSearchQuery] = useState('');
@@ -1044,6 +1046,7 @@ export const ConnectionPickerView: FC<{
             );
             if (linkedAlias !== undefined && projectUuid && linkedAppUuid) {
                 setPendingUnlink({ connection, alias: linkedAlias });
+                onUnlinkConfirmationChange?.(true);
             } else if (selectedUuids.has(connection.externalConnectionUuid)) {
                 onDeselect(connection.externalConnectionUuid);
             } else {
@@ -1062,6 +1065,7 @@ export const ConnectionPickerView: FC<{
             linkedAppUuid,
             onDeselect,
             onSelect,
+            onUnlinkConfirmationChange,
             projectUuid,
             selectedConnections,
             selectedUuids,
@@ -1079,7 +1083,20 @@ export const ConnectionPickerView: FC<{
         });
         onDeselect(pendingUnlink.connection.externalConnectionUuid);
         setPendingUnlink(null);
-    }, [linkedAppUuid, onDeselect, pendingUnlink, projectUuid, unlink]);
+        onUnlinkConfirmationChange?.(false);
+    }, [
+        linkedAppUuid,
+        onDeselect,
+        onUnlinkConfirmationChange,
+        pendingUnlink,
+        projectUuid,
+        unlink,
+    ]);
+
+    const handleCancelUnlink = useCallback(() => {
+        setPendingUnlink(null);
+        onUnlinkConfirmationChange?.(false);
+    }, [onUnlinkConfirmationChange]);
 
     return (
         <>
@@ -1177,7 +1194,7 @@ export const ConnectionPickerView: FC<{
             </Box>
             <MantineModal
                 opened={pendingUnlink !== null}
-                onClose={() => setPendingUnlink(null)}
+                onClose={handleCancelUnlink}
                 title={`Unlink ${pendingUnlink?.connection.name ?? 'connection'}?`}
                 variant="delete"
                 size="md"
@@ -1231,6 +1248,7 @@ export const AttachButton: FC<{
     const projectUuid = useProjectUuid();
     const [opened, setOpened] = useState(false);
     const [view, setView] = useState<AttachView>('menu');
+    const [unlinkConfirmationOpen, setUnlinkConfirmationOpen] = useState(false);
 
     const handleChange = useCallback((isOpen: boolean) => {
         setOpened(isOpen);
@@ -1272,6 +1290,8 @@ export const AttachButton: FC<{
             offset={8}
             shadow="md"
             trapFocus
+            closeOnClickOutside={!unlinkConfirmationOpen}
+            closeOnEscape={!unlinkConfirmationOpen}
         >
             <Popover.Target>
                 <Tooltip
@@ -1415,6 +1435,9 @@ export const AttachButton: FC<{
                                 }}
                                 enabled={opened}
                                 linkedAppUuid={linkedAppUuid}
+                                onUnlinkConfirmationChange={
+                                    setUnlinkConfirmationOpen
+                                }
                             />
                         ) : (
                             <DashboardPickerView
@@ -1460,6 +1483,7 @@ export const ConnectionAttachButton: FC<{
 }) => {
     const projectUuid = useProjectUuid();
     const [opened, setOpened] = useState(false);
+    const [unlinkConfirmationOpen, setUnlinkConfirmationOpen] = useState(false);
     const { data: existingLinks } = useAppExternalConnections(
         projectUuid,
         linkedAppUuid ?? undefined,
@@ -1499,6 +1523,8 @@ export const ConnectionAttachButton: FC<{
             offset={8}
             shadow="md"
             trapFocus
+            closeOnClickOutside={!unlinkConfirmationOpen}
+            closeOnEscape={!unlinkConfirmationOpen}
         >
             <Popover.Target>
                 <Tooltip
@@ -1551,6 +1577,7 @@ export const ConnectionAttachButton: FC<{
                     onDone={() => setOpened(false)}
                     enabled={opened}
                     linkedAppUuid={linkedAppUuid ?? undefined}
+                    onUnlinkConfirmationChange={setUnlinkConfirmationOpen}
                 />
             </Popover.Dropdown>
         </Popover>

--- a/packages/frontend/src/features/apps/AppResourcePicker.tsx
+++ b/packages/frontend/src/features/apps/AppResourcePicker.tsx
@@ -54,6 +54,7 @@ import {
     type FC,
 } from 'react';
 import MantineIcon from '../../components/common/MantineIcon';
+import MantineModal from '../../components/common/MantineModal';
 import { ModelSelector } from '../../components/common/ModelSelector/ModelSelector';
 import { ChartIcon, IconBox } from '../../components/common/ResourceIcon';
 import { getChartIcon } from '../../components/common/ResourceIcon/utils';
@@ -958,6 +959,10 @@ export const ConnectionPickerView: FC<{
 }) => {
     const projectUuid = useProjectUuid();
     const [searchQuery, setSearchQuery] = useState('');
+    const [pendingUnlink, setPendingUnlink] = useState<{
+        connection: ExternalConnection;
+        alias: string;
+    } | null>(null);
     const { data: connections, isInitialLoading } = useExternalConnections(
         enabled ? projectUuid : undefined,
     );
@@ -1038,13 +1043,7 @@ export const ConnectionPickerView: FC<{
                 connection.externalConnectionUuid,
             );
             if (linkedAlias !== undefined && projectUuid && linkedAppUuid) {
-                unlink({
-                    projectUuid,
-                    appUuid: linkedAppUuid,
-                    alias: linkedAlias,
-                    name: connection.name,
-                });
-                onDeselect(connection.externalConnectionUuid);
+                setPendingUnlink({ connection, alias: linkedAlias });
             } else if (selectedUuids.has(connection.externalConnectionUuid)) {
                 onDeselect(connection.externalConnectionUuid);
             } else {
@@ -1066,9 +1065,21 @@ export const ConnectionPickerView: FC<{
             projectUuid,
             selectedConnections,
             selectedUuids,
-            unlink,
         ],
     );
+
+    const handleConfirmUnlink = useCallback(() => {
+        if (!pendingUnlink || !projectUuid || !linkedAppUuid) return;
+
+        unlink({
+            projectUuid,
+            appUuid: linkedAppUuid,
+            alias: pendingUnlink.alias,
+            name: pendingUnlink.connection.name,
+        });
+        onDeselect(pendingUnlink.connection.externalConnectionUuid);
+        setPendingUnlink(null);
+    }, [linkedAppUuid, onDeselect, pendingUnlink, projectUuid, unlink]);
 
     return (
         <>
@@ -1164,6 +1175,17 @@ export const ConnectionPickerView: FC<{
                     Done
                 </Button>
             </Box>
+            <MantineModal
+                opened={pendingUnlink !== null}
+                onClose={() => setPendingUnlink(null)}
+                title={`Unlink ${pendingUnlink?.connection.name ?? 'connection'}?`}
+                variant="delete"
+                size="md"
+                description="Unlinking removes access to this connection. You may not be able to link it again without help from a project admin."
+                confirmLabel="Unlink connection"
+                cancelLabel="Keep connection"
+                onConfirm={handleConfirmUnlink}
+            />
         </>
     );
 };

--- a/packages/frontend/src/features/externalConnections/hooks/useUnlinkAppExternalConnection.ts
+++ b/packages/frontend/src/features/externalConnections/hooks/useUnlinkAppExternalConnection.ts
@@ -61,7 +61,7 @@ export const useUnlinkAppExternalConnection = () => {
             showToastInfo({
                 title: `Unlinked ${name}`,
                 subtitle:
-                    'The chart type still calls it until you ask for a change.',
+                    'The generated code still calls it until you ask for a change.',
             });
         },
         onError: ({ error }, { projectUuid, appUuid }, context) => {

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -2794,6 +2794,9 @@ const AppGenerate: FC = () => {
                                                         fileAttachments.length >=
                                                         MAX_APP_FILES_PER_VERSION
                                                     }
+                                                    linkedAppUuid={
+                                                        activeAppUuid
+                                                    }
                                                 />
                                                 {previewApp &&
                                                     screenshotAvailable && (


### PR DESCRIPTION
[GLITCH-708](https://linear.app/lightdash/issue/GLITCH-708/allow-editor-to-un-link-external-connection)

### Description:

```diff
Edit data app → Attach → External connections
- existing links appear unselected and cannot be removed
+ existing links appear checked and require confirmation to unlink
```

- Reuses the custom chart type unlink flow and existing optimistic mutation, including rollback when the request fails.
- Keeps an app's existing links visible even when an Editor cannot otherwise browse or link an admin-only connection.
- Warns that the user may need a project admin to restore the link; cancelling leaves the connection untouched.
- Keeps the parent picker mounted while the portalled confirmation is open, so both cancel and confirm actions complete before outside-click dismissal.
- Only persisted links require confirmation. Pending selections before the first build can still be selected or deselected normally and never call unlink.
- Leaves connection creation permissions and backend authorization unchanged. Unlinking only removes the app-to-connection alias; generated code continues using the alias until the user asks for a change.

Validation:

- `pnpm -F frontend test src/features/apps/AppResourcePicker.test.tsx src/features/externalConnections/hooks/useUnlinkAppExternalConnection.test.tsx` — 12 tests passed. The app and custom chart-type wrappers both cover the browser's `mousedown → click` ordering through confirmation.
- Targeted `oxfmt --check`, `oxlint`, and `git diff --check` passed.
- Live on `localhost:3000`: selecting the checked Open-Meteo link opened the warning; choosing **Keep connection** left the picker open and the link checked with the `1 connection` count.
- Live confirm-and-unlink was also verified manually: accepting the confirmation emitted the DELETE and removed the persisted link as expected.
- The public Editor seed account could enter the F1 project but had no access to its seeded data apps because of Space permissions, so the linked-but-not-linkable Editor branch is covered by the focused component test rather than a live permission change.
- `pnpm -F frontend typecheck` was attempted but is currently blocked by five unrelated existing `config`/`allowBrowserImages` errors in `ConnectionExamplesPanel.tsx`, `wizardValues.ts`, `wizardValues.test.ts`, and `sensitiveApiRequests.test.tsx`.

### Risk assessment:

- [ ] This is a high-risk change

Low risk: this is a focused frontend confirmation around an existing authorized DELETE endpoint. It does not expose credentials or broaden connection-management permissions, accidental clicks no longer unlink, and failed confirmed unlinks restore the cached link.

