### PR TITLE
fix(permissions): flag-scope the ceiling relief and resolve empty custom roles

### DIFF
--- a/packages/backend/src/models/UserModel.test.ts
+++ b/packages/backend/src/models/UserModel.test.ts
@@ -1,5 +1,11 @@
-import { subject, type AbilityBuilder, type RawRuleOf } from '@casl/ability';
 import {
+    Ability,
+    AbilityBuilder,
+    subject,
+    type RawRuleOf,
+} from '@casl/ability';
+import {
+    CommercialFeatureFlags,
     LightdashMode,
     LightdashUser,
     MemberAbility,
@@ -8,6 +14,7 @@ import {
     PasswordLoginBlockedError,
     projectMemberAbilities,
     ProjectMemberRole,
+    ProjectType,
     ServiceAccountScope,
     type SessionUser,
 } from '@lightdash/common';
@@ -17,6 +24,13 @@ import { getTracker, MockClient, type Tracker } from 'knex-mock-client';
 import { type LightdashConfig } from '../config/parseConfig';
 import { EmailTableName } from '../database/entities/emails';
 import { PasswordLoginTableName } from '../database/entities/passwordLogins';
+import { ProjectMembershipCustomRolesTableName } from '../database/entities/projectMembershipCustomRoles';
+import { ProjectMembershipsTableName } from '../database/entities/projectMemberships';
+import { ProjectTableName } from '../database/entities/projects';
+import {
+    RolesTableName,
+    ScopedRolesTableName,
+} from '../database/entities/roles';
 import { UserTableName } from '../database/entities/users';
 import { hashWithSecret } from '../utils/hash';
 import { type FeatureFlagModel } from './FeatureFlagModel/FeatureFlagModel';
@@ -56,6 +70,7 @@ type TestableUserModel = {
         roleUuids: string[],
         trx?: Knex,
     ) => Promise<Record<string, string[]>>;
+    roleExists: (roleUuid: string, trx?: Knex) => Promise<boolean>;
     applyServiceAccountProjectMemberships: (
         userId: number,
         userUuid: string,
@@ -501,6 +516,382 @@ describe('UserModel', () => {
                         organizationUuid: userDetails.organization_uuid,
                     }),
                 ),
+            ).toBe(true);
+        });
+    });
+
+    describe('customRoleScopes (loader)', () => {
+        // Table-scoped fake trx: avoids knex-mock-client's global tracker,
+        // whose SQL-substring matcher can't tell "roles" from "scoped_roles".
+        const createScopedRolesTrx = (
+            scopedRolesRows: { role_uuid: string; scope_name: string }[],
+        ) =>
+            vi.fn((tableName: string) => {
+                if (tableName === ScopedRolesTableName) {
+                    return {
+                        select: () => ({
+                            whereIn: async () => scopedRolesRows,
+                        }),
+                    };
+                }
+                throw new Error(`Unexpected table ${tableName}`);
+            }) as unknown as Knex;
+
+        const createRawUserModel = (
+            scopedRolesRows: { role_uuid: string; scope_name: string }[],
+        ) =>
+            new UserModel({
+                database: createScopedRolesTrx(scopedRolesRows),
+                lightdashConfig,
+                featureFlagModel,
+            }) as unknown as TestableUserModel;
+
+        // Only scoped_roles rows drive this map: an existing role with zero
+        // rows and a missing/unknown roleUuid are indistinguishable here —
+        // both produce no entry. Distinguishing them is the narrow job of
+        // `roleExists`, scoped to the human primary-org-role check only.
+        it('omits a role with zero scoped_roles rows entirely, rather than an empty list', async () => {
+            const model = createRawUserModel([]);
+
+            const result = await model.customRoleScopes(['empty-role']);
+
+            expect(result).toEqual({});
+            expect(
+                Object.prototype.hasOwnProperty.call(result, 'empty-role'),
+            ).toBe(false);
+        });
+
+        it('omits a missing/unknown roleUuid entirely, rather than an empty list', async () => {
+            const model = createRawUserModel([]);
+
+            const result = await model.customRoleScopes(['unknown-role']);
+
+            expect(result).toEqual({});
+            expect(
+                Object.prototype.hasOwnProperty.call(result, 'unknown-role'),
+            ).toBe(false);
+        });
+
+        it('still returns the stored scopes for a role that has them', async () => {
+            const model = createRawUserModel([
+                { role_uuid: 'scoped-role', scope_name: 'view:Dashboard' },
+                { role_uuid: 'scoped-role', scope_name: 'manage:Space' },
+            ]);
+
+            await expect(
+                model.customRoleScopes(['scoped-role']),
+            ).resolves.toEqual({
+                'scoped-role': ['view:Dashboard', 'manage:Space'],
+            });
+        });
+    });
+
+    describe('roleExists', () => {
+        const createRolesTrx = (rolesRows: { role_uuid: string }[]) =>
+            vi.fn((tableName: string) => {
+                if (tableName === RolesTableName) {
+                    return {
+                        select: () => ({
+                            where: () => ({
+                                first: async () => rolesRows[0],
+                            }),
+                        }),
+                    };
+                }
+                throw new Error(`Unexpected table ${tableName}`);
+            }) as unknown as Knex;
+
+        const createRawUserModel = (rolesRows: { role_uuid: string }[]) =>
+            new UserModel({
+                database: createRolesTrx(rolesRows),
+                lightdashConfig,
+                featureFlagModel,
+            }) as unknown as TestableUserModel;
+
+        it('resolves true for an existing role uuid', async () => {
+            const model = createRawUserModel([{ role_uuid: 'exists' }]);
+
+            await expect(model.roleExists('exists')).resolves.toBe(true);
+        });
+
+        it('resolves false for a missing/unknown role uuid', async () => {
+            const model = createRawUserModel([]);
+
+            await expect(model.roleExists('missing')).resolves.toBe(false);
+        });
+    });
+
+    describe('org custom role PAT scope authority (pat-scope-authoritative flag)', () => {
+        const orgCustomRoleUuid = 'org-custom-role';
+        const patHumanDetails: DbUserDetails = {
+            ...userDetails,
+            user_uuid: 'pat-human-user',
+            is_internal: false,
+            role: OrganizationMemberRole.MEMBER,
+            role_uuid: orgCustomRoleUuid,
+        };
+
+        const patLightdashConfig = {
+            ...lightdashConfig,
+            auth: {
+                pat: {
+                    enabled: true,
+                    allowedOrgRoles: [OrganizationMemberRole.MEMBER],
+                },
+            },
+            customRoles: { enabled: true },
+            license: { licenseKey: 'test-license-key' },
+        } as unknown as LightdashConfig;
+
+        const createFeatureFlagModelFor = (
+            patScopeAuthoritative: boolean,
+        ): FeatureFlagModel =>
+            ({
+                get: vi.fn(async ({ featureFlagId }) => ({
+                    id: featureFlagId,
+                    enabled:
+                        featureFlagId ===
+                        CommercialFeatureFlags.PatScopeAuthoritative
+                            ? patScopeAuthoritative
+                            : false,
+                })),
+            }) as unknown as FeatureFlagModel;
+
+        const createPatHumanModel = (
+            patScopeAuthoritative: boolean,
+            roleScopes: string[],
+        ) => {
+            const model = new UserModel({
+                database: vi.fn() as unknown as Knex,
+                lightdashConfig: patLightdashConfig,
+                featureFlagModel: createFeatureFlagModelFor(
+                    patScopeAuthoritative,
+                ),
+            }) as unknown as TestableUserModel;
+            model.hasAuthentication = vi.fn(async () => true);
+            model.getUserProjectRoles = vi.fn(async () => []);
+            model.getUserGroupProjectRoles = vi.fn(async () => []);
+            model.getOrganizationExtraRoleUuids = vi.fn(async () => []);
+            model.customRoleScopes = vi.fn(async () => ({
+                [orgCustomRoleUuid]: roleScopes,
+            }));
+            model.findServiceAccountByUserUuid = vi.fn(async () => undefined);
+            model.applyServiceAccountProjectMemberships = vi.fn(async () => {});
+            return model;
+        };
+
+        it('flag off: a role that omits the scope still gets PAT from the config fallback', async () => {
+            const model = createPatHumanModel(false, [
+                'manage:OrganizationMemberProfile',
+            ]);
+
+            const { abilityBuilder } =
+                await model.generateUserAbilityBuilder(patHumanDetails);
+
+            expect(
+                abilityBuilder.build().can('manage', 'PersonalAccessToken'),
+            ).toBe(true);
+        });
+
+        it('flag on: the same role is denied PAT once the org opts in', async () => {
+            const model = createPatHumanModel(true, [
+                'manage:OrganizationMemberProfile',
+            ]);
+
+            const { abilityBuilder } =
+                await model.generateUserAbilityBuilder(patHumanDetails);
+
+            expect(
+                abilityBuilder.build().can('manage', 'PersonalAccessToken'),
+            ).toBe(false);
+        });
+
+        it('flag on + empty role: denied, with no system-role fallback', async () => {
+            const model = createPatHumanModel(true, []);
+
+            const { abilityBuilder } =
+                await model.generateUserAbilityBuilder(patHumanDetails);
+            const ability = abilityBuilder.build();
+
+            expect(ability.can('manage', 'PersonalAccessToken')).toBe(false);
+            // A system MEMBER role would grant this; its absence proves the
+            // empty custom role did not fall back to the system role.
+            expect(
+                ability.can(
+                    'view',
+                    subject('OrganizationMemberProfile', {
+                        organizationUuid: patHumanDetails.organization_uuid,
+                    }),
+                ),
+            ).toBe(false);
+        });
+
+        // customRoleScopes only queries scoped_roles; roleExists separately
+        // confirms the uuid is a real (not deleted/unknown) role via `roles`.
+        const createExistingEmptyRoleTrx = () =>
+            vi.fn((tableName: string) => {
+                if (tableName === ScopedRolesTableName) {
+                    return { select: () => ({ whereIn: async () => [] }) };
+                }
+                if (tableName === RolesTableName) {
+                    return {
+                        select: () => ({
+                            where: () => ({
+                                first: async () => ({
+                                    role_uuid: orgCustomRoleUuid,
+                                }),
+                            }),
+                        }),
+                    };
+                }
+                throw new Error(`Unexpected table ${tableName}`);
+            }) as unknown as Knex;
+
+        it('end-to-end: flag on + an existing org custom role with zero scoped_roles rows denies PAT via the real loader, no system fallback', async () => {
+            const model = new UserModel({
+                database: createExistingEmptyRoleTrx(),
+                lightdashConfig: patLightdashConfig,
+                featureFlagModel: createFeatureFlagModelFor(true),
+            }) as unknown as TestableUserModel;
+            model.hasAuthentication = vi.fn(async () => true);
+            model.getUserProjectRoles = vi.fn(async () => []);
+            model.getUserGroupProjectRoles = vi.fn(async () => []);
+            model.getOrganizationExtraRoleUuids = vi.fn(async () => []);
+            model.findServiceAccountByUserUuid = vi.fn(async () => undefined);
+            model.applyServiceAccountProjectMemberships = vi.fn(async () => {});
+
+            const { abilityBuilder } =
+                await model.generateUserAbilityBuilder(patHumanDetails);
+            const ability = abilityBuilder.build();
+
+            expect(ability.can('manage', 'PersonalAccessToken')).toBe(false);
+            expect(
+                ability.can(
+                    'view',
+                    subject('OrganizationMemberProfile', {
+                        organizationUuid: patHumanDetails.organization_uuid,
+                    }),
+                ),
+            ).toBe(false);
+        });
+
+        it('end-to-end: flag off + the same existing empty org custom role still falls back to the system role (legacy behavior preserved)', async () => {
+            const model = new UserModel({
+                database: createExistingEmptyRoleTrx(),
+                lightdashConfig: patLightdashConfig,
+                featureFlagModel: createFeatureFlagModelFor(false),
+            }) as unknown as TestableUserModel;
+            model.hasAuthentication = vi.fn(async () => true);
+            model.getUserProjectRoles = vi.fn(async () => []);
+            model.getUserGroupProjectRoles = vi.fn(async () => []);
+            model.getOrganizationExtraRoleUuids = vi.fn(async () => []);
+            model.findServiceAccountByUserUuid = vi.fn(async () => undefined);
+            model.applyServiceAccountProjectMemberships = vi.fn(async () => {});
+
+            const { abilityBuilder } =
+                await model.generateUserAbilityBuilder(patHumanDetails);
+            const ability = abilityBuilder.build();
+
+            // System MEMBER abilities, including config-granted PAT: the
+            // narrow empty-role check never ran (flag off), so the missing
+            // scopes entry falls back exactly like it always has on main.
+            expect(ability.can('manage', 'PersonalAccessToken')).toBe(true);
+            expect(
+                ability.can(
+                    'view',
+                    subject('OrganizationMemberProfile', {
+                        organizationUuid: patHumanDetails.organization_uuid,
+                    }),
+                ),
+            ).toBe(true);
+        });
+    });
+
+    describe('empty existing role still falls back everywhere except the flagged human primary org role', () => {
+        it('a service account bound to an existing role with zero scoped_roles rows still falls back to legacy service_accounts.scopes', async () => {
+            const model = createUserModel();
+            // Restored loader semantics: an existing role with no
+            // scoped_roles rows has no entry, same as an unknown uuid.
+            model.customRoleScopes = vi.fn(async () => ({}));
+
+            const { abilityBuilder } = await model.generateUserAbilityBuilder({
+                ...userDetails,
+                role_uuid: 'custom-role',
+            });
+            const ability = abilityBuilder.build();
+
+            // createUserModel()'s default findServiceAccountByUserUuid mock
+            // returns legacy scopes: [SYSTEM_MEMBER], which grants this.
+            expect(model.findServiceAccountByUserUuid).toHaveBeenCalled();
+            expect(
+                ability.can(
+                    'view',
+                    subject('OrganizationMemberProfile', {
+                        organizationUuid: userDetails.organization_uuid,
+                    }),
+                ),
+            ).toBe(true);
+        });
+
+        it('a project membership on an existing role with zero scoped_roles rows still falls back to projectMemberAbilities', async () => {
+            const projectUuid = 'project-1';
+            const rolesTrx = vi.fn((tableName: string) => {
+                if (tableName === ProjectMembershipsTableName) {
+                    return {
+                        leftJoin: () => ({
+                            select: () => ({
+                                where: async () => [
+                                    {
+                                        project_id: 1,
+                                        project_uuid: projectUuid,
+                                        role: ProjectMemberRole.ADMIN,
+                                        role_uuid: 'empty-project-role',
+                                        project_type: ProjectType.DEFAULT,
+                                        created_by_user_uuid: null,
+                                    },
+                                ],
+                            }),
+                        }),
+                    };
+                }
+                if (tableName === ProjectMembershipCustomRolesTableName) {
+                    return {
+                        join: () => ({
+                            where: () => ({
+                                whereIn: () => ({
+                                    select: () => ({
+                                        orderBy: async () => [],
+                                    }),
+                                }),
+                            }),
+                        }),
+                    };
+                }
+                throw new Error(`Unexpected table ${tableName}`);
+            }) as unknown as Knex;
+
+            const model = new UserModel({
+                database: rolesTrx,
+                lightdashConfig,
+                featureFlagModel,
+            }) as unknown as TestableUserModel;
+            // Restored loader semantics: an existing role with no
+            // scoped_roles rows has no entry, same as an unknown uuid.
+            model.customRoleScopes = vi.fn(async () => ({}));
+
+            const builder = new AbilityBuilder<MemberAbility>(Ability);
+            await model.applyServiceAccountProjectMemberships(
+                1,
+                'sa-user',
+                builder,
+                rolesTrx,
+            );
+            const ability = builder.build();
+
+            // ADMIN grants this via projectMemberAbilities: project custom
+            // roles are untouched by the narrow human-primary-role check.
+            expect(
+                ability.can('manage', subject('DataApp', { projectUuid })),
             ).toBe(true);
         });
     });

--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -64,7 +64,10 @@ import { ProjectGroupAccessCustomRolesTableName } from '../database/entities/pro
 import { ProjectMembershipCustomRolesTableName } from '../database/entities/projectMembershipCustomRoles';
 import { ProjectMembershipsTableName } from '../database/entities/projectMemberships';
 import { ProjectTableName } from '../database/entities/projects';
-import { ScopedRolesTableName } from '../database/entities/roles';
+import {
+    RolesTableName,
+    ScopedRolesTableName,
+} from '../database/entities/roles';
 import {
     DbUser,
     DbUserIn,
@@ -891,6 +894,23 @@ export class UserModel {
         return scopesRecord;
     }
 
+    /**
+     * Whether an org custom role uuid exists in `roles` (vs. missing/unknown).
+     * Scoped narrowly to the human primary-org-role empty-role check below —
+     * project roles, extra roles, and service accounts keep the legacy
+     * "no scopes entry" fallback untouched.
+     */
+    private async roleExists(
+        roleUuid: string,
+        trx: Knex = this.database,
+    ): Promise<boolean> {
+        const row = await trx(RolesTableName)
+            .select('role_uuid')
+            .where('role_uuid', roleUuid)
+            .first();
+        return row !== undefined;
+    }
+
     private async generateUserAbilityBuilder(
         user: DbUserDetails,
         trx: Knex = this.database,
@@ -1067,6 +1087,8 @@ export class UserModel {
                 ...(role.extraRoleUuids ?? []),
             ]),
         ].filter((roleUuid): roleUuid is string => Boolean(roleUuid));
+        const isEnterprise =
+            this.lightdashConfig.license.licenseKey !== undefined;
         const [customRoleScopes, customRolesFlag, patScopeAuthoritativeFlag] =
             await Promise.all([
                 this.customRoleScopes(customRoleUuids, trx),
@@ -1086,6 +1108,25 @@ export class UserModel {
                     { trx },
                 ),
             ]);
+
+        // Narrow empty-role resolution: only the flagged enterprise human's
+        // primary org role uuid is checked for existence when it has no
+        // scopes entry. If the role still exists (zero scoped_roles rows),
+        // seed an authoritative empty list so it does not fall back to the
+        // system role. Service accounts, project roles and extra roles keep
+        // the legacy "missing entry falls back" behavior untouched.
+        if (
+            patScopeAuthoritativeFlag.enabled &&
+            isEnterprise &&
+            lightdashUser.roleUuid &&
+            !(lightdashUser.roleUuid in customRoleScopes)
+        ) {
+            const exists = await this.roleExists(lightdashUser.roleUuid, trx);
+            if (exists) {
+                customRoleScopes[lightdashUser.roleUuid] = [];
+            }
+        }
+
         const { builder: abilityBuilder, invalidScopes } =
             getUserAbilityBuilder({
                 user: lightdashUser,
@@ -1098,8 +1139,7 @@ export class UserModel {
                 customRolesEnabled:
                     this.lightdashConfig.customRoles.enabled ||
                     customRolesFlag.enabled,
-                isEnterprise:
-                    this.lightdashConfig.license.licenseKey !== undefined,
+                isEnterprise,
                 patScopeAuthoritative: patScopeAuthoritativeFlag.enabled,
             });
 

--- a/packages/backend/src/services/RolesService/RolesService.test.ts
+++ b/packages/backend/src/services/RolesService/RolesService.test.ts
@@ -1,5 +1,6 @@
 import { Ability, AbilityBuilder } from '@casl/ability';
 import {
+    CommercialFeatureFlags,
     CreateRole,
     CustomRoleAsCode,
     defineUserAbility,
@@ -1791,6 +1792,108 @@ describe('RolesService', () => {
                         { roleId: mockCustomRoleWithScopes.roleUuid },
                     ),
                 ).rejects.toThrow(ForbiddenError);
+            });
+        });
+
+        describe('upsertOrganizationUserRoleAssignment ceiling stays strict regardless of pat-scope-authoritative', () => {
+            // Mirrors limitedOrganizationManagerAccount's own ceiling: covers
+            // MEMBER's base scopes but never manage:PersonalAccessToken. The
+            // service no longer reads this flag for the ceiling decision — both
+            // mock values must still reject (config-derived token access is
+            // still self-escalation via an invited/assigned role: #26771).
+            const buildPatScopeService = (patScopeAuthoritative: boolean) =>
+                new RolesService({
+                    lightdashConfig: {
+                        customRoles: { enabled: false },
+                        auth: {
+                            pat: {
+                                enabled: true,
+                                allowedOrgRoles: Object.values(
+                                    OrganizationMemberRole,
+                                ),
+                            },
+                        },
+                    } as LightdashConfig,
+                    licenseService: {
+                        getLicenseStatus: () => ({
+                            hasLicenseKey: true,
+                            valid: true,
+                        }),
+                    } as LicenseService,
+                    analytics: mockAnalytics as unknown as LightdashAnalytics,
+                    rolesModel: mockRolesModel as unknown as RolesModel,
+                    userModel: mockUserModel as unknown as UserModel,
+                    organizationModel:
+                        mockOrganizationModel as unknown as OrganizationModel,
+                    groupsModel: mockGroupsModel as unknown as GroupsModel,
+                    projectModel: mockProjectModel as unknown as ProjectModel,
+                    emailClient: mockEmailClient as unknown as EmailClient,
+                    adminNotificationService:
+                        mockAdminNotificationService as unknown as AdminNotificationService,
+                    inviteLinkModel:
+                        mockInviteLinkModel as unknown as InviteLinkModel,
+                    organizationMemberProfileModel:
+                        mockOrganizationMemberProfileModel as unknown as OrganizationMemberProfileModel,
+                    featureFlagModel: {
+                        get: vi.fn(async ({ featureFlagId }) => ({
+                            id: featureFlagId,
+                            enabled:
+                                featureFlagId ===
+                                CommercialFeatureFlags.PatScopeAuthoritative
+                                    ? patScopeAuthoritative
+                                    : true,
+                        })),
+                    } as unknown as FeatureFlagModel,
+                });
+
+            it('flag off: rejects a config-token-carrying system role for a token-restricted caller', async () => {
+                mockRolesModel.getRoleWithScopesByUuid.mockResolvedValue({
+                    roleUuid: 'limited-org-manager-role',
+                    organizationUuid,
+                    level: 'organization',
+                    scopes: getOrganizationMemberRolePermissions(
+                        OrganizationMemberRole.MEMBER,
+                    ),
+                });
+
+                await expect(
+                    buildPatScopeService(
+                        false,
+                    ).upsertOrganizationUserRoleAssignment(
+                        limitedOrganizationManagerAccount(),
+                        organizationUuid,
+                        userUuid,
+                        { roleId: OrganizationMemberRole.MEMBER },
+                    ),
+                ).rejects.toBeInstanceOf(ForbiddenError);
+                expect(
+                    mockRolesModel.upsertOrganizationUserRoleAssignment,
+                ).not.toHaveBeenCalled();
+            });
+
+            it('flag on: still rejects the same token-restricted caller — the ceiling does not relax', async () => {
+                mockRolesModel.getRoleWithScopesByUuid.mockResolvedValue({
+                    roleUuid: 'limited-org-manager-role',
+                    organizationUuid,
+                    level: 'organization',
+                    scopes: getOrganizationMemberRolePermissions(
+                        OrganizationMemberRole.MEMBER,
+                    ),
+                });
+
+                await expect(
+                    buildPatScopeService(
+                        true,
+                    ).upsertOrganizationUserRoleAssignment(
+                        limitedOrganizationManagerAccount(),
+                        organizationUuid,
+                        userUuid,
+                        { roleId: OrganizationMemberRole.MEMBER },
+                    ),
+                ).rejects.toBeInstanceOf(ForbiddenError);
+                expect(
+                    mockRolesModel.upsertOrganizationUserRoleAssignment,
+                ).not.toHaveBeenCalled();
             });
         });
 

--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -2,6 +2,7 @@ import { Ability } from '@casl/ability';
 import {
     AnyType,
     AuthorizationError,
+    CommercialFeatureFlags,
     DeactivatedAccountError,
     defineUserAbility,
     EmailStatus,
@@ -298,7 +299,12 @@ const createUserService = (
                 get: vi.fn<FeatureFlagModel['get']>(
                     async ({ featureFlagId }) => ({
                         id: featureFlagId,
-                        enabled: featureFlagId !== FeatureFlags.NewOnboarding,
+                        // Default to unflagged (main) behavior for the two
+                        // opt-out-shaped flags; every other flag defaults on.
+                        enabled:
+                            featureFlagId !== FeatureFlags.NewOnboarding &&
+                            featureFlagId !==
+                                CommercialFeatureFlags.PatScopeAuthoritative,
                     }),
                 ),
             } as unknown as FeatureFlagModel),
@@ -4269,7 +4275,10 @@ describe('UserService', () => {
                 }).builder.build(),
             });
 
-            const buildLimitedManagerService = (patEnabled: boolean = false) =>
+            const buildLimitedManagerService = (
+                patEnabled: boolean = false,
+                patScopeAuthoritative: boolean = false,
+            ) =>
                 createUserService(
                     {
                         ...lightdashConfigMock,
@@ -4284,6 +4293,19 @@ describe('UserService', () => {
                                 .fn()
                                 .mockResolvedValue(limitedManagerRole),
                         } as unknown as RolesModel,
+                        featureFlagModel: {
+                            get: vi.fn<FeatureFlagModel['get']>(
+                                async ({ featureFlagId }) => ({
+                                    id: featureFlagId,
+                                    enabled:
+                                        featureFlagId ===
+                                        CommercialFeatureFlags.PatScopeAuthoritative
+                                            ? patScopeAuthoritative
+                                            : featureFlagId !==
+                                              FeatureFlags.NewOnboarding,
+                                }),
+                            ),
+                        },
                     },
                 );
 
@@ -4427,6 +4449,41 @@ describe('UserService', () => {
                 ).not.toHaveBeenCalled();
                 expect(
                     vi.mocked(inviteLinkModel.upsert),
+                ).not.toHaveBeenCalled();
+            });
+
+            // A caller whose own ability denies tokens must still be blocked
+            // from an invite that would carry token access from config. This
+            // ceiling never relaxes: config-derived token access is still
+            // self-escalation via an invited system role (#26771).
+            test('flag off: rejects an invite that would carry token access from config when the caller lacks it', async () => {
+                await expect(
+                    buildLimitedManagerService(
+                        true,
+                    ).createPendingUserAndInviteLink(
+                        limitedManagerUser(false),
+                        { ...inviteUser, role: OrganizationMemberRole.MEMBER },
+                    ),
+                ).rejects.toBeInstanceOf(ForbiddenError);
+
+                expect(
+                    vi.mocked(userModel.createPendingUser),
+                ).not.toHaveBeenCalled();
+            });
+
+            test('flag on: still rejects the same invite — the ceiling does not relax', async () => {
+                await expect(
+                    buildLimitedManagerService(
+                        true,
+                        true,
+                    ).createPendingUserAndInviteLink(
+                        limitedManagerUser(false),
+                        { ...inviteUser, role: OrganizationMemberRole.MEMBER },
+                    ),
+                ).rejects.toBeInstanceOf(ForbiddenError);
+
+                expect(
+                    vi.mocked(userModel.createPendingUser),
                 ).not.toHaveBeenCalled();
             });
         });

--- a/packages/backend/src/utils/organizationRolePermissions.test.ts
+++ b/packages/backend/src/utils/organizationRolePermissions.test.ts
@@ -140,4 +140,27 @@ describe('validateOrganizationScopesCanBeGranted', () => {
             }),
         ).rejects.toThrow('Cannot grant permissions exceeding your own');
     });
+
+    // Call sites always pass the pure `pat.enabled && allowedOrgRoles.includes(role)`
+    // condition — no flag ever relaxes this ceiling. Config-derived token access is
+    // still self-escalation: a token-restricted caller could grant/invite a system
+    // role that carries PAT from config, authenticate as it, and regain the token
+    // (the #26771 invariant).
+    describe('system-role grant ceiling stays strict (no flag relief)', () => {
+        it('a token-restricted caller cannot grant a system role that carries token access from config', async () => {
+            await expect(
+                validateOrganizationScopesCanBeGranted({
+                    user: customRoleCaller({
+                        canManagePersonalAccessToken: false,
+                    }),
+                    organizationUuid: ORG,
+                    grantedScopes: getOrganizationSystemRoleScopes(
+                        OrganizationMemberRole.MEMBER,
+                        { includePersonalAccessToken: true },
+                    ),
+                    rolesModel: rolesModelWithScopes(managerScopes),
+                }),
+            ).rejects.toThrow('Cannot grant permissions exceeding your own');
+        });
+    });
 });

--- a/packages/backend/src/utils/organizationRolePermissions.ts
+++ b/packages/backend/src/utils/organizationRolePermissions.ts
@@ -29,8 +29,8 @@ const getCallerOrganizationScopes = async (
         throw new ForbiddenError('You do not have permission');
     }
 
-    // Custom roles never list this scope, but the ability builder still grants
-    // it from the PAT config, so it is part of the caller's real footprint.
+    // Read off the built ability rather than the stored scope list: it
+    // already covers both a role that lists this scope and a config fallback.
     const canManagePersonalAccessToken = user.ability.can(
         'manage',
         'PersonalAccessToken',


### PR DESCRIPTION
Final PR of the PROD-8879 stack (#28353 ✓ → #28355 ✓ → #28356 → this). Merge after #28356.

## What this PR is (post security review)

Two review findings on the stack, resolved conservatively. The delegation ceiling is deliberately **NOT touched**: the caller-must-hold-what-they-grant invariant (#26771) holds in both flag states — a token-restricted manager cannot invite or assign a system role that receives PAT from configuration, because they could otherwise invite an address they control and regain token access through it. The service files are byte-identical to main; tests pin the strict outcome with the flag both off and on (`organizationRolePermissions.test.ts`, `UserService.test.ts`, `RolesService.test.ts`).

Operational consequence for opted-in orgs: a custom manager role that invites or assigns system roles must itself hold `manage:PersonalAccessToken` while the deployment config grants tokens to system roles.

## Changes

**Empty-custom-role resolution, narrowly scoped.** `UserModel.customRoleScopes` builds its map from `scoped_roles` rows only, so an *existing* role with zero scopes was indistinguishable from a *missing* one and fell back to the system role — silently restoring PAT (and everything else) to a user on a supposedly authoritative empty role. Reachable: `removeScopeFromRole` has no last-scope guard, so an assigned role can be emptied after the fact.

The fix is a targeted injection in `generateUserAbilityBuilder`'s human path only: when the org has the `pat-scope-authoritative` flag enabled AND the deployment is licensed AND the user's primary org `role_uuid` resolves to an existing role with no scope rows, an empty authoritative scope set is passed to the ability builder. Everything else is untouched and test-pinned: the loader keeps its original semantics; flag-off humans with empty roles still fall back to their system role; service accounts still fall back to legacy `service_accounts.scopes`; empty project custom roles still fall back to project system roles; missing/unknown role uuids keep the fallback and error log.

Also: a `UserService.test.ts` harness fix (the default feature-flag mock resolved almost every flag to `true`, silently running the pre-existing delegation-ceiling tests under flag-on semantics) and a stale-comment touch-up in `organizationRolePermissions.ts`.

## Testing

`UserModel.test.ts` 31/31, `RolesService.test.ts` 75/75, `UserService.test.ts` 180/180, `organizationRolePermissions.test.ts` 6/6; backend typecheck and lint clean. Source footprint outside tests: `UserModel.ts` plus one 2-line comment.

Part of PROD-8879 / #25543 (closed by #28356).