### PR TITLE
fix: resolve the sole dbt source before selector validation

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -9876,7 +9876,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 isSlackPrompt: isSlackPrompt(prompt),
                 toolCallId: args.progressId,
                 writebackPrompt,
-                dbtSourceUuid: args.dbtSourceUuid ?? options?.dbtSourceUuid,
+                dbtSourceUuid: options?.dbtSourceUuid,
                 source,
                 prUrl: args.prUrl,
                 startNewPullRequest: args.startNewPullRequest ?? null,

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
@@ -852,6 +852,21 @@ describe('AiWritebackService dbt source targeting', () => {
         });
     });
 
+    it('resolves the only source before validating an explicit dbtSourceUuid', async () => {
+        const result = await resolve(serviceWithSources([]), {
+            dbtSourceUuid: 'does-not-exist',
+        });
+
+        expect(result).toMatchObject({
+            kind: 'resolved',
+            candidate: {
+                sourceUuid: null,
+                optionUuid: PRIMARY_SOURCE_UUID,
+                isPrimary: true,
+            },
+        });
+    });
+
     it('honours an explicit additional dbtSourceUuid', async () => {
         const result = await resolve(serviceWithSources([marketingSource()]), {
             dbtSourceUuid: 'src-marketing',
@@ -876,12 +891,35 @@ describe('AiWritebackService dbt source targeting', () => {
         });
     });
 
-    it('rejects an explicit dbtSourceUuid that is not a target', async () => {
-        await expect(
-            resolve(serviceWithSources([marketingSource()]), {
-                dbtSourceUuid: 'does-not-exist',
-            }),
-        ).rejects.toThrow(ParameterError);
+    it('asks the caller to choose when an explicit dbtSourceUuid is not a target', async () => {
+        const result = await resolve(serviceWithSources([marketingSource()]), {
+            dbtSourceUuid: 'does-not-exist',
+        });
+
+        expect(result.kind).toBe('select');
+        expect(result.options).toHaveLength(2);
+        expect(result.options).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    projectDbtSourceUuid: PRIMARY_SOURCE_UUID,
+                    isPrimary: true,
+                }),
+                expect.objectContaining({
+                    projectDbtSourceUuid: 'src-marketing',
+                    repository: 'acme/marketing',
+                }),
+            ]),
+        );
+    });
+
+    it('does not infer a prompt-named source when an explicit dbtSourceUuid is not a target', async () => {
+        const result = await resolve(serviceWithSources([marketingSource()]), {
+            prompt: 'add a spend metric to the marketing models',
+            dbtSourceUuid: 'does-not-exist',
+        });
+
+        expect(result.kind).toBe('select');
+        expect(result.options).toHaveLength(2);
     });
 
     it('infers the source from the prompt when exactly one matches', async () => {
@@ -980,6 +1018,7 @@ describe('AiWritebackService dbt source targeting', () => {
             // The prompt names the primary repo, but the thread is bound to the
             // additional source — binding wins so the resumed sandbox stays put.
             prompt: 'change something in analytics',
+            dbtSourceUuid: PRIMARY_SOURCE_UUID,
             existingRow: { project_dbt_source_uuid: 'src-marketing' },
         });
         expect(result).toMatchObject({

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -2866,8 +2866,8 @@ export class AiWritebackService extends BaseService {
      * Decide which dbt source a turn targets. Precedence:
      * 1. a resumed thread stays bound to its original source (never re-infer, or
      *    a follow-up could retarget the sandbox's already-cloned repo);
-     * 2. an explicit `dbtSourceUuid` (a UI picker, or an agent re-call);
-     * 3. the only source, when the project has one — unchanged behaviour;
+     * 2. the only source, when the project has one, unconditionally;
+     * 3. an explicit `dbtSourceUuid` (a UI picker, or an agent re-call);
      * 4. the source the prompt names, when exactly one matches;
      * otherwise return the candidates for the caller to choose from.
      */
@@ -2918,20 +2918,21 @@ export class AiWritebackService extends BaseService {
             return { kind: 'resolved', candidate: primary ?? candidates[0] };
         }
 
+        if (candidates.length === 1) {
+            return { kind: 'resolved', candidate: candidates[0] };
+        }
+
         if (dbtSourceUuid) {
             const chosen = candidates.find(
                 (c) => c.optionUuid === dbtSourceUuid,
             );
-            if (!chosen) {
-                throw new ParameterError(
-                    'The specified dbt source is not a valid writeback target for this project',
-                );
+            if (chosen) {
+                return { kind: 'resolved', candidate: chosen };
             }
-            return { kind: 'resolved', candidate: chosen };
-        }
-
-        if (candidates.length === 1) {
-            return { kind: 'resolved', candidate: candidates[0] };
+            return {
+                kind: 'select',
+                options: candidates.map(AiWritebackService.toDbtSourceOption),
+            };
         }
 
         // Score each candidate by how specifically the prompt names it (the


### PR DESCRIPTION
## Summary

AI writeback exposes an optional `dbtSourceUuid` argument to the model. The model cannot know the real value, so it invents one. The resolver validated that argument before checking whether the project has only one dbt source, so a single-source project failed on an argument that could not matter. In 60 days of production, every call that supplied this argument supplied an invented value, and every one failed.

This PR:
- Resolves the sole dbt source unconditionally, before validating any explicit selector.
- Returns the existing structured source-selection result for an unmatched explicit selector on a multi-source project, instead of throwing.
- Stops an invalid explicit selector from silently falling through to prompt-name inference (an explicit-but-wrong selector should be challenged, not redirected).
- Uses only the server-trusted `dbtSourceUuid` in the scheduler payload, so a model-invented value can no longer override a value correctly resolved by review remediation.

## Scope

Part 1 of 3 in this stack. Part 2 removes `dbtSourceUuid` from the model-facing tool schemas. Part 3 delivers the selection question to Slack and fixes a related remediation-path collapse. This PR is the standalone backend fix and is safe to ship alone.

## Verification

- `AiWritebackService.test.ts`: 133/133 passing, including new coverage for the reordered precedence (sole-source override, selection on an unmatched UUID, no fallthrough to prompt matching, existing-thread binding still wins).
- Backend typecheck: passing.
- Scoped lint on touched files: passing.
- No runtime/manual verification — this needs a sandbox and a real dbt repo, out of reach here. Unit coverage plus review of the resolver ordering is the verification bar for this PR.

Linear: SPK-1694