### PR TITLE
fix: remove dbtSourceUuid from writeback tool schemas

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -10258,7 +10258,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             const writeback = await this.projectContextService.writebackEntry({
                 user,
                 projectUuid,
-                dbtSourceUuid: entry.dbtSourceUuid ?? options?.dbtSourceUuid,
+                dbtSourceUuid: options?.dbtSourceUuid,
                 entry,
                 branchTimestamp: Date.now(),
                 sourceThread,

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -9876,7 +9876,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 isSlackPrompt: isSlackPrompt(prompt),
                 toolCallId: args.progressId,
                 writebackPrompt,
-                dbtSourceUuid: args.dbtSourceUuid ?? options?.dbtSourceUuid,
+                dbtSourceUuid: options?.dbtSourceUuid,
                 source,
                 prUrl: args.prUrl,
                 startNewPullRequest: args.startNewPullRequest ?? null,

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
@@ -852,6 +852,21 @@ describe('AiWritebackService dbt source targeting', () => {
         });
     });
 
+    it('resolves the only source before validating an explicit dbtSourceUuid', async () => {
+        const result = await resolve(serviceWithSources([]), {
+            dbtSourceUuid: 'does-not-exist',
+        });
+
+        expect(result).toMatchObject({
+            kind: 'resolved',
+            candidate: {
+                sourceUuid: null,
+                optionUuid: PRIMARY_SOURCE_UUID,
+                isPrimary: true,
+            },
+        });
+    });
+
     it('honours an explicit additional dbtSourceUuid', async () => {
         const result = await resolve(serviceWithSources([marketingSource()]), {
             dbtSourceUuid: 'src-marketing',
@@ -876,12 +891,35 @@ describe('AiWritebackService dbt source targeting', () => {
         });
     });
 
-    it('rejects an explicit dbtSourceUuid that is not a target', async () => {
-        await expect(
-            resolve(serviceWithSources([marketingSource()]), {
-                dbtSourceUuid: 'does-not-exist',
-            }),
-        ).rejects.toThrow(ParameterError);
+    it('asks the caller to choose when an explicit dbtSourceUuid is not a target', async () => {
+        const result = await resolve(serviceWithSources([marketingSource()]), {
+            dbtSourceUuid: 'does-not-exist',
+        });
+
+        expect(result.kind).toBe('select');
+        expect(result.options).toHaveLength(2);
+        expect(result.options).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    projectDbtSourceUuid: PRIMARY_SOURCE_UUID,
+                    isPrimary: true,
+                }),
+                expect.objectContaining({
+                    projectDbtSourceUuid: 'src-marketing',
+                    repository: 'acme/marketing',
+                }),
+            ]),
+        );
+    });
+
+    it('does not infer a prompt-named source when an explicit dbtSourceUuid is not a target', async () => {
+        const result = await resolve(serviceWithSources([marketingSource()]), {
+            prompt: 'add a spend metric to the marketing models',
+            dbtSourceUuid: 'does-not-exist',
+        });
+
+        expect(result.kind).toBe('select');
+        expect(result.options).toHaveLength(2);
     });
 
     it('infers the source from the prompt when exactly one matches', async () => {
@@ -980,6 +1018,7 @@ describe('AiWritebackService dbt source targeting', () => {
             // The prompt names the primary repo, but the thread is bound to the
             // additional source — binding wins so the resumed sandbox stays put.
             prompt: 'change something in analytics',
+            dbtSourceUuid: PRIMARY_SOURCE_UUID,
             existingRow: { project_dbt_source_uuid: 'src-marketing' },
         });
         expect(result).toMatchObject({

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -2866,8 +2866,8 @@ export class AiWritebackService extends BaseService {
      * Decide which dbt source a turn targets. Precedence:
      * 1. a resumed thread stays bound to its original source (never re-infer, or
      *    a follow-up could retarget the sandbox's already-cloned repo);
-     * 2. an explicit `dbtSourceUuid` (a UI picker, or an agent re-call);
-     * 3. the only source, when the project has one — unchanged behaviour;
+     * 2. the only source, when the project has one, unconditionally;
+     * 3. an explicit `dbtSourceUuid` (a UI picker, or an agent re-call);
      * 4. the source the prompt names, when exactly one matches;
      * otherwise return the candidates for the caller to choose from.
      */
@@ -2918,20 +2918,21 @@ export class AiWritebackService extends BaseService {
             return { kind: 'resolved', candidate: primary ?? candidates[0] };
         }
 
+        if (candidates.length === 1) {
+            return { kind: 'resolved', candidate: candidates[0] };
+        }
+
         if (dbtSourceUuid) {
             const chosen = candidates.find(
                 (c) => c.optionUuid === dbtSourceUuid,
             );
-            if (!chosen) {
-                throw new ParameterError(
-                    'The specified dbt source is not a valid writeback target for this project',
-                );
+            if (chosen) {
+                return { kind: 'resolved', candidate: chosen };
             }
-            return { kind: 'resolved', candidate: chosen };
-        }
-
-        if (candidates.length === 1) {
-            return { kind: 'resolved', candidate: candidates[0] };
+            return {
+                kind: 'select',
+                options: candidates.map(AiWritebackService.toDbtSourceOption),
+            };
         }
 
         // Score each candidate by how specifically the prompt names it (the

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -4019,16 +4019,11 @@ Parameters:
     },
   },
   {
-    "description": "Open or update a pull request that modifies the dbt project / Lightdash semantic layer for this project. Use this tool ONLY when the user asks to CHANGE something in the underlying repo — e.g. add or rename a metric, edit a dimension definition, modify a dbt model, update YAML metadata. Do NOT use this tool for read-only questions, querying data, exploring fields, or for changes that can be made inside Lightdash (use editContent for those). This tool applies the change on your behalf: it runs in an isolated sandbox, edits the repo, runs \`lightdash compile\`, and opens a pull request — but the call returns immediately once the run has started, before any of that finishes (status: "pending"). Give a brief acknowledgement that you have started the change, then end your turn. Do not wait for it or call this tool again to check on it. A single conversation can open several pull requests: follow-up edits continue the most recent one, prUrl targets a specific existing one, and startNewPullRequest opens a fresh one for an unrelated change.",
+    "description": "Open or update a pull request that modifies the dbt project / Lightdash semantic layer for this project. Use this tool ONLY when the user asks to CHANGE something in the underlying repo — e.g. add or rename a metric, edit a dimension definition, modify a dbt model, update YAML metadata. Do NOT use this tool for read-only questions, querying data, exploring fields, or for changes that can be made inside Lightdash (use editContent for those). When a project has more than one dbt source, the prompt must name the source or its owner/repo verbatim, or you will be asked to choose one. This tool applies the change on your behalf: it runs in an isolated sandbox, edits the repo, runs \`lightdash compile\`, and opens a pull request — but the call returns immediately once the run has started, before any of that finishes (status: "pending"). Give a brief acknowledgement that you have started the change, then end your turn. Do not wait for it or call this tool again to check on it. A single conversation can open several pull requests: follow-up edits continue the most recent one, prUrl targets a specific existing one, and startNewPullRequest opens a fresh one for an unrelated change.",
     "inputSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": false,
       "properties": {
-        "dbtSourceUuid": {
-          "description": "The project dbt source UUID to edit. Use the projectDbtSourceUuid returned by a prior source-selection result. Omit it only when the project has one dbt source.",
-          "format": "uuid",
-          "type": "string",
-        },
         "prUrl": {
           "description": "To UPDATE a specific existing pull request instead of opening a new one, put its full URL here (e.g. 'https://github.com/owner/repo/pull/123'). The PR must belong to this project's own dbt repository. Use this both for a PR the user pasted AND to target one of several pull requests this conversation has already opened (get the URL from listWorkstreams or a previous editDbtProject result). Otherwise pass null.",
           "type": [
@@ -4037,7 +4032,7 @@ Parameters:
           ],
         },
         "prompt": {
-          "description": "A focused, self-contained natural-language instruction describing exactly which files in the dbt project to change and how. The change is applied in a fresh sandbox that does not see this conversation, so include every detail it needs (model name, file path hints, the literal change to make). Do not include preamble or pleasantries.",
+          "description": "A focused, self-contained natural-language instruction describing exactly which files in the dbt project to change and how. The change is applied in a fresh sandbox that does not see this conversation, so include every detail it needs (model name, file path hints, the literal change to make). When the project has multiple dbt sources, include the source name or owner/repo verbatim. Do not include preamble or pleasantries.",
           "type": "string",
         },
         "startNewPullRequest": {
@@ -4279,11 +4274,6 @@ Parameters:
       "properties": {
         "content": {
           "description": "A single self-contained sentence stating the fact (e.g. '"HR" = the high-risk diabetes cohort, not human resources.').",
-          "type": "string",
-        },
-        "dbtSourceUuid": {
-          "description": "The project dbt source UUID that owns the project context file. Omit it for the primary dbt source.",
-          "format": "uuid",
           "type": "string",
         },
         "id": {

--- a/packages/backend/src/ee/services/ai/tools/editDbtProject.ts
+++ b/packages/backend/src/ee/services/ai/tools/editDbtProject.ts
@@ -14,12 +14,11 @@ export const getEditDbtProject = ({ editDbtProject }: Dependencies) =>
     tool({
         ...toolDefinition,
         execute: async (
-            { dbtSourceUuid, prompt, prUrl: pastedPrUrl, startNewPullRequest },
+            { prompt, prUrl: pastedPrUrl, startNewPullRequest },
             { toolCallId },
         ) => {
             try {
                 const { aiWritebackRunUuid } = await editDbtProject({
-                    dbtSourceUuid,
                     prompt,
                     prUrl: pastedPrUrl,
                     startNewPullRequest,

--- a/packages/backend/src/ee/services/ai/tools/editProjectContext.ts
+++ b/packages/backend/src/ee/services/ai/tools/editProjectContext.ts
@@ -36,18 +36,9 @@ const toolDefinition = editProjectContextToolDefinition.for('agent');
 export const getEditProjectContext = ({ editProjectContext }: Dependencies) =>
     tool({
         ...toolDefinition,
-        execute: async ({
-            dbtSourceUuid,
-            op,
-            id,
-            kind,
-            content,
-            terms,
-            objects,
-        }) => {
+        execute: async ({ op, id, kind, content, terms, objects }) => {
             try {
                 const { prUrl, prAction } = await editProjectContext({
-                    dbtSourceUuid,
                     op,
                     id,
                     kind,

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -636,7 +636,6 @@ export type LoadAgentSkillFn = (
 ) => Promise<AiAgentSkill | undefined>;
 
 export type EditDbtProjectFn = (args: {
-    dbtSourceUuid?: string;
     prompt: string;
     prUrl: string | null;
     /** Open a new PR instead of continuing the thread's existing one. */
@@ -659,7 +658,7 @@ export type GenerateDataAppFn = (args: {
 // Applies a structured project-context entry to lightdash.project_context.yml
 // via the deterministic GitHub-API merge (no sandbox) and opens/updates a PR.
 export type EditProjectContextFn = (
-    entry: AiAgentJudgeProjectContextEntry & { dbtSourceUuid?: string },
+    entry: AiAgentJudgeProjectContextEntry,
 ) => Promise<{ prUrl: string; prAction: 'opened' | 'updated' }>;
 
 /**

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolEditDbtProjectArgs.test.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolEditDbtProjectArgs.test.ts
@@ -1,16 +1,9 @@
 import { toolEditDbtProjectArgsSchema } from './toolEditDbtProjectArgs';
 
 describe('toolEditDbtProjectArgsSchema', () => {
-    it('preserves an explicit dbt source identity', () => {
-        const dbtSourceUuid = '00000000-0000-0000-0000-000000000002';
-
-        expect(
-            toolEditDbtProjectArgsSchema.parse({
-                prompt: 'Update models/orders.yml',
-                prUrl: null,
-                startNewPullRequest: null,
-                dbtSourceUuid,
-            }),
-        ).toMatchObject({ dbtSourceUuid });
+    it('does not expose a dbt source identity', () => {
+        expect('dbtSourceUuid' in toolEditDbtProjectArgsSchema.shape).toBe(
+            false,
+        );
     });
 });

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolEditDbtProjectArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolEditDbtProjectArgs.ts
@@ -7,22 +7,16 @@ export const TOOL_EDIT_DBT_PROJECT_DESCRIPTION = [
     'Open or update a pull request that modifies the dbt project / Lightdash semantic layer for this project.',
     'Use this tool ONLY when the user asks to CHANGE something in the underlying repo — e.g. add or rename a metric, edit a dimension definition, modify a dbt model, update YAML metadata.',
     'Do NOT use this tool for read-only questions, querying data, exploring fields, or for changes that can be made inside Lightdash (use editContent for those).',
+    'When a project has more than one dbt source, the prompt must name the source or its owner/repo verbatim, or you will be asked to choose one.',
     'This tool applies the change on your behalf: it runs in an isolated sandbox, edits the repo, runs `lightdash compile`, and opens a pull request — but the call returns immediately once the run has started, before any of that finishes (status: "pending"). Give a brief acknowledgement that you have started the change, then end your turn. Do not wait for it or call this tool again to check on it.',
     'A single conversation can open several pull requests: follow-up edits continue the most recent one, prUrl targets a specific existing one, and startNewPullRequest opens a fresh one for an unrelated change.',
 ].join(' ');
 
 export const toolEditDbtProjectArgsSchema = z.object({
-    dbtSourceUuid: z
-        .string()
-        .uuid()
-        .optional()
-        .describe(
-            'The project dbt source UUID to edit. Use the projectDbtSourceUuid returned by a prior source-selection result. Omit it only when the project has one dbt source.',
-        ),
     prompt: z
         .string()
         .describe(
-            'A focused, self-contained natural-language instruction describing exactly which files in the dbt project to change and how. The change is applied in a fresh sandbox that does not see this conversation, so include every detail it needs (model name, file path hints, the literal change to make). Do not include preamble or pleasantries.',
+            'A focused, self-contained natural-language instruction describing exactly which files in the dbt project to change and how. The change is applied in a fresh sandbox that does not see this conversation, so include every detail it needs (model name, file path hints, the literal change to make). When the project has multiple dbt sources, include the source name or owner/repo verbatim. Do not include preamble or pleasantries.',
         ),
     prUrl: z
         .string()

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolEditProjectContextArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolEditProjectContextArgs.ts
@@ -11,13 +11,6 @@ export const TOOL_EDIT_PROJECT_CONTEXT_DESCRIPTION = [
 // Mirrors AiAgentJudgeProjectContextEntry — the structured entry the
 // deterministic ProjectContextService.writebackEntry applies to the YAML.
 export const toolEditProjectContextArgsSchema = z.object({
-    dbtSourceUuid: z
-        .string()
-        .uuid()
-        .optional()
-        .describe(
-            'The project dbt source UUID that owns the project context file. Omit it for the primary dbt source.',
-        ),
     op: z
         .enum(['create', 'update'])
         .describe(


### PR DESCRIPTION
## Summary

Stacked on #28362. The model cannot legitimately know a real dbt source UUID, so exposing it as an optional agent-tool argument invites exactly the failure #28362 fixes. This PR removes the interface, not just the symptom.

- Removes `dbtSourceUuid` from both model-facing tool schemas (`editDbtProject`, `editProjectContext`), their tool wrappers, and the corresponding dependency types.
- Adds guidance to the tool and prompt descriptions: on a multi-source project, name the source or `owner/repo` verbatim in the prompt.
- Fixes a second instance of the same trust-inversion class #28362 fixed: `editProjectContext`'s implementation read `entry.dbtSourceUuid ?? options?.dbtSourceUuid`, so a model-authored value could still override the server-trusted one. Now it reads only `options?.dbtSourceUuid`.
- Keeps `dbtSourceUuid` everywhere a trusted, non-model caller needs it: the REST/UI picker, the scheduler payload, review-remediation propagation, and run results.
- Regenerates the agent tool contract snapshot.

## Verification

- Contract snapshot test: 1 file, 3 passing.
- Common schema unit test: 1 file, 1 passing.
- Backend + common typecheck: passing.
- Scoped lint on touched files: passing.

## Security review

deepsec Step 0 triage: LOW tier — pure schema/type field removal, no new logic, no auth/secret/SQL/exec/upload signals in the diff (the one behavioural line change mirrors the already-reviewed trust-inversion fix in #28362). Orchestrator judgment: scan skipped for this PR; #28362's scan on the much larger file it touches ran ~35 minutes and errored on a tool turn-limit with zero findings, so a further scan here was not judged worth the same cost against a smaller, lower-risk diff.

Linear: SPK-1694