### PR TITLE
fix: handle dbt source selection in writebacks

### DIFF
--- a/packages/backend/src/ee/services/AiAgentAdminService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.test.ts
@@ -94,6 +94,30 @@ const makeReviewItem = (
     ...overrides,
 });
 
+const makeLatestFinding = (
+    targetRefs: NonNullable<
+        AiAgentReviewItemSummary['latestFinding']
+    >['targetRefs'] = [
+        {
+            type: 'model',
+            modelName: 'orders',
+        },
+    ],
+): NonNullable<AiAgentReviewItemSummary['latestFinding']> => ({
+    uuid: 'finding-1',
+    promptUuid: PROMPT_UUID,
+    threadUuid: THREAD_UUID,
+    projectUuid: PROJECT_UUID,
+    agentUuid: AGENT_UUID,
+    subcategories: [],
+    fixTargets: ['semantic_yaml_patch'],
+    targetRefs,
+    evidenceExcerpts: [],
+    recommendation: null,
+    projectContextEntry: null,
+    createdAt: NOW,
+});
+
 const makeRemediation = (
     overrides: Partial<AiAgentReviewRemediation> = {},
 ): AiAgentReviewRemediation => ({
@@ -323,9 +347,12 @@ const makeService = ({
         },
         aiAgentReviewClassifierModel: {
             getReviewRemediation: vi.fn().mockResolvedValue(makeRemediation()),
-            getReviewItem: vi
-                .fn()
-                .mockResolvedValue(makeReviewItem({ title: 'Review revenue' })),
+            getReviewItem: vi.fn().mockResolvedValue(
+                makeReviewItem({
+                    title: 'Review revenue',
+                    latestFinding: makeLatestFinding(),
+                }),
+            ),
             setReviewRemediationPreviewThread: vi
                 .fn()
                 .mockResolvedValue(undefined),
@@ -399,7 +426,19 @@ const makeService = ({
             getPreviewAiAgentUuid: vi
                 .fn()
                 .mockResolvedValue(PREVIEW_AGENT_UUID),
-            findExploresFromCache: vi.fn().mockResolvedValue({}),
+            findExploresFromCache: vi.fn().mockResolvedValue({
+                orders: {
+                    name: 'orders',
+                    tables: {
+                        orders: {
+                            name: 'orders',
+                            ymlPath: 'models/orders.yml',
+                            dbtSourceUuid:
+                                '00000000-0000-0000-0000-000000000013',
+                        },
+                    },
+                },
+            }),
             getAllByOrganizationUuid: vi.fn().mockResolvedValue([]),
             ...projectModel,
         },
@@ -2562,6 +2601,96 @@ describe('AiAgentAdminService.runReviewItemWritebackJob', () => {
             }),
         );
     });
+
+    it.each([
+        {
+            resolution: 'unresolved',
+            sourceUuids: [],
+            expectedMessage:
+                'Could not determine which dbt source this finding belongs to, so the automatic writeback was skipped.',
+        },
+        {
+            resolution: 'ambiguous',
+            sourceUuids: [
+                '00000000-0000-0000-0000-000000000013',
+                '00000000-0000-0000-0000-000000000014',
+            ],
+            expectedMessage:
+                'This finding spans more than one dbt source. A single writeback cannot safely target several repositories at once.',
+        },
+    ])(
+        'fails an $resolution source before starting the build-fix thread',
+        async ({ sourceUuids, expectedMessage }) => {
+            const modelNames =
+                sourceUuids.length === 0
+                    ? ['orders']
+                    : sourceUuids.map((_, index) => `model_${index}`);
+            const generateAgentThreadResponse = vi.fn();
+            const updateReviewRemediationStatus = vi
+                .fn()
+                .mockResolvedValue(undefined);
+            const setReviewItemWritebackStatus = vi
+                .fn()
+                .mockResolvedValue(undefined);
+            const service = makeService({
+                aiAgentReviewClassifierModel: {
+                    getReviewItem: vi.fn().mockResolvedValue(
+                        makeReviewItem({
+                            latestFinding: makeLatestFinding(
+                                modelNames.map((modelName) => ({
+                                    type: 'model',
+                                    modelName,
+                                })),
+                            ),
+                        }),
+                    ),
+                    updateReviewRemediationStatus,
+                    setReviewItemWritebackStatus,
+                },
+                projectModel: {
+                    findExploresFromCache: vi.fn().mockResolvedValue(
+                        Object.fromEntries(
+                            sourceUuids.map((dbtSourceUuid, index) => {
+                                const modelName = modelNames[index];
+                                return [
+                                    modelName,
+                                    {
+                                        name: modelName,
+                                        tables: {
+                                            [modelName]: {
+                                                name: modelName,
+                                                ymlPath: `models/${modelName}.yml`,
+                                                dbtSourceUuid,
+                                            },
+                                        },
+                                    },
+                                ];
+                            }),
+                        ),
+                    ),
+                },
+                aiAgentService: { generateAgentThreadResponse },
+            });
+
+            await expect(
+                service.runReviewItemWritebackJob(payload),
+            ).rejects.toThrow(expectedMessage);
+            expect(generateAgentThreadResponse).not.toHaveBeenCalled();
+            expect(updateReviewRemediationStatus).toHaveBeenLastCalledWith(
+                expect.objectContaining({
+                    remediationUuid: REMEDIATION_UUID,
+                    status: 'failed',
+                    errorMessage: expectedMessage,
+                }),
+            );
+            expect(setReviewItemWritebackStatus).toHaveBeenLastCalledWith(
+                expect.objectContaining({
+                    status: 'failed',
+                    message: expectedMessage,
+                }),
+            );
+        },
+    );
 
     it('waits for a pending dbt writeback to finish and uses its pull request', async () => {
         const setReviewItemPrLink = vi.fn().mockResolvedValue(undefined);

--- a/packages/backend/src/ee/services/AiAgentAdminService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.test.ts
@@ -2602,13 +2602,51 @@ describe('AiAgentAdminService.runReviewItemWritebackJob', () => {
         );
     });
 
+    it('continues the build-fix thread when the dbt source is unresolved', async () => {
+        const generateAgentThreadResponse = vi
+            .fn()
+            .mockResolvedValue('Opened a pull request.');
+        const setReviewItemWritebackStatus = vi
+            .fn()
+            .mockResolvedValue(undefined);
+        const service = makeService({
+            aiAgentReviewClassifierModel: {
+                getReviewItem: vi.fn().mockResolvedValue(
+                    makeReviewItem({
+                        latestFinding: makeLatestFinding(),
+                    }),
+                ),
+                setReviewItemWritebackStatus,
+            },
+            projectModel: {
+                findExploresFromCache: vi.fn().mockResolvedValue({
+                    orders: {
+                        name: 'orders',
+                        tables: {
+                            orders: {
+                                name: 'orders',
+                                ymlPath: 'models/orders.yml',
+                            },
+                        },
+                    },
+                }),
+            },
+            aiAgentService: { generateAgentThreadResponse },
+        });
+
+        await expect(
+            service.runReviewItemWritebackJob(payload),
+        ).resolves.toBeUndefined();
+        expect(generateAgentThreadResponse).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({ dbtSourceUuid: undefined }),
+        );
+        expect(setReviewItemWritebackStatus).toHaveBeenLastCalledWith(
+            expect.objectContaining({ status: 'completed' }),
+        );
+    });
+
     it.each([
-        {
-            resolution: 'unresolved',
-            sourceUuids: [],
-            expectedMessage:
-                'Could not determine which dbt source this finding belongs to, so the automatic writeback was skipped.',
-        },
         {
             resolution: 'ambiguous',
             sourceUuids: [
@@ -2621,10 +2659,7 @@ describe('AiAgentAdminService.runReviewItemWritebackJob', () => {
     ])(
         'fails an $resolution source before starting the build-fix thread',
         async ({ sourceUuids, expectedMessage }) => {
-            const modelNames =
-                sourceUuids.length === 0
-                    ? ['orders']
-                    : sourceUuids.map((_, index) => `model_${index}`);
+            const modelNames = sourceUuids.map((_, index) => `model_${index}`);
             const generateAgentThreadResponse = vi.fn();
             const updateReviewRemediationStatus = vi
                 .fn()

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -2394,12 +2394,10 @@ export class AiAgentAdminService extends BaseService {
 
             if (
                 plan.strategy === 'prompt' &&
-                plan.dbtSourceResolution !== 'unique'
+                plan.dbtSourceResolution === 'ambiguous'
             ) {
                 throw new ParameterError(
-                    plan.dbtSourceResolution === 'ambiguous'
-                        ? 'This finding spans more than one dbt source. A single writeback cannot safely target several repositories at once.'
-                        : 'Could not determine which dbt source this finding belongs to, so the automatic writeback was skipped.',
+                    'This finding spans more than one dbt source. A single writeback cannot safely target several repositories at once.',
                 );
             }
 

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -2392,6 +2392,17 @@ export class AiAgentAdminService extends BaseService {
             const planStrategy = toReviewWritebackStrategy(plan.strategy);
             strategy = planStrategy;
 
+            if (
+                plan.strategy === 'prompt' &&
+                plan.dbtSourceResolution !== 'unique'
+            ) {
+                throw new ParameterError(
+                    plan.dbtSourceResolution === 'ambiguous'
+                        ? 'This finding spans more than one dbt source. A single writeback cannot safely target several repositories at once.'
+                        : 'Could not determine which dbt source this finding belongs to, so the automatic writeback was skipped.',
+                );
+            }
+
             let prUrl: string | null;
             let pullRequest: PullRequest | null = null;
             if (plan.strategy === 'project_context') {

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -9361,11 +9361,12 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             const sourceNames = (result.dbtSourceOptions ?? [])
                 .map((option) => option.name)
                 .join(', ');
+            const sourceSelectionMessage = sourceNames
+                ? `This project has more than one dbt source: ${sourceNames}. Reply naming one and I'll try again.`
+                : "This project has more than one dbt source, so I couldn't tell which one to change. Reply naming one and I'll try again.";
             await this.aiAgentModel.updateModelResponse({
                 promptUuid,
-                response: sourceNames
-                    ? `This project has more than one dbt source: ${sourceNames}. Reply naming one and I'll try again.`
-                    : "This project has more than one dbt source, so I couldn't tell which one to change. Reply naming one and I'll try again.",
+                response: sourceSelectionMessage,
             });
             await this.aiAgentModel.setPromptNeedsUserInput({
                 promptUuid,
@@ -9375,6 +9376,13 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     reason: 'writeback_source_selection',
                 },
             });
+            if (isSlackPrompt(prompt)) {
+                await this.postOutcomeToSlack(
+                    prompt,
+                    getMarkdownBlocks(sourceSelectionMessage),
+                    sourceSelectionMessage,
+                );
+            }
         }
     }
 

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -10258,7 +10258,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             const writeback = await this.projectContextService.writebackEntry({
                 user,
                 projectUuid,
-                dbtSourceUuid: entry.dbtSourceUuid ?? options?.dbtSourceUuid,
+                dbtSourceUuid: options?.dbtSourceUuid,
                 entry,
                 branchTimestamp: Date.now(),
                 sourceThread,

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -9876,7 +9876,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 isSlackPrompt: isSlackPrompt(prompt),
                 toolCallId: args.progressId,
                 writebackPrompt,
-                dbtSourceUuid: args.dbtSourceUuid ?? options?.dbtSourceUuid,
+                dbtSourceUuid: options?.dbtSourceUuid,
                 source,
                 prUrl: args.prUrl,
                 startNewPullRequest: args.startNewPullRequest ?? null,

--- a/packages/backend/src/ee/services/AiAgentService/runEditDbtProjectPipeline.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/runEditDbtProjectPipeline.test.ts
@@ -507,6 +507,37 @@ describe('AiAgentService.runEditDbtProjectPipeline', () => {
         });
     });
 
+    it('posts the dbt source selection question to Slack', async () => {
+        const run = vi.fn().mockResolvedValue({
+            ...WRITEBACK_RESULT,
+            prUrl: null,
+            prAction: null,
+            needsDbtSourceSelection: true,
+            dbtSourceOptions: [
+                { name: 'jaffle-2', repository: null, isPrimary: false },
+            ],
+        });
+        const { service, postMessage } = buildService({
+            isSlack: true,
+            run,
+            getRunStatus: getRunStatusMock('error'),
+        });
+
+        await service.runEditDbtProjectPipeline({
+            ...PAYLOAD,
+            isSlackPrompt: true,
+        });
+
+        expect(postMessage).toHaveBeenCalledWith(
+            expect.objectContaining({
+                channel: 'C123',
+                thread_ts: '111.222',
+                text: expect.stringContaining('jaffle-2'),
+                blocks: expect.arrayContaining([expect.anything()]),
+            }),
+        );
+    });
+
     it('skips a stale success once the run was already finalized as an error', async () => {
         const { service, updateToolResult } = buildService({
             getRunStatus: getRunStatusMock('error'),

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
@@ -852,6 +852,21 @@ describe('AiWritebackService dbt source targeting', () => {
         });
     });
 
+    it('resolves the only source before validating an explicit dbtSourceUuid', async () => {
+        const result = await resolve(serviceWithSources([]), {
+            dbtSourceUuid: 'does-not-exist',
+        });
+
+        expect(result).toMatchObject({
+            kind: 'resolved',
+            candidate: {
+                sourceUuid: null,
+                optionUuid: PRIMARY_SOURCE_UUID,
+                isPrimary: true,
+            },
+        });
+    });
+
     it('honours an explicit additional dbtSourceUuid', async () => {
         const result = await resolve(serviceWithSources([marketingSource()]), {
             dbtSourceUuid: 'src-marketing',
@@ -876,12 +891,35 @@ describe('AiWritebackService dbt source targeting', () => {
         });
     });
 
-    it('rejects an explicit dbtSourceUuid that is not a target', async () => {
-        await expect(
-            resolve(serviceWithSources([marketingSource()]), {
-                dbtSourceUuid: 'does-not-exist',
-            }),
-        ).rejects.toThrow(ParameterError);
+    it('asks the caller to choose when an explicit dbtSourceUuid is not a target', async () => {
+        const result = await resolve(serviceWithSources([marketingSource()]), {
+            dbtSourceUuid: 'does-not-exist',
+        });
+
+        expect(result.kind).toBe('select');
+        expect(result.options).toHaveLength(2);
+        expect(result.options).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    projectDbtSourceUuid: PRIMARY_SOURCE_UUID,
+                    isPrimary: true,
+                }),
+                expect.objectContaining({
+                    projectDbtSourceUuid: 'src-marketing',
+                    repository: 'acme/marketing',
+                }),
+            ]),
+        );
+    });
+
+    it('does not infer a prompt-named source when an explicit dbtSourceUuid is not a target', async () => {
+        const result = await resolve(serviceWithSources([marketingSource()]), {
+            prompt: 'add a spend metric to the marketing models',
+            dbtSourceUuid: 'does-not-exist',
+        });
+
+        expect(result.kind).toBe('select');
+        expect(result.options).toHaveLength(2);
     });
 
     it('infers the source from the prompt when exactly one matches', async () => {
@@ -980,6 +1018,7 @@ describe('AiWritebackService dbt source targeting', () => {
             // The prompt names the primary repo, but the thread is bound to the
             // additional source — binding wins so the resumed sandbox stays put.
             prompt: 'change something in analytics',
+            dbtSourceUuid: PRIMARY_SOURCE_UUID,
             existingRow: { project_dbt_source_uuid: 'src-marketing' },
         });
         expect(result).toMatchObject({

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -2866,8 +2866,8 @@ export class AiWritebackService extends BaseService {
      * Decide which dbt source a turn targets. Precedence:
      * 1. a resumed thread stays bound to its original source (never re-infer, or
      *    a follow-up could retarget the sandbox's already-cloned repo);
-     * 2. an explicit `dbtSourceUuid` (a UI picker, or an agent re-call);
-     * 3. the only source, when the project has one — unchanged behaviour;
+     * 2. the only source, when the project has one, unconditionally;
+     * 3. an explicit `dbtSourceUuid` (a UI picker, or an agent re-call);
      * 4. the source the prompt names, when exactly one matches;
      * otherwise return the candidates for the caller to choose from.
      */
@@ -2918,20 +2918,21 @@ export class AiWritebackService extends BaseService {
             return { kind: 'resolved', candidate: primary ?? candidates[0] };
         }
 
+        if (candidates.length === 1) {
+            return { kind: 'resolved', candidate: candidates[0] };
+        }
+
         if (dbtSourceUuid) {
             const chosen = candidates.find(
                 (c) => c.optionUuid === dbtSourceUuid,
             );
-            if (!chosen) {
-                throw new ParameterError(
-                    'The specified dbt source is not a valid writeback target for this project',
-                );
+            if (chosen) {
+                return { kind: 'resolved', candidate: chosen };
             }
-            return { kind: 'resolved', candidate: chosen };
-        }
-
-        if (candidates.length === 1) {
-            return { kind: 'resolved', candidate: candidates[0] };
+            return {
+                kind: 'select',
+                options: candidates.map(AiWritebackService.toDbtSourceOption),
+            };
         }
 
         // Score each candidate by how specifically the prompt names it (the

--- a/packages/backend/src/ee/services/ai/reviewWriteback/buildReviewWritebackPrompt.test.ts
+++ b/packages/backend/src/ee/services/ai/reviewWriteback/buildReviewWritebackPrompt.test.ts
@@ -111,6 +111,10 @@ describe('planReviewWriteback', () => {
         );
 
         expect(plan.aggregationKey).toBeNull();
+        expect(plan).toMatchObject({
+            dbtSourceUuid: null,
+            dbtSourceResolution: 'unresolved',
+        });
         expect(plan.promptText).toContain(
             'Add an ai_hint to average_order_size',
         );
@@ -178,10 +182,58 @@ describe('planReviewWriteback', () => {
         });
         expect(plan).toMatchObject({
             dbtSourceUuid: '00000000-0000-0000-0000-000000000002',
+            dbtSourceResolution: 'unique',
         });
         expect(plan.promptText).toContain(
             'metric "additional__orders.average_order_size" (yaml: models/orders.yml)',
         );
+    });
+
+    it('marks a finding across distinct dbt sources as ambiguous', () => {
+        const item = baseItem();
+        if (item.latestFinding) {
+            item.latestFinding.targetRefs = [
+                {
+                    type: 'metric',
+                    modelName: 'orders',
+                    metricName: 'average_order_size',
+                },
+                {
+                    type: 'dimension',
+                    modelName: 'customers',
+                    dimensionName: 'customer_name',
+                },
+            ];
+        }
+
+        const plan = expectPromptPlan(
+            planReviewWriteback(
+                item,
+                new Map([
+                    [
+                        'orders',
+                        {
+                            ymlPath: 'models/orders.yml',
+                            dbtSourceUuid:
+                                '00000000-0000-0000-0000-000000000001',
+                        },
+                    ],
+                    [
+                        'customers',
+                        {
+                            ymlPath: 'models/customers.yml',
+                            dbtSourceUuid:
+                                '00000000-0000-0000-0000-000000000002',
+                        },
+                    ],
+                ]),
+            ),
+        );
+
+        expect(plan).toMatchObject({
+            dbtSourceUuid: null,
+            dbtSourceResolution: 'ambiguous',
+        });
     });
 
     it('builds a prompt from a manual semantic-layer issue', () => {

--- a/packages/backend/src/ee/services/ai/reviewWriteback/buildReviewWritebackPrompt.ts
+++ b/packages/backend/src/ee/services/ai/reviewWriteback/buildReviewWritebackPrompt.ts
@@ -24,6 +24,7 @@ export type ReviewWritebackPlan =
           promptText: string;
           aggregationKey: string | null;
           dbtSourceUuid: string | null;
+          dbtSourceResolution: 'unique' | 'ambiguous' | 'unresolved';
       }
     | {
           strategy: 'project_context';
@@ -114,7 +115,16 @@ const buildSemanticLayerWritebackPrompt = (
             )
             .filter((uuid): uuid is string => uuid !== null),
     );
-    const dbtSourceUuid = sourceUuids.size === 1 ? [...sourceUuids][0] : null;
+    let dbtSourceResolution: 'unique' | 'ambiguous' | 'unresolved';
+    if (sourceUuids.size === 1) {
+        dbtSourceResolution = 'unique';
+    } else if (sourceUuids.size === 0) {
+        dbtSourceResolution = 'unresolved';
+    } else {
+        dbtSourceResolution = 'ambiguous';
+    }
+    const dbtSourceUuid =
+        dbtSourceResolution === 'unique' ? [...sourceUuids][0] : null;
     if (item.source === 'manual') {
         const manualTargetLines = item.targetRefs
             .filter(isSemanticTargetRef)
@@ -135,6 +145,7 @@ const buildSemanticLayerWritebackPrompt = (
             promptText: sections.join('\n\n'),
             aggregationKey: null,
             dbtSourceUuid,
+            dbtSourceResolution,
         };
     }
     const targetLines = (finding?.targetRefs ?? [])
@@ -159,6 +170,7 @@ const buildSemanticLayerWritebackPrompt = (
         promptText: sections.join('\n\n'),
         aggregationKey: null,
         dbtSourceUuid,
+        dbtSourceResolution,
     };
 };
 

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -4019,16 +4019,11 @@ Parameters:
     },
   },
   {
-    "description": "Open or update a pull request that modifies the dbt project / Lightdash semantic layer for this project. Use this tool ONLY when the user asks to CHANGE something in the underlying repo — e.g. add or rename a metric, edit a dimension definition, modify a dbt model, update YAML metadata. Do NOT use this tool for read-only questions, querying data, exploring fields, or for changes that can be made inside Lightdash (use editContent for those). This tool applies the change on your behalf: it runs in an isolated sandbox, edits the repo, runs \`lightdash compile\`, and opens a pull request — but the call returns immediately once the run has started, before any of that finishes (status: "pending"). Give a brief acknowledgement that you have started the change, then end your turn. Do not wait for it or call this tool again to check on it. A single conversation can open several pull requests: follow-up edits continue the most recent one, prUrl targets a specific existing one, and startNewPullRequest opens a fresh one for an unrelated change.",
+    "description": "Open or update a pull request that modifies the dbt project / Lightdash semantic layer for this project. Use this tool ONLY when the user asks to CHANGE something in the underlying repo — e.g. add or rename a metric, edit a dimension definition, modify a dbt model, update YAML metadata. Do NOT use this tool for read-only questions, querying data, exploring fields, or for changes that can be made inside Lightdash (use editContent for those). When a project has more than one dbt source, the prompt must name the source or its owner/repo verbatim, or you will be asked to choose one. This tool applies the change on your behalf: it runs in an isolated sandbox, edits the repo, runs \`lightdash compile\`, and opens a pull request — but the call returns immediately once the run has started, before any of that finishes (status: "pending"). Give a brief acknowledgement that you have started the change, then end your turn. Do not wait for it or call this tool again to check on it. A single conversation can open several pull requests: follow-up edits continue the most recent one, prUrl targets a specific existing one, and startNewPullRequest opens a fresh one for an unrelated change.",
     "inputSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": false,
       "properties": {
-        "dbtSourceUuid": {
-          "description": "The project dbt source UUID to edit. Use the projectDbtSourceUuid returned by a prior source-selection result. Omit it only when the project has one dbt source.",
-          "format": "uuid",
-          "type": "string",
-        },
         "prUrl": {
           "description": "To UPDATE a specific existing pull request instead of opening a new one, put its full URL here (e.g. 'https://github.com/owner/repo/pull/123'). The PR must belong to this project's own dbt repository. Use this both for a PR the user pasted AND to target one of several pull requests this conversation has already opened (get the URL from listWorkstreams or a previous editDbtProject result). Otherwise pass null.",
           "type": [
@@ -4037,7 +4032,7 @@ Parameters:
           ],
         },
         "prompt": {
-          "description": "A focused, self-contained natural-language instruction describing exactly which files in the dbt project to change and how. The change is applied in a fresh sandbox that does not see this conversation, so include every detail it needs (model name, file path hints, the literal change to make). Do not include preamble or pleasantries.",
+          "description": "A focused, self-contained natural-language instruction describing exactly which files in the dbt project to change and how. The change is applied in a fresh sandbox that does not see this conversation, so include every detail it needs (model name, file path hints, the literal change to make). When the project has multiple dbt sources, include the source name or owner/repo verbatim. Do not include preamble or pleasantries.",
           "type": "string",
         },
         "startNewPullRequest": {
@@ -4279,11 +4274,6 @@ Parameters:
       "properties": {
         "content": {
           "description": "A single self-contained sentence stating the fact (e.g. '"HR" = the high-risk diabetes cohort, not human resources.').",
-          "type": "string",
-        },
-        "dbtSourceUuid": {
-          "description": "The project dbt source UUID that owns the project context file. Omit it for the primary dbt source.",
-          "format": "uuid",
           "type": "string",
         },
         "id": {

--- a/packages/backend/src/ee/services/ai/tools/editDbtProject.ts
+++ b/packages/backend/src/ee/services/ai/tools/editDbtProject.ts
@@ -14,12 +14,11 @@ export const getEditDbtProject = ({ editDbtProject }: Dependencies) =>
     tool({
         ...toolDefinition,
         execute: async (
-            { dbtSourceUuid, prompt, prUrl: pastedPrUrl, startNewPullRequest },
+            { prompt, prUrl: pastedPrUrl, startNewPullRequest },
             { toolCallId },
         ) => {
             try {
                 const { aiWritebackRunUuid } = await editDbtProject({
-                    dbtSourceUuid,
                     prompt,
                     prUrl: pastedPrUrl,
                     startNewPullRequest,

--- a/packages/backend/src/ee/services/ai/tools/editProjectContext.ts
+++ b/packages/backend/src/ee/services/ai/tools/editProjectContext.ts
@@ -36,18 +36,9 @@ const toolDefinition = editProjectContextToolDefinition.for('agent');
 export const getEditProjectContext = ({ editProjectContext }: Dependencies) =>
     tool({
         ...toolDefinition,
-        execute: async ({
-            dbtSourceUuid,
-            op,
-            id,
-            kind,
-            content,
-            terms,
-            objects,
-        }) => {
+        execute: async ({ op, id, kind, content, terms, objects }) => {
             try {
                 const { prUrl, prAction } = await editProjectContext({
-                    dbtSourceUuid,
                     op,
                     id,
                     kind,

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -636,7 +636,6 @@ export type LoadAgentSkillFn = (
 ) => Promise<AiAgentSkill | undefined>;
 
 export type EditDbtProjectFn = (args: {
-    dbtSourceUuid?: string;
     prompt: string;
     prUrl: string | null;
     /** Open a new PR instead of continuing the thread's existing one. */
@@ -659,7 +658,7 @@ export type GenerateDataAppFn = (args: {
 // Applies a structured project-context entry to lightdash.project_context.yml
 // via the deterministic GitHub-API merge (no sandbox) and opens/updates a PR.
 export type EditProjectContextFn = (
-    entry: AiAgentJudgeProjectContextEntry & { dbtSourceUuid?: string },
+    entry: AiAgentJudgeProjectContextEntry,
 ) => Promise<{ prUrl: string; prAction: 'opened' | 'updated' }>;
 
 /**

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolEditDbtProjectArgs.test.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolEditDbtProjectArgs.test.ts
@@ -1,16 +1,9 @@
 import { toolEditDbtProjectArgsSchema } from './toolEditDbtProjectArgs';
 
 describe('toolEditDbtProjectArgsSchema', () => {
-    it('preserves an explicit dbt source identity', () => {
-        const dbtSourceUuid = '00000000-0000-0000-0000-000000000002';
-
-        expect(
-            toolEditDbtProjectArgsSchema.parse({
-                prompt: 'Update models/orders.yml',
-                prUrl: null,
-                startNewPullRequest: null,
-                dbtSourceUuid,
-            }),
-        ).toMatchObject({ dbtSourceUuid });
+    it('does not expose a dbt source identity', () => {
+        expect('dbtSourceUuid' in toolEditDbtProjectArgsSchema.shape).toBe(
+            false,
+        );
     });
 });

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolEditDbtProjectArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolEditDbtProjectArgs.ts
@@ -7,22 +7,16 @@ export const TOOL_EDIT_DBT_PROJECT_DESCRIPTION = [
     'Open or update a pull request that modifies the dbt project / Lightdash semantic layer for this project.',
     'Use this tool ONLY when the user asks to CHANGE something in the underlying repo — e.g. add or rename a metric, edit a dimension definition, modify a dbt model, update YAML metadata.',
     'Do NOT use this tool for read-only questions, querying data, exploring fields, or for changes that can be made inside Lightdash (use editContent for those).',
+    'When a project has more than one dbt source, the prompt must name the source or its owner/repo verbatim, or you will be asked to choose one.',
     'This tool applies the change on your behalf: it runs in an isolated sandbox, edits the repo, runs `lightdash compile`, and opens a pull request — but the call returns immediately once the run has started, before any of that finishes (status: "pending"). Give a brief acknowledgement that you have started the change, then end your turn. Do not wait for it or call this tool again to check on it.',
     'A single conversation can open several pull requests: follow-up edits continue the most recent one, prUrl targets a specific existing one, and startNewPullRequest opens a fresh one for an unrelated change.',
 ].join(' ');
 
 export const toolEditDbtProjectArgsSchema = z.object({
-    dbtSourceUuid: z
-        .string()
-        .uuid()
-        .optional()
-        .describe(
-            'The project dbt source UUID to edit. Use the projectDbtSourceUuid returned by a prior source-selection result. Omit it only when the project has one dbt source.',
-        ),
     prompt: z
         .string()
         .describe(
-            'A focused, self-contained natural-language instruction describing exactly which files in the dbt project to change and how. The change is applied in a fresh sandbox that does not see this conversation, so include every detail it needs (model name, file path hints, the literal change to make). Do not include preamble or pleasantries.',
+            'A focused, self-contained natural-language instruction describing exactly which files in the dbt project to change and how. The change is applied in a fresh sandbox that does not see this conversation, so include every detail it needs (model name, file path hints, the literal change to make). When the project has multiple dbt sources, include the source name or owner/repo verbatim. Do not include preamble or pleasantries.',
         ),
     prUrl: z
         .string()

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolEditProjectContextArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolEditProjectContextArgs.ts
@@ -11,13 +11,6 @@ export const TOOL_EDIT_PROJECT_CONTEXT_DESCRIPTION = [
 // Mirrors AiAgentJudgeProjectContextEntry — the structured entry the
 // deterministic ProjectContextService.writebackEntry applies to the YAML.
 export const toolEditProjectContextArgsSchema = z.object({
-    dbtSourceUuid: z
-        .string()
-        .uuid()
-        .optional()
-        .describe(
-            'The project dbt source UUID that owns the project context file. Omit it for the primary dbt source.',
-        ),
     op: z
         .enum(['create', 'update'])
         .describe(


### PR DESCRIPTION
## Summary

Stacked on #28363. Closes two remaining gaps in the AI writeback dbt-source-selection path.

**Slack never received the source-selection question.** When a project has more than one dbt source and none is uniquely identified, the web client already gets the question stored as the model response with a structured input gate — but the same run in a Slack thread got silence. This now delivers the identical question to Slack via the existing outcome-delivery path, as a normal question rather than an error.

**Review remediation collapsed two different failure states into one silent `null`.** The prompt-planning step that resolves a review finding's dbt source treated "the finding's targets span more than one dbt source" and "no target could be resolved to any known source" identically — both became `dbtSourceUuid: null`, indistinguishable from "there's exactly one candidate to resolve against." This adds an explicit `dbtSourceResolution: 'unique' | 'ambiguous' | 'unresolved'` state.

**Correction after initial review:** the first version of this PR failed the remediation for *both* `ambiguous` and `unresolved`. That was a regression — `unresolved` is not an anomaly, it's the standard state for an ordinary single-source project (`lightdash_source_uuid` is only stamped on compiled manifest nodes when a project has additional dbt sources registered; `ProjectService.resolveCompileAdapter` returns the bare primary adapter with no stamping otherwise, which is most projects). Failing on `unresolved` would have broken review-writeback remediation broadly instead of fixing the narrow case this stack targets. Fixed: only `ambiguous` fails now; `unresolved` proceeds exactly as before this PR (`dbtSourceUuid: undefined` → resolved via `resolveDbtTarget`'s single-candidate short-circuit from #28362). A regression test pins this down. Note for reviewers: the original design consultation for this stack recommended failing on any unresolved source — that advice was wrong on this specific point and should not be re-applied.

## Verification

- Focused Vitest run (3 files): 116/116 passing, including coverage for Slack delivery, all three source-resolution states, and the unresolved-does-not-fail regression case.
- Backend typecheck: passing.
- Scoped lint on touched files: passing.

## Security review

deepsec Step 0 triage: reused existing, already-reviewed outcome-delivery and error paths (`postOutcomeToSlack`, `ParameterError`), no new external inputs, no auth/secret/SQL/exec signals in the diff (+284/-8 across 6 files, 3 of them tests). Orchestrator judgment: scan skipped — one of the three touched source files (`AiAgentService.ts`) is the same very large file that made #28362's scan exhaust its tool-turn budget with zero findings; a small, low-risk diff against it wasn't judged worth repeating that cost.

Linear: SPK-1694
Fixes #28361