### PR TITLE
fix: omit stale dates from terminal live activity payloads

### DIFF
--- a/packages/backend/src/clients/Apns/ApnsClient.ts
+++ b/packages/backend/src/clients/Apns/ApnsClient.ts
@@ -107,7 +107,11 @@ export const buildLiveActivityPayload = (args: {
     aps: {
         timestamp: Math.floor(args.timestamp.getTime() / 1000),
         event: args.event,
-        'stale-date': Math.floor(args.staleAt.getTime() / 1000),
+        ...(args.event === 'update'
+            ? {
+                  'stale-date': Math.floor(args.staleAt.getTime() / 1000),
+              }
+            : {}),
         'content-state': {
             state: args.state,
             projectUuid: args.projectUuid,

--- a/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationReconciler.test.ts
+++ b/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationReconciler.test.ts
@@ -159,7 +159,7 @@ describe('MobilePushNotificationReconciler.reconcileLiveActivity', () => {
         ).not.toContain('activity-token');
     });
 
-    it('ends an idle activity and dismisses it after one minute', async () => {
+    it('ends an idle activity without a stale date and dismisses it after one minute', async () => {
         const dependencies = createDependencies();
         dependencies.threadStore.findThreadLiveStateSignals.mockResolvedValue([
             {
@@ -175,19 +175,24 @@ describe('MobilePushNotificationReconciler.reconcileLiveActivity', () => {
 
         await reconciler.reconcileLiveActivity(activity.liveActivityUuid);
 
-        expect(dependencies.apnsClient.sendLiveActivity).toHaveBeenCalledWith(
-            expect.objectContaining({
-                payload: expect.objectContaining({
-                    aps: expect.objectContaining({
-                        event: 'end',
-                        'dismissal-date': 1788091320,
-                        'content-state': expect.objectContaining({
-                            state: 'idle',
-                        }),
-                    }),
-                }),
-            }),
-        );
+        expect(dependencies.apnsClient.sendLiveActivity).toHaveBeenCalledWith({
+            environment: 'sandbox',
+            pushToken: 'activity-token',
+            payload: {
+                aps: {
+                    timestamp: 1788091260,
+                    event: 'end',
+                    'dismissal-date': 1788091320,
+                    'content-state': {
+                        state: 'idle',
+                        projectUuid: 'project-uuid',
+                        agentUuid: 'agent-uuid',
+                        threadUuid: 'thread-uuid',
+                        promptUuid: 'prompt-uuid',
+                    },
+                },
+            },
+        });
         expect(
             dependencies.notificationStore.markLiveActivityDelivered,
         ).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary

- Omit stale dates from terminal live activity payloads.
- Preserve update deadlines, final state, and dismissal timing.

## Tests

- Full backend unit suite
- Backend typecheck
- Touched-path lint
- API generation

Linear: SPK-1684
Fixes SPK-1684