### PR TITLE
feat: start Live Activities for web agent runs (SPK-1707)

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -24,7 +24,7 @@
         "test:dev": "vitest watch --config vitest.config.ts --changed",
         "test:dev:nowatch": "vitest run --config vitest.config.ts --changed",
         "test:snapshots:update": "vitest run --config vitest.config.ts src/utils/QueryBuilder/metricQueryBuilderSnapshots -u",
-        "test:integration": "vitest run --config vitest.config.integration.ts",
+        "test:integration": "vitest run --config vitest.config.migrations.integration.ts && vitest run --config vitest.config.integration.ts",
         "test:integration:dev": "vitest run --config vitest.config.integration.ts --watch",
         "test:ai-filter-permutations": "TZ=UTC LANG=en_US.UTF-8 vitest run --config vitest.config.ai-filter-permutations.ts",
         "linter": "oxlint -c .oxlintrc.json --ignore-path ./../../.gitignore",

--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -560,6 +560,14 @@ import {
     McpToolCallTableName,
 } from '../ee/database/entities/mcpToolCall';
 import {
+    AiAgentLiveActivitiesTableName,
+    AiAgentLiveActivityStartAttemptsTableName,
+    AiAgentLiveActivityStartAttemptTable,
+    AiAgentLiveActivityTable,
+    MobilePushInstallationsTableName,
+    MobilePushInstallationTable,
+} from '../ee/database/entities/mobilePushNotifications';
+import {
     OrganizationHomepageSettingsTable,
     OrganizationHomepageSettingsTableName,
 } from '../ee/database/entities/organizationHomepageSettings';
@@ -718,6 +726,9 @@ declare module 'knex/types/tables' {
         [AiSlackPromptTableName]: AiSlackPromptTable;
         [AiWebAppPromptTableName]: AiWebAppPromptTable;
         [AiWritebackThreadTableName]: AiWritebackThreadTable;
+        [MobilePushInstallationsTableName]: MobilePushInstallationTable;
+        [AiAgentLiveActivitiesTableName]: AiAgentLiveActivityTable;
+        [AiAgentLiveActivityStartAttemptsTableName]: AiAgentLiveActivityStartAttemptTable;
         [AgentOnboardingRunsTableName]: AgentOnboardingRunsTable;
         [HomepageRecommendedActionSkipsTableName]: HomepageRecommendedActionSkipsTable;
         [ProjectCiStatusTableName]: ProjectCiStatusTable;

--- a/packages/backend/src/clients/Apns/ApnsClient.test.ts
+++ b/packages/backend/src/clients/Apns/ApnsClient.test.ts
@@ -1,7 +1,11 @@
+import { EventEmitter } from 'events';
+import { constants, type ClientHttp2Session } from 'http2';
 import { type MobilePushNotificationsConfig } from '../../config/parseConfig';
 import {
     ApnsClient,
     buildLiveActivityPayload,
+    buildLiveActivityStartPayload,
+    NodeApnsHttpTransport,
     type ApnsHttpTransport,
     type ApnsProviderTokenSource,
 } from './ApnsClient';
@@ -28,6 +32,44 @@ const createClient = (response: { status: number; body?: string }) => {
         providerTokenSource,
     };
 };
+
+describe('NodeApnsHttpTransport', () => {
+    it('cancels a hung HTTP/2 stream before the processing lease can reopen', async () => {
+        vi.useFakeTimers();
+        const stream = Object.assign(new EventEmitter(), {
+            setEncoding: vi.fn(),
+            end: vi.fn(),
+            close: vi.fn(),
+        });
+        const session = Object.assign(new EventEmitter(), {
+            closed: false,
+            destroyed: false,
+            request: vi.fn(() => stream),
+        }) as unknown as ClientHttp2Session;
+        const transport = new NodeApnsHttpTransport(() => session, 100);
+        const client = new ApnsClient({
+            config,
+            transport,
+            providerTokenSource: {
+                getToken: vi.fn(async () => 'provider-token'),
+            },
+        });
+
+        const delivery = client.sendLiveActivity({
+            environment: 'sandbox',
+            pushToken: 'activity-token',
+            payload: { aps: { timestamp: 1, event: 'update' } },
+        });
+        await vi.advanceTimersByTimeAsync(100);
+
+        await expect(delivery).resolves.toEqual({
+            status: 'retryable',
+            reason: 'ApnsRequestTimeoutError',
+        });
+        expect(stream.close).toHaveBeenCalledWith(constants.NGHTTP2_CANCEL);
+        vi.useRealTimers();
+    });
+});
 
 describe('ApnsClient.sendLiveActivity', () => {
     it.each<MobilePushNotificationsConfig>([
@@ -182,6 +224,52 @@ describe('ApnsClient.sendLiveActivity', () => {
     });
 });
 
+describe('ApnsClient.sendLiveActivityStart', () => {
+    it('sends the exact start payload to the push-to-start token with stable headers', async () => {
+        const { client, transport } = createClient({ status: 200 });
+        const payload = buildLiveActivityStartPayload({
+            timestamp: new Date('2026-08-31T12:00:00.000Z'),
+            staleAt: new Date('2026-08-31T12:05:00.000Z'),
+            liveActivityUuid: '00000000-0000-0000-0000-000000000008',
+            installationUuid: '00000000-0000-0000-0000-000000000003',
+            projectUuid: '00000000-0000-0000-0000-000000000004',
+            agentUuid: '00000000-0000-0000-0000-000000000005',
+            threadUuid: '00000000-0000-0000-0000-000000000006',
+            promptUuid: '00000000-0000-0000-0000-000000000007',
+        });
+
+        await client.sendLiveActivityStart({
+            environment: 'sandbox',
+            pushToStartToken: 'push-to-start-token',
+            liveActivityUuid: '00000000-0000-0000-0000-000000000008',
+            payload,
+        });
+        await client.sendLiveActivityStart({
+            environment: 'sandbox',
+            pushToStartToken: 'push-to-start-token',
+            liveActivityUuid: '00000000-0000-0000-0000-000000000008',
+            payload,
+        });
+
+        const expectedRequest = {
+            origin: 'https://api.sandbox.push.apple.com',
+            headers: {
+                ':method': 'POST',
+                ':path': '/3/device/push-to-start-token',
+                authorization: 'bearer provider-token',
+                'apns-collapse-id': '00000000-0000-0000-0000-000000000008',
+                'apns-id': '00000000-0000-0000-0000-000000000008',
+                'apns-priority': '10',
+                'apns-push-type': 'liveactivity',
+                'apns-topic': 'com.lightdash.mobile.push-type.liveactivity',
+            },
+            body: JSON.stringify(payload),
+        };
+        expect(transport.send).toHaveBeenNthCalledWith(1, expectedRequest);
+        expect(transport.send).toHaveBeenNthCalledWith(2, expectedRequest);
+    });
+});
+
 describe('ApnsClient.sendAlert', () => {
     it('sends a device alert with the app topic and a stable collapse ID', async () => {
         const { client, transport } = createClient({ status: 200 });
@@ -273,5 +361,54 @@ describe('buildLiveActivityPayload', () => {
             'dismissal-date': 1788091260,
         });
         expect(payload.aps).not.toHaveProperty('alert');
+    });
+});
+
+describe('buildLiveActivityStartPayload', () => {
+    it('matches AgentRunActivityAttributes without private prompt content', () => {
+        const payload = buildLiveActivityStartPayload({
+            timestamp: new Date('2026-08-31T12:00:00.000Z'),
+            staleAt: new Date('2026-08-31T12:05:00.000Z'),
+            liveActivityUuid: 'live-activity-uuid',
+            installationUuid: 'installation-uuid',
+            projectUuid: 'project-uuid',
+            agentUuid: 'agent-uuid',
+            threadUuid: 'thread-uuid',
+            promptUuid: 'prompt-uuid',
+        });
+
+        expect(payload).toEqual({
+            aps: {
+                timestamp: 1788177600,
+                event: 'start',
+                'content-state': {
+                    state: 'working',
+                    projectUuid: 'project-uuid',
+                    agentUuid: 'agent-uuid',
+                    threadUuid: 'thread-uuid',
+                    promptUuid: 'prompt-uuid',
+                },
+                'stale-date': 1788177900,
+                'attributes-type': 'AgentRunActivityAttributes',
+                attributes: {
+                    liveActivityUuid: 'live-activity-uuid',
+                    installationUuid: 'installation-uuid',
+                    projectUuid: 'project-uuid',
+                    agentUuid: 'agent-uuid',
+                    threadUuid: 'thread-uuid',
+                    promptUuid: 'prompt-uuid',
+                    agentName: 'Agent',
+                    taskSummary: null,
+                },
+                'input-push-token': 1,
+                alert: {
+                    title: 'Lightdash',
+                    body: 'Your agent is running.',
+                },
+            },
+        });
+        expect(JSON.stringify(payload)).not.toMatch(
+            /prompt text|answer text|dashboard|organization|customer|secret/i,
+        );
     });
 });

--- a/packages/backend/src/clients/Apns/ApnsClient.ts
+++ b/packages/backend/src/clients/Apns/ApnsClient.ts
@@ -23,6 +23,37 @@ export type LiveActivityPayload = {
     };
 };
 
+export type LiveActivityStartPayload = {
+    aps: {
+        timestamp: number;
+        event: 'start';
+        'content-state': {
+            state: 'working';
+            projectUuid: string;
+            agentUuid: string;
+            threadUuid: string;
+            promptUuid: string;
+        };
+        'stale-date': number;
+        'attributes-type': 'AgentRunActivityAttributes';
+        attributes: {
+            liveActivityUuid: string;
+            installationUuid: string;
+            projectUuid: string;
+            agentUuid: string;
+            threadUuid: string;
+            promptUuid: string;
+            agentName: 'Agent';
+            taskSummary: null;
+        };
+        'input-push-token': 1;
+        alert: {
+            title: 'Lightdash';
+            body: 'Your agent is running.';
+        };
+    };
+};
+
 export type AlertPayload = {
     aps: {
         alert: {
@@ -62,6 +93,15 @@ type ProviderTokenRequest = {
 export type ApnsProviderTokenSource = {
     getToken(request: ProviderTokenRequest): Promise<string>;
 };
+
+export const APNS_REQUEST_TIMEOUT_MS = 30_000;
+
+class ApnsRequestTimeoutError extends Error {
+    constructor() {
+        super('APNs request timed out');
+        this.name = 'ApnsRequestTimeoutError';
+    }
+}
 
 type ApnsClientDependencies = {
     config: MobilePushNotificationsConfig;
@@ -129,6 +169,46 @@ export const buildLiveActivityPayload = (args: {
     },
 });
 
+export const buildLiveActivityStartPayload = (args: {
+    timestamp: Date;
+    staleAt: Date;
+    liveActivityUuid: string;
+    installationUuid: string;
+    projectUuid: string;
+    agentUuid: string;
+    threadUuid: string;
+    promptUuid: string;
+}): LiveActivityStartPayload => ({
+    aps: {
+        timestamp: Math.floor(args.timestamp.getTime() / 1000),
+        event: 'start',
+        'content-state': {
+            state: 'working',
+            projectUuid: args.projectUuid,
+            agentUuid: args.agentUuid,
+            threadUuid: args.threadUuid,
+            promptUuid: args.promptUuid,
+        },
+        'stale-date': Math.floor(args.staleAt.getTime() / 1000),
+        'attributes-type': 'AgentRunActivityAttributes',
+        attributes: {
+            liveActivityUuid: args.liveActivityUuid,
+            installationUuid: args.installationUuid,
+            projectUuid: args.projectUuid,
+            agentUuid: args.agentUuid,
+            threadUuid: args.threadUuid,
+            promptUuid: args.promptUuid,
+            agentName: 'Agent',
+            taskSummary: null,
+        },
+        'input-push-token': 1,
+        alert: {
+            title: 'Lightdash',
+            body: 'Your agent is running.',
+        },
+    },
+});
+
 export class JoseApnsProviderTokenSource implements ApnsProviderTokenSource {
     private readonly cache = new Map<
         string,
@@ -160,13 +240,26 @@ export class JoseApnsProviderTokenSource implements ApnsProviderTokenSource {
 export class NodeApnsHttpTransport implements ApnsHttpTransport {
     private readonly sessions = new Map<string, ClientHttp2Session>();
 
+    private readonly connect: (origin: string) => ClientHttp2Session;
+
+    private readonly requestTimeoutMs: number;
+
+    constructor(
+        connect: (origin: string) => ClientHttp2Session = (origin) =>
+            http2.connect(origin),
+        requestTimeoutMs: number = APNS_REQUEST_TIMEOUT_MS,
+    ) {
+        this.connect = connect;
+        this.requestTimeoutMs = requestTimeoutMs;
+    }
+
     private getSession(origin: string): ClientHttp2Session {
         const existing = this.sessions.get(origin);
         if (existing !== undefined && !existing.closed && !existing.destroyed) {
             return existing;
         }
 
-        const session = http2.connect(origin);
+        const session = this.connect(origin);
         session.on('close', () => this.sessions.delete(origin));
         session.on('error', () => this.sessions.delete(origin));
         this.sessions.set(origin, session);
@@ -183,6 +276,25 @@ export class NodeApnsHttpTransport implements ApnsHttpTransport {
             );
             let status = 0;
             let responseBody = '';
+            let settled = false;
+            const timeout = setTimeout(() => {
+                if (settled) return;
+                settled = true;
+                stream.close(http2.constants.NGHTTP2_CANCEL);
+                reject(new ApnsRequestTimeoutError());
+            }, this.requestTimeoutMs);
+            const finish = (
+                result: { status: number; body?: string } | Error,
+            ) => {
+                if (settled) return;
+                settled = true;
+                clearTimeout(timeout);
+                if (result instanceof Error) {
+                    reject(result);
+                } else {
+                    resolve(result);
+                }
+            };
             stream.setEncoding('utf8');
             stream.on('response', (headers: IncomingHttpHeaders) => {
                 status = Number(headers[':status'] ?? 0);
@@ -191,14 +303,14 @@ export class NodeApnsHttpTransport implements ApnsHttpTransport {
                 responseBody += chunk;
             });
             stream.on('end', () =>
-                resolve({
+                finish({
                     status,
                     ...(responseBody.length === 0
                         ? {}
                         : { body: responseBody }),
                 }),
             );
-            stream.on('error', reject);
+            stream.on('error', (error) => finish(error));
             stream.end(request.body);
         });
     }
@@ -222,7 +334,7 @@ export class ApnsClient {
     private async send(args: {
         environment: MobilePushEnvironment;
         token: string;
-        payload: LiveActivityPayload | AlertPayload;
+        payload: LiveActivityPayload | LiveActivityStartPayload | AlertPayload;
         headers: OutgoingHttpHeaders;
     }): Promise<ApnsDeliveryResult> {
         const credential = this.config[args.environment];
@@ -285,6 +397,26 @@ export class ApnsClient {
             token: args.pushToken,
             payload: args.payload,
             headers: {
+                'apns-priority': '10',
+                'apns-push-type': 'liveactivity',
+                'apns-topic': `${this.config.bundleId}.push-type.liveactivity`,
+            },
+        });
+    }
+
+    async sendLiveActivityStart(args: {
+        environment: MobilePushEnvironment;
+        pushToStartToken: string;
+        liveActivityUuid: string;
+        payload: LiveActivityStartPayload;
+    }): Promise<ApnsDeliveryResult> {
+        return this.send({
+            environment: args.environment,
+            token: args.pushToStartToken,
+            payload: args.payload,
+            headers: {
+                'apns-collapse-id': args.liveActivityUuid,
+                'apns-id': args.liveActivityUuid,
                 'apns-priority': '10',
                 'apns-push-type': 'liveactivity',
                 'apns-topic': `${this.config.bundleId}.push-type.liveactivity`,

--- a/packages/backend/src/ee/controllers/mobilePushNotificationController.test.ts
+++ b/packages/backend/src/ee/controllers/mobilePushNotificationController.test.ts
@@ -1,0 +1,52 @@
+import { type UUID } from '@lightdash/common';
+import { type Request } from 'express';
+import { type ServiceRepository } from '../../services/ServiceRepository';
+import { type MobilePushNotificationService } from '../services/MobilePushNotificationService/MobilePushNotificationService';
+import { MobilePushNotificationController } from './mobilePushNotificationController';
+
+describe('MobilePushNotificationController.registerLiveActivityPushToStartToken', () => {
+    it('forwards the authenticated account and never returns the token', async () => {
+        const registerPushToStartToken = vi.fn<
+            MobilePushNotificationService['registerPushToStartToken']
+        >(async () => undefined);
+        const services = {
+            getMobilePushNotificationService: () => ({
+                registerPushToStartToken,
+            }),
+        } as unknown as ServiceRepository;
+        const controller = new MobilePushNotificationController(services);
+        const request = {
+            account: {
+                user: {
+                    type: 'registered',
+                    id: 'user-uuid',
+                    userUuid: 'user-uuid',
+                },
+                organization: {
+                    organizationUuid: 'organization-uuid',
+                    name: 'Organization',
+                    createdAt: new Date('2026-08-31T12:00:00.000Z'),
+                },
+                authentication: { type: 'session' },
+            },
+        } as unknown as Request;
+        const installationUuid = '10000000-0000-4000-8000-000000000003' as UUID;
+
+        const response = await controller.registerLiveActivityPushToStartToken(
+            request,
+            installationUuid,
+            { pushToken: 'push-to-start-token' },
+        );
+
+        expect(registerPushToStartToken).toHaveBeenCalledWith({
+            user: expect.objectContaining({
+                userUuid: 'user-uuid',
+                organizationUuid: 'organization-uuid',
+            }),
+            installationUuid,
+            pushToken: 'push-to-start-token',
+        });
+        expect(response).toEqual({ status: 'ok', results: undefined });
+        expect(JSON.stringify(response)).not.toContain('push-to-start-token');
+    });
+});

--- a/packages/backend/src/ee/controllers/mobilePushNotificationController.ts
+++ b/packages/backend/src/ee/controllers/mobilePushNotificationController.ts
@@ -3,7 +3,10 @@ import {
     type ApiErrorPayload,
     type ApiMobilePushInstallationRequest,
     type ApiMobilePushInstallationResponse,
+    type ApiMobilePushLiveActivityPushToStartTokenRequest,
+    type ApiMobilePushLiveActivityPushToStartTokenResponse,
     type ApiMobilePushNotificationStatusResponse,
+    type UUID,
 } from '@lightdash/common';
 import {
     Body,
@@ -66,6 +69,25 @@ export class MobilePushNotificationController extends BaseController {
             installationUuid,
             environment: body.environment,
             deviceToken: body.deviceToken,
+        });
+        this.setStatus(200);
+        return { status: 'ok', results: undefined };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Put('/installations/{installationUuid}/live-activity-push-to-start-token')
+    @OperationId('registerMobilePushLiveActivityPushToStartToken')
+    async registerLiveActivityPushToStartToken(
+        @Request() req: express.Request,
+        @Path() installationUuid: UUID,
+        @Body() body: ApiMobilePushLiveActivityPushToStartTokenRequest,
+    ): Promise<ApiMobilePushLiveActivityPushToStartTokenResponse> {
+        assertRegisteredAccount(req.account);
+        await this.getMobilePushNotificationService().registerPushToStartToken({
+            user: toSessionUser(req.account),
+            installationUuid,
+            pushToken: body.pushToken,
         });
         this.setStatus(200);
         return { status: 'ok', results: undefined };

--- a/packages/backend/src/ee/database/entities/mobilePushNotifications.ts
+++ b/packages/backend/src/ee/database/entities/mobilePushNotifications.ts
@@ -3,8 +3,18 @@ import { Knex } from 'knex';
 
 export const MobilePushInstallationsTableName = 'mobile_push_installations';
 export const AiAgentLiveActivitiesTableName = 'ai_agent_live_activities';
+export const AiAgentLiveActivityStartAttemptsTableName =
+    'ai_agent_live_activity_start_attempts';
 
 export type MobilePushEnvironment = 'sandbox' | 'production';
+
+export type LiveActivityStartAttemptStatus =
+    | 'excluded'
+    | 'pending'
+    | 'processing'
+    | 'retryable'
+    | 'sent'
+    | 'failed';
 
 export type DbMobilePushInstallation = {
     mobile_push_installation_uuid: string;
@@ -14,6 +24,8 @@ export type DbMobilePushInstallation = {
     environment: MobilePushEnvironment;
     encrypted_device_token: Buffer;
     device_token_fingerprint: string;
+    encrypted_push_to_start_token: Buffer | null;
+    push_to_start_token_fingerprint: string | null;
     created_at: Date;
     updated_at: Date;
 };
@@ -22,14 +34,63 @@ export type MobilePushInstallationTable = Knex.CompositeTableType<
     DbMobilePushInstallation,
     Omit<
         DbMobilePushInstallation,
-        'mobile_push_installation_uuid' | 'created_at' | 'updated_at'
-    >,
+        | 'mobile_push_installation_uuid'
+        | 'encrypted_push_to_start_token'
+        | 'push_to_start_token_fingerprint'
+        | 'created_at'
+        | 'updated_at'
+    > &
+        Partial<
+            Pick<
+                DbMobilePushInstallation,
+                | 'encrypted_push_to_start_token'
+                | 'push_to_start_token_fingerprint'
+            >
+        >,
     Partial<
         Omit<
             DbMobilePushInstallation,
             'mobile_push_installation_uuid' | 'created_at'
         >
     >
+>;
+
+export type DbAiAgentLiveActivityStartAttempt = {
+    live_activity_start_attempt_uuid: string;
+    live_activity_uuid: string;
+    mobile_push_installation_uuid: string;
+    prompt_uuid: string;
+    status: LiveActivityStartAttemptStatus;
+    attempt_count: number;
+    last_attempted_at: Date | null;
+    last_token_fingerprint: string | null;
+    completed_at: Date | null;
+    created_at: Date;
+    updated_at: Date;
+};
+
+export type AiAgentLiveActivityStartAttemptTable = Knex.CompositeTableType<
+    DbAiAgentLiveActivityStartAttempt,
+    Pick<
+        DbAiAgentLiveActivityStartAttempt,
+        'mobile_push_installation_uuid' | 'prompt_uuid' | 'status'
+    > &
+        Partial<
+            Pick<
+                DbAiAgentLiveActivityStartAttempt,
+                'completed_at' | 'live_activity_uuid'
+            >
+        >,
+    Partial<
+        Pick<
+            DbAiAgentLiveActivityStartAttempt,
+            | 'status'
+            | 'last_attempted_at'
+            | 'last_token_fingerprint'
+            | 'completed_at'
+            | 'updated_at'
+        >
+    > & { attempt_count?: number | Knex.Raw }
 >;
 
 export type DbAiAgentLiveActivity = {

--- a/packages/backend/src/ee/database/migrations/20260831120000_add_live_activity_push_to_start.ts
+++ b/packages/backend/src/ee/database/migrations/20260831120000_add_live_activity_push_to_start.ts
@@ -1,0 +1,80 @@
+import type { Knex } from 'knex';
+
+export const classification = {
+    kind: 'safe',
+    reason: 'Adds nullable push-to-start fields and an empty attempt table',
+} as const;
+
+const installationsTable = 'mobile_push_installations';
+const startAttemptsTable = 'ai_agent_live_activity_start_attempts';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '5s'`);
+
+    await knex.schema.alterTable(installationsTable, (table) => {
+        table.binary('encrypted_push_to_start_token').nullable();
+        table.string('push_to_start_token_fingerprint', 64).nullable();
+        table.unique(['environment', 'push_to_start_token_fingerprint']);
+    });
+
+    await knex.schema.createTable(startAttemptsTable, (table) => {
+        table
+            .uuid('live_activity_start_attempt_uuid')
+            .primary()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+        table
+            .uuid('live_activity_uuid')
+            .notNullable()
+            .unique()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+        table
+            .uuid('mobile_push_installation_uuid')
+            .notNullable()
+            .references('mobile_push_installation_uuid')
+            .inTable(installationsTable)
+            .onDelete('CASCADE')
+            .index();
+        table
+            .uuid('prompt_uuid')
+            .notNullable()
+            .references('ai_prompt_uuid')
+            .inTable('ai_prompt')
+            .onDelete('CASCADE')
+            .index();
+        table
+            .text('status')
+            .notNullable()
+            .checkIn([
+                'excluded',
+                'pending',
+                'processing',
+                'retryable',
+                'sent',
+                'failed',
+            ]);
+        table.integer('attempt_count').notNullable().defaultTo(0);
+        table.timestamp('last_attempted_at', { useTz: false }).nullable();
+        table.string('last_token_fingerprint', 64).nullable();
+        table.timestamp('completed_at', { useTz: false }).nullable();
+        table
+            .timestamp('created_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+        table
+            .timestamp('updated_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+
+        table.unique(['mobile_push_installation_uuid', 'prompt_uuid']);
+        table.index(['status', 'last_attempted_at']);
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '5s'`);
+    await knex.schema.dropTableIfExists(startAttemptsTable);
+    await knex.schema.alterTable(installationsTable, (table) => {
+        table.dropColumn('push_to_start_token_fingerprint');
+        table.dropColumn('encrypted_push_to_start_token');
+    });
+}

--- a/packages/backend/src/ee/database/migrations/20260831120000_add_live_activity_push_to_start.ts
+++ b/packages/backend/src/ee/database/migrations/20260831120000_add_live_activity_push_to_start.ts
@@ -7,6 +7,16 @@ export const classification = {
 
 const installationsTable = 'mobile_push_installations';
 const startAttemptsTable = 'ai_agent_live_activity_start_attempts';
+const installationsPushToStartTokenUnique =
+    'mobile_push_installations_push_start_token_uq';
+const startAttemptsInstallationForeign =
+    'live_activity_start_attempts_installation_fk';
+const startAttemptsInstallationIndex =
+    'live_activity_start_attempts_installation_idx';
+const startAttemptsInstallationPromptUnique =
+    'live_activity_start_attempts_installation_prompt_uq';
+const startAttemptsStatusAttemptedIndex =
+    'live_activity_start_attempts_status_attempted_idx';
 
 export async function up(knex: Knex): Promise<void> {
     await knex.raw(`SET LOCAL lock_timeout = '5s'`);
@@ -14,7 +24,9 @@ export async function up(knex: Knex): Promise<void> {
     await knex.schema.alterTable(installationsTable, (table) => {
         table.binary('encrypted_push_to_start_token').nullable();
         table.string('push_to_start_token_fingerprint', 64).nullable();
-        table.unique(['environment', 'push_to_start_token_fingerprint']);
+        table.unique(['environment', 'push_to_start_token_fingerprint'], {
+            indexName: installationsPushToStartTokenUnique,
+        });
     });
 
     await knex.schema.createTable(startAttemptsTable, (table) => {
@@ -33,7 +45,8 @@ export async function up(knex: Knex): Promise<void> {
             .references('mobile_push_installation_uuid')
             .inTable(installationsTable)
             .onDelete('CASCADE')
-            .index();
+            .withKeyName(startAttemptsInstallationForeign)
+            .index(startAttemptsInstallationIndex);
         table
             .uuid('prompt_uuid')
             .notNullable()
@@ -65,8 +78,13 @@ export async function up(knex: Knex): Promise<void> {
             .notNullable()
             .defaultTo(knex.fn.now());
 
-        table.unique(['mobile_push_installation_uuid', 'prompt_uuid']);
-        table.index(['status', 'last_attempted_at']);
+        table.unique(['mobile_push_installation_uuid', 'prompt_uuid'], {
+            indexName: startAttemptsInstallationPromptUnique,
+        });
+        table.index(
+            ['status', 'last_attempted_at'],
+            startAttemptsStatusAttemptedIndex,
+        );
     });
 }
 

--- a/packages/backend/src/ee/database/migrations/__tests__/20260831120000_add_live_activity_push_to_start.migration.integration.ts
+++ b/packages/backend/src/ee/database/migrations/__tests__/20260831120000_add_live_activity_push_to_start.migration.integration.ts
@@ -1,0 +1,102 @@
+import knex, { type Knex } from 'knex';
+import { down, up } from '../20260831120000_add_live_activity_push_to_start';
+
+describe('Live Activity push-to-start migration PostgreSQL integration', () => {
+    let database: Knex;
+    let transaction: Knex.Transaction;
+    const schemaName = `live_activity_push_start_${process.pid}`;
+
+    beforeAll(async () => {
+        if (!process.env.PGCONNECTIONURI) {
+            throw new Error('PGCONNECTIONURI is required');
+        }
+
+        database = knex({
+            client: 'pg',
+            connection: process.env.PGCONNECTIONURI,
+        });
+        transaction = await database.transaction();
+        await transaction.raw('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"');
+        await transaction.raw('CREATE SCHEMA ??', [schemaName]);
+        await transaction.raw('SET LOCAL search_path TO ??, public', [
+            schemaName,
+        ]);
+        await transaction.schema.createTable(
+            'mobile_push_installations',
+            (table) => {
+                table.uuid('mobile_push_installation_uuid').primary();
+                table.text('environment').notNullable();
+            },
+        );
+        await transaction.schema.createTable('ai_prompt', (table) => {
+            table.uuid('ai_prompt_uuid').primary();
+        });
+    });
+
+    afterAll(async () => {
+        if (transaction && !transaction.isCompleted()) {
+            await transaction.rollback();
+        }
+        await database?.destroy();
+    });
+
+    it('creates untruncated PostgreSQL identifiers', async () => {
+        await up(transaction);
+
+        const attemptsResult = await transaction.raw<{
+            rows: Array<{ identifier: string }>;
+        }>(`
+            SELECT indexname AS identifier
+            FROM pg_indexes
+            WHERE schemaname = current_schema()
+              AND tablename = 'ai_agent_live_activity_start_attempts'
+            UNION
+            SELECT conname AS identifier
+            FROM pg_constraint
+            WHERE conrelid = 'ai_agent_live_activity_start_attempts'::regclass
+            ORDER BY identifier
+        `);
+        const installationsResult = await transaction.raw<{
+            rows: Array<{ identifier: string }>;
+        }>(`
+            SELECT conname AS identifier
+            FROM pg_constraint
+            WHERE conrelid = 'mobile_push_installations'::regclass
+              AND pg_get_constraintdef(oid) LIKE '%push_to_start_token_fingerprint%'
+        `);
+
+        expect(attemptsResult.rows.map(({ identifier }) => identifier)).toEqual(
+            expect.arrayContaining([
+                'live_activity_start_attempts_installation_fk',
+                'live_activity_start_attempts_installation_idx',
+                'live_activity_start_attempts_installation_prompt_uq',
+                'live_activity_start_attempts_status_attempted_idx',
+            ]),
+        );
+        expect(installationsResult.rows).toEqual([
+            {
+                identifier: 'mobile_push_installations_push_start_token_uq',
+            },
+        ]);
+
+        await down(transaction);
+
+        expect(
+            await transaction.schema.hasTable(
+                'ai_agent_live_activity_start_attempts',
+            ),
+        ).toBe(false);
+        await expect(
+            transaction('information_schema.columns')
+                .select('column_name')
+                .where({
+                    table_schema: schemaName,
+                    table_name: 'mobile_push_installations',
+                })
+                .whereIn('column_name', [
+                    'encrypted_push_to_start_token',
+                    'push_to_start_token_fingerprint',
+                ]),
+        ).resolves.toEqual([]);
+    });
+});

--- a/packages/backend/src/ee/database/migrations/__tests__/20260831120000_add_live_activity_push_to_start.test.ts
+++ b/packages/backend/src/ee/database/migrations/__tests__/20260831120000_add_live_activity_push_to_start.test.ts
@@ -1,0 +1,72 @@
+import knex from 'knex';
+import { getTracker, MockClient, type Tracker } from 'knex-mock-client';
+import {
+    classification,
+    down,
+    up,
+} from '../20260831120000_add_live_activity_push_to_start';
+
+describe('Live Activity push-to-start migration', () => {
+    const database = knex({ client: MockClient, dialect: 'pg' });
+    let tracker: Tracker;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    afterEach(() => {
+        tracker.reset();
+    });
+
+    it('is safe for a rolling deployment', () => {
+        expect(classification).toEqual({
+            kind: 'safe',
+            reason: 'Adds nullable push-to-start fields and an empty attempt table',
+        });
+    });
+
+    it('adds encrypted token fields and a durable installation-prompt key', async () => {
+        tracker.on.any(() => true).response({});
+
+        await up(database);
+
+        const migrationSql = tracker.history.all
+            .map(({ sql }) => sql)
+            .join('\n');
+        expect(migrationSql).toContain(
+            'add column "encrypted_push_to_start_token" bytea null',
+        );
+        expect(migrationSql).toContain(
+            'add column "push_to_start_token_fingerprint" varchar(64) null',
+        );
+        expect(migrationSql).toContain(
+            'create table "ai_agent_live_activity_start_attempts"',
+        );
+        expect(migrationSql).toContain(
+            'unique ("mobile_push_installation_uuid", "prompt_uuid")',
+        );
+        expect(migrationSql).toContain(
+            'unique ("environment", "push_to_start_token_fingerprint")',
+        );
+        expect(migrationSql).toContain(
+            '"live_activity_uuid" uuid not null default uuid_generate_v4()',
+        );
+        expect(migrationSql).toContain(
+            "check (\"status\" in ('excluded','pending','processing','retryable','sent','failed'))",
+        );
+        expect(migrationSql).toContain('on delete CASCADE');
+    });
+
+    it('drops the attempt table before token fields', async () => {
+        tracker.on.any(() => true).response({});
+
+        await down(database);
+
+        expect(tracker.history.all.map(({ sql }) => sql)).toEqual([
+            "SET LOCAL lock_timeout = '5s'",
+            'drop table if exists "ai_agent_live_activity_start_attempts"',
+            'alter table "mobile_push_installations" drop column "push_to_start_token_fingerprint"',
+            'alter table "mobile_push_installations" drop column "encrypted_push_to_start_token"',
+        ]);
+    });
+});

--- a/packages/backend/src/ee/database/migrations/__tests__/20260831120000_add_live_activity_push_to_start.test.ts
+++ b/packages/backend/src/ee/database/migrations/__tests__/20260831120000_add_live_activity_push_to_start.test.ts
@@ -43,10 +43,19 @@ describe('Live Activity push-to-start migration', () => {
             'create table "ai_agent_live_activity_start_attempts"',
         );
         expect(migrationSql).toContain(
-            'unique ("mobile_push_installation_uuid", "prompt_uuid")',
+            'constraint "live_activity_start_attempts_installation_prompt_uq" unique ("mobile_push_installation_uuid", "prompt_uuid")',
         );
         expect(migrationSql).toContain(
-            'unique ("environment", "push_to_start_token_fingerprint")',
+            'constraint "mobile_push_installations_push_start_token_uq" unique ("environment", "push_to_start_token_fingerprint")',
+        );
+        expect(migrationSql).toContain(
+            'constraint "live_activity_start_attempts_installation_fk" foreign key ("mobile_push_installation_uuid")',
+        );
+        expect(migrationSql).toContain(
+            'create index "live_activity_start_attempts_installation_idx"',
+        );
+        expect(migrationSql).toContain(
+            'create index "live_activity_start_attempts_status_attempted_idx"',
         );
         expect(migrationSql).toContain(
             '"live_activity_uuid" uuid not null default uuid_generate_v4()',

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -171,10 +171,11 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                 const threadStore = models.getAiAgentModel<AiAgentModel>();
                 const scheduler =
                     clients.getSchedulerClient() as CommercialSchedulerClient;
+                const apnsClient = clients.getApnsClient();
                 const reconciler = new MobilePushNotificationReconciler({
                     notificationStore,
                     threadStore,
-                    apnsClient: clients.getApnsClient(),
+                    apnsClient,
                     scheduler,
                     analytics: context.lightdashAnalytics,
                     completionAlert: undefined,
@@ -182,11 +183,13 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                 return new MobilePushNotificationService({
                     mobilePushNotificationStore: notificationStore,
                     threadStore,
+                    projectStore: models.getProjectModel(),
                     mobilePushNotificationsConfig:
                         context.lightdashConfig.mobilePushNotifications,
                     scheduler,
                     reconciler,
                     analytics: context.lightdashAnalytics,
+                    apnsClient,
                 });
             },
             linearAppService: ({ models, context }) => {

--- a/packages/backend/src/ee/models/MobilePushNotificationModel.test.ts
+++ b/packages/backend/src/ee/models/MobilePushNotificationModel.test.ts
@@ -3,6 +3,7 @@ import { getTracker, MockClient, type Tracker } from 'knex-mock-client';
 import { EncryptionUtil } from '../../utils/EncryptionUtil/EncryptionUtil';
 import {
     AiAgentLiveActivitiesTableName,
+    AiAgentLiveActivityStartAttemptsTableName,
     MobilePushInstallationsTableName,
 } from '../database/entities/mobilePushNotifications';
 import { MobilePushNotificationModel } from './MobilePushNotificationModel';
@@ -30,7 +31,8 @@ afterEach(() => {
 });
 
 describe('MobilePushNotificationModel', () => {
-    it('encrypts and fingerprints a rotating device token', async () => {
+    it('serializes an absent UUID before storing a rotating device token', async () => {
+        tracker.on.any(/pg_advisory_xact_lock/).responseOnce([]);
         tracker.on.select(MobilePushInstallationsTableName).responseOnce([]);
         tracker.on.delete(MobilePushInstallationsTableName).responseOnce([]);
         tracker.on.insert(MobilePushInstallationsTableName).responseOnce([
@@ -68,6 +70,368 @@ describe('MobilePushNotificationModel', () => {
         expect(insert?.bindings).toEqual(
             expect.arrayContaining([expect.stringMatching(/^[a-f0-9]{64}$/)]),
         );
+        expect(tracker.history.all[0].sql).toContain(
+            'pg_advisory_xact_lock(hashtextextended($1, 0))',
+        );
+        expect(tracker.history.all[0].bindings).toEqual(['installation-uuid']);
+    });
+
+    it('clears token capability and attempts before an ownership transfer', async () => {
+        tracker.on.any(/pg_advisory_xact_lock/).responseOnce([]);
+        tracker.on.select(MobilePushInstallationsTableName).responseOnce([
+            {
+                mobile_push_installation_uuid: 'stored-installation-uuid',
+                organization_uuid: 'old-organization-uuid',
+                user_uuid: 'old-user-uuid',
+                environment: 'sandbox',
+            },
+        ]);
+        tracker.on.delete(AiAgentLiveActivitiesTableName).responseOnce([]);
+        tracker.on
+            .delete(AiAgentLiveActivityStartAttemptsTableName)
+            .responseOnce([]);
+        tracker.on.delete(MobilePushInstallationsTableName).responseOnce([]);
+        tracker.on.insert(MobilePushInstallationsTableName).responseOnce([
+            {
+                mobile_push_installation_uuid: 'stored-installation-uuid',
+                installation_uuid: 'installation-uuid',
+                organization_uuid: 'new-organization-uuid',
+                user_uuid: 'new-user-uuid',
+                environment: 'production',
+            },
+        ]);
+
+        await model.upsertInstallation({
+            installationUuid: 'installation-uuid',
+            organizationUuid: 'new-organization-uuid',
+            userUuid: 'new-user-uuid',
+            environment: 'production',
+            deviceToken: 'new-device-token',
+        });
+
+        const statements = tracker.history.all.map(({ sql }) => sql);
+        expect(statements[0]).toContain('pg_advisory_xact_lock');
+        expect(statements[1]).toContain('for update');
+        expect(statements[2]).toContain(AiAgentLiveActivitiesTableName);
+        expect(statements[3]).toContain(
+            AiAgentLiveActivityStartAttemptsTableName,
+        );
+        const insert = tracker.history.insert.find((query) =>
+            query.sql.includes(MobilePushInstallationsTableName),
+        );
+        expect(insert?.sql).toContain('"encrypted_push_to_start_token" = $');
+        expect(insert?.sql).toContain('"push_to_start_token_fingerprint" = $');
+        expect(insert?.bindings.filter((value) => value === null)).toHaveLength(
+            2,
+        );
+    });
+
+    it('clears push-to-start state when the installation environment changes', async () => {
+        tracker.on.any(/pg_advisory_xact_lock/).responseOnce([]);
+        tracker.on.select(MobilePushInstallationsTableName).responseOnce([
+            {
+                mobile_push_installation_uuid: 'stored-installation-uuid',
+                organization_uuid: 'organization-uuid',
+                user_uuid: 'user-uuid',
+                environment: 'sandbox',
+            },
+        ]);
+        tracker.on
+            .delete(AiAgentLiveActivityStartAttemptsTableName)
+            .responseOnce([]);
+        tracker.on.delete(MobilePushInstallationsTableName).responseOnce([]);
+        tracker.on.insert(MobilePushInstallationsTableName).responseOnce([
+            {
+                mobile_push_installation_uuid: 'stored-installation-uuid',
+                installation_uuid: 'installation-uuid',
+                organization_uuid: 'organization-uuid',
+                user_uuid: 'user-uuid',
+                environment: 'production',
+            },
+        ]);
+
+        await model.upsertInstallation({
+            installationUuid: 'installation-uuid',
+            organizationUuid: 'organization-uuid',
+            userUuid: 'user-uuid',
+            environment: 'production',
+            deviceToken: 'new-device-token',
+        });
+
+        expect(
+            tracker.history.delete.some((query) =>
+                query.sql.includes(AiAgentLiveActivityStartAttemptsTableName),
+            ),
+        ).toBe(true);
+        expect(
+            tracker.history.delete.some((query) =>
+                query.sql.includes(AiAgentLiveActivitiesTableName),
+            ),
+        ).toBe(false);
+        const insert = tracker.history.insert.find((query) =>
+            query.sql.includes(MobilePushInstallationsTableName),
+        );
+        expect(insert?.sql).toContain('"encrypted_push_to_start_token" = $');
+        expect(insert?.sql).toContain('"push_to_start_token_fingerprint" = $');
+        expect(insert?.bindings.filter((value) => value === null)).toHaveLength(
+            2,
+        );
+    });
+
+    it('preserves pending, retryable, and sent attempts during same-installation token rotation', async () => {
+        tracker.on.any(/pg_advisory_xact_lock/).response([]);
+        tracker.on.select(MobilePushInstallationsTableName).responseOnce([
+            {
+                mobile_push_installation_uuid: 'stored-installation-uuid',
+            },
+        ]);
+        tracker.on.select(MobilePushInstallationsTableName).responseOnce([]);
+        tracker.on.update(MobilePushInstallationsTableName).responseOnce(1);
+
+        await expect(
+            model.registerPushToStartToken({
+                installationUuid: 'installation-uuid',
+                organizationUuid: 'organization-uuid',
+                userUuid: 'user-uuid',
+                environment: 'sandbox',
+                pushToken: 'push-to-start-token',
+            }),
+        ).resolves.toBe(true);
+
+        const update = tracker.history.update[0];
+        expect(update.bindings).toEqual(
+            expect.arrayContaining([
+                expect.stringMatching(/^[a-f0-9]{64}$/),
+                'installation-uuid',
+                'organization-uuid',
+                'user-uuid',
+            ]),
+        );
+        expect(
+            update.bindings.some(
+                (value) =>
+                    Buffer.isBuffer(value) &&
+                    value.toString('utf8') === 'encrypted:push-to-start-token',
+            ),
+        ).toBe(true);
+        expect(update.bindings).not.toContain('push-to-start-token');
+        expect(tracker.history.all[0].sql).toContain('pg_advisory_xact_lock');
+        expect(tracker.history.all[0].bindings).toEqual([
+            expect.stringMatching(/^push-to-start:[a-f0-9]{64}$/),
+        ]);
+        expect(tracker.history.all[1].bindings).toEqual(['installation-uuid']);
+        expect(
+            tracker.history.delete.some((query) =>
+                query.sql.includes(AiAgentLiveActivityStartAttemptsTableName),
+            ),
+        ).toBe(false);
+    });
+
+    it('preserves an existing same-owner token binding', async () => {
+        tracker.on.any(/pg_advisory_xact_lock/).response([]);
+        tracker.on.select(MobilePushInstallationsTableName).responseOnce([
+            {
+                mobile_push_installation_uuid: 'target-storage-uuid',
+            },
+        ]);
+        tracker.on.select(MobilePushInstallationsTableName).responseOnce([
+            {
+                mobile_push_installation_uuid: 'source-storage-uuid',
+                organization_uuid: 'organization-uuid',
+                user_uuid: 'user-uuid',
+            },
+        ]);
+
+        await expect(
+            model.registerPushToStartToken({
+                installationUuid: 'target-installation-uuid',
+                organizationUuid: 'organization-uuid',
+                userUuid: 'user-uuid',
+                environment: 'sandbox',
+                pushToken: 'push-to-start-token',
+            }),
+        ).resolves.toBe(false);
+
+        expect(tracker.history.update).toHaveLength(0);
+        expect(tracker.history.delete).toHaveLength(0);
+    });
+
+    it('preserves a token bound to a foreign owner', async () => {
+        tracker.on.any(/pg_advisory_xact_lock/).response([]);
+        tracker.on.select(MobilePushInstallationsTableName).responseOnce([
+            {
+                mobile_push_installation_uuid: 'target-storage-uuid',
+            },
+        ]);
+        tracker.on.select(MobilePushInstallationsTableName).responseOnce([
+            {
+                mobile_push_installation_uuid: 'foreign-storage-uuid',
+                organization_uuid: 'foreign-organization-uuid',
+                user_uuid: 'foreign-user-uuid',
+            },
+        ]);
+
+        await expect(
+            model.registerPushToStartToken({
+                installationUuid: 'target-installation-uuid',
+                organizationUuid: 'organization-uuid',
+                userUuid: 'user-uuid',
+                environment: 'sandbox',
+                pushToken: 'push-to-start-token',
+            }),
+        ).resolves.toBe(false);
+
+        expect(tracker.history.update).toHaveLength(0);
+        expect(tracker.history.delete).toHaveLength(0);
+    });
+
+    it('clears only the push-to-start token fingerprint used by the attempt', async () => {
+        tracker.on.update(MobilePushInstallationsTableName).responseOnce(0);
+
+        await expect(
+            model.clearPushToStartTokenIfFingerprintMatches({
+                installationUuid: 'installation-uuid',
+                organizationUuid: 'organization-uuid',
+                userUuid: 'user-uuid',
+                pushTokenFingerprint: 'old-fingerprint',
+            }),
+        ).resolves.toBe(false);
+
+        expect(tracker.history.update[0].sql).toContain(
+            '"push_to_start_token_fingerprint" = $',
+        );
+        expect(tracker.history.update[0].bindings).toEqual(
+            expect.arrayContaining([
+                null,
+                null,
+                'installation-uuid',
+                'organization-uuid',
+                'user-uuid',
+                'old-fingerprint',
+            ]),
+        );
+    });
+
+    it('locks eligible and excluded rows in one ordered selection', async () => {
+        tracker.on.select(MobilePushInstallationsTableName).responseOnce([
+            {
+                mobile_push_installation_uuid: 'eligible-b',
+                installation_uuid: 'installation-b',
+            },
+            {
+                mobile_push_installation_uuid: 'eligible-a',
+                installation_uuid: 'installation-a',
+            },
+            {
+                mobile_push_installation_uuid: 'origin-installation',
+                installation_uuid: 'origin-public-installation',
+            },
+        ]);
+        tracker.on
+            .insert(AiAgentLiveActivityStartAttemptsTableName)
+            .responseOnce([]);
+        tracker.on
+            .select(AiAgentLiveActivityStartAttemptsTableName)
+            .responseOnce([
+                {
+                    liveActivityStartAttemptUuid: 'attempt-a',
+                    installationUuid: 'installation-a',
+                },
+                {
+                    liveActivityStartAttemptUuid: 'attempt-b',
+                    installationUuid: 'installation-b',
+                },
+            ]);
+
+        const result = await model.createLiveActivityStartAttempts({
+            organizationUuid: 'organization-uuid',
+            userUuid: 'user-uuid',
+            promptUuid: 'prompt-uuid',
+            excludedMobilePushInstallationUuid: 'origin-installation',
+            environments: ['sandbox'],
+        });
+
+        expect(result.map(({ installationUuid }) => installationUuid)).toEqual([
+            'installation-a',
+            'installation-b',
+        ]);
+        expect(tracker.history.select[0].sql).toContain('for share');
+        expect(tracker.history.select[0].sql).toContain(
+            'or "mobile_push_installation_uuid" = $',
+        );
+        expect(tracker.history.select[0].sql).toContain(
+            'order by "installation_uuid" asc',
+        );
+        const insert = tracker.history.insert[0];
+        expect(insert.sql).toContain(
+            'on conflict ("mobile_push_installation_uuid", "prompt_uuid") do nothing',
+        );
+        expect(insert.bindings).toEqual(
+            expect.arrayContaining([
+                'origin-installation',
+                'excluded',
+                'eligible-a',
+                'pending',
+                'eligible-b',
+            ]),
+        );
+    });
+
+    it('claims an attempt with one conditional state transition', async () => {
+        tracker.on
+            .update(AiAgentLiveActivityStartAttemptsTableName)
+            .responseOnce([
+                { live_activity_start_attempt_uuid: 'attempt-uuid' },
+            ]);
+        tracker.on
+            .select(AiAgentLiveActivityStartAttemptsTableName)
+            .responseOnce([
+                {
+                    liveActivityStartAttemptUuid: 'attempt-uuid',
+                    liveActivityUuid: 'activity-uuid',
+                    installationUuid: 'installation-uuid',
+                    organizationUuid: 'organization-uuid',
+                    userUuid: 'user-uuid',
+                    promptUuid: 'prompt-uuid',
+                    environment: 'sandbox',
+                    encryptedPushToStartToken: Buffer.from(
+                        'encrypted:push-to-start-token',
+                    ),
+                    pushToStartTokenFingerprint: 'fingerprint',
+                    status: 'processing',
+                    attemptCount: 1,
+                },
+            ]);
+
+        const result = await model.claimLiveActivityStartAttempt({
+            liveActivityStartAttemptUuid: 'attempt-uuid',
+            attemptedAt: new Date('2026-08-31T12:00:00.000Z'),
+            retryProcessingBefore: new Date('2026-08-31T11:55:00.000Z'),
+            maxAttempts: 5,
+        });
+
+        expect(result?.pushToStartToken).toBe('push-to-start-token');
+        expect(tracker.history.update[0].sql).toContain('"status" in (');
+        expect(tracker.history.update[0].sql).toContain('"attempt_count" < $');
+        expect(tracker.history.update[0].sql).toContain('"attempt_count" + 1');
+    });
+
+    it('marks a completion only while the attempt is processing', async () => {
+        tracker.on
+            .update(AiAgentLiveActivityStartAttemptsTableName)
+            .responseOnce(0);
+
+        await expect(
+            model.markLiveActivityStartAttempt({
+                liveActivityStartAttemptUuid: 'attempt-uuid',
+                status: 'sent',
+                pushTokenFingerprint: 'fingerprint',
+                completedAt: new Date('2026-08-31T12:00:00.000Z'),
+            }),
+        ).resolves.toBe(false);
+
+        expect(tracker.history.update[0].sql).toContain('and "status" = $');
+        expect(tracker.history.update[0].bindings).toContain('processing');
     });
 
     it('encrypts and fingerprints a rotating Live Activity token', async () => {

--- a/packages/backend/src/ee/models/MobilePushNotificationModel.ts
+++ b/packages/backend/src/ee/models/MobilePushNotificationModel.ts
@@ -1,11 +1,16 @@
 import { createHash } from 'crypto';
 import { Knex } from 'knex';
 import { type EncryptionUtil } from '../../utils/EncryptionUtil/EncryptionUtil';
+import { AiPromptTableName, AiThreadTableName } from '../database/entities/ai';
 import {
     AiAgentLiveActivitiesTableName,
+    AiAgentLiveActivityStartAttemptsTableName,
     MobilePushInstallationsTableName,
+    type AiAgentLiveActivityStartAttemptTable,
     type DbAiAgentLiveActivity,
+    type DbAiAgentLiveActivityStartAttempt,
     type DbMobilePushInstallation,
+    type LiveActivityStartAttemptStatus,
     type MobilePushEnvironment,
 } from '../database/entities/mobilePushNotifications';
 
@@ -40,6 +45,28 @@ export type AiAgentLiveActivity = {
     staleAt: Date | null;
     endedAt: Date | null;
     completionAlertCompletedAt: Date | null;
+};
+
+export type LiveActivityStartAttempt = {
+    liveActivityStartAttemptUuid: string;
+    liveActivityUuid: string;
+    installationUuid: string;
+    organizationUuid: string;
+    userUuid: string;
+    promptUuid: string;
+    environment: MobilePushEnvironment;
+    pushToStartToken: string | null;
+    pushToStartTokenFingerprint: string | null;
+    status: LiveActivityStartAttemptStatus;
+    attemptCount: number;
+};
+
+export type SchedulableLiveActivityStartAttempt = {
+    liveActivityStartAttemptUuid: string;
+    installationUuid: string;
+    organizationUuid: string;
+    projectUuid: string;
+    userUuid: string;
 };
 
 const tokenFingerprint = (token: string): string =>
@@ -85,6 +112,10 @@ export class MobilePushNotificationModel {
         );
 
         return this.database.transaction(async (trx) => {
+            await trx.raw(
+                'SELECT pg_advisory_xact_lock(hashtextextended(?, 0))',
+                [args.installationUuid],
+            );
             const existing = await trx<DbMobilePushInstallation>(
                 MobilePushInstallationsTableName,
             )
@@ -92,16 +123,36 @@ export class MobilePushNotificationModel {
                     'mobile_push_installation_uuid',
                     'organization_uuid',
                     'user_uuid',
+                    'environment',
                 )
                 .where('installation_uuid', args.installationUuid)
+                .forUpdate()
                 .first();
 
-            if (
+            const ownershipChanged =
                 existing !== undefined &&
                 (existing.organization_uuid !== args.organizationUuid ||
-                    existing.user_uuid !== args.userUuid)
-            ) {
+                    existing.user_uuid !== args.userUuid);
+            const environmentChanged =
+                existing !== undefined &&
+                existing.environment !== args.environment;
+
+            if (ownershipChanged && existing !== undefined) {
                 await trx<DbAiAgentLiveActivity>(AiAgentLiveActivitiesTableName)
+                    .where(
+                        'mobile_push_installation_uuid',
+                        existing.mobile_push_installation_uuid,
+                    )
+                    .delete();
+            }
+
+            if (
+                (ownershipChanged || environmentChanged) &&
+                existing !== undefined
+            ) {
+                await trx<DbAiAgentLiveActivityStartAttempt>(
+                    AiAgentLiveActivityStartAttemptsTableName,
+                )
                     .where(
                         'mobile_push_installation_uuid',
                         existing.mobile_push_installation_uuid,
@@ -137,6 +188,12 @@ export class MobilePushNotificationModel {
                     environment: args.environment,
                     encrypted_device_token: encryptedDeviceToken,
                     device_token_fingerprint: fingerprint,
+                    ...(ownershipChanged || environmentChanged
+                        ? {
+                              encrypted_push_to_start_token: null,
+                              push_to_start_token_fingerprint: null,
+                          }
+                        : {}),
                     updated_at: new Date(),
                 })
                 .returning([
@@ -155,6 +212,436 @@ export class MobilePushNotificationModel {
                 environment: row.environment,
             };
         });
+    }
+
+    async registerPushToStartToken(args: {
+        installationUuid: string;
+        organizationUuid: string;
+        userUuid: string;
+        environment: MobilePushEnvironment;
+        pushToken: string;
+    }): Promise<boolean> {
+        const encryptedPushToken = this.encryptionUtil.encrypt(args.pushToken);
+        const fingerprint = tokenFingerprint(args.pushToken);
+
+        return this.database.transaction(async (trx) => {
+            await trx.raw(
+                'SELECT pg_advisory_xact_lock(hashtextextended(?, 0))',
+                [`push-to-start:${fingerprint}`],
+            );
+            await trx.raw(
+                'SELECT pg_advisory_xact_lock(hashtextextended(?, 0))',
+                [args.installationUuid],
+            );
+
+            const target = await trx<DbMobilePushInstallation>(
+                MobilePushInstallationsTableName,
+            )
+                .select('mobile_push_installation_uuid')
+                .where({
+                    installation_uuid: args.installationUuid,
+                    organization_uuid: args.organizationUuid,
+                    user_uuid: args.userUuid,
+                    environment: args.environment,
+                })
+                .forUpdate()
+                .first();
+            if (target === undefined) return false;
+
+            const conflicts = await trx<DbMobilePushInstallation>(
+                MobilePushInstallationsTableName,
+            )
+                .select('mobile_push_installation_uuid')
+                .where({
+                    environment: args.environment,
+                    push_to_start_token_fingerprint: fingerprint,
+                })
+                .whereNot('installation_uuid', args.installationUuid)
+                .orderBy('installation_uuid', 'asc')
+                .forUpdate();
+            if (conflicts.length > 0) return false;
+
+            const updated = await trx<DbMobilePushInstallation>(
+                MobilePushInstallationsTableName,
+            )
+                .where({
+                    installation_uuid: args.installationUuid,
+                    organization_uuid: args.organizationUuid,
+                    user_uuid: args.userUuid,
+                    environment: args.environment,
+                })
+                .update({
+                    encrypted_push_to_start_token: encryptedPushToken,
+                    push_to_start_token_fingerprint: fingerprint,
+                    updated_at: new Date(),
+                });
+
+            return updated > 0;
+        });
+    }
+
+    async clearPushToStartTokenIfFingerprintMatches(args: {
+        installationUuid: string;
+        organizationUuid: string;
+        userUuid: string;
+        pushTokenFingerprint: string;
+    }): Promise<boolean> {
+        const updated = await this.database<DbMobilePushInstallation>(
+            MobilePushInstallationsTableName,
+        )
+            .where({
+                installation_uuid: args.installationUuid,
+                organization_uuid: args.organizationUuid,
+                user_uuid: args.userUuid,
+                push_to_start_token_fingerprint: args.pushTokenFingerprint,
+            })
+            .update({
+                encrypted_push_to_start_token: null,
+                push_to_start_token_fingerprint: null,
+                updated_at: new Date(),
+            });
+
+        return updated > 0;
+    }
+
+    async createLiveActivityStartAttempts(args: {
+        organizationUuid: string;
+        userUuid: string;
+        promptUuid: string;
+        excludedMobilePushInstallationUuid: string | null;
+        environments: MobilePushEnvironment[];
+    }): Promise<
+        Pick<
+            SchedulableLiveActivityStartAttempt,
+            'liveActivityStartAttemptUuid' | 'installationUuid'
+        >[]
+    > {
+        if (args.environments.length === 0) return [];
+
+        return this.database.transaction(async (trx) => {
+            const candidateInstallations = await trx<DbMobilePushInstallation>(
+                MobilePushInstallationsTableName,
+            )
+                .select('mobile_push_installation_uuid', 'installation_uuid')
+                .where({
+                    organization_uuid: args.organizationUuid,
+                    user_uuid: args.userUuid,
+                })
+                .andWhere((candidates) => {
+                    candidates.where((eligible) =>
+                        eligible
+                            .whereIn('environment', args.environments)
+                            .whereNotNull('encrypted_push_to_start_token')
+                            .whereNotNull('push_to_start_token_fingerprint'),
+                    );
+                    if (args.excludedMobilePushInstallationUuid !== null) {
+                        void candidates.orWhere(
+                            'mobile_push_installation_uuid',
+                            args.excludedMobilePushInstallationUuid,
+                        );
+                    }
+                })
+                .orderBy('installation_uuid', 'asc')
+                .forShare();
+
+            const excludedInstallation =
+                args.excludedMobilePushInstallationUuid === null
+                    ? undefined
+                    : candidateInstallations.find(
+                          (installation) =>
+                              installation.mobile_push_installation_uuid ===
+                              args.excludedMobilePushInstallationUuid,
+                      );
+            const eligibleInstallations = candidateInstallations.filter(
+                (installation) =>
+                    installation.mobile_push_installation_uuid !==
+                    args.excludedMobilePushInstallationUuid,
+            );
+
+            const rows: Array<
+                Pick<
+                    DbAiAgentLiveActivityStartAttempt,
+                    'mobile_push_installation_uuid' | 'prompt_uuid' | 'status'
+                > &
+                    Partial<
+                        Pick<DbAiAgentLiveActivityStartAttempt, 'completed_at'>
+                    >
+            > = [
+                ...(excludedInstallation === undefined
+                    ? []
+                    : [
+                          {
+                              mobile_push_installation_uuid:
+                                  excludedInstallation.mobile_push_installation_uuid,
+                              prompt_uuid: args.promptUuid,
+                              status: 'excluded' as const,
+                              completed_at: new Date(),
+                          },
+                      ]),
+                ...eligibleInstallations.map((installation) => ({
+                    mobile_push_installation_uuid:
+                        installation.mobile_push_installation_uuid,
+                    prompt_uuid: args.promptUuid,
+                    status: 'pending' as const,
+                })),
+            ];
+
+            if (rows.length > 0) {
+                await trx<AiAgentLiveActivityStartAttemptTable>(
+                    AiAgentLiveActivityStartAttemptsTableName,
+                )
+                    .insert(rows)
+                    .onConflict([
+                        'mobile_push_installation_uuid',
+                        'prompt_uuid',
+                    ])
+                    .ignore();
+            }
+
+            return trx<DbAiAgentLiveActivityStartAttempt>(
+                AiAgentLiveActivityStartAttemptsTableName,
+            )
+                .join<DbMobilePushInstallation>(
+                    MobilePushInstallationsTableName,
+                    `${AiAgentLiveActivityStartAttemptsTableName}.mobile_push_installation_uuid`,
+                    `${MobilePushInstallationsTableName}.mobile_push_installation_uuid`,
+                )
+                .select({
+                    liveActivityStartAttemptUuid: `${AiAgentLiveActivityStartAttemptsTableName}.live_activity_start_attempt_uuid`,
+                    installationUuid: `${MobilePushInstallationsTableName}.installation_uuid`,
+                })
+                .where(
+                    `${AiAgentLiveActivityStartAttemptsTableName}.prompt_uuid`,
+                    args.promptUuid,
+                )
+                .whereIn(
+                    `${AiAgentLiveActivityStartAttemptsTableName}.status`,
+                    ['pending', 'retryable'],
+                )
+                .where(
+                    `${MobilePushInstallationsTableName}.organization_uuid`,
+                    args.organizationUuid,
+                )
+                .where(
+                    `${MobilePushInstallationsTableName}.user_uuid`,
+                    args.userUuid,
+                )
+                .whereIn(
+                    `${MobilePushInstallationsTableName}.environment`,
+                    args.environments,
+                )
+                .whereNotNull(
+                    `${MobilePushInstallationsTableName}.encrypted_push_to_start_token`,
+                )
+                .whereNotNull(
+                    `${MobilePushInstallationsTableName}.push_to_start_token_fingerprint`,
+                )
+                .orderBy(
+                    `${MobilePushInstallationsTableName}.installation_uuid`,
+                    'asc',
+                );
+        });
+    }
+
+    async claimLiveActivityStartAttempt(args: {
+        liveActivityStartAttemptUuid: string;
+        attemptedAt: Date;
+        retryProcessingBefore: Date;
+        maxAttempts: number;
+    }): Promise<LiveActivityStartAttempt | undefined> {
+        const claimed = await this.database<DbAiAgentLiveActivityStartAttempt>(
+            AiAgentLiveActivityStartAttemptsTableName,
+        )
+            .where(
+                'live_activity_start_attempt_uuid',
+                args.liveActivityStartAttemptUuid,
+            )
+            .andWhere((query) =>
+                query
+                    .whereIn('status', ['pending', 'retryable'])
+                    .orWhere((processing) =>
+                        processing
+                            .where('status', 'processing')
+                            .where(
+                                'last_attempted_at',
+                                '<=',
+                                args.retryProcessingBefore,
+                            ),
+                    ),
+            )
+            .where('attempt_count', '<', args.maxAttempts)
+            .update({
+                status: 'processing',
+                attempt_count: this.database.raw('?? + 1', ['attempt_count']),
+                last_attempted_at: args.attemptedAt,
+                updated_at: args.attemptedAt,
+            })
+            .returning('live_activity_start_attempt_uuid');
+
+        if (claimed.length === 0) return undefined;
+        return this.findLiveActivityStartAttempt(
+            args.liveActivityStartAttemptUuid,
+        );
+    }
+
+    async findLiveActivityStartAttempt(
+        liveActivityStartAttemptUuid: string,
+    ): Promise<LiveActivityStartAttempt | undefined> {
+        const row = await this.database<DbAiAgentLiveActivityStartAttempt>(
+            AiAgentLiveActivityStartAttemptsTableName,
+        )
+            .join<DbMobilePushInstallation>(
+                MobilePushInstallationsTableName,
+                `${AiAgentLiveActivityStartAttemptsTableName}.mobile_push_installation_uuid`,
+                `${MobilePushInstallationsTableName}.mobile_push_installation_uuid`,
+            )
+            .select({
+                liveActivityStartAttemptUuid: `${AiAgentLiveActivityStartAttemptsTableName}.live_activity_start_attempt_uuid`,
+                liveActivityUuid: `${AiAgentLiveActivityStartAttemptsTableName}.live_activity_uuid`,
+                installationUuid: `${MobilePushInstallationsTableName}.installation_uuid`,
+                organizationUuid: `${MobilePushInstallationsTableName}.organization_uuid`,
+                userUuid: `${MobilePushInstallationsTableName}.user_uuid`,
+                promptUuid: `${AiAgentLiveActivityStartAttemptsTableName}.prompt_uuid`,
+                environment: `${MobilePushInstallationsTableName}.environment`,
+                encryptedPushToStartToken: `${MobilePushInstallationsTableName}.encrypted_push_to_start_token`,
+                pushToStartTokenFingerprint: `${MobilePushInstallationsTableName}.push_to_start_token_fingerprint`,
+                status: `${AiAgentLiveActivityStartAttemptsTableName}.status`,
+                attemptCount: `${AiAgentLiveActivityStartAttemptsTableName}.attempt_count`,
+            })
+            .where(
+                `${AiAgentLiveActivityStartAttemptsTableName}.live_activity_start_attempt_uuid`,
+                liveActivityStartAttemptUuid,
+            )
+            .first();
+
+        if (row === undefined) return undefined;
+        return {
+            liveActivityStartAttemptUuid: row.liveActivityStartAttemptUuid,
+            liveActivityUuid: row.liveActivityUuid,
+            installationUuid: row.installationUuid,
+            organizationUuid: row.organizationUuid,
+            userUuid: row.userUuid,
+            promptUuid: row.promptUuid,
+            environment: row.environment,
+            pushToStartToken:
+                row.encryptedPushToStartToken === null
+                    ? null
+                    : this.encryptionUtil.decrypt(
+                          row.encryptedPushToStartToken,
+                      ),
+            pushToStartTokenFingerprint: row.pushToStartTokenFingerprint,
+            status: row.status,
+            attemptCount: row.attemptCount,
+        };
+    }
+
+    async markLiveActivityStartAttempt(args: {
+        liveActivityStartAttemptUuid: string;
+        status: Extract<
+            LiveActivityStartAttemptStatus,
+            'retryable' | 'sent' | 'failed'
+        >;
+        pushTokenFingerprint: string | null;
+        completedAt: Date | null;
+    }): Promise<boolean> {
+        const updated = await this.database<DbAiAgentLiveActivityStartAttempt>(
+            AiAgentLiveActivityStartAttemptsTableName,
+        )
+            .where(
+                'live_activity_start_attempt_uuid',
+                args.liveActivityStartAttemptUuid,
+            )
+            .where('status', 'processing')
+            .update({
+                status: args.status,
+                last_token_fingerprint: args.pushTokenFingerprint,
+                completed_at: args.completedAt,
+                updated_at: new Date(),
+            });
+
+        return updated > 0;
+    }
+
+    async findLiveActivityStartAttemptsDue(args: {
+        retryProcessingBefore: Date;
+        environments: MobilePushEnvironment[];
+        limit: number;
+        maxAttempts: number;
+    }): Promise<SchedulableLiveActivityStartAttempt[]> {
+        if (args.environments.length === 0) return [];
+
+        return this.database<DbAiAgentLiveActivityStartAttempt>(
+            AiAgentLiveActivityStartAttemptsTableName,
+        )
+            .join<DbMobilePushInstallation>(
+                MobilePushInstallationsTableName,
+                `${AiAgentLiveActivityStartAttemptsTableName}.mobile_push_installation_uuid`,
+                `${MobilePushInstallationsTableName}.mobile_push_installation_uuid`,
+            )
+            .join(
+                AiPromptTableName,
+                `${AiAgentLiveActivityStartAttemptsTableName}.prompt_uuid`,
+                `${AiPromptTableName}.ai_prompt_uuid`,
+            )
+            .join(
+                AiThreadTableName,
+                `${AiPromptTableName}.ai_thread_uuid`,
+                `${AiThreadTableName}.ai_thread_uuid`,
+            )
+            .select({
+                liveActivityStartAttemptUuid: `${AiAgentLiveActivityStartAttemptsTableName}.live_activity_start_attempt_uuid`,
+                installationUuid: `${MobilePushInstallationsTableName}.installation_uuid`,
+                organizationUuid: `${AiThreadTableName}.organization_uuid`,
+                projectUuid: `${AiThreadTableName}.project_uuid`,
+                userUuid: `${AiPromptTableName}.created_by_user_uuid`,
+            })
+            .where((query) =>
+                query
+                    .whereIn(
+                        `${AiAgentLiveActivityStartAttemptsTableName}.status`,
+                        ['pending', 'retryable'],
+                    )
+                    .orWhere((processing) =>
+                        processing
+                            .where(
+                                `${AiAgentLiveActivityStartAttemptsTableName}.status`,
+                                'processing',
+                            )
+                            .where(
+                                `${AiAgentLiveActivityStartAttemptsTableName}.last_attempted_at`,
+                                '<=',
+                                args.retryProcessingBefore,
+                            ),
+                    ),
+            )
+            .whereIn(
+                `${MobilePushInstallationsTableName}.environment`,
+                args.environments,
+            )
+            .whereNotNull(
+                `${MobilePushInstallationsTableName}.encrypted_push_to_start_token`,
+            )
+            .whereNotNull(
+                `${MobilePushInstallationsTableName}.push_to_start_token_fingerprint`,
+            )
+            .where(
+                `${AiAgentLiveActivityStartAttemptsTableName}.attempt_count`,
+                '<',
+                args.maxAttempts,
+            )
+            .whereRaw('?? = ??', [
+                `${MobilePushInstallationsTableName}.organization_uuid`,
+                `${AiThreadTableName}.organization_uuid`,
+            ])
+            .whereRaw('?? = ??', [
+                `${MobilePushInstallationsTableName}.user_uuid`,
+                `${AiPromptTableName}.created_by_user_uuid`,
+            ])
+            .orderBy(
+                `${MobilePushInstallationsTableName}.installation_uuid`,
+                'asc',
+            )
+            .limit(args.limit);
     }
 
     async deleteInstallation(args: {

--- a/packages/backend/src/ee/scheduler/SchedulerClient.test.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerClient.test.ts
@@ -248,3 +248,33 @@ describe('CommercialSchedulerClient.mobilePushLiveActivity', () => {
         );
     });
 });
+
+describe('CommercialSchedulerClient.mobilePushLiveActivityStart', () => {
+    it('uses a stable attempt key and a bounded retry policy', async () => {
+        const addJob = vi.fn().mockResolvedValue({ id: 'job-1' });
+        const client = Object.create(
+            CommercialSchedulerClient.prototype,
+        ) as CommercialSchedulerClient;
+        client.graphileUtils = Promise.resolve({ addJob } as AnyType);
+        const payload = {
+            liveActivityStartAttemptUuid: 'attempt-1',
+            organizationUuid: 'organization-1',
+            projectUuid: 'project-1',
+            userUuid: 'user-1',
+        };
+        const runAt = new Date('2026-08-31T12:00:00.000Z');
+
+        await client.mobilePushLiveActivityStart(payload, runAt);
+
+        expect(addJob).toHaveBeenCalledWith(
+            EE_SCHEDULER_TASKS.MOBILE_PUSH_LIVE_ACTIVITY_START,
+            payload,
+            {
+                runAt,
+                maxAttempts: 5,
+                jobKey: 'mobile-push-live-activity-start:attempt-1',
+                priority: JobPriority.MEDIUM,
+            },
+        );
+    });
+});

--- a/packages/backend/src/ee/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerClient.ts
@@ -18,7 +18,9 @@ import {
     GenerateArtifactQuestionJobPayload,
     IngestExternalSourceJobPayload,
     JobPriority,
+    MOBILE_PUSH_LIVE_ACTIVITY_START_MAX_ATTEMPTS,
     MobilePushLiveActivityJobPayload,
+    MobilePushLiveActivityStartJobPayload,
     PublishAnnouncementPayload,
     SlackPromptJobPayload,
 } from '@lightdash/common';
@@ -58,6 +60,24 @@ export const aiAgentMemoryDistillEventRunAt = (now: Date): Date =>
     new Date(now.getTime() + MEMORY_DISTILL_EVENT_DEBOUNCE_MS);
 
 export class CommercialSchedulerClient extends SchedulerClient {
+    async mobilePushLiveActivityStart(
+        payload: MobilePushLiveActivityStartJobPayload,
+        runAt: Date = new Date(),
+    ) {
+        const graphileClient = await this.graphileUtils;
+        const { id: jobId } = await graphileClient.addJob(
+            EE_SCHEDULER_TASKS.MOBILE_PUSH_LIVE_ACTIVITY_START,
+            payload,
+            {
+                runAt,
+                maxAttempts: MOBILE_PUSH_LIVE_ACTIVITY_START_MAX_ATTEMPTS,
+                jobKey: `mobile-push-live-activity-start:${payload.liveActivityStartAttemptUuid}`,
+                priority: JobPriority.MEDIUM,
+            },
+        );
+        return { jobId };
+    }
+
     async mobilePushLiveActivity(
         payload: MobilePushLiveActivityJobPayload,
         runAt: Date = new Date(),

--- a/packages/backend/src/ee/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.ts
@@ -136,7 +136,9 @@ type CommercialSchedulerWorkerArguments = SchedulerWorkerArguments & {
     >;
     mobilePushNotificationService: Pick<
         MobilePushNotificationService,
-        'reconcileLiveActivity' | 'sweepLiveActivities'
+        | 'deliverLiveActivityStart'
+        | 'reconcileLiveActivity'
+        | 'sweepLiveActivities'
     >;
 };
 
@@ -858,6 +860,22 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                     async () => {
                         await this.mobilePushNotificationService.reconcileLiveActivity(
                             payload.liveActivityUuid,
+                        );
+                    },
+                );
+            },
+            [EE_SCHEDULER_TASKS.MOBILE_PUSH_LIVE_ACTIVITY_START]: async (
+                payload,
+                helpers,
+            ) => {
+                await SchedulerClient.processJob(
+                    EE_SCHEDULER_TASKS.MOBILE_PUSH_LIVE_ACTIVITY_START,
+                    helpers.job.id,
+                    helpers.job.run_at,
+                    payload,
+                    async () => {
+                        await this.mobilePushNotificationService.deliverLiveActivityStart(
+                            payload.liveActivityStartAttemptUuid,
                         );
                     },
                 );

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -629,7 +629,7 @@ type AiAgentServiceDependencies = {
     prometheusMetrics?: PrometheusMetrics;
     mobilePushNotificationService?: Pick<
         MobilePushNotificationService,
-        'enqueueThreadReconciliation'
+        'enqueueThreadReconciliation' | 'startLiveActivitiesForPrompt'
     >;
 };
 
@@ -1460,6 +1460,26 @@ export class AiAgentService extends BaseService {
                     error,
                 );
             });
+    }
+
+    private async startMobilePushLiveActivitiesForPrompt(args: {
+        user: SessionUser;
+        projectUuid: string;
+        agentUuid: string;
+        threadUuid: string;
+        promptUuid: string;
+        originatingInstallationUuid: string | undefined;
+    }): Promise<void> {
+        try {
+            await this.mobilePushNotificationService?.startLiveActivitiesForPrompt(
+                args,
+            );
+        } catch (error) {
+            Logger.error(
+                'Failed to enqueue mobile push Live Activity starts',
+                error,
+            );
+        }
     }
 
     /**
@@ -3497,7 +3517,7 @@ export class AiAgentService extends BaseService {
             undefined;
 
         if (body.prompt) {
-            await this.aiAgentModel.createWebAppPrompt({
+            const promptUuid = await this.aiAgentModel.createWebAppPrompt({
                 threadUuid,
                 createdByUserUuid: user.userUuid,
                 prompt: body.prompt,
@@ -3505,6 +3525,17 @@ export class AiAgentService extends BaseService {
                 modelConfig,
             });
             this.enqueueMobilePushThreadReconciliation(threadUuid);
+            if (createdFrom === 'web_app') {
+                await this.startMobilePushLiveActivitiesForPrompt({
+                    user,
+                    projectUuid: agent.projectUuid,
+                    agentUuid,
+                    threadUuid,
+                    promptUuid,
+                    originatingInstallationUuid:
+                        body.originatingInstallationUuid,
+                });
+            }
 
             this.analytics.track<AiAgentPromptCreatedEvent>({
                 event: 'ai_agent_prompt.created',
@@ -3645,6 +3676,14 @@ export class AiAgentService extends BaseService {
             hidden: body.hidden,
         });
         this.enqueueMobilePushThreadReconciliation(threadUuid);
+        await this.startMobilePushLiveActivitiesForPrompt({
+            user,
+            projectUuid: agent.projectUuid,
+            agentUuid,
+            threadUuid,
+            promptUuid: messageUuid,
+            originatingInstallationUuid: body.originatingInstallationUuid,
+        });
 
         this.analytics.track<AiAgentPromptCreatedEvent>({
             event: 'ai_agent_prompt.created',

--- a/packages/backend/src/ee/services/AiAgentService/mobilePushStartEnqueue.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/mobilePushStartEnqueue.test.ts
@@ -1,0 +1,132 @@
+import { type SessionUser } from '@lightdash/common';
+import { AiAgentService } from './AiAgentService';
+
+const organizationUuid = 'organization-uuid';
+const userUuid = 'user-uuid';
+const projectUuid = 'project-uuid';
+const agentUuid = 'agent-uuid';
+const threadUuid = 'thread-uuid';
+const promptUuid = 'prompt-uuid';
+const originUuid = '10000000-0000-4000-8000-000000000003';
+
+const user = { organizationUuid, userUuid } as SessionUser;
+
+const buildService = () => {
+    const createWebAppThread = vi.fn(async () => threadUuid);
+    const createWebAppPrompt = vi.fn(async () => promptUuid);
+    const getThread = vi.fn(async () => ({
+        uuid: threadUuid,
+        user: { uuid: userUuid },
+    }));
+    const findThreadMessage = vi.fn(async () => ({ uuid: promptUuid }));
+    const startLiveActivitiesForPrompt = vi.fn(async () => undefined);
+    const enqueueThreadReconciliation = vi.fn(async () => undefined);
+    const service = new AiAgentService({
+        aiAgentModel: {
+            getAgent: vi.fn(async () => ({
+                uuid: agentUuid,
+                projectUuid,
+                modelConfig: undefined,
+            })),
+            createWebAppThread,
+            createWebAppPrompt,
+            getThread,
+            findThreadMessage,
+        },
+        aiOrganizationSettingsService: {
+            getDefaultModelConfig: vi.fn(async () => undefined),
+        },
+        mobilePushNotificationService: {
+            startLiveActivitiesForPrompt,
+            enqueueThreadReconciliation,
+        },
+        analytics: { track: vi.fn() },
+    } as unknown as ConstructorParameters<typeof AiAgentService>[0]);
+    Object.assign(service, {
+        getIsCopilotEnabled: vi.fn(async () => true),
+        checkAgentAccess: vi.fn(async () => true),
+        checkAgentThreadAccess: vi.fn(async () => true),
+        validatePromptContextAccess: vi.fn(async () => undefined),
+    });
+
+    return {
+        service,
+        createWebAppPrompt,
+        startLiveActivitiesForPrompt,
+    };
+};
+
+describe('AiAgentService mobile push-to-start enqueue', () => {
+    it('starts after a web thread prompt is persisted and forwards its origin', async () => {
+        const { service, createWebAppPrompt, startLiveActivitiesForPrompt } =
+            buildService();
+
+        await service.createAgentThread(user, agentUuid, {
+            prompt: 'private prompt text',
+            originatingInstallationUuid: originUuid,
+        });
+
+        expect(createWebAppPrompt).toHaveBeenCalledBefore(
+            startLiveActivitiesForPrompt,
+        );
+        expect(startLiveActivitiesForPrompt).toHaveBeenCalledWith({
+            user,
+            projectUuid,
+            agentUuid,
+            threadUuid,
+            promptUuid,
+            originatingInstallationUuid: originUuid,
+        });
+        expect(
+            JSON.stringify(startLiveActivitiesForPrompt.mock.calls),
+        ).not.toContain('private prompt text');
+    });
+
+    it('does not start for a non-web thread origin', async () => {
+        const { service, startLiveActivitiesForPrompt } = buildService();
+
+        await service.createAgentThread(
+            user,
+            agentUuid,
+            { prompt: 'scheduled prompt' },
+            'scheduler',
+        );
+
+        expect(startLiveActivitiesForPrompt).not.toHaveBeenCalled();
+    });
+
+    it('starts after an appended web message is persisted', async () => {
+        const { service, createWebAppPrompt, startLiveActivitiesForPrompt } =
+            buildService();
+
+        await service.createAgentThreadMessage(user, agentUuid, threadUuid, {
+            prompt: 'private appended prompt',
+            originatingInstallationUuid: originUuid,
+        });
+
+        expect(createWebAppPrompt).toHaveBeenCalledBefore(
+            startLiveActivitiesForPrompt,
+        );
+        expect(startLiveActivitiesForPrompt).toHaveBeenCalledWith({
+            user,
+            projectUuid,
+            agentUuid,
+            threadUuid,
+            promptUuid,
+            originatingInstallationUuid: originUuid,
+        });
+    });
+
+    it('keeps prompt creation successful when remote starts are unavailable', async () => {
+        const { service, startLiveActivitiesForPrompt } = buildService();
+        startLiveActivitiesForPrompt.mockRejectedValueOnce(
+            new Error('scheduler unavailable'),
+        );
+
+        await expect(
+            service.createAgentThread(user, agentUuid, {
+                prompt: 'private prompt text',
+            }),
+        ).resolves.toEqual(expect.objectContaining({ uuid: threadUuid }));
+    });
+});

--- a/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationService.test.ts
+++ b/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationService.test.ts
@@ -18,6 +18,12 @@ const threadUuid = '00000000-0000-0000-0000-000000000006';
 const promptUuid = '00000000-0000-0000-0000-000000000007';
 const liveActivityUuid = '00000000-0000-0000-0000-000000000008';
 const liveActivityStartAttemptUuid = '00000000-0000-0000-0000-000000000009';
+const liveActivityPushToken =
+    '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+const pushToStartToken =
+    'ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789';
+const validDeviceToken =
+    'fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210';
 
 const installation = {
     mobilePushInstallationUuid: installationUuid,
@@ -164,7 +170,7 @@ const register = (
         liveActivityUuid,
         installationUuid,
         promptUuid,
-        pushToken: 'activity-token',
+        pushToken: liveActivityPushToken,
         ...overrides,
     });
 
@@ -186,7 +192,7 @@ describe('MobilePushNotificationService.registerLiveActivity', () => {
             agentUuid,
             threadUuid,
             promptUuid,
-            pushToken: 'activity-token',
+            pushToken: liveActivityPushToken,
         });
         expect(
             dependencies.scheduler.mobilePushLiveActivity,
@@ -212,7 +218,7 @@ describe('MobilePushNotificationService.registerLiveActivity', () => {
         });
         expect(
             JSON.stringify(dependencies.analytics.track.mock.calls),
-        ).not.toContain('activity-token');
+        ).not.toContain(liveActivityPushToken);
     });
 
     it('denies an installation registered to another user', async () => {
@@ -332,7 +338,7 @@ describe('MobilePushNotificationService.registerLiveActivity', () => {
         ).not.toHaveBeenCalled();
     });
 
-    it.each(['', 'x'.repeat(4097)])(
+    it.each(['', 'aa/bb', 'a'.repeat(513)])(
         'rejects an invalid Live Activity token before ownership lookup',
         async (pushToken) => {
             const dependencies = createDependencies();
@@ -359,7 +365,7 @@ describe('MobilePushNotificationService.registerPushToStartToken', () => {
         await service.registerPushToStartToken({
             user: { userUuid, organizationUuid },
             installationUuid,
-            pushToken: 'push-to-start-token',
+            pushToken: pushToStartToken,
         });
 
         expect(
@@ -369,11 +375,11 @@ describe('MobilePushNotificationService.registerPushToStartToken', () => {
             organizationUuid,
             userUuid,
             environment: 'sandbox',
-            pushToken: 'push-to-start-token',
+            pushToken: pushToStartToken,
         });
         expect(
             JSON.stringify(dependencies.analytics.track.mock.calls),
-        ).not.toContain('push-to-start-token');
+        ).not.toContain(pushToStartToken);
     });
 
     it.each([
@@ -391,7 +397,7 @@ describe('MobilePushNotificationService.registerPushToStartToken', () => {
             service.registerPushToStartToken({
                 user: { userUuid, organizationUuid },
                 installationUuid,
-                pushToken: 'push-to-start-token',
+                pushToken: pushToStartToken,
             }),
         ).rejects.toBeInstanceOf(NotFoundError);
         expect(
@@ -408,7 +414,7 @@ describe('MobilePushNotificationService.registerPushToStartToken', () => {
             service.registerPushToStartToken({
                 user: { userUuid, organizationUuid },
                 installationUuid,
-                pushToken: 'push-to-start-token',
+                pushToken: pushToStartToken,
             }),
         ).rejects.toBeInstanceOf(NotFoundError);
 
@@ -416,6 +422,29 @@ describe('MobilePushNotificationService.registerPushToStartToken', () => {
             dependencies.mobilePushNotificationStore.registerPushToStartToken,
         ).not.toHaveBeenCalled();
     });
+
+    it.each(['', 'aa/bb', 'a'.repeat(513)])(
+        'rejects an invalid token before installation lookup or storage',
+        async (pushToken) => {
+            const dependencies = createDependencies();
+            const service = new MobilePushNotificationService(dependencies);
+
+            await expect(
+                service.registerPushToStartToken({
+                    user: { userUuid, organizationUuid },
+                    installationUuid,
+                    pushToken,
+                }),
+            ).rejects.toBeInstanceOf(ParameterError);
+            expect(
+                dependencies.mobilePushNotificationStore.findInstallation,
+            ).not.toHaveBeenCalled();
+            expect(
+                dependencies.mobilePushNotificationStore
+                    .registerPushToStartToken,
+            ).not.toHaveBeenCalled();
+        },
+    );
 
     it('returns unavailable when mobile push is disabled', async () => {
         const dependencies = createDependencies();
@@ -449,7 +478,7 @@ describe('MobilePushNotificationService.registerPushToStartToken', () => {
             service.registerPushToStartToken({
                 user: { userUuid, organizationUuid },
                 installationUuid,
-                pushToken: 'push-to-start-token',
+                pushToken: pushToStartToken,
             }),
         ).rejects.toBeInstanceOf(NotFoundError);
     });
@@ -1080,7 +1109,7 @@ describe('MobilePushNotificationService installation lifecycle', () => {
             user: { userUuid, organizationUuid },
             installationUuid,
             environment: 'sandbox',
-            deviceToken: 'device-token',
+            deviceToken: validDeviceToken,
         });
 
         expect(
@@ -1090,7 +1119,7 @@ describe('MobilePushNotificationService installation lifecycle', () => {
             organizationUuid,
             userUuid,
             environment: 'sandbox',
-            deviceToken: 'device-token',
+            deviceToken: validDeviceToken,
         });
         expect(dependencies.analytics.track).toHaveBeenCalledWith({
             event: 'mobile_push.installation_registered',
@@ -1103,10 +1132,10 @@ describe('MobilePushNotificationService installation lifecycle', () => {
         });
         expect(
             JSON.stringify(dependencies.analytics.track.mock.calls),
-        ).not.toContain('device-token');
+        ).not.toContain(validDeviceToken);
     });
 
-    it.each(['', 'x'.repeat(4097)])(
+    it.each(['', 'aa/bb', 'a'.repeat(513)])(
         'rejects an invalid device token before storage',
         async (deviceToken) => {
             const dependencies = createDependencies();

--- a/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationService.test.ts
+++ b/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationService.test.ts
@@ -1,18 +1,23 @@
 import { NotFoundError, ParameterError } from '@lightdash/common';
+import { type ApnsClient } from '../../../clients/Apns/ApnsClient';
+import { type MobilePushNotificationsConfig } from '../../../config/parseConfig';
 import {
     MobilePushNotificationService,
     type MobilePushNotificationStore,
+    type MobilePushProjectStore,
     type MobilePushThreadStore,
 } from './MobilePushNotificationService';
 
 const organizationUuid = '00000000-0000-0000-0000-000000000001';
 const userUuid = '00000000-0000-0000-0000-000000000002';
 const installationUuid = '00000000-0000-0000-0000-000000000003';
+const validOriginUuid = '10000000-0000-4000-8000-000000000003';
 const projectUuid = '00000000-0000-0000-0000-000000000004';
 const agentUuid = '00000000-0000-0000-0000-000000000005';
 const threadUuid = '00000000-0000-0000-0000-000000000006';
 const promptUuid = '00000000-0000-0000-0000-000000000007';
 const liveActivityUuid = '00000000-0000-0000-0000-000000000008';
+const liveActivityStartAttemptUuid = '00000000-0000-0000-0000-000000000009';
 
 const installation = {
     mobilePushInstallationUuid: installationUuid,
@@ -40,13 +45,47 @@ const prompt = {
     createdByUserUuid: userUuid,
 };
 
+const claimedStartAttempt = {
+    liveActivityStartAttemptUuid,
+    liveActivityUuid,
+    installationUuid,
+    organizationUuid,
+    userUuid,
+    promptUuid,
+    environment: 'sandbox' as const,
+    pushToStartToken: 'push-to-start-token',
+    pushToStartTokenFingerprint: 'token-fingerprint',
+    status: 'processing' as const,
+    attemptCount: 1,
+};
+
 const createDependencies = () => {
     const mobilePushNotificationStore = {
-        findInstallation: vi.fn(async () => installation),
+        findInstallation: vi.fn<
+            MobilePushNotificationStore['findInstallation']
+        >(async () => installation),
         findLiveActivityOwner: vi.fn<
             MobilePushNotificationStore['findLiveActivityOwner']
         >(async () => undefined),
         upsertInstallation: vi.fn(async () => installation),
+        registerPushToStartToken: vi.fn<
+            MobilePushNotificationStore['registerPushToStartToken']
+        >(async () => true),
+        clearPushToStartTokenIfFingerprintMatches: vi.fn<
+            MobilePushNotificationStore['clearPushToStartTokenIfFingerprintMatches']
+        >(async () => true),
+        createLiveActivityStartAttempts: vi.fn<
+            MobilePushNotificationStore['createLiveActivityStartAttempts']
+        >(async () => []),
+        claimLiveActivityStartAttempt: vi.fn<
+            MobilePushNotificationStore['claimLiveActivityStartAttempt']
+        >(async () => undefined),
+        markLiveActivityStartAttempt: vi.fn<
+            MobilePushNotificationStore['markLiveActivityStartAttempt']
+        >(async () => true),
+        findLiveActivityStartAttemptsDue: vi.fn<
+            MobilePushNotificationStore['findLiveActivityStartAttemptsDue']
+        >(async () => []),
         deleteInstallation: vi.fn(async () => undefined),
         upsertLiveActivity: vi.fn(async () => undefined),
         deleteLiveActivity: vi.fn(async () => undefined),
@@ -58,6 +97,11 @@ const createDependencies = () => {
         >(async () => []),
     } satisfies MobilePushNotificationStore;
     const threadStore = {
+        getAgent: vi.fn<MobilePushThreadStore['getAgent']>(async () => ({
+            uuid: agentUuid,
+            organizationUuid,
+            projectUuid,
+        })),
         findThreadOwnership: vi.fn<
             MobilePushThreadStore['findThreadOwnership']
         >(async () => threadOwnership),
@@ -65,18 +109,30 @@ const createDependencies = () => {
             async () => prompt,
         ),
     } satisfies MobilePushThreadStore;
+    const projectStore = {
+        getSummary: vi.fn<MobilePushProjectStore['getSummary']>(async () => ({
+            projectUuid,
+            organizationUuid,
+        })),
+    } satisfies MobilePushProjectStore;
+
+    const mobilePushNotificationsConfig: MobilePushNotificationsConfig = {
+        enabled: true,
+        bundleId: 'com.lightdash.mobile',
+        teamId: 'TEAMID',
+        sandbox: { keyId: 'KEYID', privateKey: 'private-key' },
+        production: undefined,
+    };
 
     return {
         mobilePushNotificationStore,
         threadStore,
-        mobilePushNotificationsConfig: {
-            enabled: true,
-            bundleId: 'com.lightdash.mobile',
-            teamId: 'TEAMID',
-            sandbox: { keyId: 'KEYID', privateKey: 'private-key' },
-            production: undefined,
-        },
+        projectStore,
+        mobilePushNotificationsConfig,
         scheduler: {
+            mobilePushLiveActivityStart: vi.fn(async () => ({
+                jobId: 'start-job-uuid',
+            })),
             mobilePushLiveActivity: vi.fn(async () => ({
                 jobId: 'job-uuid',
             })),
@@ -87,6 +143,12 @@ const createDependencies = () => {
         analytics: {
             track: vi.fn(),
         },
+        apnsClient: {
+            sendLiveActivityStart: vi.fn<ApnsClient['sendLiveActivityStart']>(
+                async () => ({ status: 'sent' }),
+            ),
+        },
+        now: vi.fn(() => new Date('2026-08-31T12:00:00.000Z')),
     };
 };
 
@@ -289,7 +351,679 @@ describe('MobilePushNotificationService.registerLiveActivity', () => {
     );
 });
 
+describe('MobilePushNotificationService.registerPushToStartToken', () => {
+    it('rotates the token only on the exact owned installation', async () => {
+        const dependencies = createDependencies();
+        const service = new MobilePushNotificationService(dependencies);
+
+        await service.registerPushToStartToken({
+            user: { userUuid, organizationUuid },
+            installationUuid,
+            pushToken: 'push-to-start-token',
+        });
+
+        expect(
+            dependencies.mobilePushNotificationStore.registerPushToStartToken,
+        ).toHaveBeenCalledWith({
+            installationUuid,
+            organizationUuid,
+            userUuid,
+            environment: 'sandbox',
+            pushToken: 'push-to-start-token',
+        });
+        expect(
+            JSON.stringify(dependencies.analytics.track.mock.calls),
+        ).not.toContain('push-to-start-token');
+    });
+
+    it.each([
+        { ...installation, userUuid: 'foreign-user' },
+        { ...installation, organizationUuid: 'foreign-organization' },
+        undefined,
+    ])('denies a foreign or stale installation', async (foundInstallation) => {
+        const dependencies = createDependencies();
+        dependencies.mobilePushNotificationStore.findInstallation.mockResolvedValue(
+            foundInstallation,
+        );
+        const service = new MobilePushNotificationService(dependencies);
+
+        await expect(
+            service.registerPushToStartToken({
+                user: { userUuid, organizationUuid },
+                installationUuid,
+                pushToken: 'push-to-start-token',
+            }),
+        ).rejects.toBeInstanceOf(NotFoundError);
+        expect(
+            dependencies.mobilePushNotificationStore.registerPushToStartToken,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('returns unavailable for an unconfigured environment', async () => {
+        const dependencies = createDependencies();
+        dependencies.mobilePushNotificationsConfig.sandbox = undefined;
+        const service = new MobilePushNotificationService(dependencies);
+
+        await expect(
+            service.registerPushToStartToken({
+                user: { userUuid, organizationUuid },
+                installationUuid,
+                pushToken: 'push-to-start-token',
+            }),
+        ).rejects.toBeInstanceOf(NotFoundError);
+
+        expect(
+            dependencies.mobilePushNotificationStore.registerPushToStartToken,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('returns unavailable when mobile push is disabled', async () => {
+        const dependencies = createDependencies();
+        dependencies.mobilePushNotificationsConfig.enabled = false;
+        const service = new MobilePushNotificationService(dependencies);
+
+        await expect(
+            service.registerPushToStartToken({
+                user: { userUuid, organizationUuid },
+                installationUuid,
+                pushToken: 'push-to-start-token',
+            }),
+        ).rejects.toBeInstanceOf(NotFoundError);
+
+        expect(
+            dependencies.mobilePushNotificationStore.findInstallation,
+        ).not.toHaveBeenCalled();
+        expect(
+            dependencies.mobilePushNotificationStore.registerPushToStartToken,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('returns unavailable when ownership changes during registration', async () => {
+        const dependencies = createDependencies();
+        dependencies.mobilePushNotificationStore.registerPushToStartToken.mockResolvedValue(
+            false,
+        );
+        const service = new MobilePushNotificationService(dependencies);
+
+        await expect(
+            service.registerPushToStartToken({
+                user: { userUuid, organizationUuid },
+                installationUuid,
+                pushToken: 'push-to-start-token',
+            }),
+        ).rejects.toBeInstanceOf(NotFoundError);
+    });
+});
+
+describe('MobilePushNotificationService.startLiveActivitiesForPrompt', () => {
+    const start = (
+        service: MobilePushNotificationService,
+        originatingInstallationUuid?: string,
+    ) =>
+        service.startLiveActivitiesForPrompt({
+            user: { userUuid, organizationUuid },
+            projectUuid,
+            agentUuid,
+            threadUuid,
+            promptUuid,
+            originatingInstallationUuid,
+        });
+
+    it('starts every browser device in deterministic model order', async () => {
+        const dependencies = createDependencies();
+        dependencies.mobilePushNotificationStore.createLiveActivityStartAttempts.mockResolvedValue(
+            [
+                {
+                    liveActivityStartAttemptUuid: 'attempt-a',
+                    installationUuid: 'installation-a',
+                },
+                {
+                    liveActivityStartAttemptUuid: 'attempt-b',
+                    installationUuid: 'installation-b',
+                },
+            ],
+        );
+        const service = new MobilePushNotificationService(dependencies);
+
+        await start(service);
+
+        expect(
+            dependencies.mobilePushNotificationStore
+                .createLiveActivityStartAttempts,
+        ).toHaveBeenCalledWith({
+            organizationUuid,
+            userUuid,
+            promptUuid,
+            excludedMobilePushInstallationUuid: null,
+            environments: ['sandbox'],
+        });
+        expect(
+            dependencies.scheduler.mobilePushLiveActivityStart,
+        ).toHaveBeenNthCalledWith(1, {
+            liveActivityStartAttemptUuid: 'attempt-a',
+            organizationUuid,
+            projectUuid,
+            userUuid,
+        });
+        expect(
+            dependencies.scheduler.mobilePushLiveActivityStart,
+        ).toHaveBeenNthCalledWith(2, {
+            liveActivityStartAttemptUuid: 'attempt-b',
+            organizationUuid,
+            projectUuid,
+            userUuid,
+        });
+    });
+
+    it('does not schedule an installation without a push-to-start token', async () => {
+        const dependencies = createDependencies();
+        const service = new MobilePushNotificationService(dependencies);
+
+        await start(service);
+
+        expect(
+            dependencies.mobilePushNotificationStore
+                .createLiveActivityStartAttempts,
+        ).toHaveBeenCalled();
+        expect(
+            dependencies.scheduler.mobilePushLiveActivityStart,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('does not inspect prompts when APNs is not configured', async () => {
+        const dependencies = createDependencies();
+        dependencies.mobilePushNotificationsConfig.sandbox = undefined;
+        const service = new MobilePushNotificationService(dependencies);
+
+        await start(service);
+
+        expect(dependencies.projectStore.getSummary).not.toHaveBeenCalled();
+        expect(
+            dependencies.mobilePushNotificationStore
+                .createLiveActivityStartAttempts,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('does not inspect prompts when mobile push is disabled', async () => {
+        const dependencies = createDependencies();
+        dependencies.mobilePushNotificationsConfig.enabled = false;
+        const service = new MobilePushNotificationService(dependencies);
+
+        await start(service);
+
+        expect(dependencies.projectStore.getSummary).not.toHaveBeenCalled();
+        expect(
+            dependencies.mobilePushNotificationStore
+                .createLiveActivityStartAttempts,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('keeps a durable excluded origin and starts every other device', async () => {
+        const dependencies = createDependencies();
+        dependencies.mobilePushNotificationStore.findInstallation.mockResolvedValue(
+            {
+                ...installation,
+                mobilePushInstallationUuid: 'origin-internal-uuid',
+            },
+        );
+        dependencies.mobilePushNotificationStore.createLiveActivityStartAttempts.mockResolvedValue(
+            [
+                {
+                    liveActivityStartAttemptUuid: 'other-attempt',
+                    installationUuid: 'other-installation',
+                },
+            ],
+        );
+        const service = new MobilePushNotificationService(dependencies);
+
+        await start(service, validOriginUuid);
+
+        expect(
+            dependencies.mobilePushNotificationStore
+                .createLiveActivityStartAttempts,
+        ).toHaveBeenCalledWith(
+            expect.objectContaining({
+                excludedMobilePushInstallationUuid: 'origin-internal-uuid',
+            }),
+        );
+        expect(
+            dependencies.scheduler.mobilePushLiveActivityStart,
+        ).toHaveBeenCalledWith(
+            expect.objectContaining({
+                liveActivityStartAttemptUuid: 'other-attempt',
+            }),
+        );
+    });
+
+    it('ignores an invalid origin UUID without excluding a device', async () => {
+        const dependencies = createDependencies();
+        const service = new MobilePushNotificationService(dependencies);
+
+        await start(service, 'not-a-uuid');
+
+        expect(
+            dependencies.mobilePushNotificationStore.findInstallation,
+        ).not.toHaveBeenCalled();
+        expect(
+            dependencies.mobilePushNotificationStore
+                .createLiveActivityStartAttempts,
+        ).toHaveBeenCalledWith(
+            expect.objectContaining({
+                excludedMobilePushInstallationUuid: null,
+            }),
+        );
+    });
+
+    it.each([
+        ['deleted', undefined],
+        ['foreign', { ...installation, userUuid: 'foreign-user' }],
+        [
+            'transferred',
+            {
+                ...installation,
+                organizationUuid: 'new-organization',
+                userUuid: 'new-user',
+            },
+        ],
+    ])(
+        'ignores a %s origin without excluding another owned device',
+        async (_name, foundInstallation) => {
+            const dependencies = createDependencies();
+            dependencies.mobilePushNotificationStore.findInstallation.mockResolvedValue(
+                foundInstallation,
+            );
+            const service = new MobilePushNotificationService(dependencies);
+
+            await start(service, validOriginUuid);
+
+            expect(
+                dependencies.mobilePushNotificationStore.findInstallation,
+            ).toHaveBeenCalledWith(validOriginUuid);
+            expect(
+                dependencies.mobilePushNotificationStore
+                    .createLiveActivityStartAttempts,
+            ).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    excludedMobilePushInstallationUuid: null,
+                }),
+            );
+        },
+    );
+
+    it.each([
+        ['project organization', 'projectStore'],
+        ['agent project', 'agent'],
+        ['thread agent', 'thread'],
+        ['prompt user', 'prompt'],
+    ] as const)(
+        'does not create attempts when the %s ownership fact mismatches',
+        async (_name, mismatch) => {
+            const dependencies = createDependencies();
+            if (mismatch === 'projectStore') {
+                dependencies.projectStore.getSummary.mockResolvedValue({
+                    projectUuid,
+                    organizationUuid: 'foreign-organization',
+                });
+            }
+            if (mismatch === 'agent') {
+                dependencies.threadStore.getAgent.mockResolvedValue({
+                    uuid: agentUuid,
+                    organizationUuid,
+                    projectUuid: 'foreign-project',
+                });
+            }
+            if (mismatch === 'thread') {
+                dependencies.threadStore.findThreadOwnership.mockResolvedValue({
+                    ...threadOwnership,
+                    agentUuid: 'foreign-agent',
+                });
+            }
+            if (mismatch === 'prompt') {
+                dependencies.threadStore.findWebAppPrompt.mockResolvedValue({
+                    ...prompt,
+                    createdByUserUuid: 'foreign-user',
+                });
+            }
+            const service = new MobilePushNotificationService(dependencies);
+
+            await start(service);
+
+            expect(
+                dependencies.mobilePushNotificationStore
+                    .createLiveActivityStartAttempts,
+            ).not.toHaveBeenCalled();
+        },
+    );
+});
+
+describe('MobilePushNotificationService.deliverLiveActivityStart', () => {
+    it('allows only one concurrent claim to send to APNs', async () => {
+        const dependencies = createDependencies();
+        let status: 'pending' | 'processing' | 'sent' = 'pending';
+        dependencies.mobilePushNotificationStore.claimLiveActivityStartAttempt.mockImplementation(
+            async () => {
+                if (status !== 'pending') return undefined;
+                status = 'processing';
+                return claimedStartAttempt;
+            },
+        );
+        dependencies.mobilePushNotificationStore.markLiveActivityStartAttempt.mockImplementation(
+            async ({ status: nextStatus }) => {
+                if (status !== 'processing') return false;
+                status = nextStatus === 'sent' ? 'sent' : status;
+                return true;
+            },
+        );
+        const service = new MobilePushNotificationService(dependencies);
+
+        await Promise.all([
+            service.deliverLiveActivityStart(liveActivityStartAttemptUuid),
+            service.deliverLiveActivityStart(liveActivityStartAttemptUuid),
+        ]);
+
+        expect(
+            dependencies.apnsClient.sendLiveActivityStart,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+            dependencies.mobilePushNotificationStore
+                .markLiveActivityStartAttempt,
+        ).toHaveBeenCalledWith({
+            liveActivityStartAttemptUuid,
+            status: 'sent',
+            pushTokenFingerprint: 'token-fingerprint',
+            completedAt: new Date('2026-08-31T12:00:00.000Z'),
+        });
+    });
+
+    it('sends the exact owned prompt identifiers and five-minute stale date', async () => {
+        const dependencies = createDependencies();
+        dependencies.mobilePushNotificationStore.claimLiveActivityStartAttempt.mockResolvedValue(
+            claimedStartAttempt,
+        );
+        const service = new MobilePushNotificationService(dependencies);
+
+        await service.deliverLiveActivityStart(liveActivityStartAttemptUuid);
+
+        expect(
+            dependencies.apnsClient.sendLiveActivityStart,
+        ).toHaveBeenCalledWith({
+            environment: 'sandbox',
+            pushToStartToken: 'push-to-start-token',
+            liveActivityUuid,
+            payload: {
+                aps: {
+                    timestamp: 1788177600,
+                    event: 'start',
+                    'content-state': {
+                        state: 'working',
+                        projectUuid,
+                        agentUuid,
+                        threadUuid,
+                        promptUuid,
+                    },
+                    'stale-date': 1788177900,
+                    'attributes-type': 'AgentRunActivityAttributes',
+                    attributes: {
+                        liveActivityUuid,
+                        installationUuid,
+                        projectUuid,
+                        agentUuid,
+                        threadUuid,
+                        promptUuid,
+                        agentName: 'Agent',
+                        taskSummary: null,
+                    },
+                    'input-push-token': 1,
+                    alert: {
+                        title: 'Lightdash',
+                        body: 'Your agent is running.',
+                    },
+                },
+            },
+        });
+    });
+
+    it('retries a transient APNs failure with the stable activity identity', async () => {
+        const dependencies = createDependencies();
+        dependencies.mobilePushNotificationStore.claimLiveActivityStartAttempt
+            .mockResolvedValueOnce(claimedStartAttempt)
+            .mockResolvedValueOnce({
+                ...claimedStartAttempt,
+                pushToStartToken: 'rotated-push-to-start-token',
+                pushToStartTokenFingerprint: 'rotated-fingerprint',
+                attemptCount: 2,
+            });
+        dependencies.apnsClient.sendLiveActivityStart
+            .mockResolvedValueOnce({
+                status: 'retryable',
+                reason: 'TooManyRequests',
+            })
+            .mockResolvedValueOnce({ status: 'sent' });
+        const service = new MobilePushNotificationService(dependencies);
+
+        await expect(
+            service.deliverLiveActivityStart(liveActivityStartAttemptUuid),
+        ).rejects.toThrow('retryable');
+        await service.deliverLiveActivityStart(liveActivityStartAttemptUuid);
+
+        expect(
+            dependencies.apnsClient.sendLiveActivityStart.mock.calls.map(
+                ([args]) => args.liveActivityUuid,
+            ),
+        ).toEqual([liveActivityUuid, liveActivityUuid]);
+        expect(
+            dependencies.mobilePushNotificationStore
+                .markLiveActivityStartAttempt,
+        ).toHaveBeenNthCalledWith(1, {
+            liveActivityStartAttemptUuid,
+            status: 'retryable',
+            pushTokenFingerprint: 'token-fingerprint',
+            completedAt: null,
+        });
+        expect(
+            dependencies.mobilePushNotificationStore
+                .markLiveActivityStartAttempt,
+        ).toHaveBeenNthCalledWith(2, {
+            liveActivityStartAttemptUuid,
+            status: 'sent',
+            pushTokenFingerprint: 'rotated-fingerprint',
+            completedAt: new Date('2026-08-31T12:00:00.000Z'),
+        });
+    });
+
+    it('stops retrying at the explicit max-attempt policy', async () => {
+        const dependencies = createDependencies();
+        dependencies.mobilePushNotificationStore.claimLiveActivityStartAttempt.mockResolvedValue(
+            { ...claimedStartAttempt, attemptCount: 5 },
+        );
+        dependencies.apnsClient.sendLiveActivityStart.mockResolvedValue({
+            status: 'retryable',
+            reason: 'ServiceUnavailable',
+        });
+        const service = new MobilePushNotificationService(dependencies);
+
+        await service.deliverLiveActivityStart(liveActivityStartAttemptUuid);
+
+        expect(
+            dependencies.mobilePushNotificationStore
+                .markLiveActivityStartAttempt,
+        ).toHaveBeenCalledWith(expect.objectContaining({ status: 'failed' }));
+    });
+
+    it('does not reopen a sent attempt on later reconciliation', async () => {
+        const dependencies = createDependencies();
+        let status: 'pending' | 'processing' | 'sent' = 'pending';
+        dependencies.mobilePushNotificationStore.claimLiveActivityStartAttempt.mockImplementation(
+            async () => {
+                if (status !== 'pending') return undefined;
+                status = 'processing';
+                return claimedStartAttempt;
+            },
+        );
+        dependencies.mobilePushNotificationStore.markLiveActivityStartAttempt.mockImplementation(
+            async ({ status: nextStatus }) => {
+                if (status !== 'processing') return false;
+                status = nextStatus === 'sent' ? 'sent' : status;
+                return true;
+            },
+        );
+        const service = new MobilePushNotificationService(dependencies);
+
+        await service.deliverLiveActivityStart(liveActivityStartAttemptUuid);
+        await service.deliverLiveActivityStart(liveActivityStartAttemptUuid);
+
+        expect(
+            dependencies.apnsClient.sendLiveActivityStart,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+            dependencies.mobilePushNotificationStore
+                .markLiveActivityStartAttempt,
+        ).toHaveBeenCalledTimes(1);
+    });
+
+    it('clears an invalid token only when the attempted fingerprint still matches', async () => {
+        const dependencies = createDependencies();
+        dependencies.mobilePushNotificationStore.claimLiveActivityStartAttempt.mockResolvedValue(
+            claimedStartAttempt,
+        );
+        dependencies.apnsClient.sendLiveActivityStart.mockResolvedValue({
+            status: 'invalid_token',
+            reason: 'BadDeviceToken',
+        });
+        const service = new MobilePushNotificationService(dependencies);
+
+        await service.deliverLiveActivityStart(liveActivityStartAttemptUuid);
+
+        expect(
+            dependencies.mobilePushNotificationStore
+                .clearPushToStartTokenIfFingerprintMatches,
+        ).toHaveBeenCalledWith({
+            installationUuid,
+            organizationUuid,
+            userUuid,
+            pushTokenFingerprint: 'token-fingerprint',
+        });
+        expect(
+            dependencies.mobilePushNotificationStore
+                .markLiveActivityStartAttempt,
+        ).toHaveBeenCalledWith(expect.objectContaining({ status: 'failed' }));
+    });
+
+    it('preserves a concurrently rotated token and retries with its fingerprint', async () => {
+        const dependencies = createDependencies();
+        dependencies.mobilePushNotificationStore.claimLiveActivityStartAttempt.mockResolvedValue(
+            claimedStartAttempt,
+        );
+        dependencies.apnsClient.sendLiveActivityStart.mockResolvedValue({
+            status: 'invalid_token',
+            reason: 'Unregistered',
+        });
+        dependencies.mobilePushNotificationStore.clearPushToStartTokenIfFingerprintMatches.mockResolvedValue(
+            false,
+        );
+        const service = new MobilePushNotificationService(dependencies);
+
+        await expect(
+            service.deliverLiveActivityStart(liveActivityStartAttemptUuid),
+        ).rejects.toThrow('rotated during delivery');
+
+        expect(
+            dependencies.mobilePushNotificationStore
+                .markLiveActivityStartAttempt,
+        ).toHaveBeenCalledWith({
+            liveActivityStartAttemptUuid,
+            status: 'retryable',
+            pushTokenFingerprint: 'token-fingerprint',
+            completedAt: null,
+        });
+    });
+
+    it('revalidates ownership after the atomic claim', async () => {
+        const dependencies = createDependencies();
+        dependencies.mobilePushNotificationStore.claimLiveActivityStartAttempt.mockResolvedValue(
+            claimedStartAttempt,
+        );
+        dependencies.threadStore.findWebAppPrompt.mockResolvedValue({
+            ...prompt,
+            createdByUserUuid: 'foreign-user',
+        });
+        const service = new MobilePushNotificationService(dependencies);
+
+        await service.deliverLiveActivityStart(liveActivityStartAttemptUuid);
+
+        expect(
+            dependencies.apnsClient.sendLiveActivityStart,
+        ).not.toHaveBeenCalled();
+        expect(
+            dependencies.mobilePushNotificationStore
+                .markLiveActivityStartAttempt,
+        ).toHaveBeenCalledWith(expect.objectContaining({ status: 'failed' }));
+    });
+});
+
 describe('MobilePushNotificationService reconciliation scheduling', () => {
+    it.each(['query', 'scheduler'] as const)(
+        'enqueues existing reconciliations before a start-attempt %s failure',
+        async (failurePoint) => {
+            const dependencies = createDependencies();
+            dependencies.mobilePushNotificationStore.findLiveActivitiesDueForReconciliation.mockResolvedValue(
+                [
+                    {
+                        liveActivityUuid,
+                        organizationUuid,
+                        projectUuid,
+                        userUuid,
+                    },
+                ],
+            );
+            if (failurePoint === 'query') {
+                dependencies.mobilePushNotificationStore.findLiveActivityStartAttemptsDue.mockRejectedValue(
+                    new Error('start query unavailable'),
+                );
+            } else {
+                dependencies.mobilePushNotificationStore.findLiveActivityStartAttemptsDue.mockResolvedValue(
+                    [
+                        {
+                            liveActivityStartAttemptUuid,
+                            installationUuid,
+                            organizationUuid,
+                            projectUuid,
+                            userUuid,
+                        },
+                    ],
+                );
+                dependencies.scheduler.mobilePushLiveActivityStart.mockRejectedValue(
+                    new Error('start scheduler unavailable'),
+                );
+            }
+            const service = new MobilePushNotificationService(dependencies);
+
+            await expect(service.sweepLiveActivities()).rejects.toThrow(
+                failurePoint === 'query'
+                    ? 'start query unavailable'
+                    : 'start scheduler unavailable',
+            );
+
+            expect(
+                dependencies.scheduler.mobilePushLiveActivity,
+            ).toHaveBeenCalledWith({
+                liveActivityUuid,
+                organizationUuid,
+                projectUuid,
+                userUuid,
+            });
+            const startFailureCall =
+                failurePoint === 'query'
+                    ? dependencies.mobilePushNotificationStore
+                          .findLiveActivityStartAttemptsDue
+                    : dependencies.scheduler.mobilePushLiveActivityStart;
+            expect(
+                dependencies.scheduler.mobilePushLiveActivity.mock
+                    .invocationCallOrder[0],
+            ).toBeLessThan(startFailureCall.mock.invocationCallOrder[0]);
+        },
+    );
+
     it('enqueues every active activity for a changed thread', async () => {
         const dependencies = createDependencies();
         dependencies.mobilePushNotificationStore.findActiveLiveActivitiesForThread.mockResolvedValue(

--- a/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationService.ts
+++ b/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationService.ts
@@ -1,8 +1,18 @@
-import { NotFoundError, ParameterError } from '@lightdash/common';
+import {
+    MOBILE_PUSH_LIVE_ACTIVITY_START_MAX_ATTEMPTS,
+    NotFoundError,
+    ParameterError,
+} from '@lightdash/common';
+import { validate as isValidUuid } from 'uuid';
 import {
     type LightdashAnalytics,
     type MobilePushNotificationEvent,
 } from '../../../analytics/LightdashAnalytics';
+import {
+    buildLiveActivityStartPayload,
+    type ApnsDeliveryResult,
+    type LiveActivityStartPayload,
+} from '../../../clients/Apns/ApnsClient';
 import { type MobilePushNotificationsConfig } from '../../../config/parseConfig';
 import Logger from '../../../logging/logger';
 import { type MobilePushEnvironment } from '../../database/entities/mobilePushNotifications';
@@ -36,6 +46,34 @@ type MobilePushPrompt = {
     threadUuid: string;
     agentUuid: string | null;
     createdByUserUuid: string;
+};
+
+type LiveActivityStartAttempt = {
+    liveActivityStartAttemptUuid: string;
+    liveActivityUuid: string;
+    installationUuid: string;
+    organizationUuid: string;
+    userUuid: string;
+    promptUuid: string;
+    environment: MobilePushEnvironment;
+    pushToStartToken: string | null;
+    pushToStartTokenFingerprint: string | null;
+    status:
+        | 'excluded'
+        | 'pending'
+        | 'processing'
+        | 'retryable'
+        | 'sent'
+        | 'failed';
+    attemptCount: number;
+};
+
+type SchedulableLiveActivityStartAttempt = {
+    liveActivityStartAttemptUuid: string;
+    installationUuid: string;
+    organizationUuid: string;
+    projectUuid: string;
+    userUuid: string;
 };
 
 type UpsertLiveActivity = {
@@ -73,6 +111,49 @@ export type MobilePushNotificationStore = {
         environment: MobilePushEnvironment;
         deviceToken: string;
     }): Promise<MobilePushInstallation>;
+    registerPushToStartToken(args: {
+        installationUuid: string;
+        organizationUuid: string;
+        userUuid: string;
+        environment: MobilePushEnvironment;
+        pushToken: string;
+    }): Promise<boolean>;
+    clearPushToStartTokenIfFingerprintMatches(args: {
+        installationUuid: string;
+        organizationUuid: string;
+        userUuid: string;
+        pushTokenFingerprint: string;
+    }): Promise<boolean>;
+    createLiveActivityStartAttempts(args: {
+        organizationUuid: string;
+        userUuid: string;
+        promptUuid: string;
+        excludedMobilePushInstallationUuid: string | null;
+        environments: MobilePushEnvironment[];
+    }): Promise<
+        Pick<
+            SchedulableLiveActivityStartAttempt,
+            'liveActivityStartAttemptUuid' | 'installationUuid'
+        >[]
+    >;
+    claimLiveActivityStartAttempt(args: {
+        liveActivityStartAttemptUuid: string;
+        attemptedAt: Date;
+        retryProcessingBefore: Date;
+        maxAttempts: number;
+    }): Promise<LiveActivityStartAttempt | undefined>;
+    markLiveActivityStartAttempt(args: {
+        liveActivityStartAttemptUuid: string;
+        status: 'retryable' | 'sent' | 'failed';
+        pushTokenFingerprint: string | null;
+        completedAt: Date | null;
+    }): Promise<boolean>;
+    findLiveActivityStartAttemptsDue(args: {
+        retryProcessingBefore: Date;
+        environments: MobilePushEnvironment[];
+        limit: number;
+        maxAttempts: number;
+    }): Promise<SchedulableLiveActivityStartAttempt[]>;
     deleteInstallation(args: {
         installationUuid: string;
         organizationUuid: string;
@@ -98,6 +179,15 @@ export type MobilePushNotificationStore = {
 };
 
 export type MobilePushThreadStore = {
+    getAgent(args: {
+        organizationUuid: string;
+        projectUuid?: string;
+        agentUuid: string;
+    }): Promise<{
+        uuid: string;
+        organizationUuid: string;
+        projectUuid: string;
+    }>;
     findThreadOwnership(args: {
         organizationUuid: string;
         threadUuid: string;
@@ -105,20 +195,45 @@ export type MobilePushThreadStore = {
     findWebAppPrompt(promptUuid: string): Promise<MobilePushPrompt | undefined>;
 };
 
+export type MobilePushProjectStore = {
+    getSummary(projectUuid: string): Promise<{
+        projectUuid: string;
+        organizationUuid: string;
+    }>;
+};
+
+type MobilePushStartApnsClient = {
+    sendLiveActivityStart(args: {
+        environment: MobilePushEnvironment;
+        pushToStartToken: string;
+        liveActivityUuid: string;
+        payload: LiveActivityStartPayload;
+    }): Promise<ApnsDeliveryResult>;
+};
+
 type MobilePushNotificationServiceDependencies = {
     mobilePushNotificationStore: MobilePushNotificationStore;
     threadStore: MobilePushThreadStore;
+    projectStore: MobilePushProjectStore;
     mobilePushNotificationsConfig: MobilePushNotificationsConfig;
     scheduler: {
         mobilePushLiveActivity(
             payload: SchedulableLiveActivity,
             runAt?: Date,
         ): Promise<unknown>;
+        mobilePushLiveActivityStart(payload: {
+            liveActivityStartAttemptUuid: string;
+            organizationUuid: string;
+            projectUuid: string;
+            userUuid: string;
+        }): Promise<unknown>;
     };
     reconciler: {
         reconcileLiveActivity(liveActivityUuid: string): Promise<void>;
     };
     analytics: Pick<LightdashAnalytics, 'track'>;
+    apnsClient: MobilePushStartApnsClient;
+    now?: () => Date;
 };
 
 type RegisterLiveActivity = {
@@ -138,10 +253,15 @@ const validatePushToken = (pushToken: string): void => {
     }
 };
 
+const LIVE_ACTIVITY_START_STALE_AFTER_MS = 5 * 60 * 1000;
+const LIVE_ACTIVITY_START_PROCESSING_LEASE_MS = 5 * 60 * 1000;
+
 export class MobilePushNotificationService {
     private readonly mobilePushNotificationStore: MobilePushNotificationStore;
 
     private readonly threadStore: MobilePushThreadStore;
+
+    private readonly projectStore: MobilePushProjectStore;
 
     private readonly config: MobilePushNotificationsConfig;
 
@@ -151,14 +271,21 @@ export class MobilePushNotificationService {
 
     private readonly analytics: MobilePushNotificationServiceDependencies['analytics'];
 
+    private readonly apnsClient: MobilePushStartApnsClient;
+
+    private readonly now: () => Date;
+
     constructor(dependencies: MobilePushNotificationServiceDependencies) {
         this.mobilePushNotificationStore =
             dependencies.mobilePushNotificationStore;
         this.threadStore = dependencies.threadStore;
+        this.projectStore = dependencies.projectStore;
         this.config = dependencies.mobilePushNotificationsConfig;
         this.scheduler = dependencies.scheduler;
         this.reconciler = dependencies.reconciler;
         this.analytics = dependencies.analytics;
+        this.apnsClient = dependencies.apnsClient;
+        this.now = dependencies.now ?? (() => new Date());
     }
 
     private track(event: MobilePushNotificationEvent): void {
@@ -185,6 +312,77 @@ export class MobilePushNotificationService {
             enabled: this.config.enabled,
             environments: this.config.enabled ? environments : [],
         };
+    }
+
+    private getConfiguredEnvironments(): MobilePushEnvironment[] {
+        return (['sandbox', 'production'] as const).filter(
+            (environment) => this.config[environment] !== undefined,
+        );
+    }
+
+    private async hasExactPromptOwnership(args: {
+        organizationUuid: string;
+        projectUuid: string;
+        agentUuid: string;
+        threadUuid: string;
+        promptUuid: string;
+        userUuid: string;
+    }): Promise<boolean> {
+        try {
+            const [project, agent, ownership, prompt] = await Promise.all([
+                this.projectStore.getSummary(args.projectUuid),
+                this.threadStore.getAgent({
+                    organizationUuid: args.organizationUuid,
+                    projectUuid: args.projectUuid,
+                    agentUuid: args.agentUuid,
+                }),
+                this.threadStore.findThreadOwnership({
+                    organizationUuid: args.organizationUuid,
+                    threadUuid: args.threadUuid,
+                }),
+                this.threadStore.findWebAppPrompt(args.promptUuid),
+            ]);
+
+            return (
+                project.projectUuid === args.projectUuid &&
+                project.organizationUuid === args.organizationUuid &&
+                agent.uuid === args.agentUuid &&
+                agent.organizationUuid === args.organizationUuid &&
+                agent.projectUuid === args.projectUuid &&
+                ownership?.threadUuid === args.threadUuid &&
+                ownership.projectUuid === args.projectUuid &&
+                ownership.agentUuid === args.agentUuid &&
+                ownership.ownerUserUuid === args.userUuid &&
+                ownership.createdFrom === 'web_app' &&
+                !ownership.ownerIsServiceAccount &&
+                prompt?.organizationUuid === args.organizationUuid &&
+                prompt.projectUuid === args.projectUuid &&
+                prompt.agentUuid === args.agentUuid &&
+                prompt.threadUuid === args.threadUuid &&
+                prompt.promptUuid === args.promptUuid &&
+                prompt.createdByUserUuid === args.userUuid
+            );
+        } catch {
+            return false;
+        }
+    }
+
+    private async scheduleLiveActivityStartAttempts(
+        attempts: SchedulableLiveActivityStartAttempt[],
+    ): Promise<void> {
+        await attempts.reduce<Promise<void>>(
+            (previous, attempt) =>
+                previous.then(async () => {
+                    await this.scheduler.mobilePushLiveActivityStart({
+                        liveActivityStartAttemptUuid:
+                            attempt.liveActivityStartAttemptUuid,
+                        organizationUuid: attempt.organizationUuid,
+                        projectUuid: attempt.projectUuid,
+                        userUuid: attempt.userUuid,
+                    });
+                }),
+            Promise.resolve(),
+        );
     }
 
     async registerInstallation(args: {
@@ -219,6 +417,106 @@ export class MobilePushNotificationService {
                 environment: args.environment,
             },
         });
+    }
+
+    async registerPushToStartToken(args: {
+        user: MobilePushUser;
+        installationUuid: string;
+        pushToken: string;
+    }): Promise<void> {
+        if (!this.config.enabled) {
+            throw new NotFoundError('Mobile push registration not found');
+        }
+        validatePushToken(args.pushToken);
+        const { organizationUuid } = args.user;
+        if (organizationUuid == null) {
+            throw new NotFoundError('Mobile push registration not found');
+        }
+
+        const installation =
+            await this.mobilePushNotificationStore.findInstallation(
+                args.installationUuid,
+            );
+        if (
+            installation?.organizationUuid !== organizationUuid ||
+            installation.userUuid !== args.user.userUuid
+        ) {
+            throw new NotFoundError('Mobile push registration not found');
+        }
+        if (this.config[installation.environment] === undefined) {
+            throw new NotFoundError('Mobile push registration not found');
+        }
+
+        const registered =
+            await this.mobilePushNotificationStore.registerPushToStartToken({
+                installationUuid: args.installationUuid,
+                organizationUuid,
+                userUuid: args.user.userUuid,
+                environment: installation.environment,
+                pushToken: args.pushToken,
+            });
+        if (!registered) {
+            throw new NotFoundError('Mobile push registration not found');
+        }
+    }
+
+    async startLiveActivitiesForPrompt(args: {
+        user: MobilePushUser;
+        projectUuid: string;
+        agentUuid: string;
+        threadUuid: string;
+        promptUuid: string;
+        originatingInstallationUuid: string | undefined;
+    }): Promise<void> {
+        if (!this.config.enabled) return;
+        const { organizationUuid } = args.user;
+        if (organizationUuid == null) return;
+        const environments = this.getConfiguredEnvironments();
+        if (environments.length === 0) return;
+        if (
+            !(await this.hasExactPromptOwnership({
+                organizationUuid,
+                projectUuid: args.projectUuid,
+                agentUuid: args.agentUuid,
+                threadUuid: args.threadUuid,
+                promptUuid: args.promptUuid,
+                userUuid: args.user.userUuid,
+            }))
+        ) {
+            return;
+        }
+
+        const originInstallation =
+            args.originatingInstallationUuid !== undefined &&
+            isValidUuid(args.originatingInstallationUuid)
+                ? await this.mobilePushNotificationStore.findInstallation(
+                      args.originatingInstallationUuid,
+                  )
+                : undefined;
+        const excludedMobilePushInstallationUuid =
+            originInstallation?.organizationUuid === organizationUuid &&
+            originInstallation.userUuid === args.user.userUuid
+                ? originInstallation.mobilePushInstallationUuid
+                : null;
+        const attempts =
+            await this.mobilePushNotificationStore.createLiveActivityStartAttempts(
+                {
+                    organizationUuid,
+                    userUuid: args.user.userUuid,
+                    promptUuid: args.promptUuid,
+                    excludedMobilePushInstallationUuid,
+                    environments,
+                },
+            );
+
+        await this.scheduleLiveActivityStartAttempts(
+            attempts.map((attempt) => ({
+                ...attempt,
+                organizationUuid,
+                projectUuid: args.projectUuid,
+                userUuid: args.user.userUuid,
+            })),
+        );
     }
 
     async revokeInstallation(args: {
@@ -282,11 +580,166 @@ export class MobilePushNotificationService {
                 this.scheduler.mobilePushLiveActivity(activity),
             ),
         );
+        const startAttempts =
+            await this.mobilePushNotificationStore.findLiveActivityStartAttemptsDue(
+                {
+                    retryProcessingBefore: new Date(
+                        now.getTime() - LIVE_ACTIVITY_START_PROCESSING_LEASE_MS,
+                    ),
+                    environments: this.getConfiguredEnvironments(),
+                    limit: 500,
+                    maxAttempts: MOBILE_PUSH_LIVE_ACTIVITY_START_MAX_ATTEMPTS,
+                },
+            );
+        await this.scheduleLiveActivityStartAttempts(startAttempts);
     }
 
     async reconcileLiveActivity(liveActivityUuid: string): Promise<void> {
         if (!this.config.enabled) return;
         await this.reconciler.reconcileLiveActivity(liveActivityUuid);
+    }
+
+    async deliverLiveActivityStart(
+        liveActivityStartAttemptUuid: string,
+    ): Promise<void> {
+        if (!this.config.enabled) return;
+        const attemptedAt = this.now();
+        const attempt =
+            await this.mobilePushNotificationStore.claimLiveActivityStartAttempt(
+                {
+                    liveActivityStartAttemptUuid,
+                    attemptedAt,
+                    retryProcessingBefore: new Date(
+                        attemptedAt.getTime() -
+                            LIVE_ACTIVITY_START_PROCESSING_LEASE_MS,
+                    ),
+                    maxAttempts: MOBILE_PUSH_LIVE_ACTIVITY_START_MAX_ATTEMPTS,
+                },
+            );
+        if (attempt === undefined) return;
+
+        const prompt = await this.threadStore.findWebAppPrompt(
+            attempt.promptUuid,
+        );
+        if (
+            prompt === undefined ||
+            prompt.agentUuid === null ||
+            !(await this.hasExactPromptOwnership({
+                organizationUuid: attempt.organizationUuid,
+                projectUuid: prompt.projectUuid,
+                agentUuid: prompt.agentUuid,
+                threadUuid: prompt.threadUuid,
+                promptUuid: prompt.promptUuid,
+                userUuid: attempt.userUuid,
+            })) ||
+            attempt.pushToStartToken === null ||
+            attempt.pushToStartTokenFingerprint === null ||
+            this.config[attempt.environment] === undefined
+        ) {
+            await this.mobilePushNotificationStore.markLiveActivityStartAttempt(
+                {
+                    liveActivityStartAttemptUuid,
+                    status: 'failed',
+                    pushTokenFingerprint: attempt.pushToStartTokenFingerprint,
+                    completedAt: attemptedAt,
+                },
+            );
+            return;
+        }
+
+        const payload = buildLiveActivityStartPayload({
+            timestamp: attemptedAt,
+            staleAt: new Date(
+                attemptedAt.getTime() + LIVE_ACTIVITY_START_STALE_AFTER_MS,
+            ),
+            liveActivityUuid: attempt.liveActivityUuid,
+            installationUuid: attempt.installationUuid,
+            projectUuid: prompt.projectUuid,
+            agentUuid: prompt.agentUuid,
+            threadUuid: prompt.threadUuid,
+            promptUuid: prompt.promptUuid,
+        });
+        const result = await this.apnsClient.sendLiveActivityStart({
+            environment: attempt.environment,
+            pushToStartToken: attempt.pushToStartToken,
+            liveActivityUuid: attempt.liveActivityUuid,
+            payload,
+        });
+
+        if (result.status === 'sent') {
+            await this.mobilePushNotificationStore.markLiveActivityStartAttempt(
+                {
+                    liveActivityStartAttemptUuid,
+                    status: 'sent',
+                    pushTokenFingerprint: attempt.pushToStartTokenFingerprint,
+                    completedAt: attemptedAt,
+                },
+            );
+            return;
+        }
+
+        if (result.status === 'invalid_token') {
+            const cleared =
+                await this.mobilePushNotificationStore.clearPushToStartTokenIfFingerprintMatches(
+                    {
+                        installationUuid: attempt.installationUuid,
+                        organizationUuid: attempt.organizationUuid,
+                        userUuid: attempt.userUuid,
+                        pushTokenFingerprint:
+                            attempt.pushToStartTokenFingerprint,
+                    },
+                );
+            if (
+                cleared ||
+                attempt.attemptCount >=
+                    MOBILE_PUSH_LIVE_ACTIVITY_START_MAX_ATTEMPTS
+            ) {
+                await this.mobilePushNotificationStore.markLiveActivityStartAttempt(
+                    {
+                        liveActivityStartAttemptUuid,
+                        status: 'failed',
+                        pushTokenFingerprint:
+                            attempt.pushToStartTokenFingerprint,
+                        completedAt: attemptedAt,
+                    },
+                );
+                return;
+            }
+
+            await this.mobilePushNotificationStore.markLiveActivityStartAttempt(
+                {
+                    liveActivityStartAttemptUuid,
+                    status: 'retryable',
+                    pushTokenFingerprint: attempt.pushToStartTokenFingerprint,
+                    completedAt: null,
+                },
+            );
+            throw new Error(
+                'APNs Live Activity start token rotated during delivery',
+            );
+        }
+
+        if (
+            result.status === 'retryable' &&
+            attempt.attemptCount < MOBILE_PUSH_LIVE_ACTIVITY_START_MAX_ATTEMPTS
+        ) {
+            await this.mobilePushNotificationStore.markLiveActivityStartAttempt(
+                {
+                    liveActivityStartAttemptUuid,
+                    status: 'retryable',
+                    pushTokenFingerprint: attempt.pushToStartTokenFingerprint,
+                    completedAt: null,
+                },
+            );
+            throw new Error('APNs Live Activity start delivery is retryable');
+        }
+
+        await this.mobilePushNotificationStore.markLiveActivityStartAttempt({
+            liveActivityStartAttemptUuid,
+            status: 'failed',
+            pushTokenFingerprint: attempt.pushToStartTokenFingerprint,
+            completedAt: attemptedAt,
+        });
     }
 
     async registerLiveActivity(args: RegisterLiveActivity): Promise<void> {

--- a/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationService.ts
+++ b/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationService.ts
@@ -16,6 +16,10 @@ import {
 import { type MobilePushNotificationsConfig } from '../../../config/parseConfig';
 import Logger from '../../../logging/logger';
 import { type MobilePushEnvironment } from '../../database/entities/mobilePushNotifications';
+import {
+    type LiveActivityStartAttempt,
+    type SchedulableLiveActivityStartAttempt,
+} from '../../models/MobilePushNotificationModel';
 
 type MobilePushUser = {
     userUuid: string;
@@ -46,34 +50,6 @@ type MobilePushPrompt = {
     threadUuid: string;
     agentUuid: string | null;
     createdByUserUuid: string;
-};
-
-type LiveActivityStartAttempt = {
-    liveActivityStartAttemptUuid: string;
-    liveActivityUuid: string;
-    installationUuid: string;
-    organizationUuid: string;
-    userUuid: string;
-    promptUuid: string;
-    environment: MobilePushEnvironment;
-    pushToStartToken: string | null;
-    pushToStartTokenFingerprint: string | null;
-    status:
-        | 'excluded'
-        | 'pending'
-        | 'processing'
-        | 'retryable'
-        | 'sent'
-        | 'failed';
-    attemptCount: number;
-};
-
-type SchedulableLiveActivityStartAttempt = {
-    liveActivityStartAttemptUuid: string;
-    installationUuid: string;
-    organizationUuid: string;
-    projectUuid: string;
-    userUuid: string;
 };
 
 type UpsertLiveActivity = {

--- a/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationService.ts
+++ b/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationService.ts
@@ -224,7 +224,11 @@ type RegisterLiveActivity = {
 };
 
 const validatePushToken = (pushToken: string): void => {
-    if (pushToken.trim().length === 0 || pushToken.length > 4096) {
+    if (
+        pushToken.length === 0 ||
+        pushToken.length > 512 ||
+        !/^[0-9a-f]+$/i.test(pushToken)
+    ) {
         throw new ParameterError('Push token is invalid');
     }
 };

--- a/packages/backend/src/scheduler/SchedulerTaskTracer.ts
+++ b/packages/backend/src/scheduler/SchedulerTaskTracer.ts
@@ -278,6 +278,13 @@ const getTagsForTask: {
     [SCHEDULER_TASKS.SWEEP_STALE_AI_WRITEBACK_RUNS]: () => ({}),
     [SCHEDULER_TASKS.SWEEP_STALE_AI_DEEP_RESEARCH_RUNS]: () => ({}),
     [SCHEDULER_TASKS.SWEEP_AI_AGENT_MEMORY_THREADS]: () => ({}),
+    [SCHEDULER_TASKS.MOBILE_PUSH_LIVE_ACTIVITY_START]: (payload) => ({
+        'organization.uuid': payload.organizationUuid,
+        'project.uuid': payload.projectUuid,
+        'user.uuid': payload.userUuid,
+        'mobile_push.live_activity_start_attempt_uuid':
+            payload.liveActivityStartAttemptUuid,
+    }),
     [SCHEDULER_TASKS.MOBILE_PUSH_LIVE_ACTIVITY]: (payload) => ({
         'organization.uuid': payload.organizationUuid,
         'project.uuid': payload.projectUuid,

--- a/packages/backend/src/scripts/rotate-lightdash-secret/registry.ts
+++ b/packages/backend/src/scripts/rotate-lightdash-secret/registry.ts
@@ -107,6 +107,11 @@ export const CIPHERTEXT_REGISTRY: CiphertextRegistryEntry[] = [
         column: 'encrypted_device_token',
     },
     {
+        table: 'mobile_push_installations',
+        primaryKeyColumn: 'mobile_push_installation_uuid',
+        column: 'encrypted_push_to_start_token',
+    },
+    {
         table: 'ai_agent_live_activities',
         primaryKeyColumn: 'live_activity_uuid',
         column: 'encrypted_push_token',

--- a/packages/backend/src/scripts/rotate-lightdash-secret/rotation.test.ts
+++ b/packages/backend/src/scripts/rotate-lightdash-secret/rotation.test.ts
@@ -49,7 +49,7 @@ afterEach(() => {
 });
 
 describe('ciphertext registry', () => {
-    test('contains the full 24-field inventory', () => {
+    test('contains the full 25-field inventory', () => {
         expect(
             CIPHERTEXT_REGISTRY.map((e) => `${e.table}.${e.column}`),
         ).toEqual([
@@ -72,6 +72,7 @@ describe('ciphertext registry', () => {
             'embedding.encoded_secret',
             'managed_agent_settings.service_account_token',
             'mobile_push_installations.encrypted_device_token',
+            'mobile_push_installations.encrypted_push_to_start_token',
             'ai_agent_live_activities.encrypted_push_token',
             'ai_mcp_server_credential.encrypted_credentials',
             'ai_organization_settings.encrypted_provider_api_keys',

--- a/packages/backend/vitest.config.migrations.integration.ts
+++ b/packages/backend/vitest.config.migrations.integration.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        name: 'migration-integration-tests',
+        include: [
+            'src/**/database/migrations/__tests__/*.migration.integration.ts',
+        ],
+        environment: 'node',
+        testTimeout: 120000,
+        hookTimeout: 120000,
+        teardownTimeout: 60000,
+        globals: true,
+        env: {
+            TZ: 'UTC',
+            NODE_ENV: 'test',
+        },
+    },
+});

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -792,6 +792,7 @@ export type ApiAiAgentThreadCreateRequest = {
     prompt?: string;
     context?: AiPromptContextInput;
     modelConfig?: AiAgentModelConfig;
+    originatingInstallationUuid?: string;
 };
 
 export type ApiAiAgentThreadCreateResponse = ApiSuccess<AiAgentThreadSummary>;
@@ -800,6 +801,7 @@ export type ApiAiAgentThreadMessageCreateRequest = {
     prompt: string;
     context?: AiPromptContextInput;
     modelConfig?: AiAgentModelConfig;
+    originatingInstallationUuid?: string;
     /**
      * Inject the prompt as a hidden turn — the agent responds to it, but the UI
      * does not render the user bubble. Used by the post-merge content-migration

--- a/packages/common/src/types/api/mobilePushNotifications.ts
+++ b/packages/common/src/types/api/mobilePushNotifications.ts
@@ -15,6 +15,12 @@ export type ApiMobilePushInstallationRequest = {
 
 export type ApiMobilePushInstallationResponse = ApiSuccessEmpty;
 
+export type ApiMobilePushLiveActivityPushToStartTokenRequest = {
+    pushToken: string;
+};
+
+export type ApiMobilePushLiveActivityPushToStartTokenResponse = ApiSuccessEmpty;
+
 export type ApiMobilePushLiveActivityRequest = {
     installationUuid: UUID;
     promptUuid: UUID;

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -163,6 +163,12 @@ export type MobilePushLiveActivityJobPayload = TraceTaskBase & {
     liveActivityUuid: UUID;
 };
 
+export const MOBILE_PUSH_LIVE_ACTIVITY_START_MAX_ATTEMPTS = 5;
+
+export type MobilePushLiveActivityStartJobPayload = TraceTaskBase & {
+    liveActivityStartAttemptUuid: UUID;
+};
+
 export const EE_SCHEDULER_TASKS = {
     SLACK_AI_PROMPT: 'slackAiPrompt',
     AI_AGENT_EVAL_RESULT: 'aiAgentEvalResult',
@@ -196,6 +202,7 @@ export const EE_SCHEDULER_TASKS = {
     INGEST_EXTERNAL_SOURCE: 'ingestExternalSource',
     INGEST_EXTERNAL_SOURCE_ATTACHMENT: 'ingestExternalSourceAttachment',
     MAINTAIN_EXTERNAL_SOURCES: 'maintainExternalSources',
+    MOBILE_PUSH_LIVE_ACTIVITY_START: 'mobilePushLiveActivityStart',
     MOBILE_PUSH_LIVE_ACTIVITY: 'mobilePushLiveActivity',
     SWEEP_MOBILE_PUSH_LIVE_ACTIVITIES: 'sweepMobilePushLiveActivities',
 } as const;
@@ -315,6 +322,7 @@ export interface TaskPayloadMap {
     [SCHEDULER_TASKS.INGEST_EXTERNAL_SOURCE]: IngestExternalSourceJobPayload;
     [SCHEDULER_TASKS.INGEST_EXTERNAL_SOURCE_ATTACHMENT]: IngestExternalSourceJobPayload;
     [SCHEDULER_TASKS.MAINTAIN_EXTERNAL_SOURCES]: Record<string, never>;
+    [SCHEDULER_TASKS.MOBILE_PUSH_LIVE_ACTIVITY_START]: MobilePushLiveActivityStartJobPayload;
     [SCHEDULER_TASKS.MOBILE_PUSH_LIVE_ACTIVITY]: MobilePushLiveActivityJobPayload;
     [SCHEDULER_TASKS.SWEEP_MOBILE_PUSH_LIVE_ACTIVITIES]: Record<string, never>;
     [SCHEDULER_TASKS.AI_WRITEBACK_PIPELINE]: AiWritebackPipelineJobPayload;
@@ -356,6 +364,7 @@ export interface EETaskPayloadMap {
     [EE_SCHEDULER_TASKS.INGEST_EXTERNAL_SOURCE]: IngestExternalSourceJobPayload;
     [EE_SCHEDULER_TASKS.INGEST_EXTERNAL_SOURCE_ATTACHMENT]: IngestExternalSourceJobPayload;
     [EE_SCHEDULER_TASKS.MAINTAIN_EXTERNAL_SOURCES]: Record<string, never>;
+    [EE_SCHEDULER_TASKS.MOBILE_PUSH_LIVE_ACTIVITY_START]: MobilePushLiveActivityStartJobPayload;
     [EE_SCHEDULER_TASKS.MOBILE_PUSH_LIVE_ACTIVITY]: MobilePushLiveActivityJobPayload;
     [EE_SCHEDULER_TASKS.SWEEP_MOBILE_PUSH_LIVE_ACTIVITIES]: Record<
         string,


### PR DESCRIPTION
Closes: SPK-1707

### Description:

- Stores each push-to-start token encrypted and binds it to the signed-in user, organisation, server installation, and APNs environment.
- Starts a generic Live Activity on every other eligible owned installation after strict project, agent, thread, prompt, and user checks.
- Uses one durable installation-and-prompt attempt, an atomic claim, a stable activity identity, and a bounded five-attempt retry policy.
- Clears invalid tokens without deleting a concurrent rotation and clears or rebinds capabilities atomically on ownership transfer.
- Keeps agent prompts and Lightdash startup available when mobile push is disabled or APNs credentials are absent.

### Verification:

- [x] Ran 8 focused files: 118 tests passed.
- [x] Ran common and backend typechecks.
- [x] Ran touched-path lint and formatting checks.
- [x] Ran migration enforcement with zero errors or warnings.
- [x] Generated the API and reviewed the additive route and optional fields.
- [x] Confirmed the final diff has no visible UI change.

### Rollout:

The feature stays inactive until the matching iOS build and backend are deployed and the existing APNs integration is enabled. Self-hosted installations without APNs settings remain a clean no-op.

iOS: https://github.com/lightdash/lightdash-ios/pull/202
Security follow-up: SPK-1708

### Risk assessment:

- [x] This is a high-risk change