### PR TITLE
feat(homepage): attribute announcement Slack posts with author and category

### DIFF
--- a/packages/backend/src/ee/models/ProjectHomepageModel.test.ts
+++ b/packages/backend/src/ee/models/ProjectHomepageModel.test.ts
@@ -1,4 +1,5 @@
 import {
+    AnnouncementCategory,
     ConflictError,
     NotFoundError,
     type HomepageConfig,
@@ -6,6 +7,7 @@ import {
 import knex, { Knex } from 'knex';
 import { getTracker, MockClient, Tracker } from 'knex-mock-client';
 import { DatabaseError } from 'pg';
+import { UserTableName } from '../../database/entities/users';
 import {
     AnnouncementsTableName,
     HomepageAssignmentsTableName,
@@ -234,6 +236,109 @@ describe('ProjectHomepageModel', () => {
             await expect(
                 model.publishProjectDraftAnnouncements(PROJECT_UUID),
             ).resolves.toEqual([]);
+        });
+
+        it('hydrates authorName from the creating user', async () => {
+            tracker.on.select(AnnouncementsTableName).responseOnce([
+                {
+                    announcement_uuid: 'ann-1',
+                    pending_slack_channel_id: 'C1',
+                },
+            ]);
+            tracker.on.update(AnnouncementsTableName).responseOnce([
+                makeDbAnnouncement({
+                    created_by_user_uuid: 'user-1',
+                }),
+            ]);
+            tracker.on.select(UserTableName).responseOnce([
+                {
+                    user_uuid: 'user-1',
+                    first_name: 'Ana',
+                    last_name: 'Silva',
+                },
+            ]);
+
+            const result =
+                await model.publishProjectDraftAnnouncements(PROJECT_UUID);
+
+            expect(result[0]?.announcement.authorName).toBe('Ana Silva');
+        });
+    });
+
+    describe('createAnnouncement', () => {
+        it('hydrates authorName from the creating user', async () => {
+            tracker.on.insert(AnnouncementsTableName).responseOnce([
+                {
+                    announcement_uuid: 'ann-new',
+                    project_uuid: PROJECT_UUID,
+                    title: 'Launch',
+                    body: null,
+                    category: 'launch',
+                    pinned: false,
+                    created_by_user_uuid: 'user-1',
+                    created_at: new Date('2026-01-01T00:00:00Z'),
+                    updated_at: new Date('2026-01-01T00:00:00Z'),
+                    published_at: new Date('2026-01-01T00:00:00Z'),
+                    pending_slack_channel_id: null,
+                    scheduled_publish_at: null,
+                },
+            ]);
+            tracker.on.select(UserTableName).responseOnce([
+                {
+                    user_uuid: 'user-1',
+                    first_name: 'Ana',
+                    last_name: 'Silva',
+                },
+            ]);
+
+            const result = await model.createAnnouncement({
+                projectUuid: PROJECT_UUID,
+                title: 'Launch',
+                body: null,
+                category: AnnouncementCategory.LAUNCH,
+                createdByUserUuid: 'user-1',
+                pendingSlackChannelId: 'C1',
+                published: true,
+                scheduledPublishAt: null,
+            });
+
+            expect(result.authorName).toBe('Ana Silva');
+        });
+    });
+
+    describe('publishPendingAnnouncements', () => {
+        it('hydrates authorName and leaves it null when the user cannot be resolved', async () => {
+            tracker.on.select(AnnouncementsTableName).responseOnce([
+                {
+                    announcement_uuid: 'ann-1',
+                    pending_slack_channel_id: 'C1',
+                },
+            ]);
+            tracker.on.update(AnnouncementsTableName).responseOnce([
+                {
+                    announcement_uuid: 'ann-1',
+                    project_uuid: PROJECT_UUID,
+                    title: 'Launch',
+                    body: null,
+                    category: null,
+                    pinned: false,
+                    created_by_user_uuid: 'user-missing',
+                    created_at: new Date('2026-01-01T00:00:00Z'),
+                    updated_at: new Date('2026-01-01T00:00:00Z'),
+                    published_at: new Date('2026-01-03T00:00:00Z'),
+                    pending_slack_channel_id: null,
+                    scheduled_publish_at: null,
+                },
+            ]);
+            tracker.on.select(UserTableName).responseOnce([]);
+
+            const result = await model.publishPendingAnnouncements({
+                announcementUuid: 'ann-1',
+                onlyDue: false,
+            });
+
+            expect(result[0]?.announcement.authorName).toBeNull();
+            expect(result[0]?.slackChannelId).toBe('C1');
         });
     });
 

--- a/packages/backend/src/ee/models/ProjectHomepageModel.ts
+++ b/packages/backend/src/ee/models/ProjectHomepageModel.ts
@@ -22,6 +22,7 @@ import {
     type UpdateOrganizationHomepageSettings,
 } from '@lightdash/common';
 import { type Knex } from 'knex';
+import { UserTableName } from '../../database/entities/users';
 import { isStatementTimeout } from '../../database/errors';
 import Logger from '../../logging/logger';
 import { OrganizationHomepageSettingsTableName } from '../database/entities/organizationHomepageSettings';
@@ -763,6 +764,46 @@ export class ProjectHomepageModel {
         };
     }
 
+    private static authorNameSql(db: Knex) {
+        return db.raw(
+            `TRIM(CONCAT(${UserTableName}.first_name, ' ', ${UserTableName}.last_name)) as author_name`,
+        );
+    }
+
+    // `returning('*')` on the announcements table has no author join, so
+    // publish/create paths would otherwise notify Slack with a null author.
+    private async hydrateAuthorNames(
+        announcements: ProjectAnnouncement[],
+        db: Knex = this.database,
+    ): Promise<ProjectAnnouncement[]> {
+        const userUuids = [
+            ...new Set(
+                announcements
+                    .map((announcement) => announcement.createdByUserUuid)
+                    .filter((uuid): uuid is string => uuid != null),
+            ),
+        ];
+        if (userUuids.length === 0) {
+            return announcements;
+        }
+        const users = await db(UserTableName)
+            .whereIn('user_uuid', userUuids)
+            .select('user_uuid', 'first_name', 'last_name');
+        const authorNameByUserUuid = new Map(
+            users.map((user) => [
+                user.user_uuid,
+                `${user.first_name} ${user.last_name}`.trim() || null,
+            ]),
+        );
+        return announcements.map((announcement) => ({
+            ...announcement,
+            authorName: announcement.createdByUserUuid
+                ? (authorNameByUserUuid.get(announcement.createdByUserUuid) ??
+                  null)
+                : null,
+        }));
+    }
+
     private announcementsQuery(projectUuid: string) {
         return this.database(AnnouncementsTableName)
             .where(`${AnnouncementsTableName}.project_uuid`, projectUuid)
@@ -786,15 +827,13 @@ export class ProjectHomepageModel {
         const offset = (options.page - 1) * options.pageSize;
         const itemsQuery = this.announcementsQuery(projectUuid)
             .leftJoin(
-                'users',
-                'users.user_uuid',
+                UserTableName,
+                `${UserTableName}.user_uuid`,
                 `${AnnouncementsTableName}.created_by_user_uuid`,
             )
             .select(
                 `${AnnouncementsTableName}.*`,
-                this.database.raw(
-                    `TRIM(CONCAT(users.first_name, ' ', users.last_name)) as author_name`,
-                ),
+                ProjectHomepageModel.authorNameSql(this.database),
             )
             .offset(offset)
             .limit(options.pageSize);
@@ -852,7 +891,9 @@ export class ProjectHomepageModel {
                     : data.scheduledPublishAt,
             })
             .returning('*');
-        return ProjectHomepageModel.mapDbAnnouncement(row);
+        const mapped = ProjectHomepageModel.mapDbAnnouncement(row);
+        const [announcement] = await this.hydrateAuthorNames([mapped]);
+        return announcement ?? mapped;
     }
 
     /**
@@ -898,7 +939,7 @@ export class ProjectHomepageModel {
                     draft.pending_slack_channel_id,
                 ]),
             );
-            return rows.reduce<
+            const pending = rows.reduce<
                 Array<{
                     announcement: ProjectAnnouncement;
                     slackChannelId: string;
@@ -916,11 +957,19 @@ export class ProjectHomepageModel {
                 }
                 return acc;
             }, []);
+            const announcements = await this.hydrateAuthorNames(
+                pending.map(({ announcement }) => announcement),
+                trx,
+            );
+            return pending.map((item, index) => ({
+                ...item,
+                announcement: announcements[index] ?? item.announcement,
+            }));
         });
     }
 
     /**
-     * Publishes a single unpublished announcement (publish-now / scheduled
+     * Publishes a single unpublished announcement (publish-now / scheduled)
      * job) or every due scheduled announcement across projects (sweep).
      * Idempotent by construction: rows are locked with skipLocked and the
      * update re-checks `published_at IS NULL`, so a job+sweep race publishes
@@ -974,10 +1023,18 @@ export class ProjectHomepageModel {
                     row.pending_slack_channel_id,
                 ]),
             );
-            return rows.map((row) => ({
+            const published = rows.map((row) => ({
                 announcement: ProjectHomepageModel.mapDbAnnouncement(row),
                 slackChannelId:
                     slackChannelByUuid.get(row.announcement_uuid) ?? null,
+            }));
+            const announcements = await this.hydrateAuthorNames(
+                published.map(({ announcement }) => announcement),
+                trx,
+            );
+            return published.map((item, index) => ({
+                ...item,
+                announcement: announcements[index] ?? item.announcement,
             }));
         });
     }

--- a/packages/backend/src/ee/services/ProjectHomepageService.test.ts
+++ b/packages/backend/src/ee/services/ProjectHomepageService.test.ts
@@ -1,6 +1,7 @@
 import { Ability } from '@casl/ability';
 import {
     ANNOUNCEMENT_BODY_MAX_LENGTH,
+    AnnouncementCategory,
     ForbiddenError,
     NotFoundError,
     OrganizationMemberRole,
@@ -22,6 +23,18 @@ const ORGANIZATION_UUID = '00000000-0000-0000-0000-000000000001';
 const PROJECT_UUID = '00000000-0000-0000-0000-000000000002';
 const USER_UUID = '00000000-0000-0000-0000-000000000004';
 const HOMEPAGE_UUID = '00000000-0000-0000-0000-000000000010';
+
+type SlackBlock = {
+    type: string;
+    elements?: Array<{ text?: string }>;
+};
+
+const slackContextTexts = (blocks: SlackBlock[]): string[] =>
+    blocks
+        .filter((block) => block.type === 'context')
+        .flatMap((block) => block.elements ?? [])
+        .map((element) => element.text)
+        .filter((text): text is string => text != null);
 
 const validConfig: HomepageConfig = {
     version: 1,
@@ -498,7 +511,7 @@ describe('ProjectHomepageService', () => {
             projectUuid: PROJECT_UUID,
             title: 'Draft launch',
             body: null,
-            category: null,
+            category: AnnouncementCategory.LAUNCH,
             pinned: false,
             published: true,
             createdByUserUuid: 'user-1',
@@ -539,9 +552,14 @@ describe('ProjectHomepageService', () => {
         expect(postMessage).toHaveBeenCalledWith(
             expect.objectContaining({
                 channel: 'C1',
-                text: expect.stringContaining('Draft launch'),
+                text: '📢 Launch from Ana: Draft launch',
             }),
         );
+        const [{ blocks }] = postMessage.mock.calls[0];
+        expect(slackContextTexts(blocks)).toEqual([
+            'Launch · Posted by Ana',
+            expect.stringContaining('View on the homepage'),
+        ]);
     });
 
     it('publishHomepage retries the Slack notification without the image block', async () => {
@@ -550,7 +568,7 @@ describe('ProjectHomepageService', () => {
             projectUuid: PROJECT_UUID,
             title: 'Draft launch',
             body: 'Look ![shot](/api/v1/file/abc123)',
-            category: null,
+            category: AnnouncementCategory.UPDATE,
             pinned: false,
             published: true,
             pendingSlackChannelId: null,
@@ -601,6 +619,110 @@ describe('ProjectHomepageService', () => {
                 (block: { type: string }) => block.type === 'image',
             ),
         ).toBe(false);
+        expect(retryCall.text).toBe('📢 Update from Ana: Draft launch');
+        expect(slackContextTexts(retryCall.blocks)).toEqual([
+            'Update · Posted by Ana',
+            expect.stringContaining('View on the homepage'),
+        ]);
+    });
+
+    it('publishHomepage Slack notification omits empty author and category attribution', async () => {
+        const publishedAnnouncement = {
+            announcementUuid: 'ann-draft-3',
+            projectUuid: PROJECT_UUID,
+            title: 'Draft launch',
+            body: null,
+            category: null,
+            pinned: false,
+            published: true,
+            createdByUserUuid: null,
+            authorName: null,
+            createdAt: NOW,
+            updatedAt: NOW,
+        };
+        const postMessage = vi.fn().mockResolvedValue(undefined);
+        const service = makeService({
+            projectHomepageModel: {
+                getDefault: vi.fn().mockResolvedValue(makeHomepage()),
+                publish: vi
+                    .fn()
+                    .mockResolvedValue(
+                        makeHomepage({ publishedConfig: validConfig }),
+                    ),
+                publishProjectDraftAnnouncements: vi.fn().mockResolvedValue([
+                    {
+                        announcement: publishedAnnouncement,
+                        slackChannelId: 'C1',
+                    },
+                ]),
+            },
+            slackClient: { postMessage },
+        });
+
+        await service.publishHomepage(
+            makeAdminUser(),
+            PROJECT_UUID,
+            HOMEPAGE_UUID,
+            { type: 'everyone' },
+        );
+
+        const [{ text, blocks }] = postMessage.mock.calls[0];
+        expect(text).toBe('📢 New announcement: Draft launch');
+        expect(slackContextTexts(blocks)).toEqual([
+            expect.stringContaining('View on the homepage'),
+        ]);
+        expect(slackContextTexts(blocks).join(' ')).not.toMatch(
+            /Posted by|Launch|Update|Heads up/i,
+        );
+    });
+
+    it('publishHomepage Slack notification attributes a category without an author', async () => {
+        const publishedAnnouncement = {
+            announcementUuid: 'ann-draft-4',
+            projectUuid: PROJECT_UUID,
+            title: 'Warehouse delay',
+            body: null,
+            category: AnnouncementCategory.HEADS_UP,
+            pinned: false,
+            published: true,
+            createdByUserUuid: null,
+            authorName: null,
+            createdAt: NOW,
+            updatedAt: NOW,
+        };
+        const postMessage = vi.fn().mockResolvedValue(undefined);
+        const service = makeService({
+            projectHomepageModel: {
+                getDefault: vi.fn().mockResolvedValue(makeHomepage()),
+                publish: vi
+                    .fn()
+                    .mockResolvedValue(
+                        makeHomepage({ publishedConfig: validConfig }),
+                    ),
+                publishProjectDraftAnnouncements: vi.fn().mockResolvedValue([
+                    {
+                        announcement: publishedAnnouncement,
+                        slackChannelId: 'C1',
+                    },
+                ]),
+            },
+            slackClient: { postMessage },
+        });
+
+        await service.publishHomepage(
+            makeAdminUser(),
+            PROJECT_UUID,
+            HOMEPAGE_UUID,
+            { type: 'everyone' },
+        );
+
+        const [{ text, blocks }] = postMessage.mock.calls[0];
+        expect(text).toBe('📢 Heads up: Warehouse delay');
+        expect(slackContextTexts(blocks)).toEqual([
+            'Heads up',
+            expect.stringContaining('View on the homepage'),
+        ]);
+        expect(slackContextTexts(blocks).join(' ')).not.toContain('Posted by');
     });
 
     it('discardDraft reverts the draft to the published config for an admin when the flag is on', async () => {
@@ -919,9 +1041,11 @@ describe('ProjectHomepageService', () => {
 
         it('createAnnouncement with publishNow creates it published and notifies Slack immediately', async () => {
             const postMessage = vi.fn().mockResolvedValue(undefined);
-            const createAnnouncement = vi
-                .fn()
-                .mockResolvedValue({ ...madeAnnouncement, published: true });
+            const createAnnouncement = vi.fn().mockResolvedValue({
+                ...madeAnnouncement,
+                published: true,
+                category: AnnouncementCategory.HEADS_UP,
+            });
             const service = makeService({
                 projectHomepageModel: { createAnnouncement },
                 slackClient: { postMessage },
@@ -929,7 +1053,7 @@ describe('ProjectHomepageService', () => {
             await service.createAnnouncement(makeAdminUser(), PROJECT_UUID, {
                 title: 'Launch',
                 body: null,
-                category: null,
+                category: AnnouncementCategory.HEADS_UP,
                 slackChannelId: 'C123',
                 publishNow: true,
             });
@@ -937,8 +1061,16 @@ describe('ProjectHomepageService', () => {
                 expect.objectContaining({ published: true }),
             );
             expect(postMessage).toHaveBeenCalledWith(
-                expect.objectContaining({ channel: 'C123' }),
+                expect.objectContaining({
+                    channel: 'C123',
+                    text: '📢 Heads up from Ana: Launch',
+                }),
             );
+            const [{ blocks }] = postMessage.mock.calls[0];
+            expect(slackContextTexts(blocks)).toEqual([
+                'Heads up · Posted by Ana',
+                expect.stringContaining('View on the homepage'),
+            ]);
         });
 
         it('createAnnouncement with publishNow and no channel publishes without Slack', async () => {
@@ -1113,7 +1245,10 @@ describe('ProjectHomepageService', () => {
             });
             expect(cancelPublishAnnouncement).toHaveBeenCalledWith('ann-9');
             expect(postMessage).toHaveBeenCalledWith(
-                expect.objectContaining({ channel: 'C123' }),
+                expect.objectContaining({
+                    channel: 'C123',
+                    text: '📢 New announcement from Ana: Launch',
+                }),
             );
             expect(result.published).toBe(true);
         });
@@ -1211,8 +1346,16 @@ describe('ProjectHomepageService', () => {
             expect(count).toBe(2);
             expect(postMessage).toHaveBeenCalledTimes(1);
             expect(postMessage).toHaveBeenCalledWith(
-                expect.objectContaining({ channel: 'C123' }),
+                expect.objectContaining({
+                    channel: 'C123',
+                    text: '📢 New announcement from Ana: Launch',
+                }),
             );
+            const [{ blocks }] = postMessage.mock.calls[0];
+            expect(slackContextTexts(blocks)).toEqual([
+                'Posted by Ana',
+                expect.stringContaining('View on the homepage'),
+            ]);
         });
 
         it('createAnnouncement without publishNow stays a draft', async () => {

--- a/packages/backend/src/ee/services/ProjectHomepageService.ts
+++ b/packages/backend/src/ee/services/ProjectHomepageService.ts
@@ -1,6 +1,7 @@
 import { subject } from '@casl/ability';
 import {
     ANNOUNCEMENT_BODY_MAX_LENGTH,
+    ANNOUNCEMENT_CATEGORY_META,
     assertUnreachable,
     CommercialFeatureFlags,
     convertOrganizationRoleToProjectRole,
@@ -862,6 +863,50 @@ export class ProjectHomepageService extends BaseService {
             .trim();
     }
 
+    private static announcementCategoryLabel(
+        announcement: ProjectAnnouncement,
+    ): string | null {
+        if (announcement.category == null) {
+            return null;
+        }
+        return ANNOUNCEMENT_CATEGORY_META[announcement.category]?.label ?? null;
+    }
+
+    // Context-line attribution only — omit missing parts so Slack never
+    // shows an empty "Posted by" or a dangling separator.
+    private static announcementSlackAttribution(
+        announcement: ProjectAnnouncement,
+    ): string | null {
+        const parts: string[] = [];
+        const categoryLabel =
+            ProjectHomepageService.announcementCategoryLabel(announcement);
+        if (categoryLabel) {
+            parts.push(categoryLabel);
+        }
+        if (announcement.authorName) {
+            parts.push(`Posted by ${announcement.authorName}`);
+        }
+        return parts.length > 0 ? parts.join(' · ') : null;
+    }
+
+    private static announcementSlackFallbackText(
+        announcement: ProjectAnnouncement,
+    ): string {
+        const categoryLabel =
+            ProjectHomepageService.announcementCategoryLabel(announcement);
+        const author = announcement.authorName;
+        if (categoryLabel && author) {
+            return `📢 ${categoryLabel} from ${author}: ${announcement.title}`;
+        }
+        if (categoryLabel) {
+            return `📢 ${categoryLabel}: ${announcement.title}`;
+        }
+        if (author) {
+            return `📢 New announcement from ${author}: ${announcement.title}`;
+        }
+        return `📢 New announcement: ${announcement.title}`;
+    }
+
     private async notifyAnnouncementToSlack(
         organizationUuid: string,
         projectUuid: string,
@@ -875,6 +920,8 @@ export class ProjectHomepageService extends BaseService {
         const image = announcement.body
             ? this.announcementSlackImage(announcement.body)
             : null;
+        const attribution =
+            ProjectHomepageService.announcementSlackAttribution(announcement);
         const blocks: (KnownBlock | SlackMarkdownBlock)[] = [
             {
                 type: 'header',
@@ -884,6 +931,19 @@ export class ProjectHomepageService extends BaseService {
                     emoji: true,
                 },
             },
+            ...(attribution
+                ? [
+                      {
+                          type: 'context' as const,
+                          elements: [
+                              {
+                                  type: 'mrkdwn' as const,
+                                  text: attribution,
+                              },
+                          ],
+                      },
+                  ]
+                : []),
             ...(markdown
                 ? [{ type: 'markdown' as const, text: markdown }]
                 : []),
@@ -906,7 +966,8 @@ export class ProjectHomepageService extends BaseService {
                 ],
             },
         ];
-        const text = `📢 New announcement: ${announcement.title}`;
+        const text =
+            ProjectHomepageService.announcementSlackFallbackText(announcement);
         try {
             await this.slackClient.postMessage({
                 organizationUuid,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes: #28366

### Description:
Homepage announcement Slack posts now include the author and category (Launch / Update / Heads up) so they are distinguishable from AI agent replies posted by the same Slack app.

- Hydrate `authorName` on create and both publish paths (it was only populated by `listAnnouncements`)
- Add a context line under the title when a category and/or author is present
- Include the same attribution in the notification preview `text`
- Omit missing parts so there is no empty "Posted by" or dangling category
- Image-failure retry keeps the attribution

### Risk assessment:
- [ ] This is a high-risk change

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://lightdash.slack.com/archives/C0BGSKBLX1V/p1788250499867659?thread_ts=1788250499.867659&cid=C0BGSKBLX1V)

<div><a href="https://cursor.com/agents/bc-f3185b22-773f-5e57-b107-ac1869aff9f6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f3185b22-773f-5e57-b107-ac1869aff9f6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

