### PR TITLE
refactor(homepage): bring homepage builder functions under oxlint complexity 20

### DIFF
--- a/packages/frontend/.oxlintrc.json
+++ b/packages/frontend/.oxlintrc.json
@@ -222,6 +222,23 @@
         "vitest-js/valid-expect-in-promise": "error",
         "vitest-js/valid-title": ["error", { "allowArguments": true }]
       }
+    },
+    {
+      "files": ["**/ee/features/homepageBuilder/**/*.ts", "**/ee/features/homepageBuilder/**/*.tsx"],
+      "rules": {
+        "complexity": ["warn", { "max": 20 }],
+        "max-lines-per-function": ["warn", { "max": 200, "skipBlankLines": true, "skipComments": true }],
+        "max-statements": ["warn", { "max": 30 }],
+        "no-nested-ternary": "warn"
+      }
+    },
+    {
+      "files": ["**/ee/features/homepageBuilder/**/*.test.ts", "**/ee/features/homepageBuilder/**/*.test.tsx"],
+      "rules": {
+        "complexity": "off",
+        "max-lines-per-function": "off",
+        "max-statements": "off"
+      }
     }
   ]
 }

--- a/packages/frontend/.oxlintrc.json
+++ b/packages/frontend/.oxlintrc.json
@@ -222,23 +222,6 @@
         "vitest-js/valid-expect-in-promise": "error",
         "vitest-js/valid-title": ["error", { "allowArguments": true }]
       }
-    },
-    {
-      "files": ["**/ee/features/homepageBuilder/**/*.ts", "**/ee/features/homepageBuilder/**/*.tsx"],
-      "rules": {
-        "complexity": ["warn", { "max": 20 }],
-        "max-lines-per-function": ["warn", { "max": 200, "skipBlankLines": true, "skipComments": true }],
-        "max-statements": ["warn", { "max": 30 }],
-        "no-nested-ternary": "warn"
-      }
-    },
-    {
-      "files": ["**/ee/features/homepageBuilder/**/*.test.ts", "**/ee/features/homepageBuilder/**/*.test.tsx"],
-      "rules": {
-        "complexity": "off",
-        "max-lines-per-function": "off",
-        "max-statements": "off"
-      }
     }
   ]
 }

--- a/packages/frontend/src/ee/features/homepageBuilder/DayOneAskInput.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/DayOneAskInput.tsx
@@ -1,4 +1,3 @@
-import { subject } from '@casl/ability';
 import {
     type AgentSuggestion,
     type AiPromptContextInput,
@@ -8,7 +7,14 @@ import {
 import { Anchor, Skeleton, Text } from '@mantine/core';
 import { IconArrowUpRight } from '@tabler/icons-react';
 import { useQueryClient } from '@tanstack/react-query';
-import { useCallback, useEffect, useRef, useState, type FC } from 'react';
+import {
+    useCallback,
+    useEffect,
+    useRef,
+    useState,
+    type ComponentProps,
+    type FC,
+} from 'react';
 import { useNavigate } from 'react-router';
 import MantineIcon from '../../../components/common/MantineIcon';
 import useApp from '../../../providers/App/useApp';
@@ -33,6 +39,7 @@ import {
 import { useGetUserAgentPreferences } from '../aiCopilot/hooks/useUserAgentPreferences';
 import blockClasses from './blocks/blockStyles.module.css';
 import classes from './DayOneAskInput.module.css';
+import { useCanManageProject } from './hooks/useHomepageAbilities';
 
 const AI_ROUTER_QUERY_KEY = 'ai-router';
 
@@ -41,6 +48,16 @@ type Props = {
     preview?: boolean;
     hideSuggestions?: boolean;
 };
+
+type ProjectAgent = NonNullable<
+    ReturnType<typeof useProjectAiAgents>['data']
+>[number];
+
+type ComposerSelection = ProjectAgent | 'auto' | undefined;
+
+type CreateAgentThread = ReturnType<
+    typeof useCreateAgentThreadMutation
+>['mutateAsync'];
 
 // AgentSelector (rendered inside AgentChatInput below) already calls
 // useAiRouterConfig() to build its own dropdown. Calling that same hook a
@@ -70,8 +87,206 @@ const useAiRouterEnabledFromCache = (): boolean | undefined => {
     return enabled;
 };
 
+// Auto is the default whenever it's available — Auto mode can't have its
+// own suggestions, so the chip row always sources from a concrete reference
+// agent regardless of what the composer is currently set to.
+const useComposerAgents = (projectUuid: string | null) => {
+    const { data: agents, isInitialLoading: isLoadingAgents } =
+        useProjectAiAgents({
+            projectUuid,
+            redirectOnUnauthorized: false,
+            options: { enabled: !!projectUuid },
+        });
+    const {
+        data: userAgentPreferences,
+        isInitialLoading: isLoadingPreferences,
+    } = useGetUserAgentPreferences(projectUuid);
+    const routerEnabled = useAiRouterEnabledFromCache();
+
+    const agentCount = agents?.length ?? 0;
+    const firstAgent = agents?.[0];
+    const showAutoOption = agentCount > 1 && routerEnabled === true;
+    const validDefaultAgent = agents?.find(
+        (agent) => agent.uuid === userAgentPreferences?.defaultAgentUuid,
+    );
+    const activeSelection: ComposerSelection =
+        validDefaultAgent ?? (showAutoOption ? 'auto' : firstAgent);
+    const referenceAgent = validDefaultAgent ?? firstAgent;
+    const selectedAgent =
+        activeSelection === 'auto' ? undefined : activeSelection;
+    const isComposerLoading = isLoadingAgents || isLoadingPreferences;
+    const hasNoAgents = !isComposerLoading && !!projectUuid && agentCount === 0;
+
+    return {
+        agents,
+        activeSelection,
+        composerSelection: activeSelection ?? firstAgent,
+        referenceAgent,
+        selectedAgent,
+        isComposerLoading,
+        hasNoAgents,
+    };
+};
+
+type ComposerSqlModeProps = Pick<
+    ComponentProps<typeof AgentChatInput>,
+    'sqlMode' | 'onSqlModeChange'
+>;
+
+// The SQL toggle only exists for a concrete agent, never for Auto.
+const useComposerSqlMode = (
+    projectUuid: string | null,
+    selectedAgent: ProjectAgent | undefined,
+    referenceAgent: ProjectAgent | undefined,
+) => {
+    const sqlModeAvailable = useAiAgentSqlModeAvailable(
+        projectUuid ?? undefined,
+    );
+    const [sqlModeOverride, setSqlModeOverride] = useState<{
+        agentUuid: string;
+        value: boolean;
+    }>();
+    const sqlMode =
+        sqlModeOverride && sqlModeOverride.agentUuid === selectedAgent?.uuid
+            ? sqlModeOverride.value
+            : (selectedAgent?.enableSqlMode ?? true);
+    const suggestionsSqlMode =
+        sqlModeAvailable && (referenceAgent?.enableSqlMode ?? true);
+    const composerSqlModeProps: ComposerSqlModeProps =
+        sqlModeAvailable && selectedAgent
+            ? {
+                  sqlMode,
+                  onSqlModeChange: (value: boolean) =>
+                      setSqlModeOverride({
+                          agentUuid: selectedAgent.uuid,
+                          value,
+                      }),
+              }
+            : { sqlMode: undefined, onSqlModeChange: undefined };
+
+    return {
+        enableSqlMode: sqlModeAvailable && sqlMode,
+        suggestionsSqlMode,
+        composerSqlModeProps,
+    };
+};
+
+const useHomepageDeepResearch = ({
+    projectUuid,
+    selectedAgent,
+    createAgentThread,
+}: {
+    projectUuid: string | null;
+    selectedAgent: ProjectAgent | undefined;
+    createAgentThread: CreateAgentThread;
+}) => {
+    const { mutateAsync: startDeepResearch } =
+        useStartDeepResearchForThreadMutation(projectUuid ?? '', 'homepage');
+    const canStartDeepResearch = useDeepResearchAccess(
+        projectUuid ?? undefined,
+    );
+
+    const handleStartDeepResearch = useCallback(
+        async ({ question }: StartDeepResearchArgs) => {
+            if (!projectUuid || !selectedAgent || !canStartDeepResearch) {
+                return;
+            }
+            const thread = await createAgentThread({
+                agentUuid: selectedAgent.uuid,
+                prompt: question,
+                skipAgentResponse: true,
+            });
+            await startDeepResearch({
+                question,
+                agentUuid: selectedAgent.uuid,
+                threadUuid: thread.uuid,
+                promptUuid: thread.firstMessage.uuid,
+            });
+        },
+        [
+            canStartDeepResearch,
+            createAgentThread,
+            projectUuid,
+            selectedAgent,
+            startDeepResearch,
+        ],
+    );
+
+    return selectedAgent && canStartDeepResearch
+        ? handleStartDeepResearch
+        : undefined;
+};
+
+// Two chips, not the full generated set. On the homepage the composer is the
+// opening view and the chips are a hint at what it can do — five of them read
+// as a menu to work through, and they cost more vertical space than the
+// composer itself, pushing curated content under the fold. The thread page
+// still shows the full set, where there's nothing below to protect.
+const HOMEPAGE_SUGGESTION_LIMIT = 2;
+
+const useHomepageSuggestionChips = ({
+    projectUuid,
+    referenceAgent,
+    enableSqlMode,
+    hideSuggestions,
+}: {
+    projectUuid: string | null;
+    referenceAgent: ProjectAgent | undefined;
+    enableSqlMode: boolean;
+    hideSuggestions: boolean | undefined;
+}) => {
+    const { track, data: trackingData } = useTracking();
+    const isTrackingReady = !!trackingData.rudder;
+    const referenceAgentUuid = referenceAgent?.uuid;
+    const suggestionsQuery = useAgentSuggestions({
+        projectUuid: projectUuid ?? '',
+        agentUuid: referenceAgentUuid,
+        enableSqlMode,
+        enabled: !!projectUuid && !!referenceAgentUuid && !hideSuggestions,
+    });
+
+    // Sliced at the source so the impression/click analytics count what the
+    // viewer actually saw.
+    const chips = (suggestionsQuery.data?.chips ?? []).slice(
+        0,
+        HOMEPAGE_SUGGESTION_LIMIT,
+    );
+    const impressionFiredRef = useRef(false);
+    useEffect(() => {
+        if (impressionFiredRef.current) return;
+        if (!isTrackingReady) return;
+        if (hideSuggestions) return;
+        if (!projectUuid || !referenceAgentUuid) return;
+        if (chips.length === 0) return;
+        impressionFiredRef.current = true;
+        track({
+            name: EventName.AI_AGENT_SUGGESTION_IMPRESSION,
+            properties: {
+                projectId: projectUuid,
+                agentId: referenceAgentUuid,
+                chipCount: chips.length,
+                placement: 'homepage_hero',
+            },
+        });
+    }, [
+        isTrackingReady,
+        chips.length,
+        projectUuid,
+        referenceAgentUuid,
+        hideSuggestions,
+        track,
+    ]);
+
+    return { chips, isLoading: suggestionsQuery.isLoading };
+};
+
 const inputHoldClass = (projectUuid: string | null) =>
     projectUuid ? classes.inputHold : classes.inputHoldMinimal;
+
+const composerPlaceholder = (selection: ComposerSelection): string =>
+    selection && selection !== 'auto'
+        ? `Ask ${selection.name}…`
+        : 'Ask anything about your data…';
 
 // The composer's footprint on a surface that is still deciding whether it can
 // show a composer at all. Lives here so the reserved height is stated once,
@@ -85,13 +300,6 @@ export const DayOneAskInputPlaceholder: FC<
         {!hideSuggestions && <div className={classes.pillRow} />}
     </div>
 );
-
-// Two chips, not the full generated set. On the homepage the composer is the
-// opening view and the chips are a hint at what it can do — five of them read
-// as a menu to work through, and they cost more vertical space than the
-// composer itself, pushing curated content under the fold. The thread page
-// still shows the full set, where there's nothing below to protect.
-const HOMEPAGE_SUGGESTION_LIMIT = 2;
 
 // The chips come from an LLM generation, so on a cold view they land a second
 // or two after the composer. The row reserves one chip-line of height while
@@ -140,71 +348,34 @@ const DayOneAskInputInner: FC<Props> = ({
     hideSuggestions,
 }) => {
     const navigate = useNavigate();
-    const { track, data: trackingData } = useTracking();
-    const isTrackingReady = !!trackingData.rudder;
+    const { track } = useTracking();
     const { user } = useApp();
     const { setPendingPrompt } = usePendingPrompt();
-    const { data: agents, isInitialLoading: isLoadingAgents } =
-        useProjectAiAgents({
-            projectUuid,
-            redirectOnUnauthorized: false,
-            options: { enabled: !!projectUuid },
-        });
-    const {
-        data: userAgentPreferences,
-        isInitialLoading: isLoadingPreferences,
-    } = useGetUserAgentPreferences(projectUuid);
     const canCreateThread = useCanCreateAiAgentThread(projectUuid ?? undefined);
-    const canManageProject =
-        user.data?.ability?.can(
-            'manage',
-            subject('Project', {
-                organizationUuid: user.data?.organizationUuid,
-                projectUuid: projectUuid ?? undefined,
-            }),
-        ) ?? false;
-    const routerEnabled = useAiRouterEnabledFromCache();
+    const canManageProject = useCanManageProject(projectUuid);
     const { mutateAsync: createAgentThread, isLoading: isCreatingThread } =
         useCreateAgentThreadMutation(projectUuid ?? '');
-    const { mutateAsync: startDeepResearch } =
-        useStartDeepResearchForThreadMutation(projectUuid ?? '', 'homepage');
-    const canStartDeepResearch = useDeepResearchAccess(
-        projectUuid ?? undefined,
-    );
-
-    const showAutoOption = (agents?.length ?? 0) > 1 && routerEnabled === true;
-    const validDefaultAgent = agents?.find(
-        (agent) => agent.uuid === userAgentPreferences?.defaultAgentUuid,
-    );
-    // Auto is the default whenever it's available — Auto mode can't have its
-    // own suggestions, so the chip row below always sources from a concrete
-    // reference agent regardless of what the composer is currently set to.
-    const activeSelection =
-        validDefaultAgent ?? (showAutoOption ? 'auto' : agents?.[0]);
-    const referenceAgent = validDefaultAgent ?? agents?.[0];
-    const selectedAgent =
-        activeSelection === 'auto' ? undefined : activeSelection;
-
-    const sqlModeAvailable = useAiAgentSqlModeAvailable(
-        projectUuid ?? undefined,
-    );
-    const [sqlModeOverride, setSqlModeOverride] = useState<{
-        agentUuid: string;
-        value: boolean;
-    }>();
-    const sqlMode =
-        sqlModeOverride && sqlModeOverride.agentUuid === selectedAgent?.uuid
-            ? sqlModeOverride.value
-            : (selectedAgent?.enableSqlMode ?? true);
-    const enableSqlMode = sqlModeAvailable && sqlMode;
-    const suggestionsSqlMode =
-        sqlModeAvailable && (referenceAgent?.enableSqlMode ?? true);
-
-    const suggestionsQuery = useAgentSuggestions({
-        projectUuid: projectUuid ?? '',
-        agentUuid: referenceAgent?.uuid,
+    const {
+        agents,
+        activeSelection,
+        composerSelection,
+        referenceAgent,
+        selectedAgent,
+        isComposerLoading,
+        hasNoAgents,
+    } = useComposerAgents(projectUuid);
+    const { enableSqlMode, suggestionsSqlMode, composerSqlModeProps } =
+        useComposerSqlMode(projectUuid, selectedAgent, referenceAgent);
+    const onStartDeepResearch = useHomepageDeepResearch({
+        projectUuid,
+        selectedAgent,
+        createAgentThread,
+    });
+    const suggestions = useHomepageSuggestionChips({
+        projectUuid,
+        referenceAgent,
         enableSqlMode: suggestionsSqlMode,
-        enabled: !!projectUuid && !!referenceAgent && !hideSuggestions,
+        hideSuggestions,
     });
 
     const submitPrompt = (
@@ -264,32 +435,6 @@ const DayOneAskInputInner: FC<Props> = ({
         submitPrompt(prompt, toolHints, context, optimisticContext);
     };
 
-    const handleStartDeepResearch = useCallback(
-        async ({ question }: StartDeepResearchArgs) => {
-            if (!projectUuid || !selectedAgent || !canStartDeepResearch) {
-                return;
-            }
-            const thread = await createAgentThread({
-                agentUuid: selectedAgent.uuid,
-                prompt: question,
-                skipAgentResponse: true,
-            });
-            await startDeepResearch({
-                question,
-                agentUuid: selectedAgent.uuid,
-                threadUuid: thread.uuid,
-                promptUuid: thread.firstMessage.uuid,
-            });
-        },
-        [
-            canStartDeepResearch,
-            createAgentThread,
-            projectUuid,
-            selectedAgent,
-            startDeepResearch,
-        ],
-    );
-
     const handleChipPick = (chip: AgentSuggestion, index: number) => {
         const organizationId = user.data?.organizationUuid;
         if (organizationId && projectUuid && referenceAgent?.uuid) {
@@ -315,41 +460,7 @@ const DayOneAskInputInner: FC<Props> = ({
         submitPrompt(chip.label, [chip.tool]);
     };
 
-    // Sliced at the source so the impression/click analytics count what the
-    // viewer actually saw.
-    const chips = (suggestionsQuery.data?.chips ?? []).slice(
-        0,
-        HOMEPAGE_SUGGESTION_LIMIT,
-    );
-    const impressionFiredRef = useRef(false);
-    useEffect(() => {
-        if (impressionFiredRef.current) return;
-        if (!isTrackingReady) return;
-        if (hideSuggestions) return;
-        if (!projectUuid || !referenceAgent?.uuid) return;
-        if (chips.length === 0) return;
-        impressionFiredRef.current = true;
-        track({
-            name: EventName.AI_AGENT_SUGGESTION_IMPRESSION,
-            properties: {
-                projectId: projectUuid,
-                agentId: referenceAgent.uuid,
-                chipCount: chips.length,
-                placement: 'homepage_hero',
-            },
-        });
-    }, [
-        isTrackingReady,
-        chips.length,
-        projectUuid,
-        referenceAgent?.uuid,
-        hideSuggestions,
-        track,
-    ]);
-
-    const isComposerLoading = isLoadingAgents || isLoadingPreferences;
-
-    if (!isComposerLoading && projectUuid && (!agents || agents.length === 0)) {
+    if (hasNoAgents) {
         return (
             <div className={blockClasses.dashedEmpty}>
                 Set up an AI agent to enable Ask AI here —{' '}
@@ -376,32 +487,11 @@ const DayOneAskInputInner: FC<Props> = ({
                     projectUuid={projectUuid ?? undefined}
                     agentUuid={selectedAgent?.uuid}
                     agents={agents}
-                    selectedAgent={activeSelection ?? agents?.[0]}
-                    placeholder={
-                        activeSelection === 'auto'
-                            ? 'Ask anything about your data…'
-                            : activeSelection
-                              ? `Ask ${activeSelection.name}…`
-                              : 'Ask anything about your data…'
-                    }
+                    selectedAgent={composerSelection}
+                    placeholder={composerPlaceholder(activeSelection)}
                     onSubmit={handleSubmit}
-                    onStartDeepResearch={
-                        selectedAgent && canStartDeepResearch
-                            ? handleStartDeepResearch
-                            : undefined
-                    }
-                    sqlMode={
-                        sqlModeAvailable && selectedAgent ? sqlMode : undefined
-                    }
-                    onSqlModeChange={
-                        sqlModeAvailable && selectedAgent
-                            ? (value) =>
-                                  setSqlModeOverride({
-                                      agentUuid: selectedAgent.uuid,
-                                      value,
-                                  })
-                            : undefined
-                    }
+                    onStartDeepResearch={onStartDeepResearch}
+                    {...composerSqlModeProps}
                     loading={isCreatingThread}
                     showSuggestions={false}
                     fullWidth
@@ -424,8 +514,8 @@ const DayOneAskInputInner: FC<Props> = ({
             )}
             {!hideSuggestions && (canCreateThread || preview) && (
                 <SuggestionPills
-                    chips={chips}
-                    loading={suggestionsQuery.isLoading}
+                    chips={suggestions.chips}
+                    loading={suggestions.isLoading}
                     onPick={handleChipPick}
                 />
             )}

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageBuilderPage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageBuilderPage.tsx
@@ -1,4 +1,3 @@
-import { subject } from '@casl/ability';
 import { type ProjectHomepage } from '@lightdash/common';
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useRef, useState, type FC } from 'react';
@@ -9,9 +8,9 @@ import PageSpinner from '../../../components/PageSpinner';
 import { usePinnedItems } from '../../../hooks/pinning/usePinnedItems';
 import { useProject } from '../../../hooks/useProject';
 import { useProjectUuid } from '../../../hooks/useProjectUuid';
-import useApp from '../../../providers/App/useApp';
 import { CreateHomepageModal } from './CreateHomepageModal';
 import { HomepageEditor } from './HomepageEditor';
+import { useCanManageHomepage } from './hooks/useHomepageAbilities';
 import { useKeySpaces } from './hooks/useKeySpaces';
 import { useHomepageOpening } from './hooks/useOrgHomepageSettings';
 import {
@@ -25,69 +24,36 @@ import { buildStarterHomepage } from './starterHomepage';
 // Matches day-0's cap so the first draft is the page people were looking at.
 const MAX_STARTER_SPACES = 4;
 
-// ts-unused-exports:disable-next-line
-export const HomepageBuilderPage: FC = () => {
-    const projectUuid = useProjectUuid();
-    const [searchParams, setSearchParams] = useSearchParams();
-    const navigate = useNavigate();
-    const queryClient = useQueryClient();
-    const [editorEpoch, setEditorEpoch] = useState(0);
-    const [isCreateModalOpen, setIsCreateModalOpen] = useState(
-        searchParams.get('create') === '1',
-    );
-    const selectedHomepageUuid = searchParams.get('homepage') ?? undefined;
-    const { user } = useApp();
-    const { isEnabled: isFlagEnabled, isLoading: isFlagLoading } =
-        useHomepageBuilderFlag();
-    const { opening, isLoading: isAiStateLoading } =
-        useHomepageOpening(projectUuid);
-    // The starter homepage mirrors day-0: the project's pins and the same key
-    // spaces day-0 leads its body with.
+// When there's no homepage yet, skip any intermediate screen: create a
+// default one and drop straight into the builder. Guarded so it fires once.
+// The starter homepage mirrors day-0: the project's pins and the same key
+// spaces day-0 leads its body with.
+const useAutoCreateStarterHomepage = ({
+    projectUuid,
+    enabled,
+    homepage,
+    opening,
+    onCreated,
+}: {
+    projectUuid: string | undefined;
+    enabled: boolean;
+    homepage: ReturnType<typeof useHomepageForBuilder>;
+    opening: ReturnType<typeof useHomepageOpening>['opening'];
+    onCreated: (created: ProjectHomepage) => void;
+}) => {
     const { data: project } = useProject(projectUuid);
     const { data: pinnedItems } = usePinnedItems(
         projectUuid,
         project?.pinnedListUuid,
     );
     const { spaces: keySpaces } = useKeySpaces(projectUuid, MAX_STARTER_SPACES);
-    const homepage = useHomepageForBuilder(projectUuid, {
-        enabled: isFlagEnabled,
-        homepageUuid: selectedHomepageUuid,
-    });
-    const homepages = useProjectHomepages(projectUuid, {
-        enabled: isFlagEnabled,
-    });
     const createFirstHomepage = useCreateHomepageWithDraft(projectUuid ?? '');
-
-    const canManage =
-        user.data?.ability?.can(
-            'manage',
-            subject('ProjectHomepage', {
-                organizationUuid: user.data?.organizationUuid,
-                projectUuid,
-            }),
-        ) ?? false;
-
-    const openHomepage = useCallback(
-        (created: ProjectHomepage) => {
-            setIsCreateModalOpen(false);
-            setSearchParams({ homepage: created.homepageUuid });
-        },
-        [setSearchParams],
-    );
-
-    // When there's no homepage yet, skip any intermediate screen: create a
-    // default one and drop straight into the builder. Guarded so it fires once
-    // and never while we're navigating away after deleting the last homepage.
-    const isLeaving = useRef(false);
     const didAutoCreate = useRef(false);
     const shouldAutoCreate =
-        isFlagEnabled &&
-        !isAiStateLoading &&
-        canManage &&
+        enabled &&
         !!projectUuid &&
         homepage.isFetchedAfterMount &&
-        !homepage.data &&
-        !isLeaving.current;
+        !homepage.data;
 
     useEffect(() => {
         if (!shouldAutoCreate || didAutoCreate.current) return;
@@ -104,16 +70,65 @@ export const HomepageBuilderPage: FC = () => {
                     keySpaces.map((space) => space.uuid),
                 ),
             },
-            { onSuccess: openHomepage },
+            { onSuccess: onCreated },
         );
     }, [
         shouldAutoCreate,
         createFirstHomepage,
-        openHomepage,
+        onCreated,
         opening,
         pinnedItems,
         keySpaces,
     ]);
+};
+
+// ts-unused-exports:disable-next-line
+export const HomepageBuilderPage: FC = () => {
+    const projectUuid = useProjectUuid();
+    const [searchParams, setSearchParams] = useSearchParams();
+    const navigate = useNavigate();
+    const queryClient = useQueryClient();
+    const [editorEpoch, setEditorEpoch] = useState(0);
+    const [isCreateModalOpen, setIsCreateModalOpen] = useState(
+        searchParams.get('create') === '1',
+    );
+    const selectedHomepageUuid = searchParams.get('homepage') ?? undefined;
+    const { isEnabled: isFlagEnabled, isLoading: isFlagLoading } =
+        useHomepageBuilderFlag();
+    const { opening, isLoading: isAiStateLoading } =
+        useHomepageOpening(projectUuid);
+    const canManage = useCanManageHomepage(projectUuid);
+    const homepage = useHomepageForBuilder(projectUuid, {
+        enabled: isFlagEnabled,
+        homepageUuid: selectedHomepageUuid,
+    });
+    const homepages = useProjectHomepages(projectUuid, {
+        enabled: isFlagEnabled,
+    });
+    const homepageList = homepages.data ?? [];
+
+    const openHomepage = useCallback(
+        (created: ProjectHomepage) => {
+            setIsCreateModalOpen(false);
+            setSearchParams({ homepage: created.homepageUuid });
+        },
+        [setSearchParams],
+    );
+
+    // Never auto-create while we're navigating away after deleting the last
+    // homepage.
+    const isLeaving = useRef(false);
+    useAutoCreateStarterHomepage({
+        projectUuid,
+        enabled:
+            isFlagEnabled &&
+            !isAiStateLoading &&
+            canManage &&
+            !isLeaving.current,
+        homepage,
+        opening,
+        onCreated: openHomepage,
+    });
 
     if (isFlagLoading || isAiStateLoading) {
         return <PageSpinner />;
@@ -152,13 +167,13 @@ export const HomepageBuilderPage: FC = () => {
                 key={`${currentHomepageUuid}-${editorEpoch}`}
                 homepage={homepage.data}
                 projectUuid={projectUuid}
-                homepages={homepages.data ?? []}
+                homepages={homepageList}
                 onSwitchHomepage={(homepageUuid) =>
                     setSearchParams({ homepage: homepageUuid })
                 }
                 onCreateNew={() => setIsCreateModalOpen(true)}
                 onDeleted={() => {
-                    const remaining = (homepages.data ?? []).filter(
+                    const remaining = homepageList.filter(
                         (h) => h.homepageUuid !== currentHomepageUuid,
                     );
                     if (remaining.length > 0) {
@@ -184,7 +199,7 @@ export const HomepageBuilderPage: FC = () => {
                 opened={isCreateModalOpen}
                 onClose={closeCreateModal}
                 projectUuid={projectUuid}
-                homepages={homepages.data ?? []}
+                homepages={homepageList}
                 onCreated={openHomepage}
             />
         </Page>

--- a/packages/frontend/src/ee/features/homepageBuilder/PublishModal.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/PublishModal.tsx
@@ -1,4 +1,5 @@
 import {
+    assertUnreachable,
     ProjectMemberRole,
     ProjectMemberRoleLabels,
     type Group as OrgGroup,
@@ -54,6 +55,73 @@ const segmentedLabel = (icon: typeof IconWorld, label: string) => (
         {label}
     </Group>
 );
+
+const AUDIENCE_MODES = ['everyone', 'groups', 'roles'] as const;
+type AudienceMode = (typeof AUDIENCE_MODES)[number];
+
+const isAudienceMode = (value: string): value is AudienceMode =>
+    AUDIENCE_MODES.some((mode) => mode === value);
+
+const initialModeFor = (ownAssignments: HomepageAssignment[]): AudienceMode => {
+    if (ownAssignments.some((a) => a.targetType === 'group')) return 'groups';
+    if (ownAssignments.some((a) => a.targetType === 'role')) return 'roles';
+    return 'everyone';
+};
+
+const pluralise = (count: number, noun: string) =>
+    `${count} ${noun}${count === 1 ? '' : 's'}`;
+
+const confirmLabelFor = (
+    mode: AudienceMode,
+    groupCount: number,
+    roleCount: number,
+): string => {
+    switch (mode) {
+        case 'everyone':
+            return 'Publish to everyone';
+        case 'groups':
+            return groupCount > 0
+                ? `Publish to ${pluralise(groupCount, 'group')}`
+                : 'Publish';
+        case 'roles':
+            return roleCount > 0
+                ? `Publish to ${pluralise(roleCount, 'role')}`
+                : 'Publish';
+        default:
+            return assertUnreachable(mode, 'Unknown audience mode');
+    }
+};
+
+// Publishing the homepage also flips every draft announcement live.
+const DraftAnnouncementsCallout: FC<{ projectUuid: string }> = ({
+    projectUuid,
+}) => {
+    const { data: announcementsPage } = useAnnouncements(projectUuid, {
+        page: 1,
+        pageSize: 100,
+        includeUnpublished: true,
+    });
+    const draftAnnouncements = (announcementsPage?.items ?? []).filter(
+        (announcement) => !announcement.published,
+    );
+    const queuedSlackCount = draftAnnouncements.filter(
+        (announcement) => announcement.pendingSlackChannelId !== null,
+    ).length;
+    if (draftAnnouncements.length === 0) return null;
+    return (
+        <Callout variant="warning">
+            <Text size="sm">
+                Publishing will also make{' '}
+                {pluralise(draftAnnouncements.length, 'draft announcement')}{' '}
+                live
+                {queuedSlackCount > 0
+                    ? ' and send queued Slack notifications'
+                    : ''}
+                .
+            </Text>
+        </Callout>
+    );
+};
 
 type Props = {
     opened: boolean;
@@ -125,29 +193,12 @@ const PublishModalBody: FC<BodyProps> = ({
     assignments,
     reorderGroups,
 }) => {
-    // Publishing the homepage also flips every draft announcement live.
-    const { data: announcementsPage } = useAnnouncements(projectUuid, {
-        page: 1,
-        pageSize: 100,
-        includeUnpublished: true,
-    });
-    const draftAnnouncements = (announcementsPage?.items ?? []).filter(
-        (announcement) => !announcement.published,
-    );
-    const queuedSlackCount = draftAnnouncements.filter(
-        (announcement) => announcement.pendingSlackChannelId !== null,
-    ).length;
-
     const ownAssignments = assignments.filter(
         (assignment) => assignment.homepageUuid === homepageUuid,
     );
-    const initialMode = ownAssignments.some((a) => a.targetType === 'group')
-        ? 'groups'
-        : ownAssignments.some((a) => a.targetType === 'role')
-          ? 'roles'
-          : 'everyone';
-
-    const [mode, setMode] = useState<string>(initialMode);
+    const [mode, setMode] = useState<AudienceMode>(() =>
+        initialModeFor(ownAssignments),
+    );
     const [selectedGroups, setSelectedGroups] = useState<string[]>(() =>
         ownAssignments
             .filter((a) => a.targetType === 'group')
@@ -201,20 +252,11 @@ const PublishModalBody: FC<BodyProps> = ({
         }
     };
 
-    const confirmLabel =
-        mode === 'groups'
-            ? selectedGroups.length > 0
-                ? `Publish to ${selectedGroups.length} group${
-                      selectedGroups.length === 1 ? '' : 's'
-                  }`
-                : 'Publish'
-            : mode === 'roles'
-              ? selectedRoles.length > 0
-                  ? `Publish to ${selectedRoles.length} role${
-                        selectedRoles.length === 1 ? '' : 's'
-                    }`
-                  : 'Publish'
-              : 'Publish to everyone';
+    const confirmLabel = confirmLabelFor(
+        mode,
+        selectedGroups.length,
+        selectedRoles.length,
+    );
 
     return (
         <MantineModal
@@ -242,7 +284,9 @@ const PublishModalBody: FC<BodyProps> = ({
                 <SegmentedControl
                     fullWidth
                     value={mode}
-                    onChange={setMode}
+                    onChange={(value) => {
+                        if (isAudienceMode(value)) setMode(value);
+                    }}
                     data={[
                         {
                             value: 'everyone',
@@ -463,19 +507,7 @@ const PublishModalBody: FC<BodyProps> = ({
                     </>
                 )}
 
-                {draftAnnouncements.length > 0 && (
-                    <Callout variant="warning">
-                        <Text size="sm">
-                            Publishing will also make{' '}
-                            {draftAnnouncements.length} draft announcement
-                            {draftAnnouncements.length === 1 ? '' : 's'} live
-                            {queuedSlackCount > 0
-                                ? ' and send queued Slack notifications'
-                                : ''}
-                            .
-                        </Text>
-                    </Callout>
-                )}
+                <DraftAnnouncementsCallout projectUuid={projectUuid} />
 
                 <Group gap={7} p="10px 12px" className={classes.resolvesBar}>
                     <Text fz={11.5} fw={500} c="ldGray.5">

--- a/packages/frontend/src/ee/features/homepageBuilder/PublishModal.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/PublishModal.tsx
@@ -92,10 +92,10 @@ const confirmLabelFor = (
     }
 };
 
-// Publishing the homepage also flips every draft announcement live.
-const DraftAnnouncementsCallout: FC<{ projectUuid: string }> = ({
-    projectUuid,
-}) => {
+// Publishing the homepage also flips every draft announcement live. The
+// query stays in the body (mounted while the modal is closed) so the callout
+// is already resolved by the time the modal opens.
+const useDraftAnnouncementCounts = (projectUuid: string) => {
     const { data: announcementsPage } = useAnnouncements(projectUuid, {
         page: 1,
         pageSize: 100,
@@ -104,16 +104,24 @@ const DraftAnnouncementsCallout: FC<{ projectUuid: string }> = ({
     const draftAnnouncements = (announcementsPage?.items ?? []).filter(
         (announcement) => !announcement.published,
     );
-    const queuedSlackCount = draftAnnouncements.filter(
-        (announcement) => announcement.pendingSlackChannelId !== null,
-    ).length;
-    if (draftAnnouncements.length === 0) return null;
+    return {
+        draftCount: draftAnnouncements.length,
+        queuedSlackCount: draftAnnouncements.filter(
+            (announcement) => announcement.pendingSlackChannelId !== null,
+        ).length,
+    };
+};
+
+const DraftAnnouncementsCallout: FC<{
+    draftCount: number;
+    queuedSlackCount: number;
+}> = ({ draftCount, queuedSlackCount }) => {
+    if (draftCount === 0) return null;
     return (
         <Callout variant="warning">
             <Text size="sm">
                 Publishing will also make{' '}
-                {pluralise(draftAnnouncements.length, 'draft announcement')}{' '}
-                live
+                {pluralise(draftCount, 'draft announcement')} live
                 {queuedSlackCount > 0
                     ? ' and send queued Slack notifications'
                     : ''}
@@ -193,6 +201,7 @@ const PublishModalBody: FC<BodyProps> = ({
     assignments,
     reorderGroups,
 }) => {
+    const draftAnnouncements = useDraftAnnouncementCounts(projectUuid);
     const ownAssignments = assignments.filter(
         (assignment) => assignment.homepageUuid === homepageUuid,
     );
@@ -507,7 +516,7 @@ const PublishModalBody: FC<BodyProps> = ({
                     </>
                 )}
 
-                <DraftAnnouncementsCallout projectUuid={projectUuid} />
+                <DraftAnnouncementsCallout {...draftAnnouncements} />
 
                 <Group gap={7} p="10px 12px" className={classes.resolvesBar}>
                     <Text fz={11.5} fw={500} c="ldGray.5">

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/AnnouncementsBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/AnnouncementsBlock.tsx
@@ -1,4 +1,3 @@
-import { subject } from '@casl/ability';
 import {
     ANNOUNCEMENT_BODY_MAX_LENGTH,
     ANNOUNCEMENT_CATEGORY_META,
@@ -46,7 +45,6 @@ import MantineModal from '../../../../components/common/MantineModal';
 import { SlackChannelSelect } from '../../../../components/common/SlackChannelSelect';
 import { useGetSlack } from '../../../../hooks/slack/useSlack';
 import { useTimeAgo } from '../../../../hooks/useTimeAgo';
-import useApp from '../../../../providers/App/useApp';
 import {
     useAnnouncements,
     useCreateAnnouncement,
@@ -54,6 +52,7 @@ import {
     useUpdateAnnouncement,
     useUploadAnnouncementImage,
 } from '../hooks/useAnnouncements';
+import { useCanManageHomepage } from '../hooks/useHomepageAbilities';
 import classes from './announcements/announcements.module.css';
 import { BlockHeader } from './BlockShell';
 import { TiptapMarkdownEditor } from './markdownEditor/TiptapMarkdownEditor';
@@ -543,15 +542,7 @@ export const AnnouncementsBlockView: FC<BlockComponentProps> = ({
     block,
     projectUuid,
 }) => {
-    const { user } = useApp();
-    const canManage =
-        user.data?.ability?.can(
-            'manage',
-            subject('ProjectHomepage', {
-                organizationUuid: user.data?.organizationUuid,
-                projectUuid,
-            }),
-        ) ?? false;
+    const canManage = useCanManageHomepage(projectUuid);
     // Managers see drafts inline (tagged) so they can edit or delete them
     // from here; viewers only ever get published announcements.
     const { announcements, isLoading, isError } = useAnnouncementFeed(
@@ -635,6 +626,156 @@ export const AnnouncementsBlockView: FC<BlockComponentProps> = ({
     );
 };
 
+const DEFAULT_SCHEDULE_TIME = '09:00';
+
+const formatTimeOfDay = (date: Date): string =>
+    `${String(date.getHours()).padStart(2, '0')}:${String(
+        date.getMinutes(),
+    ).padStart(2, '0')}`;
+
+const initialFormValues = (announcement: ProjectAnnouncement | null) => ({
+    title: announcement?.title ?? '',
+    body: announcement?.body ?? '',
+    category: announcement?.category ?? null,
+    slackChannelId: announcement?.pendingSlackChannelId ?? null,
+    schedule: announcement?.scheduledPublishAt
+        ? new Date(announcement.scheduledPublishAt)
+        : null,
+});
+
+// Wall-clock date+time in the admin's local timezone → a UTC instant.
+const useScheduleFields = (initialSchedule: Date | null) => {
+    const [enabled, setEnabled] = useState(initialSchedule !== null);
+    const [date, setDate] = useState<Date | null>(initialSchedule);
+    const [time, setTime] = useState(
+        initialSchedule
+            ? formatTimeOfDay(initialSchedule)
+            : DEFAULT_SCHEDULE_TIME,
+    );
+    const scheduledAt = useMemo(() => {
+        if (!enabled || !date) return null;
+        const [hours, minutes] = time.split(':').map(Number);
+        const combined = new Date(date);
+        combined.setHours(hours || 0, minutes || 0, 0, 0);
+        return combined;
+    }, [enabled, date, time]);
+    const isInPast =
+        scheduledAt !== null && scheduledAt.getTime() <= Date.now();
+    const isValid = !enabled || (scheduledAt !== null && !isInPast);
+    return {
+        enabled,
+        setEnabled,
+        date,
+        setDate,
+        time,
+        setTime,
+        scheduledAt,
+        isInPast,
+        isValid,
+    };
+};
+
+type ScheduleFields = ReturnType<typeof useScheduleFields>;
+
+const SchedulePicker: FC<{ schedule: ScheduleFields }> = ({ schedule }) => (
+    <Stack gap="xs">
+        <Switch
+            size="xs"
+            label="Schedule publish"
+            checked={schedule.enabled}
+            onChange={(event) =>
+                schedule.setEnabled(event.currentTarget.checked)
+            }
+        />
+        {schedule.enabled && (
+            <Group grow align="flex-start" wrap="nowrap">
+                <CalendarPickerInput
+                    label="Date"
+                    size="sm"
+                    radius="md"
+                    value={schedule.date}
+                    onChange={schedule.setDate}
+                    minDate={new Date()}
+                />
+                <TimeInput
+                    label="Time"
+                    size="sm"
+                    radius="md"
+                    value={schedule.time}
+                    onChange={(event) =>
+                        schedule.setTime(event.currentTarget.value)
+                    }
+                />
+            </Group>
+        )}
+    </Stack>
+);
+
+const saveLabelFor = ({
+    isEdit,
+    isScheduled,
+    publishNow,
+    hasSlack,
+}: {
+    isEdit: boolean;
+    isScheduled: boolean;
+    publishNow: boolean;
+    hasSlack: boolean;
+}): string => {
+    if (isEdit) return 'Save';
+    if (isScheduled) return hasSlack ? 'Schedule & queue Slack' : 'Schedule';
+    if (publishNow) return hasSlack ? 'Post & send to Slack' : 'Post';
+    return hasSlack ? 'Create draft & queue Slack' : 'Create draft';
+};
+
+const PublishHint: FC<{
+    isEdit: boolean;
+    isPublished: boolean;
+    publishNow: boolean;
+    hasSlack: boolean;
+    schedule: ScheduleFields;
+}> = ({ isEdit, isPublished, publishNow, hasSlack, schedule }) => {
+    if (schedule.enabled && schedule.isInPast) {
+        return (
+            <Text size="xs" c="red">
+                Pick a publish time in the future.
+            </Text>
+        );
+    }
+    if (schedule.enabled && schedule.scheduledAt) {
+        return (
+            <Text size="xs" c="dimmed">
+                Publishes automatically on{' '}
+                {schedule.scheduledAt.toLocaleString(undefined, {
+                    weekday: 'short',
+                    month: 'short',
+                    day: 'numeric',
+                    hour: 'numeric',
+                    minute: '2-digit',
+                })}{' '}
+                (your local time)
+                {hasSlack ? ' and notifies Slack then' : ''}.
+            </Text>
+        );
+    }
+    if (!isEdit && publishNow) {
+        return (
+            <Text size="xs" c="dimmed">
+                Goes live on the homepage immediately
+                {hasSlack ? ' and notifies Slack' : ''}.
+            </Text>
+        );
+    }
+    if (isPublished) return null;
+    return (
+        <Text size="xs" c="dimmed">
+            Saved as a draft. It
+            {hasSlack ? ' and its Slack notification' : ''} goes live when you
+            publish the homepage.
+        </Text>
+    );
+};
+
 const AnnouncementFormModal: FC<{
     projectUuid: string;
     announcement: ProjectAnnouncement | null;
@@ -651,43 +792,20 @@ const AnnouncementFormModal: FC<{
     onClose,
 }) => {
     const isEdit = announcement !== null;
+    const isPublished = announcement?.published === true;
     // Slack can only be retargeted while the announcement is still a draft.
-    const slackEditable = slackInstalled && !announcement?.published;
-    const initialSlackChannelId = announcement?.pendingSlackChannelId ?? null;
-    const initialSchedule = announcement?.scheduledPublishAt
-        ? new Date(announcement.scheduledPublishAt)
-        : null;
-    const [title, setTitle] = useState(announcement?.title ?? '');
-    const [body, setBody] = useState(announcement?.body ?? '');
+    const slackEditable = slackInstalled && !isPublished;
+    const initial = initialFormValues(announcement);
+    const [title, setTitle] = useState(initial.title);
+    const [body, setBody] = useState(initial.body);
     const [category, setCategory] = useState<AnnouncementCategory | null>(
-        announcement?.category ?? null,
+        initial.category,
     );
     const [slackChannelId, setSlackChannelId] = useState<string | null>(
-        initialSlackChannelId,
+        initial.slackChannelId,
     );
-    const [scheduleEnabled, setScheduleEnabled] = useState(
-        initialSchedule !== null,
-    );
-    const [scheduleDate, setScheduleDate] = useState<Date | null>(
-        initialSchedule,
-    );
-    const [scheduleTime, setScheduleTime] = useState(
-        initialSchedule
-            ? `${String(initialSchedule.getHours()).padStart(2, '0')}:${String(
-                  initialSchedule.getMinutes(),
-              ).padStart(2, '0')}`
-            : '09:00',
-    );
-    // Wall-clock date+time in the admin's local timezone → a UTC instant.
-    const scheduledAt = useMemo(() => {
-        if (!scheduleEnabled || !scheduleDate) return null;
-        const [hours, minutes] = scheduleTime.split(':').map(Number);
-        const combined = new Date(scheduleDate);
-        combined.setHours(hours || 0, minutes || 0, 0, 0);
-        return combined;
-    }, [scheduleEnabled, scheduleDate, scheduleTime]);
-    const scheduleInPast =
-        scheduledAt !== null && scheduledAt.getTime() <= Date.now();
+    const schedule = useScheduleFields(initial.schedule);
+    const { scheduledAt } = schedule;
     const { mutate: create, isLoading: creating } =
         useCreateAnnouncement(projectUuid);
     const { mutate: update, isLoading: updating } =
@@ -695,6 +813,7 @@ const AnnouncementFormModal: FC<{
     const uploadImage = useUploadAnnouncementImage(projectUuid);
     const isLoading = creating || updating;
     const bodyTooLong = body.trim().length > ANNOUNCEMENT_BODY_MAX_LENGTH;
+    const hasSlack = !!slackChannelId;
 
     const handleSave = () => {
         const trimmedTitle = title.trim();
@@ -709,14 +828,14 @@ const AnnouncementFormModal: FC<{
                     category,
                     // Omitted when untouched — PATCH leaves it unchanged.
                     ...(slackEditable &&
-                    slackChannelId !== initialSlackChannelId
+                    slackChannelId !== initial.slackChannelId
                         ? { slackChannelId }
                         : {}),
                     ...(scheduledAt &&
-                    scheduledAt.getTime() !== initialSchedule?.getTime()
+                    scheduledAt.getTime() !== initial.schedule?.getTime()
                         ? { scheduledPublishAt: scheduledAt }
                         : {}),
-                    ...(!scheduleEnabled && initialSchedule
+                    ...(!schedule.enabled && initial.schedule
                         ? { scheduledPublishAt: null }
                         : {}),
                 },
@@ -740,14 +859,6 @@ const AnnouncementFormModal: FC<{
         }
     };
 
-    let saveLabel = 'Create draft';
-    if (isEdit) saveLabel = 'Save';
-    else if (scheduledAt)
-        saveLabel = slackChannelId ? 'Schedule & queue Slack' : 'Schedule';
-    else if (publishNow)
-        saveLabel = slackChannelId ? 'Post & send to Slack' : 'Post';
-    else if (slackChannelId) saveLabel = 'Create draft & queue Slack';
-
     return (
         <MantineModal
             opened
@@ -756,11 +867,14 @@ const AnnouncementFormModal: FC<{
             icon={IconSpeakerphone}
             size="lg"
             onConfirm={handleSave}
-            confirmLabel={saveLabel}
+            confirmLabel={saveLabelFor({
+                isEdit,
+                isScheduled: scheduledAt !== null,
+                publishNow,
+                hasSlack,
+            })}
             confirmDisabled={
-                title.trim().length === 0 ||
-                bodyTooLong ||
-                (scheduleEnabled && (!scheduledAt || scheduleInPast))
+                title.trim().length === 0 || bodyTooLong || !schedule.isValid
             }
             confirmLoading={isLoading}
         >
@@ -776,7 +890,7 @@ const AnnouncementFormModal: FC<{
                     />
                     <div className={classes.docBody}>
                         <TiptapMarkdownEditor
-                            content={announcement?.body ?? ''}
+                            content={initial.body}
                             onChange={setBody}
                             onImageUpload={async (file) =>
                                 (await uploadImage.mutateAsync(file)).url
@@ -810,41 +924,7 @@ const AnnouncementFormModal: FC<{
                         />
                     )}
                 </Group>
-                {!announcement?.published && (
-                    <Stack gap="xs">
-                        <Switch
-                            size="xs"
-                            label="Schedule publish"
-                            checked={scheduleEnabled}
-                            onChange={(event) =>
-                                setScheduleEnabled(event.currentTarget.checked)
-                            }
-                        />
-                        {scheduleEnabled && (
-                            <Group grow align="flex-start" wrap="nowrap">
-                                <CalendarPickerInput
-                                    label="Date"
-                                    size="sm"
-                                    radius="md"
-                                    value={scheduleDate}
-                                    onChange={setScheduleDate}
-                                    minDate={new Date()}
-                                />
-                                <TimeInput
-                                    label="Time"
-                                    size="sm"
-                                    radius="md"
-                                    value={scheduleTime}
-                                    onChange={(event) =>
-                                        setScheduleTime(
-                                            event.currentTarget.value,
-                                        )
-                                    }
-                                />
-                            </Group>
-                        )}
-                    </Stack>
-                )}
+                {!isPublished && <SchedulePicker schedule={schedule} />}
                 {bodyTooLong && (
                     <Text size="xs" c="red">
                         Body is {body.trim().length.toLocaleString()} characters
@@ -853,39 +933,13 @@ const AnnouncementFormModal: FC<{
                         fewer.
                     </Text>
                 )}
-                {scheduleEnabled && scheduleInPast ? (
-                    <Text size="xs" c="red">
-                        Pick a publish time in the future.
-                    </Text>
-                ) : scheduleEnabled && scheduledAt ? (
-                    <Text size="xs" c="dimmed">
-                        Publishes automatically on{' '}
-                        {scheduledAt.toLocaleString(undefined, {
-                            weekday: 'short',
-                            month: 'short',
-                            day: 'numeric',
-                            hour: 'numeric',
-                            minute: '2-digit',
-                        })}{' '}
-                        (your local time)
-                        {slackChannelId ? ' and notifies Slack then' : ''}.
-                    </Text>
-                ) : !isEdit && publishNow ? (
-                    <Text size="xs" c="dimmed">
-                        Goes live on the homepage immediately
-                        {slackChannelId ? ' and notifies Slack' : ''}.
-                    </Text>
-                ) : (
-                    !announcement?.published && (
-                        <Text size="xs" c="dimmed">
-                            Saved as a draft. It
-                            {slackChannelId
-                                ? ' and its Slack notification'
-                                : ''}{' '}
-                            goes live when you publish the homepage.
-                        </Text>
-                    )
-                )}
+                <PublishHint
+                    isEdit={isEdit}
+                    isPublished={isPublished}
+                    publishNow={publishNow}
+                    hasSlack={hasSlack}
+                    schedule={schedule}
+                />
             </Stack>
         </MantineModal>
     );

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.tsx
@@ -1,10 +1,14 @@
-import { subject } from '@casl/ability';
 import {
     FeatureFlags,
     DbtProjectType,
     DbtProjectTypeLabels,
     ProjectType,
+    type AgentOnboardingRun,
+    type HealthState,
     type HomepageRecommendedActionKey,
+    type Organization,
+    type OrganizationProject,
+    type Project,
 } from '@lightdash/common';
 import { type ReactNode } from 'react';
 import { useGithubConfig } from '../../../../components/common/GithubIntegration/hooks/useGithubIntegration';
@@ -22,6 +26,7 @@ import useApp from '../../../../providers/App/useApp';
 import { isPlaygroundProvisioningSource } from '../../../../utils/playgroundProject';
 import { useActiveAgentOnboardingRun } from '../../agentOnboarding/hooks/useAgentOnboarding';
 import { getAgentOnboardingRunUrl } from '../../agentOnboarding/utils';
+import { useCanManageProject } from '../hooks/useHomepageAbilities';
 import { useHomepageRecommendedActionSkips } from '../hooks/useHomepageRecommendedActionSkips';
 import { RECOMMENDED_ACTION_KEYS } from './recommendedActionDefaults';
 
@@ -39,6 +44,32 @@ const isTermPending = (
     query: { isFetched: boolean },
 ) => isGateOpen === undefined || (isGateOpen && !query.isFetched);
 
+type GatedQuery = readonly [
+    isGateOpen: boolean | undefined,
+    query: { isFetched: boolean },
+];
+
+const isAnyTermPending = (terms: GatedQuery[]): boolean =>
+    terms.some(([isGateOpen, query]) => isTermPending(isGateOpen, query));
+
+// A gate is unknown until the query that decides it has settled.
+const gate = (isSettled: boolean, isOpen: boolean): boolean | undefined =>
+    isSettled ? isOpen : undefined;
+
+const isFlagOn = (flag: { data: { enabled: boolean } | undefined }): boolean =>
+    flag.data?.enabled === true;
+
+const integrationFlags = (health: HealthState | undefined) => ({
+    hasGithub: !!health?.hasGithub,
+    hasGitlab: !!health?.hasGitlab,
+    hasSlack: !!health?.hasSlack,
+});
+
+type DbtConnection = Project['dbtConnection'] | undefined;
+
+const hasSemanticLayer = (dbtConnection: DbtConnection): boolean =>
+    !!dbtConnection && dbtConnection.type !== DbtProjectType.NONE;
+
 export type ActionStatus = {
     isVisible: boolean;
     isComplete: boolean;
@@ -47,6 +78,138 @@ export type ActionStatus = {
     doneIcon: ReactNode | null;
     url: string;
     ctaLabel: string;
+};
+
+// A playground is a project, so `needsProject` alone would report the
+// warehouse step as done on sample data
+const resolveWarehouse = (
+    organization: Organization | undefined,
+    projects: OrganizationProject[] | undefined,
+    project: Project | undefined,
+) => {
+    const hasRealWarehouseProject =
+        organization?.needsProject === false &&
+        (projects ?? []).some(
+            ({ type, provisioningSource }) =>
+                type === ProjectType.DEFAULT &&
+                !isPlaygroundProvisioningSource(provisioningSource),
+        );
+    const warehouseType =
+        hasRealWarehouseProject &&
+        !isPlaygroundProvisioningSource(project?.provisioningSource)
+            ? project?.warehouseConnection?.type
+            : undefined;
+    return { hasRealWarehouseProject, warehouseType };
+};
+
+const warehouseStatus = ({
+    hasRealWarehouseProject,
+    warehouseType,
+}: ReturnType<typeof resolveWarehouse>): ActionStatus => ({
+    isVisible: true,
+    isComplete: hasRealWarehouseProject,
+    annotation: warehouseType ? getWarehouseLabel(warehouseType) : null,
+    doneIcon: warehouseType ? getWarehouseIcon(warehouseType, 'sm') : null,
+    url: '/onboarding/data-source',
+    ctaLabel: DEFAULT_CTA_LABEL,
+});
+
+// An agent run left mid-flight is resumable, so the step points at the run
+// instead of restarting the flow
+const semanticLayerUrl = (
+    projectUuid: string | null,
+    activeAgentRun: AgentOnboardingRun | null,
+    hasAgentSemanticLayerEntry: boolean,
+): string => {
+    if (activeAgentRun) {
+        return getAgentOnboardingRunUrl(
+            activeAgentRun.agentOnboardingRunUuid,
+            activeAgentRun.projectUuid,
+        );
+    }
+    if (hasAgentSemanticLayerEntry) {
+        return `/projects/${projectUuid}/onboarding/agent`;
+    }
+    return `/generalSettings/projectManagement/${projectUuid}/settings`;
+};
+
+const semanticLayerStatus = ({
+    projectUuid,
+    dbtConnection,
+    activeAgentRun,
+    hasAgentSemanticLayerEntry,
+}: {
+    projectUuid: string | null;
+    dbtConnection: DbtConnection;
+    activeAgentRun: AgentOnboardingRun | null;
+    hasAgentSemanticLayerEntry: boolean;
+}): ActionStatus => ({
+    isVisible: !!projectUuid,
+    isComplete: hasSemanticLayer(dbtConnection),
+    annotation: dbtConnection ? DbtProjectTypeLabels[dbtConnection.type] : null,
+    doneIcon: null,
+    url: semanticLayerUrl(
+        projectUuid,
+        activeAgentRun,
+        hasAgentSemanticLayerEntry,
+    ),
+    ctaLabel: activeAgentRun ? 'Resume' : DEFAULT_CTA_LABEL,
+});
+
+const sourceControlAnnotation = (
+    isGithubConnected: boolean,
+    isGitlabConnected: boolean,
+    dbtConnection: DbtConnection,
+): string | null => {
+    if (isGithubConnected) return 'GitHub';
+    if (isGitlabConnected) return 'GitLab';
+    if (dbtConnection && dbtConnection.type !== DbtProjectType.NONE) {
+        return DbtProjectTypeLabels[dbtConnection.type];
+    }
+    return null;
+};
+
+const sourceControlStatus = ({
+    hasGithub,
+    hasGitlab,
+    isGithubConnected,
+    isGitlabConnected,
+    dbtConnection,
+}: {
+    hasGithub: boolean;
+    hasGitlab: boolean;
+    isGithubConnected: boolean;
+    isGitlabConnected: boolean;
+    dbtConnection: DbtConnection;
+}): ActionStatus => ({
+    isVisible: hasGithub || hasGitlab,
+    isComplete:
+        isGithubConnected ||
+        isGitlabConnected ||
+        hasSemanticLayer(dbtConnection),
+    annotation: sourceControlAnnotation(
+        isGithubConnected,
+        isGitlabConnected,
+        dbtConnection,
+    ),
+    doneIcon: null,
+    url: '/onboarding/dbt',
+    ctaLabel: DEFAULT_CTA_LABEL,
+});
+
+const slackStatus = (
+    hasSlack: boolean,
+    slackQuery: ReturnType<typeof useGetSlack>,
+): ActionStatus => {
+    const { data: slack, isSuccess } = slackQuery;
+    return {
+        isVisible: hasSlack,
+        isComplete: isSuccess && !!slack && slack.hasRequiredScopes !== false,
+        annotation: slack?.slackTeamName ?? 'Connected',
+        doneIcon: null,
+        url: '/generalSettings/integrations',
+        ctaLabel: DEFAULT_CTA_LABEL,
+    };
 };
 
 const useActionStatuses = (
@@ -61,11 +224,6 @@ const useActionStatuses = (
     const projectsQuery = useProjects();
     const githubConfigQuery = useGithubConfig();
     const slackQuery = useGetSlack();
-    const { data: organization } = organizationQuery;
-    const { data: project } = projectQuery;
-    const { data: projects } = projectsQuery;
-    const { data: githubConfig } = githubConfigQuery;
-    const { data: slack, isSuccess: isSlackSuccess } = slackQuery;
     const newOnboardingFlag = useServerFeatureFlag(FeatureFlags.NewOnboarding);
     const codingAgentOnboardingFlag = useServerFeatureFlag(
         FeatureFlags.CodingAgentOnboarding,
@@ -73,11 +231,8 @@ const useActionStatuses = (
     const areFlagsSettled =
         newOnboardingFlag.isFetched && codingAgentOnboardingFlag.isFetched;
     const hasAgentSemanticLayerEntry =
-        newOnboardingFlag.data?.enabled === true &&
-        codingAgentOnboardingFlag.data?.enabled === true;
+        isFlagOn(newOnboardingFlag) && isFlagOn(codingAgentOnboardingFlag);
 
-    // An agent run left mid-flight is resumable, so the step points at the run
-    // instead of restarting the flow
     const activeAgentRunQuery = useActiveAgentOnboardingRun(
         projectUuid ?? undefined,
         { enabled: hasAgentSemanticLayerEntry },
@@ -85,14 +240,11 @@ const useActionStatuses = (
     const activeAgentRun = activeAgentRunQuery.data ?? null;
 
     const isHealthSettled = health.isFetched;
-    const hasGithub = !!health.data?.hasGithub;
-    const hasGitlab = !!health.data?.hasGitlab;
-    const hasSlack = !!health.data?.hasSlack;
+    const { hasGithub, hasGitlab, hasSlack } = integrationFlags(health.data);
     const gitlabQuery = useGitlabRepositories({
         enabled: hasGitlab,
     });
-    const { isSuccess: isGitlabConnected } = gitlabQuery;
-    const isGithubConnected = githubConfig?.enabled === true;
+    const isGithubConnected = githubConfigQuery.data?.enabled === true;
 
     // Every step defaults to incomplete, so rendering before these have
     // settled flashes steps that are already done. Health decides which
@@ -100,107 +252,55 @@ const useActionStatuses = (
     // is looked up, so those answers gate the terms below rather than each
     // query's own idle state.
     const isLoading =
-        isTermPending(true, health) ||
-        isTermPending(true, organizationQuery) ||
-        isTermPending(!!projectUuid, projectQuery) ||
-        isTermPending(true, projectsQuery) ||
-        isTermPending(
-            isHealthSettled ? hasGithub : undefined,
-            githubConfigQuery,
-        ) ||
-        isTermPending(isHealthSettled ? hasGitlab : undefined, gitlabQuery) ||
-        isTermPending(isHealthSettled ? hasSlack : undefined, slackQuery) ||
-        isTermPending(
-            areFlagsSettled
-                ? !!projectUuid && hasAgentSemanticLayerEntry
-                : undefined,
-            activeAgentRunQuery,
-        ) ||
-        !areFlagsSettled;
+        !areFlagsSettled ||
+        isAnyTermPending([
+            [true, health],
+            [true, organizationQuery],
+            [!!projectUuid, projectQuery],
+            [true, projectsQuery],
+            [gate(isHealthSettled, hasGithub), githubConfigQuery],
+            [gate(isHealthSettled, hasGitlab), gitlabQuery],
+            [gate(isHealthSettled, hasSlack), slackQuery],
+            [
+                gate(
+                    areFlagsSettled,
+                    !!projectUuid && hasAgentSemanticLayerEntry,
+                ),
+                activeAgentRunQuery,
+            ],
+        ]);
 
-    const dbtConnection = project?.dbtConnection;
-    const hasSemanticLayer =
-        !!dbtConnection && dbtConnection.type !== DbtProjectType.NONE;
-    const isSlackConnected =
-        isSlackSuccess && !!slack && slack.hasRequiredScopes !== false;
-
-    // A playground is a project, so `needsProject` alone would report the
-    // warehouse step as done on sample data
-    const hasRealWarehouseProject =
-        organization?.needsProject === false &&
-        (projects?.some(
-            ({ type, provisioningSource }) =>
-                type === ProjectType.DEFAULT &&
-                !isPlaygroundProvisioningSource(provisioningSource),
-        ) ??
-            false);
-    const warehouseType =
-        hasRealWarehouseProject &&
-        !isPlaygroundProvisioningSource(project?.provisioningSource)
-            ? project?.warehouseConnection?.type
-            : undefined;
+    const dbtConnection = projectQuery.data?.dbtConnection;
 
     return {
         isLoading,
         statuses: {
-            'connect-warehouse': {
-                isVisible: true,
-                isComplete: hasRealWarehouseProject,
-                annotation: warehouseType
-                    ? getWarehouseLabel(warehouseType)
-                    : null,
-                doneIcon: warehouseType
-                    ? getWarehouseIcon(warehouseType, 'sm')
-                    : null,
-                url: '/onboarding/data-source',
-                ctaLabel: DEFAULT_CTA_LABEL,
-            },
-            'add-semantic-layer': {
-                isVisible: !!projectUuid,
-                isComplete: hasSemanticLayer,
-                annotation: dbtConnection
-                    ? DbtProjectTypeLabels[dbtConnection.type]
-                    : null,
-                doneIcon: null,
-                url: activeAgentRun
-                    ? getAgentOnboardingRunUrl(
-                          activeAgentRun.agentOnboardingRunUuid,
-                          activeAgentRun.projectUuid,
-                      )
-                    : hasAgentSemanticLayerEntry
-                      ? `/projects/${projectUuid}/onboarding/agent`
-                      : `/generalSettings/projectManagement/${projectUuid}/settings`,
-                ctaLabel: activeAgentRun ? 'Resume' : DEFAULT_CTA_LABEL,
-            },
-            'connect-source-control': {
-                isVisible: hasGithub || hasGitlab,
-                isComplete:
-                    isGithubConnected || isGitlabConnected || hasSemanticLayer,
-                annotation: isGithubConnected
-                    ? 'GitHub'
-                    : isGitlabConnected
-                      ? 'GitLab'
-                      : hasSemanticLayer
-                        ? DbtProjectTypeLabels[dbtConnection.type]
-                        : null,
-                doneIcon: null,
-                url: '/onboarding/dbt',
-                ctaLabel: DEFAULT_CTA_LABEL,
-            },
-            'connect-slack': {
-                isVisible: hasSlack,
-                isComplete: isSlackConnected,
-                annotation: slack?.slackTeamName ?? 'Connected',
-                doneIcon: null,
-                url: '/generalSettings/integrations',
-                ctaLabel: DEFAULT_CTA_LABEL,
-            },
+            'connect-warehouse': warehouseStatus(
+                resolveWarehouse(
+                    organizationQuery.data,
+                    projectsQuery.data,
+                    projectQuery.data,
+                ),
+            ),
+            'add-semantic-layer': semanticLayerStatus({
+                projectUuid,
+                dbtConnection,
+                activeAgentRun,
+                hasAgentSemanticLayerEntry,
+            }),
+            'connect-source-control': sourceControlStatus({
+                hasGithub,
+                hasGitlab,
+                isGithubConnected,
+                isGitlabConnected: gitlabQuery.isSuccess,
+                dbtConnection,
+            }),
+            'connect-slack': slackStatus(hasSlack, slackQuery),
         },
     };
 };
 
 export const useRecommendedActions = (projectUuid: string | null) => {
-    const { user } = useApp();
     const { statuses, isLoading: areStatusesLoading } =
         useActionStatuses(projectUuid);
     const newOnboardingFlag = useServerFeatureFlag(FeatureFlags.NewOnboarding);
@@ -208,15 +308,7 @@ export const useRecommendedActions = (projectUuid: string | null) => {
     const isPlaygroundProject = isPlaygroundProvisioningSource(
         project?.provisioningSource,
     );
-
-    const canManageProject =
-        user.data?.ability?.can(
-            'manage',
-            subject('Project', {
-                organizationUuid: user.data?.organizationUuid,
-                projectUuid: projectUuid ?? undefined,
-            }),
-        ) ?? false;
+    const canManageProject = useCanManageProject(projectUuid);
 
     const {
         skippedActions = [],
@@ -239,7 +331,7 @@ export const useRecommendedActions = (projectUuid: string | null) => {
         : RECOMMENDED_ACTION_KEYS.filter((key) => statuses[key].isVisible);
     const skippedActionKeys = new Set<string>(skippedActions);
     const hasPendingActions =
-        newOnboardingFlag.data?.enabled === true &&
+        isFlagOn(newOnboardingFlag) &&
         !isLoading &&
         canManageProject &&
         visibleActions.some(

--- a/packages/frontend/src/ee/features/homepageBuilder/hooks/useHomepageAbilities.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/hooks/useHomepageAbilities.ts
@@ -1,0 +1,26 @@
+import { subject } from '@casl/ability';
+import useApp from '../../../../providers/App/useApp';
+
+const useCanManage = (
+    subjectType: 'Project' | 'ProjectHomepage',
+    projectUuid: string | undefined,
+): boolean => {
+    const { user } = useApp();
+    return (
+        user.data?.ability?.can(
+            'manage',
+            subject(subjectType, {
+                organizationUuid: user.data?.organizationUuid,
+                projectUuid,
+            }),
+        ) ?? false
+    );
+};
+
+export const useCanManageProject = (
+    projectUuid: string | null | undefined,
+): boolean => useCanManage('Project', projectUuid ?? undefined);
+
+export const useCanManageHomepage = (
+    projectUuid: string | undefined,
+): boolean => useCanManage('ProjectHomepage', projectUuid);

--- a/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.ts
@@ -150,6 +150,12 @@ const dedupeGreetings = (
 // directions during rolling deploys — reads tolerate missing fields rather
 // than trusting the current schema. The layout reasons about what will actually paint: an invisible block
 // must not demote the hero, leave a phantom row gap, or hold a ghost column.
+const isEmptyList = (items: readonly unknown[] | undefined): boolean =>
+    (items?.length ?? 0) === 0;
+
+const isBlankText = (text: string | undefined): boolean =>
+    (text ?? '').trim() === '';
+
 const isConfigEmptyBlock = (block: HomepageBlock): boolean => {
     switch (block.type) {
         // A collection with a dynamic source has no items in config — what it
@@ -158,17 +164,17 @@ const isConfigEmptyBlock = (block: HomepageBlock): boolean => {
         case 'collection':
             return (
                 collectionSourceOf(block.config) === 'manual' &&
-                (block.config.items?.length ?? 0) === 0
+                isEmptyList(block.config.items)
             );
         case 'resources':
         case 'metrics':
-            return (block.config.items?.length ?? 0) === 0;
+            return isEmptyList(block.config.items);
         case 'quick-actions':
-            return (block.config.actions?.length ?? 0) === 0;
+            return isEmptyList(block.config.actions);
         case 'cta':
-            return (block.config.buttonLabel ?? '').trim() === '';
+            return isBlankText(block.config.buttonLabel);
         case 'markdown':
-            return (block.config.content ?? '').trim() === '';
+            return isBlankText(block.config.content);
         // Visibility depends on runtime data (viewer, AI availability, the
         // announcements feed), not config — always treat as visible.
         case 'announcements':


### PR DESCRIPTION
## Summary

Uses oxlint's `complexity` rule (ESLint cyclomatic complexity) as a refactor target for the homepage builder. Six functions scored above the default threshold of 20; each is split into hooks and pure helpers so the component/hook bodies are wiring plus JSX. No behaviour change intended.

| Function | Before | After | How |
|---|---|---|---|
| `DayOneAskInputInner` | 64 | 16 | `useComposerAgents`, `useComposerSqlMode`, `useHomepageDeepResearch`, `useHomepageSuggestionChips` (same file) plus a `composerPlaceholder` helper |
| `useActionStatuses` | 52 | 11 | `isAnyTermPending([[gate, query], ...])` replaces the 9-term `||` chain; one pure builder per checklist entry; `resolveWarehouse` / `integrationFlags` absorb the null guards |
| `AnnouncementFormModal` | 46 | ~14 | `useScheduleFields` owns date/time/`scheduledAt`/`isValid`; `SchedulePicker` and `PublishHint` components; `saveLabelFor`, `initialFormValues` pure |
| `HomepageBuilderPage` | 24 | ~14 | auto-create effect and its queries move into `useAutoCreateStarterHomepage` |
| `PublishModalBody` | 22 | ~15 | `initialModeFor`, `confirmLabelFor` (exhaustive switch), `pluralise`, `useDraftAnnouncementCounts`; `DraftAnnouncementsCallout` is presentational; `mode` typed as `AudienceMode` |
| `isConfigEmptyBlock` | 21 | ~16 | `isEmptyList` / `isBlankText` helpers |

Cross-cutting: four files had the same inline CASL `user.data?.ability?.can('manage', subject(...)) ?? false` block. That is now `useCanManageProject` / `useCanManageHomepage` in `hooks/useHomepageAbilities.ts`.

## Why

An assessment of the rule against this area showed the score is dominated by `?.` / `??` null-guarding on query results rather than real control flow, and that it does not correlate with where the churn has been (`HomepageEditor.tsx`, `types.ts`, `registry.tsx` all score under 20). So this is not a churn fix; it is a readability pass on the six densest functions, using the rule as the stopping criterion. Max in the directory is now 19 (`PreviewPane`, `HomepageEditor`, untouched).

## Regression analysis

The refactor is mechanical extraction; the things that could silently change were checked one by one:

- **Query keys**: `projectUuid ?? ''` / `?? undefined` arguments to `useAgentSuggestions`, `useCreateAgentThreadMutation`, `useStartDeepResearchForThreadMutation`, `useCreateHomepageWithDraft` are preserved verbatim, so cache keys and enabled flags are unchanged.
- **Effect dependencies**: the suggestion impression effect and the auto-create effect keep the same dependency lists (the impression effect now reads `referenceAgentUuid` instead of `referenceAgent?.uuid`, same value).
- **Loading source**: deep research still uses the same `createAgentThread` mutation instance as the composer, so `loading={isCreatingThread}` covers both paths as before.
- **Deep research guard**: the handler keeps its internal `!projectUuid || !selectedAgent || !canStartDeepResearch` check and is additionally only passed to `AgentChatInput` when `selectedAgent && canStartDeepResearch`, exactly matching the old ternary.
- **SQL mode props**: `sqlMode` / `onSqlModeChange` are `undefined` unless `sqlModeAvailable && selectedAgent`, as before.
- **`hasNoAgents`**: `(agents?.length ?? 0) === 0` is equivalent to the old `!agents || agents.length === 0`.
- **Announcement PATCH payload**: the "omit untouched fields" spreads in `handleSave` are unchanged; `initial.slackChannelId` / `initial.schedule` are the same values the old locals held.
- **Draft-announcement callout**: its query stays in `PublishModalBody`, which is mounted while the modal is closed (`Modal.Root` has no `keepMounted`), so the callout is still prefetched before open. A first version of this PR had moved the query into the modal children, which would have delayed it to open time; caught in self-review.
- **Publish hint**: the four-way ternary became early returns in `PublishHint`; the published+draft case that previously rendered `false` now returns `null`.
- **Publish modal `mode`**: was `useState<string>`; now `AudienceMode` with a type guard on `SegmentedControl` change. The three values are the only ones the control emits.
- **`isLoading` in `useActionStatuses`**: `!areFlagsSettled || isAnyTermPending([...])` is the same disjunction with the same eight gated terms, reordered (pure booleans).

## Verification

- `complexity` max 20 on the homepage builder + `common/ee/homepage`: 0 hits (was 6)
- `pnpm -F frontend run linter src/ee/features/homepageBuilder`: 0 warnings, 0 errors
- `pnpm -F frontend typecheck`: clean
- `vitest run src/ee/features/homepageBuilder`: 28 files, 262 tests pass, no test edits needed
- `oxfmt --check`: clean

Not verified in the browser. The day-0 composer and the announcement form are the two user-facing surfaces worth a manual click-through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6xKYXfrLQFnMzCiEgLZoB
