### PR TITLE
feat: registry chart type catalog + prebuilt install endpoints

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -1974,6 +1974,20 @@ export type DataAppUploadRejectedEvent = BaseTrack & {
     };
 };
 
+export type DataAppRegistryInstalledEvent = BaseTrack & {
+    event: 'data_app.registry_installed';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        appUuid: string;
+        chartSlug: string;
+        version: number;
+        registryVersion: string;
+        action: 'installed' | 'upgraded';
+    };
+};
+
 export type DataAppEvent =
     | DataAppCreatedEvent
     | DataAppIteratedEvent
@@ -1988,7 +2002,8 @@ export type DataAppEvent =
     | DataAppPromotedEvent
     | DataAppDownloadedEvent
     | DataAppUploadedEvent
-    | DataAppUploadRejectedEvent;
+    | DataAppUploadRejectedEvent
+    | DataAppRegistryInstalledEvent;
 
 export type AiWritebackStartedEvent = BaseTrack & {
     event: 'ai_writeback.started';

--- a/packages/backend/src/database/migrations/20260901143245_add_registry_slug_unique_index.ts
+++ b/packages/backend/src/database/migrations/20260901143245_add_registry_slug_unique_index.ts
@@ -1,5 +1,10 @@
 import { Knex } from 'knex';
 
+export const classification = {
+    kind: 'safe',
+    reason: 'Creates a partial unique index on registry-installed apps; additive DDL that never reads or rewrites existing rows',
+} as const;
+
 const AppsTableName = 'apps';
 const UniqueIndexName = 'apps_project_registry_slug_uniq';
 const LOCK_TIMEOUT = '5s';

--- a/packages/backend/src/database/migrations/20260901143245_add_registry_slug_unique_index.ts
+++ b/packages/backend/src/database/migrations/20260901143245_add_registry_slug_unique_index.ts
@@ -1,0 +1,26 @@
+import { Knex } from 'knex';
+
+const AppsTableName = 'apps';
+const UniqueIndexName = 'apps_project_registry_slug_uniq';
+const LOCK_TIMEOUT = '5s';
+
+// Concurrent fresh installs of the same registry chart type both pass the
+// unlocked pre-check in AppGenerateService before either has created its row,
+// so both can create an app with the same (project_uuid, registry_slug).
+// This partial unique index (deleted_at IS NULL, registry_slug IS NOT NULL)
+// makes the loser's insert fail instead of silently coexisting — the table is
+// small, so a non-concurrent build in-transaction is fine. Raw SQL because
+// Knex's unique() cannot express partial indexes.
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '${LOCK_TIMEOUT}'`);
+
+    await knex.raw(
+        `CREATE UNIQUE INDEX ${UniqueIndexName} ON ${AppsTableName} (project_uuid, registry_slug) WHERE deleted_at IS NULL AND registry_slug IS NOT NULL`,
+    );
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '${LOCK_TIMEOUT}'`);
+
+    await knex.raw(`DROP INDEX IF EXISTS ${UniqueIndexName}`);
+}

--- a/packages/backend/src/ee/controllers/appGenerateController.ts
+++ b/packages/backend/src/ee/controllers/appGenerateController.ts
@@ -23,7 +23,9 @@ import {
     type ApiGetDataAppAuthoringContextResponse,
     type ApiGetDataAppVizResponse,
     type ApiImportAppCodeResponse,
+    type ApiInstallRegistryChartTypeResponse,
     type ApiListDataAppVizsResponse,
+    type ApiListRegistryChartTypesResponse,
     type ApiMyAppsResponse,
     type ApiPreviewTokenResponse,
     type ApiPromoteAppDiffResponse,
@@ -157,6 +159,60 @@ export class AppGenerateController extends BaseController {
             projectUuid,
             'only',
         );
+        return {
+            status: 'ok',
+            results,
+        };
+    }
+
+    /**
+     * The installable chart type catalog from the configured chart
+     * registry, merged with this project's install state.
+     * @summary List installable chart types from the chart registry
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/registry/charts')
+    @OperationId('listRegistryChartTypes')
+    async listRegistryChartTypes(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+    ): Promise<ApiListRegistryChartTypesResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        const results =
+            await this.getAppGenerateService().listRegistryChartTypes(
+                toSessionUser(req.account),
+                projectUuid,
+            );
+        return {
+            status: 'ok',
+            results,
+        };
+    }
+
+    /**
+     * Install a chart type from the chart registry, or append a new version
+     * when it's already installed at an older registry version.
+     * @summary Install or upgrade a chart type from the chart registry
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('/registry/charts/{chartSlug}/install')
+    @OperationId('installRegistryChartType')
+    async installRegistryChartType(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() chartSlug: string,
+    ): Promise<ApiInstallRegistryChartTypeResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        const results =
+            await this.getAppGenerateService().installRegistryChartType(
+                toSessionUser(req.account),
+                projectUuid,
+                chartSlug,
+            );
         return {
             status: 'ok',
             results,

--- a/packages/backend/src/ee/routers/chartRegistryAssetRouter.test.ts
+++ b/packages/backend/src/ee/routers/chartRegistryAssetRouter.test.ts
@@ -1,3 +1,4 @@
+import { ForbiddenError, type SessionUser } from '@lightdash/common';
 import express from 'express';
 import { once } from 'node:events';
 import { request as httpRequest, type IncomingHttpHeaders } from 'node:http';
@@ -25,6 +26,8 @@ vi.mock('../../controllers/authentication', () => ({
 
 type AppGenerateServiceStub = Pick<AppGenerateService, 'getRegistryAsset'>;
 
+const fakeUser = { userUuid: 'user-uuid' } as SessionUser;
+
 const requestAsset = async ({
     getRegistryAsset,
     path,
@@ -38,6 +41,7 @@ const requestAsset = async ({
 }> => {
     const app = express();
     app.use((req, _res, next) => {
+        req.user = fakeUser;
         req.services = {
             getAppGenerateService: () =>
                 ({ getRegistryAsset }) as unknown as AppGenerateService,
@@ -130,7 +134,10 @@ describe('chartRegistryAssetRouter GET /assets', () => {
         });
 
         expect(response.status).toBe(404);
-        expect(getRegistryAsset).toHaveBeenCalledWith('sankey/1.3.0/thumb.png');
+        expect(getRegistryAsset).toHaveBeenCalledWith(
+            fakeUser,
+            'sankey/1.3.0/thumb.png',
+        );
     });
 
     it('returns 200 with the asset bytes and exact headers', async () => {
@@ -164,6 +171,23 @@ describe('chartRegistryAssetRouter GET /assets', () => {
         expect(response.status).toBe(500);
         expect(JSON.parse(response.body.toString('utf8'))).toEqual({
             error: 'registry unreachable',
+        });
+    });
+
+    it('propagates a ForbiddenError from the service (flags-off gate) to the error handler', async () => {
+        const getRegistryAsset = vi
+            .fn()
+            .mockRejectedValue(
+                new ForbiddenError('The chart type library is not enabled'),
+            );
+
+        const response = await requestAsset({
+            getRegistryAsset,
+            path: '/assets?path=sankey%2F1.3.0%2Fthumb.png',
+        });
+
+        expect(JSON.parse(response.body.toString('utf8'))).toEqual({
+            error: 'The chart type library is not enabled',
         });
     });
 });

--- a/packages/backend/src/ee/routers/chartRegistryAssetRouter.test.ts
+++ b/packages/backend/src/ee/routers/chartRegistryAssetRouter.test.ts
@@ -1,0 +1,169 @@
+import express from 'express';
+import { once } from 'node:events';
+import { request as httpRequest, type IncomingHttpHeaders } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import type { AppGenerateService } from '../services/AppGenerateService/AppGenerateService';
+import { chartRegistryAssetRouter } from './chartRegistryAssetRouter';
+
+// The router's own auth wiring is just `allowApiKeyAuthentication` +
+// `isAuthenticated` imported from controllers/authentication — those
+// middlewares have their own coverage. Replacing them with pass-throughs
+// here isolates the router's own logic (query validation, service
+// delegation, status/header mapping, error propagation).
+vi.mock('../../controllers/authentication', () => ({
+    allowApiKeyAuthentication: (
+        _req: express.Request,
+        _res: express.Response,
+        next: express.NextFunction,
+    ) => next(),
+    isAuthenticated: (
+        _req: express.Request,
+        _res: express.Response,
+        next: express.NextFunction,
+    ) => next(),
+}));
+
+type AppGenerateServiceStub = Pick<AppGenerateService, 'getRegistryAsset'>;
+
+const requestAsset = async ({
+    getRegistryAsset,
+    path,
+}: {
+    getRegistryAsset: AppGenerateServiceStub['getRegistryAsset'];
+    path: string;
+}): Promise<{
+    body: Buffer;
+    headers: IncomingHttpHeaders;
+    status: number;
+}> => {
+    const app = express();
+    app.use((req, _res, next) => {
+        req.services = {
+            getAppGenerateService: () =>
+                ({ getRegistryAsset }) as unknown as AppGenerateService,
+        } as Express.Request['services'];
+        next();
+    });
+    app.use('/api/v1/ee/chart-registry', chartRegistryAssetRouter);
+    // Stand-in for the app's real error handler: turns a next(err) into a
+    // 500 so the test can assert the error actually propagated instead of
+    // being swallowed.
+    app.use(
+        (
+            err: unknown,
+            _req: express.Request,
+            res: express.Response,
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            _next: express.NextFunction,
+        ) => {
+            res.status(500).json({
+                error: err instanceof Error ? err.message : 'unknown error',
+            });
+        },
+    );
+
+    const server = app.listen(0, '127.0.0.1');
+    await once(server, 'listening');
+
+    try {
+        return await new Promise((resolve, reject) => {
+            const req = httpRequest(
+                {
+                    hostname: '127.0.0.1',
+                    method: 'GET',
+                    path: `/api/v1/ee/chart-registry${path}`,
+                    port: (server.address() as AddressInfo).port,
+                },
+                (response) => {
+                    const chunks: Buffer[] = [];
+                    response.on('data', (chunk: Buffer) => chunks.push(chunk));
+                    response.on('end', () =>
+                        resolve({
+                            body: Buffer.concat(chunks),
+                            headers: response.headers,
+                            status: response.statusCode ?? 0,
+                        }),
+                    );
+                },
+            );
+            req.on('error', reject);
+            req.end();
+        });
+    } finally {
+        await new Promise<void>((resolve, reject) => {
+            server.close((error) => (error ? reject(error) : resolve()));
+        });
+    }
+};
+
+describe('chartRegistryAssetRouter GET /assets', () => {
+    it('returns 400 when the path query param is missing', async () => {
+        const getRegistryAsset = vi.fn();
+
+        const response = await requestAsset({
+            getRegistryAsset,
+            path: '/assets',
+        });
+
+        expect(response.status).toBe(400);
+        expect(getRegistryAsset).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when path is repeated (parses to an array, not a string)', async () => {
+        const getRegistryAsset = vi.fn();
+
+        const response = await requestAsset({
+            getRegistryAsset,
+            path: '/assets?path=a&path=b',
+        });
+
+        expect(response.status).toBe(400);
+        expect(getRegistryAsset).not.toHaveBeenCalled();
+    });
+
+    it('returns 404 when the service reports no asset', async () => {
+        const getRegistryAsset = vi.fn().mockResolvedValue(undefined);
+
+        const response = await requestAsset({
+            getRegistryAsset,
+            path: '/assets?path=sankey%2F1.3.0%2Fthumb.png',
+        });
+
+        expect(response.status).toBe(404);
+        expect(getRegistryAsset).toHaveBeenCalledWith('sankey/1.3.0/thumb.png');
+    });
+
+    it('returns 200 with the asset bytes and exact headers', async () => {
+        const pngBuffer = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a]);
+        const getRegistryAsset = vi.fn().mockResolvedValue({
+            buffer: pngBuffer,
+            contentType: 'image/png',
+        });
+
+        const response = await requestAsset({
+            getRegistryAsset,
+            path: '/assets?path=sankey%2F1.3.0%2Fthumb.png',
+        });
+
+        expect(response.status).toBe(200);
+        expect(response.headers['content-type']).toBe('image/png');
+        expect(response.headers['cache-control']).toBe('private, max-age=3600');
+        expect(response.body).toEqual(pngBuffer);
+    });
+
+    it('propagates a service error to the error handler', async () => {
+        const getRegistryAsset = vi
+            .fn()
+            .mockRejectedValue(new Error('registry unreachable'));
+
+        const response = await requestAsset({
+            getRegistryAsset,
+            path: '/assets?path=sankey%2F1.3.0%2Fthumb.png',
+        });
+
+        expect(response.status).toBe(500);
+        expect(JSON.parse(response.body.toString('utf8'))).toEqual({
+            error: 'registry unreachable',
+        });
+    });
+});

--- a/packages/backend/src/ee/routers/chartRegistryAssetRouter.ts
+++ b/packages/backend/src/ee/routers/chartRegistryAssetRouter.ts
@@ -1,0 +1,43 @@
+import express from 'express';
+import {
+    allowApiKeyAuthentication,
+    isAuthenticated,
+} from '../../controllers/authentication';
+import type { AppGenerateService } from '../services/AppGenerateService/AppGenerateService';
+
+/**
+ * Thin authenticated pass-through to chart registry images (thumbnails,
+ * screenshots). `ChartRegistryClient.getAsset` already enforces the real
+ * security invariants — path must be enumerated in the index, 2xx only, and
+ * an image-only content-type allowlist — so this router only handles auth
+ * and translating the result into an HTTP response.
+ */
+export const chartRegistryAssetRouter = express.Router();
+
+chartRegistryAssetRouter.get(
+    '/assets',
+    allowApiKeyAuthentication,
+    isAuthenticated,
+    async (req, res, next) => {
+        try {
+            const path =
+                typeof req.query.path === 'string' ? req.query.path : '';
+            if (!path) {
+                res.status(400).send('Missing required query param: path');
+                return;
+            }
+            const service =
+                req.services.getAppGenerateService<AppGenerateService>();
+            const asset = await service.getRegistryAsset(path);
+            if (!asset) {
+                res.status(404).send('Not found');
+                return;
+            }
+            res.setHeader('Content-Type', asset.contentType);
+            res.setHeader('Cache-Control', 'private, max-age=3600');
+            res.send(asset.buffer);
+        } catch (e) {
+            next(e);
+        }
+    },
+);

--- a/packages/backend/src/ee/routers/chartRegistryAssetRouter.ts
+++ b/packages/backend/src/ee/routers/chartRegistryAssetRouter.ts
@@ -28,7 +28,7 @@ chartRegistryAssetRouter.get(
             }
             const service =
                 req.services.getAppGenerateService<AppGenerateService>();
-            const asset = await service.getRegistryAsset(path);
+            const asset = await service.getRegistryAsset(req.user!, path);
             if (!asset) {
                 res.status(404).send('Not found');
                 return;

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.registryInstall.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.registryInstall.test.ts
@@ -679,3 +679,44 @@ describe('AppGenerateService registry feature-flag gates', () => {
         ).rejects.toThrow(ForbiddenError);
     });
 });
+
+describe('AppGenerateService.getRegistryAsset', () => {
+    it('returns undefined when the registry client is disabled, without calling getAsset', async () => {
+        const getAsset = vi.fn();
+        const svc = buildService({
+            chartRegistryClient: { isEnabled: () => false, getAsset },
+        });
+
+        const result = await svc.getRegistryAsset('sankey/1.3.0/thumb.png');
+
+        expect(result).toBeUndefined();
+        expect(getAsset).not.toHaveBeenCalled();
+    });
+
+    it('delegates to chartRegistryClient.getAsset when enabled', async () => {
+        const asset = {
+            buffer: Buffer.from('fake-png'),
+            contentType: 'image/png',
+        };
+        const getAsset = vi.fn().mockResolvedValue(asset);
+        const svc = buildService({
+            chartRegistryClient: { isEnabled: () => true, getAsset },
+        });
+
+        const result = await svc.getRegistryAsset('sankey/1.3.0/thumb.png');
+
+        expect(getAsset).toHaveBeenCalledWith('sankey/1.3.0/thumb.png');
+        expect(result).toBe(asset);
+    });
+
+    it('returns undefined when the underlying client returns undefined (path not in the index)', async () => {
+        const getAsset = vi.fn().mockResolvedValue(undefined);
+        const svc = buildService({
+            chartRegistryClient: { isEnabled: () => true, getAsset },
+        });
+
+        const result = await svc.getRegistryAsset('unknown/path.png');
+
+        expect(result).toBeUndefined();
+    });
+});

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.registryInstall.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.registryInstall.test.ts
@@ -3,6 +3,7 @@
 import {
     DATA_APP_VIZ_TEMPLATE,
     dataAppVizSchema,
+    FeatureFlags,
     ForbiddenError,
     NotFoundError,
     OrganizationMemberRole,
@@ -12,6 +13,7 @@ import {
     type DataAppVizSchema,
     type SessionUser,
 } from '@lightdash/common';
+import { DatabaseError } from 'pg';
 import { pack } from 'tar-stream';
 import { AppGenerateService } from './AppGenerateService';
 
@@ -136,6 +138,13 @@ async function buildTar(
     });
 }
 
+/** A real `pg` DatabaseError carrying the given SQLSTATE code, matching how `isUniqueConstraintViolation` detects it. */
+const databaseError = (code: string): DatabaseError => {
+    const error = new DatabaseError(`database error ${code}`, 0, 'error');
+    error.code = code;
+    return error;
+};
+
 type FakeCommand = {
     constructor: { name: string };
     input: Record<string, unknown>;
@@ -186,6 +195,8 @@ function buildService(overrides: {
     chartRegistryClient?: Record<string, unknown>;
     s3ClientOverride?: { client: never; bucket: string };
     ability?: { can: () => boolean; cannot: () => boolean };
+    // Per-featureFlagId overrides; any flag not listed defaults to enabled.
+    featureFlags?: Partial<Record<string, boolean>>;
 }): AppGenerateService {
     const {
         appModel = {},
@@ -193,6 +204,7 @@ function buildService(overrides: {
         chartRegistryClient = {},
         s3ClientOverride,
         ability = { can: () => true, cannot: () => false },
+        featureFlags = {},
     } = overrides;
 
     const fullAppModel = {
@@ -217,7 +229,13 @@ function buildService(overrides: {
     };
 
     const featureFlagModel = {
-        get: vi.fn().mockResolvedValue({ enabled: true }),
+        get: vi
+            .fn()
+            .mockImplementation(
+                async ({ featureFlagId }: { featureFlagId: string }) => ({
+                    enabled: featureFlags[featureFlagId] ?? true,
+                }),
+            ),
     };
     const spacePermissionService = {
         resolveAccess: vi.fn().mockResolvedValue({}),
@@ -563,6 +581,48 @@ describe('AppGenerateService.installRegistryChartType', () => {
         expect(fakeS3.objects.size).toBe(0);
     });
 
+    it('concurrent install losing the (app_id, version) race does NOT delete the winning install S3 keys', async () => {
+        const sourceTar = await buildTar([
+            { name: 'src/App.tsx', content: 'x' },
+        ]);
+        const distTar = await buildTar([
+            { name: 'dist/index.html', content: '<html/>' },
+        ]);
+        const fakeS3 = makeFakeS3();
+        const appModel = {
+            listRegistryInstalledApps: vi.fn().mockResolvedValue([]),
+            createWithVersion: vi
+                .fn()
+                .mockRejectedValue(databaseError('23505')),
+        };
+        const chartRegistryClient = {
+            downloadArtifact: vi
+                .fn()
+                .mockImplementation(
+                    (_entry: unknown, kind: 'source' | 'dist') =>
+                        Promise.resolve(
+                            kind === 'source' ? sourceTar : distTar,
+                        ),
+                ),
+        };
+        const svc = buildService({
+            appModel,
+            chartRegistryClient,
+            s3ClientOverride: fakeS3,
+        });
+
+        await expect(
+            svc.installRegistryChartType(fakeUser, PROJECT_UUID, 'sankey'),
+        ).rejects.toThrow(ParameterError);
+
+        const deleteCalls = fakeS3.send.mock.calls
+            .map(([cmd]) => cmd as FakeCommand)
+            .filter((cmd) => cmd.constructor.name === 'DeleteObjectsCommand');
+        expect(deleteCalls).toHaveLength(0);
+        // The winner's PutObject writes are still intact.
+        expect(fakeS3.objects.size).toBeGreaterThan(0);
+    });
+
     it('requires create DataApp ability', async () => {
         const svc = buildService({});
         vi.spyOn(
@@ -571,6 +631,48 @@ describe('AppGenerateService.installRegistryChartType', () => {
             },
             'assertDataAppAbility',
         ).mockRejectedValue(new ForbiddenError('nope'));
+
+        await expect(
+            svc.installRegistryChartType(fakeUser, PROJECT_UUID, 'sankey'),
+        ).rejects.toThrow(ForbiddenError);
+    });
+});
+
+describe('AppGenerateService registry feature-flag gates', () => {
+    it('listRegistryChartTypes throws ForbiddenError when EnableDataApps is disabled', async () => {
+        const svc = buildService({
+            featureFlags: { [FeatureFlags.EnableDataApps]: false },
+        });
+
+        await expect(
+            svc.listRegistryChartTypes(fakeUser, PROJECT_UUID),
+        ).rejects.toThrow(ForbiddenError);
+    });
+
+    it('listRegistryChartTypes throws ForbiddenError when ChartTypeRegistry is disabled', async () => {
+        const svc = buildService({
+            featureFlags: { [FeatureFlags.ChartTypeRegistry]: false },
+        });
+
+        await expect(
+            svc.listRegistryChartTypes(fakeUser, PROJECT_UUID),
+        ).rejects.toThrow(ForbiddenError);
+    });
+
+    it('installRegistryChartType throws ForbiddenError when EnableDataApps is disabled', async () => {
+        const svc = buildService({
+            featureFlags: { [FeatureFlags.EnableDataApps]: false },
+        });
+
+        await expect(
+            svc.installRegistryChartType(fakeUser, PROJECT_UUID, 'sankey'),
+        ).rejects.toThrow(ForbiddenError);
+    });
+
+    it('installRegistryChartType throws ForbiddenError when ChartTypeRegistry is disabled', async () => {
+        const svc = buildService({
+            featureFlags: { [FeatureFlags.ChartTypeRegistry]: false },
+        });
 
         await expect(
             svc.installRegistryChartType(fakeUser, PROJECT_UUID, 'sankey'),

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.registryInstall.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.registryInstall.test.ts
@@ -687,7 +687,10 @@ describe('AppGenerateService.getRegistryAsset', () => {
             chartRegistryClient: { isEnabled: () => false, getAsset },
         });
 
-        const result = await svc.getRegistryAsset('sankey/1.3.0/thumb.png');
+        const result = await svc.getRegistryAsset(
+            fakeUser,
+            'sankey/1.3.0/thumb.png',
+        );
 
         expect(result).toBeUndefined();
         expect(getAsset).not.toHaveBeenCalled();
@@ -703,7 +706,10 @@ describe('AppGenerateService.getRegistryAsset', () => {
             chartRegistryClient: { isEnabled: () => true, getAsset },
         });
 
-        const result = await svc.getRegistryAsset('sankey/1.3.0/thumb.png');
+        const result = await svc.getRegistryAsset(
+            fakeUser,
+            'sankey/1.3.0/thumb.png',
+        );
 
         expect(getAsset).toHaveBeenCalledWith('sankey/1.3.0/thumb.png');
         expect(result).toBe(asset);
@@ -715,8 +721,28 @@ describe('AppGenerateService.getRegistryAsset', () => {
             chartRegistryClient: { isEnabled: () => true, getAsset },
         });
 
-        const result = await svc.getRegistryAsset('unknown/path.png');
+        const result = await svc.getRegistryAsset(fakeUser, 'unknown/path.png');
 
         expect(result).toBeUndefined();
+    });
+
+    it('throws ForbiddenError when EnableDataApps is disabled', async () => {
+        const svc = buildService({
+            featureFlags: { [FeatureFlags.EnableDataApps]: false },
+        });
+
+        await expect(
+            svc.getRegistryAsset(fakeUser, 'sankey/1.3.0/thumb.png'),
+        ).rejects.toThrow(ForbiddenError);
+    });
+
+    it('throws ForbiddenError when ChartTypeRegistry is disabled', async () => {
+        const svc = buildService({
+            featureFlags: { [FeatureFlags.ChartTypeRegistry]: false },
+        });
+
+        await expect(
+            svc.getRegistryAsset(fakeUser, 'sankey/1.3.0/thumb.png'),
+        ).rejects.toThrow(ForbiddenError);
     });
 });

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.registryInstall.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.registryInstall.test.ts
@@ -581,7 +581,11 @@ describe('AppGenerateService.installRegistryChartType', () => {
         expect(fakeS3.objects.size).toBe(0);
     });
 
-    it('concurrent install losing the (app_id, version) race does NOT delete the winning install S3 keys', async () => {
+    it('concurrent FRESH installs racing on registry_slug: the loser cleans up its own S3 prefix and gets a friendly retry error', async () => {
+        // Both installers passed the unlocked listRegistryInstalledApps
+        // pre-check (see it below), so neither has `existing` — the DB
+        // unique violation is on (project_uuid, registry_slug), not on this
+        // loser's own (unshared) app_id/prefix, so cleaning it up is safe.
         const sourceTar = await buildTar([
             { name: 'src/App.tsx', content: 'x' },
         ]);
@@ -613,13 +617,64 @@ describe('AppGenerateService.installRegistryChartType', () => {
 
         await expect(
             svc.installRegistryChartType(fakeUser, PROJECT_UUID, 'sankey'),
-        ).rejects.toThrow(ParameterError);
+        ).rejects.toThrow(
+            'This chart type was just installed by someone else — refresh',
+        );
+
+        const deleteCalls = fakeS3.send.mock.calls
+            .map(([cmd]) => cmd as FakeCommand)
+            .filter((cmd) => cmd.constructor.name === 'DeleteObjectsCommand');
+        expect(deleteCalls.length).toBeGreaterThan(0);
+        // The loser's own writes were cleaned up — nothing left under its prefix.
+        expect(fakeS3.objects.size).toBe(0);
+    });
+
+    it('concurrent UPGRADE installs racing on (app_id, version): the loser does NOT touch S3 (the shared prefix belongs to the winner)', async () => {
+        const sourceTar = await buildTar([
+            { name: 'src/App.tsx', content: 'x' },
+        ]);
+        const distTar = await buildTar([
+            { name: 'dist/index.html', content: '<html/>' },
+        ]);
+        const fakeS3 = makeFakeS3();
+        const appModel = {
+            listRegistryInstalledApps: vi.fn().mockResolvedValue([
+                {
+                    app_id: 'existing-app-uuid',
+                    registry_slug: 'sankey',
+                    latest_ready_registry_version: '1.2.0',
+                },
+            ]),
+            getLatestVersion: vi.fn().mockResolvedValue({ version: 2 }),
+            createVersion: vi.fn().mockRejectedValue(databaseError('23505')),
+        };
+        const chartRegistryClient = {
+            downloadArtifact: vi
+                .fn()
+                .mockImplementation(
+                    (_entry: unknown, kind: 'source' | 'dist') =>
+                        Promise.resolve(
+                            kind === 'source' ? sourceTar : distTar,
+                        ),
+                ),
+        };
+        const svc = buildService({
+            appModel,
+            chartRegistryClient,
+            s3ClientOverride: fakeS3,
+        });
+
+        await expect(
+            svc.installRegistryChartType(fakeUser, PROJECT_UUID, 'sankey'),
+        ).rejects.toThrow(
+            'Another install of this chart type is in progress — retry',
+        );
 
         const deleteCalls = fakeS3.send.mock.calls
             .map(([cmd]) => cmd as FakeCommand)
             .filter((cmd) => cmd.constructor.name === 'DeleteObjectsCommand');
         expect(deleteCalls).toHaveLength(0);
-        // The winner's PutObject writes are still intact.
+        // The winner's PutObject writes under the shared prefix are still intact.
         expect(fakeS3.objects.size).toBeGreaterThan(0);
     });
 

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.registryInstall.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.registryInstall.test.ts
@@ -1,0 +1,579 @@
+// Stub the e2b/ai SDKs before importing AppGenerateService so the tests never
+// reach the real sandbox or model client.
+import {
+    DATA_APP_VIZ_TEMPLATE,
+    dataAppVizSchema,
+    ForbiddenError,
+    NotFoundError,
+    OrganizationMemberRole,
+    ParameterError,
+    type ChartRegistryEntry,
+    type ChartRegistryIndex,
+    type DataAppVizSchema,
+    type SessionUser,
+} from '@lightdash/common';
+import { pack } from 'tar-stream';
+import { AppGenerateService } from './AppGenerateService';
+
+vi.mock('e2b', () => ({
+    Sandbox: class {},
+    CommandExitError: class extends Error {},
+    ALL_TRAFFIC: '*',
+}));
+vi.mock('ai', () => ({
+    generateObject: vi.fn(),
+}));
+vi.mock('./appAuthz', () => ({
+    assertCanViewApp: vi.fn().mockResolvedValue({ directOnly: false } as never),
+}));
+
+// ── fixtures ────────────────────────────────────────────────────────────────
+
+const PROJECT_UUID = 'project-uuid-5678';
+const ORG_UUID = 'org-uuid-abcd';
+const REGISTRY_BASE_URL = 'https://registry.example.com';
+
+const VIZ_SCHEMA: DataAppVizSchema = {
+    fields: [
+        {
+            name: 'category',
+            label: 'Category',
+            type: 'dimension',
+            required: true,
+        },
+        { name: 'value', label: 'Value', type: 'metric', required: true },
+    ],
+    configOptions: [],
+    colorPalette: null,
+};
+// `installRegistryChartType` re-validates entry.vizSchema with
+// dataAppVizSchema.safeParse and stores the parsed (default-filled) result.
+const PARSED_VIZ_SCHEMA = dataAppVizSchema.parse(VIZ_SCHEMA);
+
+function makeEntry(
+    overrides: Partial<ChartRegistryEntry> = {},
+): ChartRegistryEntry {
+    return {
+        slug: 'sankey',
+        name: 'Sankey Diagram',
+        description: 'A sankey chart',
+        version: '1.3.0',
+        publishedAt: '2026-08-01T00:00:00Z',
+        tags: [],
+        changelog: '',
+        minLightdashVersion: null,
+        vizSchema: VIZ_SCHEMA,
+        thumbnail: null,
+        screenshots: [],
+        artifacts: {
+            source: { path: 'sankey/1.3.0/source.tar', sha256: 'a'.repeat(64) },
+            dist: { path: 'sankey/1.3.0/dist.tar', sha256: 'b'.repeat(64) },
+        },
+        ...overrides,
+    };
+}
+
+const SANKEY_ENTRY = makeEntry();
+const RADAR_ENTRY = makeEntry({
+    slug: 'radar',
+    name: 'Radar Chart',
+    version: '1.0.0',
+});
+
+function makeIndex(charts: ChartRegistryEntry[]): ChartRegistryIndex {
+    return { schemaVersion: 1, generatedAt: '2026-08-01T00:00:00Z', charts };
+}
+
+const fakeUser: SessionUser = {
+    userId: 1,
+    userUuid: 'user-uuid',
+    email: 'test@lightdash.com',
+    firstName: 'Test',
+    lastName: 'User',
+    organizationUuid: ORG_UUID,
+    organizationName: 'Test Org',
+    organizationCreatedAt: new Date(),
+    isTrackingAnonymized: false,
+    isMarketingOptedIn: false,
+    avatarUrl: null,
+    avatarGradient: null,
+    isSetupComplete: true,
+    role: OrganizationMemberRole.ADMIN,
+    ability: { can: () => true, cannot: () => false } as never,
+    abilityRules: [],
+    isActive: true,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    timezone: null,
+};
+
+/** Build a real tar buffer from a list of {name, content} entries via tar-stream pack(). */
+async function buildTar(
+    entries: { name: string; content: string }[],
+): Promise<Buffer> {
+    return new Promise<Buffer>((resolve, reject) => {
+        const p = pack();
+        const chunks: Buffer[] = [];
+        p.on('data', (c: Buffer) => chunks.push(c));
+        p.on('end', () => resolve(Buffer.concat(chunks)));
+        p.on('error', reject);
+
+        const addNext = (index: number): void => {
+            if (index >= entries.length) {
+                p.finalize();
+                return;
+            }
+            const entry = entries[index];
+            p.entry({ name: entry.name }, entry.content, (err) => {
+                if (err) {
+                    reject(err);
+                    return;
+                }
+                addNext(index + 1);
+            });
+        };
+        addNext(0);
+    });
+}
+
+type FakeCommand = {
+    constructor: { name: string };
+    input: Record<string, unknown>;
+};
+
+/** Stateful fake S3 client tracking PutObject writes so ListObjectsV2/DeleteObjects (used for cleanup) behave realistically. */
+function makeFakeS3() {
+    const objects = new Map<string, unknown>();
+    const send = vi.fn(async (command: FakeCommand) => {
+        const cmdName = command.constructor.name;
+        if (cmdName === 'PutObjectCommand') {
+            const { Key, Body } = command.input as {
+                Key: string;
+                Body: unknown;
+            };
+            objects.set(Key, Body);
+            return {};
+        }
+        if (cmdName === 'ListObjectsV2Command') {
+            const { Prefix } = command.input as { Prefix: string };
+            const keys = [...objects.keys()].filter((k) =>
+                k.startsWith(Prefix),
+            );
+            return {
+                Contents: keys.map((Key) => ({ Key })),
+                IsTruncated: false,
+            };
+        }
+        if (cmdName === 'DeleteObjectsCommand') {
+            const { Delete } = command.input as {
+                Delete: { Objects: { Key: string }[] };
+            };
+            Delete.Objects.forEach(({ Key }) => objects.delete(Key));
+            return {};
+        }
+        throw new Error(`Unexpected command: ${cmdName}`);
+    });
+    return { client: { send } as never, bucket: 'test-bucket', send, objects };
+}
+
+// ── service factory ──────────────────────────────────────────────────────────
+
+const analyticsTrackSpy = vi.fn();
+
+function buildService(overrides: {
+    appModel?: Record<string, unknown>;
+    projectModel?: Record<string, unknown>;
+    chartRegistryClient?: Record<string, unknown>;
+    s3ClientOverride?: { client: never; bucket: string };
+    ability?: { can: () => boolean; cannot: () => boolean };
+}): AppGenerateService {
+    const {
+        appModel = {},
+        projectModel = {},
+        chartRegistryClient = {},
+        s3ClientOverride,
+        ability = { can: () => true, cannot: () => false },
+    } = overrides;
+
+    const fullAppModel = {
+        listRegistryInstalledApps: vi.fn().mockResolvedValue([]),
+        ...appModel,
+    };
+
+    const fullProjectModel = {
+        getSummary: vi.fn().mockResolvedValue({ organizationUuid: ORG_UUID }),
+        ...projectModel,
+    };
+
+    const fullChartRegistryClient = {
+        isEnabled: () => true,
+        getBaseUrl: () => REGISTRY_BASE_URL,
+        getIndex: vi
+            .fn()
+            .mockResolvedValue(makeIndex([SANKEY_ENTRY, RADAR_ENTRY])),
+        getEntry: vi.fn().mockResolvedValue(SANKEY_ENTRY),
+        downloadArtifact: vi.fn(),
+        ...chartRegistryClient,
+    };
+
+    const featureFlagModel = {
+        get: vi.fn().mockResolvedValue({ enabled: true }),
+    };
+    const spacePermissionService = {
+        resolveAccess: vi.fn().mockResolvedValue({}),
+    };
+
+    const svc = new AppGenerateService({
+        lightdashConfig: {} as never,
+        analytics: { track: analyticsTrackSpy } as never,
+        analyticsModel: {} as never,
+        catalogModel: {} as never,
+        userModel: {} as never,
+        appModel: fullAppModel as never,
+        featureFlagModel: featureFlagModel as never,
+        organizationDesignModel: {} as never,
+        pinnedListModel: {} as never,
+        projectModel: fullProjectModel as never,
+        projectParametersModel: {} as never,
+        spaceModel: {} as never,
+        savedChartModel: {} as never,
+        schedulerClient: {} as never,
+        savedChartService: {} as never,
+        spacePermissionService: spacePermissionService as never,
+        coderService: {} as never,
+        dashboardService: {} as never,
+        projectService: {} as never,
+        promoteService: {} as never,
+        externalConnectionModel: {} as never,
+        sandboxRegistryModel: {} as never,
+        orgAiCopilotConfigResolver: {} as never,
+        chartRegistryClient: fullChartRegistryClient as never,
+    });
+
+    vi.spyOn(
+        svc as unknown as { createAuditedAbility: () => unknown },
+        'createAuditedAbility',
+    ).mockReturnValue(ability);
+
+    if (s3ClientOverride) {
+        vi.spyOn(
+            svc as unknown as { getS3Client: () => unknown },
+            'getS3Client',
+        ).mockReturnValue(s3ClientOverride);
+    }
+
+    return svc;
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+    analyticsTrackSpy.mockClear();
+});
+
+describe('AppGenerateService.listRegistryChartTypes', () => {
+    it('returns registryEnabled false when the client is disabled', async () => {
+        const svc = buildService({
+            chartRegistryClient: { isEnabled: () => false },
+        });
+
+        const result = await svc.listRegistryChartTypes(fakeUser, PROJECT_UUID);
+
+        expect(result).toEqual({ registryEnabled: false, charts: [] });
+    });
+
+    it('merges install state', async () => {
+        const appModel = {
+            listRegistryInstalledApps: vi.fn().mockResolvedValue([
+                {
+                    app_id: 'app-uuid-sankey',
+                    registry_slug: 'sankey',
+                    latest_ready_registry_version: '1.2.0',
+                },
+            ]),
+        };
+        const svc = buildService({ appModel });
+
+        const result = await svc.listRegistryChartTypes(fakeUser, PROJECT_UUID);
+
+        expect(result.registryEnabled).toBe(true);
+        const sankey = result.charts.find((c) => c.slug === 'sankey');
+        expect(sankey?.state).toBe('update_available');
+        expect(sankey?.installedAppUuid).toBe('app-uuid-sankey');
+        expect(sankey?.installedRegistryVersion).toBe('1.2.0');
+
+        const radar = result.charts.find((c) => c.slug === 'radar');
+        expect(radar?.state).toBe('not_installed');
+        expect(radar?.installedAppUuid).toBeNull();
+        expect(radar?.installedRegistryVersion).toBeNull();
+    });
+
+    it('marks entries above the instance version incompatible', async () => {
+        const futureEntry = makeEntry({
+            slug: 'future-chart',
+            minLightdashVersion: '999.0.0',
+        });
+        const svc = buildService({
+            chartRegistryClient: {
+                getIndex: vi.fn().mockResolvedValue(makeIndex([futureEntry])),
+            },
+        });
+
+        const result = await svc.listRegistryChartTypes(fakeUser, PROJECT_UUID);
+
+        expect(result.charts).toHaveLength(1);
+        expect(result.charts[0].state).toBe('incompatible');
+        expect(result.charts[0].installedAppUuid).toBeNull();
+    });
+});
+
+describe('AppGenerateService.installRegistryChartType', () => {
+    it('fresh install: uploads source.tar + extracted dist, creates ready v1 with provenance', async () => {
+        const sourceTar = await buildTar([
+            { name: 'src/App.tsx', content: 'export default function App(){}' },
+        ]);
+        const distTar = await buildTar([
+            { name: 'dist/index.html', content: '<html></html>' },
+            { name: 'dist/assets/app.js', content: 'console.log(1)' },
+        ]);
+        const fakeS3 = makeFakeS3();
+        const createWithVersion = vi.fn().mockResolvedValue(undefined);
+        const appModel = {
+            listRegistryInstalledApps: vi.fn().mockResolvedValue([]),
+            createWithVersion,
+        };
+        const chartRegistryClient = {
+            downloadArtifact: vi
+                .fn()
+                .mockImplementation(
+                    (_entry: unknown, kind: 'source' | 'dist') =>
+                        Promise.resolve(
+                            kind === 'source' ? sourceTar : distTar,
+                        ),
+                ),
+        };
+        const svc = buildService({
+            appModel,
+            chartRegistryClient,
+            s3ClientOverride: fakeS3,
+        });
+
+        const result = await svc.installRegistryChartType(
+            fakeUser,
+            PROJECT_UUID,
+            'sankey',
+        );
+
+        expect(result.action).toBe('installed');
+        expect(result.slug).toBe('sankey');
+        expect(result.version).toBe(1);
+
+        const putKeys = fakeS3.send.mock.calls
+            .map(([cmd]) => cmd as FakeCommand)
+            .filter((cmd) => cmd.constructor.name === 'PutObjectCommand')
+            .map((cmd) => (cmd.input as { Key: string }).Key);
+        expect(putKeys).toEqual(
+            expect.arrayContaining([
+                `apps/${result.appUuid}/versions/1/source.tar`,
+                `apps/${result.appUuid}/versions/1/index.html`,
+                `apps/${result.appUuid}/versions/1/assets/app.js`,
+            ]),
+        );
+
+        expect(createWithVersion).toHaveBeenCalledTimes(1);
+        const [appArg, versionArg, statusArg, , , vizSchemaArg, optsArg] =
+            createWithVersion.mock.calls[0];
+        expect(appArg).toEqual(
+            expect.objectContaining({
+                app_id: result.appUuid,
+                project_uuid: PROJECT_UUID,
+                created_by_user_uuid: fakeUser.userUuid,
+                name: SANKEY_ENTRY.name,
+                description: SANKEY_ENTRY.description,
+                slug: 'sankey',
+                template: DATA_APP_VIZ_TEMPLATE,
+                registry_slug: 'sankey',
+                registry_url: REGISTRY_BASE_URL,
+            }),
+        );
+        expect(versionArg).toEqual({ version: 1, prompt: expect.any(String) });
+        expect(statusArg).toBe('ready');
+        expect(vizSchemaArg).toEqual(PARSED_VIZ_SCHEMA);
+        expect(optsArg).toEqual({ registryVersion: '1.3.0' });
+    });
+
+    it('already installed at latest → action unchanged, no writes', async () => {
+        const fakeS3 = makeFakeS3();
+        const appModel = {
+            listRegistryInstalledApps: vi.fn().mockResolvedValue([
+                {
+                    app_id: 'existing-app-uuid',
+                    registry_slug: 'sankey',
+                    latest_ready_registry_version: '1.3.0',
+                },
+            ]),
+            getLatestReadyVersion: vi.fn().mockResolvedValue({ version: 4 }),
+            createVersion: vi.fn(),
+            createWithVersion: vi.fn(),
+        };
+        const svc = buildService({ appModel, s3ClientOverride: fakeS3 });
+
+        const result = await svc.installRegistryChartType(
+            fakeUser,
+            PROJECT_UUID,
+            'sankey',
+        );
+
+        expect(result).toEqual({
+            appUuid: 'existing-app-uuid',
+            slug: 'sankey',
+            version: 4,
+            action: 'unchanged',
+        });
+        expect(fakeS3.send).not.toHaveBeenCalled();
+        expect(appModel.createVersion).not.toHaveBeenCalled();
+        expect(appModel.createWithVersion).not.toHaveBeenCalled();
+    });
+
+    it('installed at older version → appends new version (action upgraded)', async () => {
+        const sourceTar = await buildTar([
+            { name: 'src/App.tsx', content: 'x' },
+        ]);
+        const distTar = await buildTar([
+            { name: 'dist/index.html', content: '<html/>' },
+        ]);
+        const fakeS3 = makeFakeS3();
+        const createVersion = vi.fn().mockResolvedValue({ version: 3 });
+        const appModel = {
+            listRegistryInstalledApps: vi.fn().mockResolvedValue([
+                {
+                    app_id: 'existing-app-uuid',
+                    registry_slug: 'sankey',
+                    latest_ready_registry_version: '1.2.0',
+                },
+            ]),
+            getLatestVersion: vi.fn().mockResolvedValue({ version: 2 }),
+            createVersion,
+        };
+        const chartRegistryClient = {
+            downloadArtifact: vi
+                .fn()
+                .mockImplementation(
+                    (_entry: unknown, kind: 'source' | 'dist') =>
+                        Promise.resolve(
+                            kind === 'source' ? sourceTar : distTar,
+                        ),
+                ),
+        };
+        const svc = buildService({
+            appModel,
+            chartRegistryClient,
+            s3ClientOverride: fakeS3,
+        });
+
+        const result = await svc.installRegistryChartType(
+            fakeUser,
+            PROJECT_UUID,
+            'sankey',
+        );
+
+        expect(result).toEqual({
+            appUuid: 'existing-app-uuid',
+            slug: 'sankey',
+            version: 3,
+            action: 'upgraded',
+        });
+        expect(createVersion).toHaveBeenCalledWith(
+            'existing-app-uuid',
+            { version: 3, prompt: expect.any(String) },
+            'ready',
+            fakeUser.userUuid,
+            undefined,
+            undefined,
+            PARSED_VIZ_SCHEMA,
+            { registryVersion: '1.3.0' },
+        );
+    });
+
+    it('rejects incompatible entries', async () => {
+        const incompatibleEntry = makeEntry({ minLightdashVersion: '999.0.0' });
+        const svc = buildService({
+            chartRegistryClient: {
+                getEntry: vi.fn().mockResolvedValue(incompatibleEntry),
+            },
+        });
+
+        await expect(
+            svc.installRegistryChartType(fakeUser, PROJECT_UUID, 'sankey'),
+        ).rejects.toThrow(ParameterError);
+    });
+
+    it('unknown slug → NotFoundError', async () => {
+        const svc = buildService({
+            chartRegistryClient: {
+                getEntry: vi.fn().mockResolvedValue(undefined),
+            },
+        });
+
+        await expect(
+            svc.installRegistryChartType(
+                fakeUser,
+                PROJECT_UUID,
+                'unknown-chart',
+            ),
+        ).rejects.toThrow(NotFoundError);
+    });
+
+    it('cleans up copied S3 keys when the DB write fails', async () => {
+        const sourceTar = await buildTar([
+            { name: 'src/App.tsx', content: 'x' },
+        ]);
+        const distTar = await buildTar([
+            { name: 'dist/index.html', content: '<html/>' },
+        ]);
+        const fakeS3 = makeFakeS3();
+        const appModel = {
+            listRegistryInstalledApps: vi.fn().mockResolvedValue([]),
+            createWithVersion: vi.fn().mockRejectedValue(new Error('db down')),
+        };
+        const chartRegistryClient = {
+            downloadArtifact: vi
+                .fn()
+                .mockImplementation(
+                    (_entry: unknown, kind: 'source' | 'dist') =>
+                        Promise.resolve(
+                            kind === 'source' ? sourceTar : distTar,
+                        ),
+                ),
+        };
+        const svc = buildService({
+            appModel,
+            chartRegistryClient,
+            s3ClientOverride: fakeS3,
+        });
+
+        await expect(
+            svc.installRegistryChartType(fakeUser, PROJECT_UUID, 'sankey'),
+        ).rejects.toThrow('db down');
+
+        const deleteCalls = fakeS3.send.mock.calls
+            .map(([cmd]) => cmd as FakeCommand)
+            .filter((cmd) => cmd.constructor.name === 'DeleteObjectsCommand');
+        expect(deleteCalls.length).toBeGreaterThan(0);
+        expect(fakeS3.objects.size).toBe(0);
+    });
+
+    it('requires create DataApp ability', async () => {
+        const svc = buildService({});
+        vi.spyOn(
+            svc as unknown as {
+                assertDataAppAbility: (...args: unknown[]) => Promise<unknown>;
+            },
+            'assertDataAppAbility',
+        ).mockRejectedValue(new ForbiddenError('nope'));
+
+        await expect(
+            svc.installRegistryChartType(fakeUser, PROJECT_UUID, 'sankey'),
+        ).rejects.toThrow(ForbiddenError);
+    });
+});

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.registryInstall.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.registryInstall.test.ts
@@ -266,6 +266,8 @@ function buildService(overrides: {
         sandboxRegistryModel: {} as never,
         orgAiCopilotConfigResolver: {} as never,
         chartRegistryClient: fullChartRegistryClient as never,
+        sandboxManager: null,
+        appRuntimeS3: null,
     });
 
     vi.spyOn(

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -150,6 +150,7 @@ import {
     type DbAppActivityRow,
     type DbAppVersion,
 } from '../../../database/entities/apps';
+import { isUniqueConstraintViolation } from '../../../database/errors';
 import { type CaslAuditWrapper } from '../../../logging/caslAuditWrapper';
 import { AnalyticsModel } from '../../../models/AnalyticsModel';
 import {
@@ -8790,6 +8791,15 @@ export class AppGenerateService extends BaseService {
                 );
             }
         } catch (e) {
+            // A concurrent install of the same chart type can also win the
+            // race to (app_id, version) — its createVersion/createWithVersion
+            // already committed to this exact S3 prefix, so cleaning it up
+            // here would delete the winner's just-written bundle.
+            if (isUniqueConstraintViolation(e)) {
+                throw new ParameterError(
+                    'Another install of this chart type is in progress — retry',
+                );
+            }
             await this.deleteVersionS3Prefix(
                 s3Client,
                 bucket,

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -8830,13 +8830,25 @@ export class AppGenerateService extends BaseService {
     /**
      * Thin pass-through to the chart registry's index-listed images
      * (thumbnails/screenshots). No ability check beyond route auth — these
-     * are catalog metadata, not project data — but still gated on the
-     * registry being enabled since `chartRegistryClient.getAsset` throws
-     * when it isn't.
+     * are catalog metadata, not project data — but gated the same way as
+     * `listRegistryChartTypes`: the data-apps flag, then the
+     * `ChartTypeRegistry` rollout flag, before falling back to the registry
+     * client's own enabled check (`chartRegistryClient.getAsset` throws when
+     * it isn't).
      */
     async getRegistryAsset(
+        user: SessionUser,
         path: string,
     ): Promise<{ buffer: Buffer; contentType: string } | undefined> {
+        await this.assertDataAppsEnabled(user);
+        const { enabled: registryFlagEnabled } =
+            await this.featureFlagModel.get({
+                user,
+                featureFlagId: FeatureFlags.ChartTypeRegistry,
+            });
+        if (!registryFlagEnabled) {
+            throw new ForbiddenError('The chart type library is not enabled');
+        }
         if (!this.chartRegistryClient.isEnabled()) {
             return undefined;
         }

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -298,6 +298,7 @@ import {
     copyDesignIntoSandbox,
     type DesignSandboxCopyResult,
 } from './designSandboxCopy';
+import { assertValidDistTar } from './distTarValidation';
 import { resolveOtelExportHeaders } from './gcpOtelAuth';
 import { readDesignForDownload } from './readDesignForDownload';
 import { readS3ObjectAsBuffer } from './s3Utils';
@@ -8735,6 +8736,11 @@ export class AppGenerateService extends BaseService {
             this.chartRegistryClient.downloadArtifact(entry, 'source'),
             this.chartRegistryClient.downloadArtifact(entry, 'dist'),
         ]);
+        // The registry is an external input — validate the dist bundle's
+        // shape before any S3 write, so a malicious/malformed dist.tar (e.g.
+        // an entry that would overwrite source.tar at this version prefix)
+        // never reaches extraction.
+        await assertValidDistTar(distTar);
         const { client: s3Client, bucket } = this.getS3Client();
         const appUuid = existing?.app_id ?? uuidv4();
         const version = existing
@@ -8791,13 +8797,27 @@ export class AppGenerateService extends BaseService {
                 );
             }
         } catch (e) {
-            // A concurrent install of the same chart type can also win the
-            // race to (app_id, version) — its createVersion/createWithVersion
-            // already committed to this exact S3 prefix, so cleaning it up
-            // here would delete the winner's just-written bundle.
             if (isUniqueConstraintViolation(e)) {
+                if (existing) {
+                    // A concurrent upgrade of the same app can also win the
+                    // race to (app_id, version) — its createVersion already
+                    // committed to this exact S3 prefix, so cleaning it up
+                    // here would delete the winner's just-written bundle.
+                    throw new ParameterError(
+                        'Another install of this chart type is in progress — retry',
+                    );
+                }
+                // A concurrent fresh install races on registry_slug, not on
+                // this app's own (unshared) uuid/prefix — cleaning up here
+                // only removes the loser's own bundle, never the winner's.
+                await this.deleteVersionS3Prefix(
+                    s3Client,
+                    bucket,
+                    appUuid,
+                    version,
+                );
                 throw new ParameterError(
-                    'Another install of this chart type is in progress — retry',
+                    'This chart type was just installed by someone else — refresh',
                 );
             }
             await this.deleteVersionS3Prefix(
@@ -9747,7 +9767,6 @@ export class AppGenerateService extends BaseService {
         return new Promise<{ fileCount: number; totalBytes: number }>(
             (resolve, reject) => {
                 const extractor = extract();
-                const uploads: Promise<void>[] = [];
                 let fileCount = 0;
                 let totalBytes = 0;
 
@@ -9777,7 +9796,11 @@ export class AppGenerateService extends BaseService {
                                         relativePath,
                                     );
 
-                                const upload = s3Client
+                                // Awaited before next(): uploads run
+                                // sequentially rather than firing unbounded
+                                // concurrent PutObject calls for every tar
+                                // entry — bundles are small, so this is cheap.
+                                s3Client
                                     .send(
                                         new PutObjectCommand({
                                             Bucket: bucket,
@@ -9786,10 +9809,7 @@ export class AppGenerateService extends BaseService {
                                             ContentType: contentType,
                                         }),
                                     )
-                                    .then(() => {});
-
-                                uploads.push(upload);
-                                next();
+                                    .then(() => next(), reject);
                             });
                             stream.on('error', reject);
                         } else {
@@ -9799,11 +9819,10 @@ export class AppGenerateService extends BaseService {
                     },
                 );
 
+                // Every upload was awaited before its entry's next() was
+                // called, so by the time 'finish' fires all uploads are done.
                 extractor.on('finish', () => {
-                    Promise.all(uploads).then(
-                        () => resolve({ fileCount, totalBytes }),
-                        reject,
-                    );
+                    resolve({ fileCount, totalBytes });
                 });
 
                 extractor.on('error', reject);

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -8828,6 +8828,22 @@ export class AppGenerateService extends BaseService {
     }
 
     /**
+     * Thin pass-through to the chart registry's index-listed images
+     * (thumbnails/screenshots). No ability check beyond route auth — these
+     * are catalog metadata, not project data — but still gated on the
+     * registry being enabled since `chartRegistryClient.getAsset` throws
+     * when it isn't.
+     */
+    async getRegistryAsset(
+        path: string,
+    ): Promise<{ buffer: Buffer; contentType: string } | undefined> {
+        if (!this.chartRegistryClient.isEnabled()) {
+            return undefined;
+        }
+        return this.chartRegistryClient.getAsset(path);
+    }
+
+    /**
      * `version` answers with that version's own schema instead of the latest
      * ready one, so a builder previewing an older version can configure the
      * options that version declares. It resolves through the same guard as the

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -19,6 +19,7 @@ import {
     assertUnreachable,
     ChartType,
     checkThemeLimits,
+    compareSemverVersions,
     DATA_APP_CLAUDE_MODELS,
     DATA_APP_CODEX_MODELS,
     DATA_APP_VIZ_TEMPLATE,
@@ -40,6 +41,7 @@ import {
     getVisibleDataAppClaudeModels,
     isDashboardChartTileType,
     isExploreError,
+    isSemverVersion,
     isValidDataAppSlug,
     MAX_APP_FILES_PER_VERSION,
     MissingConfigError,
@@ -110,6 +112,8 @@ import {
     type PersistedDataAppDataReferences,
     type PromoteAppAction,
     type PromoteAppDiff,
+    type RegistryChartTypeListItem,
+    type RegistryChartTypeState,
     type SavedChart,
     type SessionUser,
     type TogglePinnedItemInfo,
@@ -177,6 +181,7 @@ import {
     getOtelTraceHeaders,
     runWithOtelSpanContext,
 } from '../../../tracing/tracing';
+import { VERSION } from '../../../version';
 import { ChartRegistryClient } from '../../clients/ChartRegistryClient';
 import { type ExternalConnectionModel } from '../../models/ExternalConnectionModel';
 import type { SandboxRegistryModel } from '../../models/SandboxRegistryModel';
@@ -8569,6 +8574,249 @@ export class AppGenerateService extends BaseService {
         return { data: data.map(AppGenerateService.mapDataAppViz), pagination };
     }
 
+    /** Whether the given entry's `minLightdashVersion` is newer than this instance. Non-semver instance versions are treated as compatible. */
+    private static isRegistryEntryIncompatible(entry: {
+        minLightdashVersion: string | null;
+    }): boolean {
+        return (
+            entry.minLightdashVersion !== null &&
+            isSemverVersion(VERSION) &&
+            compareSemverVersions(VERSION, entry.minLightdashVersion) < 0
+        );
+    }
+
+    /**
+     * The catalog of installable chart types from the configured chart
+     * registry, merged with this project's install state. Gated behind
+     * both the data-apps flag and the `ChartTypeRegistry` rollout flag; the
+     * library is offered to whoever can build a chart in an explore, same as
+     * `listDataAppVisualizations`.
+     */
+    async listRegistryChartTypes(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<{
+        registryEnabled: boolean;
+        charts: RegistryChartTypeListItem[];
+    }> {
+        await this.assertDataAppsEnabled(user);
+        const { enabled: registryFlagEnabled } =
+            await this.featureFlagModel.get({
+                user,
+                featureFlagId: FeatureFlags.ChartTypeRegistry,
+            });
+        if (!registryFlagEnabled) {
+            throw new ForbiddenError('The chart type library is not enabled');
+        }
+        const { organizationUuid } =
+            await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'manage',
+                subject('Explore', { organizationUuid, projectUuid }),
+            )
+        ) {
+            throw new ForbiddenError('Insufficient permissions');
+        }
+
+        if (!this.chartRegistryClient.isEnabled()) {
+            return { registryEnabled: false, charts: [] };
+        }
+        const [index, installed] = await Promise.all([
+            this.chartRegistryClient.getIndex(),
+            this.appModel.listRegistryInstalledApps(projectUuid),
+        ]);
+        const bySlug = new Map(installed.map((a) => [a.registry_slug, a]));
+        const charts: RegistryChartTypeListItem[] = index.charts.map(
+            (entry) => {
+                const inst = bySlug.get(entry.slug);
+                const incompatible =
+                    AppGenerateService.isRegistryEntryIncompatible(entry);
+                let state: RegistryChartTypeState = 'not_installed';
+                if (inst?.latest_ready_registry_version) {
+                    state =
+                        !incompatible &&
+                        compareSemverVersions(
+                            inst.latest_ready_registry_version,
+                            entry.version,
+                        ) < 0
+                            ? 'update_available'
+                            : 'installed';
+                } else if (incompatible) {
+                    state = 'incompatible';
+                }
+                return {
+                    ...entry,
+                    state,
+                    installedAppUuid: inst?.app_id ?? null,
+                    installedRegistryVersion:
+                        inst?.latest_ready_registry_version ?? null,
+                };
+            },
+        );
+        return { registryEnabled: true, charts };
+    }
+
+    /**
+     * Install a chart type from the chart registry, or append a new version
+     * when it's already installed at an older registry version. Registry
+     * artifacts are verified (digest-checked) and downloaded before any S3 or
+     * DB write; a DB write failure rolls back the copied S3 keys.
+     */
+    async installRegistryChartType(
+        user: SessionUser,
+        projectUuid: string,
+        chartSlug: string,
+    ): Promise<{
+        appUuid: string;
+        slug: string;
+        version: number;
+        action: 'installed' | 'upgraded' | 'unchanged';
+    }> {
+        await this.assertDataAppsEnabled(user);
+        const { enabled: registryFlagEnabled } =
+            await this.featureFlagModel.get({
+                user,
+                featureFlagId: FeatureFlags.ChartTypeRegistry,
+            });
+        if (!registryFlagEnabled) {
+            throw new ForbiddenError('The chart type library is not enabled');
+        }
+        const { organizationUuid } = await this.assertDataAppAbility(
+            user,
+            'create',
+            projectUuid,
+            'Insufficient permissions to install chart types',
+        );
+
+        const entry = await this.chartRegistryClient.getEntry(chartSlug);
+        if (!entry) {
+            throw new NotFoundError(
+                `Chart type "${chartSlug}" not found in the registry`,
+            );
+        }
+        if (AppGenerateService.isRegistryEntryIncompatible(entry)) {
+            throw new ParameterError(
+                `Chart type "${entry.slug}" requires a newer Lightdash version (>= ${entry.minLightdashVersion}); this instance is on ${VERSION}`,
+            );
+        }
+        // Belt-and-braces: the index was already zod-validated when fetched.
+        const vizSchemaParse = dataAppVizSchema.safeParse(entry.vizSchema);
+        if (!vizSchemaParse.success) {
+            throw new ParameterError(
+                `Chart type "${entry.slug}" has an invalid vizSchema and cannot be installed`,
+            );
+        }
+        const vizSchema = vizSchemaParse.data;
+
+        const installedApps =
+            await this.appModel.listRegistryInstalledApps(projectUuid);
+        const existing = installedApps.find(
+            (a) => a.registry_slug === chartSlug,
+        );
+        if (
+            existing &&
+            existing.latest_ready_registry_version === entry.version
+        ) {
+            const latest = await this.appModel.getLatestReadyVersion(
+                existing.app_id,
+            );
+            return {
+                appUuid: existing.app_id,
+                slug: chartSlug,
+                version: latest!.version,
+                action: 'unchanged',
+            };
+        }
+
+        const [sourceTar, distTar] = await Promise.all([
+            this.chartRegistryClient.downloadArtifact(entry, 'source'),
+            this.chartRegistryClient.downloadArtifact(entry, 'dist'),
+        ]);
+        const { client: s3Client, bucket } = this.getS3Client();
+        const appUuid = existing?.app_id ?? uuidv4();
+        const version = existing
+            ? (await this.appModel.getLatestVersion(appUuid))!.version + 1
+            : 1;
+        const prefix = versionPrefix(appUuid, version);
+        await s3Client.send(
+            new PutObjectCommand({
+                Bucket: bucket,
+                Key: `${prefix}source.tar`,
+                Body: sourceTar,
+                ContentType: 'application/x-tar',
+            }),
+        );
+        await AppGenerateService.extractAndUploadToS3(
+            distTar,
+            s3Client,
+            bucket,
+            prefix,
+        );
+
+        const prompt = `Installed ${entry.name} v${entry.version} from the chart type library`;
+        try {
+            if (existing) {
+                await this.appModel.createVersion(
+                    appUuid,
+                    { version, prompt },
+                    'ready',
+                    user.userUuid,
+                    undefined,
+                    undefined,
+                    vizSchema,
+                    { registryVersion: entry.version },
+                );
+            } else {
+                await this.appModel.createWithVersion(
+                    {
+                        app_id: appUuid,
+                        project_uuid: projectUuid,
+                        created_by_user_uuid: user.userUuid,
+                        name: entry.name,
+                        description: entry.description,
+                        slug: entry.slug,
+                        template: DATA_APP_VIZ_TEMPLATE,
+                        registry_slug: entry.slug,
+                        registry_url: this.chartRegistryClient.getBaseUrl(),
+                    },
+                    { version: 1, prompt },
+                    'ready',
+                    undefined,
+                    undefined,
+                    vizSchema,
+                    { registryVersion: entry.version },
+                );
+            }
+        } catch (e) {
+            await this.deleteVersionS3Prefix(
+                s3Client,
+                bucket,
+                appUuid,
+                version,
+            );
+            throw e;
+        }
+
+        const action = existing ? 'upgraded' : 'installed';
+        this.analytics.track({
+            event: 'data_app.registry_installed',
+            userId: user.userUuid,
+            properties: {
+                organizationId: organizationUuid,
+                projectId: projectUuid,
+                appUuid,
+                chartSlug: entry.slug,
+                version,
+                registryVersion: entry.version,
+                action,
+            },
+        });
+
+        return { appUuid, slug: entry.slug, version, action };
+    }
+
     /**
      * `version` answers with that version's own schema instead of the latest
      * ready one, so a builder previewing an older version can configure the
@@ -9311,6 +9559,55 @@ export class AppGenerateService extends BaseService {
         this.logger.info(
             `App ${appUuid}: deleted ${totalDeleted} S3 object(s) under ${prefix}`,
         );
+    }
+
+    /**
+     * Best-effort cleanup of the objects copied for a single app version
+     * (used to roll back a registry install/upgrade when the DB write
+     * fails). Logs rather than throwing — a leaked S3 key is harmless.
+     */
+    private async deleteVersionS3Prefix(
+        s3Client: S3Client,
+        bucket: string,
+        appUuid: string,
+        version: number,
+    ): Promise<void> {
+        const prefix = versionPrefix(appUuid, version);
+        try {
+            let continuationToken: string | undefined;
+            /* eslint-disable no-await-in-loop */
+            do {
+                const listResponse = await s3Client.send(
+                    new ListObjectsV2Command({
+                        Bucket: bucket,
+                        Prefix: prefix,
+                        ContinuationToken: continuationToken,
+                    }),
+                );
+                const objects: ObjectIdentifier[] = (
+                    listResponse.Contents ?? []
+                )
+                    .map((obj) => obj.Key)
+                    .filter((key): key is string => typeof key === 'string')
+                    .map((Key) => ({ Key }));
+                if (objects.length > 0) {
+                    await s3Client.send(
+                        new DeleteObjectsCommand({
+                            Bucket: bucket,
+                            Delete: { Objects: objects, Quiet: true },
+                        }),
+                    );
+                }
+                continuationToken = listResponse.IsTruncated
+                    ? listResponse.NextContinuationToken
+                    : undefined;
+            } while (continuationToken);
+            /* eslint-enable no-await-in-loop */
+        } catch (e) {
+            this.logger.error(
+                `Failed to clean up S3 objects under ${prefix} after a failed registry install: ${getErrorMessage(e)}`,
+            );
+        }
     }
 
     /**

--- a/packages/backend/src/ee/services/AppGenerateService/distTarValidation.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/distTarValidation.test.ts
@@ -1,0 +1,183 @@
+import { ParameterError } from '@lightdash/common';
+import { pack, type Headers } from 'tar-stream';
+import { assertValidDistTar } from './distTarValidation';
+
+type TarEntrySpec = {
+    name: string;
+    content?: string;
+    type?: Headers['type'];
+};
+
+/** Build a real tar buffer from entry specs via tar-stream pack(). */
+async function buildTar(entries: TarEntrySpec[]): Promise<Buffer> {
+    return new Promise<Buffer>((resolve, reject) => {
+        const p = pack();
+        const chunks: Buffer[] = [];
+        p.on('data', (c: Buffer) => chunks.push(c));
+        p.on('end', () => resolve(Buffer.concat(chunks)));
+        p.on('error', reject);
+
+        const addNext = (index: number): void => {
+            if (index >= entries.length) {
+                p.finalize();
+                return;
+            }
+            const entry = entries[index];
+            const header: Headers = {
+                name: entry.name,
+                type: entry.type ?? 'file',
+            };
+            const onDone = (err?: Error | null): void => {
+                if (err) {
+                    reject(err);
+                    return;
+                }
+                addNext(index + 1);
+            };
+            if (header.type === 'file') {
+                p.entry(header, entry.content ?? '', onDone);
+            } else {
+                p.entry(header, onDone);
+            }
+        };
+        addNext(0);
+    });
+}
+
+const HAPPY_PATH_ENTRIES: TarEntrySpec[] = [
+    { name: 'dist/', type: 'directory' },
+    { name: 'dist/index.html', content: '<html></html>' },
+    { name: 'dist/assets/', type: 'directory' },
+    { name: 'dist/assets/app.js', content: 'console.log(1)' },
+    { name: 'dist/assets/app.css', content: 'body{}' },
+];
+
+describe('assertValidDistTar', () => {
+    it('accepts a fixture-shaped dist tar (index.html + flat assets)', async () => {
+        const tar = await buildTar(HAPPY_PATH_ENTRIES);
+
+        await expect(assertValidDistTar(tar)).resolves.toBeUndefined();
+    });
+
+    it('rejects an entry named dist/source.tar (would overwrite the source artifact)', async () => {
+        const tar = await buildTar([
+            { name: 'dist/index.html', content: '<html/>' },
+            { name: 'dist/source.tar', content: 'evil' },
+        ]);
+
+        await expect(assertValidDistTar(tar)).rejects.toThrow(ParameterError);
+        await expect(assertValidDistTar(tar)).rejects.toThrow(
+            /dist\/source\.tar/,
+        );
+    });
+
+    it('rejects a dotted-path traversal under assets (dist/assets/../x)', async () => {
+        const tar = await buildTar([
+            { name: 'dist/index.html', content: '<html/>' },
+            { name: 'dist/assets/../x', content: 'evil' },
+        ]);
+
+        await expect(assertValidDistTar(tar)).rejects.toThrow(ParameterError);
+    });
+
+    it('rejects a nested subdirectory under assets (dist/assets/sub/x.js)', async () => {
+        const tar = await buildTar([
+            { name: 'dist/index.html', content: '<html/>' },
+            { name: 'dist/assets/sub/x.js', content: 'evil' },
+        ]);
+
+        await expect(assertValidDistTar(tar)).rejects.toThrow(ParameterError);
+        await expect(assertValidDistTar(tar)).rejects.toThrow(
+            /dist\/assets\/sub\/x\.js/,
+        );
+    });
+
+    it('rejects an entry name with characters outside the allowed asset pattern', async () => {
+        const tar = await buildTar([
+            { name: 'dist/index.html', content: '<html/>' },
+            { name: 'dist/assets/../../etc/passwd', content: 'evil' },
+        ]);
+
+        await expect(assertValidDistTar(tar)).rejects.toThrow(ParameterError);
+    });
+
+    it('rejects more than 500 regular files', async () => {
+        const entries: TarEntrySpec[] = [
+            { name: 'dist/index.html', content: '<html/>' },
+        ];
+        for (let i = 0; i < 501; i += 1) {
+            entries.push({
+                name: `dist/assets/file-${i}.js`,
+                content: 'x',
+            });
+        }
+        const tar = await buildTar(entries);
+
+        await expect(assertValidDistTar(tar)).rejects.toThrow(ParameterError);
+        await expect(assertValidDistTar(tar)).rejects.toThrow(/too many files/);
+    });
+
+    it('accepts exactly 500 regular files (index.html + 499 assets)', async () => {
+        const entries: TarEntrySpec[] = [
+            { name: 'dist/index.html', content: '<html/>' },
+        ];
+        for (let i = 0; i < 499; i += 1) {
+            entries.push({
+                name: `dist/assets/file-${i}.js`,
+                content: 'x',
+            });
+        }
+        const tar = await buildTar(entries);
+
+        await expect(assertValidDistTar(tar)).resolves.toBeUndefined();
+    });
+
+    it('rejects duplicate entries', async () => {
+        const tar = await buildTar([
+            { name: 'dist/index.html', content: '<html/>' },
+            { name: 'dist/assets/app.js', content: 'a' },
+            { name: 'dist/assets/app.js', content: 'b' },
+        ]);
+
+        await expect(assertValidDistTar(tar)).rejects.toThrow(ParameterError);
+        await expect(assertValidDistTar(tar)).rejects.toThrow(/duplicate/);
+    });
+
+    it('rejects a tar missing dist/index.html', async () => {
+        const tar = await buildTar([
+            { name: 'dist/assets/app.js', content: 'a' },
+        ]);
+
+        await expect(assertValidDistTar(tar)).rejects.toThrow(ParameterError);
+        await expect(assertValidDistTar(tar)).rejects.toThrow(
+            /dist\/index\.html/,
+        );
+    });
+
+    it('rejects an unexpected directory entry', async () => {
+        const tar = await buildTar([
+            { name: 'dist/index.html', content: '<html/>' },
+            { name: 'dist/other/', type: 'directory' },
+        ]);
+
+        await expect(assertValidDistTar(tar)).rejects.toThrow(ParameterError);
+    });
+
+    it('rejects a symlink entry', async () => {
+        const tar = await buildTar([
+            { name: 'dist/index.html', content: '<html/>' },
+            { name: 'dist/assets/evil', type: 'symlink' },
+        ]);
+
+        await expect(assertValidDistTar(tar)).rejects.toThrow(ParameterError);
+    });
+
+    it('rejects a hardlink entry', async () => {
+        const tar = await buildTar([
+            { name: 'dist/index.html', content: '<html/>' },
+            { name: 'dist/assets/evil', type: 'link' },
+        ]);
+
+        await expect(assertValidDistTar(tar)).rejects.toThrow(ParameterError);
+    });
+});

--- a/packages/backend/src/ee/services/AppGenerateService/distTarValidation.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/distTarValidation.test.ts
@@ -59,6 +59,15 @@ describe('assertValidDistTar', () => {
         await expect(assertValidDistTar(tar)).resolves.toBeUndefined();
     });
 
+    it('accepts a leading-underscore asset name (rollup _commonjsHelpers chunks)', async () => {
+        const tar = await buildTar([
+            ...HAPPY_PATH_ENTRIES,
+            { name: 'dist/assets/_commonjsHelpers-Bc9lxTvG.js', content: '//' },
+        ]);
+
+        await expect(assertValidDistTar(tar)).resolves.toBeUndefined();
+    });
+
     it('rejects an entry named dist/source.tar (would overwrite the source artifact)', async () => {
         const tar = await buildTar([
             { name: 'dist/index.html', content: '<html/>' },

--- a/packages/backend/src/ee/services/AppGenerateService/distTarValidation.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/distTarValidation.ts
@@ -5,7 +5,8 @@ import { extract, type Headers } from 'tar-stream';
 const DIST_INDEX_HTML = 'dist/index.html';
 const DIST_ASSETS_PREFIX = 'dist/assets/';
 const ALLOWED_DIST_DIRECTORIES = new Set(['dist/', DIST_ASSETS_PREFIX]);
-const DIST_ASSET_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+// Leading underscore allowed: rollup emits chunks like _commonjsHelpers-<hash>.js.
+const DIST_ASSET_NAME_PATTERN = /^[A-Za-z0-9_][A-Za-z0-9._-]*$/;
 const MAX_DIST_TAR_FILES = 500;
 
 /**

--- a/packages/backend/src/ee/services/AppGenerateService/distTarValidation.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/distTarValidation.ts
@@ -1,0 +1,126 @@
+import { ParameterError } from '@lightdash/common';
+import { PassThrough } from 'node:stream';
+import { extract, type Headers } from 'tar-stream';
+
+const DIST_INDEX_HTML = 'dist/index.html';
+const DIST_ASSETS_PREFIX = 'dist/assets/';
+const ALLOWED_DIST_DIRECTORIES = new Set(['dist/', DIST_ASSETS_PREFIX]);
+const DIST_ASSET_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+const MAX_DIST_TAR_FILES = 500;
+
+/**
+ * Validates a downloaded registry dist.tar before it's extracted and
+ * uploaded to S3. The registry is an external input, so a malicious or
+ * malformed dist bundle is treated as untrusted: without this check, an
+ * entry named `dist/source.tar` would silently overwrite the
+ * digest-verified source artifact at the same version prefix, entries could
+ * escape the flat `dist/assets/` shape vite emits, and a small tar could
+ * still trigger tens of thousands of S3 uploads.
+ *
+ * Every regular-file entry must be exactly `dist/index.html` or a flat
+ * `dist/assets/<name>` (no subdirectories); directory entries are allowed
+ * only for `dist/` and `dist/assets/`; duplicates, symlinks/hardlinks/device
+ * files, and more than `MAX_DIST_TAR_FILES` regular files are all rejected.
+ * Rejects with a `ParameterError` naming the offending entry.
+ */
+export async function assertValidDistTar(tarBuffer: Buffer): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+        const extractor = extract();
+        const seenNames = new Set<string>();
+        let fileCount = 0;
+        let hasIndexHtml = false;
+        let settled = false;
+
+        const fail = (message: string): void => {
+            if (settled) return;
+            settled = true;
+            reject(new ParameterError(`Invalid dist archive: ${message}`));
+            extractor.destroy();
+        };
+
+        extractor.on(
+            'entry',
+            (header: Headers, stream: PassThrough, next: () => void) => {
+                stream.on('error', reject);
+                stream.on('end', next);
+
+                if (settled) {
+                    stream.resume();
+                    return;
+                }
+
+                const { name, type } = header;
+
+                if (!name) {
+                    fail('entry with no name');
+                    stream.resume();
+                    return;
+                }
+
+                if (type === 'directory') {
+                    if (!ALLOWED_DIST_DIRECTORIES.has(name)) {
+                        fail(`unexpected directory "${name}"`);
+                    }
+                    stream.resume();
+                    return;
+                }
+
+                if (type !== 'file') {
+                    fail(`unsupported entry type "${type}" for "${name}"`);
+                    stream.resume();
+                    return;
+                }
+
+                const assetName = name.startsWith(DIST_ASSETS_PREFIX)
+                    ? name.slice(DIST_ASSETS_PREFIX.length)
+                    : null;
+                const isIndexHtml = name === DIST_INDEX_HTML;
+                const isValidAsset =
+                    assetName !== null &&
+                    assetName.length > 0 &&
+                    DIST_ASSET_NAME_PATTERN.test(assetName);
+
+                if (!isIndexHtml && !isValidAsset) {
+                    fail(`unexpected file "${name}"`);
+                    stream.resume();
+                    return;
+                }
+
+                if (seenNames.has(name)) {
+                    fail(`duplicate entry "${name}"`);
+                    stream.resume();
+                    return;
+                }
+                seenNames.add(name);
+                if (isIndexHtml) hasIndexHtml = true;
+
+                fileCount += 1;
+                if (fileCount > MAX_DIST_TAR_FILES) {
+                    fail(
+                        `too many files (max ${MAX_DIST_TAR_FILES}, encountered "${name}")`,
+                    );
+                    stream.resume();
+                    return;
+                }
+
+                stream.resume();
+            },
+        );
+
+        extractor.on('finish', () => {
+            if (settled) return;
+            if (!hasIndexHtml) {
+                fail(`missing ${DIST_INDEX_HTML}`);
+                return;
+            }
+            settled = true;
+            resolve();
+        });
+
+        extractor.on('error', reject);
+
+        const passThrough = new PassThrough();
+        passThrough.pipe(extractor);
+        passThrough.end(tarBuffer);
+    });
+}

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -1087,6 +1087,33 @@ export class AppModel {
         return KnexPaginate.paginate(query, paginateArgs);
     }
 
+    /** Registry-installed apps in the project, with their latest ready registry version. */
+    async listRegistryInstalledApps(projectUuid: string): Promise<
+        Array<{
+            app_id: string;
+            registry_slug: string;
+            latest_ready_registry_version: string | null;
+        }>
+    > {
+        return this.joinLatestReadyVersion(this.database(AppsTableName))
+            .where(`${AppsTableName}.project_uuid`, projectUuid)
+            .whereNotNull(`${AppsTableName}.registry_slug`)
+            .whereNull(`${AppsTableName}.deleted_at`)
+            .select<
+                Array<{
+                    app_id: string;
+                    registry_slug: string;
+                    latest_ready_registry_version: string | null;
+                }>
+            >(
+                `${AppsTableName}.app_id`,
+                `${AppsTableName}.registry_slug`,
+                this.database
+                    .ref(`${AppVersionsTableName}.registry_version`)
+                    .as('latest_ready_registry_version'),
+            );
+    }
+
     /**
      * A single data app viz by its project-scoped slug, with its latest ready
      * schema. Undefined when the slug is not a schema-bearing data app viz.

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -1099,6 +1099,7 @@ export class AppModel {
             .where(`${AppsTableName}.project_uuid`, projectUuid)
             .whereNotNull(`${AppsTableName}.registry_slug`)
             .whereNull(`${AppsTableName}.deleted_at`)
+            .orderBy(`${AppsTableName}.created_at`)
             .select<
                 Array<{
                     app_id: string;

--- a/packages/backend/src/routers/apiV1Router.ts
+++ b/packages/backend/src/routers/apiV1Router.ts
@@ -33,6 +33,7 @@ import {
     createOneLoginStrategyForConfig,
     isOneLoginPassportStrategyAvailableToUse,
 } from '../controllers/authentication/strategies/oneLoginStrategy';
+import { chartRegistryAssetRouter } from '../ee/routers/chartRegistryAssetRouter';
 import { AiAgentService } from '../ee/services/AiAgentService/AiAgentService';
 import { createAuditLogEvent } from '../logging/auditLog';
 import { createActorFromUser } from '../logging/caslAuditWrapper';
@@ -903,3 +904,4 @@ apiV1Router.use('/jobs', jobsRouter);
 apiV1Router.use('/headless-browser', headlessBrowserRouter);
 apiV1Router.use('/mcp', mcpRouter);
 apiV1Router.use('/oauth', oauthRouter);
+apiV1Router.use('/ee/chart-registry', chartRegistryAssetRouter);

--- a/packages/common/src/ee/apps/registry.ts
+++ b/packages/common/src/ee/apps/registry.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { type ApiSuccess } from '../../types/api/success';
 import { isValidDataAppSlug } from './code';
-import { dataAppVizSchema } from './types';
+import { dataAppVizSchema, type DataAppVizSchema } from './types';
 
 export const CHART_REGISTRY_INDEX_SCHEMA_VERSION = 1 as const;
 
@@ -36,11 +36,39 @@ const registrySlug = z
     .string()
     .refine(isValidDataAppSlug, { message: 'must be a valid chart type slug' });
 
+// Explicit TS types (for the OpenAPI spec) plus zod schemas (runtime
+// validation of the registry index), kept in sync by the compile-time
+// assertions below — TSOA can't resolve types derived purely from
+// `z.infer<...>`, so every registry type exposed via the API is declared
+// by hand here, mirroring the data-app-viz schema/type split in `./types`.
+
+export type ChartRegistryArtifact = {
+    path: string;
+    sha256: string;
+};
+
 const registryArtifactSchema = z.object({
     path: z.string().min(1),
     sha256: z.string().regex(/^[a-f0-9]{64}$/),
 });
-export type ChartRegistryArtifact = z.infer<typeof registryArtifactSchema>;
+
+export type ChartRegistryEntry = {
+    slug: string;
+    name: string;
+    description: string;
+    version: string;
+    publishedAt: string;
+    tags: string[];
+    changelog: string;
+    minLightdashVersion: string | null;
+    vizSchema: DataAppVizSchema;
+    thumbnail: string | null;
+    screenshots: string[];
+    artifacts: {
+        source: ChartRegistryArtifact;
+        dist: ChartRegistryArtifact;
+    };
+};
 
 const registryEntrySchema = z.object({
     slug: registrySlug,
@@ -59,14 +87,29 @@ const registryEntrySchema = z.object({
         dist: registryArtifactSchema,
     }),
 });
-export type ChartRegistryEntry = z.infer<typeof registryEntrySchema>;
+
+export type ChartRegistryIndex = {
+    schemaVersion: typeof CHART_REGISTRY_INDEX_SCHEMA_VERSION;
+    generatedAt: string;
+    charts: ChartRegistryEntry[];
+};
 
 export const chartRegistryIndexSchema = z.object({
     schemaVersion: z.literal(CHART_REGISTRY_INDEX_SCHEMA_VERSION),
     generatedAt: z.string(),
     charts: z.array(registryEntrySchema),
 });
-export type ChartRegistryIndex = z.infer<typeof chartRegistryIndexSchema>;
+
+type AssertMutuallyAssignable<A, B> = [A] extends [B]
+    ? [B] extends [A]
+        ? true
+        : never
+    : never;
+const chartRegistryIndexSchemaMatchesApiType: AssertMutuallyAssignable<
+    z.infer<typeof chartRegistryIndexSchema>,
+    ChartRegistryIndex
+> = true;
+void chartRegistryIndexSchemaMatchesApiType;
 
 export type RegistryChartTypeState =
     | 'not_installed'


### PR DESCRIPTION
Part 3 of the installable chart types stack (on #28374). This PR adds the API for browsing the official chart-type registry and installing charts from it into a project.

**New endpoints** (EE, gated by `chart-type-registry` + `enable-data-apps`):

- `GET …/apps/registry/charts` — the registry catalog, annotated for this project: not installed / installed / update available / incompatible.
- `POST …/apps/registry/charts/{slug}/install` — install a chart type (requires `create:DataApp`).
- `GET /api/v1/ee/chart-registry/assets?path=…` — serves catalog screenshots to the browser.

**What install does:** download the chart's prebuilt bundle from the registry, verify its sha256 digests, copy it into the instance's S3, and create the app + a `ready` version. No sandbox build — installs work on self-hosted instances with no sandbox infra. Calling install again when the registry has a newer version appends an upgrade; re-installing the current version is a no-op.

**Safety notes for review:**

- Install deliberately bypasses `importAppCode`: registry apps are read-only (#28374), and the customer upload endpoint must never accept prebuilt bundles.
- The dist tar is validated against a strict allowlist before extraction (exactly one `index.html`, flat `assets/*` files, ≤500 entries) so a hostile bundle can't overwrite other S3 keys or flood uploads.
- Concurrent installs are safe: a partial unique index on `(project_uuid, registry_slug)` plus race-aware error handling (the loser cleans up and gets a friendly retry error).
- A failed install leaves nothing behind — S3 writes are rolled back if the DB write fails.

Relates GLITCH-714

🤖 Generated with [Claude Code](https://claude.com/claude-code)
