### PR TITLE
feat: chart type library gallery section + official/fork UX

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -8358,6 +8358,7 @@ export class AppGenerateService extends BaseService {
         }[];
         hasMore: boolean;
         latestReadyVersion: number | null;
+        registrySlug: string | null;
     }> {
         await this.assertDataAppsEnabled(user);
 
@@ -8383,6 +8384,7 @@ export class AppGenerateService extends BaseService {
             pinnedListOrder,
             versions,
             hasMore,
+            registrySlug,
         } = await this.appModel.getAppWithVersions(appUuid, projectUuid, opts);
 
         const appAuthorization = await this.assertCanViewApp(user, {
@@ -8465,6 +8467,7 @@ export class AppGenerateService extends BaseService {
             })),
             hasMore,
             latestReadyVersion: latestReady?.version ?? null,
+            registrySlug,
         };
     }
 
@@ -8544,6 +8547,7 @@ export class AppGenerateService extends BaseService {
             schema: app.viz_schema,
             createdAt: app.created_at,
             createdByUserUuid: app.created_by_user_uuid,
+            registrySlug: app.registry_slug,
         };
     }
 

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -766,6 +766,7 @@ export class AppModel {
             created_by_user_last_name: string | null;
         })[];
         hasMore: boolean;
+        registrySlug: string | null;
     }> {
         const limit = opts.limit ?? 20;
         const query = this.database(AppsTableName)
@@ -819,6 +820,7 @@ export class AppModel {
                 `${AppsTableName}.template`,
                 `${AppsTableName}.slug`,
                 `${AppsTableName}.views_count`,
+                `${AppsTableName}.registry_slug`,
                 `${OrganizationTableName}.organization_uuid`,
                 `${PinnedAppTableName}.pinned_list_uuid`,
                 `${PinnedAppTableName}.order as pinned_list_order`,
@@ -845,6 +847,7 @@ export class AppModel {
             template: DbApp['template'];
             slug: string;
             views_count: number;
+            registry_slug: string | null;
             organization_uuid: string;
             pinned_list_uuid: string | null;
             pinned_list_order: number | null;
@@ -867,6 +870,7 @@ export class AppModel {
             template,
             slug,
             views_count: viewsCount,
+            registry_slug: registrySlug,
             organization_uuid: organizationUuid,
             pinned_list_uuid: pinnedListUuid,
             pinned_list_order: pinnedListOrder,
@@ -885,6 +889,7 @@ export class AppModel {
                 template: DbApp['template'];
                 slug: string;
                 views_count: number;
+                registry_slug: string | null;
                 organization_uuid: string;
                 pinned_list_uuid: string | null;
                 pinned_list_order: number | null;
@@ -907,6 +912,7 @@ export class AppModel {
             pinnedListOrder,
             versions: versions.slice(0, limit),
             hasMore,
+            registrySlug,
         };
     }
 

--- a/packages/common/src/ee/apps/types.test.ts
+++ b/packages/common/src/ee/apps/types.test.ts
@@ -4,7 +4,7 @@ import {
     dataAppVizSchema,
     getEffectiveOptionValues,
     getVisibleDataAppClaudeModels,
-isOfficialChartType,
+    isOfficialChartType,
     pruneDataAppVizOptionValues,
     resolveDefaultDataAppClaudeModel,
     resolveDefaultVisibleDataAppClaudeModel,

--- a/packages/common/src/ee/apps/types.test.ts
+++ b/packages/common/src/ee/apps/types.test.ts
@@ -4,6 +4,7 @@ import {
     dataAppVizSchema,
     getEffectiveOptionValues,
     getVisibleDataAppClaudeModels,
+isOfficialChartType,
     pruneDataAppVizOptionValues,
     resolveDefaultDataAppClaudeModel,
     resolveDefaultVisibleDataAppClaudeModel,
@@ -23,6 +24,15 @@ const validFields = {
         { name: 'series', label: 'Series', type: 'series', required: false },
     ],
 };
+
+describe('isOfficialChartType', () => {
+    it('is true only when registrySlug is set', () => {
+        expect(isOfficialChartType({ registrySlug: 'radial-gauge' })).toBe(
+            true,
+        );
+        expect(isOfficialChartType({ registrySlug: null })).toBe(false);
+    });
+});
 
 describe('dataAppVizSchema', () => {
     it('accepts a well-formed fields declaration (configOptions defaults to [], colorPalette to null)', () => {

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -527,6 +527,9 @@ export type ApiGetAppResponse = ApiSuccess<{
     // Viewers must use this (not scan `versions`) to decide whether the app
     // can be previewed — the ready version may be older than the page window.
     latestReadyVersion: number | null;
+    // The registry slug it was installed from, or null for a project-authored
+    // (or forked) app. Registry-installed chart types are read-only.
+    registrySlug: string | null;
 }>;
 
 export type ApiUpdateAppRequest = {
@@ -1117,7 +1120,15 @@ export type DataAppViz = {
     schema: DataAppVizSchema | null;
     createdAt: Date;
     createdByUserUuid: string;
+    // Registry slug it was installed from, or null if project-authored (or
+    // forked). Registry-installed chart types are read-only; fork to edit.
+    registrySlug: string | null;
 };
+
+/** Whether a chart type is a registry install: read-only, only editable by forking. */
+export const isOfficialChartType = (
+    viz: Pick<DataAppViz, 'registrySlug'>,
+): boolean => viz.registrySlug !== null;
 
 export type ApiListDataAppVizsResponse = ApiSuccess<
     KnexPaginatedData<DataAppViz[]>

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -71,7 +71,9 @@ import type {
     ApiGetUserAgentPreferencesResponse,
     ApiHomepageLinkMetadataResponse,
     ApiHomepageViewAsResponse,
+    ApiInstallRegistryChartTypeResponse,
     ApiListDataAppVizsResponse,
+    ApiListRegistryChartTypesResponse,
     ApiManagedAgentActionResponse,
     ApiManagedAgentRunResponse,
     ApiManagedAgentRunsListResponse,
@@ -1518,6 +1520,8 @@ type ApiResults =
     | ApiGetDataAppAuthoringContextResponse['results']
     | ApiGetAppResponse['results']
     | ApiListDataAppVizsResponse['results']
+    | ApiListRegistryChartTypesResponse['results']
+    | ApiInstallRegistryChartTypeResponse['results']
     | ApiGetDataAppVizResponse['results']
     | ApiDataAppVizRenderMetadataResponse['results']
     | ApiDataAppVizPreviewTokenResponse['results']

--- a/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.test.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.test.tsx
@@ -23,6 +23,7 @@ const { mocks } = vi.hoisted(() => ({
         navigate: vi.fn(),
         dispatch: vi.fn(),
         canCreateDataApp: vi.fn(() => true),
+        canEditChartType: vi.fn(() => true),
     },
 }));
 
@@ -72,6 +73,9 @@ vi.mock(
 );
 vi.mock('../../../features/apps/hooks/useCanCreateDataApp', () => ({
     useCanCreateDataApp: () => mocks.canCreateDataApp(),
+}));
+vi.mock('../../../features/apps/hooks/useCanEditDataApp', () => ({
+    useCanEditDataAppChecker: () => mocks.canEditChartType,
 }));
 vi.mock('../../../features/explorer/store', () => ({
     useExplorerDispatch: () => mocks.dispatch,
@@ -411,6 +415,10 @@ describe('ExplorerChartTypeGallery', () => {
         vi.clearAllMocks();
         dataAppsEnabled.current = true;
         mocks.canCreateDataApp.mockReturnValue(true);
+        // False by default (mirrors the real ability hook with no grants),
+        // so existing selection/search tests keep a single "Event pulse"
+        // match; edit-affordance tests opt in explicitly.
+        mocks.canEditChartType.mockReturnValue(false);
         setProjectQuery();
     });
 
@@ -486,6 +494,48 @@ describe('ExplorerChartTypeGallery', () => {
             itemsMap,
         );
         expect(onSelected).toHaveBeenCalledTimes(1);
+    });
+
+    it('hides the edit affordance for an official (registry-installed) chart type', () => {
+        mocks.canEditChartType.mockReturnValue(true);
+        mockedUseDataAppVisualizations.mockReturnValue({
+            data: {
+                pages: [
+                    {
+                        data: [
+                            projectChartType,
+                            {
+                                ...projectChartType,
+                                dataAppVizUuid: 'official-chart-type',
+                                name: 'Radial gauge',
+                                registrySlug: 'radial-gauge',
+                            },
+                        ],
+                        pagination: {
+                            page: 1,
+                            pageSize: 25,
+                            totalPageCount: 1,
+                            totalResults: 2,
+                        },
+                    },
+                ],
+                pageParams: [1],
+            },
+            isInitialLoading: false,
+            error: null,
+            refetch: mocks.refetch,
+            hasNextPage: false,
+            fetchNextPage: mocks.fetchNextPage,
+            isFetchingNextPage: false,
+        } as unknown as ReturnType<typeof useDataAppVisualizations>);
+        renderGallery();
+
+        expect(
+            screen.getByRole('button', { name: 'Edit Event pulse' }),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByRole('button', { name: 'Edit Radial gauge' }),
+        ).not.toBeInTheDocument();
     });
 
     it('starts authoring a new chart type in place from the project section', async () => {

--- a/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.test.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.test.tsx
@@ -35,6 +35,7 @@ const projectChartType = {
     createdAt: new Date('2026-08-20T00:00:00Z'),
     createdByUserUuid: 'user-uuid',
     schema: { fields: [], configOptions: [], colorPalette: null },
+    registrySlug: null,
 } satisfies DataAppViz;
 
 const itemsMap = { orders_status: { name: 'status' } } as unknown as ItemsMap;

--- a/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.tsx
@@ -1,4 +1,8 @@
-import { FeatureFlags, type DataAppViz } from '@lightdash/common';
+import {
+    FeatureFlags,
+    isOfficialChartType,
+    type DataAppViz,
+} from '@lightdash/common';
 import {
     ActionIcon,
     Box,
@@ -445,14 +449,18 @@ const ExplorerChartTypeGallery: FC<ExplorerChartTypeGalleryProps> = ({
                     }
                     onSelected();
                 },
-                onEdit: canEditChartType(dataAppViz)
-                    ? () =>
-                          dispatch(
-                              explorerActions.startChartTypeAuthoring({
-                                  dataAppVizUuid: dataAppViz.dataAppVizUuid,
-                              }),
-                          )
-                    : null,
+                // Official (registry-installed) types are read-only; forking
+                // them lives in the gallery page, not this inline picker.
+                onEdit:
+                    canEditChartType(dataAppViz) &&
+                    !isOfficialChartType(dataAppViz)
+                        ? () =>
+                              dispatch(
+                                  explorerActions.startChartTypeAuthoring({
+                                      dataAppVizUuid: dataAppViz.dataAppVizUuid,
+                                  }),
+                              )
+                        : null,
             };
         },
     );

--- a/packages/frontend/src/components/Explorer/ChartGallery/ExplorerChartSidebar.test.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ExplorerChartSidebar.test.tsx
@@ -138,6 +138,7 @@ describe('ExplorerChartSidebar', () => {
             name: 'Event pulse',
             spaceUuid: null,
             createdByUserUuid: 'user-1',
+            registrySlug: null,
         };
         const store = createExplorerStore();
         renderSidebar(
@@ -155,6 +156,30 @@ describe('ExplorerChartSidebar', () => {
         expect(
             store.getState().explorer.chartTypeAuthoring?.dataAppVizUuid,
         ).toBe('viz-1');
+    });
+
+    it('hides the edit entry for an official (registry-installed) chart type', () => {
+        vizConfig.current = {
+            chartType: ChartType.DATA_APP_VIZ,
+            chartConfig: { dataAppVizUuid: 'viz-1' },
+        };
+        selectedProjectType.current = {
+            dataAppVizUuid: 'viz-1',
+            name: 'Sankey',
+            spaceUuid: null,
+            createdByUserUuid: 'user-1',
+            registrySlug: 'sankey',
+        };
+        renderSidebar(
+            <ExplorerChartSidebar
+                chartType={ChartType.DATA_APP_VIZ}
+                onClose={vi.fn()}
+            />,
+        );
+
+        expect(
+            screen.queryByRole('button', { name: 'Edit chart type' }),
+        ).not.toBeInTheDocument();
     });
 
     it('retitles itself while a chart type is authored', () => {

--- a/packages/frontend/src/components/Explorer/ChartGallery/ExplorerChartSidebar.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ExplorerChartSidebar.tsx
@@ -1,4 +1,8 @@
-import { FeatureFlags, type ChartType } from '@lightdash/common';
+import {
+    FeatureFlags,
+    isOfficialChartType,
+    type ChartType,
+} from '@lightdash/common';
 import { ActionIcon, Anchor, Group, Stack, Text, Tooltip } from '@mantine/core';
 import {
     IconArrowLeft,
@@ -89,7 +93,8 @@ const ExplorerChartSidebar: FC<Props> = ({ chartType, onClose }) => {
     const canEditSelectedType =
         dataAppsEnabled &&
         selectedProjectType !== undefined &&
-        canEditChartType(selectedProjectType);
+        canEditChartType(selectedProjectType) &&
+        !isOfficialChartType(selectedProjectType);
 
     const selectedItem = getSelectedChartTypeItem(
         chartType,

--- a/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoring.test.tsx
+++ b/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoring.test.tsx
@@ -157,6 +157,7 @@ const dataAppViz = {
     },
     createdAt: new Date('2026-08-19T00:00:00Z'),
     createdByUserUuid: 'user-1',
+    registrySlug: null,
 } satisfies DataAppViz;
 
 const readyVersion = {
@@ -601,6 +602,18 @@ describe('ExplorerChartTypeAuthoring', () => {
 
     it('leaves authoring when data-apps is switched off under it', () => {
         dataAppsEnabled.current = false;
+        const store = renderAuthoring({ dataAppVizUuid: 'viz-1' });
+
+        expect(showToastError).toHaveBeenCalled();
+        expect(store.getState().explorer.chartTypeAuthoring).toBeNull();
+    });
+
+    it('leaves authoring when the type is an official (registry-installed) chart type', () => {
+        vi.mocked(useChartTypeBuilderWorkspace).mockReturnValue(
+            workspaceStub({
+                dataAppViz: { ...dataAppViz, registrySlug: 'radial-gauge' },
+            }),
+        );
         const store = renderAuthoring({ dataAppVizUuid: 'viz-1' });
 
         expect(showToastError).toHaveBeenCalled();

--- a/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoring.tsx
+++ b/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoring.tsx
@@ -136,7 +136,8 @@ const ExplorerChartTypeAuthoring: FC<Props> = ({ authoring }) => {
     const isForbidden =
         (!dataAppsFlag.isLoading && !dataAppsFlag.data?.enabled) ||
         (dataAppVizUuid === null && !canCreate) ||
-        (dataAppViz !== undefined && !canEdit);
+        (dataAppViz !== undefined && !canEdit) ||
+        (dataAppViz !== undefined && dataAppViz.registrySlug !== null);
     useEffect(() => {
         if (!isForbidden) return;
         showToastError({ title: 'You cannot author this chart type' });

--- a/packages/frontend/src/components/Explorer/VisualizationCardOptions/useChartTypeOptions.test.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCardOptions/useChartTypeOptions.test.tsx
@@ -27,6 +27,7 @@ const projectChartType = {
     createdAt: new Date('2026-08-20T00:00:00Z'),
     createdByUserUuid: 'user-uuid',
     schema: { fields: [], configOptions: [], colorPalette: null },
+    registrySlug: null,
 } satisfies DataAppViz;
 
 const getSelectedItem = (

--- a/packages/frontend/src/components/VisualizationConfigs/CustomChartType/CustomChartTypePicker.test.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/CustomChartType/CustomChartTypePicker.test.tsx
@@ -25,6 +25,7 @@ const makeDataAppViz = (overrides: Partial<DataAppViz>): DataAppViz => ({
     },
     createdAt: new Date('2026-06-30'),
     createdByUserUuid: 'user-1',
+    registrySlug: null,
     ...overrides,
 });
 

--- a/packages/frontend/src/components/VisualizationConfigs/CustomChartType/useSelectProjectChartType.test.ts
+++ b/packages/frontend/src/components/VisualizationConfigs/CustomChartType/useSelectProjectChartType.test.ts
@@ -95,6 +95,7 @@ const dataAppViz = {
     },
     createdAt: new Date('2026-08-19T00:00:00Z'),
     createdByUserUuid: 'user-uuid',
+    registrySlug: null,
 } satisfies DataAppViz;
 
 describe('useSelectProjectChartType', () => {

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/AiDataAppBuildCard.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/AiDataAppBuildCard.test.tsx
@@ -86,6 +86,7 @@ const app = (
     createdByUserUuid: 'user-1',
     spaceUuid: null,
     spaceName: null,
+    registrySlug: null,
     template: null,
     pinnedListUuid: null,
     pinnedListOrder: null,

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/dataAppBuildCardState.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/dataAppBuildCardState.test.ts
@@ -37,6 +37,7 @@ const app = (
     createdByUserUuid: 'user-1',
     spaceUuid: null,
     spaceName: null,
+    registrySlug: null,
     template: null,
     pinnedListUuid: null,
     pinnedListOrder: null,

--- a/packages/frontend/src/features/apps/hooks/useDuplicateApp.ts
+++ b/packages/frontend/src/features/apps/hooks/useDuplicateApp.ts
@@ -6,15 +6,16 @@ import useToaster from '../../../hooks/toaster/useToaster';
 type DuplicateAppParams = {
     projectUuid: string;
     appUuid: string;
+    name?: string;
 };
 
 type DuplicateAppResult = ApiDuplicateAppResponse['results'];
 
-const duplicateApp = ({ projectUuid, appUuid }: DuplicateAppParams) =>
+const duplicateApp = ({ projectUuid, appUuid, name }: DuplicateAppParams) =>
     lightdashApi<DuplicateAppResult>({
         method: 'POST',
         url: `/ee/projects/${projectUuid}/apps/${appUuid}/duplicate`,
-        body: undefined,
+        body: JSON.stringify(name ? { name } : {}),
     });
 
 export const useDuplicateApp = () => {
@@ -25,6 +26,7 @@ export const useDuplicateApp = () => {
         onSuccess: () => {
             void queryClient.invalidateQueries({ queryKey: ['myApps'] });
             void queryClient.invalidateQueries({ queryKey: ['content'] });
+            void queryClient.invalidateQueries({ queryKey: ['data-app-vizs'] });
             showToastSuccess({ title: 'Data app duplicated' });
         },
         onError: ({ error }) => {

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeDetailModal.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeDetailModal.tsx
@@ -1,16 +1,19 @@
 import { getAppDisplayName, type DataAppViz } from '@lightdash/common';
-import { Box, Button, SimpleGrid, Stack, Text } from '@mantine/core';
-import { IconFilePencil, IconTrash } from '@tabler/icons-react';
-import { type FC } from 'react';
+import { Box, Button, Group, SimpleGrid, Stack, Text } from '@mantine/core';
+import { IconFilePencil, IconGitFork, IconTrash } from '@tabler/icons-react';
+import { useState, type FC } from 'react';
 import { Link, useNavigate } from 'react-router';
 import MantineIcon from '../../../components/common/MantineIcon';
 import MantineModal from '../../../components/common/MantineModal';
 import { useTimeAgo } from '../../../hooks/useTimeAgo';
 import { useAppVersionHistory } from '../../apps/hooks/useAppVersionHistory';
+import { useCanCreateDataApp } from '../../apps/hooks/useCanCreateDataApp';
 import { useCanEditDataApp } from '../../apps/hooks/useCanEditDataApp';
 import { chartTypeBuilderPath } from '../utils/chartTypeBuilderPath';
 import classes from './ChartTypeDetailModal.module.css';
+import ChartTypeForkModal from './ChartTypeForkModal';
 import ChartTypeSamplePreview from './ChartTypeSamplePreview';
+import OfficialChartTypeBadge from './OfficialChartTypeBadge';
 
 type Props = {
     projectUuid: string;
@@ -27,6 +30,9 @@ const ChartTypeDetailModal: FC<Props> = ({
 }) => {
     const navigate = useNavigate();
     const canEdit = useCanEditDataApp(projectUuid, dataAppViz);
+    const canFork = useCanCreateDataApp(projectUuid);
+    const isOfficial = isOfficialChartType(dataAppViz);
+    const [isForkOpen, setIsForkOpen] = useState(false);
     const { latestReadyVersion, oldest, latest, hasOrigin } =
         useAppVersionHistory(projectUuid, dataAppViz.dataAppVizUuid);
 
@@ -43,111 +49,141 @@ const ChartTypeDetailModal: FC<Props> = ({
     );
 
     return (
-        <MantineModal
-            opened
-            onClose={onClose}
-            title={getAppDisplayName(
-                dataAppViz.name,
-                dataAppViz.dataAppVizUuid,
-            )}
-            // The default 80vh cap clips the meta panel.
-            bodyScrollAreaMaxHeight="calc(100vh - 200px)"
-            cancelLabel={false}
-            leftActions={
-                canEdit && (
-                    // The theme's subtle variant hardcodes gray text; c overrides it.
-                    <Button
-                        variant="subtle"
-                        size="xs"
-                        color="red"
-                        c="red.7"
-                        leftSection={<MantineIcon icon={IconTrash} />}
-                        onClick={onDelete}
-                    >
-                        Delete
-                    </Button>
-                )
-            }
-            actions={
-                <Button
-                    component={Link}
-                    to={chartTypeBuilderPath(
-                        projectUuid,
-                        dataAppViz.dataAppVizUuid,
-                    )}
-                    variant="default"
-                    leftSection={<MantineIcon icon={IconFilePencil} />}
-                >
-                    Edit
-                </Button>
-            }
-            onConfirm={() =>
-                navigate(
-                    `/projects/${projectUuid}/tables?dataAppVizUuid=${dataAppViz.dataAppVizUuid}`,
-                )
-            }
-            confirmLabel="Preview in explorer"
-        >
-            <Stack gap="md">
-                <Box className={classes.preview}>
-                    <ChartTypeSamplePreview
-                        projectUuid={projectUuid}
-                        dataAppVizUuid={dataAppViz.dataAppVizUuid}
-                    />
-                </Box>
-                <Text fz="sm" c="ldGray.7" lh={1.55}>
-                    {dataAppViz.description || 'No description'}
-                </Text>
-                <SimpleGrid cols={2} className={classes.metaPanel}>
-                    {builtBy !== null && (
+        <>
+            <MantineModal
+                opened
+                onClose={onClose}
+                title={
+                    <Group gap="xs" wrap="nowrap">
+                        <Text fw={700} fz="md" c="ldDark.9">
+                            {getAppDisplayName(
+                                dataAppViz.name,
+                                dataAppViz.dataAppVizUuid,
+                            )}
+                        </Text>
+                        {isOfficial && <OfficialChartTypeBadge />}
+                    </Group>
+                }
+                // The default 80vh cap clips the meta panel.
+                bodyScrollAreaMaxHeight="calc(100vh - 200px)"
+                cancelLabel={false}
+                leftActions={
+                    canEdit && (
+                        // The theme's subtle variant hardcodes gray text; c overrides it.
+                        <Button
+                            variant="subtle"
+                            size="xs"
+                            color="red"
+                            c="red.7"
+                            leftSection={<MantineIcon icon={IconTrash} />}
+                            onClick={onDelete}
+                        >
+                            Delete
+                        </Button>
+                    )
+                }
+                actions={
+                    isOfficial ? (
+                        canFork && (
+                            <Button
+                                variant="default"
+                                leftSection={<MantineIcon icon={IconGitFork} />}
+                                onClick={() => setIsForkOpen(true)}
+                            >
+                                Fork to customize
+                            </Button>
+                        )
+                    ) : (
+                        <Button
+                            component={Link}
+                            to={chartTypeBuilderPath(
+                                projectUuid,
+                                dataAppViz.dataAppVizUuid,
+                            )}
+                            variant="default"
+                            leftSection={<MantineIcon icon={IconFilePencil} />}
+                        >
+                            Edit
+                        </Button>
+                    )
+                }
+                onConfirm={() =>
+                    navigate(
+                        `/projects/${projectUuid}/tables?dataAppVizUuid=${dataAppViz.dataAppVizUuid}`,
+                    )
+                }
+                confirmLabel="Preview in explorer"
+            >
+                <Stack gap="md">
+                    <Box className={classes.preview}>
+                        <ChartTypeSamplePreview
+                            projectUuid={projectUuid}
+                            dataAppVizUuid={dataAppViz.dataAppVizUuid}
+                        />
+                    </Box>
+                    <Text fz="sm" c="ldGray.7" lh={1.55}>
+                        {dataAppViz.description || 'No description'}
+                    </Text>
+                    <SimpleGrid cols={2} className={classes.metaPanel}>
+                        {builtBy !== null && (
+                            <Box>
+                                <Text fz="xs" fw={600} c="dimmed">
+                                    Built by
+                                </Text>
+                                <Text fz="sm" fw={500} c="ldGray.8">
+                                    {builtBy}
+                                </Text>
+                            </Box>
+                        )}
                         <Box>
                             <Text fz="xs" fw={600} c="dimmed">
-                                Built by
+                                Last updated
                             </Text>
                             <Text fz="sm" fw={500} c="ldGray.8">
-                                {builtBy}
+                                {lastUpdatedAgo}
                             </Text>
                         </Box>
+                        <Box>
+                            <Text fz="xs" fw={600} c="dimmed">
+                                Inputs
+                            </Text>
+                            <Text fz="sm" fw={500} c="ldGray.8">
+                                {dataAppViz.schema !== null
+                                    ? dataAppViz.schema.fields
+                                          .map((field) => field.label)
+                                          .join(', ')
+                                    : '—'}
+                            </Text>
+                        </Box>
+                        <Box>
+                            <Text fz="xs" fw={600} c="dimmed">
+                                Version
+                            </Text>
+                            <Text fz="sm" fw={500} c="ldGray.8">
+                                {latestReadyVersion !== null
+                                    ? `v${latestReadyVersion}`
+                                    : '—'}
+                            </Text>
+                        </Box>
+                    </SimpleGrid>
+                    {dataAppViz.schema === null && (
+                        <Text fz="sm" c="dimmed">
+                            No finished version yet. Open the builder to
+                            generate one.
+                        </Text>
                     )}
-                    <Box>
-                        <Text fz="xs" fw={600} c="dimmed">
-                            Last updated
-                        </Text>
-                        <Text fz="sm" fw={500} c="ldGray.8">
-                            {lastUpdatedAgo}
-                        </Text>
-                    </Box>
-                    <Box>
-                        <Text fz="xs" fw={600} c="dimmed">
-                            Inputs
-                        </Text>
-                        <Text fz="sm" fw={500} c="ldGray.8">
-                            {dataAppViz.schema !== null
-                                ? dataAppViz.schema.fields
-                                      .map((field) => field.label)
-                                      .join(', ')
-                                : '—'}
-                        </Text>
-                    </Box>
-                    <Box>
-                        <Text fz="xs" fw={600} c="dimmed">
-                            Version
-                        </Text>
-                        <Text fz="sm" fw={500} c="ldGray.8">
-                            {latestReadyVersion !== null
-                                ? `v${latestReadyVersion}`
-                                : '—'}
-                        </Text>
-                    </Box>
-                </SimpleGrid>
-                {dataAppViz.schema === null && (
-                    <Text fz="sm" c="dimmed">
-                        No finished version yet. Open the builder to generate
-                        one.
-                    </Text>
-                )}
-            </Stack>
-        </MantineModal>
+                </Stack>
+            </MantineModal>
+            {isForkOpen && (
+                <ChartTypeForkModal
+                    opened
+                    onClose={() => setIsForkOpen(false)}
+                    projectUuid={projectUuid}
+                    appUuid={dataAppViz.dataAppVizUuid}
+                    defaultName={`${dataAppViz.name} (custom)`}
+                />
+            )}
+        </>
     );
 };
 

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeDetailModal.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeDetailModal.tsx
@@ -1,4 +1,8 @@
-import { getAppDisplayName, type DataAppViz } from '@lightdash/common';
+import {
+    getAppDisplayName,
+    isOfficialChartType,
+    type DataAppViz,
+} from '@lightdash/common';
 import { Box, Button, Group, SimpleGrid, Stack, Text } from '@mantine/core';
 import { IconFilePencil, IconGitFork, IconTrash } from '@tabler/icons-react';
 import { useState, type FC } from 'react';

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeForkModal.test.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeForkModal.test.tsx
@@ -1,0 +1,82 @@
+import { fireEvent, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import { useDuplicateApp } from '../../apps/hooks/useDuplicateApp';
+import ChartTypeForkModal from './ChartTypeForkModal';
+
+const mockedNavigate = vi.fn();
+
+vi.mock('react-router', () => ({
+    useNavigate: () => mockedNavigate,
+}));
+
+vi.mock('../../apps/hooks/useDuplicateApp', () => ({
+    useDuplicateApp: vi.fn(),
+}));
+
+const mockedDuplicate = vi.fn();
+
+const renderModal = (
+    props: Partial<Parameters<typeof ChartTypeForkModal>[0]> = {},
+) =>
+    renderWithProviders(
+        <ChartTypeForkModal
+            opened
+            onClose={vi.fn()}
+            projectUuid="project-1"
+            appUuid="viz-1"
+            defaultName="Radial gauge (custom)"
+            {...props}
+        />,
+    );
+
+describe('ChartTypeForkModal', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(useDuplicateApp).mockReturnValue({
+            mutate: mockedDuplicate,
+            isLoading: false,
+        } as unknown as ReturnType<typeof useDuplicateApp>);
+    });
+
+    it('prefills the name and submits the fork with it', () => {
+        renderModal();
+
+        expect(screen.getByLabelText(/Name/)).toHaveValue(
+            'Radial gauge (custom)',
+        );
+
+        fireEvent.change(screen.getByLabelText(/Name/), {
+            target: { value: 'My gauge' },
+        });
+        fireEvent.click(screen.getByRole('button', { name: 'Fork' }));
+
+        expect(mockedDuplicate).toHaveBeenCalledWith(
+            { projectUuid: 'project-1', appUuid: 'viz-1', name: 'My gauge' },
+            expect.objectContaining({ onSuccess: expect.any(Function) }),
+        );
+    });
+
+    it('navigates to the builder for the new app on success', () => {
+        mockedDuplicate.mockImplementation((_params, options) =>
+            options?.onSuccess?.({ appUuid: 'viz-forked', version: 1 }),
+        );
+        renderModal();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Fork' }));
+
+        expect(mockedNavigate).toHaveBeenCalledWith(
+            '/projects/project-1/chart-types/viz-forked',
+        );
+    });
+
+    it('disables submit when the name is cleared', () => {
+        renderModal();
+
+        fireEvent.change(screen.getByLabelText(/Name/), {
+            target: { value: '' },
+        });
+
+        expect(screen.getByRole('button', { name: 'Fork' })).toBeDisabled();
+    });
+});

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeForkModal.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeForkModal.tsx
@@ -1,6 +1,7 @@
 import { Button, Stack, TextInput, type ModalProps } from '@mantine/core';
-import { useForm, zodResolver } from '@mantine/form';
+import { useForm } from '@mantine/form';
 import { IconGitFork } from '@tabler/icons-react';
+import { zod4Resolver as zodResolver } from 'mantine-form-zod-resolver';
 import { type FC } from 'react';
 import { useNavigate } from 'react-router';
 import { z } from 'zod';

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeForkModal.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeForkModal.tsx
@@ -1,0 +1,91 @@
+import { Button, Stack, TextInput, type ModalProps } from '@mantine/core';
+import { useForm, zodResolver } from '@mantine/form';
+import { IconGitFork } from '@tabler/icons-react';
+import { type FC } from 'react';
+import { useNavigate } from 'react-router';
+import { z } from 'zod';
+import MantineModal from '../../../components/common/MantineModal';
+import useToaster from '../../../hooks/toaster/useToaster';
+import { useDuplicateApp } from '../../apps/hooks/useDuplicateApp';
+import { chartTypeBuilderPath } from '../utils/chartTypeBuilderPath';
+
+type Props = {
+    opened: ModalProps['opened'];
+    onClose: ModalProps['onClose'];
+    projectUuid: string;
+    appUuid: string;
+    defaultName: string;
+};
+
+const forkSchema = z.object({
+    name: z.string().trim().min(1, { message: 'Name is required' }),
+});
+
+type FormState = z.infer<typeof forkSchema>;
+
+/** Forks an official (registry-installed) chart type into an editable copy. */
+const ChartTypeForkModal: FC<Props> = ({
+    opened,
+    onClose,
+    projectUuid,
+    appUuid,
+    defaultName,
+}) => {
+    const navigate = useNavigate();
+    const { showToastSuccess } = useToaster();
+    const { mutate: duplicate, isLoading: isForking } = useDuplicateApp();
+
+    const form = useForm<FormState>({
+        initialValues: { name: defaultName },
+        validate: zodResolver(forkSchema),
+        validateInputOnChange: true,
+    });
+
+    const handleSubmit = form.onSubmit((data) => {
+        duplicate(
+            { projectUuid, appUuid, name: data.name.trim() },
+            {
+                onSuccess: (result) => {
+                    showToastSuccess({ title: 'Chart type forked' });
+                    void navigate(
+                        chartTypeBuilderPath(projectUuid, result.appUuid),
+                    );
+                },
+            },
+        );
+    });
+
+    return (
+        <MantineModal
+            opened={opened}
+            onClose={onClose}
+            title="Fork to customize"
+            icon={IconGitFork}
+            description="Forking creates your own copy on its own version path. It won't receive registry updates."
+            actions={
+                <Button
+                    disabled={!form.isValid()}
+                    loading={isForking}
+                    type="submit"
+                    form="fork-chart-type"
+                >
+                    Fork
+                </Button>
+            }
+        >
+            <form id="fork-chart-type" onSubmit={handleSubmit}>
+                <Stack>
+                    <TextInput
+                        label="Name"
+                        required
+                        placeholder="eg. Radial gauge (custom)"
+                        disabled={isForking}
+                        {...form.getInputProps('name')}
+                    />
+                </Stack>
+            </form>
+        </MantineModal>
+    );
+};
+
+export default ChartTypeForkModal;

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeGalleryCard.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeGalleryCard.tsx
@@ -1,20 +1,36 @@
-import { getAppDisplayName, type DataAppViz } from '@lightdash/common';
-import { ActionIcon, Box, Menu, Stack, Text, Tooltip } from '@mantine/core';
+import {
+    getAppDisplayName,
+    isOfficialChartType,
+    type DataAppViz,
+} from '@lightdash/common';
+import {
+    ActionIcon,
+    Box,
+    Group,
+    Menu,
+    Stack,
+    Text,
+    Tooltip,
+} from '@mantine/core';
 import {
     IconDots,
     IconFilePencil,
+    IconGitFork,
     IconTelescope,
     IconTrash,
 } from '@tabler/icons-react';
-import { type FC } from 'react';
+import { useState, type FC } from 'react';
 import { Link } from 'react-router';
 import { FloatingActionsPill } from '../../../components/common/FloatingActionsPill';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { PolymorphicPaperButton } from '../../../components/common/PolymorphicPaperButton';
+import { useCanCreateDataApp } from '../../apps/hooks/useCanCreateDataApp';
 import { useCanEditDataApp } from '../../apps/hooks/useCanEditDataApp';
 import { chartTypeBuilderPath } from '../utils/chartTypeBuilderPath';
+import ChartTypeForkModal from './ChartTypeForkModal';
 import classes from './ChartTypeGalleryCard.module.css';
 import ChartTypeSamplePreview from './ChartTypeSamplePreview';
+import OfficialChartTypeBadge from './OfficialChartTypeBadge';
 
 type Props = {
     dataAppViz: DataAppViz;
@@ -24,96 +40,130 @@ type Props = {
 
 const ChartTypeGalleryCard: FC<Props> = ({ dataAppViz, onClick, onDelete }) => {
     const canEdit = useCanEditDataApp(dataAppViz.projectUuid, dataAppViz);
+    const canFork = useCanCreateDataApp(dataAppViz.projectUuid);
+    const isOfficial = isOfficialChartType(dataAppViz);
+    const [isForkOpen, setIsForkOpen] = useState(false);
     const displayName = getAppDisplayName(
         dataAppViz.name,
         dataAppViz.dataAppVizUuid,
     );
 
     return (
-        <PolymorphicPaperButton
-            component="div"
-            withBorder
-            radius="md"
-            shadow="subtle"
-            className={classes.card}
-            onClick={onClick}
-        >
-            <Box className={classes.preview}>
-                <ChartTypeSamplePreview
-                    projectUuid={dataAppViz.projectUuid}
-                    dataAppVizUuid={dataAppViz.dataAppVizUuid}
-                />
-            </Box>
-            <Stack gap="xs" p="sm">
-                <Text fz="sm" fw={600} truncate="end">
-                    {displayName}
-                </Text>
-                <Text fz="xs" c="dimmed" lh={1.35} lineClamp={2}>
-                    {dataAppViz.description || 'No description'}
-                </Text>
-            </Stack>
-            <FloatingActionsPill className={classes.menuHost}>
-                {canEdit && (
-                    <Tooltip label="Edit">
-                        <ActionIcon
-                            size="sm"
-                            component={Link}
-                            to={chartTypeBuilderPath(
-                                dataAppViz.projectUuid,
-                                dataAppViz.dataAppVizUuid,
+        <>
+            <PolymorphicPaperButton
+                component="div"
+                withBorder
+                radius="md"
+                shadow="subtle"
+                className={classes.card}
+                onClick={onClick}
+            >
+                <Box className={classes.preview}>
+                    <ChartTypeSamplePreview
+                        projectUuid={dataAppViz.projectUuid}
+                        dataAppVizUuid={dataAppViz.dataAppVizUuid}
+                    />
+                </Box>
+                <Stack gap="xs" p="sm">
+                    <Group gap="xs" wrap="nowrap" justify="space-between">
+                        <Text fz="sm" fw={600} truncate="end">
+                            {displayName}
+                        </Text>
+                        {isOfficial && <OfficialChartTypeBadge />}
+                    </Group>
+                    <Text fz="xs" c="dimmed" lh={1.35} lineClamp={2}>
+                        {dataAppViz.description || 'No description'}
+                    </Text>
+                </Stack>
+                <FloatingActionsPill className={classes.menuHost}>
+                    {isOfficial
+                        ? canFork && (
+                              <Tooltip label="Fork to customize">
+                                  <ActionIcon
+                                      size="sm"
+                                      aria-label={`Fork ${displayName}`}
+                                      onClick={(e) => {
+                                          e.stopPropagation();
+                                          setIsForkOpen(true);
+                                      }}
+                                  >
+                                      <MantineIcon icon={IconGitFork} />
+                                  </ActionIcon>
+                              </Tooltip>
+                          )
+                        : canEdit && (
+                              <Tooltip label="Edit">
+                                  <ActionIcon
+                                      size="sm"
+                                      component={Link}
+                                      to={chartTypeBuilderPath(
+                                          dataAppViz.projectUuid,
+                                          dataAppViz.dataAppVizUuid,
+                                      )}
+                                      aria-label={`Edit ${displayName}`}
+                                      onClick={(e) => e.stopPropagation()}
+                                  >
+                                      <MantineIcon icon={IconFilePencil} />
+                                  </ActionIcon>
+                              </Tooltip>
+                          )}
+                    <Menu
+                        withArrow
+                        position="bottom-end"
+                        offset={4}
+                        arrowOffset={10}
+                    >
+                        <Menu.Target>
+                            <ActionIcon
+                                size="sm"
+                                aria-label={`Actions for ${displayName}`}
+                                onClick={(e) => e.stopPropagation()}
+                            >
+                                <MantineIcon icon={IconDots} />
+                            </ActionIcon>
+                        </Menu.Target>
+                        <Menu.Dropdown>
+                            <Menu.Item
+                                component={Link}
+                                leftSection={
+                                    <MantineIcon icon={IconTelescope} />
+                                }
+                                to={`/projects/${dataAppViz.projectUuid}/tables?dataAppVizUuid=${dataAppViz.dataAppVizUuid}`}
+                                onClick={(e) => e.stopPropagation()}
+                            >
+                                Preview in explorer
+                            </Menu.Item>
+                            {canEdit && (
+                                <>
+                                    <Menu.Divider />
+                                    <Menu.Item
+                                        color="red"
+                                        leftSection={
+                                            <MantineIcon icon={IconTrash} />
+                                        }
+                                        onClick={(e) => {
+                                            e.stopPropagation();
+                                            onDelete();
+                                        }}
+                                    >
+                                        Delete
+                                    </Menu.Item>
+                                </>
                             )}
-                            aria-label={`Edit ${displayName}`}
-                            onClick={(e) => e.stopPropagation()}
-                        >
-                            <MantineIcon icon={IconFilePencil} />
-                        </ActionIcon>
-                    </Tooltip>
-                )}
-                <Menu
-                    withArrow
-                    position="bottom-end"
-                    offset={4}
-                    arrowOffset={10}
-                >
-                    <Menu.Target>
-                        <ActionIcon
-                            size="sm"
-                            aria-label={`Actions for ${displayName}`}
-                            onClick={(e) => e.stopPropagation()}
-                        >
-                            <MantineIcon icon={IconDots} />
-                        </ActionIcon>
-                    </Menu.Target>
-                    <Menu.Dropdown>
-                        <Menu.Item
-                            component={Link}
-                            leftSection={<MantineIcon icon={IconTelescope} />}
-                            to={`/projects/${dataAppViz.projectUuid}/tables?dataAppVizUuid=${dataAppViz.dataAppVizUuid}`}
-                            onClick={(e) => e.stopPropagation()}
-                        >
-                            Preview in explorer
-                        </Menu.Item>
-                        {canEdit && (
-                            <>
-                                <Menu.Divider />
-                                <Menu.Item
-                                    color="red"
-                                    leftSection={
-                                        <MantineIcon icon={IconTrash} />
-                                    }
-                                    onClick={(e) => {
-                                        e.stopPropagation();
-                                        onDelete();
-                                    }}
-                                >
-                                    Delete
-                                </Menu.Item>
-                            </>
-                        )}
-                    </Menu.Dropdown>
-                </Menu>
-            </FloatingActionsPill>
-        </PolymorphicPaperButton>
+                        </Menu.Dropdown>
+                    </Menu>
+                </FloatingActionsPill>
+            </PolymorphicPaperButton>
+            {isForkOpen && (
+                <ChartTypeForkModal
+                    opened
+                    onClose={() => setIsForkOpen(false)}
+                    projectUuid={dataAppViz.projectUuid}
+                    appUuid={dataAppViz.dataAppVizUuid}
+                    defaultName={`${dataAppViz.name} (custom)`}
+                />
+            )}
+        </>
     );
 };
 

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeLibraryCard.module.css
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeLibraryCard.module.css
@@ -1,6 +1,12 @@
+/* Rendered as a native <button> for keyboard access — reset the UA
+   defaults a <div> never had (see AppTemplatePicker.module.css). */
 .card {
     position: relative;
+    width: 100%;
     padding: 0;
+    text-align: left;
+    font: inherit;
+    color: inherit;
     transition:
         box-shadow 150ms ease-in-out,
         transform 150ms ease-in-out;

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeLibraryCard.module.css
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeLibraryCard.module.css
@@ -1,0 +1,26 @@
+.card {
+    position: relative;
+    padding: 0;
+    transition:
+        box-shadow 150ms ease-in-out,
+        transform 150ms ease-in-out;
+}
+
+.card:hover {
+    box-shadow: var(--mantine-shadow-heavy);
+    transform: translateY(-2px);
+}
+
+.preview {
+    height: 148px;
+    background: light-dark(#fdfdfe, var(--mantine-color-ldDark-2));
+    border-bottom: 1px solid var(--mantine-color-ldGray-1);
+    border-radius: var(--mantine-radius-md) var(--mantine-radius-md) 0 0;
+    overflow: hidden;
+}
+
+.previewImage {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeLibraryCard.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeLibraryCard.tsx
@@ -9,6 +9,7 @@ import MantineIcon from '../../../components/common/MantineIcon';
 import { PolymorphicPaperButton } from '../../../components/common/PolymorphicPaperButton';
 import { registryAssetUrl } from '../utils/registryAssetUrl';
 import classes from './ChartTypeLibraryCard.module.css';
+import OfficialChartTypeBadge from './OfficialChartTypeBadge';
 
 const StateBadge: FC<{ item: RegistryChartTypeListItem }> = ({ item }) => {
     switch (item.state) {
@@ -79,9 +80,7 @@ const ChartTypeLibraryCard: FC<Props> = ({ item, onClick }) => (
                 <Text fz={13} fw={600} truncate="end">
                     {item.name}
                 </Text>
-                <Badge size="xs" variant="light" color="blue">
-                    Official
-                </Badge>
+                <OfficialChartTypeBadge />
             </Group>
             <Text fz="xs" c="dimmed" lh={1.35} lineClamp={2}>
                 {item.description || 'No description'}

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeLibraryCard.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeLibraryCard.tsx
@@ -1,0 +1,93 @@
+import {
+    assertUnreachable,
+    type RegistryChartTypeListItem,
+} from '@lightdash/common';
+import { Badge, Box, Group, Paper, Stack, Text } from '@mantine/core';
+import { IconPhoto } from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
+import { PolymorphicPaperButton } from '../../../components/common/PolymorphicPaperButton';
+import { registryAssetUrl } from '../utils/registryAssetUrl';
+import classes from './ChartTypeLibraryCard.module.css';
+
+const StateBadge: FC<{ item: RegistryChartTypeListItem }> = ({ item }) => {
+    switch (item.state) {
+        case 'not_installed':
+            return null;
+        case 'installed':
+            return (
+                <Badge size="xs" variant="light" color="green">
+                    Installed v{item.installedRegistryVersion}
+                </Badge>
+            );
+        case 'update_available':
+            return (
+                <Badge size="xs" variant="light" color="orange">
+                    Update available
+                </Badge>
+            );
+        case 'incompatible':
+            return (
+                <Badge size="xs" variant="light" color="gray">
+                    Requires newer Lightdash
+                </Badge>
+            );
+        default:
+            return assertUnreachable(
+                item.state,
+                `Unknown registry chart type state: ${item.state}`,
+            );
+    }
+};
+
+type Props = {
+    item: RegistryChartTypeListItem;
+    onClick: () => void;
+};
+
+const ChartTypeLibraryCard: FC<Props> = ({ item, onClick }) => (
+    <PolymorphicPaperButton
+        component="div"
+        withBorder
+        radius="md"
+        shadow="subtle"
+        className={classes.card}
+        onClick={onClick}
+    >
+        <Box className={classes.preview}>
+            {item.thumbnail ? (
+                <img
+                    src={registryAssetUrl(item.thumbnail)}
+                    alt={item.name}
+                    className={classes.previewImage}
+                />
+            ) : (
+                <Paper variant="dotted" h="100%" radius={0}>
+                    <Stack align="center" justify="center" gap="xs" h="100%">
+                        <MantineIcon
+                            icon={IconPhoto}
+                            size="xl"
+                            color="ldGray.5"
+                        />
+                    </Stack>
+                </Paper>
+            )}
+        </Box>
+        <Stack gap="xs" p="sm">
+            <Group gap="xs" wrap="nowrap" justify="space-between">
+                <Text fz={13} fw={600} truncate="end">
+                    {item.name}
+                </Text>
+                <Badge size="xs" variant="light" color="blue">
+                    Official
+                </Badge>
+            </Group>
+            <Text fz="xs" c="dimmed" lh={1.35} lineClamp={2}>
+                {item.description || 'No description'}
+            </Text>
+            <StateBadge item={item} />
+        </Stack>
+    </PolymorphicPaperButton>
+);
+
+export default ChartTypeLibraryCard;

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeLibraryCard.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeLibraryCard.tsx
@@ -47,7 +47,8 @@ type Props = {
 
 const ChartTypeLibraryCard: FC<Props> = ({ item, onClick }) => (
     <PolymorphicPaperButton
-        component="div"
+        component="button"
+        type="button"
         withBorder
         radius="md"
         shadow="subtle"

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeLibraryDetailModal.module.css
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeLibraryDetailModal.module.css
@@ -1,0 +1,33 @@
+.metaPanel {
+    padding: var(--mantine-spacing-md) var(--mantine-spacing-lg);
+    background: var(--mantine-color-ldGray-0);
+    border: 1px solid var(--mantine-color-ldGray-1);
+    border-radius: var(--mantine-radius-md);
+}
+
+.preview {
+    height: 220px;
+    background: light-dark(#fdfdfe, var(--mantine-color-ldDark-2));
+    border: 1px solid var(--mantine-color-ldGray-1);
+    border-radius: var(--mantine-radius-md);
+    overflow: hidden;
+}
+
+.previewImage {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.screenshotRow {
+    display: flex;
+    gap: var(--mantine-spacing-sm);
+}
+
+.screenshot {
+    height: 220px;
+    flex-shrink: 0;
+    border: 1px solid var(--mantine-color-ldGray-1);
+    border-radius: var(--mantine-radius-md);
+    object-fit: cover;
+}

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeLibraryDetailModal.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeLibraryDetailModal.tsx
@@ -1,0 +1,224 @@
+import { subject } from '@casl/ability';
+import {
+    assertUnreachable,
+    type RegistryChartTypeListItem,
+} from '@lightdash/common';
+import {
+    Box,
+    Button,
+    Group,
+    ScrollArea,
+    SimpleGrid,
+    Stack,
+    Text,
+} from '@mantine/core';
+import { IconPhoto } from '@tabler/icons-react';
+import { type FC, type ReactNode } from 'react';
+import Callout from '../../../components/common/Callout';
+import MantineIcon from '../../../components/common/MantineIcon';
+import MantineModal from '../../../components/common/MantineModal';
+import { useTimeAgo } from '../../../hooks/useTimeAgo';
+import { Can } from '../../../providers/Ability';
+import useApp from '../../../providers/App/useApp';
+import { useInstallRegistryChartType } from '../hooks/useInstallRegistryChartType';
+import { registryAssetUrl } from '../utils/registryAssetUrl';
+import classes from './ChartTypeLibraryDetailModal.module.css';
+import DataAppVizFieldTypeBadge from './DataAppVizFieldTypeBadge';
+
+type Props = {
+    projectUuid: string;
+    item: RegistryChartTypeListItem;
+    onClose: () => void;
+};
+
+const ChartTypeLibraryDetailModal: FC<Props> = ({
+    projectUuid,
+    item,
+    onClose,
+}) => {
+    const { user } = useApp();
+    const publishedAgo = useTimeAgo(item.publishedAt);
+    const installMutation = useInstallRegistryChartType();
+
+    const handleInstall = () => {
+        installMutation.mutate(
+            { projectUuid, chartSlug: item.slug },
+            { onSuccess: onClose },
+        );
+    };
+
+    const footerAction: ReactNode = (() => {
+        switch (item.state) {
+            case 'not_installed':
+                return (
+                    <Button
+                        loading={installMutation.isLoading}
+                        onClick={handleInstall}
+                    >
+                        Install
+                    </Button>
+                );
+            case 'update_available':
+                return (
+                    <Button
+                        loading={installMutation.isLoading}
+                        onClick={handleInstall}
+                    >
+                        Upgrade to v{item.version}
+                    </Button>
+                );
+            case 'installed':
+                return (
+                    <Button variant="default" onClick={onClose}>
+                        View in gallery
+                    </Button>
+                );
+            case 'incompatible':
+                return (
+                    <Group gap="sm" wrap="nowrap">
+                        <Text fz="xs" c="dimmed">
+                            Requires Lightdash v{item.minLightdashVersion} or
+                            later
+                        </Text>
+                        <Button disabled>Install</Button>
+                    </Group>
+                );
+            default:
+                return assertUnreachable(
+                    item.state,
+                    `Unknown registry chart type state: ${item.state}`,
+                );
+        }
+    })();
+
+    return (
+        <MantineModal
+            opened
+            onClose={onClose}
+            title={item.name}
+            subtitle={`v${item.version}`}
+            bodyScrollAreaMaxHeight="calc(100vh - 200px)"
+            cancelLabel={item.state === 'installed' ? false : 'Cancel'}
+            actions={
+                <Can
+                    I="create"
+                    this={subject('DataApp', {
+                        organizationUuid: user.data?.organizationUuid,
+                        projectUuid,
+                    })}
+                >
+                    {footerAction}
+                </Can>
+            }
+        >
+            <Stack gap="md">
+                {item.screenshots.length > 0 ? (
+                    <ScrollArea type="auto" offsetScrollbars>
+                        <Group
+                            gap="sm"
+                            wrap="nowrap"
+                            className={classes.screenshotRow}
+                        >
+                            {item.screenshots.map((path) => (
+                                <img
+                                    key={path}
+                                    src={registryAssetUrl(path)}
+                                    alt={item.name}
+                                    className={classes.screenshot}
+                                />
+                            ))}
+                        </Group>
+                    </ScrollArea>
+                ) : item.thumbnail ? (
+                    <Box className={classes.preview}>
+                        <img
+                            src={registryAssetUrl(item.thumbnail)}
+                            alt={item.name}
+                            className={classes.previewImage}
+                        />
+                    </Box>
+                ) : (
+                    <Box className={classes.preview}>
+                        <Stack
+                            align="center"
+                            justify="center"
+                            gap="xs"
+                            h="100%"
+                        >
+                            <MantineIcon
+                                icon={IconPhoto}
+                                size="xl"
+                                color="ldGray.5"
+                            />
+                        </Stack>
+                    </Box>
+                )}
+
+                <Text fz="sm" c="ldGray.7" lh={1.55}>
+                    {item.description || 'No description'}
+                </Text>
+
+                {item.state === 'update_available' && (
+                    <Callout
+                        variant="warning"
+                        title="Upgrading affects every chart of this type"
+                    >
+                        Upgrading updates every chart in this project that uses
+                        this chart type.
+                        {item.changelog && (
+                            <Text fz="sm" mt="xs">
+                                {item.changelog}
+                            </Text>
+                        )}
+                    </Callout>
+                )}
+
+                <Box>
+                    <Text fz={12} fw={600} c="ldGray.6" mb={4}>
+                        Fields
+                    </Text>
+                    <Group gap="sm">
+                        {item.vizSchema.fields.map((field) => (
+                            <Group key={field.name} gap={4} wrap="nowrap">
+                                <DataAppVizFieldTypeBadge type={field.type} />
+                                <Text fz="sm">{field.label}</Text>
+                            </Group>
+                        ))}
+                    </Group>
+                </Box>
+
+                <SimpleGrid cols={2} className={classes.metaPanel}>
+                    <Box>
+                        <Text fz={12} fw={600} c="ldGray.6">
+                            Version
+                        </Text>
+                        <Text fz="sm" fw={500} c="ldGray.8">
+                            v{item.version}
+                        </Text>
+                    </Box>
+                    <Box>
+                        <Text fz={12} fw={600} c="ldGray.6">
+                            Published
+                        </Text>
+                        <Text fz="sm" fw={500} c="ldGray.8">
+                            {publishedAgo}
+                        </Text>
+                    </Box>
+                </SimpleGrid>
+
+                {item.changelog && item.state !== 'update_available' && (
+                    <Box>
+                        <Text fz={12} fw={600} c="ldGray.6" mb={4}>
+                            Changelog
+                        </Text>
+                        <Text fz="sm" c="ldGray.7">
+                            {item.changelog}
+                        </Text>
+                    </Box>
+                )}
+            </Stack>
+        </MantineModal>
+    );
+};
+
+export default ChartTypeLibraryDetailModal;

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeLibraryDetailModal.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeLibraryDetailModal.tsx
@@ -47,25 +47,40 @@ const ChartTypeLibraryDetailModal: FC<Props> = ({
         );
     };
 
+    // Only the mutating actions (Install / Upgrade) need the create
+    // permission — the informational states below (view-in-gallery,
+    // incompatible explanation) render for every viewer.
+    const canInstallGate = (button: ReactNode) => (
+        <Can
+            I="create"
+            this={subject('DataApp', {
+                organizationUuid: user.data?.organizationUuid,
+                projectUuid,
+            })}
+        >
+            {button}
+        </Can>
+    );
+
     const footerAction: ReactNode = (() => {
         switch (item.state) {
             case 'not_installed':
-                return (
+                return canInstallGate(
                     <Button
                         loading={installMutation.isLoading}
                         onClick={handleInstall}
                     >
                         Install
-                    </Button>
+                    </Button>,
                 );
             case 'update_available':
-                return (
+                return canInstallGate(
                     <Button
                         loading={installMutation.isLoading}
                         onClick={handleInstall}
                     >
                         Upgrade to v{item.version}
-                    </Button>
+                    </Button>,
                 );
             case 'installed':
                 return (
@@ -99,17 +114,7 @@ const ChartTypeLibraryDetailModal: FC<Props> = ({
             subtitle={`v${item.version}`}
             bodyScrollAreaMaxHeight="calc(100vh - 200px)"
             cancelLabel={item.state === 'installed' ? false : 'Cancel'}
-            actions={
-                <Can
-                    I="create"
-                    this={subject('DataApp', {
-                        organizationUuid: user.data?.organizationUuid,
-                        projectUuid,
-                    })}
-                >
-                    {footerAction}
-                </Can>
-            }
+            actions={footerAction}
         >
             <Stack gap="md">
                 {item.screenshots.length > 0 ? (

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeLibraryDetailModal.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeLibraryDetailModal.tsx
@@ -166,10 +166,11 @@ const ChartTypeLibraryDetailModal: FC<Props> = ({
                 {item.state === 'update_available' && (
                     <Callout
                         variant="warning"
-                        title="Upgrading affects every chart of this type"
+                        title="Existing charts keep their pinned version"
                     >
-                        Upgrading updates every chart in this project that uses
-                        this chart type.
+                        Charts pinned to an earlier version keep rendering it
+                        until each chart is upgraded; charts without a pinned
+                        version switch to v{item.version} right away.
                         {item.changelog && (
                             <Text fz="sm" mt="xs">
                                 {item.changelog}

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeLibrarySection.test.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeLibrarySection.test.tsx
@@ -1,0 +1,236 @@
+import {
+    FeatureFlags,
+    type RegistryChartTypeListItem,
+} from '@lightdash/common';
+import { fireEvent, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
+import { defaultAbility } from '../../../providers/Ability/constants';
+import { renderWithProviders } from '../../../testing/testUtils';
+import { useRegistryChartTypes } from '../hooks/useRegistryChartTypes';
+import ChartTypeLibrarySection from './ChartTypeLibrarySection';
+
+vi.mock('../../../hooks/useServerOrClientFeatureFlag', () => ({
+    useServerFeatureFlag: vi.fn(),
+}));
+
+vi.mock('../hooks/useRegistryChartTypes', () => ({
+    useRegistryChartTypes: vi.fn(),
+}));
+
+// Matches AppProviderMock's default user fixture (mockUserResponse) —
+// hardcoded rather than imported to avoid pulling in a __mocks__ file.
+const DEFAULT_ORG_UUID = '172a2270-000f-42be-9c68-c4752c23ae51';
+const PROJECT_UUID = 'project-1';
+
+const mockedUseServerFeatureFlag = vi.mocked(useServerFeatureFlag);
+const mockedUseRegistryChartTypes = vi.mocked(useRegistryChartTypes);
+
+const setFlag = (enabled: boolean, isLoading = false) => {
+    mockedUseServerFeatureFlag.mockReturnValue({
+        data: isLoading
+            ? undefined
+            : { id: FeatureFlags.ChartTypeRegistry, enabled },
+        isLoading,
+    } as ReturnType<typeof useServerFeatureFlag>);
+};
+
+const makeItem = (
+    overrides: Partial<RegistryChartTypeListItem>,
+): RegistryChartTypeListItem => ({
+    slug: 'radial-gauge',
+    name: 'Radial gauge',
+    description: 'A gauge for KPI progress',
+    version: '1.0.0',
+    publishedAt: '2026-06-30T00:00:00.000Z',
+    tags: [],
+    changelog: '',
+    minLightdashVersion: null,
+    vizSchema: {
+        fields: [
+            { name: 'value', label: 'Value', type: 'metric', required: true },
+        ],
+        configOptions: [],
+        colorPalette: null,
+    },
+    thumbnail: null,
+    screenshots: [],
+    artifacts: {
+        source: { path: 'source.zip', sha256: 'a'.repeat(64) },
+        dist: { path: 'dist.zip', sha256: 'b'.repeat(64) },
+    },
+    state: 'not_installed',
+    installedAppUuid: null,
+    installedRegistryVersion: null,
+    ...overrides,
+});
+
+const setRegistryData = (
+    charts: RegistryChartTypeListItem[],
+    overrides?: Record<string, unknown>,
+) => {
+    mockedUseRegistryChartTypes.mockReturnValue({
+        data: { registryEnabled: true, charts },
+        isInitialLoading: false,
+        error: null,
+        ...overrides,
+    } as unknown as ReturnType<typeof useRegistryChartTypes>);
+};
+
+const renderSection = () =>
+    renderWithProviders(<ChartTypeLibrarySection projectUuid={PROJECT_UUID} />);
+
+describe('ChartTypeLibrarySection', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        defaultAbility.update([]);
+    });
+
+    afterEach(() => {
+        defaultAbility.update([]);
+    });
+
+    it('renders nothing when the feature flag is off', () => {
+        setFlag(false);
+        setRegistryData([makeItem({})]);
+        renderSection();
+
+        expect(
+            screen.queryByText('Chart type library'),
+        ).not.toBeInTheDocument();
+    });
+
+    it('renders nothing while the feature flag is still resolving', () => {
+        setFlag(false, true);
+        setRegistryData([makeItem({})]);
+        renderSection();
+
+        expect(
+            screen.queryByText('Chart type library'),
+        ).not.toBeInTheDocument();
+    });
+
+    it('renders nothing when the registry is not enabled for the org', () => {
+        setFlag(true);
+        setRegistryData([makeItem({})], {
+            data: { registryEnabled: false, charts: [] },
+        });
+        renderSection();
+
+        expect(
+            screen.queryByText('Chart type library'),
+        ).not.toBeInTheDocument();
+    });
+
+    it('shows the quiet offline state when the fetch fails with no cached data', () => {
+        setFlag(true);
+        mockedUseRegistryChartTypes.mockReturnValue({
+            data: undefined,
+            isInitialLoading: false,
+            error: { name: 'Error', message: 'boom' },
+        } as unknown as ReturnType<typeof useRegistryChartTypes>);
+        renderSection();
+
+        expect(screen.getByText('Chart type library')).toBeInTheDocument();
+        expect(
+            screen.getByText(
+                'The chart type library is unavailable right now.',
+            ),
+        ).toBeInTheDocument();
+    });
+
+    it('keeps showing cached data through a background fetch error', () => {
+        setFlag(true);
+        setRegistryData([makeItem({})], {
+            error: { name: 'Error', message: 'boom' },
+        });
+        renderSection();
+
+        expect(screen.getByText('Radial gauge')).toBeInTheDocument();
+        expect(
+            screen.queryByText(
+                'The chart type library is unavailable right now.',
+            ),
+        ).not.toBeInTheDocument();
+    });
+
+    it('renders cards with state badges for the happy path', () => {
+        setFlag(true);
+        setRegistryData([
+            makeItem({ slug: 'a', name: 'Not installed chart' }),
+            makeItem({
+                slug: 'b',
+                name: 'Installed chart',
+                state: 'installed',
+                installedAppUuid: 'app-1',
+                installedRegistryVersion: '1.0.0',
+            }),
+            makeItem({
+                slug: 'c',
+                name: 'Update chart',
+                state: 'update_available',
+                installedAppUuid: 'app-2',
+                installedRegistryVersion: '0.9.0',
+            }),
+            makeItem({
+                slug: 'd',
+                name: 'Incompatible chart',
+                state: 'incompatible',
+                minLightdashVersion: '99.0.0',
+            }),
+        ]);
+        renderSection();
+
+        expect(screen.getByText('Chart type library')).toBeInTheDocument();
+        expect(screen.getByText('(4)')).toBeInTheDocument();
+        expect(screen.getAllByText('Official')).toHaveLength(4);
+
+        expect(screen.getByText('Not installed chart')).toBeInTheDocument();
+        expect(screen.getByText('Installed chart')).toBeInTheDocument();
+        expect(screen.getByText('Installed v1.0.0')).toBeInTheDocument();
+        expect(screen.getByText('Update chart')).toBeInTheDocument();
+        expect(screen.getByText('Update available')).toBeInTheDocument();
+        expect(screen.getByText('Incompatible chart')).toBeInTheDocument();
+        expect(
+            screen.getByText('Requires newer Lightdash'),
+        ).toBeInTheDocument();
+    });
+
+    it('opens the detail modal but hides Install without permission', async () => {
+        setFlag(true);
+        setRegistryData([makeItem({ slug: 'radial-gauge' })]);
+        renderSection();
+
+        fireEvent.click(screen.getByText('Radial gauge'));
+
+        expect(screen.getAllByText('A gauge for KPI progress')).toHaveLength(2);
+        // The Can check reads the async user query — findBy polls until it
+        // resolves instead of racing the first render.
+        expect(await screen.findByText('Cancel')).toBeInTheDocument();
+        expect(
+            screen.queryByRole('button', { name: 'Install' }),
+        ).not.toBeInTheDocument();
+    });
+
+    it('shows Install in the detail modal when the user can create data apps', async () => {
+        defaultAbility.update([
+            {
+                action: 'create',
+                subject: 'DataApp',
+                conditions: {
+                    organizationUuid: DEFAULT_ORG_UUID,
+                    projectUuid: PROJECT_UUID,
+                },
+            },
+        ]);
+        setFlag(true);
+        setRegistryData([makeItem({ slug: 'radial-gauge' })]);
+        renderSection();
+
+        fireEvent.click(screen.getByText('Radial gauge'));
+
+        expect(
+            await screen.findByRole('button', { name: 'Install' }),
+        ).toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeLibrarySection.test.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeLibrarySection.test.tsx
@@ -196,6 +196,16 @@ describe('ChartTypeLibrarySection', () => {
         ).toBeInTheDocument();
     });
 
+    it('renders each card as a keyboard-focusable button', () => {
+        setFlag(true);
+        setRegistryData([makeItem({ slug: 'radial-gauge' })]);
+        renderSection();
+
+        expect(
+            screen.getByRole('button', { name: /Radial gauge/ }),
+        ).toBeInTheDocument();
+    });
+
     it('opens the detail modal but hides Install without permission', async () => {
         setFlag(true);
         setRegistryData([makeItem({ slug: 'radial-gauge' })]);
@@ -231,6 +241,49 @@ describe('ChartTypeLibrarySection', () => {
 
         expect(
             await screen.findByRole('button', { name: 'Install' }),
+        ).toBeInTheDocument();
+    });
+
+    it('shows the incompatible explanation and disabled Install without gating on permission', async () => {
+        // No defaultAbility grant — the informational incompatible footer
+        // must still render for viewers who cannot create data apps.
+        setFlag(true);
+        setRegistryData([
+            makeItem({
+                slug: 'radial-gauge',
+                state: 'incompatible',
+                minLightdashVersion: '99.0.0',
+            }),
+        ]);
+        renderSection();
+
+        fireEvent.click(screen.getByText('Radial gauge'));
+
+        // findBy (rather than getBy) still gives the async user query a
+        // chance to resolve, to prove this isn't just a race that beat the
+        // (now-absent) permission gate.
+        expect(
+            await screen.findByText('Requires Lightdash v99.0.0 or later'),
+        ).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Install' })).toBeDisabled();
+    });
+
+    it('shows View in gallery for the installed state without gating on permission', async () => {
+        setFlag(true);
+        setRegistryData([
+            makeItem({
+                slug: 'radial-gauge',
+                state: 'installed',
+                installedAppUuid: 'app-1',
+                installedRegistryVersion: '1.0.0',
+            }),
+        ]);
+        renderSection();
+
+        fireEvent.click(screen.getByText('Radial gauge'));
+
+        expect(
+            await screen.findByRole('button', { name: 'View in gallery' }),
         ).toBeInTheDocument();
     });
 });

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeLibrarySection.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeLibrarySection.tsx
@@ -1,0 +1,93 @@
+import { FeatureFlags } from '@lightdash/common';
+import { Group, Paper, SimpleGrid, Stack, Text } from '@mantine/core';
+import { useState, type FC } from 'react';
+import EmptyStateLoader from '../../../components/common/EmptyStateLoader';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
+import { useRegistryChartTypes } from '../hooks/useRegistryChartTypes';
+import ChartTypeLibraryCard from './ChartTypeLibraryCard';
+import ChartTypeLibraryDetailModal from './ChartTypeLibraryDetailModal';
+
+type Props = {
+    projectUuid: string;
+};
+
+/**
+ * Installable chart types from the configured chart registry, shown as a
+ * section alongside the project's own chart types. Silent by default: no
+ * flag, a disabled registry, or an org that hasn't configured one all render
+ * nothing rather than an empty section nobody asked for.
+ */
+const ChartTypeLibrarySection: FC<Props> = ({ projectUuid }) => {
+    const flagQuery = useServerFeatureFlag(FeatureFlags.ChartTypeRegistry);
+    const flagEnabled = flagQuery.data?.enabled ?? false;
+    const registryQuery = useRegistryChartTypes(projectUuid, flagEnabled);
+    const [selectedSlug, setSelectedSlug] = useState<string | null>(null);
+
+    if (!flagEnabled) {
+        return null;
+    }
+
+    if (registryQuery.data && !registryQuery.data.registryEnabled) {
+        return null;
+    }
+
+    const charts = registryQuery.data?.charts ?? [];
+    const selected =
+        charts.find((chart) => chart.slug === selectedSlug) ?? null;
+    // A fetch error with no cached data is the only case that has to be
+    // shown; an error alongside cached data just keeps showing that data.
+    const isOffline = !!registryQuery.error && !registryQuery.data;
+
+    return (
+        <Stack gap="md">
+            <Group justify="space-between" align="center">
+                <Group gap={6} align="baseline">
+                    <Text size="md" fw={600} c="ldGray.8">
+                        Chart type library
+                    </Text>
+                    {registryQuery.data && (
+                        <Text fz="xs" c="dimmed">
+                            ({charts.length})
+                        </Text>
+                    )}
+                </Group>
+            </Group>
+
+            {registryQuery.isInitialLoading ? (
+                <EmptyStateLoader title="Loading chart type library…" />
+            ) : isOffline ? (
+                <Paper variant="dotted" p="xl">
+                    <Text ta="center" fz="xs" c="dimmed">
+                        The chart type library is unavailable right now.
+                    </Text>
+                </Paper>
+            ) : charts.length === 0 ? (
+                <Paper variant="dotted" p="xl">
+                    <Text ta="center" fz="xs" c="dimmed">
+                        No chart types available in the registry yet.
+                    </Text>
+                </Paper>
+            ) : (
+                <SimpleGrid cols={{ base: 1, sm: 2, lg: 3 }} spacing="md">
+                    {charts.map((chart) => (
+                        <ChartTypeLibraryCard
+                            key={chart.slug}
+                            item={chart}
+                            onClick={() => setSelectedSlug(chart.slug)}
+                        />
+                    ))}
+                </SimpleGrid>
+            )}
+
+            {selected && (
+                <ChartTypeLibraryDetailModal
+                    projectUuid={projectUuid}
+                    item={selected}
+                    onClose={() => setSelectedSlug(null)}
+                />
+            )}
+        </Stack>
+    );
+};
+
+export default ChartTypeLibrarySection;

--- a/packages/frontend/src/features/chartTypes/components/OfficialChartTypeBadge.tsx
+++ b/packages/frontend/src/features/chartTypes/components/OfficialChartTypeBadge.tsx
@@ -1,0 +1,11 @@
+import { Badge } from '@mantine/core';
+import { type FC } from 'react';
+
+/** Marks a chart type installed from the official chart registry. */
+const OfficialChartTypeBadge: FC = () => (
+    <Badge size="xs" variant="light" color="blue">
+        Official
+    </Badge>
+);
+
+export default OfficialChartTypeBadge;

--- a/packages/frontend/src/features/chartTypes/hooks/useInstallRegistryChartType.ts
+++ b/packages/frontend/src/features/chartTypes/hooks/useInstallRegistryChartType.ts
@@ -1,0 +1,57 @@
+import {
+    type ApiError,
+    type ApiInstallRegistryChartTypeResponse,
+} from '@lightdash/common';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { lightdashApi } from '../../../api';
+import useToaster from '../../../hooks/toaster/useToaster';
+
+type InstallRegistryChartTypeParams = {
+    projectUuid: string;
+    chartSlug: string;
+};
+
+type InstallRegistryChartTypeResult =
+    ApiInstallRegistryChartTypeResponse['results'];
+
+const installRegistryChartType = ({
+    projectUuid,
+    chartSlug,
+}: InstallRegistryChartTypeParams) =>
+    lightdashApi<InstallRegistryChartTypeResult>({
+        method: 'POST',
+        url: `/ee/projects/${projectUuid}/apps/registry/charts/${chartSlug}/install`,
+        body: undefined,
+    });
+
+export const useInstallRegistryChartType = () => {
+    const queryClient = useQueryClient();
+    const { showToastSuccess, showToastApiError } = useToaster();
+    return useMutation<
+        InstallRegistryChartTypeResult,
+        ApiError,
+        InstallRegistryChartTypeParams
+    >({
+        mutationFn: installRegistryChartType,
+        onSuccess: (result, { projectUuid }) => {
+            void queryClient.invalidateQueries({
+                queryKey: ['registry-chart-types', projectUuid],
+            });
+            void queryClient.invalidateQueries({
+                queryKey: ['data-app-vizs'],
+            });
+            showToastSuccess({
+                title:
+                    result.action === 'upgraded'
+                        ? 'Chart type upgraded'
+                        : 'Chart type installed',
+            });
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to install chart type',
+                apiError: error,
+            });
+        },
+    });
+};

--- a/packages/frontend/src/features/chartTypes/hooks/useRegistryChartTypes.ts
+++ b/packages/frontend/src/features/chartTypes/hooks/useRegistryChartTypes.ts
@@ -1,0 +1,30 @@
+import {
+    type ApiError,
+    type ApiListRegistryChartTypesResponse,
+} from '@lightdash/common';
+import { useQuery } from '@tanstack/react-query';
+import { lightdashApi } from '../../../api';
+
+const getRegistryChartTypes = async (projectUuid: string) =>
+    lightdashApi<ApiListRegistryChartTypesResponse['results']>({
+        method: 'GET',
+        url: `/ee/projects/${projectUuid}/apps/registry/charts`,
+        body: undefined,
+    });
+
+// Installable chart types from the configured chart registry, merged with
+// this project's install state. Only fetched once the registry feature flag
+// resolves enabled, so `enabled` gates the query rather than the caller
+// conditionally invoking the hook.
+export const useRegistryChartTypes = (
+    projectUuid: string | undefined,
+    enabled: boolean,
+) =>
+    useQuery<ApiListRegistryChartTypesResponse['results'], ApiError>({
+        queryKey: ['registry-chart-types', projectUuid],
+        queryFn: () => getRegistryChartTypes(projectUuid!),
+        enabled: !!projectUuid && enabled,
+        staleTime: 5 * 60 * 1000,
+        retry: false,
+        refetchOnWindowFocus: false,
+    });

--- a/packages/frontend/src/features/chartTypes/utils/registryAssetUrl.ts
+++ b/packages/frontend/src/features/chartTypes/utils/registryAssetUrl.ts
@@ -1,0 +1,5 @@
+// Same-origin authenticated asset route (thumbnails, screenshots) served
+// straight from the chart registry — a plain `<img src>` is enough, no
+// query hook needed.
+export const registryAssetUrl = (path: string): string =>
+    `/api/v1/ee/chart-registry/assets?path=${encodeURIComponent(path)}`;

--- a/packages/frontend/src/pages/ChartTypeBuilder.test.tsx
+++ b/packages/frontend/src/pages/ChartTypeBuilder.test.tsx
@@ -169,6 +169,7 @@ const appMeta = (overrides: Partial<AppMeta> = {}): AppMeta =>
         versions: [],
         hasMore: false,
         latestReadyVersion: 1,
+        registrySlug: null,
         ...overrides,
     }) as AppMeta;
 
@@ -326,6 +327,15 @@ describe('ChartTypeBuilder', () => {
     it('sends non-editors back to the gallery', () => {
         setApp(appMeta());
         vi.mocked(useCanEditDataApp).mockReturnValue(false);
+        renderBuilder(
+            '/projects/p1/chart-types/1e9a3b2c-0000-4000-8000-000000000001',
+        );
+
+        expect(screen.getByText('gallery')).toBeInTheDocument();
+    });
+
+    it('sends an official (registry-installed) chart type back to the gallery', () => {
+        setApp(appMeta({ registrySlug: 'radial-gauge' }));
         renderBuilder(
             '/projects/p1/chart-types/1e9a3b2c-0000-4000-8000-000000000001',
         );

--- a/packages/frontend/src/pages/ChartTypeBuilder.tsx
+++ b/packages/frontend/src/pages/ChartTypeBuilder.tsx
@@ -187,6 +187,11 @@ const ChartTypeBuilder: FC = () => {
         if (!canEdit) {
             return <Navigate to={`/projects/${projectUuid}/gallery`} replace />;
         }
+        // Server-enforced (registry apps are read-only); this only keeps
+        // the builder UI from being reached for an official chart type.
+        if (appMeta.registrySlug !== null) {
+            return <Navigate to={`/projects/${projectUuid}/gallery`} replace />;
+        }
     }
 
     // Remounted per viz so the selected tab belongs to the declaration on screen.

--- a/packages/frontend/src/pages/ChartTypeGallery.test.tsx
+++ b/packages/frontend/src/pages/ChartTypeGallery.test.tsx
@@ -3,8 +3,10 @@ import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useAppVersionHistory } from '../features/apps/hooks/useAppVersionHistory';
+import { useCanCreateDataApp } from '../features/apps/hooks/useCanCreateDataApp';
 import { useCanEditDataApp } from '../features/apps/hooks/useCanEditDataApp';
 import { useDeleteApp } from '../features/apps/hooks/useDeleteApp';
+import { useDuplicateApp } from '../features/apps/hooks/useDuplicateApp';
 import { useDataAppVisualizations } from '../features/chartTypes/hooks/useDataAppVisualizations';
 import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
 import { renderWithProviders } from '../testing/testUtils';
@@ -26,8 +28,16 @@ vi.mock('../features/apps/hooks/useCanEditDataApp', () => ({
     useCanEditDataApp: vi.fn(),
 }));
 
+vi.mock('../features/apps/hooks/useCanCreateDataApp', () => ({
+    useCanCreateDataApp: vi.fn(),
+}));
+
 vi.mock('../features/apps/hooks/useDeleteApp', () => ({
     useDeleteApp: vi.fn(),
+}));
+
+vi.mock('../features/apps/hooks/useDuplicateApp', () => ({
+    useDuplicateApp: vi.fn(),
 }));
 
 vi.mock('../features/chartTypes/components/ChartTypeSamplePreview', () => ({
@@ -51,6 +61,7 @@ const makeDataAppViz = (overrides: Partial<DataAppViz>): DataAppViz => ({
     },
     createdAt: new Date('2026-06-30'),
     createdByUserUuid: 'user-1',
+    registrySlug: null,
     ...overrides,
 });
 
@@ -110,6 +121,11 @@ describe('ChartTypeGallery', () => {
         vi.clearAllMocks();
         setFlag(true);
         vi.mocked(useCanEditDataApp).mockReturnValue(true);
+        vi.mocked(useCanCreateDataApp).mockReturnValue(true);
+        vi.mocked(useDuplicateApp).mockReturnValue({
+            mutate: vi.fn(),
+            isLoading: false,
+        } as unknown as ReturnType<typeof useDuplicateApp>);
         mockedDeleteApp.mockResolvedValue(undefined);
         vi.mocked(useDeleteApp).mockReturnValue({
             mutateAsync: mockedDeleteApp,
@@ -296,5 +312,73 @@ describe('ChartTypeGallery', () => {
         renderPage();
 
         expect(screen.getByText('home')).toBeInTheDocument();
+    });
+
+    describe('official (registry-installed) chart types', () => {
+        it('shows the Official badge and a fork action instead of edit', () => {
+            setData([makeDataAppViz({ registrySlug: 'radial-gauge' })]);
+            renderPage();
+
+            expect(screen.getByText('Official')).toBeInTheDocument();
+            expect(
+                screen.queryByLabelText('Edit Radial gauge'),
+            ).not.toBeInTheDocument();
+            expect(
+                screen.getByLabelText('Fork Radial gauge'),
+            ).toBeInTheDocument();
+        });
+
+        it('hides the fork action from users who cannot create data apps', () => {
+            vi.mocked(useCanCreateDataApp).mockReturnValue(false);
+            setData([makeDataAppViz({ registrySlug: 'radial-gauge' })]);
+            renderPage();
+
+            expect(
+                screen.queryByLabelText('Fork Radial gauge'),
+            ).not.toBeInTheDocument();
+            expect(
+                screen.queryByLabelText('Edit Radial gauge'),
+            ).not.toBeInTheDocument();
+        });
+
+        it('opens the fork modal from the card and submits the fork', () => {
+            const mockedDuplicate = vi.fn();
+            vi.mocked(useDuplicateApp).mockReturnValue({
+                mutate: mockedDuplicate,
+                isLoading: false,
+            } as unknown as ReturnType<typeof useDuplicateApp>);
+            setData([makeDataAppViz({ registrySlug: 'radial-gauge' })]);
+            renderPage();
+
+            fireEvent.click(screen.getByLabelText('Fork Radial gauge'));
+
+            expect(screen.getByText('Fork to customize')).toBeInTheDocument();
+            expect(screen.getByLabelText(/Name/)).toHaveValue(
+                'Radial gauge (custom)',
+            );
+
+            fireEvent.click(screen.getAllByRole('button', { name: 'Fork' })[0]);
+
+            expect(mockedDuplicate).toHaveBeenCalledWith(
+                {
+                    projectUuid: 'project-1',
+                    appUuid: 'data-app-viz-1',
+                    name: 'Radial gauge (custom)',
+                },
+                expect.objectContaining({ onSuccess: expect.any(Function) }),
+            );
+        });
+
+        it('shows the badge and a fork action in the detail modal', () => {
+            setData([makeDataAppViz({ registrySlug: 'radial-gauge' })]);
+            renderPage();
+
+            fireEvent.click(screen.getByText('Radial gauge'));
+
+            expect(
+                screen.getByRole('button', { name: /Fork to customize/ }),
+            ).toBeInTheDocument();
+            expect(screen.queryByText('Edit')).not.toBeInTheDocument();
+        });
     });
 });

--- a/packages/frontend/src/pages/ChartTypeGallery.tsx
+++ b/packages/frontend/src/pages/ChartTypeGallery.tsx
@@ -22,6 +22,7 @@ import ChartTypeDeleteModal from '../features/chartTypes/components/ChartTypeDel
 import ChartTypeDetailModal from '../features/chartTypes/components/ChartTypeDetailModal';
 import ChartTypeGalleryCard from '../features/chartTypes/components/ChartTypeGalleryCard';
 import ChartTypeGalleryEmptyState from '../features/chartTypes/components/ChartTypeGalleryEmptyState';
+import ChartTypeLibrarySection from '../features/chartTypes/components/ChartTypeLibrarySection';
 import { useDataAppVisualizations } from '../features/chartTypes/hooks/useDataAppVisualizations';
 import { chartTypeBuilderPath } from '../features/chartTypes/utils/chartTypeBuilderPath';
 import { useProjectUuid } from '../hooks/useProjectUuid';
@@ -207,6 +208,8 @@ const ChartTypeGallery = () => {
                         </>
                     )}
                 </Stack>
+
+                <ChartTypeLibrarySection projectUuid={projectUuid} />
             </Stack>
 
             {selected && (


### PR DESCRIPTION
Fourth slice of installable chart types (stacked on #28375): the user-facing surface.

- The gallery page gains a **"Chart type library"** section: registry catalog cards (thumbnail via the asset proxy, Official badge, state badges) and a detail modal (screenshots, vizSchema fields, version + changelog, state-appropriate action). Install/Upgrade gated on `create:DataApp`; incompatible entries explain the version floor; quiet offline state; never blocks the existing section; cards are real buttons (keyboard accessible).
- Installed official chart types: Official badge across gallery/picker surfaces, edit affordances replaced by **"Fork to customize"** (name-prompt modal → new app via duplicate + lineage → builder), and builder/explorer-authoring surfaces redirect or hide for officials (server-side guards in #28374 are the enforcement; this is UX). `DataAppViz.registrySlug` added for the frontend to key on.
- The upgrade confirm reflects the version pinning that landed on main independently (#28219/#28220): charts pinned to an earlier version keep rendering it until each chart is upgraded; unpinned charts switch immediately. (This stack originally carried its own save-time version stamping; it was dropped in favor of main's implementation during rebase.)

Relates GLITCH-714

🤖 Generated with [Claude Code](https://claude.com/claude-code)
