### PR TITLE
feat: local chart registry fixture + apps build --out-dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ packages/e2e/lightdash
 
 # development
 lightdash_dev.yml
+/.dev-chart-registry/
 
 # production
 /packages/frontend/build

--- a/package.json
+++ b/package.json
@@ -141,7 +141,8 @@
         "pm2:restart:frontend": "pm2 restart lightdash-frontend",
         "pm2:logs:maple": "pm2 logs lightdash-maple --lines 50",
         "pm2:restart:maple": "pm2 restart lightdash-maple",
-        "dev:pm2": "pm2 start ecosystem.config.js && pm2 logs --lines 50"
+        "dev:pm2": "pm2 start ecosystem.config.js && pm2 logs --lines 50",
+        "dev:chart-registry": "tsx scripts/dev-chart-registry.mjs"
     },
     "lint-staged": {
         "packages/frontend/src/**/*.(ts|tsx|json|css)": [

--- a/packages/backend/src/ee/services/AppGenerateService/testFixtures/buildChartRegistryFixture.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/testFixtures/buildChartRegistryFixture.test.ts
@@ -1,0 +1,125 @@
+import { chartRegistryIndexSchema } from '@lightdash/common';
+import { createHash } from 'node:crypto';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { extract } from 'tar-stream';
+import { buildChartRegistryFixture } from './buildChartRegistryFixture';
+
+function sha256(buffer: Buffer): string {
+    return createHash('sha256').update(buffer).digest('hex');
+}
+
+/** Reads back every entry name in a tar buffer via tar-stream's extract(). */
+function listTarEntryNames(buffer: Buffer): Promise<string[]> {
+    return new Promise((resolve, reject) => {
+        const names: string[] = [];
+        const extractor = extract();
+        extractor.on('entry', (header, stream, next) => {
+            names.push(header.name);
+            stream.on('end', next);
+            stream.resume();
+        });
+        extractor.on('finish', () => resolve(names));
+        extractor.on('error', reject);
+        extractor.end(buffer);
+    });
+}
+
+describe('buildChartRegistryFixture', () => {
+    let outDir: string;
+
+    beforeEach(async () => {
+        outDir = await mkdtemp(path.join(tmpdir(), 'chart-registry-fixture-'));
+    });
+
+    afterEach(async () => {
+        await rm(outDir, { recursive: true, force: true });
+    });
+
+    it('writes an index.json that parses via chartRegistryIndexSchema', async () => {
+        const { indexPath } = await buildChartRegistryFixture({ outDir });
+
+        const raw = await readFile(indexPath, 'utf-8');
+        const parsed = chartRegistryIndexSchema.parse(JSON.parse(raw));
+
+        expect(parsed.charts).toHaveLength(1);
+        expect(parsed.charts[0].slug).toBe('fixture-gauge');
+        expect(parsed.charts[0].version).toBe('1.0.0');
+        expect(parsed.charts[0].changelog).toBe('Initial fixture release.');
+    });
+
+    it('bumps the version and changelog when given a different version', async () => {
+        const { index } = await buildChartRegistryFixture({
+            outDir,
+            version: '1.1.0',
+        });
+
+        expect(index.charts[0].version).toBe('1.1.0');
+        expect(index.charts[0].changelog).toBe('Fixture upgrade');
+    });
+
+    it('digests in the index match the actual artifact bytes on disk', async () => {
+        const { index } = await buildChartRegistryFixture({
+            outDir,
+            version: '1.2.3',
+        });
+        const entry = index.charts[0];
+
+        const sourceBuffer = await readFile(
+            path.join(outDir, entry.artifacts.source.path),
+        );
+        const distBuffer = await readFile(
+            path.join(outDir, entry.artifacts.dist.path),
+        );
+
+        expect(sha256(sourceBuffer)).toBe(entry.artifacts.source.sha256);
+        expect(sha256(distBuffer)).toBe(entry.artifacts.dist.sha256);
+    });
+
+    it('thumbnail and screenshot files exist at the paths declared in the index', async () => {
+        const { index } = await buildChartRegistryFixture({ outDir });
+        const entry = index.charts[0];
+
+        expect(entry.thumbnail).not.toBeNull();
+        await expect(
+            readFile(path.join(outDir, entry.thumbnail as string)),
+        ).resolves.toBeInstanceOf(Buffer);
+        await expect(
+            readFile(path.join(outDir, entry.screenshots[0])),
+        ).resolves.toBeInstanceOf(Buffer);
+    });
+
+    it('dist.tar entries are all prefixed with dist/, matching the install extraction contract', async () => {
+        const { index } = await buildChartRegistryFixture({ outDir });
+        const entry = index.charts[0];
+        const distBuffer = await readFile(
+            path.join(outDir, entry.artifacts.dist.path),
+        );
+
+        const names = await listTarEntryNames(distBuffer);
+
+        expect(names.length).toBeGreaterThan(0);
+        names.forEach((name) => expect(name.startsWith('dist/')).toBe(true));
+        expect(names).toContain('dist/index.html');
+    });
+
+    it('source.tar entries are all prefixed with src/', async () => {
+        const { index } = await buildChartRegistryFixture({ outDir });
+        const entry = index.charts[0];
+        const sourceBuffer = await readFile(
+            path.join(outDir, entry.artifacts.source.path),
+        );
+
+        const names = await listTarEntryNames(sourceBuffer);
+
+        expect(names.length).toBeGreaterThan(0);
+        names.forEach((name) => expect(name.startsWith('src/')).toBe(true));
+    });
+
+    it('rejects a non-semver version before writing anything', async () => {
+        await expect(
+            buildChartRegistryFixture({ outDir, version: 'not-a-version' }),
+        ).rejects.toThrow();
+    });
+});

--- a/packages/backend/src/ee/services/AppGenerateService/testFixtures/buildChartRegistryFixture.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/testFixtures/buildChartRegistryFixture.test.ts
@@ -26,6 +26,26 @@ function listTarEntryNames(buffer: Buffer): Promise<string[]> {
     });
 }
 
+/** Reads back every entry's name -> utf-8 content in a tar buffer. */
+function readTarFiles(buffer: Buffer): Promise<Record<string, string>> {
+    return new Promise((resolve, reject) => {
+        const files: Record<string, string> = {};
+        const extractor = extract();
+        extractor.on('entry', (header, stream, next) => {
+            const chunks: Buffer[] = [];
+            stream.on('data', (chunk: Buffer) => chunks.push(chunk));
+            stream.on('end', () => {
+                files[header.name] = Buffer.concat(chunks).toString('utf-8');
+                next();
+            });
+            stream.resume();
+        });
+        extractor.on('finish', () => resolve(files));
+        extractor.on('error', reject);
+        extractor.end(buffer);
+    });
+}
+
 describe('buildChartRegistryFixture', () => {
     let outDir: string;
 
@@ -102,6 +122,26 @@ describe('buildChartRegistryFixture', () => {
         expect(names.length).toBeGreaterThan(0);
         names.forEach((name) => expect(name.startsWith('dist/')).toBe(true));
         expect(names).toContain('dist/index.html');
+        expect(names).toContain('dist/assets/app.js');
+    });
+
+    it('index.html has no inline script — only an external module script tag (CSP has no script-src unsafe-inline)', async () => {
+        const { index } = await buildChartRegistryFixture({ outDir });
+        const entry = index.charts[0];
+        const distBuffer = await readFile(
+            path.join(outDir, entry.artifacts.dist.path),
+        );
+        const files = await readTarFiles(distBuffer);
+        const indexHtml = files['dist/index.html'];
+
+        const scriptTags = [
+            ...indexHtml.matchAll(/<script\b[^>]*>([^<]*)<\/script>/g),
+        ];
+        expect(scriptTags).toHaveLength(1);
+        const [fullTag, body] = scriptTags[0];
+        expect(fullTag).toMatch(/type="module"/);
+        expect(fullTag).toMatch(/src="\.\/assets\/app\.js"/);
+        expect(body.trim()).toBe('');
     });
 
     it('source.tar entries are all prefixed with src/', async () => {

--- a/packages/backend/src/ee/services/AppGenerateService/testFixtures/buildChartRegistryFixture.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/testFixtures/buildChartRegistryFixture.ts
@@ -1,0 +1,205 @@
+import {
+    chartRegistryIndexSchema,
+    isSemverVersion,
+    type ChartRegistryEntry,
+    type ChartRegistryIndex,
+    type DataAppVizSchema,
+} from '@lightdash/common';
+import { createHash } from 'node:crypto';
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { pack } from 'tar-stream';
+
+/**
+ * Builds a local chart-registry fixture on disk: one chart ("fixture-gauge")
+ * with a real source.tar / dist.tar, a 1x1 PNG thumbnail/screenshot, and an
+ * index.json validated against the same schema the backend's
+ * ChartRegistryClient parses. Used by the unit test below and by
+ * `scripts/dev-chart-registry.mjs`, which imports this module directly via
+ * `tsx` and serves the output over HTTP for manual/E2E install testing.
+ *
+ * Kept dependency-free (node builtins + tar-stream, already a direct backend
+ * dependency) so it doubles as the seed of the future charts-repo publish
+ * script.
+ */
+
+const FIXTURE_SLUG = 'fixture-gauge';
+const FIXTURE_NAME = 'Fixture Gauge';
+
+const FIXTURE_VIZ_SCHEMA: DataAppVizSchema = {
+    fields: [
+        { name: 'value', label: 'Value', type: 'metric', required: true },
+        {
+            name: 'category',
+            label: 'Category',
+            type: 'dimension',
+            required: false,
+        },
+    ],
+    configOptions: [],
+    colorPalette: null,
+};
+
+// 1x1 transparent PNG, reused for both the thumbnail and the screenshot —
+// only its presence/content-type matters for the gallery/asset-proxy checks.
+const ONE_PX_PNG_BASE64 =
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=';
+
+const SOURCE_APP_JSX = `export default function App() { return null; }\n`;
+
+// Genuinely renderable: shows a placeholder immediately, then listens for the
+// host's viz-context push (mirroring @lightdash/query-sdk's useVizContext
+// handshake) and reports what it received, so an E2E check can prove the
+// bundle both loads and receives real context — without pulling in React or
+// any bundler.
+const DIST_ASSET_APP_JS = `(function () {
+  var root = document.getElementById('root');
+  function render(text) {
+    root.textContent = text;
+  }
+  render('Fixture Gauge');
+
+  window.addEventListener('message', function (event) {
+    var data = event.data;
+    if (!data || data.type !== 'lightdash:sdk:data-app-viz-context') return;
+    var rows = Array.isArray(data.rows) ? data.rows : [];
+    var fieldCount = data.fieldMapping
+      ? Object.keys(data.fieldMapping).length
+      : 0;
+    render('Fixture Gauge \\u2014 fields: ' + fieldCount + ', rows: ' + rows.length);
+  });
+
+  if (window.parent) {
+    window.parent.postMessage({ type: 'lightdash:sdk:viz-context-request' }, '*');
+  }
+})();
+`;
+
+const DIST_INDEX_HTML = `<!doctype html>
+<html>
+<head><meta charset="utf-8" /><title>Fixture Gauge</title></head>
+<body>
+<div id="root">Fixture Gauge</div>
+<script src="./assets/app.js"></script>
+</body>
+</html>
+`;
+
+/** Packs a list of {name, content} entries into a tar buffer via tar-stream. */
+function packTar(
+    entries: { name: string; content: string }[],
+): Promise<Buffer> {
+    return new Promise((resolve, reject) => {
+        const packer = pack();
+        const chunks: Buffer[] = [];
+        packer.on('data', (chunk: Buffer) => chunks.push(chunk));
+        packer.on('end', () => resolve(Buffer.concat(chunks)));
+        packer.on('error', reject);
+
+        const addNext = (index: number): void => {
+            if (index >= entries.length) {
+                packer.finalize();
+                return;
+            }
+            const entry = entries[index];
+            packer.entry({ name: entry.name }, entry.content, (err) => {
+                if (err) {
+                    reject(err);
+                    return;
+                }
+                addNext(index + 1);
+            });
+        };
+        addNext(0);
+    });
+}
+
+const sha256Hex = (buffer: Buffer): string =>
+    createHash('sha256').update(buffer).digest('hex');
+
+export type BuildChartRegistryFixtureArgs = {
+    /** Directory the fixture is written into (created if missing). */
+    outDir: string;
+    /** Strict x.y.z. Bump this to exercise the upgrade flow. */
+    version?: string;
+};
+
+export type BuildChartRegistryFixtureResult = {
+    /** The validated index — same shape ChartRegistryClient parses. */
+    index: ChartRegistryIndex;
+    /** Absolute path to the written index.json. */
+    indexPath: string;
+};
+
+export async function buildChartRegistryFixture({
+    outDir,
+    version = '1.0.0',
+}: BuildChartRegistryFixtureArgs): Promise<BuildChartRegistryFixtureResult> {
+    if (!isSemverVersion(version)) {
+        throw new Error(
+            `buildChartRegistryFixture: version "${version}" must be a strict x.y.z semver string`,
+        );
+    }
+
+    const relPrefix = `charts/${FIXTURE_SLUG}/${version}`;
+    const chartDir = path.join(outDir, ...relPrefix.split('/'));
+    await mkdir(chartDir, { recursive: true });
+
+    const sourceTar = await packTar([
+        { name: 'src/App.jsx', content: SOURCE_APP_JSX },
+    ]);
+    const distTar = await packTar([
+        { name: 'dist/index.html', content: DIST_INDEX_HTML },
+        { name: 'dist/assets/app.js', content: DIST_ASSET_APP_JS },
+    ]);
+    const thumbnailPng = Buffer.from(ONE_PX_PNG_BASE64, 'base64');
+
+    await Promise.all([
+        writeFile(path.join(chartDir, 'source.tar'), sourceTar),
+        writeFile(path.join(chartDir, 'dist.tar'), distTar),
+        writeFile(path.join(chartDir, 'thumb.png'), thumbnailPng),
+        writeFile(path.join(chartDir, 'screenshot-1.png'), thumbnailPng),
+    ]);
+
+    const changelog =
+        version === '1.0.0' ? 'Initial fixture release.' : 'Fixture upgrade';
+
+    const entry: ChartRegistryEntry = {
+        slug: FIXTURE_SLUG,
+        name: FIXTURE_NAME,
+        description:
+            'Dev/E2E fixture chart type — a minimal renderer used to validate the chart registry install/upgrade flow locally.',
+        version,
+        publishedAt: new Date().toISOString(),
+        tags: ['fixture'],
+        changelog,
+        minLightdashVersion: null,
+        vizSchema: FIXTURE_VIZ_SCHEMA,
+        thumbnail: `${relPrefix}/thumb.png`,
+        screenshots: [`${relPrefix}/screenshot-1.png`],
+        artifacts: {
+            source: {
+                path: `${relPrefix}/source.tar`,
+                sha256: sha256Hex(sourceTar),
+            },
+            dist: {
+                path: `${relPrefix}/dist.tar`,
+                sha256: sha256Hex(distTar),
+            },
+        },
+    };
+
+    const index: ChartRegistryIndex = {
+        schemaVersion: 1,
+        generatedAt: new Date().toISOString(),
+        charts: [entry],
+    };
+
+    // Throws on anything that wouldn't also parse inside ChartRegistryClient.
+    const validated = chartRegistryIndexSchema.parse(index);
+
+    const indexPath = path.join(outDir, 'index.json');
+    await writeFile(indexPath, JSON.stringify(validated, null, 2));
+
+    return { index: validated, indexPath };
+}

--- a/packages/backend/src/ee/services/AppGenerateService/testFixtures/buildChartRegistryFixture.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/testFixtures/buildChartRegistryFixture.ts
@@ -47,40 +47,52 @@ const ONE_PX_PNG_BASE64 =
 
 const SOURCE_APP_JSX = `export default function App() { return null; }\n`;
 
-// Genuinely renderable: shows a placeholder immediately, then listens for the
-// host's viz-context push (mirroring @lightdash/query-sdk's useVizContext
-// handshake) and reports what it received, so an E2E check can prove the
-// bundle both loads and receives real context — without pulling in React or
-// any bundler.
-const DIST_ASSET_APP_JS = `(function () {
-  var root = document.getElementById('root');
-  function render(text) {
-    root.textContent = text;
-  }
-  render('Fixture Gauge');
+// Genuinely renderable: shows a placeholder immediately, then runs the same
+// handshake @lightdash/query-sdk's useVizContext runs (packages/query-sdk/src/vizContext.ts):
+// listen for the host's push, then ask for it. The host's listener
+// (useAppSdkBridge.ts) is registered unconditionally on iframe mount and
+// replies to the request with no sdk:ready/sdk:manifest gate in between, so
+// no boot handshake beyond this pair is needed. All JS lives here — none
+// inline in index.html — because the preview iframe's CSP `script-src` has
+// no `'unsafe-inline'` (see appPreviewRouter.ts's buildCspHeader), only
+// `'self'`/the preview origin/blob:, matching what a same-origin external
+// file needs.
+const DIST_ASSET_APP_JS = `const root = document.getElementById('root');
 
-  window.addEventListener('message', function (event) {
-    var data = event.data;
-    if (!data || data.type !== 'lightdash:sdk:data-app-viz-context') return;
-    var rows = Array.isArray(data.rows) ? data.rows : [];
-    var fieldCount = data.fieldMapping
-      ? Object.keys(data.fieldMapping).length
-      : 0;
-    render('Fixture Gauge \\u2014 fields: ' + fieldCount + ', rows: ' + rows.length);
-  });
+function render(text) {
+  root.textContent = text;
+}
 
-  if (window.parent) {
-    window.parent.postMessage({ type: 'lightdash:sdk:viz-context-request' }, '*');
-  }
-})();
+render('Fixture Gauge');
+
+window.addEventListener('message', (event) => {
+  const data = event.data;
+  if (!data || data.type !== 'lightdash:sdk:data-app-viz-context') return;
+  const fieldMapping = data.fieldMapping || {};
+  const fieldNames = Object.keys(fieldMapping);
+  const rowCount = Array.isArray(data.rows) ? data.rows.length : 0;
+  render(
+    'Fixture Gauge \\u2014 fields: ' +
+      (fieldNames.length ? fieldNames.join(', ') : '(none)') +
+      ', rows: ' +
+      rowCount,
+  );
+});
+
+window.parent?.postMessage({ type: 'lightdash:sdk:viz-context-request' }, '*');
 `;
 
+// `type="module" crossorigin` matches the tag shape a real Vite build emits
+// (Vite's `base: './'` output) — module scripts are always CORS-mode
+// fetches, which is what the real template relies on when assets are served
+// from a CDN origin distinct from the document (see buildCspHeader's
+// `cdnOrigin`); harmless for same-origin dev serving.
 const DIST_INDEX_HTML = `<!doctype html>
 <html>
 <head><meta charset="utf-8" /><title>Fixture Gauge</title></head>
 <body>
 <div id="root">Fixture Gauge</div>
-<script src="./assets/app.js"></script>
+<script type="module" crossorigin src="./assets/app.js"></script>
 </body>
 </html>
 `;

--- a/packages/cli/src/handlers/apps/build.test.ts
+++ b/packages/cli/src/handlers/apps/build.test.ts
@@ -89,10 +89,38 @@ describe('validateDataAppBuild outDir', () => {
         await expect(fs.stat(buildDirs[0])).rejects.toThrow();
     });
 
-    it('does not copy anything and surfaces the error when the build fails', async () => {
+    it('clears stale files from a previous build before copying the new output', async () => {
         const appDir = await makeApp();
         const bundle = await readBundleFromDir(appDir);
         const outDir = await makeOutDir();
+        await fs.mkdir(outDir, { recursive: true });
+        await fs.writeFile(
+            path.join(outDir, 'stale-chunk-abc123.js'),
+            '// stale',
+        );
+
+        const issues = await validateDataAppBuild({
+            appDir,
+            bundle,
+            runCommand: fakeSuccessfulViteBuild,
+            outDir,
+        });
+
+        expect(issues).toEqual([]);
+        await expect(
+            fs.readFile(path.join(outDir, 'index.html'), 'utf-8'),
+        ).resolves.toBe('<html>built</html>');
+        await expect(
+            fs.stat(path.join(outDir, 'stale-chunk-abc123.js')),
+        ).rejects.toThrow();
+    });
+
+    it('does not copy anything and leaves a pre-existing outDir untouched when the build fails', async () => {
+        const appDir = await makeApp();
+        const bundle = await readBundleFromDir(appDir);
+        const outDir = await makeOutDir();
+        await fs.mkdir(outDir, { recursive: true });
+        await fs.writeFile(path.join(outDir, 'previous-build.js'), '// kept');
         const viteError = Object.assign(new Error('Command failed'), {
             stderr: 'src/App.tsx:1: broken import',
         });
@@ -110,7 +138,9 @@ describe('validateDataAppBuild outDir', () => {
                 message: expect.stringContaining('broken import'),
             }),
         ]);
-        await expect(fs.stat(outDir)).rejects.toThrow();
+        await expect(
+            fs.readFile(path.join(outDir, 'previous-build.js'), 'utf-8'),
+        ).resolves.toBe('// kept');
     });
 });
 

--- a/packages/cli/src/handlers/apps/build.test.ts
+++ b/packages/cli/src/handlers/apps/build.test.ts
@@ -7,8 +7,11 @@ import { promises as fs } from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { readBundleFromDir, writeBundleToDir } from './appCodeFiles';
-import { appsBuildHandler, assertOutDirDoesNotContainAppDir } from './build';
+import { appsBuildHandler } from './build';
+import { assertOutDirDoesNotContainAppDir } from './pathContainment';
 import { validateDataAppBuild, type RunDataAppBuildCommand } from './validate';
+
+const describePosix = process.platform === 'win32' ? describe.skip : describe;
 
 const defaultManifest: DataAppManifest = {
     codeVersion: 1,
@@ -48,6 +51,22 @@ const makeOutDir = async (): Promise<string> =>
         await fs.mkdtemp(path.join(os.tmpdir(), 'ld-app-build-outdir-')),
         'dist',
     );
+
+// Writes an app bundle into an already-existing directory, for symlink
+// bypass tests that need control over exactly where the real files live.
+const writeAppBundleTo = async (dir: string): Promise<void> => {
+    const code: DataAppCode = {
+        manifest: defaultManifest,
+        files: [
+            {
+                path: 'src/App.tsx',
+                contentBase64: Buffer.from(validSource).toString('base64'),
+            },
+        ],
+    };
+    await writeBundleToDir(dir, code);
+    await fs.mkdir(path.join(dir, 'node_modules'));
+};
 
 // Fakes a successful `vite build` by writing dist/index.html into the build
 // dir it receives, without actually running Vite.
@@ -246,5 +265,118 @@ describe('assertOutDirDoesNotContainAppDir', () => {
                 '/repo/apps/orders/dist',
             ),
         ).not.toThrow();
+    });
+});
+
+describePosix('out-dir containment guard: symlink bypasses', () => {
+    it('refuses when appDir is a symlink whose real location is inside outDir', async () => {
+        // outDir already exists as a real directory, and the "app" the CLI
+        // is asked to build actually lives inside it — reached only via a
+        // symlink from elsewhere, so the lexical check alone would miss it.
+        const outDir = await fs.mkdtemp(
+            path.join(os.tmpdir(), 'ld-symlink-outdir-'),
+        );
+        const realAppDir = path.join(outDir, 'app-real');
+        await fs.mkdir(realAppDir);
+        await writeAppBundleTo(realAppDir);
+
+        const linkParent = await fs.mkdtemp(
+            path.join(os.tmpdir(), 'ld-symlink-applink-'),
+        );
+        const appLink = path.join(linkParent, 'app-link');
+        await fs.symlink(realAppDir, appLink);
+
+        await expect(
+            appsBuildHandler(appLink, { outDir, verbose: false }),
+        ).rejects.toThrow(ParameterError);
+        await expect(
+            fs.stat(path.join(realAppDir, 'src', 'App.tsx')),
+        ).resolves.toBeDefined();
+    });
+
+    it('refuses when outDir is reached via a symlinked ancestor whose target contains appDir', async () => {
+        const parentDir = await fs.mkdtemp(
+            path.join(os.tmpdir(), 'ld-symlink-parent-'),
+        );
+        const appDir = path.join(parentDir, 'app');
+        await fs.mkdir(appDir);
+        await writeAppBundleTo(appDir);
+
+        const linkParent = await fs.mkdtemp(
+            path.join(os.tmpdir(), 'ld-symlink-outlink-'),
+        );
+        const outDirViaSymlink = path.join(linkParent, 'link-to-parent');
+        await fs.symlink(parentDir, outDirViaSymlink);
+
+        await expect(
+            appsBuildHandler(appDir, {
+                outDir: outDirViaSymlink,
+                verbose: false,
+            }),
+        ).rejects.toThrow(ParameterError);
+        await expect(
+            fs.stat(path.join(appDir, 'src', 'App.tsx')),
+        ).resolves.toBeDefined();
+    });
+
+    it('allows a legitimate sibling outDir reached via a symlinked ancestor', async () => {
+        const rootDir = await fs.mkdtemp(
+            path.join(os.tmpdir(), 'ld-symlink-root-'),
+        );
+        const appDir = path.join(rootDir, 'app-real');
+        await fs.mkdir(appDir);
+        await writeAppBundleTo(appDir);
+        const realOutDir = path.join(rootDir, 'out-real');
+
+        const linkParent = await fs.mkdtemp(
+            path.join(os.tmpdir(), 'ld-symlink-rootlink-'),
+        );
+        const linkToRoot = path.join(linkParent, 'link-to-root');
+        await fs.symlink(rootDir, linkToRoot);
+        const outDirViaSymlink = path.join(linkToRoot, 'out-real');
+
+        const bundle = await readBundleFromDir(appDir);
+        const issues = await validateDataAppBuild({
+            appDir,
+            bundle,
+            outDir: outDirViaSymlink,
+            runCommand: fakeSuccessfulViteBuild,
+        });
+
+        expect(issues).toEqual([]);
+        await expect(
+            fs.readFile(path.join(realOutDir, 'index.html'), 'utf-8'),
+        ).resolves.toBe('<html>built</html>');
+    });
+
+    it('validateDataAppBuild rechecks containment itself when called directly with a dangerous pair', async () => {
+        // Bypasses appsBuildHandler's guard entirely, simulating any future
+        // caller of validateDataAppBuild that doesn't run the check itself.
+        const parentDir = await fs.mkdtemp(
+            path.join(os.tmpdir(), 'ld-symlink-direct-parent-'),
+        );
+        const appDir = path.join(parentDir, 'app');
+        await fs.mkdir(appDir);
+        await writeAppBundleTo(appDir);
+
+        const linkParent = await fs.mkdtemp(
+            path.join(os.tmpdir(), 'ld-symlink-direct-link-'),
+        );
+        const outDirViaSymlink = path.join(linkParent, 'link-to-parent');
+        await fs.symlink(parentDir, outDirViaSymlink);
+
+        const bundle = await readBundleFromDir(appDir);
+
+        await expect(
+            validateDataAppBuild({
+                appDir,
+                bundle,
+                outDir: outDirViaSymlink,
+                runCommand: fakeSuccessfulViteBuild,
+            }),
+        ).rejects.toThrow(ParameterError);
+        await expect(
+            fs.stat(path.join(appDir, 'src', 'App.tsx')),
+        ).resolves.toBeDefined();
     });
 });

--- a/packages/cli/src/handlers/apps/build.test.ts
+++ b/packages/cli/src/handlers/apps/build.test.ts
@@ -1,0 +1,138 @@
+import {
+    ParameterError,
+    type DataAppCode,
+    type DataAppManifest,
+} from '@lightdash/common';
+import { promises as fs } from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { readBundleFromDir, writeBundleToDir } from './appCodeFiles';
+import { appsBuildHandler } from './build';
+import { validateDataAppBuild, type RunDataAppBuildCommand } from './validate';
+
+const defaultManifest: DataAppManifest = {
+    codeVersion: 1,
+    projectUuid: 'project-uuid',
+    slug: 'orders-app',
+    version: 1,
+    name: 'Orders app',
+    description: '',
+    template: null,
+    downloadedAt: '2026-08-01T00:00:00.000Z',
+    externalConnections: [],
+};
+
+const validSource = `
+    import { query } from '@lightdash/query-sdk';
+    query('orders').dimensions(['status']);
+`;
+
+const makeApp = async (): Promise<string> => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'ld-app-build-'));
+    const code: DataAppCode = {
+        manifest: defaultManifest,
+        files: [
+            {
+                path: 'src/App.tsx',
+                contentBase64: Buffer.from(validSource).toString('base64'),
+            },
+        ],
+    };
+    await writeBundleToDir(dir, code);
+    await fs.mkdir(path.join(dir, 'node_modules'));
+    return dir;
+};
+
+const makeOutDir = async (): Promise<string> =>
+    path.join(
+        await fs.mkdtemp(path.join(os.tmpdir(), 'ld-app-build-outdir-')),
+        'dist',
+    );
+
+// Fakes a successful `vite build` by writing dist/index.html into the build
+// dir it receives, without actually running Vite.
+const fakeSuccessfulViteBuild = async (
+    command: Parameters<RunDataAppBuildCommand>[0],
+): Promise<void> => {
+    if (command.command !== 'vite') return;
+    await fs.mkdir(path.join(command.cwd, 'dist'));
+    await fs.writeFile(
+        path.join(command.cwd, 'dist', 'index.html'),
+        '<html>built</html>',
+    );
+};
+
+describe('validateDataAppBuild outDir', () => {
+    it('copies the built dist output into outDir and still cleans the temp build dir', async () => {
+        const appDir = await makeApp();
+        const bundle = await readBundleFromDir(appDir);
+        const outDir = await makeOutDir();
+        const buildDirs: string[] = [];
+        const runCommand: RunDataAppBuildCommand = async (command) => {
+            if (command.command === 'vite') buildDirs.push(command.cwd);
+            await fakeSuccessfulViteBuild(command);
+        };
+
+        const issues = await validateDataAppBuild({
+            appDir,
+            bundle,
+            runCommand,
+            outDir,
+        });
+
+        expect(issues).toEqual([]);
+        await expect(
+            fs.readFile(path.join(outDir, 'index.html'), 'utf-8'),
+        ).resolves.toBe('<html>built</html>');
+
+        expect(buildDirs).toHaveLength(1);
+        await expect(fs.stat(buildDirs[0])).rejects.toThrow();
+    });
+
+    it('does not copy anything and surfaces the error when the build fails', async () => {
+        const appDir = await makeApp();
+        const bundle = await readBundleFromDir(appDir);
+        const outDir = await makeOutDir();
+        const viteError = Object.assign(new Error('Command failed'), {
+            stderr: 'src/App.tsx:1: broken import',
+        });
+
+        const issues = await validateDataAppBuild({
+            appDir,
+            bundle,
+            outDir,
+            runCommand: vi.fn().mockRejectedValue(viteError),
+        });
+
+        expect(issues).toEqual([
+            expect.objectContaining({
+                code: 'build',
+                message: expect.stringContaining('broken import'),
+            }),
+        ]);
+        await expect(fs.stat(outDir)).rejects.toThrow();
+    });
+});
+
+describe('appsBuildHandler', () => {
+    it('fails fast with a ParameterError when the directory has no lightdash-app.yml', async () => {
+        const dir = await fs.mkdtemp(
+            path.join(os.tmpdir(), 'ld-app-build-missing-'),
+        );
+
+        await expect(appsBuildHandler(dir, { verbose: false })).rejects.toThrow(
+            ParameterError,
+        );
+    });
+
+    it('fails fast with a ParameterError when the bundle has no files under src/', async () => {
+        const dir = await fs.mkdtemp(
+            path.join(os.tmpdir(), 'ld-app-build-empty-'),
+        );
+        await writeBundleToDir(dir, { manifest: defaultManifest, files: [] });
+
+        await expect(appsBuildHandler(dir, { verbose: false })).rejects.toThrow(
+            /no files under src\//,
+        );
+    });
+});

--- a/packages/cli/src/handlers/apps/build.test.ts
+++ b/packages/cli/src/handlers/apps/build.test.ts
@@ -7,7 +7,7 @@ import { promises as fs } from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { readBundleFromDir, writeBundleToDir } from './appCodeFiles';
-import { appsBuildHandler } from './build';
+import { appsBuildHandler, assertOutDirDoesNotContainAppDir } from './build';
 import { validateDataAppBuild, type RunDataAppBuildCommand } from './validate';
 
 const defaultManifest: DataAppManifest = {
@@ -164,5 +164,87 @@ describe('appsBuildHandler', () => {
         await expect(appsBuildHandler(dir, { verbose: false })).rejects.toThrow(
             /no files under src\//,
         );
+    });
+
+    it('refuses --out-dir equal to the app directory before doing any build work', async () => {
+        const appDir = await makeApp();
+
+        await expect(
+            appsBuildHandler(appDir, { outDir: appDir, verbose: false }),
+        ).rejects.toThrow(ParameterError);
+        // The app bundle must still be intact — no wipe happened.
+        await expect(
+            fs.stat(path.join(appDir, 'src', 'App.tsx')),
+        ).resolves.toBeDefined();
+    });
+
+    it('refuses --out-dir that is a parent of the app directory before doing any build work', async () => {
+        const parentDir = await fs.mkdtemp(
+            path.join(os.tmpdir(), 'ld-app-build-parent-'),
+        );
+        const appDir = path.join(parentDir, 'app');
+        await fs.mkdir(appDir);
+        const code: DataAppCode = {
+            manifest: defaultManifest,
+            files: [
+                {
+                    path: 'src/App.tsx',
+                    contentBase64: Buffer.from(validSource).toString('base64'),
+                },
+            ],
+        };
+        await writeBundleToDir(appDir, code);
+        await fs.mkdir(path.join(appDir, 'node_modules'));
+
+        await expect(
+            appsBuildHandler(appDir, {
+                outDir: parentDir,
+                verbose: false,
+            }),
+        ).rejects.toThrow(ParameterError);
+        await expect(
+            fs.stat(path.join(appDir, 'src', 'App.tsx')),
+        ).resolves.toBeDefined();
+    });
+});
+
+describe('assertOutDirDoesNotContainAppDir', () => {
+    it('throws when outDir equals appDir', () => {
+        expect(() =>
+            assertOutDirDoesNotContainAppDir(
+                '/repo/apps/orders',
+                '/repo/apps/orders',
+            ),
+        ).toThrow(ParameterError);
+    });
+
+    it('throws when appDir is nested inside outDir', () => {
+        expect(() =>
+            assertOutDirDoesNotContainAppDir('/repo/apps/orders', '/repo/apps'),
+        ).toThrow(ParameterError);
+    });
+
+    it('throws when outDir is the filesystem root and appDir is anywhere under it', () => {
+        expect(() =>
+            assertOutDirDoesNotContainAppDir('/repo/apps/orders', '/'),
+        ).toThrow(ParameterError);
+    });
+
+    it('does not throw for a normal sibling out-dir', () => {
+        expect(() =>
+            assertOutDirDoesNotContainAppDir(
+                '/repo/apps/orders',
+                '/repo/build-output',
+            ),
+        ).not.toThrow();
+    });
+
+    it('does not throw for the default outDir nested inside appDir (appDir/dist)', () => {
+        expect(() =>
+            assertOutDirDoesNotContainAppDir(
+                '/repo/apps/orders',
+                '/repo/apps/orders/dist',
+            ),
+        ).not.toThrow();
     });
 });

--- a/packages/cli/src/handlers/apps/build.ts
+++ b/packages/cli/src/handlers/apps/build.ts
@@ -1,0 +1,50 @@
+import { getErrorMessage, ParameterError } from '@lightdash/common';
+import * as path from 'path';
+import GlobalState from '../../globalState';
+import * as styles from '../../styles';
+import { readBundleFromDir } from './appCodeFiles';
+import { formatIssue, validateDataAppBuild } from './validate';
+
+export type AppsBuildOptions = {
+    outDir?: string;
+    verbose: boolean;
+};
+
+export const appsBuildHandler = async (
+    pathArg: string | undefined,
+    options: AppsBuildOptions,
+): Promise<void> => {
+    GlobalState.setVerbose(options.verbose);
+    const appDir = path.resolve(process.cwd(), pathArg ?? '.');
+    const outDir = path.resolve(
+        process.cwd(),
+        options.outDir ?? path.join(appDir, 'dist'),
+    );
+
+    let bundle: Awaited<ReturnType<typeof readBundleFromDir>>;
+    try {
+        bundle = await readBundleFromDir(appDir);
+    } catch (error) {
+        throw new ParameterError(getErrorMessage(error));
+    }
+
+    if (bundle.files.length === 0) {
+        throw new ParameterError(
+            `App bundle has no files under src/ to build: ${appDir}`,
+        );
+    }
+
+    const issues = await validateDataAppBuild({ appDir, bundle, outDir });
+    if (issues.length > 0) {
+        for (const buildIssue of issues) {
+            GlobalState.log(
+                `${styles.error('error')} ${formatIssue(buildIssue)}`,
+            );
+        }
+        throw new ParameterError(
+            `Build failed with ${issues.length} error(s).`,
+        );
+    }
+
+    GlobalState.log(styles.success(`✓ Built ${appDir} → ${outDir}`));
+};

--- a/packages/cli/src/handlers/apps/build.ts
+++ b/packages/cli/src/handlers/apps/build.ts
@@ -3,32 +3,15 @@ import * as path from 'path';
 import GlobalState from '../../globalState';
 import * as styles from '../../styles';
 import { readBundleFromDir } from './appCodeFiles';
+import {
+    assertOutDirDoesNotContainAppDir,
+    canonicalizeForContainment,
+} from './pathContainment';
 import { formatIssue, validateDataAppBuild } from './validate';
 
 export type AppsBuildOptions = {
     outDir?: string;
     verbose: boolean;
-};
-
-/**
- * The build wipes outDir before copying the new output in. If outDir is (or
- * contains) appDir, that wipe deletes the app source being built. Both
- * arguments must already be resolved to absolute paths.
- */
-export const assertOutDirDoesNotContainAppDir = (
-    appDir: string,
-    outDir: string,
-): void => {
-    const relativeAppDirFromOutDir = path.relative(outDir, appDir);
-    const appDirIsInsideOutDir =
-        relativeAppDirFromOutDir !== '' &&
-        !relativeAppDirFromOutDir.startsWith('..') &&
-        !path.isAbsolute(relativeAppDirFromOutDir);
-    if (outDir === appDir || appDirIsInsideOutDir) {
-        throw new ParameterError(
-            '--out-dir must not contain the app directory (would delete the app source on build)',
-        );
-    }
 };
 
 export const appsBuildHandler = async (
@@ -42,6 +25,16 @@ export const appsBuildHandler = async (
         options.outDir ?? path.join(appDir, 'dist'),
     );
     assertOutDirDoesNotContainAppDir(appDir, outDir);
+
+    // The lexical check above can be bypassed by symlinks (an appDir that is
+    // itself a symlink into outDir's real tree, or an outDir reached through
+    // a symlinked ancestor whose target contains appDir), so re-run the same
+    // check on the canonicalized paths before doing anything destructive.
+    const [canonicalAppDir, canonicalOutDir] = await Promise.all([
+        canonicalizeForContainment(appDir),
+        canonicalizeForContainment(outDir),
+    ]);
+    assertOutDirDoesNotContainAppDir(canonicalAppDir, canonicalOutDir);
 
     let bundle: Awaited<ReturnType<typeof readBundleFromDir>>;
     try {

--- a/packages/cli/src/handlers/apps/build.ts
+++ b/packages/cli/src/handlers/apps/build.ts
@@ -10,6 +10,27 @@ export type AppsBuildOptions = {
     verbose: boolean;
 };
 
+/**
+ * The build wipes outDir before copying the new output in. If outDir is (or
+ * contains) appDir, that wipe deletes the app source being built. Both
+ * arguments must already be resolved to absolute paths.
+ */
+export const assertOutDirDoesNotContainAppDir = (
+    appDir: string,
+    outDir: string,
+): void => {
+    const relativeAppDirFromOutDir = path.relative(outDir, appDir);
+    const appDirIsInsideOutDir =
+        relativeAppDirFromOutDir !== '' &&
+        !relativeAppDirFromOutDir.startsWith('..') &&
+        !path.isAbsolute(relativeAppDirFromOutDir);
+    if (outDir === appDir || appDirIsInsideOutDir) {
+        throw new ParameterError(
+            '--out-dir must not contain the app directory (would delete the app source on build)',
+        );
+    }
+};
+
 export const appsBuildHandler = async (
     pathArg: string | undefined,
     options: AppsBuildOptions,
@@ -20,6 +41,7 @@ export const appsBuildHandler = async (
         process.cwd(),
         options.outDir ?? path.join(appDir, 'dist'),
     );
+    assertOutDirDoesNotContainAppDir(appDir, outDir);
 
     let bundle: Awaited<ReturnType<typeof readBundleFromDir>>;
     try {

--- a/packages/cli/src/handlers/apps/pathContainment.test.ts
+++ b/packages/cli/src/handlers/apps/pathContainment.test.ts
@@ -1,0 +1,101 @@
+import { ParameterError } from '@lightdash/common';
+import { promises as fs } from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+    assertOutDirSafeToClear,
+    canonicalizeForContainment,
+} from './pathContainment';
+
+const describePosix = process.platform === 'win32' ? describe.skip : describe;
+
+const mkTmpDir = (prefix: string): Promise<string> =>
+    fs.mkdtemp(path.join(os.tmpdir(), prefix));
+
+describePosix('canonicalizeForContainment', () => {
+    it('returns the realpath of an existing directory unchanged when there are no symlinks', async () => {
+        const dir = await mkTmpDir('ld-canon-plain-');
+
+        await expect(canonicalizeForContainment(dir)).resolves.toBe(
+            await fs.realpath(dir),
+        );
+    });
+
+    it('resolves a symlinked existing directory to its real target', async () => {
+        const target = await mkTmpDir('ld-canon-target-');
+        const linkParent = await mkTmpDir('ld-canon-linkparent-');
+        const link = path.join(linkParent, 'link');
+        await fs.symlink(target, link);
+
+        await expect(canonicalizeForContainment(link)).resolves.toBe(
+            await fs.realpath(target),
+        );
+    });
+
+    it('walks up to the nearest existing ancestor and rejoins non-existent segments', async () => {
+        const target = await mkTmpDir('ld-canon-target-');
+        const linkParent = await mkTmpDir('ld-canon-linkparent-');
+        const link = path.join(linkParent, 'link');
+        await fs.symlink(target, link);
+        const nonExistent = path.join(link, 'not', 'yet', 'created');
+
+        await expect(canonicalizeForContainment(nonExistent)).resolves.toBe(
+            path.join(await fs.realpath(target), 'not', 'yet', 'created'),
+        );
+    });
+
+    it('rethrows a non-ENOENT realpath failure instead of treating it as non-existent', async () => {
+        const dir = await mkTmpDir('ld-canon-notdir-');
+        const filePath = path.join(dir, 'a-file');
+        await fs.writeFile(filePath, 'not a directory');
+        const impossiblePath = path.join(filePath, 'nested', 'more');
+
+        await expect(
+            canonicalizeForContainment(impossiblePath),
+        ).rejects.toMatchObject({ code: 'ENOTDIR' });
+    });
+});
+
+describePosix('assertOutDirSafeToClear', () => {
+    it('is a no-op when outDir does not exist yet', async () => {
+        const appDir = await mkTmpDir('ld-safeclear-app-');
+        const outDirParent = await mkTmpDir('ld-safeclear-outparent-');
+        const outDir = path.join(outDirParent, 'dist');
+
+        await expect(
+            assertOutDirSafeToClear(appDir, outDir),
+        ).resolves.toBeUndefined();
+    });
+
+    it('does not throw for a disjoint existing outDir', async () => {
+        const appDir = await mkTmpDir('ld-safeclear-app-');
+        const outDir = await mkTmpDir('ld-safeclear-outdir-');
+
+        await expect(
+            assertOutDirSafeToClear(appDir, outDir),
+        ).resolves.toBeUndefined();
+    });
+
+    it('throws ParameterError when an existing outDir canonically contains appDir', async () => {
+        const outDir = await mkTmpDir('ld-safeclear-container-');
+        const appDir = path.join(outDir, 'app');
+        await fs.mkdir(appDir);
+
+        await expect(assertOutDirSafeToClear(appDir, outDir)).rejects.toThrow(
+            ParameterError,
+        );
+    });
+
+    it('throws ParameterError when outDir is reached via a symlinked ancestor that contains appDir', async () => {
+        const parentDir = await mkTmpDir('ld-safeclear-parent-');
+        const appDir = path.join(parentDir, 'app');
+        await fs.mkdir(appDir);
+        const linkParent = await mkTmpDir('ld-safeclear-linkparent-');
+        const link = path.join(linkParent, 'link-to-parent');
+        await fs.symlink(parentDir, link);
+
+        await expect(assertOutDirSafeToClear(appDir, link)).rejects.toThrow(
+            ParameterError,
+        );
+    });
+});

--- a/packages/cli/src/handlers/apps/pathContainment.ts
+++ b/packages/cli/src/handlers/apps/pathContainment.ts
@@ -1,0 +1,92 @@
+import { ParameterError } from '@lightdash/common';
+import { promises as fs } from 'fs';
+import * as path from 'path';
+
+/**
+ * Resolves `absolutePath` through any symlinks so it can be safely compared
+ * for containment against another canonicalized path. The path may not
+ * exist yet (e.g. an --out-dir that hasn't been built to), so this walks up
+ * to the nearest existing ancestor, realpaths that ancestor, and re-joins
+ * the non-existent remainder lexically.
+ *
+ * Any realpath failure other than "this segment doesn't exist" (permission
+ * denied, a symlink loop, ...) is rethrown rather than swallowed. Callers
+ * must treat that as "cannot prove this path is safe" and refuse the
+ * operation — never fall back to the un-canonicalized path.
+ */
+export const canonicalizeForContainment = async (
+    absolutePath: string,
+): Promise<string> => {
+    let current = absolutePath;
+    const missingSegments: string[] = [];
+    while (true) {
+        try {
+            // eslint-disable-next-line no-await-in-loop
+            const real = await fs.realpath(current);
+            return missingSegments.length > 0
+                ? path.join(real, ...missingSegments.reverse())
+                : real;
+        } catch (error) {
+            if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+                throw error;
+            }
+            const parent = path.dirname(current);
+            if (parent === current) {
+                // Reached the filesystem root and even it didn't resolve.
+                throw error;
+            }
+            missingSegments.push(path.basename(current));
+            current = parent;
+        }
+    }
+};
+
+/**
+ * The build wipes outDir before copying the new output in. If outDir is (or
+ * contains) appDir, that wipe deletes the app source being built. Both
+ * arguments must already be resolved to absolute, canonical (symlink-free)
+ * paths — see `canonicalizeForContainment`.
+ */
+export const assertOutDirDoesNotContainAppDir = (
+    appDir: string,
+    outDir: string,
+): void => {
+    const relativeAppDirFromOutDir = path.relative(outDir, appDir);
+    const appDirIsInsideOutDir =
+        relativeAppDirFromOutDir !== '' &&
+        !relativeAppDirFromOutDir.startsWith('..') &&
+        !path.isAbsolute(relativeAppDirFromOutDir);
+    if (outDir === appDir || appDirIsInsideOutDir) {
+        throw new ParameterError(
+            '--out-dir must not contain the app directory (would delete the app source on build)',
+        );
+    }
+};
+
+/**
+ * Defense-in-depth recheck for the deletion site itself: outDir may have
+ * changed since an earlier containment check ran, or a caller may not have
+ * run one at all. If outDir doesn't exist yet there is nothing to delete,
+ * so this is a no-op. If it exists, both paths are canonicalized and
+ * re-checked with the same predicate as the pre-build guard. Throws
+ * ParameterError on violation; never trusts the caller's un-canonicalized
+ * paths.
+ */
+export const assertOutDirSafeToClear = async (
+    appDir: string,
+    outDir: string,
+): Promise<void> => {
+    let canonicalOutDir: string;
+    try {
+        canonicalOutDir = await fs.realpath(outDir);
+    } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+            // Nothing exists at outDir yet, so there's nothing to delete.
+            return;
+        }
+        // Cannot prove outDir is safe to clear — refuse rather than guess.
+        throw error;
+    }
+    const canonicalAppDir = await canonicalizeForContainment(appDir);
+    assertOutDirDoesNotContainAppDir(canonicalAppDir, canonicalOutDir);
+};

--- a/packages/cli/src/handlers/apps/validate.ts
+++ b/packages/cli/src/handlers/apps/validate.ts
@@ -375,6 +375,7 @@ export const validateDataAppBuild = async (args: {
     appDir: string;
     bundle: DataAppCode;
     runCommand?: RunDataAppBuildCommand;
+    outDir?: string;
 }): Promise<AppsValidationIssue[]> => {
     const runCommand = args.runCommand ?? runDataAppBuildCommand;
     let dependencies: Awaited<ReturnType<typeof readDependenciesFromDir>>;
@@ -487,6 +488,13 @@ export const validateDataAppBuild = async (args: {
                 ),
             ];
         }
+
+        if (args.outDir !== undefined) {
+            await fs.cp(path.join(buildDir, 'dist'), args.outDir, {
+                recursive: true,
+            });
+        }
+
         return [];
     } catch (error) {
         return [
@@ -734,7 +742,7 @@ const formatCoverage = (coverage: AppsValidationCoverage): string => {
     return `Coverage: ${coverage.unanalyzed} of ${coverage.callSites} data-reference call site(s) couldn't be fully analyzed; unresolved values were skipped and are not errors.`;
 };
 
-const formatIssue = (entry: AppsValidationIssue): string => {
+export const formatIssue = (entry: AppsValidationIssue): string => {
     const prefix = entry.location
         ? `${entry.location.path}:${entry.location.line}:${entry.location.column} — `
         : '';

--- a/packages/cli/src/handlers/apps/validate.ts
+++ b/packages/cli/src/handlers/apps/validate.ts
@@ -37,6 +37,7 @@ import {
     readDependenciesFromDir,
     writeFilesToDir,
 } from './appCodeFiles';
+import { assertOutDirSafeToClear } from './pathContainment';
 import {
     loadTemplateDependencies,
     loadVendoredBuildScaffold,
@@ -490,6 +491,12 @@ export const validateDataAppBuild = async (args: {
         }
 
         if (args.outDir !== undefined) {
+            // Defense in depth: this deletion site must not trust that a
+            // caller already checked containment (or that outDir hasn't
+            // changed since it did). Re-resolve symlinks and refuse rather
+            // than delete anything we can't prove is safe.
+            await assertOutDirSafeToClear(args.appDir, args.outDir);
+
             // Vite emits content-hashed chunk filenames, so a merge-only copy
             // would leave stale chunks from a previous build behind. Clear
             // outDir immediately before copying a successful build into it —
@@ -502,6 +509,7 @@ export const validateDataAppBuild = async (args: {
 
         return [];
     } catch (error) {
+        if (error instanceof ParameterError) throw error;
         return [
             issue(
                 'build',

--- a/packages/cli/src/handlers/apps/validate.ts
+++ b/packages/cli/src/handlers/apps/validate.ts
@@ -490,6 +490,11 @@ export const validateDataAppBuild = async (args: {
         }
 
         if (args.outDir !== undefined) {
+            // Vite emits content-hashed chunk filenames, so a merge-only copy
+            // would leave stale chunks from a previous build behind. Clear
+            // outDir immediately before copying a successful build into it —
+            // never on the failure path, which must leave it untouched.
+            await fs.rm(args.outDir, { recursive: true, force: true });
             await fs.cp(path.join(buildDir, 'dist'), args.outDir, {
                 recursive: true,
             });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1266,7 +1266,7 @@ appsProgram
     )
     .option(
         '--out-dir <dir>',
-        'Directory to write the built dist output to (default: <path>/dist)',
+        'Directory to write the built dist output to. Relative paths resolve against the current working directory (default: <path>/dist)',
     )
     .option('--verbose', undefined, false)
     .action(appsBuildHandler);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -16,6 +16,7 @@ import {
 } from './env';
 import { getDiagnosticsHint } from './error';
 import GlobalState from './globalState';
+import { appsBuildHandler } from './handlers/apps/build';
 import { createAppHandler } from './handlers/apps/createApp';
 import { appsPreviewHandler } from './handlers/apps/preview';
 import {
@@ -1258,6 +1259,17 @@ appsProgram
     )
     .option('--verbose', undefined, false)
     .action(appsValidateHandler);
+appsProgram
+    .command('build [path]')
+    .description(
+        'Build a data app or custom chart type with the same Vite production build as Lightdash Cloud, and keep the output.',
+    )
+    .option(
+        '--out-dir <dir>',
+        'Directory to write the built dist output to (default: <path>/dist)',
+    )
+    .option('--verbose', undefined, false)
+    .action(appsBuildHandler);
 
 program
     .command('deploy')

--- a/scripts/dev-chart-registry.mjs
+++ b/scripts/dev-chart-registry.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+/**
+ * Local chart-registry fixture server, for manually/E2E testing the
+ * installable chart types feature without a real charts-repo registry.
+ *
+ * Builds a one-chart fixture ("fixture-gauge") into `.dev-chart-registry/`
+ * (gitignored, repo root) via the backend's `buildChartRegistryFixture`
+ * builder, then serves that directory on 127.0.0.1:8089 with node's `http`
+ * module. No bundler, no extra dependencies — `tar-stream` is already a
+ * direct backend dependency.
+ *
+ * This file imports a `.ts` module directly, so it MUST be run through
+ * `tsx`, not plain `node`:
+ *
+ *   pnpm dev:chart-registry                  # v1.0.0
+ *   pnpm dev:chart-registry -- --version 1.1.0   # rebuild at a bumped
+ *                                                 # version (changelog:
+ *                                                 # "Fixture upgrade"), to
+ *                                                 # exercise the upgrade flow
+ *
+ * Then point the backend at it (see packages/backend/CLAUDE.md /
+ * dev-env-local-env-loading for how .env.development.local is picked up by
+ * pm2) and enable the `chart-type-registry` feature flag — see
+ * `scripts/dev-feature-flags.sh`.
+ */
+import { readFile } from 'node:fs/promises';
+import { createServer } from 'node:http';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+// Duplicated nowhere: this imports the same builder the unit test and the
+// (future) charts-repo publish script use, via tsx's on-the-fly TS support.
+import { buildChartRegistryFixture } from '../packages/backend/src/ee/services/AppGenerateService/testFixtures/buildChartRegistryFixture.ts';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.join(__dirname, '..');
+const OUT_DIR = path.join(REPO_ROOT, '.dev-chart-registry');
+const HOST = '127.0.0.1';
+const PORT = 8089;
+
+const CONTENT_TYPES = {
+    '.json': 'application/json',
+    '.tar': 'application/x-tar',
+    '.png': 'image/png',
+};
+
+function contentTypeFor(filePath) {
+    return CONTENT_TYPES[path.extname(filePath)] ?? 'application/octet-stream';
+}
+
+function parseArgs(argv) {
+    let version;
+    for (let i = 0; i < argv.length; i += 1) {
+        if (argv[i] === '--version') {
+            version = argv[i + 1];
+            i += 1;
+        }
+    }
+    return { version };
+}
+
+/** Resolves a request path against OUT_DIR, refusing to escape it (`..`). */
+function resolveRequestedFile(pathname) {
+    const relativePath = decodeURIComponent(pathname.replace(/^\/+/, ''));
+    const requestPath = relativePath === '' ? 'index.json' : relativePath;
+    const resolved = path.join(OUT_DIR, requestPath);
+    const withinOutDir =
+        resolved === OUT_DIR || resolved.startsWith(`${OUT_DIR}${path.sep}`);
+    return withinOutDir ? resolved : null;
+}
+
+async function handleRequest(req, res) {
+    const url = new URL(req.url ?? '/', `http://${HOST}:${PORT}`);
+    const resolved = resolveRequestedFile(url.pathname);
+
+    if (!resolved) {
+        res.writeHead(404, { 'Content-Type': 'text/plain' }).end('Not found');
+        console.log(`404 ${req.method} ${req.url} (outside registry root)`);
+        return;
+    }
+
+    try {
+        const body = await readFile(resolved);
+        res.writeHead(200, { 'Content-Type': contentTypeFor(resolved) });
+        res.end(body);
+        console.log(`200 ${req.method} ${req.url}`);
+    } catch {
+        res.writeHead(404, { 'Content-Type': 'text/plain' }).end('Not found');
+        console.log(`404 ${req.method} ${req.url}`);
+    }
+}
+
+async function main() {
+    const { version } = parseArgs(process.argv.slice(2));
+    const { index } = await buildChartRegistryFixture({
+        outDir: OUT_DIR,
+        ...(version ? { version } : {}),
+    });
+    const entry = index.charts[0];
+    console.log(
+        `Built fixture "${entry.slug}" v${entry.version} into ${OUT_DIR}`,
+    );
+
+    const server = createServer((req, res) => {
+        handleRequest(req, res).catch((err) => {
+            console.error(err);
+            res.writeHead(500).end('Internal error');
+        });
+    });
+
+    server.listen(PORT, HOST, () => {
+        console.log(`Chart registry fixture serving on http://${HOST}:${PORT}`);
+        console.log('Set in .env.development.local:');
+        console.log(`  LIGHTDASH_CHART_REGISTRY_URL=http://${HOST}:${PORT}`);
+        console.log('  LIGHTDASH_CHART_REGISTRY_ALLOW_INSECURE=true');
+    });
+}
+
+main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});


### PR DESCRIPTION
Final part of the installable chart types stack (on #28376). Two developer-facing pieces: a local registry for testing the feature, and the CLI build command the gallery repo's CI uses to publish charts.

**Local fixture registry** — `pnpm dev:chart-registry [--version x.y.z]` builds and serves a small, schema-valid registry on `127.0.0.1:8089` with one renderable fixture chart. Point a dev instance at it with:

```
LIGHTDASH_CHART_REGISTRY_URL=http://127.0.0.1:8089
LIGHTDASH_CHART_REGISTRY_ALLOW_INSECURE=true   # dev only — relaxes SSRF checks for localhost
```

plus the `chart-type-registry` and `explorer-chart-gallery` flags. Re-running with a bumped `--version` exercises the upgrade flow. The full E2E loop (install → render in explorer → fork → upgrade → uninstall → offline behavior) was validated against it, and then re-validated against the real `lightdash-gallery` registry.

**`lightdash apps build <path> --out-dir <dir>`** — builds a chart-type folder exactly like Lightdash Cloud does and keeps the output (the existing `apps validate --build` throws it away). This is what the [lightdash-gallery](https://github.com/lightdash/lightdash-gallery) CI runs to produce the prebuilt bundles the registry serves.

**Safety note for review:** `--out-dir` is cleared before each successful build, so the command refuses any out-dir that is (or contains) the app directory — with paths canonicalized through `realpath` so symlinks can't sneak the app source into the deletion target. The check runs both up front and again immediately before the `rm`.

Closes GLITCH-714

🤖 Generated with [Claude Code](https://claude.com/claude-code)
