### PR TITLE
feat: show apps linked to external connections

### DIFF
--- a/packages/backend/src/ee/controllers/externalConnectionController.ts
+++ b/packages/backend/src/ee/controllers/externalConnectionController.ts
@@ -2,6 +2,7 @@ import {
     assertRegisteredAccount,
     ForbiddenError,
     type ApiErrorPayload,
+    type ApiListExternalConnectionLinkedAppsResponse,
     type ApiListExternalConnectionSamplesResponse,
     type ApiProposeExternalConnectionConfigRequest,
     type ApiProposeExternalConnectionConfigResponse,
@@ -132,6 +133,31 @@ export class ExternalConnectionController extends BaseController {
         return {
             status: 'ok',
             results: await this.getService().get(
+                req.account,
+                projectUuid,
+                connectionUuid,
+            ),
+        };
+    }
+
+    /**
+     * List the data apps and chart types linked to an external connection
+     * @summary List apps linked to an external connection
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('external-connections/{connectionUuid}/linked-apps')
+    @OperationId('listExternalConnectionLinkedApps')
+    async listExternalConnectionLinkedApps(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() connectionUuid: string,
+    ): Promise<ApiListExternalConnectionLinkedAppsResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getService().listLinkedApps(
                 req.account,
                 projectUuid,
                 connectionUuid,

--- a/packages/backend/src/ee/models/ExternalConnectionModel.test.ts
+++ b/packages/backend/src/ee/models/ExternalConnectionModel.test.ts
@@ -378,6 +378,70 @@ describe('ExternalConnectionModel', () => {
         });
     });
 
+    describe('listLinkedApps', () => {
+        it('groups aliases by active app and distinguishes project chart types', async () => {
+            tracker.on.select(AppExternalConnectionsTableName).responseOnce([
+                {
+                    app_id: 'chart-type-1',
+                    name: 'Region map',
+                    slug: 'region-map',
+                    template: 'data_app_viz',
+                    space_uuid: null,
+                    space_name: null,
+                    alias: 'maps',
+                },
+                {
+                    app_id: APP_ID,
+                    name: 'Revenue dashboard',
+                    slug: 'revenue-dashboard',
+                    template: 'dashboard',
+                    space_uuid: 'space-1',
+                    space_name: 'Sales',
+                    alias: 'acme',
+                },
+                {
+                    app_id: APP_ID,
+                    name: 'Revenue dashboard',
+                    slug: 'revenue-dashboard',
+                    template: 'dashboard',
+                    space_uuid: 'space-1',
+                    space_name: 'Sales',
+                    alias: 'acme-v2',
+                },
+            ]);
+
+            await expect(
+                model.listLinkedApps(CONNECTION_UUID),
+            ).resolves.toEqual({
+                items: [
+                    {
+                        appUuid: APP_ID,
+                        name: 'Revenue dashboard',
+                        slug: 'revenue-dashboard',
+                        kind: 'data_app',
+                        spaceUuid: 'space-1',
+                        spaceName: 'Sales',
+                        aliases: ['acme', 'acme-v2'],
+                    },
+                    {
+                        appUuid: 'chart-type-1',
+                        name: 'Region map',
+                        slug: 'region-map',
+                        kind: 'project_chart_type',
+                        spaceUuid: null,
+                        spaceName: null,
+                        aliases: ['maps'],
+                    },
+                ],
+                total: 2,
+            });
+
+            const query = tracker.history.select[0];
+            expect(query.bindings).toContain(CONNECTION_UUID);
+            expect(query.sql).toContain('"apps"."deleted_at" is null');
+        });
+    });
+
     describe('update', () => {
         it('updates builder linking independently of the stored secret', async () => {
             tracker.on.select(ExternalConnectionsTableName).response([

--- a/packages/backend/src/ee/models/ExternalConnectionModel.ts
+++ b/packages/backend/src/ee/models/ExternalConnectionModel.ts
@@ -3,9 +3,11 @@ import {
     DATA_APP_VIZ_TEMPLATE,
     EXTERNAL_CONNECTION_DEFAULTS,
     generateSlug,
+    getAppDisplayName,
     NotFoundError,
     type CreateExternalConnection,
     type ExternalConnection,
+    type ExternalConnectionLinkedApps,
     type ExternalConnectionListItem,
     type ExternalConnectionSample,
     type ExternalConnectionSampleRequest,
@@ -13,7 +15,11 @@ import {
     type UpdateExternalConnection,
 } from '@lightdash/common';
 import { type Knex } from 'knex';
-import { AppsTableName } from '../../database/entities/apps';
+import {
+    AppsTableName,
+    type DbApp as DbDataApp,
+} from '../../database/entities/apps';
+import { SpaceTableName } from '../../database/entities/spaces';
 import { normalizeCredentialUrlOrigin } from '../../utils/credentialDestination';
 import { EncryptionUtil } from '../../utils/EncryptionUtil/EncryptionUtil';
 import {
@@ -423,6 +429,88 @@ export class ExternalConnectionModel {
             linkedDataAppCount: Number(row.linked_data_app_count),
             linkedChartTypeCount: Number(row.linked_chart_type_count),
         }));
+    }
+
+    async listLinkedApps(
+        externalConnectionUuid: string,
+    ): Promise<ExternalConnectionLinkedApps> {
+        const rows = await this.database(AppExternalConnectionsTableName)
+            .innerJoin(
+                AppsTableName,
+                `${AppsTableName}.app_id`,
+                `${AppExternalConnectionsTableName}.app_id`,
+            )
+            .leftJoin(SpaceTableName, function spaceJoin() {
+                void this.on(
+                    `${SpaceTableName}.space_uuid`,
+                    '=',
+                    `${AppsTableName}.space_uuid`,
+                ).andOnNull(`${SpaceTableName}.deleted_at`);
+            })
+            .where(
+                `${AppExternalConnectionsTableName}.external_connection_uuid`,
+                externalConnectionUuid,
+            )
+            .whereNull(`${AppsTableName}.deleted_at`)
+            .select<
+                Array<{
+                    app_id: string;
+                    name: string;
+                    slug: string;
+                    template: DbDataApp['template'];
+                    space_uuid: string | null;
+                    space_name: string | null;
+                    alias: string;
+                }>
+            >(
+                `${AppsTableName}.app_id`,
+                `${AppsTableName}.name`,
+                `${AppsTableName}.slug`,
+                `${AppsTableName}.template`,
+                `${AppsTableName}.space_uuid`,
+                `${SpaceTableName}.name as space_name`,
+                `${AppExternalConnectionsTableName}.alias`,
+            )
+            .orderBy(`${AppsTableName}.name`, 'asc')
+            .orderBy(`${AppExternalConnectionsTableName}.alias`, 'asc');
+
+        const linkedApps = new Map<
+            string,
+            ExternalConnectionLinkedApps['items'][number]
+        >();
+
+        rows.forEach((row) => {
+            const existing = linkedApps.get(row.app_id);
+            if (existing) {
+                existing.aliases.push(row.alias);
+                return;
+            }
+
+            linkedApps.set(row.app_id, {
+                appUuid: row.app_id,
+                name: row.name,
+                slug: row.slug,
+                kind:
+                    row.template === DATA_APP_VIZ_TEMPLATE
+                        ? 'project_chart_type'
+                        : 'data_app',
+                spaceUuid: row.space_uuid,
+                spaceName: row.space_name,
+                aliases: [row.alias],
+            });
+        });
+
+        const items = [...linkedApps.values()].sort((left, right) => {
+            if (left.kind !== right.kind) {
+                return left.kind === 'data_app' ? -1 : 1;
+            }
+
+            return getAppDisplayName(left.name, left.appUuid).localeCompare(
+                getAppDisplayName(right.name, right.appUuid),
+            );
+        });
+
+        return { items, total: items.length };
     }
 
     /**

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.test.ts
@@ -120,6 +120,7 @@ function buildService(opts: {
     findAppFn?: import('vitest').Mock;
     getCopilotConfigFn?: import('vitest').Mock;
     connections?: ExternalConnectionListItem[];
+    listLinkedAppsFn?: import('vitest').Mock;
 }) {
     const model = {
         findByUuid: vi
@@ -135,6 +136,9 @@ function buildService(opts: {
             upstreamProjectUuid: null,
         }),
         list: vi.fn().mockResolvedValue(opts.connections ?? [listedConnection]),
+        listLinkedApps:
+            opts.listLinkedAppsFn ??
+            vi.fn().mockResolvedValue({ items: [], total: 0 }),
         getDecryptedSecret: vi.fn().mockResolvedValue(opts.secret ?? 's3cr3t'),
         update:
             opts.updateFn ??
@@ -375,6 +379,48 @@ describe('ExternalConnectionService reads (view, not manage)', () => {
                 secret: null,
             }),
         ).rejects.toThrow(ForbiddenError);
+    });
+});
+
+describe('ExternalConnectionService linked app usage', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns linked apps to an external connection manager', async () => {
+        const linkedApps = {
+            items: [
+                {
+                    appUuid: 'app-1',
+                    name: 'Revenue dashboard',
+                    slug: 'revenue-dashboard',
+                    kind: 'data_app' as const,
+                    spaceUuid: null,
+                    spaceName: null,
+                    aliases: ['acme'],
+                },
+            ],
+            total: 1,
+        };
+        const listLinkedAppsFn = vi.fn().mockResolvedValue(linkedApps);
+        const { service } = buildService({ listLinkedAppsFn });
+        mockAbilityByActions(service, ['manage']);
+
+        await expect(
+            service.listLinkedApps(adminAccount, projectUuid, connectionUuid),
+        ).resolves.toEqual(linkedApps);
+        expect(listLinkedAppsFn).toHaveBeenCalledWith(connectionUuid);
+    });
+
+    it('does not expose linked app identities to a view-only builder', async () => {
+        const listLinkedAppsFn = vi.fn();
+        const { service } = buildService({ listLinkedAppsFn });
+        mockAbilityByActions(service, ['view']);
+
+        await expect(
+            service.listLinkedApps(viewerAccount, projectUuid, connectionUuid),
+        ).rejects.toThrow(ForbiddenError);
+        expect(listLinkedAppsFn).not.toHaveBeenCalled();
     });
 });
 

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
@@ -14,6 +14,7 @@ import {
     type CreateExternalConnection,
     type ExternalConnection,
     type ExternalConnectionConfigProposal,
+    type ExternalConnectionLinkedApps,
     type ExternalConnectionListItem,
     type ExternalConnectionMethod,
     type ExternalConnectionSample,
@@ -269,6 +270,15 @@ export class ExternalConnectionService extends BaseService {
         return connections.filter((connection) =>
             ability.can('view', getExternalConnectionSubject(connection)),
         );
+    }
+
+    async listLinkedApps(
+        account: RegisteredAccount,
+        projectUuid: string,
+        connectionUuid: string,
+    ): Promise<ExternalConnectionLinkedApps> {
+        await this.getOwnedConnection(account, projectUuid, connectionUuid);
+        return this.externalConnectionModel.listLinkedApps(connectionUuid);
     }
 
     private async loadConnection(

--- a/packages/common/src/ee/externalConnections/types.ts
+++ b/packages/common/src/ee/externalConnections/types.ts
@@ -93,6 +93,28 @@ export type ExternalConnectionListItem = ExternalConnection & {
     linkedChartTypeCount: number;
 };
 
+export type ExternalConnectionLinkedApp = {
+    appUuid: string;
+    name: string;
+    slug: string;
+    kind: 'data_app' | 'project_chart_type';
+    spaceUuid: string | null;
+    spaceName: string | null;
+    aliases: string[];
+};
+
+/** Kept as an object so pagination can be added later without changing the
+ *  endpoint's top-level response shape. */
+export type ExternalConnectionLinkedApps = {
+    items: ExternalConnectionLinkedApp[];
+    total: number;
+};
+
+export type ApiListExternalConnectionLinkedAppsResponse = {
+    status: 'ok';
+    results: ExternalConnectionLinkedApps;
+};
+
 /** WRITE shape — includes the secret. */
 export type CreateExternalConnection = {
     name: string;

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -95,6 +95,7 @@ import type {
     DecodedEmbed,
     EmbedUrl,
     ExternalConnection,
+    ExternalConnectionLinkedApps,
     ExternalConnectionSample,
     ExternalFetchResponse,
 } from '../ee';
@@ -1536,6 +1537,7 @@ type ApiResults =
     | DashboardPreAggregateAudit
     | ExternalConnection
     | ExternalConnection[]
+    | ExternalConnectionLinkedApps
     | ExternalConnectionSample
     | ExternalConnectionSample[]
     | AppExternalConnectionLink

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionUsageModal.module.css
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionUsageModal.module.css
@@ -1,0 +1,17 @@
+.resourceRow {
+    display: flex;
+    gap: var(--mantine-spacing-sm);
+    align-items: center;
+    padding: var(--mantine-spacing-sm);
+    border-radius: var(--mantine-radius-sm);
+    color: inherit;
+    text-decoration: none;
+
+    &:hover {
+        background-color: var(--mantine-color-ldGray-0);
+
+        @mixin dark {
+            background-color: var(--mantine-color-ldDark-3);
+        }
+    }
+}

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionUsageModal.test.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionUsageModal.test.tsx
@@ -1,0 +1,191 @@
+import {
+    type ExternalConnectionLinkedApps,
+    type ExternalConnectionListItem,
+} from '@lightdash/common';
+import { MantineProvider } from '@mantine/core';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { useState, type FC } from 'react';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ConnectionsTable } from './ConnectionsTable';
+import { ConnectionUsageModal } from './ConnectionUsageModal';
+
+const mocks = vi.hoisted(() => ({
+    data: { items: [], total: 0 } as ExternalConnectionLinkedApps,
+    refetch: vi.fn(),
+}));
+
+vi.mock(
+    '../../../features/externalConnections/hooks/useExternalConnectionLinkedApps',
+    () => ({
+        useExternalConnectionLinkedApps: () => ({
+            data: mocks.data,
+            isLoading: false,
+            isError: false,
+            refetch: mocks.refetch,
+        }),
+    }),
+);
+
+const connection: ExternalConnectionListItem = {
+    externalConnectionUuid: 'connection-uuid',
+    projectUuid: 'project-uuid',
+    organizationUuid: 'organization-uuid',
+    name: 'Example API',
+    slug: 'example-api',
+    type: 'none',
+    origin: 'https://api.example.com',
+    allowBrowserImages: false,
+    allowDataAppBuilderLinking: false,
+    instructions: null,
+    allowedPathPrefixes: ['/'],
+    allowedMethods: ['GET'],
+    allowedContentTypes: ['application/json'],
+    responseMaxBytes: 1_048_576,
+    requestMaxBytes: 262_144,
+    timeoutMs: 10_000,
+    rateLimitPerMinute: null,
+    apiKeyName: null,
+    apiKeyLocation: null,
+    oauthScopes: null,
+    customHeaders: null,
+    hasSecret: false,
+    createdByUserUuid: 'user-uuid',
+    updatedByUserUuid: 'user-uuid',
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-01T00:00:00Z'),
+    linkedDataAppCount: 0,
+    linkedChartTypeCount: 0,
+};
+
+const renderWithRouter = (component: React.ReactNode) =>
+    render(
+        <MemoryRouter>
+            <MantineProvider env="test">{component}</MantineProvider>
+        </MemoryRouter>,
+    );
+
+const UsageHarness: FC = () => {
+    const [selected, setSelected] = useState<
+        ExternalConnectionListItem | undefined
+    >();
+
+    return (
+        <>
+            <ConnectionsTable
+                connections={[connection]}
+                setConnectionToEdit={vi.fn()}
+                setConnectionToDelete={vi.fn()}
+                setConnectionToViewUsage={setSelected}
+            />
+            {selected && (
+                <ConnectionUsageModal
+                    opened
+                    onClose={() => setSelected(undefined)}
+                    projectUuid="project-uuid"
+                    connection={selected}
+                />
+            )}
+        </>
+    );
+};
+
+describe('external connection usage', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.data = { items: [], total: 0 };
+    });
+
+    it('opens the usage modal from a zero count', () => {
+        renderWithRouter(<UsageHarness />);
+
+        fireEvent.click(
+            screen.getByRole('button', {
+                name: 'View 0 data apps and 0 chart types linked to Example API',
+            }),
+        );
+
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+        expect(screen.getByText('Linked to “Example API”')).toBeInTheDocument();
+        expect(screen.getByText('No linked apps')).toBeInTheDocument();
+    });
+
+    it('keeps chart-type-only usage visible and clickable', () => {
+        const setConnectionToViewUsage = vi.fn();
+        renderWithRouter(
+            <ConnectionsTable
+                connections={[
+                    {
+                        ...connection,
+                        linkedChartTypeCount: 2,
+                    },
+                ]}
+                setConnectionToEdit={vi.fn()}
+                setConnectionToDelete={vi.fn()}
+                setConnectionToViewUsage={setConnectionToViewUsage}
+            />,
+        );
+
+        const linkedAppsButton = screen.getByRole('button', {
+            name: 'View 0 data apps and 2 chart types linked to Example API',
+        });
+        expect(linkedAppsButton).toHaveTextContent(
+            '0 data apps + 2 chart types',
+        );
+
+        fireEvent.click(linkedAppsButton);
+        expect(setConnectionToViewUsage).toHaveBeenCalledWith(
+            expect.objectContaining({
+                externalConnectionUuid: 'connection-uuid',
+            }),
+        );
+    });
+
+    it('groups data apps and chart types with their destination links', () => {
+        mocks.data = {
+            items: [
+                {
+                    appUuid: 'app-1',
+                    name: 'Revenue dashboard',
+                    slug: 'revenue-dashboard',
+                    kind: 'data_app',
+                    spaceUuid: 'space-1',
+                    spaceName: 'Sales',
+                    aliases: ['acme', 'acme-v2'],
+                },
+                {
+                    appUuid: 'chart-type-1',
+                    name: 'Region map',
+                    slug: 'region-map',
+                    kind: 'project_chart_type',
+                    spaceUuid: null,
+                    spaceName: null,
+                    aliases: ['maps'],
+                },
+            ],
+            total: 2,
+        };
+
+        renderWithRouter(
+            <ConnectionUsageModal
+                opened
+                onClose={vi.fn()}
+                projectUuid="project-uuid"
+                connection={connection}
+            />,
+        );
+
+        expect(screen.getByText('Data apps')).toBeInTheDocument();
+        expect(screen.getByText('Chart types')).toBeInTheDocument();
+        expect(
+            screen.getByRole('link', { name: /Revenue dashboard/ }),
+        ).toHaveAttribute('href', '/projects/project-uuid/apps/app-1');
+        expect(
+            screen.getByRole('link', { name: /Region map/ }),
+        ).toHaveAttribute(
+            'href',
+            '/projects/project-uuid/chart-types/chart-type-1',
+        );
+        expect(screen.queryByText(/Aliases?:/)).not.toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionUsageModal.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionUsageModal.tsx
@@ -1,0 +1,178 @@
+import {
+    getAppDisplayName,
+    type ExternalConnectionLinkedApp,
+    type ExternalConnectionListItem,
+} from '@lightdash/common';
+import {
+    Box,
+    Button,
+    Group,
+    Skeleton,
+    Stack,
+    Text,
+    ThemeIcon,
+    Title,
+} from '@mantine/core';
+import {
+    IconAppWindow,
+    IconFolder,
+    IconLink,
+    IconPuzzle,
+    IconUser,
+} from '@tabler/icons-react';
+import { type FC } from 'react';
+import { Link } from 'react-router';
+import { useExternalConnectionLinkedApps } from '../../../features/externalConnections/hooks/useExternalConnectionLinkedApps';
+import MantineIcon from '../../common/MantineIcon';
+import MantineModal from '../../common/MantineModal';
+import classes from './ConnectionUsageModal.module.css';
+
+type Props = {
+    opened: boolean;
+    onClose: () => void;
+    projectUuid: string;
+    connection: ExternalConnectionListItem;
+};
+
+const UsageRow: FC<{
+    projectUuid: string;
+    item: ExternalConnectionLinkedApp;
+}> = ({ projectUuid, item }) => {
+    const isDataApp = item.kind === 'data_app';
+    const path = isDataApp
+        ? `/projects/${projectUuid}/apps/${item.appUuid}`
+        : `/projects/${projectUuid}/chart-types/${item.appUuid}`;
+
+    return (
+        <Box
+            component={Link}
+            to={path}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={classes.resourceRow}
+        >
+            <ThemeIcon variant="light" size="lg" color="orange">
+                <MantineIcon icon={isDataApp ? IconAppWindow : IconPuzzle} />
+            </ThemeIcon>
+
+            <Stack gap={2} miw={0} flex={1}>
+                <Text fz="sm" fw={600} truncate>
+                    {getAppDisplayName(item.name, item.appUuid)}
+                </Text>
+                {isDataApp && (
+                    <Group gap={4} wrap="wrap">
+                        <MantineIcon
+                            icon={item.spaceName ? IconFolder : IconUser}
+                            size={14}
+                            color="ldGray.6"
+                        />
+                        <Text fz="xs" c="ldGray.6">
+                            {item.spaceName ?? 'Personal app'}
+                        </Text>
+                    </Group>
+                )}
+            </Stack>
+        </Box>
+    );
+};
+
+const UsageSection: FC<{
+    title: string;
+    items: ExternalConnectionLinkedApp[];
+    projectUuid: string;
+}> = ({ title, items, projectUuid }) => (
+    <Stack gap="xs">
+        <Group gap="xs">
+            <Title order={6}>{title}</Title>
+            <Text fz="xs" c="ldGray.6">
+                {items.length}
+            </Text>
+        </Group>
+        <Stack gap={0}>
+            {items.map((item) => (
+                <UsageRow
+                    key={item.appUuid}
+                    projectUuid={projectUuid}
+                    item={item}
+                />
+            ))}
+        </Stack>
+    </Stack>
+);
+
+export const ConnectionUsageModal: FC<Props> = ({
+    opened,
+    onClose,
+    projectUuid,
+    connection,
+}) => {
+    const { data, isLoading, isError, refetch } =
+        useExternalConnectionLinkedApps(
+            projectUuid,
+            opened ? connection.externalConnectionUuid : undefined,
+        );
+    const dataApps =
+        data?.items.filter((item) => item.kind === 'data_app') ?? [];
+    const chartTypes =
+        data?.items.filter((item) => item.kind === 'project_chart_type') ?? [];
+
+    return (
+        <MantineModal
+            opened={opened}
+            onClose={onClose}
+            title={`Linked to “${connection.name}”`}
+            subtitle={`Linked resources can send data to ${connection.origin}`}
+            icon={IconLink}
+            cancelLabel={false}
+            size="lg"
+        >
+            {isLoading ? (
+                <Stack gap="xs">
+                    <Skeleton height={64} />
+                    <Skeleton height={64} />
+                    <Skeleton height={64} />
+                </Stack>
+            ) : isError ? (
+                <Stack align="center" gap="sm" py="xl">
+                    <Text fz="sm" c="red">
+                        Could not load the apps using this connection.
+                    </Text>
+                    <Button
+                        size="xs"
+                        variant="default"
+                        onClick={() => void refetch()}
+                    >
+                        Try again
+                    </Button>
+                </Stack>
+            ) : (data?.total ?? 0) === 0 ? (
+                <Stack align="center" gap="xs" py="xl">
+                    <Text fz="sm" fw={600}>
+                        No linked apps
+                    </Text>
+                    <Text fz="sm" c="ldGray.6" ta="center">
+                        No data apps or chart types are linked to this
+                        connection yet.
+                    </Text>
+                </Stack>
+            ) : (
+                <Stack gap="lg">
+                    {dataApps.length > 0 && (
+                        <UsageSection
+                            title="Data apps"
+                            items={dataApps}
+                            projectUuid={projectUuid}
+                        />
+                    )}
+                    {chartTypes.length > 0 && (
+                        <UsageSection
+                            title="Chart types"
+                            items={chartTypes}
+                            projectUuid={projectUuid}
+                        />
+                    )}
+                </Stack>
+            )}
+        </MantineModal>
+    );
+};

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionsTable.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionsTable.tsx
@@ -3,8 +3,22 @@ import {
     type ExternalConnection,
     type ExternalConnectionListItem,
 } from '@lightdash/common';
-import { ActionIcon, Badge, Menu, Paper, Table, Text } from '@mantine/core';
-import { IconDots, IconPencil, IconTrash } from '@tabler/icons-react';
+import {
+    ActionIcon,
+    Badge,
+    Button,
+    Menu,
+    Paper,
+    Table,
+    Text,
+    Tooltip,
+} from '@mantine/core';
+import {
+    IconDots,
+    IconExternalLink,
+    IconPencil,
+    IconTrash,
+} from '@tabler/icons-react';
 import { type Dispatch, type FC, type SetStateAction } from 'react';
 import tableStyles from '../../../hooks/styles/tableStyles.module.css';
 import MantineIcon from '../../common/MantineIcon';
@@ -16,6 +30,9 @@ type Props = {
     >;
     setConnectionToDelete: Dispatch<
         SetStateAction<ExternalConnection | undefined>
+    >;
+    setConnectionToViewUsage: Dispatch<
+        SetStateAction<ExternalConnectionListItem | undefined>
     >;
 };
 
@@ -44,12 +61,26 @@ const accessLabel = (connection: ExternalConnection): string => {
     return methods || '—';
 };
 
+const linkedResourcesLabel = (connection: ExternalConnectionListItem): string =>
+    `${connection.linkedDataAppCount} data app${
+        connection.linkedDataAppCount === 1 ? '' : 's'
+    } and ${connection.linkedChartTypeCount} chart type${
+        connection.linkedChartTypeCount === 1 ? '' : 's'
+    }`;
+
 const ConnectionRow: FC<
     { connection: ExternalConnectionListItem } & Pick<
         Props,
-        'setConnectionToEdit' | 'setConnectionToDelete'
+        | 'setConnectionToEdit'
+        | 'setConnectionToDelete'
+        | 'setConnectionToViewUsage'
     >
-> = ({ connection, setConnectionToEdit, setConnectionToDelete }) => (
+> = ({
+    connection,
+    setConnectionToEdit,
+    setConnectionToDelete,
+    setConnectionToViewUsage,
+}) => (
     <Table.Tr>
         <Table.Td>
             <Text fw={600} fz="sm">
@@ -70,13 +101,34 @@ const ConnectionRow: FC<
             </Text>
         </Table.Td>
         <Table.Td>
-            <Text fz="sm" c="ldGray.6">
-                {connection.linkedDataAppCount}
-                {connection.linkedChartTypeCount > 0 &&
-                    ` (+${connection.linkedChartTypeCount} chart type${
-                        connection.linkedChartTypeCount !== 1 ? 's' : ''
-                    })`}
-            </Text>
+            <Tooltip
+                withinPortal
+                label={`${linkedResourcesLabel(
+                    connection,
+                )}. Click to view the full list.`}
+            >
+                <Button
+                    size="compact-xs"
+                    variant="subtle"
+                    c="ldGray.7"
+                    fw={500}
+                    px={0}
+                    onClick={() => setConnectionToViewUsage(connection)}
+                    rightSection={
+                        <MantineIcon icon={IconExternalLink} size={14} />
+                    }
+                    aria-label={`View ${linkedResourcesLabel(
+                        connection,
+                    )} linked to ${connection.name}`}
+                >
+                    {connection.linkedDataAppCount} data app
+                    {connection.linkedDataAppCount === 1 ? '' : 's'}
+                    {connection.linkedChartTypeCount > 0 &&
+                        ` + ${connection.linkedChartTypeCount} chart type${
+                            connection.linkedChartTypeCount === 1 ? '' : 's'
+                        }`}
+                </Button>
+            </Tooltip>
         </Table.Td>
         <Table.Td>
             <Badge
@@ -124,6 +176,7 @@ export const ConnectionsTable: FC<Props> = ({
     connections,
     setConnectionToEdit,
     setConnectionToDelete,
+    setConnectionToViewUsage,
 }) => {
     return (
         <Paper withBorder style={{ overflow: 'hidden' }}>
@@ -137,7 +190,7 @@ export const ConnectionsTable: FC<Props> = ({
                         <Table.Th>Origin</Table.Th>
                         <Table.Th>Auth</Table.Th>
                         <Table.Th>Access</Table.Th>
-                        <Table.Th>Linked apps</Table.Th>
+                        <Table.Th>Linked to</Table.Th>
                         <Table.Th>Builder linking</Table.Th>
                         <Table.Th></Table.Th>
                     </Table.Tr>
@@ -149,6 +202,7 @@ export const ConnectionsTable: FC<Props> = ({
                             connection={connection}
                             setConnectionToEdit={setConnectionToEdit}
                             setConnectionToDelete={setConnectionToDelete}
+                            setConnectionToViewUsage={setConnectionToViewUsage}
                         />
                     ))}
                 </Table.Tbody>

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/index.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/index.tsx
@@ -1,4 +1,7 @@
-import { type ExternalConnection } from '@lightdash/common';
+import {
+    type ExternalConnection,
+    type ExternalConnectionListItem,
+} from '@lightdash/common';
 import { Button, Skeleton, Stack } from '@mantine/core';
 import { IconPlug, IconPlus } from '@tabler/icons-react';
 import { useCallback, useState, type FC } from 'react';
@@ -11,6 +14,7 @@ import { SettingsEmptyState } from '../../common/Settings/SettingsEmptyState';
 import { SettingsPage } from '../../common/Settings/SettingsPage';
 import { AddConnectionWizard } from './AddConnectionWizard';
 import { ConnectionsTable } from './ConnectionsTable';
+import { ConnectionUsageModal } from './ConnectionUsageModal';
 import { DeleteConnectionModal } from './DeleteConnectionModal';
 import { EditConnectionModal } from './EditConnectionModal';
 
@@ -39,6 +43,9 @@ const DataAppConnectionsPanel: FC<Props> = ({ projectUuid }) => {
     >(undefined);
     const [connectionToDelete, setConnectionToDelete] = useState<
         ExternalConnection | undefined
+    >(undefined);
+    const [connectionToViewUsage, setConnectionToViewUsage] = useState<
+        ExternalConnectionListItem | undefined
     >(undefined);
     const addConnectionButton = (
         <Button
@@ -85,6 +92,9 @@ const DataAppConnectionsPanel: FC<Props> = ({ projectUuid }) => {
                                         setConnectionToDelete={
                                             setConnectionToDelete
                                         }
+                                        setConnectionToViewUsage={
+                                            setConnectionToViewUsage
+                                        }
                                     />
                                 )}
                             </Stack>
@@ -125,6 +135,15 @@ const DataAppConnectionsPanel: FC<Props> = ({ projectUuid }) => {
                     onClose={() => setConnectionToDelete(undefined)}
                     projectUuid={projectUuid}
                     connection={connectionToDelete}
+                />
+            )}
+
+            {connectionToViewUsage && (
+                <ConnectionUsageModal
+                    opened={!!connectionToViewUsage}
+                    onClose={() => setConnectionToViewUsage(undefined)}
+                    projectUuid={projectUuid}
+                    connection={connectionToViewUsage}
                 />
             )}
         </>

--- a/packages/frontend/src/features/externalConnections/hooks/useExternalConnectionLinkedApps.ts
+++ b/packages/frontend/src/features/externalConnections/hooks/useExternalConnectionLinkedApps.ts
@@ -1,0 +1,31 @@
+import {
+    type ApiError,
+    type ExternalConnectionLinkedApps,
+} from '@lightdash/common';
+import { useQuery } from '@tanstack/react-query';
+import { lightdashApi } from '../../../api';
+
+const getExternalConnectionLinkedApps = async (
+    projectUuid: string,
+    connectionUuid: string,
+) =>
+    lightdashApi<ExternalConnectionLinkedApps>({
+        url: `/ee/projects/${projectUuid}/external-connections/${connectionUuid}/linked-apps`,
+        method: 'GET',
+        body: undefined,
+    });
+
+export const useExternalConnectionLinkedApps = (
+    projectUuid: string | undefined,
+    connectionUuid: string | undefined,
+) =>
+    useQuery<ExternalConnectionLinkedApps, ApiError>({
+        queryKey: [
+            'external-connection-linked-apps',
+            projectUuid,
+            connectionUuid,
+        ],
+        queryFn: () =>
+            getExternalConnectionLinkedApps(projectUuid!, connectionUuid!),
+        enabled: !!projectUuid && !!connectionUuid,
+    });


### PR DESCRIPTION
Closes: [GLITCH-705](https://linear.app/lightdash/issue/GLITCH-705/show-admins-which-apps-use-which-external-connections)

### Description:

```diff
 External connections -> Linked to
- show aggregate usage counts only
+ open a linked-resources modal from every count, including 0
```

- Lists linked data apps and chart types on demand, grouped by resource with direct links to each editor.
- Uses the native Browse-menu resource icons, orange resource styling, and theme-aware hover states.
- Keeps linked-resource identities admin-only: the backend verifies project ownership and manage permission, and returns no connection secrets.
- Groups multiple aliases for the same resource and keeps the response shape ready for future pagination and unlinking.

### Validation:

- Backend model/service tests: 91 passed.
- Frontend usage-modal tests: 3 passed, including clickable zero and chart-type-only counts.
- Common, backend, and frontend typechecks passed.
- Targeted oxfmt, oxlint, and `git diff --check` passed.
- Live browser validation on localhost covered empty and populated usage, data-app and chart-type links, light/dark hover states, icons, and column alignment.
- No test data was persisted.
- Full monorepo test suites were not run.

### Risk assessment:

- [ ] This is a high-risk change

Low risk. This adds a read-only, lazy-loaded admin view and does not mutate links or connection configuration. Authorization reuses the existing external-connection manage boundary and validates that the connection belongs to the requested project.
