### PR TITLE
fix(content-as-code): adopt the open pull request already on a write-back branch

### DIFF
--- a/packages/backend/src/clients/github/Github.ts
+++ b/packages/backend/src/clients/github/Github.ts
@@ -1195,6 +1195,39 @@ export const getPullRequest = async ({
     }
 };
 
+export const findOpenPullRequestByHead = async ({
+    owner,
+    repo,
+    head,
+    installationId,
+    token,
+}: {
+    owner: string;
+    repo: string;
+    head: string;
+    installationId?: string;
+    token?: string;
+}): Promise<{ number: number; url: string } | null> => {
+    const { octokit, headers } = getOctokit(installationId, token);
+
+    try {
+        const response = await octokit.rest.pulls.list({
+            owner,
+            repo,
+            state: 'open',
+            head: `${owner}:${head}`,
+            per_page: 1,
+            headers,
+        });
+        const pullRequest = response.data[0];
+        return pullRequest
+            ? { number: pullRequest.number, url: pullRequest.html_url }
+            : null;
+    } catch (e) {
+        throw new UnexpectedGitError(getErrorMessage(e));
+    }
+};
+
 export const mergePullRequest = async ({
     owner,
     repo,

--- a/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.test.ts
+++ b/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.test.ts
@@ -36,6 +36,9 @@ type Overrides = {
     draft?: object | undefined;
     createError?: Error;
     openDraftCount?: number;
+    branchExists?: boolean;
+    providerPullRequest?: { prNumber: number; prUrl: string } | null;
+    pullRequestCreateError?: Error;
 };
 
 const buildService = (overrides: Overrides = {}) => {
@@ -47,16 +50,23 @@ const buildService = (overrides: Overrides = {}) => {
             path: '/',
             type: DbtProjectType.GITHUB,
         }),
-        createBranchFromSource: vi.fn().mockResolvedValue({}),
+        createBranchFromSource: overrides.branchExists
+            ? vi.fn().mockRejectedValue(new Error('Reference already exists'))
+            : vi.fn().mockResolvedValue({}),
+        findOpenPullRequestForBranch: vi
+            .fn()
+            .mockResolvedValue(overrides.providerPullRequest ?? null),
         saveFile: vi.fn().mockResolvedValue({ sha: 'new-sha', path: 'p' }),
         getFileOrDirectory:
             overrides.existingFile === 'missing' || !overrides.existingFile
                 ? vi.fn().mockRejectedValue(new Error('Not found'))
                 : vi.fn().mockResolvedValue(overrides.existingFile),
-        createPullRequestFromBranch: vi.fn().mockResolvedValue({
-            prTitle: 'Update chart',
-            prUrl: 'https://github.com/acme/analytics/pull/42',
-        }),
+        createPullRequestFromBranch: overrides.pullRequestCreateError
+            ? vi.fn().mockRejectedValue(overrides.pullRequestCreateError)
+            : vi.fn().mockResolvedValue({
+                  prTitle: 'Update chart',
+                  prUrl: 'https://github.com/acme/analytics/pull/42',
+              }),
         recordPullRequest: vi.fn().mockResolvedValue(undefined),
     };
     const coderService = {
@@ -368,6 +378,98 @@ describe('ContentAsCodeWritebackService', () => {
             gitIntegrationService.createPullRequestFromBranch.mock.calls[0][5];
         expect(prSource).toBe(PullRequestSource.CONTENT_AS_CODE);
         expect(gitIntegrationService.recordPullRequest).not.toHaveBeenCalled();
+    });
+
+    it('adopts the open PR found on the provider when the branch already exists', async () => {
+        const { service, gitIntegrationService, contentAsCodeWritebackModel } =
+            buildService({
+                branchExists: true,
+                providerPullRequest: {
+                    prNumber: 7,
+                    prUrl: 'https://github.com/acme/analytics/pull/7',
+                },
+            });
+
+        await service.propose(user, 'project-uuid', 'chart', 'monthly-revenue');
+
+        expect(
+            gitIntegrationService.findOpenPullRequestForBranch,
+        ).toHaveBeenCalledWith(
+            user,
+            'project-uuid',
+            'lightdash/write-back/app.lightdash.dev/monthly-revenue',
+        );
+        expect(gitIntegrationService.saveFile).toHaveBeenCalledTimes(1);
+        expect(
+            gitIntegrationService.createPullRequestFromBranch,
+        ).not.toHaveBeenCalled();
+        expect(contentAsCodeWritebackModel.update).toHaveBeenCalledWith(
+            'row-uuid',
+            {
+                prNumber: 7,
+                prUrl: 'https://github.com/acme/analytics/pull/7',
+                status: 'open',
+            },
+        );
+    });
+
+    it('opens a new PR when the existing branch has no open PR', async () => {
+        const { service, gitIntegrationService, contentAsCodeWritebackModel } =
+            buildService({ branchExists: true, providerPullRequest: null });
+
+        await service.propose(user, 'project-uuid', 'chart', 'monthly-revenue');
+
+        expect(
+            gitIntegrationService.createPullRequestFromBranch,
+        ).toHaveBeenCalledTimes(1);
+        expect(contentAsCodeWritebackModel.update).toHaveBeenCalledWith(
+            'row-uuid',
+            expect.objectContaining({ prNumber: 42, status: 'open' }),
+        );
+    });
+
+    it('adopts the provider PR when creating one is refused as a duplicate', async () => {
+        const { service, gitIntegrationService, contentAsCodeWritebackModel } =
+            buildService({
+                pullRequestCreateError: new Error(
+                    'Validation Failed: A pull request already exists for acme:lightdash/write-back/app.lightdash.dev/monthly-revenue.',
+                ),
+            });
+        gitIntegrationService.findOpenPullRequestForBranch.mockResolvedValue({
+            prNumber: 9,
+            prUrl: 'https://github.com/acme/analytics/pull/9',
+        });
+
+        await service.propose(user, 'project-uuid', 'chart', 'monthly-revenue');
+
+        expect(contentAsCodeWritebackModel.update).toHaveBeenCalledWith(
+            'row-uuid',
+            {
+                prNumber: 9,
+                prUrl: 'https://github.com/acme/analytics/pull/9',
+                status: 'open',
+            },
+        );
+        expect(contentAsCodeWritebackModel.update).not.toHaveBeenCalledWith(
+            'row-uuid',
+            expect.objectContaining({ status: 'error' }),
+        );
+    });
+
+    it('marks the row as error when a duplicate PR cannot be found anywhere', async () => {
+        const { service, contentAsCodeWritebackModel } = buildService({
+            pullRequestCreateError: new Error(
+                'Validation Failed: A pull request already exists for acme:lightdash/write-back/app.lightdash.dev/monthly-revenue.',
+            ),
+        });
+
+        await expect(
+            service.propose(user, 'project-uuid', 'chart', 'monthly-revenue'),
+        ).rejects.toThrow('pull request already exists');
+        expect(contentAsCodeWritebackModel.update).toHaveBeenCalledWith(
+            'row-uuid',
+            expect.objectContaining({ status: 'error' }),
+        );
     });
 
     it('writes dashboard-owned charts with portable chart type bindings', async () => {

--- a/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.ts
+++ b/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.ts
@@ -608,6 +608,7 @@ export class ContentAsCodeWritebackService extends BaseService {
         const repo =
             await this.gitIntegrationService.getProjectRepo(projectUuid);
 
+        let current = row;
         try {
             await this.gitIntegrationService.createBranchFromSource(
                 user,
@@ -621,6 +622,14 @@ export class ContentAsCodeWritebackService extends BaseService {
             // one PR per slug: later saves append commits to it.
             if (!/already exists|Reference already exists/i.test(message)) {
                 throw error;
+            }
+            if (current.prUrl === null) {
+                current =
+                    (await this.adoptOpenPullRequest(
+                        user,
+                        projectUuid,
+                        current,
+                    )) ?? current;
             }
         }
 
@@ -680,10 +689,9 @@ export class ContentAsCodeWritebackService extends BaseService {
             this.logger.debug(
                 `Content-as-code write-back for ${slug}: branch already has this content`,
             );
-            if (row.prUrl !== null && row.status === 'open') return;
         }
 
-        if (row.prUrl !== null && row.status === 'open') {
+        if (current.prUrl !== null && current.status === 'open') {
             return;
         }
 
@@ -716,8 +724,14 @@ export class ContentAsCodeWritebackService extends BaseService {
             if (!/pull request already exists/i.test(message)) {
                 throw error;
             }
-            // The branch already has an open PR from a row we lost to an
-            // earlier error: adopt it instead of failing forever
+            // The branch already has an open PR we do not track (another
+            // instance, or a row lost to an earlier error): adopt it
+            const adopted = await this.adoptOpenPullRequest(
+                user,
+                projectUuid,
+                current,
+            );
+            if (adopted !== null) return;
             const previous =
                 await this.contentAsCodeWritebackModel.findLatestForBranch(
                     projectUuid,
@@ -740,6 +754,38 @@ export class ContentAsCodeWritebackService extends BaseService {
             prUrl: pullRequest.prUrl,
             status: 'open',
         });
+    }
+
+    private async adoptOpenPullRequest(
+        user: SessionUser,
+        projectUuid: string,
+        row: ContentAsCodeWriteback,
+    ): Promise<ContentAsCodeWriteback | null> {
+        let found: { prNumber: number; prUrl: string } | null;
+        try {
+            found =
+                await this.gitIntegrationService.findOpenPullRequestForBranch(
+                    user,
+                    projectUuid,
+                    row.branch,
+                );
+        } catch (error) {
+            this.logger.warn(
+                `Could not look up an open PR for branch ${row.branch} on project ${projectUuid}`,
+                error,
+            );
+            return null;
+        }
+        if (found === null) return null;
+        await this.contentAsCodeWritebackModel.update(row.uuid, {
+            prNumber: found.prNumber,
+            prUrl: found.prUrl,
+            status: 'open',
+        });
+        this.logger.info(
+            `Content-as-code write-back for ${row.slug} adopted open PR #${found.prNumber} on branch ${row.branch}`,
+        );
+        return { ...row, ...found, status: 'open' };
     }
 
     private async collectDashboardOwnedCharts(

--- a/packages/backend/src/services/GitIntegrationService/GitIntegrationService.test.ts
+++ b/packages/backend/src/services/GitIntegrationService/GitIntegrationService.test.ts
@@ -7,6 +7,7 @@ import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
 import {
     createBranch,
     createPullRequest,
+    findOpenPullRequestByHead,
     getFileContent,
     getLastCommit,
     updateFile,
@@ -44,6 +45,7 @@ vi.mock('../../clients/github/Github.ts', () => ({
         title: 'Adds custom metric',
         number: 1,
     }),
+    findOpenPullRequestByHead: vi.fn().mockResolvedValue(null),
     getOrRefreshToken: vi.fn().mockImplementation((token, refreshToken) => ({
         token,
         refreshToken,
@@ -121,6 +123,41 @@ describe('GitIntegrationService', () => {
             expect(updateFile.mock.calls[0][0].content).toEqual(
                 EXPECTED_SCHEMA_YML_WITH_CUSTOM_DIMENSION,
             );
+        });
+    });
+
+    describe('findOpenPullRequestForBranch', () => {
+        it('returns the open PR the provider has for the branch', async () => {
+            vi.mocked(findOpenPullRequestByHead).mockResolvedValueOnce({
+                number: 12,
+                url: 'https://example.com/pull/12',
+            });
+
+            await expect(
+                service.findOpenPullRequestForBranch(
+                    { ...user, organizationUuid: 'organizationUuid' },
+                    'projectUuid',
+                    'lightdash/write-back/host/slug',
+                ),
+            ).resolves.toEqual({
+                prNumber: 12,
+                prUrl: 'https://example.com/pull/12',
+            });
+            expect(findOpenPullRequestByHead).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    head: 'lightdash/write-back/host/slug',
+                }),
+            );
+        });
+
+        it('returns null when the branch has no open PR', async () => {
+            await expect(
+                service.findOpenPullRequestForBranch(
+                    { ...user, organizationUuid: 'organizationUuid' },
+                    'projectUuid',
+                    'lightdash/write-back/host/slug',
+                ),
+            ).resolves.toBeNull();
         });
     });
 

--- a/packages/backend/src/services/GitIntegrationService/GitIntegrationService.ts
+++ b/packages/backend/src/services/GitIntegrationService/GitIntegrationService.ts
@@ -1821,4 +1821,27 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
             prUrl: pullRequest.html_url,
         };
     }
+
+    // Provider-side lookup so a branch whose PR was opened by another
+    // instance (or before a database reset) can be adopted. GitHub only.
+    async findOpenPullRequestForBranch(
+        user: SessionUser,
+        projectUuid: string,
+        branch: string,
+    ): Promise<{ prNumber: number; prUrl: string } | null> {
+        const creds = await this.getGitCredentials(user, projectUuid, {
+            preferUserToken: true,
+        });
+        if (creds.type !== DbtProjectType.GITHUB) return null;
+        const pullRequest = await GithubClient.findOpenPullRequestByHead({
+            owner: creds.owner,
+            repo: creds.repo,
+            head: branch,
+            installationId: creds.installationId,
+            token: creds.token,
+        });
+        return pullRequest
+            ? { prNumber: pullRequest.number, prUrl: pullRequest.url }
+            : null;
+    }
 }


### PR DESCRIPTION
## Summary

Proposing (or writing back a draft for) a slug whose `lightdash/write-back/<host>/<slug>` branch already carried an open PR that this instance did not know about failed for good: `createBranchFromSource` swallowed "already exists", the commit was pushed onto the stale branch, `createPullRequestFromBranch` was refused by GitHub with "A pull request already exists", and the adopt path only consulted this instance's own `content_as_code_writebacks` rows, so the writeback row was left in `error` on every retry.

That happens whenever a hostname is reused: a database reset or restore, a staging clone, two self-hosted instances behind one `SITE_URL`.

Fix: look the open PR up on the git provider by head branch and adopt it.

- `GithubClient.findOpenPullRequestByHead` (`pulls.list`, `state: open`, `head: owner:branch`).
- `GitIntegrationService.findOpenPullRequestForBranch` (GitHub only; GitLab returns `null` and keeps today's behaviour).
- `ContentAsCodeWritebackService.pushContentToBranch` adopts before committing when the branch already exists and the row has no PR, and again from the duplicate-PR error path; the old own-table lookup stays as the last fallback.

## Behaviour change

Before: 400 from the provider, row `status: error`, commit already on the stale branch.
After: 200, row `status: open` pointing at the existing PR, the commit lands on that PR. The adopted PR keeps whatever commits the other instance pushed, which is what a reviewer sees on GitHub anyway.

No effect on the normal path (fresh branch, no PR): a new PR is still opened.

## Test plan

- [x] `ContentAsCodeWritebackService.test.ts`: adopts on existing branch, opens a new PR when the branch has no open PR, adopts from the duplicate error, still errors when nothing can be found (28 tests).
- [x] `GitIntegrationService.test.ts`: provider lookup returns the PR / null.
- [x] Live on a GitHub-backed dev project: `propose` on a slug whose branch had a stale open PR from a previous instance returned 200 and adopted that PR (evidence in the run report, section E3).
- [x] `pnpm -F backend typecheck`, oxlint, oxfmt.

Closes: PROD-10807
Relates: PROD-2856

Run report: https://claude.ai/code/artifact/67b75be8-af82-4e4e-bf9f-c26e0a2f0f05