### PR TITLE
fix(content-as-code): credit the draft author in write-back commits and PRs

### DIFF
--- a/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.test.ts
+++ b/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.test.ts
@@ -162,6 +162,14 @@ const buildService = (overrides: Overrides = {}) => {
         findOpenDraft: vi.fn().mockResolvedValue(undefined),
         update: vi.fn(),
     };
+    const userModel = {
+        getUserDetailsByUuid: vi.fn().mockResolvedValue({
+            userUuid: 'author-uuid',
+            firstName: 'Draft',
+            lastName: 'Author',
+            email: 'author@lightdash.com',
+        }),
+    };
     const service = new ContentAsCodeWritebackService({
         lightdashConfig: { siteUrl: 'https://app.lightdash.dev' } as never,
         projectModel: {
@@ -180,6 +188,7 @@ const buildService = (overrides: Overrides = {}) => {
         contentAsCodeSnapshotModel: contentAsCodeSnapshotModel as never,
         contentAsCodeWritebackModel: contentAsCodeWritebackModel as never,
         contentDraftModel: contentDraftModel as never,
+        userModel: userModel as never,
     });
     return {
         service,
@@ -187,6 +196,7 @@ const buildService = (overrides: Overrides = {}) => {
         coderService,
         contentAsCodeWritebackModel,
         contentDraftModel,
+        userModel,
     };
 };
 
@@ -378,6 +388,40 @@ describe('ContentAsCodeWritebackService', () => {
             gitIntegrationService.createPullRequestFromBranch.mock.calls[0][5];
         expect(prSource).toBe(PullRequestSource.CONTENT_AS_CODE);
         expect(gitIntegrationService.recordPullRequest).not.toHaveBeenCalled();
+    });
+
+    it('credits the draft author on the commit and in the PR body', async () => {
+        const { service, gitIntegrationService, userModel } = buildService();
+
+        await service.writeBackDraft(user, 'project-uuid', 'draft-uuid');
+
+        expect(userModel.getUserDetailsByUuid).toHaveBeenCalledWith(
+            'author-uuid',
+        );
+        const message = gitIntegrationService.saveFile.mock.calls[0][6];
+        expect(message).toContain(
+            'Co-authored-by: Draft Author <author@lightdash.com>',
+        );
+        expect(message).not.toContain('demo@lightdash.com');
+        const prBody =
+            gitIntegrationService.createPullRequestFromBranch.mock.calls[0][4];
+        expect(prBody).toContain(
+            'Change by: Draft Author (author@lightdash.com)',
+        );
+    });
+
+    it('credits the reviewer when the draft author cannot be resolved', async () => {
+        const { service, gitIntegrationService, userModel } = buildService();
+        userModel.getUserDetailsByUuid.mockRejectedValueOnce(
+            new Error('user gone'),
+        );
+
+        await service.writeBackDraft(user, 'project-uuid', 'draft-uuid');
+
+        const message = gitIntegrationService.saveFile.mock.calls[0][6];
+        expect(message).toContain(
+            'Co-authored-by: Demo User <demo@lightdash.com>',
+        );
     });
 
     it('adopts the open PR found on the provider when the branch already exists', async () => {

--- a/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.ts
+++ b/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.ts
@@ -26,6 +26,7 @@ import {
     type ContentDraft,
 } from '../../models/ContentDraftModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
+import { UserModel } from '../../models/UserModel';
 import { BaseService } from '../BaseService';
 import { CoderService } from '../CoderService/CoderService';
 import { GitIntegrationService } from '../GitIntegrationService/GitIntegrationService';
@@ -39,9 +40,23 @@ type ContentAsCodeWritebackServiceArguments = {
     contentAsCodeSnapshotModel: ContentAsCodeSnapshotModel;
     contentAsCodeWritebackModel: ContentAsCodeWritebackModel;
     contentDraftModel: ContentDraftModel;
+    userModel: UserModel;
 };
 
 type WritebackContentType = 'chart' | 'dashboard';
+
+type CommitAuthor = { name: string; email: string | null };
+
+const commitAuthorFromUser = (user: {
+    firstName?: string;
+    lastName?: string;
+    email?: string;
+}): CommitAuthor => ({
+    name:
+        [user.firstName, user.lastName].filter(Boolean).join(' ') ||
+        'Lightdash user',
+    email: user.email ?? null,
+});
 
 // Matches the CLI's writeContent (packages/cli/src/handlers/download.ts):
 // updatedAt/downloadedAt are transport metadata and verification is runtime
@@ -57,11 +72,11 @@ const parsePullRequestNumber = (prUrl: string): number | null => {
 };
 
 // Fleet template repos receive commits from many people on many instances:
-// every commit names both. Co-authored-by makes the acting user visible on
-// the commit itself even though the GitHub App is the committer.
+// every commit names both. Co-authored-by credits the person who made the
+// change (the draft author, or the acting user when proposing directly).
 const buildCommitMessage = (
     slug: string | undefined,
-    user: SessionUser,
+    author: CommitAuthor,
     projectUrl: string,
 ): string => {
     const lines = [
@@ -69,15 +84,14 @@ const buildCommitMessage = (
         '',
         `Project: ${projectUrl}`,
     ];
-    const fullName = [user.firstName, user.lastName].filter(Boolean).join(' ');
-    if (user.email) {
-        lines.push(
-            '',
-            `Co-authored-by: ${fullName || 'Lightdash user'} <${user.email}>`,
-        );
+    if (author.email) {
+        lines.push('', `Co-authored-by: ${author.name} <${author.email}>`);
     }
     return lines.join('\n');
 };
+
+const describeAuthor = (author: CommitAuthor): string =>
+    author.email ? `${author.name} (${author.email})` : author.name;
 
 export class ContentAsCodeWritebackService extends BaseService {
     private readonly lightdashConfig: LightdashConfig;
@@ -96,6 +110,8 @@ export class ContentAsCodeWritebackService extends BaseService {
 
     private readonly contentDraftModel: ContentDraftModel;
 
+    private readonly userModel: UserModel;
+
     constructor(args: ContentAsCodeWritebackServiceArguments) {
         super();
         this.lightdashConfig = args.lightdashConfig;
@@ -107,6 +123,7 @@ export class ContentAsCodeWritebackService extends BaseService {
         this.contentAsCodeSnapshotModel = args.contentAsCodeSnapshotModel;
         this.contentAsCodeWritebackModel = args.contentAsCodeWritebackModel;
         this.contentDraftModel = args.contentDraftModel;
+        this.userModel = args.userModel;
     }
 
     // Identifies this instance in branch names so two instances editing the
@@ -176,6 +193,7 @@ export class ContentAsCodeWritebackService extends BaseService {
             contentUuid,
             slug,
             contentDraftUuid: null,
+            author: commitAuthorFromUser(user),
         });
     }
 
@@ -370,6 +388,7 @@ export class ContentAsCodeWritebackService extends BaseService {
             slug: draft.slug,
             contentDraftUuid: draft.uuid,
             documentOverride: draftDoc,
+            author: await this.resolveDraftAuthor(draft, user),
         });
         await this.contentDraftModel.update(draft.uuid, {
             status: 'written_back',
@@ -492,6 +511,7 @@ export class ContentAsCodeWritebackService extends BaseService {
             slug: string;
             contentDraftUuid: string | null;
             documentOverride?: ChartAsCode | DashboardAsCode;
+            author: CommitAuthor;
         },
     ): Promise<ContentAsCodeWriteback> {
         const { projectUuid, contentType, slug } = target;
@@ -601,6 +621,7 @@ export class ContentAsCodeWritebackService extends BaseService {
             slug: string;
             contentDraftUuid: string | null;
             documentOverride?: ChartAsCode | DashboardAsCode;
+            author: CommitAuthor;
         },
         row: ContentAsCodeWriteback,
     ): Promise<void> {
@@ -682,6 +703,7 @@ export class ContentAsCodeWritebackService extends BaseService {
                 projectUuid,
                 row.branch,
                 file,
+                target.author,
             );
             if (didCommit) committed += 1;
         }
@@ -715,6 +737,7 @@ export class ContentAsCodeWritebackService extends BaseService {
                         ``,
                         `- Instance: ${this.lightdashConfig.siteUrl}`,
                         `- Content: ${contentUrl}`,
+                        `- Change by: ${describeAuthor(target.author)}`,
                         ...(notes.length > 0 ? ['', ...notes] : []),
                     ].join('\n'),
                     PullRequestSource.CONTENT_AS_CODE,
@@ -754,6 +777,26 @@ export class ContentAsCodeWritebackService extends BaseService {
             prUrl: pullRequest.prUrl,
             status: 'open',
         });
+    }
+
+    // The reviewer pushes the commit, but the credit belongs to whoever made
+    // the change; fall back to the reviewer if the author cannot be resolved.
+    private async resolveDraftAuthor(
+        draft: ContentDraft,
+        actingUser: SessionUser,
+    ): Promise<CommitAuthor> {
+        try {
+            const author = await this.userModel.getUserDetailsByUuid(
+                draft.authorUserUuid,
+            );
+            return commitAuthorFromUser(author);
+        } catch (error) {
+            this.logger.warn(
+                `Could not resolve the author of draft ${draft.uuid}; crediting the reviewer instead`,
+                error,
+            );
+            return commitAuthorFromUser(actingUser);
+        }
     }
 
     private async adoptOpenPullRequest(
@@ -873,6 +916,7 @@ export class ContentAsCodeWritebackService extends BaseService {
         projectUuid: string,
         branch: string,
         file: { path: string; content: string },
+        author: CommitAuthor,
     ): Promise<boolean> {
         let existingSha: string | undefined;
         try {
@@ -906,7 +950,7 @@ export class ContentAsCodeWritebackService extends BaseService {
                 existingSha,
                 buildCommitMessage(
                     slug,
-                    user,
+                    author,
                     new URL(
                         `/projects/${projectUuid}`,
                         this.lightdashConfig.siteUrl,
@@ -938,7 +982,7 @@ export class ContentAsCodeWritebackService extends BaseService {
                 fresh.type === 'file' ? fresh.sha : undefined,
                 buildCommitMessage(
                     slug,
-                    user,
+                    author,
                     new URL(
                         `/projects/${projectUuid}`,
                         this.lightdashConfig.siteUrl,

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -1340,6 +1340,7 @@ export class ServiceRepository
                     contentAsCodeWritebackModel:
                         this.models.getContentAsCodeWritebackModel(),
                     contentDraftModel: this.models.getContentDraftModel(),
+                    userModel: this.models.getUserModel(),
                 }),
         );
     }


### PR DESCRIPTION
## Summary

Write-back commits and PRs credited the reviewer who pressed "Write back to repo", not the editor who made the change: `Co-authored-by` and the PR body both named the acting user.

Now the draft author is resolved from `content_drafts.author_user_uuid` and used for the commit trailer and a `Change by:` line in the PR body. `Triggered by` (appended by `createPullRequestFromBranch`) keeps naming the reviewer, so both people are visible. `propose` has no draft, so the acting user stays the co-author there. If the author cannot be resolved (deleted user), the reviewer is credited and a warning is logged.

`ContentAsCodeWritebackService` gains a `userModel` dependency (wired in `ServiceRepository`).

## Test plan

- [x] `ContentAsCodeWritebackService.test.ts`: author credited on commit and PR body; reviewer credited when the author cannot be resolved (30 tests).
- [x] Live: a draft by `demo2@` written back by `demo@` produced `Co-authored-by: Editor User <demo2@lightdash.com>` and `- Change by: Editor User (demo2@lightdash.com)` on the PR.
- [x] `pnpm -F backend typecheck`, oxlint, oxfmt.

Closes: PROD-10808
Relates: PROD-2856