### PR TITLE
fix(content-as-code): hand a draft back to its author when its PR is closed unmerged

### DIFF
--- a/packages/backend/src/controllers/ProjectCoderController.ts
+++ b/packages/backend/src/controllers/ProjectCoderController.ts
@@ -271,12 +271,15 @@ export class ProjectCoderController extends BaseController {
     async listContentDrafts(
         @Path() projectUuid: string,
         @Request() req: express.Request,
+        @Query() refresh?: boolean,
     ): Promise<ApiContentDraftsResponse> {
         assertRegisteredAccount(req.account);
         this.setStatus(200);
         const drafts = await this.services
             .getContentAsCodeWritebackService()
-            .listDrafts(toSessionUser(req.account), projectUuid);
+            .listDrafts(toSessionUser(req.account), projectUuid, {
+                refresh,
+            });
         return codeSuccess(drafts.map(toDraftSummary));
     }
 

--- a/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.test.ts
+++ b/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.test.ts
@@ -8,7 +8,12 @@ import {
     type SessionUser,
 } from '@lightdash/common';
 import { describe, expect, it, vi } from 'vitest';
+import { getPullRequest } from '../../clients/github/Github';
 import { ContentAsCodeWritebackService } from './ContentAsCodeWritebackService';
+
+vi.mock('../../clients/github/Github', () => ({
+    getPullRequest: vi.fn(),
+}));
 
 const user = {
     userUuid: 'user-uuid',
@@ -39,6 +44,7 @@ type Overrides = {
     branchExists?: boolean;
     providerPullRequest?: { prNumber: number; prUrl: string } | null;
     pullRequestCreateError?: Error;
+    writebackRows?: object[];
 };
 
 const buildService = (overrides: Overrides = {}) => {
@@ -68,6 +74,12 @@ const buildService = (overrides: Overrides = {}) => {
                   prUrl: 'https://github.com/acme/analytics/pull/42',
               }),
         recordPullRequest: vi.fn().mockResolvedValue(undefined),
+        getGitCredentials: vi.fn().mockResolvedValue({
+            owner: 'acme',
+            repo: 'analytics',
+            token: 'token',
+            type: DbtProjectType.GITHUB,
+        }),
     };
     const coderService = {
         getPortableChartAsCode: vi.fn().mockResolvedValue(chartAsCode),
@@ -127,6 +139,7 @@ const buildService = (overrides: Overrides = {}) => {
                       'liveRow' in overrides ? overrides.liveRow : undefined,
         ),
         findLatestForBranch: vi.fn().mockResolvedValue(undefined),
+        listByProject: vi.fn().mockResolvedValue(overrides.writebackRows ?? []),
         create: vi.fn().mockImplementation(async (args) => {
             if (overrides.createError) throw overrides.createError;
             return {
@@ -388,6 +401,100 @@ describe('ContentAsCodeWritebackService', () => {
             gitIntegrationService.createPullRequestFromBranch.mock.calls[0][5];
         expect(prSource).toBe(PullRequestSource.CONTENT_AS_CODE);
         expect(gitIntegrationService.recordPullRequest).not.toHaveBeenCalled();
+    });
+
+    it('hands a draft back as dismissed when its PR is closed without merging', async () => {
+        const openRow = {
+            uuid: 'row-uuid',
+            contentType: 'dashboard',
+            slug: 'weekly-kpis',
+            contentDraftUuid: 'draft-uuid',
+            branch: 'lightdash/write-back/app.lightdash.dev/weekly-kpis/draft-draft-uuid',
+            prNumber: 5,
+            prUrl: 'https://github.com/acme/analytics/pull/5',
+            status: 'open',
+        };
+        const { service, contentAsCodeWritebackModel, contentDraftModel } =
+            buildService({
+                writebackRows: [openRow],
+                draft: {
+                    ...dismissedDraft,
+                    status: 'written_back',
+                    prUrl: openRow.prUrl,
+                },
+            });
+        vi.mocked(getPullRequest).mockResolvedValueOnce({
+            state: 'closed',
+            merged: false,
+        } as never);
+
+        await service.listDrafts(user, 'project-uuid', { refresh: true });
+
+        expect(contentAsCodeWritebackModel.update).toHaveBeenCalledWith(
+            'row-uuid',
+            { status: 'closed' },
+        );
+        expect(contentDraftModel.update).toHaveBeenCalledWith('draft-uuid', {
+            status: 'dismissed',
+            prUrl: null,
+        });
+        expect(contentDraftModel.listByProject).toHaveBeenCalledWith(
+            'project-uuid',
+        );
+    });
+
+    it('leaves a written-back draft alone when its PR merged', async () => {
+        const { service, contentAsCodeWritebackModel, contentDraftModel } =
+            buildService({
+                writebackRows: [
+                    {
+                        uuid: 'row-uuid',
+                        contentType: 'dashboard',
+                        slug: 'weekly-kpis',
+                        contentDraftUuid: 'draft-uuid',
+                        branch: 'b',
+                        prNumber: 5,
+                        prUrl: 'https://github.com/acme/analytics/pull/5',
+                        status: 'open',
+                    },
+                ],
+            });
+        vi.mocked(getPullRequest).mockResolvedValueOnce({
+            state: 'closed',
+            merged: true,
+        } as never);
+
+        await service.listDrafts(user, 'project-uuid', { refresh: true });
+
+        expect(contentAsCodeWritebackModel.update).toHaveBeenCalledWith(
+            'row-uuid',
+            { status: 'merged' },
+        );
+        expect(contentDraftModel.update).not.toHaveBeenCalled();
+    });
+
+    it('reconciles with the provider at most once per minute per project', async () => {
+        const { service, contentAsCodeWritebackModel } = buildService();
+
+        await service.listDrafts(user, 'project-uuid', { refresh: true });
+        await service.listDrafts(user, 'project-uuid', { refresh: true });
+        await service.listDrafts(user, 'other-project', { refresh: true });
+
+        expect(contentAsCodeWritebackModel.listByProject).toHaveBeenCalledTimes(
+            2,
+        );
+    });
+
+    it('does not touch the provider when listing drafts without refresh', async () => {
+        const { service, contentAsCodeWritebackModel } = buildService();
+        vi.mocked(getPullRequest).mockClear();
+
+        await service.listDrafts(user, 'project-uuid');
+
+        expect(
+            contentAsCodeWritebackModel.listByProject,
+        ).not.toHaveBeenCalled();
+        expect(getPullRequest).not.toHaveBeenCalled();
     });
 
     it('credits the draft author on the commit and in the PR body', async () => {

--- a/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.ts
+++ b/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.ts
@@ -112,6 +112,12 @@ export class ContentAsCodeWritebackService extends BaseService {
 
     private readonly userModel: UserModel;
 
+    // The review page polls with refresh; one provider round per project per
+    // minute is enough to notice merged or closed PRs
+    private static readonly PULL_REQUEST_REFRESH_INTERVAL_MS = 60_000;
+
+    private readonly pullRequestsRefreshedAt = new Map<string, number>();
+
     constructor(args: ContentAsCodeWritebackServiceArguments) {
         super();
         this.lightdashConfig = args.lightdashConfig;
@@ -296,9 +302,30 @@ export class ContentAsCodeWritebackService extends BaseService {
     async listDrafts(
         user: SessionUser,
         projectUuid: string,
+        options: { refresh?: boolean } = {},
     ): Promise<ContentDraft[]> {
         await this.assertCanManageContentAsCode(user, projectUuid);
+        if (options.refresh && this.claimPullRequestRefresh(projectUuid)) {
+            const rows =
+                await this.contentAsCodeWritebackModel.listByProject(
+                    projectUuid,
+                );
+            await this.refreshOpenPullRequestStates(user, projectUuid, rows);
+        }
         return this.contentDraftModel.listByProject(projectUuid);
+    }
+
+    private claimPullRequestRefresh(projectUuid: string): boolean {
+        const now = Date.now();
+        const last = this.pullRequestsRefreshedAt.get(projectUuid) ?? 0;
+        if (
+            now - last <
+            ContentAsCodeWritebackService.PULL_REQUEST_REFRESH_INTERVAL_MS
+        ) {
+            return false;
+        }
+        this.pullRequestsRefreshedAt.set(projectUuid, now);
+        return true;
     }
 
     // The review payload: published vs draft, both rendered as the exact
@@ -491,6 +518,7 @@ export class ContentAsCodeWritebackService extends BaseService {
                             row.uuid,
                             { status: 'closed' },
                         );
+                        await this.releaseDraftOfClosedPullRequest(row);
                     }
                 } catch (error) {
                     this.logger.warn(
@@ -499,6 +527,23 @@ export class ContentAsCodeWritebackService extends BaseService {
                     );
                 }
             }),
+        );
+    }
+
+    // A PR closed without merging hands the change back to its author as a
+    // dismissed draft, so the existing reopen path applies.
+    private async releaseDraftOfClosedPullRequest(
+        row: ContentAsCodeWriteback,
+    ): Promise<void> {
+        if (row.contentDraftUuid === null) return;
+        const draft = await this.contentDraftModel.get(row.contentDraftUuid);
+        if (draft === undefined || draft.status !== 'written_back') return;
+        await this.contentDraftModel.update(draft.uuid, {
+            status: 'dismissed',
+            prUrl: null,
+        });
+        this.logger.info(
+            `Draft ${draft.uuid} for ${row.slug} released after PR #${row.prNumber} was closed without merging`,
         );
     }
 

--- a/packages/frontend/src/features/contentAsCode/hooks/useContentDrafts.ts
+++ b/packages/frontend/src/features/contentAsCode/hooks/useContentDrafts.ts
@@ -9,17 +9,19 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { lightdashApi } from '../../../api';
 import useToaster from '../../../hooks/toaster/useToaster';
 
+// refresh asks the server to reconcile open write-back PRs with the git
+// provider; the server throttles that to once a minute per project
 export const useContentDrafts = (projectUuid: string | undefined) =>
     useQuery<ApiContentDraftsResponse['results'], ApiError>({
         queryKey: ['content-drafts', projectUuid],
         queryFn: () =>
             lightdashApi<ApiContentDraftsResponse['results']>({
-                url: `/projects/${projectUuid}/code/drafts`,
+                url: `/projects/${projectUuid}/code/drafts?refresh=true`,
                 method: 'GET',
                 body: undefined,
             }),
         enabled: projectUuid !== undefined,
-        refetchInterval: 15000,
+        refetchInterval: 30000,
     });
 
 export const useContentDraftReview = (


### PR DESCRIPTION
## Summary

`written_back` was terminal. When a write-back PR was closed without merging, the writeback row flipped to `closed` on refresh but the draft stayed `written_back` with a dead `prUrl`; the author could not reopen it (409) and saw nothing on the dashboard.

Now a closed-unmerged PR hands the change back to its author:

- `refreshOpenPullRequestStates` flips the linked draft from `written_back` to `dismissed` and clears `prUrl`, so the existing "Your dismissed draft is still available" alert and reopen path apply.
- `GET \/code\/drafts?refresh=true` reconciles open write-back PRs with the provider before listing, throttled server-side to once a minute per project so open review pages cannot multiply GitHub calls. The Content review page always asks for it and polls every 30s.

Merged PRs leave the draft untouched (still `written_back`).

## Who's affected

Only projects with `content_as_code.sync` on and GitHub-backed write-backs; GitLab rows are not refreshed today and keep their current behaviour. The refresh call costs one provider request per open write-back PR per poll while a reviewer has the page open.

## Test plan

- [x] `ContentAsCodeWritebackService.test.ts`: closed-unmerged PR dismisses the draft and clears the PR link; merged PR leaves it; listing without `refresh` never touches the provider (33 tests).
- [x] Live: closed a write-back PR on GitHub, refreshed, draft became `dismissed` with `prUrl: null`, the author saw the alert and reopened it.
- [x] Backend and frontend typecheck, oxlint, oxfmt.

Closes: PROD-10809
Relates: PROD-2856