### PR TITLE
fix(content-as-code): freeze written-back reviews and show the real PR state

### DIFF
--- a/packages/backend/src/controllers/CoderControllerUtils.ts
+++ b/packages/backend/src/controllers/CoderControllerUtils.ts
@@ -49,6 +49,7 @@ export const toDraftSummary = (draft: ContentDraft): ContentDraftSummary => ({
     authorName: draft.authorName,
     status: draft.status as ContentDraftSummary['status'],
     prUrl: draft.prUrl,
+    writebackStatus: draft.writebackStatus,
     createdAt: draft.createdAt,
     updatedAt: draft.updatedAt,
 });

--- a/packages/backend/src/database/entities/contentDrafts.ts
+++ b/packages/backend/src/database/entities/contentDrafts.ts
@@ -12,6 +12,8 @@ export type DbContentDraft = {
     draft: object;
     status: string;
     pr_url: string | null;
+    written_back_published: object | null;
+    written_back_draft: object | null;
     created_at: Date;
     updated_at: Date;
 };
@@ -28,7 +30,15 @@ export type CreateDbContentDraft = Pick<
     Partial<Pick<DbContentDraft, 'created_at' | 'updated_at'>>;
 
 export type UpdateDbContentDraft = Partial<
-    Pick<DbContentDraft, 'draft' | 'status' | 'pr_url' | 'updated_at'>
+    Pick<
+        DbContentDraft,
+        | 'draft'
+        | 'status'
+        | 'pr_url'
+        | 'written_back_published'
+        | 'written_back_draft'
+        | 'updated_at'
+    >
 >;
 
 export type ContentDraftsTable = Knex.CompositeTableType<

--- a/packages/backend/src/database/migrations/20260901120000_add_written_back_documents_to_content_drafts.ts
+++ b/packages/backend/src/database/migrations/20260901120000_add_written_back_documents_to_content_drafts.ts
@@ -1,0 +1,27 @@
+import { Knex } from 'knex';
+
+export const classification = {
+    kind: 'safe',
+    reason: 'Adds nullable columns that freeze the reviewed documents of a written-back draft',
+} as const;
+
+const DRAFTS_TABLE = 'content_drafts';
+const LOCK_TIMEOUT = '5s';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '${LOCK_TIMEOUT}'`);
+
+    await knex.schema.alterTable(DRAFTS_TABLE, (table) => {
+        table.jsonb('written_back_published').nullable();
+        table.jsonb('written_back_draft').nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '${LOCK_TIMEOUT}'`);
+
+    await knex.schema.alterTable(DRAFTS_TABLE, (table) => {
+        table.dropColumn('written_back_published');
+        table.dropColumn('written_back_draft');
+    });
+}

--- a/packages/backend/src/models/ContentDraftModel.ts
+++ b/packages/backend/src/models/ContentDraftModel.ts
@@ -1,3 +1,8 @@
+import {
+    type ChartAsCode,
+    type ContentAsCodeWritebackStatus,
+    type DashboardAsCode,
+} from '@lightdash/common';
 import { Knex } from 'knex';
 import {
     ContentDraftsTableName,
@@ -15,6 +20,9 @@ export type ContentDraft = {
     draft: object;
     status: string;
     prUrl: string | null;
+    writebackStatus: ContentAsCodeWritebackStatus | null;
+    writtenBackPublished: ChartAsCode | DashboardAsCode | null;
+    writtenBackDraft: ChartAsCode | DashboardAsCode | null;
     createdAt: Date;
     updatedAt: Date;
 };
@@ -24,7 +32,10 @@ type ContentDraftModelArguments = {
 };
 
 const parseRow = (
-    row: DbContentDraft & { author_name?: string | null },
+    row: DbContentDraft & {
+        author_name?: string | null;
+        writeback_status?: string | null;
+    },
 ): ContentDraft => ({
     uuid: row.content_draft_uuid,
     authorName: row.author_name ?? null,
@@ -36,9 +47,23 @@ const parseRow = (
     draft: row.draft,
     status: row.status,
     prUrl: row.pr_url,
+    writebackStatus:
+        (row.writeback_status as ContentAsCodeWritebackStatus | null) ?? null,
+    writtenBackPublished:
+        (row.written_back_published as ChartAsCode | DashboardAsCode | null) ??
+        null,
+    writtenBackDraft:
+        (row.written_back_draft as ChartAsCode | DashboardAsCode | null) ??
+        null,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
 });
+
+// The latest write-back row for a draft carries the PR state
+const writebackStatusSubquery = (knex: Knex) =>
+    knex.raw(
+        `(select status from content_as_code_writebacks w where w.content_draft_uuid = ${ContentDraftsTableName}.content_draft_uuid order by w.created_at desc limit 1) as writeback_status`,
+    );
 
 export class ContentDraftModel {
     private readonly database: Knex;
@@ -187,11 +212,17 @@ export class ContentDraftModel {
                 `${ContentDraftsTableName}.author_user_uuid`,
             )
             .where({ content_draft_uuid: uuid })
-            .select<DbContentDraft & { author_name: string | null }>(
+            .select<
+                DbContentDraft & {
+                    author_name: string | null;
+                    writeback_status: string | null;
+                }
+            >(
                 `${ContentDraftsTableName}.*`,
                 this.database.raw(
                     "users.first_name || ' ' || users.last_name as author_name",
                 ),
+                writebackStatusSubquery(this.database),
             )
             .first();
         return row ? parseRow(row) : undefined;
@@ -205,25 +236,42 @@ export class ContentDraftModel {
                 `${ContentDraftsTableName}.author_user_uuid`,
             )
             .where(`${ContentDraftsTableName}.project_uuid`, projectUuid)
-            .select<(DbContentDraft & { author_name: string | null })[]>(
+            .select<
+                (DbContentDraft & {
+                    author_name: string | null;
+                    writeback_status: string | null;
+                })[]
+            >(
                 `${ContentDraftsTableName}.*`,
                 this.database.raw(
                     "users.first_name || ' ' || users.last_name as author_name",
                 ),
+                writebackStatusSubquery(this.database),
             )
-            .orderBy('updated_at', 'desc');
+            .orderBy(`${ContentDraftsTableName}.updated_at`, 'desc');
         return rows.map(parseRow);
     }
 
     async update(
         uuid: string,
-        update: { status?: string; prUrl?: string | null },
+        update: {
+            status?: string;
+            prUrl?: string | null;
+            writtenBackPublished?: ChartAsCode | DashboardAsCode | null;
+            writtenBackDraft?: ChartAsCode | DashboardAsCode | null;
+        },
     ): Promise<void> {
         await this.database(ContentDraftsTableName)
             .where({ content_draft_uuid: uuid })
             .update({
                 ...(update.status !== undefined && { status: update.status }),
                 ...(update.prUrl !== undefined && { pr_url: update.prUrl }),
+                ...(update.writtenBackPublished !== undefined && {
+                    written_back_published: update.writtenBackPublished,
+                }),
+                ...(update.writtenBackDraft !== undefined && {
+                    written_back_draft: update.writtenBackDraft,
+                }),
                 updated_at: new Date(),
             });
     }

--- a/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.test.ts
+++ b/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.test.ts
@@ -497,6 +497,70 @@ describe('ContentAsCodeWritebackService', () => {
         expect(getPullRequest).not.toHaveBeenCalled();
     });
 
+    it('freezes the reviewed documents when a draft is written back', async () => {
+        const { service, contentDraftModel } = buildService();
+
+        await service.writeBackDraft(user, 'project-uuid', 'draft-uuid');
+
+        expect(contentDraftModel.update).toHaveBeenCalledWith(
+            'draft-uuid',
+            expect.objectContaining({
+                status: 'written_back',
+                writtenBackPublished: expect.objectContaining({
+                    name: 'Weekly KPIs',
+                }),
+                writtenBackDraft: expect.objectContaining({
+                    name: 'Weekly KPIs draft',
+                }),
+            }),
+        );
+    });
+
+    it('reviews a written-back draft from its frozen documents', async () => {
+        const { service, coderService } = buildService({
+            draft: {
+                ...dismissedDraft,
+                status: 'written_back',
+                writtenBackPublished: { name: 'Frozen published', tiles: [] },
+                writtenBackDraft: { name: 'Frozen draft', tiles: [] },
+            },
+        });
+
+        const review = await service.getDraftReview(
+            user,
+            'project-uuid',
+            'draft-uuid',
+        );
+
+        expect(review.publishedYaml).toContain('name: Frozen published');
+        expect(review.draftYaml).toContain('name: Frozen draft');
+        expect(coderService.getCurrentDashboardAsCode).not.toHaveBeenCalled();
+        expect(
+            coderService.getDashboardAsCodeWithOverlay,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('reviews a draft handed back to its author live, not from the frozen documents', async () => {
+        const { service, coderService } = buildService({
+            draft: {
+                ...dismissedDraft,
+                status: 'dismissed',
+                writtenBackPublished: { name: 'Frozen published', tiles: [] },
+                writtenBackDraft: { name: 'Frozen draft', tiles: [] },
+            },
+        });
+
+        const review = await service.getDraftReview(
+            user,
+            'project-uuid',
+            'draft-uuid',
+        );
+
+        expect(review.draftYaml).toContain('Weekly KPIs draft');
+        expect(review.draftYaml).not.toContain('Frozen');
+        expect(coderService.getDashboardAsCodeWithOverlay).toHaveBeenCalled();
+    });
+
     it('credits the draft author on the commit and in the PR body', async () => {
         const { service, gitIntegrationService, userModel } = buildService();
 

--- a/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.ts
+++ b/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.ts
@@ -350,26 +350,24 @@ export class ContentAsCodeWritebackService extends BaseService {
         ) {
             throw new ParameterError('Unsupported draft content type');
         }
-        const published =
-            draft.contentType === 'chart'
-                ? await this.coderService.getPortableChartAsCode(
-                      projectUuid,
-                      draft.contentUuid,
-                  )
-                : await this.coderService.getCurrentDashboardAsCode(
-                      draft.contentUuid,
-                  );
-        const draftDoc =
-            draft.contentType === 'chart'
-                ? await this.coderService.getPortableChartAsCodeWithOverlay(
-                      projectUuid,
-                      draft.contentUuid,
-                      draft.draft,
-                  )
-                : await this.coderService.getDashboardAsCodeWithOverlay(
-                      draft.contentUuid,
-                      draft.draft,
-                  );
+        // A written-back draft shows what actually went to the repo, not a
+        // live diff that drifts as published content moves on; a draft handed
+        // back to its author is live again
+        if (
+            draft.status === 'written_back' &&
+            draft.writtenBackPublished &&
+            draft.writtenBackDraft
+        ) {
+            return {
+                draft,
+                publishedYaml: dumpContentAsCode(draft.writtenBackPublished),
+                draftYaml: dumpContentAsCode(draft.writtenBackDraft),
+            };
+        }
+        const { published, draftDoc } = await this.renderDraftDocuments(
+            projectUuid,
+            draft,
+        );
         return {
             draft,
             publishedYaml: dumpContentAsCode(published),
@@ -397,17 +395,10 @@ export class ContentAsCodeWritebackService extends BaseService {
         }
         const contentType =
             draft.contentType === 'chart' ? 'chart' : 'dashboard';
-        const draftDoc =
-            contentType === 'chart'
-                ? await this.coderService.getPortableChartAsCodeWithOverlay(
-                      projectUuid,
-                      draft.contentUuid,
-                      draft.draft,
-                  )
-                : await this.coderService.getDashboardAsCodeWithOverlay(
-                      draft.contentUuid,
-                      draft.draft,
-                  );
+        const { published, draftDoc } = await this.renderDraftDocuments(
+            projectUuid,
+            draft,
+        );
         const row = await this.writeContentToWritebackPr(user, {
             projectUuid,
             contentType,
@@ -420,8 +411,41 @@ export class ContentAsCodeWritebackService extends BaseService {
         await this.contentDraftModel.update(draft.uuid, {
             status: 'written_back',
             prUrl: row.prUrl,
+            writtenBackPublished: published,
+            writtenBackDraft: draftDoc,
         });
         return { ...draft, status: 'written_back', prUrl: row.prUrl };
+    }
+
+    private async renderDraftDocuments(
+        projectUuid: string,
+        draft: ContentDraft,
+    ): Promise<{
+        published: ChartAsCode | DashboardAsCode;
+        draftDoc: ChartAsCode | DashboardAsCode;
+    }> {
+        if (draft.contentType === 'chart') {
+            const [published, draftDoc] = await Promise.all([
+                this.coderService.getPortableChartAsCode(
+                    projectUuid,
+                    draft.contentUuid,
+                ),
+                this.coderService.getPortableChartAsCodeWithOverlay(
+                    projectUuid,
+                    draft.contentUuid,
+                    draft.draft,
+                ),
+            ]);
+            return { published, draftDoc };
+        }
+        const [published, draftDoc] = await Promise.all([
+            this.coderService.getCurrentDashboardAsCode(draft.contentUuid),
+            this.coderService.getDashboardAsCodeWithOverlay(
+                draft.contentUuid,
+                draft.draft,
+            ),
+        ]);
+        return { published, draftDoc };
     }
 
     async dismissDraft(

--- a/packages/common/src/types/contentAsCode/base.ts
+++ b/packages/common/src/types/contentAsCode/base.ts
@@ -126,6 +126,7 @@ export type ContentDraftSummary = {
     authorName: string | null;
     status: 'open' | 'written_back' | 'dismissed';
     prUrl: string | null;
+    writebackStatus: ContentAsCodeWritebackStatus | null;
     createdAt: Date;
     updatedAt: Date;
 };

--- a/packages/frontend/src/features/contentAsCode/components/ContentReviewPage.tsx
+++ b/packages/frontend/src/features/contentAsCode/components/ContentReviewPage.tsx
@@ -1,4 +1,4 @@
-import { type ContentDraftSummary } from '@lightdash/common';
+import { assertUnreachable, type ContentDraftSummary } from '@lightdash/common';
 import {
     Anchor,
     Avatar,
@@ -89,12 +89,34 @@ const changeStats = (
     return { added, removed };
 };
 
+const writebackLabel = (
+    status: ContentDraftSummary['writebackStatus'],
+): string => {
+    switch (status) {
+        case 'merged':
+            return 'PR merged';
+        case 'closed':
+            return 'PR closed';
+        case 'error':
+            return 'Write-back failed';
+        case 'pending':
+        case 'open':
+        case null:
+            return 'PR opened';
+        default:
+            return assertUnreachable(
+                status,
+                `Unknown write-back status ${status}`,
+            );
+    }
+};
+
 const rowMeta = (draft: ContentDraftSummary): string => {
     const author = draft.authorName ?? 'Unknown author';
     const when = timeAgo(draft.updatedAt);
     switch (draft.status) {
         case 'written_back':
-            return `PR opened · ${author} · ${when}`;
+            return `${writebackLabel(draft.writebackStatus)} · ${author} · ${when}`;
         case 'dismissed':
             return `Dismissed · ${author} · ${when}`;
         case 'open':


### PR DESCRIPTION
## Summary

Two review-page problems on written-back drafts:

1. The history row always said "PR opened", even after the PR merged or was closed.
2. The diff was recomputed on every view against the current published YAML, so once the merged change was uploaded (or the content moved on), an old entry showed unrelated lines.

Fix:

- New nullable `content_drafts.written_back_published` / `written_back_draft` (jsonb) freeze the documents at write-back time; `getDraftReview` renders those while the draft is still `written_back`; open, dismissed (including drafts handed back after a closed PR) and pre-existing rows keep the live diff. The two columns are typed once at the model boundary.
- `ContentDraftSummary.writebackStatus` (latest `content_as_code_writebacks` row for the draft) drives the history label: PR opened, PR merged, PR closed, Write-back failed.

Migration `20260901120000_add_written_back_documents_to_content_drafts` is additive (two nullable columns, `classification: safe`).

## Test plan

- [x] `ContentAsCodeWritebackService.test.ts`: write-back stores the frozen documents; review of a written-back draft uses them and does not touch `CoderService` (35 tests).
- [x] Live: after writing back and then changing the published dashboard, the review diff still shows the write-back-time base; history rows read "PR merged" / "PR closed".
- [x] `pnpm -F common build`, common/backend/frontend typecheck, oxlint, oxfmt.

Closes: PROD-10813
Relates: PROD-2856