### PR TITLE
fix(content-as-code): dismiss open drafts when their content is deleted

### DIFF
--- a/packages/backend/src/database/migrations/20260901130000_index_open_content_drafts_by_content.ts
+++ b/packages/backend/src/database/migrations/20260901130000_index_open_content_drafts_by_content.ts
@@ -1,0 +1,24 @@
+import { Knex } from 'knex';
+
+export const classification = {
+    kind: 'safe',
+    reason: 'Adds a partial index so delete paths find open drafts without scanning the table',
+} as const;
+
+const DRAFTS_TABLE = 'content_drafts';
+const INDEX_NAME = 'content_drafts_open_by_content_index';
+const LOCK_TIMEOUT = '5s';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '${LOCK_TIMEOUT}'`);
+    await knex.raw(`
+        CREATE INDEX IF NOT EXISTS ${INDEX_NAME}
+        ON ${DRAFTS_TABLE} (content_type, content_uuid)
+        WHERE status = 'open'
+    `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '${LOCK_TIMEOUT}'`);
+    await knex.raw(`DROP INDEX IF EXISTS ${INDEX_NAME}`);
+}

--- a/packages/backend/src/models/ContentDraftModel.test.ts
+++ b/packages/backend/src/models/ContentDraftModel.test.ts
@@ -1,0 +1,47 @@
+import knex from 'knex';
+import { getTracker, MockClient, Tracker } from 'knex-mock-client';
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { ContentDraftsTableName } from '../database/entities/contentDrafts';
+import { dismissOpenContentDrafts } from './ContentDraftModel';
+
+describe('dismissOpenContentDrafts', () => {
+    const database = knex({ client: MockClient, dialect: 'pg' });
+    let tracker: Tracker;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    afterEach(() => {
+        tracker.reset();
+    });
+
+    it('dismisses only the open drafts of the given content', async () => {
+        tracker.on.update(ContentDraftsTableName).responseOnce(2);
+
+        const count = await dismissOpenContentDrafts(database, 'chart', [
+            'chart-a',
+            'chart-b',
+        ]);
+
+        expect(count).toBe(2);
+        const [query] = tracker.history.update;
+        expect(query.sql).toContain('content_uuid');
+        expect(query.bindings).toEqual(
+            expect.arrayContaining([
+                'dismissed',
+                'chart',
+                'open',
+                'chart-a',
+                'chart-b',
+            ]),
+        );
+    });
+
+    it('does nothing for an empty list', async () => {
+        await expect(
+            dismissOpenContentDrafts(database, 'dashboard', []),
+        ).resolves.toBe(0);
+        expect(tracker.history.update).toHaveLength(0);
+    });
+});

--- a/packages/backend/src/models/ContentDraftModel.ts
+++ b/packages/backend/src/models/ContentDraftModel.ts
@@ -65,6 +65,20 @@ const writebackStatusSubquery = (knex: Knex) =>
         `(select status from content_as_code_writebacks w where w.content_draft_uuid = ${ContentDraftsTableName}.content_draft_uuid order by w.created_at desc limit 1) as writeback_status`,
     );
 
+// Called from the chart and dashboard model delete paths so every delete,
+// including cascades, releases the drafts that pointed at the content
+export const dismissOpenContentDrafts = async (
+    database: Knex,
+    contentType: 'chart' | 'dashboard',
+    contentUuids: string[],
+): Promise<number> => {
+    if (contentUuids.length === 0) return 0;
+    return database(ContentDraftsTableName)
+        .where({ content_type: contentType, status: 'open' })
+        .whereIn('content_uuid', contentUuids)
+        .update({ status: 'dismissed', updated_at: new Date() });
+};
+
 export class ContentDraftModel {
     private readonly database: Knex;
 

--- a/packages/backend/src/models/DashboardModel/DashboardModel.test.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.test.ts
@@ -8,6 +8,7 @@ import {
 import knex from 'knex';
 import { getTracker, MockClient, RawQuery, Tracker } from 'knex-mock-client';
 import { FunctionQueryMatcher } from 'knex-mock-client/types/mock-client';
+import { ContentDraftsTableName } from '../../database/entities/contentDrafts';
 import {
     DashboardsTableName,
     DashboardTabsTableName,
@@ -615,9 +616,21 @@ describe('DashboardModel', () => {
         tracker.on
             .delete(queryMatcher(DashboardsTableName, [dashboardUuid]))
             .response([]);
+        tracker.on
+            .select(queryMatcher(SavedChartsTableName, [dashboardUuid]))
+            .responseOnce([{ saved_query_uuid: 'owned-chart-uuid' }]);
+        tracker.on.update(ContentDraftsTableName).response(1);
 
         await model.permanentDelete(dashboardUuid);
         expect(tracker.history.delete).toHaveLength(1);
+        // The dashboard's open drafts and its dashboard-scoped charts' drafts are dismissed
+        expect(tracker.history.update).toHaveLength(2);
+        expect(tracker.history.update[0].bindings).toEqual(
+            expect.arrayContaining(['dismissed', 'dashboard', dashboardUuid]),
+        );
+        expect(tracker.history.update[1].bindings).toEqual(
+            expect.arrayContaining(['dismissed', 'chart', 'owned-chart-uuid']),
+        );
     });
 
     test("should error on create dashboard version if dashboard isn't found", async () => {

--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -89,6 +89,7 @@ import {
 } from '../../utils/SlugUtils';
 import { ContentVerificationModel } from '../ContentVerificationModel';
 import Transaction = Knex.Transaction;
+import { dismissOpenContentDrafts } from '../ContentDraftModel';
 
 export type GetDashboardQuery = Pick<
     DashboardTable['base'],
@@ -1727,10 +1728,33 @@ export class DashboardModel {
         const dashboard = await this.getByIdOrSlug(dashboardUuid, {
             deleted: 'any',
         });
+        const ownedChartUuids =
+            await this.getDashboardScopedChartUuids(dashboardUuid);
         await this.database(DashboardsTableName)
             .where('dashboard_uuid', dashboardUuid)
             .delete();
+        await this.dismissContentDrafts(dashboardUuid, ownedChartUuids);
         return dashboard;
+    }
+
+    private async getDashboardScopedChartUuids(
+        dashboardUuid: string,
+    ): Promise<string[]> {
+        const rows = await this.database(SavedChartsTableName)
+            .select('saved_query_uuid')
+            .where('dashboard_uuid', dashboardUuid)
+            .whereNull('space_id');
+        return rows.map((row) => row.saved_query_uuid);
+    }
+
+    private async dismissContentDrafts(
+        dashboardUuid: string,
+        ownedChartUuids: string[],
+    ): Promise<void> {
+        await dismissOpenContentDrafts(this.database, 'dashboard', [
+            dashboardUuid,
+        ]);
+        await dismissOpenContentDrafts(this.database, 'chart', ownedChartUuids);
     }
 
     async softDelete(
@@ -1755,6 +1779,10 @@ export class DashboardModel {
             .where('dashboard_uuid', dashboardUuid)
             .whereNull('space_id')
             .whereNull('deleted_at');
+        await this.dismissContentDrafts(
+            dashboardUuid,
+            await this.getDashboardScopedChartUuids(dashboardUuid),
+        );
 
         return dashboard;
     }

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -106,6 +106,7 @@ import {
     acquireProjectSlugLock,
     generateUniqueSlugScopedToProject,
 } from '../utils/SlugUtils';
+import { dismissOpenContentDrafts } from './ContentDraftModel';
 import { ContentVerificationModel } from './ContentVerificationModel';
 
 type DbSavedChartDetails = {
@@ -1338,6 +1339,9 @@ export class SavedChartModel {
         await this.database(SavedChartsTableName)
             .delete()
             .where('saved_query_uuid', savedChartUuid);
+        await dismissOpenContentDrafts(this.database, 'chart', [
+            savedChartUuid,
+        ]);
         return savedChart;
     }
 
@@ -1352,6 +1356,9 @@ export class SavedChartModel {
                 deleted_by_user_uuid: userUuid,
             })
             .where('saved_query_uuid', savedChartUuid);
+        await dismissOpenContentDrafts(this.database, 'chart', [
+            savedChartUuid,
+        ]);
         return savedChart;
     }
 

--- a/packages/backend/src/services/DashboardService/DashboardService.drafts.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.drafts.test.ts
@@ -136,7 +136,10 @@ const buildService = (overrides: Overrides = {}) => {
         schedulerClient: {} as AnyType,
         contentAsCodeProjectSettingsModel: { get: settingsGet } as AnyType,
         contentAsCodeSnapshotModel: { get: snapshotGet } as AnyType,
-        contentDraftModel: { upsertOpenDraft, listOpenForContent } as AnyType,
+        contentDraftModel: {
+            upsertOpenDraft,
+            listOpenForContent,
+        } as AnyType,
         catalogModel: {} as AnyType,
         organizationModel: {} as AnyType,
         organizationMemberProfileModel: {} as AnyType,

--- a/packages/frontend/src/features/contentAsCode/components/ContentReviewPage.tsx
+++ b/packages/frontend/src/features/contentAsCode/components/ContentReviewPage.tsx
@@ -1,4 +1,8 @@
-import { assertUnreachable, type ContentDraftSummary } from '@lightdash/common';
+import {
+    assertUnreachable,
+    type ApiError,
+    type ContentDraftSummary,
+} from '@lightdash/common';
 import {
     Anchor,
     Avatar,
@@ -163,6 +167,46 @@ const DraftRow: FC<{
     </UnstyledButton>
 );
 
+const ReviewPlaceholder: FC<{
+    active: ContentDraftSummary | undefined;
+    error: ApiError | null;
+    onDismiss: (draftUuid: string) => void;
+}> = ({ active, error, onDismiss }) => {
+    if (!active || !error) {
+        return (
+            <Box mt="xl">
+                <Text c="dimmed" ta="center">
+                    Select a draft to review
+                </Text>
+            </Box>
+        );
+    }
+    const title =
+        error.error.statusCode === 404
+            ? `This draft's ${active.contentType} no longer exists.`
+            : "This draft couldn't be loaded.";
+    return (
+        <Stack mt="xl" gap={4} align="center">
+            <Text ta="center">{title}</Text>
+            {error.error.message ? (
+                <Text size="sm" c="dimmed" ta="center">
+                    {error.error.message}
+                </Text>
+            ) : null}
+            {active.status === 'open' ? (
+                <Button
+                    mt="xs"
+                    size="xs"
+                    variant="default"
+                    onClick={() => onDismiss(active.uuid)}
+                >
+                    Dismiss draft
+                </Button>
+            ) : null}
+        </Stack>
+    );
+};
+
 type ContentReviewPageProps = {
     projectUuid: string | undefined;
 };
@@ -181,7 +225,10 @@ const ContentReviewPage: FC<ContentReviewPageProps> = ({ projectUuid }) => {
     );
     const activeUuid =
         selectedUuid ?? openDrafts[0]?.uuid ?? historyDrafts[0]?.uuid;
-    const { data: review } = useContentDraftReview(projectUuid, activeUuid);
+    const { data: review, error: reviewError } = useContentDraftReview(
+        projectUuid,
+        activeUuid,
+    );
     const { mutate: writeBack, isLoading: isWritingBack } =
         useWriteBackDraftMutation(projectUuid);
     const { mutate: dismiss } = useDismissDraftMutation(projectUuid);
@@ -439,11 +486,11 @@ const ContentReviewPage: FC<ContentReviewPageProps> = ({ projectUuid }) => {
                         </WorkerPoolContextProvider>
                     </>
                 ) : (
-                    <Box mt="xl">
-                        <Text c="dimmed" ta="center">
-                            Select a draft to review
-                        </Text>
-                    </Box>
+                    <ReviewPlaceholder
+                        active={active}
+                        error={reviewError}
+                        onDismiss={dismiss}
+                    />
                 )}
             </Stack>
         </Group>


### PR DESCRIPTION
## Summary

`content_drafts.content_uuid` has no FK, so deleting a chart or dashboard that had open drafts left them `open`: still listed under "Awaiting review", with the review and write-back endpoints answering 404 "Dashboard not found" and the review pane going blank.

Fix, in the model delete paths so every caller is covered (service deletes, the dashboard soft-delete cascade over dashboard-scoped charts, the orphan-chart purge, promotion cleanup, EE managed-agent deletes):

- `dismissOpenContentDrafts(database, contentType, contentUuids)` in `ContentDraftModel`, called from `SavedChartModel.softDelete` / `permanentDelete` and `DashboardModel.softDelete` / `permanentDelete` (the dashboard paths also release drafts of the dashboard-scoped charts they cascade over).
- Partial index `content_drafts (content_type, content_uuid) WHERE status = 'open'` so those updates never scan the table. Migration `20260901130000_index_open_content_drafts_by_content`, `classification: safe`.
- Content review shows the API error in the right pane when the review payload cannot be loaded (drafts orphaned before this change), with a "Dismiss draft" button for open ones so they can be cleared.

## Migrations and data volume

Nothing here touches `saved_queries`, `saved_queries_versions`, `dashboards` or `dashboard_versions`. The only migration creates an index on `content_drafts`, the small feature table that holds draft rows. The delete-time change is one indexed `UPDATE content_drafts …` per deleted item, not a backfill.

## Notes

- Soft delete dismisses drafts too, so restoring soft-deleted content does not bring its drafts back as open; the author still sees them as dismissed and can reopen them.

## Test plan

- [x] `ContentDraftModel.test.ts` (helper), `DashboardModel.test.ts` (permanent delete dismisses dashboard and owned-chart drafts), drafts suites for both services (103 tests across the five files).
- [x] Live: editor draft on a dashboard, admin deletes it, the draft is `dismissed` and gone from the queue; `lightdash upload` recreates the dashboard.
- [x] `pnpm -F backend typecheck`, frontend typecheck, oxlint, oxfmt.

Closes: PROD-10810
Relates: PROD-2856, PROD-10817