### PR TITLE
fix(dashboards): say a draft was saved when a dashboard save is held for review

### DIFF
--- a/packages/frontend/src/hooks/dashboard/useDashboard.test.tsx
+++ b/packages/frontend/src/hooks/dashboard/useDashboard.test.tsx
@@ -12,10 +12,14 @@ vi.mock('../../features/scheduler/hooks/useScheduler', () => ({
     pollJobStatus: vi.fn(),
 }));
 
+const { showToastSuccess } = vi.hoisted(() => ({
+    showToastSuccess: vi.fn(),
+}));
+
 vi.mock('../toaster/useToaster', () => ({
     default: () => ({
         showToastInfo: vi.fn(),
-        showToastSuccess: vi.fn(),
+        showToastSuccess,
         showToastError: vi.fn(),
         showToastWarning: vi.fn(),
         showToastApiError: vi.fn(),
@@ -41,7 +45,10 @@ vi.mock('react-router', () => ({
 
 import { lightdashApi } from '../../api';
 import { pollJobStatus } from '../../features/scheduler/hooks/useScheduler';
-import { useExportDashboardContentPreview } from './useDashboard';
+import {
+    useExportDashboardContentPreview,
+    useUpdateDashboard,
+} from './useDashboard';
 
 const mockApi = lightdashApi as unknown as Mock;
 const mockPollJobStatus = pollJobStatus as unknown as Mock;
@@ -125,5 +132,54 @@ describe('useExportDashboardContentPreview', () => {
         ).rejects.toThrow();
 
         await waitFor(() => expect(result.current.isError).toBe(true));
+    });
+});
+
+describe('useUpdateDashboard', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('says a draft was saved when the save is held for review', async () => {
+        mockApi.mockResolvedValue({
+            ...dashboard,
+            slug: 'my-dashboard',
+            hasUnpublishedChanges: true,
+        });
+
+        const { result } = renderHook(
+            () => useUpdateDashboard(dashboard.uuid, dashboard.projectUuid),
+            { wrapper: createWrapper() },
+        );
+
+        await result.current.mutateAsync({ name: 'Renamed dashboard' });
+
+        expect(showToastSuccess).toHaveBeenCalledWith(
+            expect.objectContaining({
+                title: 'Dashboard draft saved for review',
+                subtitle:
+                    'Only you can see these changes until a reviewer writes them back to the repo.',
+            }),
+        );
+    });
+
+    it('keeps the generic toast when the save is published', async () => {
+        mockApi.mockResolvedValue({ ...dashboard, slug: 'my-dashboard' });
+
+        const { result } = renderHook(
+            () => useUpdateDashboard(dashboard.uuid, dashboard.projectUuid),
+            { wrapper: createWrapper() },
+        );
+
+        await result.current.mutateAsync({ name: 'Renamed dashboard' });
+
+        expect(showToastSuccess).toHaveBeenCalledWith(
+            expect.objectContaining({
+                title: 'Success! Dashboard name was updated.',
+            }),
+        );
+        expect(showToastSuccess.mock.calls[0][0]).not.toHaveProperty(
+            'subtitle',
+        );
     });
 });

--- a/packages/frontend/src/hooks/dashboard/useDashboard.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboard.ts
@@ -514,9 +514,17 @@ export const useUpdateDashboard = (
                     Object.keys(variables).length === 1 &&
                     Object.keys(variables).includes('name');
                 showToastSuccess({
-                    title: `Success! Dashboard ${
-                        onlyUpdatedName ? 'name ' : ''
-                    }was updated.`,
+                    ...(updatedDashboard.hasUnpublishedChanges
+                        ? {
+                              title: 'Dashboard draft saved for review',
+                              subtitle:
+                                  'Only you can see these changes until a reviewer writes them back to the repo.',
+                          }
+                        : {
+                              title: `Success! Dashboard ${
+                                  onlyUpdatedName ? 'name ' : ''
+                              }was updated.`,
+                          }),
                     action: showRedirectButton
                         ? {
                               children: 'Open dashboard',


### PR DESCRIPTION
## Summary

When an editor's dashboard save is stored as a draft (`hasUnpublishedChanges: true` on the response), `useUpdateDashboard` still toasted "Success! Dashboard was updated." The header badge was the only hint that nothing was published. Charts already say "Chart draft saved for review".

Now the toast reads "Dashboard draft saved for review" with the subtitle "Only you can see these changes until a reviewer writes them back to the repo." The generic toast is unchanged for published saves.

## Test plan

- [x] `useDashboard.test.tsx`: draft response shows the draft toast; published response keeps the generic one.
- [x] Live: an editor saving a git-backed dashboard sees the draft toast.
- [x] `pnpm -F frontend typecheck`, oxlint.

Closes: PROD-10811
Relates: PROD-2856