### PR TITLE
fix(dashboards): show the author's chart draft inside dashboard tiles

### DIFF
--- a/packages/backend/src/controllers/v2/QueryController.ts
+++ b/packages/backend/src/controllers/v2/QueryController.ts
@@ -502,6 +502,7 @@ export class QueryController extends BaseController {
                 context: context ?? QueryExecutionContext.API,
                 parameters: body.parameters,
                 pivotResults: body.pivotResults,
+                includeUnpublishedDraft: body.includeUnpublishedDraft,
             });
 
         return {

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -1071,6 +1071,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                 prometheusMetrics,
             }) =>
                 new AsyncQueryService({
+                    contentDraftModel: models.getContentDraftModel(),
                     lightdashConfig: context.lightdashConfig,
                     analytics: context.lightdashAnalytics,
                     projectModel: models.getProjectModel(),

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -47,6 +47,7 @@ import type { LightdashConfig } from '../../config/parseConfig';
 import type { PreAggregateModel } from '../../ee/models/PreAggregateModel';
 import type { AnalyticsModel } from '../../models/AnalyticsModel';
 import type { CatalogModel } from '../../models/CatalogModel/CatalogModel';
+import type { ContentDraftModel } from '../../models/ContentDraftModel';
 import type { ContentModel } from '../../models/ContentModel/ContentModel';
 import type { DashboardModel } from '../../models/DashboardModel/DashboardModel';
 import type { DownloadAuditModel } from '../../models/DownloadAuditModel';
@@ -257,6 +258,9 @@ const getMockedAsyncQueryService = (
     new AsyncQueryService({
         lightdashConfig,
         analytics: analyticsMock,
+        contentDraftModel: {
+            findOpenDraft: vi.fn().mockResolvedValue(undefined),
+        } as unknown as ContentDraftModel,
         projectModel: projectModel as unknown as ProjectModel,
         projectDbtSourcesModel: {} as unknown as ProjectDbtSourcesModel,
         preAggregateModel: {} as PreAggregateModel,

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -145,6 +145,7 @@ import {
     type ReadyQueryResultsPage,
     type ResultColumns,
     type RunQueryTags,
+    type SavedChartDAO,
     type SessionUser,
     type SpaceSummaryBase,
     type UserAttributeValueMap,
@@ -175,6 +176,7 @@ import {
 import Logger from '../../logging/logger';
 import { measureTime } from '../../logging/measureTime';
 import { getAppContext, getSchedulerContext } from '../../logging/winston';
+import { ContentDraftModel } from '../../models/ContentDraftModel';
 import { DownloadAuditModel } from '../../models/DownloadAuditModel';
 import {
     mapQueryHistoryRowToListItem,
@@ -239,6 +241,7 @@ import {
     getNextAndPreviousPage,
     validatePagination,
 } from '../ProjectService/resultsPagination';
+import { mergeDraftIntoChart } from '../SavedChartsService/chartDraftOverlay';
 import {
     exploreHasFilteredAttribute,
     getFilteredExplore,
@@ -383,6 +386,7 @@ type AsyncQueryExecutionPlan =
       };
 
 type AsyncQueryServiceArguments = ProjectServiceArguments & {
+    contentDraftModel: ContentDraftModel;
     queryHistoryModel: QueryHistoryModel;
     downloadAuditModel: DownloadAuditModel;
     cacheService?: ICacheService;
@@ -501,6 +505,8 @@ export class AsyncQueryService extends ProjectService {
         }
     }
 
+    contentDraftModel: ContentDraftModel;
+
     queryHistoryModel: QueryHistoryModel;
 
     downloadAuditModel: DownloadAuditModel;
@@ -531,6 +537,7 @@ export class AsyncQueryService extends ProjectService {
 
     constructor(args: AsyncQueryServiceArguments) {
         super(args);
+        this.contentDraftModel = args.contentDraftModel;
         this.queryHistoryModel = args.queryHistoryModel;
         this.downloadAuditModel = args.downloadAuditModel;
         this.cacheService = args.cacheService;
@@ -6151,6 +6158,31 @@ export class AsyncQueryService extends ProjectService {
         };
     }
 
+    // Only the draft's author sees it; a corrupt draft falls back to the
+    // published chart, as the chart read path does
+    private async applyOpenChartDraft(
+        account: Account,
+        chart: SavedChartDAO,
+    ): Promise<SavedChartDAO> {
+        if (isJwtUser(account)) return chart;
+        const draft = await this.contentDraftModel.findOpenDraft(
+            chart.projectUuid,
+            'chart',
+            chart.uuid,
+            account.user.userUuid,
+        );
+        if (!draft) return chart;
+        try {
+            return mergeDraftIntoChart(chart, draft.draft);
+        } catch (error) {
+            this.logger.warn(
+                `Ignoring invalid chart draft ${draft.uuid} while running dashboard tile`,
+                error,
+            );
+            return chart;
+        }
+    }
+
     async executeAsyncDashboardChartQuery({
         account,
         projectUuid,
@@ -6165,17 +6197,21 @@ export class AsyncQueryService extends ProjectService {
         limit,
         parameters,
         pivotResults,
+        includeUnpublishedDraft,
         sessionTimezone,
         preloadedSavedChart,
         preloadedProjectParameters,
     }: ExecuteAsyncDashboardChartQueryArgs): Promise<ApiExecuteAsyncDashboardChartQueryResults> {
         assertIsAccountWithOrg(account);
 
-        const savedChart =
+        const publishedChart =
             preloadedSavedChart ??
             (await this.savedChartModel.get(chartUuid, undefined, {
                 projectUuid,
             }));
+        const savedChart = includeUnpublishedDraft
+            ? await this.applyOpenChartDraft(account, publishedChart)
+            : publishedChart;
         const { organizationUuid, projectUuid: savedChartProjectUuid } =
             savedChart;
 

--- a/packages/backend/src/services/AsyncQueryService/types.ts
+++ b/packages/backend/src/services/AsyncQueryService/types.ts
@@ -126,6 +126,7 @@ export type ExecuteAsyncDashboardChartQueryArgs = CommonAsyncQueryArgs & {
     dateZoom?: DateZoom;
     limit?: number | null | undefined;
     pivotResults?: boolean;
+    includeUnpublishedDraft?: boolean;
     sessionTimezone?: string | null;
     preloadedSavedChart?: SavedChartDAO;
     preloadedProjectParameters?: DbProjectParameter[];

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -100,6 +100,11 @@ import type {
 } from '../SoftDeletableService';
 import { SpacePermissionService } from '../SpaceService/SpacePermissionService';
 import { UserService } from '../UserService';
+import {
+    assertChartDraftOverlay,
+    mergeDraftIntoChart,
+    type ChartDraftOverlay,
+} from './chartDraftOverlay';
 
 type SavedChartServiceArguments = {
     analytics: LightdashAnalytics;
@@ -128,56 +133,6 @@ type SavedChartServiceArguments = {
 
 type ContentAsCodeDeleteOptions = SoftDeleteOptions & {
     contentAsCodePolicyChecked?: boolean;
-};
-
-type ChartDraftOverlay = Partial<
-    Pick<
-        SavedChartDAO,
-        | 'name'
-        | 'description'
-        | 'tableName'
-        | 'metricQuery'
-        | 'chartConfig'
-        | 'tableConfig'
-        | 'pivotConfig'
-        | 'parameters'
-        | 'merge'
-        | 'spaceUuid'
-    >
-> & { verified?: boolean };
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-    typeof value === 'object' && value !== null && !Array.isArray(value);
-
-const assertChartDraftOverlay: (
-    draft: unknown,
-) => asserts draft is ChartDraftOverlay = (draft) => {
-    if (!isRecord(draft)) throw new Error('Chart draft must be an object');
-    const validators: Record<
-        keyof ChartDraftOverlay,
-        (value: unknown) => boolean
-    > = {
-        name: (value) => typeof value === 'string',
-        description: (value) => typeof value === 'string',
-        tableName: (value) => typeof value === 'string',
-        metricQuery: isRecord,
-        chartConfig: isRecord,
-        tableConfig: isRecord,
-        pivotConfig: isRecord,
-        parameters: isRecord,
-        merge: (value) => value === null || isRecord(value),
-        spaceUuid: (value) => typeof value === 'string',
-        verified: (value) => typeof value === 'boolean',
-    };
-    for (const [field, validate] of Object.entries(validators)) {
-        if (
-            Object.prototype.hasOwnProperty.call(draft, field) &&
-            draft[field] !== undefined &&
-            !validate(draft[field])
-        ) {
-            throw new Error(`Invalid chart draft field: ${field}`);
-        }
-    }
 };
 
 type GoogleSheetValidationOptions = {
@@ -764,42 +719,6 @@ export class SavedChartService
         );
     }
 
-    private static mergeDraftIntoChart<T extends SavedChartDAO>(
-        chart: T,
-        draft: unknown,
-    ): T {
-        assertChartDraftOverlay(draft);
-        return {
-            ...chart,
-            ...(draft.name !== undefined && { name: draft.name }),
-            ...(draft.description !== undefined && {
-                description: draft.description,
-            }),
-            ...(draft.tableName !== undefined && {
-                tableName: draft.tableName,
-            }),
-            ...(draft.metricQuery !== undefined && {
-                metricQuery: draft.metricQuery,
-            }),
-            ...(draft.chartConfig !== undefined && {
-                chartConfig: draft.chartConfig,
-            }),
-            ...(draft.tableConfig !== undefined && {
-                tableConfig: draft.tableConfig,
-            }),
-            ...(draft.pivotConfig !== undefined && {
-                pivotConfig: draft.pivotConfig,
-            }),
-            ...(draft.parameters !== undefined && {
-                parameters: draft.parameters,
-            }),
-            ...(draft.merge !== undefined && { merge: draft.merge }),
-            ...(draft.spaceUuid !== undefined && {
-                spaceUuid: draft.spaceUuid,
-            }),
-        };
-    }
-
     private async maybeStoreDraft(
         user: SessionUser,
         existingChart: SavedChartDAO | ChartSummary,
@@ -869,10 +788,7 @@ export class SavedChartService
                 ? existingChart
                 : await this.savedChartModel.get(existingChart.uuid);
         return {
-            ...SavedChartService.mergeDraftIntoChart(
-                chartForOverlay,
-                stored.draft,
-            ),
+            ...mergeDraftIntoChart(chartForOverlay, stored.draft),
             verification: verificationAfterUpdate,
             ...spaceContext,
             hasUnpublishedChanges: true,
@@ -898,10 +814,7 @@ export class SavedChartService
                 try {
                     assertChartDraftOverlay(draft.draft);
                     return {
-                        ...SavedChartService.mergeDraftIntoChart(
-                            chart,
-                            draft.draft,
-                        ),
+                        ...mergeDraftIntoChart(chart, draft.draft),
                         verification:
                             draft.draft.verified === false
                                 ? null

--- a/packages/backend/src/services/SavedChartsService/chartDraftOverlay.ts
+++ b/packages/backend/src/services/SavedChartsService/chartDraftOverlay.ts
@@ -1,0 +1,87 @@
+import type { SavedChartDAO } from '@lightdash/common';
+
+export type ChartDraftOverlay = Partial<
+    Pick<
+        SavedChartDAO,
+        | 'name'
+        | 'description'
+        | 'tableName'
+        | 'metricQuery'
+        | 'chartConfig'
+        | 'tableConfig'
+        | 'pivotConfig'
+        | 'parameters'
+        | 'merge'
+        | 'spaceUuid'
+    >
+> & { verified?: boolean };
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+    typeof value === 'object' && value !== null && !Array.isArray(value);
+
+export const assertChartDraftOverlay: (
+    draft: unknown,
+) => asserts draft is ChartDraftOverlay = (draft) => {
+    if (!isRecord(draft)) throw new Error('Chart draft must be an object');
+    const validators: Record<
+        keyof ChartDraftOverlay,
+        (value: unknown) => boolean
+    > = {
+        name: (value) => typeof value === 'string',
+        description: (value) => typeof value === 'string',
+        tableName: (value) => typeof value === 'string',
+        metricQuery: isRecord,
+        chartConfig: isRecord,
+        tableConfig: isRecord,
+        pivotConfig: isRecord,
+        parameters: isRecord,
+        merge: (value) => value === null || isRecord(value),
+        spaceUuid: (value) => typeof value === 'string',
+        verified: (value) => typeof value === 'boolean',
+    };
+    for (const [field, validate] of Object.entries(validators)) {
+        if (
+            Object.prototype.hasOwnProperty.call(draft, field) &&
+            draft[field] !== undefined &&
+            !validate(draft[field])
+        ) {
+            throw new Error(`Invalid chart draft field: ${field}`);
+        }
+    }
+};
+
+export const mergeDraftIntoChart = <T extends SavedChartDAO>(
+    chart: T,
+    draft: unknown,
+): T => {
+    assertChartDraftOverlay(draft);
+    return {
+        ...chart,
+        ...(draft.name !== undefined && { name: draft.name }),
+        ...(draft.description !== undefined && {
+            description: draft.description,
+        }),
+        ...(draft.tableName !== undefined && {
+            tableName: draft.tableName,
+        }),
+        ...(draft.metricQuery !== undefined && {
+            metricQuery: draft.metricQuery,
+        }),
+        ...(draft.chartConfig !== undefined && {
+            chartConfig: draft.chartConfig,
+        }),
+        ...(draft.tableConfig !== undefined && {
+            tableConfig: draft.tableConfig,
+        }),
+        ...(draft.pivotConfig !== undefined && {
+            pivotConfig: draft.pivotConfig,
+        }),
+        ...(draft.parameters !== undefined && {
+            parameters: draft.parameters,
+        }),
+        ...(draft.merge !== undefined && { merge: draft.merge }),
+        ...(draft.spaceUuid !== undefined && {
+            spaceUuid: draft.spaceUuid,
+        }),
+    };
+};

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -948,6 +948,7 @@ export class ServiceRepository
                 new AsyncQueryService({
                     lightdashConfig: this.context.lightdashConfig,
                     analytics: this.context.lightdashAnalytics,
+                    contentDraftModel: this.models.getContentDraftModel(),
                     projectModel: this.models.getProjectModel(),
                     projectDbtSourcesModel:
                         this.models.getProjectDbtSourcesModel(),

--- a/packages/common/src/types/api/paginatedQuery.ts
+++ b/packages/common/src/types/api/paginatedQuery.ts
@@ -60,6 +60,9 @@ export type ExecuteAsyncDashboardChartRequestParams =
         dateZoom?: DateZoom;
         limit?: number | null | undefined;
         pivotResults?: boolean;
+        // Run the caller's own unpublished chart draft instead of the
+        // published chart, so a tile matches what the author sees
+        includeUnpublishedDraft?: boolean;
     };
 
 /** A merge run: the spec that produced it, recorded verbatim. */

--- a/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
@@ -123,10 +123,14 @@ export const useDashboardChartReadyQuery = (
             ?.join(',') || '';
 
     const projectUuid = useDashboardContext((c) => c.projectUuid);
+    const includeUnpublishedDraft = useDashboardContext(
+        (c) => c.includeUnpublishedDraft,
+    );
     const sessionTimezone = useSessionTimezone();
     const chartQuery = useSavedQuery({
         uuidOrSlug: chartUuid ?? undefined,
         projectUuid,
+        includeUnpublishedDraft,
     });
 
     const { data: explore, error: exploreError } = useExplore(
@@ -326,6 +330,9 @@ export const useDashboardChartReadyQuery = (
                           invalidateCache,
                           parameters: parameterValues,
                           pivotResults: true,
+                          ...(includeUnpublishedDraft && {
+                              includeUnpublishedDraft: true,
+                          }),
                       },
                   );
 

--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -1797,6 +1797,7 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
 
     const value = {
         projectUuid,
+        includeUnpublishedDraft,
         isDashboardLoading,
         dashboard: dashboard || embedDashboard,
         setEmbedDashboard,

--- a/packages/frontend/src/providers/Dashboard/types.ts
+++ b/packages/frontend/src/providers/Dashboard/types.ts
@@ -41,6 +41,7 @@ export type TilePreAggregateStatus = {
 
 export type DashboardContextType = {
     projectUuid?: string;
+    includeUnpublishedDraft: boolean;
     isDashboardLoading: boolean;
     dashboard: Dashboard | undefined;
     setEmbedDashboard: Dispatch<SetStateAction<Dashboard | undefined>>;


### PR DESCRIPTION
## Summary

Chart drafts are opt-in per read (`?includeUnpublishedDraft=true`). The dashboard page opts in for the dashboard itself, but tiles loaded their charts through `useDashboardChartReadyQuery` without the flag, and the tile query executed the published chart server-side. An author saw their chart draft in the explorer and the published chart in every tile.

Fix, both halves of a tile:

- `DashboardProvider` exposes `includeUnpublishedDraft` on the context; `useDashboardChartReadyQuery` forwards it to `useSavedQuery` (the chart definition) and to `POST /v2/projects/{projectUuid}/query/dashboard-chart` (the results).
- `AsyncQueryService.executeAsyncDashboardChartQuery` accepts `includeUnpublishedDraft` and, for registered users, merges the caller's own open draft into the chart before compiling the query (`chartDraftOverlay.ts`, the same merge the chart read path uses, now shared). JWT/embed users and callers without the flag run the published chart. An invalid draft is logged and ignored, as on the read path.

The backend only overlays the caller's own open draft, so other viewers keep seeing published content; `MinimalDashboard` (headless exports) and embeds do not set the flag, so exports and scheduled deliveries are unchanged. Cost on a sync-enabled project: one indexed `content_drafts` lookup per tile fetch and per tile query for the interactive dashboard page.

## Test plan

- [x] Live: editor renames a git-backed chart (draft); the dashboard tile using it shows the drafted name for the editor and the published name for the admin. Re-verified after the query-path change with a draft that alters the metric query.
- [x] `AsyncQueryService` and `SavedChartService` suites (119 tests), `pnpm -F backend typecheck`, `pnpm -F frontend typecheck`, oxlint, oxfmt.

Closes: PROD-10812
Relates: PROD-2856