### PR TITLE
fix(cli): report per-type counts in the upload summary

### DIFF
--- a/packages/cli/src/handlers/download.test.ts
+++ b/packages/cli/src/handlers/download.test.ts
@@ -4,6 +4,7 @@ import {
     ContentAsCodeType,
     DashboardAsCode,
     LightdashError,
+    PromotionAction,
     SpaceAsCodeAction,
     SpaceMemberRole,
     type AnyType,
@@ -35,6 +36,7 @@ import {
     uploadHandler,
     type DownloadHandlerOptions,
 } from './download';
+import { logUploadChanges } from './spacesAsCode';
 
 vi.mock('../analytics/analytics', () => ({
     LightdashAnalytics: {
@@ -93,6 +95,7 @@ const {
     summarizeUploadChanges,
     upsertAiAgents,
     upsertExternalConnections,
+    upsertResources,
     upsertSpaces,
     upsertVirtualViews,
     validateSpaceIdentity,
@@ -428,6 +431,92 @@ const makeChart = (series: Series[]): ChartAsCode =>
         },
         dashboardSlug: undefined,
     }) as ChartAsCode;
+
+const writeFolderChart = async (baseDir: string, slug: string) => {
+    const yaml = `contentType: chart\nname: ${slug}\nslug: ${slug}\nspaceSlug: test-space\ntableName: orders\nversion: 1\n`;
+    await fs.writeFile(path.join(baseDir, 'charts', `${slug}.yml`), yaml);
+};
+
+describe('upload summary counts', () => {
+    let tmpDir: string;
+
+    beforeEach(async () => {
+        vi.mocked(lightdashApi).mockReset();
+        vi.spyOn(GlobalState, 'log').mockImplementation(() => undefined);
+        vi.spyOn(GlobalState, 'debug').mockImplementation(() => undefined);
+        tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'download-test-'));
+        await fs.mkdir(path.join(tmpDir, 'charts'));
+        await fs.mkdir(path.join(tmpDir, 'dashboards'));
+    });
+
+    afterEach(async () => {
+        vi.restoreAllMocks();
+        await fs.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    it('counts only the uploaded type, not the spaces and tiles echoed by the API', async () => {
+        await writeFolderChart(tmpDir, 'chart-a');
+        await writeFolderChart(tmpDir, 'chart-b');
+        await writeFolderDashboard(tmpDir, 'dash', ['chart-a', 'chart-b']);
+        const noChanges = { action: PromotionAction.NO_CHANGES };
+        vi.mocked(lightdashApi).mockImplementation(async ({ url }) =>
+            url.includes('/code/charts/')
+                ? ({
+                      charts: [{ action: PromotionAction.UPDATE }],
+                      spaces: [noChanges],
+                      dashboards: [],
+                  } as never)
+                : ({
+                      dashboards: [{ action: PromotionAction.UPDATE }],
+                      charts: [noChanges, noChanges],
+                      spaces: [noChanges],
+                  } as never),
+        );
+        const summarySpy = vi
+            .spyOn(console, 'info')
+            .mockImplementation(() => undefined);
+
+        const changes: Record<string, number> = {};
+        const chartsResult = await upsertResources<ChartAsCode>(
+            'charts',
+            'project-uuid',
+            changes,
+            false,
+            [],
+            true,
+            tmpDir,
+        );
+        const afterCharts = { ...chartsResult.changes };
+        expect(summarizeUploadChanges({}, afterCharts).detail).toBe(
+            '2 updated',
+        );
+
+        const dashboardsResult = await upsertResources<DashboardAsCode>(
+            'dashboards',
+            'project-uuid',
+            changes,
+            false,
+            [],
+            true,
+            tmpDir,
+        );
+        expect(
+            summarizeUploadChanges(afterCharts, dashboardsResult.changes)
+                .detail,
+        ).toBe('1 updated');
+        expect(lightdashApi).toHaveBeenCalledTimes(3);
+        expect(dashboardsResult.changes).toEqual({
+            'charts updated': 2,
+            'dashboards updated': 1,
+        });
+
+        logUploadChanges(dashboardsResult.changes);
+        expect(summarySpy.mock.calls.map(([message]) => message)).toEqual([
+            'Total charts updated: 2 ',
+            'Total dashboards updated: 1 ',
+        ]);
+    });
+});
 
 describe('getDashboardChartSlugs', () => {
     let tmpDir: string;

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -2887,38 +2887,19 @@ export const downloadHandler = async (
 
 const storeUploadChanges = (
     changes: Record<string, number>,
+    type: 'charts' | 'dashboards',
     promoteChanges: PromotionChanges,
 ): Record<string, number> => {
-    const getPromoteChanges = (
-        resource: 'spaces' | 'charts' | 'dashboards',
-    ) => {
-        const promotions: { action: PromotionAction }[] =
-            promoteChanges[resource];
-        return promotions.reduce<Record<string, number>>(
-            (acc, promoteChange) => {
-                const action = getPromoteAction(promoteChange.action);
-                const key = `${resource} ${action}`;
-                acc[key] = (acc[key] ?? 0) + 1;
-                return acc;
-            },
-            {},
-        );
-    };
-
-    const updatedChanges: Record<string, number> = {
-        ...changes,
-    };
-
-    ['spaces', 'charts', 'dashboards'].forEach((resource) => {
-        const resourceChanges = getPromoteChanges(
-            resource as 'spaces' | 'charts' | 'dashboards',
-        );
-        Object.entries(resourceChanges).forEach(([key, value]) => {
-            updatedChanges[key] = (updatedChanges[key] ?? 0) + value;
-        });
-    });
-
-    return updatedChanges;
+    // The API also echoes untouched spaces and chart tiles; only count the uploaded type
+    const promotions: { action: PromotionAction }[] = promoteChanges[type];
+    return promotions.reduce<Record<string, number>>(
+        (acc, promoteChange) => {
+            const key = `${type} ${getPromoteAction(promoteChange.action)}`;
+            acc[key] = (acc[key] ?? 0) + 1;
+            return acc;
+        },
+        { ...changes },
+    );
 };
 
 const UPLOAD_CHANGE_SUFFIXES = [
@@ -3047,7 +3028,7 @@ const upsertSingleItem = async <T extends ChartAsCode | DashboardAsCode>(
         );
 
         // Merge storeUploadChanges result into changes in-place
-        const updatedChanges = storeUploadChanges(changes, upsertData);
+        const updatedChanges = storeUploadChanges(changes, type, upsertData);
         Object.keys(updatedChanges).forEach((key) => {
             changes[key] = updatedChanges[key];
         });
@@ -4753,6 +4734,7 @@ export const testHelpers = {
     summarizeUploadChanges,
     upsertAiAgents,
     upsertExternalConnections,
+    upsertResources,
     upsertSpaces,
     upsertVirtualViews,
     validateSpaceIdentity,


### PR DESCRIPTION
## Summary

`lightdash upload` printed summary counts that could not be right ("Dashboards 10 skipped, 3 updated" on a project with 3 dashboards, "Total spaces skipped: 13" with 2 spaces): the per-phase counters were accumulated across content types and the phase lines were rendered from the cumulative record.

Each phase line now reports only its own counts and the "Total ..." lines report real per-type totals. Uploads themselves were always correct; exit codes and error counts are unchanged.

## Test plan

- [x] `download.test.ts`: per-phase and total counts asserted with mocked chart and dashboard phases.
- [x] Live on a 2-space, 10-chart, 3-dashboard project: `Charts 10 updated`, `Dashboards 3 updated`, `Total spaces unchanged: 2`.
- [x] `pnpm -F cli typecheck`, `pnpm -F cli lint`.

Closes: PROD-10814
Relates: PROD-2856