### PR TITLE
fix(content-as-code): give write-back branches a type folder and keep drafts beside the propose branch

### DIFF
--- a/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.test.ts
+++ b/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.test.ts
@@ -366,7 +366,7 @@ describe('ContentAsCodeWritebackService', () => {
         ).toHaveBeenCalledWith(
             user,
             'project-uuid',
-            'lightdash/write-back/app.lightdash.dev/monthly-revenue',
+            'lightdash/write-back/app.lightdash.dev/charts/monthly-revenue',
             'main',
         );
         const [, , , filePath, content, sha] =
@@ -409,7 +409,7 @@ describe('ContentAsCodeWritebackService', () => {
             contentType: 'dashboard',
             slug: 'weekly-kpis',
             contentDraftUuid: 'draft-uuid',
-            branch: 'lightdash/write-back/app.lightdash.dev/weekly-kpis/draft-draft-uuid',
+            branch: 'lightdash/write-back/app.lightdash.dev/dashboards/weekly-kpis--draft-draft-uuid',
             prNumber: 5,
             prUrl: 'https://github.com/acme/analytics/pull/5',
             status: 'open',
@@ -595,6 +595,47 @@ describe('ContentAsCodeWritebackService', () => {
         );
     });
 
+    it('builds branch names that are safe git refs per content type', () => {
+        expect(
+            ContentAsCodeWritebackService.getWritebackBranch(
+                'app.lightdash.dev',
+                'chart',
+                'monthly-revenue',
+                null,
+            ),
+        ).toBe('lightdash/write-back/app.lightdash.dev/charts/monthly-revenue');
+        expect(
+            ContentAsCodeWritebackService.getWritebackBranch(
+                'app.lightdash.dev',
+                'dashboard',
+                'monthly-revenue',
+                'draft-uuid',
+            ),
+        ).toBe(
+            'lightdash/write-back/app.lightdash.dev/dashboards/monthly-revenue--draft-draft-uuid',
+        );
+        const odd = ContentAsCodeWritebackService.getWritebackBranch(
+            'app.lightdash.dev',
+            'chart',
+            `weird slug/with..dots~^:?*[\\${'x'.repeat(300)}.lock`,
+            null,
+        );
+        expect(odd).toMatch(
+            /^lightdash\/write-back\/app\.lightdash\.dev\/charts\/[A-Za-z0-9._-]+$/,
+        );
+        expect(odd.length).toBeLessThanOrEqual(255);
+        const longDraft = ContentAsCodeWritebackService.getWritebackBranch(
+            'analytics.some-very-long-customer-hostname.lightdash.cloud',
+            'dashboard',
+            'd'.repeat(300),
+            '296ed5f6-4f11-4124-aa19-e0da4906cc57',
+        );
+        expect(longDraft.length).toBeLessThanOrEqual(255);
+        expect(longDraft).toMatch(
+            /--draft-296ed5f6-4f11-4124-aa19-e0da4906cc57$/,
+        );
+    });
+
     it('adopts the open PR found on the provider when the branch already exists', async () => {
         const { service, gitIntegrationService, contentAsCodeWritebackModel } =
             buildService({
@@ -612,7 +653,7 @@ describe('ContentAsCodeWritebackService', () => {
         ).toHaveBeenCalledWith(
             user,
             'project-uuid',
-            'lightdash/write-back/app.lightdash.dev/monthly-revenue',
+            'lightdash/write-back/app.lightdash.dev/charts/monthly-revenue',
         );
         expect(gitIntegrationService.saveFile).toHaveBeenCalledTimes(1);
         expect(
@@ -743,7 +784,7 @@ describe('ContentAsCodeWritebackService', () => {
             liveRow: {
                 uuid: 'row-uuid',
                 contentDraftUuid: null,
-                branch: 'lightdash/write-back/app.lightdash.dev/monthly-revenue',
+                branch: 'lightdash/write-back/app.lightdash.dev/charts/monthly-revenue',
                 prUrl: 'https://github.com/acme/analytics/pull/42',
                 status: 'open',
             },
@@ -776,7 +817,7 @@ describe('ContentAsCodeWritebackService', () => {
             liveRow: {
                 uuid: 'row-uuid',
                 contentDraftUuid: null,
-                branch: 'lightdash/write-back/app.lightdash.dev/monthly-revenue',
+                branch: 'lightdash/write-back/app.lightdash.dev/charts/monthly-revenue',
                 prUrl: 'https://github.com/acme/analytics/pull/42',
                 status: 'open',
             },
@@ -831,7 +872,7 @@ describe('ContentAsCodeWritebackService', () => {
         expect(contentAsCodeWritebackModel.create).toHaveBeenCalledWith(
             expect.objectContaining({
                 contentDraftUuid: 'draft-uuid',
-                branch: 'lightdash/write-back/app.lightdash.dev/weekly-kpis/draft-draft-uuid',
+                branch: 'lightdash/write-back/app.lightdash.dev/dashboards/weekly-kpis--draft-draft-uuid',
             }),
         );
         expect(
@@ -839,7 +880,7 @@ describe('ContentAsCodeWritebackService', () => {
         ).toHaveBeenCalledWith(
             user,
             'project-uuid',
-            'lightdash/write-back/app.lightdash.dev/weekly-kpis/draft-draft-uuid',
+            'lightdash/write-back/app.lightdash.dev/dashboards/weekly-kpis--draft-draft-uuid',
             'main',
         );
     });
@@ -875,7 +916,7 @@ describe('ContentAsCodeWritebackService', () => {
         expect(gitIntegrationService.saveFile).toHaveBeenCalledWith(
             user,
             'project-uuid',
-            expect.stringContaining('/draft-chart-draft-uuid'),
+            'lightdash/write-back/app.lightdash.dev/charts/monthly-revenue--draft-chart-draft-uuid',
             'lightdash/charts/monthly-revenue.yml',
             expect.stringContaining('Monthly revenue draft'),
             undefined,
@@ -883,7 +924,7 @@ describe('ContentAsCodeWritebackService', () => {
         );
     });
 
-    it('reuses the branch and PR owned by the same draft', async () => {
+    it('reuses the branch stored on the row, including a pre-rename branch name', async () => {
         const { service, gitIntegrationService, contentAsCodeWritebackModel } =
             buildService({
                 liveRow: {
@@ -891,6 +932,7 @@ describe('ContentAsCodeWritebackService', () => {
                     contentType: 'dashboard',
                     slug: 'weekly-kpis',
                     contentDraftUuid: 'draft-uuid',
+                    // Rows from before the branch rename keep their stored branch
                     branch: 'lightdash/write-back/app.lightdash.dev/weekly-kpis/draft-draft-uuid',
                     prNumber: 42,
                     prUrl: 'https://github.com/acme/analytics/pull/42',
@@ -937,7 +979,7 @@ describe('ContentAsCodeWritebackService', () => {
                 contentType: 'dashboard',
                 slug: 'weekly-kpis',
                 contentDraftUuid: 'draft-uuid',
-                branch: 'lightdash/write-back/app.lightdash.dev/weekly-kpis/draft-draft-uuid',
+                branch: 'lightdash/write-back/app.lightdash.dev/dashboards/weekly-kpis--draft-draft-uuid',
                 prNumber: null,
                 prUrl: null,
                 status: 'pending',
@@ -966,7 +1008,7 @@ describe('ContentAsCodeWritebackService', () => {
                     contentType: 'dashboard',
                     slug: 'weekly-kpis',
                     contentDraftUuid: 'other-draft-uuid',
-                    branch: 'lightdash/write-back/app.lightdash.dev/weekly-kpis/draft-other-draft-uuid',
+                    branch: 'lightdash/write-back/app.lightdash.dev/dashboards/weekly-kpis--draft-other-draft-uuid',
                     prNumber: null,
                     prUrl: null,
                     status: 'pending',
@@ -991,7 +1033,7 @@ describe('ContentAsCodeWritebackService', () => {
             contentType: 'dashboard',
             slug: 'weekly-kpis',
             contentDraftUuid: 'other-draft-uuid',
-            branch: 'lightdash/write-back/app.lightdash.dev/weekly-kpis/draft-other-draft-uuid',
+            branch: 'lightdash/write-back/app.lightdash.dev/dashboards/weekly-kpis--draft-other-draft-uuid',
             prNumber: null,
             prUrl: null,
             status: 'pending',

--- a/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.ts
+++ b/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.ts
@@ -45,6 +45,21 @@ type ContentAsCodeWritebackServiceArguments = {
 
 type WritebackContentType = 'chart' | 'dashboard';
 
+const WRITEBACK_BRANCH_PREFIX = 'lightdash/write-back';
+
+// The stored branch column is varchar(255); file-backed git hosts cap a ref
+// component at 255 bytes too
+const MAX_BRANCH_LENGTH = 255;
+
+// Git ref component rules: no spaces or `~^:?*[\`, no `..`, no leading or
+// trailing `.`, no `.lock` suffix
+const toRefSafeComponent = (value: string): string =>
+    value
+        .replace(/[^A-Za-z0-9._-]+/g, '-')
+        .replace(/\.{2,}/g, '.')
+        .replace(/^[.-]+|[.-]+$/g, '')
+        .replace(/\.lock$/, '') || 'content';
+
 type CommitAuthor = { name: string; email: string | null };
 
 const commitAuthorFromUser = (user: {
@@ -140,6 +155,28 @@ export class ContentAsCodeWritebackService extends BaseService {
         } catch {
             return 'instance';
         }
+    }
+
+    // Mirrors the repo layout so a chart and a dashboard sharing a slug get
+    // different branches; drafts are siblings of the propose branch because
+    // git cannot hold both `<slug>` and `<slug>/...` refs
+    static getWritebackBranch(
+        instanceSlug: string,
+        contentType: WritebackContentType,
+        slug: string,
+        contentDraftUuid: string | null,
+    ): string {
+        const folder = contentType === 'chart' ? 'charts' : 'dashboards';
+        const prefix = `${WRITEBACK_BRANCH_PREFIX}/${instanceSlug}/${folder}/`;
+        const suffix = contentDraftUuid ? `--draft-${contentDraftUuid}` : '';
+        const slugBudget = Math.max(
+            20,
+            MAX_BRANCH_LENGTH - prefix.length - suffix.length,
+        );
+        const safeSlug = toRefSafeComponent(slug)
+            .slice(0, slugBudget)
+            .replace(/[.-]+$/, '');
+        return `${prefix}${safeSlug}${suffix}`;
     }
 
     private static getContentFilePath(
@@ -612,10 +649,12 @@ export class ContentAsCodeWritebackService extends BaseService {
             this.assertWritebackOwner(row, target.contentDraftUuid);
         }
         if (row === undefined) {
-            const baseBranch = `lightdash/write-back/${this.getInstanceSlug()}/${slug}`;
-            const branch = target.contentDraftUuid
-                ? `${baseBranch}/draft-${target.contentDraftUuid}`
-                : baseBranch;
+            const branch = ContentAsCodeWritebackService.getWritebackBranch(
+                this.getInstanceSlug(),
+                contentType,
+                slug,
+                target.contentDraftUuid,
+            );
             try {
                 row = await this.contentAsCodeWritebackModel.create({
                     projectUuid,


### PR DESCRIPTION
## Summary

Found while recording the fix confirmations for this stack, then widened by review. Write-back branch names had three problems:

1. Propose branches were `lightdash/write-back/<host>/<slug>` and draft branches `…/<slug>/draft-<draftUuid>`. Git refs form a directory tree, so `<slug>` and `<slug>/draft-…` cannot coexist: once a propose branch existed for a slug (or an older instance left one behind), every draft write-back for that slug failed at branch creation with GitHub's `Reference update failed`, and the writeback row was left in `error`. The reverse held too.
2. The name was keyed on `<host>/<slug>` only while rows are keyed on `(project, content type, slug)`, so a chart and a dashboard sharing a slug mapped to the same branch, and with PR adoption the second one adopted the first one's PR.
3. Slugs went into the ref unchecked: a 255-character slug plus `--draft-<uuid>` exceeds the 255-byte ref component limit on file-backed hosts, and uploaded slugs are not validated as ref-safe.

Fix, all in one static `ContentAsCodeWritebackService.getWritebackBranch`:

- `lightdash/write-back/<host>/charts/<slug>` or `…/dashboards/<slug>` for propose, `…/<slug>--draft-<draftUuid>` for drafts (siblings, never children; the type folder mirrors the repo layout).
- The slug component is made ref-safe and budgeted so the whole branch name fits the 255-character `branch` column (and the ref component limit on file-backed hosts). The branch is always read back from the row, so the stored name is what matters.
- While here: `pushContentToBranch` no longer attempts `createBranchFromSource` when the row already has an open PR (the branch must exist), which removes two provider round trips per repeat save.

Rows that already store the old branch name keep working, and the new folder never collides with legacy `<host>/<slug>` or `<host>/<slug>/draft-…` refs, so no remote cleanup is required.

## Who's affected

Nothing on this feature has shipped to customers yet (drafts and write-back landed 2026-08-27 and are gated on `content_as_code.sync`). Known limitation, unchanged: two projects on one instance pointing at the same repo share branch names for a shared slug.

## Test plan

- [x] `ContentAsCodeWritebackService.test.ts`: builder output per type, sanitised and capped slug, pre-rename stored branch still honoured, no branch create on a row with an open PR (37 tests).
- [x] Live: with a stale `…/revenue-overview` branch on the repo (open PR #71 from a previous instance), a draft write-back for `revenue-overview` failed with `Reference update failed` before this change and opens its PR after it.
- [x] `pnpm -F backend typecheck`, oxlint, oxfmt.

Closes: PROD-10815
Relates: PROD-2856