### PR TITLE
fix: queue playground dashboard queries

### DIFF
--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
@@ -4,6 +4,7 @@ import {
     DucklakeCatalogType,
     DucklakeDataPathType,
     QueryExecutionContext,
+    WarehouseQueryError,
     WarehouseTypes,
     WeekDay,
 } from '@lightdash/common';
@@ -212,6 +213,10 @@ describe('DuckdbWarehouseClient', () => {
             maxAgeMs: 60_000,
             maxEntries: 8,
         });
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
     });
 
     it('should return query rows and mapped fields', async () => {
@@ -1230,12 +1235,12 @@ describe('DuckdbWarehouseClient', () => {
         );
     });
 
-    it('rejects embedded queries beyond the process concurrency budget', async () => {
+    it('runs a queued embedded query once a same-organization holder releases', async () => {
         const pendingStreams: Array<
             (result: ReturnType<typeof getMockStreamResult>) => void
         > = [];
         const streamMock = vi.fn(
-            () =>
+            (_sql: string) =>
                 new Promise<ReturnType<typeof getMockStreamResult>>(
                     (resolve) => {
                         pendingStreams.push(resolve);
@@ -1248,43 +1253,114 @@ describe('DuckdbWarehouseClient', () => {
         );
 
         const createClient = () =>
-            new DuckdbWarehouseClient({
-                type: WarehouseTypes.DUCKDB,
-                connectionType: DuckdbConnectionType.EMBEDDED,
-                dataset: 'jaffle_shop',
-            });
-
-        const firstQuery = createClient().runQuery('SELECT 1 AS val');
-        const secondQuery = createClient().runQuery('SELECT 2 AS val');
-        await vi.waitFor(() => expect(streamMock).toHaveBeenCalledTimes(2));
-
-        await expect(
-            createClient().runQuery('SELECT 3 AS val'),
-        ).rejects.toThrow(
-            'Playground query capacity is full. Try again shortly.',
+            new DuckdbWarehouseClient(
+                {
+                    type: WarehouseTypes.DUCKDB,
+                    connectionType: DuckdbConnectionType.EMBEDDED,
+                    dataset: 'jaffle_shop',
+                },
+                { embeddedQueryTimeoutMs: 60_000 },
+            );
+        const tags = { organization_uuid: 'organization-1' };
+        const queries = Array.from({ length: 6 }, (_, index) =>
+            createClient().runQuery(`SELECT ${index + 1} AS val`, tags),
         );
-        expect(createInstanceMock).toHaveBeenCalledTimes(2);
+
+        await vi.waitFor(() => expect(streamMock).toHaveBeenCalledTimes(4));
+        expect(createInstanceMock).toHaveBeenCalledTimes(4);
+
+        pendingStreams[0](
+            getMockStreamResult([[{ val: 1 }]], [DUCKDB_TYPE_IDS.INTEGER]),
+        );
+        await queries[0];
+
+        await vi.waitFor(() => expect(streamMock).toHaveBeenCalledTimes(5));
+        expect(createInstanceMock).toHaveBeenCalledTimes(5);
+        expect(streamMock.mock.calls[4]?.[0]).toContain('SELECT 5 AS val');
+
+        pendingStreams[1](
+            getMockStreamResult([[{ val: 2 }]], [DUCKDB_TYPE_IDS.INTEGER]),
+        );
+        await queries[1];
+
+        await vi.waitFor(() => expect(streamMock).toHaveBeenCalledTimes(6));
+        expect(createInstanceMock).toHaveBeenCalledTimes(6);
+        expect(streamMock.mock.calls[5]?.[0]).toContain('SELECT 6 AS val');
 
         pendingStreams.forEach((resolve) =>
             resolve(
                 getMockStreamResult([[{ val: 1 }]], [DUCKDB_TYPE_IDS.INTEGER]),
             ),
         );
-        await Promise.all([firstQuery, secondQuery]);
+        await Promise.all(queries.slice(1));
     });
 
-    it('rejects concurrent embedded queries for the same organization', async () => {
-        let resolveStream: (
-            result: ReturnType<typeof getMockStreamResult>,
-        ) => void = () => {};
+    it('times out a queued embedded query with the existing capacity error', async () => {
+        vi.useFakeTimers();
+        const pendingStreams: Array<
+            (result: ReturnType<typeof getMockStreamResult>) => void
+        > = [];
         const streamMock = vi.fn(
             () =>
                 new Promise<ReturnType<typeof getMockStreamResult>>(
                     (resolve) => {
-                        resolveStream = resolve;
+                        pendingStreams.push(resolve);
                     },
                 ),
         );
+        createInstanceMock.mockImplementation(async () =>
+            createMockConnection(streamMock),
+        );
+
+        const createClient = () =>
+            new DuckdbWarehouseClient(
+                {
+                    type: WarehouseTypes.DUCKDB,
+                    connectionType: DuckdbConnectionType.EMBEDDED,
+                    dataset: 'jaffle_shop',
+                },
+                { embeddedQueryTimeoutMs: 60_000 },
+            );
+        const tags = { organization_uuid: 'organization-1' };
+        const activeQueries = Array.from({ length: 4 }, (_, index) =>
+            createClient().runQuery(`SELECT ${index + 1} AS val`, tags),
+        );
+        await vi.waitFor(() => expect(streamMock).toHaveBeenCalledTimes(4));
+
+        const queuedQuery = createClient().runQuery('SELECT 5 AS val', tags);
+        const capacityError = queuedQuery.catch((error: unknown) => error);
+        await vi.advanceTimersByTimeAsync(15_000);
+
+        const error = await capacityError;
+        expect(error).toBeInstanceOf(WarehouseQueryError);
+        expect(error).toMatchObject({
+            message: 'Playground query capacity is full. Try again shortly.',
+        });
+        expect(createInstanceMock).toHaveBeenCalledTimes(4);
+
+        pendingStreams.forEach((resolve) =>
+            resolve(
+                getMockStreamResult([[{ val: 1 }]], [DUCKDB_TYPE_IDS.INTEGER]),
+            ),
+        );
+        await Promise.all(activeQueries);
+    });
+
+    it('returns embedded capacity when a query throws', async () => {
+        const pendingStreams: Array<
+            (result: ReturnType<typeof getMockStreamResult>) => void
+        > = [];
+        const streamMock = vi.fn((sql: string) => {
+            if (sql.includes('SELECT 4')) {
+                return Promise.reject(new Error('Query failed'));
+            }
+
+            return new Promise<ReturnType<typeof getMockStreamResult>>(
+                (resolve) => {
+                    pendingStreams.push(resolve);
+                },
+            );
+        });
         createInstanceMock.mockImplementation(async () =>
             createMockConnection(streamMock),
         );
@@ -1296,20 +1372,93 @@ describe('DuckdbWarehouseClient', () => {
                 dataset: 'jaffle_shop',
             });
         const tags = { organization_uuid: 'organization-1' };
+        const activeQueries = Array.from({ length: 3 }, (_, index) =>
+            createClient().runQuery(`SELECT ${index + 1} AS val`, tags),
+        );
+        const failedQuery = createClient().runQuery('SELECT 4 AS val', tags);
 
-        const firstQuery = createClient().runQuery('SELECT 1 AS val', tags);
-        await vi.waitFor(() => expect(streamMock).toHaveBeenCalledOnce());
+        await expect(failedQuery).rejects.toThrow('Query failed');
 
-        await expect(
-            createClient().runQuery('SELECT 2 AS val', tags),
-        ).rejects.toThrow(
-            'Playground query capacity is full. Try again shortly.',
+        const nextQuery = createClient().runQuery('SELECT 5 AS val', tags);
+        await vi.waitFor(() => expect(streamMock).toHaveBeenCalledTimes(5));
+
+        pendingStreams.forEach((resolve) =>
+            resolve(
+                getMockStreamResult([[{ val: 1 }]], [DUCKDB_TYPE_IDS.INTEGER]),
+            ),
+        );
+        await Promise.all([...activeQueries, nextQuery]);
+    });
+
+    it('returns the global slot when organization capacity times out', async () => {
+        vi.useFakeTimers();
+        const pendingStreams: Array<
+            (result: ReturnType<typeof getMockStreamResult>) => void
+        > = [];
+        const streamMock = vi.fn(
+            () =>
+                new Promise<ReturnType<typeof getMockStreamResult>>(
+                    (resolve) => {
+                        pendingStreams.push(resolve);
+                    },
+                ),
+        );
+        createInstanceMock.mockImplementation(async () =>
+            createMockConnection(streamMock),
         );
 
-        resolveStream(
-            getMockStreamResult([[{ val: 1 }]], [DUCKDB_TYPE_IDS.INTEGER]),
+        const createClient = () =>
+            new DuckdbWarehouseClient(
+                {
+                    type: WarehouseTypes.DUCKDB,
+                    connectionType: DuckdbConnectionType.EMBEDDED,
+                    dataset: 'jaffle_shop',
+                },
+                { embeddedQueryTimeoutMs: 60_000 },
+            );
+        const organizationOneTags = {
+            organization_uuid: 'organization-1',
+        };
+        const organizationTwoTags = {
+            organization_uuid: 'organization-2',
+        };
+        const organizationOneQueries = Array.from({ length: 4 }, (_, index) =>
+            createClient().runQuery(
+                `SELECT ${index + 1} AS val`,
+                organizationOneTags,
+            ),
         );
-        await firstQuery;
+        await vi.waitFor(() => expect(streamMock).toHaveBeenCalledTimes(4));
+
+        const timedOutQuery = createClient().runQuery(
+            'SELECT 5 AS val',
+            organizationOneTags,
+        );
+        const capacityError = timedOutQuery.catch((error: unknown) => error);
+        await vi.advanceTimersByTimeAsync(15_000);
+
+        await expect(capacityError).resolves.toMatchObject({
+            name: 'WarehouseQueryError',
+            message: 'Playground query capacity is full. Try again shortly.',
+        });
+
+        const organizationTwoQueries = Array.from({ length: 4 }, (_, index) =>
+            createClient().runQuery(
+                `SELECT ${index + 6} AS val`,
+                organizationTwoTags,
+            ),
+        );
+        await vi.waitFor(() => expect(streamMock).toHaveBeenCalledTimes(8));
+
+        pendingStreams.forEach((resolve) =>
+            resolve(
+                getMockStreamResult([[{ val: 1 }]], [DUCKDB_TYPE_IDS.INTEGER]),
+            ),
+        );
+        await Promise.all([
+            ...organizationOneQueries,
+            ...organizationTwoQueries,
+        ]);
     });
 
     it('logs structured profiles for non-embedded queries and reports metrics', async () => {

--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
@@ -294,6 +294,11 @@ class AsyncSemaphore {
 class ConcurrencyBudget {
     private active = 0;
 
+    private pendingAcquires: Array<{
+        resolve: (acquired: boolean) => void;
+        timeout?: ReturnType<typeof setTimeout>;
+    }> = [];
+
     constructor(private readonly limit: number) {}
 
     tryAcquire(): boolean {
@@ -305,7 +310,44 @@ class ConcurrencyBudget {
         return true;
     }
 
+    acquire(timeoutMs: number): Promise<boolean> {
+        if (this.tryAcquire()) {
+            return Promise.resolve(true);
+        }
+
+        return new Promise<boolean>((resolve) => {
+            const pendingAcquire: (typeof this.pendingAcquires)[number] = {
+                resolve,
+            };
+            const timeout = setTimeout(() => {
+                const index = this.pendingAcquires.indexOf(pendingAcquire);
+                if (index === -1) {
+                    return;
+                }
+
+                this.pendingAcquires.splice(index, 1);
+                resolve(false);
+            }, timeoutMs);
+            timeout.unref();
+            pendingAcquire.timeout = timeout;
+            this.pendingAcquires.push(pendingAcquire);
+        });
+    }
+
     release(): void {
+        if (this.active === 0) {
+            return;
+        }
+
+        const pendingAcquire = this.pendingAcquires.shift();
+        if (pendingAcquire) {
+            if (pendingAcquire.timeout) {
+                clearTimeout(pendingAcquire.timeout);
+            }
+            pendingAcquire.resolve(true);
+            return;
+        }
+
         this.active -= 1;
     }
 
@@ -315,6 +357,13 @@ class ConcurrencyBudget {
 
     reset(): void {
         this.active = 0;
+        const pendingAcquires = this.pendingAcquires.splice(0);
+        pendingAcquires.forEach(({ resolve, timeout }) => {
+            if (timeout) {
+                clearTimeout(timeout);
+            }
+            resolve(false);
+        });
     }
 }
 
@@ -367,9 +416,35 @@ const EMBEDDED_RESOURCE_LIMITS: Required<DuckdbResourceLimits> = {
 
 const EMBEDDED_QUERY_TIMEOUT_MS = 10_000;
 
-const EMBEDDED_MAX_CONCURRENT_QUERIES = 2;
+const getPositiveIntegerEnvironmentVariable = (
+    name: string,
+    defaultValue: number,
+): number => {
+    const environmentValue = process.env[name]?.trim();
+    if (!environmentValue || !/^\d+$/.test(environmentValue)) {
+        return defaultValue;
+    }
 
-const EMBEDDED_MAX_CONCURRENT_QUERIES_PER_ORGANIZATION = 1;
+    const value = Number(environmentValue);
+    return Number.isSafeInteger(value) && value > 0 ? value : defaultValue;
+};
+
+const EMBEDDED_MAX_CONCURRENT_QUERIES = getPositiveIntegerEnvironmentVariable(
+    'PLAYGROUND_MAX_CONCURRENT_QUERIES',
+    8,
+);
+
+const EMBEDDED_MAX_CONCURRENT_QUERIES_PER_ORGANIZATION =
+    getPositiveIntegerEnvironmentVariable(
+        'PLAYGROUND_MAX_CONCURRENT_QUERIES_PER_ORGANIZATION',
+        4,
+    );
+
+const EMBEDDED_CONCURRENCY_ACQUIRE_TIMEOUT_MS =
+    getPositiveIntegerEnvironmentVariable(
+        'PLAYGROUND_CONCURRENCY_ACQUIRE_TIMEOUT_MS',
+        15_000,
+    );
 
 const resolveEmbeddedDatabasePath = (dataset: string): string => {
     if (!EMBEDDED_DATASET_PATTERN.test(dataset)) {
@@ -643,16 +718,28 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
         return this.instanceCacheKey;
     }
 
-    private static tryAcquireEmbeddedConcurrency(
+    private static async tryAcquireEmbeddedConcurrency(
         organizationUuid?: string,
-    ): (() => void) | undefined {
-        if (!DuckdbWarehouseClient.embeddedConcurrencyBudget.tryAcquire()) {
+    ): Promise<(() => void) | undefined> {
+        const acquireDeadline =
+            Date.now() + EMBEDDED_CONCURRENCY_ACQUIRE_TIMEOUT_MS;
+        const globalAcquired =
+            await DuckdbWarehouseClient.embeddedConcurrencyBudget.acquire(
+                EMBEDDED_CONCURRENCY_ACQUIRE_TIMEOUT_MS,
+            );
+        if (!globalAcquired) {
             return undefined;
         }
 
         if (!organizationUuid) {
-            return () =>
+            let released = false;
+            return () => {
+                if (released) {
+                    return;
+                }
+                released = true;
                 DuckdbWarehouseClient.embeddedConcurrencyBudget.release();
+            };
         }
 
         const organizationBudget =
@@ -667,12 +754,20 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
             organizationBudget,
         );
 
-        if (!organizationBudget.tryAcquire()) {
+        const organizationAcquired = await organizationBudget.acquire(
+            Math.max(0, acquireDeadline - Date.now()),
+        );
+        if (!organizationAcquired) {
             DuckdbWarehouseClient.embeddedConcurrencyBudget.release();
             return undefined;
         }
 
+        let released = false;
         return () => {
+            if (released) {
+                return;
+            }
+            released = true;
             organizationBudget.release();
             DuckdbWarehouseClient.embeddedConcurrencyBudget.release();
             if (organizationBudget.isIdle()) {
@@ -999,6 +1094,9 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
         DuckdbWarehouseClient.sharedInstanceResourceLimits.clear();
         DuckdbWarehouseClient.sharedInstanceSemaphores.clear();
         DuckdbWarehouseClient.embeddedConcurrencyBudget.reset();
+        DuckdbWarehouseClient.embeddedOrganizationConcurrencyBudgets.forEach(
+            (budget) => budget.reset(),
+        );
         DuckdbWarehouseClient.embeddedOrganizationConcurrencyBudgets.clear();
     }
 
@@ -1729,7 +1827,7 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
         const sessionStart = performance.now();
 
         const releaseEmbeddedConcurrency = this.embeddedConfig
-            ? DuckdbWarehouseClient.tryAcquireEmbeddedConcurrency(
+            ? await DuckdbWarehouseClient.tryAcquireEmbeddedConcurrency(
                   organizationUuid,
               )
             : undefined;


### PR DESCRIPTION
## What breaks

People who open a playground dashboard see most tiles fail with a capacity error because every tile starts at the same time.

## What changed

- Queue embedded DuckDB queries for up to 15 seconds instead of rejecting them immediately.
- Keep the queue first-in, first-out and return capacity on timeouts and query failures.
- Raise the default limits to 8 queries globally and 4 per organisation.
- Allow operators to tune both limits and the wait timeout through environment variables.

## Risk

Medium. The change allows more embedded DuckDB instances to run at once, but the global and per-organisation caps still bound memory use. The timeout and failure tests cover permit cleanup so capacity cannot leak under contention.

## Tests

- `pnpm -F @lightdash/warehouses typecheck`
- `pnpm -F @lightdash/warehouses test`
- `pnpm --filter @lightdash/warehouses run linter src/warehouseClients/DuckdbWarehouseClient.ts src/warehouseClients/DuckdbWarehouseClient.test.ts`

Linear: SPK-1729