### PR TITLE
fix: scope warehouse client ownership

### DIFF
--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -981,34 +981,6 @@ export class EmbedService extends BaseService {
         }
     }
 
-    private async _getWarehouseClient(
-        account: AnonymousAccount,
-        projectUuid: string,
-        explore: Explore,
-    ) {
-        // Resolve via ProjectService so OAuth tokens are refreshed before use
-        // (e.g. Databricks oauth_m2m must exchange client_id+secret for an
-        // access token — fetching the raw row from the model would yield an
-        // empty `token` and crash the warehouse client).
-        const credentials =
-            await this.projectService.getWarehouseCredentialsForEmbed({
-                projectUuid,
-                account,
-            });
-
-        const { warehouseClient, sshTunnel } =
-            await this.projectService._getWarehouseClient(
-                projectUuid,
-                credentials,
-                {
-                    snowflakeVirtualWarehouse: explore.warehouse,
-                    databricksCompute: explore.databricksCompute,
-                },
-            );
-
-        return { warehouseClient, sshTunnel };
-    }
-
     // eslint-disable-next-line class-methods-use-this
     private getAccessControls(account: AnonymousAccount): UserAccessControls {
         const { userAttributes, intrinsicUserAttributes } =
@@ -1076,63 +1048,83 @@ export class EmbedService extends BaseService {
         combinedParameters?: ParametersValuesMap;
         useTimezoneAwareDateTrunc: boolean;
     }) {
-        const { warehouseClient, sshTunnel } = await this._getWarehouseClient(
-            account,
-            projectUuid,
-            explore,
-        );
-
-        const { userAttributes, intrinsicUserAttributes } =
-            this.getAccessControls(account);
-
-        // Filter the explore access and fields based on the user attributes
-        const filteredExplore = getFilteredExplore(explore, userAttributes);
-
-        const availableParameterDefinitions = await this.getAvailableParameters(
-            projectUuid,
-            filteredExplore,
-        );
-
-        const compiledQuery = new QueryComposer(
-            { metricQuery },
-            {
-                explore: filteredExplore,
-                warehouseSqlBuilder: warehouseClient,
-                intrinsicUserAttributes,
-                userAttributes,
-                timezone,
-                dateZoom: dateZoomGranularity
-                    ? {
-                          granularity: dateZoomGranularity,
-                      }
-                    : undefined,
-                parameters: combinedParameters,
-                availableParameterDefinitions,
-                useTimezoneAwareDateTrunc,
-                columnTimezone: getColumnTimezone(warehouseClient.credentials),
-                dataTimezone: warehouseClient.credentials.dataTimezone,
-            },
-        ).compile();
-
-        const results =
-            await this.projectService.getResultsFromCacheOrWarehouse({
+        // ProjectService resolves short-lived credentials such as Databricks
+        // oauth_m2m tokens; stored credentials alone are not executable.
+        const credentials =
+            await this.projectService.getWarehouseCredentialsForEmbed({
                 projectUuid,
-                userUuid: null,
-                user: {
-                    userUuid: account.user.id,
-                    organizationUuid: account.organization.organizationUuid,
-                    organizationName: account.organization.name,
-                },
-                context: QueryExecutionContext.EMBED,
-                warehouseClient,
-                metricQuery,
-                resolvedTimezone: timezone,
-                query: compiledQuery.query,
-                queryTags,
-                invalidateCache: false,
+                account,
             });
-        await sshTunnel.disconnect();
-        return { ...results, fields: compiledQuery.fields };
+
+        return this.projectService.withWarehouseClient(
+            {
+                projectUuid,
+                credentials,
+                overrides: {
+                    snowflakeVirtualWarehouse: explore.warehouse,
+                    databricksCompute: explore.databricksCompute,
+                },
+            },
+            async ({ warehouseClient }) => {
+                const { userAttributes, intrinsicUserAttributes } =
+                    this.getAccessControls(account);
+
+                // Filter the explore access and fields based on the user attributes
+                const filteredExplore = getFilteredExplore(
+                    explore,
+                    userAttributes,
+                );
+
+                const availableParameterDefinitions =
+                    await this.getAvailableParameters(
+                        projectUuid,
+                        filteredExplore,
+                    );
+
+                const compiledQuery = new QueryComposer(
+                    { metricQuery },
+                    {
+                        explore: filteredExplore,
+                        warehouseSqlBuilder: warehouseClient,
+                        intrinsicUserAttributes,
+                        userAttributes,
+                        timezone,
+                        dateZoom: dateZoomGranularity
+                            ? {
+                                  granularity: dateZoomGranularity,
+                              }
+                            : undefined,
+                        parameters: combinedParameters,
+                        availableParameterDefinitions,
+                        useTimezoneAwareDateTrunc,
+                        columnTimezone: getColumnTimezone(
+                            warehouseClient.credentials,
+                        ),
+                        dataTimezone: warehouseClient.credentials.dataTimezone,
+                    },
+                ).compile();
+
+                const results =
+                    await this.projectService.getResultsFromCacheOrWarehouse({
+                        projectUuid,
+                        userUuid: null,
+                        user: {
+                            userUuid: account.user.id,
+                            organizationUuid:
+                                account.organization.organizationUuid,
+                            organizationName: account.organization.name,
+                        },
+                        context: QueryExecutionContext.EMBED,
+                        warehouseClient,
+                        metricQuery,
+                        resolvedTimezone: timezone,
+                        query: compiledQuery.query,
+                        queryTags,
+                        invalidateCache: false,
+                    });
+                return { ...results, fields: compiledQuery.fields };
+            },
+        );
     }
 
     private async _getChartFromDashboardTiles(

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -62,6 +62,7 @@ import {
     WarehouseCredentials,
     WarehouseTypes,
     type SummaryExplore,
+    type WarehouseSqlBuilder,
 } from '@lightdash/common';
 import {
     buildMotherduckConnectionString,
@@ -4487,13 +4488,13 @@ export class ProjectModel {
             columns,
             parameterValues,
         }: CreateVirtualViewPayload,
-        warehouseClient: WarehouseClient,
+        warehouseSqlBuilder: WarehouseSqlBuilder,
     ): Promise<Explore> {
         const virtualView = createVirtualView(
             name,
             sql,
             columns,
-            warehouseClient,
+            warehouseSqlBuilder,
             label,
             parameterValues,
         );
@@ -4526,14 +4527,14 @@ export class ProjectModel {
         projectUuid: string,
         exploreName: string,
         payload: UpdateVirtualViewPayload,
-        warehouseClient: WarehouseClient,
+        warehouseSqlBuilder: WarehouseSqlBuilder,
         expectedExplore?: Explore,
     ) {
         const translatedToExplore = createVirtualView(
             exploreName,
             payload.sql,
             payload.columns,
-            warehouseClient,
+            warehouseSqlBuilder,
             payload.name, // label
             payload.parameterValues,
         );

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -221,7 +221,9 @@ const projectModel = {
     getWarehouseCredentialsForProject: vi.fn(
         async () => warehouseClientMock.credentials,
     ),
-    getWarehouseClientFromCredentials: vi.fn(() => ({
+    getWarehouseClientFromCredentials: vi.fn<
+        ProjectModel['getWarehouseClientFromCredentials']
+    >(() => ({
         ...warehouseClientMock,
         runQuery: vi.fn(async () => resultsWith1Row),
     })),
@@ -3727,11 +3729,31 @@ describe('AsyncQueryService', () => {
                 dbname: 'testdb',
                 schema: 'public',
             };
+            const getRunAsyncArgs = (): RunAsyncWarehouseQueryArgs => ({
+                userUuid: sessionAccount.user.id,
+                organizationUuid: sessionAccount.organization.organizationUuid!,
+                isPreviewProject: false,
+                isRegisteredUser: true,
+                onboardingFlow: 'legacy',
+                projectUuid,
+                query: 'SELECT * FROM test',
+                fieldsMap: {},
+                usedParameters: null,
+                queryTags: { query_context: QueryExecutionContext.EXPLORE },
+                warehouseCredentialsOverrides: undefined,
+                queryUuid: 'test-query-uuid',
+                cacheKey: 'test-cache-key',
+                pivotConfiguration: undefined,
+                originalColumns: undefined,
+                queryCreatedAt: new Date(),
+                displayTimezone: null,
+            });
 
             beforeEach(() => {
                 (
                     mockSshTunnel.connect as import('vitest').Mock
                 ).mockReturnValueOnce(Promise.resolve(sshTunnelCredentials));
+                vi.mocked(mockSshTunnel.disconnect).mockReset();
             });
 
             test('SSH Tunnel Integration - Complete Flow', async () => {
@@ -3759,49 +3781,18 @@ describe('AsyncQueryService', () => {
                 // Mock query history update
                 service.queryHistoryModel.update = vi.fn();
 
-                const getWarehouseClientSpy = vi.spyOn(
-                    service,
-                    '_getWarehouseClient',
-                );
-
                 const runQueryAndTransformRowsSpy = vi.spyOn(
                     AsyncQueryService,
                     'runQueryAndTransformRows',
                 );
 
-                const runAsyncArgs: RunAsyncWarehouseQueryArgs = {
-                    userUuid: sessionAccount.user.id,
-                    organizationUuid:
-                        sessionAccount.organization.organizationUuid!,
-                    isPreviewProject: false,
-                    isRegisteredUser: true,
-                    onboardingFlow: 'legacy',
-                    projectUuid,
-                    query: 'SELECT * FROM test',
-                    fieldsMap: {},
-                    usedParameters: null,
-                    queryTags: { query_context: QueryExecutionContext.EXPLORE },
-                    warehouseCredentialsOverrides: undefined,
-                    queryUuid: 'test-query-uuid',
-                    cacheKey: 'test-cache-key',
-                    pivotConfiguration: undefined,
-                    originalColumns: undefined,
-                    queryCreatedAt: new Date(),
-                    displayTimezone: null,
-                };
+                const runAsyncArgs = getRunAsyncArgs();
 
                 // WHEN: runAsyncWarehouseQuery is called
                 await service.runAsyncWarehouseQuery(runAsyncArgs);
 
                 // THEN: SSH tunnel connection established with tunnel credentials
                 expect(mockSshTunnel.connect).toHaveBeenCalledWith();
-
-                // THEN: _getWarehouseClient called with original credentials
-                expect(getWarehouseClientSpy).toHaveBeenCalledWith(
-                    projectUuid,
-                    originalCredentials,
-                    undefined,
-                );
 
                 // THEN: Warehouse client created with tunneled credentials
                 expect(
@@ -3835,6 +3826,42 @@ describe('AsyncQueryService', () => {
                         error: null,
                     }),
                     expect.any(Object), // session account
+                );
+            });
+
+            test('rejects when tunnel cleanup fails after a successful query', async () => {
+                const cleanupError = new Error('tunnel cleanup failed');
+                vi.mocked(mockSshTunnel.disconnect).mockRejectedValueOnce(
+                    cleanupError,
+                );
+                const mockProjectModel = {
+                    ...projectModel,
+                    getWarehouseCredentialsForProject: vi.fn(
+                        async () => originalCredentials,
+                    ),
+                    getWarehouseClientFromCredentials: vi.fn(() => ({
+                        ...warehouseClientMock,
+                        credentials: sshTunnelCredentials,
+                    })),
+                };
+                const service = getMockedAsyncQueryService(
+                    lightdashConfigMock,
+                    {
+                        projectModel:
+                            mockProjectModel as unknown as ProjectModel,
+                    },
+                );
+
+                await expect(
+                    service.runAsyncWarehouseQuery(getRunAsyncArgs()),
+                ).rejects.toBe(cleanupError);
+                expect(
+                    service.queryHistoryModel.updateStatusToError,
+                ).toHaveBeenCalledWith(
+                    'test-query-uuid',
+                    projectUuid,
+                    cleanupError.message,
+                    expect.any(Object),
                 );
             });
         });
@@ -4078,6 +4105,10 @@ describe('AsyncQueryService', () => {
     });
 
     describe('executeAsyncSqlQuery', () => {
+        beforeEach(() => {
+            vi.mocked(mockSshTunnel.disconnect).mockReset();
+        });
+
         it('throws ForbiddenError when the account lacks manage:SqlRunner', async () => {
             const service = getMockedAsyncQueryService(lightdashConfigMock);
 
@@ -4103,23 +4134,19 @@ describe('AsyncQueryService', () => {
 
         it('disconnects the SSH tunnel when column discovery fails', async () => {
             const service = getMockedAsyncQueryService(lightdashConfigMock);
-            const disconnect = vi.fn();
             const discoveryError = new Error('Column discovery failed');
 
             service.getUserAttributes = vi.fn(async () => ({
                 userAttributes: {},
                 intrinsicUserAttributes: { email: 'test@example.com' },
             }));
-            service._getWarehouseClient = vi.fn(async () => ({
-                warehouseClient: {
-                    ...warehouseClientMock,
-                    streamQuery: vi.fn().mockRejectedValue(discoveryError),
-                },
-                sshTunnel: {
-                    disconnect,
-                } as unknown as SshTunnel<CreateWarehouseCredentials>,
-                tunnelConnectMs: null,
-            }));
+            const warehouseClient: WarehouseClient = {
+                ...warehouseClientMock,
+                streamQuery: vi.fn().mockRejectedValue(discoveryError),
+            };
+            vi.mocked(
+                projectModel.getWarehouseClientFromCredentials,
+            ).mockReturnValueOnce(warehouseClient);
 
             await expect(
                 service.executeAsyncSqlQuery({
@@ -4129,7 +4156,7 @@ describe('AsyncQueryService', () => {
                     context: QueryExecutionContext.SQL_RUNNER,
                 }),
             ).rejects.toBe(discoveryError);
-            expect(disconnect).toHaveBeenCalledOnce();
+            expect(mockSshTunnel.disconnect).toHaveBeenCalledOnce();
         });
 
         describe('cache invalidation', () => {
@@ -4181,11 +4208,13 @@ describe('AsyncQueryService', () => {
                     }),
                 };
 
-                service._getWarehouseClient = vi.fn(async () => ({
-                    warehouseClient: mockWarehouseClient,
-                    sshTunnel: mockSshTunnel,
-                    tunnelConnectMs: null,
-                }));
+                vi.mocked(
+                    projectModel.getWarehouseClientFromCredentials,
+                ).mockReturnValueOnce(
+                    mockWarehouseClient as ReturnType<
+                        ProjectModel['getWarehouseClientFromCredentials']
+                    >,
+                );
 
                 await service.executeAsyncSqlQuery({
                     account: sessionAccount,
@@ -4269,12 +4298,13 @@ describe('AsyncQueryService', () => {
                     }),
                 };
 
-                // Override the _getWarehouseClient method to return our mock
-                service._getWarehouseClient = vi.fn(async () => ({
-                    warehouseClient: mockWarehouseClient,
-                    sshTunnel: mockSshTunnel,
-                    tunnelConnectMs: null,
-                }));
+                vi.mocked(
+                    projectModel.getWarehouseClientFromCredentials,
+                ).mockReturnValueOnce(
+                    mockWarehouseClient as ReturnType<
+                        ProjectModel['getWarehouseClientFromCredentials']
+                    >,
+                );
 
                 // WHEN: executeAsyncSqlQuery is called with SQL containing user attributes
                 const sqlWithUserAttributes =
@@ -4417,14 +4447,14 @@ describe('AsyncQueryService', () => {
 
                 const streamQuery = vi.fn();
 
-                service._getWarehouseClient = vi.fn(async () => ({
-                    warehouseClient: {
-                        ...warehouseClientMock,
-                        streamQuery,
-                    },
-                    sshTunnel: mockSshTunnel,
-                    tunnelConnectMs: null,
-                }));
+                vi.mocked(
+                    projectModel.getWarehouseClientFromCredentials,
+                ).mockReturnValueOnce({
+                    ...warehouseClientMock,
+                    streamQuery,
+                } as ReturnType<
+                    ProjectModel['getWarehouseClientFromCredentials']
+                >);
 
                 return { service, streamQuery };
             };

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -153,7 +153,10 @@ import {
     type WarehouseResults,
     type WarehouseSqlBuilder,
 } from '@lightdash/common';
-import { DuckdbWarehouseClient, SshTunnel } from '@lightdash/warehouses';
+import {
+    DuckdbWarehouseClient,
+    warehouseSqlBuilderFromType,
+} from '@lightdash/warehouses';
 import * as Sentry from '@sentry/node';
 import { Readable, Writable } from 'stream';
 import {
@@ -3245,13 +3248,10 @@ export class AsyncQueryService extends ProjectService {
               }
             | undefined;
 
-        let sshTunnel: SshTunnel<CreateWarehouseCredentials> | undefined;
-
         let warehouseCredentialsType:
             | CreateWarehouseCredentials['type']
             | undefined;
-        let warehouseClient: WarehouseClient;
-        let tunnelConnectMs: number | null = null;
+        let warehouseQueryCompletedBeforeCleanup = false;
 
         const analyticsIdentity = isRegisteredUser
             ? { userId: userUuid }
@@ -3267,35 +3267,19 @@ export class AsyncQueryService extends ProjectService {
             warehouseClientOverride ? 'pre_aggregate_duckdb' : 'warehouse';
         let queryStartTime = Date.now();
 
-        try {
-            if (warehouseClientOverride) {
-                warehouseClient = warehouseClientOverride;
-                warehouseCredentialsType =
-                    warehouseCredentialsTypeOverride ??
-                    warehouseClient.credentials.type;
-            } else {
-                const warehouseCredentials = await this.getWarehouseCredentials(
-                    {
-                        projectUuid,
-                        userId: userUuid,
-                        isRegisteredUser,
-                        isServiceAccount,
-                    },
+        const executeWithWarehouseClient = async ({
+            warehouseClient,
+            tunnelConnectMs,
+        }: {
+            warehouseClient: WarehouseClient;
+            tunnelConnectMs: number | null;
+        }) => {
+            const credentialsType = warehouseCredentialsType;
+            if (credentialsType === undefined) {
+                throw new UnexpectedServerError(
+                    'Warehouse credentials type unavailable for query execution',
                 );
-
-                warehouseCredentialsType = warehouseCredentials.type;
-
-                // Get warehouse client using the projectService
-                const warehouseConnection = await this._getWarehouseClient(
-                    projectUuid,
-                    warehouseCredentials,
-                    warehouseCredentialsOverrides,
-                );
-                warehouseClient = warehouseConnection.warehouseClient;
-                sshTunnel = warehouseConnection.sshTunnel;
-                tunnelConnectMs = warehouseConnection.tunnelConnectMs;
             }
-
             const isTimezoneSupportEnabled =
                 await this.isTimezoneSupportEnabled({
                     userUuid,
@@ -3423,13 +3407,13 @@ export class AsyncQueryService extends ProjectService {
 
             this.prometheusMetrics?.observeWarehouseDuration(
                 durationMs,
-                warehouseCredentialsType,
+                credentialsType,
                 queryTags.query_context,
             );
 
             this.prometheusMetrics?.observeWarehousePhaseDurations(
                 warehousePhaseTimings,
-                warehouseCredentialsType,
+                credentialsType,
                 queryTags.query_context,
             );
 
@@ -3441,7 +3425,7 @@ export class AsyncQueryService extends ProjectService {
                 this.prometheusMetrics?.observeProjectQueryPhaseDurations(
                     projectUuid,
                     warehousePhaseTimings,
-                    warehouseCredentialsType,
+                    credentialsType,
                     queryTags.query_context,
                 );
             }
@@ -3617,7 +3601,53 @@ export class AsyncQueryService extends ProjectService {
                 queryCreatedAt,
                 queryTags.query_context || 'unknown',
             );
+        };
+
+        try {
+            if (warehouseClientOverride) {
+                warehouseCredentialsType =
+                    warehouseCredentialsTypeOverride ??
+                    warehouseClientOverride.credentials.type;
+                await executeWithWarehouseClient({
+                    warehouseClient: warehouseClientOverride,
+                    tunnelConnectMs: null,
+                });
+            } else {
+                const warehouseCredentials = await this.getWarehouseCredentials(
+                    {
+                        projectUuid,
+                        userId: userUuid,
+                        isRegisteredUser,
+                        isServiceAccount,
+                    },
+                );
+                warehouseCredentialsType = warehouseCredentials.type;
+                await this.withWarehouseClient(
+                    {
+                        projectUuid,
+                        credentials: warehouseCredentials,
+                        overrides: warehouseCredentialsOverrides,
+                    },
+                    async ({ warehouseClient, tunnelConnectMs }) => {
+                        await executeWithWarehouseClient({
+                            warehouseClient,
+                            tunnelConnectMs,
+                        });
+                        warehouseQueryCompletedBeforeCleanup = true;
+                    },
+                );
+            }
         } catch (e) {
+            if (warehouseQueryCompletedBeforeCleanup) {
+                await this.queryHistoryModel.updateStatusToError(
+                    queryUuid,
+                    projectUuid,
+                    getErrorMessage(e),
+                    queryHistoryAccount,
+                );
+                throw e;
+            }
+
             this.logger.error(
                 `Query ${queryUuid} execution error: ${getErrorMessage(e)}`,
                 {
@@ -3663,7 +3693,6 @@ export class AsyncQueryService extends ProjectService {
 
         try {
             // await for the cleanup functions so that the error is thrown if they fail
-            await sshTunnel?.disconnect();
             await stream?.close();
         } catch (e) {
             await this.queryHistoryModel.updateStatusToError(
@@ -6841,7 +6870,6 @@ export class AsyncQueryService extends ProjectService {
         );
 
         const {
-            warehouseConnection,
             warehouseCredentials,
             queryTags,
             queryComposer,
@@ -6858,9 +6886,6 @@ export class AsyncQueryService extends ProjectService {
             parameters: combinedParameters,
             pivotConfiguration,
         });
-
-        // Disconnect the ssh tunnel to avoid leaking connections, another client is created in the scheduler task
-        await warehouseConnection.sshTunnel.disconnect();
 
         const { queryUuid, cacheMetadata } = await this.executeAsyncQuery(
             {
@@ -7130,7 +7155,7 @@ export class AsyncQueryService extends ProjectService {
         const placeholderComposer = new SqlQueryComposer({
             userSql: sql,
             columns: [],
-            warehouseClient,
+            warehouseSqlBuilder: warehouseClient,
             pivotConfiguration: undefined,
             limit,
             parameters: undefined,
@@ -7355,7 +7380,7 @@ export class AsyncQueryService extends ProjectService {
         const placeholderComposer = new SqlQueryComposer({
             userSql: sql,
             columns: [],
-            warehouseClient,
+            warehouseSqlBuilder: warehouseClient,
             pivotConfiguration: undefined,
             limit,
             parameters: undefined,
@@ -7592,7 +7617,7 @@ export class AsyncQueryService extends ProjectService {
             const composer = new SqlQueryComposer({
                 userSql: resolvedSql,
                 columns,
-                warehouseClient,
+                warehouseSqlBuilder: warehouseClient,
                 pivotConfiguration: undefined,
                 limit,
                 parameters: undefined,
@@ -7922,28 +7947,23 @@ export class AsyncQueryService extends ProjectService {
             }),
             this.getUserAttributes({ account }),
         ]);
-        const { warehouseClient, sshTunnel } = await this._getWarehouseClient(
-            projectUuid,
-            warehouseCredentials,
+        const warehouseSqlBuilder = warehouseSqlBuilderFromType(
+            warehouseCredentials.type,
+            warehouseCredentials.startOfWeek,
         );
 
-        let composer: MergeQueryComposer;
-        try {
-            composer = new MergeQueryComposer({
-                coreSql: compiledMerge.coreSql,
-                terminalWrapper: compiledMerge.terminalWrapper,
-                itemsMap: compiledMerge.itemsMap,
-                typedColumns: compiledMerge.typedColumns,
-                columnOrder: Object.values(compiledMerge.fieldIdByColumn),
-                limit: mergeQuery.limit,
-                parameterReferences: compiledMerge.parameterReferences,
-                usedParametersValues: compiledMerge.usedParametersValues,
-                warehouseClient,
-                pivotConfiguration,
-            });
-        } finally {
-            await sshTunnel.disconnect();
-        }
+        const composer = new MergeQueryComposer({
+            coreSql: compiledMerge.coreSql,
+            terminalWrapper: compiledMerge.terminalWrapper,
+            itemsMap: compiledMerge.itemsMap,
+            typedColumns: compiledMerge.typedColumns,
+            columnOrder: Object.values(compiledMerge.fieldIdByColumn),
+            limit: mergeQuery.limit,
+            parameterReferences: compiledMerge.parameterReferences,
+            usedParametersValues: compiledMerge.usedParametersValues,
+            warehouseSqlBuilder,
+            pivotConfiguration,
+        });
 
         const baseQueryTags: RunQueryTags = {
             ...this.getUserQueryTags(account),
@@ -8132,7 +8152,7 @@ export class AsyncQueryService extends ProjectService {
             limit: mergeQuery.limit,
             parameterReferences: compiledMerge.parameterReferences,
             usedParametersValues: compiledMerge.usedParametersValues,
-            warehouseClient,
+            warehouseSqlBuilder: warehouseClient,
             pivotConfiguration,
         });
         const sql = composer.getSql({
@@ -8452,189 +8472,211 @@ export class AsyncQueryService extends ProjectService {
             }),
             this.getUserAttributes({ account }),
         ]);
-        const warehouseConnection = await this._getWarehouseClient(
-            projectUuid,
-            warehouseCredentials,
+        const warehouseSqlBuilder = warehouseSqlBuilderFromType(
+            warehouseCredentials.type,
+            warehouseCredentials.startOfWeek,
         );
+        return this.withWarehouseClient(
+            { projectUuid, credentials: warehouseCredentials },
+            async ({ warehouseClient }) => {
+                const baseQueryTags: RunQueryTags = {
+                    ...this.getUserQueryTags(account),
+                    ...AsyncQueryService.getSchedulerQueryTags(),
+                    organization_uuid: organizationUuid,
+                    project_uuid: projectUuid,
+                    query_context: context,
+                    ...(chartUuid ? { chart_uuid: chartUuid } : {}),
+                    ...(dashboardUuid ? { dashboard_uuid: dashboardUuid } : {}),
+                };
+                const queryTags = AsyncQueryService.addUserAttributeQueryTags(
+                    baseQueryTags,
+                    { userAttributes, intrinsicUserAttributes },
+                );
+                const durationWarehouseAndUserAttributes =
+                    performance.now() - sectionStartWarehouse;
 
-        const baseQueryTags: RunQueryTags = {
-            ...this.getUserQueryTags(account),
-            ...AsyncQueryService.getSchedulerQueryTags(),
-            organization_uuid: organizationUuid,
-            project_uuid: projectUuid,
-            query_context: context,
-            ...(chartUuid ? { chart_uuid: chartUuid } : {}),
-            ...(dashboardUuid ? { dashboard_uuid: dashboardUuid } : {}),
-        };
-        const queryTags = AsyncQueryService.addUserAttributeQueryTags(
-            baseQueryTags,
-            { userAttributes, intrinsicUserAttributes },
-        );
-        const durationWarehouseAndUserAttributes =
-            performance.now() - sectionStartWarehouse;
+                // 3. Column Discovery
+                const sectionStartColumnDiscovery = performance.now();
+                // Get one row to get the column definitions
+                const columns: { name: string; type: DimensionType }[] = [];
 
-        // 3. Column Discovery
-        const sectionStartColumnDiscovery = performance.now();
-        // Get one row to get the column definitions
-        const columns: { name: string; type: DimensionType }[] = [];
+                // Replace user attributes first
+                const sqlWithUserAttributes = replaceUserAttributesAsStrings(
+                    sql,
+                    intrinsicUserAttributes,
+                    userAttributes,
+                    warehouseSqlBuilder,
+                    { noWrap: true },
+                );
 
-        // Replace user attributes first
-        const sqlWithUserAttributes = replaceUserAttributesAsStrings(
-            sql,
-            intrinsicUserAttributes,
-            userAttributes,
-            warehouseConnection.warehouseClient,
-            { noWrap: true },
-        );
+                // Then replace parameters in SQL before running column discovery query
+                const {
+                    replacedSql: columnDiscoverySql,
+                    missingReferences: columnDiscoveryMissingParameters,
+                } = safeReplaceParametersWithSqlBuilder(
+                    sqlWithUserAttributes,
+                    parameters ?? {},
+                    warehouseSqlBuilder,
+                );
 
-        // Then replace parameters in SQL before running column discovery query
-        const {
-            replacedSql: columnDiscoverySql,
-            missingReferences: columnDiscoveryMissingParameters,
-        } = safeReplaceParametersWithSqlBuilder(
-            sqlWithUserAttributes,
-            parameters ?? {},
-            warehouseConnection.warehouseClient,
-        );
+                if (columnDiscoveryMissingParameters.size > 0) {
+                    const missing = Array.from(
+                        columnDiscoveryMissingParameters,
+                    );
+                    throw new ParameterError(
+                        `Missing values for SQL parameter(s): ${missing.join(', ')}`,
+                        { missingReferences: missing },
+                    );
+                }
 
-        if (columnDiscoveryMissingParameters.size > 0) {
-            const missing = Array.from(columnDiscoveryMissingParameters);
-            throw new ParameterError(
-                `Missing values for SQL parameter(s): ${missing.join(', ')}`,
-                { missingReferences: missing },
-            );
-        }
+                const limitedColumnDiscoverySql = applyLimitToSqlQuery({
+                    sqlQuery: columnDiscoverySql,
+                    limit: 1,
+                });
+                this.logger.info('column_discovery.started', {
+                    event: 'column_discovery.started',
+                    projectUuid,
+                    sqlBytes: Buffer.byteLength(
+                        limitedColumnDiscoverySql,
+                        'utf8',
+                    ),
+                    ...queryTags,
+                });
+                try {
+                    await warehouseClient.streamQuery(
+                        limitedColumnDiscoverySql,
+                        (chunk) => {
+                            // Only handle the first call
+                            if (columns.length === 0 && chunk.fields) {
+                                Object.keys(chunk.fields).forEach((key) => {
+                                    columns.push({
+                                        name: key,
+                                        type: chunk.fields[key].type,
+                                    });
+                                });
+                            }
+                        },
+                        {
+                            tags: queryTags,
+                        },
+                    );
+                } catch (e) {
+                    const durationMs =
+                        performance.now() - sectionStartColumnDiscovery;
+                    this.logger.error('column_discovery.failed', {
+                        event: 'column_discovery.failed',
+                        projectUuid,
+                        durationMs,
+                        sqlBytes: Buffer.byteLength(
+                            limitedColumnDiscoverySql,
+                            'utf8',
+                        ),
+                        errorName: e instanceof Error ? e.name : undefined,
+                        errorCode: (e as { code?: string })?.code,
+                        errorMessage: getErrorMessage(e),
+                        ...queryTags,
+                    });
+                    throw e;
+                }
+                const durationColumnDiscovery =
+                    performance.now() - sectionStartColumnDiscovery;
+                this.logger.info('column_discovery.completed', {
+                    event: 'column_discovery.completed',
+                    projectUuid,
+                    durationMs: durationColumnDiscovery,
+                    sqlBytes: Buffer.byteLength(
+                        limitedColumnDiscoverySql,
+                        'utf8',
+                    ),
+                    columnCount: columns.length,
+                    ...queryTags,
+                });
 
-        const limitedColumnDiscoverySql = applyLimitToSqlQuery({
-            sqlQuery: columnDiscoverySql,
-            limit: 1,
-        });
-        this.logger.info('column_discovery.started', {
-            event: 'column_discovery.started',
-            projectUuid,
-            sqlBytes: Buffer.byteLength(limitedColumnDiscoverySql, 'utf8'),
-            ...queryTags,
-        });
-        try {
-            await warehouseConnection.warehouseClient.streamQuery(
-                limitedColumnDiscoverySql,
-                (chunk) => {
-                    // Only handle the first call
-                    if (columns.length === 0 && chunk.fields) {
-                        Object.keys(chunk.fields).forEach((key) => {
-                            columns.push({
-                                name: key,
-                                type: chunk.fields[key].type,
-                            });
-                        });
-                    }
-                },
-                {
-                    tags: queryTags,
-                },
-            );
-        } catch (e) {
-            const durationMs = performance.now() - sectionStartColumnDiscovery;
-            this.logger.error('column_discovery.failed', {
-                event: 'column_discovery.failed',
-                projectUuid,
-                durationMs,
-                sqlBytes: Buffer.byteLength(limitedColumnDiscoverySql, 'utf8'),
-                errorName: e instanceof Error ? e.name : undefined,
-                errorCode: (e as { code?: string })?.code,
-                errorMessage: getErrorMessage(e),
-                ...queryTags,
-            });
-            await warehouseConnection.sshTunnel.disconnect();
-            throw e;
-        }
-        const durationColumnDiscovery =
-            performance.now() - sectionStartColumnDiscovery;
-        this.logger.info('column_discovery.completed', {
-            event: 'column_discovery.completed',
-            projectUuid,
-            durationMs: durationColumnDiscovery,
-            sqlBytes: Buffer.byteLength(limitedColumnDiscoverySql, 'utf8'),
-            columnCount: columns.length,
-            ...queryTags,
-        });
+                // 4. Query Building
+                const sectionStartQueryBuilding = performance.now();
+                // Convert to ResultColumns format for storing as original columns
+                const originalColumns: ResultColumns = columns.reduce(
+                    (acc, col) => {
+                        acc[col.name] = {
+                            reference: col.name,
+                            type: col.type,
+                        };
+                        return acc;
+                    },
+                    {} as ResultColumns,
+                );
 
-        // 4. Query Building
-        const sectionStartQueryBuilding = performance.now();
-        // Convert to ResultColumns format for storing as original columns
-        const originalColumns: ResultColumns = columns.reduce((acc, col) => {
-            acc[col.name] = {
-                reference: col.name,
-                type: col.type,
-            };
-            return acc;
-        }, {} as ResultColumns);
+                // Pivot comes from the request (SQL runner) or the chart config
+                // (saved/dashboard SQL charts).
+                const resolvedPivotConfiguration:
+                    | PivotConfiguration
+                    | undefined =
+                    pivotConfiguration ??
+                    (config && !isVizTableConfig(config) && config.fieldConfig
+                        ? {
+                              indexColumn: config.fieldConfig.x,
+                              valuesColumns: config.fieldConfig.y,
+                              groupByColumns: config.fieldConfig.groupBy,
+                              sortBy: config.fieldConfig.sortBy,
+                          }
+                        : undefined);
 
-        // Pivot comes from the request (SQL runner) or the chart config
-        // (saved/dashboard SQL charts).
-        const resolvedPivotConfiguration: PivotConfiguration | undefined =
-            pivotConfiguration ??
-            (config && !isVizTableConfig(config) && config.fieldConfig
-                ? {
-                      indexColumn: config.fieldConfig.x,
-                      valuesColumns: config.fieldConfig.y,
-                      groupByColumns: config.fieldConfig.groupBy,
-                      sortBy: config.fieldConfig.sortBy,
-                  }
-                : undefined);
+                const composer = new SqlQueryComposer({
+                    userSql: sqlWithUserAttributes,
+                    columns,
+                    warehouseSqlBuilder,
+                    pivotConfiguration: resolvedPivotConfiguration,
+                    limit,
+                    parameters,
+                    dashboardFilters,
+                    tileUuid,
+                    dashboardSorts,
+                });
+                const durationQueryBuilding =
+                    performance.now() - sectionStartQueryBuilding;
 
-        const composer = new SqlQueryComposer({
-            userSql: sqlWithUserAttributes,
-            columns,
-            warehouseClient: warehouseConnection.warehouseClient,
-            pivotConfiguration: resolvedPivotConfiguration,
-            limit,
-            parameters,
-            dashboardFilters,
-            tileUuid,
-            dashboardSorts,
-        });
-        const durationQueryBuilding =
-            performance.now() - sectionStartQueryBuilding;
+                const sectionStartSqlGeneration = performance.now();
+                const compiled = composer.compile();
+                const durationSqlGeneration =
+                    performance.now() - sectionStartSqlGeneration;
 
-        const sectionStartSqlGeneration = performance.now();
-        const compiled = composer.compile();
-        const durationSqlGeneration =
-            performance.now() - sectionStartSqlGeneration;
+                const totalTime = performance.now() - startTime;
 
-        const totalTime = performance.now() - startTime;
+                this.logger.info(
+                    `prepareSqlChartAsyncQueryArgs completed in ${totalTime.toFixed(2)}`,
+                    {
+                        event: 'prepare_sql_chart_async_query_args.completed',
+                        projectUuid,
+                        totalTimeMs: totalTime,
+                        warehouseAndUserAttributesMs:
+                            durationWarehouseAndUserAttributes,
+                        columnDiscoveryMs: durationColumnDiscovery,
+                        queryBuildingMs: durationQueryBuilding,
+                        sqlGenerationMs: durationSqlGeneration,
+                        ...queryTags,
+                    },
+                );
 
-        this.logger.info(
-            `prepareSqlChartAsyncQueryArgs completed in ${totalTime.toFixed(2)}`,
-            {
-                event: 'prepare_sql_chart_async_query_args.completed',
-                projectUuid,
-                totalTimeMs: totalTime,
-                warehouseAndUserAttributesMs:
-                    durationWarehouseAndUserAttributes,
-                columnDiscoveryMs: durationColumnDiscovery,
-                queryBuildingMs: durationQueryBuilding,
-                sqlGenerationMs: durationSqlGeneration,
-                ...queryTags,
+                return {
+                    metricQuery: composer.getMetricQuery(),
+                    pivotConfiguration: composer.getPivotConfiguration(),
+                    virtualView: composer.getExplore(),
+                    queryTags,
+                    warehouseCredentials,
+                    queryComposer: composer,
+                    parameterReferences: Array.from(
+                        compiled.parameterReferences,
+                    ),
+                    missingParameterReferences: Array.from(
+                        compiled.missingParameterReferences,
+                    ),
+                    appliedDashboardFilters:
+                        composer.getAppliedDashboardFilters(),
+                    originalColumns,
+                    usedParameters: compiled.usedParameters,
+                };
             },
         );
-
-        return {
-            metricQuery: composer.getMetricQuery(),
-            pivotConfiguration: composer.getPivotConfiguration(),
-            virtualView: composer.getExplore(),
-            queryTags,
-            warehouseConnection,
-            warehouseCredentials,
-            queryComposer: composer,
-            parameterReferences: Array.from(compiled.parameterReferences),
-            missingParameterReferences: Array.from(
-                compiled.missingParameterReferences,
-            ),
-            appliedDashboardFilters: composer.getAppliedDashboardFilters(),
-            originalColumns,
-            usedParameters: compiled.usedParameters,
-        };
     }
 
     async executeAsyncSqlChartQuery(
@@ -8662,7 +8704,6 @@ export class AsyncQueryService extends ProjectService {
         );
 
         const {
-            warehouseConnection,
             warehouseCredentials,
             queryTags,
             metricQuery,
@@ -8681,9 +8722,6 @@ export class AsyncQueryService extends ProjectService {
             parameters: combinedParameters,
             chartUuid: sqlChart.savedSqlUuid,
         });
-
-        // Disconnect the ssh tunnel to avoid leaking connections, another client is created in the scheduler task
-        await warehouseConnection.sshTunnel.disconnect();
 
         const { queryUuid, cacheMetadata } = await this.executeAsyncQuery(
             {
@@ -8804,7 +8842,6 @@ export class AsyncQueryService extends ProjectService {
         );
 
         const {
-            warehouseConnection,
             warehouseCredentials,
             queryTags,
             metricQuery,
@@ -8828,9 +8865,6 @@ export class AsyncQueryService extends ProjectService {
             chartUuid: savedChart.savedSqlUuid,
             dashboardUuid,
         });
-
-        // Disconnect the ssh tunnel to avoid leaking connections, another client is created in the scheduler task
-        await warehouseConnection.sshTunnel.disconnect();
 
         const { queryUuid, cacheMetadata } = await this.executeAsyncQuery(
             {

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -48,9 +48,13 @@ import {
     type RegisteredAccount,
     type UpdateProject,
     type UserWarehouseCredentialsWithSecrets,
+    type WarehouseClient,
     type WarehouseLocation,
 } from '@lightdash/common';
-import { warehouseClientFromCredentials } from '@lightdash/warehouses';
+import {
+    SshTunnel,
+    warehouseClientFromCredentials,
+} from '@lightdash/warehouses';
 import { Readable } from 'stream';
 import { gunzipSync } from 'zlib';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
@@ -178,20 +182,23 @@ vi.mock('worker_threads', async () => {
     };
 });
 
+const mockSshTunnel = {
+    connect: vi.fn(() => warehouseClientMock.credentials),
+    disconnect: vi.fn(),
+};
+
 vi.mock('@lightdash/warehouses', () => ({
     SshTunnel: vi.fn().mockImplementation(
         // eslint-disable-next-line prefer-arrow-callback
         function MockSshTunnel() {
-            return {
-                connect: vi.fn(() => warehouseClientMock.credentials),
-                disconnect: vi.fn(),
-            };
+            return mockSshTunnel;
         },
     ),
     exchangeDatabricksOAuthCredentials: vi.fn(),
     refreshDatabricksOAuthToken: vi.fn(),
     DATABRICKS_DEFAULT_OAUTH_CLIENT_ID: 'default-client-id',
     warehouseClientFromCredentials: vi.fn(() => warehouseClientMock),
+    warehouseSqlBuilderFromType: vi.fn(() => warehouseClientMock),
 }));
 
 const projectModel = {
@@ -222,7 +229,9 @@ const projectModel = {
     getWarehouseCredentialsForProject: vi.fn(
         async () => warehouseClientMock.credentials,
     ),
-    getWarehouseClientFromCredentials: vi.fn(() => ({
+    getWarehouseClientFromCredentials: vi.fn<
+        ProjectModel['getWarehouseClientFromCredentials']
+    >(() => ({
         ...warehouseClientMock,
         runQuery: vi.fn(async () => resultsWith1Row),
     })),
@@ -245,6 +254,8 @@ const projectModel = {
     ),
     update: vi.fn(async () => undefined),
     delete: vi.fn(async () => undefined),
+    createVirtualView: vi.fn(async () => virtualExplore),
+    updateVirtualView: vi.fn(async () => virtualExplore),
     getResultsCacheSettings: vi.fn<ProjectModel['getResultsCacheSettings']>(
         async () => ({ cacheTtlSeconds: null }),
     ),
@@ -534,6 +545,161 @@ describe('ProjectService', () => {
     const { projectUuid } = defaultProject;
     const service = getMockedProjectService(lightdashConfigMock);
 
+    beforeEach(() => {
+        mockSshTunnel.connect.mockReset();
+        mockSshTunnel.connect.mockResolvedValue(
+            warehouseClientMock.credentials,
+        );
+        mockSshTunnel.disconnect.mockReset();
+        vi.mocked(SshTunnel).mockClear();
+    });
+
+    describe('withWarehouseClient', () => {
+        const sshCredentials = [
+            {
+                type: WarehouseTypes.POSTGRES,
+                host: 'warehouse.internal',
+                user: 'warehouse-user',
+                password: 'password',
+                port: 5432,
+                dbname: 'analytics',
+                schema: 'public',
+                useSshTunnel: true,
+                sshTunnelHost: 'ssh.internal',
+                sshTunnelPort: 22,
+                sshTunnelUser: 'ssh-user',
+                sshTunnelPrivateKey: 'private-key',
+            },
+            {
+                type: WarehouseTypes.REDSHIFT,
+                host: 'warehouse.internal',
+                user: 'warehouse-user',
+                password: 'password',
+                port: 5439,
+                dbname: 'analytics',
+                schema: 'public',
+                authenticationType: RedshiftAuthenticationType.PASSWORD,
+                useSshTunnel: true,
+                sshTunnelHost: 'ssh.internal',
+                sshTunnelPort: 22,
+                sshTunnelUser: 'ssh-user',
+                sshTunnelPrivateKey: 'private-key',
+            },
+        ] satisfies CreateWarehouseCredentials[];
+
+        test.each(sshCredentials)(
+            'releases a $type tunnel after a successful callback',
+            async (credentials) => {
+                mockSshTunnel.connect.mockResolvedValueOnce({
+                    ...credentials,
+                    host: '127.0.0.1',
+                    port: 32000,
+                });
+
+                const result = await service.withWarehouseClient(
+                    { projectUuid, credentials },
+                    async () => 'callback result',
+                );
+
+                expect(result).toBe('callback result');
+                expect(mockSshTunnel.disconnect).toHaveBeenCalledOnce();
+            },
+        );
+
+        it('releases the tunnel when the callback fails', async () => {
+            const callbackError = new Error('query failed');
+
+            await expect(
+                service.withWarehouseClient(
+                    { projectUuid, credentials: sshCredentials[0] },
+                    async () => {
+                        throw callbackError;
+                    },
+                ),
+            ).rejects.toBe(callbackError);
+            expect(mockSshTunnel.disconnect).toHaveBeenCalledOnce();
+        });
+
+        it('releases a connected tunnel when client construction fails', async () => {
+            const constructionError = new Error('client construction failed');
+            vi.mocked(
+                projectModel.getWarehouseClientFromCredentials,
+            ).mockImplementationOnce(() => {
+                throw constructionError;
+            });
+
+            await expect(
+                service.withWarehouseClient(
+                    {
+                        projectUuid: 'partial-acquisition-project',
+                        credentials: sshCredentials[0],
+                    },
+                    async () => undefined,
+                ),
+            ).rejects.toBe(constructionError);
+            expect(mockSshTunnel.disconnect).toHaveBeenCalledOnce();
+        });
+
+        it('does not reuse clients created for SSH tunnels', async () => {
+            const credentials = sshCredentials[0];
+            const tunneledCredentials = {
+                ...credentials,
+                host: '127.0.0.1',
+                port: 32000,
+            };
+            const firstClient: WarehouseClient = {
+                ...warehouseClientMock,
+                credentials: tunneledCredentials,
+            };
+            const secondClient: WarehouseClient = {
+                ...warehouseClientMock,
+                credentials: tunneledCredentials,
+            };
+            mockSshTunnel.connect
+                .mockResolvedValueOnce(tunneledCredentials)
+                .mockResolvedValueOnce(tunneledCredentials);
+            vi.mocked(projectModel.getWarehouseClientFromCredentials)
+                .mockReturnValueOnce(firstClient)
+                .mockReturnValueOnce(secondClient);
+
+            const first = await service.withWarehouseClient(
+                { projectUuid: 'ssh-cache-project', credentials },
+                async ({ warehouseClient }) => warehouseClient,
+            );
+            const second = await service.withWarehouseClient(
+                { projectUuid: 'ssh-cache-project', credentials },
+                async ({ warehouseClient }) => warehouseClient,
+            );
+
+            expect(first).toBe(firstClient);
+            expect(second).toBe(secondClient);
+        });
+    });
+
+    describe('compile-only warehouse work', () => {
+        it('creates a virtual view without opening an SSH tunnel', async () => {
+            const virtualViewAccount = buildAccount();
+            virtualViewAccount.user.ability = new Ability<PossibleAbilities>([
+                { subject: 'Project', action: 'view' },
+                { subject: 'VirtualView', action: 'create' },
+            ]);
+            projectModel.findExploresFromCache.mockResolvedValueOnce([]);
+
+            await service.createVirtualView(
+                virtualViewAccount,
+                projectUuid,
+                {
+                    name: 'orders_view',
+                    sql: 'select * from orders',
+                    columns: [],
+                },
+                false,
+            );
+
+            expect(SshTunnel).not.toHaveBeenCalled();
+        });
+    });
+
     describe('MotherDuck instance cache enablement', () => {
         test.each([
             {
@@ -613,9 +779,12 @@ describe('ProjectService', () => {
                     projectModel.getWarehouseClientFromCredentials,
                 ).mockClear();
 
-                await configuredService._getWarehouseClient(
-                    targetProjectUuid,
-                    warehouseClientMock.credentials,
+                await configuredService.withWarehouseClient(
+                    {
+                        projectUuid: targetProjectUuid,
+                        credentials: warehouseClientMock.credentials,
+                    },
+                    async () => undefined,
                 );
 
                 expect(
@@ -641,9 +810,12 @@ describe('ProjectService', () => {
                 projectModel.getWarehouseClientFromCredentials,
             ).mockClear();
 
-            await configuredService._getWarehouseClient(
-                projectUuid,
-                warehouseClientMock.credentials,
+            await configuredService.withWarehouseClient(
+                {
+                    projectUuid,
+                    credentials: warehouseClientMock.credentials,
+                },
+                async () => undefined,
             );
 
             expect(

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -498,6 +498,18 @@ type ResolvedCompileAdapter = {
     adapter: ProjectAdapter;
     stagedMergedManifest?: Buffer;
 };
+
+type WarehouseClientOverrides = {
+    snowflakeVirtualWarehouse?: string;
+    databricksCompute?: string;
+};
+
+type WithWarehouseClientArgs = {
+    projectUuid: UUID;
+    credentials: CreateWarehouseCredentials;
+    overrides?: WarehouseClientOverrides;
+};
+
 export class ProjectService extends BaseService {
     static CREATE_PROJECT_JOB_ENQUEUE_GRACE_MS = 15 * 60 * 1000;
 
@@ -2066,123 +2078,154 @@ export class ProjectService extends BaseService {
         });
     }
 
-    async _getWarehouseClient(
-        projectUuid: string,
+    private async acquireWarehouseClient(
+        projectUuid: UUID,
         credentials: CreateWarehouseCredentials,
-        overrides?: {
-            snowflakeVirtualWarehouse?: string;
-            databricksCompute?: string;
-        },
+        overrides?: WarehouseClientOverrides,
     ): Promise<{
         warehouseClient: WarehouseClient;
         sshTunnel: SshTunnel<CreateWarehouseCredentials>;
         tunnelConnectMs: number | null;
     }> {
         Sentry.setTag('warehouse.type', credentials.type);
-        // Setup SSH tunnel for client (user needs to close this)
         const sshTunnel = new SshTunnel(credentials);
-        const usedSshTunnel =
-            'useSshTunnel' in credentials && !!credentials.useSshTunnel;
-        const tunnelStart = performance.now();
-        const warehouseSshCredentials = await sshTunnel.connect();
-        const tunnelConnectMs = usedSshTunnel
-            ? performance.now() - tunnelStart
-            : null;
+        try {
+            const usedSshTunnel =
+                'useSshTunnel' in credentials && !!credentials.useSshTunnel;
+            const tunnelStart = performance.now();
+            const warehouseSshCredentials = await sshTunnel.connect();
+            const tunnelConnectMs = usedSshTunnel
+                ? performance.now() - tunnelStart
+                : null;
 
-        const { snowflakeVirtualWarehouse, databricksCompute } =
-            overrides || {};
+            const { snowflakeVirtualWarehouse, databricksCompute } =
+                overrides || {};
 
-        const cacheKey = `${projectUuid}${snowflakeVirtualWarehouse || ''}${
-            databricksCompute || ''
-        }`;
-        // Check cache for existing client (always false if ssh tunnel was connected)
-        const existingClient = this.warehouseClients[cacheKey] as
-            | (typeof this.warehouseClients)[string]
-            | undefined;
-        if (
-            existingClient &&
-            deepEqual(existingClient.credentials, warehouseSshCredentials)
-        ) {
-            // if existing client uses identical credentials, use it
-            return {
-                warehouseClient: existingClient,
-                sshTunnel,
-                tunnelConnectMs,
-            };
-        }
-        // otherwise create a new client and cache for future use
-        const getSnowflakeWarehouse = (
-            snowflakeCredentials: CreateSnowflakeCredentials,
-        ): string => {
-            if (snowflakeCredentials.override) {
-                this.logger.debug(
-                    `Overriding snowflake warehouse ${snowflakeVirtualWarehouse} with ${snowflakeCredentials.warehouse}`,
-                );
-                return snowflakeCredentials.warehouse;
+            const cacheKey = `${projectUuid}${snowflakeVirtualWarehouse || ''}${
+                databricksCompute || ''
+            }`;
+            const existingClient = usedSshTunnel
+                ? undefined
+                : (this.warehouseClients[cacheKey] as
+                      | (typeof this.warehouseClients)[string]
+                      | undefined);
+            if (
+                existingClient &&
+                deepEqual(existingClient.credentials, warehouseSshCredentials)
+            ) {
+                // if existing client uses identical credentials, use it
+                return {
+                    warehouseClient: existingClient,
+                    sshTunnel,
+                    tunnelConnectMs,
+                };
             }
-            return snowflakeVirtualWarehouse || snowflakeCredentials.warehouse;
-        };
-
-        const credsType = warehouseSshCredentials.type;
-        let credentialsWithOverrides: CreateWarehouseCredentials;
-
-        switch (credsType) {
-            case WarehouseTypes.SNOWFLAKE:
-                credentialsWithOverrides = {
-                    ...warehouseSshCredentials,
-                    warehouse: getSnowflakeWarehouse(warehouseSshCredentials),
-                };
-                break;
-            case WarehouseTypes.DATABRICKS:
-                const getDatabricksHttpPath = (
-                    databricksCredentials: CreateDatabricksCredentials,
-                ): string => {
-                    if (databricksCredentials.compute) {
-                        return (
-                            databricksCredentials.compute.find(
-                                (compute) => compute.name === databricksCompute,
-                            )?.httpPath ?? databricksCredentials.httpPath
-                        );
-                    }
-                    return databricksCredentials.httpPath;
-                };
-
-                credentialsWithOverrides = {
-                    ...warehouseSshCredentials,
-                    httpPath: getDatabricksHttpPath(warehouseSshCredentials),
-                };
-                break;
-            case WarehouseTypes.REDSHIFT:
-            case WarehouseTypes.POSTGRES:
-            case WarehouseTypes.BIGQUERY:
-            case WarehouseTypes.TRINO:
-            case WarehouseTypes.CLICKHOUSE:
-            case WarehouseTypes.ATHENA:
-            case WarehouseTypes.DUCKDB:
-                credentialsWithOverrides = warehouseSshCredentials;
-                break;
-            default:
-                return assertUnreachable(
-                    credsType,
-                    `Unknown warehouse type: ${credsType}`,
+            // otherwise create a new client and cache for future use
+            const getSnowflakeWarehouse = (
+                snowflakeCredentials: CreateSnowflakeCredentials,
+            ): string => {
+                if (snowflakeCredentials.override) {
+                    this.logger.debug(
+                        `Overriding snowflake warehouse ${snowflakeVirtualWarehouse} with ${snowflakeCredentials.warehouse}`,
+                    );
+                    return snowflakeCredentials.warehouse;
+                }
+                return (
+                    snowflakeVirtualWarehouse || snowflakeCredentials.warehouse
                 );
-        }
+            };
 
-        const { enabled, projectUuids } =
-            this.lightdashConfig.motherduckInstanceCache;
-        const emptyAllowlistEnablesAllProjects =
-            this.lightdashConfig.lightdashCloudInstance === undefined;
-        const enableInstanceCache =
-            enabled &&
-            (projectUuids.includes(projectUuid) ||
-                (projectUuids.length === 0 &&
-                    emptyAllowlistEnablesAllProjects));
-        const client = this.projectModel.getWarehouseClientFromCredentials(
-            credentialsWithOverrides,
-            { enableInstanceCache, projectUuid, logger: this.logger },
-        );
-        this.warehouseClients[cacheKey] = client;
-        return { warehouseClient: client, sshTunnel, tunnelConnectMs };
+            const credsType = warehouseSshCredentials.type;
+            let credentialsWithOverrides: CreateWarehouseCredentials;
+
+            switch (credsType) {
+                case WarehouseTypes.SNOWFLAKE:
+                    credentialsWithOverrides = {
+                        ...warehouseSshCredentials,
+                        warehouse: getSnowflakeWarehouse(
+                            warehouseSshCredentials,
+                        ),
+                    };
+                    break;
+                case WarehouseTypes.DATABRICKS:
+                    const getDatabricksHttpPath = (
+                        databricksCredentials: CreateDatabricksCredentials,
+                    ): string => {
+                        if (databricksCredentials.compute) {
+                            return (
+                                databricksCredentials.compute.find(
+                                    (compute) =>
+                                        compute.name === databricksCompute,
+                                )?.httpPath ?? databricksCredentials.httpPath
+                            );
+                        }
+                        return databricksCredentials.httpPath;
+                    };
+
+                    credentialsWithOverrides = {
+                        ...warehouseSshCredentials,
+                        httpPath: getDatabricksHttpPath(
+                            warehouseSshCredentials,
+                        ),
+                    };
+                    break;
+                case WarehouseTypes.REDSHIFT:
+                case WarehouseTypes.POSTGRES:
+                case WarehouseTypes.BIGQUERY:
+                case WarehouseTypes.TRINO:
+                case WarehouseTypes.CLICKHOUSE:
+                case WarehouseTypes.ATHENA:
+                case WarehouseTypes.DUCKDB:
+                    credentialsWithOverrides = warehouseSshCredentials;
+                    break;
+                default:
+                    return assertUnreachable(
+                        credsType,
+                        `Unknown warehouse type: ${credsType}`,
+                    );
+            }
+
+            const { enabled, projectUuids } =
+                this.lightdashConfig.motherduckInstanceCache;
+            const emptyAllowlistEnablesAllProjects =
+                this.lightdashConfig.lightdashCloudInstance === undefined;
+            const enableInstanceCache =
+                enabled &&
+                (projectUuids.includes(projectUuid) ||
+                    (projectUuids.length === 0 &&
+                        emptyAllowlistEnablesAllProjects));
+            const client = this.projectModel.getWarehouseClientFromCredentials(
+                credentialsWithOverrides,
+                { enableInstanceCache, projectUuid, logger: this.logger },
+            );
+            if (!usedSshTunnel) {
+                this.warehouseClients[cacheKey] = client;
+            }
+            return { warehouseClient: client, sshTunnel, tunnelConnectMs };
+        } catch (error) {
+            await sshTunnel.disconnect();
+            throw error;
+        }
+    }
+
+    async withWarehouseClient<T>(
+        { projectUuid, credentials, overrides }: WithWarehouseClientArgs,
+        callback: (connection: {
+            warehouseClient: WarehouseClient;
+            tunnelConnectMs: number | null;
+        }) => Promise<T>,
+    ): Promise<T> {
+        const { warehouseClient, sshTunnel, tunnelConnectMs } =
+            await this.acquireWarehouseClient(
+                projectUuid,
+                credentials,
+                overrides,
+            );
+        try {
+            return await callback({ warehouseClient, tunnelConnectMs });
+        } finally {
+            await sshTunnel.disconnect();
+        }
     }
 
     private async syncPreAggregateDefinitionsRegistry(
@@ -7391,185 +7434,208 @@ export class ProjectService extends BaseService {
                             isRegisteredUser: account.isRegisteredUser(),
                             isServiceAccount: account.isServiceAccount(),
                         });
-                    const { warehouseClient, sshTunnel } =
-                        await this._getWarehouseClient(
+                    return await this.withWarehouseClient(
+                        {
                             projectUuid,
-                            warehouseCredentials,
-                            {
+                            credentials: warehouseCredentials,
+                            overrides: {
                                 snowflakeVirtualWarehouse: explore.warehouse,
                                 databricksCompute: explore.databricksCompute,
                             },
-                        );
-
-                    const { userAttributes, intrinsicUserAttributes } =
-                        await this.getUserAttributes({
-                            account,
-                        });
-
-                    const mergedUserAttributes = userAttributeOverrides
-                        ? {
-                              ...userAttributes,
-                              ...userAttributeOverrides,
-                          }
-                        : userAttributes;
-
-                    const availableParameterDefinitions =
-                        await this.getAvailableParameters(projectUuid, explore);
-
-                    const projectTimezone =
-                        await this.getQueryTimezoneForProject(projectUuid);
-                    const timezone = resolveQueryTimezone({
-                        sessionTimezone: null,
-                        metricQuery: metricQueryWithLimit,
-                        projectTimezone,
-                        userTimezone: getAccountUserTimezone(account),
-                    });
-                    const useTimezoneAwareDateTrunc =
-                        await this.isTimezoneSupportEnabled({
-                            userUuid: account.user.id,
-                            organizationUuid:
-                                account.organization.organizationUuid,
-                        });
-
-                    const fullQuery = new QueryComposer(
-                        { metricQuery: metricQueryWithLimit },
-                        {
-                            explore,
-                            warehouseSqlBuilder: warehouseClient,
-                            intrinsicUserAttributes,
-                            userAttributes: mergedUserAttributes,
-                            timezone,
-                            dateZoom,
-                            parameters,
-                            availableParameterDefinitions,
-                            pivotDimensions:
-                                metricQueryWithLimit.pivotDimensions,
-                            useTimezoneAwareDateTrunc,
-                            columnTimezone: getColumnTimezone(
-                                warehouseClient.credentials,
-                            ),
-                            dataTimezone:
-                                warehouseClient.credentials.dataTimezone,
                         },
-                    ).compile();
+                        async ({ warehouseClient }) => {
+                            const { userAttributes, intrinsicUserAttributes } =
+                                await this.getUserAttributes({
+                                    account,
+                                });
 
-                    const { query } = fullQuery;
+                            const mergedUserAttributes = userAttributeOverrides
+                                ? {
+                                      ...userAttributes,
+                                      ...userAttributeOverrides,
+                                  }
+                                : userAttributes;
 
-                    const resolvedMetricOverrides =
-                        getMetricOverridesWithPopInheritance(metricQuery);
-
-                    const fieldsWithOverrides: ItemsMap = Object.fromEntries(
-                        Object.entries(fullQuery.fields).map(([key, value]) => {
-                            // Check for metric or dimension overrides. PoP
-                            // metric overrides are inherited from their base
-                            // metric by the shared util above.
-                            const override =
-                                resolvedMetricOverrides[key] ||
-                                metricQuery.dimensionOverrides?.[key];
-                            const formatOptions = override?.formatOptions;
-                            if (formatOptions) {
-                                return [
-                                    key,
-                                    {
-                                        ...value,
-                                        ...getFieldFormatOverrideProps(
-                                            formatOptions,
-                                        ),
-                                    },
-                                ];
-                            }
-                            return [key, value];
-                        }),
-                    );
-
-                    const onboardingFlow = await this.getOnboardingFlow({
-                        userUuid: account.user.id,
-                        organizationUuid: account.organization.organizationUuid,
-                    });
-                    const onboardingRecord =
-                        await this.onboardingModel.getByOrganizationUuid(
-                            account.organization.organizationUuid,
-                        );
-                    if (!onboardingRecord.ranQueryAt) {
-                        await this.onboardingModel.update(
-                            account.organization.organizationUuid,
-                            {
-                                ranQueryAt: new Date(),
-                            },
-                        );
-                        this.analytics.trackAccount(account, {
-                            event: 'onboarding.step_completed',
-                            properties: {
-                                step: 'first_query',
-                                stepIndex: 5,
-                                onboardingFlow,
-                                organizationId:
-                                    account.organization.organizationUuid,
-                            },
-                        });
-                    }
-
-                    this.analytics.trackAccount(account, {
-                        event: 'query.executed',
-                        properties: {
-                            organizationId: organizationUuid,
-                            projectId: projectUuid,
-                            context,
-                            onboardingFlow,
-                            ...ProjectService.getMetricQueryExecutionProperties(
-                                {
-                                    metricQuery: metricQueryWithLimit,
-                                    queryTags,
-                                    chartUuid,
-                                    dateZoom,
+                            const availableParameterDefinitions =
+                                await this.getAvailableParameters(
+                                    projectUuid,
                                     explore,
-                                    parameters,
-                                },
-                            ),
-                        },
-                    });
-                    this.logger.debug(
-                        `Fetch query results from cache or warehouse`,
-                    );
-                    span.setAttribute('generatedSql', query);
+                                );
 
-                    span.setAttribute('lightdash.projectUuid', projectUuid);
-                    span.setAttribute(
-                        'warehouse.type',
-                        warehouseClient.credentials.type,
-                    );
-                    const userUuid = getCacheUserUuid(
-                        warehouseCredentials,
-                        account.user.id,
-                    );
-                    const { rows, cacheMetadata } =
-                        await this.getResultsFromCacheOrWarehouse({
-                            projectUuid,
-                            userUuid,
-                            user: {
-                                userUuid: account.user.id,
-                                organizationUuid:
+                            const projectTimezone =
+                                await this.getQueryTimezoneForProject(
+                                    projectUuid,
+                                );
+                            const timezone = resolveQueryTimezone({
+                                sessionTimezone: null,
+                                metricQuery: metricQueryWithLimit,
+                                projectTimezone,
+                                userTimezone: getAccountUserTimezone(account),
+                            });
+                            const useTimezoneAwareDateTrunc =
+                                await this.isTimezoneSupportEnabled({
+                                    userUuid: account.user.id,
+                                    organizationUuid:
+                                        account.organization.organizationUuid,
+                                });
+
+                            const fullQuery = new QueryComposer(
+                                { metricQuery: metricQueryWithLimit },
+                                {
+                                    explore,
+                                    warehouseSqlBuilder: warehouseClient,
+                                    intrinsicUserAttributes,
+                                    userAttributes: mergedUserAttributes,
+                                    timezone,
+                                    dateZoom,
+                                    parameters,
+                                    availableParameterDefinitions,
+                                    pivotDimensions:
+                                        metricQueryWithLimit.pivotDimensions,
+                                    useTimezoneAwareDateTrunc,
+                                    columnTimezone: getColumnTimezone(
+                                        warehouseClient.credentials,
+                                    ),
+                                    dataTimezone:
+                                        warehouseClient.credentials
+                                            .dataTimezone,
+                                },
+                            ).compile();
+
+                            const { query } = fullQuery;
+
+                            const resolvedMetricOverrides =
+                                getMetricOverridesWithPopInheritance(
+                                    metricQuery,
+                                );
+
+                            const fieldsWithOverrides: ItemsMap =
+                                Object.fromEntries(
+                                    Object.entries(fullQuery.fields).map(
+                                        ([key, value]) => {
+                                            // Check for metric or dimension overrides. PoP
+                                            // metric overrides are inherited from their base
+                                            // metric by the shared util above.
+                                            const override =
+                                                resolvedMetricOverrides[key] ||
+                                                metricQuery
+                                                    .dimensionOverrides?.[key];
+                                            const formatOptions =
+                                                override?.formatOptions;
+                                            if (formatOptions) {
+                                                return [
+                                                    key,
+                                                    {
+                                                        ...value,
+                                                        ...getFieldFormatOverrideProps(
+                                                            formatOptions,
+                                                        ),
+                                                    },
+                                                ];
+                                            }
+                                            return [key, value];
+                                        },
+                                    ),
+                                );
+
+                            const onboardingFlow = await this.getOnboardingFlow(
+                                {
+                                    userUuid: account.user.id,
+                                    organizationUuid:
+                                        account.organization.organizationUuid,
+                                },
+                            );
+                            const onboardingRecord =
+                                await this.onboardingModel.getByOrganizationUuid(
                                     account.organization.organizationUuid,
-                                organizationName: account.organization.name,
-                            },
-                            context,
-                            warehouseClient,
-                            metricQuery: metricQueryWithLimit,
-                            resolvedTimezone: timezone,
-                            query,
-                            queryTags,
-                            invalidateCache,
-                        });
-                    await sshTunnel.disconnect();
-                    return {
-                        rows,
-                        cacheMetadata,
-                        fields: fieldsWithOverrides,
-                        displayTimezone: useTimezoneAwareDateTrunc
-                            ? timezone
-                            : undefined,
-                        warehouseType: warehouseClient.credentials.type,
-                    };
+                                );
+                            if (!onboardingRecord.ranQueryAt) {
+                                await this.onboardingModel.update(
+                                    account.organization.organizationUuid,
+                                    {
+                                        ranQueryAt: new Date(),
+                                    },
+                                );
+                                this.analytics.trackAccount(account, {
+                                    event: 'onboarding.step_completed',
+                                    properties: {
+                                        step: 'first_query',
+                                        stepIndex: 5,
+                                        onboardingFlow,
+                                        organizationId:
+                                            account.organization
+                                                .organizationUuid,
+                                    },
+                                });
+                            }
+
+                            this.analytics.trackAccount(account, {
+                                event: 'query.executed',
+                                properties: {
+                                    organizationId: organizationUuid,
+                                    projectId: projectUuid,
+                                    context,
+                                    onboardingFlow,
+                                    ...ProjectService.getMetricQueryExecutionProperties(
+                                        {
+                                            metricQuery: metricQueryWithLimit,
+                                            queryTags,
+                                            chartUuid,
+                                            dateZoom,
+                                            explore,
+                                            parameters,
+                                        },
+                                    ),
+                                },
+                            });
+                            this.logger.debug(
+                                `Fetch query results from cache or warehouse`,
+                            );
+                            span.setAttribute('generatedSql', query);
+
+                            span.setAttribute(
+                                'lightdash.projectUuid',
+                                projectUuid,
+                            );
+                            span.setAttribute(
+                                'warehouse.type',
+                                warehouseClient.credentials.type,
+                            );
+                            const userUuid = getCacheUserUuid(
+                                warehouseCredentials,
+                                account.user.id,
+                            );
+                            const { rows, cacheMetadata } =
+                                await this.getResultsFromCacheOrWarehouse({
+                                    projectUuid,
+                                    userUuid,
+                                    user: {
+                                        userUuid: account.user.id,
+                                        organizationUuid:
+                                            account.organization
+                                                .organizationUuid,
+                                        organizationName:
+                                            account.organization.name,
+                                    },
+                                    context,
+                                    warehouseClient,
+                                    metricQuery: metricQueryWithLimit,
+                                    resolvedTimezone: timezone,
+                                    query,
+                                    queryTags,
+                                    invalidateCache,
+                                });
+                            return {
+                                rows,
+                                cacheMetadata,
+                                fields: fieldsWithOverrides,
+                                displayTimezone: useTimezoneAwareDateTrunc
+                                    ? timezone
+                                    : undefined,
+                                warehouseType: warehouseClient.credentials.type,
+                            };
+                        },
+                    );
                 } catch (e) {
                     span.setStatus({
                         code: 2, // ERROR
@@ -7612,36 +7678,38 @@ export class ProjectService extends BaseService {
                 onboardingFlow: await this.getOnboardingFlow(user),
             },
         });
-        const { warehouseClient, sshTunnel } = await this._getWarehouseClient(
-            projectUuid,
-            await this.getWarehouseCredentials({
+        return this.withWarehouseClient(
+            {
                 projectUuid,
-                userId: user.userUuid,
-                isRegisteredUser: true,
-            }),
+                credentials: await this.getWarehouseCredentials({
+                    projectUuid,
+                    userId: user.userUuid,
+                    isRegisteredUser: true,
+                }),
+            },
+            async ({ warehouseClient }) => {
+                this.logger.debug(`Run query against warehouse`);
+                const queryTags: RunQueryTags = {
+                    organization_uuid: organizationUuid,
+                    user_uuid: user.userUuid,
+                    query_context: QueryExecutionContext.SQL_RUNNER,
+                };
+
+                const { maxLimit } = await resolveOrganizationExportLimits(
+                    this.organizationSettingsModel,
+                    this.lightdashConfig.query,
+                    organizationUuid,
+                );
+
+                // enforce limit for current SQL queries as it may crash server. We are working on a new SQL runner that supports streaming
+                const cteWithLimit = applyLimitToSqlQuery({
+                    sqlQuery: sql,
+                    limit: maxLimit,
+                });
+
+                return warehouseClient.runQuery(cteWithLimit, queryTags);
+            },
         );
-        this.logger.debug(`Run query against warehouse`);
-        const queryTags: RunQueryTags = {
-            organization_uuid: organizationUuid,
-            user_uuid: user.userUuid,
-            query_context: QueryExecutionContext.SQL_RUNNER,
-        };
-
-        const { maxLimit } = await resolveOrganizationExportLimits(
-            this.organizationSettingsModel,
-            this.lightdashConfig.query,
-            organizationUuid,
-        );
-
-        // enforce limit for current SQL queries as it may crash server. We are working on a new SQL runner that supports streaming
-        const cteWithLimit = applyLimitToSqlQuery({
-            sqlQuery: sql,
-            limit: maxLimit,
-        });
-
-        const results = await warehouseClient.runQuery(cteWithLimit, queryTags);
-        await sshTunnel.disconnect();
-        return results;
     }
 
     // TODO: consider removing this method in milestone #212
@@ -7677,54 +7745,58 @@ export class ProjectService extends BaseService {
                 }),
             },
         });
-        const { warehouseClient, sshTunnel } = await this._getWarehouseClient(
-            projectUuid,
-            await this.getWarehouseCredentials({
+        return this.withWarehouseClient(
+            {
                 projectUuid,
-                userId: userUuid,
-                isRegisteredUser: true,
-            }),
-        );
-        this.logger.debug(`Stream query against warehouse`);
-        const queryTags: RunQueryTags = {
-            organization_uuid: organizationUuid,
-            user_uuid: userUuid,
-            query_context: context,
-        };
+                credentials: await this.getWarehouseCredentials({
+                    projectUuid,
+                    userId: userUuid,
+                    isRegisteredUser: true,
+                }),
+            },
+            async ({ warehouseClient }) => {
+                this.logger.debug(`Stream query against warehouse`);
+                const queryTags: RunQueryTags = {
+                    organization_uuid: organizationUuid,
+                    user_uuid: userUuid,
+                    query_context: context,
+                };
 
-        const columns: VizColumn[] = [];
+                const columns: VizColumn[] = [];
 
-        const fileUrl = await this.downloadFileModel.streamFunction(
-            this.fileStorageClient,
-            projectUuid,
-        )(
-            `${this.lightdashConfig.siteUrl}/api/v1/projects/${projectUuid}/sqlRunner/results`,
-            async (writer) => {
-                await warehouseClient.streamQuery(
-                    query,
-                    async ({ rows, fields }) => {
-                        if (!columns.length) {
-                            // Get column types from first row of results
-                            columns.push(
-                                ...Object.keys(fields).map((fieldName) => ({
-                                    reference: fieldName,
-                                    type: fields[fieldName].type,
-                                })),
-                            );
-                        }
+                const fileUrl = await this.downloadFileModel.streamFunction(
+                    this.fileStorageClient,
+                    projectUuid,
+                )(
+                    `${this.lightdashConfig.siteUrl}/api/v1/projects/${projectUuid}/sqlRunner/results`,
+                    async (writer) => {
+                        await warehouseClient.streamQuery(
+                            query,
+                            async ({ rows, fields }) => {
+                                if (!columns.length) {
+                                    // Get column types from first row of results
+                                    columns.push(
+                                        ...Object.keys(fields).map(
+                                            (fieldName) => ({
+                                                reference: fieldName,
+                                                type: fields[fieldName].type,
+                                            }),
+                                        ),
+                                    );
+                                }
 
-                        rows.forEach(writer);
-                    },
-                    {
-                        tags: queryTags,
+                                rows.forEach(writer);
+                            },
+                            {
+                                tags: queryTags,
+                            },
+                        );
                     },
                 );
+
+                return { fileUrl, columns };
             },
         );
-
-        await sshTunnel.disconnect();
-
-        return { fileUrl, columns };
     }
 
     async pivotQueryWorkerTask({
@@ -7769,159 +7841,174 @@ export class ProjectService extends BaseService {
                 }),
             },
         });
-        const { warehouseClient, sshTunnel } = await this._getWarehouseClient(
-            projectUuid,
-            warehouseCredentials,
-        );
+        return this.withWarehouseClient(
+            { projectUuid, credentials: warehouseCredentials },
+            async ({ warehouseClient }) => {
+                // Apply limit and pivot to the SQL query
+                const pivotQueryBuilder = new PivotQueryBuilder(
+                    sql,
+                    {
+                        indexColumn: indexColumns,
+                        valuesColumns,
+                        groupByColumns,
+                        sortBy,
+                    },
+                    warehouseClient,
+                    limit,
+                );
 
-        // Apply limit and pivot to the SQL query
-        const pivotQueryBuilder = new PivotQueryBuilder(
-            sql,
-            {
-                indexColumn: indexColumns,
-                valuesColumns,
-                groupByColumns,
-                sortBy,
-            },
-            warehouseClient,
-            limit,
-        );
+                const pivotedSql = pivotQueryBuilder.toSql({
+                    columnLimit: this.lightdashConfig.pivotTable.maxColumnLimit,
+                });
 
-        const pivotedSql = pivotQueryBuilder.toSql({
-            columnLimit: this.lightdashConfig.pivotTable.maxColumnLimit,
-        });
+                this.logger.debug(`Stream query against warehouse`);
+                const queryTags: RunQueryTags = {
+                    organization_uuid: organizationUuid,
+                    user_uuid: userUuid,
+                    query_context: context,
+                };
 
-        this.logger.debug(`Stream query against warehouse`);
-        const queryTags: RunQueryTags = {
-            organization_uuid: organizationUuid,
-            user_uuid: userUuid,
-            query_context: context,
-        };
+                const columns: VizColumn[] = [];
+                let currentRowIndex = 0;
+                let currentTransformedRow: ResultRow | undefined;
+                const valuesColumnData = new Map<string, PivotValuesColumn>();
 
-        const columns: VizColumn[] = [];
-        let currentRowIndex = 0;
-        let currentTransformedRow: ResultRow | undefined;
-        const valuesColumnData = new Map<string, PivotValuesColumn>();
+                let columnCount: undefined | number;
 
-        let columnCount: undefined | number;
-
-        const fileUrl = await this.downloadFileModel.streamFunction(
-            this.fileStorageClient,
-            projectUuid,
-        )(
-            `${this.lightdashConfig.siteUrl}/api/v1/projects/${projectUuid}/sqlRunner/results`,
-            async (writer) => {
-                try {
-                    await warehouseClient.streamQuery(
-                        pivotedSql,
-                        async ({ rows, fields }) => {
-                            if ('total_columns' in rows[0]) {
-                                columnCount = rows[0].total_columns;
-                            }
-                            if (
-                                !groupByColumns ||
-                                groupByColumns.length === 0
-                            ) {
-                                rows.forEach(writer);
-                                return;
-                            }
-
-                            // columns appears unused
-                            if (!columns.length) {
-                                // Get column types from first row of results
-                                columns.push(
-                                    ...Object.keys(fields).map((fieldName) => ({
-                                        reference: fieldName,
-                                        type: fields[fieldName].type,
-                                    })),
-                                );
-                            }
-
-                            rows.forEach((row) => {
-                                // Write rows to file in order of row_index. This is so that we can pivot the data later
-                                if (currentRowIndex !== row.row_index) {
-                                    if (currentTransformedRow) {
-                                        writer(currentTransformedRow);
+                const fileUrl = await this.downloadFileModel.streamFunction(
+                    this.fileStorageClient,
+                    projectUuid,
+                )(
+                    `${this.lightdashConfig.siteUrl}/api/v1/projects/${projectUuid}/sqlRunner/results`,
+                    async (writer) => {
+                        try {
+                            await warehouseClient.streamQuery(
+                                pivotedSql,
+                                async ({ rows, fields }) => {
+                                    if ('total_columns' in rows[0]) {
+                                        columnCount = rows[0].total_columns;
+                                    }
+                                    if (
+                                        !groupByColumns ||
+                                        groupByColumns.length === 0
+                                    ) {
+                                        rows.forEach(writer);
+                                        return;
                                     }
 
-                                    currentTransformedRow =
-                                        indexColumns.reduce<ResultRow>(
-                                            (acc, indexCol) => {
-                                                acc[indexCol.reference] =
-                                                    row[indexCol.reference];
-                                                return acc;
-                                            },
-                                            {},
+                                    // columns appears unused
+                                    if (!columns.length) {
+                                        // Get column types from first row of results
+                                        columns.push(
+                                            ...Object.keys(fields).map(
+                                                (fieldName) => ({
+                                                    reference: fieldName,
+                                                    type: fields[fieldName]
+                                                        .type,
+                                                }),
+                                            ),
                                         );
+                                    }
 
-                                    currentRowIndex = row.row_index;
-                                }
-                                // Suffix the value column with the group by columns to avoid collisions.
-                                // E.g. if we have a row with the value 1 and the group by columns are ['a', 'b'],
-                                // then the value column will be 'value_1_a_b'
-                                const valueSuffix = groupByColumns
-                                    ?.map((col) => row[col.reference])
-                                    .join('_');
-                                valuesColumns.forEach((col) => {
-                                    const valueColumnReference = `${col.reference}_${col.aggregation}_${valueSuffix}`;
-                                    valuesColumnData.set(valueColumnReference, {
-                                        referenceField: col.reference, // The original y field name
-                                        pivotColumnName: valueColumnReference, // The pivoted y field name and agg eg amount_avg_false
-                                        aggregation: col.aggregation,
-                                        pivotValues: groupByColumns?.map(
-                                            (c) => ({
-                                                referenceField: c.reference,
-                                                value: row[c.reference],
-                                            }),
-                                        ),
+                                    rows.forEach((row) => {
+                                        // Write rows to file in order of row_index. This is so that we can pivot the data later
+                                        if (currentRowIndex !== row.row_index) {
+                                            if (currentTransformedRow) {
+                                                writer(currentTransformedRow);
+                                            }
+
+                                            currentTransformedRow =
+                                                indexColumns.reduce<ResultRow>(
+                                                    (acc, indexCol) => {
+                                                        acc[
+                                                            indexCol.reference
+                                                        ] =
+                                                            row[
+                                                                indexCol.reference
+                                                            ];
+                                                        return acc;
+                                                    },
+                                                    {},
+                                                );
+
+                                            currentRowIndex = row.row_index;
+                                        }
+                                        // Suffix the value column with the group by columns to avoid collisions.
+                                        // E.g. if we have a row with the value 1 and the group by columns are ['a', 'b'],
+                                        // then the value column will be 'value_1_a_b'
+                                        const valueSuffix = groupByColumns
+                                            ?.map((col) => row[col.reference])
+                                            .join('_');
+                                        valuesColumns.forEach((col) => {
+                                            const valueColumnReference = `${col.reference}_${col.aggregation}_${valueSuffix}`;
+                                            valuesColumnData.set(
+                                                valueColumnReference,
+                                                {
+                                                    referenceField:
+                                                        col.reference, // The original y field name
+                                                    pivotColumnName:
+                                                        valueColumnReference, // The pivoted y field name and agg eg amount_avg_false
+                                                    aggregation:
+                                                        col.aggregation,
+                                                    pivotValues:
+                                                        groupByColumns?.map(
+                                                            (c) => ({
+                                                                referenceField:
+                                                                    c.reference,
+                                                                value: row[
+                                                                    c.reference
+                                                                ],
+                                                            }),
+                                                        ),
+                                                },
+                                            );
+                                            currentTransformedRow =
+                                                currentTransformedRow ?? {};
+                                            currentTransformedRow[
+                                                valueColumnReference
+                                            ] =
+                                                row[
+                                                    `${col.reference}_${col.aggregation}`
+                                                ];
+                                        });
                                     });
-                                    currentTransformedRow =
-                                        currentTransformedRow ?? {};
-                                    currentTransformedRow[
-                                        valueColumnReference
-                                    ] =
-                                        row[
-                                            `${col.reference}_${col.aggregation}`
-                                        ];
-                                });
-                            });
-                        },
-                        {
-                            tags: queryTags,
-                        },
-                    );
-                } catch (error) {
-                    this.logger.error(
-                        `Error running pivot query: ${error}\nSQL: ${pivotedSql}`,
-                    );
-                    throw error;
-                }
-                // Write the last row
-                if (currentTransformedRow) {
-                    writer(currentTransformedRow);
-                }
+                                },
+                                {
+                                    tags: queryTags,
+                                },
+                            );
+                        } catch (error) {
+                            this.logger.error(
+                                `Error running pivot query: ${error}\nSQL: ${pivotedSql}`,
+                            );
+                            throw error;
+                        }
+                        // Write the last row
+                        if (currentTransformedRow) {
+                            writer(currentTransformedRow);
+                        }
+                    },
+                );
+
+                const processedColumns =
+                    groupByColumns && groupByColumns.length > 0
+                        ? Array.from(valuesColumnData.values())
+                        : valuesColumns.map((col) => ({
+                              referenceField: col.reference,
+                              pivotColumnName: `${col.reference}_${col.aggregation}`,
+                              aggregation: col.aggregation,
+                              pivotValues: [],
+                          }));
+
+                return {
+                    queryUuid: undefined,
+                    fileUrl,
+                    valuesColumns: processedColumns,
+                    indexColumn: indexColumns,
+                    columnCount: Number(columnCount) || undefined,
+                };
             },
         );
-
-        await sshTunnel.disconnect();
-
-        const processedColumns =
-            groupByColumns && groupByColumns.length > 0
-                ? Array.from(valuesColumnData.values())
-                : valuesColumns.map((col) => ({
-                      referenceField: col.reference,
-                      pivotColumnName: `${col.reference}_${col.aggregation}`,
-                      aggregation: col.aggregation,
-                      pivotValues: [],
-                  }));
-
-        return {
-            queryUuid: undefined,
-            fileUrl,
-            valuesColumns: processedColumns,
-            indexColumn: indexColumns,
-            columnCount: Number(columnCount) || undefined,
-        };
     }
 
     /** @deprecated Only used by the deprecated SQL runner results endpoint; use AsyncQueryService.getAsyncQueryResults instead. */
@@ -8089,149 +8176,159 @@ export class ProjectService extends BaseService {
             this.isTimezoneSupportEnabled(user),
         ]);
 
-        const { warehouseClient, sshTunnel } = await this._getWarehouseClient(
-            projectUuid,
-            warehouseCredentials,
+        return this.withWarehouseClient(
             {
-                snowflakeVirtualWarehouse: explore.warehouse,
-                databricksCompute: explore.databricksCompute,
+                projectUuid,
+                credentials: warehouseCredentials,
+                overrides: {
+                    snowflakeVirtualWarehouse: explore.warehouse,
+                    databricksCompute: explore.databricksCompute,
+                },
             },
-        );
+            async ({ warehouseClient }) => {
+                const mergedUserAttributes = userAttributeOverrides
+                    ? {
+                          ...userAttributes,
+                          ...userAttributeOverrides,
+                      }
+                    : userAttributes;
 
-        const mergedUserAttributes = userAttributeOverrides
-            ? {
-                  ...userAttributes,
-                  ...userAttributeOverrides,
-              }
-            : userAttributes;
+                const timezone = resolveQueryTimezone({
+                    sessionTimezone: null,
+                    metricQuery,
+                    projectTimezone,
+                    userTimezone: user.timezone,
+                });
 
-        const timezone = resolveQueryTimezone({
-            sessionTimezone: null,
-            metricQuery,
-            projectTimezone,
-            userTimezone: user.timezone,
-        });
+                const { query } = new QueryComposer(
+                    { metricQuery },
+                    {
+                        explore,
+                        warehouseSqlBuilder: warehouseClient,
+                        intrinsicUserAttributes,
+                        userAttributes: mergedUserAttributes,
+                        timezone,
+                        parameters: combinedParameters,
+                        availableParameterDefinitions,
+                        useTimezoneAwareDateTrunc,
+                        columnTimezone: getColumnTimezone(
+                            warehouseClient.credentials,
+                        ),
+                    },
+                ).compile();
 
-        const { query } = new QueryComposer(
-            { metricQuery },
-            {
-                explore,
-                warehouseSqlBuilder: warehouseClient,
-                intrinsicUserAttributes,
-                userAttributes: mergedUserAttributes,
-                timezone,
-                parameters: combinedParameters,
-                availableParameterDefinitions,
-                useTimezoneAwareDateTrunc,
-                columnTimezone: getColumnTimezone(warehouseClient.credentials),
-            },
-        ).compile();
+                const isUserCacheEnabled =
+                    this.lightdashConfig.results.autocompleteEnabled &&
+                    !!user.userUuid;
 
-        const isUserCacheEnabled =
-            this.lightdashConfig.results.autocompleteEnabled && !!user.userUuid;
+                const userUuid = getCacheUserUuid(
+                    warehouseCredentials,
+                    user.userUuid,
+                );
 
-        const userUuid = getCacheUserUuid(warehouseCredentials, user.userUuid);
+                const hashParts = [
+                    projectUuid,
+                    userUuid,
+                    'cache_autocomplete',
+                    query,
+                    timezone,
+                ];
+                const queryHash = buildCacheHash(hashParts);
 
-        const hashParts = [
-            projectUuid,
-            userUuid,
-            'cache_autocomplete',
-            query,
-            timezone,
-        ];
-        const queryHash = buildCacheHash(hashParts);
-
-        if (!forceRefresh && isUserCacheEnabled) {
-            const stringResults = await this.s3CacheClient
-                .getIfFresh(
-                    queryHash,
-                    this.lightdashConfig.results.cacheStateTimeSeconds,
-                )
-                .catch(() => undefined);
-            if (stringResults) {
-                try {
-                    await sshTunnel.disconnect();
-                    return JSON.parse(stringResults);
-                } catch (e) {
-                    this.logger.error(
-                        'Error parsing autocomplete cache results:',
-                        e,
-                    );
-                }
-            }
-        }
-
-        const queryTags: RunQueryTags = {
-            organization_uuid: organizationUuid,
-            user_uuid: user.userUuid,
-            project_uuid: projectUuid,
-            explore_name: explore.name,
-            query_context: context,
-        };
-
-        const { rows } = await warehouseClient.runQuery(query, queryTags);
-        const valueFieldId = getItemId(field);
-        const allResults: Set<string | number | boolean> = new Set();
-        const resultsWithLabels: FilterAutocompleteValue[] = [];
-        const seenLabeledValues = new Set<string>();
-        for (const row of rows) {
-            const value = row[valueFieldId];
-            if (value !== null && value !== undefined) {
-                allResults.add(value);
-                if (labelFieldId) {
-                    const valueKey = String(value);
-                    if (!seenLabeledValues.has(valueKey)) {
-                        seenLabeledValues.add(valueKey);
-                        const rawLabel = row[labelFieldId];
-                        resultsWithLabels.push({
-                            value: valueKey,
-                            label:
-                                rawLabel !== null && rawLabel !== undefined
-                                    ? String(rawLabel)
-                                    : valueKey,
-                        });
+                if (!forceRefresh && isUserCacheEnabled) {
+                    const stringResults = await this.s3CacheClient
+                        .getIfFresh(
+                            queryHash,
+                            this.lightdashConfig.results.cacheStateTimeSeconds,
+                        )
+                        .catch(() => undefined);
+                    if (stringResults) {
+                        try {
+                            return JSON.parse(stringResults);
+                        } catch (e) {
+                            this.logger.error(
+                                'Error parsing autocomplete cache results:',
+                                e,
+                            );
+                        }
                     }
                 }
-            }
-        }
 
-        const resultsArray = Array.from(allResults);
+                const queryTags: RunQueryTags = {
+                    organization_uuid: organizationUuid,
+                    user_uuid: user.userUuid,
+                    project_uuid: projectUuid,
+                    explore_name: explore.name,
+                    query_context: context,
+                };
 
-        if (isUserCacheEnabled) {
-            const searchResults = {
-                search,
-                results: resultsArray,
-                ...(labelFieldId ? { resultsWithLabels } : {}),
-                refreshedAt: new Date(),
-                cached: true,
-            };
-            const buffer = Buffer.from(JSON.stringify(searchResults));
-            this.s3CacheClient
-                .uploadResults(queryHash, buffer, queryTags)
-                .catch(() => undefined);
-        }
+                const { rows } = await warehouseClient.runQuery(
+                    query,
+                    queryTags,
+                );
+                const valueFieldId = getItemId(field);
+                const allResults: Set<string | number | boolean> = new Set();
+                const resultsWithLabels: FilterAutocompleteValue[] = [];
+                const seenLabeledValues = new Set<string>();
+                for (const row of rows) {
+                    const value = row[valueFieldId];
+                    if (value !== null && value !== undefined) {
+                        allResults.add(value);
+                        if (labelFieldId) {
+                            const valueKey = String(value);
+                            if (!seenLabeledValues.has(valueKey)) {
+                                seenLabeledValues.add(valueKey);
+                                const rawLabel = row[labelFieldId];
+                                resultsWithLabels.push({
+                                    value: valueKey,
+                                    label:
+                                        rawLabel !== null &&
+                                        rawLabel !== undefined
+                                            ? String(rawLabel)
+                                            : valueKey,
+                                });
+                            }
+                        }
+                    }
+                }
 
-        await sshTunnel.disconnect();
+                const resultsArray = Array.from(allResults);
 
-        this.analytics.track({
-            event: 'field_value.search',
-            userId: user.userUuid,
-            properties: {
-                projectId: projectUuid,
-                fieldId: valueFieldId,
-                searchCharCount: search.length,
-                resultsCount: resultsArray.length,
-                searchLimit: metricQuery.limit,
+                if (isUserCacheEnabled) {
+                    const searchResults = {
+                        search,
+                        results: resultsArray,
+                        ...(labelFieldId ? { resultsWithLabels } : {}),
+                        refreshedAt: new Date(),
+                        cached: true,
+                    };
+                    const buffer = Buffer.from(JSON.stringify(searchResults));
+                    this.s3CacheClient
+                        .uploadResults(queryHash, buffer, queryTags)
+                        .catch(() => undefined);
+                }
+
+                this.analytics.track({
+                    event: 'field_value.search',
+                    userId: user.userUuid,
+                    properties: {
+                        projectId: projectUuid,
+                        fieldId: valueFieldId,
+                        searchCharCount: search.length,
+                        resultsCount: resultsArray.length,
+                        searchLimit: metricQuery.limit,
+                    },
+                });
+
+                return {
+                    search,
+                    results: resultsArray,
+                    ...(labelFieldId ? { resultsWithLabels } : {}),
+                    refreshedAt: new Date(),
+                    cached: false,
+                };
             },
-        });
-
-        return {
-            search,
-            results: resultsArray,
-            ...(labelFieldId ? { resultsWithLabels } : {}),
-            refreshedAt: new Date(),
-            cached: false,
-        };
+        );
     }
 
     private async getProjectContextFromAdapter({
@@ -9388,35 +9485,34 @@ export class ProjectService extends BaseService {
             isRegisteredUser: true,
         });
 
-        const { warehouseClient, sshTunnel } = await this._getWarehouseClient(
-            projectUuid,
-            credentials,
+        return this.withWarehouseClient(
+            { projectUuid, credentials },
+            async ({ warehouseClient }) => {
+                const warehouseTables = await warehouseClient.getAllTables();
+
+                const catalog =
+                    WarehouseAvailableTablesModel.toWarehouseCatalog(
+                        warehouseTables.map((t) => ({
+                            ...t,
+                            partition_column: t.partitionColumn || null,
+                        })),
+                    );
+
+                if (credentials.userWarehouseCredentialsUuid) {
+                    await this.warehouseAvailableTablesModel.createAvailableTablesForUserWarehouseCredentials(
+                        credentials.userWarehouseCredentialsUuid,
+                        warehouseTables,
+                    );
+                } else {
+                    await this.warehouseAvailableTablesModel.createAvailableTablesForProjectWarehouseCredentials(
+                        projectUuid,
+                        warehouseTables,
+                    );
+                }
+
+                return catalog;
+            },
         );
-
-        const warehouseTables = await warehouseClient.getAllTables();
-
-        const catalog = WarehouseAvailableTablesModel.toWarehouseCatalog(
-            warehouseTables.map((t) => ({
-                ...t,
-                partition_column: t.partitionColumn || null,
-            })),
-        );
-
-        if (credentials.userWarehouseCredentialsUuid) {
-            await this.warehouseAvailableTablesModel.createAvailableTablesForUserWarehouseCredentials(
-                credentials.userWarehouseCredentialsUuid,
-                warehouseTables,
-            );
-        } else {
-            await this.warehouseAvailableTablesModel.createAvailableTablesForProjectWarehouseCredentials(
-                projectUuid,
-                warehouseTables,
-            );
-        }
-
-        await sshTunnel.disconnect();
-
-        return catalog;
     }
 
     async getWarehouseTables(
@@ -9503,11 +9599,6 @@ export class ProjectService extends BaseService {
             isRegisteredUser: true,
         });
 
-        const { warehouseClient, sshTunnel } = await this._getWarehouseClient(
-            projectUuid,
-            credentials,
-        );
-
         const queryTags: RunQueryTags = {
             organization_uuid: user.organizationUuid,
             project_uuid: projectUuid,
@@ -9533,26 +9624,31 @@ export class ProjectService extends BaseService {
             throw new ParameterError('Table name is required');
         }
 
-        try {
-            const warehouseCatalog = await warehouseClient.getFields(
-                tableName,
-                schemaName,
-                database,
-                queryTags,
-            );
+        return this.withWarehouseClient(
+            { projectUuid, credentials },
+            async ({ warehouseClient }) => {
+                try {
+                    const warehouseCatalog = await warehouseClient.getFields(
+                        tableName,
+                        schemaName,
+                        database,
+                        queryTags,
+                    );
 
-            await sshTunnel.disconnect();
-
-            return warehouseCatalog[database][schemaName][tableName];
-        } catch (error) {
-            this.logger.error('Error fetching warehouse fields', { error });
-            if (error instanceof WarehouseConnectionError) {
-                throw error;
-            }
-            throw new NotFoundError(
-                `Could not find table "${tableName}" in schema "${schemaName}" of database "${database}". Please verify the table exists and you have access to it.`,
-            );
-        }
+                    return warehouseCatalog[database][schemaName][tableName];
+                } catch (error) {
+                    this.logger.error('Error fetching warehouse fields', {
+                        error,
+                    });
+                    if (error instanceof WarehouseConnectionError) {
+                        throw error;
+                    }
+                    throw new NotFoundError(
+                        `Could not find table "${tableName}" in schema "${schemaName}" of database "${database}". Please verify the table exists and you have access to it.`,
+                    );
+                }
+            },
+        );
     }
 
     async getTablesConfiguration(
@@ -11238,14 +11334,15 @@ export class ProjectService extends BaseService {
                 'Virtual view with this name already exists',
             );
         }
-        const { warehouseClient } = await this._getWarehouseClient(
+        const warehouseCredentials = await this.getWarehouseCredentials({
             projectUuid,
-            await this.getWarehouseCredentials({
-                projectUuid,
-                userId: account.user.id,
-                isRegisteredUser: account.isRegisteredUser(),
-                isServiceAccount: account.isServiceAccount(),
-            }),
+            userId: account.user.id,
+            isRegisteredUser: account.isRegisteredUser(),
+            isServiceAccount: account.isServiceAccount(),
+        });
+        const warehouseSqlBuilder = warehouseSqlBuilderFromType(
+            warehouseCredentials.type,
+            warehouseCredentials.startOfWeek,
         );
         const effectiveParameterValues = resolveParameterValues
             ? await this.resolveVirtualViewParameters(
@@ -11261,7 +11358,7 @@ export class ProjectService extends BaseService {
                 ...payload,
                 parameterValues: effectiveParameterValues,
             },
-            warehouseClient,
+            warehouseSqlBuilder,
         );
 
         this.analytics.trackAccount(account, {
@@ -11318,14 +11415,15 @@ export class ProjectService extends BaseService {
             throw new ForbiddenError();
         }
 
-        const { warehouseClient } = await this._getWarehouseClient(
+        const warehouseCredentials = await this.getWarehouseCredentials({
             projectUuid,
-            await this.getWarehouseCredentials({
-                projectUuid,
-                userId: account.user.id,
-                isRegisteredUser: account.isRegisteredUser(),
-                isServiceAccount: account.isServiceAccount(),
-            }),
+            userId: account.user.id,
+            isRegisteredUser: account.isRegisteredUser(),
+            isServiceAccount: account.isServiceAccount(),
+        });
+        const warehouseSqlBuilder = warehouseSqlBuilderFromType(
+            warehouseCredentials.type,
+            warehouseCredentials.startOfWeek,
         );
 
         const effectiveParameterValues = resolveParameterValues
@@ -11343,7 +11441,7 @@ export class ProjectService extends BaseService {
                 ...payload,
                 parameterValues: effectiveParameterValues,
             },
-            warehouseClient,
+            warehouseSqlBuilder,
             expectedExplore,
         );
 
@@ -12074,14 +12172,14 @@ export class ProjectService extends BaseService {
                 ['model', 'seed'].includes(node.resource_type) && node.meta,
         ) as DbtRawModelNode[];
 
-        const { warehouseClient } = await this._getWarehouseClient(
-            projectUuid,
-            project.warehouseConnection,
+        const warehouseSqlBuilder = warehouseSqlBuilderFromType(
+            project.warehouseConnection.type,
+            project.warehouseConnection.startOfWeek,
         );
 
         const [dbtModelNode, exploreErrors] =
             DbtBaseProjectAdapter._validateDbtModel(
-                warehouseClient.getAdapterType(),
+                warehouseSqlBuilder.getAdapterType(),
                 models,
                 DbtManifestVersion.V12,
             );
@@ -12092,8 +12190,8 @@ export class ProjectService extends BaseService {
         const convertedExplores = await convertExplores(
             dbtModelNode,
             false,
-            warehouseClient.getAdapterType(),
-            warehouseClient,
+            warehouseSqlBuilder.getAdapterType(),
+            warehouseSqlBuilder,
             {
                 spotlight: {
                     default_visibility: 'hide', // todo: pass correct config

--- a/packages/backend/src/utils/QueryBuilder/CLAUDE.md
+++ b/packages/backend/src/utils/QueryBuilder/CLAUDE.md
@@ -109,7 +109,7 @@ rather than add another embed:
   (dropped from the collapsed query, never aggregated). Persisted per-calc in
   `saved_queries_version_table_calculations.total_mode`.
 
-**SqlQueryComposer** — the facade for SQL charts (`extends QueryComposer`). SQL charts run user-written SQL rather than compiling a metric query, so this builds everything from raw inputs — the virtual view (`createVirtualView`) from the discovered columns, the wrapping `SqlQueryBuilder` (reference map + dialect config off the warehouse client), a mock `MetricQuery` metadata carrier, and (on the dashboard path) the applied dashboard filters/sorts — then overrides `computeCompiled()` to shape the wrapped user SQL into a `CompiledQuery`. Because `getSql()` is inherited, a request/config `pivotConfiguration` flows through the same seam as metric queries. Used by `AsyncQueryService.prepareSqlChartAsyncQueryArgs` for all three SQL execute paths (raw SQL runner, saved SQL chart, dashboard SQL chart).
+**SqlQueryComposer** — the facade for SQL charts (`extends QueryComposer`). SQL charts run user-written SQL rather than compiling a metric query, so this builds everything from raw inputs — the virtual view (`createVirtualView`) from the discovered columns, the wrapping `SqlQueryBuilder` (reference map + dialect config off the warehouse SQL builder), a mock `MetricQuery` metadata carrier, and (on the dashboard path) the applied dashboard filters/sorts — then overrides `computeCompiled()` to shape the wrapped user SQL into a `CompiledQuery`. Because `getSql()` is inherited, a request/config `pivotConfiguration` flows through the same seam as metric queries. Used by `AsyncQueryService.prepareSqlChartAsyncQueryArgs` for all three SQL execute paths (raw SQL runner, saved SQL chart, dashboard SQL chart).
 
 ```typescript
 import { SqlQueryComposer } from './SqlQueryComposer';
@@ -117,7 +117,7 @@ import { SqlQueryComposer } from './SqlQueryComposer';
 const composer = new SqlQueryComposer({
     userSql, // user SQL with user attributes already replaced
     columns, // discovered via a LIMIT 1 probe query
-    warehouseClient,
+    warehouseSqlBuilder,
     pivotConfiguration, // request-supplied (SQL runner) or derived from chart config
     limit,
     parameters,

--- a/packages/backend/src/utils/QueryBuilder/MergeQueryComposer.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MergeQueryComposer.test.ts
@@ -101,7 +101,7 @@ const compose = () =>
         columnOrder: ['merge_k0', 'a_followers_count'],
         limit: 500,
         ...parameterMetadata,
-        warehouseClient: mockWarehouseClient,
+        warehouseSqlBuilder: mockWarehouseClient,
     });
 
 describe('MergeQueryComposer', () => {
@@ -161,7 +161,7 @@ describe('MergeQueryComposer', () => {
             columnOrder: ['merge_k0', 'merge_k1', 'a_followers_count'],
             limit: 500,
             ...parameterMetadata,
-            warehouseClient: mockWarehouseClient,
+            warehouseSqlBuilder: mockWarehouseClient,
             pivotConfiguration: {
                 indexColumn: { reference: 'merge_k0', type: VizIndexType.TIME },
                 valuesColumns: [
@@ -196,7 +196,7 @@ describe('MergeQueryComposer', () => {
             columnOrder: ['merge_k0', 'merge_k1', 'a_followers_count'],
             limit: 500,
             ...parameterMetadata,
-            warehouseClient: mockWarehouseClient,
+            warehouseSqlBuilder: mockWarehouseClient,
             pivotConfiguration: {
                 indexColumn: { reference: 'merge_k0', type: VizIndexType.TIME },
                 valuesColumns: [

--- a/packages/backend/src/utils/QueryBuilder/MergeQueryComposer.ts
+++ b/packages/backend/src/utils/QueryBuilder/MergeQueryComposer.ts
@@ -9,7 +9,7 @@ import {
     type MetricQuery,
     type ParametersValuesMap,
     type PivotConfiguration,
-    type WarehouseClient,
+    type WarehouseSqlBuilder,
 } from '@lightdash/common';
 import { applyMergeTerminalWrapper } from './MergeQueryBuilder';
 import { type CompiledQuery } from './MetricQueryBuilder';
@@ -28,7 +28,7 @@ export type MergeQueryComposerArguments = {
     limit: number;
     parameterReferences: string[];
     usedParametersValues: ParametersValuesMap;
-    warehouseClient: WarehouseClient;
+    warehouseSqlBuilder: WarehouseSqlBuilder;
     /**
      * Standard pivot stage over the merged rows. Every merged dimension is a
      * join key part, so anything pivotable here is shared by both sources.
@@ -100,7 +100,7 @@ export class MergeQueryComposer extends QueryComposer {
             limit,
             parameterReferences,
             usedParametersValues,
-            warehouseClient,
+            warehouseSqlBuilder,
             pivotConfiguration,
         } = args;
 
@@ -117,9 +117,9 @@ export class MergeQueryComposer extends QueryComposer {
                 explore: MergeQueryComposer.buildVirtualView(
                     coreSql,
                     typedColumns,
-                    warehouseClient,
+                    warehouseSqlBuilder,
                 ),
-                warehouseSqlBuilder: warehouseClient,
+                warehouseSqlBuilder,
                 // The pivot resolves field metadata against the merged items
                 // map — there is no freshly compiled metric query to fall
                 // back on.
@@ -165,13 +165,13 @@ export class MergeQueryComposer extends QueryComposer {
     private static buildVirtualView(
         sql: string,
         typedColumns: MergeTypedColumn[],
-        warehouseClient: WarehouseClient,
+        warehouseSqlBuilder: WarehouseSqlBuilder,
     ): Explore {
         return createVirtualView(
             MERGE_TABLE_NAME,
             sql,
             typedColumns.map(({ reference, type }) => ({ reference, type })),
-            warehouseClient,
+            warehouseSqlBuilder,
         );
     }
 }

--- a/packages/backend/src/utils/QueryBuilder/SqlQueryComposer.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/SqlQueryComposer.test.ts
@@ -34,7 +34,7 @@ const PIVOT_CONFIGURATION: PivotConfiguration = {
 const baseArgs = {
     userSql: USER_SQL,
     columns: COLUMNS,
-    warehouseClient: warehouseClientMock,
+    warehouseSqlBuilder: warehouseClientMock,
     limit: 500,
     parameters: undefined,
     dashboardFilters: undefined,

--- a/packages/backend/src/utils/QueryBuilder/SqlQueryComposer.ts
+++ b/packages/backend/src/utils/QueryBuilder/SqlQueryComposer.ts
@@ -12,7 +12,7 @@ import {
     type ParametersValuesMap,
     type PivotConfiguration,
     type SortField,
-    type WarehouseClient,
+    type WarehouseSqlBuilder,
 } from '@lightdash/common';
 import { v4 as uuidv4 } from 'uuid';
 import { CompiledQuery } from './MetricQueryBuilder';
@@ -30,7 +30,7 @@ export type SqlQueryComposerArguments = {
     /** User SQL with user attributes already replaced. */
     userSql: string;
     columns: SqlQueryColumn[];
-    warehouseClient: WarehouseClient;
+    warehouseSqlBuilder: WarehouseSqlBuilder;
     pivotConfiguration: PivotConfiguration | undefined;
     limit: number | undefined;
     parameters: ParametersValuesMap | undefined;
@@ -63,7 +63,7 @@ export class SqlQueryComposer extends QueryComposer {
             },
             {
                 explore: built.virtualView,
-                warehouseSqlBuilder: args.warehouseClient,
+                warehouseSqlBuilder: args.warehouseSqlBuilder,
                 parameters: args.parameters,
                 displayTimezone: null,
             },
@@ -106,7 +106,7 @@ export class SqlQueryComposer extends QueryComposer {
         const {
             userSql,
             columns,
-            warehouseClient,
+            warehouseSqlBuilder,
             limit,
             parameters,
             dashboardFilters,
@@ -123,7 +123,7 @@ export class SqlQueryComposer extends QueryComposer {
             SQL_QUERY_MOCK_EXPLORER_NAME,
             userSql,
             vizColumns,
-            warehouseClient,
+            warehouseSqlBuilder,
         );
 
         // Only the columns the SQL actually selects — the virtual view also
@@ -134,8 +134,8 @@ export class SqlQueryComposer extends QueryComposer {
             .filter((d) => d.timeInterval === undefined)
             .map((d) => convertFieldRefToFieldId(d.name, virtualView.name));
 
-        const fieldQuoteChar = warehouseClient.getFieldQuoteChar();
-        const adapterType = warehouseClient.getAdapterType();
+        const fieldQuoteChar = warehouseSqlBuilder.getFieldQuoteChar();
+        const adapterType = warehouseSqlBuilder.getAdapterType();
 
         const referenceMap: ReferenceMap = {};
         vizColumns.forEach((col) => {
@@ -203,13 +203,13 @@ export class SqlQueryComposer extends QueryComposer {
             },
             {
                 fieldQuoteChar,
-                stringQuoteChar: warehouseClient.getStringQuoteChar(),
+                stringQuoteChar: warehouseSqlBuilder.getStringQuoteChar(),
                 escapeStringQuoteChar:
-                    warehouseClient.getEscapeStringQuoteChar(),
-                startOfWeek: warehouseClient.getStartOfWeek(),
-                adapterType: warehouseClient.getAdapterType(),
+                    warehouseSqlBuilder.getEscapeStringQuoteChar(),
+                startOfWeek: warehouseSqlBuilder.getStartOfWeek(),
+                adapterType: warehouseSqlBuilder.getAdapterType(),
                 escapeString:
-                    warehouseClient.escapeString.bind(warehouseClient),
+                    warehouseSqlBuilder.escapeString.bind(warehouseSqlBuilder),
             },
         );
 

--- a/packages/backend/src/utils/QueryBuilder/composeMergeSql.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/composeMergeSql.test.ts
@@ -330,7 +330,7 @@ describe('buildComposeMergeSql', () => {
             limit: 500,
             parameterReferences: [],
             usedParametersValues: {},
-            warehouseClient: duckdbWarehouseClient,
+            warehouseSqlBuilder: duckdbWarehouseClient,
             // Indexed pivot (groupByColumns present), so the DENSE_RANK
             // row/column-index pipeline compiles for the DuckDB dialect —
             // the shape a pivoted merged visualization sends

--- a/packages/common/src/utils/virtualView.test.ts
+++ b/packages/common/src/utils/virtualView.test.ts
@@ -7,7 +7,7 @@ import { TimeFrames } from '../types/timeFrames';
 import type { WarehouseClient } from '../types/warehouse';
 import type { VizColumn } from '../visualizations/types';
 import { WeekDay } from './timeFrames';
-import { createVirtualView } from './virtualView';
+import { createVirtualView, getVirtualViewWarehouseType } from './virtualView';
 import { defaultNullSafeEqualSql } from './warehouse';
 
 const fakeWarehouseClient: WarehouseClient = {
@@ -78,6 +78,21 @@ const columns: VizColumn[] = [
 ];
 
 describe('createVirtualView', () => {
+    test.each([
+        [SupportedDbtAdapter.BIGQUERY, WarehouseTypes.BIGQUERY],
+        [SupportedDbtAdapter.DATABRICKS, WarehouseTypes.DATABRICKS],
+        [SupportedDbtAdapter.SPARK, WarehouseTypes.DATABRICKS],
+        [SupportedDbtAdapter.SNOWFLAKE, WarehouseTypes.SNOWFLAKE],
+        [SupportedDbtAdapter.REDSHIFT, WarehouseTypes.REDSHIFT],
+        [SupportedDbtAdapter.POSTGRES, WarehouseTypes.POSTGRES],
+        [SupportedDbtAdapter.DUCKDB, WarehouseTypes.DUCKDB],
+        [SupportedDbtAdapter.TRINO, WarehouseTypes.TRINO],
+        [SupportedDbtAdapter.CLICKHOUSE, WarehouseTypes.CLICKHOUSE],
+        [SupportedDbtAdapter.ATHENA, WarehouseTypes.ATHENA],
+    ])('maps %s adapter metadata to %s warehouse metadata', (adapter, type) => {
+        expect(getVirtualViewWarehouseType(adapter)).toBe(type);
+    });
+
     test('should create a virtual view with basic properties', () => {
         const result = createVirtualView(
             'my_view',

--- a/packages/common/src/utils/virtualView.ts
+++ b/packages/common/src/utils/virtualView.ts
@@ -15,11 +15,43 @@ import {
     type WarehouseSqlBuilder,
 } from '../types/warehouse';
 import { type VizColumn } from '../visualizations/types';
+import assertUnreachable from './assertUnreachable';
 import { getDefaultTimeFrames, timeFrameConfigs, WeekDay } from './timeFrames';
 import { defaultNullSafeEqualSql, quoteFieldReference } from './warehouse';
 
 const isIntervalColumnType = (type: DimensionType): boolean =>
     type === DimensionType.DATE || type === DimensionType.TIMESTAMP;
+
+export const getVirtualViewWarehouseType = (
+    adapterType: SupportedDbtAdapter,
+): WarehouseTypes => {
+    switch (adapterType) {
+        case SupportedDbtAdapter.BIGQUERY:
+            return WarehouseTypes.BIGQUERY;
+        case SupportedDbtAdapter.DATABRICKS:
+        case SupportedDbtAdapter.SPARK:
+            return WarehouseTypes.DATABRICKS;
+        case SupportedDbtAdapter.SNOWFLAKE:
+            return WarehouseTypes.SNOWFLAKE;
+        case SupportedDbtAdapter.REDSHIFT:
+            return WarehouseTypes.REDSHIFT;
+        case SupportedDbtAdapter.POSTGRES:
+            return WarehouseTypes.POSTGRES;
+        case SupportedDbtAdapter.DUCKDB:
+            return WarehouseTypes.DUCKDB;
+        case SupportedDbtAdapter.TRINO:
+            return WarehouseTypes.TRINO;
+        case SupportedDbtAdapter.CLICKHOUSE:
+            return WarehouseTypes.CLICKHOUSE;
+        case SupportedDbtAdapter.ATHENA:
+            return WarehouseTypes.ATHENA;
+        default:
+            return assertUnreachable(
+                adapterType,
+                `Unsupported adapter type: ${adapterType}`,
+            );
+    }
+};
 
 /**
  * Build one dimension per column, plus the default time-interval dimensions
@@ -105,11 +137,11 @@ export const createVirtualView = (
     virtualViewName: string,
     sql: string,
     columns: VizColumn[],
-    warehouseClient: WarehouseClient,
+    warehouseSqlBuilder: WarehouseSqlBuilder,
     label?: string,
     parameterValues?: ParametersValuesMap,
 ): Explore => {
-    const exploreCompiler = new ExploreCompiler(warehouseClient);
+    const exploreCompiler = new ExploreCompiler(warehouseSqlBuilder);
 
     const tableLabel = friendlyName(virtualViewName);
 
@@ -117,7 +149,7 @@ export const createVirtualView = (
         tableName: virtualViewName,
         tableLabel,
         columns,
-        warehouseSqlBuilder: warehouseClient,
+        warehouseSqlBuilder,
     });
 
     const compiledTable: Table = {
@@ -127,7 +159,9 @@ export const createVirtualView = (
         dimensions,
         metrics: {},
         lineageGraph: { nodes: [], edges: [] },
-        database: warehouseClient.credentials.type,
+        database: getVirtualViewWarehouseType(
+            warehouseSqlBuilder.getAdapterType(),
+        ),
         schema: '', // TODO: what should this be?
     };
 
@@ -138,7 +172,7 @@ export const createVirtualView = (
         baseTable: virtualViewName,
         joinedTables: [],
         tables: { [virtualViewName]: compiledTable },
-        targetDatabase: warehouseClient.getAdapterType(),
+        targetDatabase: warehouseSqlBuilder.getAdapterType(),
         meta: {},
     });
 


### PR DESCRIPTION
## Summary

- scope warehouse client acquisition behind a callback that always releases SSH tunnels
- migrate query paths and use SQL-only builders for compile-only work
- prevent tunneled clients from entering the shared client cache

## Testing

- 344 focused backend tests
- 18 focused common tests
- backend and common typechecks
- real PostgreSQL-over-SSH API check: repeated warehouse failures returned to zero established SSH sessions
- virtual-view compile check: zero SSH sessions opened

Closes: PROD-10784
Relates: #28334
