### PR TITLE
fix: size ClickHouse client connection pool from NATS worker concurrency

### DIFF
--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -4470,12 +4470,16 @@ export class ProjectModel {
     }
 
     // Easier to mock in ProjectService
-    // eslint-disable-next-line class-methods-use-this
     getWarehouseClientFromCredentials(
         credentials: CreateWarehouseCredentials,
         options?: Parameters<typeof warehouseClientFromCredentials>[1],
     ) {
-        return warehouseClientFromCredentials(credentials, options);
+        return warehouseClientFromCredentials(credentials, {
+            // The client is shared by all concurrent async query jobs
+            maxOpenConnections:
+                this.lightdashConfig.natsWorker.workerConcurrency,
+            ...options,
+        });
     }
 
     async createVirtualView(

--- a/packages/warehouses/src/warehouseClientFromCredentials.ts
+++ b/packages/warehouses/src/warehouseClientFromCredentials.ts
@@ -7,7 +7,10 @@ import {
 import { WarehouseClient } from './types';
 import { AthenaWarehouseClient } from './warehouseClients/AthenaWarehouseClient';
 import { BigqueryWarehouseClient } from './warehouseClients/BigqueryWarehouseClient';
-import { ClickhouseWarehouseClient } from './warehouseClients/ClickhouseWarehouseClient';
+import {
+    ClickhouseWarehouseClient,
+    type ClickhouseWarehouseClientOptions,
+} from './warehouseClients/ClickhouseWarehouseClient';
 import { DatabricksWarehouseClient } from './warehouseClients/DatabricksWarehouseClient';
 import {
     DuckdbWarehouseClient,
@@ -18,9 +21,12 @@ import { RedshiftWarehouseClient } from './warehouseClients/RedshiftWarehouseCli
 import { SnowflakeWarehouseClient } from './warehouseClients/SnowflakeWarehouseClient';
 import { TrinoWarehouseClient } from './warehouseClients/TrinoWarehouseClient';
 
+export type WarehouseClientOptions = DuckdbWarehouseClientOptions &
+    ClickhouseWarehouseClientOptions;
+
 export const warehouseClientFromCredentials = (
     credentials: CreateWarehouseCredentials,
-    options?: DuckdbWarehouseClientOptions,
+    options?: WarehouseClientOptions,
 ): WarehouseClient => {
     switch (credentials.type) {
         case WarehouseTypes.SNOWFLAKE:
@@ -36,7 +42,7 @@ export const warehouseClientFromCredentials = (
         case WarehouseTypes.TRINO:
             return new TrinoWarehouseClient(credentials);
         case WarehouseTypes.CLICKHOUSE:
-            return new ClickhouseWarehouseClient(credentials);
+            return new ClickhouseWarehouseClient(credentials, options);
         case WarehouseTypes.ATHENA:
             return new AthenaWarehouseClient(credentials);
         case WarehouseTypes.DUCKDB:

--- a/packages/warehouses/src/warehouseClients/ClickhouseWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/ClickhouseWarehouseClient.test.ts
@@ -7,24 +7,17 @@ import {
 } from './ClickhouseWarehouseClient';
 
 describe('getMaxOpenConnections', () => {
-    afterEach(() => {
-        delete process.env.NATS_WORKER_CONCURRENCY;
+    it('defaults to 10 when concurrency is unknown', () => {
+        expect(getMaxOpenConnections()).toBe(10);
+        expect(getMaxOpenConnections(NaN)).toBe(10);
     });
 
-    it('defaults to 10 when NATS_WORKER_CONCURRENCY is unset or invalid', () => {
-        expect(getMaxOpenConnections()).toBe(10);
-        process.env.NATS_WORKER_CONCURRENCY = 'abc';
-        expect(getMaxOpenConnections()).toBe(10);
-    });
-
-    it('matches NATS_WORKER_CONCURRENCY when larger than the default', () => {
-        process.env.NATS_WORKER_CONCURRENCY = '100';
-        expect(getMaxOpenConnections()).toBe(100);
+    it('matches the given concurrency when larger than the default', () => {
+        expect(getMaxOpenConnections(100)).toBe(100);
     });
 
     it('never shrinks below the default', () => {
-        process.env.NATS_WORKER_CONCURRENCY = '1';
-        expect(getMaxOpenConnections()).toBe(10);
+        expect(getMaxOpenConnections(1)).toBe(10);
     });
 });
 

--- a/packages/warehouses/src/warehouseClients/ClickhouseWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/ClickhouseWarehouseClient.test.ts
@@ -3,7 +3,30 @@ import {
     ClickhouseSqlBuilder,
     ClickhouseTypes,
     convertDataTypeToDimensionType,
+    getMaxOpenConnections,
 } from './ClickhouseWarehouseClient';
+
+describe('getMaxOpenConnections', () => {
+    afterEach(() => {
+        delete process.env.NATS_WORKER_CONCURRENCY;
+    });
+
+    it('defaults to 10 when NATS_WORKER_CONCURRENCY is unset or invalid', () => {
+        expect(getMaxOpenConnections()).toBe(10);
+        process.env.NATS_WORKER_CONCURRENCY = 'abc';
+        expect(getMaxOpenConnections()).toBe(10);
+    });
+
+    it('matches NATS_WORKER_CONCURRENCY when larger than the default', () => {
+        process.env.NATS_WORKER_CONCURRENCY = '100';
+        expect(getMaxOpenConnections()).toBe(100);
+    });
+
+    it('never shrinks below the default', () => {
+        process.env.NATS_WORKER_CONCURRENCY = '1';
+        expect(getMaxOpenConnections()).toBe(10);
+    });
+});
 
 describe('ClickhouseSqlBuilder', () => {
     const builder = new ClickhouseSqlBuilder();

--- a/packages/warehouses/src/warehouseClients/ClickhouseWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/ClickhouseWarehouseClient.ts
@@ -251,6 +251,18 @@ export class ClickhouseSqlBuilder extends WarehouseBaseSqlBuilder {
     }
 }
 
+const DEFAULT_MAX_OPEN_CONNECTIONS = 10;
+
+// The client is cached per project and shared by all concurrent query jobs,
+// so the socket pool must be at least as large as the async query worker
+// concurrency — otherwise jobs queue on sockets and report inflated exec times.
+export const getMaxOpenConnections = (): number => {
+    const workerConcurrency = Number(process.env.NATS_WORKER_CONCURRENCY);
+    return Number.isInteger(workerConcurrency)
+        ? Math.max(workerConcurrency, DEFAULT_MAX_OPEN_CONNECTIONS)
+        : DEFAULT_MAX_OPEN_CONNECTIONS;
+};
+
 export class ClickhouseWarehouseClient extends WarehouseBaseClient<CreateClickhouseCredentials> {
     client: ClickHouseClient;
 
@@ -266,6 +278,7 @@ export class ClickhouseWarehouseClient extends WarehouseBaseClient<CreateClickho
             password: credentials.password,
             database: credentials.schema, // In clickhouse schema = database
             request_timeout: (credentials.timeoutSeconds || 30) * 1000,
+            max_open_connections: getMaxOpenConnections(),
         });
     }
 

--- a/packages/warehouses/src/warehouseClients/ClickhouseWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/ClickhouseWarehouseClient.ts
@@ -255,17 +255,23 @@ const DEFAULT_MAX_OPEN_CONNECTIONS = 10;
 
 // The client is cached per project and shared by all concurrent query jobs;
 // when jobs outnumber sockets they queue and report inflated exec times.
-export const getMaxOpenConnections = (): number => {
-    const workerConcurrency = Number(process.env.NATS_WORKER_CONCURRENCY);
-    return Number.isInteger(workerConcurrency)
-        ? Math.max(workerConcurrency, DEFAULT_MAX_OPEN_CONNECTIONS)
+export const getMaxOpenConnections = (maxOpenConnections?: number): number =>
+    Number.isInteger(maxOpenConnections)
+        ? Math.max(maxOpenConnections as number, DEFAULT_MAX_OPEN_CONNECTIONS)
         : DEFAULT_MAX_OPEN_CONNECTIONS;
+
+export type ClickhouseWarehouseClientOptions = {
+    /** Upper bound of concurrent queries sharing this client; sizes the HTTP socket pool. */
+    maxOpenConnections?: number;
 };
 
 export class ClickhouseWarehouseClient extends WarehouseBaseClient<CreateClickhouseCredentials> {
     client: ClickHouseClient;
 
-    constructor(credentials: CreateClickhouseCredentials) {
+    constructor(
+        credentials: CreateClickhouseCredentials,
+        options?: ClickhouseWarehouseClientOptions,
+    ) {
         super(credentials, new ClickhouseSqlBuilder(credentials.startOfWeek));
 
         const protocol = credentials.secure ? 'https' : 'http';
@@ -277,7 +283,9 @@ export class ClickhouseWarehouseClient extends WarehouseBaseClient<CreateClickho
             password: credentials.password,
             database: credentials.schema, // In clickhouse schema = database
             request_timeout: (credentials.timeoutSeconds || 30) * 1000,
-            max_open_connections: getMaxOpenConnections(),
+            max_open_connections: getMaxOpenConnections(
+                options?.maxOpenConnections,
+            ),
         });
     }
 

--- a/packages/warehouses/src/warehouseClients/ClickhouseWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/ClickhouseWarehouseClient.ts
@@ -253,9 +253,8 @@ export class ClickhouseSqlBuilder extends WarehouseBaseSqlBuilder {
 
 const DEFAULT_MAX_OPEN_CONNECTIONS = 10;
 
-// The client is cached per project and shared by all concurrent query jobs,
-// so the socket pool must be at least as large as the async query worker
-// concurrency — otherwise jobs queue on sockets and report inflated exec times.
+// The client is cached per project and shared by all concurrent query jobs;
+// when jobs outnumber sockets they queue and report inflated exec times.
 export const getMaxOpenConnections = (): number => {
     const workerConcurrency = Number(process.env.NATS_WORKER_CONCURRENCY);
     return Number.isInteger(workerConcurrency)


### PR DESCRIPTION
## Description

The per-project cached `ClickhouseWarehouseClient` never set `max_open_connections`, so `@clickhouse/client` capped it at its default of 10 sockets while the async query NATS worker runs up to `NATS_WORKER_CONCURRENCY` (100 in cloud) concurrent jobs. Under sustained load, in-flight jobs queue FIFO on sockets inside `client.query()`, and every query — even 1-row results — waits minutes; the wait is counted in `query_exec`, masquerading as slow warehouse execution. A customer hit this with all queries hanging 4–5+ minutes while their warehouse answered directly in ~0.2s.

## Fix

Size the pool from config, plumbed through the constructor:

- `parseConfig` → `lightdashConfig.natsWorker.workerConcurrency` → `ProjectModel.getWarehouseClientFromCredentials` injects `maxOpenConnections` → `warehouseClientFromCredentials` → `ClickhouseWarehouseClient` sets `max_open_connections`, never below the library default of 10.
- CLI and dbt-adapter paths pass no option and keep the default of 10.

## Testing

- Unit tests for `getMaxOpenConnections` (unknown/NaN, larger-than-default, never-shrinks-below-default)
- `pnpm -F @lightdash/warehouses test`, and `tsc --noEmit` for warehouses, backend, and cli all pass

Closes: PROD-10820
Closes: #28393

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FMHXHxZarNuuXPn96uPjXH