### PR TITLE
feat(data-apps): unlink external connections from settings

### DIFF
--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionUsageModal.module.css
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionUsageModal.module.css
@@ -1,11 +1,9 @@
 .resourceRow {
     display: flex;
-    gap: var(--mantine-spacing-sm);
     align-items: center;
+    gap: var(--mantine-spacing-xs);
     padding: var(--mantine-spacing-sm);
     border-radius: var(--mantine-radius-sm);
-    color: inherit;
-    text-decoration: none;
 
     &:hover {
         background-color: var(--mantine-color-ldGray-0);
@@ -14,4 +12,14 @@
             background-color: var(--mantine-color-ldDark-3);
         }
     }
+}
+
+.resourceLink {
+    display: flex;
+    flex: 1;
+    gap: var(--mantine-spacing-sm);
+    align-items: center;
+    min-width: 0;
+    color: inherit;
+    text-decoration: none;
 }

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionUsageModal.test.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionUsageModal.test.tsx
@@ -13,6 +13,7 @@ import { ConnectionUsageModal } from './ConnectionUsageModal';
 const mocks = vi.hoisted(() => ({
     data: { items: [], total: 0 } as ExternalConnectionLinkedApps,
     refetch: vi.fn(),
+    unlink: vi.fn(),
 }));
 
 vi.mock(
@@ -23,6 +24,16 @@ vi.mock(
             isLoading: false,
             isError: false,
             refetch: mocks.refetch,
+        }),
+    }),
+);
+
+vi.mock(
+    '../../../features/externalConnections/hooks/useUnlinkAppExternalConnection',
+    () => ({
+        useUnlinkAppExternalConnection: () => ({
+            mutate: mocks.unlink,
+            isLoading: false,
         }),
     }),
 );
@@ -141,7 +152,7 @@ describe('external connection usage', () => {
         );
     });
 
-    it('groups data apps and chart types with their destination links', () => {
+    it('shows linked resources and confirms before unlinking every alias', () => {
         mocks.data = {
             items: [
                 {
@@ -187,5 +198,34 @@ describe('external connection usage', () => {
             '/projects/project-uuid/chart-types/chart-type-1',
         );
         expect(screen.queryByText(/Aliases?:/)).not.toBeInTheDocument();
+
+        fireEvent.click(
+            screen.getByRole('button', {
+                name: 'Unlink Revenue dashboard',
+            }),
+        );
+
+        const confirmation = screen
+            .getByText('Unlink Example API?')
+            .closest('[role="dialog"]');
+        expect(confirmation).toHaveTextContent(
+            'Unlinking removes access to this connection.',
+        );
+        expect(confirmation).not.toHaveTextContent(
+            'You may not be able to link it again without help from a project admin.',
+        );
+
+        fireEvent.click(
+            screen.getByRole('button', { name: 'Unlink connection' }),
+        );
+        expect(mocks.unlink).toHaveBeenCalledWith(
+            {
+                projectUuid: 'project-uuid',
+                appUuid: 'app-1',
+                aliases: ['acme', 'acme-v2'],
+                name: 'Example API',
+            },
+            expect.objectContaining({ onSuccess: expect.any(Function) }),
+        );
     });
 });

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionUsageModal.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionUsageModal.tsx
@@ -17,12 +17,14 @@ import {
     IconAppWindow,
     IconFolder,
     IconLink,
+    IconUnlink,
     IconPuzzle,
     IconUser,
 } from '@tabler/icons-react';
-import { type FC } from 'react';
+import { useState, type FC } from 'react';
 import { Link } from 'react-router';
 import { useExternalConnectionLinkedApps } from '../../../features/externalConnections/hooks/useExternalConnectionLinkedApps';
+import { useUnlinkAppExternalConnection } from '../../../features/externalConnections/hooks/useUnlinkAppExternalConnection';
 import MantineIcon from '../../common/MantineIcon';
 import MantineModal from '../../common/MantineModal';
 import classes from './ConnectionUsageModal.module.css';
@@ -37,41 +39,57 @@ type Props = {
 const UsageRow: FC<{
     projectUuid: string;
     item: ExternalConnectionLinkedApp;
-}> = ({ projectUuid, item }) => {
+    onUnlink: (item: ExternalConnectionLinkedApp) => void;
+}> = ({ projectUuid, item, onUnlink }) => {
     const isDataApp = item.kind === 'data_app';
     const path = isDataApp
         ? `/projects/${projectUuid}/apps/${item.appUuid}`
         : `/projects/${projectUuid}/chart-types/${item.appUuid}`;
+    const displayName = getAppDisplayName(item.name, item.appUuid);
 
     return (
-        <Box
-            component={Link}
-            to={path}
-            target="_blank"
-            rel="noopener noreferrer"
-            className={classes.resourceRow}
-        >
-            <ThemeIcon variant="light" size="lg" color="orange">
-                <MantineIcon icon={isDataApp ? IconAppWindow : IconPuzzle} />
-            </ThemeIcon>
+        <Box className={classes.resourceRow}>
+            <Box
+                component={Link}
+                to={path}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={classes.resourceLink}
+            >
+                <ThemeIcon variant="light" size="lg" color="orange">
+                    <MantineIcon
+                        icon={isDataApp ? IconAppWindow : IconPuzzle}
+                    />
+                </ThemeIcon>
 
-            <Stack gap={2} miw={0} flex={1}>
-                <Text fz="sm" fw={600} truncate>
-                    {getAppDisplayName(item.name, item.appUuid)}
-                </Text>
-                {isDataApp && (
-                    <Group gap={4} wrap="wrap">
-                        <MantineIcon
-                            icon={item.spaceName ? IconFolder : IconUser}
-                            size={14}
-                            color="ldGray.6"
-                        />
-                        <Text fz="xs" c="ldGray.6">
-                            {item.spaceName ?? 'Personal app'}
-                        </Text>
-                    </Group>
-                )}
-            </Stack>
+                <Stack gap={2} miw={0} flex={1}>
+                    <Text fz="sm" fw={600} truncate>
+                        {displayName}
+                    </Text>
+                    {isDataApp && (
+                        <Group gap={4} wrap="wrap">
+                            <MantineIcon
+                                icon={item.spaceName ? IconFolder : IconUser}
+                                size={14}
+                                color="ldGray.6"
+                            />
+                            <Text fz="xs" c="ldGray.6">
+                                {item.spaceName ?? 'Personal app'}
+                            </Text>
+                        </Group>
+                    )}
+                </Stack>
+            </Box>
+            <Button
+                variant="subtle"
+                color="red"
+                size="compact-sm"
+                leftSection={<MantineIcon icon={IconUnlink} size={14} />}
+                onClick={() => onUnlink(item)}
+                aria-label={`Unlink ${displayName}`}
+            >
+                Unlink
+            </Button>
         </Box>
     );
 };
@@ -80,7 +98,8 @@ const UsageSection: FC<{
     title: string;
     items: ExternalConnectionLinkedApp[];
     projectUuid: string;
-}> = ({ title, items, projectUuid }) => (
+    onUnlink: (item: ExternalConnectionLinkedApp) => void;
+}> = ({ title, items, projectUuid, onUnlink }) => (
     <Stack gap="xs">
         <Group gap="xs">
             <Title order={6}>{title}</Title>
@@ -94,6 +113,7 @@ const UsageSection: FC<{
                     key={item.appUuid}
                     projectUuid={projectUuid}
                     item={item}
+                    onUnlink={onUnlink}
                 />
             ))}
         </Stack>
@@ -106,15 +126,31 @@ export const ConnectionUsageModal: FC<Props> = ({
     projectUuid,
     connection,
 }) => {
+    const [pendingUnlink, setPendingUnlink] =
+        useState<ExternalConnectionLinkedApp>();
     const { data, isLoading, isError, refetch } =
         useExternalConnectionLinkedApps(
             projectUuid,
             opened ? connection.externalConnectionUuid : undefined,
         );
+    const { mutate: unlink, isLoading: isUnlinking } =
+        useUnlinkAppExternalConnection();
     const dataApps =
         data?.items.filter((item) => item.kind === 'data_app') ?? [];
     const chartTypes =
         data?.items.filter((item) => item.kind === 'project_chart_type') ?? [];
+    const handleConfirmUnlink = () => {
+        if (!pendingUnlink) return;
+        unlink(
+            {
+                projectUuid,
+                appUuid: pendingUnlink.appUuid,
+                aliases: pendingUnlink.aliases,
+                name: connection.name,
+            },
+            { onSuccess: () => setPendingUnlink(undefined) },
+        );
+    };
 
     return (
         <MantineModal
@@ -162,6 +198,7 @@ export const ConnectionUsageModal: FC<Props> = ({
                             title="Data apps"
                             items={dataApps}
                             projectUuid={projectUuid}
+                            onUnlink={setPendingUnlink}
                         />
                     )}
                     {chartTypes.length > 0 && (
@@ -169,10 +206,25 @@ export const ConnectionUsageModal: FC<Props> = ({
                             title="Chart types"
                             items={chartTypes}
                             projectUuid={projectUuid}
+                            onUnlink={setPendingUnlink}
                         />
                     )}
                 </Stack>
             )}
+            <MantineModal
+                opened={pendingUnlink !== undefined}
+                onClose={() => setPendingUnlink(undefined)}
+                title={`Unlink ${connection.name}?`}
+                variant="delete"
+                icon={IconUnlink}
+                size="md"
+                description="Unlinking removes access to this connection."
+                confirmLabel="Unlink connection"
+                cancelLabel="Keep connection"
+                confirmLoading={isUnlinking}
+                cancelDisabled={isUnlinking}
+                onConfirm={handleConfirmUnlink}
+            />
         </MantineModal>
     );
 };

--- a/packages/frontend/src/features/externalConnections/hooks/useUnlinkAppExternalConnection.test.tsx
+++ b/packages/frontend/src/features/externalConnections/hooks/useUnlinkAppExternalConnection.test.tsx
@@ -2,7 +2,7 @@ import { type AppExternalConnectionLinked } from '@lightdash/common';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import { type FC, type PropsWithChildren } from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { lightdashApi } from '../../../api';
 import { useUnlinkAppExternalConnection } from './useUnlinkAppExternalConnection';
 
@@ -14,6 +14,10 @@ vi.mock('../../../hooks/toaster/useToaster', () => ({
 const queryKey = ['app-external-connections', 'project-1', 'app-1'];
 const links = [
     { alias: 'weather', connection: { externalConnectionUuid: 'c-weather' } },
+    {
+        alias: 'weather-v2',
+        connection: { externalConnectionUuid: 'c-weather' },
+    },
     { alias: 'images', connection: { externalConnectionUuid: 'c-images' } },
 ] as unknown as AppExternalConnectionLinked[];
 
@@ -37,24 +41,34 @@ const setup = () => {
 };
 
 describe('useUnlinkAppExternalConnection', () => {
-    it('DELETEs by alias and drops the link from the cache', async () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('DELETEs every alias and drops the links from the cache', async () => {
         vi.mocked(lightdashApi).mockResolvedValue(undefined as never);
         const { queryClient, result } = setup();
 
         result.current.mutate({
             projectUuid: 'project-1',
             appUuid: 'app-1',
-            alias: 'weather',
+            aliases: ['weather', 'weather-v2'],
             name: 'Weather',
         });
 
         await waitFor(() => expect(result.current.isSuccess).toBe(true));
-        expect(lightdashApi).toHaveBeenCalledWith({
+        expect(lightdashApi).toHaveBeenCalledTimes(2);
+        expect(lightdashApi).toHaveBeenNthCalledWith(1, {
             url: '/ee/projects/project-1/apps/app-1/external-connections/weather',
             method: 'DELETE',
             body: undefined,
         });
-        expect(queryClient.getQueryData(queryKey)).toEqual([links[1]]);
+        expect(lightdashApi).toHaveBeenNthCalledWith(2, {
+            url: '/ee/projects/project-1/apps/app-1/external-connections/weather-v2',
+            method: 'DELETE',
+            body: undefined,
+        });
+        expect(queryClient.getQueryData(queryKey)).toEqual([links[2]]);
     });
 
     it('restores the link when the request fails', async () => {

--- a/packages/frontend/src/features/externalConnections/hooks/useUnlinkAppExternalConnection.ts
+++ b/packages/frontend/src/features/externalConnections/hooks/useUnlinkAppExternalConnection.ts
@@ -9,22 +9,29 @@ import useToaster from '../../../hooks/toaster/useToaster';
 type UnlinkParams = {
     projectUuid: string;
     appUuid: string;
-    alias: string;
     name: string;
-};
+} & ({ alias: string } | { aliases: string[] });
 
-const unlinkAppExternalConnection = async ({
-    projectUuid,
-    appUuid,
-    alias,
-}: UnlinkParams) =>
-    lightdashApi<undefined>({
-        url: `/ee/projects/${projectUuid}/apps/${appUuid}/external-connections/${encodeURIComponent(
-            alias,
-        )}`,
-        method: 'DELETE',
-        body: undefined,
-    });
+const getAliases = (params: UnlinkParams) =>
+    'aliases' in params ? params.aliases : [params.alias];
+
+const unlinkAppExternalConnection = async (
+    params: UnlinkParams,
+): Promise<undefined> => {
+    const { projectUuid, appUuid } = params;
+    await Promise.all(
+        getAliases(params).map((alias) =>
+            lightdashApi<undefined>({
+                url: `/ee/projects/${projectUuid}/apps/${appUuid}/external-connections/${encodeURIComponent(
+                    alias,
+                )}`,
+                method: 'DELETE',
+                body: undefined,
+            }),
+        ),
+    );
+    return undefined;
+};
 
 const linksQueryKey = (projectUuid: string, appUuid: string) => [
     'app-external-connections',
@@ -33,7 +40,7 @@ const linksQueryKey = (projectUuid: string, appUuid: string) => [
 ];
 
 /** Unlinks optimistically and rolls back on failure. The app keeps calling
- *  the alias until it is rebuilt, so the toast points at the composer. */
+ *  removed aliases until it is rebuilt, so the toast points at the composer. */
 export const useUnlinkAppExternalConnection = () => {
     const queryClient = useQueryClient();
     const { showToastInfo, showToastApiError } = useToaster();
@@ -44,7 +51,9 @@ export const useUnlinkAppExternalConnection = () => {
         { previousLinks: AppExternalConnectionLinked[] | undefined }
     >({
         mutationFn: unlinkAppExternalConnection,
-        onMutate: async ({ projectUuid, appUuid, alias }) => {
+        onMutate: async (params) => {
+            const { projectUuid, appUuid } = params;
+            const aliases = getAliases(params);
             const queryKey = linksQueryKey(projectUuid, appUuid);
             await queryClient.cancelQueries({ queryKey });
             const previousLinks =
@@ -53,7 +62,8 @@ export const useUnlinkAppExternalConnection = () => {
                 );
             queryClient.setQueryData<AppExternalConnectionLinked[]>(
                 queryKey,
-                (links) => links?.filter((link) => link.alias !== alias),
+                (links) =>
+                    links?.filter((link) => !aliases.includes(link.alias)),
             );
             return { previousLinks };
         },
@@ -75,9 +85,17 @@ export const useUnlinkAppExternalConnection = () => {
             });
         },
         onSettled: async (_data, _error, { projectUuid, appUuid }) => {
-            await queryClient.invalidateQueries({
-                queryKey: linksQueryKey(projectUuid, appUuid),
-            });
+            await Promise.all([
+                queryClient.invalidateQueries({
+                    queryKey: linksQueryKey(projectUuid, appUuid),
+                }),
+                queryClient.invalidateQueries({
+                    queryKey: ['external-connection-linked-apps', projectUuid],
+                }),
+                queryClient.invalidateQueries({
+                    queryKey: ['external-connections', projectUuid],
+                }),
+            ]);
         },
     });
 };


### PR DESCRIPTION
Closes: [GLITCH-707](https://linear.app/lightdash/issue/GLITCH-707/allow-admins-to-un-link-external-connections-to-apps-directly)

### Description:

```diff
 Project settings -> Data app connections -> Linked apps
- open the app to unlink a connection
+ unlink the app or chart type directly, with confirmation
```

- Reuses the existing app/alias unlink endpoint and its `manage:DataApp` authorization.
- Removes every alias represented by a grouped linked-app row, then refreshes the linked resources and table counts.
- If a batched unlink partially fails, the confirmation stays open and queries refetch the authoritative link state.

### Validation:

- `pnpm -F @lightdash/frontend test src/components/Settings/DataAppConnectionsPanel/ConnectionUsageModal.test.tsx src/features/externalConnections/hooks/useUnlinkAppExternalConnection.test.tsx` (2 files, 5 tests)
- `pnpm -F @lightdash/frontend typecheck`
- `pnpm -F @lightdash/frontend lint`
- `pnpm -F @lightdash/frontend format`
- `git diff --check`
- Not browser-tested because no environment URL was provided.

### Risk assessment:

- [ ] This is a high-risk change

Low risk: frontend-only, reuses the existing authorization and endpoint, and requires confirmation. Failures refetch the server state before the user retries.
