### PR TITLE
fix: show context for web-started Live Activities

### DIFF
--- a/packages/backend/src/clients/Apns/ApnsClient.test.ts
+++ b/packages/backend/src/clients/Apns/ApnsClient.test.ts
@@ -236,6 +236,8 @@ describe('ApnsClient.sendLiveActivityStart', () => {
             agentUuid: '00000000-0000-0000-0000-000000000005',
             threadUuid: '00000000-0000-0000-0000-000000000006',
             promptUuid: '00000000-0000-0000-0000-000000000007',
+            agentName: 'Mobile Demo Agent',
+            taskSummary: 'Getting your Chrome usage stats',
         });
 
         await client.sendLiveActivityStart({
@@ -365,7 +367,7 @@ describe('buildLiveActivityPayload', () => {
 });
 
 describe('buildLiveActivityStartPayload', () => {
-    it('matches AgentRunActivityAttributes without private prompt content', () => {
+    it('matches AgentRunActivityAttributes with display context', () => {
         const payload = buildLiveActivityStartPayload({
             timestamp: new Date('2026-08-31T12:00:00.000Z'),
             staleAt: new Date('2026-08-31T12:05:00.000Z'),
@@ -375,6 +377,8 @@ describe('buildLiveActivityStartPayload', () => {
             agentUuid: 'agent-uuid',
             threadUuid: 'thread-uuid',
             promptUuid: 'prompt-uuid',
+            agentName: 'Mobile Demo Agent',
+            taskSummary: 'Getting your Chrome usage stats',
         });
 
         expect(payload).toEqual({
@@ -397,8 +401,8 @@ describe('buildLiveActivityStartPayload', () => {
                     agentUuid: 'agent-uuid',
                     threadUuid: 'thread-uuid',
                     promptUuid: 'prompt-uuid',
-                    agentName: 'Agent',
-                    taskSummary: null,
+                    agentName: 'Mobile Demo Agent',
+                    taskSummary: 'Getting your Chrome usage stats',
                 },
                 'input-push-token': 1,
                 alert: {
@@ -408,7 +412,45 @@ describe('buildLiveActivityStartPayload', () => {
             },
         });
         expect(JSON.stringify(payload)).not.toMatch(
-            /prompt text|answer text|dashboard|organization|customer|secret/i,
+            /answer text|dashboard|organization|customer|secret/i,
         );
+    });
+
+    it('limits display context to the text rendered by iOS', () => {
+        const payload = buildLiveActivityStartPayload({
+            timestamp: new Date('2026-08-31T12:00:00.000Z'),
+            staleAt: new Date('2026-08-31T12:05:00.000Z'),
+            liveActivityUuid: 'live-activity-uuid',
+            installationUuid: 'installation-uuid',
+            projectUuid: 'project-uuid',
+            agentUuid: 'agent-uuid',
+            threadUuid: 'thread-uuid',
+            promptUuid: 'prompt-uuid',
+            agentName: '  Mobile\n Demo   Agent  ',
+            taskSummary: `  ${'chrome usage '.repeat(40)}  `,
+        });
+
+        expect(payload.aps.attributes.agentName).toBe('Mobile Demo Agent');
+        expect(payload.aps.attributes.taskSummary).toBe(
+            'chrome usage chrome usage chrome usage chrome usage chrome…',
+        );
+    });
+
+    it('keeps the safe fallback when display context is empty', () => {
+        const payload = buildLiveActivityStartPayload({
+            timestamp: new Date('2026-08-31T12:00:00.000Z'),
+            staleAt: new Date('2026-08-31T12:05:00.000Z'),
+            liveActivityUuid: 'live-activity-uuid',
+            installationUuid: 'installation-uuid',
+            projectUuid: 'project-uuid',
+            agentUuid: 'agent-uuid',
+            threadUuid: 'thread-uuid',
+            promptUuid: 'prompt-uuid',
+            agentName: '   ',
+            taskSummary: '\n',
+        });
+
+        expect(payload.aps.attributes.agentName).toBeNull();
+        expect(payload.aps.attributes.taskSummary).toBeNull();
     });
 });

--- a/packages/backend/src/clients/Apns/ApnsClient.ts
+++ b/packages/backend/src/clients/Apns/ApnsClient.ts
@@ -43,8 +43,8 @@ export type LiveActivityStartPayload = {
             agentUuid: string;
             threadUuid: string;
             promptUuid: string;
-            agentName: 'Agent';
-            taskSummary: null;
+            agentName: string | null;
+            taskSummary: string | null;
         };
         'input-push-token': 1;
         alert: {
@@ -95,6 +95,10 @@ export type ApnsProviderTokenSource = {
 };
 
 export const APNS_REQUEST_TIMEOUT_MS = 30_000;
+
+const LIVE_ACTIVITY_AGENT_NAME_LIMIT = 28;
+
+const LIVE_ACTIVITY_TASK_SUMMARY_LIMIT = 60;
 
 class ApnsRequestTimeoutError extends Error {
     constructor() {
@@ -169,6 +173,21 @@ export const buildLiveActivityPayload = (args: {
     },
 });
 
+const condenseLiveActivityText = (
+    text: string | null,
+    limit: number,
+): string | null => {
+    const collapsed = text?.trim().split(/\s+/u).join(' ') ?? '';
+    if (collapsed.length === 0) return null;
+
+    const characters = Array.from(collapsed);
+    if (characters.length <= limit) return collapsed;
+
+    const clipped = characters.slice(0, limit).join('');
+    const boundary = clipped.lastIndexOf(' ');
+    return `${boundary < 0 ? clipped : clipped.slice(0, boundary)}…`;
+};
+
 export const buildLiveActivityStartPayload = (args: {
     timestamp: Date;
     staleAt: Date;
@@ -178,6 +197,8 @@ export const buildLiveActivityStartPayload = (args: {
     agentUuid: string;
     threadUuid: string;
     promptUuid: string;
+    agentName: string | null;
+    taskSummary: string | null;
 }): LiveActivityStartPayload => ({
     aps: {
         timestamp: Math.floor(args.timestamp.getTime() / 1000),
@@ -198,8 +219,14 @@ export const buildLiveActivityStartPayload = (args: {
             agentUuid: args.agentUuid,
             threadUuid: args.threadUuid,
             promptUuid: args.promptUuid,
-            agentName: 'Agent',
-            taskSummary: null,
+            agentName: condenseLiveActivityText(
+                args.agentName,
+                LIVE_ACTIVITY_AGENT_NAME_LIMIT,
+            ),
+            taskSummary: condenseLiveActivityText(
+                args.taskSummary,
+                LIVE_ACTIVITY_TASK_SUMMARY_LIMIT,
+            ),
         },
         'input-push-token': 1,
         alert: {

--- a/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationService.test.ts
+++ b/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationService.test.ts
@@ -42,6 +42,13 @@ const threadOwnership = {
     ownerIsServiceAccount: false,
 };
 
+const agent = {
+    uuid: agentUuid,
+    organizationUuid,
+    projectUuid,
+    name: 'Mobile Demo Agent',
+};
+
 const prompt = {
     organizationUuid,
     projectUuid,
@@ -49,6 +56,7 @@ const prompt = {
     threadUuid,
     agentUuid,
     createdByUserUuid: userUuid,
+    prompt: 'How many people used Chrome last month?',
 };
 
 const claimedStartAttempt = {
@@ -103,11 +111,7 @@ const createDependencies = () => {
         >(async () => []),
     } satisfies MobilePushNotificationStore;
     const threadStore = {
-        getAgent: vi.fn<MobilePushThreadStore['getAgent']>(async () => ({
-            uuid: agentUuid,
-            organizationUuid,
-            projectUuid,
-        })),
+        getAgent: vi.fn<MobilePushThreadStore['getAgent']>(async () => agent),
         findThreadOwnership: vi.fn<
             MobilePushThreadStore['findThreadOwnership']
         >(async () => threadOwnership),
@@ -699,6 +703,7 @@ describe('MobilePushNotificationService.startLiveActivitiesForPrompt', () => {
                     uuid: agentUuid,
                     organizationUuid,
                     projectUuid: 'foreign-project',
+                    name: 'Mobile Demo Agent',
                 });
             }
             if (mismatch === 'thread') {
@@ -799,8 +804,8 @@ describe('MobilePushNotificationService.deliverLiveActivityStart', () => {
                         agentUuid,
                         threadUuid,
                         promptUuid,
-                        agentName: 'Agent',
-                        taskSummary: null,
+                        agentName: 'Mobile Demo Agent',
+                        taskSummary: 'How many people used Chrome last month?',
                     },
                     'input-push-token': 1,
                     alert: {

--- a/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationService.ts
+++ b/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationService.ts
@@ -50,6 +50,7 @@ type MobilePushPrompt = {
     threadUuid: string;
     agentUuid: string | null;
     createdByUserUuid: string;
+    prompt: string;
 };
 
 type UpsertLiveActivity = {
@@ -163,6 +164,7 @@ export type MobilePushThreadStore = {
         uuid: string;
         organizationUuid: string;
         projectUuid: string;
+        name: string;
     }>;
     findThreadOwnership(args: {
         organizationUuid: string;
@@ -627,6 +629,12 @@ export class MobilePushNotificationService {
             return;
         }
 
+        const agent = await this.threadStore.getAgent({
+            organizationUuid: attempt.organizationUuid,
+            projectUuid: prompt.projectUuid,
+            agentUuid: prompt.agentUuid,
+        });
+
         const payload = buildLiveActivityStartPayload({
             timestamp: attemptedAt,
             staleAt: new Date(
@@ -638,6 +646,8 @@ export class MobilePushNotificationService {
             agentUuid: prompt.agentUuid,
             threadUuid: prompt.threadUuid,
             promptUuid: prompt.promptUuid,
+            agentName: agent.name,
+            taskSummary: prompt.prompt,
         });
         const result = await this.apnsClient.sendLiveActivityStart({
             environment: attempt.environment,


### PR DESCRIPTION
## What changes

- Include the selected agent name and user-visible task summary in web-started Live Activities.
- Collapse whitespace and cap the display values to the same limits as iOS-started activities.
- Keep the existing safe fallback when the display context is empty.

## Why

Web-started activities reach the phone and follow the run state, but the backend replaces their context with a generic agent name and no task summary.

## Verification

- 75 focused backend tests pass.
- Backend typecheck passes.
- Scoped lint and formatting checks pass.
- The regression test fails before the fix with `Agent` and `null`, then passes with the resolved agent and task.

## Screenshots

The before-state screenshots are attached to the private Linear ticket because they include personal Lock Screen details.

Linear: SPK-1733