### PR TITLE
fix(ai): let Enter send when the @-mention menu has nothing to select

### DIFF
--- a/packages/frontend/src/components/common/PromptComposer/PromptComposer.test.tsx
+++ b/packages/frontend/src/components/common/PromptComposer/PromptComposer.test.tsx
@@ -1,5 +1,5 @@
-import { type Editor } from '@tiptap/react';
 import { fireEvent, screen } from '@testing-library/react';
+import { type Editor } from '@tiptap/react';
 import { createRef } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '../../../testing/testUtils';

--- a/packages/frontend/src/components/common/PromptComposer/PromptComposer.test.tsx
+++ b/packages/frontend/src/components/common/PromptComposer/PromptComposer.test.tsx
@@ -1,0 +1,79 @@
+import { type Editor } from '@tiptap/react';
+import { fireEvent, screen } from '@testing-library/react';
+import { createRef } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import PromptComposer, { type PromptComposerHandle } from './PromptComposer';
+
+/** jsdom can't type into a contenteditable, so drive the editor directly and
+ *  dispatch the key events the composer reacts to. */
+const setup = (
+    props: Partial<Parameters<typeof PromptComposer>[0]> = {},
+    text = 'what changed last week',
+) => {
+    const onSubmit = vi.fn();
+    const ref = createRef<PromptComposerHandle>();
+    renderWithProviders(
+        <PromptComposer ref={ref} onSubmit={onSubmit} {...props} />,
+    );
+    const editor = ref.current?.editor as Editor;
+    editor.commands.setContent(text);
+    return { onSubmit, editor, element: screen.getByRole('textbox') };
+};
+
+describe('PromptComposer keyboard handling', () => {
+    it('submits on Enter', () => {
+        const { onSubmit, element } = setup();
+
+        fireEvent.keyDown(element, { key: 'Enter' });
+
+        expect(onSubmit).toHaveBeenCalledWith('what changed last week');
+    });
+
+    it('inserts a line break on Shift+Enter instead of submitting', () => {
+        const { onSubmit, editor, element } = setup();
+
+        fireEvent.keyDown(element, { key: 'Enter', shiftKey: true });
+
+        expect(onSubmit).not.toHaveBeenCalled();
+        expect(editor.getText({ blockSeparator: '\n' })).toContain('\n');
+    });
+
+    it('does not submit on Enter during IME composition', () => {
+        const { onSubmit, element } = setup({}, 'こんにちは');
+
+        fireEvent.keyDown(element, { key: 'Enter', isComposing: true });
+
+        expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('does not submit while another consumer owns Enter', () => {
+        const { onSubmit, element } = setup({
+            shouldBlockSubmit: () => true,
+        });
+
+        fireEvent.keyDown(element, { key: 'Enter' });
+
+        expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('does not submit an empty composer', () => {
+        const { onSubmit, element } = setup({}, '   ');
+
+        fireEvent.keyDown(element, { key: 'Enter' });
+
+        expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('swallows Enter while submission is gated, keeping the draft intact', () => {
+        const { onSubmit, editor, element } = setup(
+            { submitDisabled: true },
+            'queued draft',
+        );
+
+        fireEvent.keyDown(element, { key: 'Enter' });
+
+        expect(onSubmit).not.toHaveBeenCalled();
+        expect(editor.getText({ blockSeparator: '\n' })).toBe('queued draft');
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.keyboard.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.keyboard.test.tsx
@@ -1,0 +1,55 @@
+import { fireEvent, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../../../testing/testUtils';
+import { store } from '../../store';
+import { AgentChatInput } from './AgentChatInput';
+
+vi.mock('../../hooks/useDeepResearch', () => ({
+    useHasActiveDeepResearchRun: vi.fn(() => false),
+}));
+
+vi.mock('../../../../../hooks/useServerOrClientFeatureFlag', () => ({
+    useServerFeatureFlag: vi.fn(() => ({ data: { enabled: false } })),
+}));
+
+const renderInput = () => {
+    const onSubmit = vi.fn();
+    renderWithProviders(
+        <Provider store={store}>
+            <MemoryRouter>
+                <AgentChatInput
+                    onSubmit={onSubmit}
+                    projectUuid="project-1"
+                    agentUuid="agent-1"
+                    defaultValue="Why did enterprise retention fall?"
+                    showSuggestions={false}
+                />
+            </MemoryRouter>
+        </Provider>,
+    );
+    return { onSubmit, element: screen.getByRole('textbox') };
+};
+
+describe('AgentChatInput keyboard handling', () => {
+    it('sends the message on Enter', () => {
+        const { onSubmit, element } = renderInput();
+
+        fireEvent.keyDown(element, { key: 'Enter' });
+
+        expect(onSubmit).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: 'Why did enterprise retention fall?',
+            }),
+        );
+    });
+
+    it('does not send on Shift+Enter', () => {
+        const { onSubmit, element } = renderInput();
+
+        fireEvent.keyDown(element, { key: 'Enter', shiftKey: true });
+
+        expect(onSubmit).not.toHaveBeenCalled();
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -75,9 +75,12 @@ import { type Agent } from '../AgentSelector/AgentSelectorUtils';
 import styles from './AgentChatInput.module.css';
 import { AgentSuggestionChips } from './AgentSuggestionChips';
 import {
+    CLOSED_CONTENT_MENTION_MENU,
+    contentMentionMenuOwnsEnter,
     createContentMentionExtension,
     extractContentMentionContext,
     isContentMentionSuggestionActive,
+    type ContentMentionMenuState,
     type ContentMentionSuggestionItem,
 } from './contentMentions';
 import { getAgentSuggestionModes } from './suggestionModes';
@@ -274,11 +277,12 @@ export const AgentChatInput = ({
     projectUuidRef.current = projectUuid;
     const contentMentionPriorityItemsRef = useRef(contentMentionPriorityItems);
     contentMentionPriorityItemsRef.current = contentMentionPriorityItems;
-    // Tracks whether the @-mention dropdown is open, sourced from the suggestion
-    // render lifecycle. Enter must select from the dropdown (or be a no-op while
-    // it loads), never submit, so we guard on this in addition to the plugin's
-    // `active` flag — which can read stale in the keydown vs async-items race.
-    const contentMentionPopupOpenRef = useRef(false);
+    // What the @-mention dropdown is doing, sourced from the suggestion render
+    // lifecycle — the plugin's own `active` flag alone can't tell an open
+    // menu from a dismissed or empty one.
+    const contentMentionMenuRef = useRef<ContentMentionMenuState>(
+        CLOSED_CONTENT_MENTION_MENU,
+    );
 
     // Hide the chip strip while the user is scrolled away from the input.
     // Reappears as they scroll back toward the bottom of the thread — chips
@@ -384,19 +388,22 @@ export const AgentChatInput = ({
             createContentMentionExtension({
                 getProjectUuid: () => projectUuidRef.current,
                 getPriorityItems: () => contentMentionPriorityItemsRef.current,
-                onPopupOpenChange: (open) => {
-                    contentMentionPopupOpenRef.current = open;
+                onMenuStateChange: (state) => {
+                    contentMentionMenuRef.current = state;
                 },
             }),
         ],
         [],
     );
 
-    // An open @-mention dropdown owns Enter — it selects rather than submits.
+    // An @-mention dropdown with something to select owns Enter — it selects
+    // rather than submits.
     const shouldBlockSubmit = useCallback(
         (ed: Editor | null) =>
-            isContentMentionSuggestionActive(ed) ||
-            contentMentionPopupOpenRef.current,
+            contentMentionMenuOwnsEnter(
+                contentMentionMenuRef.current,
+                isContentMentionSuggestionActive(ed),
+            ),
         [],
     );
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { lightdashApi } from '../../../../../api';
 import {
     buildContentMentionSuggestionItems,
+    contentMentionMenuOwnsEnter,
     contextItemsToContentMentionSuggestions,
     fuzzyContentMentionLabelMatch,
     getContentMentionEmptyMessage,
@@ -269,5 +270,40 @@ describe('contentMentions', () => {
             'Type 1 more character to search content',
         );
         expect(getContentMentionEmptyMessage('re')).toBe('No content found');
+    });
+
+    describe('Enter ownership', () => {
+        it('lets the dropdown select while it has items', () => {
+            expect(
+                contentMentionMenuOwnsEnter(
+                    { status: 'open', itemCount: 3 },
+                    true,
+                ),
+            ).toBe(true);
+        });
+
+        it('hands Enter back when the dropdown has no items', () => {
+            expect(
+                contentMentionMenuOwnsEnter(
+                    { status: 'open', itemCount: 0 },
+                    true,
+                ),
+            ).toBe(false);
+        });
+
+        it('hands Enter back once the dropdown is dismissed', () => {
+            expect(
+                contentMentionMenuOwnsEnter({ status: 'dismissed' }, true),
+            ).toBe(false);
+        });
+
+        it('holds Enter while items are still resolving', () => {
+            expect(
+                contentMentionMenuOwnsEnter({ status: 'closed' }, true),
+            ).toBe(true);
+            expect(
+                contentMentionMenuOwnsEnter({ status: 'closed' }, false),
+            ).toBe(false);
+        });
     });
 });

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.tsx
@@ -243,6 +243,42 @@ export const isContentMentionSuggestionActive = (editor: Editor | null) => {
     return state?.active === true;
 };
 
+/** What the @-mention dropdown is doing, per the suggestion renderer. */
+export type ContentMentionMenuState =
+    | { status: 'closed' }
+    | { status: 'dismissed' }
+    | { status: 'open'; itemCount: number };
+
+export const CLOSED_CONTENT_MENTION_MENU: ContentMentionMenuState = {
+    status: 'closed',
+};
+
+/**
+ * Enter belongs to the dropdown only while it has something to select. Mentions
+ * allow spaces, so a stray `@` keeps the query alive for the rest of the
+ * sentence — a menu showing "no results", or one dismissed with Escape, must
+ * hand Enter back to the composer. While items are still resolving there is no
+ * menu yet, so fall back to the plugin's own active flag.
+ */
+export const contentMentionMenuOwnsEnter = (
+    menu: ContentMentionMenuState,
+    isSuggestionActive: boolean,
+) => {
+    switch (menu.status) {
+        case 'open':
+            return menu.itemCount > 0;
+        case 'dismissed':
+            return false;
+        case 'closed':
+            return isSuggestionActive;
+        default:
+            return assertUnreachable(
+                menu,
+                'Unknown content mention menu state',
+            );
+    }
+};
+
 const getContentMentionContentType = (value: unknown) => {
     if (value === FILE_MENTION_CONTENT_TYPE) return FILE_MENTION_CONTENT_TYPE;
     if (value === REPOSITORY_MENTION_CONTENT_TYPE)
@@ -642,12 +678,12 @@ const renderContentMentionItem = (
 const generateContentMentionSuggestion = ({
     getProjectUuid,
     getPriorityItems,
-    onPopupOpenChange,
+    onMenuStateChange,
     includeFilesAndRepositories,
 }: {
     getProjectUuid: () => string | undefined;
     getPriorityItems: () => ContentMentionSuggestionItem[];
-    onPopupOpenChange?: (open: boolean) => void;
+    onMenuStateChange?: (state: ContentMentionMenuState) => void;
     includeFilesAndRepositories: boolean;
 }): MentionOptions['suggestion'] => ({
     char: '@',
@@ -733,10 +769,18 @@ const generateContentMentionSuggestion = ({
     render: () => {
         let component: ReactRenderer<SuggestionListRef> | undefined;
         let popup: TippyInstance | undefined;
+        // Escape hides the dropdown but leaves the suggestion match in place;
+        // it must stay hidden — and stay out of Enter's way — until the match
+        // exits.
+        let dismissed = false;
 
         return {
             onStart: (props) => {
-                onPopupOpenChange?.(true);
+                dismissed = false;
+                onMenuStateChange?.({
+                    status: 'open',
+                    itemCount: props.items.length,
+                });
                 component = new ReactRenderer(SuggestionList, {
                     props: {
                         ...props,
@@ -764,6 +808,11 @@ const generateContentMentionSuggestion = ({
                 })[0];
             },
             onUpdate: (props) => {
+                if (dismissed) return;
+                onMenuStateChange?.({
+                    status: 'open',
+                    itemCount: props.items.length,
+                });
                 component?.updateProps({
                     ...props,
                     renderItem: renderContentMentionItem,
@@ -779,14 +828,17 @@ const generateContentMentionSuggestion = ({
             },
             onKeyDown: (props) => {
                 if (props.event.key === 'Escape') {
-                    onPopupOpenChange?.(false);
+                    dismissed = true;
+                    onMenuStateChange?.({ status: 'dismissed' });
                     popup?.hide();
                     return true;
                 }
+                if (dismissed) return false;
                 return component?.ref?.onKeyDown(props) ?? false;
             },
             onExit: () => {
-                onPopupOpenChange?.(false);
+                dismissed = false;
+                onMenuStateChange?.(CLOSED_CONTENT_MENTION_MENU);
                 popup?.destroy();
                 component?.destroy();
                 popup = undefined;
@@ -799,12 +851,12 @@ const generateContentMentionSuggestion = ({
 export const createContentMentionExtension = ({
     getProjectUuid,
     getPriorityItems,
-    onPopupOpenChange,
+    onMenuStateChange,
     includeFilesAndRepositories = true,
 }: {
     getProjectUuid: () => string | undefined;
     getPriorityItems: () => ContentMentionSuggestionItem[];
-    onPopupOpenChange?: (open: boolean) => void;
+    onMenuStateChange?: (state: ContentMentionMenuState) => void;
     includeFilesAndRepositories?: boolean;
 }) =>
     Mention.extend({
@@ -852,7 +904,7 @@ export const createContentMentionExtension = ({
         suggestion: generateContentMentionSuggestion({
             getProjectUuid,
             getPriorityItems,
-            onPopupOpenChange,
+            onMenuStateChange,
             includeFilesAndRepositories,
         }),
         renderText: ({ node }) =>


### PR DESCRIPTION
### Description:

Enter in the agent composer inserts a newline instead of sending once the message contains an `@`. The composer handed Enter to the @-mention dropdown whenever the suggestion plugin was active, and mentions allow spaces — so a stray `@` anywhere ("what about @ revenue") keeps the match alive for the rest of the sentence and Enter never submits. Escape had the same effect: it hid the dropdown but left the match active, so Enter stayed blocked.

The suggestion renderer now reports what the menu is actually doing — `open` (with an item count), `dismissed`, or `closed` — and Enter only belongs to the menu when it has something to select. While items are still resolving there is no menu yet, so we keep falling back to the plugin's active flag as before. Escape now also stops the hidden list from consuming arrow/Enter keys.

Verified in a real Chromium against the Agent Chat Input story: before the change `hello @ world` + Enter and `@rev` + Escape + Enter both added a newline; after, both send. Shift+Enter still inserts a line break. Added keyboard tests for `PromptComposer` (Enter sends, Shift+Enter newline, IME composition, blocked-submit, empty draft) and unit tests for the menu's Enter ownership.

### Risk assessment:

- [ ] This is a high-risk change
