### PR TITLE
fix(frontend): keep metric explore comparison selection

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreComparison.test.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreComparison.test.tsx
@@ -55,7 +55,10 @@ describe('MetricExploreComparison', () => {
     it('keeps the metric selected when choosing a comparison metric', async () => {
         renderWithProviders(<ControlledComparison />);
 
-        await userEvent.click(screen.getByPlaceholderText('Select a metric'));
+        const metricSelect = screen.getByPlaceholderText('Select a metric');
+        expect(metricSelect).not.toHaveAttribute('data-disabled');
+
+        await userEvent.click(metricSelect);
         await userEvent.click(
             await screen.findByRole('option', { name: 'Total sales' }),
         );

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreComparison.test.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreComparison.test.tsx
@@ -1,0 +1,65 @@
+import {
+    FieldType,
+    MetricExplorerComparison,
+    MetricType,
+    TimeFrames,
+    type MetricExplorerQuery,
+    type MetricWithAssociatedTimeDimension,
+} from '@lightdash/common';
+import { type UseQueryResult } from '@tanstack/react-query';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+import { describe, expect, it } from 'vitest';
+import { renderWithProviders } from '../../../../testing/testUtils';
+import { MetricExploreComparison } from './MetricExploreComparison';
+
+const comparisonMetric = {
+    table: 'orders',
+    tableLabel: 'Orders',
+    name: 'total_sales',
+    label: 'Total sales',
+    fieldType: FieldType.METRIC,
+    type: MetricType.SUM,
+    sql: '${TABLE}.amount',
+    timeDimension: {
+        table: 'orders',
+        field: 'order_date',
+        interval: TimeFrames.WEEK,
+    },
+} as MetricWithAssociatedTimeDimension;
+
+const metricsQuery = {
+    data: [comparisonMetric],
+    isLoading: false,
+    isSuccess: true,
+} as UseQueryResult<MetricWithAssociatedTimeDimension[], unknown>;
+
+const ControlledComparison = () => {
+    const [query, setQuery] = useState<MetricExplorerQuery>({
+        comparison: MetricExplorerComparison.DIFFERENT_METRIC,
+        metric: { table: '', name: '', label: '' },
+    });
+
+    return (
+        <MetricExploreComparison
+            baseMetricLabel="Order count"
+            query={query}
+            onQueryChange={setQuery}
+            metricsWithTimeDimensionsQuery={metricsQuery}
+        />
+    );
+};
+
+describe('MetricExploreComparison', () => {
+    it('keeps the metric selected when choosing a comparison metric', async () => {
+        renderWithProviders(<ControlledComparison />);
+
+        await userEvent.click(screen.getByPlaceholderText('Select a metric'));
+        await userEvent.click(
+            await screen.findByRole('option', { name: 'Total sales' }),
+        );
+
+        expect(screen.getByDisplayValue('Total sales')).toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreComparison.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreComparison.tsx
@@ -147,9 +147,11 @@ export const MetricExploreComparison: FC<Props> = ({
                                     query.comparison === comparison.type ||
                                     undefined
                                 }
-                                onClick={() =>
-                                    handleComparisonChange(comparison.type)
-                                }
+                                onClick={() => {
+                                    if (query.comparison !== comparison.type) {
+                                        handleComparisonChange(comparison.type);
+                                    }
+                                }}
                             >
                                 <Stack>
                                     <Group

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreComparison.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreComparison.tsx
@@ -221,7 +221,8 @@ export const MetricExploreComparison: FC<Props> = ({
                                                     />
                                                 )}
                                                 data-disabled={
-                                                    !metricsWithTimeDimensionsQuery.isSuccess
+                                                    !metricsWithTimeDimensionsQuery.isSuccess ||
+                                                    undefined
                                                 }
                                                 rightSection={
                                                     metricsWithTimeDimensionsQuery.isLoading ? (


### PR DESCRIPTION
## What changed

## Summary

- Prevent clicks inside an already-selected comparison card from resetting its metric selection.
- Add a controlled component regression test that selects a comparison metric and verifies the chosen label remains visible.

### Validation

- `pnpm -F frontend test src/features/metricsCatalog/components/visualization/MetricExploreComparison.test.tsx` — confirmed the regression test failed before the fix (1 file, 1 failing test); sealed proof reran it after the fix with 1 file and 1 test passing.
- `pnpm -F frontend exec oxfmt src/features/metricsCatalog/components/visualization/MetricExploreComparison.test.tsx src/features/metricsCatalog/components/visualization/MetricExploreComparison.tsx --check` — passed.
- `pnpm -F frontend run --if-present lint` — passed.
- `pnpm -F frontend run --if-present typecheck` — passed.
- `pnpm -F frontend exec vitest related src/features/metricsCatalog/components/visualization/MetricExploreComparison.test.tsx src/features/metricsCatalog/components/visualization/MetricExploreComparison.tsx --run --passWithNoTests` — passed.

## Proof of work

🟠 **BLOCKED** — The focused interaction test passes, but required end-to-end visual evidence could not be captured and inspected.

Revision: `d0f3339473e4a0f0f308d5f5276a0c29b779480a`

### Select and apply another metric in Metrics Explore

- Expected: After choosing “Compare to another metric” and selecting “Completed order count,” the field retains that metric and the comparison chart renders.
- Observed: The focused component interaction test passed and confirmed the selected metric remains displayed. However, the initial host capture timed out waiting for input[value='Completed order count']; the focused replacement advanced through selecting the option but timed out waiting for .echarts-for-react canvas, so no inspectable walkthrough artifact was returned.
- Evidence:
  - CLI: pnpm -F frontend test src/features/metricsCatalog/components/visualization/MetricExploreComparison.test.tsx — 1 test file passed, 1 test passed.
  - Initial capture failure: Walkthrough recorder exited with 1: step 7 (waitFor) failed: locator.waitFor: Timeout 15000ms exceeded.
  - Focused replacement failure: Walkthrough recorder exited with 1: step 6 (waitFor) failed: locator.waitFor: Timeout 15000ms exceeded.

## Development environment

[Open the public Lightdash development environment](https://ld-runner-prod-10823-b04aaf622ef5.exe.xyz) (anyone with the URL can access it)

Login: `demo@lightdash.com` / `demo_password!`

## References

Closes: PROD-10823

