### PR TITLE
chore(dev): give each dev instance its own maple home dir

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -74,9 +74,16 @@ const mapleBin = (() => {
     return (stdout || '').trim() || undefined;
 })();
 
-// One Maple server per data dir, so namespace it by instance the same way the
-// port is — two worktrees must not fight over ~/.maple/data.
-const mapleDataDir = path.join(os.homedir(), '.maple', `data-${instanceId}`);
+// Maple anchors its pidfile and store markers in the data dir's PARENT, so
+// each instance needs its own parent directory — sibling data dirs directly
+// under ~/.maple would share one maple.pid and lock each other out.
+const mapleDataDir = path.join(
+    os.homedir(),
+    '.maple',
+    'instances',
+    instanceId,
+    'data',
+);
 
 // Each app adds its own OTEL_SERVICE_NAME on top of this: service.name is what
 // namespaces traces per checkout in the Maple UI.


### PR DESCRIPTION
### Description:

Running two worktree dev instances at once, only one instance's Maple tracing server could start — the other crash-looped with `maple is already running` until PM2 marked it errored (115k restarts on the second instance here), and that instance silently exported traces to a dead port.

Root cause: maple anchors its pidfile and store markers (`maple.pid`, `maple-store-open`, `maple-store-version.json`) in the **parent** directory of `--data-dir`. `ecosystem.config.js` namespaced instances as sibling dirs directly under `~/.maple/` (`data-<instanceId>`), so every instance resolved to the same `~/.maple/maple.pid` — an accidental machine-wide mutex.

#### Changes (ecosystem.config.js):
- maple data dir moves from `~/.maple/data-<instanceId>` to `~/.maple/instances/<instanceId>/data`, giving each instance its own parent dir for the pidfile and store markers.

Verified locally with both instances' maples running concurrently, each with its own pidfile, and traces flowing from the previously-broken instance's API and scheduler.

Note for existing checkouts: on the next `pm2:start` after picking this up, maple bootstraps a fresh store at the new path (dev traces are disposable); the old `~/.maple/data-<instanceId>` dir and root-level `maple.pid`/marker files can be deleted.

### Risk assessment:

- [ ] This is a high-risk change

High-risk changes require approval from a reviewer other than the author before merging.

Closes: GLITCH-720

🤖 Generated with [Claude Code](https://claude.com/claude-code)