### PR TITLE
feat(content-as-code): configurable repo path for content-as-code files

### DIFF
--- a/packages/backend/src/controllers/ProjectCoderController.ts
+++ b/packages/backend/src/controllers/ProjectCoderController.ts
@@ -36,6 +36,7 @@ import {
     type ApiVirtualViewAsCodeListResponse,
     type ApiVirtualViewAsCodeUpsertResponse,
     type ChartAsCode,
+    type ContentAsCodeSettingsStamp,
     type ContentSlugRenameRequest,
     type DashboardAsCode,
     type ExternalConnectionAsCode,
@@ -304,6 +305,7 @@ export class ProjectCoderController extends BaseController {
             .getDraftReview(toSessionUser(req.account), projectUuid, draftUuid);
         return codeSuccess({
             summary: toDraftSummary(review.draft),
+            filePath: review.filePath,
             publishedYaml: review.publishedYaml,
             draftYaml: review.draftYaml,
         });
@@ -389,7 +391,7 @@ export class ProjectCoderController extends BaseController {
     async stampContentAsCodeSettings(
         @Path() projectUuid: string,
         @Request() req: express.Request,
-        @Body() body: { sync: boolean },
+        @Body() body: ContentAsCodeSettingsStamp,
     ): Promise<ApiSuccessEmpty> {
         assertRegisteredAccount(req.account);
         this.setStatus(200);

--- a/packages/backend/src/database/entities/contentAsCodeWritebacks.ts
+++ b/packages/backend/src/database/entities/contentAsCodeWritebacks.ts
@@ -6,18 +6,21 @@ export const ContentAsCodeProjectSettingsTableName =
 export type DbContentAsCodeProjectSettings = {
     project_uuid: string;
     sync_enabled: boolean;
+    content_path: string;
     stamped_at: Date;
 };
 
 export type CreateDbContentAsCodeProjectSettings = Pick<
     DbContentAsCodeProjectSettings,
     'project_uuid' | 'sync_enabled'
->;
+> &
+    Partial<Pick<DbContentAsCodeProjectSettings, 'content_path'>>;
 
 export type ContentAsCodeProjectSettingsTable = Knex.CompositeTableType<
     DbContentAsCodeProjectSettings,
     CreateDbContentAsCodeProjectSettings,
-    Pick<DbContentAsCodeProjectSettings, 'sync_enabled' | 'stamped_at'>
+    Pick<DbContentAsCodeProjectSettings, 'sync_enabled' | 'stamped_at'> &
+        Partial<Pick<DbContentAsCodeProjectSettings, 'content_path'>>
 >;
 
 export const ContentAsCodeWritebacksTableName = 'content_as_code_writebacks';

--- a/packages/backend/src/database/migrations/20260901150000_add_content_path_to_content_as_code_project_settings.ts
+++ b/packages/backend/src/database/migrations/20260901150000_add_content_path_to_content_as_code_project_settings.ts
@@ -1,0 +1,25 @@
+import { Knex } from 'knex';
+
+export const classification = {
+    kind: 'safe',
+    reason: 'Adds a defaulted column so write-back can resolve the repo directory that holds content-as-code files',
+} as const;
+
+const SETTINGS_TABLE = 'content_as_code_project_settings';
+const LOCK_TIMEOUT = '5s';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '${LOCK_TIMEOUT}'`);
+
+    await knex.schema.alterTable(SETTINGS_TABLE, (table) => {
+        table.text('content_path').notNullable().defaultTo('lightdash');
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '${LOCK_TIMEOUT}'`);
+
+    await knex.schema.alterTable(SETTINGS_TABLE, (table) => {
+        table.dropColumn('content_path');
+    });
+}

--- a/packages/backend/src/models/ContentAsCodeProjectSettingsModel.ts
+++ b/packages/backend/src/models/ContentAsCodeProjectSettingsModel.ts
@@ -1,10 +1,6 @@
+import { type ContentAsCodeProjectSettings } from '@lightdash/common';
 import { Knex } from 'knex';
 import { ContentAsCodeProjectSettingsTableName } from '../database/entities/contentAsCodeWritebacks';
-
-export type ContentAsCodeProjectSettings = {
-    syncEnabled: boolean;
-    stampedAt: Date;
-};
 
 type ContentAsCodeProjectSettingsModelArguments = {
     database: Knex;
@@ -26,23 +22,30 @@ export class ContentAsCodeProjectSettingsModel {
         if (row === undefined) return undefined;
         return {
             syncEnabled: row.sync_enabled,
+            path: row.content_path,
             stampedAt: row.stamped_at,
         };
     }
 
+    // path null: the stamping client predates the setting, keep what is stored
     async upsert(args: {
         projectUuid: string;
         syncEnabled: boolean;
+        path: string | null;
     }): Promise<void> {
+        const pathColumn =
+            args.path === null ? {} : { content_path: args.path };
         await this.database(ContentAsCodeProjectSettingsTableName)
             .insert({
                 project_uuid: args.projectUuid,
                 sync_enabled: args.syncEnabled,
+                ...pathColumn,
             })
             .onConflict('project_uuid')
             .merge({
                 sync_enabled: args.syncEnabled,
                 stamped_at: this.database.fn.now(),
+                ...pathColumn,
             });
     }
 }

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -63,6 +63,7 @@ import {
     isSchedulerGsheetsOptions,
     isSchedulerImageOptions,
     isSlackTarget,
+    normalizeContentAsCodePath,
     NotFoundError,
     NotificationFrequency,
     NotImplementedError,
@@ -88,6 +89,8 @@ import {
     UpdatedByUser,
     validateEmail,
     VirtualViewAsCode,
+    type ContentAsCodeProjectSettings,
+    type ContentAsCodeSettingsStamp,
     type ContentVerificationInfo,
     type DashboardTileWithSlug,
     type Filters,
@@ -3040,10 +3043,7 @@ export class CoderService extends BaseService {
     async getContentAsCodeSettings(
         user: SessionUser,
         projectUuid: string,
-    ): Promise<{
-        syncEnabled: boolean;
-        stampedAt: Date;
-    } | null> {
+    ): Promise<ContentAsCodeProjectSettings | null> {
         const project = await this.projectModel.getSummary(projectUuid);
         const auditedAbility = this.createAuditedAbility(user);
         if (
@@ -3102,7 +3102,7 @@ export class CoderService extends BaseService {
     async stampContentAsCodeSettings(
         user: SessionUser,
         projectUuid: string,
-        settings: { sync: boolean },
+        settings: ContentAsCodeSettingsStamp,
     ): Promise<void> {
         const project = await this.projectModel.get(projectUuid);
         const auditedAbility = this.createAuditedAbility(user);
@@ -3126,6 +3126,10 @@ export class CoderService extends BaseService {
         await this.contentAsCodeProjectSettingsModel.upsert({
             projectUuid,
             syncEnabled: settings.sync,
+            path:
+                settings.path === undefined
+                    ? null
+                    : normalizeContentAsCodePath(settings.path),
         });
     }
 

--- a/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.test.ts
+++ b/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.test.ts
@@ -516,6 +516,32 @@ describe('ContentAsCodeWritebackService', () => {
         );
     });
 
+    it('writes files under the stamped content path', async () => {
+        const { service, gitIntegrationService } = buildService({
+            settings: { syncEnabled: true, path: 'analytics/content' },
+        });
+        await service.propose(user, 'project-uuid', 'chart', 'monthly-revenue');
+
+        const [, , , filePath] = gitIntegrationService.saveFile.mock.calls[0];
+        expect(filePath).toBe('analytics/content/charts/monthly-revenue.yml');
+    });
+
+    it('names the reviewed file by the stamped content path', async () => {
+        const { service } = buildService({
+            settings: { syncEnabled: true, path: 'analytics/content' },
+        });
+
+        const review = await service.getDraftReview(
+            user,
+            'project-uuid',
+            'draft-uuid',
+        );
+
+        expect(review.filePath).toBe(
+            'analytics/content/dashboards/weekly-kpis.yml',
+        );
+    });
+
     it('reviews a written-back draft from its frozen documents', async () => {
         const { service, coderService } = buildService({
             draft: {

--- a/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.ts
+++ b/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.ts
@@ -3,7 +3,9 @@ import {
     ConflictError,
     ContentAsCodeType,
     DbtProjectType,
+    DEFAULT_CONTENT_AS_CODE_PATH,
     ForbiddenError,
+    getContentAsCodeFilePath,
     NotFoundError,
     ParameterError,
     PullRequestSource,
@@ -181,13 +183,19 @@ export class ContentAsCodeWritebackService extends BaseService {
 
     private static getContentFilePath(
         repoPath: string,
+        contentPath: string,
         contentType: WritebackContentType,
         slug: string,
     ): string {
         const prefix = repoPath.replace(/^\/+|\/+$/g, '');
-        const folder = contentType === 'chart' ? 'charts' : 'dashboards';
-        const base = `lightdash/${folder}/${slug}.yml`;
+        const base = getContentAsCodeFilePath(contentPath, contentType, slug);
         return prefix === '' ? base : `${prefix}/${base}`;
+    }
+
+    private async getContentPath(projectUuid: string): Promise<string> {
+        const settings =
+            await this.contentAsCodeProjectSettingsModel.get(projectUuid);
+        return settings?.path ?? DEFAULT_CONTENT_AS_CODE_PATH;
     }
 
     // The migration path: instances are already ahead today, so drifted
@@ -373,6 +381,7 @@ export class ContentAsCodeWritebackService extends BaseService {
         draftUuid: string,
     ): Promise<{
         draft: ContentDraft;
+        filePath: string;
         publishedYaml: string;
         draftYaml: string;
     }> {
@@ -387,6 +396,11 @@ export class ContentAsCodeWritebackService extends BaseService {
         ) {
             throw new ParameterError('Unsupported draft content type');
         }
+        const filePath = getContentAsCodeFilePath(
+            await this.getContentPath(projectUuid),
+            draft.contentType,
+            draft.slug,
+        );
         // A written-back draft shows what actually went to the repo, not a
         // live diff that drifts as published content moves on; a draft handed
         // back to its author is live again
@@ -397,6 +411,7 @@ export class ContentAsCodeWritebackService extends BaseService {
         ) {
             return {
                 draft,
+                filePath,
                 publishedYaml: dumpContentAsCode(draft.writtenBackPublished),
                 draftYaml: dumpContentAsCode(draft.writtenBackDraft),
             };
@@ -407,6 +422,7 @@ export class ContentAsCodeWritebackService extends BaseService {
         );
         return {
             draft,
+            filePath,
             publishedYaml: dumpContentAsCode(published),
             draftYaml: dumpContentAsCode(draftDoc),
         };
@@ -736,6 +752,7 @@ export class ContentAsCodeWritebackService extends BaseService {
         const { projectUuid, contentType, contentUuid, slug } = target;
         const repo =
             await this.gitIntegrationService.getProjectRepo(projectUuid);
+        const contentDir = await this.getContentPath(projectUuid);
 
         let current = row;
         try {
@@ -774,6 +791,7 @@ export class ContentAsCodeWritebackService extends BaseService {
             files.push({
                 path: ContentAsCodeWritebackService.getContentFilePath(
                     repo.path,
+                    contentDir,
                     'chart',
                     slug,
                 ),
@@ -788,6 +806,7 @@ export class ContentAsCodeWritebackService extends BaseService {
             files.push({
                 path: ContentAsCodeWritebackService.getContentFilePath(
                     repo.path,
+                    contentDir,
                     'dashboard',
                     slug,
                 ),
@@ -798,6 +817,7 @@ export class ContentAsCodeWritebackService extends BaseService {
                 projectUuid,
                 dashboardAsCode,
                 repo.path,
+                contentDir,
                 notes,
             );
             files.push(...ownedChartFiles);
@@ -944,6 +964,7 @@ export class ContentAsCodeWritebackService extends BaseService {
         projectUuid: string,
         dashboardAsCode: DashboardAsCode,
         repoPath: string,
+        contentPath: string,
         notes: string[],
     ): Promise<{ path: string; content: string }[]> {
         const chartSlugs = Array.from(
@@ -997,6 +1018,7 @@ export class ContentAsCodeWritebackService extends BaseService {
                         return {
                             path: ContentAsCodeWritebackService.getContentFilePath(
                                 repoPath,
+                                contentPath,
                                 'chart',
                                 chartSlug,
                             ),

--- a/packages/cli/src/handlers/contentAsCode/fileDiscovery.ts
+++ b/packages/cli/src/handlers/contentAsCode/fileDiscovery.ts
@@ -1,14 +1,14 @@
+import {
+    classifyContentAsCodeFilePath,
+    isSqlChartContent,
+    type ContentAsCodeFileClassification,
+    type ContentAsCodeFileType,
+} from '@lightdash/common';
 import * as path from 'path';
 
-export type ContentFileType = 'chart' | 'dashboard';
+export type ContentFileType = ContentAsCodeFileType;
 
-export type ContentFileClassification =
-    | {
-          kind: 'content';
-          contentType: ContentFileType;
-          supportedExtension: boolean;
-      }
-    | { kind: 'loose'; supportedExtension: boolean };
+export type ContentFileClassification = ContentAsCodeFileClassification;
 
 const isWithinRoot = (filePath: string, rootPath: string): boolean => {
     const relativePath = path.relative(rootPath, filePath);
@@ -25,30 +25,7 @@ export const classifyContentFilePath = (
     rootPath?: string,
 ): ContentFileClassification | undefined => {
     if (rootPath && !isWithinRoot(filePath, rootPath)) return undefined;
-
-    const supportedExtension = filePath.endsWith('.yml');
-    if (!supportedExtension && !filePath.endsWith('.yaml')) return undefined;
-
-    if (
-        filePath.endsWith('.space.yml') ||
-        filePath.endsWith('.language.map.yml')
-    ) {
-        return undefined;
-    }
-
-    const parentFolder = path.basename(path.dirname(filePath));
-    if (parentFolder === 'charts') {
-        return { kind: 'content', contentType: 'chart', supportedExtension };
-    }
-    if (parentFolder === 'dashboards') {
-        return {
-            kind: 'content',
-            contentType: 'dashboard',
-            supportedExtension,
-        };
-    }
-    return { kind: 'loose', supportedExtension };
+    return classifyContentAsCodeFilePath(filePath.split(path.sep).join('/'));
 };
 
-export const isSqlChartContent = (item: object): boolean =>
-    'sql' in item && !('tableName' in item);
+export { isSqlChartContent };

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -39,6 +39,7 @@ import {
     getErrorMessage,
     GoogleSheetsSyncAsCode,
     LightdashError,
+    normalizeContentAsCodePath,
     ParameterError,
     Project,
     PromotionAction,
@@ -48,9 +49,11 @@ import {
     SqlChartAsCode,
     validateDataAppDependencies,
     VirtualViewAsCode,
+    type ContentAsCodeSettingsStamp,
     type ContentAsCodeUploadAdvisory,
     type DashboardAsCodeUpsertResult,
     type DataAppCodeDownload,
+    type LightdashProjectConfig,
     type SpaceAsCode,
 } from '@lightdash/common';
 import { Dirent, promises as fs, type Stats } from 'fs';
@@ -3504,10 +3507,48 @@ const reportOpenDraftsForUpload = async (
     }
 };
 
+// null when the project dir has no lightdash.config.yml
+const readUploadProjectConfig =
+    async (): Promise<LightdashProjectConfig | null> => {
+        const configExists = await fs
+            .access(path.join(process.cwd(), 'lightdash.config.yml'))
+            .then(() => true)
+            .catch(() => false);
+        if (!configExists) return null;
+        try {
+            return await readAndLoadLightdashProjectConfig(process.cwd());
+        } catch (error) {
+            throw new LightdashError({
+                message: `Upload aborted: lightdash.config.yml exists but could not be read, so the repo's content_as_code settings cannot be honoured. Fix the config and retry. ${getErrorMessage(error)}`,
+                name: 'ParseError',
+                statusCode: 400,
+                data: {},
+            });
+        }
+    };
+
+// The stamped path is the uploaded directory relative to the project dir;
+// a directory outside it has no repo path to stamp
+const getStampedContentPath = (uploadRoot: string): string | undefined => {
+    const relative = path.relative(process.cwd(), uploadRoot);
+    if (
+        path.isAbsolute(relative) ||
+        relative === '..' ||
+        relative.startsWith(`..${path.sep}`)
+    ) {
+        return undefined;
+    }
+    return normalizeContentAsCodePath(relative.split(path.sep).join('/'));
+};
+
 export const uploadHandler = async (
     options: DownloadHandlerOptions,
 ): Promise<void> => {
     GlobalState.setVerbose(options.verbose);
+    const projectConfig = await readUploadProjectConfig();
+    // --path wins; otherwise content_as_code.path from lightdash.config.yml
+    const contentPathOption =
+        options.path ?? projectConfig?.content_as_code?.path;
 
     if (options.spacesOnly && options.skipSpaces) {
         throw new ParameterError(
@@ -3583,7 +3624,7 @@ export const uploadHandler = async (
     let preflightSpaceFiles: SpaceCodeFile[] = [];
     if (shouldReconcileSpaces) {
         try {
-            preflightSpaceFiles = await readSpaceFiles(options.path);
+            preflightSpaceFiles = await readSpaceFiles(contentPathOption);
         } catch (error) {
             throw createSpaceAsCodeUploadError(getErrorMessage(error));
         }
@@ -3602,7 +3643,7 @@ export const uploadHandler = async (
 
     if (isOrganizationUpload) {
         await uploadOrganizationContent({
-            customPath: options.path,
+            customPath: contentPathOption,
             config,
             sendInvites: options.sendInvites,
         });
@@ -3626,33 +3667,16 @@ export const uploadHandler = async (
     await reportOpenDraftsForUpload(projectId);
 
     // Persist repo-owned sync settings for the review/write-back workflow.
-    let syncEnabled: boolean | undefined;
-    const configExists = await fs
-        .access(path.join(process.cwd(), 'lightdash.config.yml'))
-        .then(() => true)
-        .catch(() => false);
-    if (configExists) {
-        try {
-            const projectConfig = await readAndLoadLightdashProjectConfig(
-                process.cwd(),
-                projectId,
-            );
-            syncEnabled = projectConfig.content_as_code?.sync === true;
-        } catch (error) {
-            throw new LightdashError({
-                message: `Upload aborted: lightdash.config.yml exists but could not be read, so the repo's content_as_code.sync opt-in cannot be honoured. Fix the config and retry. ${getErrorMessage(error)}`,
-                name: 'ParseError',
-                statusCode: 400,
-                data: {},
-            });
-        }
+    if (projectConfig) {
+        const stamp: ContentAsCodeSettingsStamp = {
+            sync: projectConfig.content_as_code?.sync === true,
+            path: getStampedContentPath(getDownloadFolder(contentPathOption)),
+        };
         try {
             await lightdashApi({
                 method: 'POST',
                 url: `/api/v1/projects/${projectId}/code/sync-settings`,
-                body: JSON.stringify({
-                    sync: syncEnabled,
-                }),
+                body: JSON.stringify(stamp),
             });
         } catch (error) {
             // Older servers don't have this endpoint; stamping is advisory.
@@ -3680,7 +3704,7 @@ export const uploadHandler = async (
         operation: 'upload',
         scope: 'project',
     });
-    const uploadRoot = getDownloadFolder(options.path);
+    const uploadRoot = getDownloadFolder(contentPathOption);
     const completeUpload = () => {
         const renderedSummary = output.complete(
             uploadRoot,
@@ -3706,7 +3730,7 @@ export const uploadHandler = async (
         const spaceFiles = preflightSpaceFiles;
         const spaceNames = shouldReconcileSpaces
             ? getSpaceNames(spaceFiles)
-            : await readSpaceNames(options.path);
+            : await readSpaceNames(contentPathOption);
         if (spaceFiles.length > 0) {
             logContentAsCodeDiscovery(
                 `Found ${spaceFiles.length} space definition(s)`,
@@ -3758,7 +3782,7 @@ export const uploadHandler = async (
         // Discover loose YAML files (outside charts/ and dashboards/) classified by contentType
         const looseFiles = await output.runItem({
             label: 'Content files',
-            action: () => readLooseCodeFiles(options.path),
+            action: () => readLooseCodeFiles(contentPathOption),
             detail: ({ charts, dashboards }) =>
                 `${charts.length + dashboards.length} discovered`,
         });
@@ -3793,7 +3817,7 @@ export const uploadHandler = async (
         const loadDashboardItems = () => {
             dashboardItemsPromise =
                 dashboardItemsPromise ??
-                readDashboardItems(options.path, looseFiles.dashboards);
+                readDashboardItems(contentPathOption, looseFiles.dashboards);
             return dashboardItemsPromise;
         };
 
@@ -3811,7 +3835,7 @@ export const uploadHandler = async (
                     chartItems: [
                         ...(await readCodeFiles<ChartAsCode>(
                             'charts',
-                            options.path,
+                            contentPathOption,
                         )),
                         ...looseFiles.charts,
                     ],
@@ -3847,7 +3871,7 @@ export const uploadHandler = async (
                             changes,
                             options.force,
                             uploadPermissions.virtualViews,
-                            options.path,
+                            contentPathOption,
                             virtualViewCandidates,
                         ),
                     onCount: (count) => {
@@ -3878,7 +3902,7 @@ export const uploadHandler = async (
                             changes,
                             options.force,
                             uploadPermissions.externalConnections,
-                            options.path,
+                            contentPathOption,
                         ),
                     onCount: (count) => {
                         counts.externalConnectionsNum = count;
@@ -4056,7 +4080,7 @@ export const uploadHandler = async (
                 );
             }
 
-            const baseDir = getDownloadFolder(options.path);
+            const baseDir = getDownloadFolder(contentPathOption);
             const appsDir = path.join(baseDir, phase.dirName);
 
             let appFolderEntries: import('fs').Dirent[];
@@ -4490,7 +4514,7 @@ export const uploadHandler = async (
                     options.force,
                     chartSlugs,
                     uploadPermissions.charts,
-                    options.path,
+                    contentPathOption,
                     options.skipSpaceCreate,
                     options.public,
                     options.validate,
@@ -4544,7 +4568,7 @@ export const uploadHandler = async (
                     options.force,
                     options.dashboards,
                     uploadPermissions.dashboards,
-                    options.path,
+                    contentPathOption,
                     options.skipSpaceCreate,
                     options.public,
                     options.validate,
@@ -4575,7 +4599,7 @@ export const uploadHandler = async (
                                 options.agents,
                                 changes,
                                 options.force,
-                                options.path,
+                                contentPathOption,
                                 options.agents.length === 0,
                             ),
                         onCount: (count) => {
@@ -4606,7 +4630,7 @@ export const uploadHandler = async (
                             options.force,
                             ContentAsCodeTypeEnum.ALERT,
                             uploadPermissions.alerts,
-                            options.path,
+                            contentPathOption,
                         ),
                     onCount: (count) => {
                         counts.alertsNum = count;
@@ -4635,7 +4659,7 @@ export const uploadHandler = async (
                             options.force,
                             ContentAsCodeTypeEnum.SCHEDULED_DELIVERY,
                             uploadPermissions.scheduledDeliveries,
-                            options.path,
+                            contentPathOption,
                         ),
                     onCount: (count) => {
                         counts.scheduledDeliveriesNum = count;
@@ -4664,7 +4688,7 @@ export const uploadHandler = async (
                             options.force,
                             ContentAsCodeTypeEnum.GOOGLE_SHEETS_SYNC,
                             uploadPermissions.googleSheets,
-                            options.path,
+                            contentPathOption,
                         ),
                     onCount: (count) => {
                         counts.googleSheetsNum = count;

--- a/packages/common/src/schemas/json/lightdash-project-config-1.0.json
+++ b/packages/common/src/schemas/json/lightdash-project-config-1.0.json
@@ -12,6 +12,11 @@
                     "type": "boolean",
                     "default": false,
                     "description": "When true, uploaded content is tracked as Git-backed for content review and write-back workflows."
+                },
+                "path": {
+                    "type": "string",
+                    "default": "lightdash",
+                    "description": "Directory that holds the charts/ and dashboards/ folders, relative to the dbt project directory. Write-back pull requests put content files under it."
                 }
             },
             "additionalProperties": false

--- a/packages/common/src/types/contentAsCode/base.test.ts
+++ b/packages/common/src/types/contentAsCode/base.test.ts
@@ -1,0 +1,100 @@
+import { ParameterError } from '../errors';
+import { getContentAsCodeFilePath, normalizeContentAsCodePath } from './base';
+import {
+    classifyContentAsCodeFilePath,
+    joinContentAsCodePath,
+} from './fileDiscovery';
+
+describe('normalizeContentAsCodePath', () => {
+    it('strips dot segments and surrounding slashes', () => {
+        expect(normalizeContentAsCodePath('lightdash')).toBe('lightdash');
+        expect(normalizeContentAsCodePath('./analytics/content/')).toBe(
+            'analytics/content',
+        );
+        expect(normalizeContentAsCodePath(' analytics//content ')).toBe(
+            'analytics/content',
+        );
+        expect(normalizeContentAsCodePath('analytics\\content')).toBe(
+            'analytics/content',
+        );
+    });
+
+    it('treats the project directory itself as an empty path', () => {
+        expect(normalizeContentAsCodePath('.')).toBe('');
+        expect(normalizeContentAsCodePath('')).toBe('');
+    });
+
+    it('rejects absolute paths and parent traversal', () => {
+        expect(() => normalizeContentAsCodePath('/srv/lightdash')).toThrow(
+            ParameterError,
+        );
+        expect(() => normalizeContentAsCodePath('../shared')).toThrow(
+            ParameterError,
+        );
+        expect(() => normalizeContentAsCodePath('a/../../b')).toThrow(
+            ParameterError,
+        );
+    });
+});
+
+describe('classifyContentAsCodeFilePath', () => {
+    it('classifies by parent folder at any depth and skips space and language files', () => {
+        expect(classifyContentAsCodeFilePath('lightdash/charts/a.yml')).toEqual(
+            { kind: 'content', contentType: 'chart', supportedExtension: true },
+        );
+        expect(
+            classifyContentAsCodeFilePath(
+                'lightdash/proj/space/dashboards/b.yml',
+            ),
+        ).toEqual({
+            kind: 'content',
+            contentType: 'dashboard',
+            supportedExtension: true,
+        });
+        expect(classifyContentAsCodeFilePath('lightdash/kpis.yml')).toEqual({
+            kind: 'loose',
+            supportedExtension: true,
+        });
+        expect(
+            classifyContentAsCodeFilePath('lightdash/charts/a.yaml'),
+        ).toEqual({
+            kind: 'content',
+            contentType: 'chart',
+            supportedExtension: false,
+        });
+        expect(
+            classifyContentAsCodeFilePath('lightdash/sales.space.yml'),
+        ).toBeUndefined();
+        expect(
+            classifyContentAsCodeFilePath('lightdash/fr.language.map.yml'),
+        ).toBeUndefined();
+        expect(classifyContentAsCodeFilePath('README.md')).toBeUndefined();
+    });
+});
+
+describe('joinContentAsCodePath', () => {
+    it('drops empty segments and stray slashes', () => {
+        expect(joinContentAsCodePath('/', 'lightdash', 'charts/')).toBe(
+            'lightdash/charts',
+        );
+        expect(joinContentAsCodePath('', '', 'a.yml')).toBe('a.yml');
+        expect(joinContentAsCodePath()).toBe('');
+    });
+});
+
+describe('getContentAsCodeFilePath', () => {
+    it('places charts and dashboards under their type folder', () => {
+        expect(getContentAsCodeFilePath('lightdash', 'chart', 'revenue')).toBe(
+            'lightdash/charts/revenue.yml',
+        );
+        expect(
+            getContentAsCodeFilePath('analytics/content', 'dashboard', 'kpis'),
+        ).toBe('analytics/content/dashboards/kpis.yml');
+    });
+
+    it('keeps files at the project root for an empty path', () => {
+        expect(getContentAsCodeFilePath('', 'chart', 'revenue')).toBe(
+            'charts/revenue.yml',
+        );
+    });
+});

--- a/packages/common/src/types/contentAsCode/base.ts
+++ b/packages/common/src/types/contentAsCode/base.ts
@@ -1,4 +1,36 @@
+import { ParameterError } from '../errors';
 import type { PromotionAction } from '../promotion';
+import { joinContentAsCodePath } from './fileDiscovery';
+
+export const DEFAULT_CONTENT_AS_CODE_PATH = 'lightdash';
+
+// Repo directory for charts/ and dashboards/, relative to the project dir; '' is the project dir itself
+export const normalizeContentAsCodePath = (raw: string): string => {
+    const value = raw.trim().replace(/\\/g, '/');
+    if (value.startsWith('/')) {
+        throw new ParameterError(
+            'content_as_code.path must be relative to the project directory',
+        );
+    }
+    const segments = value
+        .split('/')
+        .filter((segment) => segment !== '' && segment !== '.');
+    if (segments.includes('..')) {
+        throw new ParameterError(
+            'content_as_code.path cannot point outside the project directory',
+        );
+    }
+    return segments.join('/');
+};
+
+export const getContentAsCodeFilePath = (
+    contentPath: string,
+    contentType: 'chart' | 'dashboard',
+    slug: string,
+): string => {
+    const folder = contentType === 'chart' ? 'charts' : 'dashboards';
+    return joinContentAsCodePath(contentPath, folder, `${slug}.yml`);
+};
 
 export const CONTENT_AS_CODE_VERSION = 1 as const;
 
@@ -100,7 +132,14 @@ export type ApiContentAsCodeProposeResponse = {
 
 export type ContentAsCodeProjectSettings = {
     syncEnabled: boolean;
+    path: string;
     stampedAt: Date;
+};
+
+// What an upload or pull stamps; path absent means the client predates it
+export type ContentAsCodeSettingsStamp = {
+    sync: boolean;
+    path?: string;
 };
 
 export type ApiContentAsCodeSettingsResponse = {
@@ -133,6 +172,7 @@ export type ContentDraftSummary = {
 
 export type ContentDraftReview = {
     summary: ContentDraftSummary;
+    filePath: string;
     publishedYaml: string;
     draftYaml: string;
 };

--- a/packages/common/src/types/contentAsCode/fileDiscovery.ts
+++ b/packages/common/src/types/contentAsCode/fileDiscovery.ts
@@ -1,0 +1,48 @@
+export type ContentAsCodeFileType = 'chart' | 'dashboard';
+
+export type ContentAsCodeFileClassification =
+    | {
+          kind: 'content';
+          contentType: ContentAsCodeFileType;
+          supportedExtension: boolean;
+      }
+    | { kind: 'loose'; supportedExtension: boolean };
+
+// Joins repo path segments, dropping empty ones and stray slashes
+export const joinContentAsCodePath = (...segments: string[]): string =>
+    segments
+        .map((segment) => segment.replace(/^\/+|\/+$/g, ''))
+        .filter((segment) => segment !== '')
+        .join('/');
+
+// Same rules as `lightdash upload`: YAML under a charts/ or dashboards/
+// folder is that content type, other YAML is classified by its contentType
+export const classifyContentAsCodeFilePath = (
+    posixPath: string,
+): ContentAsCodeFileClassification | undefined => {
+    const supportedExtension = posixPath.endsWith('.yml');
+    if (!supportedExtension && !posixPath.endsWith('.yaml')) return undefined;
+    if (
+        posixPath.endsWith('.space.yml') ||
+        posixPath.endsWith('.language.map.yml')
+    ) {
+        return undefined;
+    }
+    const segments = posixPath.split('/');
+    const parentFolder =
+        segments.length > 1 ? segments[segments.length - 2] : '';
+    if (parentFolder === 'charts') {
+        return { kind: 'content', contentType: 'chart', supportedExtension };
+    }
+    if (parentFolder === 'dashboards') {
+        return {
+            kind: 'content',
+            contentType: 'dashboard',
+            supportedExtension,
+        };
+    }
+    return { kind: 'loose', supportedExtension };
+};
+
+export const isSqlChartContent = (item: object): boolean =>
+    'sql' in item && !('tableName' in item);

--- a/packages/common/src/types/contentAsCode/index.ts
+++ b/packages/common/src/types/contentAsCode/index.ts
@@ -2,6 +2,7 @@ export * from './base';
 export * from './charts';
 export * from './core';
 export * from './dashboards';
+export * from './fileDiscovery';
 export * from './parsers';
 export * from './scheduledContent';
 export * from './spaces';

--- a/packages/common/src/types/lightdashProjectConfig.ts
+++ b/packages/common/src/types/lightdashProjectConfig.ts
@@ -104,6 +104,8 @@ export type CustomGranularity = {
 export type ContentAsCodeConfig = {
     /** Track uploaded content as Git-backed for review/write-back workflows. */
     sync?: boolean;
+    /** Directory holding charts/ and dashboards/, relative to the project dir. Defaults to `lightdash`. */
+    path?: string;
 };
 
 export type LightdashProjectConfig = {

--- a/packages/common/src/utils/loadLightdashProjectConfig.test.ts
+++ b/packages/common/src/utils/loadLightdashProjectConfig.test.ts
@@ -33,6 +33,18 @@ describe('loadLightdashProjectConfig', () => {
         });
     });
 
+    it('should load content_as_code sync and path', async () => {
+        const config = await loadLightdashProjectConfig(`
+content_as_code:
+  sync: true
+  path: analytics/content
+`);
+        expect(config.content_as_code).toEqual({
+            sync: true,
+            path: 'analytics/content',
+        });
+    });
+
     it('should load a valid config with parameters', async () => {
         const config = await loadLightdashProjectConfig(
             validConfigWithParameters,

--- a/packages/frontend/src/features/contentAsCode/components/ContentReviewPage.tsx
+++ b/packages/frontend/src/features/contentAsCode/components/ContentReviewPage.tsx
@@ -464,19 +464,11 @@ const ContentReviewPage: FC<ContentReviewPageProps> = ({ projectUuid }) => {
                                 >
                                     <MultiFileDiff
                                         oldFile={{
-                                            name: `lightdash/${
-                                                active.contentType === 'chart'
-                                                    ? 'charts'
-                                                    : 'dashboards'
-                                            }/${active.slug}.yml`,
+                                            name: review.filePath,
                                             contents: review.publishedYaml,
                                         }}
                                         newFile={{
-                                            name: `lightdash/${
-                                                active.contentType === 'chart'
-                                                    ? 'charts'
-                                                    : 'dashboards'
-                                            }/${active.slug}.yml`,
+                                            name: review.filePath,
                                             contents: review.draftYaml,
                                         }}
                                         style={{ colorScheme }}


### PR DESCRIPTION
Closes PROD-10626

## Why

Customers do not always keep content-as-code under a top-level `lightdash/` folder. The CLI already accepts `--path` on `download` and `upload`, but write-back hardcoded `lightdash/{charts,dashboards}/{slug}.yml`, so every draft or propose PR landed in a folder the customer's upload never reads.

## What

- `content_as_code.path` in `lightdash.config.yml` (schema + type), relative to the dbt project directory, default `lightdash`.
- `lightdash upload` reads it: `--path` now defaults to `content_as_code.path`, and the stamp sent to `POST /code/sync-settings` is the directory the upload actually read, relative to the project dir (an upload from outside the project dir leaves the stored path untouched). The backend normalises the value (`./`, trailing slashes, backslashes) and rejects absolute paths and `..`.
- New `content_path` column on `content_as_code_project_settings`, defaulted to `lightdash`; an older CLI that omits `path` leaves the stored value untouched.
- Write-back (propose, draft write-back, dashboard-owned tile charts) resolves file paths through the stamped path.
- The review diff header shows the real file path (`filePath` added to the draft review payload).

## Regression analysis

- Existing projects: the column defaults to `lightdash` and the CLI sends `lightdash` when the key is absent, so file paths are byte-identical to before.
- API: `POST /code/sync-settings` gains an optional `path`; `GET /code/sync-settings` and `GET /code/drafts/{uuid}/review` gain fields. Additive only.
- Migration adds a defaulted column to a small table under a 5s lock timeout.

## Verified

- Unit: path normalisation and file-path helpers, config loading, write-back paths and review `filePath` under a custom path.
- Live on a GitHub-backed project: stamp round trip (custom path, traversal rejected with 400, old-client omission keeps the stored path), review `filePath`, a propose commit landing at `analytics/content/charts/<slug>.yml` on the write-back branch, and `lightdash upload` with a config path and no `--path` reading and stamping `analytics/content`, `--path lightdash` overriding and stamping `lightdash`, and `--path ../elsewhere` leaving the stamp alone.

- Shared helpers in `@lightdash/common` (`joinContentAsCodePath`, `classifyContentAsCodeFilePath`, `isSqlChartContent`): the CLI's file discovery now delegates to them so the server can classify repo files by the same rules.
- One `ContentAsCodeProjectSettings` / `ContentAsCodeSettingsStamp` type in common, used by the model, service, controller, and CLI.

## Not in this PR

`lightdash download` still uses `./lightdash` unless `--path` is given.
