### PR TITLE
fix(mcp): match query guidance to the tools available in each session

### DIFF
--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -3082,109 +3082,118 @@ export class McpService extends BaseService {
             );
         }
 
-        registerAppTool(
-            this.mcpServer,
-            mcpRenderChartTool.name,
-            {
-                title: mcpRenderChartTool.title,
-                description: mcpRenderChartTool.description,
-                inputSchema: mcpRenderChartTool.inputSchema.shape,
-                outputSchema: mcpRenderChartTool.outputSchema,
-                annotations: mcpRenderChartTool.annotations,
-                _meta: { ui: { resourceUri: chartResourceUri } },
-            },
-            this.wrapToolCallback(
+        // render_chart only renders metric queries, so it follows the same gate.
+        if (options.runMetricQueryEnabled) {
+            registerAppTool(
+                this.mcpServer,
                 mcpRenderChartTool.name,
-                async (args, extra) => {
-                    const ctx = getMcpContext(extra);
+                {
+                    title: mcpRenderChartTool.title,
+                    description: mcpRenderChartTool.description,
+                    inputSchema: mcpRenderChartTool.inputSchema.shape,
+                    outputSchema: mcpRenderChartTool.outputSchema,
+                    annotations: mcpRenderChartTool.annotations,
+                    _meta: { ui: { resourceUri: chartResourceUri } },
+                },
+                this.wrapToolCallback(
+                    mcpRenderChartTool.name,
+                    async (args, extra) => {
+                        const ctx = getMcpContext(extra);
 
-                    const projectUuid = await this.resolveToolProjectUuid(
-                        ctx,
-                        args.projectUuid,
-                    );
-                    const argsWithProject = { ...args, projectUuid };
+                        const projectUuid = await this.resolveToolProjectUuid(
+                            ctx,
+                            args.projectUuid,
+                        );
+                        const argsWithProject = { ...args, projectUuid };
 
-                    try {
-                        const { user, account } = McpService.getAccount(ctx);
-                        const renderTool =
-                            toolRenderChartArgsSchemaTransformed.parse(
-                                argsWithProject,
-                            );
+                        try {
+                            const { user, account } =
+                                McpService.getAccount(ctx);
+                            const renderTool =
+                                toolRenderChartArgsSchemaTransformed.parse(
+                                    argsWithProject,
+                                );
 
-                        const queryHistory =
-                            await this.asyncQueryService.getAsyncQueryHistory({
-                                account,
+                            const queryHistory =
+                                await this.asyncQueryService.getAsyncQueryHistory(
+                                    {
+                                        account,
+                                        projectUuid,
+                                        queryUuid: renderTool.queryUuid,
+                                    },
+                                );
+
+                            if (
+                                queryHistory.context !==
+                                QueryExecutionContext.MCP_RUN_METRIC_QUERY
+                            ) {
+                                throw new ParameterError(
+                                    'render_chart currently supports queries started by run_metric_query',
+                                );
+                            }
+
+                            if (
+                                queryHistory.status !== QueryHistoryStatus.READY
+                            ) {
+                                throw new UnexpectedServerError(
+                                    queryHistory.error ??
+                                        `Query is not ready to render; current status is ${queryHistory.status}`,
+                                );
+                            }
+
+                            await this.assertMetricQueryInEffectiveScope({
+                                ctx,
+                                user,
                                 projectUuid,
-                                queryUuid: renderTool.queryUuid,
+                                agentUuid: args.agentUuid,
+                                metricQuery: queryHistory.metricQuery,
                             });
 
-                        if (
-                            queryHistory.context !==
-                            QueryExecutionContext.MCP_RUN_METRIC_QUERY
-                        ) {
-                            throw new ParameterError(
-                                'render_chart currently supports queries started by run_metric_query',
+                            const queryTool =
+                                McpService.buildRenderChartQueryTool({
+                                    renderTool,
+                                    metricQuery: queryHistory.metricQuery,
+                                });
+
+                            const results =
+                                await this.asyncQueryService.getRawAsyncQueryResults(
+                                    {
+                                        account,
+                                        projectUuid,
+                                        queryUuid: renderTool.queryUuid,
+                                    },
+                                );
+
+                            return await this.buildRenderChartResponse({
+                                ctx,
+                                queryUuid: renderTool.queryUuid,
+                                projectUuid,
+                                agentUuid: args.agentUuid,
+                                queryTool,
+                                query: queryHistory.metricQuery,
+                                rows: results.rows,
+                                fields: results.fields,
+                            });
+                        } catch (e) {
+                            const errorMessage =
+                                e instanceof Error ? e.message : String(e);
+                            this.logger.error(
+                                `[McpService] Error in render_chart tool: ${errorMessage}`,
                             );
+                            return {
+                                content: [
+                                    {
+                                        type: 'text' as const,
+                                        text: `Error rendering chart: ${errorMessage}`,
+                                    },
+                                ],
+                                isError: true,
+                            };
                         }
-
-                        if (queryHistory.status !== QueryHistoryStatus.READY) {
-                            throw new UnexpectedServerError(
-                                queryHistory.error ??
-                                    `Query is not ready to render; current status is ${queryHistory.status}`,
-                            );
-                        }
-
-                        await this.assertMetricQueryInEffectiveScope({
-                            ctx,
-                            user,
-                            projectUuid,
-                            agentUuid: args.agentUuid,
-                            metricQuery: queryHistory.metricQuery,
-                        });
-
-                        const queryTool = McpService.buildRenderChartQueryTool({
-                            renderTool,
-                            metricQuery: queryHistory.metricQuery,
-                        });
-
-                        const results =
-                            await this.asyncQueryService.getRawAsyncQueryResults(
-                                {
-                                    account,
-                                    projectUuid,
-                                    queryUuid: renderTool.queryUuid,
-                                },
-                            );
-
-                        return await this.buildRenderChartResponse({
-                            ctx,
-                            queryUuid: renderTool.queryUuid,
-                            projectUuid,
-                            agentUuid: args.agentUuid,
-                            queryTool,
-                            query: queryHistory.metricQuery,
-                            rows: results.rows,
-                            fields: results.fields,
-                        });
-                    } catch (e) {
-                        const errorMessage =
-                            e instanceof Error ? e.message : String(e);
-                        this.logger.error(
-                            `[McpService] Error in render_chart tool: ${errorMessage}`,
-                        );
-                        return {
-                            content: [
-                                {
-                                    type: 'text' as const,
-                                    text: `Error rendering chart: ${errorMessage}`,
-                                },
-                            ],
-                            isError: true,
-                        };
-                    }
-                },
-            ),
-        );
+                    },
+                ),
+            );
+        }
 
         if (options.runMetricQueryEnabled) {
             const searchFieldValuesToolView = options.filterExpressionsEnabled
@@ -3359,173 +3368,184 @@ export class McpService extends BaseService {
             );
         }
 
-        this.registerTrackedTool(
-            mcpGetQueryResultTool.name,
-            {
-                title: mcpGetQueryResultTool.title,
-                description: mcpGetQueryResultTool.description,
-                inputSchema: mcpGetQueryResultTool.inputSchema.shape,
-                outputSchema: mcpGetQueryResultTool.outputSchema,
-                annotations: mcpGetQueryResultTool.annotations,
-            },
-            async (args, extra) => {
-                const ctx = getMcpContext(extra);
+        // get_query_result only polls queries started by the execution tools.
+        if (options.runSqlEnabled || options.runMetricQueryEnabled) {
+            this.registerTrackedTool(
+                mcpGetQueryResultTool.name,
+                {
+                    title: mcpGetQueryResultTool.title,
+                    description: mcpGetQueryResultTool.description,
+                    inputSchema: mcpGetQueryResultTool.inputSchema.shape,
+                    outputSchema: mcpGetQueryResultTool.outputSchema,
+                    annotations: mcpGetQueryResultTool.annotations,
+                },
+                async (args, extra) => {
+                    const ctx = getMcpContext(extra);
 
-                const { user, account } = McpService.getAccount(ctx);
-                const projectUuid = await this.resolveToolProjectUuid(
-                    ctx,
-                    args.projectUuid,
-                );
+                    const { user, account } = McpService.getAccount(ctx);
+                    const projectUuid = await this.resolveToolProjectUuid(
+                        ctx,
+                        args.projectUuid,
+                    );
 
-                try {
-                    let queryHistory =
-                        await this.asyncQueryService.getAsyncQueryHistory({
-                            account,
-                            projectUuid,
-                            queryUuid: args.queryUuid,
-                        });
-                    const isMcpSqlQuery =
-                        queryHistory.context ===
-                        QueryExecutionContext.MCP_RUN_SQL;
-                    const isMcpMetricQuery =
-                        queryHistory.context ===
-                        QueryExecutionContext.MCP_RUN_METRIC_QUERY;
+                    try {
+                        let queryHistory =
+                            await this.asyncQueryService.getAsyncQueryHistory({
+                                account,
+                                projectUuid,
+                                queryUuid: args.queryUuid,
+                            });
+                        const isMcpSqlQuery =
+                            queryHistory.context ===
+                            QueryExecutionContext.MCP_RUN_SQL;
+                        const isMcpMetricQuery =
+                            queryHistory.context ===
+                            QueryExecutionContext.MCP_RUN_METRIC_QUERY;
 
-                    if (!isMcpSqlQuery && !isMcpMetricQuery) {
-                        throw new ParameterError(
-                            'Query was not started by an MCP query tool',
-                        );
-                    }
-
-                    if (McpService.isQueryRunningStatus(queryHistory.status)) {
-                        queryHistory =
-                            await this.asyncQueryService.pollQueryHistoryUntilDeadline(
-                                {
-                                    account,
-                                    projectUuid,
-                                    queryUuid: args.queryUuid,
-                                    deadlineMs:
-                                        Date.now() +
-                                        McpService.getMcpQueryWaitMs(extra),
-                                    pollIntervalMs: MCP_QUERY_POLL_INTERVAL_MS,
-                                    signal: extra.signal,
-                                },
+                        if (!isMcpSqlQuery && !isMcpMetricQuery) {
+                            throw new ParameterError(
+                                'Query was not started by an MCP query tool',
                             );
+                        }
 
                         if (
                             McpService.isQueryRunningStatus(queryHistory.status)
                         ) {
-                            return McpService.getRunningQueryResponse(
-                                args.queryUuid,
+                            queryHistory =
+                                await this.asyncQueryService.pollQueryHistoryUntilDeadline(
+                                    {
+                                        account,
+                                        projectUuid,
+                                        queryUuid: args.queryUuid,
+                                        deadlineMs:
+                                            Date.now() +
+                                            McpService.getMcpQueryWaitMs(extra),
+                                        pollIntervalMs:
+                                            MCP_QUERY_POLL_INTERVAL_MS,
+                                        signal: extra.signal,
+                                    },
+                                );
+
+                            if (
+                                McpService.isQueryRunningStatus(
+                                    queryHistory.status,
+                                )
+                            ) {
+                                return McpService.getRunningQueryResponse(
+                                    args.queryUuid,
+                                );
+                            }
+                        }
+
+                        if (
+                            queryHistory.status === QueryHistoryStatus.ERROR ||
+                            queryHistory.status ===
+                                QueryHistoryStatus.CANCELLED ||
+                            queryHistory.status === QueryHistoryStatus.EXPIRED
+                        ) {
+                            return await this.buildScopedResponse(
+                                ctx,
+                                queryHistory.error ??
+                                    `Query ${queryHistory.status}`,
+                                {
+                                    result: {
+                                        status: McpService.getPollingStatus(
+                                            queryHistory.status,
+                                        ),
+                                        queryUuid: args.queryUuid,
+                                        error: queryHistory.error ?? null,
+                                    },
+                                },
+                                projectUuid,
+                                args.agentUuid,
                             );
                         }
-                    }
 
-                    if (
-                        queryHistory.status === QueryHistoryStatus.ERROR ||
-                        queryHistory.status === QueryHistoryStatus.CANCELLED ||
-                        queryHistory.status === QueryHistoryStatus.EXPIRED
-                    ) {
-                        return await this.buildScopedResponse(
-                            ctx,
-                            queryHistory.error ??
-                                `Query ${queryHistory.status}`,
-                            {
-                                result: {
-                                    status: McpService.getPollingStatus(
-                                        queryHistory.status,
-                                    ),
-                                    queryUuid: args.queryUuid,
-                                    error: queryHistory.error ?? null,
-                                },
-                            },
-                            projectUuid,
-                            args.agentUuid,
-                        );
-                    }
-
-                    if (isMcpSqlQuery) {
-                        const { requestParameters } = queryHistory;
-                        const sqlRequestParameters =
-                            requestParameters && 'sql' in requestParameters
-                                ? requestParameters
+                        if (isMcpSqlQuery) {
+                            const { requestParameters } = queryHistory;
+                            const sqlRequestParameters =
+                                requestParameters && 'sql' in requestParameters
+                                    ? requestParameters
+                                    : null;
+                            const sqlRunnerUrl = sqlRequestParameters
+                                ? await this.buildSqlRunnerUrl({
+                                      ctx,
+                                      projectUuid,
+                                      sql: sqlRequestParameters.sql,
+                                      limit: sqlRequestParameters.limit,
+                                  })
                                 : null;
-                        const sqlRunnerUrl = sqlRequestParameters
-                            ? await this.buildSqlRunnerUrl({
-                                  ctx,
-                                  projectUuid,
-                                  sql: sqlRequestParameters.sql,
-                                  limit: sqlRequestParameters.limit,
-                              })
-                            : null;
 
-                        return await this.buildSqlQueryResultResponse({
-                            ctx,
-                            queryUuid: args.queryUuid,
-                            projectUuid,
-                            agentUuid: args.agentUuid,
-                            pageSize: sqlRequestParameters?.limit,
-                            includeStatus: true,
-                            sqlRunnerUrl,
-                        });
-                    }
+                            return await this.buildSqlQueryResultResponse({
+                                ctx,
+                                queryUuid: args.queryUuid,
+                                projectUuid,
+                                agentUuid: args.agentUuid,
+                                pageSize: sqlRequestParameters?.limit,
+                                includeStatus: true,
+                                sqlRunnerUrl,
+                            });
+                        }
 
-                    if (isMcpMetricQuery) {
-                        await this.assertMetricQueryInEffectiveScope({
-                            ctx,
-                            user,
-                            projectUuid,
-                            agentUuid: args.agentUuid,
-                            metricQuery: queryHistory.metricQuery,
-                        });
+                        if (isMcpMetricQuery) {
+                            await this.assertMetricQueryInEffectiveScope({
+                                ctx,
+                                user,
+                                projectUuid,
+                                agentUuid: args.agentUuid,
+                                metricQuery: queryHistory.metricQuery,
+                            });
 
-                        const results =
-                            await this.asyncQueryService.getRawAsyncQueryResults(
+                            const results =
+                                await this.asyncQueryService.getRawAsyncQueryResults(
+                                    {
+                                        account,
+                                        projectUuid,
+                                        queryUuid: args.queryUuid,
+                                    },
+                                );
+                            const exploreUrl = await this.buildMetricExploreUrl(
                                 {
-                                    account,
+                                    ctx,
                                     projectUuid,
-                                    queryUuid: args.queryUuid,
+                                    metricQuery: queryHistory.metricQuery,
+                                    fieldsMap: results.fields,
+                                    columnOrder: results.rows[0]
+                                        ? Object.keys(results.rows[0])
+                                        : Object.keys(results.fields),
                                 },
                             );
-                        const exploreUrl = await this.buildMetricExploreUrl({
-                            ctx,
-                            projectUuid,
-                            metricQuery: queryHistory.metricQuery,
-                            fieldsMap: results.fields,
-                            columnOrder: results.rows[0]
-                                ? Object.keys(results.rows[0])
-                                : Object.keys(results.fields),
-                        });
 
-                        return McpService.buildMetricQueryPollResult({
-                            queryUuid: args.queryUuid,
-                            rows: results.rows,
-                            fields: results.fields,
-                            exploreUrl,
-                        });
+                            return McpService.buildMetricQueryPollResult({
+                                queryUuid: args.queryUuid,
+                                rows: results.rows,
+                                fields: results.fields,
+                                exploreUrl,
+                            });
+                        }
+
+                        throw new ParameterError(
+                            'Query was not started by an MCP query tool',
+                        );
+                    } catch (e) {
+                        const errorMessage =
+                            e instanceof Error ? e.message : String(e);
+                        this.logger.error(
+                            `[McpService] Error in get_query_result tool: ${errorMessage}`,
+                        );
+                        return {
+                            content: [
+                                {
+                                    type: 'text' as const,
+                                    text: `Error getting query result: ${errorMessage}`,
+                                },
+                            ],
+                            isError: true,
+                        };
                     }
-
-                    throw new ParameterError(
-                        'Query was not started by an MCP query tool',
-                    );
-                } catch (e) {
-                    const errorMessage =
-                        e instanceof Error ? e.message : String(e);
-                    this.logger.error(
-                        `[McpService] Error in get_query_result tool: ${errorMessage}`,
-                    );
-                    return {
-                        content: [
-                            {
-                                type: 'text' as const,
-                                text: `Error getting query result: ${errorMessage}`,
-                            },
-                        ],
-                        isError: true,
-                    };
-                }
-            },
-        );
+                },
+            );
+        }
 
         this.registerTrackedTool(
             mcpListVerifiedContentTool.name,
@@ -3616,6 +3636,7 @@ export class McpService extends BaseService {
             async () => {
                 const promptText = getMcpAnalystPrompt({
                     runSqlEnabled: options.runSqlEnabled,
+                    runMetricQueryEnabled: options.runMetricQueryEnabled,
                 });
 
                 return {

--- a/packages/backend/src/ee/services/McpService/mcpToolContracts.snapshot.test.ts
+++ b/packages/backend/src/ee/services/McpService/mcpToolContracts.snapshot.test.ts
@@ -260,8 +260,27 @@ describe('MCP tool contracts', () => {
         expect(registeredNames).not.toContain(McpToolName.GET_METADATA);
         expect(registeredNames).not.toContain(McpToolName.SEARCH_FIELD_VALUES);
         expect(registeredNames).not.toContain(McpToolName.RUN_METRIC_QUERY);
+        expect(registeredNames).not.toContain(McpToolName.RENDER_CHART);
+        expect(registeredNames).not.toContain(McpToolName.GET_QUERY_RESULT);
         expect(registeredNames).toContain(McpToolName.FIND_CONTENT);
         expect(registeredNames).toContain(McpToolName.LIST_CONTENT);
+    });
+
+    it('registers only SQL execution tools when metric queries are disabled', async () => {
+        const mcpService = makeMcpService();
+
+        mockRegisteredMcpTools.length = 0;
+        await mcpService.createServer({
+            aiWritebackEnabled: true,
+            runSqlEnabled: true,
+            runMetricQueryEnabled: false,
+        });
+
+        const registeredNames = mockRegisteredMcpTools.map(({ name }) => name);
+        expect(registeredNames).toContain(McpToolName.RUN_SQL);
+        expect(registeredNames).toContain(McpToolName.GET_QUERY_RESULT);
+        expect(registeredNames).not.toContain(McpToolName.RENDER_CHART);
+        expect(registeredNames).not.toContain(McpToolName.RUN_METRIC_QUERY);
     });
 
     it('matches the filter-expression run_metric_query tools/list snapshot', async () => {

--- a/packages/backend/src/ee/services/ai/prompts/mcpAnalyst.test.ts
+++ b/packages/backend/src/ee/services/ai/prompts/mcpAnalyst.test.ts
@@ -32,4 +32,19 @@ describe('getMcpAnalystPrompt', () => {
         expect(prompt).not.toContain('run_metric_query');
         expect(prompt).not.toContain('run_sql');
     });
+
+    it('returns SQL runner mode when only run_sql is available', () => {
+        const prompt = getMcpAnalystPrompt({
+            runSqlEnabled: true,
+            runMetricQueryEnabled: false,
+        });
+
+        expect(prompt).toContain('SQL Runner Mode');
+        expect(prompt).toContain('not available in this session');
+        expect(prompt).toContain('run_sql');
+        expect(prompt).not.toContain('grep_fields');
+        expect(prompt).not.toContain('get_metadata');
+        expect(prompt).not.toContain('search_field_values');
+        expect(prompt).not.toContain('render_chart');
+    });
 });

--- a/packages/backend/src/ee/services/ai/prompts/mcpAnalyst.ts
+++ b/packages/backend/src/ee/services/ai/prompts/mcpAnalyst.ts
@@ -28,6 +28,26 @@ Rules:
 - Page parameters are numbers — never \`NaN\` or \`"null"\`
 `;
 
+const SQL_ONLY_PROMPT = `# Lightdash MCP — SQL Runner Mode
+
+Governed metric execution (\`run_metric_query\`) is not available in this session, so the semantic layer cannot answer questions here. \`run_sql\` is the only way to execute queries.
+
+## Query Workflow
+
+0. **Get started with context**: Call \`get_context\` first, select the relevant project, and pass its \`projectUuid\` to every project-scoped tool
+1. **Confirm the schema**: Semantic-layer discovery tools are not available in this session. If the user's request does not include the warehouse tables and columns you need, ask for the missing identifiers — never guess or invent them
+2. **Run queries**: Call \`run_sql\` with the raw SQL
+   - Defaults to 500 rows (max 5000) — use the \`limit\` parameter to control result size
+   - Use the SQL dialect appropriate for the connected warehouse
+3. **Poll long-running queries**: If a query returns \`status: "running"\`, call \`get_query_result\` with the \`queryUuid\` until it returns done/error/cancelled/expired
+4. **Browse content**: Use \`list_content\` to browse accessible spaces and \`find_content\` to search dashboards, charts, and Data Apps — \`read_content\` returns definitions and links, not data values
+
+## Rules
+
+- When an answer depends on governed metric definitions, prefer linking the user to existing saved content over re-deriving the metric in SQL
+- Page parameters are numbers — never \`NaN\` or \`"null"\`
+`;
+
 const buildMcpAnalystPrompt = (
     runSqlEnabled: boolean,
 ): string => `# Lightdash MCP Tools — Usage Guidelines
@@ -100,6 +120,9 @@ export const getMcpAnalystPrompt = (args?: {
     const runMetricQueryEnabled = args?.runMetricQueryEnabled ?? true;
     if (!runSqlEnabled && !runMetricQueryEnabled) {
         return CONTENT_ONLY_PROMPT;
+    }
+    if (!runMetricQueryEnabled) {
+        return SQL_ONLY_PROMPT;
     }
     return buildMcpAnalystPrompt(runSqlEnabled);
 };


### PR DESCRIPTION
Permission-gated MCP sessions could receive query guidance referencing tools absent from their catalogue: a SQL-only caller was still walked through the semantic-layer workflow, and sessions without any query execution kept polling and rendering tools with nothing to operate on. This made clients loop on unavailable tools and misreport why a query path failed.

Closes: #27798