### PR TITLE
feat(ai): render data app build summaries as markdown and truncate them

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/DataAppBuildCard.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/DataAppBuildCard.module.css
@@ -73,6 +73,41 @@
     padding-left: calc(var(--card-icon-size) + var(--mantine-spacing-xs));
 }
 
+.summary {
+    --ai-markdown-padding-left: 0;
+    --ai-markdown-font-size: 12px;
+    --summary-line-height: 1.55;
+    --summary-collapsed-lines: 6;
+    width: 100%;
+}
+
+/* Clamped to whole lines so the cut lands between them, not through one;
+   the last line fades out to show there's more behind "See more". */
+.summaryClamped {
+    max-height: calc(
+        var(--summary-collapsed-lines) * var(--summary-line-height) *
+            var(--ai-markdown-font-size)
+    );
+    overflow: hidden;
+    mask-image: linear-gradient(
+        to bottom,
+        black calc(100% - 18px),
+        transparent
+    );
+}
+
+.summaryToggle {
+    font-size: 12px;
+    font-weight: 500;
+    line-height: 1.55;
+    color: var(--mantine-color-ldGray-6);
+}
+
+.summaryToggle:hover {
+    color: var(--mantine-color-ldGray-9);
+    text-decoration: underline;
+}
+
 .actions {
     grid-column: 2;
     justify-self: end;

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/DataAppBuildCard.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/DataAppBuildCard.test.tsx
@@ -1,10 +1,20 @@
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '../../../../../../testing/testUtils';
 import { DataAppBuildCard } from './DataAppBuildCard';
 
 const noop = () => undefined;
+
+/** jsdom lays nothing out, so overflow has to be faked to test the clamp. */
+const mockSummaryOverflow = () => {
+    vi.spyOn(HTMLElement.prototype, 'scrollHeight', 'get').mockReturnValue(400);
+    vi.spyOn(HTMLElement.prototype, 'clientHeight', 'get').mockReturnValue(100);
+};
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
 
 describe('DataAppBuildCard', () => {
     it('queued: explains the wait and offers the builder', async () => {
@@ -115,6 +125,77 @@ describe('DataAppBuildCard', () => {
             />,
         );
         expect(screen.getByText('v3')).toBeVisible();
+    });
+
+    it('ready: renders the summary as markdown', () => {
+        renderWithProviders(
+            <DataAppBuildCard
+                state={{
+                    kind: 'ready',
+                    name: 'Weekly revenue by region',
+                    version: 1,
+                    durationMs: 372_000,
+                    completionMessage:
+                        'Built **five pages** from `src/App.jsx`.',
+                }}
+                compact={false}
+                isActive={false}
+                onOpenBuilder={noop}
+                onView={noop}
+            />,
+        );
+        expect(screen.getByText('five pages')).toHaveAttribute(
+            'data-streamdown',
+            'strong',
+        );
+        expect(screen.getByText('src/App.jsx')).toHaveAttribute(
+            'data-streamdown',
+            'inline-code',
+        );
+    });
+
+    it('ready: a long summary stays clamped until See more is clicked', async () => {
+        mockSummaryOverflow();
+        renderWithProviders(
+            <DataAppBuildCard
+                state={{
+                    kind: 'ready',
+                    name: 'Weekly revenue by region',
+                    version: 1,
+                    durationMs: 372_000,
+                    completionMessage: 'A very long summary. '.repeat(50),
+                }}
+                compact={false}
+                isActive={false}
+                onOpenBuilder={noop}
+                onView={noop}
+            />,
+        );
+        await userEvent.click(
+            await screen.findByRole('button', { name: 'See more' }),
+        );
+        expect(screen.getByRole('button', { name: 'See less' })).toBeVisible();
+    });
+
+    it('ready: a short summary has no See more button', () => {
+        renderWithProviders(
+            <DataAppBuildCard
+                state={{
+                    kind: 'ready',
+                    name: 'Weekly revenue by region',
+                    version: 1,
+                    durationMs: 372_000,
+                    completionMessage: 'Your app is ready.',
+                }}
+                compact={false}
+                isActive={false}
+                onOpenBuilder={noop}
+                onView={noop}
+            />,
+        );
+        expect(
+            screen.queryByRole('button', { name: 'See more' }),
+        ).not.toBeInTheDocument();
     });
 
     it('failed: shows the builder failure message and opens the builder', async () => {

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/DataAppBuildCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/DataAppBuildCard.tsx
@@ -8,6 +8,7 @@ import {
     Stack,
     Text,
     ThemeIcon,
+    UnstyledButton,
 } from '@mantine/core';
 import {
     IconAlertTriangle,
@@ -18,7 +19,8 @@ import {
     IconEye,
 } from '@tabler/icons-react';
 import clsx from 'clsx';
-import { type FC, type ReactNode } from 'react';
+import { useEffect, useRef, useState, type FC, type ReactNode } from 'react';
+import { AiMarkdown } from '../../../../../../components/common/AiMarkdown';
 import MantineIcon from '../../../../../../components/common/MantineIcon';
 import AppVersionNarration from '../../../../../../features/apps/components/AppVersionNarration';
 import { formatBuildDuration } from '../../../../../../features/apps/utils/formatBuildDuration';
@@ -161,6 +163,51 @@ const Muted: FC<{ children: ReactNode }> = ({ children }) => (
     </Text>
 );
 
+/**
+ * The agent's closing summary, as markdown. Long summaries would otherwise
+ * push the chat's next turn off screen, so they clamp to a few lines until
+ * the reader asks for the rest.
+ */
+const Summary: FC<{ children: string }> = ({ children }) => {
+    const clampRef = useRef<HTMLDivElement>(null);
+    const [expanded, setExpanded] = useState(false);
+    const [canExpand, setCanExpand] = useState(false);
+
+    // Only measured while clamped: expanding removes the overflow, and the
+    // flag has to survive that so "See less" stays available.
+    useEffect(() => {
+        const clamp = clampRef.current;
+        if (!clamp || expanded) return;
+        const measure = () =>
+            setCanExpand(clamp.scrollHeight > clamp.clientHeight + 1);
+        measure();
+        const observer = new ResizeObserver(measure);
+        observer.observe(clamp);
+        return () => observer.disconnect();
+    }, [expanded, children]);
+
+    return (
+        <Stack gap={2} align="flex-start">
+            <Box
+                ref={clampRef}
+                className={clsx(styles.summary, {
+                    [styles.summaryClamped]: !expanded,
+                })}
+            >
+                <AiMarkdown>{children}</AiMarkdown>
+            </Box>
+            {canExpand && (
+                <UnstyledButton
+                    className={styles.summaryToggle}
+                    onClick={() => setExpanded((open) => !open)}
+                >
+                    {expanded ? 'See less' : 'See more'}
+                </UnstyledButton>
+            )}
+        </Stack>
+    );
+};
+
 /** One-line "title · detail" header used by rows that must stay single-line. */
 const InlineTitle: FC<{ title: string; detail: string }> = ({
     title,
@@ -268,7 +315,7 @@ const renderCells = (
                         />
                     </Actions>
                     <Body>
-                        <Text size="xs">{state.completionMessage}</Text>
+                        <Summary>{state.completionMessage}</Summary>
                     </Body>
                 </>
             );

--- a/packages/frontend/src/stories/DataAppBuildCard.stories.tsx
+++ b/packages/frontend/src/stories/DataAppBuildCard.stories.tsx
@@ -72,6 +72,23 @@ export const ReadyWithoutDuration: Story = {
     args: { state: { ...states.ready, version: 3, durationMs: null } },
 };
 
+export const ReadyWithLongSummary: Story = {
+    args: {
+        state: {
+            ...states.ready,
+            completionMessage: [
+                'This completes the report build. Summary of what was built:',
+                '',
+                '-   **`src/App.jsx`** — full report shell with a screen-only toolbar (Print + Download PDF), title page, and 6 content sections.',
+                '-   **`src/components/`** — `ReportPage`/`SectionHeading` (A4 page shell), `HeadlineKpis`, `MonthlyTrendChart`, `EventFamilyChart`, `TopOrgsTable`, each with loading and error states.',
+                '-   **`src/lib/constants.js`** — shared `EXPLORE`, an explicit date-range filter, and the `Lightdash Internal` org exclusion.',
+                '',
+                'Narrative text stays descriptive and historical only, as requested.',
+            ].join('\n'),
+        },
+    },
+};
+
 export const Failed: Story = { args: { state: states.failed } };
 
 export const Cancelled: Story = { args: { state: states.cancelled } };


### PR DESCRIPTION
The agent's closing summary on the data app build card was rendered as plain text, so markdown showed up raw (`**bold**`, backticked paths, `-` bullets on one line) and a long summary pushed the rest of the chat off screen.

It now renders through the shared `AiMarkdown` renderer, clamped to six lines with a "See more" / "See less" toggle. The toggle only appears when the summary actually overflows — measured on the clamp element and kept sticky once expanded, so "See less" doesn't vanish. Adds a `ReadyWithLongSummary` story for the truncated state.
