### PR TITLE
feat(content-as-code): refresh dbt split button that also syncs content from the repo

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -128,6 +128,8 @@ const schedulerWorkerFactory = (context: {
         dashboardService: context.serviceRepository.getDashboardService(),
         deployService: context.serviceRepository.getDeployService(),
         projectService: context.serviceRepository.getProjectService(),
+        contentAsCodeWritebackService:
+            context.serviceRepository.getContentAsCodeWritebackService(),
         schedulerService: context.serviceRepository.getSchedulerService(),
         validationService: context.serviceRepository.getValidationService(),
         userService: context.serviceRepository.getUserService(),

--- a/packages/backend/src/SchedulerApp.ts
+++ b/packages/backend/src/SchedulerApp.ts
@@ -98,6 +98,8 @@ const schedulerWorkerFactory = (context: {
         dashboardService: context.serviceRepository.getDashboardService(),
         deployService: context.serviceRepository.getDeployService(),
         projectService: context.serviceRepository.getProjectService(),
+        contentAsCodeWritebackService:
+            context.serviceRepository.getContentAsCodeWritebackService(),
         schedulerService: context.serviceRepository.getSchedulerService(),
         validationService: context.serviceRepository.getValidationService(),
         userService: context.serviceRepository.getUserService(),

--- a/packages/backend/src/controllers/ProjectCoderController.ts
+++ b/packages/backend/src/controllers/ProjectCoderController.ts
@@ -11,6 +11,7 @@ import {
     type ApiChartAsCodeListResponse,
     type ApiChartAsCodeUpsertResponse,
     type ApiContentAsCodeProposeResponse,
+    type ApiContentAsCodePullResponse,
     type ApiContentAsCodeSettingsResponse,
     type ApiContentAsCodeUploadAdvisoryResponse,
     type ApiContentAsCodeWritebacksResponse,
@@ -235,6 +236,29 @@ export class ProjectCoderController extends BaseController {
                     toSessionUser(req.account),
                     projectUuid,
                 ),
+        );
+    }
+
+    /**
+     * Apply charts and dashboards as code from the project's repo, the in-app
+     * equivalent of `lightdash upload`
+     * @summary Pull content from git
+     */
+    @Tags('Projects')
+    @Middlewares(CODE_WRITE_MIDDLEWARES)
+    @SuccessResponse('200', 'Success')
+    @Post('/code/pull')
+    @OperationId('pullContentAsCodeFromGit')
+    async pullContentAsCodeFromGit(
+        @Path() projectUuid: string,
+        @Request() req: express.Request,
+    ): Promise<ApiContentAsCodePullResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return codeSuccess(
+            await this.services
+                .getContentAsCodeWritebackService()
+                .pullFromGit(toSessionUser(req.account), projectUuid),
         );
     }
 

--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -67,6 +67,7 @@ import {
     type ApiExecuteAsyncMetricQueryResults,
     type ApiGetDashboardsResponse,
     type ApiGetTagsResponse,
+    type ApiRefreshBody,
     type ApiRefreshResults,
     type ApiSuccess,
     type ApiTableGroupsResults,
@@ -1794,6 +1795,7 @@ Migrate to the v2 async query flow: [Execute SQL query](https://docs.lightdash.c
     async refresh(
         @Path() projectUuid: string,
         @Request() req: express.Request,
+        @Body() body?: ApiRefreshBody,
     ): Promise<ApiSuccess<ApiRefreshResults>> {
         assertRegisteredAccount(req.account);
         this.setStatus(200);
@@ -1806,6 +1808,9 @@ Migrate to the v2 async query flow: [Execute SQL query](https://docs.lightdash.c
                 toSessionUser(req.account),
                 projectUuid,
                 context,
+                false,
+                false,
+                body?.syncContent === true,
             );
         return {
             status: 'ok',

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -1354,6 +1354,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     context.serviceRepository.getSchedulerService(),
                 validationService:
                     context.serviceRepository.getValidationService(),
+                contentAsCodeWritebackService:
+                    context.serviceRepository.getContentAsCodeWritebackService(),
                 userService: context.serviceRepository.getUserService(),
                 emailClient: context.clients.getEmailClient(),
                 googleDriveClient: context.clients.getGoogleDriveClient(),

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -67,6 +67,7 @@ import {
     isTableChartConfig,
     isTileInSelectedTabs,
     isVizTableConfig,
+    JobStepType,
     LightdashPage,
     MAX_DELIVERY_QUERIES,
     MAX_SAFE_INTEGER,
@@ -180,6 +181,7 @@ import { WarehouseConnectCodeModel } from '../models/WarehouseConnectCodeModel';
 import { AsyncQueryService } from '../services/AsyncQueryService/AsyncQueryService';
 import { SCHEDULER_POLLING_OPTIONS } from '../services/AsyncQueryService/types';
 import type { CatalogService } from '../services/CatalogService/CatalogService';
+import { ContentAsCodeWritebackService } from '../services/ContentAsCodeWritebackService/ContentAsCodeWritebackService';
 import {
     CsvService,
     getSchedulerCsvLimit,
@@ -234,6 +236,7 @@ export type SchedulerTaskArguments = {
     dashboardService: DashboardService;
     deployService: DeployService;
     projectService: ProjectService;
+    contentAsCodeWritebackService: ContentAsCodeWritebackService;
     schedulerService: SchedulerService;
     unfurlService: UnfurlService;
     userService: UserService;
@@ -507,6 +510,8 @@ export default class SchedulerTask {
 
     protected readonly projectService: ProjectService;
 
+    protected readonly contentAsCodeWritebackService: ContentAsCodeWritebackService;
+
     protected readonly schedulerService: SchedulerService;
 
     protected readonly unfurlService: UnfurlService;
@@ -563,6 +568,7 @@ export default class SchedulerTask {
         this.unfurlService = args.unfurlService;
         this.userService = args.userService;
         this.validationService = args.validationService;
+        this.contentAsCodeWritebackService = args.contentAsCodeWritebackService;
         this.emailClient = args.emailClient;
         this.googleDriveClient = args.googleDriveClient;
         this.fileStorageClient = args.fileStorageClient;
@@ -2786,6 +2792,16 @@ export default class SchedulerTask {
                 payload.projectUuid,
                 getRequestMethod(payload.requestMethod),
                 payload.jobUuid,
+                payload.syncContentAfterCompile
+                    ? {
+                          stepType: JobStepType.SYNCING_CONTENT,
+                          run: () =>
+                              this.syncContentFromRepo(
+                                  user,
+                                  payload.projectUuid,
+                              ),
+                      }
+                    : undefined,
             );
             await this.schedulerService.logSchedulerJob({
                 ...baseLog,
@@ -2833,6 +2849,24 @@ export default class SchedulerTask {
                 },
             });
             throw e;
+        }
+    }
+
+    // Files that could not be applied fail the step so the job details say why
+    private async syncContentFromRepo(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<void> {
+        const summary = await this.contentAsCodeWritebackService.pullFromGit(
+            user,
+            projectUuid,
+        );
+        if (summary.failures.length > 0) {
+            throw new Error(
+                `Applied ${summary.charts} charts and ${summary.dashboards} dashboards from the repo; ${summary.failures.length} file(s) could not be applied: ${summary.failures
+                    .map((failure) => `${failure.file}: ${failure.message}`)
+                    .join('; ')}`,
+            );
         }
     }
 

--- a/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.test.ts
+++ b/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.test.ts
@@ -3,16 +3,23 @@ import {
     ConflictError,
     DbtProjectType,
     ForbiddenError,
+    NotFoundError,
     PossibleAbilities,
     PullRequestSource,
     type SessionUser,
 } from '@lightdash/common';
-import { describe, expect, it, vi } from 'vitest';
-import { getPullRequest } from '../../clients/github/Github';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+    getFileContent,
+    getPullRequest,
+    getRepoTree,
+} from '../../clients/github/Github';
 import { ContentAsCodeWritebackService } from './ContentAsCodeWritebackService';
 
 vi.mock('../../clients/github/Github', () => ({
     getPullRequest: vi.fn(),
+    getRepoTree: vi.fn(),
+    getFileContent: vi.fn(),
 }));
 
 const user = {
@@ -112,6 +119,10 @@ const buildService = (overrides: Overrides = {}) => {
             slug: 'weekly-kpis',
             tiles: [],
         }),
+        upsertChart: vi.fn().mockResolvedValue({ action: 'update' }),
+        upsertSqlChart: vi.fn().mockResolvedValue({ action: 'update' }),
+        upsertDashboard: vi.fn().mockResolvedValue({ action: 'update' }),
+        stampContentAsCodeSettings: vi.fn().mockResolvedValue(undefined),
     };
     const contentAsCodeProjectSettingsModel = {
         get: vi
@@ -121,6 +132,7 @@ const buildService = (overrides: Overrides = {}) => {
                     ? overrides.settings
                     : { syncEnabled: true },
             ),
+        upsert: vi.fn().mockResolvedValue(undefined),
     };
     const contentAsCodeSnapshotModel = {
         get: vi
@@ -207,6 +219,7 @@ const buildService = (overrides: Overrides = {}) => {
         service,
         gitIntegrationService,
         coderService,
+        contentAsCodeProjectSettingsModel,
         contentAsCodeWritebackModel,
         contentDraftModel,
         userModel,
@@ -1140,5 +1153,178 @@ describe('ContentAsCodeWritebackService', () => {
             gitIntegrationService.createPullRequestFromBranch,
         ).toHaveBeenCalledTimes(1);
         expect(contentDraftModel.update).toHaveBeenCalledTimes(1);
+    });
+
+    describe('pullFromGit', () => {
+        beforeEach(() => {
+            vi.mocked(getRepoTree).mockReset();
+            vi.mocked(getFileContent).mockReset();
+        });
+
+        const chart = (slug: string, extra = '') =>
+            `slug: ${slug}\nname: ${slug}\n${extra}`;
+        const dashboard = (slug: string, chartSlugs: string[]) =>
+            `slug: ${slug}\nname: ${slug}\ntiles:\n${chartSlugs
+                .map(
+                    (chartSlug) =>
+                        `  - type: saved_chart\n    properties:\n      chartSlug: ${chartSlug}\n`,
+                )
+                .join('')}`;
+        const syncConfig =
+            'content_as_code:\n  sync: true\n  path: analytics/content\n';
+
+        const stubRepo = (files: Record<string, string>) => {
+            vi.mocked(getRepoTree).mockResolvedValue({
+                files: Object.keys(files).map((path) => ({ path, size: 1 })),
+                truncated: false,
+            });
+            vi.mocked(getFileContent).mockImplementation(
+                async ({ fileName }) => {
+                    if (fileName in files) {
+                        return { content: files[fileName], sha: 'sha' };
+                    }
+                    throw new NotFoundError(`${fileName} not found`);
+                },
+            );
+        };
+
+        it('stamps the repo settings and applies charts before dashboards from the configured path', async () => {
+            const { service, coderService } = buildService();
+            stubRepo({
+                'lightdash.config.yml': syncConfig,
+                'analytics/content/charts/monthly-revenue.yml':
+                    chart('monthly-revenue'),
+                'analytics/content/sales/charts/nested.yml': chart('nested'),
+                'analytics/content/charts/raw.sql.yml': chart(
+                    'raw',
+                    'sql: select 1\n',
+                ),
+                'analytics/content/kpis.yml': `${dashboard('kpis', [
+                    'nested',
+                ])}contentType: dashboard\n`,
+                'analytics/content/dashboards/weekly-kpis.yml': dashboard(
+                    'weekly-kpis',
+                    ['monthly-revenue'],
+                ),
+                'analytics/content/sales.space.yml': 'slug: sales\n',
+                'analytics/content/charts/README.md': 'ignored',
+                'lightdash/charts/elsewhere.yml': chart('elsewhere'),
+            });
+
+            const summary = await service.pullFromGit(user, 'project-uuid');
+
+            expect(summary).toEqual({ charts: 3, dashboards: 2, failures: [] });
+            expect(
+                coderService.stampContentAsCodeSettings,
+            ).toHaveBeenCalledWith(user, 'project-uuid', {
+                sync: true,
+                path: 'analytics/content',
+            });
+            expect(
+                coderService.upsertChart.mock.calls.map((call) => call[2]),
+            ).toEqual(['monthly-revenue', 'nested']);
+            expect(coderService.upsertSqlChart).toHaveBeenCalledWith(
+                user,
+                'project-uuid',
+                'raw',
+                expect.objectContaining({ sql: 'select 1' }),
+            );
+            expect(
+                coderService.upsertDashboard.mock.calls.map((call) => call[2]),
+            ).toEqual(['kpis', 'weekly-kpis']);
+            expect(
+                Math.max(...coderService.upsertChart.mock.invocationCallOrder),
+            ).toBeLessThan(
+                Math.min(
+                    ...coderService.upsertDashboard.mock.invocationCallOrder,
+                ),
+            );
+            expect(getRepoTree).toHaveBeenCalledTimes(1);
+        });
+
+        it('holds back dashboards that use a chart which failed to apply', async () => {
+            const { service, coderService } = buildService();
+            coderService.upsertChart.mockRejectedValueOnce(
+                new Error('metric not found'),
+            );
+            stubRepo({
+                'lightdash.config.yml': 'content_as_code:\n  sync: true\n',
+                'lightdash/charts/broken.yml': chart('broken'),
+                'lightdash/charts/fine.yml': chart('fine'),
+                'lightdash/dashboards/uses-broken.yml': dashboard(
+                    'uses-broken',
+                    ['broken'],
+                ),
+                'lightdash/dashboards/uses-fine.yml': dashboard('uses-fine', [
+                    'fine',
+                ]),
+            });
+
+            const summary = await service.pullFromGit(user, 'project-uuid');
+
+            expect(summary.charts).toBe(1);
+            expect(summary.dashboards).toBe(1);
+            expect(summary.failures).toEqual([
+                {
+                    file: 'lightdash/charts/broken.yml',
+                    message: 'metric not found',
+                },
+                {
+                    file: 'lightdash/dashboards/uses-broken.yml',
+                    message:
+                        'Skipped: depends on charts that failed to apply (broken)',
+                },
+            ]);
+            expect(
+                coderService.upsertDashboard.mock.calls.map((call) => call[2]),
+            ).toEqual(['uses-fine']);
+        });
+
+        it('stamps sync off and refuses to apply when the repo has not opted in', async () => {
+            const { service, coderService } = buildService();
+            stubRepo({
+                'lightdash.config.yml':
+                    'spotlight:\n  default_visibility: show\n',
+                'lightdash/charts/a.yml': chart('a'),
+            });
+
+            await expect(
+                service.pullFromGit(user, 'project-uuid'),
+            ).rejects.toThrow('content_as_code.sync');
+
+            expect(
+                coderService.stampContentAsCodeSettings,
+            ).toHaveBeenCalledWith(user, 'project-uuid', {
+                sync: false,
+                path: 'lightdash',
+            });
+            expect(getRepoTree).not.toHaveBeenCalled();
+            expect(coderService.upsertChart).not.toHaveBeenCalled();
+        });
+
+        it('fails clearly when the repo has no lightdash.config.yml', async () => {
+            const { service } = buildService();
+            stubRepo({ 'lightdash/charts/a.yml': chart('a') });
+
+            await expect(
+                service.pullFromGit(user, 'project-uuid'),
+            ).rejects.toThrow('lightdash.config.yml not found');
+        });
+
+        it('refuses a truncated tree instead of applying a partial repo', async () => {
+            const { service, coderService } = buildService();
+            stubRepo({
+                'lightdash.config.yml': 'content_as_code:\n  sync: true\n',
+            });
+            vi.mocked(getRepoTree).mockResolvedValue({
+                files: [],
+                truncated: true,
+            });
+
+            await expect(
+                service.pullFromGit(user, 'project-uuid'),
+            ).rejects.toThrow('too large');
+            expect(coderService.upsertChart).not.toHaveBeenCalled();
+        });
     });
 });

--- a/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.ts
+++ b/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.ts
@@ -1,21 +1,34 @@
 import { subject } from '@casl/ability';
 import {
+    assertUnreachable,
+    classifyContentAsCodeFilePath,
     ConflictError,
     ContentAsCodeType,
     DbtProjectType,
     DEFAULT_CONTENT_AS_CODE_PATH,
     ForbiddenError,
     getContentAsCodeFilePath,
+    getErrorMessage,
+    isSqlChartContent,
+    joinContentAsCodePath,
+    loadLightdashProjectConfig,
+    normalizeContentAsCodePath,
     NotFoundError,
     ParameterError,
     PullRequestSource,
     type ChartAsCode,
+    type ContentAsCodeFileClassification,
+    type ContentAsCodePullSummary,
     type ContentAsCodeUploadAdvisory,
     type DashboardAsCode,
+    type LightdashProjectConfig,
     type SessionUser,
+    type SqlChartAsCode,
 } from '@lightdash/common';
 import * as yaml from 'js-yaml';
+import pLimit from 'p-limit';
 import * as GithubClient from '../../clients/github/Github';
+import * as GitlabClient from '../../clients/gitlab/Gitlab';
 import { LightdashConfig } from '../../config/parseConfig';
 import { ContentAsCodeProjectSettingsModel } from '../../models/ContentAsCodeProjectSettingsModel';
 import { ContentAsCodeSnapshotModel } from '../../models/ContentAsCodeSnapshotModel';
@@ -46,6 +59,16 @@ type ContentAsCodeWritebackServiceArguments = {
 };
 
 type WritebackContentType = 'chart' | 'dashboard';
+
+type RepoReadCredentials = Awaited<
+    ReturnType<GitIntegrationService['getGitCredentials']>
+> & { branch: string };
+
+type RepoContentFile = {
+    path: string;
+    classification: ContentAsCodeFileClassification;
+    content: string;
+};
 
 const WRITEBACK_BRANCH_PREFIX = 'lightdash/write-back';
 
@@ -187,9 +210,10 @@ export class ContentAsCodeWritebackService extends BaseService {
         contentType: WritebackContentType,
         slug: string,
     ): string {
-        const prefix = repoPath.replace(/^\/+|\/+$/g, '');
-        const base = getContentAsCodeFilePath(contentPath, contentType, slug);
-        return prefix === '' ? base : `${prefix}/${base}`;
+        return joinContentAsCodePath(
+            repoPath,
+            getContentAsCodeFilePath(contentPath, contentType, slug),
+        );
     }
 
     private async getContentPath(projectUuid: string): Promise<string> {
@@ -342,6 +366,298 @@ export class ContentAsCodeWritebackService extends BaseService {
             return this.contentAsCodeWritebackModel.listByProject(projectUuid);
         }
         return rows;
+    }
+
+    // The in-app `lightdash upload`: stamps the repo's content_as_code
+    // settings, then applies the content files the CLI would
+    async pullFromGit(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<ContentAsCodePullSummary> {
+        await this.assertCanManageContentAsCode(user, projectUuid);
+        const repo =
+            await this.gitIntegrationService.getProjectRepo(projectUuid);
+        const creds = {
+            ...(await this.gitIntegrationService.getGitCredentials(
+                user,
+                projectUuid,
+            )),
+            branch: repo.branch,
+        };
+        const prefix = joinContentAsCodePath(repo.path);
+
+        const config =
+            await ContentAsCodeWritebackService.readRepoProjectConfig(
+                creds,
+                joinContentAsCodePath(prefix, 'lightdash.config.yml'),
+            );
+        const configuredPath =
+            config.content_as_code?.path ?? DEFAULT_CONTENT_AS_CODE_PATH;
+        await this.coderService.stampContentAsCodeSettings(user, projectUuid, {
+            sync: config.content_as_code?.sync === true,
+            path: configuredPath,
+        });
+        if (config.content_as_code?.sync !== true) {
+            throw new ParameterError(
+                'Pulling content from the repo requires content_as_code.sync: true in lightdash.config.yml',
+            );
+        }
+
+        const files = await ContentAsCodeWritebackService.readContentFiles(
+            creds,
+            joinContentAsCodePath(
+                prefix,
+                normalizeContentAsCodePath(configuredPath),
+            ),
+        );
+        return this.applyContentFiles(user, projectUuid, files);
+    }
+
+    private static async readRepoProjectConfig(
+        creds: RepoReadCredentials,
+        filePath: string,
+    ): Promise<LightdashProjectConfig> {
+        try {
+            return await loadLightdashProjectConfig(
+                await ContentAsCodeWritebackService.readRepoFile(
+                    creds,
+                    filePath,
+                ),
+            );
+        } catch (error) {
+            if (error instanceof NotFoundError) {
+                throw new ParameterError(
+                    `lightdash.config.yml not found at ${filePath} on ${creds.branch}`,
+                );
+            }
+            throw error;
+        }
+    }
+
+    // One tree listing plus bounded parallel reads with the same credentials
+    private static async readContentFiles(
+        creds: RepoReadCredentials,
+        contentRoot: string,
+    ): Promise<RepoContentFile[]> {
+        const tree =
+            creds.type === DbtProjectType.GITHUB
+                ? await GithubClient.getRepoTree({
+                      owner: creds.owner,
+                      repo: creds.repo,
+                      branch: creds.branch,
+                      installationId: creds.installationId,
+                      token: creds.token,
+                  })
+                : await GitlabClient.getGitlabRepoTree({
+                      owner: creds.owner,
+                      repo: creds.repo,
+                      branch: creds.branch,
+                      token: creds.token,
+                      hostDomain: creds.hostDomain,
+                  });
+        if (tree.truncated) {
+            throw new ParameterError(
+                'The repo is too large to list in one request; run lightdash upload instead',
+            );
+        }
+        const candidates = tree.files.flatMap(({ path }) => {
+            if (contentRoot !== '' && !path.startsWith(`${contentRoot}/`)) {
+                return [];
+            }
+            const classification = classifyContentAsCodeFilePath(path);
+            return classification?.supportedExtension
+                ? [{ path, classification }]
+                : [];
+        });
+        const limit = pLimit(8);
+        return Promise.all(
+            candidates.map((candidate) =>
+                limit(async () => ({
+                    ...candidate,
+                    content: await ContentAsCodeWritebackService.readRepoFile(
+                        creds,
+                        candidate.path,
+                    ),
+                })),
+            ),
+        );
+    }
+
+    private static async readRepoFile(
+        creds: RepoReadCredentials,
+        filePath: string,
+    ): Promise<string> {
+        const getFileContent =
+            creds.type === DbtProjectType.GITHUB
+                ? GithubClient.getFileContent
+                : GitlabClient.getFileContent;
+        const { content } = await getFileContent({
+            fileName: filePath,
+            owner: creds.owner,
+            repo: creds.repo,
+            branch: creds.branch,
+            installationId: creds.installationId,
+            token: creds.token,
+            hostDomain: creds.hostDomain,
+        });
+        return content;
+    }
+
+    // Charts before dashboards (tiles reference chart slugs), one at a time
+    // so slug and space creation never race; a failed chart holds back the
+    // dashboards that use it, as `lightdash upload` does
+    private async applyContentFiles(
+        user: SessionUser,
+        projectUuid: string,
+        files: RepoContentFile[],
+    ): Promise<ContentAsCodePullSummary> {
+        const summary: ContentAsCodePullSummary = {
+            charts: 0,
+            dashboards: 0,
+            failures: [],
+        };
+        const charts: {
+            file: string;
+            document: ChartAsCode | SqlChartAsCode;
+        }[] = [];
+        const dashboards: { file: string; document: DashboardAsCode }[] = [];
+        for (const file of files) {
+            try {
+                const sorted =
+                    ContentAsCodeWritebackService.sortContentFile(file);
+                if (sorted?.kind === 'chart') {
+                    charts.push({ file: file.path, document: sorted.document });
+                } else if (sorted?.kind === 'dashboard') {
+                    dashboards.push({
+                        file: file.path,
+                        document: sorted.document,
+                    });
+                }
+            } catch (error) {
+                summary.failures.push({
+                    file: file.path,
+                    message: getErrorMessage(error),
+                });
+            }
+        }
+
+        const failedChartSlugs = new Set<string>();
+        /* eslint-disable no-await-in-loop */
+        for (const { file, document } of charts) {
+            try {
+                if (isSqlChartContent(document)) {
+                    await this.coderService.upsertSqlChart(
+                        user,
+                        projectUuid,
+                        document.slug,
+                        document as SqlChartAsCode,
+                    );
+                } else {
+                    await this.coderService.upsertChart(
+                        user,
+                        projectUuid,
+                        document.slug,
+                        document as ChartAsCode,
+                        { syncEnabled: true },
+                    );
+                }
+                summary.charts += 1;
+            } catch (error) {
+                failedChartSlugs.add(document.slug);
+                summary.failures.push({
+                    file,
+                    message: getErrorMessage(error),
+                });
+            }
+        }
+        for (const { file, document } of dashboards) {
+            const blockedBy = document.tiles.flatMap((tile) =>
+                'chartSlug' in tile.properties &&
+                typeof tile.properties.chartSlug === 'string' &&
+                failedChartSlugs.has(tile.properties.chartSlug)
+                    ? [tile.properties.chartSlug]
+                    : [],
+            );
+            if (blockedBy.length > 0) {
+                summary.failures.push({
+                    file,
+                    message: `Skipped: depends on charts that failed to apply (${blockedBy.join(', ')})`,
+                });
+            } else {
+                try {
+                    await this.coderService.upsertDashboard(
+                        user,
+                        projectUuid,
+                        document.slug,
+                        document,
+                        { syncEnabled: true },
+                    );
+                    summary.dashboards += 1;
+                } catch (error) {
+                    summary.failures.push({
+                        file,
+                        message: getErrorMessage(error),
+                    });
+                }
+            }
+        }
+        /* eslint-enable no-await-in-loop */
+        return summary;
+    }
+
+    // Same trust as `lightdash upload`: a document with a slug is the as-code
+    // type of its folder, loose files declare theirs with contentType
+    private static sortContentFile(
+        file: RepoContentFile,
+    ):
+        | { kind: 'chart'; document: ChartAsCode | SqlChartAsCode }
+        | { kind: 'dashboard'; document: DashboardAsCode }
+        | null {
+        let parsed: unknown;
+        try {
+            parsed = yaml.load(file.content);
+        } catch {
+            throw new ParameterError(`Could not parse ${file.path} as YAML`);
+        }
+        if (
+            parsed === null ||
+            typeof parsed !== 'object' ||
+            !('slug' in parsed) ||
+            typeof parsed.slug !== 'string'
+        ) {
+            throw new ParameterError(`${file.path} has no slug`);
+        }
+        const kind =
+            file.classification.kind === 'content'
+                ? file.classification.contentType
+                : ContentAsCodeWritebackService.looseContentKind(parsed);
+        switch (kind) {
+            case 'chart':
+                return {
+                    kind,
+                    document: parsed as ChartAsCode | SqlChartAsCode,
+                };
+            case 'dashboard':
+                return { kind, document: parsed as DashboardAsCode };
+            case null:
+                return null;
+            default:
+                return assertUnreachable(kind, 'Unknown content kind');
+        }
+    }
+
+    private static looseContentKind(
+        parsed: object,
+    ): 'chart' | 'dashboard' | null {
+        const contentType =
+            'contentType' in parsed ? parsed.contentType : undefined;
+        if (
+            contentType === ContentAsCodeType.CHART ||
+            contentType === ContentAsCodeType.SQL_CHART
+        ) {
+            return 'chart';
+        }
+        return contentType === ContentAsCodeType.DASHBOARD ? 'dashboard' : null;
     }
 
     async listDrafts(

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -3537,6 +3537,91 @@ describe('ProjectService', () => {
             });
         });
 
+        const compileUser: SessionUser = {
+            ...user,
+            ability: new Ability<PossibleAbilities>([
+                { subject: 'Job', action: ['create'] },
+                { subject: 'CompileProject', action: ['manage'] },
+                { subject: 'Project', action: ['update', 'view'] },
+                { subject: 'Tags', action: ['manage'] },
+            ]),
+        };
+
+        const stubCompile = () =>
+            vi
+                .spyOn(
+                    service as unknown as {
+                        refreshTablesAndProjectConfig: () => Promise<unknown>;
+                    },
+                    'refreshTablesAndProjectConfig',
+                )
+                .mockResolvedValueOnce({
+                    explores: [validExplore],
+                    lightdashProjectConfig: {
+                        spotlight: { categories: {} },
+                        parameters: {},
+                        table_groups: {},
+                    },
+                    projectContext: undefined,
+                });
+
+        test('runs the afterCompile step after compiling and before the job is done', async () => {
+            const compileJobUuid = 'compile-job-uuid';
+            stubCompile();
+            const run = vi.fn(async () => undefined);
+
+            await service.compileProject(
+                compileUser,
+                projectUuid,
+                RequestMethod.WEB_APP,
+                compileJobUuid,
+                { stepType: JobStepType.SYNCING_CONTENT, run },
+            );
+
+            expect(jobModel.tryJobStep).toHaveBeenCalledWith(
+                compileJobUuid,
+                JobStepType.SYNCING_CONTENT,
+                run,
+            );
+            expect(run).toHaveBeenCalledTimes(1);
+            const doneCall = (
+                jobModel.update as import('vitest').Mock
+            ).mock.calls.findIndex(
+                ([uuid, update]) =>
+                    uuid === compileJobUuid &&
+                    update.jobStatus === JobStatusType.DONE,
+            );
+            expect(doneCall).toBeGreaterThan(-1);
+            expect(run.mock.invocationCallOrder[0]).toBeLessThan(
+                (jobModel.update as import('vitest').Mock).mock
+                    .invocationCallOrder[doneCall],
+            );
+        });
+
+        test('a failing afterCompile step leaves the job in error instead of done', async () => {
+            const compileJobUuid = 'compile-job-uuid';
+            stubCompile();
+            const run = vi.fn(async () => {
+                throw new Error('2 files could not be applied');
+            });
+
+            await service.compileProject(
+                compileUser,
+                projectUuid,
+                RequestMethod.WEB_APP,
+                compileJobUuid,
+                { stepType: JobStepType.SYNCING_CONTENT, run },
+            );
+
+            expect(jobModel.update).toHaveBeenCalledWith(compileJobUuid, {
+                jobStatus: JobStatusType.ERROR,
+            });
+            expect(jobModel.update).not.toHaveBeenCalledWith(
+                compileJobUuid,
+                expect.objectContaining({ jobStatus: JobStatusType.DONE }),
+            );
+        });
+
         test('requires manage tag permissions for direct YAML tag sync', async () => {
             const noTagUser: SessionUser = {
                 ...user,

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -8727,6 +8727,7 @@ export class ProjectService extends BaseService {
         requestMethod: RequestMethod,
         skipPermissionCheck: boolean = false,
         validateAfterCompile: boolean = false,
+        syncContentAfterCompile: boolean = false,
     ): Promise<{ jobUuid: string }> {
         const { organizationUuid, type } =
             await this.projectModel.getSummary(projectUuid);
@@ -8758,7 +8759,12 @@ export class ProjectService extends BaseService {
             jobStatus: JobStatusType.STARTED,
             userUuid: user.userUuid,
             projectUuid,
-            steps: [{ stepType: JobStepType.COMPILING }],
+            steps: [
+                { stepType: JobStepType.COMPILING },
+                ...(syncContentAfterCompile
+                    ? [{ stepType: JobStepType.SYNCING_CONTENT }]
+                    : []),
+            ],
         };
 
         await this.jobModel.create(job, type === ProjectType.PREVIEW);
@@ -8771,17 +8777,21 @@ export class ProjectService extends BaseService {
             jobUuid: job.jobUuid,
             isPreview: type === ProjectType.PREVIEW,
             validateAfterCompile,
+            syncContentAfterCompile,
             userUuid: user.userUuid,
         });
 
         return { jobUuid: job.jobUuid };
     }
 
+    // afterCompile runs as its own job step inside the project lock, before
+    // the job is marked done, so callers polling the job see the whole run
     async compileProject(
         user: SessionUser,
         projectUuid: string,
         requestMethod: RequestMethod,
         jobUuid: string,
+        afterCompile?: { stepType: JobStepType; run: () => Promise<void> },
     ) {
         const totalStartTime = performance.now();
 
@@ -8920,6 +8930,14 @@ export class ProjectService extends BaseService {
                         };
                     },
                 );
+
+                if (afterCompile) {
+                    await this.jobModel.tryJobStep(
+                        job.jobUuid,
+                        afterCompile.stepType,
+                        afterCompile.run,
+                    );
+                }
 
                 await this.jobModel.update(job.jobUuid, {
                     jobStatus: JobStatusType.DONE,

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -144,6 +144,7 @@ import {
     type ApiChartAsCodeListResponse,
     type ApiChartAsCodeUpsertResponse,
     type ApiContentAsCodeProposeResponse,
+    type ApiContentAsCodePullResponse,
     type ApiContentAsCodeSettingsResponse,
     type ApiContentAsCodeUploadAdvisoryResponse,
     type ApiContentAsCodeWritebacksResponse,
@@ -460,6 +461,11 @@ export type ApiStatusResults = 'loading' | 'ready' | 'error';
 
 export type ApiRefreshResults = {
     jobUuid: string;
+};
+
+export type ApiRefreshBody = {
+    // Run the content-as-code pull as a job step after compiling
+    syncContent: boolean;
 };
 
 export type ApiCreatePreviewResults = {
@@ -1395,6 +1401,7 @@ type ApiResults =
     | ApiContentDraftReopenResponse['results']
     | ApiContentDraftWriteBackResponse['results']
     | ApiContentAsCodeProposeResponse['results']
+    | ApiContentAsCodePullResponse['results']
     | ApiContentAsCodeSettingsResponse['results']
     | ApiContentAsCodeUploadAdvisoryResponse['results']
     | ApiGetMetricsTree['results']

--- a/packages/common/src/types/contentAsCode/base.ts
+++ b/packages/common/src/types/contentAsCode/base.ts
@@ -142,6 +142,23 @@ export type ContentAsCodeSettingsStamp = {
     path?: string;
 };
 
+export type ContentAsCodePullFailure = {
+    file: string;
+    message: string;
+};
+
+// Outcome of pulling content-as-code from the project's repo in the app
+export type ContentAsCodePullSummary = {
+    charts: number;
+    dashboards: number;
+    failures: ContentAsCodePullFailure[];
+};
+
+export type ApiContentAsCodePullResponse = {
+    status: 'ok';
+    results: ContentAsCodePullSummary;
+};
+
 export type ApiContentAsCodeSettingsResponse = {
     status: 'ok';
     results: ContentAsCodeProjectSettings | null;

--- a/packages/common/src/types/job.ts
+++ b/packages/common/src/types/job.ts
@@ -27,6 +27,7 @@ export enum JobStepType {
     COMPILING = 'COMPILING',
     CREATING_PROJECT = 'CREATING_PROJECT',
     CACHING = 'CACHING',
+    SYNCING_CONTENT = 'SYNCING_CONTENT',
 }
 
 export const JobLabels = {
@@ -39,6 +40,7 @@ export const JobLabels = {
     COMPILING: 'Compiling',
     CREATING_PROJECT: 'Creating project',
     CACHING: 'Saving cache',
+    SYNCING_CONTENT: 'Syncing content from the repo',
 };
 
 export type BaseJob = {

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -831,6 +831,8 @@ export type CompileProjectPayload = TraceTaskBase & {
     jobUuid: string;
     isPreview: boolean;
     validateAfterCompile?: boolean;
+    // Apply charts and dashboards as code from the repo once compiled
+    syncContentAfterCompile?: boolean;
     compilationSource?: CompilationSource;
 };
 

--- a/packages/frontend/src/components/RefreshDbtButton/index.tsx
+++ b/packages/frontend/src/components/RefreshDbtButton/index.tsx
@@ -1,3 +1,4 @@
+import { subject } from '@casl/ability';
 import { DbtProjectType, JobStatusType, ProjectType } from '@lightdash/common';
 import {
     Anchor,
@@ -5,13 +6,16 @@ import {
     Box,
     Button,
     Group,
+    Menu,
     Popover,
+    Stack,
     Text,
     Tooltip,
     type ButtonProps,
 } from '@mantine/core';
-import { IconRefresh } from '@tabler/icons-react';
+import { IconChevronDown, IconRefresh } from '@tabler/icons-react';
 import { useEffect, useState, type FC } from 'react';
+import { useContentAsCodeSettings } from '../../features/contentAsCode/hooks/useContentAsCodeSettings';
 import { useProject } from '../../hooks/useProject';
 import { useProjectUuid } from '../../hooks/useProjectUuid';
 import { useRefreshServer } from '../../hooks/useRefreshServer';
@@ -20,14 +24,63 @@ import useActiveJob from '../../providers/ActiveJob/useActiveJob';
 import useTracking from '../../providers/Tracking/useTracking';
 import { EventName } from '../../types/Events';
 import MantineIcon from '../common/MantineIcon';
+import { useIsGitProject } from '../Explorer/WriteBackModal/hooks';
+
+type RefreshMode = 'dbt' | 'dbt-and-content';
+
+// Remembered per project: teams differ on whether a refresh should also sync
+const refreshModeStorageKey = (projectUuid: string) =>
+    `lightdash-refresh-dbt-mode:${projectUuid}`;
+
+const MODE_COPY: Record<
+    RefreshMode,
+    { label: string; description: string; busy: string; tooltip: string }
+> = {
+    dbt: {
+        label: 'Refresh dbt',
+        description: 'Recompile explores from your dbt project',
+        busy: 'Refreshing dbt',
+        tooltip:
+            "If you've updated your YAML files, you can sync your changes to Lightdash by clicking this button.",
+    },
+    'dbt-and-content': {
+        label: 'Refresh dbt and sync content',
+        description: 'Then pull charts and dashboards as code from the repo',
+        busy: 'Refreshing dbt and content',
+        tooltip:
+            'Recompiles your dbt project, then applies charts and dashboards as code from the repo.',
+    },
+};
+
+const loadStoredMode = (projectUuid: string): RefreshMode => {
+    try {
+        return localStorage.getItem(refreshModeStorageKey(projectUuid)) ===
+            'dbt-and-content'
+            ? 'dbt-and-content'
+            : 'dbt';
+    } catch {
+        return 'dbt';
+    }
+};
+
+const storeMode = (projectUuid: string, mode: RefreshMode) => {
+    try {
+        localStorage.setItem(refreshModeStorageKey(projectUuid), mode);
+    } catch {
+        // Per-viewer convenience only
+    }
+};
 
 const RefreshDbtButton: FC<{
+    // Surfaces with their own refresh copy keep the plain button
+    allowContentSync?: boolean;
     onClick?: () => void;
     buttonStyles?: ButtonProps['style'];
     leftIcon?: React.ReactNode;
     defaultTextOverride?: React.ReactNode;
     refreshingTextOverride?: React.ReactNode;
 }> = ({
+    allowContentSync = true,
     onClick,
     buttonStyles,
     leftIcon,
@@ -40,6 +93,12 @@ const RefreshDbtButton: FC<{
     const { mutate: refreshDbtServer } = useRefreshServer();
     const [isLoading, setIsLoading] = useState(false);
     const ability = useAbilityContext();
+    const isGitProject = useIsGitProject(projectUuid ?? '');
+    const { data: contentAsCodeSettings } =
+        useContentAsCodeSettings(projectUuid);
+    const [mode, setMode] = useState<RefreshMode>(() =>
+        loadStoredMode(projectUuid ?? ''),
+    );
 
     const { track } = useTracking();
 
@@ -139,37 +198,118 @@ const RefreshDbtButton: FC<{
         );
     }
 
+    const canSyncContent =
+        allowContentSync &&
+        isGitProject &&
+        contentAsCodeSettings?.syncEnabled === true &&
+        ability.can(
+            'manage',
+            subject('ContentAsCode', {
+                organizationUuid: data?.organizationUuid,
+                projectUuid,
+            }),
+        );
+    const activeMode: RefreshMode = canSyncContent ? mode : 'dbt';
+
     const handleRefresh = () => {
         setIsLoading(true);
-        refreshDbtServer();
+        refreshDbtServer(
+            { syncContent: activeMode === 'dbt-and-content' },
+            { onError: () => setIsLoading(false) },
+        );
         onClick?.();
         track({
             name: EventName.REFRESH_DBT_CONNECTION_BUTTON_CLICKED,
         });
     };
 
+    const selectMode = (nextMode: RefreshMode) => {
+        setMode(nextMode);
+        if (projectUuid) storeMode(projectUuid, nextMode);
+    };
+
+    const busy = isLoading;
+    const busyLabel = MODE_COPY[activeMode].busy;
+
+    const refreshButton = (
+        <Tooltip
+            withinPortal
+            multiline
+            w={320}
+            position="bottom"
+            label={MODE_COPY[activeMode].tooltip}
+        >
+            <Button
+                size="xs"
+                variant="default"
+                leftSection={leftIcon ?? <MantineIcon icon={IconRefresh} />}
+                loading={busy}
+                onClick={handleRefresh}
+                style={canSyncContent ? undefined : buttonStyles}
+            >
+                {!busy
+                    ? (defaultTextOverride ?? MODE_COPY[activeMode].label)
+                    : (refreshingTextOverride ?? busyLabel)}
+            </Button>
+        </Tooltip>
+    );
+
     return (
         <Group gap="xs">
-            <Tooltip
-                withinPortal
-                multiline
-                w={320}
-                position="bottom"
-                label="If you've updated your YAML files, you can sync your changes to Lightdash by clicking this button."
-            >
-                <Button
-                    size="xs"
-                    variant="default"
-                    leftSection={leftIcon ?? <MantineIcon icon={IconRefresh} />}
-                    loading={isLoading}
-                    onClick={handleRefresh}
-                    style={buttonStyles}
-                >
-                    {!isLoading
-                        ? (defaultTextOverride ?? 'Refresh dbt')
-                        : (refreshingTextOverride ?? 'Refreshing dbt')}
-                </Button>
-            </Tooltip>
+            {canSyncContent ? (
+                <Button.Group>
+                    {refreshButton}
+                    <Menu
+                        withinPortal
+                        position="bottom-end"
+                        withArrow
+                        shadow="md"
+                        offset={2}
+                        arrowOffset={10}
+                    >
+                        <Menu.Target>
+                            <Button
+                                size="xs"
+                                p={4}
+                                variant="default"
+                                disabled={busy}
+                                aria-label="Change refresh mode"
+                            >
+                                <MantineIcon icon={IconChevronDown} size="sm" />
+                            </Button>
+                        </Menu.Target>
+                        <Menu.Dropdown>
+                            {(['dbt', 'dbt-and-content'] as const).map(
+                                (option) => (
+                                    <Menu.Item
+                                        key={option}
+                                        onClick={() => selectMode(option)}
+                                    >
+                                        <Stack gap="two">
+                                            <Text
+                                                fz="xs"
+                                                fw={600}
+                                                c={
+                                                    activeMode === option
+                                                        ? 'blue'
+                                                        : undefined
+                                                }
+                                            >
+                                                {MODE_COPY[option].label}
+                                            </Text>
+                                            <Text fz={10} c="ldGray.6">
+                                                {MODE_COPY[option].description}
+                                            </Text>
+                                        </Stack>
+                                    </Menu.Item>
+                                ),
+                            )}
+                        </Menu.Dropdown>
+                    </Menu>
+                </Button.Group>
+            ) : (
+                refreshButton
+            )}
             {data?.type === ProjectType.PREVIEW && (
                 <Tooltip
                     withinPortal

--- a/packages/frontend/src/features/contentAsCode/hooks/useContentAsCodeSettings.ts
+++ b/packages/frontend/src/features/contentAsCode/hooks/useContentAsCodeSettings.ts
@@ -1,0 +1,21 @@
+import {
+    type ApiContentAsCodeSettingsResponse,
+    type ApiError,
+} from '@lightdash/common';
+import { useQuery } from '@tanstack/react-query';
+import { lightdashApi } from '../../../api';
+
+const CONTENT_AS_CODE_SETTINGS_QUERY_KEY = 'content-as-code-settings';
+
+// The content_as_code flags last stamped on the project by an upload or pull
+export const useContentAsCodeSettings = (projectUuid: string | undefined) =>
+    useQuery<ApiContentAsCodeSettingsResponse['results'], ApiError>({
+        queryKey: [CONTENT_AS_CODE_SETTINGS_QUERY_KEY, projectUuid],
+        queryFn: () =>
+            lightdashApi<ApiContentAsCodeSettingsResponse['results']>({
+                url: `/projects/${projectUuid}/code/sync-settings`,
+                method: 'GET',
+                body: undefined,
+            }),
+        enabled: projectUuid !== undefined,
+    });

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
@@ -504,6 +504,7 @@ export const MetricsCatalogPanel: FC<MetricsCatalogPanelProps> = ({
                         </Button>
                     ) : (
                         <RefreshDbtButton
+                            allowContentSync={false}
                             leftIcon={
                                 <MantineIcon
                                     size="sm"

--- a/packages/frontend/src/features/sourceCodeEditor/components/SourceCodeEditorContent.tsx
+++ b/packages/frontend/src/features/sourceCodeEditor/components/SourceCodeEditorContent.tsx
@@ -327,7 +327,7 @@ const SourceCodeEditorContent: FC = () => {
                 : null;
 
         if (projectBranch && currentBranch === projectBranch) {
-            refreshServer.mutate();
+            refreshServer.mutate({ syncContent: false });
         }
     }, [
         currentBranch,

--- a/packages/frontend/src/hooks/useRefreshServer.ts
+++ b/packages/frontend/src/hooks/useRefreshServer.ts
@@ -103,11 +103,16 @@ export const runningStepsInfo = (steps: JobStep[]) => {
 
 export const TOAST_KEY_FOR_REFRESH_JOB = 'refresh-job';
 
-const refresh = async (projectUuid: string) =>
+export type RefreshServerVariables = { syncContent: boolean };
+
+const refresh = async (
+    projectUuid: string,
+    { syncContent }: RefreshServerVariables,
+) =>
     lightdashApi<ApiRefreshResults>({
         method: 'POST',
         url: `/projects/${projectUuid}/refresh`,
-        body: undefined,
+        body: JSON.stringify({ syncContent }),
     });
 
 const getJob = async (jobUuid: string) =>
@@ -149,9 +154,9 @@ export const useRefreshServer = () => {
     const queryClient = useQueryClient();
     const { setActiveJobId } = useActiveJob();
     const { showToastApiError } = useToaster();
-    return useMutation<ApiRefreshResults, ApiError>({
+    return useMutation<ApiRefreshResults, ApiError, RefreshServerVariables>({
         mutationKey: ['refresh', projectUuid],
-        mutationFn: () => refresh(projectUuid!),
+        mutationFn: (variables) => refresh(projectUuid!, variables),
         onSettled: async () =>
             queryClient.setQueryData(['status', projectUuid], 'loading'),
         onSuccess: (data) => setActiveJobId(data.jobUuid),


### PR DESCRIPTION
Closes PROD-10632

## Why

Once a project opts into content-as-code sync, publishing the repo's charts and dashboards should not require the CLI. The refresh flow in the app already recompiles dbt; this adds the second half.

## What

- `POST /code/pull`: reads `lightdash.config.yml` from the project's repo, re-stamps `content_as_code.sync` and `path` through the same `stampContentAsCodeSettings` the CLI uses, lists the repo once (GitHub tree API, GitLab tree API) and reads the content files with shared credentials and bounded concurrency, classifies them by the CLI's rules (`charts/` and `dashboards/` folders at any depth, loose files by `contentType`, `*.sql.yml` to `upsertSqlChart`, space and language files skipped), then applies charts first. A chart that fails holds back the dashboards that use it, as `lightdash upload` does; failures come back in the summary and in the toast. Refuses when the repo has not opted in or the tree listing is truncated. Requires manage on content-as-code (it re-stamps project settings).
- `POST /refresh` accepts `{ syncContent: true }`. The compile job then carries a second step, "Syncing content from the repo", run by the scheduler worker inside the project lock after compiling and before the job is marked done (the same place `validateAfterCompile` hangs off). Files that could not be applied fail that step with the list in the job details, so the outcome survives navigation and lands where every other compile outcome does.
- `RefreshDbtButton` becomes a split button (same pattern as the SQL runner header) for content-as-code managers on git projects whose stamped settings say sync is on. Modes: "Refresh dbt" and "Refresh dbt and sync content"; the choice is remembered per browser and per project. Surfaces with their own refresh copy (the metrics catalog) opt out with `allowContentSync={false}`.
- `useContentAsCodeSettings` hook for the stamped settings.

## Regression analysis

- Projects without a `sync: true` stamp see the exact button they had before; the settings query is the only new request.
- The sync only runs when the request says so. It writes through the existing `upsertChart`/`upsertSqlChart`/`upsertDashboard` paths, so behaviour matches a CLI upload, including the absence of drift detection on main.
- `useRefreshServer` now takes `{ syncContent }`; both existing callers pass `false`.
- Spaces are not pulled: space-as-code re-applies access rules, which is too destructive for a one-click refresh.

## Verified

- Unit: stamp and apply order across nested folders, loose files, and a SQL chart; hold-back of dashboards whose chart failed; refusal when sync is off (still stamps); missing config; truncated tree.
- Unit: `compileProject` runs the after-compile step before marking the job done, and a failing step leaves the job in error.
- Live on a GitHub-backed project: `POST /code/pull` applied 10 charts and 3 dashboards with no failures; in the browser the split button, menu, and mode switch render, and a full "Refresh dbt and sync content" click produced one job with `COMPILING=DONE, SYNCING_CONTENT=DONE` and the usual "Successfully synced dbt project!" toast.

## Known limitations

- The first stamp still comes from a CLI upload; the compile path does not read `content_as_code` yet, so a project that never ran `lightdash upload` will not see the split button.
- `POST /code/pull` still exists for direct API use and runs inline; the button path goes through the job.
