### PR TITLE
feat(data-apps): link external connections from settings

### DIFF
--- a/packages/backend/src/ee/models/ExternalConnectionModel.test.ts
+++ b/packages/backend/src/ee/models/ExternalConnectionModel.test.ts
@@ -1,3 +1,4 @@
+import { ConflictError } from '@lightdash/common';
 import knex, { type Knex } from 'knex';
 import { getTracker, MockClient, type Tracker } from 'knex-mock-client';
 import { EncryptionUtil } from '../../utils/EncryptionUtil/EncryptionUtil';
@@ -623,6 +624,30 @@ describe('ExternalConnectionModel', () => {
             expect(bindings).toEqual(
                 expect.arrayContaining([APP_ID, CONNECTION_UUID, 'acme']),
             );
+        });
+
+        it('keeps retries of the same app alias and connection idempotent', async () => {
+            tracker.on.insert(AppExternalConnectionsTableName).responseOnce([]);
+            tracker.on
+                .select(AppExternalConnectionsTableName)
+                .responseOnce([{ external_connection_uuid: CONNECTION_UUID }]);
+
+            await expect(
+                model.linkToApp(APP_ID, CONNECTION_UUID, 'acme'),
+            ).resolves.toBeUndefined();
+        });
+
+        it('rejects an app alias already owned by another connection', async () => {
+            tracker.on.insert(AppExternalConnectionsTableName).responseOnce([]);
+            tracker.on
+                .select(AppExternalConnectionsTableName)
+                .responseOnce([
+                    { external_connection_uuid: 'another-connection' },
+                ]);
+
+            await expect(
+                model.linkToApp(APP_ID, CONNECTION_UUID, 'acme'),
+            ).rejects.toThrow(ConflictError);
         });
 
         it('replaceAppLinks deletes stale aliases and upserts with repoint-on-conflict', async () => {

--- a/packages/backend/src/ee/models/ExternalConnectionModel.ts
+++ b/packages/backend/src/ee/models/ExternalConnectionModel.ts
@@ -1,5 +1,6 @@
 import {
     AlreadyExistsError,
+    ConflictError,
     DATA_APP_VIZ_TEMPLATE,
     EXTERNAL_CONNECTION_DEFAULTS,
     generateSlug,
@@ -907,15 +908,34 @@ export class ExternalConnectionModel {
         externalConnectionUuid: string,
         alias: string,
     ): Promise<void> {
-        // Idempotent: re-linking the same alias (e.g. on iteration) is a no-op.
-        await this.database(AppExternalConnectionsTableName)
+        const inserted = await this.database(AppExternalConnectionsTableName)
             .insert({
                 app_id: appId,
                 external_connection_uuid: externalConnectionUuid,
                 alias,
             })
             .onConflict(['app_id', 'alias'])
-            .ignore();
+            .ignore()
+            .returning('external_connection_uuid');
+
+        if (inserted.length > 0) return;
+
+        const existing = await this.database(AppExternalConnectionsTableName)
+            .where('app_id', appId)
+            .where('alias', alias)
+            .first<{ external_connection_uuid: string } | undefined>(
+                'external_connection_uuid',
+            );
+
+        // Preserve idempotency for retries of the same link, but never report
+        // success when this alias points at a different connection.
+        if (existing?.external_connection_uuid === externalConnectionUuid) {
+            return;
+        }
+
+        throw new ConflictError(
+            `Alias "${alias}" is already linked to another external connection for this app`,
+        );
     }
 
     /**

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionUsageModal.test.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionUsageModal.test.tsx
@@ -1,4 +1,5 @@
 import {
+    type EmbedProjectApp,
     type ExternalConnectionLinkedApps,
     type ExternalConnectionListItem,
 } from '@lightdash/common';
@@ -14,6 +15,20 @@ const mocks = vi.hoisted(() => ({
     data: { items: [], total: 0 } as ExternalConnectionLinkedApps,
     refetch: vi.fn(),
     unlink: vi.fn(),
+    link: vi.fn(),
+    projectApps: [] as EmbedProjectApp[],
+    projectChartTypes: [] as EmbedProjectApp[],
+}));
+
+vi.mock('../../../features/apps/hooks/useProjectApps', () => ({
+    useProjectAppsByKind: (
+        _projectUuid: string,
+        kind: 'data_app' | 'project_chart_type',
+    ) => ({
+        data: kind === 'data_app' ? mocks.projectApps : mocks.projectChartTypes,
+        isLoading: false,
+        isError: false,
+    }),
 }));
 
 vi.mock(
@@ -33,6 +48,16 @@ vi.mock(
     () => ({
         useUnlinkAppExternalConnection: () => ({
             mutate: mocks.unlink,
+            isLoading: false,
+        }),
+    }),
+);
+
+vi.mock(
+    '../../../features/externalConnections/hooks/useLinkAppExternalConnection',
+    () => ({
+        useLinkAppExternalConnection: () => ({
+            mutate: mocks.link,
             isLoading: false,
         }),
     }),
@@ -105,6 +130,8 @@ describe('external connection usage', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         mocks.data = { items: [], total: 0 };
+        mocks.projectApps = [];
+        mocks.projectChartTypes = [];
     });
 
     it('opens the usage modal from a zero count', () => {
@@ -118,7 +145,15 @@ describe('external connection usage', () => {
 
         expect(screen.getByRole('dialog')).toBeInTheDocument();
         expect(screen.getByText('Linked to “Example API”')).toBeInTheDocument();
-        expect(screen.getByText('No linked apps')).toBeInTheDocument();
+        expect(
+            screen.getByRole('tab', { name: 'Data apps (0)' }),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole('tab', { name: 'Chart types (0)' }),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole('textbox', { name: 'Link a data app' }),
+        ).toBeInTheDocument();
     });
 
     it('keeps chart-type-only usage visible and clickable', () => {
@@ -186,11 +221,20 @@ describe('external connection usage', () => {
             />,
         );
 
-        expect(screen.getByText('Data apps')).toBeInTheDocument();
-        expect(screen.getByText('Chart types')).toBeInTheDocument();
+        expect(
+            screen.getByRole('tab', { name: 'Data apps (1)' }),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole('tab', { name: 'Chart types (1)' }),
+        ).toBeInTheDocument();
         expect(
             screen.getByRole('link', { name: /Revenue dashboard/ }),
         ).toHaveAttribute('href', '/projects/project-uuid/apps/app-1');
+        expect(
+            screen.queryByRole('link', { name: /Region map/ }),
+        ).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('tab', { name: 'Chart types (1)' }));
         expect(
             screen.getByRole('link', { name: /Region map/ }),
         ).toHaveAttribute(
@@ -198,6 +242,8 @@ describe('external connection usage', () => {
             '/projects/project-uuid/chart-types/chart-type-1',
         );
         expect(screen.queryByText(/Aliases?:/)).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('tab', { name: 'Data apps (1)' }));
 
         fireEvent.click(
             screen.getByRole('button', {
@@ -227,5 +273,103 @@ describe('external connection usage', () => {
             },
             expect.objectContaining({ onSuccess: expect.any(Function) }),
         );
+    });
+
+    it('links an unlinked data app from the inline add row', () => {
+        mocks.data = {
+            items: [
+                {
+                    appUuid: 'app-1',
+                    name: 'Already linked',
+                    slug: 'already-linked',
+                    kind: 'data_app',
+                    spaceUuid: null,
+                    spaceName: null,
+                    aliases: ['example_api'],
+                },
+            ],
+            total: 1,
+        };
+        mocks.projectApps = [
+            {
+                appUuid: 'app-1',
+                name: 'Already linked',
+                slug: 'already-linked',
+            },
+            {
+                appUuid: 'app-2',
+                name: 'Revenue dashboard',
+                slug: 'revenue-dashboard',
+            },
+        ];
+        renderWithRouter(
+            <ConnectionUsageModal
+                opened
+                onClose={vi.fn()}
+                projectUuid="project-uuid"
+                connection={connection}
+            />,
+        );
+
+        expect(screen.getAllByRole('dialog')).toHaveLength(1);
+        expect(
+            screen.getByRole('link', { name: /Already linked/ }),
+        ).toBeInTheDocument();
+        fireEvent.click(
+            screen.getByRole('textbox', { name: 'Link a data app' }),
+        );
+
+        expect(
+            screen.queryByRole('option', { name: /Already linked/ }),
+        ).not.toBeInTheDocument();
+        fireEvent.click(
+            screen.getByRole('option', {
+                name: 'Revenue dashboard · revenue-dashboard',
+            }),
+        );
+
+        expect(mocks.link).toHaveBeenCalledWith({
+            projectUuid: 'project-uuid',
+            appUuid: 'app-2',
+            appName: 'Revenue dashboard',
+            externalConnectionUuid: 'connection-uuid',
+            connectionName: 'Example API',
+        });
+    });
+
+    it('links an unlinked chart type from its tab', () => {
+        mocks.projectChartTypes = [
+            {
+                appUuid: 'chart-type-1',
+                name: 'Region map',
+                slug: 'region-map',
+            },
+        ];
+        renderWithRouter(
+            <ConnectionUsageModal
+                opened
+                onClose={vi.fn()}
+                projectUuid="project-uuid"
+                connection={connection}
+            />,
+        );
+
+        fireEvent.click(screen.getByRole('tab', { name: 'Chart types (0)' }));
+        fireEvent.click(
+            screen.getByRole('textbox', { name: 'Link a chart type' }),
+        );
+        fireEvent.click(
+            screen.getByRole('option', {
+                name: 'Region map · region-map',
+            }),
+        );
+
+        expect(mocks.link).toHaveBeenCalledWith({
+            projectUuid: 'project-uuid',
+            appUuid: 'chart-type-1',
+            appName: 'Region map',
+            externalConnectionUuid: 'connection-uuid',
+            connectionName: 'Example API',
+        });
     });
 });

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionUsageModal.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionUsageModal.tsx
@@ -9,9 +9,9 @@ import {
     Group,
     Skeleton,
     Stack,
+    Tabs,
     Text,
     ThemeIcon,
-    Title,
 } from '@mantine/core';
 import {
     IconAppWindow,
@@ -21,13 +21,14 @@ import {
     IconPuzzle,
     IconUser,
 } from '@tabler/icons-react';
-import { useState, type FC } from 'react';
+import { useState, type FC, type ReactNode } from 'react';
 import { Link } from 'react-router';
 import { useExternalConnectionLinkedApps } from '../../../features/externalConnections/hooks/useExternalConnectionLinkedApps';
 import { useUnlinkAppExternalConnection } from '../../../features/externalConnections/hooks/useUnlinkAppExternalConnection';
 import MantineIcon from '../../common/MantineIcon';
 import MantineModal from '../../common/MantineModal';
 import classes from './ConnectionUsageModal.module.css';
+import { LinkAppRow } from './LinkAppRow';
 
 type Props = {
     opened: boolean;
@@ -94,29 +95,22 @@ const UsageRow: FC<{
     );
 };
 
-const UsageSection: FC<{
-    title: string;
+const UsageList: FC<{
     items: ExternalConnectionLinkedApp[];
     projectUuid: string;
     onUnlink: (item: ExternalConnectionLinkedApp) => void;
-}> = ({ title, items, projectUuid, onUnlink }) => (
-    <Stack gap="xs">
-        <Group gap="xs">
-            <Title order={6}>{title}</Title>
-            <Text fz="xs" c="ldGray.6">
-                {items.length}
-            </Text>
-        </Group>
-        <Stack gap={0}>
-            {items.map((item) => (
-                <UsageRow
-                    key={item.appUuid}
-                    projectUuid={projectUuid}
-                    item={item}
-                    onUnlink={onUnlink}
-                />
-            ))}
-        </Stack>
+    children?: ReactNode;
+}> = ({ items, projectUuid, onUnlink, children }) => (
+    <Stack gap={0}>
+        {items.map((item) => (
+            <UsageRow
+                key={item.appUuid}
+                projectUuid={projectUuid}
+                item={item}
+                onUnlink={onUnlink}
+            />
+        ))}
+        {children}
     </Stack>
 );
 
@@ -181,35 +175,58 @@ export const ConnectionUsageModal: FC<Props> = ({
                         Try again
                     </Button>
                 </Stack>
-            ) : (data?.total ?? 0) === 0 ? (
-                <Stack align="center" gap="xs" py="xl">
-                    <Text fz="sm" fw={600}>
-                        No linked apps
-                    </Text>
-                    <Text fz="sm" c="ldGray.6" ta="center">
-                        No data apps or chart types are linked to this
-                        connection yet.
-                    </Text>
-                </Stack>
             ) : (
-                <Stack gap="lg">
-                    {dataApps.length > 0 && (
-                        <UsageSection
-                            title="Data apps"
+                <Tabs
+                    defaultValue={
+                        dataApps.length === 0 && chartTypes.length > 0
+                            ? 'chartTypes'
+                            : 'dataApps'
+                    }
+                    keepMounted={false}
+                >
+                    <Tabs.List grow>
+                        <Tabs.Tab value="dataApps">
+                            Data apps ({dataApps.length})
+                        </Tabs.Tab>
+                        <Tabs.Tab value="chartTypes">
+                            Chart types ({chartTypes.length})
+                        </Tabs.Tab>
+                    </Tabs.List>
+
+                    <Tabs.Panel value="dataApps" pt="md">
+                        <UsageList
                             items={dataApps}
                             projectUuid={projectUuid}
                             onUnlink={setPendingUnlink}
-                        />
-                    )}
-                    {chartTypes.length > 0 && (
-                        <UsageSection
-                            title="Chart types"
+                        >
+                            <LinkAppRow
+                                kind="data_app"
+                                projectUuid={projectUuid}
+                                connection={connection}
+                                linkedAppUuids={dataApps.map(
+                                    (item) => item.appUuid,
+                                )}
+                            />
+                        </UsageList>
+                    </Tabs.Panel>
+
+                    <Tabs.Panel value="chartTypes" pt="md">
+                        <UsageList
                             items={chartTypes}
                             projectUuid={projectUuid}
                             onUnlink={setPendingUnlink}
-                        />
-                    )}
-                </Stack>
+                        >
+                            <LinkAppRow
+                                kind="project_chart_type"
+                                projectUuid={projectUuid}
+                                connection={connection}
+                                linkedAppUuids={chartTypes.map(
+                                    (item) => item.appUuid,
+                                )}
+                            />
+                        </UsageList>
+                    </Tabs.Panel>
+                </Tabs>
             )}
             <MantineModal
                 opened={pendingUnlink !== undefined}

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/LinkAppRow.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/LinkAppRow.tsx
@@ -1,0 +1,103 @@
+import {
+    getAppDisplayName,
+    type ExternalConnectionListItem,
+} from '@lightdash/common';
+import { Box, Loader, Select, ThemeIcon } from '@mantine/core';
+import { IconPlus } from '@tabler/icons-react';
+import { type FC } from 'react';
+import {
+    useProjectAppsByKind,
+    type ProjectAppKind,
+} from '../../../features/apps/hooks/useProjectApps';
+import { useLinkAppExternalConnection } from '../../../features/externalConnections/hooks/useLinkAppExternalConnection';
+import MantineIcon from '../../common/MantineIcon';
+import classes from './ConnectionUsageModal.module.css';
+
+type Props = {
+    projectUuid: string;
+    connection: ExternalConnectionListItem;
+    linkedAppUuids: string[];
+    kind: ProjectAppKind;
+};
+
+export const LinkAppRow: FC<Props> = ({
+    projectUuid,
+    connection,
+    linkedAppUuids,
+    kind,
+}) => {
+    const {
+        data: projectApps,
+        isLoading: isLoadingApps,
+        isError: isAppsError,
+    } = useProjectAppsByKind(projectUuid, kind);
+    const { mutate: link, isLoading: isLinking } =
+        useLinkAppExternalConnection();
+    const linked = new Set(linkedAppUuids);
+    const availableApps = (projectApps ?? [])
+        .filter((app) => !linked.has(app.appUuid))
+        .sort((left, right) =>
+            getAppDisplayName(left.name, left.appUuid).localeCompare(
+                getAppDisplayName(right.name, right.appUuid),
+            ),
+        );
+
+    const handleSelect = (appUuid: string | null) => {
+        const app = availableApps.find(
+            (candidate) => candidate.appUuid === appUuid,
+        );
+        if (!app) return;
+
+        link({
+            projectUuid,
+            appUuid: app.appUuid,
+            appName: getAppDisplayName(app.name, app.appUuid),
+            externalConnectionUuid: connection.externalConnectionUuid,
+            connectionName: connection.name,
+        });
+    };
+
+    const resourceName = kind === 'data_app' ? 'data app' : 'chart type';
+    const resourceNamePlural =
+        kind === 'data_app' ? 'data apps' : 'chart types';
+    const placeholder = isLoadingApps
+        ? `Loading ${resourceNamePlural}...`
+        : isAppsError
+          ? `Could not load ${resourceNamePlural}`
+          : projectApps?.length === 0
+            ? `No ${resourceNamePlural} available`
+            : availableApps.length === 0
+              ? `All ${resourceNamePlural} are linked`
+              : `Link a ${resourceName}...`;
+
+    return (
+        <Box className={classes.resourceRow}>
+            <ThemeIcon variant="light" size="lg" color="gray">
+                <MantineIcon icon={IconPlus} />
+            </ThemeIcon>
+            <Select
+                aria-label={`Link a ${resourceName}`}
+                searchable
+                variant="unstyled"
+                flex={1}
+                placeholder={
+                    isLinking ? `Linking ${resourceName}...` : placeholder
+                }
+                nothingFoundMessage={`No matching ${resourceNamePlural}`}
+                data={availableApps.map((app) => ({
+                    value: app.appUuid,
+                    label: `${getAppDisplayName(app.name, app.appUuid)} · ${app.slug}`,
+                }))}
+                value={null}
+                onChange={handleSelect}
+                disabled={
+                    isLoadingApps ||
+                    isAppsError ||
+                    isLinking ||
+                    availableApps.length === 0
+                }
+                rightSection={isLinking ? <Loader size={14} /> : undefined}
+            />
+        </Box>
+    );
+};

--- a/packages/frontend/src/features/apps/hooks/useProjectApps.ts
+++ b/packages/frontend/src/features/apps/hooks/useProjectApps.ts
@@ -2,13 +2,31 @@ import { type ApiError, type EmbedProjectApp } from '@lightdash/common';
 import { useQuery } from '@tanstack/react-query';
 import { lightdashApi } from '../../../api';
 
+export type ProjectAppKind = 'data_app' | 'project_chart_type';
+
 const getProjectApps = async (
     projectUuid: string,
+    kind: ProjectAppKind,
 ): Promise<EmbedProjectApp[]> =>
     lightdashApi<EmbedProjectApp[]>({
         method: 'GET',
-        url: `/ee/projects/${projectUuid}/apps`,
+        url: `/ee/projects/${projectUuid}/apps${
+            kind === 'project_chart_type' ? '/chart-types' : ''
+        }`,
         body: undefined,
+    });
+
+export const useProjectAppsByKind = (
+    projectUuid: string | undefined,
+    kind: ProjectAppKind,
+) =>
+    useQuery<EmbedProjectApp[], ApiError>({
+        queryKey: [
+            kind === 'data_app' ? 'project-apps' : 'project-chart-types',
+            projectUuid,
+        ],
+        queryFn: () => getProjectApps(projectUuid!, kind),
+        enabled: !!projectUuid,
     });
 
 /**
@@ -16,8 +34,4 @@ const getProjectApps = async (
  * config's standalone-app allowlist picker.
  */
 export const useProjectApps = (projectUuid: string | undefined) =>
-    useQuery<EmbedProjectApp[], ApiError>({
-        queryKey: ['project-apps', projectUuid],
-        queryFn: () => getProjectApps(projectUuid!),
-        enabled: !!projectUuid,
-    });
+    useProjectAppsByKind(projectUuid, 'data_app');

--- a/packages/frontend/src/features/externalConnections/hooks/useAppExternalConnections.ts
+++ b/packages/frontend/src/features/externalConnections/hooks/useAppExternalConnections.ts
@@ -5,7 +5,7 @@ import {
 import { useQuery } from '@tanstack/react-query';
 import { lightdashApi } from '../../../api';
 
-const getAppExternalConnections = async (
+export const getAppExternalConnections = async (
     projectUuid: string,
     appUuid: string,
 ) =>

--- a/packages/frontend/src/features/externalConnections/hooks/useLinkAppExternalConnection.test.tsx
+++ b/packages/frontend/src/features/externalConnections/hooks/useLinkAppExternalConnection.test.tsx
@@ -1,0 +1,69 @@
+import { type AppExternalConnectionLinked } from '@lightdash/common';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { type FC, type PropsWithChildren } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { lightdashApi } from '../../../api';
+import { useLinkAppExternalConnection } from './useLinkAppExternalConnection';
+
+vi.mock('../../../api', () => ({ lightdashApi: vi.fn() }));
+vi.mock('../../../hooks/toaster/useToaster', () => ({
+    default: () => ({
+        showToastSuccess: vi.fn(),
+        showToastApiError: vi.fn(),
+    }),
+}));
+
+const setup = () => {
+    const queryClient = new QueryClient({
+        defaultOptions: {
+            queries: { retry: false },
+            mutations: { retry: false },
+        },
+    });
+    const wrapper: FC<PropsWithChildren> = ({ children }) => (
+        <QueryClientProvider client={queryClient}>
+            {children}
+        </QueryClientProvider>
+    );
+
+    return renderHook(() => useLinkAppExternalConnection(), { wrapper });
+};
+
+describe('useLinkAppExternalConnection', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('generates a unique alias from the app links before linking', async () => {
+        vi.mocked(lightdashApi)
+            .mockResolvedValueOnce([
+                { alias: 'example_api' },
+            ] as AppExternalConnectionLinked[])
+            .mockResolvedValueOnce(undefined as never);
+        const { result } = setup();
+
+        result.current.mutate({
+            projectUuid: 'project-1',
+            appUuid: 'app-1',
+            appName: 'Revenue dashboard',
+            externalConnectionUuid: 'connection-1',
+            connectionName: 'Example API',
+        });
+
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+        expect(lightdashApi).toHaveBeenNthCalledWith(1, {
+            url: '/ee/projects/project-1/apps/app-1/external-connections',
+            method: 'GET',
+            body: undefined,
+        });
+        expect(lightdashApi).toHaveBeenNthCalledWith(2, {
+            url: '/ee/projects/project-1/apps/app-1/external-connections',
+            method: 'POST',
+            body: JSON.stringify({
+                externalConnectionUuid: 'connection-1',
+                alias: 'example_api_2',
+            }),
+        });
+    });
+});

--- a/packages/frontend/src/features/externalConnections/hooks/useLinkAppExternalConnection.ts
+++ b/packages/frontend/src/features/externalConnections/hooks/useLinkAppExternalConnection.ts
@@ -1,0 +1,70 @@
+import { type ApiError } from '@lightdash/common';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { lightdashApi } from '../../../api';
+import useToaster from '../../../hooks/toaster/useToaster';
+import { uniqueAliasFromName } from '../utils/aliasFromName';
+import { getAppExternalConnections } from './useAppExternalConnections';
+
+type LinkParams = {
+    projectUuid: string;
+    appUuid: string;
+    appName: string;
+    externalConnectionUuid: string;
+    connectionName: string;
+};
+
+const linkAppExternalConnection = async (
+    params: LinkParams,
+): Promise<undefined> => {
+    const { projectUuid, appUuid, externalConnectionUuid, connectionName } =
+        params;
+    const existingLinks = await getAppExternalConnections(projectUuid, appUuid);
+    const alias = uniqueAliasFromName(
+        connectionName,
+        existingLinks.map((link) => link.alias),
+    );
+
+    return lightdashApi<undefined>({
+        url: `/ee/projects/${projectUuid}/apps/${appUuid}/external-connections`,
+        method: 'POST',
+        body: JSON.stringify({ externalConnectionUuid, alias }),
+    });
+};
+
+export const useLinkAppExternalConnection = () => {
+    const queryClient = useQueryClient();
+    const { showToastSuccess, showToastApiError } = useToaster();
+
+    return useMutation<undefined, ApiError, LinkParams>({
+        mutationFn: linkAppExternalConnection,
+        onSuccess: (_data, { appName, connectionName }) => {
+            showToastSuccess({
+                title: `Linked ${connectionName}`,
+                subtitle: `${appName} can use this connection immediately. No new version was created.`,
+            });
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to link connection',
+                apiError: error,
+            });
+        },
+        onSettled: async (_data, _error, { projectUuid, appUuid }) => {
+            await Promise.all([
+                queryClient.invalidateQueries({
+                    queryKey: [
+                        'app-external-connections',
+                        projectUuid,
+                        appUuid,
+                    ],
+                }),
+                queryClient.invalidateQueries({
+                    queryKey: ['external-connection-linked-apps', projectUuid],
+                }),
+                queryClient.invalidateQueries({
+                    queryKey: ['external-connections', projectUuid],
+                }),
+            ]);
+        },
+    });
+};


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/GLITCH-706/allow-admins-to-link-external-connections-to-apps-directly

### Description:

```diff
 Data app connections -> Linked resources
- inspect and unlink existing links
+ link data apps and chart types inline from separate tabs
```

- Adds searchable one-line link rows to the Data apps and Chart types tabs.
- Generates a code-safe alias from the connection name and keeps it unique within the target app; admins do not choose it.
- Persists links immediately through the existing app link API without creating an app version.
- Preserves the existing target-app management and connection-linkability checks. Failed links show an error and do not update the linked-resource state.
- Keeps same-link retries idempotent while rejecting an alias already owned by another connection instead of silently reporting success.

Validation:

- Frontend Vitest: 2 files, 6 tests passed.
- Backend Vitest: 2 files, 93 tests passed.
- Frontend and backend typechecks passed.
- Targeted Oxlint and Oxfmt checks passed.
- Commit hooks and git diff --check passed.
- Live browser validation was not run because no current development environment URL was supplied.

### Risk assessment:

- [ ] This is a high-risk change

Low risk. The UI is additive and reuses existing authorized link/unlink endpoints. There are no migrations or credential-handling changes, and alias conflicts cannot repoint an existing link.