### PR TITLE
fix(data-apps): preserve example inputs across tabs

### DIFF
--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionExamplesPanel.test.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionExamplesPanel.test.tsx
@@ -1,11 +1,14 @@
 import {
+    type ApiSaveExternalConnectionSampleRequest,
     type ExternalConnection,
     type ExternalFetchResponse,
+    type UpdateExternalConnection,
 } from '@lightdash/common';
 import { MantineProvider } from '@mantine/core';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ConnectionExamplesPanel } from './ConnectionExamplesPanel';
+import { EditConnectionModal } from './EditConnectionModal';
 
 const mocks = vi.hoisted(() => ({
     test: vi.fn(),
@@ -32,6 +35,16 @@ vi.mock(
     () => ({
         useSaveConnectionSample: () => ({
             mutate: mocks.saveSample,
+            mutateAsync: mocks.saveSample,
+            isLoading: false,
+        }),
+    }),
+);
+vi.mock(
+    '../../../features/externalConnections/hooks/useUpdateExternalConnection',
+    () => ({
+        useUpdateExternalConnection: () => ({
+            mutateAsync: vi.fn(),
             isLoading: false,
         }),
     }),
@@ -47,7 +60,6 @@ vi.mock(
         }),
     }),
 );
-
 const connection: ExternalConnection = {
     externalConnectionUuid: 'connection-uuid',
     projectUuid: 'project-uuid',
@@ -77,24 +89,35 @@ const connection: ExternalConnection = {
     updatedAt: new Date('2026-01-01T00:00:00Z'),
 };
 
+const panel = (
+    config: UpdateExternalConnection,
+    onQueueSample: (sample: ApiSaveExternalConnectionSampleRequest) => void,
+) => (
+    <MantineProvider env="test">
+        <ConnectionExamplesPanel
+            projectUuid="project-uuid"
+            connection={connection}
+            config={config}
+            configFingerprint={JSON.stringify(config)}
+            hasUnsavedChanges
+            isSampleQueued={false}
+            onQueueSample={onQueueSample}
+            onClearQueuedSample={vi.fn()}
+        />
+    </MantineProvider>
+);
+
 const renderPanel = (
     allowedMethods: ExternalConnection['allowedMethods'],
     onQueueSample = vi.fn(),
 ) => {
-    render(
-        <MantineProvider env="test">
-            <ConnectionExamplesPanel
-                projectUuid="project-uuid"
-                connection={connection}
-                config={{ allowedMethods }}
-                hasUnsavedChanges
-                isSampleQueued={false}
-                onQueueSample={onQueueSample}
-                onClearQueuedSample={vi.fn()}
-            />
-        </MantineProvider>,
-    );
-    return { onQueueSample };
+    const result = render(panel({ allowedMethods }, onQueueSample));
+    return {
+        ...result,
+        onQueueSample,
+        rerenderWithConfig: (config: UpdateExternalConnection) =>
+            result.rerender(panel(config, onQueueSample)),
+    };
 };
 
 describe('ConnectionExamplesPanel draft config', () => {
@@ -172,5 +195,58 @@ describe('ConnectionExamplesPanel draft config', () => {
             response: { id: 1 },
         });
         expect(mocks.saveSample).not.toHaveBeenCalled();
+    });
+
+    it('does not expose a test result produced with an older draft config', () => {
+        mocks.testResult = {
+            status: 200,
+            contentType: 'application/json',
+            body: { id: 1 },
+            truncated: false,
+        };
+        const onQueueSample = vi.fn();
+        const { rerenderWithConfig } = renderPanel(['GET'], onQueueSample);
+
+        fireEvent.click(
+            screen.getByRole('button', { name: 'Send test request' }),
+        );
+        expect(
+            screen.getByRole('button', { name: 'Save with connection' }),
+        ).toBeInTheDocument();
+
+        rerenderWithConfig({
+            origin: 'https://api.other-example.com',
+            allowedMethods: ['GET'],
+        });
+
+        expect(
+            screen.queryByRole('button', { name: 'Save with connection' }),
+        ).not.toBeInTheDocument();
+        expect(onQueueSample).not.toHaveBeenCalled();
+    });
+
+    it('keeps the example path when switching tabs', () => {
+        render(
+            <MantineProvider env="test">
+                <EditConnectionModal
+                    opened
+                    onClose={vi.fn()}
+                    projectUuid="project-uuid"
+                    connection={connection}
+                />
+            </MantineProvider>,
+        );
+
+        fireEvent.click(screen.getByRole('tab', { name: 'Examples' }));
+        fireEvent.change(screen.getByRole('textbox', { name: 'Path' }), {
+            target: { value: '/v1/drivers' },
+        });
+
+        fireEvent.click(screen.getByRole('tab', { name: 'Instructions' }));
+        fireEvent.click(screen.getByRole('tab', { name: 'Examples' }));
+
+        expect(screen.getByRole('textbox', { name: 'Path' })).toHaveValue(
+            '/v1/drivers',
+        );
     });
 });

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionExamplesPanel.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionExamplesPanel.tsx
@@ -196,6 +196,7 @@ type Props = {
     projectUuid: string;
     connection: ExternalConnection;
     config: UpdateExternalConnection;
+    configFingerprint: string;
     hasUnsavedChanges: boolean;
     isSampleQueued: boolean;
     onQueueSample: (sample: ApiSaveExternalConnectionSampleRequest) => void;
@@ -206,6 +207,7 @@ export const ConnectionExamplesPanel: FC<Props> = ({
     projectUuid,
     connection,
     config,
+    configFingerprint,
     hasUnsavedChanges,
     isSampleQueued,
     onQueueSample,
@@ -222,10 +224,12 @@ export const ConnectionExamplesPanel: FC<Props> = ({
         validate: zodResolver(exampleFormSchema),
     });
 
-    // The exact request that produced the current test result. Saved verbatim so
-    // a sample never pairs the latest form edits with an older response.
-    const [testedRequest, setTestedRequest] =
-        useState<ExternalConnectionSampleRequest | null>(null);
+    // The exact request and config that produced the current test result. Saved
+    // verbatim so a sample never pairs later edits with an older response.
+    const [testedRequest, setTestedRequest] = useState<{
+        request: ExternalConnectionSampleRequest;
+        configFingerprint: string;
+    } | null>(null);
 
     const testMutation = useTestConnection();
     const saveSampleMutation = useSaveConnectionSample();
@@ -241,6 +245,16 @@ export const ConnectionExamplesPanel: FC<Props> = ({
     const method = methodOptions.includes(form.values.method)
         ? form.values.method
         : (methodOptions[0] ?? 'GET');
+    // This panel stays mounted across tabs, so a draft edit can make the last
+    // response stale. Keep the request inputs, but only expose results produced
+    // by the current config.
+    const validTestedRequest =
+        testedRequest?.configFingerprint === configFingerprint
+            ? testedRequest.request
+            : null;
+    const validTestResponse = validTestedRequest
+        ? testMutation.data
+        : undefined;
 
     // Pasting a URL (or path) with a query string splits the query out into the
     // key/value rows instead of leaving it stuck in the path. The pasted URL is
@@ -269,7 +283,7 @@ export const ConnectionExamplesPanel: FC<Props> = ({
                         ? parseJson(values.requestBody)
                         : undefined,
             };
-            setTestedRequest(request);
+            setTestedRequest({ request, configFingerprint });
             testMutation.mutate({
                 projectUuid,
                 connectionUuid: connection.externalConnectionUuid,
@@ -282,11 +296,11 @@ export const ConnectionExamplesPanel: FC<Props> = ({
     const handleSaveSample = (data: ExternalFetchResponse) => {
         // Save the immutable snapshot of the request that produced this
         // response — not the current (possibly edited) form state.
-        if (!testedRequest) return;
+        if (!validTestedRequest) return;
 
         const sample: ApiSaveExternalConnectionSampleRequest = {
             label: form.values.sampleLabel.trim() || null,
-            request: testedRequest,
+            request: validTestedRequest,
             response: data.body,
         };
         if (hasUnsavedChanges) {
@@ -443,11 +457,11 @@ export const ConnectionExamplesPanel: FC<Props> = ({
                 </Group>
             )}
 
-            {methodOptions.length > 0 && testMutation.data && (
+            {methodOptions.length > 0 && validTestResponse && (
                 <Stack gap="xs">
-                    <ConnectionTestResult response={testMutation.data} />
+                    <ConnectionTestResult response={validTestResponse} />
 
-                    {testMutation.data.status < 300 && (
+                    {validTestResponse.status < 300 && (
                         <>
                             <TextInput
                                 label="Sample label (optional)"
@@ -462,7 +476,7 @@ export const ConnectionExamplesPanel: FC<Props> = ({
                                     size="xs"
                                     variant="outline"
                                     onClick={() =>
-                                        handleSaveSample(testMutation.data!)
+                                        handleSaveSample(validTestResponse)
                                     }
                                     loading={saveSampleMutation.isLoading}
                                 >

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/EditConnectionModal.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/EditConnectionModal.tsx
@@ -244,11 +244,12 @@ const EditConnectionModalContent: FC<Props> = ({
                         </Stack>
                     </Tabs.Panel>
 
-                    <Tabs.Panel value="examples">
+                    <Tabs.Panel value="examples" keepMounted>
                         <ConnectionExamplesPanel
                             projectUuid={projectUuid}
                             connection={connection}
                             config={draftConfig}
+                            configFingerprint={draftConfigFingerprint}
                             hasUnsavedChanges={form.isDirty()}
                             isSampleQueued={validPendingSample !== null}
                             onQueueSample={(sample) =>


### PR DESCRIPTION
Closes: [GLITCH-721](https://linear.app/lightdash/issue/GLITCH-721/dont-clear-example-input-when-switching-tabs)

### Description:

```diff
 Edit connection -> Examples
- switching tabs resets the method, path, query parameters, and request body
+ switching tabs preserves the in-progress example request
```

- Keeps the Examples panel mounted for the lifetime of the edit modal.
- Ties each test result to the draft configuration that produced it, so changing connection settings hides the stale result and prevents it from being queued or saved.
- Closing or cancelling the modal still discards the draft; connection settings and samples are persisted only through the existing save actions.

Validation:
- `pnpm -F frontend test src/components/Settings/DataAppConnectionsPanel/ConnectionExamplesPanel.test.tsx` — 1 file, 6 tests
- `pnpm -F frontend typecheck`
- Targeted Oxfmt and Oxlint on the three changed files
- `git diff --check`
- Live-tested on `localhost:3000`: POST method, path, query parameters, and JSON body survived Examples -> Instructions -> Examples unchanged
- Cancelled the live modal without sending a request or persisting connection/sample data

Untested boundary: no live external request or persisted sample save was performed.

### Risk assessment:

- [ ] This is a high-risk change

Low risk. The change is frontend-only and preserves existing authorization, proxy, credential, and persistence paths. Stale test results are explicitly invalidated when the draft connection configuration changes.