### PR TITLE
feat(content-as-code): record draft bases, flag stale drafts, and let authors update to the latest repo version

### DIFF
--- a/packages/backend/src/controllers/CoderControllerUtils.ts
+++ b/packages/backend/src/controllers/CoderControllerUtils.ts
@@ -50,6 +50,13 @@ export const toDraftSummary = (draft: ContentDraft): ContentDraftSummary => ({
     status: draft.status as ContentDraftSummary['status'],
     prUrl: draft.prUrl,
     writebackStatus: draft.writebackStatus,
+    stale:
+        draft.status === 'open' &&
+        Boolean(
+            draft.baseSnapshotHash &&
+            draft.currentSnapshotHash &&
+            draft.baseSnapshotHash !== draft.currentSnapshotHash,
+        ),
     createdAt: draft.createdAt,
     updatedAt: draft.updatedAt,
 });

--- a/packages/backend/src/controllers/ProjectCoderController.ts
+++ b/packages/backend/src/controllers/ProjectCoderController.ts
@@ -15,9 +15,11 @@ import {
     type ApiContentAsCodeSettingsResponse,
     type ApiContentAsCodeUploadAdvisoryResponse,
     type ApiContentAsCodeWritebacksResponse,
+    type ApiContentDraftRebaseResponse,
     type ApiContentDraftReopenResponse,
     type ApiContentDraftReviewResponse,
     type ApiContentDraftsResponse,
+    type ApiContentDraftStalenessResponse,
     type ApiContentDraftWriteBackResponse,
     type ApiDashboardAsCodeListResponse,
     type ApiDashboardAsCodeUpsertResponse,
@@ -38,6 +40,7 @@ import {
     type ApiVirtualViewAsCodeUpsertResponse,
     type ChartAsCode,
     type ContentAsCodeSettingsStamp,
+    type ContentDraftRebaseRequest,
     type ContentSlugRenameRequest,
     type DashboardAsCode,
     type ExternalConnectionAsCode,
@@ -332,7 +335,63 @@ export class ProjectCoderController extends BaseController {
             filePath: review.filePath,
             publishedYaml: review.publishedYaml,
             draftYaml: review.draftYaml,
+            staleness: review.staleness,
         });
+    }
+
+    /**
+     * What the repo and the draft each changed since the draft's base
+     * @summary Get content draft staleness
+     */
+    @Tags('Projects')
+    @Middlewares(CODE_READ_MIDDLEWARES)
+    @SuccessResponse('200', 'Success')
+    @Get('/code/drafts/{draftUuid}/staleness')
+    @OperationId('getContentDraftStaleness')
+    async getContentDraftStaleness(
+        @Path() projectUuid: string,
+        @Path() draftUuid: string,
+        @Request() req: express.Request,
+    ): Promise<ApiContentDraftStalenessResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return codeSuccess(
+            await this.services
+                .getContentAsCodeWritebackService()
+                .getDraftStalenessDetails(
+                    toSessionUser(req.account),
+                    projectUuid,
+                    draftUuid,
+                ),
+        );
+    }
+
+    /**
+     * Move the caller's draft onto the repo's latest upload snapshot
+     * @summary Rebase content draft
+     */
+    @Tags('Projects')
+    @Middlewares(CODE_WRITE_MIDDLEWARES)
+    @SuccessResponse('200', 'Success')
+    @Post('/code/drafts/{draftUuid}/rebase')
+    @OperationId('rebaseContentDraft')
+    async rebaseContentDraft(
+        @Path() projectUuid: string,
+        @Path() draftUuid: string,
+        @Request() req: express.Request,
+        @Body() body: ContentDraftRebaseRequest,
+    ): Promise<ApiContentDraftRebaseResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        const draft = await this.services
+            .getContentAsCodeWritebackService()
+            .rebaseDraft(
+                toSessionUser(req.account),
+                projectUuid,
+                draftUuid,
+                body.resolutions,
+            );
+        return codeSuccess(toDraftSummary(draft));
     }
 
     /**

--- a/packages/backend/src/database/entities/contentDrafts.ts
+++ b/packages/backend/src/database/entities/contentDrafts.ts
@@ -14,6 +14,8 @@ export type DbContentDraft = {
     pr_url: string | null;
     written_back_published: object | null;
     written_back_draft: object | null;
+    base_snapshot: object | null;
+    base_snapshot_hash: string | null;
     created_at: Date;
     updated_at: Date;
 };
@@ -27,7 +29,12 @@ export type CreateDbContentDraft = Pick<
     | 'author_user_uuid'
     | 'draft'
 > &
-    Partial<Pick<DbContentDraft, 'created_at' | 'updated_at'>>;
+    Partial<
+        Pick<
+            DbContentDraft,
+            'base_snapshot' | 'base_snapshot_hash' | 'created_at' | 'updated_at'
+        >
+    >;
 
 export type UpdateDbContentDraft = Partial<
     Pick<
@@ -37,6 +44,8 @@ export type UpdateDbContentDraft = Partial<
         | 'pr_url'
         | 'written_back_published'
         | 'written_back_draft'
+        | 'base_snapshot'
+        | 'base_snapshot_hash'
         | 'updated_at'
     >
 >;

--- a/packages/backend/src/database/migrations/20260901170000_add_base_snapshot_to_content_drafts.ts
+++ b/packages/backend/src/database/migrations/20260901170000_add_base_snapshot_to_content_drafts.ts
@@ -1,0 +1,27 @@
+import { Knex } from 'knex';
+
+export const classification = {
+    kind: 'safe',
+    reason: 'Adds nullable columns recording the upload snapshot a draft was started from',
+} as const;
+
+const DRAFTS_TABLE = 'content_drafts';
+const LOCK_TIMEOUT = '5s';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '${LOCK_TIMEOUT}'`);
+
+    await knex.schema.alterTable(DRAFTS_TABLE, (table) => {
+        table.jsonb('base_snapshot').nullable();
+        table.string('base_snapshot_hash', 64).nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '${LOCK_TIMEOUT}'`);
+
+    await knex.schema.alterTable(DRAFTS_TABLE, (table) => {
+        table.dropColumn('base_snapshot');
+        table.dropColumn('base_snapshot_hash');
+    });
+}

--- a/packages/backend/src/models/ContentDraftModel.ts
+++ b/packages/backend/src/models/ContentDraftModel.ts
@@ -23,9 +23,30 @@ export type ContentDraft = {
     writebackStatus: ContentAsCodeWritebackStatus | null;
     writtenBackPublished: ChartAsCode | DashboardAsCode | null;
     writtenBackDraft: ChartAsCode | DashboardAsCode | null;
+    // The upload snapshot the draft started from, and the slug's current one
+    baseSnapshot: object | null;
+    baseSnapshotHash: string | null;
+    currentSnapshotHash: string | null;
     createdAt: Date;
     updatedAt: Date;
 };
+
+export type ContentDraftBase = { snapshot: object; hash: string };
+
+// Save payloads carry every field of their form, changed or not; a draft
+// should only claim the fields the author actually changed
+export const pruneUnchangedDraftFields = <T extends object>(
+    published: object,
+    fields: T,
+): T =>
+    Object.fromEntries(
+        Object.entries(fields).filter(
+            ([key, value]) =>
+                !(key in published) ||
+                JSON.stringify(value) !==
+                    JSON.stringify((published as Record<string, unknown>)[key]),
+        ),
+    ) as T;
 
 type ContentDraftModelArguments = {
     database: Knex;
@@ -35,6 +56,7 @@ const parseRow = (
     row: DbContentDraft & {
         author_name?: string | null;
         writeback_status?: string | null;
+        current_snapshot_hash?: string | null;
     },
 ): ContentDraft => ({
     uuid: row.content_draft_uuid,
@@ -55,9 +77,18 @@ const parseRow = (
     writtenBackDraft:
         (row.written_back_draft as ChartAsCode | DashboardAsCode | null) ??
         null,
+    baseSnapshot: row.base_snapshot,
+    baseSnapshotHash: row.base_snapshot_hash,
+    currentSnapshotHash: row.current_snapshot_hash ?? null,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
 });
+
+// The slug's last-applied upload snapshot, to tell stale drafts apart
+const currentSnapshotHashSubquery = (knex: Knex) =>
+    knex.raw(
+        `(select s.snapshot_hash from content_as_code_snapshots s where s.project_uuid = ${ContentDraftsTableName}.project_uuid and s.content_type = ${ContentDraftsTableName}.content_type and s.slug = ${ContentDraftsTableName}.slug) as current_snapshot_hash`,
+    );
 
 // The latest write-back row for a draft carries the PR state
 const writebackStatusSubquery = (knex: Knex) =>
@@ -93,6 +124,7 @@ export class ContentDraftModel {
         slug: string;
         authorUserUuid: string;
         draft: object;
+        base: ContentDraftBase | null;
     }): Promise<ContentDraft> {
         const existing = await this.database(ContentDraftsTableName)
             .where({
@@ -109,12 +141,20 @@ export class ContentDraftModel {
             // would silently discard tiles or filters the author drafted
             // earlier. `||` merges shallowly in a single statement, so
             // concurrent saves cannot lose a field between read and write.
+            // Drafts from before bases were recorded adopt one on their
+            // next save; a recorded base is never moved by a save
+            const adoptedBase =
+                existing.base_snapshot_hash === null ? args.base : null;
             const [row] = await this.database(ContentDraftsTableName)
                 .where({ content_draft_uuid: existing.content_draft_uuid })
                 .update({
                     draft: this.database.raw('draft || ?::jsonb', [
                         JSON.stringify(args.draft),
                     ]),
+                    ...(adoptedBase !== null && {
+                        base_snapshot: adoptedBase.snapshot,
+                        base_snapshot_hash: adoptedBase.hash,
+                    }),
                     updated_at: new Date(),
                 })
                 .returning('*');
@@ -129,12 +169,34 @@ export class ContentDraftModel {
                 slug: args.slug,
                 author_user_uuid: args.authorUserUuid,
                 draft: args.draft,
+                base_snapshot: args.base?.snapshot ?? null,
+                base_snapshot_hash: args.base?.hash ?? null,
                 // Same clock as updates, so relative times stay consistent
                 created_at: now,
                 updated_at: now,
             })
             .returning('*');
         return parseRow(row);
+    }
+
+    // Moves the draft onto a newer upload snapshot, dropping the overlay keys
+    // the author chose to take from the repo
+    async rebase(
+        uuid: string,
+        args: { base: ContentDraftBase; removeKeys: string[] },
+    ): Promise<void> {
+        await this.database(ContentDraftsTableName)
+            .where({ content_draft_uuid: uuid })
+            .update({
+                ...(args.removeKeys.length > 0 && {
+                    draft: this.database.raw('draft - ?::text[]', [
+                        args.removeKeys,
+                    ]),
+                }),
+                base_snapshot: args.base.snapshot,
+                base_snapshot_hash: args.base.hash,
+                updated_at: new Date(),
+            });
     }
 
     async findOpenDraft(
@@ -230,6 +292,7 @@ export class ContentDraftModel {
                 DbContentDraft & {
                     author_name: string | null;
                     writeback_status: string | null;
+                    current_snapshot_hash: string | null;
                 }
             >(
                 `${ContentDraftsTableName}.*`,
@@ -237,6 +300,7 @@ export class ContentDraftModel {
                     "users.first_name || ' ' || users.last_name as author_name",
                 ),
                 writebackStatusSubquery(this.database),
+                currentSnapshotHashSubquery(this.database),
             )
             .first();
         return row ? parseRow(row) : undefined;
@@ -254,6 +318,7 @@ export class ContentDraftModel {
                 (DbContentDraft & {
                     author_name: string | null;
                     writeback_status: string | null;
+                    current_snapshot_hash: string | null;
                 })[]
             >(
                 `${ContentDraftsTableName}.*`,
@@ -261,6 +326,7 @@ export class ContentDraftModel {
                     "users.first_name || ' ' || users.last_name as author_name",
                 ),
                 writebackStatusSubquery(this.database),
+                currentSnapshotHashSubquery(this.database),
             )
             .orderBy(`${ContentDraftsTableName}.updated_at`, 'desc');
         return rows.map(parseRow);

--- a/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.test.ts
+++ b/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.test.ts
@@ -181,6 +181,7 @@ const buildService = (overrides: Overrides = {}) => {
                   },
         ),
         listByProject: vi.fn(),
+        rebase: vi.fn().mockResolvedValue(undefined),
         countOpenByProject: vi
             .fn()
             .mockResolvedValue(overrides.openDraftCount ?? 0),
@@ -1153,6 +1154,201 @@ describe('ContentAsCodeWritebackService', () => {
             gitIntegrationService.createPullRequestFromBranch,
         ).toHaveBeenCalledTimes(1);
         expect(contentDraftModel.update).toHaveBeenCalledTimes(1);
+    });
+
+    describe('stale drafts', () => {
+        const staleDraft = {
+            uuid: 'draft-uuid',
+            projectUuid: 'project-uuid',
+            contentType: 'dashboard',
+            contentUuid: 'dashboard-uuid',
+            slug: 'weekly-kpis',
+            authorUserUuid: 'author-uuid',
+            draft: { name: 'Weekly KPIs draft', tiles: [] },
+            status: 'open',
+            prUrl: null,
+            baseSnapshot: {
+                name: 'Weekly KPIs',
+                description: 'Old',
+                tiles: [],
+            },
+            baseSnapshotHash: 'old-hash',
+        };
+        const movedSnapshot = {
+            snapshotHash: 'new-hash',
+            snapshot: {
+                name: 'Weekly KPIs',
+                description: 'New',
+                tiles: [{ properties: { chartSlug: 'admin-tile' } }],
+            },
+        };
+
+        it('reports what the repo changed and where the draft collides', async () => {
+            const { service } = buildService({
+                draft: staleDraft,
+                snapshot: movedSnapshot,
+            });
+
+            const review = await service.getDraftReview(
+                user,
+                'project-uuid',
+                'draft-uuid',
+            );
+
+            expect(review.staleness).toEqual({
+                draftUuid: 'draft-uuid',
+                changedFields: ['description', 'tiles'],
+                conflictingFields: ['tiles'],
+            });
+        });
+
+        it('describes what the repo and the draft each did to the moved fields', async () => {
+            const { service, coderService } = buildService({
+                draft: staleDraft,
+                snapshot: movedSnapshot,
+            });
+            coderService.getDashboardAsCodeWithOverlay.mockResolvedValueOnce({
+                name: 'Weekly KPIs draft',
+                slug: 'weekly-kpis',
+                description: 'Old',
+                tiles: [
+                    { type: 'markdown', properties: { title: 'Editor note' } },
+                ],
+            });
+            const draftAuthor = { ...user, userUuid: 'author-uuid' };
+
+            const details = await service.getDraftStalenessDetails(
+                draftAuthor,
+                'project-uuid',
+                'draft-uuid',
+            );
+
+            expect(details?.changes).toEqual([
+                { field: 'description', repo: '"Old" → "New"', mine: null },
+                {
+                    field: 'tiles',
+                    repo: 'added 1 tile (admin-tile)',
+                    mine: 'added 1 tile (Editor note)',
+                },
+            ]);
+        });
+
+        it('refuses to write a stale draft back over newer repo content', async () => {
+            const { service, gitIntegrationService } = buildService({
+                draft: staleDraft,
+                snapshot: movedSnapshot,
+            });
+
+            await expect(
+                service.writeBackDraft(user, 'project-uuid', 'draft-uuid'),
+            ).rejects.toThrow('behind the repo');
+            expect(gitIntegrationService.saveFile).not.toHaveBeenCalled();
+        });
+
+        it('is not stale when the repo has not moved', async () => {
+            const { service } = buildService({
+                draft: staleDraft,
+                snapshot: {
+                    snapshotHash: 'old-hash',
+                    snapshot: staleDraft.baseSnapshot,
+                },
+            });
+
+            const review = await service.getDraftReview(
+                user,
+                'project-uuid',
+                'draft-uuid',
+            );
+
+            expect(review.staleness).toBeNull();
+        });
+
+        it('rebases onto the latest snapshot, dropping the fields the author gives up', async () => {
+            const { service, contentDraftModel } = buildService({
+                draft: staleDraft,
+                snapshot: movedSnapshot,
+            });
+            const draftAuthor = { ...user, userUuid: 'author-uuid' };
+
+            await service.rebaseDraft(
+                draftAuthor,
+                'project-uuid',
+                'draft-uuid',
+                {
+                    tiles: 'latest',
+                },
+            );
+
+            expect(contentDraftModel.rebase).toHaveBeenCalledWith(
+                'draft-uuid',
+                {
+                    base: {
+                        snapshot: movedSnapshot.snapshot,
+                        hash: 'new-hash',
+                    },
+                    removeKeys: ['tiles'],
+                },
+            );
+        });
+
+        it("keeps the author's field when they choose mine", async () => {
+            const { service, contentDraftModel } = buildService({
+                draft: staleDraft,
+                snapshot: movedSnapshot,
+            });
+            const draftAuthor = { ...user, userUuid: 'author-uuid' };
+
+            await service.rebaseDraft(
+                draftAuthor,
+                'project-uuid',
+                'draft-uuid',
+                {
+                    tiles: 'mine',
+                },
+            );
+
+            expect(contentDraftModel.rebase).toHaveBeenCalledWith(
+                'draft-uuid',
+                {
+                    base: {
+                        snapshot: movedSnapshot.snapshot,
+                        hash: 'new-hash',
+                    },
+                    removeKeys: [],
+                },
+            );
+        });
+
+        it('asks for a decision on every conflicting field', async () => {
+            const { service, contentDraftModel } = buildService({
+                draft: staleDraft,
+                snapshot: movedSnapshot,
+            });
+            const draftAuthor = { ...user, userUuid: 'author-uuid' };
+
+            await expect(
+                service.rebaseDraft(
+                    draftAuthor,
+                    'project-uuid',
+                    'draft-uuid',
+                    {},
+                ),
+            ).rejects.toThrow('tiles');
+            expect(contentDraftModel.rebase).not.toHaveBeenCalled();
+        });
+
+        it('only lets the author rebase their draft', async () => {
+            const { service } = buildService({
+                draft: staleDraft,
+                snapshot: movedSnapshot,
+            });
+
+            await expect(
+                service.rebaseDraft(user, 'project-uuid', 'draft-uuid', {
+                    tiles: 'mine',
+                }),
+            ).rejects.toThrow(ForbiddenError);
+        });
     });
 
     describe('pullFromGit', () => {

--- a/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.ts
+++ b/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.ts
@@ -2,10 +2,12 @@ import { subject } from '@casl/ability';
 import {
     assertUnreachable,
     classifyContentAsCodeFilePath,
+    computeContentDraftStaleness,
     ConflictError,
     ContentAsCodeType,
     DbtProjectType,
     DEFAULT_CONTENT_AS_CODE_PATH,
+    describeContentDraftStaleness,
     ForbiddenError,
     getContentAsCodeFilePath,
     getErrorMessage,
@@ -14,12 +16,16 @@ import {
     loadLightdashProjectConfig,
     normalizeContentAsCodePath,
     NotFoundError,
+    overlayKeysForAsCodeField,
     ParameterError,
     PullRequestSource,
     type ChartAsCode,
     type ContentAsCodeFileClassification,
     type ContentAsCodePullSummary,
     type ContentAsCodeUploadAdvisory,
+    type ContentDraftFieldResolution,
+    type ContentDraftStaleness,
+    type ContentDraftStalenessDetails,
     type DashboardAsCode,
     type LightdashProjectConfig,
     type SessionUser,
@@ -44,6 +50,7 @@ import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { UserModel } from '../../models/UserModel';
 import { BaseService } from '../BaseService';
 import { CoderService } from '../CoderService/CoderService';
+import { buildContentAsCodeSnapshot } from '../CoderService/contentAsCodeSnapshot';
 import { GitIntegrationService } from '../GitIntegrationService/GitIntegrationService';
 
 type ContentAsCodeWritebackServiceArguments = {
@@ -700,6 +707,7 @@ export class ContentAsCodeWritebackService extends BaseService {
         filePath: string;
         publishedYaml: string;
         draftYaml: string;
+        staleness: ContentDraftStaleness | null;
     }> {
         await this.assertCanManageContentAsCode(user, projectUuid);
         const draft = await this.contentDraftModel.get(draftUuid);
@@ -717,6 +725,10 @@ export class ContentAsCodeWritebackService extends BaseService {
             draft.contentType,
             draft.slug,
         );
+        const staleness =
+            draft.status === 'open'
+                ? await this.getDraftStaleness(draft)
+                : null;
         // A written-back draft shows what actually went to the repo, not a
         // live diff that drifts as published content moves on; a draft handed
         // back to its author is live again
@@ -730,6 +742,7 @@ export class ContentAsCodeWritebackService extends BaseService {
                 filePath,
                 publishedYaml: dumpContentAsCode(draft.writtenBackPublished),
                 draftYaml: dumpContentAsCode(draft.writtenBackDraft),
+                staleness,
             };
         }
         const { published, draftDoc } = await this.renderDraftDocuments(
@@ -741,6 +754,7 @@ export class ContentAsCodeWritebackService extends BaseService {
             filePath,
             publishedYaml: dumpContentAsCode(published),
             draftYaml: dumpContentAsCode(draftDoc),
+            staleness,
         };
     }
 
@@ -764,6 +778,14 @@ export class ContentAsCodeWritebackService extends BaseService {
         }
         const contentType =
             draft.contentType === 'chart' ? 'chart' : 'dashboard';
+        // Writing a stale draft back would carry the base it started from
+        // over whatever the repo published since
+        const staleness = await this.getDraftStaleness(draft);
+        if (staleness !== null) {
+            throw new ConflictError(
+                `This draft is behind the repo (changed since: ${staleness.changedFields.join(', ')}). Ask the author to update it to the latest version first.`,
+            );
+        }
         const { published, draftDoc } = await this.renderDraftDocuments(
             projectUuid,
             draft,
@@ -830,6 +852,136 @@ export class ContentAsCodeWritebackService extends BaseService {
         await this.contentDraftModel.update(draft.uuid, {
             status: 'dismissed',
         });
+    }
+
+    // Null when the draft has no recorded base or the repo has not moved
+    private async getDraftStaleness(
+        draft: ContentDraft,
+    ): Promise<ContentDraftStaleness | null> {
+        if (!draft.baseSnapshotHash) return null;
+        if (
+            draft.contentType !== 'chart' &&
+            draft.contentType !== 'dashboard'
+        ) {
+            return null;
+        }
+        const current = await this.contentAsCodeSnapshotModel.get(
+            draft.projectUuid,
+            draft.contentType === 'chart'
+                ? ContentAsCodeType.CHART
+                : ContentAsCodeType.DASHBOARD,
+            draft.slug,
+        );
+        if (!current || current.snapshotHash === draft.baseSnapshotHash) {
+            return null;
+        }
+        return computeContentDraftStaleness({
+            draftUuid: draft.uuid,
+            contentType: draft.contentType,
+            base: draft.baseSnapshot,
+            current: current.snapshot,
+            overlay: draft.draft,
+        });
+    }
+
+    // What the repo and the draft each did to the fields that moved, for the
+    // author's banner and the reviewer's stale state
+    async getDraftStalenessDetails(
+        user: SessionUser,
+        projectUuid: string,
+        draftUuid: string,
+    ): Promise<ContentDraftStalenessDetails | null> {
+        await this.assertCanViewContentAsCode(user, projectUuid);
+        const draft = await this.contentDraftModel.get(draftUuid);
+        if (!draft || draft.projectUuid !== projectUuid) {
+            throw new ParameterError('Draft not found');
+        }
+        if (draft.authorUserUuid !== user.userUuid) {
+            await this.assertCanManageContentAsCode(user, projectUuid);
+        }
+        const staleness = await this.getDraftStaleness(draft);
+        if (staleness === null) return null;
+        const current = await this.contentAsCodeSnapshotModel.get(
+            projectUuid,
+            draft.contentType === 'chart'
+                ? ContentAsCodeType.CHART
+                : ContentAsCodeType.DASHBOARD,
+            draft.slug,
+        );
+        const { draftDoc } = await this.renderDraftDocuments(
+            projectUuid,
+            draft,
+        );
+        return describeContentDraftStaleness({
+            staleness,
+            base: draft.baseSnapshot,
+            current: current?.snapshot,
+            draft: buildContentAsCodeSnapshot(draftDoc).snapshot,
+        });
+    }
+
+    // The author's gesture: move the draft onto the repo's latest snapshot,
+    // keeping their edits where the repo did not touch the same field and
+    // taking their call on the fields both sides changed
+    async rebaseDraft(
+        user: SessionUser,
+        projectUuid: string,
+        draftUuid: string,
+        resolutions: Record<string, ContentDraftFieldResolution>,
+    ): Promise<ContentDraft> {
+        await this.assertCanViewContentAsCode(user, projectUuid);
+        const draft = await this.contentDraftModel.get(draftUuid);
+        if (!draft || draft.projectUuid !== projectUuid) {
+            throw new ParameterError('Draft not found');
+        }
+        if (draft.authorUserUuid !== user.userUuid) {
+            throw new ForbiddenError();
+        }
+        if (draft.status !== 'open') {
+            throw new ConflictError('Only open drafts can be updated');
+        }
+        if (
+            draft.contentType !== 'chart' &&
+            draft.contentType !== 'dashboard'
+        ) {
+            throw new ParameterError('Unsupported draft content type');
+        }
+        const current = await this.contentAsCodeSnapshotModel.get(
+            projectUuid,
+            draft.contentType === 'chart'
+                ? ContentAsCodeType.CHART
+                : ContentAsCodeType.DASHBOARD,
+            draft.slug,
+        );
+        if (!current) {
+            throw new ConflictError(
+                'This content has no upload snapshot to update to',
+            );
+        }
+        const staleness = await this.getDraftStaleness(draft);
+        const unresolved = (staleness?.conflictingFields ?? []).filter(
+            (field) => resolutions[field] === undefined,
+        );
+        if (unresolved.length > 0) {
+            throw new ParameterError(
+                `Choose what to keep for: ${unresolved.join(', ')}`,
+            );
+        }
+        const removeKeys = (staleness?.conflictingFields ?? [])
+            .filter((field) => resolutions[field] === 'latest')
+            .flatMap((field) =>
+                overlayKeysForAsCodeField(
+                    draft.contentType === 'chart' ? 'chart' : 'dashboard',
+                    field,
+                ),
+            );
+        await this.contentDraftModel.rebase(draft.uuid, {
+            base: { snapshot: current.snapshot, hash: current.snapshotHash },
+            removeKeys,
+        });
+        const updated = await this.contentDraftModel.get(draft.uuid);
+        if (!updated) throw new ParameterError('Draft not found');
+        return updated;
     }
 
     async reopenDraft(

--- a/packages/backend/src/services/DashboardService/DashboardService.drafts.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.drafts.test.ts
@@ -240,15 +240,20 @@ describe('DashboardService drafts gating (sync + git-backed only)', () => {
         expect(upsertOpenDraft).not.toHaveBeenCalled();
     });
 
-    it('publishes normally for content-as-code managers', async () => {
+    it('drafts for content-as-code managers too, recording the upload snapshot as base', async () => {
         const { service, upsertOpenDraft } = buildService();
         const result = await service['maybeStoreDraft'](
             reviewerUser,
             dashboardDao,
             draftFields,
         );
-        expect(result).toBeUndefined();
-        expect(upsertOpenDraft).not.toHaveBeenCalled();
+        expect(result?.hasUnpublishedChanges).toBe(true);
+        expect(upsertOpenDraft).toHaveBeenCalledWith(
+            expect.objectContaining({
+                authorUserUuid: reviewerUser.userUuid,
+                base: expect.objectContaining({ hash: 'abc' }),
+            }),
+        );
     });
 
     it('turns a Git-backed dashboard move into a portable draft field', async () => {
@@ -355,7 +360,7 @@ describe('DashboardService drafts gating (sync + git-backed only)', () => {
         );
     });
 
-    it('publishes every bulk dashboard update for a Content as Code manager', async () => {
+    it('drafts every bulk dashboard update for a Content as Code manager', async () => {
         const managedDashboard = {
             ...dashboardDao,
             uuid: 'managed-dashboard',
@@ -377,11 +382,8 @@ describe('DashboardService drafts gating (sync + git-backed only)', () => {
 
         await service.updateMultiple(reviewerUser, PROJECT_UUID, updates);
 
-        expect(upsertOpenDraft).not.toHaveBeenCalled();
-        expect(dashboardUpdateMultiple).toHaveBeenCalledWith(
-            PROJECT_UUID,
-            updates,
-        );
+        expect(upsertOpenDraft).toHaveBeenCalledTimes(1);
+        expect(dashboardUpdateMultiple).not.toHaveBeenCalled();
     });
 
     it('blocks an editor from deleting a Git-backed dashboard', async () => {

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -4,6 +4,7 @@ import {
     assertRegisteredAccount,
     BulkActionable,
     canMutateVerifiedContent,
+    computeContentDraftStaleness,
     ContentAsCodeType,
     ContentType,
     CreateDashboard,
@@ -51,6 +52,7 @@ import {
     type ChartFieldUpdates,
     type ChartVersionDifference,
     type ChartVersionSummary,
+    type ContentDraftStaleness,
     type ContentVerificationInfo,
     type CreateDashboardSqlChartTile,
     type DashboardBasicDetailsWithTileTypes,
@@ -84,7 +86,9 @@ import { ContentAsCodeProjectSettingsModel } from '../../models/ContentAsCodePro
 import { ContentAsCodeSnapshotModel } from '../../models/ContentAsCodeSnapshotModel';
 import {
     ContentDraftModel,
+    pruneUnchangedDraftFields,
     type ContentDraft,
+    type ContentDraftBase,
 } from '../../models/ContentDraftModel';
 import { ContentVerificationModel } from '../../models/ContentVerificationModel';
 import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
@@ -1797,52 +1801,50 @@ export class DashboardService
         };
     }
 
-    // Drafts mode: with content_as_code.sync on, a business user's save of
-    // GIT-BACKED content becomes an unpublished draft that only they see;
-    // reviewers later write it back to the repo. The published dashboard is
-    // untouched. Content never uploaded as code (no last-applied snapshot
-    // row) publishes normally — drafts exist to protect the repo contract,
-    // not to intercept every save in the project.
+    // Drafts mode: with content_as_code.sync on, every save of GIT-BACKED
+    // content becomes an unpublished draft that only its author sees, for
+    // any role; the repo is the only publisher, through a reviewed
+    // write-back and an upload. Content never uploaded as code (no
+    // last-applied snapshot row) publishes normally — drafts exist to
+    // protect the repo contract, not to intercept every save in the project.
     private async maybeStoreDraft(
         user: SessionUser,
         existingDashboardDao: DashboardDAO,
         dashboardFields: object,
     ): Promise<Dashboard | undefined> {
-        if (!(await this.shouldStoreDraft(user, existingDashboardDao))) {
-            return undefined;
-        }
-        return this.storeDraft(user, existingDashboardDao, dashboardFields);
+        const base = await this.resolveDraftBase(existingDashboardDao);
+        if (base === null) return undefined;
+        return this.storeDraft(
+            user,
+            existingDashboardDao,
+            dashboardFields,
+            base,
+        );
     }
 
-    private async shouldStoreDraft(
-        user: SessionUser,
+    // The upload snapshot a draft starts from, or null when the save should
+    // publish normally
+    private async resolveDraftBase(
         existingDashboardDao: Pick<DashboardDAO, 'projectUuid' | 'slug'>,
-    ): Promise<boolean> {
+    ): Promise<ContentDraftBase | null> {
         const settings = await this.contentAsCodeProjectSettingsModel.get(
             existingDashboardDao.projectUuid,
         );
-        if (!settings?.syncEnabled) return false;
+        if (!settings?.syncEnabled) return null;
         const snapshot = await this.contentAsCodeSnapshotModel.get(
             existingDashboardDao.projectUuid,
             ContentAsCodeType.DASHBOARD,
             existingDashboardDao.slug,
         );
-        if (snapshot === undefined) return false;
-        if (
-            await this.canManageContentAsCode(
-                user,
-                existingDashboardDao.projectUuid,
-            )
-        ) {
-            return false;
-        }
-        return true;
+        if (snapshot === undefined) return null;
+        return { snapshot: snapshot.snapshot, hash: snapshot.snapshotHash };
     }
 
     private async storeDraft(
         user: SessionUser,
         existingDashboardDao: DashboardDAO,
         dashboardFields: object,
+        base: ContentDraftBase,
     ): Promise<Dashboard> {
         DashboardService.mergeDraftIntoDashboard(
             existingDashboardDao,
@@ -1854,7 +1856,11 @@ export class DashboardService
             contentUuid: existingDashboardDao.uuid,
             slug: existingDashboardDao.slug,
             authorUserUuid: user.userUuid,
-            draft: dashboardFields,
+            draft: pruneUnchangedDraftFields(
+                existingDashboardDao,
+                dashboardFields,
+            ),
+            base,
         });
         const overlaid = DashboardService.mergeDraftIntoDashboard(
             existingDashboardDao,
@@ -1889,12 +1895,18 @@ export class DashboardService
             );
             if (draft) {
                 try {
+                    const overlaid = DashboardService.mergeDraftIntoDashboard(
+                        dashboard,
+                        draft.draft,
+                    );
+                    const draftStaleness = await this.getDraftStaleness(
+                        dashboard,
+                        draft,
+                    );
                     return {
-                        ...DashboardService.mergeDraftIntoDashboard(
-                            dashboard,
-                            draft.draft,
-                        ),
+                        ...overlaid,
                         hasUnpublishedChanges: true,
+                        ...(draftStaleness && { draftStaleness }),
                     };
                 } catch (error) {
                     this.logger.warn(
@@ -1951,6 +1963,29 @@ export class DashboardService
             this.logger.warn('Draft overlay failed', error);
             return dashboard;
         }
+    }
+
+    // The repo moved past the snapshot the draft started from
+    private async getDraftStaleness(
+        dashboard: Pick<DashboardDAO, 'projectUuid' | 'slug'>,
+        draft: ContentDraft,
+    ): Promise<ContentDraftStaleness | null> {
+        if (!draft.baseSnapshotHash) return null;
+        const current = await this.contentAsCodeSnapshotModel.get(
+            dashboard.projectUuid,
+            ContentAsCodeType.DASHBOARD,
+            dashboard.slug,
+        );
+        if (!current || current.snapshotHash === draft.baseSnapshotHash) {
+            return null;
+        }
+        return computeContentDraftStaleness({
+            draftUuid: draft.uuid,
+            contentType: 'dashboard',
+            base: draft.baseSnapshot,
+            current: current.snapshot,
+            overlay: draft.draft,
+        });
     }
 
     async update(
@@ -2468,24 +2503,31 @@ export class DashboardService
             }),
         );
 
-        const shouldStoreDraft = await Promise.all(
+        const draftBases = await Promise.all(
             dashboardContexts.map(({ dashboard }) =>
-                this.shouldStoreDraft(user, dashboard),
+                this.resolveDraftBase(dashboard),
             ),
         );
         // Draft upserts are idempotent and happen before the transactional
         // published update, so a retry cannot duplicate or partially publish.
         const draftResults = await Promise.all(
             dashboardContexts.map(
-                async ({ dashboardToUpdate, dashboard }, index) =>
-                    shouldStoreDraft[index]
-                        ? this.storeDraft(user, dashboard, dashboardToUpdate)
-                        : undefined,
+                async ({ dashboardToUpdate, dashboard }, index) => {
+                    const base = draftBases[index];
+                    return base === null
+                        ? undefined
+                        : this.storeDraft(
+                              user,
+                              dashboard,
+                              dashboardToUpdate,
+                              base,
+                          );
+                },
             ),
         );
 
         const directUpdates = dashboards.filter(
-            (_dashboard, index) => !shouldStoreDraft[index],
+            (_dashboard, index) => draftBases[index] === null,
         );
         const updatedDashboards =
             directUpdates.length > 0

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.drafts.test.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.drafts.test.ts
@@ -344,7 +344,7 @@ describe('SavedChartService chart drafts', () => {
         );
     });
 
-    it('publishes every bulk chart update for a Content as Code manager', async () => {
+    it('drafts every bulk chart update for a Content as Code manager', async () => {
         const managedChart = {
             ...chart,
             uuid: 'managed-chart',
@@ -365,11 +365,8 @@ describe('SavedChartService chart drafts', () => {
 
         await service.updateMultiple(reviewer, chart.projectUuid, updates);
 
-        expect(upsertOpenDraft).not.toHaveBeenCalled();
-        expect(savedChartModel.updateMultiple).toHaveBeenCalledWith(
-            chart.projectUuid,
-            updates,
-        );
+        expect(upsertOpenDraft).toHaveBeenCalledTimes(1);
+        expect(savedChartModel.updateMultiple).not.toHaveBeenCalled();
     });
 
     it('publishes UI-only charts through the existing path', async () => {
@@ -389,7 +386,7 @@ describe('SavedChartService chart drafts', () => {
         expect(upsertOpenDraft).not.toHaveBeenCalled();
     });
 
-    it('lets content-as-code reviewers publish directly', async () => {
+    it('drafts for content-as-code reviewers too, recording the upload snapshot as base', async () => {
         const { service, upsertOpenDraft } = buildService();
 
         const result = await service['maybeStoreDraft'](
@@ -400,8 +397,13 @@ describe('SavedChartService chart drafts', () => {
             spaceContext,
         );
 
-        expect(result).toBeUndefined();
-        expect(upsertOpenDraft).not.toHaveBeenCalled();
+        expect(result?.hasUnpublishedChanges).toBe(true);
+        expect(upsertOpenDraft).toHaveBeenCalledWith(
+            expect.objectContaining({
+                authorUserUuid: reviewer.userUuid,
+                base: expect.objectContaining({ hash: 'hash' }),
+            }),
+        );
     });
 
     it('blocks an editor from deleting a Git-backed chart', async () => {

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -9,6 +9,7 @@ import {
     ChartSummary,
     ChartType,
     ChartVersion,
+    computeContentDraftStaleness,
     ContentAsCodeType,
     ContentType,
     countCustomDimensionsInMetricQuery,
@@ -56,6 +57,7 @@ import {
     UpdateSavedChart,
     ViewStatistics,
     type ChartFieldUpdates,
+    type ContentDraftStaleness,
     type ContentVerificationInfo,
     type Explore,
     type ExploreError,
@@ -81,7 +83,12 @@ import type { CatalogModel } from '../../models/CatalogModel/CatalogModel';
 import { getChartFieldUsageChanges } from '../../models/CatalogModel/utils';
 import { ContentAsCodeProjectSettingsModel } from '../../models/ContentAsCodeProjectSettingsModel';
 import { ContentAsCodeSnapshotModel } from '../../models/ContentAsCodeSnapshotModel';
-import { ContentDraftModel } from '../../models/ContentDraftModel';
+import {
+    ContentDraftModel,
+    pruneUnchangedDraftFields,
+    type ContentDraft,
+    type ContentDraftBase,
+} from '../../models/ContentDraftModel';
 import { ContentVerificationModel } from '../../models/ContentVerificationModel';
 import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
 import { OrganizationModel } from '../../models/OrganizationModel';
@@ -730,38 +737,34 @@ export class SavedChartService
         },
     ): Promise<SavedChart | undefined> {
         if (Object.keys(draftFields).length === 0) return undefined;
-        if (!(await this.shouldStoreDraft(user, existingChart))) {
-            return undefined;
-        }
+        const base = await this.resolveDraftBase(existingChart);
+        if (base === null) return undefined;
         return this.storeDraft(
             user,
             existingChart,
             draftFields,
             verificationAfterUpdate,
             spaceContext,
+            base,
         );
     }
 
-    private async shouldStoreDraft(
-        user: SessionUser,
+    // Every role drafts git-backed content; the repo is the only publisher.
+    // Null means the save publishes normally
+    private async resolveDraftBase(
         existingChart: Pick<SavedChartDAO, 'projectUuid' | 'slug'>,
-    ): Promise<boolean> {
+    ): Promise<ContentDraftBase | null> {
         const settings = await this.contentAsCodeProjectSettingsModel.get(
             existingChart.projectUuid,
         );
-        if (!settings?.syncEnabled) return false;
+        if (!settings?.syncEnabled) return null;
         const snapshot = await this.contentAsCodeSnapshotModel.get(
             existingChart.projectUuid,
             ContentAsCodeType.CHART,
             existingChart.slug,
         );
-        if (snapshot === undefined) return false;
-        if (
-            await this.canManageContentAsCode(user, existingChart.projectUuid)
-        ) {
-            return false;
-        }
-        return true;
+        if (snapshot === undefined) return null;
+        return { snapshot: snapshot.snapshot, hash: snapshot.snapshotHash };
     }
 
     private async storeDraft(
@@ -773,6 +776,7 @@ export class SavedChartService
             inheritsFromOrgOrProject: boolean;
             access: SpaceAccess[];
         },
+        base: ContentDraftBase,
     ): Promise<SavedChart> {
         assertChartDraftOverlay(draftFields);
         const stored = await this.contentDraftModel.upsertOpenDraft({
@@ -781,7 +785,8 @@ export class SavedChartService
             contentUuid: existingChart.uuid,
             slug: existingChart.slug,
             authorUserUuid: user.userUuid,
-            draft: draftFields,
+            draft: pruneUnchangedDraftFields(existingChart, draftFields),
+            base,
         });
         const chartForOverlay =
             'metricQuery' in existingChart
@@ -813,6 +818,10 @@ export class SavedChartService
             if (draft) {
                 try {
                     assertChartDraftOverlay(draft.draft);
+                    const draftStaleness = await this.getDraftStaleness(
+                        chart,
+                        draft,
+                    );
                     return {
                         ...mergeDraftIntoChart(chart, draft.draft),
                         verification:
@@ -820,6 +829,7 @@ export class SavedChartService
                                 ? null
                                 : chart.verification,
                         hasUnpublishedChanges: true,
+                        ...(draftStaleness && { draftStaleness }),
                     };
                 } catch (error) {
                     this.logger.warn(
@@ -873,6 +883,28 @@ export class SavedChartService
             this.logger.warn('Chart draft overlay failed', error);
             return chart;
         }
+    }
+
+    private async getDraftStaleness(
+        chart: Pick<SavedChartDAO, 'projectUuid' | 'slug'>,
+        draft: ContentDraft,
+    ): Promise<ContentDraftStaleness | null> {
+        if (!draft.baseSnapshotHash) return null;
+        const current = await this.contentAsCodeSnapshotModel.get(
+            chart.projectUuid,
+            ContentAsCodeType.CHART,
+            chart.slug,
+        );
+        if (!current || current.snapshotHash === draft.baseSnapshotHash) {
+            return null;
+        }
+        return computeContentDraftStaleness({
+            draftUuid: draft.uuid,
+            contentType: 'chart',
+            base: draft.baseSnapshot,
+            current: current.snapshot,
+            overlay: draft.draft,
+        });
     }
 
     async createVersion(
@@ -1511,9 +1543,9 @@ export class SavedChartService
             }),
         );
 
-        const shouldStoreDraft = await Promise.all(
+        const draftBases = await Promise.all(
             chartSpaceContexts.map(({ existingChart }) =>
-                this.shouldStoreDraft(user, existingChart),
+                this.resolveDraftBase(existingChart),
             ),
         );
         // Draft upserts are idempotent and happen before the transactional
@@ -1523,9 +1555,11 @@ export class SavedChartService
                 async (
                     { chart, existingChart, spaceContexts, verification },
                     index,
-                ) =>
-                    shouldStoreDraft[index]
-                        ? this.storeDraft(
+                ) => {
+                    const base = draftBases[index];
+                    return base === null
+                        ? undefined
+                        : this.storeDraft(
                               user,
                               existingChart,
                               {
@@ -1535,13 +1569,14 @@ export class SavedChartService
                               },
                               verification,
                               spaceContexts[1],
-                          )
-                        : undefined,
+                              base,
+                          );
+                },
             ),
         );
 
         const directUpdates = data.filter(
-            (_chart, index) => !shouldStoreDraft[index],
+            (_chart, index) => draftBases[index] === null,
         );
         const savedChartsDaos =
             directUpdates.length > 0

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -148,9 +148,11 @@ import {
     type ApiContentAsCodeSettingsResponse,
     type ApiContentAsCodeUploadAdvisoryResponse,
     type ApiContentAsCodeWritebacksResponse,
+    type ApiContentDraftRebaseResponse,
     type ApiContentDraftReopenResponse,
     type ApiContentDraftReviewResponse,
     type ApiContentDraftsResponse,
+    type ApiContentDraftStalenessResponse,
     type ApiContentDraftWriteBackResponse,
     type ApiDashboardAsCodeListResponse,
     type ApiGoogleSheetsSyncAsCodeListResponse,
@@ -1398,6 +1400,8 @@ type ApiResults =
     | ApiContentAsCodeWritebacksResponse['results']
     | ApiContentDraftsResponse['results']
     | ApiContentDraftReviewResponse['results']
+    | ApiContentDraftRebaseResponse['results']
+    | ApiContentDraftStalenessResponse['results']
     | ApiContentDraftReopenResponse['results']
     | ApiContentDraftWriteBackResponse['results']
     | ApiContentAsCodeProposeResponse['results']

--- a/packages/common/src/types/contentAsCode/base.ts
+++ b/packages/common/src/types/contentAsCode/base.ts
@@ -1,5 +1,10 @@
 import { ParameterError } from '../errors';
 import type { PromotionAction } from '../promotion';
+import type {
+    ContentDraftFieldResolution,
+    ContentDraftStaleness,
+    ContentDraftStalenessDetails,
+} from './draftRebase';
 import { joinContentAsCodePath } from './fileDiscovery';
 
 export const DEFAULT_CONTENT_AS_CODE_PATH = 'lightdash';
@@ -183,6 +188,8 @@ export type ContentDraftSummary = {
     status: 'open' | 'written_back' | 'dismissed';
     prUrl: string | null;
     writebackStatus: ContentAsCodeWritebackStatus | null;
+    // The repo moved past the upload snapshot the draft started from
+    stale: boolean;
     createdAt: Date;
     updatedAt: Date;
 };
@@ -192,6 +199,21 @@ export type ContentDraftReview = {
     filePath: string;
     publishedYaml: string;
     draftYaml: string;
+    staleness: ContentDraftStaleness | null;
+};
+
+export type ContentDraftRebaseRequest = {
+    resolutions: Record<string, ContentDraftFieldResolution>;
+};
+
+export type ApiContentDraftRebaseResponse = {
+    status: 'ok';
+    results: ContentDraftSummary;
+};
+
+export type ApiContentDraftStalenessResponse = {
+    status: 'ok';
+    results: ContentDraftStalenessDetails | null;
 };
 
 export type ApiContentDraftsResponse = {

--- a/packages/common/src/types/contentAsCode/draftRebase.test.ts
+++ b/packages/common/src/types/contentAsCode/draftRebase.test.ts
@@ -1,0 +1,156 @@
+import {
+    asCodeFieldsChangedBetween,
+    computeContentDraftStaleness,
+    describeAsCodeFieldChange,
+    describeContentDraftStaleness,
+    overlayKeysForAsCodeField,
+} from './draftRebase';
+
+const base = {
+    name: 'Revenue',
+    description: 'Before',
+    tiles: [{ properties: { chartSlug: 'a' } }],
+    tabs: [],
+    spaceSlug: 'sales',
+};
+
+describe('asCodeFieldsChangedBetween', () => {
+    it('lists the fields whose canonical value differs', () => {
+        expect(
+            asCodeFieldsChangedBetween(base, {
+                ...base,
+                description: 'After',
+                tiles: [],
+            }),
+        ).toEqual(['description', 'tiles']);
+        expect(asCodeFieldsChangedBetween(base, base)).toEqual([]);
+    });
+
+    it('counts fields added or removed on either side', () => {
+        expect(
+            asCodeFieldsChangedBetween(base, { ...base, filters: {} }),
+        ).toEqual(['filters']);
+    });
+});
+
+describe('computeContentDraftStaleness', () => {
+    it('only conflicts on fields the draft also changed', () => {
+        const staleness = computeContentDraftStaleness({
+            draftUuid: 'd',
+            contentType: 'dashboard',
+            base,
+            current: { ...base, description: 'After', tiles: [] },
+            overlay: { tiles: [{ x: 1 }], name: 'Revenue 2' },
+        });
+        expect(staleness).toEqual({
+            draftUuid: 'd',
+            changedFields: ['description', 'tiles'],
+            conflictingFields: ['tiles'],
+        });
+    });
+
+    it('maps DAO overlay keys onto as-code fields', () => {
+        const staleness = computeContentDraftStaleness({
+            draftUuid: 'd',
+            contentType: 'chart',
+            base: { spaceSlug: 'sales' },
+            current: { spaceSlug: 'finance' },
+            overlay: { spaceUuid: 'uuid', verified: true },
+        });
+        expect(staleness.conflictingFields).toEqual(['spaceSlug']);
+    });
+});
+
+describe('overlayKeysForAsCodeField', () => {
+    it('finds the overlay keys behind an as-code field', () => {
+        expect(overlayKeysForAsCodeField('dashboard', 'spaceSlug')).toEqual([
+            'spaceUuid',
+        ]);
+        expect(overlayKeysForAsCodeField('chart', 'metricQuery')).toEqual([
+            'metricQuery',
+        ]);
+        expect(overlayKeysForAsCodeField('chart', 'unknown')).toEqual([]);
+    });
+});
+
+describe('describeAsCodeFieldChange', () => {
+    it('reads scalar changes as before and after', () => {
+        expect(describeAsCodeFieldChange('description', 'Old', 'New')).toBe(
+            '"Old" → "New"',
+        );
+        expect(describeAsCodeFieldChange('description', undefined, 'New')).toBe(
+            'set to "New"',
+        );
+    });
+
+    it('counts tiles by identity and names them', () => {
+        const chart = {
+            type: 'saved_chart',
+            x: 0,
+            properties: { chartSlug: 'mrr', title: 'MRR' },
+        };
+        expect(
+            describeAsCodeFieldChange(
+                'tiles',
+                [chart],
+                [
+                    chart,
+                    {
+                        type: 'markdown',
+                        properties: { title: 'Admin tile', content: 'x' },
+                    },
+                ],
+            ),
+        ).toBe('added 1 tile (Admin tile)');
+        expect(
+            describeAsCodeFieldChange('tiles', [chart], [{ ...chart, x: 6 }]),
+        ).toBe('changed 1 tile (MRR)');
+        expect(describeAsCodeFieldChange('tiles', [chart], [])).toBe(
+            'removed 1 tile (MRR)',
+        );
+        expect(
+            describeAsCodeFieldChange('tiles', [chart], [{ ...chart, x: 6 }], {
+                reportEdits: false,
+            }),
+        ).toBe('edited tiles');
+    });
+
+    it('lists the keys that moved inside an object field', () => {
+        expect(
+            describeAsCodeFieldChange(
+                'metricQuery',
+                { limit: 10, metrics: ['a'] },
+                { limit: 500, metrics: ['a'] },
+            ),
+        ).toBe('changed limit');
+    });
+});
+
+describe('describeContentDraftStaleness', () => {
+    it('describes both sides of a conflict and one side of a repo-only change', () => {
+        const details = describeContentDraftStaleness({
+            staleness: {
+                draftUuid: 'd',
+                changedFields: ['description', 'tiles'],
+                conflictingFields: ['tiles'],
+            },
+            base: { description: 'Old', tiles: [] },
+            current: {
+                description: 'New',
+                tiles: [{ type: 'markdown', properties: { title: 'Admin' } }],
+            },
+            draft: {
+                description: 'Old',
+                tiles: [{ type: 'markdown', properties: { title: 'Mine' } }],
+            },
+        });
+        expect(details.changes).toEqual([
+            { field: 'description', repo: '"Old" → "New"', mine: null },
+            {
+                field: 'tiles',
+                repo: 'added 1 tile (Admin)',
+                mine: 'added 1 tile (Mine)',
+            },
+        ]);
+    });
+});

--- a/packages/common/src/types/contentAsCode/draftRebase.ts
+++ b/packages/common/src/types/contentAsCode/draftRebase.ts
@@ -1,0 +1,261 @@
+export type ContentDraftFieldResolution = 'mine' | 'latest';
+
+export type ContentDraftStaleness = {
+    draftUuid: string;
+    // As-code fields the repo changed since the draft's base
+    changedFields: string[];
+    // The subset the draft also changed; whole-field conflicts
+    conflictingFields: string[];
+};
+
+// Draft overlays are stored in DAO shape; snapshots are as-code documents
+const OVERLAY_TO_AS_CODE_FIELD: Record<
+    'chart' | 'dashboard',
+    Record<string, string>
+> = {
+    chart: {
+        name: 'name',
+        description: 'description',
+        tableName: 'tableName',
+        metricQuery: 'metricQuery',
+        chartConfig: 'chartConfig',
+        tableConfig: 'tableConfig',
+        pivotConfig: 'pivotConfig',
+        parameters: 'parameters',
+        merge: 'merge',
+        spaceUuid: 'spaceSlug',
+    },
+    dashboard: {
+        name: 'name',
+        description: 'description',
+        tiles: 'tiles',
+        filters: 'filters',
+        tabs: 'tabs',
+        config: 'config',
+        parameters: 'parameters',
+        spaceUuid: 'spaceSlug',
+    },
+};
+
+export const overlayKeysForAsCodeField = (
+    contentType: 'chart' | 'dashboard',
+    field: string,
+): string[] =>
+    Object.entries(OVERLAY_TO_AS_CODE_FIELD[contentType])
+        .filter(([, asCodeField]) => asCodeField === field)
+        .map(([overlayKey]) => overlayKey);
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+    typeof value === 'object' && value !== null && !Array.isArray(value);
+
+// Snapshots are canonical (sorted keys, no undefined), so string equality
+// is structural equality
+export const asCodeFieldsChangedBetween = (
+    base: unknown,
+    current: unknown,
+): string[] => {
+    const baseDoc = isObject(base) ? base : {};
+    const currentDoc = isObject(current) ? current : {};
+    const keys = new Set([...Object.keys(baseDoc), ...Object.keys(currentDoc)]);
+    return Array.from(keys)
+        .filter(
+            (key) =>
+                JSON.stringify(baseDoc[key]) !==
+                JSON.stringify(currentDoc[key]),
+        )
+        .sort();
+};
+
+export const computeContentDraftStaleness = ({
+    draftUuid,
+    contentType,
+    base,
+    current,
+    overlay,
+}: {
+    draftUuid: string;
+    contentType: 'chart' | 'dashboard';
+    base: unknown;
+    current: unknown;
+    overlay: unknown;
+}): ContentDraftStaleness => {
+    const changedFields = asCodeFieldsChangedBetween(base, current);
+    const overlayKeys = isObject(overlay) ? Object.keys(overlay) : [];
+    const draftedFields = new Set(
+        overlayKeys.flatMap((key) => {
+            const field = OVERLAY_TO_AS_CODE_FIELD[contentType][key];
+            return field === undefined ? [] : [field];
+        }),
+    );
+    return {
+        draftUuid,
+        changedFields,
+        conflictingFields: changedFields.filter((field) =>
+            draftedFields.has(field),
+        ),
+    };
+};
+
+export type ContentDraftFieldChange = {
+    field: string;
+    // What the repo did to the field since the draft's base
+    repo: string;
+    // What the draft did to the same field, when it also changed it
+    mine: string | null;
+};
+
+export type ContentDraftStalenessDetails = ContentDraftStaleness & {
+    changes: ContentDraftFieldChange[];
+};
+
+const asRecord = (value: unknown): Record<string, unknown> | null =>
+    isObject(value) ? value : null;
+
+const tileIdentity = (tile: Record<string, unknown>): string => {
+    if (typeof tile.tileSlug === 'string') return tile.tileSlug;
+    const properties = asRecord(tile.properties) ?? {};
+    const handle =
+        properties.chartSlug ?? properties.title ?? properties.appSlug ?? '';
+    return `${String(tile.type)}:${String(handle)}`;
+};
+
+const tileLabel = (tile: Record<string, unknown>): string => {
+    const properties = asRecord(tile.properties) ?? {};
+    const label =
+        properties.title ?? properties.chartName ?? properties.chartSlug;
+    return typeof label === 'string' && label !== ''
+        ? label
+        : `untitled ${String(tile.type ?? 'tile').replace(/_/g, ' ')}`;
+};
+
+const quote = (value: unknown): string => {
+    if (value === null || value === undefined || value === '') return 'empty';
+    const text = typeof value === 'string' ? value : JSON.stringify(value);
+    return text.length > 48 ? `"${text.slice(0, 45)}…"` : `"${text}"`;
+};
+
+const plural = (count: number, noun: string) =>
+    `${count} ${noun}${count === 1 ? '' : 's'}`;
+
+const describeKeyedList = (
+    before: unknown[],
+    after: unknown[],
+    noun: string,
+    identity: (item: Record<string, unknown>) => string,
+    label: (item: Record<string, unknown>) => string,
+    // Documents rendered by different producers differ in incidental shape,
+    // so edits inside surviving items are only reported when asked
+    reportEdits: boolean,
+): string => {
+    const beforeItems = new Map(
+        before.flatMap((item) => {
+            const record = asRecord(item);
+            return record ? [[identity(record), record] as const] : [];
+        }),
+    );
+    const afterItems = new Map(
+        after.flatMap((item) => {
+            const record = asRecord(item);
+            return record ? [[identity(record), record] as const] : [];
+        }),
+    );
+    const added = [...afterItems]
+        .filter(([key]) => !beforeItems.has(key))
+        .map(([, item]) => label(item));
+    const removed = [...beforeItems]
+        .filter(([key]) => !afterItems.has(key))
+        .map(([, item]) => label(item));
+    const changed = reportEdits
+        ? [...afterItems]
+              .filter(
+                  ([key, item]) =>
+                      beforeItems.has(key) &&
+                      JSON.stringify(beforeItems.get(key)) !==
+                          JSON.stringify(item),
+              )
+              .map(([, item]) => label(item))
+        : [];
+    const parts = [
+        added.length > 0 &&
+            `added ${plural(added.length, noun)} (${added.join(', ')})`,
+        removed.length > 0 &&
+            `removed ${plural(removed.length, noun)} (${removed.join(', ')})`,
+        changed.length > 0 &&
+            `changed ${plural(changed.length, noun)} (${changed.join(', ')})`,
+    ].filter((part): part is string => typeof part === 'string');
+    return parts.length > 0 ? parts.join('; ') : `edited ${noun}s`;
+};
+
+// A one-line, human account of how a field moved between two documents
+export const describeAsCodeFieldChange = (
+    field: string,
+    before: unknown,
+    after: unknown,
+    options: { reportEdits: boolean } = { reportEdits: true },
+): string => {
+    if (before === undefined) return `set to ${quote(after)}`;
+    if (after === undefined) return 'removed';
+    if (field === 'tiles' && Array.isArray(before) && Array.isArray(after)) {
+        return describeKeyedList(
+            before,
+            after,
+            'tile',
+            tileIdentity,
+            tileLabel,
+            options.reportEdits,
+        );
+    }
+    if (field === 'tabs' && Array.isArray(before) && Array.isArray(after)) {
+        return describeKeyedList(
+            before,
+            after,
+            'tab',
+            (tab) => String(tab.slug ?? tab.uuid ?? tab.name),
+            (tab) => String(tab.name ?? 'tab'),
+            options.reportEdits,
+        );
+    }
+    if (typeof before !== 'object' || typeof after !== 'object') {
+        return `${quote(before)} → ${quote(after)}`;
+    }
+    const changedKeys = asCodeFieldsChangedBetween(before, after);
+    return changedKeys.length > 0
+        ? `changed ${changedKeys.join(', ')}`
+        : 'changed';
+};
+
+export const describeContentDraftStaleness = ({
+    staleness,
+    base,
+    current,
+    draft,
+}: {
+    staleness: ContentDraftStaleness;
+    base: unknown;
+    current: unknown;
+    draft: unknown;
+}): ContentDraftStalenessDetails => {
+    const baseDoc = asRecord(base) ?? {};
+    const currentDoc = asRecord(current) ?? {};
+    const draftDoc = asRecord(draft) ?? {};
+    return {
+        ...staleness,
+        changes: staleness.changedFields.map((field) => ({
+            field,
+            repo: describeAsCodeFieldChange(
+                field,
+                baseDoc[field],
+                currentDoc[field],
+            ),
+            // The draft is rendered by the instance, the base by the CLI
+            mine: staleness.conflictingFields.includes(field)
+                ? describeAsCodeFieldChange(
+                      field,
+                      baseDoc[field],
+                      draftDoc[field],
+                      { reportEdits: false },
+                  )
+                : null,
+        })),
+    };
+};

--- a/packages/common/src/types/contentAsCode/index.ts
+++ b/packages/common/src/types/contentAsCode/index.ts
@@ -2,6 +2,7 @@ export * from './base';
 export * from './charts';
 export * from './core';
 export * from './dashboards';
+export * from './draftRebase';
 export * from './fileDiscovery';
 export * from './parsers';
 export * from './scheduledContent';

--- a/packages/common/src/types/dashboard.ts
+++ b/packages/common/src/types/dashboard.ts
@@ -1,3 +1,4 @@
+import { type ContentDraftStaleness } from './contentAsCode/draftRebase';
 import { type ContentVerificationInfo } from './contentVerification';
 import { type FilterableDimension, type Metric } from './field';
 import { type DashboardFieldTarget, type DashboardFilters } from './filter';
@@ -268,6 +269,8 @@ export type Dashboard = {
     draftOverlayError?: DashboardDraftOverlayError;
     /** The viewer authored a dismissed draft that can be reopened */
     dismissedDraftUuid?: string;
+    /** The viewer's draft started from an upload snapshot the repo has since moved past */
+    draftStaleness?: ContentDraftStaleness;
     dashboardVersionId: number;
     versionUuid: string;
     uuid: string;

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -4,6 +4,7 @@ import { type ViewStatistics } from './analytics';
 import { type DateZoom } from './api/paginatedQuery';
 import { type ConditionalFormattingConfig } from './conditionalFormatting';
 import { type ChartSourceType } from './content';
+import { type ContentDraftStaleness } from './contentAsCode/draftRebase';
 import { type ContentVerificationInfo } from './contentVerification';
 import { type CompactOrAlias, type FieldId } from './field';
 import { type KnexPaginatedData } from './knex-paginate';
@@ -999,6 +1000,8 @@ export type SavedChart = {
     draftsAwaitingReview?: number;
     /** The caller's latest dismissed draft, available to reopen. */
     dismissedDraftUuid?: string;
+    /** The caller's draft started from an upload snapshot the repo has since moved past. */
+    draftStaleness?: ContentDraftStaleness;
     /** The caller's draft could not be safely applied. */
     draftOverlayError?: {
         code: 'invalid_chart_draft';

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -63,7 +63,12 @@ import { AskAiAgentMenuItem } from '../../../ee/features/aiCopilot/components/As
 import ChartAsCodeModal from '../../../features/contentAsCode/components/ChartAsCodeModal';
 import DismissedDraftAlert from '../../../features/contentAsCode/components/DismissedDraftAlert';
 import DraftOverlayFailureAlert from '../../../features/contentAsCode/components/DraftOverlayFailureAlert';
-import { useReopenDraftMutation } from '../../../features/contentAsCode/hooks/useContentDrafts';
+import DraftStaleAlert from '../../../features/contentAsCode/components/DraftStaleAlert';
+import {
+    useDraftStaleness,
+    useRebaseDraftMutation,
+    useReopenDraftMutation,
+} from '../../../features/contentAsCode/hooks/useContentDrafts';
 import {
     DirectAccessModal,
     useCanManageDirectAccess,
@@ -186,6 +191,12 @@ const SavedChartsHeader: FC = () => {
     const savedChart = useExplorerSelector(selectSavedChart);
     const { mutate: reopenDraft, isLoading: isReopeningDraft } =
         useReopenDraftMutation(projectUuid);
+    const { mutate: rebaseDraft, isLoading: isRebasingDraft } =
+        useRebaseDraftMutation(projectUuid);
+    const { data: draftStalenessDetails } = useDraftStaleness(
+        projectUuid,
+        savedChart?.draftStaleness?.draftUuid,
+    );
     const dashboardIdentifier = savedChart?.dashboardSlug ?? dashboardUuid;
 
     const hasUnsavedChanges = useExplorerSelector(selectHasUnsavedChanges);
@@ -1197,6 +1208,21 @@ const SavedChartsHeader: FC = () => {
                 <DismissedDraftAlert
                     isReopening={isReopeningDraft}
                     onReopen={() => reopenDraft(savedChart.dismissedDraftUuid!)}
+                />
+            ) : null}
+
+            {savedChart?.draftStaleness ? (
+                <DraftStaleAlert
+                    contentLabel="chart"
+                    staleness={savedChart.draftStaleness}
+                    details={draftStalenessDetails}
+                    isUpdating={isRebasingDraft}
+                    onUpdate={(resolutions) =>
+                        rebaseDraft({
+                            draftUuid: savedChart.draftStaleness!.draftUuid,
+                            resolutions,
+                        })
+                    }
                 />
             ) : null}
 

--- a/packages/frontend/src/features/contentAsCode/components/ContentReviewPage.tsx
+++ b/packages/frontend/src/features/contentAsCode/components/ContentReviewPage.tsx
@@ -5,6 +5,7 @@ import {
 } from '@lightdash/common';
 import {
     Anchor,
+    Badge,
     Avatar,
     Box,
     Button,
@@ -40,11 +41,14 @@ import {
 } from '../../../ee/features/aiCopilot/components/Admin/pierreDiffConfig';
 import {
     useContentDraftReview,
+    useDraftStaleness,
     useContentDrafts,
     useDismissDraftMutation,
     useWriteBackDraftMutation,
 } from '../hooks/useContentDrafts';
+import { draftFieldLabel } from '../utils/draftFieldLabel';
 import classes from './ContentReviewPage.module.css';
+import staleClasses from './DraftStalePanel.module.css';
 
 const timeAgo = (date: Date | string): string => {
     const seconds = Math.max(
@@ -156,9 +160,16 @@ const DraftRow: FC<{
                 </Text>
             </Avatar>
             <Stack gap={1} style={{ flex: 1, minWidth: 0 }}>
-                <Text size="sm" fw={isActive ? 600 : 500} truncate>
-                    {draft.slug}
-                </Text>
+                <Group gap={6} wrap="nowrap">
+                    <Text size="sm" fw={isActive ? 600 : 500} truncate>
+                        {draft.slug}
+                    </Text>
+                    {draft.stale ? (
+                        <Badge size="xs" color="yellow" variant="light">
+                            Behind repo
+                        </Badge>
+                    ) : null}
+                </Group>
                 <Text size="xs" c="dimmed" truncate>
                     {rowMeta(draft)}
                 </Text>
@@ -228,6 +239,10 @@ const ContentReviewPage: FC<ContentReviewPageProps> = ({ projectUuid }) => {
     const { data: review, error: reviewError } = useContentDraftReview(
         projectUuid,
         activeUuid,
+    );
+    const { data: stalenessDetails } = useDraftStaleness(
+        projectUuid,
+        review?.staleness ? activeUuid : undefined,
     );
     const { mutate: writeBack, isLoading: isWritingBack } =
         useWriteBackDraftMutation(projectUuid);
@@ -426,11 +441,20 @@ const ContentReviewPage: FC<ContentReviewPageProps> = ({ projectUuid }) => {
                                             </Popover.Dropdown>
                                         </Popover>
                                         <Tooltip
-                                            label={`Opens this ${active.contentType}'s pull request with the draft's content`}
+                                            label={
+                                                review.staleness
+                                                    ? `The repo changed ${review.staleness.changedFields.join(', ')} since this draft started. The author has to update it first.`
+                                                    : `Opens this ${active.contentType}'s pull request with the draft's content`
+                                            }
                                             withinPortal
+                                            multiline
+                                            w={300}
                                         >
                                             <Button
                                                 loading={isWritingBack}
+                                                disabled={
+                                                    review.staleness !== null
+                                                }
                                                 leftSection={
                                                     <MantineIcon
                                                         icon={
@@ -449,6 +473,38 @@ const ContentReviewPage: FC<ContentReviewPageProps> = ({ projectUuid }) => {
                                 ) : null}
                             </Group>
                         </Group>
+                        {review.staleness ? (
+                            <Box className={staleClasses.panel}>
+                                <Stack gap={4}>
+                                    <Group gap={8} wrap="nowrap">
+                                        <span className={staleClasses.dot} />
+                                        <Text size="sm" fw={600}>
+                                            Behind the repo
+                                        </Text>
+                                    </Group>
+                                    <Text size="sm" c="dimmed">
+                                        The repo published past the version this
+                                        draft started from. The author has to
+                                        update it before it can be written back.
+                                    </Text>
+                                    {(stalenessDetails?.changes ?? []).map(
+                                        (change) => (
+                                            <Text size="sm" key={change.field}>
+                                                <Text span fw={500}>
+                                                    {draftFieldLabel(
+                                                        change.field,
+                                                    )}
+                                                </Text>
+                                                : repo {change.repo}
+                                                {change.mine
+                                                    ? `; this draft ${change.mine}`
+                                                    : ''}
+                                            </Text>
+                                        ),
+                                    )}
+                                </Stack>
+                            </Box>
+                        ) : null}
                         <WorkerPoolContextProvider
                             poolOptions={PIERRE_POOL_OPTIONS}
                             highlighterOptions={PIERRE_HIGHLIGHTER_OPTIONS}

--- a/packages/frontend/src/features/contentAsCode/components/DraftStaleAlert.tsx
+++ b/packages/frontend/src/features/contentAsCode/components/DraftStaleAlert.tsx
@@ -1,0 +1,203 @@
+import {
+    type ContentDraftFieldResolution,
+    type ContentDraftStaleness,
+    type ContentDraftStalenessDetails,
+} from '@lightdash/common';
+import {
+    Box,
+    Button,
+    Group,
+    SegmentedControl,
+    Stack,
+    Table,
+    Text,
+} from '@mantine/core';
+import { useState, type FC } from 'react';
+import { draftFieldLabel } from '../utils/draftFieldLabel';
+import classes from './DraftStalePanel.module.css';
+
+type DraftStaleAlertProps = {
+    contentLabel: 'dashboard' | 'chart';
+    staleness: ContentDraftStaleness;
+    details: ContentDraftStalenessDetails | null | undefined;
+    isUpdating: boolean;
+    onUpdate: (
+        resolutions: Record<string, ContentDraftFieldResolution>,
+    ) => void;
+};
+
+// Shown to the author when the repo published past the snapshot their draft
+// started from; the panel says what each side did before asking anything
+const DraftStaleAlert: FC<DraftStaleAlertProps> = ({
+    contentLabel,
+    staleness,
+    details,
+    isUpdating,
+    onUpdate,
+}) => {
+    const [reviewing, setReviewing] = useState(false);
+    const [resolutions, setResolutions] = useState<
+        Record<string, ContentDraftFieldResolution>
+    >({});
+    const conflicts = staleness.conflictingFields;
+    const hasConflicts = conflicts.length > 0;
+    const undecided = conflicts.some(
+        (field) => resolutions[field] === undefined,
+    );
+    const changes = details?.changes ?? [];
+
+    return (
+        <Box className={classes.panel} mx="md" mt="md">
+            <Stack gap="sm">
+                <Group justify="space-between" wrap="nowrap" align="flex-start">
+                    <Stack gap={2}>
+                        <Group gap={8} wrap="nowrap">
+                            <span className={classes.dot} />
+                            <Text size="sm" fw={600}>
+                                This {contentLabel} changed in the repo since
+                                your draft
+                            </Text>
+                        </Group>
+                        <Text size="sm" c="dimmed">
+                            {hasConflicts
+                                ? `You both changed ${conflicts
+                                      .map((field) =>
+                                          draftFieldLabel(field).toLowerCase(),
+                                      )
+                                      .join(
+                                          ', ',
+                                      )}. Pick which version to keep; everything else carries over.`
+                                : 'Your edits do not overlap with it, so they carry over as they are.'}
+                        </Text>
+                    </Stack>
+                    {!reviewing ? (
+                        <Button
+                            size="xs"
+                            loading={isUpdating}
+                            onClick={() =>
+                                hasConflicts ? setReviewing(true) : onUpdate({})
+                            }
+                        >
+                            {hasConflicts
+                                ? 'Review changes'
+                                : 'Update to latest'}
+                        </Button>
+                    ) : null}
+                </Group>
+                {reviewing ? (
+                    <Stack gap="sm">
+                        <Table
+                            className={classes.table}
+                            withRowBorders={false}
+                            verticalSpacing={6}
+                            horizontalSpacing="sm"
+                        >
+                            <Table.Thead>
+                                <Table.Tr>
+                                    <Table.Th w={130}>Field</Table.Th>
+                                    <Table.Th>In the repo</Table.Th>
+                                    <Table.Th>In your draft</Table.Th>
+                                    <Table.Th w={190}>Keep</Table.Th>
+                                </Table.Tr>
+                            </Table.Thead>
+                            <Table.Tbody>
+                                {changes.map((change) => {
+                                    const conflicting = conflicts.includes(
+                                        change.field,
+                                    );
+                                    return (
+                                        <Table.Tr key={change.field}>
+                                            <Table.Td>
+                                                <Text size="sm" fw={500}>
+                                                    {draftFieldLabel(
+                                                        change.field,
+                                                    )}
+                                                </Text>
+                                            </Table.Td>
+                                            <Table.Td>
+                                                <Text size="sm">
+                                                    {change.repo}
+                                                </Text>
+                                            </Table.Td>
+                                            <Table.Td>
+                                                <Text
+                                                    size="sm"
+                                                    c={
+                                                        conflicting
+                                                            ? undefined
+                                                            : 'dimmed'
+                                                    }
+                                                >
+                                                    {change.mine ?? 'unchanged'}
+                                                </Text>
+                                            </Table.Td>
+                                            <Table.Td>
+                                                {conflicting ? (
+                                                    <SegmentedControl
+                                                        size="xs"
+                                                        value={
+                                                            resolutions[
+                                                                change.field
+                                                            ] ?? ''
+                                                        }
+                                                        onChange={(value) =>
+                                                            setResolutions(
+                                                                (current) => ({
+                                                                    ...current,
+                                                                    [change.field]:
+                                                                        value ===
+                                                                        'latest'
+                                                                            ? 'latest'
+                                                                            : 'mine',
+                                                                }),
+                                                            )
+                                                        }
+                                                        data={[
+                                                            {
+                                                                label: 'Mine',
+                                                                value: 'mine',
+                                                            },
+                                                            {
+                                                                label: 'Repo',
+                                                                value: 'latest',
+                                                            },
+                                                        ]}
+                                                    />
+                                                ) : (
+                                                    <Text size="xs" c="dimmed">
+                                                        Repo version,
+                                                        automatically
+                                                    </Text>
+                                                )}
+                                            </Table.Td>
+                                        </Table.Tr>
+                                    );
+                                })}
+                            </Table.Tbody>
+                        </Table>
+                        <Group justify="flex-end" gap="xs">
+                            <Button
+                                size="xs"
+                                variant="subtle"
+                                color="gray"
+                                onClick={() => setReviewing(false)}
+                            >
+                                Not now
+                            </Button>
+                            <Button
+                                size="xs"
+                                loading={isUpdating}
+                                disabled={undecided || details === undefined}
+                                onClick={() => onUpdate(resolutions)}
+                            >
+                                Update draft
+                            </Button>
+                        </Group>
+                    </Stack>
+                ) : null}
+            </Stack>
+        </Box>
+    );
+};
+
+export default DraftStaleAlert;

--- a/packages/frontend/src/features/contentAsCode/components/DraftStalePanel.module.css
+++ b/packages/frontend/src/features/contentAsCode/components/DraftStalePanel.module.css
@@ -1,0 +1,31 @@
+.panel {
+    border: 1px solid
+        light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
+    border-radius: var(--mantine-radius-md);
+    background-color: light-dark(
+        var(--mantine-color-gray-0),
+        var(--mantine-color-dark-6)
+    );
+    padding: 14px 16px;
+}
+
+.dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background-color: var(--mantine-color-yellow-6);
+    flex-shrink: 0;
+}
+
+.table th {
+    font-size: var(--mantine-font-size-xs);
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: light-dark(var(--mantine-color-gray-6), var(--mantine-color-dark-2));
+    padding-bottom: 4px;
+}
+
+.table td {
+    vertical-align: top;
+}

--- a/packages/frontend/src/features/contentAsCode/hooks/useContentDrafts.ts
+++ b/packages/frontend/src/features/contentAsCode/hooks/useContentDrafts.ts
@@ -1,4 +1,6 @@
 import {
+    type ApiContentDraftStalenessResponse,
+    type ContentDraftRebaseRequest,
     type ApiContentDraftReviewResponse,
     type ApiContentDraftsResponse,
     type ApiError,
@@ -99,6 +101,64 @@ export const useDismissDraftMutation = (projectUuid: string | undefined) => {
             onError: (error) => {
                 showToastError({
                     title: 'Failed to dismiss draft',
+                    subtitle: error.error.message,
+                });
+            },
+        },
+    );
+};
+
+// Only fetched once a draft is known to be stale
+export const useDraftStaleness = (
+    projectUuid: string | undefined,
+    draftUuid: string | undefined,
+) =>
+    useQuery<ApiContentDraftStalenessResponse['results'], ApiError>({
+        queryKey: ['content-draft-staleness', projectUuid, draftUuid],
+        queryFn: () =>
+            lightdashApi<ApiContentDraftStalenessResponse['results']>({
+                url: `/projects/${projectUuid}/code/drafts/${draftUuid}/staleness`,
+                method: 'GET',
+                body: undefined,
+            }),
+        enabled: projectUuid !== undefined && draftUuid !== undefined,
+    });
+
+export const useRebaseDraftMutation = (projectUuid: string | undefined) => {
+    const { showToastSuccess, showToastError } = useToaster();
+    const queryClient = useQueryClient();
+    return useMutation<
+        ContentDraftSummary,
+        ApiError,
+        {
+            draftUuid: string;
+            resolutions: ContentDraftRebaseRequest['resolutions'];
+        }
+    >(
+        ({ draftUuid, resolutions }) =>
+            lightdashApi<ContentDraftSummary>({
+                url: `/projects/${projectUuid}/code/drafts/${draftUuid}/rebase`,
+                method: 'POST',
+                body: JSON.stringify({ resolutions }),
+            }),
+        {
+            onSuccess: () => {
+                void Promise.all([
+                    queryClient.invalidateQueries([
+                        'content-drafts',
+                        projectUuid,
+                    ]),
+                    queryClient.invalidateQueries(['content-draft-review']),
+                    queryClient.invalidateQueries(['saved_dashboard_query']),
+                    queryClient.invalidateQueries(['saved_query']),
+                ]);
+                showToastSuccess({
+                    title: 'Draft updated to the latest version',
+                });
+            },
+            onError: (error) => {
+                showToastError({
+                    title: 'Failed to update draft',
                     subtitle: error.error.message,
                 });
             },

--- a/packages/frontend/src/features/contentAsCode/utils/draftFieldLabel.ts
+++ b/packages/frontend/src/features/contentAsCode/utils/draftFieldLabel.ts
@@ -1,0 +1,8 @@
+export const draftFieldLabel = (field: string) =>
+    field === 'spaceSlug'
+        ? 'Space'
+        : field.charAt(0).toUpperCase() +
+          field
+              .slice(1)
+              .replace(/([A-Z])/g, ' $1')
+              .toLowerCase();

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -36,7 +36,12 @@ import PageSpinner from '../components/PageSpinner';
 import { useDashboardCommentsCheck } from '../features/comments';
 import DismissedDraftAlert from '../features/contentAsCode/components/DismissedDraftAlert';
 import DraftOverlayFailureAlert from '../features/contentAsCode/components/DraftOverlayFailureAlert';
-import { useReopenDraftMutation } from '../features/contentAsCode/hooks/useContentDrafts';
+import DraftStaleAlert from '../features/contentAsCode/components/DraftStaleAlert';
+import {
+    useDraftStaleness,
+    useRebaseDraftMutation,
+    useReopenDraftMutation,
+} from '../features/contentAsCode/hooks/useContentDrafts';
 import { FilterBarPopoversProvider } from '../features/dashboardFilters/FilterRequirements/FilterBarPopoversProvider';
 import DashboardTabs from '../features/dashboardTabs';
 import {
@@ -75,6 +80,12 @@ const Dashboard: FC = () => {
     const dashboardIdentifier = dashboard?.slug ?? routeDashboardIdentifier;
     const { mutate: reopenDraft, isLoading: isReopeningDraft } =
         useReopenDraftMutation(projectUuid);
+    const { mutate: rebaseDraft, isLoading: isRebasingDraft } =
+        useRebaseDraftMutation(projectUuid);
+    const { data: draftStalenessDetails } = useDraftStaleness(
+        projectUuid,
+        dashboard?.draftStaleness?.draftUuid,
+    );
 
     const dashboardError = useDashboardContext((c) => c.dashboardError);
     const dashboardFilters = useDashboardContext((c) => c.dashboardFilters);
@@ -1029,6 +1040,22 @@ const Dashboard: FC = () => {
                             isReopening={isReopeningDraft}
                             onReopen={() =>
                                 reopenDraft(dashboard.dismissedDraftUuid!)
+                            }
+                        />
+                    ) : null}
+
+                    {dashboard.draftStaleness ? (
+                        <DraftStaleAlert
+                            contentLabel="dashboard"
+                            staleness={dashboard.draftStaleness}
+                            details={draftStalenessDetails}
+                            isUpdating={isRebasingDraft}
+                            onUpdate={(resolutions) =>
+                                rebaseDraft({
+                                    draftUuid:
+                                        dashboard.draftStaleness!.draftUuid,
+                                    resolutions,
+                                })
                             }
                         />
                     ) : null}


### PR DESCRIPTION
Closes PROD-10696 (first slice of PROD-10628)

## Why

A draft stored only a partial overlay and both the author view and the reviewer diff read published live, so nothing knew what the author started from. When the repo published past a draft, the reviewer diff showed unrelated changes as the author's, and writing the draft back overwrote them (the E2 lost-update on PROD-10628).

## Decisions (confirmed with product)

- **Every role drafts on git-backed content.** Managers no longer publish directly; the repo is the only publisher, through write-back, PR, and an upload or in-app sync. That makes the last-applied upload snapshot the one base a draft can start from.
- **Stale drafts block write-back** until the author updates them.

## What

- `content_drafts.base_snapshot` / `base_snapshot_hash`: the slug's upload snapshot at draft creation. Later saves keep it; pre-existing drafts adopt one on their next save.
- Stale = the slug's current snapshot hash differs from the draft's base hash (`stale` on `ContentDraftSummary`, `draftStaleness` on the viewer's dashboard/chart, `staleness` on the review payload).
- Three-way per top-level as-code field between base, current snapshot, and the draft overlay (`computeContentDraftStaleness` in common): fields only the author touched carry over; fields both sides touched are conflicts, whole-field in this slice (`tiles` included; per-tile is PROD-10697).
- `POST /code/drafts/{uuid}/rebase` with per-field resolutions (`mine` | `latest`): drops the overlay keys the author gives up and moves the base to the current snapshot. Author-only.
- Draft overlays now only keep the fields the save actually changed (the metadata form always sends name, description, and space), so unchanged fields do not register as conflicts.
- `GET /code/drafts/{uuid}/staleness` (author or manager): what the repo and the draft each did to every moved field, in words (`"Old" → "New"`, `added 1 tile (Admin tile)`, `changed limit`), computed from base, current snapshot, and the rendered draft.
- Author UI: a banner on the dashboard/chart that names what changed; "Review changes" opens an inline panel (no modal) listing each field with "In the repo" / "In your draft" and a Mine/Repo choice only where both sides changed it; everything else carries over automatically. Reviewer UI: "Behind repo" badge, the same descriptions above the diff, write-back disabled with the reason.

## Regression analysis

- Projects without `content_as_code.sync` are untouched: no draft is created and no staleness is computed.
- Managers editing git-backed content will notice the change: their saves are drafts now and go through write-back. Uploads and the in-app sync still write published content directly.
- Migration adds two nullable columns under a 5s lock timeout; `stale` is only ever true for open drafts with a recorded base.

## Verified

- Unit: staleness and field mapping (common), stale review payload, refused write-back, rebase with mine/latest, unresolved conflicts, author-only; both draft services for managers drafting and base recording (145 tests across the touched files).
- Live, recorded: editor drafts rename + tile; manager drafts description + tile, writes back, PR merged and synced; editor's draft flagged with `tiles` the only conflict and write-back refused with 409; update to latest keeps the rename and takes the repo's tiles; reviewer writes it back as its own PR. Proof page with stills and recordings linked from the ticket.
