### PR TITLE
fix: keep mobile sign-in available after session expiry

### DIFF
--- a/packages/backend/src/ee/controllers/mobilePushNotificationController.test.ts
+++ b/packages/backend/src/ee/controllers/mobilePushNotificationController.test.ts
@@ -1,5 +1,10 @@
 import { type UUID } from '@lightdash/common';
+import { fetchMiddlewares } from '@tsoa/runtime';
 import { type Request } from 'express';
+import {
+    allowApiKeyAuthentication,
+    isAuthenticated,
+} from '../../controllers/authentication';
 import { type ServiceRepository } from '../../services/ServiceRepository';
 import { type MobilePushNotificationService } from '../services/MobilePushNotificationService/MobilePushNotificationService';
 import { MobilePushNotificationController } from './mobilePushNotificationController';
@@ -48,5 +53,47 @@ describe('MobilePushNotificationController.registerLiveActivityPushToStartToken'
         });
         expect(response).toEqual({ status: 'ok', results: undefined });
         expect(JSON.stringify(response)).not.toContain('push-to-start-token');
+    });
+});
+
+describe('MobilePushNotificationController.revokeInstallation', () => {
+    it('keeps installation registration and token updates authenticated', () => {
+        expect(
+            fetchMiddlewares(
+                MobilePushNotificationController.prototype.registerInstallation,
+            ),
+        ).toEqual([[allowApiKeyAuthentication, isAuthenticated]]);
+        expect(
+            fetchMiddlewares(
+                MobilePushNotificationController.prototype
+                    .registerLiveActivityPushToStartToken,
+            ),
+        ).toEqual([[allowApiKeyAuthentication, isAuthenticated]]);
+    });
+
+    it('allows an unauthenticated caller to revoke an installation', async () => {
+        const revokeInstallation = vi.fn<
+            MobilePushNotificationService['revokeInstallation']
+        >(async () => undefined);
+        const services = {
+            getMobilePushNotificationService: () => ({
+                revokeInstallation,
+            }),
+        } as unknown as ServiceRepository;
+        const controller = new MobilePushNotificationController(services);
+        const installationUuid = '10000000-0000-4000-8000-000000000003' as UUID;
+
+        expect(
+            fetchMiddlewares(
+                MobilePushNotificationController.prototype.revokeInstallation,
+            ),
+        ).toEqual([]);
+        const response = await controller.revokeInstallation(
+            {} as Request,
+            installationUuid,
+        );
+
+        expect(revokeInstallation).toHaveBeenCalledWith({ installationUuid });
+        expect(response).toEqual({ status: 'ok', results: undefined });
     });
 });

--- a/packages/backend/src/ee/controllers/mobilePushNotificationController.ts
+++ b/packages/backend/src/ee/controllers/mobilePushNotificationController.ts
@@ -93,17 +93,14 @@ export class MobilePushNotificationController extends BaseController {
         return { status: 'ok', results: undefined };
     }
 
-    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
     @Delete('/installations/{installationUuid}')
     @OperationId('revokeMobilePushInstallation')
     async revokeInstallation(
-        @Request() req: express.Request,
+        @Request() _req: express.Request,
         @Path() installationUuid: string,
     ): Promise<ApiMobilePushInstallationResponse> {
-        assertRegisteredAccount(req.account);
         await this.getMobilePushNotificationService().revokeInstallation({
-            user: toSessionUser(req.account),
             installationUuid,
         });
         this.setStatus(200);

--- a/packages/backend/src/ee/models/MobilePushNotificationModel.test.ts
+++ b/packages/backend/src/ee/models/MobilePushNotificationModel.test.ts
@@ -31,6 +31,24 @@ afterEach(() => {
 });
 
 describe('MobilePushNotificationModel', () => {
+    it('deletes only the installation identified by the supplied UUID', async () => {
+        tracker.on.delete(MobilePushInstallationsTableName).responseOnce(0);
+
+        await expect(
+            model.deleteInstallation({
+                installationUuid: '10000000-0000-4000-8000-000000000003',
+            }),
+        ).resolves.toBeUndefined();
+
+        expect(tracker.history.delete).toHaveLength(1);
+        expect(tracker.history.delete[0].sql).toContain(
+            'where "installation_uuid" = $1',
+        );
+        expect(tracker.history.delete[0].bindings).toEqual([
+            '10000000-0000-4000-8000-000000000003',
+        ]);
+    });
+
     it('serializes an absent UUID before storing a rotating device token', async () => {
         tracker.on.any(/pg_advisory_xact_lock/).responseOnce([]);
         tracker.on.select(MobilePushInstallationsTableName).responseOnce([]);

--- a/packages/backend/src/ee/models/MobilePushNotificationModel.ts
+++ b/packages/backend/src/ee/models/MobilePushNotificationModel.ts
@@ -646,17 +646,11 @@ export class MobilePushNotificationModel {
 
     async deleteInstallation(args: {
         installationUuid: string;
-        organizationUuid: string;
-        userUuid: string;
     }): Promise<void> {
         await this.database<DbMobilePushInstallation>(
             MobilePushInstallationsTableName,
         )
-            .where({
-                installation_uuid: args.installationUuid,
-                organization_uuid: args.organizationUuid,
-                user_uuid: args.userUuid,
-            })
+            .where('installation_uuid', args.installationUuid)
             .delete();
     }
 

--- a/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationService.test.ts
+++ b/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationService.test.ts
@@ -1177,23 +1177,37 @@ describe('MobilePushNotificationService installation lifecycle', () => {
         ).not.toHaveBeenCalled();
     });
 
-    it('revokes only the current account installation on sign-out', async () => {
+    it('revokes only the installation identified by the supplied UUID', async () => {
         const dependencies = createDependencies();
         const service = new MobilePushNotificationService(dependencies);
 
         await service.revokeInstallation({
-            user: { userUuid, organizationUuid },
-            installationUuid,
+            installationUuid: validOriginUuid,
         });
 
         expect(
             dependencies.mobilePushNotificationStore.deleteInstallation,
         ).toHaveBeenCalledWith({
-            installationUuid,
-            organizationUuid,
-            userUuid,
+            installationUuid: validOriginUuid,
         });
     });
+
+    it.each(['not-a-uuid', '10000000-0000-4000-7000-000000000003'])(
+        'rejects invalid installation identifier %s',
+        async (invalidInstallationUuid) => {
+            const dependencies = createDependencies();
+            const service = new MobilePushNotificationService(dependencies);
+
+            await expect(
+                service.revokeInstallation({
+                    installationUuid: invalidInstallationUuid,
+                }),
+            ).rejects.toBeInstanceOf(ParameterError);
+            expect(
+                dependencies.mobilePushNotificationStore.deleteInstallation,
+            ).not.toHaveBeenCalled();
+        },
+    );
 
     it('revokes only the current account activity tuple', async () => {
         const dependencies = createDependencies();

--- a/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationService.ts
+++ b/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationService.ts
@@ -131,11 +131,7 @@ export type MobilePushNotificationStore = {
         limit: number;
         maxAttempts: number;
     }): Promise<SchedulableLiveActivityStartAttempt[]>;
-    deleteInstallation(args: {
-        installationUuid: string;
-        organizationUuid: string;
-        userUuid: string;
-    }): Promise<void>;
+    deleteInstallation(args: { installationUuid: string }): Promise<void>;
     upsertLiveActivity(activity: UpsertLiveActivity): Promise<void>;
     deleteLiveActivity(args: {
         liveActivityUuid: string;
@@ -502,16 +498,14 @@ export class MobilePushNotificationService {
     }
 
     async revokeInstallation(args: {
-        user: MobilePushUser;
         installationUuid: string;
     }): Promise<void> {
-        const { organizationUuid } = args.user;
-        if (organizationUuid == null) return;
+        if (!isValidUuid(args.installationUuid)) {
+            throw new ParameterError('Invalid installation UUID');
+        }
 
         await this.mobilePushNotificationStore.deleteInstallation({
             installationUuid: args.installationUuid,
-            organizationUuid,
-            userUuid: args.user.userUuid,
         });
     }
 


### PR DESCRIPTION
## Problem

An expired mobile session can leave a pending push-installation cleanup marker on the device. The deployed app retries that cleanup before authentication, but the API currently rejects the request after the session cookie has been cleared. Sign-in then stops before the login request is sent.

## Change

- Let deployed mobile clients revoke one push installation after the previous session expires.
- Treat the opaque installation UUID as a narrow revocation capability.
- Keep installation registration and Live Activity token updates authenticated.
- Validate the UUID and delete only that exact installation.
- Return the same empty success response whether the installation exists or not.

This server-side compatibility change restores sign-in for already-deployed builds. A paired iOS change makes cleanup failure non-blocking so future app versions do not depend on this request succeeding before authentication.

## Capability boundary

The endpoint can only revoke the installation named by its random UUID. It cannot read, list, create, or update installations, and it does not reveal whether the UUID exists.

## Tests

- 74 focused controller, service, and model tests pass.
- Backend typecheck passes.
- Touched-path lint and format checks pass.
- Full exact-head CI passes, including Build & Test, API E2E, OpenAPI compatibility, deploy preview, and release safety.
- DeepSec HIGH-tier review completed on the exact PR diff. Findings were triaged privately.

Linear: SPK-1740
