### PR TITLE
chore(ai): enable custom org AI provider keys by default

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -243,7 +243,6 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         lightdashConfig: context.lightdashConfig,
                         aiOrganizationSettingsModel:
                             models.getAiOrganizationSettingsModel(),
-                        featureFlagService: repository.getFeatureFlagService(),
                         aiModelCatalog,
                     }),
                     lightdashConfig: context.lightdashConfig,
@@ -477,7 +476,6 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         lightdashConfig: context.lightdashConfig,
                         aiOrganizationSettingsModel:
                             models.getAiOrganizationSettingsModel(),
-                        featureFlagService: repository.getFeatureFlagService(),
                         aiModelCatalog,
                     }),
                     sandboxManager: null,
@@ -526,7 +524,6 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         lightdashConfig: context.lightdashConfig,
                         aiOrganizationSettingsModel:
                             models.getAiOrganizationSettingsModel(),
-                        featureFlagService: repository.getFeatureFlagService(),
                         aiModelCatalog,
                     }),
                 }),
@@ -635,7 +632,6 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         lightdashConfig: context.lightdashConfig,
                         aiOrganizationSettingsModel:
                             models.getAiOrganizationSettingsModel(),
-                        featureFlagService: repository.getFeatureFlagService(),
                         aiModelCatalog,
                     }),
                     shareService: repository.getShareService(),
@@ -727,7 +723,6 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         lightdashConfig: context.lightdashConfig,
                         aiOrganizationSettingsModel:
                             models.getAiOrganizationSettingsModel(),
-                        featureFlagService: repository.getFeatureFlagService(),
                         aiModelCatalog,
                     }),
                 }),
@@ -743,7 +738,6 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         lightdashConfig: context.lightdashConfig,
                         aiOrganizationSettingsModel:
                             models.getAiOrganizationSettingsModel(),
-                        featureFlagService: repository.getFeatureFlagService(),
                         aiModelCatalog,
                     }),
                 }),
@@ -760,7 +754,6 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         lightdashConfig: context.lightdashConfig,
                         aiOrganizationSettingsModel:
                             models.getAiOrganizationSettingsModel(),
-                        featureFlagService: repository.getFeatureFlagService(),
                         aiModelCatalog,
                     }),
                     catalogModel: models.getCatalogModel(),
@@ -771,7 +764,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     aiAgentReviewNotificationService:
                         repository.getAiAgentReviewNotificationService<AiAgentReviewNotificationService>(),
                 }),
-            aiOrganizationSettingsService: ({ models, context, repository }) =>
+            aiOrganizationSettingsService: ({ models, context }) =>
                 new AiOrganizationSettingsService({
                     aiOrganizationSettingsModel:
                         models.getAiOrganizationSettingsModel(),
@@ -783,7 +776,6 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         lightdashConfig: context.lightdashConfig,
                         aiOrganizationSettingsModel:
                             models.getAiOrganizationSettingsModel(),
-                        featureFlagService: repository.getFeatureFlagService(),
                         aiModelCatalog,
                     }),
                 }),
@@ -840,7 +832,6 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         lightdashConfig: context.lightdashConfig,
                         aiOrganizationSettingsModel:
                             models.getAiOrganizationSettingsModel(),
-                        featureFlagService: repository.getFeatureFlagService(),
                         aiModelCatalog,
                     }),
                 }),

--- a/packages/backend/src/ee/services/AiOrganizationSettingsService.ts
+++ b/packages/backend/src/ee/services/AiOrganizationSettingsService.ts
@@ -580,15 +580,12 @@ export class AiOrganizationSettingsService extends BaseService {
             aiSettingsUpdate.providerApiKeys !== undefined ||
             aiSettingsUpdate.modelVisibility !== undefined
         ) {
-            // BYO keys and model visibility require both AI copilot (env/ai-copilot
-            // flag) and the org-ai-provider-api-keys flag to be enabled for this org.
-            const [copilotEnabled, byoKeysEnabled] = await Promise.all([
-                this.getIsCopilotEnabled(user),
-                this.orgAiCopilotConfigResolver.isEnabled(organizationUuid),
-            ]);
-            if (!copilotEnabled || !byoKeysEnabled) {
+            // BYO keys and model visibility require AI copilot (env/ai-copilot
+            // flag) to be enabled for this org.
+            const copilotEnabled = await this.getIsCopilotEnabled(user);
+            if (!copilotEnabled) {
                 throw new ForbiddenError(
-                    'Organization AI provider API keys are not enabled',
+                    'AI copilot is not enabled for this organization',
                 );
             }
         }

--- a/packages/backend/src/ee/services/ai/OrgAiCopilotConfigResolver.test.ts
+++ b/packages/backend/src/ee/services/ai/OrgAiCopilotConfigResolver.test.ts
@@ -5,7 +5,6 @@ import type {
 import { vi } from 'vitest';
 import { aiCopilotConfigSchema } from '../../../config/aiConfigSchema';
 import { LightdashConfig } from '../../../config/parseConfig';
-import { FeatureFlagService } from '../../../services/FeatureFlag/FeatureFlagService';
 import { AiModelCatalog } from '../../clients/Ai/AiModelCatalog';
 import {
     AiOrganizationSettingsModel,
@@ -235,7 +234,6 @@ describe('resolveEffectiveModelVisibility', () => {
 
 describe('OrgAiCopilotConfigResolver', () => {
     type ResolverOptions = {
-        flagEnabled: boolean;
         orgKeys?: AiOrgProviderApiKeys | null;
         modelVisibility?: AiOrgModelVisibility | null;
         accessibleModelIds?: string[] | null;
@@ -243,12 +241,11 @@ describe('OrgAiCopilotConfigResolver', () => {
     };
 
     const makeResolver = ({
-        flagEnabled,
         orgKeys = { openai: 'org-openai-key' },
         modelVisibility = null,
         accessibleModelIds = null,
         instanceConfig = baseConfig,
-    }: ResolverOptions) =>
+    }: ResolverOptions = {}) =>
         new OrgAiCopilotConfigResolver({
             lightdashConfig: {
                 ai: { copilot: instanceConfig },
@@ -264,12 +261,6 @@ describe('OrgAiCopilotConfigResolver', () => {
                 AiOrganizationSettingsModel,
                 'findDecryptedProviderApiKeys' | 'findByOrganizationUuid'
             > as AiOrganizationSettingsModel,
-            featureFlagService: {
-                get: vi.fn().mockResolvedValue({
-                    id: 'org-ai-provider-api-keys',
-                    enabled: flagEnabled,
-                }),
-            } as Pick<FeatureFlagService, 'get'> as FeatureFlagService,
             aiModelCatalog: {
                 getAccessibleModelIds: vi
                     .fn()
@@ -280,23 +271,13 @@ describe('OrgAiCopilotConfigResolver', () => {
             > as AiModelCatalog,
         });
 
-    it('returns the base config untouched when the feature flag is off', async () => {
-        const result = await makeResolver({
-            flagEnabled: false,
-        }).getCopilotConfig('org-uuid');
-        expect(result.providers.openai?.apiKey).toBe('instance-openai-key');
-    });
-
-    it('overlays org keys when the feature flag is on', async () => {
-        const result = await makeResolver({
-            flagEnabled: true,
-        }).getCopilotConfig('org-uuid');
+    it('overlays org keys onto the instance config', async () => {
+        const result = await makeResolver().getCopilotConfig('org-uuid');
         expect(result.providers.openai?.apiKey).toBe('org-openai-key');
     });
 
     it('uses configured Anthropic models without probing a gateway catalog', async () => {
         const resolver = makeResolver({
-            flagEnabled: true,
             accessibleModelIds: null,
         });
 
@@ -311,7 +292,6 @@ describe('OrgAiCopilotConfigResolver', () => {
     describe('getClaudeCodeConfig', () => {
         it('returns the instance config unchanged without an organization uuid', async () => {
             const result = await makeResolver({
-                flagEnabled: true,
                 instanceConfig: bothProvidersConfig,
             }).getClaudeCodeConfig(null);
             expect(result.defaultProvider).toBe('openai');
@@ -320,21 +300,8 @@ describe('OrgAiCopilotConfigResolver', () => {
             );
         });
 
-        it('returns the instance config unchanged when the feature flag is off', async () => {
-            const result = await makeResolver({
-                flagEnabled: false,
-                orgKeys: { anthropic: 'org-anthropic-key' },
-                instanceConfig: bothProvidersConfig,
-            }).getClaudeCodeConfig('org-uuid');
-            expect(result.defaultProvider).toBe('openai');
-            expect(result.providers.anthropic?.apiKey).toBe(
-                'instance-anthropic-key',
-            );
-        });
-
         it('returns the instance config unchanged when the org has no keys', async () => {
             const result = await makeResolver({
-                flagEnabled: true,
                 orgKeys: null,
                 instanceConfig: bothProvidersConfig,
             }).getClaudeCodeConfig('org-uuid');
@@ -345,7 +312,6 @@ describe('OrgAiCopilotConfigResolver', () => {
 
         it('runs a BYO org on its own Anthropic key and forces the Anthropic provider', async () => {
             const result = await makeResolver({
-                flagEnabled: true,
                 orgKeys: { anthropic: 'org-anthropic-key' },
                 instanceConfig: bothProvidersConfig,
             }).getClaudeCodeConfig('org-uuid');
@@ -357,7 +323,6 @@ describe('OrgAiCopilotConfigResolver', () => {
 
         it('never leaks the instance Anthropic key to a BYO org that only keyed OpenAI', async () => {
             const result = await makeResolver({
-                flagEnabled: true,
                 orgKeys: { openai: 'org-openai-key' },
                 instanceConfig: bothProvidersConfig,
             }).getClaudeCodeConfig('org-uuid');
@@ -372,7 +337,6 @@ describe('OrgAiCopilotConfigResolver', () => {
     describe('getCodexConfig', () => {
         it('keeps instance Bedrock as the managed Codex provider', async () => {
             const result = await makeResolver({
-                flagEnabled: true,
                 orgKeys: null,
                 instanceConfig: bedrockConfig,
             }).getCodexConfig('org-uuid');
@@ -382,7 +346,6 @@ describe('OrgAiCopilotConfigResolver', () => {
 
         it('returns the instance config unchanged without an organization uuid', async () => {
             const result = await makeResolver({
-                flagEnabled: true,
                 instanceConfig: bothProvidersConfig,
             }).getCodexConfig(null);
             expect(result.providers.openai?.apiKey).toBe('instance-openai-key');
@@ -390,7 +353,6 @@ describe('OrgAiCopilotConfigResolver', () => {
 
         it('runs a BYO org on its own OpenAI key', async () => {
             const result = await makeResolver({
-                flagEnabled: true,
                 orgKeys: { openai: 'org-openai-key' },
                 instanceConfig: bothProvidersConfig,
             }).getCodexConfig('org-uuid');
@@ -400,7 +362,6 @@ describe('OrgAiCopilotConfigResolver', () => {
 
         it('never leaks the instance OpenAI key to a BYO org that only keyed Anthropic', async () => {
             const result = await makeResolver({
-                flagEnabled: true,
                 orgKeys: { anthropic: 'org-anthropic-key' },
                 instanceConfig: bothProvidersConfig,
             }).getCodexConfig('org-uuid');
@@ -412,7 +373,6 @@ describe('OrgAiCopilotConfigResolver', () => {
     describe('resolveEffectiveModelVisibilityForOrg', () => {
         it('merges the implicit auto-hide under the submitted visibility', async () => {
             const resolver = makeResolver({
-                flagEnabled: true,
                 orgKeys: { anthropic: 'sk-ant' },
             });
             const effective =
@@ -428,7 +388,6 @@ describe('OrgAiCopilotConfigResolver', () => {
 
         it('blocks the lockout: an anthropic-only org disabling anthropic leaves no models', async () => {
             const resolver = makeResolver({
-                flagEnabled: true,
                 orgKeys: { anthropic: 'sk-ant' },
             });
             const effective =
@@ -459,7 +418,6 @@ describe('OrgAiCopilotConfigResolver', () => {
 
         it('returns the submission unchanged when the org has no keys', async () => {
             const resolver = makeResolver({
-                flagEnabled: true,
                 orgKeys: null,
             });
             const submitted = { openai: { enabled: false } };
@@ -476,23 +434,12 @@ describe('OrgAiCopilotConfigResolver', () => {
         const none = { modelVisibility: null, keyAccessibleModelIds: null };
 
         it('returns no overrides without an organization uuid', async () => {
-            const resolver = makeResolver({ flagEnabled: true });
+            const resolver = makeResolver();
             expect(await resolver.getOrgModelOverrides(null)).toEqual(none);
-        });
-
-        it('returns no overrides when the feature flag is off', async () => {
-            const resolver = makeResolver({
-                flagEnabled: false,
-                modelVisibility: { openai: { enabled: false } },
-            });
-            expect(await resolver.getOrgModelOverrides('org-uuid')).toEqual(
-                none,
-            );
         });
 
         it('returns no overrides without BYO keys (settings become inert)', async () => {
             const resolver = makeResolver({
-                flagEnabled: true,
                 orgKeys: null,
                 modelVisibility: { openai: { enabled: false } },
             });
@@ -503,7 +450,6 @@ describe('OrgAiCopilotConfigResolver', () => {
 
         it('returns stored visibility and key-accessible ids with an anthropic key', async () => {
             const resolver = makeResolver({
-                flagEnabled: true,
                 orgKeys: { anthropic: 'sk-ant-x' },
                 modelVisibility: { openai: { enabled: false } },
                 accessibleModelIds: ['claude-opus-4-8'],
@@ -516,7 +462,6 @@ describe('OrgAiCopilotConfigResolver', () => {
 
         it('auto-hides openai when only an anthropic key is set', async () => {
             const resolver = makeResolver({
-                flagEnabled: true,
                 orgKeys: { anthropic: 'sk-ant-x' },
                 modelVisibility: null,
                 accessibleModelIds: ['claude-opus-4-8'],
@@ -529,7 +474,6 @@ describe('OrgAiCopilotConfigResolver', () => {
 
         it('does not query the catalog with only an openai key', async () => {
             const resolver = makeResolver({
-                flagEnabled: true,
                 orgKeys: { openai: 'sk-x' },
                 modelVisibility: { anthropic: { enabled: true } },
                 accessibleModelIds: ['claude-opus-4-8'],
@@ -542,7 +486,6 @@ describe('OrgAiCopilotConfigResolver', () => {
 
         it('fails closed when the catalog returns null', async () => {
             const resolver = makeResolver({
-                flagEnabled: true,
                 orgKeys: { anthropic: 'sk-ant-x' },
                 modelVisibility: { openai: { enabled: false } },
                 accessibleModelIds: null,
@@ -555,7 +498,6 @@ describe('OrgAiCopilotConfigResolver', () => {
 
         it('does not probe a BYO Anthropic key through an instance gateway', async () => {
             const resolver = makeResolver({
-                flagEnabled: true,
                 orgKeys: { anthropic: 'sk-ant-x' },
                 accessibleModelIds: ['claude-opus-4-8'],
                 instanceConfig: anthropicGatewayConfig,
@@ -572,24 +514,14 @@ describe('OrgAiCopilotConfigResolver', () => {
         const none = { hasActiveByoKey: false, canJudgeOnByoKey: false };
 
         it('returns no BYO without an organization uuid', async () => {
-            const resolver = makeResolver({ flagEnabled: true });
+            const resolver = makeResolver();
             expect(await resolver.getReviewJudgeAvailability(null)).toEqual(
                 none,
             );
         });
 
-        it('returns no BYO when the flag is off', async () => {
-            const resolver = makeResolver({
-                flagEnabled: false,
-                orgKeys: { anthropic: 'sk-ant-x' },
-            });
-            expect(
-                await resolver.getReviewJudgeAvailability('org-uuid'),
-            ).toEqual(none);
-        });
-
         it('returns no BYO when there are no keys', async () => {
-            const resolver = makeResolver({ flagEnabled: true, orgKeys: null });
+            const resolver = makeResolver({ orgKeys: null });
             expect(
                 await resolver.getReviewJudgeAvailability('org-uuid'),
             ).toEqual(none);
@@ -597,7 +529,6 @@ describe('OrgAiCopilotConfigResolver', () => {
 
         it('can judge when the anthropic key serves haiku', async () => {
             const resolver = makeResolver({
-                flagEnabled: true,
                 orgKeys: { anthropic: 'sk-ant-x' },
                 accessibleModelIds: ['claude-haiku-4-5-20251001'],
             });
@@ -608,7 +539,6 @@ describe('OrgAiCopilotConfigResolver', () => {
 
         it('cannot judge when the anthropic key lacks haiku', async () => {
             const resolver = makeResolver({
-                flagEnabled: true,
                 orgKeys: { anthropic: 'sk-ant-x' },
                 accessibleModelIds: ['claude-opus-4-8'],
             });
@@ -619,7 +549,6 @@ describe('OrgAiCopilotConfigResolver', () => {
 
         it('fails closed when the catalog returns null', async () => {
             const resolver = makeResolver({
-                flagEnabled: true,
                 orgKeys: { anthropic: 'sk-ant-x' },
                 accessibleModelIds: null,
             });
@@ -630,7 +559,6 @@ describe('OrgAiCopilotConfigResolver', () => {
 
         it('has an active key but cannot judge with only an openai key', async () => {
             const resolver = makeResolver({
-                flagEnabled: true,
                 orgKeys: { openai: 'sk-x' },
             });
             expect(
@@ -640,7 +568,6 @@ describe('OrgAiCopilotConfigResolver', () => {
 
         it('does not judge with a BYO Anthropic key through an instance gateway', async () => {
             const resolver = makeResolver({
-                flagEnabled: true,
                 orgKeys: { anthropic: 'sk-ant-x' },
                 accessibleModelIds: ['claude-haiku-4-5-20251001'],
                 instanceConfig: anthropicGatewayConfig,

--- a/packages/backend/src/ee/services/ai/OrgAiCopilotConfigResolver.ts
+++ b/packages/backend/src/ee/services/ai/OrgAiCopilotConfigResolver.ts
@@ -1,6 +1,5 @@
 import {
     BYO_AI_PROVIDERS,
-    FeatureFlags,
     MissingConfigError,
     type AiOrgModelVisibility,
     type ByoAiProvider,
@@ -8,7 +7,6 @@ import {
 } from '@lightdash/common';
 import { AiCopilotConfigSchemaType } from '../../../config/aiConfigSchema';
 import { LightdashConfig } from '../../../config/parseConfig';
-import { FeatureFlagService } from '../../../services/FeatureFlag/FeatureFlagService';
 import { AiModelCatalog } from '../../clients/Ai/AiModelCatalog';
 import {
     AiOrganizationSettingsModel,
@@ -121,7 +119,6 @@ export const overlayOrgProviderApiKeys = (
 type Dependencies = {
     lightdashConfig: LightdashConfig;
     aiOrganizationSettingsModel: AiOrganizationSettingsModel;
-    featureFlagService: FeatureFlagService;
     aiModelCatalog: AiModelCatalog;
 };
 
@@ -130,27 +127,13 @@ export class OrgAiCopilotConfigResolver {
 
     private aiOrganizationSettingsModel: AiOrganizationSettingsModel;
 
-    private featureFlagService: FeatureFlagService;
-
     private aiModelCatalog: AiModelCatalog;
 
     constructor(dependencies: Dependencies) {
         this.lightdashConfig = dependencies.lightdashConfig;
         this.aiOrganizationSettingsModel =
             dependencies.aiOrganizationSettingsModel;
-        this.featureFlagService = dependencies.featureFlagService;
         this.aiModelCatalog = dependencies.aiModelCatalog;
-    }
-
-    async isEnabled(organizationUuid: string): Promise<boolean> {
-        // Org-scoped check with no acting user: use the 'system' placeholder
-        // like other AI flag checks; a non-uuid userUuid skips the per-user
-        // lookup and the flag resolves via the org override.
-        const flag = await this.featureFlagService.get({
-            user: { userUuid: 'system', organizationUuid },
-            featureFlagId: FeatureFlags.OrgAiProviderApiKeys,
-        });
-        return flag.enabled;
     }
 
     async getCopilotConfig(
@@ -159,7 +142,6 @@ export class OrgAiCopilotConfigResolver {
         const base = this.lightdashConfig.ai.copilot;
         const managed: ResolvedCopilotConfig = { ...base, byoProviders: [] };
         if (!organizationUuid) return managed;
-        if (!(await this.isEnabled(organizationUuid))) return managed;
         const orgKeys =
             await this.aiOrganizationSettingsModel.findDecryptedProviderApiKeys(
                 organizationUuid,
@@ -185,7 +167,6 @@ export class OrgAiCopilotConfigResolver {
         const base = this.lightdashConfig.ai.copilot;
         const managed: ResolvedCopilotConfig = { ...base, byoProviders: [] };
         if (!organizationUuid) return managed;
-        if (!(await this.isEnabled(organizationUuid))) return managed;
         const orgKeys =
             await this.aiOrganizationSettingsModel.findDecryptedProviderApiKeys(
                 organizationUuid,
@@ -215,7 +196,6 @@ export class OrgAiCopilotConfigResolver {
         const base = this.lightdashConfig.ai.copilot;
         const managed: ResolvedCopilotConfig = { ...base, byoProviders: [] };
         if (!organizationUuid) return managed;
-        if (!(await this.isEnabled(organizationUuid))) return managed;
         const orgKeys =
             await this.aiOrganizationSettingsModel.findDecryptedProviderApiKeys(
                 organizationUuid,
@@ -235,8 +215,8 @@ export class OrgAiCopilotConfigResolver {
     /**
      * Org overrides for model LISTINGS (visibility settings + which hidden
      * models the org's own Anthropic key unlocks). Both are null unless the
-     * feature flag is on AND the org has at least one BYO key, so deleting
-     * the key leaves stored visibility settings inert.
+     * org has at least one BYO key, so deleting the key leaves stored
+     * visibility settings inert.
      */
     async getOrgModelOverrides(
         organizationUuid: string | null | undefined,
@@ -246,7 +226,6 @@ export class OrgAiCopilotConfigResolver {
             keyAccessibleModelIds: null,
         };
         if (!organizationUuid) return none;
-        if (!(await this.isEnabled(organizationUuid))) return none;
         const orgKeys =
             await this.aiOrganizationSettingsModel.findDecryptedProviderApiKeys(
                 organizationUuid,
@@ -299,8 +278,8 @@ export class OrgAiCopilotConfigResolver {
 
     /**
      * Org-admin visibility settings for Data App Claude models (opus/sonnet/
-     * haiku). Gated the same way as getOrgModelOverrides: null unless the flag
-     * is on AND the org brings its own Anthropic key, so removing the key
+     * haiku). Gated the same way as getOrgModelOverrides: null unless the org
+     * brings its own Anthropic key, so removing the key
      * leaves stored settings inert rather than restricting models on the
      * instance's own key. Anthropic specifically — getClaudeCodeConfig only
      * swaps in an org key for Anthropic, since the Claude CLI speaks no other
@@ -310,7 +289,6 @@ export class OrgAiCopilotConfigResolver {
         organizationUuid: string | null | undefined,
     ): Promise<DataAppModelVisibility | null> {
         if (!organizationUuid) return null;
-        if (!(await this.isEnabled(organizationUuid))) return null;
         const orgKeys =
             await this.aiOrganizationSettingsModel.findDecryptedProviderApiKeys(
                 organizationUuid,
@@ -385,7 +363,6 @@ export class OrgAiCopilotConfigResolver {
             canJudgeOnByoKey: false,
         };
         if (!organizationUuid) return none;
-        if (!(await this.isEnabled(organizationUuid))) return none;
         const orgKeys =
             await this.aiOrganizationSettingsModel.findDecryptedProviderApiKeys(
                 organizationUuid,

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -240,11 +240,6 @@ export enum FeatureFlags {
     CodingAgentOnboarding = 'coding-agent-onboarding',
 
     /**
-     * Let org admins set their own Anthropic/OpenAI API keys for AI agents.
-     */
-    OrgAiProviderApiKeys = 'org-ai-provider-api-keys',
-
-    /**
      * Allow storing long-lived GitHub personal access tokens as GitHub MCP
      * credentials (guided connect flow and generic bearer endpoints targeting
      * the hosted GitHub MCP URL). Off by default — orgs should authenticate

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiGeneralSettingsPage.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiGeneralSettingsPage.tsx
@@ -64,9 +64,6 @@ export const AiGeneralSettingsPage = () => {
     const { mutate: updateSettings, isLoading: isUpdatingSettings } =
         useUpdateAiOrganizationSettings();
 
-    const orgAiProviderKeysFlag = useServerFeatureFlag(
-        FeatureFlags.OrgAiProviderApiKeys,
-    );
     const dataAppsFlag = useServerFeatureFlag(FeatureFlags.EnableDataApps);
     const threadRetentionFlag = useServerFeatureFlag(
         FeatureFlags.AiThreadRetention,
@@ -321,49 +318,45 @@ export const AiGeneralSettingsPage = () => {
                         </SettingsCard>
                     </Section>
 
-                    {orgAiProviderKeysFlag.data?.enabled &&
-                        settings.isCopilotEnabled && (
-                            <Section
-                                label="Providers & keys"
-                                description="Your own keys take precedence over the instance keys."
-                            >
-                                <AiProvidersCard
-                                    providerApiKeysSet={
-                                        settings.providerApiKeysSet
-                                    }
-                                    providerApiKeyHints={
-                                        settings.providerApiKeyHints
-                                    }
-                                    modelVisibility={
-                                        settings.modelVisibility ?? null
-                                    }
-                                    configurableModelOptions={
-                                        settings.configurableModelOptions ??
-                                        null
-                                    }
-                                    dataAppModelVisibility={
-                                        settings.dataAppModelVisibility ?? null
-                                    }
-                                    showDataAppModels={
-                                        dataAppsFlag.data?.enabled === true
-                                    }
-                                    disabled={isUpdatingSettings}
-                                    onUpdateKeys={(providerApiKeys) =>
-                                        updateSettings({ providerApiKeys })
-                                    }
-                                    onUpdateVisibility={(modelVisibility) =>
-                                        updateSettings({ modelVisibility })
-                                    }
-                                    onUpdateDataAppVisibility={(
+                    {settings.isCopilotEnabled && (
+                        <Section
+                            label="Providers & keys"
+                            description="Your own keys take precedence over the instance keys."
+                        >
+                            <AiProvidersCard
+                                providerApiKeysSet={settings.providerApiKeysSet}
+                                providerApiKeyHints={
+                                    settings.providerApiKeyHints
+                                }
+                                modelVisibility={
+                                    settings.modelVisibility ?? null
+                                }
+                                configurableModelOptions={
+                                    settings.configurableModelOptions ?? null
+                                }
+                                dataAppModelVisibility={
+                                    settings.dataAppModelVisibility ?? null
+                                }
+                                showDataAppModels={
+                                    dataAppsFlag.data?.enabled === true
+                                }
+                                disabled={isUpdatingSettings}
+                                onUpdateKeys={(providerApiKeys) =>
+                                    updateSettings({ providerApiKeys })
+                                }
+                                onUpdateVisibility={(modelVisibility) =>
+                                    updateSettings({ modelVisibility })
+                                }
+                                onUpdateDataAppVisibility={(
+                                    dataAppModelVisibility,
+                                ) =>
+                                    updateSettings({
                                         dataAppModelVisibility,
-                                    ) =>
-                                        updateSettings({
-                                            dataAppModelVisibility,
-                                        })
-                                    }
-                                />
-                            </Section>
-                        )}
+                                    })
+                                }
+                            />
+                        </Section>
+                    )}
 
                     <Section label="Quality & review">
                         <SettingsCard>


### PR DESCRIPTION
Removes the `org-ai-provider-api-keys` feature flag and treats it as enabled: org admins can always set their own Anthropic/OpenAI keys, and stored BYO keys are always overlaid onto the instance copilot config.

- Drops `FeatureFlags.OrgAiProviderApiKeys` and `OrgAiCopilotConfigResolver.isEnabled()` (plus the now-unused `featureFlagService` dependency).
- Settings writes for provider keys / model visibility now only require AI copilot to be enabled for the org; error message updated accordingly.
- The "Providers & keys" settings section renders whenever copilot is enabled.

Existing gates are unchanged: overrides are still inert unless the org actually has a BYO key, and the BYO-isolation rules (never fall back to instance keys, Anthropic gateway conflict) still apply.

Follow-up tracked in PROD-10830 for the reverse control (disabling instance keys for BYOK-only customers).
