### PR TITLE
fix(api): keep POST /projects/{uuid}/refresh working without a body

### DIFF
--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -463,9 +463,10 @@ export type ApiRefreshResults = {
     jobUuid: string;
 };
 
+// Optional so callers that send no body (the CLI, API clients) keep working
 export type ApiRefreshBody = {
     // Run the content-as-code pull as a job step after compiling
-    syncContent: boolean;
+    syncContent?: boolean;
 };
 
 export type ApiCreatePreviewResults = {


### PR DESCRIPTION
Follow-up to #28405. `ApiRefreshBody.syncContent` was required, so any `POST /projects/{uuid}/refresh` without a body (the CLI, API clients, the api-tests helper) failed TSOA validation with 422 `'syncContent' is required`. Optional again; the Refresh dbt button still sends it explicitly, and the controller already treats absence as false.

Caught by the E2E API run on #28405 (every `createAndRefreshProject` call), which Graphite merged before the fix landed.