### PR TITLE
test(content-as-code): skip draftStaleness in the schema contract

### DIFF
--- a/packages/backend/src/contentAsCode/fieldCoverage/chart.test.ts
+++ b/packages/backend/src/contentAsCode/fieldCoverage/chart.test.ts
@@ -14,6 +14,7 @@ describeContentAsCodeSchemaContract({
         // Overlay flags for unpublished drafts; not part of the as-code document.
         'dismissedDraftUuid',
         'draftOverlayError',
+        'draftStaleness',
         'draftsAwaitingReview',
         'hasUnpublishedChanges',
         'organizationUuid',

--- a/packages/backend/src/contentAsCode/fieldCoverage/dashboard.test.ts
+++ b/packages/backend/src/contentAsCode/fieldCoverage/dashboard.test.ts
@@ -12,6 +12,7 @@ describeContentAsCodeSchemaContract({
         // Overlay flags for unpublished drafts; not part of the as-code document.
         'dismissedDraftUuid',
         'draftOverlayError',
+        'draftStaleness',
         'draftsAwaitingReview',
         'firstViewedAt',
         'hasUnpublishedChanges',


### PR DESCRIPTION
Follow-up to #28411. `draftStaleness` is a viewer-only overlay flag on dashboards and charts (like `hasUnpublishedChanges` and `draftOverlayError`), not part of the as-code document, so it belongs in `skippedModelFields` of the chart and dashboard schema-contract tests. Build & Test on `main` fails without it.