### PR TITLE
feat: flagged Forecaster data app template

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/templates.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/templates.test.ts
@@ -3,6 +3,13 @@ import { describe, expect, it } from 'vitest';
 import { getTemplateInstructions } from './templates';
 
 describe('getTemplateInstructions', () => {
+    it('returns instructions for the forecaster template', () => {
+        const instructions = getTemplateInstructions('forecaster');
+        expect(instructions).toContain('[Starter template: Forecaster]');
+        expect(instructions).toContain('baseline');
+        expect(instructions).toContain('useUrlState');
+    });
+
     it('keeps the existing templates behaving identically', () => {
         expect(getTemplateInstructions('dashboard')).toContain(
             'single-page dashboard',

--- a/packages/backend/src/ee/services/AppGenerateService/templates.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/templates.ts
@@ -47,6 +47,17 @@ Wire the standard data-point action: when \`useVizContext().underlyingData.enabl
 
 You are done when the chart renders for real and the declaration you emit is the one that skill describes: every field and every config option the component reads, and nothing a viewer would plausibly want different left hardcoded.`;
 
+const FORECASTER_INSTRUCTIONS = `[Starter template: Forecaster]
+Build a scenario-forecast app for one monthly metric:
+- Query a monthly history series from the semantic layer: a month-grain time dimension plus the metric being forecast. When the user names a limit (committed spend, capacity, budget), bind it as a second "ceiling" metric and forecast against it.
+- Derive defaults from the data, never hardcode them: fit a monthly growth rate to the history and derive a calendar-month seasonal index from the actuals.
+- Offer scenario levers wired through \`useUrlState\` so every scenario is a shareable link: growth %, and a planned step change (which month it lands and its size - it raises the ceiling when one is bound, otherwise the value). Seed lever defaults from the fitted values and provide a reset-to-baseline control.
+- Project 18-30 months ahead with a pure in-app function of history + levers, and always draw the scenario against the untouched baseline.
+- Report outcomes fit for the binding: with a ceiling, months-until-limit and when the next step is needed (90% threshold); without one, projected run rate and the next-12-months total vs baseline.
+- Chart: actuals first, then the projection in a visually distinct future zone, baseline dashed; ceiling and threshold lines when bound. Every axis gets a tickFormatter.
+- Close with a copyable plain-text plan summary of the assumptions and the outcome.
+- Every number traces to governed semantic-layer metrics: no hardcoded history, no invented data.`;
+
 // Exhaustive by construction: a new DataAppTemplate value fails to compile
 // until its instructions (or an explicit null, for free-form templates) are
 // registered here.
@@ -56,6 +67,7 @@ const TEMPLATE_INSTRUCTIONS: Record<DataAppTemplate, string | null> = {
     pdf: PDF_REPORT_INSTRUCTIONS,
     custom: null,
     data_app_viz: DATA_APP_VIZ_INSTRUCTIONS,
+    forecaster: FORECASTER_INSTRUCTIONS,
 };
 
 export const getTemplateInstructions = (

--- a/packages/common/src/ee/apps/templates.test.ts
+++ b/packages/common/src/ee/apps/templates.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { FeatureFlags } from '../../types/featureFlags';
 import { DATA_APP_TEMPLATE_DEFINITIONS } from './templates';
 import { DATA_APP_TEMPLATES } from './types';
 
@@ -12,6 +13,14 @@ describe('data app template registry', () => {
             expect(def.description.length).toBeGreaterThan(0);
             expect(def.category.length).toBeGreaterThan(0);
         }
+    });
+
+    it('includes forecaster, surfaced in the gallery behind the templates flag', () => {
+        expect(DATA_APP_TEMPLATES).toContain('forecaster');
+        const def = DATA_APP_TEMPLATE_DEFINITIONS.forecaster;
+        expect(def.inPicker).toBe(false);
+        expect(def.inGallery).toBe(true);
+        expect(def.requiredFlag).toBe(FeatureFlags.EnableDataAppTemplates);
     });
 
     it('keeps the original five templates ungated', () => {

--- a/packages/common/src/ee/apps/templates.ts
+++ b/packages/common/src/ee/apps/templates.ts
@@ -1,4 +1,4 @@
-import { type FeatureFlags } from '../../types/featureFlags';
+import { FeatureFlags } from '../../types/featureFlags';
 import { type DataAppTemplate } from './types';
 
 /**
@@ -74,5 +74,15 @@ export const DATA_APP_TEMPLATE_DEFINITIONS: Record<
         category: 'Building blocks',
         inPicker: false,
         inGallery: false,
+    },
+    forecaster: {
+        id: 'forecaster',
+        title: 'Forecaster',
+        description:
+            'A live what-if forecast: scenario levers, a baseline, and a copyable plan.',
+        category: 'Forecasting',
+        inPicker: false,
+        inGallery: true,
+        requiredFlag: FeatureFlags.EnableDataAppTemplates,
     },
 };

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -107,6 +107,7 @@ export const DATA_APP_TEMPLATES = [
     'pdf',
     'custom',
     DATA_APP_VIZ_TEMPLATE,
+    'forecaster',
 ] as const;
 export type DataAppTemplate = (typeof DATA_APP_TEMPLATES)[number];
 

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -103,6 +103,13 @@ export enum FeatureFlags {
     EnableDataApps = 'enable-data-apps',
 
     /**
+     * Show gated data app templates (e.g. Forecaster) on the app-create
+     * picker. Gates new template registry entries only; the original
+     * templates are always offered.
+     */
+    EnableDataAppTemplates = 'enable-data-app-templates',
+
+    /**
      * Keep Explorer fields mounted on the left while chart selection and
      * configuration render in a right sidebar.
      */

--- a/packages/frontend/src/features/apps/AppTemplatePicker.test.tsx
+++ b/packages/frontend/src/features/apps/AppTemplatePicker.test.tsx
@@ -3,6 +3,15 @@ import { MantineProvider } from '@mantine/core';
 import { fireEvent, render, screen } from '@testing-library/react';
 import AppTemplatePicker from './AppTemplatePicker';
 
+// The picker reads the templates flag through react-query; the fan under
+// test is the ungated one, so resolve the flag as off without a client.
+vi.mock('../../hooks/useServerOrClientFeatureFlag', () => ({
+    useServerFeatureFlag: () => ({
+        isLoading: false,
+        data: { enabled: false },
+    }),
+}));
+
 const setup = (
     selected:
         | 'dashboard'

--- a/packages/frontend/src/features/apps/AppTemplatePicker.tsx
+++ b/packages/frontend/src/features/apps/AppTemplatePicker.tsx
@@ -1,7 +1,8 @@
-import { type DataAppTemplate } from '@lightdash/common';
+import { FeatureFlags, type DataAppTemplate } from '@lightdash/common';
 import { Stack, Text, ThemeIcon } from '@mantine/core';
 import { type CSSProperties, type FC } from 'react';
 import { PolymorphicPaperButton } from '../../components/common/PolymorphicPaperButton';
+import { useServerFeatureFlag } from '../../hooks/useServerOrClientFeatureFlag';
 import classes from './AppTemplatePicker.module.css';
 import { getPickerTemplates } from './templates';
 
@@ -34,7 +35,22 @@ const fanStyle = (index: number, count: number): CSSProperties => {
 };
 
 const AppTemplatePicker: FC<Props> = ({ selected, onSelectedChange }) => {
-    const pickerTemplates = getPickerTemplates(new Set());
+    const templatesFlag = useServerFeatureFlag(
+        FeatureFlags.EnableDataAppTemplates,
+    );
+    if (templatesFlag.isLoading) {
+        // Hold the fan until the flag is known: painting the ungated cards
+        // and then re-fanning when the flag resolves reads as the last card
+        // popping in late. The empty fan keeps the layout height reserved.
+        return <div className={classes.fan} />;
+    }
+    const pickerTemplates = getPickerTemplates(
+        new Set(
+            templatesFlag.data?.enabled
+                ? [FeatureFlags.EnableDataAppTemplates]
+                : [],
+        ),
+    );
     return (
         <div className={classes.fan}>
             {pickerTemplates.map((template, index) => {

--- a/packages/frontend/src/features/apps/templates.test.ts
+++ b/packages/frontend/src/features/apps/templates.test.ts
@@ -1,6 +1,10 @@
-import { type FeatureFlags } from '@lightdash/common';
+import { FeatureFlags } from '@lightdash/common';
 import { describe, expect, it } from 'vitest';
-import { getPickerTemplates, getTemplate } from './templates';
+import {
+    getGalleryTemplates,
+    getPickerTemplates,
+    getTemplate,
+} from './templates';
 
 describe('picker templates', () => {
     it('offers the original four templates without any flags', () => {
@@ -10,7 +14,23 @@ describe('picker templates', () => {
         expect(ids).toEqual(['dashboard', 'slideshow', 'pdf', 'custom']);
     });
 
+    it('keeps forecaster off the fan even when the templates flag is on', () => {
+        const ids = getPickerTemplates(
+            new Set([FeatureFlags.EnableDataAppTemplates]),
+        ).map((t) => t.id);
+        expect(ids).toEqual(['dashboard', 'slideshow', 'pdf', 'custom']);
+    });
+
+    it('gates the gallery on enable-data-app-templates', () => {
+        expect(getGalleryTemplates(new Set<FeatureFlags>())).toEqual([]);
+        const ids = getGalleryTemplates(
+            new Set([FeatureFlags.EnableDataAppTemplates]),
+        ).map((t) => t.id);
+        expect(ids).toEqual(['forecaster']);
+    });
+
     it('resolves a definition with an icon for every template', () => {
+        expect(getTemplate('forecaster').icon).toBeDefined();
         expect(getTemplate('dashboard').icon).toBeDefined();
         expect(getTemplate('dashboard').title).toBe('Dashboard');
     });

--- a/packages/frontend/src/features/apps/templates.ts
+++ b/packages/frontend/src/features/apps/templates.ts
@@ -4,6 +4,7 @@ import {
     type FeatureFlags,
 } from '@lightdash/common';
 import {
+    IconChartLine,
     IconFileText,
     IconLayoutDashboard,
     IconPencil,
@@ -28,6 +29,7 @@ const TEMPLATE_ICONS: Record<DataAppTemplate, TablerIcon> = {
     pdf: IconFileText,
     custom: IconPencil,
     data_app_viz: IconPuzzle,
+    forecaster: IconChartLine,
 };
 
 const toDefinition = (id: DataAppTemplate): TemplateDefinition => {
@@ -55,6 +57,22 @@ export const getPickerTemplates = (
         .filter(
             (def) =>
                 def.inPicker &&
+                (def.requiredFlag === undefined ||
+                    enabledFlags.has(def.requiredFlag)),
+        )
+        .map((def) => toDefinition(def.id));
+
+/**
+ * Templates listed in the gallery behind the picker's "From Template" card,
+ * honoring each definition's feature-flag gate.
+ */
+export const getGalleryTemplates = (
+    enabledFlags: Set<FeatureFlags>,
+): TemplateDefinition[] =>
+    Object.values(DATA_APP_TEMPLATE_DEFINITIONS)
+        .filter(
+            (def) =>
+                def.inGallery &&
                 (def.requiredFlag === undefined ||
                     enabledFlags.has(def.requiredFlag)),
         )

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -720,6 +720,12 @@ const AppGenerate: FC = () => {
         return capture();
     }, []);
     const dataAppsFlag = useServerFeatureFlag(FeatureFlags.EnableDataApps);
+    // Fetched in parallel with EnableDataApps and included in the page gate
+    // below, so the first paint always has the template set settled and the
+    // fan renders fully populated with the page — no late card pop-in.
+    const templatesFlag = useServerFeatureFlag(
+        FeatureFlags.EnableDataAppTemplates,
+    );
     const { user, health } = useApp();
     const sampleDataEnabled = health.data?.dataApps.sampleDataEnabled !== false;
     const ability = useAbilityContext();
@@ -1285,7 +1291,7 @@ const AppGenerate: FC = () => {
         };
     }, []);
 
-    if (dataAppsFlag.isLoading) {
+    if (dataAppsFlag.isLoading || templatesFlag.isLoading) {
         return null;
     }
     if (!dataAppsFlag.data?.enabled) {


### PR DESCRIPTION
## Summary

Middle of the template stack (#28422 registry below, gallery PR above). Adds `forecaster` to the template registry:

- Instruction block distilled from the reference implementation: scenario levers seeded from history (fitted growth, seasonality from actuals), scenario vs untouched baseline, optional ceiling binding (cost vs committed spend), copyable plan summary, URL-shareable state.
- Surfaced in the template **gallery** (`inGallery`, not a fan card), gated behind the `enable-data-app-templates` server feature flag; the gallery UI itself lands in the next PR up the stack.
- `getGalleryTemplates()` accessor + flag prefetch/gate on AppGenerate so the picker paints once, fully settled.
- Flag off: zero change anywhere.

Context: PoC toward instance-specific template galleries (Linear CS-190; agreed with Marshall 2026-09-01 — Josh PoCs, Glitch productionises if UKG validates).

## Test plan

- Registry gating tests (common), forecaster instruction tests (backend), picker/gallery gating tests (frontend)
- Backend + frontend typecheck ✓ on latest main

## Evidence

Screenshots, the verification transcript and the review order for the whole stack: [Templated Data Apps Review](https://claude.ai/code/artifact/c906e241-f1aa-4dd3-8eea-858b0df20451#pr-28420) (section for this PR). Restacked onto main 2.82.2 on 2026-09-02; affected suites green after the restack (frontend 567, common 926, backend 379) and the end-to-end gallery flow passes 11/11 in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VU9L8WJ97vLUB4WJmaUKDa
