### PR TITLE
feat(content-as-code): write back to the file an item was uploaded from

### DIFF
--- a/packages/backend/src/controllers/ProjectCoderController.ts
+++ b/packages/backend/src/controllers/ProjectCoderController.ts
@@ -926,6 +926,7 @@ export class ProjectCoderController extends BaseController {
             spaceNames?: Record<string, string>;
             chartConfig: AnyType;
             description?: string | null;
+            filePath?: string;
         },
         @Request() req: express.Request,
     ): Promise<ApiChartAsCodeUpsertResponse> {
@@ -942,6 +943,7 @@ export class ProjectCoderController extends BaseController {
                     publicSpaceCreate: chart.publicSpaceCreate,
                     force: chart.force,
                     spaceNames: chart.spaceNames,
+                    filePath: chart.filePath,
                 },
             ),
         );
@@ -1008,6 +1010,7 @@ export class ProjectCoderController extends BaseController {
             spaceNames?: Record<string, string>;
             tiles: AnyType;
             description?: string | null;
+            filePath?: string;
         },
         @Request() req: express.Request,
     ): Promise<ApiDashboardAsCodeUpsertResponse> {
@@ -1027,6 +1030,7 @@ export class ProjectCoderController extends BaseController {
                     publicSpaceCreate: dashboard.publicSpaceCreate,
                     force: dashboard.force,
                     spaceNames: dashboard.spaceNames,
+                    filePath: dashboard.filePath,
                 },
             ),
         );

--- a/packages/backend/src/database/entities/contentAsCodeSnapshots.ts
+++ b/packages/backend/src/database/entities/contentAsCodeSnapshots.ts
@@ -11,6 +11,8 @@ export type DbContentAsCodeSnapshot = {
     snapshot_hash: string;
     applied_at: Date;
     applied_by_user_uuid: string | null;
+    // Repo file the snapshot was applied from, relative to the project dir
+    file_path: string | null;
 };
 
 export type CreateDbContentAsCodeSnapshot = Pick<
@@ -21,12 +23,14 @@ export type CreateDbContentAsCodeSnapshot = Pick<
     | 'snapshot'
     | 'snapshot_hash'
     | 'applied_by_user_uuid'
->;
+> &
+    Partial<Pick<DbContentAsCodeSnapshot, 'file_path'>>;
 
 export type UpdateDbContentAsCodeSnapshot = Pick<
     DbContentAsCodeSnapshot,
     'snapshot' | 'snapshot_hash' | 'applied_at' | 'applied_by_user_uuid'
->;
+> &
+    Partial<Pick<DbContentAsCodeSnapshot, 'file_path'>>;
 
 export type ContentAsCodeSnapshotTable = Knex.CompositeTableType<
     DbContentAsCodeSnapshot,

--- a/packages/backend/src/database/migrations/20260901180000_add_file_path_to_content_as_code_snapshots.ts
+++ b/packages/backend/src/database/migrations/20260901180000_add_file_path_to_content_as_code_snapshots.ts
@@ -1,0 +1,25 @@
+import { Knex } from 'knex';
+
+export const classification = {
+    kind: 'safe',
+    reason: 'Adds a nullable column recording the repo file each snapshot was applied from',
+} as const;
+
+const SNAPSHOTS_TABLE = 'content_as_code_snapshots';
+const LOCK_TIMEOUT = '5s';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '${LOCK_TIMEOUT}'`);
+
+    await knex.schema.alterTable(SNAPSHOTS_TABLE, (table) => {
+        table.text('file_path').nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '${LOCK_TIMEOUT}'`);
+
+    await knex.schema.alterTable(SNAPSHOTS_TABLE, (table) => {
+        table.dropColumn('file_path');
+    });
+}

--- a/packages/backend/src/models/ContentAsCodeSnapshotModel.ts
+++ b/packages/backend/src/models/ContentAsCodeSnapshotModel.ts
@@ -15,6 +15,8 @@ export type ContentAsCodeSnapshot = {
     snapshot: object;
     snapshotHash: string;
     appliedAt: Date;
+    // Where the item lives in the repo, when the applying client said
+    filePath: string | null;
 };
 
 export class ContentAsCodeSnapshotModel {
@@ -41,6 +43,7 @@ export class ContentAsCodeSnapshotModel {
             snapshot: row.snapshot,
             snapshotHash: row.snapshot_hash,
             appliedAt: row.applied_at,
+            filePath: row.file_path,
         };
     }
 
@@ -51,6 +54,7 @@ export class ContentAsCodeSnapshotModel {
         snapshot,
         snapshotHash,
         appliedByUserUuid,
+        filePath,
     }: {
         projectUuid: string;
         contentType: ContentAsCodeSnapshotType;
@@ -58,7 +62,10 @@ export class ContentAsCodeSnapshotModel {
         snapshot: object;
         snapshotHash: string;
         appliedByUserUuid: string | null;
+        // null: the client did not say, keep whatever is stored
+        filePath: string | null;
     }): Promise<void> {
+        const filePathColumn = filePath === null ? {} : { file_path: filePath };
         await this.database(ContentAsCodeSnapshotsTableName)
             .insert({
                 project_uuid: projectUuid,
@@ -67,6 +74,7 @@ export class ContentAsCodeSnapshotModel {
                 snapshot,
                 snapshot_hash: snapshotHash,
                 applied_by_user_uuid: appliedByUserUuid,
+                ...filePathColumn,
             })
             .onConflict(['project_uuid', 'content_type', 'slug'])
             .merge({
@@ -74,6 +82,7 @@ export class ContentAsCodeSnapshotModel {
                 snapshot_hash: snapshotHash,
                 applied_at: this.database.fn.now(),
                 applied_by_user_uuid: appliedByUserUuid,
+                ...filePathColumn,
             });
     }
 }

--- a/packages/backend/src/services/CoderService/CoderService.snapshotGating.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.snapshotGating.test.ts
@@ -102,6 +102,7 @@ describe('CoderService snapshot recording gated on content_as_code.sync', () => 
                 PROJECT_UUID,
                 chartDao.uuid,
                 true,
+                undefined,
             );
             expect(snapshotUpsert).toHaveBeenCalledTimes(1);
             expect(snapshotUpsert).toHaveBeenCalledWith(
@@ -113,6 +114,36 @@ describe('CoderService snapshot recording gated on content_as_code.sync', () => 
             );
         });
 
+        it('records where the chart was applied from', async () => {
+            const { service, snapshotUpsert } = buildService();
+            await service['stampAppliedChartSnapshot'](
+                user,
+                PROJECT_UUID,
+                chartDao.uuid,
+                true,
+                './packages/team_a/lightdash/charts/revenue.yml',
+            );
+            expect(snapshotUpsert).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    filePath: 'packages/team_a/lightdash/charts/revenue.yml',
+                }),
+            );
+        });
+
+        it('keeps the stored path when the client sends none', async () => {
+            const { service, snapshotUpsert } = buildService();
+            await service['stampAppliedChartSnapshot'](
+                user,
+                PROJECT_UUID,
+                chartDao.uuid,
+                true,
+                undefined,
+            );
+            expect(snapshotUpsert).toHaveBeenCalledWith(
+                expect.objectContaining({ filePath: null }),
+            );
+        });
+
         it('does not record or fetch anything when sync is disabled', async () => {
             const { service, snapshotUpsert, savedChartGet } = buildService();
             await service['stampAppliedChartSnapshot'](
@@ -120,6 +151,7 @@ describe('CoderService snapshot recording gated on content_as_code.sync', () => 
                 PROJECT_UUID,
                 chartDao.uuid,
                 false,
+                undefined,
             );
             expect(savedChartGet).not.toHaveBeenCalled();
             expect(snapshotUpsert).not.toHaveBeenCalled();
@@ -134,6 +166,7 @@ describe('CoderService snapshot recording gated on content_as_code.sync', () => 
                 PROJECT_UUID,
                 dashboardDao.uuid,
                 true,
+                undefined,
             );
             expect(snapshotUpsert).toHaveBeenCalledTimes(1);
             expect(snapshotUpsert).toHaveBeenCalledWith(
@@ -151,6 +184,7 @@ describe('CoderService snapshot recording gated on content_as_code.sync', () => 
                 PROJECT_UUID,
                 dashboardDao.uuid,
                 false,
+                undefined,
             );
             expect(dashboardGet).not.toHaveBeenCalled();
             expect(snapshotUpsert).not.toHaveBeenCalled();

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -211,6 +211,9 @@ type UpsertContentAsCodeOptions = {
     // Gates snapshot recording: a project that never opts into sync has no
     // use for a last-applied baseline.
     syncEnabled?: boolean;
+    // Repo file the document came from, relative to the project dir, so
+    // write-back returns to the same place
+    filePath?: string;
 };
 
 export class CoderService extends BaseService {
@@ -2891,6 +2894,7 @@ export class CoderService extends BaseService {
         contentType: ContentAsCodeSnapshotType,
         content: SnapshotAsCodeContent,
         appliedByUserUuid: string,
+        filePath: string | undefined,
     ): Promise<void> {
         const { snapshot, snapshotHash } = buildContentAsCodeSnapshot(content);
         await this.contentAsCodeSnapshotModel.upsert({
@@ -2900,7 +2904,19 @@ export class CoderService extends BaseService {
             snapshot,
             snapshotHash,
             appliedByUserUuid,
+            filePath: CoderService.sourceFilePath(filePath),
         });
+    }
+
+    // A malformed path from a client is not worth failing the upload over
+    private static sourceFilePath(filePath: string | undefined): string | null {
+        if (filePath === undefined) return null;
+        try {
+            const normalized = normalizeContentAsCodePath(filePath);
+            return normalized === '' ? null : normalized;
+        } catch {
+            return null;
+        }
     }
 
     // The instance content in its canonical as-code form — the same document
@@ -3160,6 +3176,7 @@ export class CoderService extends BaseService {
         projectUuid: string,
         chartUuid: string,
         syncEnabled: boolean,
+        filePath: string | undefined,
     ): Promise<void> {
         if (!syncEnabled) return;
         try {
@@ -3187,6 +3204,7 @@ export class CoderService extends BaseService {
                     verificationMap,
                 ),
                 user.userUuid,
+                filePath,
             );
         } catch (error) {
             this.logger.warn(
@@ -3201,6 +3219,7 @@ export class CoderService extends BaseService {
         projectUuid: string,
         dashboardUuid: string,
         syncEnabled: boolean,
+        filePath: string | undefined,
     ): Promise<void> {
         if (!syncEnabled) return;
         try {
@@ -3223,6 +3242,7 @@ export class CoderService extends BaseService {
                     verificationMap,
                 ),
                 user.userUuid,
+                filePath,
             );
         } catch (error) {
             this.logger.warn(
@@ -3262,6 +3282,7 @@ export class CoderService extends BaseService {
                     row.path,
                 ),
                 user.userUuid,
+                undefined,
             );
         } catch (error) {
             this.logger.warn(
@@ -3535,6 +3556,7 @@ export class CoderService extends BaseService {
                     projectUuid,
                     newChart.uuid,
                     syncEnabled,
+                    options.filePath,
                 );
             }
 
@@ -3693,6 +3715,7 @@ export class CoderService extends BaseService {
                 projectUuid,
                 chart.uuid,
                 syncEnabled,
+                options.filePath,
             );
         }
 
@@ -4595,6 +4618,7 @@ export class CoderService extends BaseService {
                     projectUuid,
                     newDashboard.uuid,
                     syncEnabled,
+                    options.filePath,
                 );
             }
 
@@ -4759,6 +4783,7 @@ export class CoderService extends BaseService {
                 projectUuid,
                 dashboard.uuid,
                 syncEnabled,
+                options.filePath,
             );
         }
 

--- a/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.test.ts
+++ b/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.test.ts
@@ -530,6 +530,43 @@ describe('ContentAsCodeWritebackService', () => {
         );
     });
 
+    it('writes back to the file the item was last applied from', async () => {
+        const { service, gitIntegrationService } = buildService({
+            settings: { syncEnabled: true, path: 'packages' },
+            snapshot: {
+                snapshotHash: 'abc',
+                filePath:
+                    'packages/team_a/lightdash/charts/monthly-revenue.yml',
+            },
+        });
+        await service.propose(user, 'project-uuid', 'chart', 'monthly-revenue');
+
+        const [, , , filePath] = gitIntegrationService.saveFile.mock.calls[0];
+        expect(filePath).toBe(
+            'packages/team_a/lightdash/charts/monthly-revenue.yml',
+        );
+    });
+
+    it('names the reviewed file by the recorded source path', async () => {
+        const { service } = buildService({
+            snapshot: {
+                snapshotHash: 'abc',
+                filePath:
+                    'packages/team_b/lightdash/dashboards/weekly-kpis.yml',
+            },
+        });
+
+        const review = await service.getDraftReview(
+            user,
+            'project-uuid',
+            'draft-uuid',
+        );
+
+        expect(review.filePath).toBe(
+            'packages/team_b/lightdash/dashboards/weekly-kpis.yml',
+        );
+    });
+
     it('writes files under the stamped content path', async () => {
         const { service, gitIntegrationService } = buildService({
             settings: { syncEnabled: true, path: 'analytics/content' },
@@ -1403,6 +1440,9 @@ describe('ContentAsCodeWritebackService', () => {
                     ['monthly-revenue'],
                 ),
                 'analytics/content/sales.space.yml': 'slug: sales\n',
+                'analytics/content/models/orders.yml':
+                    'version: 2\nmodels:\n  - name: orders\n',
+                'analytics/content/dbt_project.yml': 'name: jaffle\n',
                 'analytics/content/charts/README.md': 'ignored',
                 'lightdash/charts/elsewhere.yml': chart('elsewhere'),
             });
@@ -1419,6 +1459,10 @@ describe('ContentAsCodeWritebackService', () => {
             expect(
                 coderService.upsertChart.mock.calls.map((call) => call[2]),
             ).toEqual(['monthly-revenue', 'nested']);
+            expect(coderService.upsertChart.mock.calls[0][4]).toEqual({
+                syncEnabled: true,
+                filePath: 'analytics/content/charts/monthly-revenue.yml',
+            });
             expect(coderService.upsertSqlChart).toHaveBeenCalledWith(
                 user,
                 'project-uuid',
@@ -1476,6 +1520,32 @@ describe('ContentAsCodeWritebackService', () => {
             ).toEqual(['uses-fine']);
         });
 
+        it("keeps the instance's stamped root when the repo config names no path", async () => {
+            const { service, coderService } = buildService({
+                settings: {
+                    syncEnabled: true,
+                    path: 'packages/package_a/lightdash',
+                },
+            });
+            stubRepo({
+                'lightdash.config.yml': 'content_as_code:\n  sync: true\n',
+                'packages/package_a/lightdash/charts/mine.yml': chart('mine'),
+                'packages/package_b/lightdash/charts/theirs.yml':
+                    chart('theirs'),
+                'lightdash/charts/root.yml': chart('root'),
+            });
+
+            const summary = await service.pullFromGit(user, 'project-uuid');
+
+            expect(summary.charts).toBe(1);
+            expect(
+                coderService.upsertChart.mock.calls.map((call) => call[2]),
+            ).toEqual(['mine']);
+            expect(
+                coderService.stampContentAsCodeSettings,
+            ).toHaveBeenCalledWith(user, 'project-uuid', { sync: true });
+        });
+
         it('stamps sync off and refuses to apply when the repo has not opted in', async () => {
             const { service, coderService } = buildService();
             stubRepo({
@@ -1490,10 +1560,7 @@ describe('ContentAsCodeWritebackService', () => {
 
             expect(
                 coderService.stampContentAsCodeSettings,
-            ).toHaveBeenCalledWith(user, 'project-uuid', {
-                sync: false,
-                path: 'lightdash',
-            });
+            ).toHaveBeenCalledWith(user, 'project-uuid', { sync: false });
             expect(getRepoTree).not.toHaveBeenCalled();
             expect(coderService.upsertChart).not.toHaveBeenCalled();
         });

--- a/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.ts
+++ b/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.ts
@@ -71,6 +71,9 @@ type RepoReadCredentials = Awaited<
     ReturnType<GitIntegrationService['getGitCredentials']>
 > & { branch: string };
 
+const isYamlDocument = (value: unknown): value is Record<string, unknown> =>
+    typeof value === 'object' && value !== null && !Array.isArray(value);
+
 type RepoContentFile = {
     path: string;
     classification: ContentAsCodeFileClassification;
@@ -211,15 +214,42 @@ export class ContentAsCodeWritebackService extends BaseService {
         return `${prefix}${safeSlug}${suffix}`;
     }
 
-    private static getContentFilePath(
-        repoPath: string,
-        contentPath: string,
+    // The file an item was last applied from wins; content that never came
+    // from the repo gets the conventional place under the content path
+    private async resolveContentFilePath(
+        projectUuid: string,
         contentType: WritebackContentType,
         slug: string,
-    ): string {
+        contentPath: string,
+    ): Promise<string> {
+        const snapshot = await this.contentAsCodeSnapshotModel.get(
+            projectUuid,
+            contentType === 'chart'
+                ? ContentAsCodeType.CHART
+                : ContentAsCodeType.DASHBOARD,
+            slug,
+        );
+        return (
+            snapshot?.filePath ??
+            getContentAsCodeFilePath(contentPath, contentType, slug)
+        );
+    }
+
+    private async resolveRepoFilePath(
+        projectUuid: string,
+        contentType: WritebackContentType,
+        slug: string,
+        repoPath: string,
+        contentPath: string,
+    ): Promise<string> {
         return joinContentAsCodePath(
             repoPath,
-            getContentAsCodeFilePath(contentPath, contentType, slug),
+            await this.resolveContentFilePath(
+                projectUuid,
+                contentType,
+                slug,
+                contentPath,
+            ),
         );
     }
 
@@ -398,26 +428,29 @@ export class ContentAsCodeWritebackService extends BaseService {
                 creds,
                 joinContentAsCodePath(prefix, 'lightdash.config.yml'),
             );
-        const configuredPath =
-            config.content_as_code?.path ?? DEFAULT_CONTENT_AS_CODE_PATH;
+        // The repo config wins when it names a path. When it is silent the
+        // instance keeps the root its own upload stamped, so one repo can
+        // serve several instances that each own a folder
+        const configuredPath = config.content_as_code?.path;
         await this.coderService.stampContentAsCodeSettings(user, projectUuid, {
             sync: config.content_as_code?.sync === true,
-            path: configuredPath,
+            ...(configuredPath !== undefined && { path: configuredPath }),
         });
         if (config.content_as_code?.sync !== true) {
             throw new ParameterError(
                 'Pulling content from the repo requires content_as_code.sync: true in lightdash.config.yml',
             );
         }
+        const contentPath =
+            configuredPath !== undefined
+                ? normalizeContentAsCodePath(configuredPath)
+                : await this.getContentPath(projectUuid);
 
         const files = await ContentAsCodeWritebackService.readContentFiles(
             creds,
-            joinContentAsCodePath(
-                prefix,
-                normalizeContentAsCodePath(configuredPath),
-            ),
+            joinContentAsCodePath(prefix, contentPath),
         );
-        return this.applyContentFiles(user, projectUuid, files);
+        return this.applyContentFiles(user, projectUuid, files, prefix);
     }
 
     private static async readRepoProjectConfig(
@@ -517,7 +550,13 @@ export class ContentAsCodeWritebackService extends BaseService {
         user: SessionUser,
         projectUuid: string,
         files: RepoContentFile[],
+        projectPrefix: string,
     ): Promise<ContentAsCodePullSummary> {
+        // Snapshots record paths relative to the project dir, as the CLI does
+        const projectRelative = (repoFilePath: string) =>
+            projectPrefix !== '' && repoFilePath.startsWith(`${projectPrefix}/`)
+                ? repoFilePath.slice(projectPrefix.length + 1)
+                : repoFilePath;
         const summary: ContentAsCodePullSummary = {
             charts: 0,
             dashboards: 0,
@@ -565,7 +604,7 @@ export class ContentAsCodeWritebackService extends BaseService {
                         projectUuid,
                         document.slug,
                         document as ChartAsCode,
-                        { syncEnabled: true },
+                        { syncEnabled: true, filePath: projectRelative(file) },
                     );
                 }
                 summary.charts += 1;
@@ -597,7 +636,7 @@ export class ContentAsCodeWritebackService extends BaseService {
                         projectUuid,
                         document.slug,
                         document,
-                        { syncEnabled: true },
+                        { syncEnabled: true, filePath: projectRelative(file) },
                     );
                     summary.dashboards += 1;
                 } catch (error) {
@@ -612,8 +651,9 @@ export class ContentAsCodeWritebackService extends BaseService {
         return summary;
     }
 
-    // Same trust as `lightdash upload`: a document with a slug is the as-code
-    // type of its folder, loose files declare theirs with contentType
+    // Same trust as `lightdash upload`: a file under charts/ or dashboards/
+    // is that type; any other YAML counts only when it declares a
+    // contentType, so dbt model files and the like are skipped, not failed
     private static sortContentFile(
         file: RepoContentFile,
     ):
@@ -626,28 +666,25 @@ export class ContentAsCodeWritebackService extends BaseService {
         } catch {
             throw new ParameterError(`Could not parse ${file.path} as YAML`);
         }
-        if (
-            parsed === null ||
-            typeof parsed !== 'object' ||
-            !('slug' in parsed) ||
-            typeof parsed.slug !== 'string'
-        ) {
+        const document = isYamlDocument(parsed) ? parsed : null;
+        let kind: 'chart' | 'dashboard' | null = null;
+        if (file.classification.kind === 'content') {
+            kind = file.classification.contentType;
+        } else if (document !== null) {
+            kind = ContentAsCodeWritebackService.looseContentKind(document);
+        }
+        if (kind === null) return null;
+        if (document === null || typeof document.slug !== 'string') {
             throw new ParameterError(`${file.path} has no slug`);
         }
-        const kind =
-            file.classification.kind === 'content'
-                ? file.classification.contentType
-                : ContentAsCodeWritebackService.looseContentKind(parsed);
         switch (kind) {
             case 'chart':
                 return {
                     kind,
-                    document: parsed as ChartAsCode | SqlChartAsCode,
+                    document: document as ChartAsCode | SqlChartAsCode,
                 };
             case 'dashboard':
-                return { kind, document: parsed as DashboardAsCode };
-            case null:
-                return null;
+                return { kind, document: document as DashboardAsCode };
             default:
                 return assertUnreachable(kind, 'Unknown content kind');
         }
@@ -720,10 +757,11 @@ export class ContentAsCodeWritebackService extends BaseService {
         ) {
             throw new ParameterError('Unsupported draft content type');
         }
-        const filePath = getContentAsCodeFilePath(
-            await this.getContentPath(projectUuid),
+        const filePath = await this.resolveContentFilePath(
+            projectUuid,
             draft.contentType,
             draft.slug,
+            await this.getContentPath(projectUuid),
         );
         const staleness =
             draft.status === 'open'
@@ -1257,11 +1295,12 @@ export class ContentAsCodeWritebackService extends BaseService {
                     contentUuid,
                 ));
             files.push({
-                path: ContentAsCodeWritebackService.getContentFilePath(
-                    repo.path,
-                    contentDir,
+                path: await this.resolveRepoFilePath(
+                    projectUuid,
                     'chart',
                     slug,
+                    repo.path,
+                    contentDir,
                 ),
                 content: dumpContentAsCode(chartAsCode),
             });
@@ -1272,11 +1311,12 @@ export class ContentAsCodeWritebackService extends BaseService {
                     contentUuid,
                 ));
             files.push({
-                path: ContentAsCodeWritebackService.getContentFilePath(
-                    repo.path,
-                    contentDir,
+                path: await this.resolveRepoFilePath(
+                    projectUuid,
                     'dashboard',
                     slug,
+                    repo.path,
+                    contentDir,
                 ),
                 content: dumpContentAsCode(dashboardAsCode),
             });
@@ -1484,11 +1524,12 @@ export class ContentAsCodeWritebackService extends BaseService {
                             return null;
                         }
                         return {
-                            path: ContentAsCodeWritebackService.getContentFilePath(
-                                repoPath,
-                                contentPath,
+                            path: await this.resolveRepoFilePath(
+                                projectUuid,
                                 'chart',
                                 chartSlug,
+                                repoPath,
+                                contentPath,
                             ),
                             content: dumpContentAsCode(chartAsCode),
                         };

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -485,6 +485,19 @@ const isLooseContentFile = (entry: Dirent) => {
     );
 };
 
+// The file's path relative to the project dir, posix; undefined outside it
+const sourceFilePath = (filePath: string): string | undefined => {
+    const relative = path.relative(process.cwd(), filePath);
+    if (
+        path.isAbsolute(relative) ||
+        relative === '..' ||
+        relative.startsWith(`..${path.sep}`)
+    ) {
+        return undefined;
+    }
+    return relative.split(path.sep).join('/');
+};
+
 const processYamlItem = <
     T extends ChartAsCode | DashboardAsCode | SqlChartAsCode,
 >(
@@ -493,6 +506,7 @@ const processYamlItem = <
     stats: Stats,
     folder: 'charts' | 'dashboards',
     metadata: LightdashMetadata,
+    filePath: string,
 ) => {
     if (hasUnsortedKeys(item)) {
         GlobalState.log(
@@ -520,6 +534,8 @@ const processYamlItem = <
         ...item,
         updatedAt: needsUpdating ? stats.mtime : item.updatedAt,
         needsUpdating: needsUpdating ?? true,
+        // Sent with the upsert so write-back returns to this file
+        filePath: sourceFilePath(filePath),
     };
 };
 
@@ -537,7 +553,7 @@ const loadYamlFile = async <
     ]);
 
     const item = yaml.load(fileContent) as T;
-    return processYamlItem(item, file.name, stats, folder, metadata);
+    return processYamlItem(item, file.name, stats, folder, metadata, filePath);
 };
 
 const readCodeFiles = async <
@@ -646,6 +662,7 @@ const readLooseCodeFiles = async (
                                 stats,
                                 'charts',
                                 metadata,
+                                filePath,
                             ),
                         );
                     } else if (
@@ -658,6 +675,7 @@ const readLooseCodeFiles = async (
                                 stats,
                                 'dashboards',
                                 metadata,
+                                filePath,
                             ),
                         );
                     } else if (contentType === ContentAsCodeTypeEnum.SPACE) {


### PR DESCRIPTION
Closes PROD-10834

## Why

A repo with one `lightdash/` folder per package or team (`packages/package_a/lightdash/…`, `packages/package_c/team_a/lightdash/…`) uploads and syncs fine, because discovery is recursive by parent folder. But every write-back wrote to `<content path>/charts/<slug>.yml`, so a draft on `packages/team_a/lightdash/charts/x.yml` opened a PR that **added** `charts/x.yml` somewhere else, and after merge the upload saw two files for the slug. Reported for a self-hosted enterprise customer running one repo for many instances.

## What

- `content_as_code_snapshots.file_path` (nullable): the repo file each item was last applied from, relative to the project directory.
- `lightdash upload` sends `filePath` with each chart and dashboard upsert (it knows the file it read); the in-app sync records the tree path it read, minus the project sub-path. An upload from outside the project directory sends nothing and keeps whatever is stored.
- Write-back (draft write-back, propose, dashboard-owned tile charts) and the review diff header use the recorded path; content that never came from the repo keeps the conventional `<path>/<type>s/<slug>.yml`.
- The in-app sync no longer overwrites an instance's stamped root with the repo default: when `lightdash.config.yml` names no `content_as_code.path`, the sync reads from and keeps the root that instance's last `lightdash upload --path` stamped. A configured `path` still wins. Before this, one click of "Refresh dbt and sync content" on an instance that owns `packages/package_a/lightdash` reset it to `lightdash/`.
- Fix found on the way: the in-app sync failed every loose YAML without a `contentType` (dbt model files, `dbt_project.yml`) when the content path is the project root. It now skips them the way `lightdash upload` does.

## Regression analysis

- Single-folder layouts are unchanged: the recorded path equals the computed one.
- Older CLIs that send no `filePath` leave the stored value untouched; nothing depends on the column being set.
- Migration adds one nullable column under a 5s lock timeout. `filePath` on the upsert bodies is optional.
- SQL charts are untouched (sync does not record snapshots for them yet).

## Verified

- Unit: write-back and review use the recorded path, the sync records project-relative paths and skips loose non-content YAML, the snapshot stamp normalises and stores the path (62 tests across the touched files).
- Live on a GitHub-backed project with `instance-only-chart.yml` moved to `packages/team_a/lightdash/charts/`: `lightdash upload --path .` recorded `packages/team_a/lightdash/charts/instance-only-chart.yml` for it and `lightdash/charts/…` for the rest; the review header shows the real path; the editor's draft wrote back as PR #99 **modifying** that file (+2 −2), no new file; with `content_as_code.path: .` the in-app sync recorded the same paths and applied 10 charts and 3 dashboards with no failures.

## For multi-instance setups

Leave `content_as_code.path` out of the shared config. Each instance's CI runs `lightdash upload --path <its folder>`; that root is stamped, write-back edits the recorded file, and the in-app sync follows the stamp. Set `path` only in single-instance repos with a non-standard folder.
