### PR TITLE
feat(review-requests): service and API

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -2942,6 +2942,28 @@ export type ContentVerificationEvent = BaseTrack & {
     };
 };
 
+export type ContentReviewRequestEvent = BaseTrack & {
+    event:
+        | 'content_review_request.submitted'
+        | 'content_review_request.approved'
+        | 'content_review_request.rejected'
+        | 'content_review_request.cancelled';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        contentType: ContentType;
+        contentId: string;
+        targetSpaceId: string | null;
+        routedTo?: 'space_editors' | 'group';
+        reviewerCount?: number;
+        movedItemCount?: number;
+        similarContentShown?: number;
+        verified?: boolean;
+        turnaroundSeconds?: number;
+    };
+};
+
 export type AiAgentArtifactVersionVerifiedEvent = BaseTrack & {
     event: 'ai_agent.artifact_version_verified';
     userId: string;
@@ -3628,6 +3650,7 @@ type TypedEvent =
     | AiRouterInstructionsUpdatedEvent
     | AiRouterMessageRoutedEvent
     | ContentVerificationEvent
+    | ContentReviewRequestEvent
     | SchedulerOwnershipReassignedEvent
     | DashboardOwnershipReassignedEvent
     | ImpersonationEvent

--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -8,6 +8,7 @@ import {
     CartesianSeriesType,
     ChartKind,
     ChartType,
+    ContentReviewContentType,
     ContentType,
     DbtProjectType,
     getRequestMethod,
@@ -2952,7 +2953,7 @@ export type ContentReviewRequestEvent = BaseTrack & {
     properties: {
         organizationId: string;
         projectId: string;
-        contentType: ContentType;
+        contentType: ContentReviewContentType;
         contentId: string;
         targetSpaceId: string | null;
         routedTo?: 'space_editors' | 'group';

--- a/packages/backend/src/ee/controllers/ContentReviewRequestController.ts
+++ b/packages/backend/src/ee/controllers/ContentReviewRequestController.ts
@@ -1,0 +1,301 @@
+import {
+    assertRegisteredAccount,
+    ContentReviewRequestView,
+    type ApiContentReviewRequestListResponse,
+    type ApiContentReviewRequestOrNullResponse,
+    type ApiContentReviewRequestResponse,
+    type ApiContentReviewSettingsResponse,
+    type ApiErrorPayload,
+    type ApproveContentReviewRequestBody,
+    type ContentReviewContentType,
+    type ContentReviewRequestStatus,
+    type CreateContentReviewRequestBody,
+    type RejectContentReviewRequestBody,
+    type UpdateContentReviewSettings,
+    type UUID,
+} from '@lightdash/common';
+import {
+    Body,
+    Get,
+    Middlewares,
+    OperationId,
+    Patch,
+    Path,
+    Post,
+    Query,
+    Request,
+    Response,
+    Route,
+    SuccessResponse,
+    Tags,
+} from '@tsoa/runtime';
+import express from 'express';
+import { toSessionUser } from '../../auth/account/account';
+import {
+    allowApiKeyAuthentication,
+    isAuthenticated,
+    unauthorisedInDemo,
+} from '../../controllers/authentication';
+import { BaseController } from '../../controllers/baseController';
+import { type ContentReviewRequestService } from '../services/ContentReviewRequestService/ContentReviewRequestService';
+
+const DEFAULT_PAGE_SIZE = 25;
+
+@Route('/api/v1/projects/{projectUuid}/review-requests')
+@Response<ApiErrorPayload>('default', 'Error')
+@Tags('Content Review Requests')
+export class ContentReviewRequestController extends BaseController {
+    private getService(): ContentReviewRequestService {
+        return this.services.getContentReviewRequestService<ContentReviewRequestService>();
+    }
+
+    /**
+     * Review settings for a project: reviewer group, verify-on-approve default and Slack channel
+     * @summary Get review settings
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/settings')
+    @OperationId('getContentReviewSettings')
+    async getSettings(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+    ): Promise<ApiContentReviewSettingsResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getService().getSettings(
+                toSessionUser(req.account),
+                projectUuid,
+            ),
+        };
+    }
+
+    /**
+     * @summary Update review settings
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Patch('/settings')
+    @OperationId('updateContentReviewSettings')
+    async updateSettings(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+        @Body() body: UpdateContentReviewSettings,
+    ): Promise<ApiContentReviewSettingsResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getService().updateSettings(
+                toSessionUser(req.account),
+                projectUuid,
+                body,
+            ),
+        };
+    }
+
+    /**
+     * The open review request on a chart or dashboard, if any
+     * @summary Get the pending review request for content
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/content/{contentType}/{contentUuid}')
+    @OperationId('getPendingContentReviewRequest')
+    async getPendingForContent(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+        @Path() contentType: ContentReviewContentType,
+        @Path() contentUuid: UUID,
+    ): Promise<ApiContentReviewRequestOrNullResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getService().findPendingForContent(
+                toSessionUser(req.account),
+                projectUuid,
+                contentType,
+                contentUuid,
+            ),
+        };
+    }
+
+    /**
+     * Requests to review (routed to the caller) or the caller's own requests
+     * @summary List review requests
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/')
+    @OperationId('listContentReviewRequests')
+    async list(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+        @Query()
+        view: ContentReviewRequestView = ContentReviewRequestView.TO_REVIEW,
+        @Query() status?: ContentReviewRequestStatus,
+        @Query() page: number = 1,
+        @Query() pageSize: number = DEFAULT_PAGE_SIZE,
+    ): Promise<ApiContentReviewRequestListResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getService().list(
+                toSessionUser(req.account),
+                projectUuid,
+                { view, status: status ?? null },
+                { page, pageSize },
+            ),
+        };
+    }
+
+    /**
+     * Ask for a chart or dashboard in your personal space to be reviewed and moved to a shared space
+     * @summary Submit a review request
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('201', 'Created')
+    @Post('/')
+    @OperationId('createContentReviewRequest')
+    async submit(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+        @Body() body: CreateContentReviewRequestBody,
+    ): Promise<ApiContentReviewRequestResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(201);
+        return {
+            status: 'ok',
+            results: await this.getService().submit(
+                toSessionUser(req.account),
+                projectUuid,
+                body,
+            ),
+        };
+    }
+
+    /**
+     * @summary Get a review request
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/{requestUuid}')
+    @OperationId('getContentReviewRequest')
+    async get(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+        @Path() requestUuid: UUID,
+    ): Promise<ApiContentReviewRequestResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getService().get(
+                toSessionUser(req.account),
+                projectUuid,
+                requestUuid,
+            ),
+        };
+    }
+
+    /**
+     * Move the content to the target space and optionally verify it
+     * @summary Approve a review request
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Post('/{requestUuid}/approve')
+    @OperationId('approveContentReviewRequest')
+    async approve(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+        @Path() requestUuid: UUID,
+        @Body() body: ApproveContentReviewRequestBody,
+    ): Promise<ApiContentReviewRequestResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getService().approve(
+                toSessionUser(req.account),
+                projectUuid,
+                requestUuid,
+                body,
+            ),
+        };
+    }
+
+    /**
+     * @summary Reject a review request
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Post('/{requestUuid}/reject')
+    @OperationId('rejectContentReviewRequest')
+    async reject(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+        @Path() requestUuid: UUID,
+        @Body() body: RejectContentReviewRequestBody,
+    ): Promise<ApiContentReviewRequestResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getService().reject(
+                toSessionUser(req.account),
+                projectUuid,
+                requestUuid,
+                body,
+            ),
+        };
+    }
+
+    /**
+     * @summary Cancel your own review request
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Post('/{requestUuid}/cancel')
+    @OperationId('cancelContentReviewRequest')
+    async cancel(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+        @Path() requestUuid: UUID,
+    ): Promise<ApiContentReviewRequestResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getService().cancel(
+                toSessionUser(req.account),
+                projectUuid,
+                requestUuid,
+            ),
+        };
+    }
+}

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -288,7 +288,6 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     directAccessFeatureGate:
                         repository.getDirectAccessFeatureGate(),
                     directAccessModel: models.getDirectAccessModel(),
-                    featureFlagService: repository.getFeatureFlagService(),
                     groupsModel: models.getGroupsModel(),
                     projectModel: models.getProjectModel(),
                     savedChartService: repository.getSavedChartService(),

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -284,6 +284,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         models.getContentVerificationModel(),
                     dashboardModel: models.getDashboardModel(),
                     dashboardService: repository.getDashboardService(),
+                    savedSqlService: repository.getSavedSqlService(),
                     directAccessFeatureGate:
                         repository.getDirectAccessFeatureGate(),
                     directAccessModel: models.getDirectAccessModel(),

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -88,6 +88,7 @@ import { PreAggregationDuckDbClient } from './services/AsyncQueryService/PreAggr
 import { PreAggregationExternalResolver } from './services/AsyncQueryService/PreAggregationExternalResolver';
 import { CommercialCacheService } from './services/CommercialCacheService';
 import { CommercialSlackIntegrationService } from './services/CommercialSlackIntegrationService';
+import { ContentReviewRequestService } from './services/ContentReviewRequestService/ContentReviewRequestService';
 import { EmbedService } from './services/EmbedService/EmbedService';
 import { ExternalConnectionCoderService } from './services/ExternalConnectionCoderService/ExternalConnectionCoderService';
 import { ExternalConnectionService } from './services/ExternalConnectionService/ExternalConnectionService';
@@ -271,6 +272,28 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     lightdashConfig: context.lightdashConfig,
                     schedulerClient:
                         clients.getSchedulerClient() as CommercialSchedulerClient,
+                }),
+            contentReviewRequestService: ({ models, repository, context }) =>
+                new ContentReviewRequestService({
+                    analytics: context.lightdashAnalytics,
+                    contentReviewRequestModel:
+                        models.getContentReviewRequestModel(),
+                    contentReviewSettingsModel:
+                        models.getContentReviewSettingsModel(),
+                    contentVerificationModel:
+                        models.getContentVerificationModel(),
+                    dashboardModel: models.getDashboardModel(),
+                    dashboardService: repository.getDashboardService(),
+                    directAccessFeatureGate:
+                        repository.getDirectAccessFeatureGate(),
+                    directAccessModel: models.getDirectAccessModel(),
+                    featureFlagService: repository.getFeatureFlagService(),
+                    groupsModel: models.getGroupsModel(),
+                    projectModel: models.getProjectModel(),
+                    savedChartService: repository.getSavedChartService(),
+                    spaceModel: models.getSpaceModel(),
+                    spacePermissionService:
+                        repository.getSpacePermissionService(),
                 }),
             homepageRecommendedActionSkipsService: ({ models }) =>
                 new HomepageRecommendedActionSkipsService({

--- a/packages/backend/src/ee/services/ContentReviewRequestService/ContentReviewRequestService.test.ts
+++ b/packages/backend/src/ee/services/ContentReviewRequestService/ContentReviewRequestService.test.ts
@@ -1,8 +1,10 @@
 import { Ability, type RawRuleOf } from '@casl/ability';
 import {
+    ContentReviewContentType,
     ContentReviewRequestStatus,
     ContentReviewRequestView,
     ContentType,
+    DashboardTileTypes,
     DirectAccessPrincipalType,
     DirectAccessResourceType,
     OrganizationMemberRole,
@@ -29,6 +31,7 @@ import { type DashboardService } from '../../../services/DashboardService/Dashbo
 import { type DirectAccessFeatureGate } from '../../../services/DirectAccess/DirectAccessFeatureGate';
 import { type FeatureFlagService } from '../../../services/FeatureFlag/FeatureFlagService';
 import { type SavedChartService } from '../../../services/SavedChartsService/SavedChartService';
+import { type SavedSqlService } from '../../../services/SavedSqlService/SavedSqlService';
 import { type SpacePermissionService } from '../../../services/SpaceService/SpacePermissionService';
 import { ContentReviewRequestService } from './ContentReviewRequestService';
 
@@ -117,7 +120,7 @@ const defaultSettings: ContentReviewSettings = {
 const pendingRequest: ContentReviewRequest = {
     uuid: 'request-uuid',
     projectUuid: PROJECT,
-    contentType: ContentType.CHART,
+    contentType: ContentReviewContentType.CHART,
     contentUuid: CHART,
     sourceSpaceUuid: PERSONAL_SPACE,
     targetSpaceUuid: SHARED_SPACE,
@@ -141,10 +144,13 @@ const pendingRequest: ContentReviewRequest = {
     updatedAt: new Date('2026-09-01T10:00:00Z'),
 };
 
+let dashboardModelMock: { getByIdOrSlug: ReturnType<typeof vi.fn> };
+
 const buildService = () => {
     const contentReviewRequestModel = {
         findChartLocations: vi.fn().mockResolvedValue([chartLocation]),
         findDashboardLocations: vi.fn().mockResolvedValue([]),
+        findSqlChartLocations: vi.fn().mockResolvedValue([]),
         findSpaceInfo: vi.fn().mockResolvedValue(spaces),
         findPendingByContentUuids: vi.fn().mockResolvedValue(new Map()),
         findPendingByContent: vi.fn().mockResolvedValue(null),
@@ -177,6 +183,7 @@ const buildService = () => {
         verify: vi.fn().mockResolvedValue(undefined),
     };
     const dashboardModel = { getByIdOrSlug: vi.fn() };
+    dashboardModelMock = dashboardModel;
     const dashboardService = { moveToSpace: vi.fn() };
     const directAccessFeatureGate = {
         isEnabledForUser: vi.fn().mockResolvedValue(true),
@@ -196,6 +203,9 @@ const buildService = () => {
         getSummary: vi.fn().mockResolvedValue({ organizationUuid: ORG }),
     };
     const savedChartService = {
+        moveToSpace: vi.fn().mockResolvedValue(undefined),
+    };
+    const savedSqlService = {
         moveToSpace: vi.fn().mockResolvedValue(undefined),
     };
     const spaceModel = {
@@ -235,6 +245,7 @@ const buildService = () => {
         groupsModel: groupsModel as unknown as GroupsModel,
         projectModel: projectModel as unknown as ProjectModel,
         savedChartService: savedChartService as unknown as SavedChartService,
+        savedSqlService: savedSqlService as unknown as SavedSqlService,
         spaceModel: spaceModel as unknown as SpaceModel,
         spacePermissionService:
             spacePermissionService as unknown as SpacePermissionService,
@@ -243,6 +254,8 @@ const buildService = () => {
     return {
         service,
         contentReviewRequestModel,
+        savedSqlService,
+        dashboardService,
         contentReviewSettingsModel,
         contentVerificationModel,
         directAccessFeatureGate,
@@ -256,7 +269,7 @@ const buildService = () => {
 };
 
 const submitBody = {
-    contentType: ContentType.CHART as const,
+    contentType: ContentReviewContentType.CHART as const,
     contentUuid: CHART,
     targetSpaceUuid: SHARED_SPACE,
     note: 'Useful for the weekly review',
@@ -410,7 +423,7 @@ describe('ContentReviewRequestService', () => {
                     verifiedOnApprove: true,
                     movedContent: [
                         {
-                            contentType: ContentType.CHART,
+                            contentType: ContentReviewContentType.CHART,
                             contentUuid: CHART,
                             name: 'Weekly revenue',
                         },
@@ -419,7 +432,7 @@ describe('ContentReviewRequestService', () => {
                 { tx: 'tx' },
             );
             expect(contentVerificationModel.verify).toHaveBeenCalledWith(
-                ContentType.CHART,
+                ContentReviewContentType.CHART,
                 CHART,
                 PROJECT,
                 REVIEWER,
@@ -598,11 +611,122 @@ describe('ContentReviewRequestService', () => {
             expect(detail.verifyByDefault).toBe(true);
             expect(detail.moveSet).toEqual([
                 {
-                    contentType: ContentType.CHART,
+                    contentType: ContentReviewContentType.CHART,
                     contentUuid: CHART,
                     name: 'Weekly revenue',
                 },
             ]);
+        });
+    });
+
+    describe('SQL runner charts', () => {
+        const DASHBOARD = 'dashboard-uuid';
+        const SQL_CHART = 'sql-chart-uuid';
+        const dashboardLocation = {
+            uuid: DASHBOARD,
+            name: 'Ops board',
+            slug: 'ops-board',
+            spaceUuid: PERSONAL_SPACE,
+            dashboardUuid: null,
+            deleted: false,
+        };
+        const sqlChartLocation = {
+            uuid: SQL_CHART,
+            name: 'Raw orders',
+            slug: 'raw-orders',
+            spaceUuid: PERSONAL_SPACE,
+            dashboardUuid: null,
+            deleted: false,
+        };
+
+        test('a dashboard takes its personal-space SQL tiles along', async () => {
+            const {
+                service,
+                contentReviewRequestModel,
+                savedSqlService,
+                dashboardService,
+                contentVerificationModel,
+            } = buildService();
+            contentReviewRequestModel.getByUuid.mockResolvedValue({
+                ...pendingRequest,
+                contentType: ContentReviewContentType.DASHBOARD,
+                contentUuid: DASHBOARD,
+            });
+            contentReviewRequestModel.findDashboardLocations.mockResolvedValue([
+                dashboardLocation,
+            ]);
+            contentReviewRequestModel.findChartLocations.mockResolvedValue([]);
+            contentReviewRequestModel.findSqlChartLocations.mockResolvedValue([
+                sqlChartLocation,
+            ]);
+            dashboardModelMock.getByIdOrSlug.mockResolvedValue({
+                tiles: [
+                    {
+                        type: DashboardTileTypes.SQL_CHART,
+                        properties: { savedSqlUuid: SQL_CHART },
+                    },
+                ],
+            });
+
+            await service.approve(verifier, PROJECT, pendingRequest.uuid, {
+                verify: true,
+                note: null,
+            });
+
+            expect(dashboardService.moveToSpace).toHaveBeenCalledWith(
+                verifier,
+                expect.objectContaining({ itemUuid: DASHBOARD }),
+                expect.anything(),
+            );
+            expect(savedSqlService.moveToSpace).toHaveBeenCalledWith(
+                verifier,
+                expect.objectContaining({ itemUuid: SQL_CHART }),
+                expect.anything(),
+            );
+            expect(contentVerificationModel.verify).toHaveBeenCalledWith(
+                ContentType.DASHBOARD,
+                DASHBOARD,
+                PROJECT,
+                REVIEWER,
+            );
+        });
+
+        test('a SQL chart moves through the SQL service and is never verified', async () => {
+            const {
+                service,
+                contentReviewRequestModel,
+                savedSqlService,
+                savedChartService,
+                contentVerificationModel,
+            } = buildService();
+            contentReviewRequestModel.getByUuid.mockResolvedValue({
+                ...pendingRequest,
+                contentType: ContentReviewContentType.SQL_CHART,
+                contentUuid: SQL_CHART,
+            });
+            contentReviewRequestModel.findSqlChartLocations.mockResolvedValue([
+                sqlChartLocation,
+            ]);
+
+            const detail = await service.get(
+                verifier,
+                PROJECT,
+                pendingRequest.uuid,
+            );
+            expect(detail.canVerify).toBe(false);
+
+            await service.approve(verifier, PROJECT, pendingRequest.uuid, {
+                verify: false,
+                note: null,
+            });
+
+            expect(savedSqlService.moveToSpace).toHaveBeenCalledWith(
+                verifier,
+                expect.objectContaining({ itemUuid: SQL_CHART }),
+                expect.anything(),
+            );
+            expect(savedChartService.moveToSpace).not.toHaveBeenCalled();
+            expect(contentVerificationModel.verify).not.toHaveBeenCalled();
         });
     });
 });

--- a/packages/backend/src/ee/services/ContentReviewRequestService/ContentReviewRequestService.test.ts
+++ b/packages/backend/src/ee/services/ContentReviewRequestService/ContentReviewRequestService.test.ts
@@ -1,0 +1,608 @@
+import { Ability, type RawRuleOf } from '@casl/ability';
+import {
+    ContentReviewRequestStatus,
+    ContentReviewRequestView,
+    ContentType,
+    DirectAccessPrincipalType,
+    DirectAccessResourceType,
+    OrganizationMemberRole,
+    SpaceMemberRole,
+    type ContentReviewRequest,
+    type ContentReviewSettings,
+    type PossibleAbilities,
+    type SessionUser,
+} from '@lightdash/common';
+import { type LightdashAnalytics } from '../../../analytics/LightdashAnalytics';
+import {
+    type ContentReviewContentLocation,
+    type ContentReviewRequestModel,
+    type ContentReviewSpaceInfo,
+} from '../../../models/ContentReviewRequestModel';
+import { type ContentReviewSettingsModel } from '../../../models/ContentReviewSettingsModel';
+import { type ContentVerificationModel } from '../../../models/ContentVerificationModel';
+import { type DashboardModel } from '../../../models/DashboardModel/DashboardModel';
+import { type DirectAccessModel } from '../../../models/DirectAccessModel';
+import { type GroupsModel } from '../../../models/GroupsModel';
+import { type ProjectModel } from '../../../models/ProjectModel/ProjectModel';
+import { type SpaceModel } from '../../../models/SpaceModel';
+import { type DashboardService } from '../../../services/DashboardService/DashboardService';
+import { type DirectAccessFeatureGate } from '../../../services/DirectAccess/DirectAccessFeatureGate';
+import { type FeatureFlagService } from '../../../services/FeatureFlag/FeatureFlagService';
+import { type SavedChartService } from '../../../services/SavedChartsService/SavedChartService';
+import { type SpacePermissionService } from '../../../services/SpaceService/SpacePermissionService';
+import { ContentReviewRequestService } from './ContentReviewRequestService';
+
+const ORG = 'org-uuid';
+const PROJECT = 'project-uuid';
+const PERSONAL_SPACE = 'personal-space-uuid';
+const SHARED_SPACE = 'shared-space-uuid';
+const CHART = 'chart-uuid';
+const REQUESTER = 'requester-uuid';
+const REVIEWER = 'reviewer-uuid';
+
+const buildUser = (
+    userUuid: string,
+    rules: RawRuleOf<Ability<PossibleAbilities>>[] = [],
+): SessionUser => ({
+    userUuid,
+    email: `${userUuid}@test.com`,
+    firstName: 'Test',
+    lastName: 'User',
+    organizationUuid: ORG,
+    organizationName: 'Test Org',
+    organizationCreatedAt: new Date(),
+    isTrackingAnonymized: false,
+    isMarketingOptedIn: false,
+    avatarUrl: null,
+    avatarGradient: null,
+    timezone: null,
+    isSetupComplete: true,
+    userId: 1,
+    role: OrganizationMemberRole.EDITOR,
+    ability: new Ability<PossibleAbilities>([
+        { subject: 'Project', action: 'view' },
+        ...rules,
+    ]),
+    isActive: true,
+    abilityRules: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+});
+
+const requester = buildUser(REQUESTER);
+const reviewer = buildUser(REVIEWER);
+const verifier = buildUser(REVIEWER, [
+    { subject: 'ContentVerification', action: 'manage' },
+]);
+
+const chartLocation: ContentReviewContentLocation = {
+    uuid: CHART,
+    name: 'Weekly revenue',
+    slug: 'weekly-revenue',
+    spaceUuid: PERSONAL_SPACE,
+    dashboardUuid: null,
+    deleted: false,
+};
+
+const spaces = new Map<string, ContentReviewSpaceInfo>([
+    [
+        PERSONAL_SPACE,
+        {
+            uuid: PERSONAL_SPACE,
+            name: 'Personal',
+            projectUuid: PROJECT,
+            isDefaultUserSpace: true,
+            deleted: false,
+        },
+    ],
+    [
+        SHARED_SPACE,
+        {
+            uuid: SHARED_SPACE,
+            name: 'Finance',
+            projectUuid: PROJECT,
+            isDefaultUserSpace: false,
+            deleted: false,
+        },
+    ],
+]);
+
+const defaultSettings: ContentReviewSettings = {
+    projectUuid: PROJECT,
+    reviewerGroupUuid: null,
+    verifyOnApproveDefault: true,
+    slackChannelId: null,
+};
+
+const pendingRequest: ContentReviewRequest = {
+    uuid: 'request-uuid',
+    projectUuid: PROJECT,
+    contentType: ContentType.CHART,
+    contentUuid: CHART,
+    sourceSpaceUuid: PERSONAL_SPACE,
+    targetSpaceUuid: SHARED_SPACE,
+    requestedBy: { userUuid: REQUESTER, firstName: 'Test', lastName: 'User' },
+    requestNote: null,
+    similarContent: [],
+    status: ContentReviewRequestStatus.PENDING,
+    reviewedBy: null,
+    reviewedAt: null,
+    reviewNote: null,
+    verifiedOnApprove: null,
+    movedContent: [],
+    grantedPrincipals: [
+        {
+            resourceType: DirectAccessResourceType.CHART,
+            resourceUuid: CHART,
+            principal: { type: DirectAccessPrincipalType.USER, uuid: REVIEWER },
+        },
+    ],
+    createdAt: new Date('2026-09-01T10:00:00Z'),
+    updatedAt: new Date('2026-09-01T10:00:00Z'),
+};
+
+const buildService = () => {
+    const contentReviewRequestModel = {
+        findChartLocations: vi.fn().mockResolvedValue([chartLocation]),
+        findDashboardLocations: vi.fn().mockResolvedValue([]),
+        findSpaceInfo: vi.fn().mockResolvedValue(spaces),
+        findPendingByContentUuids: vi.fn().mockResolvedValue(new Map()),
+        findPendingByContent: vi.fn().mockResolvedValue(null),
+        create: vi.fn().mockResolvedValue(pendingRequest),
+        getByUuid: vi.fn().mockResolvedValue(pendingRequest),
+        list: vi.fn().mockResolvedValue({ data: [pendingRequest] }),
+        approve: vi.fn().mockResolvedValue({
+            ...pendingRequest,
+            status: ContentReviewRequestStatus.APPROVED,
+        }),
+        reject: vi.fn().mockResolvedValue({
+            ...pendingRequest,
+            status: ContentReviewRequestStatus.REJECTED,
+        }),
+        cancel: vi.fn().mockResolvedValue({
+            ...pendingRequest,
+            status: ContentReviewRequestStatus.CANCELLED,
+        }),
+        clearGrantedPrincipals: vi.fn().mockResolvedValue(undefined),
+        transaction: vi.fn(
+            async (callback: (tx: unknown) => Promise<unknown>) =>
+                callback('tx'),
+        ),
+    };
+    const contentReviewSettingsModel = {
+        get: vi.fn().mockResolvedValue(defaultSettings),
+        upsert: vi.fn(),
+    };
+    const contentVerificationModel = {
+        verify: vi.fn().mockResolvedValue(undefined),
+    };
+    const dashboardModel = { getByIdOrSlug: vi.fn() };
+    const dashboardService = { moveToSpace: vi.fn() };
+    const directAccessFeatureGate = {
+        isEnabledForUser: vi.fn().mockResolvedValue(true),
+    };
+    const directAccessModel = {
+        upsertAccess: vi.fn().mockResolvedValue({}),
+        revokeAccess: vi.fn().mockResolvedValue({}),
+    };
+    const featureFlagService = {
+        get: vi.fn().mockResolvedValue({ enabled: true }),
+    };
+    const groupsModel = {
+        findUserInGroups: vi.fn().mockResolvedValue([]),
+        getGroup: vi.fn(),
+    };
+    const projectModel = {
+        getSummary: vi.fn().mockResolvedValue({ organizationUuid: ORG }),
+    };
+    const savedChartService = {
+        moveToSpace: vi.fn().mockResolvedValue(undefined),
+    };
+    const spaceModel = {
+        findPersonalSpace: vi.fn().mockResolvedValue({
+            uuid: PERSONAL_SPACE,
+            name: 'Personal',
+            slug: 'personal',
+        }),
+    };
+    const spacePermissionService = {
+        can: vi.fn().mockResolvedValue(true),
+        getAccessibleSpaceUuids: vi.fn().mockResolvedValue([SHARED_SPACE]),
+        getPaginatedSpaceAccess: vi.fn().mockResolvedValue({
+            data: [
+                { userUuid: REVIEWER, role: SpaceMemberRole.EDITOR },
+                { userUuid: 'viewer-uuid', role: SpaceMemberRole.VIEWER },
+                { userUuid: REQUESTER, role: SpaceMemberRole.ADMIN },
+            ],
+        }),
+    };
+    const analytics = { track: vi.fn() };
+
+    const service = new ContentReviewRequestService({
+        analytics: analytics as unknown as LightdashAnalytics,
+        contentReviewRequestModel:
+            contentReviewRequestModel as unknown as ContentReviewRequestModel,
+        contentReviewSettingsModel:
+            contentReviewSettingsModel as unknown as ContentReviewSettingsModel,
+        contentVerificationModel:
+            contentVerificationModel as unknown as ContentVerificationModel,
+        dashboardModel: dashboardModel as unknown as DashboardModel,
+        dashboardService: dashboardService as unknown as DashboardService,
+        directAccessFeatureGate:
+            directAccessFeatureGate as unknown as DirectAccessFeatureGate,
+        directAccessModel: directAccessModel as unknown as DirectAccessModel,
+        featureFlagService: featureFlagService as unknown as FeatureFlagService,
+        groupsModel: groupsModel as unknown as GroupsModel,
+        projectModel: projectModel as unknown as ProjectModel,
+        savedChartService: savedChartService as unknown as SavedChartService,
+        spaceModel: spaceModel as unknown as SpaceModel,
+        spacePermissionService:
+            spacePermissionService as unknown as SpacePermissionService,
+    });
+
+    return {
+        service,
+        contentReviewRequestModel,
+        contentReviewSettingsModel,
+        contentVerificationModel,
+        directAccessFeatureGate,
+        directAccessModel,
+        featureFlagService,
+        groupsModel,
+        savedChartService,
+        spacePermissionService,
+        analytics,
+    };
+};
+
+const submitBody = {
+    contentType: ContentType.CHART as const,
+    contentUuid: CHART,
+    targetSpaceUuid: SHARED_SPACE,
+    note: 'Useful for the weekly review',
+    similarContent: [],
+};
+
+describe('ContentReviewRequestService', () => {
+    describe('submit', () => {
+        test('grants viewer access to target-space editors and creates the request', async () => {
+            const { service, directAccessModel, contentReviewRequestModel } =
+                buildService();
+
+            const detail = await service.submit(requester, PROJECT, submitBody);
+
+            expect(directAccessModel.upsertAccess).toHaveBeenCalledTimes(1);
+            expect(directAccessModel.upsertAccess).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    resourceType: DirectAccessResourceType.CHART,
+                    resourceUuid: CHART,
+                    principal: {
+                        type: DirectAccessPrincipalType.USER,
+                        uuid: REVIEWER,
+                    },
+                    role: SpaceMemberRole.VIEWER,
+                    grantedByUserUuid: REQUESTER,
+                }),
+            );
+            expect(contentReviewRequestModel.create).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    contentUuid: CHART,
+                    sourceSpaceUuid: PERSONAL_SPACE,
+                    targetSpaceUuid: SHARED_SPACE,
+                    requestedByUserUuid: REQUESTER,
+                    grantedPrincipals: [
+                        expect.objectContaining({ resourceUuid: CHART }),
+                    ],
+                }),
+            );
+            expect(detail.content).toEqual({
+                name: 'Weekly revenue',
+                slug: 'weekly-revenue',
+            });
+            expect(detail.targetSpaceName).toBe('Finance');
+        });
+
+        test('routes to the reviewer group when one is configured', async () => {
+            const { service, directAccessModel, contentReviewSettingsModel } =
+                buildService();
+            contentReviewSettingsModel.get.mockResolvedValue({
+                ...defaultSettings,
+                reviewerGroupUuid: 'group-uuid',
+            });
+
+            await service.submit(requester, PROJECT, submitBody);
+
+            expect(directAccessModel.upsertAccess).toHaveBeenCalledTimes(1);
+            expect(directAccessModel.upsertAccess).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    principal: {
+                        type: DirectAccessPrincipalType.GROUP,
+                        uuid: 'group-uuid',
+                    },
+                }),
+            );
+        });
+
+        test('rejects content that is not in the requester personal space', async () => {
+            const { service, contentReviewRequestModel } = buildService();
+            contentReviewRequestModel.findChartLocations.mockResolvedValue([
+                { ...chartLocation, spaceUuid: SHARED_SPACE },
+            ]);
+
+            await expect(
+                service.submit(requester, PROJECT, submitBody),
+            ).rejects.toThrow('Only content in your personal space');
+        });
+
+        test('rejects a personal space as the target', async () => {
+            const { service } = buildService();
+
+            await expect(
+                service.submit(requester, PROJECT, {
+                    ...submitBody,
+                    targetSpaceUuid: PERSONAL_SPACE,
+                }),
+            ).rejects.toThrow('Choose a shared space');
+        });
+
+        test('conflicts when the content already has a pending request', async () => {
+            const { service, contentReviewRequestModel } = buildService();
+            contentReviewRequestModel.findPendingByContentUuids.mockResolvedValue(
+                new Map([[CHART, pendingRequest]]),
+            );
+
+            await expect(
+                service.submit(requester, PROJECT, submitBody),
+            ).rejects.toThrow('already waiting for review');
+        });
+
+        test('revokes grants when the request row cannot be created', async () => {
+            const { service, contentReviewRequestModel, directAccessModel } =
+                buildService();
+            contentReviewRequestModel.create.mockRejectedValue(
+                new Error('boom'),
+            );
+
+            await expect(
+                service.submit(requester, PROJECT, submitBody),
+            ).rejects.toThrow('boom');
+            expect(directAccessModel.revokeAccess).toHaveBeenCalledTimes(1);
+        });
+
+        test('is forbidden when the flag is off', async () => {
+            const { service, featureFlagService } = buildService();
+            featureFlagService.get.mockResolvedValue({ enabled: false });
+
+            await expect(
+                service.submit(requester, PROJECT, submitBody),
+            ).rejects.toThrow('not enabled');
+        });
+    });
+
+    describe('approve', () => {
+        test('moves without re-checking source access, verifies, and releases grants', async () => {
+            const {
+                service,
+                savedChartService,
+                contentVerificationModel,
+                directAccessModel,
+                contentReviewRequestModel,
+            } = buildService();
+
+            await service.approve(verifier, PROJECT, pendingRequest.uuid, {
+                verify: true,
+                note: null,
+            });
+
+            expect(savedChartService.moveToSpace).toHaveBeenCalledWith(
+                verifier,
+                {
+                    projectUuid: PROJECT,
+                    itemUuid: CHART,
+                    targetSpaceUuid: SHARED_SPACE,
+                },
+                { tx: 'tx', checkForAccess: false, trackEvent: true },
+            );
+            expect(contentReviewRequestModel.approve).toHaveBeenCalledWith(
+                pendingRequest.uuid,
+                expect.objectContaining({
+                    reviewedByUserUuid: REVIEWER,
+                    verifiedOnApprove: true,
+                    movedContent: [
+                        {
+                            contentType: ContentType.CHART,
+                            contentUuid: CHART,
+                            name: 'Weekly revenue',
+                        },
+                    ],
+                }),
+                { tx: 'tx' },
+            );
+            expect(contentVerificationModel.verify).toHaveBeenCalledWith(
+                ContentType.CHART,
+                CHART,
+                PROJECT,
+                REVIEWER,
+            );
+            expect(directAccessModel.revokeAccess).toHaveBeenCalledWith(
+                expect.objectContaining({ resourceUuid: CHART }),
+            );
+            expect(
+                contentReviewRequestModel.clearGrantedPrincipals,
+            ).toHaveBeenCalledWith(pendingRequest.uuid);
+        });
+
+        test('refuses to verify without the verification permission', async () => {
+            const { service, savedChartService } = buildService();
+
+            await expect(
+                service.approve(reviewer, PROJECT, pendingRequest.uuid, {
+                    verify: true,
+                    note: null,
+                }),
+            ).rejects.toThrow('permission to verify');
+            expect(savedChartService.moveToSpace).not.toHaveBeenCalled();
+        });
+
+        test('requires update rights on the target space', async () => {
+            const { service, spacePermissionService } = buildService();
+            spacePermissionService.can.mockResolvedValue(false);
+
+            await expect(
+                service.approve(reviewer, PROJECT, pendingRequest.uuid, {
+                    verify: false,
+                    note: null,
+                }),
+            ).rejects.toThrow('permission to review');
+        });
+
+        test('requires reviewer group membership when a group is configured', async () => {
+            const { service, contentReviewSettingsModel, groupsModel } =
+                buildService();
+            contentReviewSettingsModel.get.mockResolvedValue({
+                ...defaultSettings,
+                reviewerGroupUuid: 'group-uuid',
+            });
+            groupsModel.findUserInGroups.mockResolvedValue([]);
+
+            await expect(
+                service.approve(reviewer, PROJECT, pendingRequest.uuid, {
+                    verify: false,
+                    note: null,
+                }),
+            ).rejects.toThrow('permission to review');
+        });
+
+        test('conflicts when the request is no longer pending', async () => {
+            const { service, contentReviewRequestModel } = buildService();
+            contentReviewRequestModel.getByUuid.mockResolvedValue({
+                ...pendingRequest,
+                status: ContentReviewRequestStatus.REJECTED,
+            });
+
+            await expect(
+                service.approve(reviewer, PROJECT, pendingRequest.uuid, {
+                    verify: false,
+                    note: null,
+                }),
+            ).rejects.toThrow('already been decided');
+        });
+    });
+
+    describe('reject and cancel', () => {
+        test('reject needs a note for the requester', async () => {
+            const { service } = buildService();
+
+            await expect(
+                service.reject(reviewer, PROJECT, pendingRequest.uuid, {
+                    note: '   ',
+                }),
+            ).rejects.toThrow('why the request was rejected');
+        });
+
+        test('reject records the note and releases grants', async () => {
+            const { service, contentReviewRequestModel, directAccessModel } =
+                buildService();
+
+            const detail = await service.reject(
+                reviewer,
+                PROJECT,
+                pendingRequest.uuid,
+                { note: 'Duplicate of the finance dashboard' },
+            );
+
+            expect(contentReviewRequestModel.reject).toHaveBeenCalledWith(
+                pendingRequest.uuid,
+                {
+                    reviewedByUserUuid: REVIEWER,
+                    reviewNote: 'Duplicate of the finance dashboard',
+                },
+            );
+            expect(directAccessModel.revokeAccess).toHaveBeenCalledTimes(1);
+            expect(detail.status).toBe(ContentReviewRequestStatus.REJECTED);
+        });
+
+        test('only the requester can cancel', async () => {
+            const { service, contentReviewRequestModel } = buildService();
+
+            await expect(
+                service.cancel(reviewer, PROJECT, pendingRequest.uuid),
+            ).rejects.toThrow('Only the requester');
+
+            await service.cancel(requester, PROJECT, pendingRequest.uuid);
+            expect(contentReviewRequestModel.cancel).toHaveBeenCalledWith(
+                pendingRequest.uuid,
+            );
+        });
+    });
+
+    describe('list and get', () => {
+        test('to-review only shows requests whose target the caller can update', async () => {
+            const { service, spacePermissionService } = buildService();
+            spacePermissionService.getAccessibleSpaceUuids.mockResolvedValue(
+                [],
+            );
+
+            const result = await service.list(
+                reviewer,
+                PROJECT,
+                { view: ContentReviewRequestView.TO_REVIEW, status: null },
+                { page: 1, pageSize: 10 },
+            );
+
+            expect(result.data).toEqual([]);
+            expect(result.pagination?.totalResults).toBe(0);
+        });
+
+        test('mine lists the caller requests with content and space names', async () => {
+            const { service, contentReviewRequestModel } = buildService();
+
+            const result = await service.list(
+                requester,
+                PROJECT,
+                { view: ContentReviewRequestView.MINE, status: null },
+                { page: 1, pageSize: 10 },
+            );
+
+            expect(contentReviewRequestModel.list).toHaveBeenCalledWith(
+                expect.objectContaining({ requestedByUserUuid: REQUESTER }),
+            );
+            expect(result.data[0].sourceSpaceName).toBe('Personal');
+            expect(result.data[0].targetSpaceName).toBe('Finance');
+        });
+
+        test('get is forbidden for someone who is neither requester nor reviewer', async () => {
+            const { service, spacePermissionService } = buildService();
+            spacePermissionService.can.mockResolvedValue(false);
+
+            await expect(
+                service.get(
+                    buildUser('stranger'),
+                    PROJECT,
+                    pendingRequest.uuid,
+                ),
+            ).rejects.toThrow('permission to view');
+        });
+
+        test('get reports what approval would move and whether the caller can verify', async () => {
+            const { service } = buildService();
+
+            const detail = await service.get(
+                verifier,
+                PROJECT,
+                pendingRequest.uuid,
+            );
+
+            expect(detail.canReview).toBe(true);
+            expect(detail.canVerify).toBe(true);
+            expect(detail.verifyByDefault).toBe(true);
+            expect(detail.moveSet).toEqual([
+                {
+                    contentType: ContentType.CHART,
+                    contentUuid: CHART,
+                    name: 'Weekly revenue',
+                },
+            ]);
+        });
+    });
+});

--- a/packages/backend/src/ee/services/ContentReviewRequestService/ContentReviewRequestService.test.ts
+++ b/packages/backend/src/ee/services/ContentReviewRequestService/ContentReviewRequestService.test.ts
@@ -29,7 +29,6 @@ import { type ProjectModel } from '../../../models/ProjectModel/ProjectModel';
 import { type SpaceModel } from '../../../models/SpaceModel';
 import { type DashboardService } from '../../../services/DashboardService/DashboardService';
 import { type DirectAccessFeatureGate } from '../../../services/DirectAccess/DirectAccessFeatureGate';
-import { type FeatureFlagService } from '../../../services/FeatureFlag/FeatureFlagService';
 import { type SavedChartService } from '../../../services/SavedChartsService/SavedChartService';
 import { type SavedSqlService } from '../../../services/SavedSqlService/SavedSqlService';
 import { type SpacePermissionService } from '../../../services/SpaceService/SpacePermissionService';
@@ -192,9 +191,6 @@ const buildService = () => {
         upsertAccess: vi.fn().mockResolvedValue({}),
         revokeAccess: vi.fn().mockResolvedValue({}),
     };
-    const featureFlagService = {
-        get: vi.fn().mockResolvedValue({ enabled: true }),
-    };
     const groupsModel = {
         findUserInGroups: vi.fn().mockResolvedValue([]),
         getGroup: vi.fn(),
@@ -241,7 +237,6 @@ const buildService = () => {
         directAccessFeatureGate:
             directAccessFeatureGate as unknown as DirectAccessFeatureGate,
         directAccessModel: directAccessModel as unknown as DirectAccessModel,
-        featureFlagService: featureFlagService as unknown as FeatureFlagService,
         groupsModel: groupsModel as unknown as GroupsModel,
         projectModel: projectModel as unknown as ProjectModel,
         savedChartService: savedChartService as unknown as SavedChartService,
@@ -260,7 +255,6 @@ const buildService = () => {
         contentVerificationModel,
         directAccessFeatureGate,
         directAccessModel,
-        featureFlagService,
         groupsModel,
         savedChartService,
         spacePermissionService,
@@ -382,9 +376,9 @@ describe('ContentReviewRequestService', () => {
             expect(directAccessModel.revokeAccess).toHaveBeenCalledTimes(1);
         });
 
-        test('is forbidden when the flag is off', async () => {
-            const { service, featureFlagService } = buildService();
-            featureFlagService.get.mockResolvedValue({ enabled: false });
+        test('is forbidden when direct access is off', async () => {
+            const { service, directAccessFeatureGate } = buildService();
+            directAccessFeatureGate.isEnabledForUser.mockResolvedValue(false);
 
             await expect(
                 service.submit(requester, PROJECT, submitBody),

--- a/packages/backend/src/ee/services/ContentReviewRequestService/ContentReviewRequestService.ts
+++ b/packages/backend/src/ee/services/ContentReviewRequestService/ContentReviewRequestService.ts
@@ -1,0 +1,1023 @@
+import { subject } from '@casl/ability';
+import {
+    assertUnreachable,
+    CommercialFeatureFlags,
+    ConflictError,
+    ContentReviewRequestStatus,
+    ContentReviewRequestView,
+    ContentType,
+    DirectAccessPrincipalType,
+    DirectAccessResourceType,
+    ForbiddenError,
+    isDashboardChartTileType,
+    NotFoundError,
+    ParameterError,
+    SpaceMemberRole,
+    type ApproveContentReviewRequestBody,
+    type ContentReviewContentType,
+    type ContentReviewGrantedPrincipal,
+    type ContentReviewMovedItem,
+    type ContentReviewRequest,
+    type ContentReviewRequestDetail,
+    type ContentReviewRequestListItem,
+    type ContentReviewSettings,
+    type CreateContentReviewRequestBody,
+    type DirectAccessPrincipalRef,
+    type KnexPaginateArgs,
+    type KnexPaginatedData,
+    type RejectContentReviewRequestBody,
+    type SessionUser,
+    type UpdateContentReviewSettings,
+} from '@lightdash/common';
+import { type LightdashAnalytics } from '../../../analytics/LightdashAnalytics';
+import {
+    type ContentReviewContentLocation,
+    type ContentReviewRequestModel,
+    type ContentReviewSpaceInfo,
+} from '../../../models/ContentReviewRequestModel';
+import { type ContentReviewSettingsModel } from '../../../models/ContentReviewSettingsModel';
+import { type ContentVerificationModel } from '../../../models/ContentVerificationModel';
+import { type DashboardModel } from '../../../models/DashboardModel/DashboardModel';
+import { type DirectAccessModel } from '../../../models/DirectAccessModel';
+import { type GroupsModel } from '../../../models/GroupsModel';
+import { type ProjectModel } from '../../../models/ProjectModel/ProjectModel';
+import { type SpaceModel } from '../../../models/SpaceModel';
+import { BaseService } from '../../../services/BaseService';
+import { type DashboardService } from '../../../services/DashboardService/DashboardService';
+import { type DirectAccessFeatureGate } from '../../../services/DirectAccess/DirectAccessFeatureGate';
+import { type FeatureFlagService } from '../../../services/FeatureFlag/FeatureFlagService';
+import { type SavedChartService } from '../../../services/SavedChartsService/SavedChartService';
+import { type SpacePermissionService } from '../../../services/SpaceService/SpacePermissionService';
+
+type ContentReviewRequestServiceArguments = {
+    analytics: LightdashAnalytics;
+    contentReviewRequestModel: ContentReviewRequestModel;
+    contentReviewSettingsModel: ContentReviewSettingsModel;
+    contentVerificationModel: ContentVerificationModel;
+    dashboardModel: DashboardModel;
+    dashboardService: DashboardService;
+    directAccessFeatureGate: DirectAccessFeatureGate;
+    directAccessModel: DirectAccessModel;
+    featureFlagService: FeatureFlagService;
+    groupsModel: GroupsModel;
+    projectModel: ProjectModel;
+    savedChartService: SavedChartService;
+    spaceModel: SpaceModel;
+    spacePermissionService: SpacePermissionService;
+};
+
+type ProjectContext = { organizationUuid: string; projectUuid: string };
+
+type ContentLookups = {
+    locations: Map<string, ContentReviewContentLocation>;
+    spaces: Map<string, ContentReviewSpaceInfo>;
+};
+
+const toDirectAccessResourceType = (
+    contentType: ContentReviewContentType,
+): DirectAccessResourceType => {
+    switch (contentType) {
+        case ContentType.CHART:
+            return DirectAccessResourceType.CHART;
+        case ContentType.DASHBOARD:
+            return DirectAccessResourceType.DASHBOARD;
+        default:
+            return assertUnreachable(
+                contentType,
+                'Unsupported review content type',
+            );
+    }
+};
+
+export class ContentReviewRequestService extends BaseService {
+    private readonly analytics: LightdashAnalytics;
+
+    private readonly contentReviewRequestModel: ContentReviewRequestModel;
+
+    private readonly contentReviewSettingsModel: ContentReviewSettingsModel;
+
+    private readonly contentVerificationModel: ContentVerificationModel;
+
+    private readonly dashboardModel: DashboardModel;
+
+    private readonly dashboardService: DashboardService;
+
+    private readonly directAccessFeatureGate: DirectAccessFeatureGate;
+
+    private readonly directAccessModel: DirectAccessModel;
+
+    private readonly featureFlagService: FeatureFlagService;
+
+    private readonly groupsModel: GroupsModel;
+
+    private readonly projectModel: ProjectModel;
+
+    private readonly savedChartService: SavedChartService;
+
+    private readonly spaceModel: SpaceModel;
+
+    private readonly spacePermissionService: SpacePermissionService;
+
+    constructor(args: ContentReviewRequestServiceArguments) {
+        super({ serviceName: 'ContentReviewRequestService' });
+        this.analytics = args.analytics;
+        this.contentReviewRequestModel = args.contentReviewRequestModel;
+        this.contentReviewSettingsModel = args.contentReviewSettingsModel;
+        this.contentVerificationModel = args.contentVerificationModel;
+        this.dashboardModel = args.dashboardModel;
+        this.dashboardService = args.dashboardService;
+        this.directAccessFeatureGate = args.directAccessFeatureGate;
+        this.directAccessModel = args.directAccessModel;
+        this.featureFlagService = args.featureFlagService;
+        this.groupsModel = args.groupsModel;
+        this.projectModel = args.projectModel;
+        this.savedChartService = args.savedChartService;
+        this.spaceModel = args.spaceModel;
+        this.spacePermissionService = args.spacePermissionService;
+    }
+
+    // Reviewers see personal-space content through direct-access grants, so
+    // the feature needs both flags
+    async isEnabled(user: SessionUser): Promise<boolean> {
+        const flag = await this.featureFlagService.get({
+            user,
+            featureFlagId: CommercialFeatureFlags.ContentReviewRequests,
+        });
+        if (!flag.enabled) return false;
+        return this.directAccessFeatureGate.isEnabledForUser({
+            userUuid: user.userUuid,
+            organizationUuid: user.organizationUuid,
+        });
+    }
+
+    private async getProjectContext(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<ProjectContext> {
+        if (!(await this.isEnabled(user))) {
+            throw new ForbiddenError('Content review requests are not enabled');
+        }
+        const { organizationUuid } =
+            await this.projectModel.getSummary(projectUuid);
+        if (
+            this.createAuditedAbility(user).cannot(
+                'view',
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid,
+                    metadata: { projectUuid },
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+        return { organizationUuid, projectUuid };
+    }
+
+    private async getContentLocation(
+        contentType: ContentReviewContentType,
+        contentUuid: string,
+    ): Promise<ContentReviewContentLocation> {
+        const [location] =
+            contentType === ContentType.CHART
+                ? await this.contentReviewRequestModel.findChartLocations([
+                      contentUuid,
+                  ])
+                : await this.contentReviewRequestModel.findDashboardLocations([
+                      contentUuid,
+                  ]);
+        if (location === undefined || location.deleted) {
+            throw new NotFoundError('Content not found');
+        }
+        return location;
+    }
+
+    private async getSpaceInfo(
+        spaceUuid: string,
+    ): Promise<ContentReviewSpaceInfo> {
+        const space = (
+            await this.contentReviewRequestModel.findSpaceInfo([spaceUuid])
+        ).get(spaceUuid);
+        if (space === undefined || space.deleted) {
+            throw new NotFoundError('Space not found');
+        }
+        return space;
+    }
+
+    private async getPendingRequest(
+        projectUuid: string,
+        requestUuid: string,
+    ): Promise<ContentReviewRequest> {
+        const request =
+            await this.contentReviewRequestModel.getByUuid(requestUuid);
+        if (request.projectUuid !== projectUuid) {
+            throw new NotFoundError('Review request not found');
+        }
+        if (request.status !== ContentReviewRequestStatus.PENDING) {
+            throw new ConflictError('This request has already been decided');
+        }
+        return request;
+    }
+
+    // A dashboard brings the personal-space charts its tiles use; charts
+    // saved inside the dashboard follow it automatically
+    private async computeMoveSet(request: {
+        contentType: ContentReviewContentType;
+        contentUuid: string;
+        sourceSpaceUuid: string;
+    }): Promise<ContentReviewMovedItem[]> {
+        const primary = await this.getContentLocation(
+            request.contentType,
+            request.contentUuid,
+        );
+        const items: ContentReviewMovedItem[] = [
+            {
+                contentType: request.contentType,
+                contentUuid: primary.uuid,
+                name: primary.name,
+            },
+        ];
+        if (request.contentType === ContentType.CHART) {
+            return items;
+        }
+        const dashboard = await this.dashboardModel.getByIdOrSlug(
+            request.contentUuid,
+        );
+        const tileChartUuids = [
+            ...new Set(
+                dashboard.tiles
+                    .filter(isDashboardChartTileType)
+                    .flatMap((tile) =>
+                        tile.properties.savedChartUuid
+                            ? [tile.properties.savedChartUuid]
+                            : [],
+                    ),
+            ),
+        ];
+        const charts =
+            await this.contentReviewRequestModel.findChartLocations(
+                tileChartUuids,
+            );
+        charts
+            .filter(
+                (chart) =>
+                    !chart.deleted &&
+                    chart.spaceUuid === request.sourceSpaceUuid,
+            )
+            .forEach((chart) => {
+                items.push({
+                    contentType: ContentType.CHART,
+                    contentUuid: chart.uuid,
+                    name: chart.name,
+                });
+            });
+        return items;
+    }
+
+    private async isReviewerGroupMember(
+        user: SessionUser,
+        settings: ContentReviewSettings,
+        organizationUuid: string,
+    ): Promise<boolean> {
+        if (settings.reviewerGroupUuid === null) return false;
+        const memberships = await this.groupsModel.findUserInGroups({
+            userUuid: user.userUuid,
+            organizationUuid,
+            groupUuids: [settings.reviewerGroupUuid],
+        });
+        return memberships.length > 0;
+    }
+
+    // Reviewers are the configured group, otherwise whoever can edit the
+    // target space. Either way the move needs update rights on the target.
+    private async canReview(
+        user: SessionUser,
+        request: ContentReviewRequest,
+        settings: ContentReviewSettings,
+        organizationUuid: string,
+    ): Promise<boolean> {
+        if (request.targetSpaceUuid === null) return false;
+        const canUpdateTarget = await this.spacePermissionService.can(
+            'update',
+            user,
+            request.targetSpaceUuid,
+        );
+        if (!canUpdateTarget) return false;
+        if (settings.reviewerGroupUuid === null) return true;
+        return this.isReviewerGroupMember(user, settings, organizationUuid);
+    }
+
+    private canVerify(user: SessionUser, context: ProjectContext): boolean {
+        return this.createAuditedAbility(user).can(
+            'manage',
+            subject('ContentVerification', {
+                organizationUuid: context.organizationUuid,
+                projectUuid: context.projectUuid,
+                metadata: { projectUuid: context.projectUuid },
+            }),
+        );
+    }
+
+    private async resolveReviewerPrincipals(
+        settings: ContentReviewSettings,
+        targetSpaceUuid: string,
+        requesterUuid: string,
+    ): Promise<DirectAccessPrincipalRef[]> {
+        if (settings.reviewerGroupUuid !== null) {
+            return [
+                {
+                    type: DirectAccessPrincipalType.GROUP,
+                    uuid: settings.reviewerGroupUuid,
+                },
+            ];
+        }
+        const { data: access } =
+            await this.spacePermissionService.getPaginatedSpaceAccess(
+                targetSpaceUuid,
+                {},
+            );
+        return access
+            .filter(
+                (share) =>
+                    share.userUuid !== requesterUuid &&
+                    (share.role === SpaceMemberRole.EDITOR ||
+                        share.role === SpaceMemberRole.ADMIN),
+            )
+            .map((share) => ({
+                type: DirectAccessPrincipalType.USER,
+                uuid: share.userUuid,
+            }));
+    }
+
+    private async grantReviewerAccess(
+        moveSet: ContentReviewMovedItem[],
+        principals: DirectAccessPrincipalRef[],
+        organizationUuid: string,
+        requesterUuid: string,
+    ): Promise<ContentReviewGrantedPrincipal[]> {
+        const granted: ContentReviewGrantedPrincipal[] = [];
+        try {
+            for (const item of moveSet) {
+                const resourceType = toDirectAccessResourceType(
+                    item.contentType,
+                );
+                for (const principal of principals) {
+                    // Sequential on purpose: each grant locks the owner chain
+                    // eslint-disable-next-line no-await-in-loop
+                    await this.directAccessModel.upsertAccess({
+                        resourceType,
+                        resourceUuid: item.contentUuid,
+                        principal,
+                        role: SpaceMemberRole.VIEWER,
+                        organizationUuid,
+                        grantedByUserUuid: requesterUuid,
+                    });
+                    granted.push({
+                        resourceType,
+                        resourceUuid: item.contentUuid,
+                        principal,
+                    });
+                }
+            }
+        } catch (error) {
+            await this.revokeGrants(granted, organizationUuid);
+            throw error;
+        }
+        return granted;
+    }
+
+    private async revokeGrants(
+        grants: ContentReviewGrantedPrincipal[],
+        organizationUuid: string,
+    ): Promise<void> {
+        for (const grant of grants) {
+            // eslint-disable-next-line no-await-in-loop
+            await this.directAccessModel.revokeAccess({
+                resourceType: grant.resourceType,
+                resourceUuid: grant.resourceUuid,
+                principal: grant.principal,
+                organizationUuid,
+            });
+        }
+    }
+
+    private async releaseRequestGrants(
+        request: ContentReviewRequest,
+        organizationUuid: string,
+    ): Promise<void> {
+        await this.revokeGrants(request.grantedPrincipals, organizationUuid);
+        await this.contentReviewRequestModel.clearGrantedPrincipals(
+            request.uuid,
+        );
+    }
+
+    private async lookupContent(
+        requests: ContentReviewRequest[],
+    ): Promise<ContentLookups> {
+        const chartUuids = requests
+            .filter((r) => r.contentType === ContentType.CHART)
+            .map((r) => r.contentUuid);
+        const dashboardUuids = requests
+            .filter((r) => r.contentType === ContentType.DASHBOARD)
+            .map((r) => r.contentUuid);
+        const spaceUuids = [
+            ...new Set(
+                requests.flatMap((r) =>
+                    r.targetSpaceUuid === null
+                        ? [r.sourceSpaceUuid]
+                        : [r.sourceSpaceUuid, r.targetSpaceUuid],
+                ),
+            ),
+        ];
+        const [charts, dashboards, spaces] = await Promise.all([
+            this.contentReviewRequestModel.findChartLocations(chartUuids),
+            this.contentReviewRequestModel.findDashboardLocations(
+                dashboardUuids,
+            ),
+            this.contentReviewRequestModel.findSpaceInfo(spaceUuids),
+        ]);
+        return {
+            locations: new Map(
+                [...charts, ...dashboards].map((location) => [
+                    location.uuid,
+                    location,
+                ]),
+            ),
+            spaces,
+        };
+    }
+
+    private static toListItem(
+        request: ContentReviewRequest,
+        lookups: ContentLookups,
+    ): ContentReviewRequestListItem {
+        const location = lookups.locations.get(request.contentUuid);
+        return {
+            ...request,
+            content:
+                location === undefined || location.deleted
+                    ? null
+                    : { name: location.name, slug: location.slug },
+            sourceSpaceName:
+                lookups.spaces.get(request.sourceSpaceUuid)?.name ?? null,
+            targetSpaceName:
+                request.targetSpaceUuid === null
+                    ? null
+                    : (lookups.spaces.get(request.targetSpaceUuid)?.name ??
+                      null),
+        };
+    }
+
+    private async toDetail(
+        user: SessionUser,
+        context: ProjectContext,
+        request: ContentReviewRequest,
+        settings: ContentReviewSettings,
+    ): Promise<ContentReviewRequestDetail> {
+        const [lookups, canReview] = await Promise.all([
+            this.lookupContent([request]),
+            this.canReview(user, request, settings, context.organizationUuid),
+        ]);
+        const item = ContentReviewRequestService.toListItem(request, lookups);
+        const moveSet =
+            request.status === ContentReviewRequestStatus.PENDING &&
+            item.content !== null
+                ? await this.computeMoveSet(request)
+                : request.movedContent;
+        return {
+            ...item,
+            moveSet,
+            canReview,
+            canVerify: this.canVerify(user, context),
+            verifyByDefault: settings.verifyOnApproveDefault,
+        };
+    }
+
+    async submit(
+        user: SessionUser,
+        projectUuid: string,
+        body: CreateContentReviewRequestBody,
+    ): Promise<ContentReviewRequestDetail> {
+        const context = await this.getProjectContext(user, projectUuid);
+
+        const personalSpace = await this.spaceModel.findPersonalSpace(
+            projectUuid,
+            user.userId,
+        );
+        if (personalSpace === null) {
+            throw new ForbiddenError(
+                'You need a personal space in this project to request a review',
+            );
+        }
+
+        const content = await this.getContentLocation(
+            body.contentType,
+            body.contentUuid,
+        );
+        if (content.spaceUuid !== personalSpace.uuid) {
+            throw new ParameterError(
+                'Only content in your personal space can be submitted for review',
+            );
+        }
+
+        const targetSpace = await this.getSpaceInfo(body.targetSpaceUuid);
+        if (
+            targetSpace.projectUuid !== projectUuid ||
+            targetSpace.isDefaultUserSpace
+        ) {
+            throw new ParameterError(
+                'Choose a shared space in this project as the target',
+            );
+        }
+        if (
+            !(await this.spacePermissionService.can(
+                'view',
+                user,
+                targetSpace.uuid,
+            ))
+        ) {
+            throw new ForbiddenError(
+                'You do not have access to the target space',
+            );
+        }
+
+        const moveSet = await this.computeMoveSet({
+            contentType: body.contentType,
+            contentUuid: body.contentUuid,
+            sourceSpaceUuid: personalSpace.uuid,
+        });
+        const [pendingCharts, pendingDashboards] = await Promise.all([
+            this.contentReviewRequestModel.findPendingByContentUuids(
+                ContentType.CHART,
+                moveSet
+                    .filter((i) => i.contentType === ContentType.CHART)
+                    .map((i) => i.contentUuid),
+            ),
+            this.contentReviewRequestModel.findPendingByContentUuids(
+                ContentType.DASHBOARD,
+                moveSet
+                    .filter((i) => i.contentType === ContentType.DASHBOARD)
+                    .map((i) => i.contentUuid),
+            ),
+        ]);
+        if (pendingCharts.size > 0 || pendingDashboards.size > 0) {
+            throw new ConflictError(
+                'This content is already waiting for review',
+            );
+        }
+
+        const settings = await this.contentReviewSettingsModel.get(projectUuid);
+        const principals = await this.resolveReviewerPrincipals(
+            settings,
+            targetSpace.uuid,
+            user.userUuid,
+        );
+        const grantedPrincipals = await this.grantReviewerAccess(
+            moveSet,
+            principals,
+            context.organizationUuid,
+            user.userUuid,
+        );
+
+        let request: ContentReviewRequest;
+        try {
+            request = await this.contentReviewRequestModel.create({
+                projectUuid,
+                contentType: body.contentType,
+                contentUuid: body.contentUuid,
+                sourceSpaceUuid: personalSpace.uuid,
+                targetSpaceUuid: targetSpace.uuid,
+                requestedByUserUuid: user.userUuid,
+                requestNote: body.note,
+                similarContent: body.similarContent,
+                grantedPrincipals,
+            });
+        } catch (error) {
+            await this.revokeGrants(
+                grantedPrincipals,
+                context.organizationUuid,
+            );
+            throw error;
+        }
+
+        this.analytics.track({
+            event: 'content_review_request.submitted',
+            userId: user.userUuid,
+            properties: {
+                organizationId: context.organizationUuid,
+                projectId: projectUuid,
+                contentType: body.contentType,
+                contentId: body.contentUuid,
+                targetSpaceId: targetSpace.uuid,
+                routedTo:
+                    settings.reviewerGroupUuid === null
+                        ? 'space_editors'
+                        : 'group',
+                reviewerCount: principals.length,
+                movedItemCount: moveSet.length,
+                similarContentShown: body.similarContent.length,
+            },
+        });
+
+        return this.toDetail(user, context, request, settings);
+    }
+
+    async list(
+        user: SessionUser,
+        projectUuid: string,
+        filters: {
+            view: ContentReviewRequestView;
+            status: ContentReviewRequestStatus | null;
+        },
+        paginateArgs: KnexPaginateArgs,
+    ): Promise<KnexPaginatedData<ContentReviewRequestListItem[]>> {
+        const context = await this.getProjectContext(user, projectUuid);
+        const settings = await this.contentReviewSettingsModel.get(projectUuid);
+
+        let requests: ContentReviewRequest[];
+        switch (filters.view) {
+            case ContentReviewRequestView.MINE: {
+                const { data } = await this.contentReviewRequestModel.list({
+                    projectUuid,
+                    status: filters.status,
+                    requestedByUserUuid: user.userUuid,
+                    targetSpaceUuids: null,
+                });
+                requests = data;
+                break;
+            }
+            case ContentReviewRequestView.TO_REVIEW: {
+                const { data } = await this.contentReviewRequestModel.list({
+                    projectUuid,
+                    status: filters.status,
+                    requestedByUserUuid: null,
+                    targetSpaceUuids: null,
+                });
+                requests = await this.filterReviewable(
+                    user,
+                    data,
+                    settings,
+                    context.organizationUuid,
+                );
+                break;
+            }
+            default:
+                return assertUnreachable(
+                    filters.view,
+                    'Unknown review request view',
+                );
+        }
+
+        const offset = (paginateArgs.page - 1) * paginateArgs.pageSize;
+        const page = requests.slice(offset, offset + paginateArgs.pageSize);
+        const lookups = await this.lookupContent(page);
+        return {
+            data: page.map((request) =>
+                ContentReviewRequestService.toListItem(request, lookups),
+            ),
+            pagination: {
+                ...paginateArgs,
+                totalResults: requests.length,
+                totalPageCount: Math.ceil(
+                    requests.length / paginateArgs.pageSize,
+                ),
+            },
+        };
+    }
+
+    private async filterReviewable(
+        user: SessionUser,
+        requests: ContentReviewRequest[],
+        settings: ContentReviewSettings,
+        organizationUuid: string,
+    ): Promise<ContentReviewRequest[]> {
+        const withTarget = requests.filter(
+            (r): r is ContentReviewRequest & { targetSpaceUuid: string } =>
+                r.targetSpaceUuid !== null,
+        );
+        if (withTarget.length === 0) return [];
+        if (
+            settings.reviewerGroupUuid !== null &&
+            !(await this.isReviewerGroupMember(
+                user,
+                settings,
+                organizationUuid,
+            ))
+        ) {
+            return [];
+        }
+        const updatable = new Set(
+            await this.spacePermissionService.getAccessibleSpaceUuids(
+                'update',
+                user,
+                [...new Set(withTarget.map((r) => r.targetSpaceUuid))],
+            ),
+        );
+        return withTarget.filter((r) => updatable.has(r.targetSpaceUuid));
+    }
+
+    async get(
+        user: SessionUser,
+        projectUuid: string,
+        requestUuid: string,
+    ): Promise<ContentReviewRequestDetail> {
+        const context = await this.getProjectContext(user, projectUuid);
+        const request =
+            await this.contentReviewRequestModel.getByUuid(requestUuid);
+        if (request.projectUuid !== projectUuid) {
+            throw new NotFoundError('Review request not found');
+        }
+        const settings = await this.contentReviewSettingsModel.get(projectUuid);
+        const detail = await this.toDetail(user, context, request, settings);
+        if (
+            request.requestedBy.userUuid !== user.userUuid &&
+            !detail.canReview
+        ) {
+            throw new ForbiddenError(
+                'You do not have permission to view this review request',
+            );
+        }
+        return detail;
+    }
+
+    // For headers and badges: the open request on an item, if the caller
+    // may see it
+    async findPendingForContent(
+        user: SessionUser,
+        projectUuid: string,
+        contentType: ContentReviewContentType,
+        contentUuid: string,
+    ): Promise<ContentReviewRequest | null> {
+        const context = await this.getProjectContext(user, projectUuid);
+        const request =
+            await this.contentReviewRequestModel.findPendingByContent(
+                contentType,
+                contentUuid,
+            );
+        if (request === null || request.projectUuid !== projectUuid) {
+            return null;
+        }
+        if (request.requestedBy.userUuid === user.userUuid) return request;
+        const settings = await this.contentReviewSettingsModel.get(projectUuid);
+        return (await this.canReview(
+            user,
+            request,
+            settings,
+            context.organizationUuid,
+        ))
+            ? request
+            : null;
+    }
+
+    async approve(
+        user: SessionUser,
+        projectUuid: string,
+        requestUuid: string,
+        body: ApproveContentReviewRequestBody,
+    ): Promise<ContentReviewRequestDetail> {
+        const context = await this.getProjectContext(user, projectUuid);
+        const request = await this.getPendingRequest(projectUuid, requestUuid);
+        const settings = await this.contentReviewSettingsModel.get(projectUuid);
+        if (
+            !(await this.canReview(
+                user,
+                request,
+                settings,
+                context.organizationUuid,
+            ))
+        ) {
+            throw new ForbiddenError(
+                'You do not have permission to review this request',
+            );
+        }
+        if (body.verify && !this.canVerify(user, context)) {
+            throw new ForbiddenError(
+                'You do not have permission to verify content',
+            );
+        }
+        const { targetSpaceUuid } = request;
+        if (targetSpaceUuid === null) {
+            throw new ConflictError('The target space no longer exists');
+        }
+
+        const moveSet = await this.computeMoveSet(request);
+        // Access was checked above against the target; the per-type move
+        // would otherwise fail on the personal source space
+        const approved = await this.contentReviewRequestModel.transaction(
+            async (tx) => {
+                for (const item of moveSet) {
+                    const moveArgs = {
+                        projectUuid,
+                        itemUuid: item.contentUuid,
+                        targetSpaceUuid,
+                    };
+                    const moveOptions = {
+                        tx,
+                        checkForAccess: false,
+                        trackEvent: true,
+                    };
+                    // eslint-disable-next-line no-await-in-loop
+                    await (item.contentType === ContentType.CHART
+                        ? this.savedChartService.moveToSpace(
+                              user,
+                              moveArgs,
+                              moveOptions,
+                          )
+                        : this.dashboardService.moveToSpace(
+                              user,
+                              moveArgs,
+                              moveOptions,
+                          ));
+                }
+                return this.contentReviewRequestModel.approve(
+                    request.uuid,
+                    {
+                        reviewedByUserUuid: user.userUuid,
+                        reviewNote: body.note,
+                        verifiedOnApprove: body.verify,
+                        movedContent: moveSet,
+                    },
+                    { tx },
+                );
+            },
+        );
+
+        if (body.verify) {
+            await this.contentVerificationModel.verify(
+                request.contentType,
+                request.contentUuid,
+                projectUuid,
+                user.userUuid,
+            );
+        }
+        await this.releaseRequestGrants(request, context.organizationUuid);
+
+        this.analytics.track({
+            event: 'content_review_request.approved',
+            userId: user.userUuid,
+            properties: {
+                organizationId: context.organizationUuid,
+                projectId: projectUuid,
+                contentType: request.contentType,
+                contentId: request.contentUuid,
+                targetSpaceId: targetSpaceUuid,
+                verified: body.verify,
+                movedItemCount: moveSet.length,
+                turnaroundSeconds: Math.round(
+                    (Date.now() - request.createdAt.getTime()) / 1000,
+                ),
+            },
+        });
+
+        return this.toDetail(
+            user,
+            context,
+            { ...approved, grantedPrincipals: [] },
+            settings,
+        );
+    }
+
+    async reject(
+        user: SessionUser,
+        projectUuid: string,
+        requestUuid: string,
+        body: RejectContentReviewRequestBody,
+    ): Promise<ContentReviewRequestDetail> {
+        const context = await this.getProjectContext(user, projectUuid);
+        if (body.note.trim().length === 0) {
+            throw new ParameterError(
+                'Tell the requester why the request was rejected',
+            );
+        }
+        const request = await this.getPendingRequest(projectUuid, requestUuid);
+        const settings = await this.contentReviewSettingsModel.get(projectUuid);
+        if (
+            !(await this.canReview(
+                user,
+                request,
+                settings,
+                context.organizationUuid,
+            ))
+        ) {
+            throw new ForbiddenError(
+                'You do not have permission to review this request',
+            );
+        }
+
+        const rejected = await this.contentReviewRequestModel.reject(
+            request.uuid,
+            { reviewedByUserUuid: user.userUuid, reviewNote: body.note },
+        );
+        await this.releaseRequestGrants(request, context.organizationUuid);
+
+        this.analytics.track({
+            event: 'content_review_request.rejected',
+            userId: user.userUuid,
+            properties: {
+                organizationId: context.organizationUuid,
+                projectId: projectUuid,
+                contentType: request.contentType,
+                contentId: request.contentUuid,
+                targetSpaceId: request.targetSpaceUuid,
+                turnaroundSeconds: Math.round(
+                    (Date.now() - request.createdAt.getTime()) / 1000,
+                ),
+            },
+        });
+
+        return this.toDetail(
+            user,
+            context,
+            { ...rejected, grantedPrincipals: [] },
+            settings,
+        );
+    }
+
+    async cancel(
+        user: SessionUser,
+        projectUuid: string,
+        requestUuid: string,
+    ): Promise<ContentReviewRequestDetail> {
+        const context = await this.getProjectContext(user, projectUuid);
+        const request = await this.getPendingRequest(projectUuid, requestUuid);
+        if (request.requestedBy.userUuid !== user.userUuid) {
+            throw new ForbiddenError(
+                'Only the requester can cancel a review request',
+            );
+        }
+
+        const cancelled = await this.contentReviewRequestModel.cancel(
+            request.uuid,
+        );
+        await this.releaseRequestGrants(request, context.organizationUuid);
+
+        this.analytics.track({
+            event: 'content_review_request.cancelled',
+            userId: user.userUuid,
+            properties: {
+                organizationId: context.organizationUuid,
+                projectId: projectUuid,
+                contentType: request.contentType,
+                contentId: request.contentUuid,
+                targetSpaceId: request.targetSpaceUuid,
+            },
+        });
+
+        const settings = await this.contentReviewSettingsModel.get(projectUuid);
+        return this.toDetail(
+            user,
+            context,
+            { ...cancelled, grantedPrincipals: [] },
+            settings,
+        );
+    }
+
+    private assertCanManageSettings(
+        user: SessionUser,
+        context: ProjectContext,
+    ): void {
+        if (
+            this.createAuditedAbility(user).cannot(
+                'manage',
+                subject('Project', {
+                    organizationUuid: context.organizationUuid,
+                    projectUuid: context.projectUuid,
+                    metadata: { projectUuid: context.projectUuid },
+                }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'You do not have permission to manage review settings',
+            );
+        }
+    }
+
+    async getSettings(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<ContentReviewSettings> {
+        await this.getProjectContext(user, projectUuid);
+        return this.contentReviewSettingsModel.get(projectUuid);
+    }
+
+    async updateSettings(
+        user: SessionUser,
+        projectUuid: string,
+        update: UpdateContentReviewSettings,
+    ): Promise<ContentReviewSettings> {
+        const context = await this.getProjectContext(user, projectUuid);
+        this.assertCanManageSettings(user, context);
+        if (
+            update.reviewerGroupUuid !== undefined &&
+            update.reviewerGroupUuid !== null
+        ) {
+            const group = await this.groupsModel.getGroup(
+                update.reviewerGroupUuid,
+            );
+            if (group.organizationUuid !== context.organizationUuid) {
+                throw new NotFoundError('Group not found');
+            }
+        }
+        return this.contentReviewSettingsModel.upsert(projectUuid, update);
+    }
+}

--- a/packages/backend/src/ee/services/ContentReviewRequestService/ContentReviewRequestService.ts
+++ b/packages/backend/src/ee/services/ContentReviewRequestService/ContentReviewRequestService.ts
@@ -3,6 +3,7 @@ import {
     assertUnreachable,
     CommercialFeatureFlags,
     ConflictError,
+    ContentReviewContentType,
     ContentReviewRequestStatus,
     ContentReviewRequestView,
     ContentType,
@@ -10,11 +11,11 @@ import {
     DirectAccessResourceType,
     ForbiddenError,
     isDashboardChartTileType,
+    isDashboardSqlChartTile,
     NotFoundError,
     ParameterError,
     SpaceMemberRole,
     type ApproveContentReviewRequestBody,
-    type ContentReviewContentType,
     type ContentReviewGrantedPrincipal,
     type ContentReviewMovedItem,
     type ContentReviewRequest,
@@ -29,6 +30,7 @@ import {
     type SessionUser,
     type UpdateContentReviewSettings,
 } from '@lightdash/common';
+import { type Knex } from 'knex';
 import { type LightdashAnalytics } from '../../../analytics/LightdashAnalytics';
 import {
     type ContentReviewContentLocation,
@@ -47,6 +49,7 @@ import { type DashboardService } from '../../../services/DashboardService/Dashbo
 import { type DirectAccessFeatureGate } from '../../../services/DirectAccess/DirectAccessFeatureGate';
 import { type FeatureFlagService } from '../../../services/FeatureFlag/FeatureFlagService';
 import { type SavedChartService } from '../../../services/SavedChartsService/SavedChartService';
+import { type SavedSqlService } from '../../../services/SavedSqlService/SavedSqlService';
 import { type SpacePermissionService } from '../../../services/SpaceService/SpacePermissionService';
 
 type ContentReviewRequestServiceArguments = {
@@ -62,6 +65,7 @@ type ContentReviewRequestServiceArguments = {
     groupsModel: GroupsModel;
     projectModel: ProjectModel;
     savedChartService: SavedChartService;
+    savedSqlService: SavedSqlService;
     spaceModel: SpaceModel;
     spacePermissionService: SpacePermissionService;
 };
@@ -77,9 +81,11 @@ const toDirectAccessResourceType = (
     contentType: ContentReviewContentType,
 ): DirectAccessResourceType => {
     switch (contentType) {
-        case ContentType.CHART:
+        case ContentReviewContentType.CHART:
             return DirectAccessResourceType.CHART;
-        case ContentType.DASHBOARD:
+        case ContentReviewContentType.SQL_CHART:
+            return DirectAccessResourceType.SQL_CHART;
+        case ContentReviewContentType.DASHBOARD:
             return DirectAccessResourceType.DASHBOARD;
         default:
             return assertUnreachable(
@@ -114,6 +120,8 @@ export class ContentReviewRequestService extends BaseService {
 
     private readonly savedChartService: SavedChartService;
 
+    private readonly savedSqlService: SavedSqlService;
+
     private readonly spaceModel: SpaceModel;
 
     private readonly spacePermissionService: SpacePermissionService;
@@ -132,6 +140,7 @@ export class ContentReviewRequestService extends BaseService {
         this.groupsModel = args.groupsModel;
         this.projectModel = args.projectModel;
         this.savedChartService = args.savedChartService;
+        this.savedSqlService = args.savedSqlService;
         this.spaceModel = args.spaceModel;
         this.spacePermissionService = args.spacePermissionService;
     }
@@ -174,18 +183,36 @@ export class ContentReviewRequestService extends BaseService {
         return { organizationUuid, projectUuid };
     }
 
+    private findLocations(
+        contentType: ContentReviewContentType,
+        contentUuids: string[],
+    ): Promise<ContentReviewContentLocation[]> {
+        switch (contentType) {
+            case ContentReviewContentType.CHART:
+                return this.contentReviewRequestModel.findChartLocations(
+                    contentUuids,
+                );
+            case ContentReviewContentType.SQL_CHART:
+                return this.contentReviewRequestModel.findSqlChartLocations(
+                    contentUuids,
+                );
+            case ContentReviewContentType.DASHBOARD:
+                return this.contentReviewRequestModel.findDashboardLocations(
+                    contentUuids,
+                );
+            default:
+                return assertUnreachable(
+                    contentType,
+                    'Unknown review content type',
+                );
+        }
+    }
+
     private async getContentLocation(
         contentType: ContentReviewContentType,
         contentUuid: string,
     ): Promise<ContentReviewContentLocation> {
-        const [location] =
-            contentType === ContentType.CHART
-                ? await this.contentReviewRequestModel.findChartLocations([
-                      contentUuid,
-                  ])
-                : await this.contentReviewRequestModel.findDashboardLocations([
-                      contentUuid,
-                  ]);
+        const [location] = await this.findLocations(contentType, [contentUuid]);
         if (location === undefined || location.deleted) {
             throw new NotFoundError('Content not found');
         }
@@ -237,7 +264,7 @@ export class ContentReviewRequestService extends BaseService {
                 name: primary.name,
             },
         ];
-        if (request.contentType === ContentType.CHART) {
+        if (request.contentType !== ContentReviewContentType.DASHBOARD) {
             return items;
         }
         const dashboard = await this.dashboardModel.getByIdOrSlug(
@@ -266,7 +293,36 @@ export class ContentReviewRequestService extends BaseService {
             )
             .forEach((chart) => {
                 items.push({
-                    contentType: ContentType.CHART,
+                    contentType: ContentReviewContentType.CHART,
+                    contentUuid: chart.uuid,
+                    name: chart.name,
+                });
+            });
+        // SQL runner tiles travel with the dashboard the same way
+        const tileSqlChartUuids = [
+            ...new Set(
+                dashboard.tiles
+                    .filter(isDashboardSqlChartTile)
+                    .flatMap((tile) =>
+                        tile.properties.savedSqlUuid
+                            ? [tile.properties.savedSqlUuid]
+                            : [],
+                    ),
+            ),
+        ];
+        const sqlCharts =
+            await this.contentReviewRequestModel.findSqlChartLocations(
+                tileSqlChartUuids,
+            );
+        sqlCharts
+            .filter(
+                (chart) =>
+                    !chart.deleted &&
+                    chart.spaceUuid === request.sourceSpaceUuid,
+            )
+            .forEach((chart) => {
+                items.push({
+                    contentType: ContentReviewContentType.SQL_CHART,
                     contentUuid: chart.uuid,
                     name: chart.name,
                 });
@@ -307,7 +363,73 @@ export class ContentReviewRequestService extends BaseService {
         return this.isReviewerGroupMember(user, settings, organizationUuid);
     }
 
-    private canVerify(user: SessionUser, context: ProjectContext): boolean {
+    private moveItem(
+        user: SessionUser,
+        contentType: ContentReviewContentType,
+        moveArgs: {
+            projectUuid: string;
+            itemUuid: string;
+            targetSpaceUuid: string;
+        },
+        moveOptions: { tx: Knex; checkForAccess: boolean; trackEvent: boolean },
+    ): Promise<unknown> {
+        switch (contentType) {
+            case ContentReviewContentType.CHART:
+                return this.savedChartService.moveToSpace(
+                    user,
+                    moveArgs,
+                    moveOptions,
+                );
+            case ContentReviewContentType.SQL_CHART:
+                return this.savedSqlService.moveToSpace(
+                    user,
+                    moveArgs,
+                    moveOptions,
+                );
+            case ContentReviewContentType.DASHBOARD:
+                return this.dashboardService.moveToSpace(
+                    user,
+                    moveArgs,
+                    moveOptions,
+                );
+            default:
+                return assertUnreachable(
+                    contentType,
+                    'Unknown review content type',
+                );
+        }
+    }
+
+    // Verification only exists for explorer charts and dashboards today
+    private static toVerifiableContentType(
+        contentType: ContentReviewContentType,
+    ): ContentType | null {
+        switch (contentType) {
+            case ContentReviewContentType.CHART:
+                return ContentType.CHART;
+            case ContentReviewContentType.DASHBOARD:
+                return ContentType.DASHBOARD;
+            case ContentReviewContentType.SQL_CHART:
+                return null;
+            default:
+                return assertUnreachable(
+                    contentType,
+                    'Unknown review content type',
+                );
+        }
+    }
+
+    private canVerify(
+        user: SessionUser,
+        context: ProjectContext,
+        contentType: ContentReviewContentType,
+    ): boolean {
+        if (
+            ContentReviewRequestService.toVerifiableContentType(contentType) ===
+            null
+        ) {
+            return false;
+        }
         return this.createAuditedAbility(user).can(
             'manage',
             subject('ContentVerification', {
@@ -414,12 +536,13 @@ export class ContentReviewRequestService extends BaseService {
     private async lookupContent(
         requests: ContentReviewRequest[],
     ): Promise<ContentLookups> {
-        const chartUuids = requests
-            .filter((r) => r.contentType === ContentType.CHART)
-            .map((r) => r.contentUuid);
-        const dashboardUuids = requests
-            .filter((r) => r.contentType === ContentType.DASHBOARD)
-            .map((r) => r.contentUuid);
+        const uuidsOf = (contentType: ContentReviewContentType) =>
+            requests
+                .filter((r) => r.contentType === contentType)
+                .map((r) => r.contentUuid);
+        const chartUuids = uuidsOf(ContentReviewContentType.CHART);
+        const sqlChartUuids = uuidsOf(ContentReviewContentType.SQL_CHART);
+        const dashboardUuids = uuidsOf(ContentReviewContentType.DASHBOARD);
         const spaceUuids = [
             ...new Set(
                 requests.flatMap((r) =>
@@ -429,8 +552,9 @@ export class ContentReviewRequestService extends BaseService {
                 ),
             ),
         ];
-        const [charts, dashboards, spaces] = await Promise.all([
+        const [charts, sqlCharts, dashboards, spaces] = await Promise.all([
             this.contentReviewRequestModel.findChartLocations(chartUuids),
+            this.contentReviewRequestModel.findSqlChartLocations(sqlChartUuids),
             this.contentReviewRequestModel.findDashboardLocations(
                 dashboardUuids,
             ),
@@ -438,7 +562,7 @@ export class ContentReviewRequestService extends BaseService {
         ]);
         return {
             locations: new Map(
-                [...charts, ...dashboards].map((location) => [
+                [...charts, ...sqlCharts, ...dashboards].map((location) => [
                     location.uuid,
                     location,
                 ]),
@@ -488,7 +612,7 @@ export class ContentReviewRequestService extends BaseService {
             ...item,
             moveSet,
             canReview,
-            canVerify: this.canVerify(user, context),
+            canVerify: this.canVerify(user, context, request.contentType),
             verifyByDefault: settings.verifyOnApproveDefault,
         };
     }
@@ -546,21 +670,17 @@ export class ContentReviewRequestService extends BaseService {
             contentUuid: body.contentUuid,
             sourceSpaceUuid: personalSpace.uuid,
         });
-        const [pendingCharts, pendingDashboards] = await Promise.all([
-            this.contentReviewRequestModel.findPendingByContentUuids(
-                ContentType.CHART,
-                moveSet
-                    .filter((i) => i.contentType === ContentType.CHART)
-                    .map((i) => i.contentUuid),
+        const pendingByType = await Promise.all(
+            Object.values(ContentReviewContentType).map((contentType) =>
+                this.contentReviewRequestModel.findPendingByContentUuids(
+                    contentType,
+                    moveSet
+                        .filter((i) => i.contentType === contentType)
+                        .map((i) => i.contentUuid),
+                ),
             ),
-            this.contentReviewRequestModel.findPendingByContentUuids(
-                ContentType.DASHBOARD,
-                moveSet
-                    .filter((i) => i.contentType === ContentType.DASHBOARD)
-                    .map((i) => i.contentUuid),
-            ),
-        ]);
-        if (pendingCharts.size > 0 || pendingDashboards.size > 0) {
+        );
+        if (pendingByType.some((pending) => pending.size > 0)) {
             throw new ConflictError(
                 'This content is already waiting for review',
             );
@@ -790,7 +910,10 @@ export class ContentReviewRequestService extends BaseService {
                 'You do not have permission to review this request',
             );
         }
-        if (body.verify && !this.canVerify(user, context)) {
+        if (
+            body.verify &&
+            !this.canVerify(user, context, request.contentType)
+        ) {
             throw new ForbiddenError(
                 'You do not have permission to verify content',
             );
@@ -817,17 +940,12 @@ export class ContentReviewRequestService extends BaseService {
                         trackEvent: true,
                     };
                     // eslint-disable-next-line no-await-in-loop
-                    await (item.contentType === ContentType.CHART
-                        ? this.savedChartService.moveToSpace(
-                              user,
-                              moveArgs,
-                              moveOptions,
-                          )
-                        : this.dashboardService.moveToSpace(
-                              user,
-                              moveArgs,
-                              moveOptions,
-                          ));
+                    await this.moveItem(
+                        user,
+                        item.contentType,
+                        moveArgs,
+                        moveOptions,
+                    );
                 }
                 return this.contentReviewRequestModel.approve(
                     request.uuid,
@@ -842,9 +960,13 @@ export class ContentReviewRequestService extends BaseService {
             },
         );
 
-        if (body.verify) {
-            await this.contentVerificationModel.verify(
+        const verifiableType =
+            ContentReviewRequestService.toVerifiableContentType(
                 request.contentType,
+            );
+        if (body.verify && verifiableType !== null) {
+            await this.contentVerificationModel.verify(
+                verifiableType,
                 request.contentUuid,
                 projectUuid,
                 user.userUuid,

--- a/packages/backend/src/ee/services/ContentReviewRequestService/ContentReviewRequestService.ts
+++ b/packages/backend/src/ee/services/ContentReviewRequestService/ContentReviewRequestService.ts
@@ -1,7 +1,6 @@
 import { subject } from '@casl/ability';
 import {
     assertUnreachable,
-    CommercialFeatureFlags,
     ConflictError,
     ContentReviewContentType,
     ContentReviewRequestStatus,
@@ -47,7 +46,6 @@ import { type SpaceModel } from '../../../models/SpaceModel';
 import { BaseService } from '../../../services/BaseService';
 import { type DashboardService } from '../../../services/DashboardService/DashboardService';
 import { type DirectAccessFeatureGate } from '../../../services/DirectAccess/DirectAccessFeatureGate';
-import { type FeatureFlagService } from '../../../services/FeatureFlag/FeatureFlagService';
 import { type SavedChartService } from '../../../services/SavedChartsService/SavedChartService';
 import { type SavedSqlService } from '../../../services/SavedSqlService/SavedSqlService';
 import { type SpacePermissionService } from '../../../services/SpaceService/SpacePermissionService';
@@ -61,7 +59,6 @@ type ContentReviewRequestServiceArguments = {
     dashboardService: DashboardService;
     directAccessFeatureGate: DirectAccessFeatureGate;
     directAccessModel: DirectAccessModel;
-    featureFlagService: FeatureFlagService;
     groupsModel: GroupsModel;
     projectModel: ProjectModel;
     savedChartService: SavedChartService;
@@ -112,8 +109,6 @@ export class ContentReviewRequestService extends BaseService {
 
     private readonly directAccessModel: DirectAccessModel;
 
-    private readonly featureFlagService: FeatureFlagService;
-
     private readonly groupsModel: GroupsModel;
 
     private readonly projectModel: ProjectModel;
@@ -136,7 +131,6 @@ export class ContentReviewRequestService extends BaseService {
         this.dashboardService = args.dashboardService;
         this.directAccessFeatureGate = args.directAccessFeatureGate;
         this.directAccessModel = args.directAccessModel;
-        this.featureFlagService = args.featureFlagService;
         this.groupsModel = args.groupsModel;
         this.projectModel = args.projectModel;
         this.savedChartService = args.savedChartService;
@@ -146,13 +140,8 @@ export class ContentReviewRequestService extends BaseService {
     }
 
     // Reviewers see personal-space content through direct-access grants, so
-    // the feature needs both flags
+    // that flag is the switch for the whole loop
     async isEnabled(user: SessionUser): Promise<boolean> {
-        const flag = await this.featureFlagService.get({
-            user,
-            featureFlagId: CommercialFeatureFlags.ContentReviewRequests,
-        });
-        if (!flag.enabled) return false;
         return this.directAccessFeatureGate.isEnabledForUser({
             userUuid: user.userUuid,
             organizationUuid: user.organizationUuid,

--- a/packages/backend/src/models/ContentReviewRequestModel.ts
+++ b/packages/backend/src/models/ContentReviewRequestModel.ts
@@ -14,6 +14,10 @@ import {
     ContentReviewRequestsTableName,
     type DbContentReviewRequest,
 } from '../database/entities/contentReviewRequests';
+import { DashboardsTableName } from '../database/entities/dashboards';
+import { ProjectTableName } from '../database/entities/projects';
+import { SavedChartsTableName } from '../database/entities/savedCharts';
+import { SpaceTableName } from '../database/entities/spaces';
 import { UserTableName } from '../database/entities/users';
 import KnexPaginate from '../database/pagination';
 
@@ -77,6 +81,43 @@ export type CreateContentReviewRequest = {
     similarContent: ContentReviewSimilarContentItem[];
     grantedPrincipals: ContentReviewGrantedPrincipal[];
 };
+
+export type ContentReviewContentLocation = {
+    uuid: string;
+    name: string;
+    slug: string;
+    spaceUuid: string | null;
+    dashboardUuid: string | null;
+    deleted: boolean;
+};
+
+export type ContentReviewSpaceInfo = {
+    uuid: string;
+    name: string;
+    projectUuid: string;
+    isDefaultUserSpace: boolean;
+    deleted: boolean;
+};
+
+type DbLocationRow = {
+    uuid: string;
+    name: string;
+    slug: string;
+    space_uuid: string | null;
+    dashboard_uuid: string | null;
+    deleted_at: Date | null;
+};
+
+const parseLocationRow = (
+    row: DbLocationRow,
+): ContentReviewContentLocation => ({
+    uuid: row.uuid,
+    name: row.name,
+    slug: row.slug,
+    spaceUuid: row.space_uuid,
+    dashboardUuid: row.dashboard_uuid,
+    deleted: row.deleted_at !== null,
+});
 
 export type ListContentReviewRequestsFilters = {
     projectUuid: string;
@@ -352,5 +393,93 @@ export class ContentReviewRequestModel {
                 granted_principals: JSON.stringify([]),
                 updated_at: new Date(),
             });
+    }
+
+    async transaction<T>(callback: (tx: Knex) => Promise<T>): Promise<T> {
+        return this.database.transaction(callback);
+    }
+
+    async findChartLocations(
+        chartUuids: string[],
+    ): Promise<ContentReviewContentLocation[]> {
+        if (chartUuids.length === 0) return [];
+        const rows = await this.database(SavedChartsTableName)
+            .leftJoin(
+                SpaceTableName,
+                `${SavedChartsTableName}.space_id`,
+                `${SpaceTableName}.space_id`,
+            )
+            .whereIn(`${SavedChartsTableName}.saved_query_uuid`, chartUuids)
+            .select<DbLocationRow[]>(
+                `${SavedChartsTableName}.saved_query_uuid as uuid`,
+                `${SavedChartsTableName}.name`,
+                `${SavedChartsTableName}.slug`,
+                `${SpaceTableName}.space_uuid`,
+                `${SavedChartsTableName}.dashboard_uuid`,
+                `${SavedChartsTableName}.deleted_at`,
+            );
+        return rows.map(parseLocationRow);
+    }
+
+    async findDashboardLocations(
+        dashboardUuids: string[],
+    ): Promise<ContentReviewContentLocation[]> {
+        if (dashboardUuids.length === 0) return [];
+        const rows = await this.database(DashboardsTableName)
+            .leftJoin(
+                SpaceTableName,
+                `${DashboardsTableName}.space_id`,
+                `${SpaceTableName}.space_id`,
+            )
+            .whereIn(`${DashboardsTableName}.dashboard_uuid`, dashboardUuids)
+            .select<DbLocationRow[]>(
+                `${DashboardsTableName}.dashboard_uuid as uuid`,
+                `${DashboardsTableName}.name`,
+                `${DashboardsTableName}.slug`,
+                `${SpaceTableName}.space_uuid`,
+                this.database.raw('null as dashboard_uuid'),
+                `${DashboardsTableName}.deleted_at`,
+            );
+        return rows.map(parseLocationRow);
+    }
+
+    async findSpaceInfo(
+        spaceUuids: string[],
+    ): Promise<Map<string, ContentReviewSpaceInfo>> {
+        if (spaceUuids.length === 0) return new Map();
+        const rows = await this.database(SpaceTableName)
+            .innerJoin(
+                ProjectTableName,
+                `${ProjectTableName}.project_id`,
+                `${SpaceTableName}.project_id`,
+            )
+            .whereIn(`${SpaceTableName}.space_uuid`, spaceUuids)
+            .select<
+                {
+                    space_uuid: string;
+                    name: string;
+                    project_uuid: string;
+                    is_default_user_space: boolean;
+                    deleted_at: Date | null;
+                }[]
+            >(
+                `${SpaceTableName}.space_uuid`,
+                `${SpaceTableName}.name`,
+                `${ProjectTableName}.project_uuid`,
+                `${SpaceTableName}.is_default_user_space`,
+                `${SpaceTableName}.deleted_at`,
+            );
+        return new Map(
+            rows.map((row) => [
+                row.space_uuid,
+                {
+                    uuid: row.space_uuid,
+                    name: row.name,
+                    projectUuid: row.project_uuid,
+                    isDefaultUserSpace: row.is_default_user_space,
+                    deleted: row.deleted_at !== null,
+                },
+            ]),
+        );
     }
 }

--- a/packages/backend/src/models/ContentReviewRequestModel.ts
+++ b/packages/backend/src/models/ContentReviewRequestModel.ts
@@ -17,6 +17,7 @@ import {
 import { DashboardsTableName } from '../database/entities/dashboards';
 import { ProjectTableName } from '../database/entities/projects';
 import { SavedChartsTableName } from '../database/entities/savedCharts';
+import { SavedSqlTableName } from '../database/entities/savedSql';
 import { SpaceTableName } from '../database/entities/spaces';
 import { UserTableName } from '../database/entities/users';
 import KnexPaginate from '../database/pagination';
@@ -417,6 +418,23 @@ export class ContentReviewRequestModel {
                 `${SpaceTableName}.space_uuid`,
                 `${SavedChartsTableName}.dashboard_uuid`,
                 `${SavedChartsTableName}.deleted_at`,
+            );
+        return rows.map(parseLocationRow);
+    }
+
+    async findSqlChartLocations(
+        sqlChartUuids: string[],
+    ): Promise<ContentReviewContentLocation[]> {
+        if (sqlChartUuids.length === 0) return [];
+        const rows = await this.database(SavedSqlTableName)
+            .whereIn(`${SavedSqlTableName}.saved_sql_uuid`, sqlChartUuids)
+            .select<DbLocationRow[]>(
+                `${SavedSqlTableName}.saved_sql_uuid as uuid`,
+                `${SavedSqlTableName}.name`,
+                `${SavedSqlTableName}.slug`,
+                `${SavedSqlTableName}.space_uuid`,
+                `${SavedSqlTableName}.dashboard_uuid`,
+                `${SavedSqlTableName}.deleted_at`,
             );
         return rows.map(parseLocationRow);
     }

--- a/packages/backend/src/models/DashboardModel/DashboardModel.test.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.test.ts
@@ -9,6 +9,7 @@ import knex from 'knex';
 import { getTracker, MockClient, RawQuery, Tracker } from 'knex-mock-client';
 import { FunctionQueryMatcher } from 'knex-mock-client/types/mock-client';
 import { ContentDraftsTableName } from '../../database/entities/contentDrafts';
+import { ContentReviewRequestsTableName } from '../../database/entities/contentReviewRequests';
 import {
     DashboardsTableName,
     DashboardTabsTableName,
@@ -620,16 +621,24 @@ describe('DashboardModel', () => {
             .select(queryMatcher(SavedChartsTableName, [dashboardUuid]))
             .responseOnce([{ saved_query_uuid: 'owned-chart-uuid' }]);
         tracker.on.update(ContentDraftsTableName).response(1);
+        tracker.on.update(ContentReviewRequestsTableName).response(0);
 
         await model.permanentDelete(dashboardUuid);
         expect(tracker.history.delete).toHaveLength(1);
-        // The dashboard's open drafts and its dashboard-scoped charts' drafts are dismissed
-        expect(tracker.history.update).toHaveLength(2);
+        // Open drafts are dismissed and pending review requests cancelled for
+        // the dashboard and its dashboard-scoped charts
+        expect(tracker.history.update).toHaveLength(4);
         expect(tracker.history.update[0].bindings).toEqual(
             expect.arrayContaining(['dismissed', 'dashboard', dashboardUuid]),
         );
         expect(tracker.history.update[1].bindings).toEqual(
             expect.arrayContaining(['dismissed', 'chart', 'owned-chart-uuid']),
+        );
+        expect(tracker.history.update[2].bindings).toEqual(
+            expect.arrayContaining(['cancelled', 'dashboard', dashboardUuid]),
+        );
+        expect(tracker.history.update[3].bindings).toEqual(
+            expect.arrayContaining(['cancelled', 'chart', 'owned-chart-uuid']),
         );
     });
 

--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -1,6 +1,7 @@
 import {
     assertUnreachable,
     ConflictError,
+    ContentReviewContentType,
     ContentType,
     CreateDashboard,
     CreateDashboardChartTile,
@@ -1758,12 +1759,12 @@ export class DashboardModel {
         await dismissOpenContentDrafts(this.database, 'chart', ownedChartUuids);
         await cancelPendingContentReviewRequests(
             this.database,
-            ContentType.DASHBOARD,
+            ContentReviewContentType.DASHBOARD,
             [dashboardUuid],
         );
         await cancelPendingContentReviewRequests(
             this.database,
-            ContentType.CHART,
+            ContentReviewContentType.CHART,
             ownedChartUuids,
         );
     }

--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -90,6 +90,7 @@ import {
 import { ContentVerificationModel } from '../ContentVerificationModel';
 import Transaction = Knex.Transaction;
 import { dismissOpenContentDrafts } from '../ContentDraftModel';
+import { cancelPendingContentReviewRequests } from '../ContentReviewRequestModel';
 
 export type GetDashboardQuery = Pick<
     DashboardTable['base'],
@@ -1755,6 +1756,16 @@ export class DashboardModel {
             dashboardUuid,
         ]);
         await dismissOpenContentDrafts(this.database, 'chart', ownedChartUuids);
+        await cancelPendingContentReviewRequests(
+            this.database,
+            ContentType.DASHBOARD,
+            [dashboardUuid],
+        );
+        await cancelPendingContentReviewRequests(
+            this.database,
+            ContentType.CHART,
+            ownedChartUuids,
+        );
     }
 
     async softDelete(

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -107,6 +107,7 @@ import {
     generateUniqueSlugScopedToProject,
 } from '../utils/SlugUtils';
 import { dismissOpenContentDrafts } from './ContentDraftModel';
+import { cancelPendingContentReviewRequests } from './ContentReviewRequestModel';
 import { ContentVerificationModel } from './ContentVerificationModel';
 
 type DbSavedChartDetails = {
@@ -1342,6 +1343,11 @@ export class SavedChartModel {
         await dismissOpenContentDrafts(this.database, 'chart', [
             savedChartUuid,
         ]);
+        await cancelPendingContentReviewRequests(
+            this.database,
+            ContentType.CHART,
+            [savedChartUuid],
+        );
         return savedChart;
     }
 
@@ -1359,6 +1365,11 @@ export class SavedChartModel {
         await dismissOpenContentDrafts(this.database, 'chart', [
             savedChartUuid,
         ]);
+        await cancelPendingContentReviewRequests(
+            this.database,
+            ContentType.CHART,
+            [savedChartUuid],
+        );
         return savedChart;
     }
 

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -8,6 +8,7 @@ import {
     ChartSummary,
     ChartVersionSummary,
     ConflictError,
+    ContentReviewContentType,
     ContentType,
     CreateSavedChart,
     CreateSavedChartVersion,
@@ -1345,7 +1346,7 @@ export class SavedChartModel {
         ]);
         await cancelPendingContentReviewRequests(
             this.database,
-            ContentType.CHART,
+            ContentReviewContentType.CHART,
             [savedChartUuid],
         );
         return savedChart;
@@ -1367,7 +1368,7 @@ export class SavedChartModel {
         ]);
         await cancelPendingContentReviewRequests(
             this.database,
-            ContentType.CHART,
+            ContentReviewContentType.CHART,
             [savedChartUuid],
         );
         return savedChart;

--- a/packages/backend/src/models/SavedSqlModel.ts
+++ b/packages/backend/src/models/SavedSqlModel.ts
@@ -1,6 +1,7 @@
 import {
     AllVizChartConfig,
     ConflictError,
+    ContentReviewContentType,
     CreateSqlChart,
     generateSlug,
     NotFoundError,
@@ -31,6 +32,7 @@ import {
     acquireProjectSlugLock,
     generateUniqueSlugScopedToProject,
 } from '../utils/SlugUtils';
+import { cancelPendingContentReviewRequests } from './ContentReviewRequestModel';
 
 const isProjectSlugUniqueViolation = (error: unknown): boolean =>
     error instanceof DatabaseError &&
@@ -447,6 +449,11 @@ export class SavedSqlModel {
         if (updateCount !== 1) {
             throw new NotFoundError('Saved sql not found');
         }
+        await cancelPendingContentReviewRequests(
+            this.database,
+            ContentReviewContentType.SQL_CHART,
+            [savedSqlUuid],
+        );
     }
 
     async restore(savedSqlUuid: string): Promise<void> {

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -181,6 +181,7 @@ interface ServiceManifest {
     aiService: unknown;
     aiAgentCoderService: unknown;
     projectHomepageService: unknown;
+    contentReviewRequestService: unknown;
     aiAgentService: unknown;
     aiAgentToolsService: unknown;
     aiAgentAdminService: unknown;
@@ -1625,6 +1626,12 @@ export class ServiceRepository
         ProjectHomepageServiceImplT,
     >(): ProjectHomepageServiceImplT {
         return this.getService('projectHomepageService');
+    }
+
+    public getContentReviewRequestService<
+        ContentReviewRequestServiceImplT,
+    >(): ContentReviewRequestServiceImplT {
+        return this.getService('contentReviewRequestService');
     }
 
     public getHomepageRecommendedActionSkipsService<

--- a/packages/common/src/types/contentReviewRequests.ts
+++ b/packages/common/src/types/contentReviewRequests.ts
@@ -2,6 +2,7 @@ import {
     type DirectAccessPrincipalRef,
     type DirectAccessResourceType,
 } from './directAccess';
+import { type KnexPaginatedData } from './knex-paginate';
 
 // Review-specific so SQL charts can be reviewed without widening the
 // global content type
@@ -80,3 +81,65 @@ export type ContentReviewSettings = {
 export type UpdateContentReviewSettings = Partial<
     Omit<ContentReviewSettings, 'projectUuid'>
 >;
+
+export enum ContentReviewRequestView {
+    TO_REVIEW = 'to-review',
+    MINE = 'mine',
+}
+
+export type CreateContentReviewRequestBody = {
+    contentType: ContentReviewContentType;
+    contentUuid: string;
+    targetSpaceUuid: string;
+    note: string | null;
+    similarContent: ContentReviewSimilarContentItem[];
+};
+
+export type ApproveContentReviewRequestBody = {
+    verify: boolean;
+    note: string | null;
+};
+
+export type RejectContentReviewRequestBody = {
+    note: string;
+};
+
+// Null when the content was deleted after the request was made
+export type ContentReviewContentSummary = {
+    name: string;
+    slug: string;
+};
+
+export type ContentReviewRequestListItem = ContentReviewRequest & {
+    content: ContentReviewContentSummary | null;
+    sourceSpaceName: string | null;
+    targetSpaceName: string | null;
+};
+
+export type ContentReviewRequestDetail = ContentReviewRequestListItem & {
+    // What approval would move today, recomputed on every read
+    moveSet: ContentReviewMovedItem[];
+    canReview: boolean;
+    canVerify: boolean;
+    verifyByDefault: boolean;
+};
+
+export type ApiContentReviewRequestResponse = {
+    status: 'ok';
+    results: ContentReviewRequestDetail;
+};
+
+export type ApiContentReviewRequestOrNullResponse = {
+    status: 'ok';
+    results: ContentReviewRequest | null;
+};
+
+export type ApiContentReviewRequestListResponse = {
+    status: 'ok';
+    results: KnexPaginatedData<ContentReviewRequestListItem[]>;
+};
+
+export type ApiContentReviewSettingsResponse = {
+    status: 'ok';
+    results: ContentReviewSettings;
+};


### PR DESCRIPTION
## Summary

Second PR of the content review requests stack, on top of #28426. Adds the service and API behind the `ContentReviewRequests` commercial flag. No UI yet; notifications and the requester and reviewer UI follow.

### The flow

1. **Submit** (`POST /api/v1/projects/{projectUuid}/review-requests`): the requester picks a chart or dashboard in their personal space and a shared target space in the same project they can view. The service computes what approval would move (a chart, or a dashboard plus every personal-space chart its tiles use; charts saved inside the dashboard follow it automatically), refuses if any of those items already has a pending request, then writes direct-access viewer grants so reviewers can open the content, and stores the request with the exact grants it made.
2. **Reviewers** are the configured reviewer group when there is one, otherwise the target space's editors and admins. Either way, reviewing requires `update` on the target space, because that is what the move needs.
3. **Approve** (`POST .../{requestUuid}/approve`, body `{ verify, note }`): recomputes the move set, moves every item inside one transaction through the existing per-type `moveToSpace` with `checkForAccess: false` (the reviewer's rights were checked against the target above; the default check would fail on the personal source space), then verifies the primary item when asked. `verify: true` needs `manage ContentVerification`, otherwise 403.
4. **Reject** (`POST .../reject`, body `{ note }`): note required, so the requester knows what to change. **Cancel**: requester only.
5. Every terminal state revokes the request's grants and clears the recorded list.

Also: `GET /` with `view=to-review|mine`, `GET /{requestUuid}` (includes `moveSet`, `canReview`, `canVerify`, `verifyByDefault`), `GET /content/{contentType}/{contentUuid}` for headers and badges, and `GET`/`PATCH /settings` (`manage Project`).

### Other changes

- `SavedChartModel` and `DashboardModel` delete paths cancel pending requests, next to the existing draft dismissal.
- `ContentReviewRequestModel` gains content and space location lookups and a `transaction` helper.
- `content_review_request.{submitted,approved,rejected,cancelled}` analytics events with turnaround seconds on decisions.
- Common API request and response types.

## Regression analysis

- The feature is gated twice: the new flag (default off) and the direct-access gate; every entry point goes through `getProjectContext`, which throws 403 when either is off.
- The only changes to existing code paths are the two delete hooks, which run one indexed `UPDATE ... WHERE status = 'pending'` after the draft dismissal that already runs there. With no requests in the table they are no-ops.
- `moveToSpace` in `SavedChartService` and `DashboardService` is called with the existing `checkForAccess: false` option that content-as-code and promotion already use; the functions themselves are untouched.
- Direct-access grants go through `DirectAccessModel.upsertAccess`, which keeps its own tenant and ownership checks. The flow never grants above viewer.
- `generate-api` produces the new routes with no changes to existing paths.

## Testing

- `ContentReviewRequestService.test.ts` (19 cases, mocked models): editor routing and group routing of grants, personal-space and target-space validation, pending conflict, grant rollback when the insert fails, flag off, approve moves with `checkForAccess: false` and verifies and releases grants, verify without permission, missing target update rights, group membership, decided requests, reject note, requester-only cancel, to-review filtering, mine listing, detail visibility.
- `pnpm -F backend typecheck`, `pnpm -F backend lint`, `pnpm -F common lint`, `pnpm generate-api`.

Relates: PROD-9730
Relates: #26967

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7bgpm3JZGoF2bRviShXWP

## SQL runner charts (second commit)

SQL charts can be requested on their own, and a dashboard's SQL tiles that sit in the requester's personal space move with it (same rule as explorer chart tiles). Grants use `DirectAccessResourceType.SQL_CHART`, approval moves through `SavedSqlService.moveToSpace`, soft-deleting a SQL chart cancels its pending request, and the analytics event type uses the review enum. Verification stays limited to explorer charts and dashboards: `canVerify` is false for SQL charts and approve never writes a verification row for them. Two unit tests cover the dashboard-with-SQL-tiles move and the SQL-chart approve path (21 pass).

## Gate

`isEnabled` checks the direct-access feature gate only; the feature flag service dependency is removed from the service and its wiring. The "forbidden when off" test now flips direct access.