### PR TITLE
feat(ai-reviews): show Linear identifiers and attach review links

### DIFF
--- a/packages/backend/src/clients/linear/Linear.test.ts
+++ b/packages/backend/src/clients/linear/Linear.test.ts
@@ -6,6 +6,7 @@ import {
     getLinearOrganization,
     getLinearProjects,
     getLinearTeams,
+    linkLinearIssueUrl,
 } from './Linear';
 
 describe('Linear client', () => {
@@ -253,5 +254,33 @@ describe('Linear client', () => {
             url: 'https://linear.app/acme/issue/PRD-12',
             title: 'Broken metric',
         });
+    });
+
+    it('attaches a URL to an existing Linear issue', async () => {
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                data: {
+                    attachmentLinkURL: {
+                        success: true,
+                    },
+                },
+            }),
+        });
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(
+            linkLinearIssueUrl('token', {
+                issueId: 'issue-1',
+                url: 'https://app.example.com/reviews',
+                title: 'Open in app',
+            }),
+        ).resolves.toBeUndefined();
+        expect(fetchMock).toHaveBeenCalledWith(
+            'https://api.linear.app/graphql',
+            expect.objectContaining({
+                body: expect.stringContaining('LinearAttachmentLinkURL'),
+            }),
+        );
     });
 });

--- a/packages/backend/src/clients/linear/Linear.ts
+++ b/packages/backend/src/clients/linear/Linear.ts
@@ -327,3 +327,34 @@ export const createLinearIssue = async (
 
     return data.issueCreate.issue;
 };
+
+export const linkLinearIssueUrl = async (
+    token: string,
+    input: {
+        issueId: string;
+        url: string;
+        title: string;
+    },
+): Promise<void> => {
+    const data = await linearGraphql<{
+        attachmentLinkURL: {
+            success: boolean;
+        };
+    }>(
+        token,
+        `mutation LinearAttachmentLinkURL($issueId: String!, $url: String!, $title: String) {
+            attachmentLinkURL(issueId: $issueId, url: $url, title: $title) {
+                success
+            }
+        }`,
+        {
+            issueId: input.issueId,
+            url: input.url,
+            title: input.title,
+        },
+    );
+
+    if (!data.attachmentLinkURL.success) {
+        throw new UnexpectedServerError('Failed to attach URL to Linear issue');
+    }
+};

--- a/packages/backend/src/ee/scheduler/tasks/createReviewLinearIssue.test.ts
+++ b/packages/backend/src/ee/scheduler/tasks/createReviewLinearIssue.test.ts
@@ -24,6 +24,7 @@ const makeDeps = (overrides: Record<string, unknown> = {}) => {
         url: 'https://linear.app/acme/issue/PRD-12',
         title: 'Broken metric',
     });
+    const linkIssueUrlForOrganization = vi.fn().mockResolvedValue(undefined);
     const updateReviewItemLinkedIssueUrl = vi.fn().mockResolvedValue(undefined);
 
     return {
@@ -70,6 +71,7 @@ const makeDeps = (overrides: Record<string, unknown> = {}) => {
         },
         linearAppService: {
             createIssueForOrganization,
+            linkIssueUrlForOrganization,
         },
         analytics: {
             track: vi.fn(),
@@ -133,6 +135,13 @@ describe('createReviewLinearIssue', () => {
             fingerprint: FINGERPRINT,
             linkedIssueUrl: 'https://linear.app/acme/issue/PRD-12',
         });
+        expect(
+            deps.linearAppService.linkIssueUrlForOrganization,
+        ).toHaveBeenCalledWith(ORGANIZATION_UUID, {
+            issueId: 'issue-1',
+            url: expect.stringContaining('/generalSettings/ai/reviews'),
+            title: 'Open in Lightdash', // pragma: allowlist secret
+        });
     });
 
     it('fails the job when Linear rejects an item so it is retried', async () => {
@@ -171,6 +180,30 @@ describe('createReviewLinearIssue', () => {
         await createReviewLinearIssue(deps)(payload);
 
         expect(deps.createIssueForOrganization).not.toHaveBeenCalled();
+    });
+
+    it('still stores the Linear URL when attaching the review link fails', async () => {
+        const deps = makeDeps({
+            linearAppService: {
+                createIssueForOrganization: vi.fn().mockResolvedValue({
+                    id: 'issue-1',
+                    identifier: 'PRD-12',
+                    url: 'https://linear.app/acme/issue/PRD-12',
+                    title: 'Broken metric',
+                }),
+                linkIssueUrlForOrganization: vi
+                    .fn()
+                    .mockRejectedValue(new Error('missing write scope')),
+            },
+        });
+
+        await createReviewLinearIssue(deps)(payload);
+
+        expect(deps.updateReviewItemLinkedIssueUrl).toHaveBeenCalledWith({
+            organizationUuid: ORGANIZATION_UUID,
+            fingerprint: FINGERPRINT,
+            linkedIssueUrl: 'https://linear.app/acme/issue/PRD-12',
+        });
     });
 });
 

--- a/packages/backend/src/ee/scheduler/tasks/createReviewLinearIssue.ts
+++ b/packages/backend/src/ee/scheduler/tasks/createReviewLinearIssue.ts
@@ -131,6 +131,23 @@ export const createReviewLinearIssue =
                         },
                     );
 
+                    try {
+                        await deps.linearAppService.linkIssueUrlForOrganization(
+                            payload.organizationUuid,
+                            {
+                                issueId: created.id,
+                                url: reviewUrl,
+                                title: 'Open in Lightdash', // pragma: allowlist secret
+                            },
+                        );
+                    } catch (error) {
+                        Logger.warn(
+                            `Failed to attach review URL to Linear issue ${created.identifier}: ${getErrorMessage(
+                                error,
+                            )}`,
+                        );
+                    }
+
                     deps.analytics.track({
                         event: 'ai_review_linear_issue.created',
                         anonymousId: payload.organizationUuid,

--- a/packages/backend/src/services/LinearAppService/LinearAppService.test.ts
+++ b/packages/backend/src/services/LinearAppService/LinearAppService.test.ts
@@ -22,6 +22,7 @@ vi.mock('../../clients/linear/Linear', () => ({
     getLinearOrganization: vi.fn(),
     getLinearProjects: vi.fn(),
     getLinearTeams: vi.fn(),
+    linkLinearIssueUrl: vi.fn(),
     refreshLinearToken: vi.fn(),
 }));
 

--- a/packages/backend/src/services/LinearAppService/LinearAppService.ts
+++ b/packages/backend/src/services/LinearAppService/LinearAppService.ts
@@ -24,6 +24,7 @@ import {
     getLinearOrganization,
     getLinearProjects,
     getLinearTeams,
+    linkLinearIssueUrl,
     refreshLinearToken,
 } from '../../clients/linear/Linear';
 import { LightdashConfig } from '../../config/parseConfig'; // pragma: allowlist secret
@@ -296,6 +297,23 @@ export class LinearAppService extends BaseService {
     ): Promise<LinearCreatedIssue> {
         return this.withValidToken(organizationUuid, (token) =>
             createLinearIssue(token, input),
+        );
+    }
+
+    /**
+     * Trusted internal caller (scheduler). Attaches a URL to a Linear issue
+     * so both sides can jump to the other without syncing status.
+     */
+    async linkIssueUrlForOrganization(
+        organizationUuid: string,
+        input: {
+            issueId: string;
+            url: string;
+            title: string;
+        },
+    ): Promise<void> {
+        return this.withValidToken(organizationUuid, (token) =>
+            linkLinearIssueUrl(token, input),
         );
     }
 

--- a/packages/common/src/types/linear.test.ts
+++ b/packages/common/src/types/linear.test.ts
@@ -1,0 +1,21 @@
+import { getLinearIssueIdentifier } from './linear';
+
+describe('getLinearIssueIdentifier', () => {
+    it('reads the identifier from a Linear issue URL', () => {
+        expect(
+            getLinearIssueIdentifier(
+                'https://linear.app/acme/issue/PRD-12/broken-metric',
+            ),
+        ).toBe('PRD-12');
+    });
+
+    it('returns null for a non-Linear URL', () => {
+        expect(
+            getLinearIssueIdentifier('https://github.com/acme/repo/issues/12'),
+        ).toBeNull();
+    });
+
+    it('returns null for an invalid URL', () => {
+        expect(getLinearIssueIdentifier('not-a-url')).toBeNull();
+    });
+});

--- a/packages/common/src/types/linear.ts
+++ b/packages/common/src/types/linear.ts
@@ -28,3 +28,17 @@ export type LinearCreatedIssue = {
 export type ApiLinearInstallationResponse = ApiSuccess<LinearInstallation>;
 export type ApiLinearTeamsResponse = ApiSuccess<LinearTeam[]>;
 export type ApiLinearProjectsResponse = ApiSuccess<LinearProject[]>;
+
+const LINEAR_ISSUE_IDENTIFIER_IN_URL = /\/issue\/([A-Za-z0-9]+-\d+)/;
+
+export const getLinearIssueIdentifier = (url: string): string | null => {
+    try {
+        const { hostname, pathname } = new URL(url);
+        if (hostname !== 'linear.app') {
+            return null;
+        }
+        return pathname.match(LINEAR_ISSUE_IDENTIFIER_IN_URL)?.[1] ?? null;
+    } catch {
+        return null;
+    }
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/IssueDetailModal.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/IssueDetailModal.test.tsx
@@ -226,6 +226,20 @@ describe('IssueDetailModal', () => {
         expect(await screen.findByText('chat-evidence')).toBeInTheDocument();
     });
 
+    it('links to the Linear issue when one has been exported', () => {
+        mockReviewItem.current = makeReviewItem({
+            linkedIssueUrl: 'https://linear.app/acme/issue/PRD-12/broken-metric',
+        });
+
+        renderModal();
+
+        const linearLink = screen.getByRole('link', { name: 'PRD-12' });
+        expect(linearLink).toHaveAttribute(
+            'href',
+            'https://linear.app/acme/issue/PRD-12/broken-metric',
+        );
+    });
+
     it('shows memory provenance instead of turn evidence for promotion items', () => {
         mockReviewItem.current = makeReviewItem({
             source: 'memory',

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/IssueDetailModal.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/IssueDetailModal.test.tsx
@@ -228,7 +228,8 @@ describe('IssueDetailModal', () => {
 
     it('links to the Linear issue when one has been exported', () => {
         mockReviewItem.current = makeReviewItem({
-            linkedIssueUrl: 'https://linear.app/acme/issue/PRD-12/broken-metric',
+            linkedIssueUrl:
+                'https://linear.app/acme/issue/PRD-12/broken-metric',
         });
 
         renderModal();

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/IssueDetailModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/IssueDetailModal.tsx
@@ -1,4 +1,8 @@
-import { capitalize, type AiAgentReviewItemSummary } from '@lightdash/common';
+import {
+    capitalize,
+    getLinearIssueIdentifier,
+    type AiAgentReviewItemSummary,
+} from '@lightdash/common'; // pragma: allowlist secret
 import {
     Anchor,
     Box,
@@ -410,6 +414,25 @@ export const IssueDetailModal: FC<Props> = ({
                                             <Text className={styles.railText}>
                                                 {seenValue}
                                             </Text>
+                                        </RailRow>
+                                    )}
+                                    {item.linkedIssueUrl && (
+                                        <RailRow label="Linear">
+                                            <Anchor
+                                                href={item.linkedIssueUrl}
+                                                target="_blank"
+                                                rel="noopener noreferrer"
+                                                className={styles.railLink}
+                                            >
+                                                <MantineIcon
+                                                    icon={IconExternalLink}
+                                                    size={14}
+                                                    stroke={1.4}
+                                                />
+                                                {getLinearIssueIdentifier(
+                                                    item.linkedIssueUrl,
+                                                ) ?? 'Open in Linear'}
+                                            </Anchor>
                                         </RailRow>
                                     )}
                                     {item.linkedPrUrl && (

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ThreadPreviewSidebar.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ThreadPreviewSidebar.tsx
@@ -1,3 +1,4 @@
+import { getLinearIssueIdentifier } from '@lightdash/common'; // pragma: allowlist secret
 import {
     ActionIcon,
     Badge,
@@ -695,6 +696,35 @@ export const ThreadPreviewSidebar: FC<ThreadPreviewSidebarProps> = ({
                                                     >
                                                         View issue
                                                     </Button>
+
+                                                    {reviewItem.linkedIssueUrl && (
+                                                        <Button
+                                                            component="a"
+                                                            href={
+                                                                reviewItem.linkedIssueUrl
+                                                            }
+                                                            target="_blank"
+                                                            rel="noopener noreferrer"
+                                                            size="compact-xs"
+                                                            variant="subtle"
+                                                            color="gray"
+                                                            leftSection={
+                                                                <MantineIcon
+                                                                    icon={
+                                                                        IconExternalLink
+                                                                    }
+                                                                    size="xs"
+                                                                />
+                                                            }
+                                                            onClick={(event) =>
+                                                                event.stopPropagation()
+                                                            }
+                                                        >
+                                                            {getLinearIssueIdentifier(
+                                                                reviewItem.linkedIssueUrl,
+                                                            ) ?? 'Linear'}
+                                                        </Button>
+                                                    )}
 
                                                     {reviewItem.linkedPrUrl && (
                                                         <Button


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Relates: ticket pending

### Description:
New Linear issues already included a review URL in the description. This slice also:

- Attaches the review URL on the Linear issue (best-effort; a failure is logged and the export still succeeds)
- Shows the Linear identifier on the review issue rail and thread preview

Status is still one-way. Closing or moving a Linear issue does not update the review board.

### Risk assessment:
- [ ] This is a high-risk change

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://lightdash.slack.com/archives/C0BC1LFAH35/p1788278205402839?thread_ts=1788278205.402839&cid=C0BC1LFAH35)

<div><a href="https://cursor.com/agents/bc-8baf4f6d-9a38-5ded-bca7-28c26816591d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8baf4f6d-9a38-5ded-bca7-28c26816591d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

