### PR TITLE
feat(review-requests): notifications

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -9,6 +9,7 @@ import {
     ChartKind,
     ChartType,
     ContentReviewContentType,
+    ContentReviewNotificationEvent,
     ContentType,
     DbtProjectType,
     getRequestMethod,
@@ -2943,6 +2944,21 @@ export type ContentVerificationEvent = BaseTrack & {
     };
 };
 
+export type ContentReviewNotificationSentEvent = BaseTrack & {
+    event:
+        | 'content_review_notification.sent'
+        | 'content_review_notification.errored';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        channel: 'email' | 'slack_channel' | 'slack_dm';
+        notificationEvent: ContentReviewNotificationEvent;
+        recipientCount: number;
+        error: string | undefined;
+    };
+};
+
 export type ContentReviewRequestEvent = BaseTrack & {
     event:
         | 'content_review_request.submitted'
@@ -3652,6 +3668,7 @@ type TypedEvent =
     | AiRouterMessageRoutedEvent
     | ContentVerificationEvent
     | ContentReviewRequestEvent
+    | ContentReviewNotificationSentEvent
     | SchedulerOwnershipReassignedEvent
     | DashboardOwnershipReassignedEvent
     | ImpersonationEvent

--- a/packages/backend/src/clients/Slack/SlackContentReviewMessageBlocks.ts
+++ b/packages/backend/src/clients/Slack/SlackContentReviewMessageBlocks.ts
@@ -1,0 +1,82 @@
+import { type KnownBlock } from '@slack/bolt';
+import { safeUrl, sanitizeText, truncateText } from './SlackMessageBlocks';
+
+const SECTION_TEXT_LIMIT = 3000;
+const HEADER_TEXT_LIMIT = 150;
+const BUTTON_TEXT_LIMIT = 75;
+
+type ContentReviewBlockArgs = {
+    header: string;
+    body: string;
+    note: string | null;
+    projectName: string;
+    requestUrl: string;
+    buttonLabel: string;
+};
+
+export const buildContentReviewBlocks = (
+    args: ContentReviewBlockArgs,
+): KnownBlock[] => {
+    const url = safeUrl(args.requestUrl);
+    const blocks: KnownBlock[] = [
+        {
+            type: 'header',
+            text: {
+                type: 'plain_text',
+                text: truncateText(
+                    sanitizeText(args.header),
+                    HEADER_TEXT_LIMIT,
+                ),
+            },
+        },
+        {
+            type: 'section',
+            text: {
+                type: 'mrkdwn',
+                text: truncateText(sanitizeText(args.body), SECTION_TEXT_LIMIT),
+            },
+        },
+    ];
+    if (args.note !== null && args.note.trim().length > 0) {
+        blocks.push({
+            type: 'section',
+            text: {
+                type: 'mrkdwn',
+                text: truncateText(
+                    `> ${sanitizeText(args.note)}`,
+                    SECTION_TEXT_LIMIT,
+                ),
+            },
+        });
+    }
+    blocks.push({
+        type: 'context',
+        elements: [
+            {
+                type: 'mrkdwn',
+                text: truncateText(
+                    `Project: ${sanitizeText(args.projectName)}`,
+                    SECTION_TEXT_LIMIT,
+                ),
+            },
+        ],
+    });
+    if (url) {
+        blocks.push({
+            type: 'actions',
+            elements: [
+                {
+                    type: 'button',
+                    text: {
+                        type: 'plain_text',
+                        text: truncateText(args.buttonLabel, BUTTON_TEXT_LIMIT),
+                        emoji: true,
+                    },
+                    url,
+                    action_id: 'content_review_open',
+                },
+            ],
+        });
+    }
+    return blocks;
+};

--- a/packages/backend/src/database/entities/notifications.ts
+++ b/packages/backend/src/database/entities/notifications.ts
@@ -1,9 +1,13 @@
-import { type NotificationAiReview } from '@lightdash/common';
+import {
+    type NotificationAiReview,
+    type NotificationContentReview,
+} from '@lightdash/common';
 import { Knex } from 'knex';
 
 export enum DbNotificationResourceType {
     DashboardComments = 'dashboard_comments',
     AiReviewItem = 'ai_review_item',
+    ContentReviewRequest = 'content_review_request',
 }
 
 export const NotificationsTableName = 'notifications';
@@ -27,6 +31,7 @@ type DbNotifications = {
     metadata:
         | DbNotificationDashboardTileCommentMetadata
         | NotificationAiReview['metadata']
+        | NotificationContentReview['metadata']
         | null;
 };
 

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -88,6 +88,7 @@ import { PreAggregationDuckDbClient } from './services/AsyncQueryService/PreAggr
 import { PreAggregationExternalResolver } from './services/AsyncQueryService/PreAggregationExternalResolver';
 import { CommercialCacheService } from './services/CommercialCacheService';
 import { CommercialSlackIntegrationService } from './services/CommercialSlackIntegrationService';
+import { ContentReviewNotificationService } from './services/ContentReviewNotificationService/ContentReviewNotificationService';
 import { ContentReviewRequestService } from './services/ContentReviewRequestService/ContentReviewRequestService';
 import { EmbedService } from './services/EmbedService/EmbedService';
 import { ExternalConnectionCoderService } from './services/ExternalConnectionCoderService/ExternalConnectionCoderService';
@@ -273,9 +274,23 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     schedulerClient:
                         clients.getSchedulerClient() as CommercialSchedulerClient,
                 }),
+            contentReviewNotificationService: ({
+                models,
+                repository,
+                clients,
+            }) =>
+                new ContentReviewNotificationService({
+                    groupsModel: models.getGroupsModel(),
+                    notificationsModel: models.getNotificationsModel(),
+                    schedulerClient: clients.getSchedulerClient(),
+                    spacePermissionService:
+                        repository.getSpacePermissionService(),
+                }),
             contentReviewRequestService: ({ models, repository, context }) =>
                 new ContentReviewRequestService({
                     analytics: context.lightdashAnalytics,
+                    contentReviewNotificationService:
+                        repository.getContentReviewNotificationService<ContentReviewNotificationService>(),
                     contentReviewRequestModel:
                         models.getContentReviewRequestModel(),
                     contentReviewSettingsModel:
@@ -1442,6 +1457,11 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     context.serviceRepository.getExternalSourceService<ExternalSourceService>(),
                 mobilePushNotificationService:
                     context.serviceRepository.getMobilePushNotificationService<MobilePushNotificationService>(),
+                contentReviewRequestModel:
+                    context.models.getContentReviewRequestModel(),
+                contentReviewSettingsModel:
+                    context.models.getContentReviewSettingsModel(),
+                userModel: context.models.getUserModel(),
                 prometheusMetrics: context.prometheusMetrics,
             }),
         clientProviders: {

--- a/packages/backend/src/ee/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.ts
@@ -10,8 +10,11 @@ import {
 } from '@lightdash/common';
 import type { AddJobFunction } from 'graphile-worker';
 import Logger from '../../logging/logger';
+import { type ContentReviewRequestModel } from '../../models/ContentReviewRequestModel';
+import { type ContentReviewSettingsModel } from '../../models/ContentReviewSettingsModel';
 import { type OpenIdIdentityModel } from '../../models/OpenIdIdentitiesModel';
 import { type ProjectModel } from '../../models/ProjectModel/ProjectModel';
+import { type UserModel } from '../../models/UserModel';
 import type PrometheusMetrics from '../../prometheus/PrometheusMetrics';
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
 import { tryJobOrTimeout } from '../../scheduler/SchedulerJobTimeout';
@@ -41,6 +44,7 @@ import { type OnboardingAgentService } from '../services/OnboardingAgentService/
 import { ProjectContextService } from '../services/ProjectContextService/ProjectContextService';
 import type { ProjectHomepageService } from '../services/ProjectHomepageService';
 import { createReviewLinearIssue } from './tasks/createReviewLinearIssue';
+import { sendContentReviewNotification } from './tasks/sendContentReviewNotification';
 import { sendReviewNotification } from './tasks/sendReviewNotification';
 
 const MCP_TOOL_CALL_RETENTION_DAYS = 90;
@@ -140,6 +144,9 @@ type CommercialSchedulerWorkerArguments = SchedulerWorkerArguments & {
         | 'reconcileLiveActivity'
         | 'sweepLiveActivities'
     >;
+    contentReviewRequestModel: ContentReviewRequestModel;
+    contentReviewSettingsModel: ContentReviewSettingsModel;
+    userModel: UserModel;
 };
 
 export class CommercialSchedulerWorker extends SchedulerWorker {
@@ -187,6 +194,12 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
 
     protected readonly mobilePushNotificationService: CommercialSchedulerWorkerArguments['mobilePushNotificationService'];
 
+    protected readonly contentReviewRequestModel: ContentReviewRequestModel;
+
+    protected readonly contentReviewSettingsModel: ContentReviewSettingsModel;
+
+    protected readonly userModel: UserModel;
+
     private readonly cleanupMetrics: PrometheusMetrics | null;
 
     constructor(args: CommercialSchedulerWorkerArguments) {
@@ -216,6 +229,9 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
         this.projectHomepageService = args.projectHomepageService;
         this.externalSourceService = args.externalSourceService;
         this.mobilePushNotificationService = args.mobilePushNotificationService;
+        this.contentReviewRequestModel = args.contentReviewRequestModel;
+        this.contentReviewSettingsModel = args.contentReviewSettingsModel;
+        this.userModel = args.userModel;
         this.cleanupMetrics = args.prometheusMetrics ?? null;
     }
 
@@ -1026,6 +1042,21 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                         this.aiAgentReviewClassifierModel,
                     projectModel: this.projectModel,
                     openIdIdentityModel: this.openIdIdentityModel,
+                    slackClient: this.slackClient,
+                    analytics: this.analytics,
+                })(payload);
+            },
+            [EE_SCHEDULER_TASKS.SEND_CONTENT_REVIEW_NOTIFICATION]: async (
+                payload,
+            ) => {
+                await sendContentReviewNotification({
+                    siteUrl: this.lightdashConfig.siteUrl,
+                    contentReviewRequestModel: this.contentReviewRequestModel,
+                    contentReviewSettingsModel: this.contentReviewSettingsModel,
+                    projectModel: this.projectModel,
+                    userModel: this.userModel,
+                    openIdIdentityModel: this.openIdIdentityModel,
+                    emailClient: this.emailClient,
                     slackClient: this.slackClient,
                     analytics: this.analytics,
                 })(payload);

--- a/packages/backend/src/ee/scheduler/tasks/sendContentReviewNotification.test.ts
+++ b/packages/backend/src/ee/scheduler/tasks/sendContentReviewNotification.test.ts
@@ -1,0 +1,219 @@
+import {
+    ContentReviewNotificationEvent,
+    ContentReviewRequestStatus,
+    ContentType,
+    type ContentReviewRequest,
+    type SendContentReviewNotificationPayload,
+} from '@lightdash/common';
+import { type LightdashAnalytics } from '../../../analytics/LightdashAnalytics';
+import type EmailClient from '../../../clients/EmailClient/EmailClient';
+import { type SlackClient } from '../../../clients/Slack/SlackClient';
+import { type ContentReviewRequestModel } from '../../../models/ContentReviewRequestModel';
+import { type ContentReviewSettingsModel } from '../../../models/ContentReviewSettingsModel';
+import { type OpenIdIdentityModel } from '../../../models/OpenIdIdentitiesModel';
+import { type ProjectModel } from '../../../models/ProjectModel/ProjectModel';
+import { type UserModel } from '../../../models/UserModel';
+import { sendContentReviewNotification } from './sendContentReviewNotification';
+
+const request: ContentReviewRequest = {
+    uuid: 'request-uuid',
+    projectUuid: 'project-uuid',
+    contentType: ContentType.CHART,
+    contentUuid: 'chart-uuid',
+    sourceSpaceUuid: 'personal-space',
+    targetSpaceUuid: 'shared-space',
+    requestedBy: { userUuid: 'requester', firstName: 'Ada', lastName: 'L' },
+    requestNote: 'Please review',
+    similarContent: [],
+    status: ContentReviewRequestStatus.PENDING,
+    reviewedBy: null,
+    reviewedAt: null,
+    reviewNote: null,
+    verifiedOnApprove: null,
+    movedContent: [],
+    grantedPrincipals: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+};
+
+const basePayload: SendContentReviewNotificationPayload = {
+    organizationUuid: 'org-uuid',
+    projectUuid: 'project-uuid',
+    requestUuid: 'request-uuid',
+    event: ContentReviewNotificationEvent.SUBMITTED,
+    recipientUserUuids: ['editor', 'admin'],
+    userUuid: 'requester',
+};
+
+const buildDeps = () => {
+    const postMessage = vi.fn().mockResolvedValue(undefined);
+    const conversationsOpen = vi
+        .fn()
+        .mockResolvedValue({ ok: true, channel: { id: 'D123' } });
+    const deps = {
+        siteUrl: 'https://app.test',
+        contentReviewRequestModel: {
+            findByUuid: vi.fn().mockResolvedValue(request),
+            findChartLocations: vi.fn().mockResolvedValue([
+                {
+                    uuid: 'chart-uuid',
+                    name: 'Weekly revenue',
+                    slug: 'weekly-revenue',
+                    spaceUuid: 'personal-space',
+                    dashboardUuid: null,
+                    deleted: false,
+                },
+            ]),
+            findDashboardLocations: vi.fn().mockResolvedValue([]),
+            findSpaceInfo: vi.fn().mockResolvedValue(
+                new Map([
+                    ['personal-space', { name: 'Personal' }],
+                    ['shared-space', { name: 'Finance' }],
+                ]),
+            ),
+        },
+        contentReviewSettingsModel: {
+            get: vi.fn().mockResolvedValue({ slackChannelId: null }),
+        },
+        projectModel: {
+            getSummary: vi.fn().mockResolvedValue({ name: 'Jaffle' }),
+        },
+        userModel: {
+            getUserDetailsByUuid: vi
+                .fn()
+                .mockImplementation(async (uuid: string) => ({
+                    email: `${uuid}@test.com`,
+                })),
+        },
+        openIdIdentityModel: {
+            findIdentityByUserUuid: vi
+                .fn()
+                .mockResolvedValue({ subject: 'U999' }),
+        },
+        emailClient: {
+            sendGenericNotificationEmail: vi.fn().mockResolvedValue(undefined),
+        },
+        slackClient: {
+            getNotificationChannel: vi.fn().mockResolvedValue('C123'),
+            postMessage,
+            getWebClient: vi.fn().mockResolvedValue({
+                conversations: { open: conversationsOpen },
+            }),
+        },
+        analytics: { track: vi.fn() },
+    };
+    return {
+        deps,
+        run: sendContentReviewNotification({
+            ...deps,
+            contentReviewRequestModel:
+                deps.contentReviewRequestModel as unknown as ContentReviewRequestModel,
+            contentReviewSettingsModel:
+                deps.contentReviewSettingsModel as unknown as ContentReviewSettingsModel,
+            projectModel: deps.projectModel as unknown as ProjectModel,
+            userModel: deps.userModel as unknown as UserModel,
+            openIdIdentityModel:
+                deps.openIdIdentityModel as unknown as OpenIdIdentityModel,
+            emailClient: deps.emailClient as unknown as EmailClient,
+            slackClient: deps.slackClient as unknown as SlackClient,
+            analytics: deps.analytics as unknown as LightdashAnalytics,
+        }),
+    };
+};
+
+describe('sendContentReviewNotification', () => {
+    test('submitted emails reviewers and posts to the notification channel', async () => {
+        const { deps, run } = buildDeps();
+
+        await run(basePayload);
+
+        expect(
+            deps.emailClient.sendGenericNotificationEmail,
+        ).toHaveBeenCalledWith(
+            ['editor@test.com', 'admin@test.com'],
+            'Content review requested',
+            'Content review requested',
+            expect.stringContaining(
+                'https://app.test/projects/project-uuid/review-requests/request-uuid',
+            ),
+        );
+        expect(deps.slackClient.postMessage).toHaveBeenCalledWith(
+            expect.objectContaining({
+                organizationUuid: 'org-uuid',
+                channel: 'C123',
+                text: 'Ada L asked for "Weekly revenue" to be reviewed for Finance',
+            }),
+        );
+        expect(deps.analytics.track).toHaveBeenCalledWith(
+            expect.objectContaining({
+                event: 'content_review_notification.sent',
+                properties: expect.objectContaining({ channel: 'email' }),
+            }),
+        );
+    });
+
+    test('a project Slack channel wins over the org channel', async () => {
+        const { deps, run } = buildDeps();
+        deps.contentReviewSettingsModel.get.mockResolvedValue({
+            slackChannelId: 'CPROJ',
+        });
+
+        await run(basePayload);
+
+        expect(deps.slackClient.getNotificationChannel).not.toHaveBeenCalled();
+        expect(deps.slackClient.postMessage).toHaveBeenCalledWith(
+            expect.objectContaining({ channel: 'CPROJ' }),
+        );
+    });
+
+    test('decisions DM the requester when a Slack identity exists', async () => {
+        const { deps, run } = buildDeps();
+
+        await run({
+            ...basePayload,
+            event: ContentReviewNotificationEvent.REJECTED,
+            recipientUserUuids: ['requester'],
+            userUuid: 'admin',
+        });
+
+        expect(deps.slackClient.getNotificationChannel).not.toHaveBeenCalled();
+        expect(deps.slackClient.postMessage).toHaveBeenCalledWith(
+            expect.objectContaining({
+                channel: 'D123',
+                text: '"Weekly revenue" was not approved for Finance',
+            }),
+        );
+    });
+
+    test('Slack failures are recorded and do not break email', async () => {
+        const { deps, run } = buildDeps();
+        deps.slackClient.postMessage.mockRejectedValue(new Error('slack down'));
+
+        await run(basePayload);
+
+        expect(
+            deps.emailClient.sendGenericNotificationEmail,
+        ).toHaveBeenCalled();
+        expect(deps.analytics.track).toHaveBeenCalledWith(
+            expect.objectContaining({
+                event: 'content_review_notification.errored',
+                properties: expect.objectContaining({
+                    channel: 'slack_channel',
+                    error: 'slack down',
+                }),
+            }),
+        );
+    });
+
+    test('does nothing when the request is gone', async () => {
+        const { deps, run } = buildDeps();
+        deps.contentReviewRequestModel.findByUuid.mockResolvedValue(null);
+
+        await run(basePayload);
+
+        expect(
+            deps.emailClient.sendGenericNotificationEmail,
+        ).not.toHaveBeenCalled();
+        expect(deps.slackClient.postMessage).not.toHaveBeenCalled();
+    });
+});

--- a/packages/backend/src/ee/scheduler/tasks/sendContentReviewNotification.test.ts
+++ b/packages/backend/src/ee/scheduler/tasks/sendContentReviewNotification.test.ts
@@ -1,7 +1,7 @@
 import {
+    ContentReviewContentType,
     ContentReviewNotificationEvent,
     ContentReviewRequestStatus,
-    ContentType,
     type ContentReviewRequest,
     type SendContentReviewNotificationPayload,
 } from '@lightdash/common';
@@ -18,7 +18,7 @@ import { sendContentReviewNotification } from './sendContentReviewNotification';
 const request: ContentReviewRequest = {
     uuid: 'request-uuid',
     projectUuid: 'project-uuid',
-    contentType: ContentType.CHART,
+    contentType: ContentReviewContentType.CHART,
     contentUuid: 'chart-uuid',
     sourceSpaceUuid: 'personal-space',
     targetSpaceUuid: 'shared-space',

--- a/packages/backend/src/ee/scheduler/tasks/sendContentReviewNotification.ts
+++ b/packages/backend/src/ee/scheduler/tasks/sendContentReviewNotification.ts
@@ -1,7 +1,7 @@
 import {
     assertUnreachable,
+    ContentReviewContentType,
     ContentReviewNotificationEvent,
-    ContentType,
     getContentReviewRequestPath,
     getErrorMessage,
     OpenIdIdentityIssuerType,
@@ -56,19 +56,33 @@ const getHeader = (event: ContentReviewNotificationEvent): string => {
     }
 };
 
+const findRequestLocations = (
+    deps: SendContentReviewNotificationDeps,
+    request: ContentReviewRequest,
+) => {
+    const uuids = [request.contentUuid];
+    switch (request.contentType) {
+        case ContentReviewContentType.CHART:
+            return deps.contentReviewRequestModel.findChartLocations(uuids);
+        case ContentReviewContentType.SQL_CHART:
+            return deps.contentReviewRequestModel.findSqlChartLocations(uuids);
+        case ContentReviewContentType.DASHBOARD:
+            return deps.contentReviewRequestModel.findDashboardLocations(uuids);
+        default:
+            return assertUnreachable(
+                request.contentType,
+                'Unknown review content type',
+            );
+    }
+};
+
 const getCopy = async (
     deps: SendContentReviewNotificationDeps,
     payload: SendContentReviewNotificationPayload,
     request: ContentReviewRequest,
 ): Promise<NotificationCopy> => {
     const [locations, spaces, project] = await Promise.all([
-        request.contentType === ContentType.CHART
-            ? deps.contentReviewRequestModel.findChartLocations([
-                  request.contentUuid,
-              ])
-            : deps.contentReviewRequestModel.findDashboardLocations([
-                  request.contentUuid,
-              ]),
+        findRequestLocations(deps, request),
         deps.contentReviewRequestModel.findSpaceInfo(
             request.targetSpaceUuid === null
                 ? [request.sourceSpaceUuid]

--- a/packages/backend/src/ee/scheduler/tasks/sendContentReviewNotification.ts
+++ b/packages/backend/src/ee/scheduler/tasks/sendContentReviewNotification.ts
@@ -1,0 +1,251 @@
+import {
+    assertUnreachable,
+    ContentReviewNotificationEvent,
+    ContentType,
+    getContentReviewRequestPath,
+    getErrorMessage,
+    OpenIdIdentityIssuerType,
+    type ContentReviewRequest,
+    type SendContentReviewNotificationPayload,
+} from '@lightdash/common';
+import { type LightdashAnalytics } from '../../../analytics/LightdashAnalytics';
+import type EmailClient from '../../../clients/EmailClient/EmailClient';
+import { type SlackClient } from '../../../clients/Slack/SlackClient';
+import { buildContentReviewBlocks } from '../../../clients/Slack/SlackContentReviewMessageBlocks';
+import Logger from '../../../logging/logger';
+import { type ContentReviewRequestModel } from '../../../models/ContentReviewRequestModel';
+import { type ContentReviewSettingsModel } from '../../../models/ContentReviewSettingsModel';
+import { type OpenIdIdentityModel } from '../../../models/OpenIdIdentitiesModel';
+import { type ProjectModel } from '../../../models/ProjectModel/ProjectModel';
+import { type UserModel } from '../../../models/UserModel';
+import { buildContentReviewNotificationMessage } from '../../services/ContentReviewNotificationService/ContentReviewNotificationService';
+
+type SendContentReviewNotificationDeps = {
+    siteUrl: string;
+    contentReviewRequestModel: ContentReviewRequestModel;
+    contentReviewSettingsModel: ContentReviewSettingsModel;
+    projectModel: ProjectModel;
+    userModel: UserModel;
+    openIdIdentityModel: OpenIdIdentityModel;
+    emailClient: EmailClient;
+    slackClient: SlackClient;
+    analytics: LightdashAnalytics;
+};
+
+type NotificationChannel = 'email' | 'slack_channel' | 'slack_dm';
+
+type NotificationCopy = {
+    header: string;
+    body: string;
+    note: string | null;
+    projectName: string;
+    requestUrl: string;
+    buttonLabel: string;
+};
+
+const getHeader = (event: ContentReviewNotificationEvent): string => {
+    switch (event) {
+        case ContentReviewNotificationEvent.SUBMITTED:
+            return 'Content review requested';
+        case ContentReviewNotificationEvent.APPROVED:
+            return 'Review request approved';
+        case ContentReviewNotificationEvent.REJECTED:
+            return 'Review request rejected';
+        default:
+            return assertUnreachable(event, 'Unknown notification event');
+    }
+};
+
+const getCopy = async (
+    deps: SendContentReviewNotificationDeps,
+    payload: SendContentReviewNotificationPayload,
+    request: ContentReviewRequest,
+): Promise<NotificationCopy> => {
+    const [locations, spaces, project] = await Promise.all([
+        request.contentType === ContentType.CHART
+            ? deps.contentReviewRequestModel.findChartLocations([
+                  request.contentUuid,
+              ])
+            : deps.contentReviewRequestModel.findDashboardLocations([
+                  request.contentUuid,
+              ]),
+        deps.contentReviewRequestModel.findSpaceInfo(
+            request.targetSpaceUuid === null
+                ? [request.sourceSpaceUuid]
+                : [request.sourceSpaceUuid, request.targetSpaceUuid],
+        ),
+        deps.projectModel.getSummary(payload.projectUuid),
+    ]);
+    const location = locations[0];
+    const item = {
+        ...request,
+        content:
+            location === undefined || location.deleted
+                ? null
+                : { name: location.name, slug: location.slug },
+        sourceSpaceName: spaces.get(request.sourceSpaceUuid)?.name ?? null,
+        targetSpaceName:
+            request.targetSpaceUuid === null
+                ? null
+                : (spaces.get(request.targetSpaceUuid)?.name ?? null),
+    };
+    const body = buildContentReviewNotificationMessage(item, payload.event);
+    const header = getHeader(payload.event);
+    return {
+        header,
+        body,
+        note:
+            payload.event === ContentReviewNotificationEvent.SUBMITTED
+                ? request.requestNote
+                : request.reviewNote,
+        projectName: project.name,
+        requestUrl: `${deps.siteUrl}${getContentReviewRequestPath(
+            payload.projectUuid,
+            payload.requestUuid,
+        )}`,
+        buttonLabel:
+            payload.event === ContentReviewNotificationEvent.SUBMITTED
+                ? 'Review request'
+                : 'Open request',
+    };
+};
+
+const track = (
+    deps: SendContentReviewNotificationDeps,
+    payload: SendContentReviewNotificationPayload,
+    channel: NotificationChannel,
+    outcome: { sent: number } | { error: string },
+) =>
+    deps.analytics.track({
+        event:
+            'error' in outcome
+                ? 'content_review_notification.errored'
+                : 'content_review_notification.sent',
+        userId: payload.userUuid,
+        properties: {
+            organizationId: payload.organizationUuid,
+            projectId: payload.projectUuid,
+            channel,
+            notificationEvent: payload.event,
+            recipientCount: 'sent' in outcome ? outcome.sent : 0,
+            error: 'error' in outcome ? outcome.error : undefined,
+        },
+    });
+
+const sendEmails = async (
+    deps: SendContentReviewNotificationDeps,
+    payload: SendContentReviewNotificationPayload,
+    copy: NotificationCopy,
+): Promise<void> => {
+    const users = await Promise.all(
+        payload.recipientUserUuids.map((uuid) =>
+            deps.userModel.getUserDetailsByUuid(uuid),
+        ),
+    );
+    const emails = users.flatMap((user) => (user.email ? [user.email] : []));
+    if (emails.length === 0) return;
+    try {
+        const note = copy.note ? `\n\n> ${copy.note}` : '';
+        await deps.emailClient.sendGenericNotificationEmail(
+            emails,
+            copy.header,
+            copy.header,
+            `${copy.body}${note}\n\n[${copy.buttonLabel}](${copy.requestUrl})`,
+        );
+        track(deps, payload, 'email', { sent: emails.length });
+    } catch (error) {
+        const message = getErrorMessage(error);
+        Logger.error(
+            `Unable to email content review notification for request ${payload.requestUuid}: ${message}`,
+        );
+        track(deps, payload, 'email', { error: message });
+    }
+};
+
+const postToSlackChannel = async (
+    deps: SendContentReviewNotificationDeps,
+    payload: SendContentReviewNotificationPayload,
+    copy: NotificationCopy,
+): Promise<void> => {
+    const settings = await deps.contentReviewSettingsModel.get(
+        payload.projectUuid,
+    );
+    try {
+        const channel =
+            settings.slackChannelId ??
+            (await deps.slackClient.getNotificationChannel(
+                payload.organizationUuid,
+            ));
+        if (!channel) return;
+        await deps.slackClient.postMessage({
+            organizationUuid: payload.organizationUuid,
+            channel,
+            text: copy.body,
+            blocks: buildContentReviewBlocks(copy),
+        });
+        track(deps, payload, 'slack_channel', { sent: 1 });
+    } catch (error) {
+        const message = getErrorMessage(error);
+        Logger.warn(
+            `Unable to post content review notification to Slack for request ${payload.requestUuid}: ${message}`,
+        );
+        track(deps, payload, 'slack_channel', { error: message });
+    }
+};
+
+const sendSlackDm = async (
+    deps: SendContentReviewNotificationDeps,
+    payload: SendContentReviewNotificationPayload,
+    copy: NotificationCopy,
+    recipientUserUuid: string,
+): Promise<void> => {
+    const identity = await deps.openIdIdentityModel.findIdentityByUserUuid(
+        recipientUserUuid,
+        OpenIdIdentityIssuerType.SLACK,
+    );
+    if (!identity) return;
+    try {
+        const webClient = await deps.slackClient.getWebClient(
+            payload.organizationUuid,
+        );
+        const conversation = await webClient.conversations.open({
+            users: identity.subject,
+        });
+        if (!conversation.ok || !conversation.channel?.id) {
+            throw new Error('Failed to open Slack DM');
+        }
+        await deps.slackClient.postMessage({
+            organizationUuid: payload.organizationUuid,
+            channel: conversation.channel.id,
+            text: copy.body,
+            blocks: buildContentReviewBlocks(copy),
+        });
+        track(deps, payload, 'slack_dm', { sent: 1 });
+    } catch (error) {
+        const message = getErrorMessage(error);
+        Logger.warn(
+            `Unable to send content review DM for request ${payload.requestUuid}: ${message}`,
+        );
+        track(deps, payload, 'slack_dm', { error: message });
+    }
+};
+
+export const sendContentReviewNotification =
+    (deps: SendContentReviewNotificationDeps) =>
+    async (payload: SendContentReviewNotificationPayload): Promise<void> => {
+        const request = await deps.contentReviewRequestModel.findByUuid(
+            payload.requestUuid,
+        );
+        if (request === null) return;
+        const copy = await getCopy(deps, payload, request);
+
+        await sendEmails(deps, payload, copy);
+        if (payload.event === ContentReviewNotificationEvent.SUBMITTED) {
+            await postToSlackChannel(deps, payload, copy);
+            return;
+        }
+        for (const recipientUserUuid of payload.recipientUserUuids) {
+            // eslint-disable-next-line no-await-in-loop
+            await sendSlackDm(deps, payload, copy, recipientUserUuid);
+        }
+    };

--- a/packages/backend/src/ee/services/ContentReviewNotificationService/ContentReviewNotificationService.test.ts
+++ b/packages/backend/src/ee/services/ContentReviewNotificationService/ContentReviewNotificationService.test.ts
@@ -1,0 +1,197 @@
+import {
+    ContentReviewNotificationEvent,
+    ContentReviewRequestStatus,
+    ContentType,
+    EE_SCHEDULER_TASKS,
+    SpaceMemberRole,
+    type ContentReviewRequestListItem,
+    type ContentReviewSettings,
+} from '@lightdash/common';
+import { type GroupsModel } from '../../../models/GroupsModel';
+import { type NotificationsModel } from '../../../models/NotificationsModel/NotificationsModel';
+import { type SchedulerClient } from '../../../scheduler/SchedulerClient';
+import { type SpacePermissionService } from '../../../services/SpaceService/SpacePermissionService';
+import {
+    buildContentReviewNotificationMessage,
+    ContentReviewNotificationService,
+} from './ContentReviewNotificationService';
+
+const ORG = 'org-uuid';
+const PROJECT = 'project-uuid';
+const REQUESTER = 'requester-uuid';
+const EDITOR = 'editor-uuid';
+const ADMIN = 'admin-uuid';
+
+const item: ContentReviewRequestListItem = {
+    uuid: 'request-uuid',
+    projectUuid: PROJECT,
+    contentType: ContentType.CHART,
+    contentUuid: 'chart-uuid',
+    sourceSpaceUuid: 'personal-space',
+    targetSpaceUuid: 'shared-space',
+    requestedBy: {
+        userUuid: REQUESTER,
+        firstName: 'Ada',
+        lastName: 'Lovelace',
+    },
+    requestNote: 'Useful for the weekly review',
+    similarContent: [],
+    status: ContentReviewRequestStatus.PENDING,
+    reviewedBy: null,
+    reviewedAt: null,
+    reviewNote: null,
+    verifiedOnApprove: null,
+    movedContent: [],
+    grantedPrincipals: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    content: { name: 'Weekly revenue', slug: 'weekly-revenue' },
+    sourceSpaceName: 'Personal',
+    targetSpaceName: 'Finance',
+};
+
+const settings: ContentReviewSettings = {
+    projectUuid: PROJECT,
+    reviewerGroupUuid: null,
+    verifyOnApproveDefault: true,
+    slackChannelId: null,
+};
+
+const buildService = () => {
+    const groupsModel = {
+        findGroupMembers: vi.fn().mockResolvedValue({
+            data: [{ userUuid: ADMIN }, { userUuid: REQUESTER }],
+        }),
+    };
+    const notificationsModel = {
+        createContentReviewNotifications: vi.fn().mockResolvedValue(undefined),
+    };
+    const schedulerClient = {
+        scheduleTask: vi.fn().mockResolvedValue(undefined),
+    };
+    const spacePermissionService = {
+        getPaginatedSpaceAccess: vi.fn().mockResolvedValue({
+            data: [
+                { userUuid: EDITOR, role: SpaceMemberRole.EDITOR },
+                { userUuid: ADMIN, role: SpaceMemberRole.ADMIN },
+                { userUuid: 'viewer-uuid', role: SpaceMemberRole.VIEWER },
+                { userUuid: REQUESTER, role: SpaceMemberRole.ADMIN },
+            ],
+        }),
+    };
+    const service = new ContentReviewNotificationService({
+        groupsModel: groupsModel as unknown as GroupsModel,
+        notificationsModel: notificationsModel as unknown as NotificationsModel,
+        schedulerClient: schedulerClient as unknown as SchedulerClient,
+        spacePermissionService:
+            spacePermissionService as unknown as SpacePermissionService,
+    });
+    return {
+        service,
+        groupsModel,
+        notificationsModel,
+        schedulerClient,
+        spacePermissionService,
+    };
+};
+
+describe('ContentReviewNotificationService', () => {
+    test('submitted notifies target-space editors and admins, not the requester', async () => {
+        const { service, notificationsModel, schedulerClient } = buildService();
+
+        await service.notifySubmitted({
+            item,
+            settings,
+            organizationUuid: ORG,
+        });
+
+        expect(
+            notificationsModel.createContentReviewNotifications,
+        ).toHaveBeenCalledWith(
+            expect.objectContaining({
+                recipients: [{ userUuid: EDITOR }, { userUuid: ADMIN }],
+                message:
+                    'Ada Lovelace asked for "Weekly revenue" to be reviewed for Finance',
+                url: '/projects/project-uuid/review-requests/request-uuid',
+                metadata: expect.objectContaining({
+                    requestUuid: 'request-uuid',
+                    event: ContentReviewNotificationEvent.SUBMITTED,
+                    requesterName: 'Ada Lovelace',
+                }),
+            }),
+        );
+        expect(schedulerClient.scheduleTask).toHaveBeenCalledWith(
+            EE_SCHEDULER_TASKS.SEND_CONTENT_REVIEW_NOTIFICATION,
+            {
+                organizationUuid: ORG,
+                projectUuid: PROJECT,
+                requestUuid: 'request-uuid',
+                event: ContentReviewNotificationEvent.SUBMITTED,
+                recipientUserUuids: [EDITOR, ADMIN],
+                userUuid: REQUESTER,
+            },
+        );
+    });
+
+    test('submitted notifies the reviewer group when configured', async () => {
+        const { service, groupsModel, schedulerClient } = buildService();
+
+        await service.notifySubmitted({
+            item,
+            settings: { ...settings, reviewerGroupUuid: 'group-uuid' },
+            organizationUuid: ORG,
+        });
+
+        expect(groupsModel.findGroupMembers).toHaveBeenCalledWith({
+            organizationUuid: ORG,
+            groupUuids: ['group-uuid'],
+        });
+        expect(schedulerClient.scheduleTask).toHaveBeenCalledWith(
+            EE_SCHEDULER_TASKS.SEND_CONTENT_REVIEW_NOTIFICATION,
+            expect.objectContaining({ recipientUserUuids: [ADMIN] }),
+        );
+    });
+
+    test('decisions go to the requester only', async () => {
+        const { service, notificationsModel, schedulerClient } = buildService();
+
+        await service.notifyDecided({
+            item: { ...item, verifiedOnApprove: true },
+            event: ContentReviewNotificationEvent.APPROVED,
+            organizationUuid: ORG,
+            actorUserUuid: ADMIN,
+        });
+
+        expect(
+            notificationsModel.createContentReviewNotifications,
+        ).toHaveBeenCalledWith(
+            expect.objectContaining({
+                recipients: [{ userUuid: REQUESTER }],
+                message:
+                    '"Weekly revenue" was approved, moved to Finance and verified',
+            }),
+        );
+        expect(schedulerClient.scheduleTask).toHaveBeenCalledWith(
+            EE_SCHEDULER_TASKS.SEND_CONTENT_REVIEW_NOTIFICATION,
+            expect.objectContaining({
+                recipientUserUuids: [REQUESTER],
+                userUuid: ADMIN,
+            }),
+        );
+    });
+
+    test('messages cover every event', () => {
+        expect(
+            buildContentReviewNotificationMessage(
+                item,
+                ContentReviewNotificationEvent.REJECTED,
+            ),
+        ).toBe('"Weekly revenue" was not approved for Finance');
+        expect(
+            buildContentReviewNotificationMessage(
+                { ...item, content: null, targetSpaceName: null },
+                ContentReviewNotificationEvent.APPROVED,
+            ),
+        ).toBe('"Deleted content" was approved and moved to a shared space');
+    });
+});

--- a/packages/backend/src/ee/services/ContentReviewNotificationService/ContentReviewNotificationService.test.ts
+++ b/packages/backend/src/ee/services/ContentReviewNotificationService/ContentReviewNotificationService.test.ts
@@ -1,7 +1,7 @@
 import {
+    ContentReviewContentType,
     ContentReviewNotificationEvent,
     ContentReviewRequestStatus,
-    ContentType,
     EE_SCHEDULER_TASKS,
     SpaceMemberRole,
     type ContentReviewRequestListItem,
@@ -25,7 +25,7 @@ const ADMIN = 'admin-uuid';
 const item: ContentReviewRequestListItem = {
     uuid: 'request-uuid',
     projectUuid: PROJECT,
-    contentType: ContentType.CHART,
+    contentType: ContentReviewContentType.CHART,
     contentUuid: 'chart-uuid',
     sourceSpaceUuid: 'personal-space',
     targetSpaceUuid: 'shared-space',

--- a/packages/backend/src/ee/services/ContentReviewNotificationService/ContentReviewNotificationService.ts
+++ b/packages/backend/src/ee/services/ContentReviewNotificationService/ContentReviewNotificationService.ts
@@ -1,0 +1,198 @@
+import {
+    assertUnreachable,
+    ContentReviewNotificationEvent,
+    EE_SCHEDULER_TASKS,
+    getContentReviewRequestPath,
+    SpaceMemberRole,
+    type ContentReviewRequestListItem,
+    type ContentReviewSettings,
+    type NotificationContentReview,
+} from '@lightdash/common';
+import { type GroupsModel } from '../../../models/GroupsModel';
+import { type NotificationsModel } from '../../../models/NotificationsModel/NotificationsModel';
+import { type SchedulerClient } from '../../../scheduler/SchedulerClient';
+import { BaseService } from '../../../services/BaseService';
+import { type SpacePermissionService } from '../../../services/SpaceService/SpacePermissionService';
+
+type ContentReviewNotificationServiceArguments = {
+    groupsModel: GroupsModel;
+    notificationsModel: NotificationsModel;
+    schedulerClient: SchedulerClient;
+    spacePermissionService: SpacePermissionService;
+};
+
+type DispatchArgs = {
+    item: ContentReviewRequestListItem;
+    event: ContentReviewNotificationEvent;
+    recipientUserUuids: string[];
+    organizationUuid: string;
+    actorUserUuid: string;
+};
+
+const requesterName = (item: ContentReviewRequestListItem): string =>
+    `${item.requestedBy.firstName} ${item.requestedBy.lastName}`.trim();
+
+export const buildContentReviewNotificationMessage = (
+    item: ContentReviewRequestListItem,
+    event: ContentReviewNotificationEvent,
+): string => {
+    const contentName = item.content?.name ?? 'Deleted content';
+    const targetSpaceName = item.targetSpaceName ?? 'a shared space';
+    switch (event) {
+        case ContentReviewNotificationEvent.SUBMITTED:
+            return `${requesterName(item)} asked for "${contentName}" to be reviewed for ${targetSpaceName}`;
+        case ContentReviewNotificationEvent.APPROVED:
+            return item.verifiedOnApprove
+                ? `"${contentName}" was approved, moved to ${targetSpaceName} and verified`
+                : `"${contentName}" was approved and moved to ${targetSpaceName}`;
+        case ContentReviewNotificationEvent.REJECTED:
+            return `"${contentName}" was not approved for ${targetSpaceName}`;
+        default:
+            return assertUnreachable(
+                event,
+                'Unknown content review notification event',
+            );
+    }
+};
+
+export class ContentReviewNotificationService extends BaseService {
+    private readonly groupsModel: GroupsModel;
+
+    private readonly notificationsModel: NotificationsModel;
+
+    private readonly schedulerClient: SchedulerClient;
+
+    private readonly spacePermissionService: SpacePermissionService;
+
+    constructor(args: ContentReviewNotificationServiceArguments) {
+        super({ serviceName: 'ContentReviewNotificationService' });
+        this.groupsModel = args.groupsModel;
+        this.notificationsModel = args.notificationsModel;
+        this.schedulerClient = args.schedulerClient;
+        this.spacePermissionService = args.spacePermissionService;
+    }
+
+    // Mirrors the grant routing: the reviewer group, or whoever can edit the
+    // target space, never the requester
+    async resolveReviewerUserUuids({
+        settings,
+        targetSpaceUuid,
+        requesterUuid,
+        organizationUuid,
+    }: {
+        settings: ContentReviewSettings;
+        targetSpaceUuid: string;
+        requesterUuid: string;
+        organizationUuid: string;
+    }): Promise<string[]> {
+        if (settings.reviewerGroupUuid !== null) {
+            const { data: members } = await this.groupsModel.findGroupMembers({
+                organizationUuid,
+                groupUuids: [settings.reviewerGroupUuid],
+            });
+            return [
+                ...new Set(
+                    members
+                        .map((member) => member.userUuid)
+                        .filter((uuid) => uuid !== requesterUuid),
+                ),
+            ];
+        }
+        const { data: access } =
+            await this.spacePermissionService.getPaginatedSpaceAccess(
+                targetSpaceUuid,
+                {},
+            );
+        return access
+            .filter(
+                (share) =>
+                    share.userUuid !== requesterUuid &&
+                    (share.role === SpaceMemberRole.EDITOR ||
+                        share.role === SpaceMemberRole.ADMIN),
+            )
+            .map((share) => share.userUuid);
+    }
+
+    async notifySubmitted({
+        item,
+        settings,
+        organizationUuid,
+    }: {
+        item: ContentReviewRequestListItem;
+        settings: ContentReviewSettings;
+        organizationUuid: string;
+    }): Promise<void> {
+        if (item.targetSpaceUuid === null) return;
+        const recipientUserUuids = await this.resolveReviewerUserUuids({
+            settings,
+            targetSpaceUuid: item.targetSpaceUuid,
+            requesterUuid: item.requestedBy.userUuid,
+            organizationUuid,
+        });
+        await this.dispatch({
+            item,
+            event: ContentReviewNotificationEvent.SUBMITTED,
+            recipientUserUuids,
+            organizationUuid,
+            actorUserUuid: item.requestedBy.userUuid,
+        });
+    }
+
+    async notifyDecided({
+        item,
+        event,
+        organizationUuid,
+        actorUserUuid,
+    }: {
+        item: ContentReviewRequestListItem;
+        event:
+            | ContentReviewNotificationEvent.APPROVED
+            | ContentReviewNotificationEvent.REJECTED;
+        organizationUuid: string;
+        actorUserUuid: string;
+    }): Promise<void> {
+        await this.dispatch({
+            item,
+            event,
+            recipientUserUuids: [item.requestedBy.userUuid],
+            organizationUuid,
+            actorUserUuid,
+        });
+    }
+
+    private async dispatch({
+        item,
+        event,
+        recipientUserUuids,
+        organizationUuid,
+        actorUserUuid,
+    }: DispatchArgs): Promise<void> {
+        const metadata: NotificationContentReview['metadata'] = {
+            requestUuid: item.uuid,
+            projectUuid: item.projectUuid,
+            contentType: item.contentType,
+            contentUuid: item.contentUuid,
+            contentName: item.content?.name ?? 'Deleted content',
+            targetSpaceName: item.targetSpaceName ?? '',
+            requesterName: requesterName(item),
+            event,
+        };
+        await this.notificationsModel.createContentReviewNotifications({
+            recipients: recipientUserUuids.map((userUuid) => ({ userUuid })),
+            metadata,
+            message: buildContentReviewNotificationMessage(item, event),
+            url: getContentReviewRequestPath(item.projectUuid, item.uuid),
+        });
+        await this.schedulerClient.scheduleTask(
+            EE_SCHEDULER_TASKS.SEND_CONTENT_REVIEW_NOTIFICATION,
+            {
+                organizationUuid,
+                projectUuid: item.projectUuid,
+                requestUuid: item.uuid,
+                event,
+                recipientUserUuids,
+                userUuid: actorUserUuid,
+            },
+        );
+    }
+}

--- a/packages/backend/src/ee/services/ContentReviewRequestService/ContentReviewRequestService.test.ts
+++ b/packages/backend/src/ee/services/ContentReviewRequestService/ContentReviewRequestService.test.ts
@@ -32,6 +32,7 @@ import { type DirectAccessFeatureGate } from '../../../services/DirectAccess/Dir
 import { type SavedChartService } from '../../../services/SavedChartsService/SavedChartService';
 import { type SavedSqlService } from '../../../services/SavedSqlService/SavedSqlService';
 import { type SpacePermissionService } from '../../../services/SpaceService/SpacePermissionService';
+import { type ContentReviewNotificationService } from '../ContentReviewNotificationService/ContentReviewNotificationService';
 import { ContentReviewRequestService } from './ContentReviewRequestService';
 
 const ORG = 'org-uuid';
@@ -223,9 +224,15 @@ const buildService = () => {
         }),
     };
     const analytics = { track: vi.fn() };
+    const contentReviewNotificationService = {
+        notifySubmitted: vi.fn().mockResolvedValue(undefined),
+        notifyDecided: vi.fn().mockResolvedValue(undefined),
+    };
 
     const service = new ContentReviewRequestService({
         analytics: analytics as unknown as LightdashAnalytics,
+        contentReviewNotificationService:
+            contentReviewNotificationService as unknown as ContentReviewNotificationService,
         contentReviewRequestModel:
             contentReviewRequestModel as unknown as ContentReviewRequestModel,
         contentReviewSettingsModel:
@@ -259,6 +266,7 @@ const buildService = () => {
         savedChartService,
         spacePermissionService,
         analytics,
+        contentReviewNotificationService,
     };
 };
 

--- a/packages/backend/src/ee/services/ContentReviewRequestService/ContentReviewRequestService.ts
+++ b/packages/backend/src/ee/services/ContentReviewRequestService/ContentReviewRequestService.ts
@@ -3,12 +3,14 @@ import {
     assertUnreachable,
     ConflictError,
     ContentReviewContentType,
+    ContentReviewNotificationEvent,
     ContentReviewRequestStatus,
     ContentReviewRequestView,
     ContentType,
     DirectAccessPrincipalType,
     DirectAccessResourceType,
     ForbiddenError,
+    getErrorMessage,
     isDashboardChartTileType,
     isDashboardSqlChartTile,
     NotFoundError,
@@ -31,6 +33,7 @@ import {
 } from '@lightdash/common';
 import { type Knex } from 'knex';
 import { type LightdashAnalytics } from '../../../analytics/LightdashAnalytics';
+import Logger from '../../../logging/logger';
 import {
     type ContentReviewContentLocation,
     type ContentReviewRequestModel,
@@ -49,9 +52,11 @@ import { type DirectAccessFeatureGate } from '../../../services/DirectAccess/Dir
 import { type SavedChartService } from '../../../services/SavedChartsService/SavedChartService';
 import { type SavedSqlService } from '../../../services/SavedSqlService/SavedSqlService';
 import { type SpacePermissionService } from '../../../services/SpaceService/SpacePermissionService';
+import { type ContentReviewNotificationService } from '../ContentReviewNotificationService/ContentReviewNotificationService';
 
 type ContentReviewRequestServiceArguments = {
     analytics: LightdashAnalytics;
+    contentReviewNotificationService: ContentReviewNotificationService;
     contentReviewRequestModel: ContentReviewRequestModel;
     contentReviewSettingsModel: ContentReviewSettingsModel;
     contentVerificationModel: ContentVerificationModel;
@@ -95,6 +100,8 @@ const toDirectAccessResourceType = (
 export class ContentReviewRequestService extends BaseService {
     private readonly analytics: LightdashAnalytics;
 
+    private readonly contentReviewNotificationService: ContentReviewNotificationService;
+
     private readonly contentReviewRequestModel: ContentReviewRequestModel;
 
     private readonly contentReviewSettingsModel: ContentReviewSettingsModel;
@@ -124,6 +131,8 @@ export class ContentReviewRequestService extends BaseService {
     constructor(args: ContentReviewRequestServiceArguments) {
         super({ serviceName: 'ContentReviewRequestService' });
         this.analytics = args.analytics;
+        this.contentReviewNotificationService =
+            args.contentReviewNotificationService;
         this.contentReviewRequestModel = args.contentReviewRequestModel;
         this.contentReviewSettingsModel = args.contentReviewSettingsModel;
         this.contentVerificationModel = args.contentVerificationModel;
@@ -728,7 +737,26 @@ export class ContentReviewRequestService extends BaseService {
             },
         });
 
-        return this.toDetail(user, context, request, settings);
+        const detail = await this.toDetail(user, context, request, settings);
+        await this.notify(() =>
+            this.contentReviewNotificationService.notifySubmitted({
+                item: detail,
+                settings,
+                organizationUuid: context.organizationUuid,
+            }),
+        );
+        return detail;
+    }
+
+    // A failed notification must not fail the request itself
+    private async notify(send: () => Promise<void>): Promise<void> {
+        try {
+            await send();
+        } catch (error) {
+            Logger.error(
+                `Content review notification failed: ${getErrorMessage(error)}`,
+            );
+        }
     }
 
     async list(
@@ -980,12 +1008,21 @@ export class ContentReviewRequestService extends BaseService {
             },
         });
 
-        return this.toDetail(
+        const detail = await this.toDetail(
             user,
             context,
             { ...approved, grantedPrincipals: [] },
             settings,
         );
+        await this.notify(() =>
+            this.contentReviewNotificationService.notifyDecided({
+                item: detail,
+                event: ContentReviewNotificationEvent.APPROVED,
+                organizationUuid: context.organizationUuid,
+                actorUserUuid: user.userUuid,
+            }),
+        );
+        return detail;
     }
 
     async reject(
@@ -1036,12 +1073,21 @@ export class ContentReviewRequestService extends BaseService {
             },
         });
 
-        return this.toDetail(
+        const detail = await this.toDetail(
             user,
             context,
             { ...rejected, grantedPrincipals: [] },
             settings,
         );
+        await this.notify(() =>
+            this.contentReviewNotificationService.notifyDecided({
+                item: detail,
+                event: ContentReviewNotificationEvent.REJECTED,
+                organizationUuid: context.organizationUuid,
+                actorUserUuid: user.userUuid,
+            }),
+        );
+        return detail;
     }
 
     async cancel(

--- a/packages/backend/src/models/NotificationsModel/NotificationsModel.ts
+++ b/packages/backend/src/models/NotificationsModel/NotificationsModel.ts
@@ -6,6 +6,7 @@ import {
     DashboardTile,
     LightdashUser,
     NotificationAiReview,
+    NotificationContentReview,
     NotificationDashboardComment,
 } from '@lightdash/common';
 import { Knex } from 'knex';
@@ -83,6 +84,30 @@ export class NotificationsModel {
             createdAt: notif.created_at,
             resourceUuid: notif.resource_uuid ?? undefined,
             metadata: notif.metadata as NotificationAiReview['metadata'],
+        }));
+    }
+
+    async getContentReviewNotifications(
+        userUuid: string,
+    ): Promise<NotificationContentReview[]> {
+        const notifications = await this.database(NotificationsTableName)
+            .select()
+            .where(`${NotificationsTableName}.user_uuid`, userUuid)
+            .andWhere(
+                `${NotificationsTableName}.resource_type`,
+                DbNotificationResourceType.ContentReviewRequest,
+            )
+            .orderBy(`${NotificationsTableName}.created_at`, 'desc');
+
+        return notifications.map((notif) => ({
+            notificationId: notif.notification_id,
+            resourceType: ApiNotificationResourceType.ContentReview,
+            message: notif.message ?? undefined,
+            url: notif.url ?? undefined,
+            viewed: notif.viewed,
+            createdAt: notif.created_at,
+            resourceUuid: notif.resource_uuid ?? undefined,
+            metadata: notif.metadata as NotificationContentReview['metadata'],
         }));
     }
 
@@ -177,6 +202,32 @@ export class NotificationsModel {
                     user_uuid: userUuid,
                     resource_uuid: metadata.fingerprint,
                     resource_type: DbNotificationResourceType.AiReviewItem,
+                    message,
+                    url,
+                    metadata: JSON.stringify(metadata),
+                });
+            }),
+        );
+    }
+
+    async createContentReviewNotifications({
+        recipients,
+        metadata,
+        message,
+        url,
+    }: {
+        recipients: { userUuid: string }[];
+        metadata: NotificationContentReview['metadata'];
+        message: string;
+        url: string;
+    }): Promise<void> {
+        await Promise.all(
+            recipients.map(async ({ userUuid }) => {
+                await this.database(NotificationsTableName).insert({
+                    user_uuid: userUuid,
+                    resource_uuid: metadata.requestUuid,
+                    resource_type:
+                        DbNotificationResourceType.ContentReviewRequest,
                     message,
                     url,
                     metadata: JSON.stringify(metadata),

--- a/packages/backend/src/scheduler/SchedulerTaskTracer.ts
+++ b/packages/backend/src/scheduler/SchedulerTaskTracer.ts
@@ -216,6 +216,13 @@ const getTagsForTask: {
         'user.uuid': payload.userUuid ?? '',
     }),
 
+    [SCHEDULER_TASKS.SEND_CONTENT_REVIEW_NOTIFICATION]: (payload) => ({
+        'organization.uuid': payload.organizationUuid,
+        'project.uuid': payload.projectUuid,
+        'user.uuid': payload.userUuid,
+        'content_review_request.uuid': payload.requestUuid,
+    }),
+
     [SCHEDULER_TASKS.CREATE_REVIEW_LINEAR_ISSUE]: (payload) => ({
         'organization.uuid': payload.organizationUuid,
         'project.uuid': payload.projectUuid,

--- a/packages/backend/src/services/NotificationsService/NotificationsService.ts
+++ b/packages/backend/src/services/NotificationsService/NotificationsService.ts
@@ -32,6 +32,10 @@ export class NotificationsService extends BaseService {
                 return this.notificationsModel.getAiReviewNotifications(
                     userUuid,
                 );
+            case ApiNotificationResourceType.ContentReview:
+                return this.notificationsModel.getContentReviewNotifications(
+                    userUuid,
+                );
             default:
                 return assertUnreachable(
                     type,

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -182,6 +182,7 @@ interface ServiceManifest {
     aiAgentCoderService: unknown;
     projectHomepageService: unknown;
     contentReviewRequestService: unknown;
+    contentReviewNotificationService: unknown;
     aiAgentService: unknown;
     aiAgentToolsService: unknown;
     aiAgentAdminService: unknown;
@@ -1632,6 +1633,12 @@ export class ServiceRepository
         ContentReviewRequestServiceImplT,
     >(): ContentReviewRequestServiceImplT {
         return this.getService('contentReviewRequestService');
+    }
+
+    public getContentReviewNotificationService<
+        ContentReviewNotificationServiceImplT,
+    >(): ContentReviewNotificationServiceImplT {
+        return this.getService('contentReviewNotificationService');
     }
 
     public getHomepageRecommendedActionSkipsService<

--- a/packages/common/src/types/api/notifications.ts
+++ b/packages/common/src/types/api/notifications.ts
@@ -1,8 +1,13 @@
 import { type AiReviewNotificationEvent } from '../../ee/types/aiReviewNotification';
+import {
+    type ContentReviewContentType,
+    type ContentReviewNotificationEvent,
+} from '../contentReviewRequests';
 
 export enum ApiNotificationResourceType {
     DashboardComments = 'dashboardComments',
     AiReview = 'aiReview',
+    ContentReview = 'contentReview',
 }
 
 interface NotificationDashboardTileCommentMetadata {
@@ -39,7 +44,24 @@ export type NotificationAiReview = NotificationBase & {
     };
 };
 
-export type Notification = NotificationDashboardComment | NotificationAiReview;
+export type NotificationContentReview = NotificationBase & {
+    resourceType: ApiNotificationResourceType.ContentReview;
+    metadata: {
+        requestUuid: string;
+        projectUuid: string;
+        contentType: ContentReviewContentType;
+        contentUuid: string;
+        contentName: string;
+        targetSpaceName: string;
+        requesterName: string;
+        event: ContentReviewNotificationEvent;
+    };
+};
+
+export type Notification =
+    | NotificationDashboardComment
+    | NotificationAiReview
+    | NotificationContentReview;
 
 export type ApiNotificationUpdateParams = Pick<Notification, 'viewed'>;
 export type ApiNotificationsResults = Notification[];

--- a/packages/common/src/types/contentReviewRequests.ts
+++ b/packages/common/src/types/contentReviewRequests.ts
@@ -143,3 +143,17 @@ export type ApiContentReviewSettingsResponse = {
     status: 'ok';
     results: ContentReviewSettings;
 };
+
+export enum ContentReviewNotificationEvent {
+    SUBMITTED = 'submitted',
+    APPROVED = 'approved',
+    REJECTED = 'rejected',
+}
+
+export const getContentReviewRequestsPath = (projectUuid: string): string =>
+    `/projects/${projectUuid}/review-requests`;
+
+export const getContentReviewRequestPath = (
+    projectUuid: string,
+    requestUuid: string,
+): string => `${getContentReviewRequestsPath(projectUuid)}/${requestUuid}`;

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -3,6 +3,7 @@ import assertUnreachable from '../utils/assertUnreachable';
 import { type AnyType } from './any';
 import { type ApiSuccess } from './api/success';
 import { type ConditionalFormattingConfig } from './conditionalFormatting';
+import { type ContentReviewNotificationEvent } from './contentReviewRequests';
 import type { DownloadFileType } from './downloadFile';
 import { type Explore, type ExploreError } from './explore';
 import {
@@ -1023,6 +1024,16 @@ export type SendReviewNotificationPayload = {
     reviewRunUuid: string | null;
     schedulerUuid?: string;
     userUuid?: string;
+};
+
+export type SendContentReviewNotificationPayload = {
+    organizationUuid: string;
+    projectUuid: string;
+    requestUuid: string;
+    event: ContentReviewNotificationEvent;
+    recipientUserUuids: string[];
+    userUuid: string;
+    schedulerUuid?: string;
 };
 
 export type CreateReviewLinearIssuePayload = {

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -45,6 +45,7 @@ import {
     type ReplaceCustomFieldsPayload,
     type ScheduledDeliveryPayload,
     type SchedulerCreateProjectWithCompilePayload,
+    type SendContentReviewNotificationPayload,
     type SendReviewNotificationPayload,
     type SlackBatchNotificationPayload,
     type SlackNotificationPayload,
@@ -178,6 +179,7 @@ export const EE_SCHEDULER_TASKS = {
     AI_AGENT_REVIEW_REMEDIATION_COMPILE: 'aiAgentReviewRemediationCompile',
     AI_AGENT_REVIEW_REMEDIATION_RUN: 'aiAgentReviewRemediationRun',
     SEND_REVIEW_NOTIFICATION: 'sendReviewNotification',
+    SEND_CONTENT_REVIEW_NOTIFICATION: 'sendContentReviewNotification',
     CREATE_REVIEW_LINEAR_ISSUE: 'createReviewLinearIssue',
     EMBED_ARTIFACT_VERSION: 'embedArtifactVersion',
     GENERATE_ARTIFACT_QUESTION: 'generateArtifactQuestion',
@@ -302,6 +304,7 @@ export interface TaskPayloadMap {
     [SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_COMPILE]: AiAgentReviewRemediationCompileJobPayload;
     [SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_RUN]: AiAgentReviewRemediationRunJobPayload;
     [SCHEDULER_TASKS.SEND_REVIEW_NOTIFICATION]: SendReviewNotificationPayload;
+    [SCHEDULER_TASKS.SEND_CONTENT_REVIEW_NOTIFICATION]: SendContentReviewNotificationPayload;
     [SCHEDULER_TASKS.CREATE_REVIEW_LINEAR_ISSUE]: CreateReviewLinearIssuePayload;
     [SCHEDULER_TASKS.EMBED_ARTIFACT_VERSION]: EmbedArtifactVersionJobPayload;
     [SCHEDULER_TASKS.GENERATE_ARTIFACT_QUESTION]: GenerateArtifactQuestionJobPayload;
@@ -340,6 +343,7 @@ export interface EETaskPayloadMap {
     [EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_COMPILE]: AiAgentReviewRemediationCompileJobPayload;
     [EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_RUN]: AiAgentReviewRemediationRunJobPayload;
     [EE_SCHEDULER_TASKS.SEND_REVIEW_NOTIFICATION]: SendReviewNotificationPayload;
+    [EE_SCHEDULER_TASKS.SEND_CONTENT_REVIEW_NOTIFICATION]: SendContentReviewNotificationPayload;
     [EE_SCHEDULER_TASKS.CREATE_REVIEW_LINEAR_ISSUE]: CreateReviewLinearIssuePayload;
     [EE_SCHEDULER_TASKS.EMBED_ARTIFACT_VERSION]: EmbedArtifactVersionJobPayload;
     [EE_SCHEDULER_TASKS.GENERATE_ARTIFACT_QUESTION]: GenerateArtifactQuestionJobPayload;

--- a/packages/frontend/src/components/NavBar/NotificationsMenu/index.tsx
+++ b/packages/frontend/src/components/NavBar/NotificationsMenu/index.tsx
@@ -1,4 +1,5 @@
 import {
+    assertUnreachable,
     type Notification,
     NotificationResourceType,
     ValidationErrorType,
@@ -7,9 +8,11 @@ import { Button, getDefaultZIndex, Indicator, Menu } from '@mantine/core';
 import { IconBell } from '@tabler/icons-react';
 import { Fragment, type FC, useMemo } from 'react';
 import { useAiAgentOrgPermission } from '../../../ee/features/aiCopilot/hooks/useAiAgentPermission';
+import { useContentReviewAvailability } from '../../../ee/features/contentReview/hooks/useContentReviewAvailability';
 import { useDashboardCommentsCheck } from '../../../features/comments';
 import {
     AiReviewNotifications,
+    ContentReviewNotifications,
     DashboardCommentsNotifications,
     useGetNotifications,
 } from '../../../features/notifications';
@@ -56,17 +59,30 @@ export const NotificationsMenu: FC<{ projectUuid: string }> = ({
     );
     const hasAiReviewNotifications =
         aiReviewNotifications && aiReviewNotifications.length > 0;
+    const { isAvailable: canViewContentReviews } =
+        useContentReviewAvailability();
+    const { data: contentReviewNotifications } = useGetNotifications(
+        NotificationResourceType.ContentReview,
+        canViewContentReviews,
+    );
+    const hasContentReviewNotifications =
+        contentReviewNotifications && contentReviewNotifications.length > 0;
     const notifications = useMemo<Notification[]>(
         () =>
             [
                 ...(dashboardCommentsNotifications ?? []),
                 ...(aiReviewNotifications ?? []),
+                ...(contentReviewNotifications ?? []),
             ].sort(
                 (a, b) =>
                     new Date(b.createdAt).getTime() -
                     new Date(a.createdAt).getTime(),
             ),
-        [aiReviewNotifications, dashboardCommentsNotifications],
+        [
+            aiReviewNotifications,
+            contentReviewNotifications,
+            dashboardCommentsNotifications,
+        ],
     );
 
     const showNotificationBadge = () => {
@@ -93,13 +109,46 @@ export const NotificationsMenu: FC<{ projectUuid: string }> = ({
             if (hasUnreadAiReviews) return true;
         }
 
+        if (canViewContentReviews) {
+            const hasUnreadContentReviews = contentReviewNotifications?.some(
+                (n) => !n.viewed,
+            );
+            if (hasUnreadContentReviews) return true;
+        }
+
         return false;
+    };
+
+    const renderNotification = (notification: Notification) => {
+        switch (notification.resourceType) {
+            case NotificationResourceType.DashboardComments:
+                return (
+                    <DashboardCommentsNotifications
+                        notifications={[notification]}
+                        projectUuid={projectUuid}
+                    />
+                );
+            case NotificationResourceType.AiReview:
+                return <AiReviewNotifications notifications={[notification]} />;
+            case NotificationResourceType.ContentReview:
+                return (
+                    <ContentReviewNotifications
+                        notifications={[notification]}
+                    />
+                );
+            default:
+                return assertUnreachable(
+                    notification,
+                    'Unknown notification type',
+                );
+        }
     };
 
     const shouldDisplayMenu =
         canViewDashboardComments ||
         canUserManageValidations ||
-        canViewAiReviews;
+        canViewAiReviews ||
+        canViewContentReviews;
 
     return shouldDisplayMenu ? (
         <Menu
@@ -140,24 +189,15 @@ export const NotificationsMenu: FC<{ projectUuid: string }> = ({
                     <>
                         {notifications.map((notification) => (
                             <Fragment key={notification.notificationId}>
-                                {notification.resourceType ===
-                                NotificationResourceType.DashboardComments ? (
-                                    <DashboardCommentsNotifications
-                                        notifications={[notification]}
-                                        projectUuid={projectUuid}
-                                    />
-                                ) : (
-                                    <AiReviewNotifications
-                                        notifications={[notification]}
-                                    />
-                                )}
+                                {renderNotification(notification)}
                             </Fragment>
                         ))}
                     </>
                 )}
                 {!hasValidationNotifications &&
                     !hasDashboardCommentsNotifications &&
-                    !hasAiReviewNotifications && (
+                    !hasAiReviewNotifications &&
+                    !hasContentReviewNotifications && (
                         <Menu.Item fz="sm">No notifications</Menu.Item>
                     )}
             </Menu.Dropdown>

--- a/packages/frontend/src/ee/features/contentReview/hooks/useContentReviewAvailability.ts
+++ b/packages/frontend/src/ee/features/contentReview/hooks/useContentReviewAvailability.ts
@@ -2,25 +2,15 @@ import { CommercialFeatureFlags } from '@lightdash/common';
 import { useServerFeatureFlag } from '../../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../../providers/App/useApp';
 
-// Mirrors the backend gate: the review flag, direct access, and a valid
-// license
+// Mirrors the backend gate: direct access and a valid license
 export const useContentReviewAvailability = () => {
     const { health } = useApp();
-    const reviewFlag = useServerFeatureFlag(
-        CommercialFeatureFlags.ContentReviewRequests,
-    );
     const directAccessFlag = useServerFeatureFlag(
         CommercialFeatureFlags.DirectAccess,
     );
     const licenseValid = health.data?.license?.valid ?? false;
     return {
-        isAvailable:
-            (reviewFlag.data?.enabled ?? false) &&
-            (directAccessFlag.data?.enabled ?? false) &&
-            licenseValid,
-        isLoading:
-            reviewFlag.isInitialLoading ||
-            directAccessFlag.isInitialLoading ||
-            health.isInitialLoading,
+        isAvailable: (directAccessFlag.data?.enabled ?? false) && licenseValid,
+        isLoading: directAccessFlag.isInitialLoading || health.isInitialLoading,
     };
 };

--- a/packages/frontend/src/ee/features/contentReview/hooks/useContentReviewAvailability.ts
+++ b/packages/frontend/src/ee/features/contentReview/hooks/useContentReviewAvailability.ts
@@ -1,0 +1,26 @@
+import { CommercialFeatureFlags } from '@lightdash/common';
+import { useServerFeatureFlag } from '../../../../hooks/useServerOrClientFeatureFlag';
+import useApp from '../../../../providers/App/useApp';
+
+// Mirrors the backend gate: the review flag, direct access, and a valid
+// license
+export const useContentReviewAvailability = () => {
+    const { health } = useApp();
+    const reviewFlag = useServerFeatureFlag(
+        CommercialFeatureFlags.ContentReviewRequests,
+    );
+    const directAccessFlag = useServerFeatureFlag(
+        CommercialFeatureFlags.DirectAccess,
+    );
+    const licenseValid = health.data?.license?.valid ?? false;
+    return {
+        isAvailable:
+            (reviewFlag.data?.enabled ?? false) &&
+            (directAccessFlag.data?.enabled ?? false) &&
+            licenseValid,
+        isLoading:
+            reviewFlag.isInitialLoading ||
+            directAccessFlag.isInitialLoading ||
+            health.isInitialLoading,
+    };
+};

--- a/packages/frontend/src/features/notifications/components/ContentReviewNotifications.tsx
+++ b/packages/frontend/src/features/notifications/components/ContentReviewNotifications.tsx
@@ -1,0 +1,102 @@
+import { type NotificationContentReview } from '@lightdash/common';
+import { Group, Menu, Text, Tooltip, useMantineTheme } from '@mantine/core';
+import { IconCircleFilled } from '@tabler/icons-react';
+import dayjs from 'dayjs';
+import { useCallback, type FC } from 'react';
+import { useNavigate } from 'react-router';
+import MantineIcon from '../../../components/common/MantineIcon';
+import { useTimeAgo } from '../../../hooks/useTimeAgo';
+import useTracking from '../../../providers/Tracking/useTracking';
+import { EventName } from '../../../types/Events';
+import { useUpdateNotification } from '../hooks/useNotifications';
+import classes from './DashboardCommentsNotifications.module.css';
+
+type Props = {
+    notifications: NotificationContentReview[];
+};
+
+const NotificationTime: FC<{ createdAt: Date }> = ({ createdAt }) => {
+    const date = useTimeAgo(createdAt);
+    return (
+        <Tooltip
+            position="top-end"
+            offset={-2}
+            label={
+                <Text fz="xs">
+                    {dayjs(createdAt).format('YYYY-MM-DD HH:mm:ss')}
+                </Text>
+            }
+        >
+            <Text
+                fz="sm"
+                ta="right"
+                mb="one"
+                fw={500}
+                className={classes.notificationTime}
+            >
+                {date}
+            </Text>
+        </Tooltip>
+    );
+};
+
+export const ContentReviewNotifications: FC<Props> = ({ notifications }) => {
+    const { track } = useTracking();
+    const theme = useMantineTheme();
+    const navigate = useNavigate();
+    const { mutateAsync: updateNotification } = useUpdateNotification();
+
+    const handleOnNotificationClick = useCallback(
+        async (notification: NotificationContentReview) => {
+            await updateNotification({
+                notificationId: notification.notificationId,
+                resourceType: notification.resourceType,
+                toUpdate: { viewed: true },
+            });
+
+            track({
+                name: EventName.NOTIFICATIONS_ITEM_CLICKED,
+                properties: {
+                    resourceType: notification.resourceType,
+                    event: notification.metadata.event,
+                    projectUuid: notification.metadata.projectUuid,
+                    requestUuid: notification.metadata.requestUuid,
+                },
+            });
+
+            if (notification.url) {
+                void navigate(notification.url);
+            }
+        },
+        [navigate, track, updateNotification],
+    );
+
+    return (
+        <>
+            {notifications.map((notification) => (
+                <Menu.Item
+                    p="xs"
+                    key={notification.notificationId}
+                    onClick={() => handleOnNotificationClick(notification)}
+                    fz="sm"
+                >
+                    <NotificationTime createdAt={notification.createdAt} />
+                    <Group gap={6} wrap="nowrap" align="center">
+                        <MantineIcon
+                            size={8}
+                            icon={IconCircleFilled}
+                            style={{
+                                color: notification.viewed
+                                    ? 'transparent'
+                                    : theme.colors.teal[5],
+                            }}
+                        />
+                        <Text fz="sm" className={classes.notificationMessage}>
+                            {notification.message}
+                        </Text>
+                    </Group>
+                </Menu.Item>
+            ))}
+        </>
+    );
+};

--- a/packages/frontend/src/features/notifications/index.ts
+++ b/packages/frontend/src/features/notifications/index.ts
@@ -1,3 +1,4 @@
 export * from './components/AiReviewNotifications';
+export * from './components/ContentReviewNotifications';
 export * from './components/DashboardCommentsNotifications';
 export { useGetNotifications } from './hooks/useNotifications';


### PR DESCRIPTION
## Summary

Third PR of the content review requests stack, on top of #28427. Reviewers and requesters are told about requests where they already look: the in-app bell, email, and Slack. One customer said plainly that they would never watch a queue, so the Slack ping is the primary channel and the queue is the fallback.

### What happens

- **Submitted**: recipients are the reviewer group when one is configured, otherwise the target space's editors and admins (never the requester). Each gets an in-app notification and an email; the request is posted to the project's Slack channel from review settings, falling back to the org notification channel.
- **Approved / rejected**: the requester gets an in-app notification, an email, and a Slack DM when they have a linked Slack identity. The reviewer's note is included.

### How

- `ContentReviewNotificationService` (EE) resolves recipients, writes the in-app rows through `NotificationsModel.createContentReviewNotifications`, and schedules `SEND_CONTENT_REVIEW_NOTIFICATION`. `ContentReviewRequestService` calls it after submit, approve and reject; a notification failure is logged and never fails the request.
- `sendContentReviewNotification` scheduler task (modelled on the AI review notification task) sends the email via the generic notification template, posts the Slack channel message or DM with a button to the request, and tracks `content_review_notification.sent` / `.errored` per channel. Slack and email failures are isolated from each other.
- New notification resource type `contentReview` through the entity, `NotificationsModel`, `NotificationsService`, and the frontend `NotificationsMenu` (`ContentReviewNotifications` renderer, shown when the review flag, direct access, and a valid license are all present).
- Path helpers `getContentReviewRequestsPath` / `getContentReviewRequestPath` in common define the queue and detail URLs the UI PRs will register.

## Regression analysis

- Existing notification types are untouched; the model and service gain a new case only. The frontend menu now dispatches on resource type with `assertUnreachable`, which is behaviour-preserving for the two existing types.
- The scheduler task is new and only enqueued by the new service. The tracer map gains an entry for it.
- The EE worker gains three constructor dependencies (request model, settings model, user model) that already exist in the model repository.
- No migration: the `notifications` table is generic and the new type is a string value.

## Testing

- `ContentReviewNotificationService.test.ts` (4 cases): editor/admin routing excluding the requester, reviewer group routing, decision to requester with verified copy, message variants.
- `sendContentReviewNotification.test.ts` (5 cases): email plus channel post on submit, project channel precedence over org channel, DM on decision, Slack failure isolated from email and tracked, missing request is a no-op.
- `ContentReviewRequestService.test.ts` updated for the injected service (19 cases still green).
- `pnpm -F backend typecheck`, `pnpm -F frontend typecheck`, backend/common/frontend lint, `pnpm generate-api`.

Relates: PROD-9730
Relates: #26967

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7bgpm3JZGoF2bRviShXWP

## SQL runner charts

Email and Slack copy resolve SQL chart locations through the new lookup, with an exhaustive switch over the review content type.

## Gate

`useContentReviewAvailability` is the direct-access flag plus a valid license.