### PR TITLE
feat: template gallery behind a From Template picker card

### DIFF
--- a/packages/frontend/src/features/apps/AppTemplatePicker.tsx
+++ b/packages/frontend/src/features/apps/AppTemplatePicker.tsx
@@ -1,10 +1,12 @@
 import { FeatureFlags, type DataAppTemplate } from '@lightdash/common';
 import { Stack, Text, ThemeIcon } from '@mantine/core';
-import { type CSSProperties, type FC } from 'react';
+import { IconTemplate, type Icon as TablerIcon } from '@tabler/icons-react';
+import { useState, type CSSProperties, type FC } from 'react';
 import { PolymorphicPaperButton } from '../../components/common/PolymorphicPaperButton';
 import { useServerFeatureFlag } from '../../hooks/useServerOrClientFeatureFlag';
 import classes from './AppTemplatePicker.module.css';
-import { getPickerTemplates } from './templates';
+import TemplateGalleryModal from './TemplateGalleryModal';
+import { getGalleryTemplates, getPickerTemplates } from './templates';
 
 type Props = {
     selected: DataAppTemplate | null;
@@ -13,11 +15,11 @@ type Props = {
 
 // Fan geometry, derived from the card count. The fan keeps a FIXED footprint
 // (the original hand-tuned four-card arch: outermost centres at ±249px,
-// ±12° rotation, y rising 4px → 32px) and packs cards denser as the count
-// grows, so more templates never overflow the panel. The vertical arch is
-// quadratic so an odd count's centre card sits smoothly at the top of the
-// curve. For four cards this reproduces the previously hardcoded values
-// exactly (x ±83/±249, y 4/32, rot ±4°/±12°).
+// ±12° rotation) and packs cards denser as the count grows, so more templates
+// never overflow the panel. The vertical arch is quadratic so an odd count's
+// centre card sits smoothly at the top of the curve. For four cards this
+// reproduces the previously hardcoded values exactly (x ±83/±249, y 4/32,
+// rot ±4°/±12°).
 const FAN_X_MAX = 249;
 const FAN_ROT_MAX = 12;
 const FAN_Y_MIN = 0.5; // y at the fan's centre (unit = 0)
@@ -34,70 +36,129 @@ const fanStyle = (index: number, count: number): CSSProperties => {
     } as CSSProperties;
 };
 
+type FanCardContent = {
+    key: string;
+    title: string;
+    description: string;
+    icon: TablerIcon;
+    pressed: boolean;
+    onClick: () => void;
+};
+
+const FanCard: FC<{ card: FanCardContent; index: number; count: number }> = ({
+    card,
+    index,
+    count,
+}) => {
+    const Icon = card.icon;
+    return (
+        <PolymorphicPaperButton
+            component="button"
+            type="button"
+            radius="md"
+            className={`${classes.card} ${card.pressed ? classes.cardSelected : ''}`}
+            data-pos={index}
+            style={fanStyle(index, count)}
+            aria-pressed={card.pressed}
+            data-selected={card.pressed ? 'true' : undefined}
+            onClick={card.onClick}
+        >
+            <Stack gap="xs" align="flex-start">
+                <ThemeIcon
+                    size="lg"
+                    radius="md"
+                    variant="light"
+                    color="gray"
+                    className={classes.cardIcon}
+                >
+                    <Icon size={20} />
+                </ThemeIcon>
+                <Stack gap={4} className={classes.cardContent}>
+                    <Text fw={600} size="sm" className={classes.cardTitle}>
+                        {card.title}
+                    </Text>
+                    <Text size="xs" c="dimmed" lineClamp={3}>
+                        {card.description}
+                    </Text>
+                </Stack>
+            </Stack>
+        </PolymorphicPaperButton>
+    );
+};
+
 const AppTemplatePicker: FC<Props> = ({ selected, onSelectedChange }) => {
     const templatesFlag = useServerFeatureFlag(
         FeatureFlags.EnableDataAppTemplates,
     );
+    const [galleryOpen, setGalleryOpen] = useState(false);
     if (templatesFlag.isLoading) {
         // Hold the fan until the flag is known: painting the ungated cards
         // and then re-fanning when the flag resolves reads as the last card
-        // popping in late. The empty fan keeps the layout height reserved.
+        // popping in late. The empty fan keeps the layout height reserved,
+        // and AppGenerate gates its first paint on this same query, so in
+        // practice the cache is settled before we mount.
         return <div className={classes.fan} />;
     }
-    const pickerTemplates = getPickerTemplates(
-        new Set(
-            templatesFlag.data?.enabled
-                ? [FeatureFlags.EnableDataAppTemplates]
-                : [],
-        ),
+    const enabledFlags = new Set(
+        templatesFlag.data?.enabled
+            ? [FeatureFlags.EnableDataAppTemplates]
+            : [],
     );
+    const pickerTemplates = getPickerTemplates(enabledFlags);
+    const galleryTemplates = getGalleryTemplates(enabledFlags);
+    const selectedGalleryTemplate =
+        galleryTemplates.find((t) => t.id === selected) ?? null;
+
+    const cards: FanCardContent[] = pickerTemplates.map((template) => ({
+        key: template.id,
+        title: template.title,
+        description: template.description,
+        icon: template.icon,
+        pressed: selected === template.id,
+        onClick: () =>
+            onSelectedChange(selected === template.id ? null : template.id),
+    }));
+    if (galleryTemplates.length > 0) {
+        // The gallery's entry point rides the fan as a synthetic card: it
+        // never selects itself, it opens the gallery, and it reflects the
+        // gallery selection (pressed state + the chosen template's name).
+        cards.push({
+            key: 'from-template',
+            title: 'From Template',
+            description: selectedGalleryTemplate
+                ? selectedGalleryTemplate.title
+                : 'Start from a ready-made app in the template gallery.',
+            icon: IconTemplate,
+            pressed: selectedGalleryTemplate !== null,
+            onClick: () => setGalleryOpen(true),
+        });
+    }
+
     return (
-        <div className={classes.fan}>
-            {pickerTemplates.map((template, index) => {
-                const Icon = template.icon;
-                const isSelected = selected === template.id;
-                return (
-                    <PolymorphicPaperButton
-                        key={template.id}
-                        component="button"
-                        type="button"
-                        radius="md"
-                        className={`${classes.card} ${isSelected ? classes.cardSelected : ''}`}
-                        data-pos={index}
-                        style={fanStyle(index, pickerTemplates.length)}
-                        aria-pressed={isSelected}
-                        data-selected={isSelected ? 'true' : undefined}
-                        onClick={() =>
-                            onSelectedChange(isSelected ? null : template.id)
-                        }
-                    >
-                        <Stack gap="xs" align="flex-start">
-                            <ThemeIcon
-                                size="lg"
-                                radius="md"
-                                variant="light"
-                                color="gray"
-                                className={classes.cardIcon}
-                            >
-                                <Icon size={20} />
-                            </ThemeIcon>
-                            <Stack gap={4} className={classes.cardContent}>
-                                <Text
-                                    fw={600}
-                                    size="sm"
-                                    className={classes.cardTitle}
-                                >
-                                    {template.title}
-                                </Text>
-                                <Text size="xs" c="dimmed" lineClamp={3}>
-                                    {template.description}
-                                </Text>
-                            </Stack>
-                        </Stack>
-                    </PolymorphicPaperButton>
-                );
-            })}
-        </div>
+        <>
+            <div className={classes.fan}>
+                {cards.map((card, index) => (
+                    <FanCard
+                        key={card.key}
+                        card={card}
+                        index={index}
+                        count={cards.length}
+                    />
+                ))}
+            </div>
+            <TemplateGalleryModal
+                opened={galleryOpen}
+                onClose={() => setGalleryOpen(false)}
+                templates={galleryTemplates}
+                selected={selectedGalleryTemplate?.id ?? null}
+                onSelect={(templateId) => {
+                    onSelectedChange(
+                        selected === templateId ? null : templateId,
+                    );
+                    setGalleryOpen(false);
+                }}
+            />
+        </>
     );
 };
 

--- a/packages/frontend/src/features/apps/TemplateGalleryModal.tsx
+++ b/packages/frontend/src/features/apps/TemplateGalleryModal.tsx
@@ -1,0 +1,92 @@
+import { type DataAppTemplate } from '@lightdash/common';
+import {
+    Badge,
+    Modal,
+    Paper,
+    SimpleGrid,
+    Stack,
+    Text,
+    ThemeIcon,
+} from '@mantine/core';
+import { type FC } from 'react';
+import { type TemplateDefinition } from './templates';
+
+type Props = {
+    opened: boolean;
+    onClose: () => void;
+    templates: TemplateDefinition[];
+    selected: DataAppTemplate | null;
+    onSelect: (templateId: DataAppTemplate) => void;
+};
+
+/**
+ * The gallery behind the picker's "From Template" card: every registry
+ * template surfaced with `inGallery`, in a grid that scales as the set grows.
+ * Selecting a card hands the template id back to the picker's selection.
+ */
+const TemplateGalleryModal: FC<Props> = ({
+    opened,
+    onClose,
+    templates,
+    selected,
+    onSelect,
+}) => (
+    <Modal
+        opened={opened}
+        onClose={onClose}
+        title="Template gallery"
+        size="xl"
+        centered
+    >
+        <SimpleGrid cols={{ base: 1, sm: 2, md: 3 }} spacing="md">
+            {templates.map((template) => {
+                const Icon = template.icon;
+                const isSelected = selected === template.id;
+                return (
+                    <Paper
+                        key={template.id}
+                        component="button"
+                        type="button"
+                        withBorder
+                        radius="md"
+                        p="md"
+                        aria-pressed={isSelected}
+                        onClick={() => onSelect(template.id)}
+                        style={{
+                            cursor: 'pointer',
+                            textAlign: 'left',
+                            font: 'inherit',
+                            boxShadow: isSelected
+                                ? '0 0 0 2px var(--mantine-primary-color-filled)'
+                                : undefined,
+                        }}
+                    >
+                        <Stack gap="xs" align="flex-start">
+                            <ThemeIcon
+                                size="lg"
+                                radius="md"
+                                variant="light"
+                                color="gray"
+                            >
+                                <Icon size={20} />
+                            </ThemeIcon>
+                            <Stack gap={4}>
+                                <Text fw={600} size="sm">
+                                    {template.title}
+                                </Text>
+                                <Badge size="xs" variant="light" color="gray">
+                                    {template.category}
+                                </Badge>
+                                <Text size="xs" c="dimmed" lineClamp={3}>
+                                    {template.description}
+                                </Text>
+                            </Stack>
+                        </Stack>
+                    </Paper>
+                );
+            })}
+        </SimpleGrid>
+    </Modal>
+);
+
+export default TemplateGalleryModal;


### PR DESCRIPTION
## Summary

Top of the template stack (#28422 registry → #28420 forecaster → this). The builder fan keeps its four built-ins plus one flag-gated **From Template** card; gallery-surfaced registry templates (`inGallery`) live in a modal grid behind it that scales as the set grows.

- Picking a gallery template drives the same selection state as a fan card; the From Template card reflects the choice (pressed state + chosen template's name).
- `enable-data-app-templates` off: four built-ins, no gallery, unchanged.
- Linear: CS-193.

## Test plan

- getPickerTemplates/getGalleryTemplates gating unit tests (in #28420)
- Recorded click-through on docker-dev: fan renders 5 cards, From Template opens the gallery, picking Forecaster selects and closes
- Frontend typecheck ✓

## Evidence

Screenshots, the verification transcript and the review order for the whole stack: [Templated Data Apps Review](https://claude.ai/code/artifact/c906e241-f1aa-4dd3-8eea-858b0df20451#pr-28433) (section for this PR). Restacked onto main 2.82.2 on 2026-09-02; affected suites green after the restack (frontend 567, common 926, backend 379) and the end-to-end gallery flow passes 11/11 in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VU9L8WJ97vLUB4WJmaUKDa
