### PR TITLE
feat(review-requests): reviewer UI and settings

### DIFF
--- a/packages/frontend/src/Routes.tsx
+++ b/packages/frontend/src/Routes.tsx
@@ -628,6 +628,40 @@ const PROJECT_LAYOUT_ROUTES: RouteObject[] = [
         },
     },
     {
+        path: 'review-requests',
+        lazy: async () => {
+            const ContentReviewRequestsPage = await loadLazyRouteDefault(
+                './ee/features/contentReview/pages/ContentReviewRequestsPage',
+                () =>
+                    import('./ee/features/contentReview/pages/ContentReviewRequestsPage'),
+            );
+            return {
+                Component: () => (
+                    <TrackPage name={PageName.CONTENT_REVIEW_REQUESTS}>
+                        <ContentReviewRequestsPage />
+                    </TrackPage>
+                ),
+            };
+        },
+    },
+    {
+        path: 'review-requests/:requestUuid',
+        lazy: async () => {
+            const ContentReviewRequestPage = await loadLazyRouteDefault(
+                './ee/features/contentReview/pages/ContentReviewRequestPage',
+                () =>
+                    import('./ee/features/contentReview/pages/ContentReviewRequestPage'),
+            );
+            return {
+                Component: () => (
+                    <TrackPage name={PageName.CONTENT_REVIEW_REQUEST}>
+                        <ContentReviewRequestPage />
+                    </TrackPage>
+                ),
+            };
+        },
+    },
+    {
         path: 'autopilot',
         lazy: async () => {
             const ManagedAgentActivityPage = await loadLazyRouteDefault(

--- a/packages/frontend/src/components/NavBar/BrowseMenu.tsx
+++ b/packages/frontend/src/components/NavBar/BrowseMenu.tsx
@@ -30,6 +30,7 @@ import {
 } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
 import { Link } from 'react-router';
+import { ReviewRequestsMenuItem } from '../../ee/features/contentReview';
 import { useHasMetricsInCatalog } from '../../features/metricsCatalog/hooks/useMetricsCatalog';
 import { useFavorites } from '../../hooks/favorites/useFavorites';
 import { useOptionalProjectRoute } from '../../hooks/useProjectRoute';
@@ -191,6 +192,8 @@ const BrowseMenu: FC<Props> = ({ projectUuid }) => {
                 {!hasMetrics && (
                     <MetricsLink projectUuid={projectUuid} asMenu />
                 )}
+
+                <ReviewRequestsMenuItem projectUuid={projectUuid} />
 
                 {hasFavorites ? (
                     <>

--- a/packages/frontend/src/components/Settings/ProjectSettings.tsx
+++ b/packages/frontend/src/components/Settings/ProjectSettings.tsx
@@ -15,6 +15,8 @@ import {
     type RouteObject,
 } from 'react-router';
 import { useAiOrganizationSettings } from '../../ee/features/aiCopilot/hooks/useAiOrganizationSettings';
+import { ContentReviewSettingsPanel } from '../../ee/features/contentReview';
+import { useContentReviewAvailability } from '../../ee/features/contentReview/hooks/useContentReviewAvailability';
 import SettingsEmbed from '../../ee/features/embed/SettingsEmbed';
 import ContentReviewPage from '../../features/contentAsCode/components/ContentReviewPage';
 import { ExternalSourcesSettingsPanel } from '../../features/externalSources/components/ExternalSourcesSettingsPanel';
@@ -121,6 +123,19 @@ const ProjectSettings: FC<{ externalSourcesEnabled: boolean }> = ({
         (user.data?.ability.can(
             'manage',
             subject('ExternalSource', {
+                organizationUuid: project.organizationUuid,
+                projectUuid: project.projectUuid,
+            }),
+        ) ??
+            false);
+
+    const contentReviewAvailability = useContentReviewAvailability();
+    const canViewContentReviewSettings =
+        contentReviewAvailability.isAvailable &&
+        !!project &&
+        (user.data?.ability.can(
+            'manage',
+            subject('Project', {
                 organizationUuid: project.organizationUuid,
                 projectUuid: project.projectUuid,
             }),
@@ -236,6 +251,23 @@ const ProjectSettings: FC<{ externalSourcesEnabled: boolean }> = ({
                     </ProjectSettingsPage>
                 ),
             },
+            ...(canViewContentReviewSettings
+                ? [
+                      {
+                          path: `/reviewRequests`,
+                          element: (
+                              <ProjectSettingsPage
+                                  title="Review requests"
+                                  description="Who reviews content submitted from personal spaces, and what happens on approval."
+                              >
+                                  <ContentReviewSettingsPanel
+                                      projectUuid={projectUuid}
+                                  />
+                              </ProjectSettingsPage>
+                          ),
+                      },
+                  ]
+                : []),
             {
                 path: `/dataOps`,
                 element: (
@@ -505,6 +537,7 @@ const ProjectSettings: FC<{ externalSourcesEnabled: boolean }> = ({
         user.data?.ability,
         canManageExternalConnections,
         canManageExternalSources,
+        canViewContentReviewSettings,
         isAiCopilotEnabledOrTrial,
     ]);
     const routesElements = useRoutes(routes);

--- a/packages/frontend/src/components/Settings/ProjectSettings.tsx
+++ b/packages/frontend/src/components/Settings/ProjectSettings.tsx
@@ -562,13 +562,20 @@ const ProjectSettings: FC<{ externalSourcesEnabled: boolean }> = ({
             '/generalSettings/projectManagement/:projectUuid/caching',
             location.pathname,
         );
+    const isAwaitingReviewRequestsRoute =
+        contentReviewAvailability.isLoading &&
+        !!matchPath(
+            '/generalSettings/projectManagement/:projectUuid/reviewRequests',
+            location.pathname,
+        );
 
     if (
         isInitialLoading ||
         !project ||
         !projectUuid ||
         isAwaitingDataAppConnectionsRoute ||
-        isAwaitingCachingRoute
+        isAwaitingCachingRoute ||
+        isAwaitingReviewRequestsRoute
     ) {
         return (
             <div style={{ marginTop: '20px' }}>

--- a/packages/frontend/src/ee/features/contentReview/api.ts
+++ b/packages/frontend/src/ee/features/contentReview/api.ts
@@ -1,8 +1,15 @@
 import {
+    type ApiContentReviewRequestListResponse,
     type ApiContentReviewRequestOrNullResponse,
     type ApiContentReviewRequestResponse,
+    type ApiContentReviewSettingsResponse,
+    type ApproveContentReviewRequestBody,
     type ContentReviewContentType,
+    type ContentReviewRequestStatus,
+    type ContentReviewRequestView,
     type CreateContentReviewRequestBody,
+    type RejectContentReviewRequestBody,
+    type UpdateContentReviewSettings,
 } from '@lightdash/common';
 import { lightdashApi } from '../../../api';
 
@@ -40,4 +47,75 @@ export const cancelContentReviewRequest = (
         url: `${contentReviewBasePath(projectUuid)}/${requestUuid}/cancel`,
         method: 'POST',
         body: undefined,
+    });
+
+export const listContentReviewRequests = (
+    projectUuid: string,
+    params: {
+        view: ContentReviewRequestView;
+        status: ContentReviewRequestStatus | null;
+        page: number;
+        pageSize: number;
+    },
+) => {
+    const search = new URLSearchParams({
+        view: params.view,
+        page: String(params.page),
+        pageSize: String(params.pageSize),
+    });
+    if (params.status !== null) search.set('status', params.status);
+    return lightdashApi<ApiContentReviewRequestListResponse['results']>({
+        url: `${contentReviewBasePath(projectUuid)}?${search.toString()}`,
+        method: 'GET',
+        body: undefined,
+    });
+};
+
+export const getContentReviewRequest = (
+    projectUuid: string,
+    requestUuid: string,
+) =>
+    lightdashApi<ApiContentReviewRequestResponse['results']>({
+        url: `${contentReviewBasePath(projectUuid)}/${requestUuid}`,
+        method: 'GET',
+        body: undefined,
+    });
+
+export const approveContentReviewRequest = (
+    projectUuid: string,
+    requestUuid: string,
+    body: ApproveContentReviewRequestBody,
+) =>
+    lightdashApi<ApiContentReviewRequestResponse['results']>({
+        url: `${contentReviewBasePath(projectUuid)}/${requestUuid}/approve`,
+        method: 'POST',
+        body: JSON.stringify(body),
+    });
+
+export const rejectContentReviewRequest = (
+    projectUuid: string,
+    requestUuid: string,
+    body: RejectContentReviewRequestBody,
+) =>
+    lightdashApi<ApiContentReviewRequestResponse['results']>({
+        url: `${contentReviewBasePath(projectUuid)}/${requestUuid}/reject`,
+        method: 'POST',
+        body: JSON.stringify(body),
+    });
+
+export const getContentReviewSettings = (projectUuid: string) =>
+    lightdashApi<ApiContentReviewSettingsResponse['results']>({
+        url: `${contentReviewBasePath(projectUuid)}/settings`,
+        method: 'GET',
+        body: undefined,
+    });
+
+export const updateContentReviewSettings = (
+    projectUuid: string,
+    body: UpdateContentReviewSettings,
+) =>
+    lightdashApi<ApiContentReviewSettingsResponse['results']>({
+        url: `${contentReviewBasePath(projectUuid)}/settings`,
+        method: 'PATCH',
+        body: JSON.stringify(body),
     });

--- a/packages/frontend/src/ee/features/contentReview/components/ContentReviewItemRow.module.css
+++ b/packages/frontend/src/ee/features/contentReview/components/ContentReviewItemRow.module.css
@@ -1,0 +1,40 @@
+.row {
+    padding: var(--mantine-spacing-xs) var(--mantine-spacing-sm);
+    border-radius: var(--mantine-radius-md);
+}
+
+.compact {
+    padding: 6px var(--mantine-spacing-sm);
+}
+
+.text {
+    flex: 1;
+    min-width: 0;
+}
+
+.link {
+    display: block;
+}
+
+.link:hover .row {
+    background-color: var(--mantine-color-default-hover);
+}
+
+.linkIcon {
+    opacity: 0;
+    transition: opacity 120ms ease;
+}
+
+.link:hover .linkIcon {
+    opacity: 1;
+}
+
+.name {
+    flex: 0 1 auto;
+    min-width: 0;
+}
+
+.meta {
+    flex: 0 0 auto;
+    white-space: nowrap;
+}

--- a/packages/frontend/src/ee/features/contentReview/components/ContentReviewItemRow.tsx
+++ b/packages/frontend/src/ee/features/contentReview/components/ContentReviewItemRow.tsx
@@ -1,0 +1,116 @@
+import { type ContentReviewContentType } from '@lightdash/common';
+import { Anchor, Badge, Group, Stack, Text } from '@mantine/core';
+import { IconCircleCheckFilled, IconExternalLink } from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineIcon from '../../../../components/common/MantineIcon';
+import { IconBox } from '../../../../components/common/ResourceIcon';
+import {
+    getContentTypeColor,
+    getContentTypeIcon,
+    getContentTypeLabel,
+} from '../utils';
+import classes from './ContentReviewItemRow.module.css';
+
+type Props = {
+    contentType: ContentReviewContentType;
+    name: string;
+    meta?: string;
+    href?: string;
+    isVerified?: boolean;
+    compact?: boolean;
+};
+
+// One chart or dashboard, as a row in a list. Links open in a new tab so the
+// modal or request page underneath stays put. Compact rows fit inside modals.
+const ContentReviewItemRow: FC<Props> = ({
+    contentType,
+    name,
+    meta,
+    href,
+    isVerified = false,
+    compact = false,
+}) => {
+    const metaLabel = meta ?? getContentTypeLabel(contentType);
+    const body = (
+        <Group
+            gap="sm"
+            wrap="nowrap"
+            className={
+                compact ? `${classes.row} ${classes.compact}` : classes.row
+            }
+        >
+            {compact ? (
+                <MantineIcon
+                    icon={getContentTypeIcon(contentType)}
+                    color={getContentTypeColor(contentType)}
+                />
+            ) : (
+                <IconBox
+                    icon={getContentTypeIcon(contentType)}
+                    color={getContentTypeColor(contentType)}
+                    boxSize={28}
+                    size="md"
+                />
+            )}
+            {compact ? (
+                <Group gap={6} wrap="nowrap" className={classes.text}>
+                    <Text
+                        fz="sm"
+                        fw={500}
+                        lineClamp={1}
+                        className={classes.name}
+                    >
+                        {name}
+                    </Text>
+                    <Text fz="xs" c="dimmed" className={classes.meta}>
+                        {metaLabel}
+                    </Text>
+                </Group>
+            ) : (
+                <Stack gap={0} className={classes.text}>
+                    <Text fz="sm" fw={500} lineClamp={1}>
+                        {name}
+                    </Text>
+                    <Text fz="xs" c="dimmed" lineClamp={1}>
+                        {metaLabel}
+                    </Text>
+                </Stack>
+            )}
+            {isVerified && (
+                <Badge
+                    size="xs"
+                    color="green"
+                    variant="light"
+                    leftSection={
+                        <MantineIcon icon={IconCircleCheckFilled} size={10} />
+                    }
+                >
+                    Verified
+                </Badge>
+            )}
+            {href && (
+                <MantineIcon
+                    icon={IconExternalLink}
+                    color="dimmed"
+                    className={classes.linkIcon}
+                />
+            )}
+        </Group>
+    );
+
+    if (!href) return body;
+    return (
+        <Anchor
+            href={href}
+            target="_blank"
+            rel="noreferrer"
+            c="inherit"
+            underline="never"
+            className={classes.link}
+        >
+            {body}
+        </Anchor>
+    );
+};
+
+export default ContentReviewItemRow;

--- a/packages/frontend/src/ee/features/contentReview/components/ContentReviewItemRow.tsx
+++ b/packages/frontend/src/ee/features/contentReview/components/ContentReviewItemRow.tsx
@@ -1,5 +1,5 @@
 import { type ContentReviewContentType } from '@lightdash/common';
-import { Anchor, Badge, Group, Stack, Text } from '@mantine/core';
+import { Anchor, Group, Stack, Text, Tooltip } from '@mantine/core';
 import { IconCircleCheckFilled, IconExternalLink } from '@tabler/icons-react';
 import { type FC } from 'react';
 import MantineIcon from '../../../../components/common/MantineIcon';
@@ -77,16 +77,13 @@ const ContentReviewItemRow: FC<Props> = ({
                 </Stack>
             )}
             {isVerified && (
-                <Badge
-                    size="xs"
-                    color="green"
-                    variant="light"
-                    leftSection={
-                        <MantineIcon icon={IconCircleCheckFilled} size={10} />
-                    }
-                >
-                    Verified
-                </Badge>
+                <Tooltip label="Verified" withArrow>
+                    <MantineIcon
+                        icon={IconCircleCheckFilled}
+                        color="green.6"
+                        aria-label="Verified"
+                    />
+                </Tooltip>
             )}
             {href && (
                 <MantineIcon

--- a/packages/frontend/src/ee/features/contentReview/components/ContentReviewSettingsPanel.tsx
+++ b/packages/frontend/src/ee/features/contentReview/components/ContentReviewSettingsPanel.tsx
@@ -11,10 +11,13 @@ import {
     Stack,
     Switch,
     Text,
+    Title,
 } from '@mantine/core';
 import { useForm } from '@mantine/form';
+import { IconArrowUpRight } from '@tabler/icons-react';
 import { useMemo, type FC } from 'react';
 import { Link } from 'react-router';
+import MantineIcon from '../../../../components/common/MantineIcon';
 import { SettingsGridCard } from '../../../../components/common/Settings/SettingsCard';
 import { SlackChannelSelect } from '../../../../components/common/SlackChannelSelect';
 import { useGetSlack } from '../../../../hooks/slack/useSlack';
@@ -47,11 +50,22 @@ const SettingsForm: FC<{
 
     const groupOptions = useMemo(
         () => [
-            { value: SPACE_EDITORS, label: 'Editors of the target space' },
-            ...groups.map((group) => ({
-                value: group.uuid,
-                label: group.name,
-            })),
+            {
+                group: 'Default',
+                items: [
+                    {
+                        value: SPACE_EDITORS,
+                        label: 'Editors of the target space',
+                    },
+                ],
+            },
+            {
+                group: 'Organization groups',
+                items: groups.map((group) => ({
+                    value: group.uuid,
+                    label: group.name,
+                })),
+            },
         ],
         [groups],
     );
@@ -69,10 +83,10 @@ const SettingsForm: FC<{
                 });
             })}
         >
-            <Stack gap="md">
+            <Stack gap="lg">
                 <Select
                     label="Who reviews requests"
-                    description="Requests go to these people. They must also be able to edit the target space."
+                    description="A group needs access to this project, and its members must be able to edit the target space."
                     data={groupOptions}
                     rightSection={isLoadingGroups ? <Loader size="xs" /> : null}
                     allowDeselect={false}
@@ -80,7 +94,7 @@ const SettingsForm: FC<{
                 />
                 <Switch
                     label="Verify content when approving"
-                    description="Reviewers can still untick it per request"
+                    description="Ticked by default on every request. Reviewers can still untick it."
                     {...form.getInputProps('verifyOnApproveDefault', {
                         type: 'checkbox',
                     })}
@@ -95,19 +109,33 @@ const SettingsForm: FC<{
                         }
                     />
                 ) : (
-                    <Text fz="xs" c="ldGray.6">
-                        Connect Slack in organization settings to post new
-                        requests to a channel.
-                    </Text>
+                    <Stack gap={2}>
+                        <Text fz="sm" fw={500}>
+                            Slack channel for new requests
+                        </Text>
+                        <Text fz="xs" c="dimmed">
+                            <Anchor
+                                component={Link}
+                                to="/generalSettings/integrations"
+                                fz="xs"
+                            >
+                                Connect Slack
+                            </Anchor>{' '}
+                            to post new requests to a channel and send decisions
+                            as direct messages.
+                        </Text>
+                    </Stack>
                 )}
                 <Group justify="space-between">
-                    <Anchor
+                    <Button
                         component={Link}
                         to={getContentReviewRequestsPath(projectUuid)}
-                        fz="sm"
+                        variant="subtle"
+                        size="xs"
+                        rightSection={<MantineIcon icon={IconArrowUpRight} />}
                     >
                         Open the review queue
-                    </Anchor>
+                    </Button>
                     <Button
                         type="submit"
                         loading={isSaving}
@@ -131,8 +159,8 @@ const ContentReviewSettingsPanel: FC<{ projectUuid: string }> = ({
     return (
         <SettingsGridCard>
             <Stack gap="xs">
-                <Text fw={600}>Review requests</Text>
-                <Text c="ldGray.6" fz="xs">
+                <Title order={5}>Review requests</Title>
+                <Text c="dimmed" fz="xs">
                     People submit charts and dashboards from their personal
                     space. Approving moves the content to the shared space they
                     picked.

--- a/packages/frontend/src/ee/features/contentReview/components/ContentReviewSettingsPanel.tsx
+++ b/packages/frontend/src/ee/features/contentReview/components/ContentReviewSettingsPanel.tsx
@@ -1,0 +1,154 @@
+import {
+    getContentReviewRequestsPath,
+    type ContentReviewSettings,
+} from '@lightdash/common';
+import {
+    Anchor,
+    Button,
+    Group,
+    Loader,
+    Select,
+    Stack,
+    Switch,
+    Text,
+} from '@mantine/core';
+import { useForm } from '@mantine/form';
+import { useMemo, type FC } from 'react';
+import { Link } from 'react-router';
+import { SettingsGridCard } from '../../../../components/common/Settings/SettingsCard';
+import { SlackChannelSelect } from '../../../../components/common/SlackChannelSelect';
+import { useGetSlack } from '../../../../hooks/slack/useSlack';
+import { useOrganizationGroups } from '../../../../hooks/useOrganizationGroups';
+import {
+    useContentReviewSettings,
+    useUpdateContentReviewSettings,
+} from '../hooks/useContentReviewRequests';
+
+const SPACE_EDITORS = '__space_editors__';
+
+const SettingsForm: FC<{
+    projectUuid: string;
+    settings: ContentReviewSettings;
+}> = ({ projectUuid, settings }) => {
+    const { data: groups = [], isInitialLoading: isLoadingGroups } =
+        useOrganizationGroups({});
+    const { data: slack } = useGetSlack();
+    const isSlackConnected = !!slack?.organizationUuid;
+    const { mutate: updateSettings, isLoading: isSaving } =
+        useUpdateContentReviewSettings(projectUuid);
+
+    const form = useForm({
+        initialValues: {
+            reviewerGroupUuid: settings.reviewerGroupUuid ?? SPACE_EDITORS,
+            verifyOnApproveDefault: settings.verifyOnApproveDefault,
+            slackChannelId: settings.slackChannelId,
+        },
+    });
+
+    const groupOptions = useMemo(
+        () => [
+            { value: SPACE_EDITORS, label: 'Editors of the target space' },
+            ...groups.map((group) => ({
+                value: group.uuid,
+                label: group.name,
+            })),
+        ],
+        [groups],
+    );
+
+    return (
+        <form
+            onSubmit={form.onSubmit((values) => {
+                updateSettings({
+                    reviewerGroupUuid:
+                        values.reviewerGroupUuid === SPACE_EDITORS
+                            ? null
+                            : values.reviewerGroupUuid,
+                    verifyOnApproveDefault: values.verifyOnApproveDefault,
+                    slackChannelId: values.slackChannelId,
+                });
+            })}
+        >
+            <Stack gap="md">
+                <Select
+                    label="Who reviews requests"
+                    description="Requests go to these people. They must also be able to edit the target space."
+                    data={groupOptions}
+                    rightSection={isLoadingGroups ? <Loader size="xs" /> : null}
+                    allowDeselect={false}
+                    {...form.getInputProps('reviewerGroupUuid')}
+                />
+                <Switch
+                    label="Verify content when approving"
+                    description="Reviewers can still untick it per request"
+                    {...form.getInputProps('verifyOnApproveDefault', {
+                        type: 'checkbox',
+                    })}
+                />
+                {isSlackConnected ? (
+                    <SlackChannelSelect
+                        label="Slack channel for new requests"
+                        placeholder="Organization notification channel"
+                        value={form.values.slackChannelId}
+                        onChange={(value) =>
+                            form.setFieldValue('slackChannelId', value)
+                        }
+                    />
+                ) : (
+                    <Text fz="xs" c="ldGray.6">
+                        Connect Slack in organization settings to post new
+                        requests to a channel.
+                    </Text>
+                )}
+                <Group justify="space-between">
+                    <Anchor
+                        component={Link}
+                        to={getContentReviewRequestsPath(projectUuid)}
+                        fz="sm"
+                    >
+                        Open the review queue
+                    </Anchor>
+                    <Button
+                        type="submit"
+                        loading={isSaving}
+                        disabled={!form.isDirty()}
+                    >
+                        Save
+                    </Button>
+                </Group>
+            </Stack>
+        </form>
+    );
+};
+
+const ContentReviewSettingsPanel: FC<{ projectUuid: string }> = ({
+    projectUuid,
+}) => {
+    const { data: settings, isInitialLoading } = useContentReviewSettings(
+        projectUuid,
+        true,
+    );
+    return (
+        <SettingsGridCard>
+            <Stack gap="xs">
+                <Text fw={600}>Review requests</Text>
+                <Text c="ldGray.6" fz="xs">
+                    People submit charts and dashboards from their personal
+                    space. Approving moves the content to the shared space they
+                    picked.
+                </Text>
+            </Stack>
+            {isInitialLoading || !settings ? (
+                <Loader size="sm" />
+            ) : (
+                <SettingsForm
+                    key={projectUuid}
+                    projectUuid={projectUuid}
+                    settings={settings}
+                />
+            )}
+        </SettingsGridCard>
+    );
+};
+
+export default ContentReviewSettingsPanel;

--- a/packages/frontend/src/ee/features/contentReview/components/ContentReviewStatusBadge.tsx
+++ b/packages/frontend/src/ee/features/contentReview/components/ContentReviewStatusBadge.tsx
@@ -1,0 +1,36 @@
+import {
+    assertUnreachable,
+    ContentReviewRequestStatus,
+} from '@lightdash/common';
+import { Badge } from '@mantine/core';
+import { type FC } from 'react';
+
+const getStatusProps = (
+    status: ContentReviewRequestStatus,
+): { color: string; label: string } => {
+    switch (status) {
+        case ContentReviewRequestStatus.PENDING:
+            return { color: 'yellow', label: 'Pending' };
+        case ContentReviewRequestStatus.APPROVED:
+            return { color: 'green', label: 'Approved' };
+        case ContentReviewRequestStatus.REJECTED:
+            return { color: 'red', label: 'Rejected' };
+        case ContentReviewRequestStatus.CANCELLED:
+            return { color: 'gray', label: 'Cancelled' };
+        default:
+            return assertUnreachable(status, 'Unknown review request status');
+    }
+};
+
+const ContentReviewStatusBadge: FC<{ status: ContentReviewRequestStatus }> = ({
+    status,
+}) => {
+    const { color, label } = getStatusProps(status);
+    return (
+        <Badge color={color} variant="light" size="sm" radius="sm" tt="none">
+            {label}
+        </Badge>
+    );
+};
+
+export default ContentReviewStatusBadge;

--- a/packages/frontend/src/ee/features/contentReview/components/ContentReviewUserChip.tsx
+++ b/packages/frontend/src/ee/features/contentReview/components/ContentReviewUserChip.tsx
@@ -1,0 +1,23 @@
+import { type ContentReviewUser } from '@lightdash/common';
+import { Group, Text } from '@mantine/core';
+import { type FC } from 'react';
+import { LightdashUserAvatar } from '../../../../components/Avatar';
+import { getUserFullName, getUserInitials } from '../utils';
+
+type Props = {
+    user: ContentReviewUser;
+    label?: string;
+};
+
+const ContentReviewUserChip: FC<Props> = ({ user, label }) => (
+    <Group gap={6} wrap="nowrap">
+        <LightdashUserAvatar size={20} userUuid={user.userUuid} fz="xs">
+            {getUserInitials(user)}
+        </LightdashUserAvatar>
+        <Text fz="sm" fw={500} truncate="end">
+            {label ?? getUserFullName(user)}
+        </Text>
+    </Group>
+);
+
+export default ContentReviewUserChip;

--- a/packages/frontend/src/ee/features/contentReview/components/ReviewRequestsMenuItem.tsx
+++ b/packages/frontend/src/ee/features/contentReview/components/ReviewRequestsMenuItem.tsx
@@ -1,0 +1,41 @@
+import { getContentReviewRequestsPath } from '@lightdash/common';
+import { Badge, Menu } from '@mantine/core';
+import { IconSend } from '@tabler/icons-react';
+import { type FC } from 'react';
+import { Link } from 'react-router';
+import MantineIcon from '../../../../components/common/MantineIcon';
+import { useContentReviewAvailability } from '../hooks/useContentReviewAvailability';
+import { usePendingContentReviewCount } from '../hooks/useContentReviewRequests';
+
+type Props = {
+    projectUuid: string;
+};
+
+// Browse menu entry for the review queue, with how many requests are waiting
+// on the viewer
+const ReviewRequestsMenuItem: FC<Props> = ({ projectUuid }) => {
+    const { isAvailable } = useContentReviewAvailability();
+    const { data: pendingCount = 0 } = usePendingContentReviewCount(
+        projectUuid,
+        isAvailable,
+    );
+    if (!isAvailable) return null;
+    return (
+        <Menu.Item
+            component={Link}
+            to={getContentReviewRequestsPath(projectUuid)}
+            leftSection={<MantineIcon icon={IconSend} />}
+            rightSection={
+                pendingCount > 0 ? (
+                    <Badge size="xs" color="yellow" variant="light" circle>
+                        {pendingCount}
+                    </Badge>
+                ) : null
+            }
+        >
+            Review requests
+        </Menu.Item>
+    );
+};
+
+export default ReviewRequestsMenuItem;

--- a/packages/frontend/src/ee/features/contentReview/hooks/useContentReviewRequests.ts
+++ b/packages/frontend/src/ee/features/contentReview/hooks/useContentReviewRequests.ts
@@ -5,8 +5,8 @@ import {
     type ContentReviewRequest,
     type ContentReviewRequestDetail,
     type ContentReviewRequestListItem,
-    type ContentReviewRequestStatus,
-    type ContentReviewRequestView,
+    ContentReviewRequestStatus,
+    ContentReviewRequestView,
     type ContentReviewSettings,
     type CreateContentReviewRequestBody,
     type KnexPaginatedData,
@@ -238,3 +238,26 @@ export const useUpdateContentReviewSettings = (projectUuid: string) => {
         },
     });
 };
+
+// Cheap count for nav badges: one row, read the pagination total
+export const usePendingContentReviewCount = (
+    projectUuid: string,
+    enabled: boolean,
+) =>
+    useQuery<
+        KnexPaginatedData<ContentReviewRequestListItem[]>,
+        ApiError,
+        number
+    >({
+        queryKey: [CONTENT_REVIEW_QUERY_KEY, projectUuid, 'pending-count'],
+        queryFn: () =>
+            listContentReviewRequests(projectUuid, {
+                view: ContentReviewRequestView.TO_REVIEW,
+                status: ContentReviewRequestStatus.PENDING,
+                page: 1,
+                pageSize: 1,
+            }),
+        select: (data) => data.pagination?.totalResults ?? 0,
+        enabled,
+        staleTime: 60_000,
+    });

--- a/packages/frontend/src/ee/features/contentReview/hooks/useContentReviewRequests.ts
+++ b/packages/frontend/src/ee/features/contentReview/hooks/useContentReviewRequests.ts
@@ -1,16 +1,30 @@
 import {
     type ApiError,
+    type ApproveContentReviewRequestBody,
     type ContentReviewContentType,
     type ContentReviewRequest,
     type ContentReviewRequestDetail,
+    type ContentReviewRequestListItem,
+    type ContentReviewRequestStatus,
+    type ContentReviewRequestView,
+    type ContentReviewSettings,
     type CreateContentReviewRequestBody,
+    type KnexPaginatedData,
+    type RejectContentReviewRequestBody,
+    type UpdateContentReviewSettings,
 } from '@lightdash/common';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import useToaster from '../../../../hooks/toaster/useToaster';
 import {
+    approveContentReviewRequest,
     cancelContentReviewRequest,
     createContentReviewRequest,
+    getContentReviewRequest,
+    getContentReviewSettings,
     getPendingContentReviewRequest,
+    listContentReviewRequests,
+    rejectContentReviewRequest,
+    updateContentReviewSettings,
 } from '../api';
 
 const CONTENT_REVIEW_QUERY_KEY = 'content-review';
@@ -95,4 +109,132 @@ export const useCancelContentReviewRequest = (projectUuid: string) => {
             },
         },
     );
+};
+
+export const useContentReviewRequests = (
+    projectUuid: string,
+    params: {
+        view: ContentReviewRequestView;
+        status: ContentReviewRequestStatus | null;
+        page: number;
+        pageSize: number;
+    },
+    enabled: boolean,
+) =>
+    useQuery<KnexPaginatedData<ContentReviewRequestListItem[]>, ApiError>({
+        queryKey: [CONTENT_REVIEW_QUERY_KEY, projectUuid, 'list', params],
+        queryFn: () => listContentReviewRequests(projectUuid, params),
+        enabled,
+        keepPreviousData: true,
+    });
+
+export const useContentReviewRequest = (
+    projectUuid: string,
+    requestUuid: string | undefined,
+) =>
+    useQuery<ContentReviewRequestDetail, ApiError>({
+        queryKey: [
+            CONTENT_REVIEW_QUERY_KEY,
+            projectUuid,
+            'request',
+            requestUuid,
+        ],
+        queryFn: () => getContentReviewRequest(projectUuid, requestUuid!),
+        enabled: !!requestUuid,
+    });
+
+export const useApproveContentReviewRequest = (projectUuid: string) => {
+    const { showToastSuccess, showToastApiError } = useToaster();
+    const invalidate = useInvalidateContentReview();
+    const queryClient = useQueryClient();
+    return useMutation<
+        ContentReviewRequestDetail,
+        ApiError,
+        { requestUuid: string; body: ApproveContentReviewRequestBody }
+    >(
+        ({ requestUuid, body }) =>
+            approveContentReviewRequest(projectUuid, requestUuid, body),
+        {
+            mutationKey: ['content-review-request-approve'],
+            onSuccess: async (detail) => {
+                await invalidate(projectUuid);
+                // The content moved, so space and content lists are stale
+                await queryClient.invalidateQueries(['spaces']);
+                await queryClient.invalidateQueries(['content']);
+                await queryClient.invalidateQueries(['verified-content']);
+                showToastSuccess({
+                    title: detail.verifiedOnApprove
+                        ? 'Request approved and content verified'
+                        : 'Request approved',
+                    subtitle: detail.targetSpaceName
+                        ? `Moved to ${detail.targetSpaceName}`
+                        : undefined,
+                });
+            },
+            onError: ({ error }) => {
+                showToastApiError({
+                    title: 'Failed to approve the request',
+                    apiError: error,
+                });
+            },
+        },
+    );
+};
+
+export const useRejectContentReviewRequest = (projectUuid: string) => {
+    const { showToastSuccess, showToastApiError } = useToaster();
+    const invalidate = useInvalidateContentReview();
+    return useMutation<
+        ContentReviewRequestDetail,
+        ApiError,
+        { requestUuid: string; body: RejectContentReviewRequestBody }
+    >(
+        ({ requestUuid, body }) =>
+            rejectContentReviewRequest(projectUuid, requestUuid, body),
+        {
+            mutationKey: ['content-review-request-reject'],
+            onSuccess: async () => {
+                await invalidate(projectUuid);
+                showToastSuccess({ title: 'Request rejected' });
+            },
+            onError: ({ error }) => {
+                showToastApiError({
+                    title: 'Failed to reject the request',
+                    apiError: error,
+                });
+            },
+        },
+    );
+};
+
+export const useContentReviewSettings = (
+    projectUuid: string,
+    enabled: boolean,
+) =>
+    useQuery<ContentReviewSettings, ApiError>({
+        queryKey: [CONTENT_REVIEW_QUERY_KEY, projectUuid, 'settings'],
+        queryFn: () => getContentReviewSettings(projectUuid),
+        enabled,
+    });
+
+export const useUpdateContentReviewSettings = (projectUuid: string) => {
+    const { showToastSuccess, showToastApiError } = useToaster();
+    const invalidate = useInvalidateContentReview();
+    return useMutation<
+        ContentReviewSettings,
+        ApiError,
+        UpdateContentReviewSettings
+    >((body) => updateContentReviewSettings(projectUuid, body), {
+        mutationKey: ['content-review-settings-update'],
+        onSuccess: async () => {
+            await invalidate(projectUuid);
+            showToastSuccess({ title: 'Review settings saved' });
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to save review settings',
+                apiError: error,
+            });
+        },
+    });
 };

--- a/packages/frontend/src/ee/features/contentReview/index.ts
+++ b/packages/frontend/src/ee/features/contentReview/index.ts
@@ -2,3 +2,4 @@ export { default as PendingReviewBadge } from './components/PendingReviewBadge';
 export { default as RequestReviewModal } from './components/RequestReviewModal';
 export { useContentReviewEligibility } from './hooks/useContentReviewEligibility';
 export { default as ContentReviewSettingsPanel } from './components/ContentReviewSettingsPanel';
+export { default as ReviewRequestsMenuItem } from './components/ReviewRequestsMenuItem';

--- a/packages/frontend/src/ee/features/contentReview/index.ts
+++ b/packages/frontend/src/ee/features/contentReview/index.ts
@@ -1,3 +1,4 @@
 export { default as PendingReviewBadge } from './components/PendingReviewBadge';
 export { default as RequestReviewModal } from './components/RequestReviewModal';
 export { useContentReviewEligibility } from './hooks/useContentReviewEligibility';
+export { default as ContentReviewSettingsPanel } from './components/ContentReviewSettingsPanel';

--- a/packages/frontend/src/ee/features/contentReview/pages/ContentReviewRequestPage.module.css
+++ b/packages/frontend/src/ee/features/contentReview/pages/ContentReviewRequestPage.module.css
@@ -1,0 +1,19 @@
+.spaceChip {
+    min-width: 0;
+    padding: 4px var(--mantine-spacing-sm);
+    border: 1px solid var(--mantine-color-default-border);
+    border-radius: var(--mantine-radius-md);
+    background-color: var(--mantine-color-body);
+}
+
+.list {
+    margin: 0 calc(var(--mantine-spacing-sm) * -1);
+}
+
+.note {
+    white-space: pre-wrap;
+    padding: var(--mantine-spacing-sm) var(--mantine-spacing-md);
+    border-left: 3px solid var(--mantine-color-default-border);
+    background-color: var(--mantine-color-ldGray-0);
+    border-radius: 0 var(--mantine-radius-md) var(--mantine-radius-md) 0;
+}

--- a/packages/frontend/src/ee/features/contentReview/pages/ContentReviewRequestPage.test.tsx
+++ b/packages/frontend/src/ee/features/contentReview/pages/ContentReviewRequestPage.test.tsx
@@ -1,6 +1,6 @@
 import {
+    ContentReviewContentType,
     ContentReviewRequestStatus,
-    ContentType,
     type ContentReviewRequestDetail,
 } from '@lightdash/common';
 import { screen, waitFor } from '@testing-library/react';
@@ -31,7 +31,7 @@ vi.mock('../hooks/useContentReviewRequests', () => ({
 const request: ContentReviewRequestDetail = {
     uuid: 'request-uuid',
     projectUuid: 'project',
-    contentType: ContentType.DASHBOARD,
+    contentType: ContentReviewContentType.DASHBOARD,
     contentUuid: 'dashboard',
     sourceSpaceUuid: 'personal',
     targetSpaceUuid: 'finance',
@@ -52,11 +52,15 @@ const request: ContentReviewRequestDetail = {
     targetSpaceName: 'Finance',
     moveSet: [
         {
-            contentType: ContentType.DASHBOARD,
+            contentType: ContentReviewContentType.DASHBOARD,
             contentUuid: 'dashboard',
             name: 'Weekly revenue',
         },
-        { contentType: ContentType.CHART, contentUuid: 'c1', name: 'Revenue' },
+        {
+            contentType: ContentReviewContentType.CHART,
+            contentUuid: 'c1',
+            name: 'Revenue',
+        },
     ],
     canReview: true,
     canVerify: true,

--- a/packages/frontend/src/ee/features/contentReview/pages/ContentReviewRequestPage.test.tsx
+++ b/packages/frontend/src/ee/features/contentReview/pages/ContentReviewRequestPage.test.tsx
@@ -1,0 +1,146 @@
+import {
+    ContentReviewRequestStatus,
+    ContentType,
+    type ContentReviewRequestDetail,
+} from '@lightdash/common';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router';
+import { renderWithProviders } from '../../../../testing/testUtils';
+import { ContentReviewRequestDetailView } from './ContentReviewRequestPage';
+
+const approve = vi.fn().mockResolvedValue({});
+const reject = vi.fn().mockResolvedValue({});
+const cancel = vi.fn();
+
+vi.mock('../hooks/useContentReviewRequests', () => ({
+    useApproveContentReviewRequest: () => ({
+        mutateAsync: approve,
+        isLoading: false,
+    }),
+    useRejectContentReviewRequest: () => ({
+        mutateAsync: reject,
+        isLoading: false,
+    }),
+    useCancelContentReviewRequest: () => ({
+        mutate: cancel,
+        isLoading: false,
+    }),
+}));
+
+const request: ContentReviewRequestDetail = {
+    uuid: 'request-uuid',
+    projectUuid: 'project',
+    contentType: ContentType.DASHBOARD,
+    contentUuid: 'dashboard',
+    sourceSpaceUuid: 'personal',
+    targetSpaceUuid: 'finance',
+    requestedBy: { userUuid: 'requester', firstName: 'Ada', lastName: 'L' },
+    requestNote: 'Please review',
+    similarContent: [],
+    status: ContentReviewRequestStatus.PENDING,
+    reviewedBy: null,
+    reviewedAt: null,
+    reviewNote: null,
+    verifiedOnApprove: null,
+    movedContent: [],
+    grantedPrincipals: [],
+    createdAt: new Date('2026-09-01T10:00:00Z'),
+    updatedAt: new Date('2026-09-01T10:00:00Z'),
+    content: { name: 'Weekly revenue', slug: 'weekly-revenue' },
+    sourceSpaceName: 'Personal',
+    targetSpaceName: 'Finance',
+    moveSet: [
+        {
+            contentType: ContentType.DASHBOARD,
+            contentUuid: 'dashboard',
+            name: 'Weekly revenue',
+        },
+        { contentType: ContentType.CHART, contentUuid: 'c1', name: 'Revenue' },
+    ],
+    canReview: true,
+    canVerify: true,
+    verifyByDefault: true,
+};
+
+const renderView = (overrides: Partial<ContentReviewRequestDetail> = {}) =>
+    renderWithProviders(
+        <MemoryRouter>
+            <ContentReviewRequestDetailView
+                projectUuid="project"
+                request={{ ...request, ...overrides }}
+            />
+        </MemoryRouter>,
+    );
+
+describe('ContentReviewRequestDetailView', () => {
+    beforeEach(() => {
+        approve.mockClear();
+        reject.mockClear();
+    });
+
+    it('lists what will move and approves with the verify default', async () => {
+        renderView();
+
+        expect(screen.getByText('What will move')).toBeInTheDocument();
+        expect(screen.getByText('Revenue')).toBeInTheDocument();
+        expect(screen.getByLabelText('Verify on approve')).toBeChecked();
+
+        await userEvent.click(
+            screen.getByRole('button', { name: 'Approve and move' }),
+        );
+
+        await waitFor(() =>
+            expect(approve).toHaveBeenCalledWith({
+                requestUuid: 'request-uuid',
+                body: { verify: true, note: null },
+            }),
+        );
+    });
+
+    it('disables verification without the permission', () => {
+        renderView({ canVerify: false });
+
+        const checkbox = screen.getByLabelText('Verify on approve');
+        expect(checkbox).toBeDisabled();
+        expect(checkbox).not.toBeChecked();
+    });
+
+    it('requires a note to reject', async () => {
+        renderView();
+
+        await userEvent.click(screen.getByRole('button', { name: 'Reject' }));
+        const confirmButton = () =>
+            screen.getAllByRole('button', { name: 'Reject' }).at(-1)!;
+        await waitFor(() => expect(confirmButton()).toBeDisabled());
+
+        await userEvent.type(
+            screen.getByLabelText('Tell the requester why'),
+            'Duplicate of the finance dashboard',
+        );
+        await userEvent.click(confirmButton());
+
+        await waitFor(() =>
+            expect(reject).toHaveBeenCalledWith({
+                requestUuid: 'request-uuid',
+                body: { note: 'Duplicate of the finance dashboard' },
+            }),
+        );
+    });
+
+    it('hides decisions for a decided request', () => {
+        renderView({
+            status: ContentReviewRequestStatus.REJECTED,
+            reviewedBy: { userUuid: 'admin', firstName: 'Bob', lastName: 'K' },
+            reviewedAt: new Date('2026-09-01T12:00:00Z'),
+            reviewNote: 'Not yet',
+            canReview: true,
+        });
+
+        expect(
+            screen.queryByRole('button', { name: 'Approve and move' }),
+        ).not.toBeInTheDocument();
+        expect(screen.getByText(/Rejected by Bob K/)).toBeInTheDocument();
+        expect(screen.getByText('Not yet')).toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/ee/features/contentReview/pages/ContentReviewRequestPage.tsx
+++ b/packages/frontend/src/ee/features/contentReview/pages/ContentReviewRequestPage.tsx
@@ -1,5 +1,6 @@
 import {
     assertUnreachable,
+    ContentReviewContentType,
     ContentReviewRequestStatus,
     getContentReviewRequestsPath,
     type ContentReviewRequestDetail,
@@ -150,7 +151,12 @@ const DecisionCard: FC<{
                     </Text>
                 </Stack>
                 <Tooltip
-                    label="You need permission to verify content"
+                    label={
+                        request.contentType ===
+                        ContentReviewContentType.SQL_CHART
+                            ? 'SQL charts cannot be verified yet'
+                            : 'You need permission to verify content'
+                    }
                     disabled={request.canVerify}
                     withArrow
                 >

--- a/packages/frontend/src/ee/features/contentReview/pages/ContentReviewRequestPage.tsx
+++ b/packages/frontend/src/ee/features/contentReview/pages/ContentReviewRequestPage.tsx
@@ -1,0 +1,359 @@
+import {
+    ContentReviewRequestStatus,
+    getContentReviewRequestsPath,
+    type ContentReviewRequestDetail,
+} from '@lightdash/common';
+import {
+    Anchor,
+    Badge,
+    Blockquote,
+    Button,
+    Checkbox,
+    Group,
+    List,
+    Loader,
+    Paper,
+    Stack,
+    Text,
+    Textarea,
+    Title,
+    Tooltip,
+} from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import { IconAlertCircle, IconArrowRight, IconX } from '@tabler/icons-react';
+import { useState, type FC } from 'react';
+import { Link, useParams } from 'react-router';
+import MantineIcon from '../../../../components/common/MantineIcon';
+import MantineModal from '../../../../components/common/MantineModal';
+import Page from '../../../../components/common/Page/Page';
+import PageBreadcrumbs from '../../../../components/common/PageBreadcrumbs';
+import { SettingsEmptyState } from '../../../../components/common/Settings/SettingsEmptyState';
+import { useProjectUuid } from '../../../../hooks/useProjectUuid';
+import { useTimeAgo } from '../../../../hooks/useTimeAgo';
+import useApp from '../../../../providers/App/useApp';
+import ContentReviewStatusBadge from '../components/ContentReviewStatusBadge';
+import {
+    useApproveContentReviewRequest,
+    useCancelContentReviewRequest,
+    useContentReviewRequest,
+    useRejectContentReviewRequest,
+} from '../hooks/useContentReviewRequests';
+import { getContentHref, getContentTypeLabel } from '../utils';
+
+const Timestamp: FC<{ prefix: string; date: Date }> = ({ prefix, date }) => {
+    const ago = useTimeAgo(new Date(date));
+    return (
+        <Text fz="sm" c="ldGray.7">
+            {prefix} {ago}
+        </Text>
+    );
+};
+
+const RejectModal: FC<{
+    opened: boolean;
+    onClose: () => void;
+    onConfirm: (note: string) => Promise<void>;
+    isLoading: boolean;
+}> = ({ opened, onClose, onConfirm, isLoading }) => {
+    const [note, setNote] = useState('');
+    const canConfirm = note.trim().length > 0;
+    return (
+        <MantineModal
+            opened={opened}
+            onClose={onClose}
+            title="Reject request"
+            icon={IconX}
+            actions={
+                <Button
+                    color="red"
+                    loading={isLoading}
+                    disabled={!canConfirm}
+                    onClick={async () => {
+                        await onConfirm(note.trim());
+                        setNote('');
+                    }}
+                >
+                    Reject
+                </Button>
+            }
+        >
+            <Textarea
+                label="Tell the requester why"
+                description="They will see this note and can resubmit after changes"
+                autosize
+                minRows={3}
+                value={note}
+                onChange={(event) => setNote(event.currentTarget.value)}
+                data-autofocus
+            />
+        </MantineModal>
+    );
+};
+
+export const ContentReviewRequestDetailView: FC<{
+    projectUuid: string;
+    request: ContentReviewRequestDetail;
+}> = ({ projectUuid, request }) => {
+    const { user } = useApp();
+    const [verify, setVerify] = useState(
+        request.verifyByDefault && request.canVerify,
+    );
+    const [isRejectOpen, rejectHandlers] = useDisclosure(false);
+    const { mutateAsync: approve, isLoading: isApproving } =
+        useApproveContentReviewRequest(projectUuid);
+    const { mutateAsync: reject, isLoading: isRejecting } =
+        useRejectContentReviewRequest(projectUuid);
+    const { mutate: cancel, isLoading: isCancelling } =
+        useCancelContentReviewRequest(projectUuid);
+
+    const isPending = request.status === ContentReviewRequestStatus.PENDING;
+    const isRequester = user.data?.userUuid === request.requestedBy.userUuid;
+    const contentName = request.content?.name ?? 'Deleted content';
+
+    return (
+        <Stack gap="lg">
+            <Group justify="space-between" align="flex-start">
+                <Stack gap="xs">
+                    <Group gap="sm">
+                        <Title order={3}>{contentName}</Title>
+                        <Badge variant="light" color="blue">
+                            {getContentTypeLabel(request.contentType)}
+                        </Badge>
+                        <ContentReviewStatusBadge status={request.status} />
+                    </Group>
+                    <Group gap="xs">
+                        <Text fz="sm" c="ldGray.7">
+                            {request.requestedBy.firstName}{' '}
+                            {request.requestedBy.lastName} asked to move this
+                            from{' '}
+                            {request.sourceSpaceName ?? 'their personal space'}
+                        </Text>
+                        <MantineIcon icon={IconArrowRight} size="sm" />
+                        <Text fz="sm" fw={500}>
+                            {request.targetSpaceName ?? 'a deleted space'}
+                        </Text>
+                    </Group>
+                    <Timestamp prefix="Requested" date={request.createdAt} />
+                </Stack>
+                {request.content && (
+                    <Button
+                        component={Link}
+                        to={getContentHref(
+                            projectUuid,
+                            request.contentType,
+                            request.content,
+                        )}
+                        variant="default"
+                        size="xs"
+                    >
+                        Open{' '}
+                        {getContentTypeLabel(request.contentType).toLowerCase()}
+                    </Button>
+                )}
+            </Group>
+
+            {request.requestNote && (
+                <Blockquote fz="sm" p="sm">
+                    {request.requestNote}
+                </Blockquote>
+            )}
+
+            <Paper withBorder p="md">
+                <Stack gap="xs">
+                    <Text fz="sm" fw={600}>
+                        {isPending ? 'What will move' : 'What moved'}
+                    </Text>
+                    {request.moveSet.length === 0 ? (
+                        <Text fz="sm" c="ldGray.6">
+                            Nothing
+                        </Text>
+                    ) : (
+                        <List fz="sm" spacing={4}>
+                            {request.moveSet.map((item) => (
+                                <List.Item key={item.contentUuid}>
+                                    {item.name}{' '}
+                                    <Text component="span" c="ldGray.6" fz="xs">
+                                        (
+                                        {getContentTypeLabel(
+                                            item.contentType,
+                                        ).toLowerCase()}
+                                        )
+                                    </Text>
+                                </List.Item>
+                            ))}
+                        </List>
+                    )}
+                </Stack>
+            </Paper>
+
+            {request.similarContent.length > 0 && (
+                <Paper withBorder p="md">
+                    <Stack gap="xs">
+                        <Text fz="sm" fw={600}>
+                            Similar content the requester was shown
+                        </Text>
+                        <List fz="sm" spacing={4}>
+                            {request.similarContent.map((item) => (
+                                <List.Item key={item.contentUuid}>
+                                    {item.name}{' '}
+                                    <Text component="span" c="ldGray.6" fz="xs">
+                                        in {item.spaceName}
+                                        {item.isVerified ? ', verified' : ''}
+                                    </Text>
+                                </List.Item>
+                            ))}
+                        </List>
+                    </Stack>
+                </Paper>
+            )}
+
+            {!isPending && request.reviewedBy && request.reviewedAt && (
+                <Paper withBorder p="md">
+                    <Stack gap="xs">
+                        <Text fz="sm">
+                            {request.status ===
+                            ContentReviewRequestStatus.APPROVED
+                                ? 'Approved'
+                                : 'Rejected'}{' '}
+                            by {request.reviewedBy.firstName}{' '}
+                            {request.reviewedBy.lastName}
+                            {request.verifiedOnApprove ? ', and verified' : ''}
+                        </Text>
+                        <Timestamp prefix="Decided" date={request.reviewedAt} />
+                        {request.reviewNote && (
+                            <Blockquote fz="sm" p="sm">
+                                {request.reviewNote}
+                            </Blockquote>
+                        )}
+                    </Stack>
+                </Paper>
+            )}
+
+            {isPending && request.canReview && (
+                <Paper withBorder p="md">
+                    <Group justify="space-between">
+                        <Tooltip
+                            label="You need permission to verify content"
+                            disabled={request.canVerify}
+                            withArrow
+                        >
+                            <Checkbox
+                                label="Verify on approve"
+                                checked={verify}
+                                disabled={!request.canVerify}
+                                onChange={(event) =>
+                                    setVerify(event.currentTarget.checked)
+                                }
+                            />
+                        </Tooltip>
+                        <Group gap="xs">
+                            <Button
+                                variant="default"
+                                color="red"
+                                onClick={rejectHandlers.open}
+                                disabled={isApproving}
+                            >
+                                Reject
+                            </Button>
+                            <Button
+                                loading={isApproving}
+                                onClick={() =>
+                                    approve({
+                                        requestUuid: request.uuid,
+                                        body: { verify, note: null },
+                                    })
+                                }
+                            >
+                                Approve and move
+                            </Button>
+                        </Group>
+                    </Group>
+                </Paper>
+            )}
+
+            {isPending && isRequester && !request.canReview && (
+                <Group justify="flex-end">
+                    <Button
+                        variant="default"
+                        loading={isCancelling}
+                        onClick={() => cancel(request.uuid)}
+                    >
+                        Cancel request
+                    </Button>
+                </Group>
+            )}
+
+            <RejectModal
+                opened={isRejectOpen}
+                onClose={rejectHandlers.close}
+                isLoading={isRejecting}
+                onConfirm={async (note) => {
+                    await reject({
+                        requestUuid: request.uuid,
+                        body: { note },
+                    });
+                    rejectHandlers.close();
+                }}
+            />
+        </Stack>
+    );
+};
+
+const ContentReviewRequestPage: FC = () => {
+    const projectUuid = useProjectUuid();
+    const { requestUuid } = useParams<{ requestUuid: string }>();
+    const {
+        data: request,
+        isInitialLoading,
+        error,
+    } = useContentReviewRequest(projectUuid ?? '', requestUuid);
+
+    if (!projectUuid) return null;
+
+    return (
+        <Page
+            title="Review request"
+            withCenteredContent
+            withXLargePaddedContent
+        >
+            <Stack gap="md">
+                <PageBreadcrumbs
+                    items={[
+                        {
+                            title: 'Review requests',
+                            to: getContentReviewRequestsPath(projectUuid),
+                        },
+                        {
+                            title: request?.content?.name ?? 'Request',
+                            active: true,
+                        },
+                    ]}
+                />
+                {isInitialLoading && <Loader size="sm" />}
+                {error && (
+                    <SettingsEmptyState
+                        icon={IconAlertCircle}
+                        title="Request not available"
+                        description={error.error.message}
+                    />
+                )}
+                {request && (
+                    <ContentReviewRequestDetailView
+                        key={`${request.uuid}-${request.status}`}
+                        projectUuid={projectUuid}
+                        request={request}
+                    />
+                )}
+                <Anchor
+                    component={Link}
+                    to={getContentReviewRequestsPath(projectUuid)}
+                    fz="sm"
+                >
+                    Back to review requests
+                </Anchor>
+            </Stack>
+        </Page>
+    );
+};
+
+export default ContentReviewRequestPage;

--- a/packages/frontend/src/ee/features/contentReview/pages/ContentReviewRequestPage.tsx
+++ b/packages/frontend/src/ee/features/contentReview/pages/ContentReviewRequestPage.tsx
@@ -58,6 +58,7 @@ import {
     getContentTypeColor,
     getContentTypeIcon,
     getContentTypeLabel,
+    getContentTypeNoun,
     getUserFullName,
 } from '../utils';
 import classes from './ContentReviewRequestPage.module.css';
@@ -409,7 +410,7 @@ export const ContentReviewRequestDetailView: FC<{
                         size="xs"
                         leftSection={<MantineIcon icon={IconExternalLink} />}
                     >
-                        Open {typeLabel.toLowerCase()}
+                        Open {getContentTypeNoun(request.contentType)}
                     </Button>
                 )}
             </Group>

--- a/packages/frontend/src/ee/features/contentReview/pages/ContentReviewRequestPage.tsx
+++ b/packages/frontend/src/ee/features/contentReview/pages/ContentReviewRequestPage.tsx
@@ -1,50 +1,71 @@
 import {
+    assertUnreachable,
     ContentReviewRequestStatus,
     getContentReviewRequestsPath,
     type ContentReviewRequestDetail,
 } from '@lightdash/common';
 import {
-    Anchor,
     Badge,
-    Blockquote,
     Button,
     Checkbox,
+    Grid,
     Group,
-    List,
-    Loader,
     Paper,
     Stack,
     Text,
     Textarea,
+    Timeline,
     Title,
     Tooltip,
 } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
-import { IconAlertCircle, IconArrowRight, IconX } from '@tabler/icons-react';
+import {
+    IconAlertCircle,
+    IconArrowRight,
+    IconCheck,
+    IconCircleCheckFilled,
+    IconClockHour4,
+    IconExternalLink,
+    IconFolder,
+    IconSend,
+    IconUser,
+    IconX,
+} from '@tabler/icons-react';
 import { useState, type FC } from 'react';
 import { Link, useParams } from 'react-router';
+import EmptyStateLoader from '../../../../components/common/EmptyStateLoader';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import MantineModal from '../../../../components/common/MantineModal';
 import Page from '../../../../components/common/Page/Page';
 import PageBreadcrumbs from '../../../../components/common/PageBreadcrumbs';
+import { IconBox } from '../../../../components/common/ResourceIcon';
 import { SettingsEmptyState } from '../../../../components/common/Settings/SettingsEmptyState';
 import { useProjectUuid } from '../../../../hooks/useProjectUuid';
 import { useTimeAgo } from '../../../../hooks/useTimeAgo';
 import useApp from '../../../../providers/App/useApp';
+import ContentReviewItemRow from '../components/ContentReviewItemRow';
 import ContentReviewStatusBadge from '../components/ContentReviewStatusBadge';
+import ContentReviewUserChip from '../components/ContentReviewUserChip';
 import {
     useApproveContentReviewRequest,
     useCancelContentReviewRequest,
     useContentReviewRequest,
     useRejectContentReviewRequest,
 } from '../hooks/useContentReviewRequests';
-import { getContentHref, getContentTypeLabel } from '../utils';
+import {
+    getContentHref,
+    getContentTypeColor,
+    getContentTypeIcon,
+    getContentTypeLabel,
+    getUserFullName,
+} from '../utils';
+import classes from './ContentReviewRequestPage.module.css';
 
-const Timestamp: FC<{ prefix: string; date: Date }> = ({ prefix, date }) => {
+const TimeAgo: FC<{ date: Date }> = ({ date }) => {
     const ago = useTimeAgo(new Date(date));
     return (
-        <Text fz="sm" c="ldGray.7">
-            {prefix} {ago}
+        <Text fz="xs" c="dimmed">
+            {ago}
         </Text>
     );
 };
@@ -90,11 +111,22 @@ const RejectModal: FC<{
     );
 };
 
-export const ContentReviewRequestDetailView: FC<{
-    projectUuid: string;
+const SpaceChip: FC<{ name: string; personal?: boolean }> = ({
+    name,
+    personal = false,
+}) => (
+    <Group gap={6} wrap="nowrap" className={classes.spaceChip}>
+        <MantineIcon icon={personal ? IconUser : IconFolder} color="dimmed" />
+        <Text fz="sm" fw={500} truncate="end">
+            {name}
+        </Text>
+    </Group>
+);
+
+const DecisionCard: FC<{
     request: ContentReviewRequestDetail;
-}> = ({ projectUuid, request }) => {
-    const { user } = useApp();
+    projectUuid: string;
+}> = ({ request, projectUuid }) => {
     const [verify, setVerify] = useState(
         request.verifyByDefault && request.canVerify,
     );
@@ -103,186 +135,60 @@ export const ContentReviewRequestDetailView: FC<{
         useApproveContentReviewRequest(projectUuid);
     const { mutateAsync: reject, isLoading: isRejecting } =
         useRejectContentReviewRequest(projectUuid);
-    const { mutate: cancel, isLoading: isCancelling } =
-        useCancelContentReviewRequest(projectUuid);
-
-    const isPending = request.status === ContentReviewRequestStatus.PENDING;
-    const isRequester = user.data?.userUuid === request.requestedBy.userUuid;
-    const contentName = request.content?.name ?? 'Deleted content';
+    const itemCount = request.moveSet.length;
+    const target = request.targetSpaceName ?? 'the target space';
 
     return (
-        <Stack gap="lg">
-            <Group justify="space-between" align="flex-start">
-                <Stack gap="xs">
-                    <Group gap="sm">
-                        <Title order={3}>{contentName}</Title>
-                        <Badge variant="light" color="blue">
-                            {getContentTypeLabel(request.contentType)}
-                        </Badge>
-                        <ContentReviewStatusBadge status={request.status} />
-                    </Group>
-                    <Group gap="xs">
-                        <Text fz="sm" c="ldGray.7">
-                            {request.requestedBy.firstName}{' '}
-                            {request.requestedBy.lastName} asked to move this
-                            from{' '}
-                            {request.sourceSpaceName ?? 'their personal space'}
-                        </Text>
-                        <MantineIcon icon={IconArrowRight} size="sm" />
-                        <Text fz="sm" fw={500}>
-                            {request.targetSpaceName ?? 'a deleted space'}
-                        </Text>
-                    </Group>
-                    <Timestamp prefix="Requested" date={request.createdAt} />
-                </Stack>
-                {request.content && (
-                    <Button
-                        component={Link}
-                        to={getContentHref(
-                            projectUuid,
-                            request.contentType,
-                            request.content,
-                        )}
-                        variant="default"
-                        size="xs"
-                    >
-                        Open{' '}
-                        {getContentTypeLabel(request.contentType).toLowerCase()}
-                    </Button>
-                )}
-            </Group>
-
-            {request.requestNote && (
-                <Blockquote fz="sm" p="sm">
-                    {request.requestNote}
-                </Blockquote>
-            )}
-
-            <Paper withBorder p="md">
-                <Stack gap="xs">
-                    <Text fz="sm" fw={600}>
-                        {isPending ? 'What will move' : 'What moved'}
+        <Paper p="md">
+            <Stack gap="md">
+                <Stack gap={4}>
+                    <Title order={5}>Your decision</Title>
+                    <Text fz="sm" c="dimmed">
+                        Approving moves{' '}
+                        {itemCount === 1 ? 'this item' : `${itemCount} items`}{' '}
+                        to {target} and releases the temporary access.
                     </Text>
-                    {request.moveSet.length === 0 ? (
-                        <Text fz="sm" c="ldGray.6">
-                            Nothing
-                        </Text>
-                    ) : (
-                        <List fz="sm" spacing={4}>
-                            {request.moveSet.map((item) => (
-                                <List.Item key={item.contentUuid}>
-                                    {item.name}{' '}
-                                    <Text component="span" c="ldGray.6" fz="xs">
-                                        (
-                                        {getContentTypeLabel(
-                                            item.contentType,
-                                        ).toLowerCase()}
-                                        )
-                                    </Text>
-                                </List.Item>
-                            ))}
-                        </List>
-                    )}
                 </Stack>
-            </Paper>
-
-            {request.similarContent.length > 0 && (
-                <Paper withBorder p="md">
-                    <Stack gap="xs">
-                        <Text fz="sm" fw={600}>
-                            Similar content the requester was shown
-                        </Text>
-                        <List fz="sm" spacing={4}>
-                            {request.similarContent.map((item) => (
-                                <List.Item key={item.contentUuid}>
-                                    {item.name}{' '}
-                                    <Text component="span" c="ldGray.6" fz="xs">
-                                        in {item.spaceName}
-                                        {item.isVerified ? ', verified' : ''}
-                                    </Text>
-                                </List.Item>
-                            ))}
-                        </List>
-                    </Stack>
-                </Paper>
-            )}
-
-            {!isPending && request.reviewedBy && request.reviewedAt && (
-                <Paper withBorder p="md">
-                    <Stack gap="xs">
-                        <Text fz="sm">
-                            {request.status ===
-                            ContentReviewRequestStatus.APPROVED
-                                ? 'Approved'
-                                : 'Rejected'}{' '}
-                            by {request.reviewedBy.firstName}{' '}
-                            {request.reviewedBy.lastName}
-                            {request.verifiedOnApprove ? ', and verified' : ''}
-                        </Text>
-                        <Timestamp prefix="Decided" date={request.reviewedAt} />
-                        {request.reviewNote && (
-                            <Blockquote fz="sm" p="sm">
-                                {request.reviewNote}
-                            </Blockquote>
-                        )}
-                    </Stack>
-                </Paper>
-            )}
-
-            {isPending && request.canReview && (
-                <Paper withBorder p="md">
-                    <Group justify="space-between">
-                        <Tooltip
-                            label="You need permission to verify content"
-                            disabled={request.canVerify}
-                            withArrow
-                        >
-                            <Checkbox
-                                label="Verify on approve"
-                                checked={verify}
-                                disabled={!request.canVerify}
-                                onChange={(event) =>
-                                    setVerify(event.currentTarget.checked)
-                                }
-                            />
-                        </Tooltip>
-                        <Group gap="xs">
-                            <Button
-                                variant="default"
-                                color="red"
-                                onClick={rejectHandlers.open}
-                                disabled={isApproving}
-                            >
-                                Reject
-                            </Button>
-                            <Button
-                                loading={isApproving}
-                                onClick={() =>
-                                    approve({
-                                        requestUuid: request.uuid,
-                                        body: { verify, note: null },
-                                    })
-                                }
-                            >
-                                Approve and move
-                            </Button>
-                        </Group>
-                    </Group>
-                </Paper>
-            )}
-
-            {isPending && isRequester && !request.canReview && (
-                <Group justify="flex-end">
+                <Tooltip
+                    label="You need permission to verify content"
+                    disabled={request.canVerify}
+                    withArrow
+                >
+                    <Checkbox
+                        label="Verify on approve"
+                        description="Marks it as the trusted version in the shared space"
+                        checked={verify}
+                        disabled={!request.canVerify}
+                        onChange={(event) =>
+                            setVerify(event.currentTarget.checked)
+                        }
+                    />
+                </Tooltip>
+                <Stack gap="xs">
                     <Button
-                        variant="default"
-                        loading={isCancelling}
-                        onClick={() => cancel(request.uuid)}
+                        fullWidth
+                        loading={isApproving}
+                        leftSection={<MantineIcon icon={IconCheck} />}
+                        onClick={() =>
+                            approve({
+                                requestUuid: request.uuid,
+                                body: { verify, note: null },
+                            })
+                        }
                     >
-                        Cancel request
+                        Approve and move
                     </Button>
-                </Group>
-            )}
-
+                    <Button
+                        fullWidth
+                        variant="default"
+                        color="red"
+                        onClick={rejectHandlers.open}
+                        disabled={isApproving}
+                    >
+                        Reject
+                    </Button>
+                </Stack>
+            </Stack>
             <RejectModal
                 opened={isRejectOpen}
                 onClose={rejectHandlers.close}
@@ -295,6 +201,327 @@ export const ContentReviewRequestDetailView: FC<{
                     rejectHandlers.close();
                 }}
             />
+        </Paper>
+    );
+};
+
+const WaitingCard: FC<{
+    request: ContentReviewRequestDetail;
+    projectUuid: string;
+}> = ({ request, projectUuid }) => {
+    const { mutate: cancel, isLoading: isCancelling } =
+        useCancelContentReviewRequest(projectUuid);
+    return (
+        <Paper p="md">
+            <Stack gap="md">
+                <Stack gap={4}>
+                    <Title order={5}>Waiting for a reviewer</Title>
+                    <Text fz="sm" c="dimmed">
+                        Reviewers for{' '}
+                        {request.targetSpaceName ?? 'the target space'} have
+                        been notified. You can pull the request back at any
+                        time.
+                    </Text>
+                </Stack>
+                <Button
+                    fullWidth
+                    variant="default"
+                    loading={isCancelling}
+                    onClick={() => cancel(request.uuid)}
+                >
+                    Cancel request
+                </Button>
+            </Stack>
+        </Paper>
+    );
+};
+
+const getDecisionLabel = (status: ContentReviewRequestStatus): string => {
+    switch (status) {
+        case ContentReviewRequestStatus.APPROVED:
+            return 'Approved';
+        case ContentReviewRequestStatus.REJECTED:
+            return 'Rejected';
+        case ContentReviewRequestStatus.CANCELLED:
+            return 'Cancelled';
+        case ContentReviewRequestStatus.PENDING:
+            return 'Pending';
+        default:
+            return assertUnreachable(status, 'Unknown review request status');
+    }
+};
+
+const ActivityCard: FC<{ request: ContentReviewRequestDetail }> = ({
+    request,
+}) => {
+    const isPending = request.status === ContentReviewRequestStatus.PENDING;
+    const isApproved = request.status === ContentReviewRequestStatus.APPROVED;
+    const decisionLabel = getDecisionLabel(request.status);
+
+    return (
+        <Paper p="md">
+            <Stack gap="md">
+                <Title order={5}>Activity</Title>
+                <Timeline
+                    active={isPending ? 0 : 1}
+                    bulletSize={22}
+                    lineWidth={2}
+                >
+                    <Timeline.Item
+                        bullet={<MantineIcon icon={IconSend} size={12} />}
+                        title={
+                            <Text fz="sm" fw={500}>
+                                Requested by{' '}
+                                {getUserFullName(request.requestedBy)}
+                            </Text>
+                        }
+                    >
+                        <TimeAgo date={request.createdAt} />
+                    </Timeline.Item>
+                    {isPending ? (
+                        <Timeline.Item
+                            bullet={
+                                <MantineIcon icon={IconClockHour4} size={12} />
+                            }
+                            title={
+                                <Text fz="sm" fw={500} c="dimmed">
+                                    Waiting for review
+                                </Text>
+                            }
+                        />
+                    ) : (
+                        <Timeline.Item
+                            bullet={
+                                <MantineIcon
+                                    icon={isApproved ? IconCheck : IconX}
+                                    size={12}
+                                />
+                            }
+                            color={isApproved ? 'green' : 'red'}
+                            title={
+                                <Group gap="xs">
+                                    <Text fz="sm" fw={500}>
+                                        {decisionLabel}
+                                        {request.reviewedBy
+                                            ? ` by ${getUserFullName(request.reviewedBy)}`
+                                            : ''}
+                                    </Text>
+                                    {request.verifiedOnApprove && (
+                                        <Badge
+                                            size="xs"
+                                            color="green"
+                                            variant="light"
+                                            leftSection={
+                                                <MantineIcon
+                                                    icon={IconCircleCheckFilled}
+                                                    size={10}
+                                                />
+                                            }
+                                        >
+                                            Verified
+                                        </Badge>
+                                    )}
+                                </Group>
+                            }
+                        >
+                            <Stack gap="xs">
+                                {request.reviewedAt && (
+                                    <TimeAgo date={request.reviewedAt} />
+                                )}
+                                {request.reviewNote && (
+                                    <Text fz="sm" className={classes.note}>
+                                        {request.reviewNote}
+                                    </Text>
+                                )}
+                            </Stack>
+                        </Timeline.Item>
+                    )}
+                </Timeline>
+            </Stack>
+        </Paper>
+    );
+};
+
+export const ContentReviewRequestDetailView: FC<{
+    projectUuid: string;
+    request: ContentReviewRequestDetail;
+}> = ({ projectUuid, request }) => {
+    const { user } = useApp();
+    const isPending = request.status === ContentReviewRequestStatus.PENDING;
+    const isRequester = user.data?.userUuid === request.requestedBy.userUuid;
+    const contentName = request.content?.name ?? 'Deleted content';
+    const typeLabel = getContentTypeLabel(request.contentType);
+    const isApproved = request.status === ContentReviewRequestStatus.APPROVED;
+    const moveTitle = isPending
+        ? 'What will move'
+        : isApproved
+          ? 'What moved'
+          : 'Requested move';
+    // Null means the request ended without a move
+    const moveItems = isPending
+        ? request.moveSet
+        : isApproved
+          ? request.movedContent
+          : null;
+
+    return (
+        <Stack gap="lg">
+            <Group justify="space-between" align="flex-start" wrap="nowrap">
+                <Group gap="sm" align="flex-start" wrap="nowrap">
+                    <IconBox
+                        icon={getContentTypeIcon(request.contentType)}
+                        color={getContentTypeColor(request.contentType)}
+                        boxSize={40}
+                        size="xl"
+                    />
+                    <Stack gap={4}>
+                        <Group gap="sm">
+                            <Title order={3}>{contentName}</Title>
+                            <ContentReviewStatusBadge status={request.status} />
+                        </Group>
+                        <Group gap="xs">
+                            <Text fz="sm" c="dimmed">
+                                {typeLabel} requested by
+                            </Text>
+                            <ContentReviewUserChip user={request.requestedBy} />
+                            <Text fz="sm" c="dimmed">
+                                ·
+                            </Text>
+                            <TimeAgo date={request.createdAt} />
+                        </Group>
+                    </Stack>
+                </Group>
+                {request.content && (
+                    <Button
+                        component={Link}
+                        to={getContentHref(
+                            projectUuid,
+                            request.contentType,
+                            request.content,
+                        )}
+                        variant="default"
+                        size="xs"
+                        leftSection={<MantineIcon icon={IconExternalLink} />}
+                    >
+                        Open {typeLabel.toLowerCase()}
+                    </Button>
+                )}
+            </Group>
+
+            <Grid gutter="lg">
+                <Grid.Col span={{ base: 12, md: 8 }}>
+                    <Stack gap="lg">
+                        <Paper p="md">
+                            <Stack gap="md">
+                                <Title order={5}>{moveTitle}</Title>
+                                <Group gap="sm" wrap="nowrap">
+                                    <SpaceChip
+                                        name={
+                                            request.sourceSpaceName ??
+                                            'Personal space'
+                                        }
+                                        personal
+                                    />
+                                    <MantineIcon
+                                        icon={IconArrowRight}
+                                        color="dimmed"
+                                    />
+                                    <SpaceChip
+                                        name={
+                                            request.targetSpaceName ??
+                                            'Deleted space'
+                                        }
+                                    />
+                                </Group>
+                                {moveItems === null ? (
+                                    <Text fz="sm" c="dimmed">
+                                        Nothing moved. It stayed in{' '}
+                                        {request.sourceSpaceName ??
+                                            'the personal space'}
+                                        .
+                                    </Text>
+                                ) : moveItems.length === 0 ? (
+                                    <Text fz="sm" c="dimmed">
+                                        Nothing
+                                    </Text>
+                                ) : (
+                                    <Stack gap={0} className={classes.list}>
+                                        {moveItems.map((item) => (
+                                            <ContentReviewItemRow
+                                                key={item.contentUuid}
+                                                contentType={item.contentType}
+                                                name={item.name}
+                                            />
+                                        ))}
+                                    </Stack>
+                                )}
+                            </Stack>
+                        </Paper>
+
+                        <Paper p="md">
+                            <Stack gap="sm">
+                                <Title order={5}>
+                                    Note from {request.requestedBy.firstName}
+                                </Title>
+                                {request.requestNote ? (
+                                    <Text fz="sm" className={classes.note}>
+                                        {request.requestNote}
+                                    </Text>
+                                ) : (
+                                    <Text fz="sm" c="dimmed">
+                                        No note was added.
+                                    </Text>
+                                )}
+                            </Stack>
+                        </Paper>
+
+                        {request.similarContent.length > 0 && (
+                            <Paper p="md">
+                                <Stack gap="sm">
+                                    <Stack gap={2}>
+                                        <Title order={5}>
+                                            Similar content the requester was
+                                            shown
+                                        </Title>
+                                        <Text fz="xs" c="dimmed">
+                                            These already lived in shared spaces
+                                            when the request was made.
+                                        </Text>
+                                    </Stack>
+                                    <Stack gap={0} className={classes.list}>
+                                        {request.similarContent.map((item) => (
+                                            <ContentReviewItemRow
+                                                key={item.contentUuid}
+                                                contentType={item.contentType}
+                                                name={item.name}
+                                                meta={`${getContentTypeLabel(item.contentType)} in ${item.spaceName}`}
+                                                isVerified={item.isVerified}
+                                            />
+                                        ))}
+                                    </Stack>
+                                </Stack>
+                            </Paper>
+                        )}
+                    </Stack>
+                </Grid.Col>
+                <Grid.Col span={{ base: 12, md: 4 }}>
+                    <Stack gap="lg">
+                        {isPending && request.canReview && (
+                            <DecisionCard
+                                request={request}
+                                projectUuid={projectUuid}
+                            />
+                        )}
+                        {isPending && isRequester && !request.canReview && (
+                            <WaitingCard
+                                request={request}
+                                projectUuid={projectUuid}
+                            />
+                        )}
+                        <ActivityCard request={request} />
+                    </Stack>
+                </Grid.Col>
+            </Grid>
         </Stack>
     );
 };
@@ -316,7 +543,7 @@ const ContentReviewRequestPage: FC = () => {
             withCenteredContent
             withXLargePaddedContent
         >
-            <Stack gap="md">
+            <Stack gap="lg">
                 <PageBreadcrumbs
                     items={[
                         {
@@ -329,7 +556,7 @@ const ContentReviewRequestPage: FC = () => {
                         },
                     ]}
                 />
-                {isInitialLoading && <Loader size="sm" />}
+                {isInitialLoading && <EmptyStateLoader />}
                 {error && (
                     <SettingsEmptyState
                         icon={IconAlertCircle}
@@ -344,13 +571,6 @@ const ContentReviewRequestPage: FC = () => {
                         request={request}
                     />
                 )}
-                <Anchor
-                    component={Link}
-                    to={getContentReviewRequestsPath(projectUuid)}
-                    fz="sm"
-                >
-                    Back to review requests
-                </Anchor>
             </Stack>
         </Page>
     );

--- a/packages/frontend/src/ee/features/contentReview/pages/ContentReviewRequestsPage.tsx
+++ b/packages/frontend/src/ee/features/contentReview/pages/ContentReviewRequestsPage.tsx
@@ -1,0 +1,312 @@
+import { subject } from '@casl/ability';
+import {
+    ContentReviewRequestStatus,
+    ContentReviewRequestView,
+    ContentType,
+    getContentReviewRequestPath,
+    getContentReviewRequestsPath,
+    type ContentReviewRequestListItem,
+} from '@lightdash/common';
+import {
+    Anchor,
+    Badge,
+    Group,
+    SegmentedControl,
+    Select,
+    Stack,
+    Text,
+} from '@mantine/core';
+import { IconChartBar, IconLayoutDashboard } from '@tabler/icons-react';
+import { useMemo, useState, type FC } from 'react';
+import { Link, Navigate, useNavigate } from 'react-router';
+import {
+    ContentTable,
+    useContentTable,
+    type ContentTableColumnDef,
+} from '../../../../components/common/ContentTable';
+import MantineIcon from '../../../../components/common/MantineIcon';
+import Page from '../../../../components/common/Page/Page';
+import PageBreadcrumbs from '../../../../components/common/PageBreadcrumbs';
+import { useProjectUuid } from '../../../../hooks/useProjectUuid';
+import { useTimeAgo } from '../../../../hooks/useTimeAgo';
+import useApp from '../../../../providers/App/useApp';
+import ContentReviewStatusBadge from '../components/ContentReviewStatusBadge';
+import { useContentReviewAvailability } from '../hooks/useContentReviewAvailability';
+import { useContentReviewRequests } from '../hooks/useContentReviewRequests';
+import { getContentHref, getContentTypeLabel } from '../utils';
+
+const PAGE_SIZE = 200;
+
+const STATUS_OPTIONS: {
+    value: ContentReviewRequestStatus | 'all';
+    label: string;
+}[] = [
+    { value: 'all', label: 'All statuses' },
+    { value: ContentReviewRequestStatus.PENDING, label: 'Pending' },
+    { value: ContentReviewRequestStatus.APPROVED, label: 'Approved' },
+    { value: ContentReviewRequestStatus.REJECTED, label: 'Rejected' },
+    { value: ContentReviewRequestStatus.CANCELLED, label: 'Cancelled' },
+];
+
+const RequestedAgo: FC<{ createdAt: Date }> = ({ createdAt }) => {
+    const ago = useTimeAgo(new Date(createdAt));
+    return (
+        <Text fz="sm" c="ldGray.7">
+            {ago}
+        </Text>
+    );
+};
+
+const ContentReviewRequestsPage: FC = () => {
+    const projectUuid = useProjectUuid();
+    const navigate = useNavigate();
+    const { user } = useApp();
+    const { isAvailable, isLoading: isLoadingAvailability } =
+        useContentReviewAvailability();
+    const canManageSettings =
+        !!projectUuid &&
+        (user.data?.ability.can(
+            'manage',
+            subject('Project', {
+                organizationUuid: user.data.organizationUuid,
+                projectUuid,
+            }),
+        ) ??
+            false);
+    const [view, setView] = useState<ContentReviewRequestView>(
+        ContentReviewRequestView.TO_REVIEW,
+    );
+    const [status, setStatus] = useState<ContentReviewRequestStatus | 'all'>(
+        ContentReviewRequestStatus.PENDING,
+    );
+
+    const { data, isInitialLoading } = useContentReviewRequests(
+        projectUuid ?? '',
+        {
+            view,
+            status: status === 'all' ? null : status,
+            page: 1,
+            pageSize: PAGE_SIZE,
+        },
+        !!projectUuid && isAvailable,
+    );
+    const items = useMemo(() => data?.data ?? [], [data]);
+
+    const columns: ContentTableColumnDef<ContentReviewRequestListItem>[] =
+        useMemo(
+            () => [
+                {
+                    accessorKey: 'content',
+                    header: 'Content',
+                    enableSorting: false,
+                    size: 260,
+                    Cell: ({ row }) => {
+                        const { content, contentType } = row.original;
+                        if (!content || !projectUuid) {
+                            return (
+                                <Text fz="sm" c="ldGray.6" fs="italic">
+                                    Deleted content
+                                </Text>
+                            );
+                        }
+                        return (
+                            <Anchor
+                                component={Link}
+                                to={getContentHref(
+                                    projectUuid,
+                                    contentType,
+                                    content,
+                                )}
+                                fz="sm"
+                                fw={500}
+                                truncate="end"
+                                onClick={(e) => e.stopPropagation()}
+                            >
+                                {content.name}
+                            </Anchor>
+                        );
+                    },
+                },
+                {
+                    accessorKey: 'contentType',
+                    header: 'Type',
+                    enableSorting: false,
+                    size: 120,
+                    Cell: ({ row }) => {
+                        const isChart =
+                            row.original.contentType === ContentType.CHART;
+                        return (
+                            <Badge
+                                variant="light"
+                                color={isChart ? 'blue' : 'violet'}
+                                leftSection={
+                                    <MantineIcon
+                                        icon={
+                                            isChart
+                                                ? IconChartBar
+                                                : IconLayoutDashboard
+                                        }
+                                        size="sm"
+                                    />
+                                }
+                            >
+                                {getContentTypeLabel(row.original.contentType)}
+                            </Badge>
+                        );
+                    },
+                },
+                {
+                    accessorKey: 'requestedBy',
+                    header: 'Requested by',
+                    enableSorting: false,
+                    size: 160,
+                    Cell: ({ row }) => (
+                        <Text fz="sm" c="ldGray.7">
+                            {row.original.requestedBy.firstName}{' '}
+                            {row.original.requestedBy.lastName}
+                        </Text>
+                    ),
+                },
+                {
+                    accessorKey: 'targetSpaceName',
+                    header: 'Target space',
+                    enableSorting: false,
+                    size: 160,
+                    Cell: ({ row }) => (
+                        <Text fz="sm" c="ldGray.7">
+                            {row.original.targetSpaceName ?? 'Deleted space'}
+                        </Text>
+                    ),
+                },
+                {
+                    accessorKey: 'status',
+                    header: 'Status',
+                    enableSorting: false,
+                    size: 110,
+                    Cell: ({ row }) => (
+                        <ContentReviewStatusBadge
+                            status={row.original.status}
+                        />
+                    ),
+                },
+                {
+                    accessorKey: 'createdAt',
+                    header: 'Requested',
+                    enableSorting: false,
+                    size: 140,
+                    Cell: ({ row }) => (
+                        <RequestedAgo createdAt={row.original.createdAt} />
+                    ),
+                },
+            ],
+            [projectUuid],
+        );
+
+    const table = useContentTable({
+        columns,
+        data: items,
+        enableSorting: false,
+        enablePagination: false,
+        enableBottomToolbar: false,
+        enableTopToolbar: false,
+        enableRowSelection: false,
+        enableStickyHeader: true,
+        state: { isLoading: isInitialLoading },
+        mantineTableProps: {
+            highlightOnHover: true,
+            withColumnBorders: Boolean(items.length),
+        },
+        mantineTableBodyRowProps: ({ row }) => ({
+            onClick: () => {
+                if (!projectUuid) return;
+                void navigate(
+                    getContentReviewRequestPath(projectUuid, row.original.uuid),
+                );
+            },
+        }),
+        renderEmptyRowsFallback: () => (
+            <Text fz="sm" c="ldGray.6" ta="center" py="xl">
+                {view === ContentReviewRequestView.TO_REVIEW
+                    ? 'Nothing waiting for your review'
+                    : 'You have not requested any reviews yet'}
+            </Text>
+        ),
+    });
+
+    if (!projectUuid) return null;
+    if (!isLoadingAvailability && !isAvailable) {
+        return <Navigate to={`/projects/${projectUuid}/home`} replace />;
+    }
+
+    return (
+        <Page
+            title="Review requests"
+            withCenteredContent
+            withXLargePaddedContent
+        >
+            <Stack gap="md">
+                <PageBreadcrumbs
+                    items={[
+                        {
+                            title: 'Review requests',
+                            to: getContentReviewRequestsPath(projectUuid),
+                            active: true,
+                        },
+                    ]}
+                />
+                <Group justify="space-between">
+                    <SegmentedControl
+                        value={view}
+                        onChange={(value) => {
+                            const nextView = value as ContentReviewRequestView;
+                            setView(nextView);
+                            setStatus(
+                                nextView === ContentReviewRequestView.TO_REVIEW
+                                    ? ContentReviewRequestStatus.PENDING
+                                    : 'all',
+                            );
+                        }}
+                        data={[
+                            {
+                                value: ContentReviewRequestView.TO_REVIEW,
+                                label: 'To review',
+                            },
+                            {
+                                value: ContentReviewRequestView.MINE,
+                                label: 'My requests',
+                            },
+                        ]}
+                    />
+                    <Group gap="sm">
+                        {canManageSettings && (
+                            <Anchor
+                                component={Link}
+                                to={`/generalSettings/projectManagement/${projectUuid}/reviewRequests`}
+                                fz="sm"
+                            >
+                                Review settings
+                            </Anchor>
+                        )}
+                        <Select
+                            size="xs"
+                            w={160}
+                            value={status}
+                            onChange={(value) =>
+                                setStatus(
+                                    (value as
+                                        | ContentReviewRequestStatus
+                                        | 'all') ?? 'all',
+                                )
+                            }
+                            data={STATUS_OPTIONS}
+                            allowDeselect={false}
+                        />
+                    </Group>
+                </Group>
+                <ContentTable table={table} />
+            </Stack>
+        </Page>
+    );
+};
+
+export default ContentReviewRequestsPage;

--- a/packages/frontend/src/ee/features/contentReview/pages/ContentReviewRequestsPage.tsx
+++ b/packages/frontend/src/ee/features/contentReview/pages/ContentReviewRequestsPage.tsx
@@ -2,21 +2,20 @@ import { subject } from '@casl/ability';
 import {
     ContentReviewRequestStatus,
     ContentReviewRequestView,
-    ContentType,
     getContentReviewRequestPath,
-    getContentReviewRequestsPath,
     type ContentReviewRequestListItem,
 } from '@lightdash/common';
 import {
     Anchor,
-    Badge,
+    Button,
     Group,
     SegmentedControl,
     Select,
     Stack,
     Text,
+    Title,
 } from '@mantine/core';
-import { IconChartBar, IconLayoutDashboard } from '@tabler/icons-react';
+import { IconFolder, IconInbox, IconSettings } from '@tabler/icons-react';
 import { useMemo, useState, type FC } from 'react';
 import { Link, Navigate, useNavigate } from 'react-router';
 import {
@@ -26,14 +25,20 @@ import {
 } from '../../../../components/common/ContentTable';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import Page from '../../../../components/common/Page/Page';
-import PageBreadcrumbs from '../../../../components/common/PageBreadcrumbs';
+import { IconBox } from '../../../../components/common/ResourceIcon';
 import { useProjectUuid } from '../../../../hooks/useProjectUuid';
 import { useTimeAgo } from '../../../../hooks/useTimeAgo';
 import useApp from '../../../../providers/App/useApp';
 import ContentReviewStatusBadge from '../components/ContentReviewStatusBadge';
+import ContentReviewUserChip from '../components/ContentReviewUserChip';
 import { useContentReviewAvailability } from '../hooks/useContentReviewAvailability';
 import { useContentReviewRequests } from '../hooks/useContentReviewRequests';
-import { getContentHref, getContentTypeLabel } from '../utils';
+import {
+    getContentHref,
+    getContentTypeColor,
+    getContentTypeIcon,
+    getContentTypeLabel,
+} from '../utils';
 
 const PAGE_SIZE = 200;
 
@@ -51,7 +56,7 @@ const STATUS_OPTIONS: {
 const RequestedAgo: FC<{ createdAt: Date }> = ({ createdAt }) => {
     const ago = useTimeAgo(new Date(createdAt));
     return (
-        <Text fz="sm" c="ldGray.7">
+        <Text fz="sm" c="dimmed">
             {ago}
         </Text>
     );
@@ -99,59 +104,44 @@ const ContentReviewRequestsPage: FC = () => {
                     accessorKey: 'content',
                     header: 'Content',
                     enableSorting: false,
-                    size: 260,
+                    size: 320,
                     Cell: ({ row }) => {
                         const { content, contentType } = row.original;
-                        if (!content || !projectUuid) {
-                            return (
-                                <Text fz="sm" c="ldGray.6" fs="italic">
-                                    Deleted content
-                                </Text>
-                            );
-                        }
                         return (
-                            <Anchor
-                                component={Link}
-                                to={getContentHref(
-                                    projectUuid,
-                                    contentType,
-                                    content,
-                                )}
-                                fz="sm"
-                                fw={500}
-                                truncate="end"
-                                onClick={(e) => e.stopPropagation()}
-                            >
-                                {content.name}
-                            </Anchor>
-                        );
-                    },
-                },
-                {
-                    accessorKey: 'contentType',
-                    header: 'Type',
-                    enableSorting: false,
-                    size: 120,
-                    Cell: ({ row }) => {
-                        const isChart =
-                            row.original.contentType === ContentType.CHART;
-                        return (
-                            <Badge
-                                variant="light"
-                                color={isChart ? 'blue' : 'violet'}
-                                leftSection={
-                                    <MantineIcon
-                                        icon={
-                                            isChart
-                                                ? IconChartBar
-                                                : IconLayoutDashboard
-                                        }
-                                        size="sm"
-                                    />
-                                }
-                            >
-                                {getContentTypeLabel(row.original.contentType)}
-                            </Badge>
+                            <Group gap="sm" wrap="nowrap">
+                                <IconBox
+                                    icon={getContentTypeIcon(contentType)}
+                                    color={getContentTypeColor(contentType)}
+                                    boxSize={28}
+                                    size="md"
+                                />
+                                <Stack gap={0} miw={0}>
+                                    {content && projectUuid ? (
+                                        <Anchor
+                                            component={Link}
+                                            to={getContentHref(
+                                                projectUuid,
+                                                contentType,
+                                                content,
+                                            )}
+                                            fz="sm"
+                                            fw={500}
+                                            c="text"
+                                            truncate="end"
+                                            onClick={(e) => e.stopPropagation()}
+                                        >
+                                            {content.name}
+                                        </Anchor>
+                                    ) : (
+                                        <Text fz="sm" c="dimmed" fs="italic">
+                                            Deleted content
+                                        </Text>
+                                    )}
+                                    <Text fz="xs" c="dimmed">
+                                        {getContentTypeLabel(contentType)}
+                                    </Text>
+                                </Stack>
+                            </Group>
                         );
                     },
                 },
@@ -159,23 +149,26 @@ const ContentReviewRequestsPage: FC = () => {
                     accessorKey: 'requestedBy',
                     header: 'Requested by',
                     enableSorting: false,
-                    size: 160,
+                    size: 180,
                     Cell: ({ row }) => (
-                        <Text fz="sm" c="ldGray.7">
-                            {row.original.requestedBy.firstName}{' '}
-                            {row.original.requestedBy.lastName}
-                        </Text>
+                        <ContentReviewUserChip
+                            user={row.original.requestedBy}
+                        />
                     ),
                 },
                 {
                     accessorKey: 'targetSpaceName',
-                    header: 'Target space',
+                    header: 'Moving to',
                     enableSorting: false,
-                    size: 160,
+                    size: 180,
                     Cell: ({ row }) => (
-                        <Text fz="sm" c="ldGray.7">
-                            {row.original.targetSpaceName ?? 'Deleted space'}
-                        </Text>
+                        <Group gap={6} wrap="nowrap">
+                            <MantineIcon icon={IconFolder} color="dimmed" />
+                            <Text fz="sm" truncate="end">
+                                {row.original.targetSpaceName ??
+                                    'Deleted space'}
+                            </Text>
+                        </Group>
                     ),
                 },
                 {
@@ -214,7 +207,6 @@ const ContentReviewRequestsPage: FC = () => {
         state: { isLoading: isInitialLoading },
         mantineTableProps: {
             highlightOnHover: true,
-            withColumnBorders: Boolean(items.length),
         },
         mantineTableBodyRowProps: ({ row }) => ({
             onClick: () => {
@@ -225,11 +217,19 @@ const ContentReviewRequestsPage: FC = () => {
             },
         }),
         renderEmptyRowsFallback: () => (
-            <Text fz="sm" c="ldGray.6" ta="center" py="xl">
-                {view === ContentReviewRequestView.TO_REVIEW
-                    ? 'Nothing waiting for your review'
-                    : 'You have not requested any reviews yet'}
-            </Text>
+            <Stack align="center" gap="xs" py="xl">
+                <MantineIcon icon={IconInbox} size="xl" color="dimmed" />
+                <Text fz="sm" fw={500}>
+                    {view === ContentReviewRequestView.TO_REVIEW
+                        ? 'Nothing waiting for your review'
+                        : 'You have not requested any reviews yet'}
+                </Text>
+                <Text fz="xs" c="dimmed" ta="center" maw={360}>
+                    {view === ContentReviewRequestView.TO_REVIEW
+                        ? 'Requests to move content into spaces you can edit will show up here.'
+                        : 'Open a chart or dashboard in your personal space and choose Request review.'}
+                </Text>
+            </Stack>
         ),
     });
 
@@ -244,16 +244,27 @@ const ContentReviewRequestsPage: FC = () => {
             withCenteredContent
             withXLargePaddedContent
         >
-            <Stack gap="md">
-                <PageBreadcrumbs
-                    items={[
-                        {
-                            title: 'Review requests',
-                            to: getContentReviewRequestsPath(projectUuid),
-                            active: true,
-                        },
-                    ]}
-                />
+            <Stack gap="lg">
+                <Group justify="space-between" align="flex-start">
+                    <Stack gap={4}>
+                        <Title order={3}>Review requests</Title>
+                        <Text fz="sm" c="dimmed">
+                            Charts and dashboards waiting to move from a
+                            personal space into a shared one.
+                        </Text>
+                    </Stack>
+                    {canManageSettings && (
+                        <Button
+                            component={Link}
+                            to={`/generalSettings/projectManagement/${projectUuid}/reviewRequests`}
+                            variant="default"
+                            size="xs"
+                            leftSection={<MantineIcon icon={IconSettings} />}
+                        >
+                            Review settings
+                        </Button>
+                    )}
+                </Group>
                 <Group justify="space-between">
                     <SegmentedControl
                         value={view}
@@ -277,31 +288,19 @@ const ContentReviewRequestsPage: FC = () => {
                             },
                         ]}
                     />
-                    <Group gap="sm">
-                        {canManageSettings && (
-                            <Anchor
-                                component={Link}
-                                to={`/generalSettings/projectManagement/${projectUuid}/reviewRequests`}
-                                fz="sm"
-                            >
-                                Review settings
-                            </Anchor>
-                        )}
-                        <Select
-                            size="xs"
-                            w={160}
-                            value={status}
-                            onChange={(value) =>
-                                setStatus(
-                                    (value as
-                                        | ContentReviewRequestStatus
-                                        | 'all') ?? 'all',
-                                )
-                            }
-                            data={STATUS_OPTIONS}
-                            allowDeselect={false}
-                        />
-                    </Group>
+                    <Select
+                        size="xs"
+                        w={160}
+                        value={status}
+                        onChange={(value) =>
+                            setStatus(
+                                (value as ContentReviewRequestStatus | 'all') ??
+                                    'all',
+                            )
+                        }
+                        data={STATUS_OPTIONS}
+                        allowDeselect={false}
+                    />
                 </Group>
                 <ContentTable table={table} />
             </Stack>

--- a/packages/frontend/src/ee/features/contentReview/utils.ts
+++ b/packages/frontend/src/ee/features/contentReview/utils.ts
@@ -19,7 +19,10 @@ export const getContentTypeIcon = (contentType: ContentReviewContentType) => {
         case ContentReviewContentType.DASHBOARD:
             return IconLayoutDashboard;
         default:
-            return assertUnreachable(contentType, 'Unknown review content type');
+            return assertUnreachable(
+                contentType,
+                'Unknown review content type',
+            );
     }
 };
 
@@ -33,7 +36,10 @@ export const getContentTypeColor = (
         case ContentReviewContentType.DASHBOARD:
             return 'green.6';
         default:
-            return assertUnreachable(contentType, 'Unknown review content type');
+            return assertUnreachable(
+                contentType,
+                'Unknown review content type',
+            );
     }
 };
 
@@ -49,7 +55,10 @@ export const getContentTypeNoun = (
         case ContentReviewContentType.DASHBOARD:
             return 'dashboard';
         default:
-            return assertUnreachable(contentType, 'Unknown review content type');
+            return assertUnreachable(
+                contentType,
+                'Unknown review content type',
+            );
     }
 };
 
@@ -72,7 +81,10 @@ export const getContentHref = (
         case ContentReviewContentType.DASHBOARD:
             return `/projects/${projectUuid}/dashboards/${content.slug}`;
         default:
-            return assertUnreachable(contentType, 'Unknown review content type');
+            return assertUnreachable(
+                contentType,
+                'Unknown review content type',
+            );
     }
 };
 
@@ -87,6 +99,9 @@ export const getContentTypeLabel = (
         case ContentReviewContentType.DASHBOARD:
             return 'Dashboard';
         default:
-            return assertUnreachable(contentType, 'Unknown review content type');
+            return assertUnreachable(
+                contentType,
+                'Unknown review content type',
+            );
     }
 };

--- a/packages/frontend/src/ee/features/contentReview/utils.ts
+++ b/packages/frontend/src/ee/features/contentReview/utils.ts
@@ -1,6 +1,7 @@
 import {
     assertUnreachable,
     ContentReviewContentType,
+    type ContentReviewContentSummary,
     type ContentReviewUser,
 } from '@lightdash/common';
 import {
@@ -18,10 +19,7 @@ export const getContentTypeIcon = (contentType: ContentReviewContentType) => {
         case ContentReviewContentType.DASHBOARD:
             return IconLayoutDashboard;
         default:
-            return assertUnreachable(
-                contentType,
-                'Unknown review content type',
-            );
+            return assertUnreachable(contentType, 'Unknown review content type');
     }
 };
 
@@ -35,10 +33,7 @@ export const getContentTypeColor = (
         case ContentReviewContentType.DASHBOARD:
             return 'green.6';
         default:
-            return assertUnreachable(
-                contentType,
-                'Unknown review content type',
-            );
+            return assertUnreachable(contentType, 'Unknown review content type');
     }
 };
 
@@ -54,10 +49,7 @@ export const getContentTypeNoun = (
         case ContentReviewContentType.DASHBOARD:
             return 'dashboard';
         default:
-            return assertUnreachable(
-                contentType,
-                'Unknown review content type',
-            );
+            return assertUnreachable(contentType, 'Unknown review content type');
     }
 };
 
@@ -66,3 +58,35 @@ export const getUserFullName = (user: ContentReviewUser): string =>
 
 export const getUserInitials = (user: ContentReviewUser): string =>
     `${user.firstName.charAt(0)}${user.lastName.charAt(0)}`.toUpperCase();
+
+export const getContentHref = (
+    projectUuid: string,
+    contentType: ContentReviewContentType,
+    content: ContentReviewContentSummary,
+): string => {
+    switch (contentType) {
+        case ContentReviewContentType.CHART:
+            return `/projects/${projectUuid}/saved/${content.slug}`;
+        case ContentReviewContentType.SQL_CHART:
+            return `/projects/${projectUuid}/sql-runner/${content.slug}`;
+        case ContentReviewContentType.DASHBOARD:
+            return `/projects/${projectUuid}/dashboards/${content.slug}`;
+        default:
+            return assertUnreachable(contentType, 'Unknown review content type');
+    }
+};
+
+export const getContentTypeLabel = (
+    contentType: ContentReviewContentType,
+): string => {
+    switch (contentType) {
+        case ContentReviewContentType.CHART:
+            return 'Chart';
+        case ContentReviewContentType.SQL_CHART:
+            return 'SQL chart';
+        case ContentReviewContentType.DASHBOARD:
+            return 'Dashboard';
+        default:
+            return assertUnreachable(contentType, 'Unknown review content type');
+    }
+};

--- a/packages/frontend/src/hooks/settings/types.ts
+++ b/packages/frontend/src/hooks/settings/types.ts
@@ -86,6 +86,7 @@ export type SettingsContext = {
     isGroupManagementEnabled: boolean;
     isWarehouseCredentialsEnabled: boolean;
     isGitProject: boolean;
+    isContentReviewAvailable: boolean;
     isHealthLoading: boolean;
     healthError: ApiError | null;
     isUserLoading: boolean;

--- a/packages/frontend/src/hooks/settings/useSettingsContext.ts
+++ b/packages/frontend/src/hooks/settings/useSettingsContext.ts
@@ -3,6 +3,7 @@ import { CommercialFeatureFlags, FeatureFlags } from '@lightdash/common';
 import { matchPath, useLocation } from 'react-router';
 import { useIsGitProject } from '../../components/Explorer/WriteBackModal/hooks';
 import { useAiOrganizationSettings } from '../../ee/features/aiCopilot/hooks/useAiOrganizationSettings';
+import { useContentReviewAvailability } from '../../ee/features/contentReview/hooks/useContentReviewAvailability';
 import useApp from '../../providers/App/useApp';
 import { useOrganization } from '../organization/useOrganization';
 import { useActiveProjectUuid } from '../useActiveProject';
@@ -129,6 +130,8 @@ export const useSettingsContext = (): SettingsContext => {
     } = useProject(settingsProjectUuid);
 
     const isGitProject = useIsGitProject(settingsProjectUuid ?? '');
+    const { isAvailable: isContentReviewAvailable } =
+        useContentReviewAvailability();
 
     // "Ask AI" settings are visible to org AI admins (all projects) and to
     // project-scoped AI admins (only the projects they can reach). These are
@@ -215,6 +218,7 @@ export const useSettingsContext = (): SettingsContext => {
         isGroupManagementEnabled,
         isWarehouseCredentialsEnabled,
         isGitProject,
+        isContentReviewAvailable,
         isHealthLoading,
         healthError,
         isUserLoading,

--- a/packages/frontend/src/hooks/settings/useSettingsNavigation.ts
+++ b/packages/frontend/src/hooks/settings/useSettingsNavigation.ts
@@ -33,6 +33,7 @@ import {
     IconReportAnalytics,
     IconRoad,
     IconRobotFace,
+    IconSend,
     IconSettings,
     IconShieldCheck,
     IconTableOptions,
@@ -92,6 +93,7 @@ export const useSettingsNavigation = (
         externalSourcesFlag,
         isResultsCacheEnabled,
         isGitProject,
+        isContentReviewAvailable,
     } = context;
 
     const isEmbeddingEnabled = embeddingEnabled?.enabled ?? false;
@@ -949,6 +951,31 @@ export const useSettingsNavigation = (
             }
 
             if (
+                isContentReviewAvailable &&
+                ability?.can(
+                    'manage',
+                    subject('Project', {
+                        organizationUuid: project.organizationUuid,
+                        projectUuid: project.projectUuid,
+                    }),
+                )
+            ) {
+                projectItems.push({
+                    label: 'Review requests',
+                    to: `${base}/reviewRequests`,
+                    icon: IconSend,
+                    keywords: [
+                        'review',
+                        'personal space',
+                        'approve',
+                        'reviewers',
+                    ],
+                    children: [],
+                    exact: true,
+                });
+            }
+
+            if (
                 ability?.can(
                     'promote',
                     subject('SavedChart', {
@@ -1052,6 +1079,7 @@ export const useSettingsNavigation = (
         isExternalSourcesEnabled,
         isResultsCacheEnabled,
         isGitProject,
+        isContentReviewAvailable,
         track,
     ]);
 };

--- a/packages/frontend/src/types/Events.ts
+++ b/packages/frontend/src/types/Events.ts
@@ -45,6 +45,8 @@ export enum PageName {
     NO_PROJECT_ACCESS = 'no_project_access',
     SPACE = 'space',
     SPACES = 'spaces',
+    CONTENT_REVIEW_REQUESTS = 'content_review_requests',
+    CONTENT_REVIEW_REQUEST = 'content_review_request',
     SHARED_WITH_ME = 'shared_with_me',
     SHARE = 'share',
     USER_ACTIVITY = 'user_activity',


### PR DESCRIPTION
## Summary

Fifth PR of the content review requests stack, on top of #28434. The reviewer side and the per-project settings.

### Pages

- `/projects/:projectUuid/review-requests`: the queue. "To review" shows pending requests routed to the viewer; "My requests" shows the viewer's own with a status filter. Rows open the request; content names link to the item (reviewers can open personal-space content because of the grant written on submit). Project admins get a link to the settings panel.
- `/projects/:projectUuid/review-requests/:requestUuid`: the request. Requester, source and target space, the note, what approval will move (recomputed live while pending, the recorded set afterwards), the similar content the requester was shown, and the decision with the reviewer's note.
  - Reviewers see "Approve and move" with a "Verify on approve" checkbox that defaults to the project setting and is disabled (with the reason) without `manage ContentVerification`, and "Reject", which requires a note.
  - Requesters can cancel a pending request.
- Both are registered as lazy project routes and tracked as pages.

### Settings

`ContentReviewSettingsPanel` under project settings (`/reviewRequests`, `manage Project` only, shown when the feature is available): who reviews (editors of the target space, or an organization group), whether approval verifies by default, and a Slack channel for new requests when Slack is connected. Like the verified content panel it has no sidebar entry; it's reached from the queue page.

### Hooks

List, detail, approve, reject, settings read and update, all under `ee/features/contentReview`. Approving also invalidates space and content queries because the content moved.

## Regression analysis

- Two new routes under the project layout; no existing route or component changes beyond adding the settings route to `ProjectSettings` behind an availability check and the existing `manage Project` ability.
- `PageName` gains two members. The tracking event union is untyped on properties, so no other change was required.
- Everything is gated by `useContentReviewAvailability` (flag, direct access, license); with the flag off the queue page redirects home and the settings route is not registered.

## Testing

- `ContentReviewRequestPage.test.tsx`: the move set renders, approve sends the verify default, the checkbox is disabled and unchecked without permission, reject is blocked until a note is entered, decided requests show the outcome and hide the actions.
- `pnpm -F frontend typecheck`, `pnpm -F frontend run linter` on the touched files, `pnpm -F frontend unused-exports`.
- Note for reviewers: the working tree this was built in had unrelated in-progress theme edits that break `MantineProvider` in vitest, so the frontend tests for this PR were run from a clean checkout of the commit.

Relates: PROD-9730
Relates: #26967

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7bgpm3JZGoF2bRviShXWP

## Polish (second commit)

Request page: header with type icon, status and requester chip; content on the left (source to target chips, what will move, the note, the similar-content snapshot) and a decision card plus an activity timeline on the right. Rejected and cancelled requests say "Requested move, nothing moved"; approved ones list `movedContent`. Queue: real header, "Review settings" button, content cell with icon and type, requester avatar chip, inbox empty state. Settings: grouped picker, descriptions that state the project-access requirement, Slack copy links to integrations.

Discovery: the queue is listed in the Browse menu with a pending count (reuses the list endpoint with page size one), the settings page has a sidebar entry under the project section, and a hard load of its URL waits for the availability flags instead of bouncing to the settings index.

Still open on the stack: a reviewer group without project access makes every submit fail with "Direct access target not found", and the API still accepts "Default User Spaces" as a target.

## SQL runner charts

The reviewer page and its test use the review enum, the disabled verify checkbox explains "SQL charts cannot be verified yet", and the open button reads "Open SQL chart". Links use the SQL runner route for SQL charts.