### PR TITLE
feat(review-requests): similar content nudge

### DIFF
--- a/packages/backend/src/ee/controllers/ContentReviewRequestController.ts
+++ b/packages/backend/src/ee/controllers/ContentReviewRequestController.ts
@@ -5,6 +5,7 @@ import {
     type ApiContentReviewRequestOrNullResponse,
     type ApiContentReviewRequestResponse,
     type ApiContentReviewSettingsResponse,
+    type ApiContentReviewSimilarContentResponse,
     type ApiErrorPayload,
     type ApproveContentReviewRequestBody,
     type ContentReviewContentType,
@@ -96,6 +97,37 @@ export class ContentReviewRequestController extends BaseController {
                 toSessionUser(req.account),
                 projectUuid,
                 body,
+            ),
+        };
+    }
+
+    /**
+     * Charts or dashboards in shared spaces with a similar name, so a requester can check before submitting
+     * @summary Find similar content
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/similar')
+    @OperationId('findSimilarContentForReview')
+    async findSimilar(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+        @Query() contentType: ContentReviewContentType,
+        @Query() name: string,
+        @Query() excludeContentUuid?: UUID,
+    ): Promise<ApiContentReviewSimilarContentResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getService().findSimilarContent(
+                toSessionUser(req.account),
+                projectUuid,
+                {
+                    contentType,
+                    name,
+                    excludeContentUuid: excludeContentUuid ?? null,
+                },
             ),
         };
     }

--- a/packages/backend/src/ee/services/ContentReviewRequestService/ContentReviewRequestService.ts
+++ b/packages/backend/src/ee/services/ContentReviewRequestService/ContentReviewRequestService.ts
@@ -23,6 +23,7 @@ import {
     type ContentReviewRequestDetail,
     type ContentReviewRequestListItem,
     type ContentReviewSettings,
+    type ContentReviewSimilarContentItem,
     type CreateContentReviewRequestBody,
     type DirectAccessPrincipalRef,
     type KnexPaginateArgs,
@@ -73,6 +74,10 @@ type ContentReviewRequestServiceArguments = {
 };
 
 type ProjectContext = { organizationUuid: string; projectUuid: string };
+
+const SIMILAR_CANDIDATE_LIMIT = 20;
+const SIMILAR_RESULT_LIMIT = 5;
+const VERIFIED_SCORE_BOOST = 10;
 
 type ContentLookups = {
     locations: Map<string, ContentReviewContentLocation>;
@@ -1127,6 +1132,58 @@ export class ContentReviewRequestService extends BaseService {
             { ...cancelled, grantedPrincipals: [] },
             settings,
         );
+    }
+
+    // Name lookalikes in shared spaces the caller can see, verified ones
+    // first so the sanctioned version is easy to spot
+    async findSimilarContent(
+        user: SessionUser,
+        projectUuid: string,
+        params: {
+            contentType: ContentReviewContentType;
+            name: string;
+            excludeContentUuid: string | null;
+        },
+    ): Promise<ContentReviewSimilarContentItem[]> {
+        await this.getProjectContext(user, projectUuid);
+        if (params.name.trim().length === 0) return [];
+        const candidates =
+            await this.contentReviewRequestModel.findSimilarByName({
+                projectUuid,
+                contentType: params.contentType,
+                name: params.name,
+                excludeContentUuid: params.excludeContentUuid,
+                limit: SIMILAR_CANDIDATE_LIMIT,
+            });
+        if (candidates.length === 0) return [];
+        const accessible = new Set(
+            await this.spacePermissionService.getAccessibleSpaceUuids(
+                'view',
+                user,
+                [...new Set(candidates.map((c) => c.spaceUuid))],
+            ),
+        );
+        const visible = candidates.filter((c) => accessible.has(c.spaceUuid));
+        const verified = await this.contentVerificationModel.getByContentUuids(
+            params.contentType,
+            visible.map((c) => c.uuid),
+        );
+        return visible
+            .map((c) => {
+                const isVerified = verified.has(c.uuid);
+                return {
+                    contentType: params.contentType,
+                    contentUuid: c.uuid,
+                    name: c.name,
+                    slug: c.slug,
+                    spaceUuid: c.spaceUuid,
+                    spaceName: c.spaceName,
+                    isVerified,
+                    score: c.score + (isVerified ? VERIFIED_SCORE_BOOST : 0),
+                };
+            })
+            .sort((a, b) => b.score - a.score)
+            .slice(0, SIMILAR_RESULT_LIMIT);
     }
 
     private assertCanManageSettings(

--- a/packages/backend/src/ee/services/ContentReviewRequestService/ContentReviewRequestService.ts
+++ b/packages/backend/src/ee/services/ContentReviewRequestService/ContentReviewRequestService.ts
@@ -1164,15 +1164,32 @@ export class ContentReviewRequestService extends BaseService {
             ),
         );
         const visible = candidates.filter((c) => accessible.has(c.spaceUuid));
-        const verified = await this.contentVerificationModel.getByContentUuids(
-            params.contentType,
-            visible.map((c) => c.uuid),
+        const verifiedByType = new Map<ContentReviewContentType, Set<string>>();
+        await Promise.all(
+            [...new Set(visible.map((c) => c.contentType))].map(
+                async (candidateType) => {
+                    const verifiableType =
+                        ContentReviewRequestService.toVerifiableContentType(
+                            candidateType,
+                        );
+                    if (verifiableType === null) return;
+                    const verified =
+                        await this.contentVerificationModel.getByContentUuids(
+                            verifiableType,
+                            visible
+                                .filter((c) => c.contentType === candidateType)
+                                .map((c) => c.uuid),
+                        );
+                    verifiedByType.set(candidateType, new Set(verified.keys()));
+                },
+            ),
         );
         return visible
             .map((c) => {
-                const isVerified = verified.has(c.uuid);
+                const isVerified =
+                    verifiedByType.get(c.contentType)?.has(c.uuid) ?? false;
                 return {
-                    contentType: params.contentType,
+                    contentType: c.contentType,
                     contentUuid: c.uuid,
                     name: c.name,
                     slug: c.slug,

--- a/packages/backend/src/models/ContentReviewRequestModel.integration.test.ts
+++ b/packages/backend/src/models/ContentReviewRequestModel.integration.test.ts
@@ -259,17 +259,18 @@ describe('ContentReviewRequestModel PostgreSQL integration', () => {
         const bCreated = await model.create(b);
         await model.cancel(bCreated.uuid);
 
-        const found = await model.findPendingByContentUuids(ContentReviewContentType.CHART, [
-            a.contentUuid,
-            b.contentUuid,
-            randomUUID(),
-        ]);
+        const found = await model.findPendingByContentUuids(
+            ContentReviewContentType.CHART,
+            [a.contentUuid, b.contentUuid, randomUUID()],
+        );
         expect([...found.keys()]).toEqual([a.contentUuid]);
     });
 
     test('cancelPendingContentReviewRequests cancels pending rows for deleted content', async () => {
         const a = buildRequest();
-        const b = buildRequest({ contentType: ContentReviewContentType.DASHBOARD });
+        const b = buildRequest({
+            contentType: ContentReviewContentType.DASHBOARD,
+        });
         const aCreated = await model.create(a);
         const bCreated = await model.create(b);
 

--- a/packages/backend/src/models/ContentReviewRequestModel.integration.test.ts
+++ b/packages/backend/src/models/ContentReviewRequestModel.integration.test.ts
@@ -1,4 +1,5 @@
 import {
+    ChartKind,
     ContentReviewContentType,
     ContentReviewRequestStatus,
     DirectAccessPrincipalType,
@@ -9,6 +10,7 @@ import {
 import { type Knex } from 'knex';
 import { randomUUID } from 'node:crypto';
 import { ProjectTableName } from '../database/entities/projects';
+import { SavedChartsTableName } from '../database/entities/savedCharts';
 import { SpaceTableName } from '../database/entities/spaces';
 import { UserTableName } from '../database/entities/users';
 import { getTestContext } from '../vitest.setup.integration';
@@ -257,18 +259,17 @@ describe('ContentReviewRequestModel PostgreSQL integration', () => {
         const bCreated = await model.create(b);
         await model.cancel(bCreated.uuid);
 
-        const found = await model.findPendingByContentUuids(
-            ContentReviewContentType.CHART,
-            [a.contentUuid, b.contentUuid, randomUUID()],
-        );
+        const found = await model.findPendingByContentUuids(ContentReviewContentType.CHART, [
+            a.contentUuid,
+            b.contentUuid,
+            randomUUID(),
+        ]);
         expect([...found.keys()]).toEqual([a.contentUuid]);
     });
 
     test('cancelPendingContentReviewRequests cancels pending rows for deleted content', async () => {
         const a = buildRequest();
-        const b = buildRequest({
-            contentType: ContentReviewContentType.DASHBOARD,
-        });
+        const b = buildRequest({ contentType: ContentReviewContentType.DASHBOARD });
         const aCreated = await model.create(a);
         const bCreated = await model.create(b);
 
@@ -309,6 +310,73 @@ describe('ContentReviewRequestModel PostgreSQL integration', () => {
         expect(
             (await model.getByUuid(created.uuid)).targetSpaceUuid,
         ).toBeNull();
+    });
+
+    describe('findSimilarByName', () => {
+        const createChart = async (name: string, spaceUuid: string) => {
+            const space = await transaction(SpaceTableName)
+                .where('space_uuid', spaceUuid)
+                .first<{ space_id: number }>('space_id');
+            if (!space) throw new Error('space not found');
+            const [chart] = await transaction(SavedChartsTableName)
+                .insert({
+                    name,
+                    description: undefined,
+                    slug: `similar-${randomUUID()}`,
+                    project_uuid: projectUuid,
+                    space_id: space.space_id,
+                    dashboard_uuid: null,
+                    last_version_chart_kind: ChartKind.TABLE,
+                    color_palette_uuid: null,
+                    last_version_updated_by_user_uuid: userUuid,
+                })
+                .returning('saved_query_uuid');
+            return chart.saved_query_uuid;
+        };
+
+        test('ranks exact, contained and word matches in shared spaces only', async () => {
+            const exact = await createChart('Weekly Revenue!', sharedSpaceUuid);
+            const contained = await createChart(
+                'Weekly revenue by region',
+                sharedSpaceUuid,
+            );
+            const wordMatch = await createChart(
+                'Revenue forecast',
+                sharedSpaceUuid,
+            );
+            await createChart('Weekly revenue', personalSpaceUuid);
+            await createChart('Customer churn', sharedSpaceUuid);
+            const self = await createChart('Weekly revenue', sharedSpaceUuid);
+
+            const results = await model.findSimilarByName({
+                projectUuid,
+                contentType: ContentReviewContentType.CHART,
+                name: 'weekly revenue',
+                excludeContentUuid: self,
+                limit: 10,
+            });
+
+            const uuids = results.map((r) => r.uuid);
+            expect(uuids.slice(0, 2)).toEqual([exact, contained]);
+            expect(uuids).toContain(wordMatch);
+            expect(uuids).not.toContain(self);
+            expect(results.some((r) => r.spaceUuid === personalSpaceUuid)).toBe(
+                false,
+            );
+            expect(results[0].score).toBeGreaterThan(results[1].score);
+        });
+
+        test('returns nothing for an empty name', async () => {
+            expect(
+                await model.findSimilarByName({
+                    projectUuid,
+                    contentType: ContentReviewContentType.CHART,
+                    name: '   ',
+                    excludeContentUuid: null,
+                    limit: 5,
+                }),
+            ).toEqual([]);
+        });
     });
 
     describe('ContentReviewSettingsModel', () => {

--- a/packages/backend/src/models/ContentReviewRequestModel.ts
+++ b/packages/backend/src/models/ContentReviewRequestModel.ts
@@ -1,8 +1,7 @@
 import {
+    ContentReviewContentType,
     ContentReviewRequestStatus,
-    ContentType,
     NotFoundError,
-    type ContentReviewContentType,
     type ContentReviewGrantedPrincipal,
     type ContentReviewMovedItem,
     type ContentReviewRequest,
@@ -123,6 +122,7 @@ const parseLocationRow = (
 });
 
 export type ContentReviewSimilarCandidate = {
+    contentType: ContentReviewContentType;
     uuid: string;
     name: string;
     slug: string;
@@ -134,6 +134,46 @@ export type ContentReviewSimilarCandidate = {
 const EXACT_NAME_SCORE = 100;
 const CONTAINED_NAME_SCORE = 50;
 const COMPACT_NAME_SQL = "regexp_replace(lower(??), '[^a-z0-9]+', '', 'g')";
+
+type SimilarSource = {
+    contentType: ContentReviewContentType;
+    table: string;
+    uuidColumn: string;
+    spaceJoin: { left: string; right: string };
+};
+
+const SIMILAR_SOURCES: Record<
+    'chart' | 'sqlChart' | 'dashboard',
+    SimilarSource
+> = {
+    chart: {
+        contentType: ContentReviewContentType.CHART,
+        table: SavedChartsTableName,
+        uuidColumn: 'saved_query_uuid',
+        spaceJoin: {
+            left: `${SavedChartsTableName}.space_id`,
+            right: `${SpaceTableName}.space_id`,
+        },
+    },
+    sqlChart: {
+        contentType: ContentReviewContentType.SQL_CHART,
+        table: SavedSqlTableName,
+        uuidColumn: 'saved_sql_uuid',
+        spaceJoin: {
+            left: `${SavedSqlTableName}.space_uuid`,
+            right: `${SpaceTableName}.space_uuid`,
+        },
+    },
+    dashboard: {
+        contentType: ContentReviewContentType.DASHBOARD,
+        table: DashboardsTableName,
+        uuidColumn: 'dashboard_uuid',
+        spaceJoin: {
+            left: `${DashboardsTableName}.space_id`,
+            right: `${SpaceTableName}.space_id`,
+        },
+    },
+};
 
 export type ListContentReviewRequestsFilters = {
     projectUuid: string;
@@ -539,9 +579,45 @@ export class ContentReviewRequestModel {
             .split(/\s+/)
             .filter((word) => word.length > 0)
             .join(' OR ');
-        const isChart = contentType === ContentType.CHART;
-        const table = isChart ? SavedChartsTableName : DashboardsTableName;
-        const uuidColumn = isChart ? 'saved_query_uuid' : 'dashboard_uuid';
+        // A chart duplicate can live in either chart table
+        const sources =
+            contentType === ContentReviewContentType.DASHBOARD
+                ? [SIMILAR_SOURCES.dashboard]
+                : [SIMILAR_SOURCES.chart, SIMILAR_SOURCES.sqlChart];
+        const results = await Promise.all(
+            sources.map((source) =>
+                this.findSimilarInSource({
+                    source,
+                    projectUuid,
+                    compact,
+                    wordQuery,
+                    excludeContentUuid,
+                    limit,
+                }),
+            ),
+        );
+        return results
+            .flat()
+            .sort((a, b) => b.score - a.score || a.name.localeCompare(b.name))
+            .slice(0, limit);
+    }
+
+    private async findSimilarInSource({
+        source,
+        projectUuid,
+        compact,
+        wordQuery,
+        excludeContentUuid,
+        limit,
+    }: {
+        source: SimilarSource;
+        projectUuid: string;
+        compact: string;
+        wordQuery: string;
+        excludeContentUuid: string | null;
+        limit: number;
+    }): Promise<ContentReviewSimilarCandidate[]> {
+        const { table, uuidColumn } = source;
         const nameColumn = `${table}.name`;
 
         const scoreSql = this.database.raw(
@@ -566,8 +642,8 @@ export class ContentReviewRequestModel {
         const query = this.database(table)
             .innerJoin(
                 SpaceTableName,
-                `${table}.space_id`,
-                `${SpaceTableName}.space_id`,
+                source.spaceJoin.left,
+                source.spaceJoin.right,
             )
             .innerJoin(
                 ProjectTableName,
@@ -621,6 +697,7 @@ export class ContentReviewRequestModel {
         const rows = await query;
         return rows
             .map((row) => ({
+                contentType: source.contentType,
                 uuid: row.uuid,
                 name: row.name,
                 slug: row.slug,

--- a/packages/backend/src/models/ContentReviewRequestModel.ts
+++ b/packages/backend/src/models/ContentReviewRequestModel.ts
@@ -1,5 +1,6 @@
 import {
     ContentReviewRequestStatus,
+    ContentType,
     NotFoundError,
     type ContentReviewContentType,
     type ContentReviewGrantedPrincipal,
@@ -21,6 +22,7 @@ import { SavedSqlTableName } from '../database/entities/savedSql';
 import { SpaceTableName } from '../database/entities/spaces';
 import { UserTableName } from '../database/entities/users';
 import KnexPaginate from '../database/pagination';
+import { compactContentSearchText } from './ContentModel/ContentSearchUtils';
 
 type ContentReviewRequestModelArguments = {
     database: Knex;
@@ -119,6 +121,19 @@ const parseLocationRow = (
     dashboardUuid: row.dashboard_uuid,
     deleted: row.deleted_at !== null,
 });
+
+export type ContentReviewSimilarCandidate = {
+    uuid: string;
+    name: string;
+    slug: string;
+    spaceUuid: string;
+    spaceName: string;
+    score: number;
+};
+
+const EXACT_NAME_SCORE = 100;
+const CONTAINED_NAME_SCORE = 50;
+const COMPACT_NAME_SQL = "regexp_replace(lower(??), '[^a-z0-9]+', '', 'g')";
 
 export type ListContentReviewRequestsFilters = {
     projectUuid: string;
@@ -499,5 +514,120 @@ export class ContentReviewRequestModel {
                 },
             ]),
         );
+    }
+
+    // Name-based lookalikes in shared spaces: exact compact match first,
+    // containment next, then full-text rank on the name
+    async findSimilarByName({
+        projectUuid,
+        contentType,
+        name,
+        excludeContentUuid,
+        limit,
+    }: {
+        projectUuid: string;
+        contentType: ContentReviewContentType;
+        name: string;
+        excludeContentUuid: string | null;
+        limit: number;
+    }): Promise<ContentReviewSimilarCandidate[]> {
+        const compact = compactContentSearchText(name);
+        const trimmed = name.trim();
+        if (compact.length === 0 && trimmed.length === 0) return [];
+        // Any shared word counts as similar; ts_rank orders the overlap
+        const wordQuery = trimmed
+            .split(/\s+/)
+            .filter((word) => word.length > 0)
+            .join(' OR ');
+        const isChart = contentType === ContentType.CHART;
+        const table = isChart ? SavedChartsTableName : DashboardsTableName;
+        const uuidColumn = isChart ? 'saved_query_uuid' : 'dashboard_uuid';
+        const nameColumn = `${table}.name`;
+
+        const scoreSql = this.database.raw(
+            `CASE
+                WHEN ${COMPACT_NAME_SQL} = ? THEN ${EXACT_NAME_SCORE}
+                WHEN ? <> '' AND (${COMPACT_NAME_SQL} LIKE '%' || ? || '%' OR ? LIKE '%' || ${COMPACT_NAME_SQL} || '%') THEN ${CONTAINED_NAME_SCORE}
+                ELSE 0
+            END + COALESCE(ts_rank_cd(??, websearch_to_tsquery('lightdash_english_config', ?), 32), 0)`,
+            [
+                nameColumn,
+                compact,
+                compact,
+                nameColumn,
+                compact,
+                compact,
+                nameColumn,
+                `${table}.search_vector`,
+                wordQuery,
+            ],
+        );
+
+        const query = this.database(table)
+            .innerJoin(
+                SpaceTableName,
+                `${table}.space_id`,
+                `${SpaceTableName}.space_id`,
+            )
+            .innerJoin(
+                ProjectTableName,
+                `${ProjectTableName}.project_id`,
+                `${SpaceTableName}.project_id`,
+            )
+            .where(`${ProjectTableName}.project_uuid`, projectUuid)
+            .where(`${SpaceTableName}.is_default_user_space`, false)
+            .whereNull(`${SpaceTableName}.deleted_at`)
+            .whereNull(`${table}.deleted_at`)
+            .where((builder) => {
+                void builder.whereRaw(
+                    `?? @@ websearch_to_tsquery('lightdash_english_config', ?)`,
+                    [`${table}.search_vector`, wordQuery],
+                );
+                if (compact.length > 0) {
+                    void builder
+                        .orWhereRaw(`${COMPACT_NAME_SQL} LIKE ?`, [
+                            nameColumn,
+                            `%${compact}%`,
+                        ])
+                        .orWhereRaw(
+                            `? LIKE '%' || ${COMPACT_NAME_SQL} || '%'`,
+                            [compact, nameColumn],
+                        );
+                }
+            })
+            .select<
+                {
+                    uuid: string;
+                    name: string;
+                    slug: string;
+                    space_uuid: string;
+                    space_name: string;
+                    score: number;
+                }[]
+            >(
+                `${table}.${uuidColumn} as uuid`,
+                `${table}.name`,
+                `${table}.slug`,
+                `${SpaceTableName}.space_uuid`,
+                this.database.ref(`${SpaceTableName}.name`).as('space_name'),
+                this.database.raw('(?) as score', [scoreSql]),
+            )
+            .orderBy('score', 'desc')
+            .orderBy(`${table}.name`, 'asc')
+            .limit(limit);
+        if (excludeContentUuid !== null) {
+            void query.whereNot(`${table}.${uuidColumn}`, excludeContentUuid);
+        }
+        const rows = await query;
+        return rows
+            .map((row) => ({
+                uuid: row.uuid,
+                name: row.name,
+                slug: row.slug,
+                spaceUuid: row.space_uuid,
+                spaceName: row.space_name,
+                score: Number(row.score),
+            }))
+            .filter((row) => row.score > 0);
     }
 }

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -176,6 +176,7 @@ import {
     type ContentReviewRequestDetail,
     type ContentReviewRequestListItem,
     type ContentReviewSettings,
+    type ContentReviewSimilarContentItem,
 } from './contentReviewRequests';
 import {
     type ApiContentVerificationDeleteResponse,
@@ -1237,6 +1238,7 @@ type ApiResults =
     | ContentReviewRequest
     | ContentReviewRequestDetail
     | ContentReviewSettings
+    | ContentReviewSimilarContentItem[]
     | KnexPaginatedData<ContentReviewRequestListItem[]>
     | BigqueryProjectRecommendation
     | EnsurePlaygroundProjectResults

--- a/packages/common/src/types/contentReviewRequests.ts
+++ b/packages/common/src/types/contentReviewRequests.ts
@@ -157,3 +157,8 @@ export const getContentReviewRequestPath = (
     projectUuid: string,
     requestUuid: string,
 ): string => `${getContentReviewRequestsPath(projectUuid)}/${requestUuid}`;
+
+export type ApiContentReviewSimilarContentResponse = {
+    status: 'ok';
+    results: ContentReviewSimilarContentItem[];
+};

--- a/packages/frontend/src/ee/features/contentReview/api.ts
+++ b/packages/frontend/src/ee/features/contentReview/api.ts
@@ -3,6 +3,7 @@ import {
     type ApiContentReviewRequestOrNullResponse,
     type ApiContentReviewRequestResponse,
     type ApiContentReviewSettingsResponse,
+    type ApiContentReviewSimilarContentResponse,
     type ApproveContentReviewRequestBody,
     type ContentReviewContentType,
     type ContentReviewRequestStatus,
@@ -119,3 +120,23 @@ export const updateContentReviewSettings = (
         method: 'PATCH',
         body: JSON.stringify(body),
     });
+
+export const getSimilarContentForReview = (
+    projectUuid: string,
+    params: {
+        contentType: ContentReviewContentType;
+        name: string;
+        excludeContentUuid: string;
+    },
+) => {
+    const search = new URLSearchParams({
+        contentType: params.contentType,
+        name: params.name,
+        excludeContentUuid: params.excludeContentUuid,
+    });
+    return lightdashApi<ApiContentReviewSimilarContentResponse['results']>({
+        url: `${contentReviewBasePath(projectUuid)}/similar?${search.toString()}`,
+        method: 'GET',
+        body: undefined,
+    });
+};

--- a/packages/frontend/src/ee/features/contentReview/components/RequestReviewModal.test.tsx
+++ b/packages/frontend/src/ee/features/contentReview/components/RequestReviewModal.test.tsx
@@ -5,6 +5,11 @@ import { renderWithProviders } from '../../../../testing/testUtils';
 import RequestReviewModal from './RequestReviewModal';
 
 const createRequest = vi.fn().mockResolvedValue({});
+const similarContent = vi.fn().mockReturnValue({ data: [] });
+
+vi.mock('../hooks/useSimilarContent', () => ({
+    useSimilarContent: () => similarContent(),
+}));
 
 vi.mock('../hooks/useContentReviewRequests', () => ({
     useCreateContentReviewRequest: () => ({
@@ -79,6 +84,7 @@ const pickFinanceAndContinue = async () => {
 describe('RequestReviewModal', () => {
     beforeEach(() => {
         createRequest.mockClear();
+        similarContent.mockReturnValue({ data: [] });
     });
 
     it('offers only shared spaces and waits for a target before continuing', async () => {
@@ -119,5 +125,45 @@ describe('RequestReviewModal', () => {
 
         await userEvent.click(screen.getByRole('button', { name: 'Back' }));
         expect(screen.getByRole('button', { name: 'Continue' })).toBeEnabled();
+    });
+
+    it('requires a note when similar content exists and snapshots it', async () => {
+        const match = {
+            contentType: ContentType.CHART,
+            contentUuid: 'existing',
+            name: 'Weekly revenue by region',
+            slug: 'weekly-revenue-by-region',
+            spaceUuid: 'finance',
+            spaceName: 'Finance',
+            isVerified: true,
+            score: 150,
+        };
+        similarContent.mockReturnValue({ data: [match] });
+        renderModal();
+
+        await pickFinanceAndContinue();
+        expect(
+            screen.getByText('Something similar already exists'),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole('button', { name: 'Request review' }),
+        ).toBeDisabled();
+
+        await userEvent.type(
+            screen.getByLabelText(/Note for reviewers/),
+            'Adds a forecast',
+        );
+        await userEvent.click(
+            screen.getByRole('button', { name: 'Request review' }),
+        );
+
+        await waitFor(() =>
+            expect(createRequest).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    note: 'Adds a forecast',
+                    similarContent: [match],
+                }),
+            ),
+        );
     });
 });

--- a/packages/frontend/src/ee/features/contentReview/components/RequestReviewModal.test.tsx
+++ b/packages/frontend/src/ee/features/contentReview/components/RequestReviewModal.test.tsx
@@ -129,7 +129,7 @@ describe('RequestReviewModal', () => {
 
     it('requires a note when similar content exists and snapshots it', async () => {
         const match = {
-            contentType: ContentType.CHART,
+            contentType: ContentReviewContentType.CHART,
             contentUuid: 'existing',
             name: 'Weekly revenue by region',
             slug: 'weekly-revenue-by-region',

--- a/packages/frontend/src/ee/features/contentReview/components/RequestReviewModal.tsx
+++ b/packages/frontend/src/ee/features/contentReview/components/RequestReviewModal.tsx
@@ -17,12 +17,14 @@ import {
     useSpaceSummaries,
 } from '../../../../hooks/useSpaces';
 import { useCreateContentReviewRequest } from '../hooks/useContentReviewRequests';
+import { useSimilarContent } from '../hooks/useSimilarContent';
 import {
     getContentTypeColor,
     getContentTypeIcon,
     getContentTypeNoun,
 } from '../utils';
 import classes from './RequestReviewModal.module.css';
+import SimilarContentPanel from './SimilarContentPanel';
 
 type Props = {
     projectUuid: string;
@@ -81,6 +83,13 @@ const RequestReviewModal: FC<Props> = ({
     );
     const { mutateAsync: createRequest, isLoading: isSubmitting } =
         useCreateContentReviewRequest(projectUuid);
+    const { data: similarContent = [] } = useSimilarContent(
+        projectUuid,
+        { contentType, name: contentName, excludeContentUuid: contentUuid },
+        opened,
+    );
+    // When lookalikes exist the requester has to say what theirs adds
+    const noteRequired = similarContent.length > 0;
 
     const form = useForm<{ targetSpaceUuid: string | null; note: string }>({
         initialValues: { targetSpaceUuid: null, note: '' },
@@ -98,12 +107,13 @@ const RequestReviewModal: FC<Props> = ({
     const handleSubmit = form.onSubmit(async (values) => {
         if (values.targetSpaceUuid === null) return;
         const note = values.note.trim();
+        if (noteRequired && note.length === 0) return;
         await createRequest({
             contentType,
             contentUuid,
             targetSpaceUuid: values.targetSpaceUuid,
             note: note.length > 0 ? note : null,
-            similarContent: [],
+            similarContent,
         });
         handleClose();
     });
@@ -143,7 +153,11 @@ const RequestReviewModal: FC<Props> = ({
                         type="submit"
                         form="request-review-form"
                         loading={isSubmitting}
-                        disabled={form.values.targetSpaceUuid === null}
+                        disabled={
+                            form.values.targetSpaceUuid === null ||
+                            (noteRequired &&
+                                form.values.note.trim().length === 0)
+                        }
                     >
                         Request review
                     </Button>
@@ -202,9 +216,19 @@ const RequestReviewModal: FC<Props> = ({
                                 </Text>
                             </Group>
                         </Group>
+                        <SimilarContentPanel
+                            projectUuid={projectUuid}
+                            items={similarContent}
+                        />
                         <Textarea
                             label="Note for reviewers"
-                            description="What does it show, and who is it for?"
+                            description={
+                                noteRequired
+                                    ? 'What does yours add that the existing content does not?'
+                                    : 'What does it show, and who is it for?'
+                            }
+                            required={noteRequired}
+                            withAsterisk={noteRequired}
                             autosize
                             minRows={3}
                             maxRows={6}

--- a/packages/frontend/src/ee/features/contentReview/components/SimilarContentPanel.module.css
+++ b/packages/frontend/src/ee/features/contentReview/components/SimilarContentPanel.module.css
@@ -1,0 +1,15 @@
+.panel {
+    overflow: hidden;
+    border-color: var(--mantine-color-yellow-outline);
+}
+
+.header {
+    padding: var(--mantine-spacing-sm) var(--mantine-spacing-md);
+    background-color: var(--mantine-color-yellow-light);
+    border-bottom: 1px solid var(--mantine-color-yellow-outline);
+}
+
+.toggle {
+    align-self: flex-start;
+    margin: 2px var(--mantine-spacing-xs) 4px;
+}

--- a/packages/frontend/src/ee/features/contentReview/components/SimilarContentPanel.tsx
+++ b/packages/frontend/src/ee/features/contentReview/components/SimilarContentPanel.tsx
@@ -1,10 +1,13 @@
 import { type ContentReviewSimilarContentItem } from '@lightdash/common';
-import { Anchor, Badge, Group, Stack, Text } from '@mantine/core';
-import { IconCircleCheckFilled } from '@tabler/icons-react';
-import { type FC } from 'react';
-import Callout from '../../../../components/common/Callout';
+import { Button, Group, Paper, Stack, Text } from '@mantine/core';
+import { IconAlertTriangle } from '@tabler/icons-react';
+import { useState, type FC } from 'react';
 import MantineIcon from '../../../../components/common/MantineIcon';
-import { getContentHref, getContentTypeLabel } from '../utils';
+import { getContentHref } from '../utils';
+import ContentReviewItemRow from './ContentReviewItemRow';
+import classes from './SimilarContentPanel.module.css';
+
+const VISIBLE_ROWS = 3;
 
 type Props = {
     projectUuid: string;
@@ -12,58 +15,54 @@ type Props = {
 };
 
 const SimilarContentPanel: FC<Props> = ({ projectUuid, items }) => {
+    const [showAll, setShowAll] = useState(false);
     if (items.length === 0) return null;
+    const hidden = Math.max(items.length - VISIBLE_ROWS, 0);
+    const visible = showAll ? items : items.slice(0, VISIBLE_ROWS);
     return (
-        <Callout
-            variant="warning"
-            title={`${items.length === 1 ? 'Something similar already exists' : 'Similar content already exists'}`}
-        >
-            <Stack gap="xs">
-                <Text fz="sm">
-                    Have a look before you submit. If yours adds something, say
-                    what in the note so reviewers know.
-                </Text>
-                <Stack gap={4}>
-                    {items.map((item) => (
-                        <Group key={item.contentUuid} gap="xs" wrap="nowrap">
-                            <Anchor
-                                href={getContentHref(
-                                    projectUuid,
-                                    item.contentType,
-                                    item,
-                                )}
-                                target="_blank"
-                                rel="noreferrer"
-                                fz="sm"
-                                fw={500}
-                                truncate="end"
-                            >
-                                {item.name}
-                            </Anchor>
-                            <Text fz="xs" c="ldGray.6">
-                                {getContentTypeLabel(item.contentType)} in{' '}
-                                {item.spaceName}
-                            </Text>
-                            {item.isVerified && (
-                                <Badge
-                                    size="xs"
-                                    color="green"
-                                    variant="light"
-                                    leftSection={
-                                        <MantineIcon
-                                            icon={IconCircleCheckFilled}
-                                            size={10}
-                                        />
-                                    }
-                                >
-                                    Verified
-                                </Badge>
-                            )}
-                        </Group>
-                    ))}
+        <Paper className={classes.panel}>
+            <Group gap="sm" wrap="nowrap" className={classes.header}>
+                <MantineIcon icon={IconAlertTriangle} color="yellow.7" />
+                <Stack gap={0}>
+                    <Text fz="sm" fw={500}>
+                        {items.length === 1
+                            ? 'Something similar already exists'
+                            : 'Similar content already exists'}
+                    </Text>
+                    <Text fz="xs" c="dimmed">
+                        Have a look before you submit. If yours adds something,
+                        say what in the note so reviewers know.
+                    </Text>
                 </Stack>
+            </Group>
+            <Stack gap={0} p={4}>
+                {visible.map((item) => (
+                    <ContentReviewItemRow
+                        key={item.contentUuid}
+                        contentType={item.contentType}
+                        name={item.name}
+                        meta={`in ${item.spaceName}`}
+                        href={getContentHref(
+                            projectUuid,
+                            item.contentType,
+                            item,
+                        )}
+                        isVerified={item.isVerified}
+                        compact
+                    />
+                ))}
+                {hidden > 0 && (
+                    <Button
+                        variant="subtle"
+                        size="compact-xs"
+                        className={classes.toggle}
+                        onClick={() => setShowAll((current) => !current)}
+                    >
+                        {showAll ? 'Show fewer' : `Show ${hidden} more`}
+                    </Button>
+                )}
             </Stack>
-        </Callout>
+        </Paper>
     );
 };
 

--- a/packages/frontend/src/ee/features/contentReview/components/SimilarContentPanel.tsx
+++ b/packages/frontend/src/ee/features/contentReview/components/SimilarContentPanel.tsx
@@ -1,0 +1,70 @@
+import { type ContentReviewSimilarContentItem } from '@lightdash/common';
+import { Anchor, Badge, Group, Stack, Text } from '@mantine/core';
+import { IconCircleCheckFilled } from '@tabler/icons-react';
+import { type FC } from 'react';
+import Callout from '../../../../components/common/Callout';
+import MantineIcon from '../../../../components/common/MantineIcon';
+import { getContentHref, getContentTypeLabel } from '../utils';
+
+type Props = {
+    projectUuid: string;
+    items: ContentReviewSimilarContentItem[];
+};
+
+const SimilarContentPanel: FC<Props> = ({ projectUuid, items }) => {
+    if (items.length === 0) return null;
+    return (
+        <Callout
+            variant="warning"
+            title={`${items.length === 1 ? 'Something similar already exists' : 'Similar content already exists'}`}
+        >
+            <Stack gap="xs">
+                <Text fz="sm">
+                    Have a look before you submit. If yours adds something, say
+                    what in the note so reviewers know.
+                </Text>
+                <Stack gap={4}>
+                    {items.map((item) => (
+                        <Group key={item.contentUuid} gap="xs" wrap="nowrap">
+                            <Anchor
+                                href={getContentHref(
+                                    projectUuid,
+                                    item.contentType,
+                                    item,
+                                )}
+                                target="_blank"
+                                rel="noreferrer"
+                                fz="sm"
+                                fw={500}
+                                truncate="end"
+                            >
+                                {item.name}
+                            </Anchor>
+                            <Text fz="xs" c="ldGray.6">
+                                {getContentTypeLabel(item.contentType)} in{' '}
+                                {item.spaceName}
+                            </Text>
+                            {item.isVerified && (
+                                <Badge
+                                    size="xs"
+                                    color="green"
+                                    variant="light"
+                                    leftSection={
+                                        <MantineIcon
+                                            icon={IconCircleCheckFilled}
+                                            size={10}
+                                        />
+                                    }
+                                >
+                                    Verified
+                                </Badge>
+                            )}
+                        </Group>
+                    ))}
+                </Stack>
+            </Stack>
+        </Callout>
+    );
+};
+
+export default SimilarContentPanel;

--- a/packages/frontend/src/ee/features/contentReview/hooks/useSimilarContent.ts
+++ b/packages/frontend/src/ee/features/contentReview/hooks/useSimilarContent.ts
@@ -1,0 +1,23 @@
+import {
+    type ApiError,
+    type ContentReviewContentType,
+    type ContentReviewSimilarContentItem,
+} from '@lightdash/common';
+import { useQuery } from '@tanstack/react-query';
+import { getSimilarContentForReview } from '../api';
+
+export const useSimilarContent = (
+    projectUuid: string,
+    params: {
+        contentType: ContentReviewContentType;
+        name: string;
+        excludeContentUuid: string;
+    },
+    enabled: boolean,
+) =>
+    useQuery<ContentReviewSimilarContentItem[], ApiError>({
+        queryKey: ['content-review', projectUuid, 'similar', params],
+        queryFn: () => getSimilarContentForReview(projectUuid, params),
+        enabled: enabled && params.name.trim().length > 0,
+        staleTime: 60 * 1000,
+    });

--- a/packages/frontend/src/ee/features/contentReview/pages/ContentReviewRequestPage.tsx
+++ b/packages/frontend/src/ee/features/contentReview/pages/ContentReviewRequestPage.tsx
@@ -502,6 +502,11 @@ export const ContentReviewRequestDetailView: FC<{
                                                 contentType={item.contentType}
                                                 name={item.name}
                                                 meta={`${getContentTypeLabel(item.contentType)} in ${item.spaceName}`}
+                                                href={getContentHref(
+                                                    projectUuid,
+                                                    item.contentType,
+                                                    item,
+                                                )}
                                                 isVerified={item.isVerified}
                                             />
                                         ))}


### PR DESCRIPTION
## Summary

Last PR of the content review requests stack, on top of #28435. Before someone submits a request, show them charts or dashboards in shared spaces whose names look like theirs, and make them say what theirs adds. One customer put it as: even looking only at chart names will do most of the job.

### Backend

- `ContentReviewRequestModel.findSimilarByName`: candidates are same-type items in the project's shared spaces (personal spaces and deleted content excluded, the item itself excluded). Score: exact compact-name match (punctuation and case stripped) scores highest, containment either way next, then `ts_rank_cd` over the generated `search_vector` with the words ORed so any shared word counts. Rows with score 0 are dropped.
- `ContentReviewRequestService.findSimilarContent`: filters to spaces the caller can view, adds a small boost for verified items so the sanctioned version sorts first, returns the top five.
- `GET /api/v1/projects/{projectUuid}/review-requests/similar?contentType=&name=&excludeContentUuid=` (declared before `/{requestUuid}`).
- `ContentReviewSimilarContentItem` gains `slug` so the UI can link to the item.

### Frontend

- `SimilarContentPanel` inside `RequestReviewModal`: a warning callout listing the matches with type, space and a verified badge, each opening in a new tab.
- When matches exist the note becomes required, its hint changes to "What does yours add that the existing content does not?", and the matches are snapshotted onto the request so reviewers see exactly what the requester was shown (the request page from #28435 already renders that list).

No new Postgres extension. If precision turns out poor on real names, `pg_trgm` similarity can replace the last scoring term without changing the endpoint.

## Regression analysis

- New model method, service method and route only; nothing existing changes shape. The modal's `aside` slot from #28434 is replaced by the panel it was reserved for.
- The query uses the existing generated `search_vector` column and `lightdash_english_config`; the GIN index is used by the `@@` predicate before ranking.
- Submitting with no matches behaves exactly as before (`similarContent: []`, note optional).

## Testing

- `ContentReviewRequestModel.integration.test.ts` (2 new cases, 13 total): exact and contained names rank above a word-only match, the item itself and personal-space copies are excluded, blank names return nothing.
- `RequestReviewModal.test.tsx` (new case): the callout renders, submit stays disabled until a note is typed, and the payload carries the note and the snapshot.
- Backend and frontend typecheck and lint, `pnpm -F frontend unused-exports`, `pnpm generate-api`. Frontend tests run from a clean checkout of the commit (see the note on #28435).

Closes: PROD-9824
Relates: PROD-9730
Relates: #26967

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7bgpm3JZGoF2bRviShXWP

## Polish (second commit)

The nudge is a bordered panel with the top three matches as compact rows and a "Show N more" toggle, each opening in a new tab with a Verified badge where it applies. The request page's snapshot rows now link to the item since the type carries a slug. Ranking note: a one-word chart named "week" outranked real lookalikes for "Orders over time, weekly", so the containment boost could use a length or token floor.

## SQL runner charts

A chart or SQL chart request is matched against both chart tables; each candidate carries its own type and links to its own route, and verification is looked up per type (skipped for SQL charts). Dashboards still match dashboards only.