### PR TITLE
feat: template questions replace the blank prompt when creating from a template

### DIFF
--- a/packages/common/src/ee/apps/templates.test.ts
+++ b/packages/common/src/ee/apps/templates.test.ts
@@ -31,6 +31,29 @@ describe('data app template registry', () => {
         expect(def.requiredFlag).toBe(FeatureFlags.EnableDataAppTemplates);
     });
 
+    it('declares template questions for the seeded templates', () => {
+        for (const id of ['forecaster', 'scorecard'] as const) {
+            const questions = DATA_APP_TEMPLATE_DEFINITIONS[id].questions ?? [];
+            expect(questions.length).toBeGreaterThanOrEqual(3);
+            expect(new Set(questions.map((q) => q.key)).size).toBe(
+                questions.length,
+            );
+            for (const q of questions) {
+                expect(q.label.length).toBeGreaterThan(0);
+            }
+        }
+        // The scorecard's tiles are a repeatable list, not a single value.
+        expect(
+            DATA_APP_TEMPLATE_DEFINITIONS.scorecard.questions?.some(
+                (q) => q.kind === 'list',
+            ),
+        ).toBe(true);
+        // Built-ins keep the freeform composer.
+        expect(
+            DATA_APP_TEMPLATE_DEFINITIONS.dashboard.questions,
+        ).toBeUndefined();
+    });
+
     it('keeps the original five templates ungated', () => {
         const originalIds = [
             'dashboard',

--- a/packages/common/src/ee/apps/templates.ts
+++ b/packages/common/src/ee/apps/templates.ts
@@ -8,6 +8,22 @@ import { type DataAppTemplate } from './types';
  * backend's AppGenerateService templates, and an icon in the frontend's icon
  * map — the exhaustive Records turn a missing piece into a compile error.
  */
+/**
+ * A question the create-from-template flow asks instead of a blank prompt.
+ * Answers travel to the build as clarifications (question/answer pairs), so
+ * the backend generate path is unchanged. `list` questions collect one entry
+ * per line — the repeatable-slot shape (e.g. a scorecard's tiles).
+ */
+export type TemplateQuestion = {
+    key: string;
+    label: string;
+    placeholder?: string;
+    /** Pre-filled answer; the user can build without editing it. */
+    default?: string;
+    required?: boolean;
+    kind?: 'text' | 'list';
+};
+
 export type DataAppTemplateDefinition = {
     id: DataAppTemplate;
     title: string;
@@ -26,6 +42,11 @@ export type DataAppTemplateDefinition = {
     inGallery: boolean;
     /** Feature flag gating visibility on either surface; undefined = always offered. */
     requiredFlag?: FeatureFlags;
+    /**
+     * Declared questions shown in place of the freeform composer when this
+     * template is chosen. Undefined = the template keeps the freeform flow.
+     */
+    questions?: TemplateQuestion[];
 };
 
 export const DATA_APP_TEMPLATE_DEFINITIONS: Record<
@@ -84,6 +105,26 @@ export const DATA_APP_TEMPLATE_DEFINITIONS: Record<
         inPicker: false,
         inGallery: true,
         requiredFlag: FeatureFlags.EnableDataAppTemplates,
+        questions: [
+            {
+                key: 'metric',
+                label: 'What should we forecast?',
+                placeholder: 'e.g. total order revenue',
+                default: 'Total order revenue',
+                required: true,
+            },
+            {
+                key: 'ceiling',
+                label: 'Is there a limit to forecast against?',
+                placeholder:
+                    'A budget, committed spend, or capacity metric — leave blank if none',
+            },
+            {
+                key: 'horizon',
+                label: 'How far ahead?',
+                default: '24 months',
+            },
+        ],
     },
     scorecard: {
         id: 'scorecard',
@@ -94,5 +135,32 @@ export const DATA_APP_TEMPLATE_DEFINITIONS: Record<
         inPicker: false,
         inGallery: true,
         requiredFlag: FeatureFlags.EnableDataAppTemplates,
+        questions: [
+            {
+                key: 'tiles',
+                label: 'Which metrics belong on the scorecard?',
+                placeholder: 'One per line',
+                default:
+                    'Revenue\nAverage order size\nShipping revenue\nNew customers',
+                required: true,
+                kind: 'list',
+            },
+            {
+                key: 'period',
+                label: 'Default period',
+                default: 'Last 90 days',
+            },
+            {
+                key: 'comparison',
+                label: 'Compare each metric to the previous period?',
+                default: 'Yes',
+            },
+            {
+                key: 'targets',
+                label: 'Any targets?',
+                placeholder: 'metric: value, one per line — optional',
+                kind: 'list',
+            },
+        ],
     },
 };

--- a/packages/frontend/src/features/apps/TemplateQuestionsForm.tsx
+++ b/packages/frontend/src/features/apps/TemplateQuestionsForm.tsx
@@ -1,0 +1,160 @@
+import { type AppClarification } from '@lightdash/common';
+import {
+    Button,
+    Group,
+    Paper,
+    Stack,
+    Text,
+    Textarea,
+    TextInput,
+    ThemeIcon,
+} from '@mantine/core';
+import { useState, type FC } from 'react';
+import { type TemplateDefinition } from './templates';
+
+type Props = {
+    template: TemplateDefinition;
+    disabled?: boolean;
+    onBuild: (payload: {
+        clarifications: AppClarification[];
+        prompt: string;
+    }) => void;
+    onChangeTemplate: () => void;
+};
+
+/**
+ * The create-from-template step: the template's declared questions in place
+ * of the freeform composer, pre-filled from the registry defaults so a user
+ * can build without typing. Answers travel as clarifications — the form is
+ * the clarification round — and the only freeform slot is the closing
+ * "anything else?", which becomes the build prompt.
+ */
+const TemplateQuestionsForm: FC<Props> = ({
+    template,
+    disabled = false,
+    onBuild,
+    onChangeTemplate,
+}) => {
+    const questions = template.questions ?? [];
+    const [answers, setAnswers] = useState<Record<string, string>>(() =>
+        Object.fromEntries(questions.map((q) => [q.key, q.default ?? ''])),
+    );
+    const [extra, setExtra] = useState('');
+    const missing = questions.filter(
+        (q) => q.required && !(answers[q.key] ?? '').trim(),
+    );
+    const Icon = template.icon;
+
+    const handleBuild = () => {
+        if (missing.length > 0) return;
+        const clarifications: AppClarification[] = questions
+            .map((q) => ({
+                question: q.label,
+                answer: (answers[q.key] ?? '').trim(),
+            }))
+            .filter((c) => c.answer.length > 0);
+        onBuild({
+            clarifications,
+            prompt:
+                extra.trim() || `Build the ${template.title} as configured.`,
+        });
+    };
+
+    return (
+        <Paper withBorder radius="md" p="md">
+            <Stack gap="sm">
+                <Group gap="sm" wrap="nowrap" align="flex-start">
+                    <ThemeIcon
+                        size="lg"
+                        radius="md"
+                        variant="light"
+                        color="gray"
+                    >
+                        <Icon size={20} />
+                    </ThemeIcon>
+                    <div>
+                        <Text fw={600} size="sm">
+                            {template.title}
+                        </Text>
+                        <Text size="xs" c="dimmed">
+                            Answer a few questions and the template is bound to
+                            your data. Refine anything else in chat after the
+                            first build.
+                        </Text>
+                    </div>
+                </Group>
+
+                {questions.map((q) =>
+                    q.kind === 'list' ? (
+                        <Textarea
+                            size="sm"
+                            key={q.key}
+                            label={q.label}
+                            description="One per line"
+                            placeholder={q.placeholder}
+                            withAsterisk={q.required}
+                            autosize
+                            minRows={2}
+                            value={answers[q.key] ?? ''}
+                            onChange={(e) => {
+                                const { value } = e.currentTarget;
+                                setAnswers((prev) => ({
+                                    ...prev,
+                                    [q.key]: value,
+                                }));
+                            }}
+                            disabled={disabled}
+                        />
+                    ) : (
+                        <TextInput
+                            size="sm"
+                            key={q.key}
+                            label={q.label}
+                            placeholder={q.placeholder}
+                            withAsterisk={q.required}
+                            value={answers[q.key] ?? ''}
+                            onChange={(e) => {
+                                const { value } = e.currentTarget;
+                                setAnswers((prev) => ({
+                                    ...prev,
+                                    [q.key]: value,
+                                }));
+                            }}
+                            disabled={disabled}
+                        />
+                    ),
+                )}
+
+                <Textarea
+                    label="Anything else you'd like this app to do?"
+                    placeholder="Optional"
+                    autosize
+                    minRows={1}
+                    value={extra}
+                    onChange={(e) => setExtra(e.currentTarget.value)}
+                    disabled={disabled}
+                />
+
+                <Group justify="space-between">
+                    <Button
+                        variant="subtle"
+                        color="gray"
+                        size="xs"
+                        onClick={onChangeTemplate}
+                        disabled={disabled}
+                    >
+                        Change template
+                    </Button>
+                    <Button
+                        onClick={handleBuild}
+                        disabled={disabled || missing.length > 0}
+                    >
+                        Build
+                    </Button>
+                </Group>
+            </Stack>
+        </Paper>
+    );
+};
+
+export default TemplateQuestionsForm;

--- a/packages/frontend/src/features/apps/templates.test.ts
+++ b/packages/frontend/src/features/apps/templates.test.ts
@@ -29,6 +29,11 @@ describe('picker templates', () => {
         expect(ids).toEqual(['forecaster', 'scorecard']);
     });
 
+    it('exposes template questions on resolved definitions', () => {
+        expect(getTemplate('forecaster').questions?.length).toBeGreaterThan(0);
+        expect(getTemplate('dashboard').questions).toBeUndefined();
+    });
+
     it('resolves a definition with an icon for every template', () => {
         expect(getTemplate('forecaster').icon).toBeDefined();
         expect(getTemplate('dashboard').icon).toBeDefined();

--- a/packages/frontend/src/features/apps/templates.ts
+++ b/packages/frontend/src/features/apps/templates.ts
@@ -2,6 +2,7 @@ import {
     DATA_APP_TEMPLATE_DEFINITIONS,
     type DataAppTemplate,
     type FeatureFlags,
+    type TemplateQuestion,
 } from '@lightdash/common';
 import {
     IconChartLine,
@@ -20,6 +21,7 @@ export type TemplateDefinition = {
     description: string;
     category: string;
     icon: TablerIcon;
+    questions?: TemplateQuestion[];
 };
 
 // Icons are React components so they stay on the frontend; everything else
@@ -45,6 +47,7 @@ const toDefinition = (id: DataAppTemplate): TemplateDefinition => {
         description: def.description,
         category: def.category,
         icon: TEMPLATE_ICONS[id],
+        questions: def.questions,
     };
 };
 

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -120,6 +120,7 @@ import {
     useTrackedAppQueries,
 } from '../features/apps/hooks/useTrackedAppQueries';
 import { useTrackedExternalRequests } from '../features/apps/hooks/useTrackedExternalRequests';
+import TemplateQuestionsForm from '../features/apps/TemplateQuestionsForm';
 import { getTemplate } from '../features/apps/templates';
 import {
     toAppClarifyParams,
@@ -894,6 +895,13 @@ const AppGenerate: FC = () => {
             : null;
     // New-app empty screen: arch + composer, centered, no preview/split yet.
     const newAppLanding = isNewApp && messages.length === 0 && !isLoading;
+    // A gallery template with declared questions swaps the composer for its
+    // question form on the landing view; the form is the clarification round.
+    const templateQuestionsDefinition = useMemo(() => {
+        if (!selectedTemplate || !newAppLanding) return null;
+        const def = getTemplate(selectedTemplate);
+        return def.questions && def.questions.length > 0 ? def : null;
+    }, [selectedTemplate, newAppLanding]);
 
     // `hasNextPage` reflects the server's "more pages exist" signal, but we
     // accumulate versions across fetches in `versionCacheRef` — so even if the
@@ -1709,6 +1717,68 @@ const AppGenerate: FC = () => {
         }
     };
 
+    // Build straight from a template's question form: the answers are the
+    // clarifications, so the generic clarify round is skipped and the first
+    // build runs immediately through the same path a clarified build takes.
+    const handleTemplateFormBuild = ({
+        clarifications,
+        prompt,
+    }: {
+        clarifications: AppClarification[];
+        prompt: string;
+    }) => {
+        if (isLoading || isSubmittingRef.current || !selectedTemplate) return;
+        isSubmittingRef.current = true;
+        if (newAppLanding) {
+            withViewTransition(() => {
+                setIsSubmitting(true);
+            });
+        } else {
+            setIsSubmitting(true);
+        }
+        try {
+            const targetAppUuid = uuid4();
+            setThemeChipOverride({
+                appUuid: targetAppUuid,
+                designUuid: selectedThemeUuid,
+            });
+            setLocalMessages((prev) => [
+                ...prev,
+                {
+                    ...emptyChatMessage(),
+                    role: 'user',
+                    content: prompt,
+                    timestamp: new Date(),
+                    userName:
+                        [user.data?.firstName, user.data?.lastName]
+                            .filter((s): s is string => !!s && s.length > 0)
+                            .join(' ') || null,
+                    submittedAtVersion: maxHistoryVersion,
+                },
+            ]);
+            resetGenerate();
+            resetIterate();
+            onClarifiedBuild(
+                {
+                    prompt,
+                    template: selectedTemplate,
+                    fileIds: undefined,
+                    appUuid: targetAppUuid,
+                    charts: undefined,
+                    dashboard: undefined,
+                    externalConnections: undefined,
+                    spaceUuid: targetSpaceUuid,
+                    modelRequest,
+                    designUuid: selectedThemeUuid,
+                },
+                clarifications,
+            );
+        } finally {
+            isSubmittingRef.current = false;
+            setIsSubmitting(false);
+        }
+    };
+
     const handleCancel = () => {
         if (
             !projectUuid ||
@@ -1771,14 +1841,21 @@ const AppGenerate: FC = () => {
                                         Build a Data App
                                     </Text>
                                     <Text size="sm" c="dimmed">
-                                        Pick a starting point, then describe
-                                        what you want to build.
+                                        {templateQuestionsDefinition
+                                            ? 'Answer a few questions and the template is bound to your data.'
+                                            : 'Pick a starting point, then describe what you want to build.'}
                                     </Text>
                                 </Stack>
-                                <AppTemplatePicker
-                                    selected={selectedTemplate}
-                                    onSelectedChange={setSelectedTemplate}
-                                />
+                                {/* Once a template with questions is chosen the
+                                    fan is the previous step: collapse it so the
+                                    form fits, and let "Change template" bring
+                                    it back. */}
+                                {templateQuestionsDefinition ? null : (
+                                    <AppTemplatePicker
+                                        selected={selectedTemplate}
+                                        onSelectedChange={setSelectedTemplate}
+                                    />
+                                )}
                             </Stack>
                         )}
                         <Box
@@ -2486,464 +2563,508 @@ const AppGenerate: FC = () => {
                                         )}
                                     </Group>
                                 )}
-                                <Box
-                                    onDragOver={handleDragOver}
-                                    onDrop={handleDrop}
-                                >
-                                    <PromptComposer
-                                        ref={promptEditorRef}
-                                        size="md"
-                                        placeholder="Describe the app you want to build..."
-                                        autoFocus
-                                        // Editable while the agent works so the next prompt
-                                        // can be drafted; disabled only during the
-                                        // client-side submit, where clear() would wipe text.
-                                        disabled={isSubmitting}
-                                        submitDisabled={isLoading}
-                                        onEmptyChange={setIsPromptEmpty}
-                                        onSubmit={() => void handleSubmit()}
-                                        onPaste={handlePaste}
-                                        attachments={
-                                            (selectedCharts.length > 0 ||
-                                                selectedDashboard ||
-                                                selectedConnections.length >
-                                                    0 ||
-                                                selectedElementRefs.length >
-                                                    0 ||
-                                                fileAttachments.length > 0) && (
-                                                <Box
-                                                    className={
-                                                        classes.attachedResources
-                                                    }
-                                                >
-                                                    {selectedElementRefs.length >
-                                                        0 && (
-                                                        <Group gap={4}>
-                                                            {selectedElementRefs.map(
-                                                                (ref) => (
-                                                                    <ElementRefChip
-                                                                        key={elementRefKey(
-                                                                            ref,
-                                                                        )}
-                                                                        elementRef={
-                                                                            ref
-                                                                        }
-                                                                        onRemove={() =>
-                                                                            setSelectedElementRefs(
-                                                                                (
-                                                                                    prev,
-                                                                                ) =>
-                                                                                    prev.filter(
-                                                                                        (
-                                                                                            r,
-                                                                                        ) =>
-                                                                                            elementRefKey(
-                                                                                                r,
-                                                                                            ) !==
-                                                                                            elementRefKey(
-                                                                                                ref,
-                                                                                            ),
-                                                                                    ),
-                                                                            )
-                                                                        }
-                                                                    />
-                                                                ),
-                                                            )}
-                                                        </Group>
-                                                    )}
-                                                    {selectedConnections.length >
-                                                        0 && (
-                                                        <Group gap="xs">
-                                                            {selectedConnections.map(
-                                                                (c) => (
-                                                                    <ConnectionChip
-                                                                        key={
-                                                                            c.externalConnectionUuid
-                                                                        }
-                                                                        name={
-                                                                            c.name
-                                                                        }
-                                                                        onRemove={() =>
-                                                                            setSelectedConnections(
-                                                                                (
-                                                                                    prev,
-                                                                                ) =>
-                                                                                    prev.filter(
-                                                                                        (
-                                                                                            x,
-                                                                                        ) =>
-                                                                                            x.externalConnectionUuid !==
-                                                                                            c.externalConnectionUuid,
-                                                                                    ),
-                                                                            )
-                                                                        }
-                                                                    />
-                                                                ),
-                                                            )}
-                                                        </Group>
-                                                    )}
-                                                    {selectedCharts.length >
-                                                        0 && (
-                                                        <SelectedQuerySection
-                                                            sampleDataEnabled={
-                                                                sampleDataEnabled
-                                                            }
-                                                            charts={
-                                                                selectedCharts
-                                                            }
-                                                            onRemove={(uuid) =>
-                                                                setSelectedCharts(
-                                                                    (prev) =>
-                                                                        prev.filter(
-                                                                            (
-                                                                                c,
-                                                                            ) =>
-                                                                                c.uuid !==
-                                                                                uuid,
-                                                                        ),
-                                                                )
-                                                            }
-                                                            onToggleSampleData={(
-                                                                uuid,
-                                                            ) =>
-                                                                setSelectedCharts(
-                                                                    (prev) =>
-                                                                        prev.map(
-                                                                            (
-                                                                                c,
-                                                                            ) =>
-                                                                                c.uuid ===
-                                                                                uuid
-                                                                                    ? {
-                                                                                          ...c,
-                                                                                          includeSampleData:
-                                                                                              !c.includeSampleData,
-                                                                                      }
-                                                                                    : c,
-                                                                        ),
-                                                                )
-                                                            }
-                                                            onToggleLink={(
-                                                                uuid,
-                                                            ) =>
-                                                                setSelectedCharts(
-                                                                    (prev) =>
-                                                                        prev.map(
-                                                                            (
-                                                                                c,
-                                                                            ) =>
-                                                                                c.uuid ===
-                                                                                uuid
-                                                                                    ? {
-                                                                                          ...c,
-                                                                                          linkLive:
-                                                                                              !c.linkLive,
-                                                                                          includeSampleData:
-                                                                                              c.linkLive
-                                                                                                  ? c.includeSampleData
-                                                                                                  : false,
-                                                                                      }
-                                                                                    : c,
-                                                                        ),
-                                                                )
-                                                            }
-                                                            disabled={
-                                                                isSubmitting
-                                                            }
-                                                        />
-                                                    )}
-                                                    {selectedDashboard && (
-                                                        <SelectedDashboardSection
-                                                            sampleDataEnabled={
-                                                                sampleDataEnabled
-                                                            }
-                                                            dashboard={
-                                                                selectedDashboard
-                                                            }
-                                                            onRemove={() =>
-                                                                setSelectedDashboard(
-                                                                    null,
-                                                                )
-                                                            }
-                                                            onToggleSampleData={() =>
-                                                                setSelectedDashboard(
-                                                                    (prev) =>
-                                                                        prev
-                                                                            ? {
-                                                                                  ...prev,
-                                                                                  includeSampleData:
-                                                                                      !prev.includeSampleData,
-                                                                              }
-                                                                            : null,
-                                                                )
-                                                            }
-                                                            disabled={
-                                                                isSubmitting
-                                                            }
-                                                        />
-                                                    )}
-                                                    {fileAttachments.length >
-                                                        0 && (
-                                                        <SelectedAttachmentSection
-                                                            attachments={fileAttachments.map(
-                                                                (att) => ({
-                                                                    id: att.localId,
-                                                                    previewUrl:
-                                                                        att.previewUrl,
-                                                                    filename:
-                                                                        att.file
-                                                                            .name,
-                                                                }),
-                                                            )}
-                                                            onRemove={
-                                                                clearAttachment
-                                                            }
-                                                            disabled={
-                                                                isSubmitting
-                                                            }
-                                                            loading={
-                                                                isSubmitting
-                                                            }
-                                                        />
-                                                    )}
-                                                </Box>
-                                            )
+                                {templateQuestionsDefinition ? (
+                                    <TemplateQuestionsForm
+                                        key={templateQuestionsDefinition.id}
+                                        template={templateQuestionsDefinition}
+                                        disabled={isSubmitting || isLoading}
+                                        onBuild={handleTemplateFormBuild}
+                                        onChangeTemplate={() =>
+                                            setSelectedTemplate(null)
                                         }
-                                        toolbarLeft={
-                                            <Group gap={4}>
-                                                <AttachButton
-                                                    selectedCharts={
-                                                        selectedCharts
-                                                    }
-                                                    onSelectChart={(chart) =>
-                                                        setSelectedCharts(
-                                                            (prev) =>
-                                                                prev.some(
-                                                                    (c) =>
-                                                                        c.uuid ===
-                                                                        chart.uuid,
-                                                                )
-                                                                    ? prev
-                                                                    : [
-                                                                          ...prev,
-                                                                          chart,
-                                                                      ],
-                                                        )
-                                                    }
-                                                    onDeselectChart={(uuid) =>
-                                                        setSelectedCharts(
-                                                            (prev) =>
-                                                                prev.filter(
-                                                                    (c) =>
-                                                                        c.uuid !==
-                                                                        uuid,
-                                                                ),
-                                                        )
-                                                    }
-                                                    selectedDashboard={
-                                                        selectedDashboard
-                                                    }
-                                                    onSelectDashboard={
-                                                        setSelectedDashboard
-                                                    }
-                                                    onDeselectDashboard={() =>
-                                                        setSelectedDashboard(
-                                                            null,
-                                                        )
-                                                    }
-                                                    selectedConnections={
-                                                        selectedConnections
-                                                    }
-                                                    onSelectConnection={(
-                                                        connection,
-                                                    ) =>
-                                                        setSelectedConnections(
-                                                            (prev) => [
-                                                                ...prev,
-                                                                connection,
-                                                            ],
-                                                        )
-                                                    }
-                                                    onDeselectConnection={(
-                                                        uuid,
-                                                    ) =>
-                                                        setSelectedConnections(
-                                                            (prev) =>
-                                                                prev.filter(
-                                                                    (c) =>
-                                                                        c.externalConnectionUuid !==
-                                                                        uuid,
-                                                                ),
-                                                        )
-                                                    }
-                                                    onAddFiles={() =>
-                                                        fileInputRef.current?.click()
-                                                    }
-                                                    disabled={isSubmitting}
-                                                    filesDisabled={
-                                                        fileAttachments.length >=
-                                                        MAX_APP_FILES_PER_VERSION
-                                                    }
-                                                    linkedAppUuid={
-                                                        activeAppUuid
-                                                    }
-                                                />
-                                                {previewApp &&
-                                                    screenshotAvailable && (
-                                                        <ScreenshotButton
-                                                            onClick={() =>
-                                                                void handleCaptureScreenshot()
+                                    />
+                                ) : (
+                                    <Box
+                                        onDragOver={handleDragOver}
+                                        onDrop={handleDrop}
+                                    >
+                                        <PromptComposer
+                                            ref={promptEditorRef}
+                                            size="md"
+                                            placeholder="Describe the app you want to build..."
+                                            autoFocus
+                                            // Editable while the agent works so the next prompt
+                                            // can be drafted; disabled only during the
+                                            // client-side submit, where clear() would wipe text.
+                                            disabled={isSubmitting}
+                                            submitDisabled={isLoading}
+                                            onEmptyChange={setIsPromptEmpty}
+                                            onSubmit={() => void handleSubmit()}
+                                            onPaste={handlePaste}
+                                            attachments={
+                                                (selectedCharts.length > 0 ||
+                                                    selectedDashboard ||
+                                                    selectedConnections.length >
+                                                        0 ||
+                                                    selectedElementRefs.length >
+                                                        0 ||
+                                                    fileAttachments.length >
+                                                        0) && (
+                                                    <Box
+                                                        className={
+                                                            classes.attachedResources
+                                                        }
+                                                    >
+                                                        {selectedElementRefs.length >
+                                                            0 && (
+                                                            <Group gap={4}>
+                                                                {selectedElementRefs.map(
+                                                                    (ref) => (
+                                                                        <ElementRefChip
+                                                                            key={elementRefKey(
+                                                                                ref,
+                                                                            )}
+                                                                            elementRef={
+                                                                                ref
+                                                                            }
+                                                                            onRemove={() =>
+                                                                                setSelectedElementRefs(
+                                                                                    (
+                                                                                        prev,
+                                                                                    ) =>
+                                                                                        prev.filter(
+                                                                                            (
+                                                                                                r,
+                                                                                            ) =>
+                                                                                                elementRefKey(
+                                                                                                    r,
+                                                                                                ) !==
+                                                                                                elementRefKey(
+                                                                                                    ref,
+                                                                                                ),
+                                                                                        ),
+                                                                                )
+                                                                            }
+                                                                        />
+                                                                    ),
+                                                                )}
+                                                            </Group>
+                                                        )}
+                                                        {selectedConnections.length >
+                                                            0 && (
+                                                            <Group gap="xs">
+                                                                {selectedConnections.map(
+                                                                    (c) => (
+                                                                        <ConnectionChip
+                                                                            key={
+                                                                                c.externalConnectionUuid
+                                                                            }
+                                                                            name={
+                                                                                c.name
+                                                                            }
+                                                                            onRemove={() =>
+                                                                                setSelectedConnections(
+                                                                                    (
+                                                                                        prev,
+                                                                                    ) =>
+                                                                                        prev.filter(
+                                                                                            (
+                                                                                                x,
+                                                                                            ) =>
+                                                                                                x.externalConnectionUuid !==
+                                                                                                c.externalConnectionUuid,
+                                                                                        ),
+                                                                                )
+                                                                            }
+                                                                        />
+                                                                    ),
+                                                                )}
+                                                            </Group>
+                                                        )}
+                                                        {selectedCharts.length >
+                                                            0 && (
+                                                            <SelectedQuerySection
+                                                                sampleDataEnabled={
+                                                                    sampleDataEnabled
+                                                                }
+                                                                charts={
+                                                                    selectedCharts
+                                                                }
+                                                                onRemove={(
+                                                                    uuid,
+                                                                ) =>
+                                                                    setSelectedCharts(
+                                                                        (
+                                                                            prev,
+                                                                        ) =>
+                                                                            prev.filter(
+                                                                                (
+                                                                                    c,
+                                                                                ) =>
+                                                                                    c.uuid !==
+                                                                                    uuid,
+                                                                            ),
+                                                                    )
+                                                                }
+                                                                onToggleSampleData={(
+                                                                    uuid,
+                                                                ) =>
+                                                                    setSelectedCharts(
+                                                                        (
+                                                                            prev,
+                                                                        ) =>
+                                                                            prev.map(
+                                                                                (
+                                                                                    c,
+                                                                                ) =>
+                                                                                    c.uuid ===
+                                                                                    uuid
+                                                                                        ? {
+                                                                                              ...c,
+                                                                                              includeSampleData:
+                                                                                                  !c.includeSampleData,
+                                                                                          }
+                                                                                        : c,
+                                                                            ),
+                                                                    )
+                                                                }
+                                                                onToggleLink={(
+                                                                    uuid,
+                                                                ) =>
+                                                                    setSelectedCharts(
+                                                                        (
+                                                                            prev,
+                                                                        ) =>
+                                                                            prev.map(
+                                                                                (
+                                                                                    c,
+                                                                                ) =>
+                                                                                    c.uuid ===
+                                                                                    uuid
+                                                                                        ? {
+                                                                                              ...c,
+                                                                                              linkLive:
+                                                                                                  !c.linkLive,
+                                                                                              includeSampleData:
+                                                                                                  c.linkLive
+                                                                                                      ? c.includeSampleData
+                                                                                                      : false,
+                                                                                          }
+                                                                                        : c,
+                                                                            ),
+                                                                    )
+                                                                }
+                                                                disabled={
+                                                                    isSubmitting
+                                                                }
+                                                            />
+                                                        )}
+                                                        {selectedDashboard && (
+                                                            <SelectedDashboardSection
+                                                                sampleDataEnabled={
+                                                                    sampleDataEnabled
+                                                                }
+                                                                dashboard={
+                                                                    selectedDashboard
+                                                                }
+                                                                onRemove={() =>
+                                                                    setSelectedDashboard(
+                                                                        null,
+                                                                    )
+                                                                }
+                                                                onToggleSampleData={() =>
+                                                                    setSelectedDashboard(
+                                                                        (
+                                                                            prev,
+                                                                        ) =>
+                                                                            prev
+                                                                                ? {
+                                                                                      ...prev,
+                                                                                      includeSampleData:
+                                                                                          !prev.includeSampleData,
+                                                                                  }
+                                                                                : null,
+                                                                    )
+                                                                }
+                                                                disabled={
+                                                                    isSubmitting
+                                                                }
+                                                            />
+                                                        )}
+                                                        {fileAttachments.length >
+                                                            0 && (
+                                                            <SelectedAttachmentSection
+                                                                attachments={fileAttachments.map(
+                                                                    (att) => ({
+                                                                        id: att.localId,
+                                                                        previewUrl:
+                                                                            att.previewUrl,
+                                                                        filename:
+                                                                            att
+                                                                                .file
+                                                                                .name,
+                                                                    }),
+                                                                )}
+                                                                onRemove={
+                                                                    clearAttachment
+                                                                }
+                                                                disabled={
+                                                                    isSubmitting
+                                                                }
+                                                                loading={
+                                                                    isSubmitting
+                                                                }
+                                                            />
+                                                        )}
+                                                    </Box>
+                                                )
+                                            }
+                                            toolbarLeft={
+                                                <Group gap={4}>
+                                                    <AttachButton
+                                                        selectedCharts={
+                                                            selectedCharts
+                                                        }
+                                                        onSelectChart={(
+                                                            chart,
+                                                        ) =>
+                                                            setSelectedCharts(
+                                                                (prev) =>
+                                                                    prev.some(
+                                                                        (c) =>
+                                                                            c.uuid ===
+                                                                            chart.uuid,
+                                                                    )
+                                                                        ? prev
+                                                                        : [
+                                                                              ...prev,
+                                                                              chart,
+                                                                          ],
+                                                            )
+                                                        }
+                                                        onDeselectChart={(
+                                                            uuid,
+                                                        ) =>
+                                                            setSelectedCharts(
+                                                                (prev) =>
+                                                                    prev.filter(
+                                                                        (c) =>
+                                                                            c.uuid !==
+                                                                            uuid,
+                                                                    ),
+                                                            )
+                                                        }
+                                                        selectedDashboard={
+                                                            selectedDashboard
+                                                        }
+                                                        onSelectDashboard={
+                                                            setSelectedDashboard
+                                                        }
+                                                        onDeselectDashboard={() =>
+                                                            setSelectedDashboard(
+                                                                null,
+                                                            )
+                                                        }
+                                                        selectedConnections={
+                                                            selectedConnections
+                                                        }
+                                                        onSelectConnection={(
+                                                            connection,
+                                                        ) =>
+                                                            setSelectedConnections(
+                                                                (prev) => [
+                                                                    ...prev,
+                                                                    connection,
+                                                                ],
+                                                            )
+                                                        }
+                                                        onDeselectConnection={(
+                                                            uuid,
+                                                        ) =>
+                                                            setSelectedConnections(
+                                                                (prev) =>
+                                                                    prev.filter(
+                                                                        (c) =>
+                                                                            c.externalConnectionUuid !==
+                                                                            uuid,
+                                                                    ),
+                                                            )
+                                                        }
+                                                        onAddFiles={() =>
+                                                            fileInputRef.current?.click()
+                                                        }
+                                                        disabled={isSubmitting}
+                                                        filesDisabled={
+                                                            fileAttachments.length >=
+                                                            MAX_APP_FILES_PER_VERSION
+                                                        }
+                                                        linkedAppUuid={
+                                                            activeAppUuid
+                                                        }
+                                                    />
+                                                    {previewApp &&
+                                                        screenshotAvailable && (
+                                                            <ScreenshotButton
+                                                                onClick={() =>
+                                                                    void handleCaptureScreenshot()
+                                                                }
+                                                                disabled={
+                                                                    isSubmitting ||
+                                                                    fileAttachments.length >=
+                                                                        MAX_APP_FILES_PER_VERSION
+                                                                }
+                                                                loading={
+                                                                    isCapturingScreenshot
+                                                                }
+                                                            />
+                                                        )}
+                                                    {inspectorAvailable && (
+                                                        <InspectButton
+                                                            enabled={
+                                                                inspectorEnabled
                                                             }
-                                                            disabled={
-                                                                isSubmitting ||
-                                                                fileAttachments.length >=
-                                                                    MAX_APP_FILES_PER_VERSION
+                                                            onToggle={() => {
+                                                                setInspectorEnabled(
+                                                                    (v) => {
+                                                                        const next =
+                                                                            !v;
+                                                                        if (
+                                                                            next
+                                                                        )
+                                                                            setLineageEnabled(
+                                                                                false,
+                                                                            );
+                                                                        return next;
+                                                                    },
+                                                                );
+                                                                // Entering inspector
+                                                                // mode force-disables
+                                                                // lineage — drop its
+                                                                // selection too.
+                                                                setFocusedQueryUuid(
+                                                                    null,
+                                                                );
+                                                            }}
+                                                        />
+                                                    )}
+                                                    {newAppLanding && (
+                                                        <Divider
+                                                            orientation="vertical"
+                                                            h={16}
+                                                            my="auto"
+                                                        />
+                                                    )}
+                                                    {newAppLanding && (
+                                                        <ThemePicker
+                                                            compact
+                                                            value={
+                                                                currentThemeUuid
                                                             }
-                                                            loading={
-                                                                isCapturingScreenshot
+                                                            onChange={
+                                                                handleThemeChange
                                                             }
                                                         />
                                                     )}
-                                                {inspectorAvailable && (
-                                                    <InspectButton
-                                                        enabled={
-                                                            inspectorEnabled
-                                                        }
-                                                        onToggle={() => {
-                                                            setInspectorEnabled(
-                                                                (v) => {
-                                                                    const next =
-                                                                        !v;
-                                                                    if (next)
-                                                                        setLineageEnabled(
-                                                                            false,
-                                                                        );
-                                                                    return next;
-                                                                },
-                                                            );
-                                                            // Entering inspector
-                                                            // mode force-disables
-                                                            // lineage — drop its
-                                                            // selection too.
-                                                            setFocusedQueryUuid(
-                                                                null,
-                                                            );
-                                                        }}
-                                                    />
-                                                )}
-                                                {newAppLanding && (
-                                                    <Divider
-                                                        orientation="vertical"
-                                                        h={16}
-                                                        my="auto"
-                                                    />
-                                                )}
-                                                {newAppLanding && (
-                                                    <ThemePicker
-                                                        compact
-                                                        value={currentThemeUuid}
-                                                        onChange={
-                                                            handleThemeChange
-                                                        }
-                                                    />
-                                                )}
-                                                {newAppLanding &&
-                                                    selectedTemplate !==
-                                                        null && (
-                                                        <Group
-                                                            gap={5}
-                                                            wrap="nowrap"
-                                                            className={
-                                                                classes.startingFromChip
-                                                            }
-                                                            title={`Starting from ${
-                                                                getTemplate(
-                                                                    selectedTemplate,
-                                                                ).title
-                                                            }`}
-                                                        >
-                                                            <MantineIcon
-                                                                icon={
-                                                                    getTemplate(
-                                                                        selectedTemplate,
-                                                                    ).icon
-                                                                }
-                                                                size={14}
-                                                            />
-                                                            <Text
-                                                                span
-                                                                size="xs"
-                                                                fw={500}
-                                                                lh={1.2}
+                                                    {newAppLanding &&
+                                                        selectedTemplate !==
+                                                            null && (
+                                                            <Group
+                                                                gap={5}
+                                                                wrap="nowrap"
                                                                 className={
-                                                                    classes.startingFromLabel
+                                                                    classes.startingFromChip
                                                                 }
-                                                            >
-                                                                Template:
-                                                            </Text>
-                                                            <Text
-                                                                span
-                                                                size="xs"
-                                                                fw={600}
-                                                                lh={1.2}
-                                                                c="inherit"
-                                                                lineClamp={1}
-                                                            >
-                                                                {
+                                                                title={`Starting from ${
                                                                     getTemplate(
                                                                         selectedTemplate,
                                                                     ).title
-                                                                }
-                                                            </Text>
-                                                        </Group>
-                                                    )}
-                                            </Group>
-                                        }
-                                        toolbarRight={
-                                            <Group gap="xs">
-                                                <ModelPicker
-                                                    value={selectedModel}
-                                                    onChange={handleModelChange}
-                                                    codingAgent={codingAgent}
-                                                    disabled={
-                                                        isSubmitting ||
-                                                        isModelVisibilityLoading
-                                                    }
-                                                    visibleModels={
-                                                        visibleModels
-                                                    }
-                                                />
-                                                {isBuilding ? (
-                                                    <ComposerSubmitButton
-                                                        icon={IconPlayerStop}
-                                                        label="Stop generation"
-                                                        onClick={handleCancel}
-                                                        loading={isCancelling}
-                                                    />
-                                                ) : (
-                                                    <ComposerSubmitButton
-                                                        icon={IconArrowUp}
-                                                        label="Send message"
-                                                        onClick={() =>
-                                                            void handleSubmit()
+                                                                }`}
+                                                            >
+                                                                <MantineIcon
+                                                                    icon={
+                                                                        getTemplate(
+                                                                            selectedTemplate,
+                                                                        ).icon
+                                                                    }
+                                                                    size={14}
+                                                                />
+                                                                <Text
+                                                                    span
+                                                                    size="xs"
+                                                                    fw={500}
+                                                                    lh={1.2}
+                                                                    className={
+                                                                        classes.startingFromLabel
+                                                                    }
+                                                                >
+                                                                    Template:
+                                                                </Text>
+                                                                <Text
+                                                                    span
+                                                                    size="xs"
+                                                                    fw={600}
+                                                                    lh={1.2}
+                                                                    c="inherit"
+                                                                    lineClamp={
+                                                                        1
+                                                                    }
+                                                                >
+                                                                    {
+                                                                        getTemplate(
+                                                                            selectedTemplate,
+                                                                        ).title
+                                                                    }
+                                                                </Text>
+                                                            </Group>
+                                                        )}
+                                                </Group>
+                                            }
+                                            toolbarRight={
+                                                <Group gap="xs">
+                                                    <ModelPicker
+                                                        value={selectedModel}
+                                                        onChange={
+                                                            handleModelChange
+                                                        }
+                                                        codingAgent={
+                                                            codingAgent
                                                         }
                                                         disabled={
-                                                            (isPromptEmpty &&
-                                                                selectedElementRefs.length ===
-                                                                    0) ||
-                                                            isLoading
-                                                        }
-                                                        loading={
                                                             isSubmitting ||
-                                                            isGenerating ||
-                                                            isIterating
+                                                            isModelVisibilityLoading
+                                                        }
+                                                        visibleModels={
+                                                            visibleModels
                                                         }
                                                     />
-                                                )}
-                                            </Group>
-                                        }
-                                    />
-                                </Box>
+                                                    {isBuilding ? (
+                                                        <ComposerSubmitButton
+                                                            icon={
+                                                                IconPlayerStop
+                                                            }
+                                                            label="Stop generation"
+                                                            onClick={
+                                                                handleCancel
+                                                            }
+                                                            loading={
+                                                                isCancelling
+                                                            }
+                                                        />
+                                                    ) : (
+                                                        <ComposerSubmitButton
+                                                            icon={IconArrowUp}
+                                                            label="Send message"
+                                                            onClick={() =>
+                                                                void handleSubmit()
+                                                            }
+                                                            disabled={
+                                                                (isPromptEmpty &&
+                                                                    selectedElementRefs.length ===
+                                                                        0) ||
+                                                                isLoading
+                                                            }
+                                                            loading={
+                                                                isSubmitting ||
+                                                                isGenerating ||
+                                                                isIterating
+                                                            }
+                                                        />
+                                                    )}
+                                                </Group>
+                                            }
+                                        />
+                                    </Box>
+                                )}
                             </Box>
                         )}
                     </Box>


### PR DESCRIPTION
## Summary

Fifth level of the template stack (#28422 → #28420 → #28433 → #28437 → this). Linear CS-197.

- Registry templates can declare `questions` (text or one-per-line `list`, with defaults + required). Forecaster and Scorecard ship question sets; the Scorecard's tiles question is the list-valued manifest showing through.
- Choosing a gallery template **auto-proceeds** to its question form in place of the freeform composer — no extra click, no blank prompt. Pre-filled defaults mean Build works with zero typing.
- Submit builds directly: answers become the request's `clarifications` (the form *is* the clarification round, so the generic LLM clarify pass is skipped) and the closing optional "anything else?" becomes the prompt. Backend generate path unchanged.
- Iteration turns after the first build are unchanged; templates without questions keep today's composer; flag-gated.

## Test plan

- Registry tests for question sets (keys unique, list kind on scorecard, built-ins undefined); frontend definition test
- Frontend typecheck + oxlint ✓
- Recorded click-through on docker-dev

## Evidence

Screenshots, the verification transcript and the review order for the whole stack: [Templated Data Apps Review](https://claude.ai/code/artifact/c906e241-f1aa-4dd3-8eea-858b0df20451#pr-28441) (section for this PR). Restacked onto main 2.82.2 on 2026-09-02; affected suites green after the restack (frontend 567, common 926, backend 379) and the end-to-end gallery flow passes 11/11 in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VU9L8WJ97vLUB4WJmaUKDa

> Reviewer note: most of the AppGenerate.tsx diff is a formatter re-indent from wrapping the composer block in a ternary — hide whitespace to see the ~60 real lines (the memo, the handler, and the render switch).
