### PR TITLE
feat(sql-runner): card-based layout with a permanent tables sidebar

### DIFF
--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.module.css
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.module.css
@@ -1,0 +1,89 @@
+.root {
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
+}
+
+.panel {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+}
+
+.panel[hidden] {
+    display: none;
+}
+
+/* Editor and results are cards, like the Explorer's sections. */
+.card {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
+}
+
+.cardHeader {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--mantine-spacing-sm);
+    flex-shrink: 0;
+    min-height: rem(44px);
+    padding: rem(6px) var(--mantine-spacing-sm);
+    border-bottom: 1px solid var(--mantine-color-default-border);
+}
+
+.cardBody {
+    position: relative;
+    flex: 1;
+    min-height: 0;
+}
+
+/* Charts breathe inside the card; tables sit flush so the card is their frame. */
+.cardBody[data-padded='true'] {
+    padding: var(--mantine-spacing-md);
+}
+
+.editorSurface {
+    position: absolute;
+    inset: 0;
+    overflow: hidden;
+}
+
+.editorSurface[data-scroll='true'] {
+    overflow-y: auto;
+}
+
+.resultsBody {
+    height: 100%;
+    position: relative;
+    overflow: auto;
+}
+
+/* The gap between the cards doubles as the drag handle; a pill appears on
+   hover so the affordance is discoverable without being drawn all the time. */
+.resizeHandle {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: var(--mantine-spacing-md);
+    cursor: row-resize;
+}
+
+.resizeHandle::before {
+    content: '';
+    width: rem(48px);
+    height: rem(4px);
+    border-radius: rem(999px);
+    background-color: transparent;
+    transition: background-color 120ms ease;
+}
+
+.resizeHandle:hover::before,
+.resizeHandle[data-resize-handle-state='drag']::before {
+    background-color: light-dark(
+        var(--mantine-color-gray-3),
+        var(--mantine-color-dark-3)
+    );
+}

--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -18,6 +18,7 @@ import {
     Indicator,
     LoadingOverlay,
     SegmentedControl,
+    Title,
     Transition,
     Tooltip,
 } from '@mantine/core';
@@ -27,7 +28,7 @@ import {
     IconAlertCircle,
     IconChartHistogram,
     IconCode,
-    IconGripHorizontal,
+    IconTable,
 } from '@tabler/icons-react';
 import {
     useCallback,
@@ -45,6 +46,7 @@ import {
 } from 'react-resizable-panels';
 import { ConditionalVisibility } from '../../../components/common/ConditionalVisibility';
 import MantineIcon from '../../../components/common/MantineIcon';
+import SuboptimalState from '../../../components/common/SuboptimalState/SuboptimalState';
 import { updateChartSortBy } from '../../../components/DataViz/store/actions/commonChartActions';
 import {
     cartesianChartSelectors,
@@ -84,9 +86,9 @@ import {
 } from '../store/sqlRunnerSlice';
 import { prepareAndFetchChartData, runSqlQuery } from '../store/thunks';
 import { executeSqlDownloadQuery } from '../utils/executeSqlDownloadQuery';
+import styles from './ContentPanel.module.css';
 import { ChartDownload } from './Download/ChartDownload';
 import ResultsDownloadButton from './Download/ResultsDownloadButton';
-import styles from './ResizeHandle.module.css';
 import { SqlEditor } from './SqlEditor';
 import { SqlEditorPreferencesPopover } from './SqlEditorPreferencesPopover';
 import { SqlQueryHistory } from './SqlQueryHistory';
@@ -127,7 +129,7 @@ export const ContentPanel: FC = () => {
     const { showToastError } = useToaster();
 
     // State tracked by this component
-    const [panelSizes, setPanelSizes] = useState<number[]>([100, 0]);
+    const [panelSizes, setPanelSizes] = useState<number[]>([60, 40]);
     const resultsPanelRef = useRef<ImperativePanelHandle>(null);
 
     // state for helping highlight errors in the editor
@@ -436,188 +438,8 @@ export const ContentPanel: FC = () => {
     } = useParameters(projectUuid, Array.from(parameterReferences ?? []));
 
     return (
-        <Stack gap="none" style={{ flex: 1, overflow: 'hidden' }}>
+        <Stack gap={0} p="lg" pt="md" className={styles.root}>
             <Tooltip.Group>
-                <Paper
-                    shadow="none"
-                    radius={0}
-                    withBorder={false}
-                    px="md"
-                    py={6}
-                    className={styles.toolbarPaper}
-                >
-                    <Group justify="space-between">
-                        <Group justify="space-between">
-                            <Indicator
-                                color="red.6"
-                                offset={10}
-                                disabled={!hasErrors || mode === 'virtualView'}
-                            >
-                                <SegmentedControl
-                                    display={
-                                        mode === 'virtualView'
-                                            ? 'none'
-                                            : undefined
-                                    }
-                                    size="sm"
-                                    radius="md"
-                                    data={[
-                                        {
-                                            value: EditorTabs.SQL,
-                                            label: (
-                                                <Tooltip
-                                                    disabled={!hasUnrunChanges}
-                                                    withinPortal
-                                                    label="You haven't run this query yet."
-                                                >
-                                                    <Group
-                                                        gap={4}
-                                                        wrap="nowrap"
-                                                    >
-                                                        <SqlEditorPreferencesPopover />
-
-                                                        <Text fz="sm">SQL</Text>
-                                                    </Group>
-                                                </Tooltip>
-                                            ),
-                                        },
-
-                                        {
-                                            value: EditorTabs.VISUALIZATION,
-                                            label: (
-                                                <Tooltip
-                                                    disabled={
-                                                        !!queryResults?.results
-                                                    }
-                                                    withinPortal
-                                                    label="Run a query to see the chart"
-                                                >
-                                                    <Group
-                                                        gap={4}
-                                                        wrap="nowrap"
-                                                    >
-                                                        <MantineIcon
-                                                            color="ldGray.6"
-                                                            icon={
-                                                                IconChartHistogram
-                                                            }
-                                                        />
-                                                        <Text fz="sm">
-                                                            Chart
-                                                        </Text>
-                                                    </Group>
-                                                </Tooltip>
-                                            ),
-                                        },
-                                    ]}
-                                    value={activeEditorTab}
-                                    onChange={(value) => {
-                                        const editorTab = value as EditorTabs;
-
-                                        if (isLoadingSqlQuery) {
-                                            return;
-                                        }
-
-                                        if (
-                                            editorTab ===
-                                                EditorTabs.VISUALIZATION &&
-                                            !queryResults?.results
-                                        ) {
-                                            return;
-                                        }
-
-                                        dispatch(setActiveEditorTab(editorTab));
-                                    }}
-                                />
-                            </Indicator>
-                        </Group>
-                        <Group gap="xs">
-                            <Parameters
-                                isEditMode={false}
-                                parameters={projectParameters}
-                                parameterValues={parameterValues}
-                                onParameterChange={handleParameterChange}
-                                onClearAll={clearAllParameters}
-                                isLoading={isProjectParametersLoading}
-                                isError={isProjectParametersError}
-                            />
-                            {activeEditorTab === EditorTabs.SQL && (
-                                <SqlQueryHistory />
-                            )}
-                            <RunSqlQueryButton
-                                isLoading={isLoadingSqlQuery}
-                                disabled={!sql}
-                                onSubmit={() => handleRunQuery(sql)}
-                                {...(canSetSqlLimit
-                                    ? {
-                                          onLimitChange: (l) =>
-                                              dispatch(setSqlLimit(l)),
-                                          limit,
-                                      }
-                                    : {})}
-                            />
-                            {activeEditorTab === EditorTabs.SQL && (
-                                <Tooltip
-                                    label="Format SQL"
-                                    withArrow
-                                    position="bottom"
-                                >
-                                    <ActionIcon
-                                        onClick={handleFormatSql}
-                                        disabled={!sql}
-                                        variant="default"
-                                    >
-                                        <MantineIcon icon={IconCode} />
-                                    </ActionIcon>
-                                </Tooltip>
-                            )}
-                            {activeEditorTab === EditorTabs.VISUALIZATION &&
-                            !isVizTableConfig(currentVizConfig) &&
-                            !isVizBigNumberConfig(currentVizConfig) &&
-                            selectedChartType ? (
-                                <ChartDownload
-                                    chartName={savedSqlChart?.name}
-                                    echartsInstance={activeEchartsInstance!}
-                                    projectUuid={projectUuid}
-                                    disabled={isLoadingSqlQuery}
-                                    hideLimitSelection={true}
-                                    totalResults={
-                                        resultsRunner.getRows().length
-                                    }
-                                    columnOrder={
-                                        pivotedChartInfo?.data?.columns?.map(
-                                            (c) => c.reference,
-                                        ) ?? []
-                                    }
-                                    getDownloadQueryUuid={
-                                        getDownloadPivotQueryUuid
-                                    }
-                                />
-                            ) : (
-                                mode === 'default' && (
-                                    <ResultsDownloadButton
-                                        projectUuid={projectUuid}
-                                        disabled={isLoadingSqlQuery}
-                                        chartName={savedSqlChart?.name}
-                                        vizTableConfig={
-                                            isVizTableConfig(currentVizConfig)
-                                                ? currentVizConfig
-                                                : undefined
-                                        }
-                                        totalResults={
-                                            resultsRunner.getRows().length
-                                        }
-                                        columnOrder={resultsRunner.getColumnNames()}
-                                        getDownloadQueryUuid={
-                                            getDownloadQueryUuid
-                                        }
-                                    />
-                                )
-                            )}
-                        </Group>
-                    </Group>
-                </Paper>
-
                 <PanelGroup
                     direction="vertical"
                     onLayout={(sizes) => setPanelSizes(sizes)}
@@ -626,169 +448,352 @@ export const ContentPanel: FC = () => {
                         id="sql-runner-panel-sql-or-charts"
                         order={1}
                         minSize={30}
-                        style={{ display: 'flex', flexDirection: 'column' }}
+                        className={styles.panel}
                     >
-                        <Paper
-                            ref={inputSectionRef}
-                            shadow="none"
-                            radius={0}
-                            withBorder={false}
-                            style={{ flex: 1, position: 'relative' }}
-                            className={styles.inputPaper}
-                        >
-                            <Box
-                                style={{
-                                    flex: 1,
-                                    position: 'absolute',
-                                    inset: 0,
-                                    overflowY: isVizTableConfig(
-                                        currentVizConfig,
-                                    )
-                                        ? 'auto'
-                                        : 'hidden',
-                                }}
-                            >
-                                <ConditionalVisibility
-                                    isVisible={
-                                        activeEditorTab === EditorTabs.SQL
-                                    }
-                                >
-                                    <SqlEditor
-                                        resetHighlightError={() =>
-                                            dispatch(
-                                                setEditorHighlightError(
-                                                    undefined,
-                                                ),
-                                            )
+                        <Paper className={styles.card}>
+                            <Box className={styles.cardHeader}>
+                                <Group justify="space-between">
+                                    <Indicator
+                                        color="red.6"
+                                        offset={10}
+                                        disabled={
+                                            !hasErrors || mode === 'virtualView'
                                         }
-                                        onSubmit={(submittedSQL) =>
-                                            handleRunQuery(submittedSQL ?? '')
-                                        }
-                                        highlightText={
-                                            editorHighlightError
-                                                ? {
-                                                      // set set single character highlight (no end/range defined)
-                                                      start: editorHighlightError,
-                                                      end: undefined,
-                                                  }
-                                                : undefined
-                                        }
-                                    />
-                                </ConditionalVisibility>
-
-                                <ConditionalVisibility
-                                    isVisible={
-                                        activeEditorTab ===
-                                        EditorTabs.VISUALIZATION
-                                    }
-                                >
-                                    {queryResults?.results &&
-                                        currentVizConfig && (
-                                            <>
-                                                <Transition
-                                                    keepMounted
-                                                    mounted={!showTable}
-                                                    transition="fade"
-                                                    duration={400}
-                                                    timingFunction="ease"
-                                                >
-                                                    {(styles) => (
-                                                        <Box
-                                                            px="sm"
-                                                            pb="sm"
-                                                            style={styles}
+                                    >
+                                        <SegmentedControl
+                                            display={
+                                                mode === 'virtualView'
+                                                    ? 'none'
+                                                    : undefined
+                                            }
+                                            size="sm"
+                                            radius="md"
+                                            data={[
+                                                {
+                                                    value: EditorTabs.SQL,
+                                                    label: (
+                                                        <Tooltip
+                                                            disabled={
+                                                                !hasUnrunChanges
+                                                            }
+                                                            withinPortal
+                                                            label="You haven't run this query yet."
                                                         >
-                                                            {activeConfigs.chartConfigs.map(
-                                                                (c) => (
-                                                                    <ConditionalVisibility
-                                                                        key={
-                                                                            c.type
-                                                                        }
-                                                                        isVisible={
-                                                                            selectedChartType ===
-                                                                            c.type
-                                                                        }
-                                                                    >
-                                                                        <SqlRunnerChart
-                                                                            config={
-                                                                                c
-                                                                            }
-                                                                            spec={pivotedChartInfo?.data?.getChartSpec(
-                                                                                chartColors,
-                                                                            )}
-                                                                            isLoading={
-                                                                                !!pivotedChartInfo?.loading
-                                                                            }
-                                                                            error={
-                                                                                pivotedChartInfo?.error
-                                                                            }
-                                                                            height={
-                                                                                inputSectionHeight
-                                                                            }
-                                                                            width={
-                                                                                inputSectionWidth
-                                                                            }
-                                                                            onEchartsReady={(
-                                                                                instance,
-                                                                            ) => {
-                                                                                if (
-                                                                                    c.type ===
-                                                                                    selectedChartType
-                                                                                ) {
-                                                                                    setActiveEchartsInstance(
-                                                                                        instance,
-                                                                                    );
-                                                                                }
-                                                                            }}
-                                                                        />
-                                                                    </ConditionalVisibility>
-                                                                ),
-                                                            )}
-                                                        </Box>
-                                                    )}
-                                                </Transition>
-
-                                                <Transition
-                                                    keepMounted
-                                                    mounted={showTable}
-                                                    transition="fade"
-                                                    duration={300}
-                                                    timingFunction="ease"
-                                                >
-                                                    {(styles) => (
-                                                        <Box
-                                                            style={{
-                                                                flex: 1,
-                                                                height: inputSectionHeight,
-                                                                ...styles,
-                                                            }}
-                                                        >
-                                                            <ConditionalVisibility
-                                                                isVisible={
-                                                                    showTable
-                                                                }
+                                                            <Group
+                                                                gap={4}
+                                                                wrap="nowrap"
                                                             >
-                                                                <Table
-                                                                    resultsRunner={
-                                                                        resultsRunner
+                                                                <SqlEditorPreferencesPopover />
+
+                                                                <Text fz="sm">
+                                                                    SQL
+                                                                </Text>
+                                                            </Group>
+                                                        </Tooltip>
+                                                    ),
+                                                },
+
+                                                {
+                                                    value: EditorTabs.VISUALIZATION,
+                                                    label: (
+                                                        <Tooltip
+                                                            disabled={
+                                                                !!queryResults?.results
+                                                            }
+                                                            withinPortal
+                                                            label="Run a query to see the chart"
+                                                        >
+                                                            <Group
+                                                                gap={4}
+                                                                wrap="nowrap"
+                                                            >
+                                                                <MantineIcon
+                                                                    color="ldGray.6"
+                                                                    icon={
+                                                                        IconChartHistogram
                                                                     }
-                                                                    columnsConfig={
-                                                                        activeConfigs
-                                                                            .tableConfig
-                                                                            ?.columns ??
-                                                                        {}
-                                                                    }
-                                                                    flexProps={{
-                                                                        mah: '100%',
-                                                                    }}
                                                                 />
-                                                            </ConditionalVisibility>
-                                                        </Box>
-                                                    )}
-                                                </Transition>
-                                            </>
-                                        )}
-                                </ConditionalVisibility>
+                                                                <Text fz="sm">
+                                                                    Chart
+                                                                </Text>
+                                                            </Group>
+                                                        </Tooltip>
+                                                    ),
+                                                },
+                                            ]}
+                                            value={activeEditorTab}
+                                            onChange={(value) => {
+                                                const editorTab =
+                                                    value as EditorTabs;
+
+                                                if (isLoadingSqlQuery) {
+                                                    return;
+                                                }
+
+                                                if (
+                                                    editorTab ===
+                                                        EditorTabs.VISUALIZATION &&
+                                                    !queryResults?.results
+                                                ) {
+                                                    return;
+                                                }
+
+                                                dispatch(
+                                                    setActiveEditorTab(
+                                                        editorTab,
+                                                    ),
+                                                );
+                                            }}
+                                        />
+                                    </Indicator>
+                                </Group>
+                                <Group gap="xs">
+                                    <Parameters
+                                        isEditMode={false}
+                                        parameters={projectParameters}
+                                        parameterValues={parameterValues}
+                                        onParameterChange={
+                                            handleParameterChange
+                                        }
+                                        onClearAll={clearAllParameters}
+                                        isLoading={isProjectParametersLoading}
+                                        isError={isProjectParametersError}
+                                    />
+                                    {activeEditorTab === EditorTabs.SQL && (
+                                        <SqlQueryHistory />
+                                    )}
+                                    <RunSqlQueryButton
+                                        isLoading={isLoadingSqlQuery}
+                                        disabled={!sql}
+                                        onSubmit={() => handleRunQuery(sql)}
+                                        {...(canSetSqlLimit
+                                            ? {
+                                                  onLimitChange: (l) =>
+                                                      dispatch(setSqlLimit(l)),
+                                                  limit,
+                                              }
+                                            : {})}
+                                    />
+                                    {activeEditorTab === EditorTabs.SQL && (
+                                        <Tooltip
+                                            label="Format SQL"
+                                            withArrow
+                                            position="bottom"
+                                        >
+                                            <ActionIcon
+                                                onClick={handleFormatSql}
+                                                disabled={!sql}
+                                                variant="default"
+                                            >
+                                                <MantineIcon icon={IconCode} />
+                                            </ActionIcon>
+                                        </Tooltip>
+                                    )}
+                                    {activeEditorTab ===
+                                        EditorTabs.VISUALIZATION &&
+                                    !isVizTableConfig(currentVizConfig) &&
+                                    !isVizBigNumberConfig(currentVizConfig) &&
+                                    selectedChartType ? (
+                                        <ChartDownload
+                                            chartName={savedSqlChart?.name}
+                                            echartsInstance={
+                                                activeEchartsInstance!
+                                            }
+                                            projectUuid={projectUuid}
+                                            disabled={isLoadingSqlQuery}
+                                            hideLimitSelection={true}
+                                            totalResults={
+                                                resultsRunner.getRows().length
+                                            }
+                                            columnOrder={
+                                                pivotedChartInfo?.data?.columns?.map(
+                                                    (c) => c.reference,
+                                                ) ?? []
+                                            }
+                                            getDownloadQueryUuid={
+                                                getDownloadPivotQueryUuid
+                                            }
+                                        />
+                                    ) : (
+                                        mode === 'default' && (
+                                            <ResultsDownloadButton
+                                                projectUuid={projectUuid}
+                                                disabled={isLoadingSqlQuery}
+                                                chartName={savedSqlChart?.name}
+                                                vizTableConfig={
+                                                    isVizTableConfig(
+                                                        currentVizConfig,
+                                                    )
+                                                        ? currentVizConfig
+                                                        : undefined
+                                                }
+                                                totalResults={
+                                                    resultsRunner.getRows()
+                                                        .length
+                                                }
+                                                columnOrder={resultsRunner.getColumnNames()}
+                                                getDownloadQueryUuid={
+                                                    getDownloadQueryUuid
+                                                }
+                                            />
+                                        )
+                                    )}
+                                </Group>
+                            </Box>
+                            <Box
+                                ref={inputSectionRef}
+                                className={styles.cardBody}
+                            >
+                                <Box
+                                    className={styles.editorSurface}
+                                    data-scroll={isVizTableConfig(
+                                        currentVizConfig,
+                                    )}
+                                >
+                                    <ConditionalVisibility
+                                        isVisible={
+                                            activeEditorTab === EditorTabs.SQL
+                                        }
+                                    >
+                                        <SqlEditor
+                                            resetHighlightError={() =>
+                                                dispatch(
+                                                    setEditorHighlightError(
+                                                        undefined,
+                                                    ),
+                                                )
+                                            }
+                                            onSubmit={(submittedSQL) =>
+                                                handleRunQuery(
+                                                    submittedSQL ?? '',
+                                                )
+                                            }
+                                            highlightText={
+                                                editorHighlightError
+                                                    ? {
+                                                          // set set single character highlight (no end/range defined)
+                                                          start: editorHighlightError,
+                                                          end: undefined,
+                                                      }
+                                                    : undefined
+                                            }
+                                        />
+                                    </ConditionalVisibility>
+
+                                    <ConditionalVisibility
+                                        isVisible={
+                                            activeEditorTab ===
+                                            EditorTabs.VISUALIZATION
+                                        }
+                                    >
+                                        {queryResults?.results &&
+                                            currentVizConfig && (
+                                                <>
+                                                    <Transition
+                                                        keepMounted
+                                                        mounted={!showTable}
+                                                        transition="fade"
+                                                        duration={400}
+                                                        timingFunction="ease"
+                                                    >
+                                                        {(styles) => (
+                                                            <Box
+                                                                px="sm"
+                                                                pb="sm"
+                                                                style={styles}
+                                                            >
+                                                                {activeConfigs.chartConfigs.map(
+                                                                    (c) => (
+                                                                        <ConditionalVisibility
+                                                                            key={
+                                                                                c.type
+                                                                            }
+                                                                            isVisible={
+                                                                                selectedChartType ===
+                                                                                c.type
+                                                                            }
+                                                                        >
+                                                                            <SqlRunnerChart
+                                                                                config={
+                                                                                    c
+                                                                                }
+                                                                                spec={pivotedChartInfo?.data?.getChartSpec(
+                                                                                    chartColors,
+                                                                                )}
+                                                                                isLoading={
+                                                                                    !!pivotedChartInfo?.loading
+                                                                                }
+                                                                                error={
+                                                                                    pivotedChartInfo?.error
+                                                                                }
+                                                                                height={
+                                                                                    inputSectionHeight
+                                                                                }
+                                                                                width={
+                                                                                    inputSectionWidth
+                                                                                }
+                                                                                onEchartsReady={(
+                                                                                    instance,
+                                                                                ) => {
+                                                                                    if (
+                                                                                        c.type ===
+                                                                                        selectedChartType
+                                                                                    ) {
+                                                                                        setActiveEchartsInstance(
+                                                                                            instance,
+                                                                                        );
+                                                                                    }
+                                                                                }}
+                                                                            />
+                                                                        </ConditionalVisibility>
+                                                                    ),
+                                                                )}
+                                                            </Box>
+                                                        )}
+                                                    </Transition>
+
+                                                    <Transition
+                                                        keepMounted
+                                                        mounted={showTable}
+                                                        transition="fade"
+                                                        duration={300}
+                                                        timingFunction="ease"
+                                                    >
+                                                        {(styles) => (
+                                                            <Box
+                                                                style={{
+                                                                    flex: 1,
+                                                                    height: inputSectionHeight,
+                                                                    ...styles,
+                                                                }}
+                                                            >
+                                                                <ConditionalVisibility
+                                                                    isVisible={
+                                                                        showTable
+                                                                    }
+                                                                >
+                                                                    <Table
+                                                                        resultsRunner={
+                                                                            resultsRunner
+                                                                        }
+                                                                        columnsConfig={
+                                                                            activeConfigs
+                                                                                .tableConfig
+                                                                                ?.columns ??
+                                                                            {}
+                                                                        }
+                                                                        flexProps={{
+                                                                            mah: '100%',
+                                                                        }}
+                                                                    />
+                                                                </ConditionalVisibility>
+                                                            </Box>
+                                                        )}
+                                                    </Transition>
+                                                </>
+                                            )}
+                                    </ConditionalVisibility>
+                                </Box>
                             </Box>
                         </Paper>
                     </Panel>
@@ -796,28 +801,8 @@ export const ContentPanel: FC = () => {
                     <Box
                         hidden={hideResultsPanel}
                         component={PanelResizeHandle}
-                        h={15}
-                        className={styles.resultsResizeHandle}
-                    >
-                        <MantineIcon
-                            color="gray"
-                            icon={IconGripHorizontal}
-                            size={12}
-                        />
-
-                        {showLimitText && (
-                            <>
-                                <Text fz="xs" fw={400} c="ldGray.7">
-                                    Showing first {defaultQueryLimit} rows
-                                </Text>
-                                <MantineIcon
-                                    color="gray"
-                                    icon={IconGripHorizontal}
-                                    size={12}
-                                />
-                            </>
-                        )}
-                    </Box>
+                        className={styles.resizeHandle}
+                    />
 
                     <Panel
                         id="sql-runner-panel-results"
@@ -825,113 +810,135 @@ export const ContentPanel: FC = () => {
                         defaultSize={panelSizes[1]}
                         maxSize={500}
                         ref={resultsPanelRef}
-                        style={{
-                            display: hideResultsPanel ? 'none' : 'flex',
-                            flexDirection: 'column',
-                        }}
-                        className="sentry-block ph-no-capture"
+                        hidden={hideResultsPanel}
+                        className={`${styles.panel} sentry-block ph-no-capture`}
                     >
-                        <Box
-                            h="100%"
-                            pos="relative"
-                            style={{
-                                overflow: 'auto',
-                            }}
-                        >
-                            <LoadingOverlay
-                                pos="absolute"
-                                loaderProps={{
-                                    size: 'xs',
-                                }}
-                                visible={isLoadingSqlQuery}
-                            />
-                            {queryResults?.results && resultsRunner && (
-                                <>
-                                    <ConditionalVisibility
-                                        isVisible={showSqlResultsTable}
-                                    >
-                                        <Table
-                                            resultsRunner={resultsRunner}
-                                            columnsConfig={
-                                                resultsTableConfig?.columns ??
-                                                {}
-                                            }
-                                            enableJsonViewer
-                                            flexProps={{
-                                                mah: '100%',
-                                            }}
-                                        />
-                                    </ConditionalVisibility>
+                        <Paper className={styles.card}>
+                            <Box className={styles.cardHeader}>
+                                <Group gap="sm">
+                                    <Title order={6}>Results</Title>
+                                    {queryResults?.results && (
+                                        <Text fz="xs" c="dimmed">
+                                            {resultsRunner.getRows().length}{' '}
+                                            rows
+                                            {showLimitText
+                                                ? `, limited to ${defaultQueryLimit}`
+                                                : ''}
+                                        </Text>
+                                    )}
+                                </Group>
+                            </Box>
+                            <Box className={styles.resultsBody}>
+                                <LoadingOverlay
+                                    pos="absolute"
+                                    loaderProps={{
+                                        size: 'xs',
+                                    }}
+                                    visible={isLoadingSqlQuery}
+                                />
+                                {!queryResults?.results && (
+                                    <SuboptimalState
+                                        icon={IconTable}
+                                        title="No results yet"
+                                        description="Run the query to see its rows here."
+                                    />
+                                )}
+                                {queryResults?.results && resultsRunner && (
+                                    <>
+                                        <ConditionalVisibility
+                                            isVisible={showSqlResultsTable}
+                                        >
+                                            <Table
+                                                resultsRunner={resultsRunner}
+                                                columnsConfig={
+                                                    resultsTableConfig?.columns ??
+                                                    {}
+                                                }
+                                                enableJsonViewer
+                                                flexProps={{
+                                                    mah: '100%',
+                                                }}
+                                            />
+                                        </ConditionalVisibility>
 
-                                    <ConditionalVisibility
-                                        isVisible={showChartResultsTable}
-                                    >
-                                        {selectedChartType &&
-                                            pivotedChartInfo?.data
-                                                ?.tableData && (
-                                                <>
-                                                    {hasReachedPivotColumnLimit &&
-                                                        maxColumnLimit && (
-                                                            <Group
-                                                                justify="center"
-                                                                gap="xs"
-                                                            >
-                                                                <MantineIcon
-                                                                    color="gray"
-                                                                    icon={
-                                                                        IconAlertCircle
-                                                                    }
-                                                                />
-                                                                <Text
-                                                                    fz="xs"
-                                                                    fw={400}
-                                                                    c="ldGray.7"
-                                                                    ta="center"
+                                        <ConditionalVisibility
+                                            isVisible={showChartResultsTable}
+                                        >
+                                            {selectedChartType &&
+                                                pivotedChartInfo?.data
+                                                    ?.tableData && (
+                                                    <>
+                                                        {hasReachedPivotColumnLimit &&
+                                                            maxColumnLimit && (
+                                                                <Group
+                                                                    justify="center"
+                                                                    gap="xs"
                                                                 >
-                                                                    This query
-                                                                    exceeds the
-                                                                    maximum
-                                                                    number of
-                                                                    columns (
-                                                                    {
-                                                                        maxColumnLimit
-                                                                    }
-                                                                    ). Showing
-                                                                    the first{' '}
-                                                                    {
-                                                                        maxColumnLimit
-                                                                    }{' '}
-                                                                    columns.
-                                                                </Text>
-                                                            </Group>
-                                                        )}
-                                                    <ChartDataTable
-                                                        columnNames={
-                                                            pivotedChartInfo
-                                                                ?.data.tableData
-                                                                ?.columns
-                                                        }
-                                                        rows={
-                                                            pivotedChartInfo
-                                                                ?.data.tableData
-                                                                ?.rows ?? []
-                                                        }
-                                                        flexProps={{
-                                                            mah: '100%',
-                                                        }}
-                                                        onTHClick={
-                                                            handleTableHeaderClick
-                                                        }
-                                                        thSortConfig={
-                                                            sortConfig
-                                                        }
-                                                    />
-                                                </>
-                                            )}
-                                    </ConditionalVisibility>
-                                </>
-                            )}
-                        </Box>
+                                                                    <MantineIcon
+                                                                        color="gray"
+                                                                        icon={
+                                                                            IconAlertCircle
+                                                                        }
+                                                                    />
+                                                                    <Text
+                                                                        fz="xs"
+                                                                        fw={400}
+                                                                        c="ldGray.7"
+                                                                        ta="center"
+                                                                    >
+                                                                        This
+                                                                        query
+                                                                        exceeds
+                                                                        the
+                                                                        maximum
+                                                                        number
+                                                                        of
+                                                                        columns
+                                                                        (
+                                                                        {
+                                                                            maxColumnLimit
+                                                                        }
+                                                                        ).
+                                                                        Showing
+                                                                        the
+                                                                        first{' '}
+                                                                        {
+                                                                            maxColumnLimit
+                                                                        }{' '}
+                                                                        columns.
+                                                                    </Text>
+                                                                </Group>
+                                                            )}
+                                                        <ChartDataTable
+                                                            columnNames={
+                                                                pivotedChartInfo
+                                                                    ?.data
+                                                                    .tableData
+                                                                    ?.columns
+                                                            }
+                                                            rows={
+                                                                pivotedChartInfo
+                                                                    ?.data
+                                                                    .tableData
+                                                                    ?.rows ?? []
+                                                            }
+                                                            flexProps={{
+                                                                mah: '100%',
+                                                            }}
+                                                            onTHClick={
+                                                                handleTableHeaderClick
+                                                            }
+                                                            thSortConfig={
+                                                                sortConfig
+                                                            }
+                                                        />
+                                                    </>
+                                                )}
+                                        </ConditionalVisibility>
+                                    </>
+                                )}
+                            </Box>
+                        </Paper>
                     </Panel>
                 </PanelGroup>
             </Tooltip.Group>

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
@@ -2,7 +2,6 @@ import { subject } from '@casl/ability';
 import { DbtProjectType } from '@lightdash/common';
 import {
     Group,
-    Paper,
     Stack,
     Text,
     Button,
@@ -20,6 +19,7 @@ import {
 } from '@tabler/icons-react';
 import { useCallback, useMemo, useState, type FC } from 'react';
 import MantineIcon from '../../../../components/common/MantineIcon';
+import PageHeader from '../../../../components/common/Page/PageHeader';
 import { cartesianChartSelectors } from '../../../../components/DataViz/store/selectors';
 import { EditableText } from '../../../../components/VisualizationConfigs/common/EditableText';
 import { useGitIntegration } from '../../../../hooks/gitIntegration/useGitIntegration';
@@ -40,7 +40,6 @@ import {
 import { ChartErrorsAlert } from '../ChartErrorsAlert';
 import { SaveSqlChartModal } from '../SaveSqlChartModal';
 import { WriteBackToDbtModal } from '../WriteBackToDbtModal';
-import headerStyles from './HeaderPaper.module.css';
 
 type CtaAction = 'save' | 'createVirtualView' | 'writeBackToDbt';
 
@@ -264,18 +263,12 @@ export const HeaderCreate: FC = () => {
 
     return (
         <>
-            <Paper
-                shadow="none"
-                radius={0}
-                withBorder={false}
-                px="md"
-                py="xs"
-                className={headerStyles.paper}
-            >
-                <Group justify="space-between">
+            <PageHeader cardProps={{ py: 'xs' }}>
+                <Group justify="space-between" flex={1} wrap="nowrap">
                     <Group gap="two">
                         {hasAnyAction && (
                             <EditableText
+                                heading
                                 size="md"
                                 w={400}
                                 placeholder={untitledName}
@@ -366,7 +359,7 @@ export const HeaderCreate: FC = () => {
                                                             }
                                                         </Text>
                                                         <Text
-                                                            fz={10}
+                                                            fz="xs"
                                                             c="ldGray.6"
                                                         >
                                                             {
@@ -423,7 +416,7 @@ export const HeaderCreate: FC = () => {
                                                             }
                                                         </Text>
                                                         <Text
-                                                            fz={10}
+                                                            fz="xs"
                                                             c="ldGray.6"
                                                         >
                                                             {
@@ -492,7 +485,7 @@ export const HeaderCreate: FC = () => {
                                                             }
                                                         </Text>
                                                         <Text
-                                                            fz={10}
+                                                            fz="xs"
                                                             c="ldGray.6"
                                                         >
                                                             {
@@ -517,7 +510,7 @@ export const HeaderCreate: FC = () => {
                         </ActionIcon>
                     </Group>
                 </Group>
-            </Paper>
+            </PageHeader>
             <SaveSqlChartModal
                 key={`${isSaveModalOpen}-saveChartModal`}
                 opened={isSaveModalOpen}

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderEdit.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderEdit.tsx
@@ -160,14 +160,14 @@ export const HeaderEdit: FC = () => {
         <>
             <PageHeader cardProps={{ py: 'xs' }}>
                 <Group justify="space-between" flex={1} wrap="nowrap">
-                    <Stack gap="none">
-                        <Group gap="two">
+                    <Stack gap={0} miw={0}>
+                        <Group gap={4} wrap="nowrap">
                             <TitleBreadCrumbs
                                 projectUuid={savedSqlChart.project.projectUuid}
                                 spaceUuid={savedSqlChart.space.uuid}
                                 spaceName={savedSqlChart.space.name}
                             />
-                            <Title c="ldDark.9" order={5} fw={600}>
+                            <Title order={5} maw={500} lineClamp={1}>
                                 {savedSqlChart.name}
                             </Title>
                             <ActionIcon

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderEdit.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderEdit.tsx
@@ -1,7 +1,6 @@
 import { type SqlChart } from '@lightdash/common';
 import {
     Group,
-    Paper,
     Stack,
     Title,
     Button,
@@ -21,6 +20,7 @@ import isEqual from 'lodash/isEqual';
 import { useCallback, useMemo, useState, type FC } from 'react';
 import { useNavigate } from 'react-router';
 import MantineIcon from '../../../../components/common/MantineIcon';
+import PageHeader from '../../../../components/common/Page/PageHeader';
 import { UpdatedInfo } from '../../../../components/common/PageHeader/UpdatedInfo';
 import { ResourceInfoPopup } from '../../../../components/common/ResourceInfoPopup/ResourceInfoPopup';
 import {
@@ -41,7 +41,6 @@ import { DeleteSqlChartModal } from '../DeleteSqlChartModal';
 import { SaveSqlChartModal } from '../SaveSqlChartModal';
 import { SqlQueryBeforeSaveAlert } from '../SqlQueryBeforeSaveAlert';
 import { UpdateSqlChartModal } from '../UpdateSqlChartModal';
-import headerStyles from './HeaderPaper.module.css';
 
 export const HeaderEdit: FC = () => {
     const queryClient = useQueryClient();
@@ -159,15 +158,8 @@ export const HeaderEdit: FC = () => {
 
     return (
         <>
-            <Paper
-                shadow="none"
-                radius={0}
-                withBorder={false}
-                px="md"
-                py="xs"
-                className={headerStyles.paper}
-            >
-                <Group justify="space-between">
+            <PageHeader cardProps={{ py: 'xs' }}>
+                <Group justify="space-between" flex={1} wrap="nowrap">
                     <Stack gap="none">
                         <Group gap="two">
                             <TitleBreadCrumbs
@@ -175,7 +167,7 @@ export const HeaderEdit: FC = () => {
                                 spaceUuid={savedSqlChart.space.uuid}
                                 spaceName={savedSqlChart.space.name}
                             />
-                            <Title c="ldDark.6" order={5} fw={600}>
+                            <Title c="ldDark.9" order={5} fw={600}>
                                 {savedSqlChart.name}
                             </Title>
                             <ActionIcon
@@ -281,7 +273,7 @@ export const HeaderEdit: FC = () => {
                         </Menu>
                     </Group>
                 </Group>
-            </Paper>
+            </PageHeader>
             <SaveSqlChartModal
                 key={`${isSaveModalOpen}-saveChartModal`}
                 opened={isSaveModalOpen}

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderPaper.module.css
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderPaper.module.css
@@ -1,4 +1,0 @@
-.paper {
-    border-bottom: 1px solid
-        light-dark(var(--mantine-color-ldGray-3), var(--mantine-color-ldDark-8));
-}

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderView.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderView.tsx
@@ -5,7 +5,6 @@ import {
 } from '@lightdash/common';
 import {
     Group,
-    Paper,
     Stack,
     Title,
     Button,
@@ -25,6 +24,7 @@ import {
 import { useCallback, useEffect, useRef, type FC } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 import MantineIcon from '../../../../components/common/MantineIcon';
+import PageHeader from '../../../../components/common/Page/PageHeader';
 import { UpdatedInfo } from '../../../../components/common/PageHeader/UpdatedInfo';
 import { ResourceInfoPopup } from '../../../../components/common/ResourceInfoPopup/ResourceInfoPopup';
 import { TitleBreadCrumbs } from '../../../../components/Explorer/SavedChartsHeader/TitleBreadcrumbs';
@@ -49,7 +49,6 @@ import {
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import { toggleModal } from '../../store/sqlRunnerSlice';
 import { DeleteSqlChartModal } from '../DeleteSqlChartModal';
-import headerStyles from './HeaderPaper.module.css';
 
 export const HeaderView: FC = () => {
     const navigate = useNavigate();
@@ -184,15 +183,8 @@ export const HeaderView: FC = () => {
 
     return (
         <>
-            <Paper
-                shadow="none"
-                radius={0}
-                withBorder={false}
-                px="md"
-                py="xs"
-                className={headerStyles.paper}
-            >
-                <Group justify="space-between">
+            <PageHeader cardProps={{ py: 'xs' }}>
+                <Group justify="space-between" flex={1} wrap="nowrap">
                     <Stack gap="none">
                         <Group gap="two">
                             {space && (
@@ -202,7 +194,7 @@ export const HeaderView: FC = () => {
                                     spaceName={space.name}
                                 />
                             )}
-                            <Title c="ldDark.6" order={5} fw={600}>
+                            <Title c="ldDark.9" order={5} fw={600}>
                                 {savedSqlChart.name}
                             </Title>
                         </Group>
@@ -361,7 +353,7 @@ export const HeaderView: FC = () => {
                         )}
                     </Group>
                 </Group>
-            </Paper>
+            </PageHeader>
 
             {isDirectAccessModalOpen && savedSqlChart && (
                 <DirectAccessModal

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderView.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderView.tsx
@@ -185,8 +185,8 @@ export const HeaderView: FC = () => {
         <>
             <PageHeader cardProps={{ py: 'xs' }}>
                 <Group justify="space-between" flex={1} wrap="nowrap">
-                    <Stack gap="none">
-                        <Group gap="two">
+                    <Stack gap={0} miw={0}>
+                        <Group gap={4} wrap="nowrap">
                             {space && (
                                 <TitleBreadCrumbs
                                     projectUuid={projectUuid}
@@ -194,7 +194,7 @@ export const HeaderView: FC = () => {
                                     spaceName={space.name}
                                 />
                             )}
-                            <Title c="ldDark.9" order={5} fw={600}>
+                            <Title order={5} maw={500} lineClamp={1}>
                                 {savedSqlChart.name}
                             </Title>
                         </Group>

--- a/packages/frontend/src/features/sqlRunner/components/ResizeHandle.module.css
+++ b/packages/frontend/src/features/sqlRunner/components/ResizeHandle.module.css
@@ -13,26 +13,3 @@
 .resizeHandle[data-resize-handle-state='drag'] {
     background-color: var(--mantine-color-ldGray-3);
 }
-
-.resultsResizeHandle {
-    composes: resizeHandle;
-    gap: 5px;
-    border-left: 1px solid var(--mantine-color-ldGray-3);
-}
-
-.toolbarPaper {
-    border-width: 0 0 1px 1px;
-    border-style: solid;
-    border-color: var(--mantine-color-ldGray-3);
-}
-
-.inputPaper {
-    overflow: auto;
-    border-width: 0 0 0 1px;
-    border-style: solid;
-    border-color: var(--mantine-color-ldGray-3);
-    background-color: light-dark(
-        var(--mantine-color-white),
-        var(--mantine-color-dark-6)
-    );
-}

--- a/packages/frontend/src/features/sqlRunner/components/Sidebar.module.css
+++ b/packages/frontend/src/features/sqlRunner/components/Sidebar.module.css
@@ -1,0 +1,13 @@
+.root {
+    flex: 1;
+    overflow: hidden;
+}
+
+.panel {
+    flex: 1;
+    overflow: hidden;
+}
+
+.panel[data-active='false'] {
+    display: none;
+}

--- a/packages/frontend/src/features/sqlRunner/components/Sidebar.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Sidebar.tsx
@@ -7,7 +7,7 @@ import {
     Title,
     Tooltip,
 } from '@mantine/core';
-import { IconLayoutSidebarLeftCollapse, IconReload } from '@tabler/icons-react';
+import { IconReload } from '@tabler/icons-react';
 import { type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { VisualizationConfigPanel } from '../../../components/DataViz/VisualizationConfigPanel';
@@ -15,13 +15,10 @@ import scrollAreaClasses from '../../../styles/ScrollArea.module.css';
 import { useRefreshTables } from '../hooks/useTables';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
 import { setSelectedChartType, SidebarTabs } from '../store/sqlRunnerSlice';
+import classes from './Sidebar.module.css';
 import { TablesPanel } from './TablesPanel';
 
-type Props = {
-    setSidebarOpen: (isOpen: boolean) => void;
-};
-
-export const Sidebar: FC<Props> = ({ setSidebarOpen }) => {
+export const Sidebar: FC = () => {
     const dispatch = useAppDispatch();
     const projectUuid = useAppSelector((state) => state.sqlRunner.projectUuid);
 
@@ -38,45 +35,22 @@ export const Sidebar: FC<Props> = ({ setSidebarOpen }) => {
         (state) => state.sqlRunner.activeSidebarTab,
     );
     const sqlColumns = useAppSelector((state) => state.sqlRunner.sqlColumns);
+    const isTablesTab = activeSidebarTab === SidebarTabs.TABLES;
 
     return (
-        <Stack gap="xs" style={{ flex: 1, overflow: 'hidden' }}>
-            <Group justify="space-between" p="sm">
-                <Group wrap="nowrap" gap="xs">
-                    <Title order={5} fz="sm" c="ldGray.6">
-                        {activeSidebarTab === SidebarTabs.TABLES
-                            ? 'TABLES'
-                            : 'VISUALIZATION'}
-                    </Title>
-                    {activeSidebarTab === SidebarTabs.TABLES && (
-                        <Tooltip label="Refresh tables" position="right">
-                            <ActionIcon
-                                variant="subtle"
-                                color="gray"
-                                size="xs"
-                                onClick={() => updateTables()}
-                            >
-                                <MantineIcon icon={IconReload}></MantineIcon>
-                            </ActionIcon>
-                        </Tooltip>
-                    )}
-                </Group>
-                <Tooltip label="Close sidebar" position="left">
-                    <ActionIcon variant="subtle" color="gray" size="xs">
-                        <MantineIcon
-                            icon={IconLayoutSidebarLeftCollapse}
-                            onClick={() => setSidebarOpen(false)}
-                        />
-                    </ActionIcon>
-                </Tooltip>
+        <Stack gap="sm" className={classes.root}>
+            <Group justify="space-between" wrap="nowrap" gap="xs">
+                <Title order={4}>{isTablesTab ? 'Tables' : 'Chart'}</Title>
+                {isTablesTab && (
+                    <Tooltip label="Refresh tables" position="right">
+                        <ActionIcon size="sm" onClick={() => updateTables()}>
+                            <MantineIcon icon={IconReload} />
+                        </ActionIcon>
+                    </Tooltip>
+                )}
             </Group>
 
-            <Stack
-                display={
-                    activeSidebarTab === SidebarTabs.TABLES ? 'inherit' : 'none'
-                }
-                style={{ flex: 1, overflow: 'hidden' }}
-            >
+            <Stack className={classes.panel} data-active={isTablesTab}>
                 <TablesPanel
                     isLoading={isLoading}
                     error={error?.error.message || null}
@@ -87,16 +61,10 @@ export const Sidebar: FC<Props> = ({ setSidebarOpen }) => {
                 offsetScrollbars
                 scrollbars="y"
                 classNames={{ content: scrollAreaClasses.verticalContent }}
-                px="sm"
-                style={{
-                    flex: 1,
-                    display:
-                        activeSidebarTab === SidebarTabs.VISUALIZATION
-                            ? 'inherit'
-                            : 'none',
-                }}
+                className={classes.panel}
+                data-active={!isTablesTab}
             >
-                <Stack style={{ flex: 1, overflow: 'hidden' }}>
+                <Stack className={classes.panel}>
                     <VisualizationConfigPanel
                         selectedChartType={selectedChartType || ChartKind.TABLE}
                         setSelectedChartType={(value) =>

--- a/packages/frontend/src/features/sqlRunner/components/TableFields.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/TableFields.tsx
@@ -69,7 +69,7 @@ const TableField: FC<{
                     ref={truncatedRef}
                     fw={500}
                     p={4}
-                    fz={13}
+                    fz="sm"
                     c="ldGray.7"
                     style={{ flex: 1 }}
                     truncate
@@ -83,7 +83,7 @@ const TableField: FC<{
                     </Highlight>
                 </Text>
             </Tooltip>
-            <Text fz={12} c="ldGray.5">
+            <Text fz="xs" c="ldGray.5">
                 {field.type}
             </Text>
         </Group>

--- a/packages/frontend/src/features/sqlRunner/components/Tables.module.css
+++ b/packages/frontend/src/features/sqlRunner/components/Tables.module.css
@@ -1,25 +1,55 @@
-.tableButton {
-    border-radius: var(--mantine-radius-sm);
-    color: var(--mantine-color-ldGray-7);
-}
-
-.tableButton:hover {
-    background-color: var(--mantine-color-ldGray-2);
-}
-
-.tableButton[data-active] {
-    color: var(--mantine-color-ldGray-8);
-    background-color: var(--mantine-color-ldGray-1);
-}
-
-.tableButton[data-active]:hover {
-    background-color: var(--mantine-color-ldGray-3);
-}
-
 .schemaButton {
+    width: 100%;
+    padding: rem(6px) rem(8px);
     border-radius: var(--mantine-radius-md);
+    color: var(--mantine-color-text);
+    transition: background-color 120ms ease;
 }
 
 .schemaButton:hover {
-    background-color: var(--mantine-color-ldGray-1);
+    background-color: var(--mantine-color-default-hover);
+}
+
+.chevron {
+    flex-shrink: 0;
+    color: var(--mantine-color-dimmed);
+}
+
+.tableButton {
+    border-radius: var(--mantine-radius-md);
+    padding: rem(4px) rem(8px) rem(4px) rem(28px);
+    color: light-dark(var(--mantine-color-gray-7), var(--mantine-color-dark-1));
+    transition:
+        background-color 120ms ease,
+        color 120ms ease;
+}
+
+.tableButton:hover {
+    background-color: var(--mantine-color-default-hover);
+    color: var(--mantine-color-text);
+}
+
+.tableButton[data-active] {
+    background-color: light-dark(rgb(24 24 27 / 0.07), rgb(236 236 238 / 0.09));
+    color: var(--mantine-color-text);
+    font-weight: 500;
+}
+
+.tableButton[data-active]:hover {
+    background-color: light-dark(rgb(24 24 27 / 0.1), rgb(236 236 238 / 0.13));
+}
+
+.tableIcon {
+    flex-shrink: 0;
+    color: var(--mantine-color-dimmed);
+}
+
+.tableButton[data-active] .tableIcon {
+    color: var(--mantine-color-text);
+}
+
+.copyButton {
+    position: absolute;
+    top: rem(4px);
+    right: rem(6px);
 }

--- a/packages/frontend/src/features/sqlRunner/components/Tables.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Tables.tsx
@@ -21,6 +21,7 @@ import {
     IconChevronRight,
     IconCopy,
     IconSearch,
+    IconTable,
     IconX,
 } from '@tabler/icons-react';
 import dayjs from 'dayjs';
@@ -100,47 +101,44 @@ const TableItem: FC<TableItemProps> = memo(
                         dispatch(toggleActiveTable({ table, schema }));
                     }}
                     w="100%"
-                    p={4}
-                    flex={1}
                     fz="sm"
                     data-active={isActive || undefined}
                     className={styles.tableButton}
                 >
-                    <Tooltip
-                        withinPortal
-                        label={table}
-                        disabled={!isTruncated}
-                        multiline
-                        maw={300}
-                        style={{
-                            wordBreak: 'break-word',
-                        }}
-                    >
-                        {search.length > 2 ? (
-                            <Text
-                                ref={truncatedRef}
-                                truncate
-                                fz="sm"
-                                style={{ flex: 1 }}
-                            >
-                                <Highlight
-                                    component="span"
-                                    highlight={search || ''}
-                                    inherit
-                                >
+                    <Group gap="xs" wrap="nowrap">
+                        <MantineIcon
+                            icon={IconTable}
+                            size="sm"
+                            className={styles.tableIcon}
+                        />
+                        <Tooltip
+                            withinPortal
+                            label={table}
+                            disabled={!isTruncated}
+                            multiline
+                            maw={300}
+                        >
+                            {search.length > 2 ? (
+                                <Text ref={truncatedRef} truncate fz="sm">
+                                    <Highlight
+                                        component="span"
+                                        highlight={search || ''}
+                                        inherit
+                                    >
+                                        {table}
+                                    </Highlight>
+                                </Text>
+                            ) : (
+                                <Text fz="sm" truncate>
                                     {table}
-                                </Highlight>
-                            </Text>
-                        ) : (
-                            <Text fz="sm">{table}</Text>
-                        )}
-                    </Tooltip>
+                                </Text>
+                            )}
+                        </Tooltip>
+                    </Group>
                 </UnstyledButton>
 
                 <Box
-                    pos="absolute"
-                    top={4}
-                    right={8}
+                    className={styles.copyButton}
                     display={hovered ? 'block' : 'none'}
                 >
                     <CopyButton value={`${quotedTable}`}>
@@ -150,17 +148,10 @@ const TableItem: FC<TableItemProps> = memo(
                                 withArrow
                                 position="right"
                             >
-                                <ActionIcon
-                                    variant="subtle"
-                                    color="gray"
-                                    size={16}
-                                    onClick={copy}
-                                    bg="ldGray.1"
-                                >
+                                <ActionIcon size="xs" onClick={copy} bg="body">
                                     <MantineIcon
                                         icon={IconCopy}
-                                        color={copied ? 'green' : 'blue'}
-                                        onClick={copy}
+                                        color={copied ? 'green' : undefined}
                                     />
                                 </ActionIcon>
                             </Tooltip>
@@ -215,14 +206,15 @@ const Table: FC<{
                 className={styles.schemaButton}
                 ff="inherit"
             >
-                <Group wrap="nowrap" gap="two">
-                    <Text p={6} fz="sm" c="ldGray.8">
-                        {schema}
-                    </Text>
-
+                <Group wrap="nowrap" gap="xs">
                     <MantineIcon
                         icon={isExpanded ? IconChevronDown : IconChevronRight}
+                        size="sm"
+                        className={styles.chevron}
                     />
+                    <Text fz="sm" fw={500} truncate>
+                        {schema}
+                    </Text>
                 </Group>
             </UnstyledButton>
             {isExpanded && (
@@ -241,11 +233,10 @@ const Table: FC<{
                                 schema={`${schema}`}
                                 database={database}
                                 partitionColumn={tables[table].partitionColumn}
-                                ml="sm"
                             />
                         ))}
                     {Object.keys(tables).length > limitTableResults && (
-                        <Text ml="md" c="ldGray.5">
+                        <Text ml="md" fz="xs" c="dimmed">
                             Filtering first {limitTableResults} of{' '}
                             {Object.keys(tables).length} tables, search to see
                             more
@@ -341,14 +332,14 @@ export const Tables: FC = () => {
 
     return (
         <>
-            <Box px="sm">
+            <Box>
                 <Tooltip
                     opened={search.length > 0 && search.length < 3}
                     label="Enter at least 3 characters to search"
                     withinPortal
                 >
                     <TextInput
-                        size="xs"
+                        size="sm"
                         disabled={!data && !debouncedSearch}
                         leftSection={
                             isLoading ? (
@@ -365,8 +356,6 @@ export const Tables: FC = () => {
                                     onMouseDown={(event) =>
                                         event.preventDefault()
                                     }
-                                    variant="subtle"
-                                    color="gray"
                                     size="xs"
                                     onClick={() => setSearch('')}
                                 >
@@ -377,12 +366,6 @@ export const Tables: FC = () => {
                         placeholder="Search tables"
                         value={search}
                         onChange={(e) => setSearch(e.target.value)}
-                        styles={(theme) => ({
-                            input: {
-                                borderRadius: theme.radius.md,
-                                border: `1px solid ${theme.colors.ldGray[3]}`,
-                            },
-                        })}
                     />
                 </Tooltip>
             </Box>
@@ -391,10 +374,8 @@ export const Tables: FC = () => {
                 offsetScrollbars
                 scrollbars="y"
                 classNames={{ content: scrollAreaClasses.verticalContent }}
-                pl="sm"
-                style={{ flex: 1 }}
+                flex={1}
                 type="auto"
-                scrollbarSize={8}
             >
                 {isSuccess &&
                     filteredTablesBySchema &&
@@ -415,7 +396,9 @@ export const Tables: FC = () => {
 
             {isSuccess && !data && (
                 <Center p="sm">
-                    <Text c="ldGray.4">No results found</Text>
+                    <Text c="dimmed" fz="sm">
+                        No results found
+                    </Text>
                 </Center>
             )}
         </>

--- a/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
+++ b/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
@@ -81,7 +81,6 @@ export interface SqlRunnerState {
             isOpen: boolean;
         };
     };
-    isLeftSidebarOpen: boolean;
     quoteChar: string;
     warehouseConnectionType: WarehouseTypes | undefined;
     sqlColumns: VizColumn[] | undefined;
@@ -136,7 +135,6 @@ export const initialState: SqlRunnerState = {
             isOpen: false,
         },
     },
-    isLeftSidebarOpen: true,
     quoteChar: '"',
     warehouseConnectionType: undefined,
     sqlColumns: undefined,
@@ -267,10 +265,6 @@ export const sqlRunnerSlice = createSlice({
                 if (!state.selectedChartType) {
                     state.selectedChartType = ChartKind.VERTICAL_BAR;
                 }
-                // Show the sidebar when switching to the chart tab
-                if (!state.isLeftSidebarOpen) {
-                    state.isLeftSidebarOpen = true;
-                }
             }
             if (action.payload === EditorTabs.SQL) {
                 state.activeSidebarTab = SidebarTabs.TABLES;
@@ -309,9 +303,6 @@ export const sqlRunnerSlice = createSlice({
         ) => {
             state.modals[action.payload].isOpen =
                 !state.modals[action.payload].isOpen;
-        },
-        setSidebarOpen: (state, action: PayloadAction<boolean>) => {
-            state.isLeftSidebarOpen = action.payload;
         },
         setQuoteChar: (state, action: PayloadAction<string>) => {
             state.quoteChar = action.payload;
@@ -432,7 +423,6 @@ export const {
     setSavedChartData,
     setSelectedChartType,
     toggleModal,
-    setSidebarOpen,
     resetState,
     setQuoteChar,
     setWarehouseConnectionType,

--- a/packages/frontend/src/features/sqlRunner/utils/monaco.ts
+++ b/packages/frontend/src/features/sqlRunner/utils/monaco.ts
@@ -93,10 +93,10 @@ export const getLightdashMonacoTheme = (colorScheme: 'light' | 'dark') => {
                 { token: 'comment', foreground: '6272a4', fontStyle: 'italic' },
             ],
             colors: {
-                'editor.background': '#1a1a1a',
+                'editor.background': '#1e1e21',
                 'editor.foreground': '#f8f8f2',
-                'editor.lineHighlightBackground': '#242424',
-                'editor.lineHighlight': '#242424',
+                'editor.lineHighlightBackground': '#26262a',
+                'editor.lineHighlight': '#26262a',
                 'editorCursor.foreground': '#7262FF',
                 'editorWhitespace.foreground': '#3b3b3b',
                 'editor.selectionBackground': '#3d3d5c',
@@ -104,7 +104,7 @@ export const getLightdashMonacoTheme = (colorScheme: 'light' | 'dark') => {
                 'editor.wordHighlightBackground': '#454545',
                 'editor.selectionHighlightBorder': '#7262FF',
                 // Subtle indentation guides
-                'editorIndentGuide.background': '#2a2a2a',
+                'editorIndentGuide.background': '#303034',
                 'editorIndentGuide.activeBackground': '#3a3a3a',
                 // Bracket pair colors
                 'editorBracketHighlight.foreground1': '#7262FF',
@@ -114,10 +114,10 @@ export const getLightdashMonacoTheme = (colorScheme: 'light' | 'dark') => {
                 'editorBracketHighlight.foreground5': '#8be9fd',
                 'editorBracketHighlight.foreground6': '#bd93f9',
                 // Line numbers
-                'editorLineNumber.foreground': '#4a4a4a',
-                'editorLineNumber.activeForeground': '#888888',
+                'editorLineNumber.foreground': '#55555c',
+                'editorLineNumber.activeForeground': '#9a9aa3',
                 // Gutter
-                'editorGutter.background': '#1a1a1a',
+                'editorGutter.background': '#1e1e21',
             },
         };
     }
@@ -135,10 +135,10 @@ export const getLightdashMonacoTheme = (colorScheme: 'light' | 'dark') => {
             { token: 'comment', foreground: '6b7280', fontStyle: 'italic' },
         ],
         colors: {
-            'editor.background': '#f8f9fa',
+            'editor.background': '#ffffff',
             'editor.foreground': '#24292e',
-            'editor.lineHighlightBackground': '#f0f1f4',
-            'editor.lineHighlight': '#f0f1f4',
+            'editor.lineHighlightBackground': '#f4f4f5',
+            'editor.lineHighlight': '#f4f4f5',
             'editorCursor.foreground': '#7262FF',
             'editorWhitespace.foreground': '#e1e4e8',
             'editor.selectionBackground': '#E6E3FF',
@@ -146,8 +146,8 @@ export const getLightdashMonacoTheme = (colorScheme: 'light' | 'dark') => {
             'editor.wordHighlightBackground': '#dce6f0',
             'editor.selectionHighlightBorder': '#7262FF',
             // Subtle indentation guides
-            'editorIndentGuide.background': '#e8e8e8',
-            'editorIndentGuide.activeBackground': '#d0d0d0',
+            'editorIndentGuide.background': '#ebebee',
+            'editorIndentGuide.activeBackground': '#dcdce0',
             // Bracket pair colors
             'editorBracketHighlight.foreground1': '#7262FF',
             'editorBracketHighlight.foreground2': '#d6336c',
@@ -156,10 +156,10 @@ export const getLightdashMonacoTheme = (colorScheme: 'light' | 'dark') => {
             'editorBracketHighlight.foreground5': '#0078d4',
             'editorBracketHighlight.foreground6': '#8b5cf6',
             // Line numbers
-            'editorLineNumber.foreground': '#b0b0b0',
-            'editorLineNumber.activeForeground': '#6b7280',
+            'editorLineNumber.foreground': '#a1a1aa',
+            'editorLineNumber.activeForeground': '#71717a',
             // Gutter
-            'editorGutter.background': '#f8f9fa',
+            'editorGutter.background': '#ffffff',
         },
     };
 };

--- a/packages/frontend/src/pages/SqlRunner.tsx
+++ b/packages/frontend/src/pages/SqlRunner.tsx
@@ -1,12 +1,10 @@
 import { getFieldQuoteChar } from '@lightdash/common';
-import { Group, Paper, Stack, ActionIcon, Tooltip } from '@mantine/core';
-import { IconLayoutSidebarLeftExpand } from '@tabler/icons-react';
+import { Stack } from '@mantine/core';
 import { useEffect } from 'react';
 import { Provider } from 'react-redux';
 import { useLocation, useNavigate, useParams } from 'react-router';
 import { useMount, useUnmount } from 'react-use';
 import ErrorState from '../components/common/ErrorState';
-import MantineIcon from '../components/common/MantineIcon';
 import Page from '../components/common/Page/Page';
 import {
     resetChartState,
@@ -30,7 +28,6 @@ import {
     setProjectUuid,
     setQuoteChar,
     setSavedChartData,
-    setSidebarOpen,
     setSql,
     setSqlLimit,
     setState,
@@ -65,9 +62,6 @@ const SqlRunner = ({
     const location = useLocation();
     const navigate = useNavigate();
 
-    const isLeftSidebarOpen = useAppSelector(
-        (state) => state.sqlRunner.isLeftSidebarOpen,
-    );
     const { data: project } = useProject(projectUuid);
     const { showToastError } = useToaster();
 
@@ -163,10 +157,6 @@ const SqlRunner = ({
         }
     }, [dispatch, warehouseType, warehouseConnectionType]);
 
-    const handleSetSidebarOpen = (isOpen: boolean) => {
-        dispatch(setSidebarOpen(isOpen));
-    };
-
     if (chartError) {
         return <ErrorState error={chartError.error} />;
     }
@@ -176,52 +166,16 @@ const SqlRunner = ({
             title="SQL Runner"
             noContentPadding
             flexContent
-            header={
-                mode === 'virtualView' && virtualViewState ? (
+            sidebar={<Sidebar />}
+        >
+            <Stack gap={0} flex={1} miw={0}>
+                {mode === 'virtualView' && virtualViewState ? (
                     <HeaderVirtualView virtualViewState={virtualViewState} />
                 ) : (
                     <Header mode={params.slug ? 'edit' : 'create'} />
-                )
-            }
-            isSidebarOpen={isLeftSidebarOpen}
-            sidebar={<Sidebar setSidebarOpen={handleSetSidebarOpen} />}
-            noSidebarPadding
-        >
-            <Group
-                align="stretch"
-                grow
-                gap="none"
-                p={0}
-                style={{ flex: 1 }}
-                w={'100%'}
-            >
-                {!isLeftSidebarOpen && (
-                    <Paper
-                        shadow="none"
-                        radius={0}
-                        withBorder={false}
-                        px="sm"
-                        py="lg"
-                        style={{ flexGrow: 0 }}
-                    >
-                        <Stack gap="xs">
-                            <Tooltip label={'Open sidebar'} position="right">
-                                <ActionIcon
-                                    variant="subtle"
-                                    color="gray"
-                                    size="sm"
-                                    onClick={() => handleSetSidebarOpen(true)}
-                                >
-                                    <MantineIcon
-                                        icon={IconLayoutSidebarLeftExpand}
-                                    />
-                                </ActionIcon>
-                            </Tooltip>
-                        </Stack>
-                    </Paper>
                 )}
                 <ContentPanel />
-            </Group>
+            </Stack>
         </Page>
     );
 };

--- a/packages/frontend/src/pages/ViewSqlChart.tsx
+++ b/packages/frontend/src/pages/ViewSqlChart.tsx
@@ -27,6 +27,7 @@ import ChartView from '../components/DataViz/visualizations/ChartView';
 import { Table } from '../components/DataViz/visualizations/Table';
 import type { EChartsInstance } from '../components/EChartsReactWrapper';
 import { Parameters, useParameters } from '../features/parameters';
+import styles from '../features/sqlRunner/components/ContentPanel.module.css';
 import { ChartDownload } from '../features/sqlRunner/components/Download/ChartDownload';
 import ResultsDownloadButton from '../features/sqlRunner/components/Download/ResultsDownloadButton';
 import { Header } from '../features/sqlRunner/components/Header';
@@ -124,14 +125,12 @@ const ViewSqlChart = () => {
             withFullHeight
             header={<Header mode="view" />}
         >
-            <Paper shadow="none" radius={0} px="md" pb={0} pt="sm" flex={1}>
-                <Stack h="100%">
-                    <Group justify="space-between">
+            <Stack p="lg" flex={1} miw={0} className={styles.root}>
+                <Paper className={styles.card}>
+                    <Box className={styles.cardHeader}>
                         <Group justify="space-between">
                             <SegmentedControl
-                                color="ldGray.9"
-                                size="xs"
-                                radius="md"
+                                size="sm"
                                 disabled={isChartResultsLoading}
                                 data={[
                                     {
@@ -230,7 +229,7 @@ const ViewSqlChart = () => {
                                     />
                                 )}
                         </Group>
-                    </Group>
+                    </Box>
 
                     {chartError && <ErrorState error={chartError.error} />}
                     {chartResultsError && (
@@ -238,7 +237,13 @@ const ViewSqlChart = () => {
                     )}
 
                     {chartData && !isChartLoading && (
-                        <Box h="100%" pos="relative" flex={1}>
+                        <Box
+                            className={styles.cardBody}
+                            data-padded={
+                                activeTab === TabOption.CHART &&
+                                !isVizTableConfig(chartData.config)
+                            }
+                        >
                             <ConditionalVisibility
                                 isVisible={activeTab === TabOption.CHART}
                             >
@@ -342,8 +347,8 @@ const ViewSqlChart = () => {
                             </ConditionalVisibility>
                         </Box>
                     )}
-                </Stack>
-            </Paper>
+                </Paper>
+            </Stack>
         </Page>
     );
 };


### PR DESCRIPTION
## Summary

Gives the SQL runner the Explorer's card-based layout. Third PR of the theme stack.

## What changed

- Editor and results are bordered cards on the canvas; the SQL/Chart control and run actions live in the editor card's header, the resize handle is the gap between the cards.
- The results card is always visible, with an empty state before the first run and a row count afterwards.
- The Tables sidebar is permanent (no collapse toggle); schema rows have a leading chevron and table rows a table icon with a quiet active fill. The `isLeftSidebarOpen` state and `setSidebarOpen` action are removed from the slice.
- All three header modes (create, edit, view) use the shared `PageHeader` bar and sit in the content column; the saved-chart headers mirror the Explorer's saved-chart header (breadcrumb, clamped title, edited line).
- The saved SQL chart view puts its chart/results tabs in a card whose body is padded only for charts, so tables are framed by the card border.
- Monaco background matches the surface colour in both schemes.

## Regression analysis

- Query execution, tab switching and pivot caching are untouched (`ContentPanel` only changed its markup); the `hideResultsPanel` behaviour for the table visualisation is preserved.
- The removed slice state was only read by the removed collapse toggle; `ts-unused-exports` passes.
- Verified live: run a query, switch to Chart, change chart type, resize the panels, open a saved SQL chart in view and edit mode, in light and dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Hr8bA9fzAkqy4yULJ6Qd9
