### PR TITLE
chore(frontend): normalise font weights and sizes to the theme scale

### DIFF
--- a/packages/frontend/src/components/DataViz/visualizations/ChartDataTable.tsx
+++ b/packages/frontend/src/components/DataViz/visualizations/ChartDataTable.tsx
@@ -106,7 +106,7 @@ export const ChartDataTable = ({
                                                 position="top"
                                                 withinPortal
                                             >
-                                                <Group gap="two" fz={13}>
+                                                <Group gap="two" fz="sm">
                                                     {columnsConfig?.[header.id]
                                                         ?.aggregation && (
                                                         <Badge

--- a/packages/frontend/src/components/DataViz/visualizations/Table.tsx
+++ b/packages/frontend/src/components/DataViz/visualizations/Table.tsx
@@ -138,7 +138,7 @@ export const Table = <T extends IResultsRunner>({
                                                   }
                                         }
                                     >
-                                        <Group gap="two" fz={13}>
+                                        <Group gap="two" fz="sm">
                                             {columnsConfig[header.id]
                                                 ?.aggregation && (
                                                 <Badge

--- a/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
+++ b/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
@@ -255,7 +255,7 @@ const QueryAFiltersCard: FC = memo(() => {
                         filterRule.operator !== FilterOperator.NOT_NULL ? (
                             <>
                                 {' '}
-                                <Text span fw={700}>
+                                <Text span fw={600}>
                                     {labels.value}
                                 </Text>
                             </>
@@ -306,7 +306,7 @@ const QueryAFiltersCard: FC = memo(() => {
                                 <span key={`${path}-${item.id}`}>
                                     {index > 0 ? (
                                         <>
-                                            <Text span c="dimmed" fw={700}>
+                                            <Text span c="dimmed" fw={600}>
                                                 {expression.operator.toUpperCase()}
                                             </Text>{' '}
                                         </>
@@ -337,7 +337,7 @@ const QueryAFiltersCard: FC = memo(() => {
                         <Text
                             key={`${path}-${index}-operator`}
                             c="dimmed"
-                            fw={700}
+                            fw={600}
                             style={{ paddingLeft: itemDepth * 12 }}
                         >
                             {expression.operator.toUpperCase()}

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationConfig.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationConfig.tsx
@@ -87,7 +87,7 @@ const VisualizationConfig: FC<Props> = ({
             {withHeader ? (
                 <>
                     <Group justify="space-between">
-                        <Text fz={16} fw={600}>
+                        <Text fz="md" fw={600}>
                             Configure chart
                         </Text>
 

--- a/packages/frontend/src/components/Explorer/WriteBackModal/CreatedPullRequestModalContent.tsx
+++ b/packages/frontend/src/components/Explorer/WriteBackModal/CreatedPullRequestModalContent.tsx
@@ -24,7 +24,7 @@ export const CreatedPullRequestModalContent = ({
             <Stack gap="md">
                 <Text>
                     Your pull request{' '}
-                    <Anchor href={data.prUrl} target="_blank" fw={700}>
+                    <Anchor href={data.prUrl} target="_blank" fw={600}>
                         #{data.prUrl.split('/').pop()}
                     </Anchor>{' '}
                     was successfully created on git.

--- a/packages/frontend/src/components/ExportResults/index.tsx
+++ b/packages/frontend/src/components/ExportResults/index.tsx
@@ -311,7 +311,7 @@ const ExportResults: FC<ExportResultsProps> = memo(
             <Stack gap="md" miw="20rem">
                 {isDialog && (
                     <Stack gap="xs">
-                        <Text fz="xs" fw={700} tt="uppercase" c="dimmed">
+                        <Text fz="xs" fw={600} tt="uppercase" c="dimmed">
                             Export configuration
                         </Text>
                         <Text fz="sm" c="dimmed">

--- a/packages/frontend/src/components/PinnedParameters.tsx
+++ b/packages/frontend/src/components/PinnedParameters.tsx
@@ -102,7 +102,7 @@ const PinnedParameter: FC<PinnedParameterProps> = ({
                 >
                     <Text truncate>
                         <Text span>{parameter.label || parameterKey}:</Text>{' '}
-                        <Text fw={700} span>
+                        <Text fw={600} span>
                             {displayValue}
                         </Text>
                     </Text>

--- a/packages/frontend/src/components/PreAggregateAudit/index.tsx
+++ b/packages/frontend/src/components/PreAggregateAudit/index.tsx
@@ -87,28 +87,28 @@ const PreAggregateAudit: FC<PreAggregateAuditProps> = ({ projectUuid }) => {
             >
                 <SimpleGrid cols={3}>
                     <Card withBorder p="md">
-                        <Text size="xs" c="dimmed" tt="uppercase" fw={700}>
+                        <Text size="xs" c="dimmed" tt="uppercase" fw={600}>
                             Cache Rate (3 days)
                         </Text>
-                        <Text size="xl" fw={700}>
+                        <Text size="xl" fw={600}>
                             {summary.totalQueries > 0
                                 ? `${summary.hitRate}%`
                                 : 'No data'}
                         </Text>
                     </Card>
                     <Card withBorder p="md">
-                        <Text size="xs" c="dimmed" tt="uppercase" fw={700}>
+                        <Text size="xs" c="dimmed" tt="uppercase" fw={600}>
                             Total Queries
                         </Text>
-                        <Text size="xl" fw={700}>
+                        <Text size="xl" fw={600}>
                             {summary.totalQueries}
                         </Text>
                     </Card>
                     <Card withBorder p="md">
-                        <Text size="xs" c="dimmed" tt="uppercase" fw={700}>
+                        <Text size="xs" c="dimmed" tt="uppercase" fw={600}>
                             Explores with Pre-Aggregates
                         </Text>
-                        <Text size="xl" fw={700}>
+                        <Text size="xl" fw={600}>
                             {summary.exploreCount}
                         </Text>
                     </Card>

--- a/packages/frontend/src/components/ProjectAccess/ProjectAccess.tsx
+++ b/packages/frontend/src/components/ProjectAccess/ProjectAccess.tsx
@@ -405,7 +405,7 @@ const ProjectAccess: FC<ProjectAccessProps> = ({ projectUuid }) => {
                         // Build role summary tooltip
                         const roleSummary = (
                             <Stack>
-                                <Text fw={300} fz="xs">
+                                <Text fw={400} fz="xs">
                                     Organization role:{' '}
                                     <Text fw={600} span fz="xs">
                                         {getRoleName(
@@ -414,7 +414,7 @@ const ProjectAccess: FC<ProjectAccessProps> = ({ projectUuid }) => {
                                     </Text>
                                 </Text>
                                 {u.userGroupAccesses.map((uga) => (
-                                    <Text key={uga.group.uuid} fw={300}>
+                                    <Text key={uga.group.uuid} fw={400}>
                                         Group{' '}
                                         <Text fw={600} span>
                                             {uga.group.name}
@@ -426,7 +426,7 @@ const ProjectAccess: FC<ProjectAccessProps> = ({ projectUuid }) => {
                                     </Text>
                                 ))}
                                 {u.hasProjectRole && (
-                                    <Text fw={300}>
+                                    <Text fw={400}>
                                         Project role:{' '}
                                         <Text fw={600} span>
                                             {u.projectRole}

--- a/packages/frontend/src/components/ProjectConnection/Inputs/BooleanSwitch.tsx
+++ b/packages/frontend/src/components/ProjectConnection/Inputs/BooleanSwitch.tsx
@@ -27,7 +27,7 @@ const BooleanSwitch: FC<BooleanSwitchProps> = ({
     return (
         <Stack className={`input-wrapper ${className}`} gap="two">
             <Group gap="xs" justify="space-between">
-                <Text fw={450} fz="sm">
+                <Text fw={500} fz="sm">
                     {label} <span style={{ flex: 1 }}>{requiredLabel}</span>
                 </Text>
 

--- a/packages/frontend/src/components/RefreshDbtButton/index.tsx
+++ b/packages/frontend/src/components/RefreshDbtButton/index.tsx
@@ -297,7 +297,7 @@ const RefreshDbtButton: FC<{
                                             >
                                                 {MODE_COPY[option].label}
                                             </Text>
-                                            <Text fz={10} c="ldGray.6">
+                                            <Text fz="xs" c="ldGray.6">
                                                 {MODE_COPY[option].description}
                                             </Text>
                                         </Stack>

--- a/packages/frontend/src/components/Settings/SettingsNavigation.tsx
+++ b/packages/frontend/src/components/Settings/SettingsNavigation.tsx
@@ -76,7 +76,7 @@ const SettingsNavigation: FC<SettingsNavigationProps> = ({
                             {section.title}
                         </Title>
                         {section.subtitle !== null && (
-                            <Text fz="sm" fw={700} mt={2}>
+                            <Text fz="sm" fw={600} mt={2}>
                                 {section.subtitle}
                             </Text>
                         )}

--- a/packages/frontend/src/components/SettingsAgentDataScope/index.tsx
+++ b/packages/frontend/src/components/SettingsAgentDataScope/index.tsx
@@ -256,7 +256,7 @@ const SettingsAgentDataScope: FC<SettingsAgentDataScopeProps> = ({
                         <MantineIcon icon={IconLock} size="md" />
                     </Paper>
                     <Stack gap={2}>
-                        <Title order={5} c="ldGray.9" fw={700}>
+                        <Title order={5} c="ldGray.9" fw={600}>
                             Warehouse access
                         </Title>
                         <Text size="xs" c="dimmed">

--- a/packages/frontend/src/components/SettingsValidator/ValidationSummarySection.tsx
+++ b/packages/frontend/src/components/SettingsValidator/ValidationSummarySection.tsx
@@ -126,7 +126,7 @@ export const ValidationSummarySection: FC<Props> = ({
                                                 >
                                                     {getGroupTitle(group)}
                                                 </Text>
-                                                <Text fz={10} c="ldGray.6">
+                                                <Text fz="xs" c="ldGray.6">
                                                     {getAffectedLabel(group)}
                                                 </Text>
                                             </Stack>

--- a/packages/frontend/src/components/SettingsValidator/ValidatorTable/ErrorMessage.tsx
+++ b/packages/frontend/src/components/SettingsValidator/ValidatorTable/ErrorMessage.tsx
@@ -14,7 +14,7 @@ import { type FC } from 'react';
 import classes from './ErrorMessage.module.css';
 
 const CustomMark: FC<React.PropsWithChildren<{}>> = ({ children }) => (
-    <Mark color="gray" px={2} fw={500} fz={11} className={classes.mark}>
+    <Mark color="gray" px={2} fw={500} fz="xs" className={classes.mark}>
         {children}
     </Mark>
 );
@@ -28,7 +28,7 @@ const ErrorMessageByType: FC<{
             validationError.errorType === ValidationErrorType.ChartConfiguration
         ) {
             return (
-                <Text fz={11}>
+                <Text fz="xs">
                     <CustomMark>{validationError.fieldName}</CustomMark>
                     {': '}
                     {validationError.error}
@@ -38,7 +38,7 @@ const ErrorMessageByType: FC<{
         // Model-level errors: the whole model is gone or failed to compile
         if (validationError.errorType === ValidationErrorType.Model) {
             return (
-                <Text fz={11}>
+                <Text fz="xs">
                     Model <CustomMark>{validationError.tableName}</CustomMark>{' '}
                     {validationError.error.includes('failed to compile')
                         ? 'failed to compile'
@@ -47,7 +47,7 @@ const ErrorMessageByType: FC<{
             );
         }
         return (
-            <Text fz={11}>
+            <Text fz="xs">
                 <CustomMark>{validationError.fieldName}</CustomMark> no longer
                 exists
             </Text>
@@ -60,7 +60,7 @@ const ErrorMessageByType: FC<{
             switch (validationError.dashboardFilterErrorType) {
                 case DashboardFilterValidationErrorType.TableNotUsedByAnyChart:
                     return (
-                        <Text fz={11}>
+                        <Text fz="xs">
                             <CustomMark>{validationError.fieldName}</CustomMark>{' '}
                             references table{' '}
                             <CustomMark>{validationError.tableName}</CustomMark>{' '}
@@ -69,14 +69,14 @@ const ErrorMessageByType: FC<{
                     );
                 case DashboardFilterValidationErrorType.FieldDoesNotExist:
                     return (
-                        <Text fz={11}>
+                        <Text fz="xs">
                             <CustomMark>{validationError.fieldName}</CustomMark>{' '}
                             no longer exists
                         </Text>
                     );
                 case DashboardFilterValidationErrorType.TableDoesNotExist:
                     return (
-                        <Text fz={11}>
+                        <Text fz="xs">
                             Table{' '}
                             <CustomMark>{validationError.tableName}</CustomMark>{' '}
                             no longer exists
@@ -84,7 +84,7 @@ const ErrorMessageByType: FC<{
                     );
                 case DashboardFilterValidationErrorType.FieldTableMismatch:
                     return (
-                        <Text fz={11}>
+                        <Text fz="xs">
                             <CustomMark>{validationError.fieldName}</CustomMark>{' '}
                             does not match table{' '}
                             <CustomMark>{validationError.tableName}</CustomMark>
@@ -101,7 +101,7 @@ const ErrorMessageByType: FC<{
         // Handle broken chart errors
         if (validationError.chartName) {
             return (
-                <Text fz={11}>
+                <Text fz="xs">
                     <CustomMark>{validationError.chartName}</CustomMark> is
                     broken
                 </Text>
@@ -109,15 +109,15 @@ const ErrorMessageByType: FC<{
         }
 
         // Fallback for unexpected cases
-        return <Text fz={11}>{validationError.error}</Text>;
+        return <Text fz="xs">{validationError.error}</Text>;
     }
 
     if (isDataAppValidationError(validationError)) {
-        return <Text fz={11}>{validationError.error}</Text>;
+        return <Text fz="xs">{validationError.error}</Text>;
     }
 
     if (isTableValidationError(validationError) && validationError) {
-        return <Text fz={11}>{validationError.error}</Text>;
+        return <Text fz="xs">{validationError.error}</Text>;
     }
 
     return null;
@@ -132,7 +132,7 @@ export const ErrorMessage: FC<{ validationError: ValidationResponse }> = ({
 
     return (
         <Stack gap={4}>
-            <Text fw={600} c={isWarning ? 'orange.6' : 'red.6'} fz={10}>
+            <Text fw={600} c={isWarning ? 'orange.6' : 'red.6'} fz="xs">
                 {validationError.errorType
                     ? friendlyName(validationError.errorType)
                     : ''}{' '}

--- a/packages/frontend/src/components/SettingsValidator/ValidatorTable/index.tsx
+++ b/packages/frontend/src/components/SettingsValidator/ValidatorTable/index.tsx
@@ -219,7 +219,7 @@ export const ValidatorTable: FC<ValidatorTableProps> = ({
                                             validationError,
                                         )) &&
                                         !isDeleted(validationError) && (
-                                            <Text fz={10} c="ldGray.6">
+                                            <Text fz="xs" c="ldGray.6">
                                                 {getViews(validationError)} view
                                                 {getViews(validationError) === 1
                                                     ? ''
@@ -233,7 +233,7 @@ export const ValidatorTable: FC<ValidatorTableProps> = ({
                                                         <Text
                                                             span
                                                             fw={500}
-                                                            fz={10}
+                                                            fz="xs"
                                                         >
                                                             {
                                                                 validationError.lastUpdatedBy

--- a/packages/frontend/src/components/SimpleMap/MapLegend.tsx
+++ b/packages/frontend/src/components/SimpleMap/MapLegend.tsx
@@ -98,7 +98,7 @@ const MapLegend: FC<MapLegendProps> = ({
                                                     1,
                                             }}
                                         />
-                                        <Text fz={10} c="ldGray.6" truncate>
+                                        <Text fz="xs" c="ldGray.6" truncate>
                                             {entry.value}
                                         </Text>
                                     </Group>

--- a/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/BrandPreview.tsx
+++ b/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/BrandPreview.tsx
@@ -168,7 +168,7 @@ export const BrandPreview: FC<BrandPreviewProps> = ({
                         />
                     ) : (
                         <Box className={classes.navLogoFallback}>
-                            <Text size="xs" fw={700} c={primary}>
+                            <Text size="xs" fw={600} c={primary}>
                                 {displayName[0]?.toUpperCase() ?? 'A'}
                             </Text>
                         </Box>
@@ -198,7 +198,7 @@ export const BrandPreview: FC<BrandPreviewProps> = ({
                 <Group justify="space-between" align="flex-start" wrap="nowrap">
                     <Stack gap={2}>
                         <Text
-                            fw={700}
+                            fw={600}
                             fz={22}
                             ff={titleFamily}
                             className={classes.title}
@@ -223,7 +223,7 @@ export const BrandPreview: FC<BrandPreviewProps> = ({
                         <Text size="xs" c="dimmed" ff={bodyFamily}>
                             Total revenue
                         </Text>
-                        <Text fw={700} fz={24} ff={titleFamily}>
+                        <Text fw={600} fz={24} ff={titleFamily}>
                             $1.24M
                         </Text>
                         <Text size="xs" c="teal" ff={bodyFamily}>

--- a/packages/frontend/src/components/UserSettings/ImpersonationPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/ImpersonationPanel/index.tsx
@@ -37,7 +37,7 @@ const ImpersonationPanel: FC = () => {
                 <Text fz="xs">
                     If the project requires users to provide their own warehouse
                     credentials, queries run with the impersonated user's{' '}
-                    <Text span inherit fw={700}>
+                    <Text span inherit fw={600}>
                         personal warehouse credentials
                     </Text>{' '}
                     (including SSO-backed credentials).

--- a/packages/frontend/src/components/VisualizationConfigs/common/Config.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/common/Config.tsx
@@ -36,7 +36,7 @@ const Heading: FC<PropsWithChildren> = ({ children }) => (
 );
 
 const Subheading: FC<PropsWithChildren> = ({ children }) => (
-    <Text c="ldGray.7" fz={13} fw={600}>
+    <Text c="ldGray.7" fz="sm" fw={600}>
         {children}
     </Text>
 );

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -713,7 +713,7 @@ const DashboardHeader = memo(
                                             color="ldGray.6"
                                         />
 
-                                        <Text fz={11} c="dimmed">
+                                        <Text fz="xs" c="dimmed">
                                             {dayjs(oldestCacheTime).format(
                                                 'MMM D, h:mm A',
                                             )}

--- a/packages/frontend/src/components/common/Dashboard/PreAggregateAuditIndicator.tsx
+++ b/packages/frontend/src/components/common/Dashboard/PreAggregateAuditIndicator.tsx
@@ -50,7 +50,7 @@ type TabGroup = {
 function TileDetail({ tile }: { tile: TilePreAggregateStatus }) {
     if (tile.hit && tile.preAggregateName) {
         return (
-            <Text fz={10} className={classes.tileDetail}>
+            <Text fz="xs" className={classes.tileDetail}>
                 {tile.preAggregateName}
             </Text>
         );
@@ -65,7 +65,7 @@ function TileDetail({ tile }: { tile: TilePreAggregateStatus }) {
                 : null;
         if (!fieldId) {
             return (
-                <Text fz={10} className={classes.tileDetail}>
+                <Text fz="xs" className={classes.tileDetail}>
                     {reasonLabel}
                 </Text>
             );
@@ -74,7 +74,7 @@ function TileDetail({ tile }: { tile: TilePreAggregateStatus }) {
         const showTooltip =
             tile.reasonFieldLabel !== null && tile.reasonFieldLabel !== fieldId;
         return (
-            <Text fz={10} className={classes.tileDetail}>
+            <Text fz="xs" className={classes.tileDetail}>
                 {reasonLabel}:{' '}
                 {showTooltip ? (
                     <Tooltip
@@ -84,7 +84,7 @@ function TileDetail({ tile }: { tile: TilePreAggregateStatus }) {
                         openDelay={150}
                         classNames={{ tooltip: classes.fieldIdTooltip }}
                     >
-                        <Text span fz={10} className={classes.fieldLabelHover}>
+                        <Text span fz="xs" className={classes.fieldLabelHover}>
                             {fieldDisplay}
                         </Text>
                     </Tooltip>
@@ -95,7 +95,7 @@ function TileDetail({ tile }: { tile: TilePreAggregateStatus }) {
         );
     }
     return (
-        <Text fz={10} className={classes.tileDetail}>
+        <Text fz="xs" className={classes.tileDetail}>
             —
         </Text>
     );
@@ -155,7 +155,7 @@ function IneligibleSection({ tiles }: { tiles: TilePreAggregateStatus[] }) {
                     size="xs"
                     color="ldGray.5"
                 />
-                <Text fz={11} className={classes.tileDetail}>
+                <Text fz="xs" className={classes.tileDetail}>
                     {tiles.length} without pre-aggregates
                 </Text>
             </PolymorphicGroupButton>

--- a/packages/frontend/src/components/common/MantineModal/index.tsx
+++ b/packages/frontend/src/components/common/MantineModal/index.tsx
@@ -363,7 +363,7 @@ const MantineModal: React.FC<MantineModalProps> = ({
                                 </Paper>
                             ) : null}
                             <Stack gap={2} miw={0}>
-                                <Text c="ldDark.9" fw={700} fz="md" lh="28px">
+                                <Text c="ldDark.9" fw={600} fz="md" lh="28px">
                                     {title}
                                 </Text>
                                 {subtitle ? (
@@ -438,7 +438,7 @@ const MantineModal: React.FC<MantineModalProps> = ({
                             px="xl"
                             py="md"
                         >
-                            <Text c="ldDark.9" fw={700} fz="md" lh="28px">
+                            <Text c="ldDark.9" fw={600} fz="md" lh="28px">
                                 Unsaved changes
                             </Text>
                             <Modal.CloseButton />

--- a/packages/frontend/src/components/common/PageHeader/DashboardInfoOverlay.tsx
+++ b/packages/frontend/src/components/common/PageHeader/DashboardInfoOverlay.tsx
@@ -74,7 +74,7 @@ const DashboardInfoOverlay: FC<DashboardInfoOverlayProps> = ({
                         <Anchor
                             component={Link}
                             to={`/projects/${projectUrlIdentifier}/spaces/${dashboard.spaceUuid}`}
-                            fz={12}
+                            fz="xs"
                             fw={500}
                         >
                             {dashboard.spaceName}
@@ -90,7 +90,7 @@ const DashboardInfoOverlay: FC<DashboardInfoOverlayProps> = ({
                             <UnstyledButton onClick={copy}>
                                 <Group gap={6} wrap="nowrap">
                                     <Text
-                                        fz={11}
+                                        fz="xs"
                                         fw={500}
                                         c="ldGray.9"
                                         ff="monospace"

--- a/packages/frontend/src/components/common/ResourceInfoPopup/ResourceInfoPopup.tsx
+++ b/packages/frontend/src/components/common/ResourceInfoPopup/ResourceInfoPopup.tsx
@@ -166,7 +166,7 @@ export const ResourceInfoPopupContent: FC<ResourceInfoPopupProps> = ({
                         <Anchor
                             component={Link}
                             to={`/projects/${projectUrlIdentifier}/spaces/${spaceUuid}`}
-                            fz={12}
+                            fz="xs"
                             fw={500}
                         >
                             {spaceName}
@@ -209,7 +209,7 @@ export const ResourceInfoPopupContent: FC<ResourceInfoPopupProps> = ({
                                     <UnstyledButton onClick={copy}>
                                         <Group gap={6} wrap="nowrap">
                                             <Text
-                                                fz={11}
+                                                fz="xs"
                                                 fw={500}
                                                 c="ldGray.9"
                                                 ff="monospace"

--- a/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
+++ b/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
@@ -286,7 +286,7 @@ const InfiniteResourceTable = ({
                             onClick={(e: React.MouseEvent<HTMLAnchorElement>) =>
                                 e.stopPropagation()
                             }
-                            fz={12}
+                            fz="xs"
                             fw={500}
                         >
                             {space.name}
@@ -297,7 +297,7 @@ const InfiniteResourceTable = ({
                 // Personal (space-less) data apps have no space to link to.
                 if (isResourceViewDataAppItem(item) && !item.data.spaceUuid) {
                     return (
-                        <Text fz={12} fw={500} c="dimmed">
+                        <Text fz="xs" fw={500} c="dimmed">
                             -
                         </Text>
                     );
@@ -309,7 +309,7 @@ const InfiniteResourceTable = ({
                     : undefined;
                 if (inaccessibleSpaceName) {
                     return (
-                        <Text fz={12} fw={500} c="ldGray.7">
+                        <Text fz="xs" fw={500} c="ldGray.7">
                             {inaccessibleSpaceName}
                         </Text>
                     );
@@ -326,7 +326,7 @@ const InfiniteResourceTable = ({
             Cell: ({ row }) => {
                 if (isResourceViewSpaceItem(row.original))
                     return (
-                        <Text fz={12} fw={500} c="ldGray.7">
+                        <Text fz="xs" fw={500} c="ldGray.7">
                             -
                         </Text>
                     );
@@ -343,7 +343,7 @@ const InfiniteResourceTable = ({
                 const item = row.original;
                 if (!isResourceViewItemDashboard(item) || !item.data.owner) {
                     return (
-                        <Text fz={12} fw={500} c="dimmed">
+                        <Text fz="xs" fw={500} c="dimmed">
                             -
                         </Text>
                     );
@@ -352,7 +352,7 @@ const InfiniteResourceTable = ({
                 const ownerName =
                     `${firstName} ${lastName}`.trim() || email || '-';
                 return (
-                    <Text fz={12} fw={500} c="ldGray.7">
+                    <Text fz="xs" fw={500} c="ldGray.7">
                         {ownerName}
                     </Text>
                 );
@@ -367,12 +367,12 @@ const InfiniteResourceTable = ({
             Cell: ({ row }) => {
                 if (isResourceViewSpaceItem(row.original))
                     return (
-                        <Text fz={12} fw={500} c="ldGray.7">
+                        <Text fz="xs" fw={500} c="ldGray.7">
                             -
                         </Text>
                     );
                 return (
-                    <Text fz={12} fw={500} c="ldGray.7">
+                    <Text fz="xs" fw={500} c="ldGray.7">
                         {row.original.data.views}
                     </Text>
                 );

--- a/packages/frontend/src/components/common/ResourceView/InfiniteResourceTableColumnName.tsx
+++ b/packages/frontend/src/components/common/ResourceView/InfiniteResourceTableColumnName.tsx
@@ -239,7 +239,7 @@ const InfiniteResourceTableColumnName = ({
                     </Group>
                     {showTypeAndViews && (
                         <Group gap="xs" wrap="nowrap">
-                            <Text fz={12} c="ldGray.6">
+                            <Text fz="xs" c="ldGray.6">
                                 {getResourceTypeName(item)} •{' '}
                                 <Tooltip
                                     position="top-start"

--- a/packages/frontend/src/components/common/ResourceView/ResourceLastEdited.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceLastEdited.tsx
@@ -29,13 +29,13 @@ const ResourceLastEdited: FC<ResourceLastEditedProps> = ({
                 position="top-start"
                 label={dayjs(updatedAt).format('YYYY-MM-DD HH:mm:ss')}
             >
-                <Text fz={12} fw={500} c="ldGray.7">
+                <Text fz="xs" fw={500} c="ldGray.7">
                     {timeAgo}
                 </Text>
             </Tooltip>
 
             {user && user.firstName ? (
-                <Text fz={12} c="ldGray.6">
+                <Text fz="xs" c="ldGray.6">
                     by {user.firstName} {user.lastName}
                 </Text>
             ) : null}

--- a/packages/frontend/src/components/common/SpaceActionModal/DeleteSpaceModal.tsx
+++ b/packages/frontend/src/components/common/SpaceActionModal/DeleteSpaceModal.tsx
@@ -89,7 +89,7 @@ const DeleteSpaceModalContent: FC<
                     />
                     <Text
                         size="sm"
-                        fw={700}
+                        fw={600}
                         c={softDeleteEnabled ? 'yellow.7' : 'red.7'}
                     >
                         {descendantCount} space
@@ -105,7 +105,7 @@ const DeleteSpaceModalContent: FC<
                     />
                     <Text
                         size="sm"
-                        fw={700}
+                        fw={600}
                         c={softDeleteEnabled ? 'yellow.7' : 'red.7'}
                     >
                         {impact.chartCount} chart
@@ -121,7 +121,7 @@ const DeleteSpaceModalContent: FC<
                     />
                     <Text
                         size="sm"
-                        fw={700}
+                        fw={600}
                         c={softDeleteEnabled ? 'yellow.7' : 'red.7'}
                     >
                         {impact.dashboardCount} dashboard
@@ -138,7 +138,7 @@ const DeleteSpaceModalContent: FC<
                         />
                         <Text
                             size="sm"
-                            fw={700}
+                            fw={600}
                             c={softDeleteEnabled ? 'yellow.7' : 'red.7'}
                         >
                             {impact.appCount} data app
@@ -181,7 +181,7 @@ export const DeleteSpaceModal: FC<DeleteSpaceModalBody> = ({
                 {softDeleteEnabled ? (
                     <>
                         Are you sure you want to delete the space{' '}
-                        <Text span fw={700} fz="sm">
+                        <Text span fw={600} fz="sm">
                             &ldquo;{data?.name}&rdquo;
                         </Text>
                         ?
@@ -189,7 +189,7 @@ export const DeleteSpaceModal: FC<DeleteSpaceModalBody> = ({
                 ) : (
                     <>
                         Are you sure you want to delete the space{' '}
-                        <Text span fw={700}>
+                        <Text span fw={600}>
                             &ldquo;{data?.name}&rdquo;
                         </Text>
                         ?

--- a/packages/frontend/src/ee/components/Home/AiSearchBox/AiSearchBox.tsx
+++ b/packages/frontend/src/ee/components/Home/AiSearchBox/AiSearchBox.tsx
@@ -354,7 +354,7 @@ const AiSearchBoxInner: FC<Props> = ({
                                         className={styles.reviewsPromoButton}
                                     >
                                         <Group gap="xs" wrap="nowrap">
-                                            <Text span fz="xs" fw={700}>
+                                            <Text span fz="xs" fw={600}>
                                                 {reviewsPromoLabel}
                                             </Text>
                                             <CategoryBadge

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.tsx
@@ -377,7 +377,7 @@ const FindingCell = ({
 }: {
     reviewItem: AiAgentReviewItemSummary;
 }) => (
-    <Text fw={700} fz="sm" c="ldGray.9" lineClamp={2}>
+    <Text fw={600} fz="sm" c="ldGray.9" lineClamp={2}>
         {getIssueTitle(reviewItem)}
     </Text>
 );
@@ -816,7 +816,7 @@ const AiAgentAdminReviewItemsTable = ({
                             wrap="nowrap"
                             className={styles.toolbarHeading}
                         >
-                            <Text fz="sm" fw={700} c="ldGray.9">
+                            <Text fz="sm" fw={600} c="ldGray.9">
                                 Issues
                             </Text>
                             <ReviewConceptHelp />

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/EvalPreviewSidebar.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/EvalPreviewSidebar.tsx
@@ -26,7 +26,7 @@ const MetaField: FC<{ label: string; children: React.ReactNode }> = ({
     children,
 }) => (
     <Stack gap={2}>
-        <Text fz={10} fw={700} c="dimmed" tt="uppercase" lts={0.4}>
+        <Text fz="xs" fw={600} c="dimmed" tt="uppercase" lts={0.4}>
             {label}
         </Text>
         {children}
@@ -122,7 +122,7 @@ export const EvalPreviewSidebar: FC<EvalPreviewSidebarProps> = ({
             <Divider color="ldGray.2" />
 
             <Box p="lg" flex={1} style={{ overflowY: 'auto', minHeight: 0 }}>
-                <Text fz={10} fw={700} c="dimmed" tt="uppercase" lts={0.4}>
+                <Text fz="xs" fw={600} c="dimmed" tt="uppercase" lts={0.4}>
                     Prompts ({evalSummary.promptCount})
                 </Text>
                 {isInitialLoading ? (

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/McpActivityOverview.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/McpActivityOverview.tsx
@@ -251,7 +251,7 @@ const RecentErrorsCard: FC<{
                                 label={formatToolCallTimeFull(item.createdAt)}
                             >
                                 <Text
-                                    fz={11}
+                                    fz="xs"
                                     c="ldGray.5"
                                     className={styles.noShrink}
                                 >

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewAssigneeMenu.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewAssigneeMenu.tsx
@@ -113,7 +113,7 @@ export const ReviewAssigneeMenu: FC<Props> = ({
                                     // ff needed: the UnstyledButton ancestor
                                     // reintroduces the UA's button font.
                                     <Text
-                                        fz={12}
+                                        fz="xs"
                                         fw={500}
                                         c="ldGray.9"
                                         ff="var(--mantine-font-family)"

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.tsx
@@ -644,7 +644,7 @@ export const ReviewKanbanBoard: FC<Props> = ({
                                             bg={`${lane.color}.5`}
                                             style={{ borderRadius: 3 }}
                                         />
-                                        <Text fz="sm" fw={650}>
+                                        <Text fz="sm" fw={600}>
                                             {lane.label}
                                         </Text>
                                         <Badge

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanCard.tsx
@@ -130,12 +130,12 @@ export const ReviewKanbanCard: FC<Props> = ({ item, isSelected, onSelect }) => {
                                     Example
                                 </Badge>
                             )}
-                            <Text fz="sm" fw={550} lineClamp={2}>
+                            <Text fz="sm" fw={500} lineClamp={2}>
                                 {title}
                             </Text>
                             {targetAnchor && (
                                 <Code
-                                    fz={10}
+                                    fz="xs"
                                     c="dimmed"
                                     w="fit-content"
                                     maw="100%"

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewRemediationWorkspace.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewRemediationWorkspace.tsx
@@ -557,7 +557,7 @@ export const ReviewRemediationWorkspace = () => {
                             </ThemeIcon>
                             <Box miw={0}>
                                 <Group gap="xs" wrap="nowrap" miw={0}>
-                                    <Text fw={700} fz="md">
+                                    <Text fw={600} fz="md">
                                         Test the fix
                                     </Text>
                                     {testBadge && renderBadge(testBadge)}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewValidationList.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewValidationList.tsx
@@ -63,7 +63,7 @@ export const ReviewValidationList: FC<Props> = ({ previewProjectUuid }) => {
 
     return (
         <Stack gap="xs" pt="xs">
-            <Text fz="xs" fw={700} tt="uppercase" lts={0.4} c="ldGray.7">
+            <Text fz="xs" fw={600} tt="uppercase" lts={0.4} c="ldGray.7">
                 {total} validation {total === 1 ? 'error' : 'errors'}
             </Text>
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ThreadPreviewSidebar.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ThreadPreviewSidebar.tsx
@@ -82,7 +82,7 @@ const ReviewMetadataField = ({
     tooltip?: string;
 }) => (
     <Stack gap={2} className={styles.metaField}>
-        <Text fz={10} fw={700} c="dimmed" tt="uppercase" lts={0.4}>
+        <Text fz="xs" fw={600} c="dimmed" tt="uppercase" lts={0.4}>
             {label}
         </Text>
         <Tooltip
@@ -461,7 +461,7 @@ export const ThreadPreviewSidebar: FC<ThreadPreviewSidebarProps> = ({
                                         <Stack gap="xs" pt="xs">
                                             <Text
                                                 fz="xs"
-                                                fw={700}
+                                                fw={600}
                                                 tt="uppercase"
                                                 lts={0.4}
                                                 c="ldGray.7"
@@ -491,7 +491,7 @@ export const ThreadPreviewSidebar: FC<ThreadPreviewSidebarProps> = ({
                                     <Stack gap={6} pt="xs">
                                         <Text
                                             size="10px"
-                                            fw={700}
+                                            fw={600}
                                             tt="uppercase"
                                             lts={0.4}
                                             c="ldGray.7"
@@ -780,7 +780,7 @@ export const ThreadPreviewSidebar: FC<ThreadPreviewSidebarProps> = ({
                         >
                             <Text
                                 size="10px"
-                                fw={700}
+                                fw={600}
                                 tt="uppercase"
                                 lts={0.4}
                                 c="ldGray.7"

--- a/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/AgentSelector.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/AgentSelector.tsx
@@ -141,7 +141,7 @@ export const AgentSelector = ({
                         <Combobox.Option value={AUTO_VALUE} p={2}>
                             <Group gap="xs" wrap="nowrap" miw={0} flex={1}>
                                 <Avatar size={22} color="ldGray" radius="xl">
-                                    <Text size="10px" fw={700} c="ldGray.6">
+                                    <Text size="10px" fw={600} c="ldGray.6">
                                         AI
                                     </Text>
                                 </Avatar>

--- a/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/AgentSettingsSelector.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/AgentSettingsSelector.tsx
@@ -96,7 +96,7 @@ export const AgentSettingsSelector = ({
                     <Combobox.Option value={ASK_AI_VALUE} p={2}>
                         <Group gap="xs" wrap="nowrap" miw={0} flex={1}>
                             <Avatar size={22} color="ldGray" radius="xl">
-                                <Text size="10px" fw={700} c="ldGray.6">
+                                <Text size="10px" fw={600} c="ldGray.6">
                                     AI
                                 </Text>
                             </Avatar>

--- a/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/CompactAgentSelector.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/CompactAgentSelector.tsx
@@ -72,7 +72,7 @@ export const CompactAgentSelector = ({
                         <Group gap="two">
                             {isAuto ? (
                                 <Avatar size="md" color="ldGray" radius="xl">
-                                    <Text size="xs" fw={700} c="ldGray.6">
+                                    <Text size="xs" fw={600} c="ldGray.6">
                                         AI
                                     </Text>
                                 </Avatar>
@@ -105,7 +105,7 @@ export const CompactAgentSelector = ({
                     <Combobox.Option value={AI_ROUTING_AUTO_VALUE}>
                         <Group gap="xs" wrap="nowrap" miw={0} flex={1}>
                             <Avatar size={22} color="ldGray" radius="xl">
-                                <Text size="10px" fw={700} c="ldGray.6">
+                                <Text size="10px" fw={600} c="ldGray.6">
                                     AI
                                 </Text>
                             </Avatar>

--- a/packages/frontend/src/ee/features/aiCopilot/components/AgentSettingsSection.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AgentSettingsSection.tsx
@@ -51,7 +51,7 @@ export const AgentSettingsSection: FC<Props> = ({
                                 id={`${id}-title`}
                                 order={5}
                                 c="ldGray.9"
-                                fw={700}
+                                fw={600}
                             >
                                 {title}
                             </Title>

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServerToolsPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServerToolsPanel.tsx
@@ -93,13 +93,13 @@ const ToolDescriptionModal = ({
         >
             <Stack gap="md">
                 <Box>
-                    <Text size="xs" fw={700} c="dimmed" tt="uppercase">
+                    <Text size="xs" fw={600} c="dimmed" tt="uppercase">
                         Tool name
                     </Text>
                     <Text size="sm">{toolName}</Text>
                 </Box>
                 <Box>
-                    <Text size="xs" fw={700} c="dimmed" tt="uppercase" mb="xs">
+                    <Text size="xs" fw={600} c="dimmed" tt="uppercase" mb="xs">
                         Description
                     </Text>
                     <Box data-color-mode={colorScheme}>
@@ -435,7 +435,7 @@ export const AiAgentMcpServerToolsPanel: FC<Props> = ({
                                                     <TruncatedText
                                                         maxWidth="100%"
                                                         fz="sm"
-                                                        fw={700}
+                                                        fw={600}
                                                         c="ldGray.9"
                                                     >
                                                         {tool.title ||

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServersInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServersInput.tsx
@@ -1604,7 +1604,7 @@ export const AiAgentMcpServersInput = ({
                                                     <Text
                                                         size="sm"
                                                         c="dimmed"
-                                                        fw={450}
+                                                        fw={500}
                                                     >
                                                         {getMcpAuthTypeLabel(
                                                             mcpServer.authType,

--- a/packages/frontend/src/ee/features/aiCopilot/components/AskAiAgentMenuItem/AskAiAgentMenuItem.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AskAiAgentMenuItem/AskAiAgentMenuItem.tsx
@@ -42,7 +42,7 @@ export const AskAiAgentMenuItem: FC<Props> = ({
             <Menu.Item
                 leftSection={<AiAgentIcon size={13} />}
                 onClick={handleClick}
-                fw={550}
+                fw={500}
             >
                 Ask AI Agent
             </Menu.Item>

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatUserBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatUserBubble.tsx
@@ -85,7 +85,7 @@ export const UserBubble: FC<Props> = ({
                     <Anchor
                         component={Link}
                         c="dimmed"
-                        fz={10}
+                        fz="xs"
                         to={`/projects/${projectUuid}/ai-agents/${agentUuid}/threads/${message.threadUuid}/messages/${message.uuid}`}
                     >
                         {timeAgo}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentVisualizationFilters.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentVisualizationFilters.tsx
@@ -61,7 +61,7 @@ const FilterRuleDisplay: FC<{
                 {ruleLabels.value && (
                     <>
                         {' '}
-                        <Text fw={700} span fz="xs">
+                        <Text fw={600} span fz="xs">
                             {ruleLabels.value}
                         </Text>
                     </>

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentVisualizationParameters.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentVisualizationParameters.tsx
@@ -37,7 +37,7 @@ const AgentVisualizationParameters: FC<Props> = ({ parameterValues }) => {
                         <Text span c="dimmed" fz="xs">
                             is
                         </Text>{' '}
-                        <Text fw={700} span fz="xs">
+                        <Text fw={600} span fz="xs">
                             {formatParameterValue(value)}
                         </Text>
                     </Text>

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MemoryCitation.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MemoryCitation.tsx
@@ -81,7 +81,7 @@ export const MemoryCitation = ({
                                 align="flex-start"
                                 wrap="nowrap"
                             >
-                                <Text fw={650} size="sm" lh={1.3}>
+                                <Text fw={600} size="sm" lh={1.3}>
                                     {memoryQuery.data.title}
                                 </Text>
                                 {memoryQuery.data.status !== 'active' ? (

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.tsx
@@ -139,7 +139,7 @@ export const DeepResearchRunHeading = ({
                 <Group gap="xs" align="baseline" wrap="nowrap">
                     <Text
                         size="xs"
-                        fw={700}
+                        fw={600}
                         ff="monospace"
                         tt="uppercase"
                         className={styles.eyebrow}
@@ -422,7 +422,7 @@ export const DeepResearchRunCard = ({
                                     size={16}
                                     color="ldGray.6"
                                 />
-                                <Text size="sm" fw={700}>
+                                <Text size="sm" fw={600}>
                                     Research summary
                                 </Text>
                             </Group>

--- a/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalRunDetails.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalRunDetails.tsx
@@ -322,7 +322,7 @@ export const EvalRunDetails: FC<Props> = ({
                         <Paper p="xxs" withBorder radius="sm">
                             <MantineIcon icon={IconTarget} size="md" />
                         </Paper>
-                        <Title order={5} c="ldGray.9" fw={700}>
+                        <Title order={5} c="ldGray.9" fw={600}>
                             Run Overview
                         </Title>
                     </Group>

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
@@ -337,7 +337,7 @@ const NewThreadPanel: FC<{
                 >
                     {isAuto ? (
                         <Avatar size="lg" color="ldGray" radius="xl">
-                            <Text size="sm" fw={700} c="ldGray.6">
+                            <Text size="sm" fw={600} c="ldGray.6">
                                 AI
                             </Text>
                         </Avatar>

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/PanelHeader.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/PanelHeader.tsx
@@ -125,7 +125,7 @@ export const PanelHeader: FC<Props> = ({
                                         >
                                             <Text
                                                 size="10px"
-                                                fw={700}
+                                                fw={600}
                                                 c="ldGray.6"
                                             >
                                                 AI
@@ -164,7 +164,7 @@ export const PanelHeader: FC<Props> = ({
                                         >
                                             <Text
                                                 size="9px"
-                                                fw={700}
+                                                fw={600}
                                                 c="ldGray.6"
                                             >
                                                 AI
@@ -209,7 +209,7 @@ export const PanelHeader: FC<Props> = ({
                     <Group gap="xs" wrap="nowrap" className={styles.minWidth0}>
                         {isAuto ? (
                             <Avatar size="sm" color="ldGray" radius="xl">
-                                <Text size="10px" fw={700} c="ldGray.6">
+                                <Text size="10px" fw={600} c="ldGray.6">
                                     AI
                                 </Text>
                             </Avatar>

--- a/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryDetails.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryDetails.tsx
@@ -76,7 +76,7 @@ const SourceRow: FC<{
         <Box className={styles.sourceRow}>
             <Group justify="space-between" align="flex-start" wrap="nowrap">
                 <Box miw={0}>
-                    <Text fw={550} size="sm" lineClamp={1}>
+                    <Text fw={500} size="sm" lineClamp={1}>
                         {source.threadTitle ?? 'AI agent thread'}
                     </Text>
                     <AiMarkdown className={styles.sourceSummary}>
@@ -316,7 +316,7 @@ export const MemoryDetails: FC<MemoryDetailsProps> = ({
                                         <Box miw={0}>
                                             <Text
                                                 size="xs"
-                                                fw={550}
+                                                fw={500}
                                                 lineClamp={1}
                                             >
                                                 {getObjectLabel(object)}

--- a/packages/frontend/src/ee/features/aiCopilot/components/MyMemories/MyMemoriesModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/MyMemories/MyMemoriesModal.tsx
@@ -142,7 +142,7 @@ export const MyMemoriesModal: FC<MyMemoriesModalProps> = ({
     } else if (memories.length === 0) {
         content = (
             <Stack gap="xs" className={styles.emptyState}>
-                <Text size="sm" fw={550}>
+                <Text size="sm" fw={500}>
                     No memories yet
                 </Text>
                 <Text size="sm" c="dimmed">

--- a/packages/frontend/src/ee/features/aiCopilot/components/PinnedContextCard/PinnedReviewEntityCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/PinnedContextCard/PinnedReviewEntityCard.tsx
@@ -102,7 +102,7 @@ const ProposedChangeRow: FC<{
                 {summary}
             </Text>
             {objectRefs.length > 0 && (
-                <Text fz={11} c="dimmed">
+                <Text fz="xs" c="dimmed">
                     {objectRefs.join(', ')}
                 </Text>
             )}
@@ -120,7 +120,7 @@ const ReviewFindingRow: FC<{
             icon={IconSearch}
             right={
                 item.findingCount > 1 ? (
-                    <Text fz={10} fw={600} c="dimmed" style={{ flexShrink: 0 }}>
+                    <Text fz="xs" fw={600} c="dimmed" style={{ flexShrink: 0 }}>
                         {item.findingCount}×
                     </Text>
                 ) : undefined
@@ -135,7 +135,7 @@ const ReviewFindingRow: FC<{
                         component="button"
                         type="button"
                         onClick={toggleEvidence}
-                        fz={11}
+                        fz="xs"
                         c="dimmed"
                         underline="never"
                         mt={2}
@@ -161,7 +161,7 @@ const ReviewFindingRow: FC<{
                             {item.evidenceExcerpts.map((excerpt, idx) => (
                                 <Text
                                     key={idx}
-                                    fz={11}
+                                    fz="xs"
                                     c="dimmed"
                                     className={
                                         excerpt.redacted

--- a/packages/frontend/src/ee/features/customRoles/components/ScopeSelector/ScopeSelector.tsx
+++ b/packages/frontend/src/ee/features/customRoles/components/ScopeSelector/ScopeSelector.tsx
@@ -228,7 +228,7 @@ const ScopePanel: FC<{
                                         className={styles.scopeContent}
                                         gap="two"
                                     >
-                                        <Text fw={500} fz={13}>
+                                        <Text fw={500} fz="sm">
                                             {formatScopeName(scope.name)}
                                         </Text>
                                         <Text
@@ -262,7 +262,7 @@ const ScopePanel: FC<{
                                                                 }
                                                             />
                                                             <Text
-                                                                fz={11}
+                                                                fz="xs"
                                                                 c="dimmed"
                                                                 fw={500}
                                                             >

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedFiltersInteractivity.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedFiltersInteractivity.tsx
@@ -304,7 +304,7 @@ const EmbedFiltersInteractivity: React.FC<Props> = ({
                                                             }{' '}
                                                         </Text>
                                                         <Text
-                                                            fw={700}
+                                                            fw={600}
                                                             span
                                                             fz="xs"
                                                         >

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageStars.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageStars.tsx
@@ -444,7 +444,7 @@ const STAR_DEFS: StarDef[] = [
                     <Text size="xs" c="dimmed" lineClamp={1}>
                         {kpi.label}
                     </Text>
-                    <Text fw={700} size="xl" mb={4}>
+                    <Text fw={600} size="xl" mb={4}>
                         {kpi.value}
                     </Text>
                     <StarSparkline

--- a/packages/frontend/src/ee/features/homepageBuilder/PublishModal.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/PublishModal.tsx
@@ -383,7 +383,7 @@ const PublishModalBody: FC<BodyProps> = ({
                         {groupAssignments.length > 1 && (
                             <Box p="sm" className={classes.borderedPanel}>
                                 <Text
-                                    fz={11}
+                                    fz="xs"
                                     fw={600}
                                     tt="uppercase"
                                     lts="0.05em"
@@ -413,7 +413,7 @@ const PublishModalBody: FC<BodyProps> = ({
                                                     {index + 1}
                                                 </span>
                                                 <Box flex={1}>
-                                                    <Text fz={13} fw={500}>
+                                                    <Text fz="sm" fw={500}>
                                                         {assignment.groupName}
                                                     </Text>
                                                     <Text fz={11.5} c="dimmed">
@@ -502,7 +502,7 @@ const PublishModalBody: FC<BodyProps> = ({
                                         <Text fz={13.5} fw={500}>
                                             {ProjectMemberRoleLabels[role]}
                                         </Text>
-                                        <Text fz={12} c="dimmed">
+                                        <Text fz="xs" c="dimmed">
                                             {ROLE_DESCRIPTIONS[role]}
                                         </Text>
                                     </Box>
@@ -510,7 +510,7 @@ const PublishModalBody: FC<BodyProps> = ({
                                 </label>
                             ))}
                         </div>
-                        <Text fz={12} c="dimmed" lh={1.45}>
+                        <Text fz="xs" c="dimmed" lh={1.45}>
                             A group assignment always wins over a role.
                         </Text>
                     </>

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/FavoritesBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/FavoritesBlock.tsx
@@ -82,7 +82,7 @@ const FavoritePills: FC<{
                     <TruncatedText
                         maxWidth={160}
                         inline
-                        fz={13}
+                        fz="sm"
                         fw={500}
                         c="inherit"
                     >

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -284,7 +284,7 @@ const SetupSection: FC<{
                         <Box className={classes.setupOrb}>
                             <IconTarget size={16} />
                         </Box>
-                        <Title order={4} fw={700}>
+                        <Title order={4} fw={600}>
                             Autopilot
                         </Title>
                         <Box className={classes.activeBadge}>
@@ -421,7 +421,7 @@ const formatAbsoluteTimestamp = (dateStr: string) =>
 // --- Detail Sidebar ---
 
 const MetadataLabel: FC<{ label: string }> = ({ label }) => (
-    <Text fz={10} fw={600} c="dimmed" tt="uppercase" lts={0.5}>
+    <Text fz="xs" fw={600} c="dimmed" tt="uppercase" lts={0.5}>
         {label}
     </Text>
 );
@@ -437,7 +437,7 @@ const MetadataFieldList: FC<{ label: string; fields: string[] }> = ({
                 {fields.map((f) => (
                     <Text
                         key={f}
-                        fz={11}
+                        fz="xs"
                         ff="monospace"
                         className={classes.fieldPill}
                     >
@@ -473,7 +473,7 @@ const ChartDetails: FC<{ metadata: Record<string, unknown> }> = ({
             <Group gap="lg">
                 {chartType && (
                     <Stack gap={2}>
-                        <Text fz={10} c="dimmed">
+                        <Text fz="xs" c="dimmed">
                             Type
                         </Text>
                         <Text fz="xs" fw={500}>
@@ -483,7 +483,7 @@ const ChartDetails: FC<{ metadata: Record<string, unknown> }> = ({
                 )}
                 {exploreName && (
                     <Stack gap={2}>
-                        <Text fz={10} c="dimmed">
+                        <Text fz="xs" c="dimmed">
                             Explore
                         </Text>
                         <Text fz="xs" fw={500}>
@@ -587,7 +587,7 @@ const FieldDiffRow: FC<{ diff: FieldDiff }> = ({ diff }) => {
                 {diff.removed.map((f) => (
                     <Text
                         key={`removed-${f}`}
-                        fz={11}
+                        fz="xs"
                         ff="monospace"
                         className={classes.fieldPillRemoved}
                     >
@@ -597,7 +597,7 @@ const FieldDiffRow: FC<{ diff: FieldDiff }> = ({ diff }) => {
                 {diff.added.map((f) => (
                     <Text
                         key={`added-${f}`}
-                        fz={11}
+                        fz="xs"
                         ff="monospace"
                         className={classes.fieldPillAdded}
                     >
@@ -1561,7 +1561,7 @@ const SettingsSidebar: FC<{
                                             <Text fz="xs" fw={500}>
                                                 {capability.label}
                                             </Text>
-                                            <Text fz={11} c="dimmed">
+                                            <Text fz="xs" c="dimmed">
                                                 {capability.description}
                                             </Text>
                                         </Stack>
@@ -1673,7 +1673,7 @@ const SettingsSidebar: FC<{
                                             </Button>
                                         </Group>
                                     )}
-                                    <Text fz={11} c="dimmed">
+                                    <Text fz="xs" c="dimmed">
                                         {spaceScopeSummary}{' '}
                                         {policy.spaceScopeMode === 'only'
                                             ? 'New spaces are not monitored until added here. Selections include child spaces.'
@@ -1841,7 +1841,7 @@ const SettingsSidebar: FC<{
                                     <Text fz="xs" fw={500}>
                                         Protect verified content
                                     </Text>
-                                    <Text fz={11} c="dimmed">
+                                    <Text fz="xs" c="dimmed">
                                         Autopilot can report on verified charts
                                         and dashboards but never changes or
                                         deletes them.
@@ -2007,7 +2007,7 @@ const RunHeaderRow: FC<{
                             </Box>
                         </Tooltip>
                     )}
-                    <Text fz={11} fw={700} tt="uppercase" c="bright" lts={0.4}>
+                    <Text fz="xs" fw={600} tt="uppercase" c="bright" lts={0.4}>
                         Run
                     </Text>
                     {variant !== 'live' && (
@@ -2040,7 +2040,7 @@ const RunHeaderRow: FC<{
                 </Group>
                 <Group gap={6} wrap="nowrap">
                     {variant === 'completed-empty' ? (
-                        <Text fz={11} c="dimmed">
+                        <Text fz="xs" c="dimmed">
                             No actions
                         </Text>
                     ) : run.actionCount > 0 ? (
@@ -2074,7 +2074,7 @@ const RunHeaderRow: FC<{
                                     );
                                 },
                             )}
-                            <Text fz={11} c="dimmed">
+                            <Text fz="xs" c="dimmed">
                                 {run.actionCount}{' '}
                                 {run.actionCount === 1 ? 'action' : 'actions'}
                             </Text>
@@ -2219,7 +2219,7 @@ const QuietRunsGroup: FC<{
                                 />
                                 <Group gap={4} wrap="nowrap">
                                     <Text
-                                        fz={10}
+                                        fz="xs"
                                         fw={600}
                                         tt="uppercase"
                                         c="dimmed"
@@ -2227,7 +2227,7 @@ const QuietRunsGroup: FC<{
                                     >
                                         Run
                                     </Text>
-                                    <Text fz={10} c="dimmed">
+                                    <Text fz="xs" c="dimmed">
                                         ·{' '}
                                         {formatTimestamp(
                                             run.startedAt.toString(),
@@ -2235,7 +2235,7 @@ const QuietRunsGroup: FC<{
                                     </Text>
                                 </Group>
                             </Group>
-                            <Text fz={10} c="dimmed">
+                            <Text fz="xs" c="dimmed">
                                 No actions
                             </Text>
                         </Group>
@@ -2605,8 +2605,8 @@ const FilteredActionsView: FC<{
                             <Table.Tr className={classes.dayHeaderRow}>
                                 <Table.Td colSpan={3}>
                                     <Text
-                                        fz={11}
-                                        fw={700}
+                                        fz="xs"
+                                        fw={600}
                                         tt="uppercase"
                                         c="dimmed"
                                         lts={0.4}

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentHomeCard.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentHomeCard.tsx
@@ -186,7 +186,7 @@ export const ManagedAgentHomeCard: FC<{ projectUuid: string }> = ({
                         </Box>
                         <Stack gap={4}>
                             <Group gap={8} align="center">
-                                <Text fz="lg" fw={700}>
+                                <Text fz="lg" fw={600}>
                                     Autopilot
                                 </Text>
                                 <BetaBadge />
@@ -238,7 +238,7 @@ export const ManagedAgentHomeCard: FC<{ projectUuid: string }> = ({
                         </Box>
                         <Stack gap={4}>
                             <Group gap={8} align="center">
-                                <Text fz="lg" fw={700}>
+                                <Text fz="lg" fw={600}>
                                     Autopilot
                                 </Text>
                                 <BetaBadge />

--- a/packages/frontend/src/ee/features/managedAgent/SuggestionsSpaceAccess.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/SuggestionsSpaceAccess.tsx
@@ -118,7 +118,7 @@ export const SuggestionsSpaceAccess: FC<{
                             </Badge>
                         )}
                     </Group>
-                    <Text fz={11} c="dimmed">
+                    <Text fz="xs" c="dimmed">
                         {description}
                     </Text>
                 </Stack>

--- a/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsTable.tsx
+++ b/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsTable.tsx
@@ -409,7 +409,7 @@ export const ServiceAccountsTable: FC<Props> = ({
                                     </HoverCard.Target>
                                     <HoverCard.Dropdown>
                                         <Stack>
-                                            <Text fw={700}>Permissions</Text>
+                                            <Text fw={600}>Permissions</Text>
                                             {scopes.map((scope) => (
                                                 <Badge
                                                     key={scope}

--- a/packages/frontend/src/ee/pages/Roadmap.tsx
+++ b/packages/frontend/src/ee/pages/Roadmap.tsx
@@ -328,7 +328,7 @@ const RoadmapColumn: FC<{
                     bg={`${color}.5`}
                     className={styles.statusDot}
                 />
-                <Text fz="sm" fw={650}>
+                <Text fz="sm" fw={600}>
                     {label}
                 </Text>
                 <Badge color="gray" variant="light" size="sm">
@@ -375,7 +375,7 @@ const RoadmapColumn: FC<{
                                         gap="sm"
                                         wrap="nowrap"
                                     >
-                                        <Text fw={550} fz="sm" lineClamp={3}>
+                                        <Text fw={500} fz="sm" lineClamp={3}>
                                             {item.title}
                                         </Text>
                                         <Text

--- a/packages/frontend/src/features/apps/ExternalRequestInspector.tsx
+++ b/packages/frontend/src/features/apps/ExternalRequestInspector.tsx
@@ -124,7 +124,7 @@ const ExternalRequestRow: FC<{ request: ExternalRequestEvent }> = ({
                                 <Text size="xs" fw={600} c="dimmed">
                                     Request body
                                 </Text>
-                                <Code block fz={10}>
+                                <Code block fz="xs">
                                     {toJson(request.requestBody)}
                                 </Code>
                             </Box>
@@ -225,7 +225,7 @@ const ExternalRequestRow: FC<{ request: ExternalRequestEvent }> = ({
                             </Group>
                             <Collapse in={jsonExpanded}>
                                 <ScrollArea.Autosize mah={200}>
-                                    <Code block fz={10}>
+                                    <Code block fz="xs">
                                         {toJson(request.responseBody)}
                                     </Code>
                                 </ScrollArea.Autosize>

--- a/packages/frontend/src/features/apps/QueryInspector.tsx
+++ b/packages/frontend/src/features/apps/QueryInspector.tsx
@@ -314,7 +314,7 @@ const QueryRow: FC<{
                             </Group>
                             <Collapse in={jsonExpanded}>
                                 <ScrollArea.Autosize mah={200}>
-                                    <Code block fz={10}>
+                                    <Code block fz="xs">
                                         {JSON.stringify(
                                             query.rawMetricQuery,
                                             null,

--- a/packages/frontend/src/features/apps/components/AppInfoOverlay.tsx
+++ b/packages/frontend/src/features/apps/components/AppInfoOverlay.tsx
@@ -87,7 +87,7 @@ const AppInfoOverlay: FC<Props> = ({
                     <Anchor
                         component={Link}
                         to={`/projects/${projectUuid}/spaces/${spaceUuid}`}
-                        fz={12}
+                        fz="xs"
                         fw={500}
                     >
                         {spaceName ?? 'Space'}
@@ -109,7 +109,7 @@ const AppInfoOverlay: FC<Props> = ({
                                 <UnstyledButton onClick={copy}>
                                     <Group gap={6} wrap="nowrap">
                                         <Text
-                                            fz={11}
+                                            fz="xs"
                                             fw={500}
                                             c="ldGray.9"
                                             ff="monospace"

--- a/packages/frontend/src/features/chartTypes/builder/BuilderPromptBar.tsx
+++ b/packages/frontend/src/features/chartTypes/builder/BuilderPromptBar.tsx
@@ -687,7 +687,7 @@ const BuilderPromptBar = forwardRef<BuilderPromptBarHandle, Props>(
             <Box className={classes.wrap}>
                 {props.build.error !== null && (
                     <Box className={classes.failedPill}>
-                        <Text fz={13} c="red.7" lineClamp={1}>
+                        <Text fz="sm" c="red.7" lineClamp={1}>
                             {props.build.error}
                         </Text>
                         {props.build.retry && (

--- a/packages/frontend/src/features/chartTypes/builder/BuilderPromptExamples.tsx
+++ b/packages/frontend/src/features/chartTypes/builder/BuilderPromptExamples.tsx
@@ -122,7 +122,7 @@ const BuilderPromptExamples: FC<Props> = ({ projectUuid, onPick }) => {
                     onClick={() => onPick(prompt)}
                 >
                     <Thumbnail colors={colors} />
-                    <Text fz={13} fw={500} c="ldGray.8" lh={1.35}>
+                    <Text fz="sm" fw={500} c="ldGray.8" lh={1.35}>
                         {prompt}
                     </Text>
                 </UnstyledButton>

--- a/packages/frontend/src/features/chartTypes/builder/VersionHistoryPanel.tsx
+++ b/packages/frontend/src/features/chartTypes/builder/VersionHistoryPanel.tsx
@@ -55,14 +55,14 @@ type Props = {
 const RelativeTime: FC<{ at: Date }> = ({ at }) => {
     const timeAgo = useTimeAgo(at);
     return (
-        <Text fz={11} c="dimmed">
+        <Text fz="xs" c="dimmed">
             {timeAgo}
         </Text>
     );
 };
 
 const AbsoluteTime: FC<{ at: Date }> = ({ at }) => (
-    <Text fz={11} c="dimmed">
+    <Text fz="xs" c="dimmed">
         {format(at, 'MMM d, HH:mm')}
     </Text>
 );
@@ -77,7 +77,7 @@ const AuthorLine: FC<{ version: ApiAppVersionSummary }> = ({ version }) => {
                 name={name}
                 userUuid={version.createdByUser?.userUuid}
             />
-            <Text fz={11} c="dimmed" truncate="end">
+            <Text fz="xs" c="dimmed" truncate="end">
                 {name}
             </Text>
         </>
@@ -106,7 +106,7 @@ const VersionBuildDetails: FC<{ version: ApiAppVersionSummary }> = ({
                     className={classes.buildDetailsChevron}
                     data-open={open || undefined}
                 />
-                <Text fz={11} fw={600}>
+                <Text fz="xs" fw={600}>
                     Build details
                 </Text>
             </UnstyledButton>
@@ -142,10 +142,10 @@ const VersionChanges: FC<{
                     className={classes.buildDetailsChevron}
                     data-open={open || undefined}
                 />
-                <Text fz={11} fw={600} flex="0 0 auto">
+                <Text fz="xs" fw={600} flex="0 0 auto">
                     What changed
                 </Text>
-                <Text fz={11} c="dimmed" truncate="end" ml={2} miw={0}>
+                <Text fz="xs" c="dimmed" truncate="end" ml={2} miw={0}>
                     {summary}
                 </Text>
             </UnstyledButton>
@@ -286,14 +286,14 @@ const VersionHistoryPanel: FC<Props> = ({
                             )}
                         </Box>
                     </Box>
-                    <Text fz={13} lh={1.45} c="ldGray.8">
+                    <Text fz="sm" lh={1.45} c="ldGray.8">
                         {version.prompt || 'Uploaded from source'}
                     </Text>
                 </UnstyledButton>
 
                 {isFailed && (
                     <Box className={classes.failure}>
-                        <Text fz={11} lh={1.4} c="red.7">
+                        <Text fz="xs" lh={1.4} c="red.7">
                             {getAppVersionFailureMessage(version)}
                         </Text>
                     </Box>
@@ -310,7 +310,7 @@ const VersionHistoryPanel: FC<Props> = ({
 
                 {isReady && isUpgrade && version.statusMessage && (
                     <Box className={classes.upgradeSummary}>
-                        <Text fz={11} fw={600} c="blue.8" mb={4}>
+                        <Text fz="xs" fw={600} c="blue.8" mb={4}>
                             Upgrade summary
                         </Text>
                         <AiMarkdown className={classes.upgradeSummaryMarkdown}>
@@ -380,7 +380,7 @@ const VersionHistoryPanel: FC<Props> = ({
                             )}
                         </Box>
                         {build.pendingPrompt && (
-                            <Text fz={13} lh={1.45} c="ldGray.8">
+                            <Text fz="sm" lh={1.45} c="ldGray.8">
                                 {build.pendingPrompt}
                             </Text>
                         )}

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeDetailModal.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeDetailModal.tsx
@@ -101,7 +101,7 @@ const ChartTypeDetailModal: FC<Props> = ({
                 <SimpleGrid cols={2} className={classes.metaPanel}>
                     {builtBy !== null && (
                         <Box>
-                            <Text fz={12} fw={600} c="ldGray.6">
+                            <Text fz="xs" fw={600} c="ldGray.6">
                                 Built by
                             </Text>
                             <Text fz="sm" fw={500} c="ldGray.8">
@@ -110,7 +110,7 @@ const ChartTypeDetailModal: FC<Props> = ({
                         </Box>
                     )}
                     <Box>
-                        <Text fz={12} fw={600} c="ldGray.6">
+                        <Text fz="xs" fw={600} c="ldGray.6">
                             Last updated
                         </Text>
                         <Text fz="sm" fw={500} c="ldGray.8">
@@ -118,7 +118,7 @@ const ChartTypeDetailModal: FC<Props> = ({
                         </Text>
                     </Box>
                     <Box>
-                        <Text fz={12} fw={600} c="ldGray.6">
+                        <Text fz="xs" fw={600} c="ldGray.6">
                             Inputs
                         </Text>
                         <Text fz="sm" fw={500} c="ldGray.8">
@@ -130,7 +130,7 @@ const ChartTypeDetailModal: FC<Props> = ({
                         </Text>
                     </Box>
                     <Box>
-                        <Text fz={12} fw={600} c="ldGray.6">
+                        <Text fz="xs" fw={600} c="ldGray.6">
                             Version
                         </Text>
                         <Text fz="sm" fw={500} c="ldGray.8">

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeGalleryCard.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeGalleryCard.tsx
@@ -45,7 +45,7 @@ const ChartTypeGalleryCard: FC<Props> = ({ dataAppViz, onClick, onDelete }) => {
                 />
             </Box>
             <Stack gap="xs" p="sm">
-                <Text fz={13} fw={600} truncate="end">
+                <Text fz="sm" fw={600} truncate="end">
                     {displayName}
                 </Text>
                 <Text fz="xs" c="dimmed" lh={1.35} lineClamp={2}>

--- a/packages/frontend/src/features/dashboardTabs/index.tsx
+++ b/packages/frontend/src/features/dashboardTabs/index.tsx
@@ -1026,7 +1026,7 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
                                                             <Button
                                                                 ml="sm"
                                                                 size="sm"
-                                                                fz={13}
+                                                                fz="sm"
                                                                 variant="subtle"
                                                                 flex="0 0 auto"
                                                                 disabled={

--- a/packages/frontend/src/features/dateZoom/components/DateZoomInfoOnTile.tsx
+++ b/packages/frontend/src/features/dateZoom/components/DateZoomInfoOnTile.tsx
@@ -46,7 +46,7 @@ export const DateZoomInfoOnTile: FC<DateZoomInfoOnTileProps> = ({
             <Paper radius="sm" py="xxs" px="xs" shadow="0">
                 <Group wrap="nowrap" gap="xxs">
                     <MantineIcon icon={IconCalendar} size="sm" />
-                    <Text fz={11}>{label}</Text>
+                    <Text fz="xs">{label}</Text>
                 </Group>
             </Paper>
         </Tooltip>

--- a/packages/frontend/src/features/metricsCatalog/components/Canvas/SavedTreeCanvasFlow.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/Canvas/SavedTreeCanvasFlow.tsx
@@ -144,7 +144,7 @@ const SavedTreeCanvasFlow: FC<Props> = ({
                                 style={{ margin: '14px 27px' }}
                             >
                                 <Group gap="xs">
-                                    <Text fz={14} fw={500} c="ldGray.6">
+                                    <Text fz="sm" fw={500} c="ldGray.6">
                                         Canvas mode:
                                     </Text>
                                     <CanvasTimeFramePicker

--- a/packages/frontend/src/features/metricsCatalog/components/Canvas/TreeComponents/nodes/ExpandedNode.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/Canvas/TreeComponents/nodes/ExpandedNode.tsx
@@ -71,7 +71,7 @@ const ChangeIndicator: FC<{
             withinPortal
         >
             <Badge
-                fz={13}
+                fz="sm"
                 fw={500}
                 size="lg"
                 radius="md"
@@ -208,7 +208,7 @@ const ExpandedNode: React.FC<NodeProps<ExpandedNodeData>> = ({
     return (
         <Paper
             p="md"
-            fz={14}
+            fz="sm"
             withBorder
             style={(theme) => ({
                 borderColor: selected
@@ -226,7 +226,7 @@ const ExpandedNode: React.FC<NodeProps<ExpandedNodeData>> = ({
             />
             <Stack key={data.label} gap="xs">
                 <Group justify="space-between">
-                    <Title fz={14} fw={500} c="ldGray.7">
+                    <Title fz="sm" fw={500} c="ldGray.7">
                         {title}
                     </Title>
                     <Group gap="xs" wrap="nowrap">

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
@@ -107,7 +107,7 @@ const LearnMorePopover: FC<{ buttonStyles?: ButtonProps['style'] }> = ({
             >
                 <Stack gap="sm" w="100%" ref={ref}>
                     <Group justify="space-between">
-                        <Text fw={600} fz={14}>
+                        <Text fw={600} fz="sm">
                             ✨ Lightdash Spotlight is here!
                         </Text>
                         <ActionIcon
@@ -120,7 +120,7 @@ const LearnMorePopover: FC<{ buttonStyles?: ButtonProps['style'] }> = ({
                         </ActionIcon>
                     </Group>
                     <LearnMoreContent width="100%" height="100%" />
-                    <Text fz={13} c="ldGray.3">
+                    <Text fz="sm" c="ldGray.3">
                         Explore and curate your key Metrics in the{' '}
                         <Text span fw={600} inherit>
                             Catalog

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
@@ -130,7 +130,7 @@ const SortableColumn: FC<{
                         </ActionIcon>
                     </Box>
                 </Tooltip>
-                <Text fz={13} fw={500} c="ldDark.9">
+                <Text fz="sm" fw={500} c="ldDark.9">
                     {column.name}
                 </Text>
             </Group>

--- a/packages/frontend/src/features/metricsCatalog/components/SavedTrees/TreeListSidebar.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/SavedTrees/TreeListSidebar.tsx
@@ -151,7 +151,7 @@ const TreeListSidebar: FC = () => {
                                             </Group>
                                             {tree.description && (
                                                 <Text
-                                                    fz={10}
+                                                    fz="xs"
                                                     c="dimmed"
                                                     truncate
                                                     mt={2}

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/CanvasTimeFramePicker.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/CanvasTimeFramePicker.tsx
@@ -105,7 +105,7 @@ export const CanvasTimeFramePicker: FC<Props> = ({
                     {dateRanges.currentRange}
                 </Text>
             </Group>
-            <Text c="ldGray.6" fz={14} fw={500}>
+            <Text c="ldGray.6" fz="sm" fw={500}>
                 compared to
             </Text>
             <Text

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreComparison.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreComparison.tsx
@@ -244,7 +244,7 @@ export const MetricExploreComparison: FC<Props> = ({
                                                 }}
                                             />
                                         ) : (
-                                            <Text span c="ldGray.7" fz={13}>
+                                            <Text span c="ldGray.7" fz="sm">
                                                 Only metrics with a time
                                                 dimension defined in the .yml
                                                 can be compared.{' '}

--- a/packages/frontend/src/features/parameters/components/ParameterInput.tsx
+++ b/packages/frontend/src/features/parameters/components/ParameterInput.tsx
@@ -367,7 +367,7 @@ export const ParameterInput: FC<ParameterInputProps> = ({
                 }Options loaded at ${refreshedAt.toLocaleTimeString()} - ↻ Click to refresh`;
 
                 return (
-                    <Box fz={11} className={styles.refreshItem}>
+                    <Box fz="xs" className={styles.refreshItem}>
                         {refreshLabel}
                     </Box>
                 );

--- a/packages/frontend/src/features/pullRequests/components/PullRequestsPage.tsx
+++ b/packages/frontend/src/features/pullRequests/components/PullRequestsPage.tsx
@@ -211,7 +211,7 @@ const PullRequestsPage: FC<Props> = ({ projectUuid }) => {
                                         {pr.author ? (
                                             <>
                                                 {' by '}
-                                                <Text span fw={700} fz="xs">
+                                                <Text span fw={600} fz="xs">
                                                     {pr.author.name}
                                                 </Text>
                                             </>

--- a/packages/frontend/src/features/recentlyDeleted/components/RecentlyDeletedPage.tsx
+++ b/packages/frontend/src/features/recentlyDeleted/components/RecentlyDeletedPage.tsx
@@ -299,7 +299,7 @@ const RecentlyDeletedPage: FC<Props> = ({ projectUuid }) => {
                                     {row.original.name}
                                 </Text>
                                 {description && (
-                                    <Text fz={12} c="dimmed" lineClamp={1}>
+                                    <Text fz="xs" c="dimmed" lineClamp={1}>
                                         {description}
                                     </Text>
                                 )}

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/SchedulerFormFiltersTab.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/SchedulerFormFiltersTab.tsx
@@ -67,7 +67,7 @@ const FilterSummaryLabel: FC<
             <Text span color="ldGray.7">
                 {filterSummary?.operator}{' '}
             </Text>
-            <Text fw={700} span>
+            <Text fw={600} span>
                 {filterSummary?.value}
             </Text>
         </Text>

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerList.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerList.tsx
@@ -638,7 +638,7 @@ export const SchedulerList: FC<Props> = ({
                         size={32}
                         color="ldGray.5"
                     />
-                    <Text fw={700} fz="lg">
+                    <Text fw={600} fz="lg">
                         {isThresholdAlert
                             ? 'Get notified when your data crosses a threshold'
                             : 'Deliver this on a schedule'}

--- a/packages/frontend/src/features/sync/components/GoogleSheetsInfoPopover.tsx
+++ b/packages/frontend/src/features/sync/components/GoogleSheetsInfoPopover.tsx
@@ -8,7 +8,7 @@ export const GoogleSheetsInfoPopover = () => {
             <HoverCard.Target>
                 <Button
                     size="xs"
-                    fz={9}
+                    fz="xs"
                     variant="subtle"
                     color="ldGray.3"
                     leftSection={

--- a/packages/frontend/src/features/sync/components/SyncModalView.tsx
+++ b/packages/frontend/src/features/sync/components/SyncModalView.tsx
@@ -290,7 +290,7 @@ export const SyncModalView: FC<Props> = ({
                 </Box>
             ) : (
                 <Group justify="center" ta="center" gap="xs" my="sm" pt="md">
-                    <Text fz="sm" fw={450} c="ldGray.7">
+                    <Text fz="sm" fw={500} c="ldGray.7">
                         This {resourceLabel} has no Syncs set up yet
                     </Text>
                     <Text fz="xs" fw={400} c="ldGray.6">

--- a/packages/frontend/src/features/virtualView/components/HeaderVirtualView.tsx
+++ b/packages/frontend/src/features/virtualView/components/HeaderVirtualView.tsx
@@ -104,7 +104,7 @@ const ChartErrorListItem: FC<{
                 label={
                     <Stack gap={2}>
                         {errorMessages.map((message, index) => (
-                            <Text fz={11} key={index}>
+                            <Text fz="xs" key={index}>
                                 {message}
                             </Text>
                         ))}

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -1774,7 +1774,7 @@ const AppGenerate: FC = () => {
                             <Stack gap="lg" className={classes.composeHeading}>
                                 <Stack gap={6}>
                                     <Text
-                                        fw={700}
+                                        fw={600}
                                         fz={28}
                                         className={classes.composeTitle}
                                     >

--- a/packages/frontend/src/pages/DashboardVersionComparison.tsx
+++ b/packages/frontend/src/pages/DashboardVersionComparison.tsx
@@ -287,7 +287,7 @@ const TilesTable = ({ data }: { data: any[] }) => {
                 header: 'Tile Type',
                 size: 150,
                 Footer: () => (
-                    <Text size="xs" fw={700}>
+                    <Text size="xs" fw={600}>
                         Total
                     </Text>
                 ),
@@ -303,7 +303,7 @@ const TilesTable = ({ data }: { data: any[] }) => {
                 ),
                 Footer: () =>
                     totals ? (
-                        <Text size="xs" ta="right" fw={700}>
+                        <Text size="xs" ta="right" fw={600}>
                             {totals.current}
                         </Text>
                     ) : null,
@@ -319,7 +319,7 @@ const TilesTable = ({ data }: { data: any[] }) => {
                 ),
                 Footer: () =>
                     totals ? (
-                        <Text size="xs" ta="right" fw={700}>
+                        <Text size="xs" ta="right" fw={600}>
                             {totals.selected}
                         </Text>
                     ) : null,

--- a/packages/frontend/src/pages/OnboardingDataSource.tsx
+++ b/packages/frontend/src/pages/OnboardingDataSource.tsx
@@ -144,7 +144,7 @@ const DataSourcePicker: FC = () => {
     return (
         <Box className={classes.column}>
             <Stack align="center" gap="xs">
-                <Title order={1} ta="center" fw={700}>
+                <Title order={1} ta="center" fw={600}>
                     Add a data source
                 </Title>
                 <Text size="md" c="dimmed" ta="center">

--- a/packages/frontend/src/pages/OnboardingDbt.tsx
+++ b/packages/frontend/src/pages/OnboardingDbt.tsx
@@ -90,7 +90,7 @@ const DbtMethodPicker: FC = () => {
     return (
         <Box className={classes.column}>
             <Stack align="center" gap="xs">
-                <Title order={1} ta="center" fw={700}>
+                <Title order={1} ta="center" fw={600}>
                     Let's get you set up!
                 </Title>
                 <Text size="md" c="dimmed" ta="center">
@@ -283,7 +283,7 @@ const DbtCliWaiting: FC = () => {
         <Box className={classes.column}>
             <Stack align="center" gap="xs">
                 <Loader size="sm" />
-                <Title order={1} ta="center" fw={700}>
+                <Title order={1} ta="center" fw={600}>
                     Waiting for data
                 </Title>
                 <Text size="md" c="dimmed" ta="center">

--- a/packages/frontend/src/pages/OnboardingInviteExpert.tsx
+++ b/packages/frontend/src/pages/OnboardingInviteExpert.tsx
@@ -364,7 +364,7 @@ const OnboardingInviteExpert: FC = () => {
                         <Title
                             order={1}
                             ta="center"
-                            fw={700}
+                            fw={600}
                             ref={titleRef}
                             tabIndex={-1}
                             className={classes.title}
@@ -402,7 +402,7 @@ const OnboardingInviteExpert: FC = () => {
                     <Title
                         order={1}
                         ta="center"
-                        fw={700}
+                        fw={600}
                         ref={titleRef}
                         tabIndex={-1}
                         className={classes.title}

--- a/packages/frontend/src/pages/OrganizationSetup.tsx
+++ b/packages/frontend/src/pages/OrganizationSetup.tsx
@@ -375,8 +375,8 @@ const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
                                                     />
                                                 ) : (
                                                     <Text
-                                                        fw={700}
-                                                        fz={20}
+                                                        fw={600}
+                                                        fz="xl"
                                                         c="white"
                                                     >
                                                         {logoTileInitial}

--- a/packages/frontend/src/stories/DeepResearchReportContent.stories.tsx
+++ b/packages/frontend/src/stories/DeepResearchReportContent.stories.tsx
@@ -39,7 +39,7 @@ const SimulatedChart = () => {
 
     return (
         <Stack h="100%" gap="lg">
-            <Text fw={650}>Renewal rate by incident exposure</Text>
+            <Text fw={600}>Renewal rate by incident exposure</Text>
             <Box
                 role="img"
                 aria-label="Simulated renewal rate chart"

--- a/packages/frontend/src/utils/roleAccessWarnings.tsx
+++ b/packages/frontend/src/utils/roleAccessWarnings.tsx
@@ -57,13 +57,13 @@ const getLegacyCustomGroupWarning = (
     customGroup: UserGroupAccess,
 ): ReactNode => (
     <>
-        <Text fw={300}>
+        <Text fw={400}>
             This user belongs to a group{' '}
             <Text fw={600} span>
                 {customGroup.group.name}
             </Text>{' '}
         </Text>
-        <Text fw={300}>
+        <Text fw={400}>
             which has a custom role
             <Text fw={600} span>
                 {' '}
@@ -71,7 +71,7 @@ const getLegacyCustomGroupWarning = (
             </Text>{' '}
             assigned.{' '}
         </Text>
-        <Text fw={300}>
+        <Text fw={400}>
             Make sure the organization or project role doesn't override the
             group role permissions.
         </Text>
@@ -129,7 +129,7 @@ export const getAccessWarning = ({
                         systemRolesOrder.indexOf(typedProjectRole)
                 ) {
                     return (
-                        <Text fw={300} fz="sm">
+                        <Text fw={400} fz="sm">
                             User inherits role{' '}
                             <Text fw={600} span fz="sm">
                                 {bestGroup.roleName}
@@ -150,7 +150,7 @@ export const getAccessWarning = ({
                 systemRolesOrder.indexOf(typedProjectRole)
             ) {
                 return (
-                    <Text fw={300} fz="sm">
+                    <Text fw={400} fz="sm">
                         User inherits higher role{' '}
                         <Text fw={600} span fz="sm">
                             {organizationRole}
@@ -169,14 +169,14 @@ export const getAccessWarning = ({
                 // Scope data unavailable — keep the conservative warning
                 return (
                     <>
-                        <Text fw={300}>
+                        <Text fw={400}>
                             This user has a custom role and an organization role{' '}
                             <Text fw={600} span>
                                 {organizationRoleName ?? organizationRole}
                             </Text>{' '}
                             assigned.{' '}
                         </Text>
-                        <Text fw={300}>
+                        <Text fw={400}>
                             Make sure the organization or group role doesn't
                             override the project role permissions.
                         </Text>
@@ -233,7 +233,7 @@ export const getAccessWarning = ({
 
             return (
                 <>
-                    <Text fw={300}>
+                    <Text fw={400}>
                         This user has a custom role, but{' '}
                         {joinWithAnd(conflicts.map((c) => c.label))} grant
                         {conflicts.length === 1 ? 's' : ''} them permissions the
@@ -243,7 +243,7 @@ export const getAccessWarning = ({
                         </Text>
                         ).
                     </Text>
-                    <Text fw={300}>
+                    <Text fw={400}>
                         Organization and group permissions are additive and
                         cannot be restricted by the project role.
                     </Text>
@@ -287,7 +287,7 @@ export const getAccessWarning = ({
             if (uncoveredScopes.length > 0) {
                 return (
                     <>
-                        <Text fw={300}>
+                        <Text fw={400}>
                             This user belongs to group{' '}
                             <Text fw={600} span>
                                 {customGroup.group.name}
@@ -303,7 +303,7 @@ export const getAccessWarning = ({
                             </Text>
                             ).
                         </Text>
-                        <Text fw={300}>
+                        <Text fw={400}>
                             Organization and project permissions are additive
                             and cannot be restricted by the group role.
                         </Text>


### PR DESCRIPTION
## Summary

Mechanical sweep so text across the app sits on the theme's scale. Fourth PR of the theme stack; review with whitespace changes hidden.

## What changed

- `fw={700}`, `fw={800}` and `fw={650}` become `fw={600}`; `fw={550}` and `fw={450}` become `fw={500}`; `fw={300}` becomes `fw={400}`. Weights now collapse to 400/500/600, which are also the only weights loaded from Google Fonts.
- Numeric `fz={9|10|11|12}` become `fz="xs"`, `fz={13|14}` become `fz="sm"`, `16/18/20` map to `md/lg/xl`.

## Regression analysis

- Purely a prop-value rewrite (no structure changes); 100 files, one line changed per site.
- Sites with 9–11px text are now 12px, which is the smallest size the scale allows; nothing else moves.
- Typecheck, oxlint, oxfmt and the unit suite are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Hr8bA9fzAkqy4yULJ6Qd9
