### PR TITLE
style(chart-config): align the configure panel with the theme

### DIFF
--- a/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
@@ -1,6 +1,6 @@
 import { ChartType, FeatureFlags } from '@lightdash/common';
 import { Button, Menu } from '@mantine/core';
-import { IconChevronDown, IconCode } from '@tabler/icons-react';
+import { IconCheck, IconChevronDown, IconCode } from '@tabler/icons-react';
 import { memo, type FC } from 'react';
 import { useCanCreateDataApp } from '../../../features/apps/hooks/useCanCreateDataApp';
 import { useProjectUuid } from '../../../hooks/useProjectUuid';
@@ -79,7 +79,11 @@ const VisualizationCardOptions: FC = memo(() => {
                     <Menu.Item
                         key={option.id}
                         disabled={disabled}
-                        color={option.selected ? 'blue' : undefined}
+                        rightSection={
+                            option.selected ? (
+                                <MantineIcon icon={IconCheck} />
+                            ) : undefined
+                        }
                         leftSection={
                             <MantineIcon
                                 icon={option.icon}
@@ -98,7 +102,11 @@ const VisualizationCardOptions: FC = memo(() => {
 
                 <Menu.Item
                     disabled={disabled}
-                    color={isCustomChart ? 'blue' : undefined}
+                    rightSection={
+                        isCustomChart ? (
+                            <MantineIcon icon={IconCheck} />
+                        ) : undefined
+                    }
                     leftSection={<MantineIcon icon={IconCode} />}
                     onClick={handleSelectCustom}
                 >

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
@@ -287,6 +287,7 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
                         <Group gap="xs">
                             <Config.Label>Sort</Config.Label>
                             <Select
+                                size="xs"
                                 allowDeselect={false}
                                 value={getXAxisSort(
                                     dirtyEchartsConfig?.xAxis?.[0],

--- a/packages/frontend/src/components/VisualizationConfigs/common/LabelEditor.module.css
+++ b/packages/frontend/src/components/VisualizationConfigs/common/LabelEditor.module.css
@@ -1,13 +1,7 @@
 .editorWrapper {
     overflow: hidden;
     padding-top: 8px;
-
-    @mixin light {
-        border-color: var(--mantine-color-ldGray-2);
-    }
-    @mixin dark {
-        border-color: var(--mantine-color-ldDark-4);
-    }
+    border-color: var(--mantine-color-default-border);
 }
 
 .editorWrapperReadOnly {

--- a/packages/frontend/src/components/VisualizationConfigs/common/LabelEditor.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/common/LabelEditor.tsx
@@ -37,6 +37,7 @@ const MONACO_DEFAULT_OPTIONS: EditorProps['options'] = {
     lineDecorationsWidth: 0,
     lineNumbersMinChars: 0,
     fixedOverflowWidgets: true,
+    renderLineHighlight: 'none',
 };
 
 // Each LabelEditor registers its completion provider against a private Monaco
@@ -216,7 +217,7 @@ export const LabelEditor: FC<LabelEditorProps> = ({
         <Input.Wrapper label={label} description={description}>
             <Paper
                 className={`${styles.editorWrapper} ${readOnly ? styles.editorWrapperReadOnly : ''}`}
-                radius="sm"
+                radius="md"
                 pos="relative"
             >
                 {localValue.length === 0 && placeholder ? (

--- a/packages/frontend/src/components/common/FieldSelect/index.tsx
+++ b/packages/frontend/src/components/common/FieldSelect/index.tsx
@@ -11,6 +11,8 @@ import {
     type Item,
 } from '@lightdash/common';
 import {
+    Box,
+    CheckIcon,
     Group,
     Select,
     Text,
@@ -227,7 +229,7 @@ const FieldSelectComponent = <T extends Item = Item>({
     }, [sortedItems, hasGrouping, tableLabelMap, inactiveItemIds]);
 
     const renderOption = useCallback(
-        ({ option }: { option: ComboboxItem }) => {
+        ({ option, checked }: { option: ComboboxItem; checked?: boolean }) => {
             const fieldOption = option as FieldSelectItem;
             const fieldItem = fieldOption.item;
             return (
@@ -253,6 +255,11 @@ const FieldSelectComponent = <T extends Item = Item>({
                         >
                             {fieldOption.label}
                         </Text>
+                        {checked && (
+                            <Box component="span" ml="auto" display="flex">
+                                <CheckIcon size={12} />
+                            </Box>
+                        )}
                     </Group>
                 </Tooltip>
             );


### PR DESCRIPTION
Sixth PR of the theme revamp stack. Polishes the chart configure panel so it reads as part of the new theme.

## What changed

- **Axis label editor** (`LabelEditor`): Monaco no longer paints its current-line highlight, so a one-line editor stops showing a darker band across the middle. The wrapper takes the input border colour and the input radius instead of the Paper defaults and its own light/dark border mixins.
- **Sort select** on the Axes tab uses the panel's compact size, matching the Rotation input beside it.
- **Chart type menu**: the selected type is marked with a check on the right instead of a blue tint.
- **Field selects**: the selected field shows a check at the end of its row (Mantine skips its own check icon when `renderOption` is used).

## Regression analysis

- `renderLineHighlight: 'none'` only affects the label editors, which never had multi-line cursor tracking; the SQL runner editor keeps its own options.
- `LabelEditor.module.css` still forces `overflow: hidden`, the top padding and the Monaco width rules; only the border-colour mixins were replaced by the theme token.
- `FieldSelect`'s `renderOption` signature gains the `checked` flag Mantine already passes; no data or callback changes.
- The chart type menu items keep their click handlers and disabled state; only `color` was replaced by `rightSection`.

## Verified

- Explorer configure panel in light mode: Layout (field select dropdown), Axes (label editors, Sort select), chart type menu.
- `pnpm -F frontend typecheck`, oxlint and oxfmt on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Hr8bA9fzAkqy4yULJ6Qd9
