### PR TITLE
style(frontend): primary actions use the theme ink instead of blue or dark

### DIFF
--- a/packages/frontend/src/components/NavBar/CreatePreviewProjectModal.tsx
+++ b/packages/frontend/src/components/NavBar/CreatePreviewProjectModal.tsx
@@ -428,7 +428,6 @@ const CreatePreviewModal: FC<Props> = ({
             title={modalTitle}
             actions={
                 <Button
-                    color="dark"
                     disabled={
                         isPreviewCreating ||
                         !selectedProjectUuid ||

--- a/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/PaletteModalBase.tsx
+++ b/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/PaletteModalBase.tsx
@@ -152,7 +152,6 @@ export const PaletteModalBase: FC<PaletteModalBaseProps> = ({
 
                 <Button
                     variant="subtle"
-                    color="blue"
                     size="compact-xs"
                     onClick={() => setShowAllColors(!showAllColors)}
                     rightSection={

--- a/packages/frontend/src/components/UserSettings/GithubSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/GithubSettingsPanel/index.tsx
@@ -180,7 +180,6 @@ const GithubSettingsPanel: FC = () => {
                                 size="xs"
                                 component="a"
                                 target="_blank"
-                                color="blue"
                                 href={GITHUB_INSTALL_URL}
                             >
                                 Install

--- a/packages/frontend/src/components/UserSettings/GithubUserSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/GithubUserSettingsPanel/index.tsx
@@ -69,7 +69,6 @@ const GithubUserSettingsPanel: FC = () => {
                             size="xs"
                             component="a"
                             target="_blank"
-                            color="blue"
                             href={`${GITHUB_USER_AUTHORIZE_URL}?redirect=/generalSettings/profile`}
                             leftSection={<MantineIcon icon={IconBrandGithub} />}
                         >

--- a/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
@@ -637,7 +637,6 @@ const SlackSettingsPanel: FC = () => {
                             size="xs"
                             component="a"
                             target="_blank"
-                            color="blue"
                             href={SLACK_INSTALL_URL}
                         >
                             Add to Slack

--- a/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
+++ b/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
@@ -828,7 +828,6 @@ const InfiniteResourceTable = ({
                             <Button
                                 ml="auto"
                                 size="xs"
-                                color="blue"
                                 leftSection={
                                     <MantineIcon icon={IconFolderSymlink} />
                                 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewRemediationWorkspace.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewRemediationWorkspace.tsx
@@ -432,7 +432,6 @@ export const ReviewRemediationWorkspace = () => {
                     )}
                     {reviewItem.status !== 'resolved' && (
                         <Button
-                            color="dark"
                             size="xs"
                             variant={isVerified ? 'filled' : 'default'}
                             leftSection={

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewWorkspaceSummary.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewWorkspaceSummary.tsx
@@ -54,7 +54,6 @@ export const ReviewWorkspaceSummary: FC<Props> = ({
                 to={workspaceUrl}
                 onClick={onNavigate}
                 size="xs"
-                color="dark"
                 fullWidth
                 leftSection={<MantineIcon icon={IconLayoutColumns} size={14} />}
             >

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -318,7 +318,6 @@ const SetupSection: FC<{
                         <ActionIcon
                             aria-label="Run Autopilot now"
                             variant="default"
-                            color="dark"
                             size="md"
                             onClick={onRunNow}
                             disabled={!enabled || isRunNowLoading || isRunning}
@@ -329,7 +328,6 @@ const SetupSection: FC<{
                     </Tooltip>
                     <Button
                         variant={settingsOpen ? 'light' : 'default'}
-                        color="dark"
                         size="xs"
                         leftSection={<IconSettings size={14} />}
                         onClick={onOpenSettings}

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentHomeCard.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentHomeCard.tsx
@@ -262,7 +262,6 @@ export const ManagedAgentHomeCard: FC<{ projectUuid: string }> = ({
 
                     <Box ml={52}>
                         <Button
-                            color="dark"
                             size="sm"
                             rightSection={<IconArrowRight size={14} />}
                         >

--- a/packages/frontend/src/features/dashboardFilters/ActiveFilters/Filter.tsx
+++ b/packages/frontend/src/features/dashboardFilters/ActiveFilters/Filter.tsx
@@ -371,7 +371,6 @@ const Filter: FC<Props> = ({
                                                             handleLockToggle
                                                         }
                                                         size="xs"
-                                                        color="dark"
                                                         radius="xl"
                                                         aria-label={
                                                             isLocked
@@ -415,7 +414,6 @@ const Filter: FC<Props> = ({
                                         <ActionIcon
                                             onClick={onRemove}
                                             size="xs"
-                                            color="dark"
                                             radius="xl"
                                         >
                                             <MantineIcon

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/FilterRequirementsButton.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/FilterRequirementsButton.tsx
@@ -442,7 +442,6 @@ const FilterRequirementsButton: FC = () => {
                     <Button
                         size="xs"
                         variant="subtle"
-                        color="blue"
                         fullWidth
                         leftSection={<MantineIcon icon={IconPlus} />}
                         onClick={handleAddRule}

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/RequiredFilterCard.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/RequiredFilterCard.tsx
@@ -143,7 +143,6 @@ const RequiredFilterCard: FC<Props> = ({
                             <Button
                                 size="compact-xs"
                                 variant="light"
-                                color="blue"
                                 radius="xl"
                                 w="max-content"
                                 leftSection={<MantineIcon icon={IconPlus} />}

--- a/packages/frontend/src/features/dashboardFilters/InvalidFilter.tsx
+++ b/packages/frontend/src/features/dashboardFilters/InvalidFilter.tsx
@@ -37,12 +37,7 @@ const InvalidFilter: FC<Props> = ({ isEditMode, filterRule, onRemove }) => {
                 }
                 rightSection={
                     isEditMode && (
-                        <ActionIcon
-                            onClick={onRemove}
-                            size="xs"
-                            color="dark"
-                            radius="xl"
-                        >
+                        <ActionIcon onClick={onRemove} size="xs" radius="xl">
                             <MantineIcon size="sm" icon={IconX} />
                         </ActionIcon>
                     )

--- a/packages/frontend/src/features/metricsCatalog/components/MetricExploreModal/MetricExploreModal.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricExploreModal/MetricExploreModal.tsx
@@ -603,7 +603,6 @@ export const MetricExploreModal: FC<Props> = (props) => {
                                         </Text>
                                         <Button
                                             variant="subtle"
-                                            color="dark"
                                             size="compact-xs"
                                             className={styles.clearButton}
                                             data-visible={

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreDatePicker.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreDatePicker.tsx
@@ -311,7 +311,6 @@ export const MetricExploreDatePicker: FC<Props> = ({
                                     </Button>
                                     <Button
                                         size="xs"
-                                        color="dark"
                                         onClick={() => {
                                             handleApply();
 

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreFilter.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreFilter.tsx
@@ -4,14 +4,7 @@ import {
     type CompiledDimension,
     type FilterRule,
 } from '@lightdash/common';
-import {
-    Button,
-    Group,
-    Select,
-    Stack,
-    Text,
-    useMantineColorScheme,
-} from '@mantine/core';
+import { Button, Group, Select, Stack, Text } from '@mantine/core';
 import { IconFilter, IconX } from '@tabler/icons-react';
 import { useCallback, useMemo, useState, type FC } from 'react';
 import MantineIcon from '../../../../components/common/MantineIcon';
@@ -51,8 +44,6 @@ export const MetricExploreFilter: FC<Props> = ({
     onFilterApply,
     initialFilterRule,
 }) => {
-    const { colorScheme } = useMantineColorScheme();
-
     // Seed from the metric's default filter on mount. The parent remounts this
     // component (via key) per metric, so this initializer re-runs on switch.
     const [filterState, setFilterState] = useState<FilterState>(() =>
@@ -204,7 +195,6 @@ export const MetricExploreFilter: FC<Props> = ({
                     <Button
                         variant="subtle"
                         size="compact-xs"
-                        color="dark"
                         rightSection={
                             <MantineIcon
                                 icon={IconX}
@@ -311,7 +301,6 @@ export const MetricExploreFilter: FC<Props> = ({
             </Stack>
             {filterState.fieldId && dimensionMetadata?.requiresValues && (
                 <Button
-                    color={colorScheme === 'dark' ? 'ldGray.2' : 'dark'}
                     size="compact-xs"
                     disabled={!canApplyFilter}
                     className={filterStyles.applyButton}

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreSegmentationPicker.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreSegmentationPicker.tsx
@@ -63,7 +63,6 @@ export const MetricExploreSegmentationPicker: FC<Props> = ({
                 <Button
                     variant="subtle"
                     size="compact-xs"
-                    color="dark"
                     rightSection={
                         <MantineIcon icon={IconX} color="ldGray.5" size={12} />
                     }

--- a/packages/frontend/src/features/parameters/components/Parameter.tsx
+++ b/packages/frontend/src/features/parameters/components/Parameter.tsx
@@ -170,7 +170,6 @@ const Parameter: FC<Props> = ({
                                     <ActionIcon
                                         onClick={handleClear}
                                         size="xs"
-                                        color="dark"
                                         radius="xl"
                                     >
                                         <MantineIcon size="sm" icon={IconX} />

--- a/packages/frontend/src/features/pullRequests/components/PullRequestsPage.tsx
+++ b/packages/frontend/src/features/pullRequests/components/PullRequestsPage.tsx
@@ -365,7 +365,6 @@ const PullRequestsPage: FC<Props> = ({ projectUuid }) => {
                             href={pr.prUrl}
                             target="_blank"
                             rel="noreferrer"
-                            color="dark"
                             aria-label={`View pull request on ${getProviderLabel(
                                 pr.provider,
                             )}`}

--- a/packages/frontend/src/pages/OrganizationSetup.tsx
+++ b/packages/frontend/src/pages/OrganizationSetup.tsx
@@ -414,7 +414,6 @@ const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
                                 <Group>
                                     <Button
                                         type="submit"
-                                        color="dark"
                                         size="md"
                                         disabled={
                                             !form.values.organizationName.trim()
@@ -506,7 +505,6 @@ const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
                                     )}
                                     <Button
                                         type="submit"
-                                        color="dark"
                                         size="md"
                                         loading={completeMutation.isLoading}
                                         disabled={!form.values.jobTitle}


### PR DESCRIPTION
Follow-up to the theme revamp stack (#28442 to #28447). No ticket; agreed with the developer. First of ten refactor PRs; each is independent in content and stacked only to avoid conflicts.

## What changed
- Filled call-to-action buttons that hard-coded `color="blue"` (Add to Slack, Install, Connect GitHub account, Move to space) now use the theme primary, the ink colour.
- Three neutral actions tinted blue (Add rule, Add an alternative filter, Show all colors) follow the `light` / `subtle` neutral look used by Add filter.
- 18 Buttons and ActionIcons that hard-coded `color="dark"` inherit the primary instead. In light mode that is the same ink; in dark mode it is the near-white primary rather than a near-black button on a dark surface. One of them also dropped a colour-scheme ternary and an unused hook.

## Regression analysis
- Only `color` props were removed; no handlers, variants, sizes or labels changed. 21 files, 2 insertions, 40 deletions.
- Left untouched on purpose: green save/verify/merge buttons, indigo AI actions, blue upgrade nudges, `color="dark"` on Badges, Loaders and date pickers.

## Verified
- Integrations page in light mode (Add to Slack, Install), typecheck, oxlint, oxfmt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Hr8bA9fzAkqy4yULJ6Qd9
