### PR TITLE
refactor(frontend): shared copy, favourite and confirm-delete controls

### DIFF
--- a/packages/frontend/src/components/CompilationHistory/CompilationLogDrawer.tsx
+++ b/packages/frontend/src/components/CompilationHistory/CompilationLogDrawer.tsx
@@ -1,20 +1,9 @@
-import {
-    ActionIcon,
-    Box,
-    CopyButton,
-    Drawer,
-    Group,
-    ScrollArea,
-    Stack,
-    Text,
-    Tooltip,
-} from '@mantine/core';
-import { IconCheck, IconCopy } from '@tabler/icons-react';
+import { Box, Drawer, Group, ScrollArea, Stack, Text } from '@mantine/core';
 import { type FC } from 'react';
 import ReactJson from 'react-json-view';
 import { type ProjectCompileLog } from '../../hooks/useProjectCompileLogs';
 import { useRjvTheme } from '../../hooks/useRjvTheme';
-import MantineIcon from '../common/MantineIcon';
+import { CopyActionIcon } from '../common/CopyActionIcon';
 
 type CompilationLogDrawerProps = {
     opened: boolean;
@@ -40,25 +29,10 @@ export const CompilationLogDrawer: FC<CompilationLogDrawerProps> = ({
                         Compilation Log Details
                     </Text>
                     {log && (
-                        <CopyButton
+                        <CopyActionIcon
                             value={JSON.stringify(log, null, 2)}
-                            timeout={2000}
-                        >
-                            {({ copied, copy }) => (
-                                <Tooltip
-                                    label={copied ? 'Copied' : 'Copy JSON'}
-                                >
-                                    <ActionIcon
-                                        color={copied ? 'teal' : 'gray'}
-                                        onClick={copy}
-                                    >
-                                        <MantineIcon
-                                            icon={copied ? IconCheck : IconCopy}
-                                        />
-                                    </ActionIcon>
-                                </Tooltip>
-                            )}
-                        </CopyButton>
+                            copyLabel="Copy JSON"
+                        />
                     )}
                 </Group>
             }

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/ItemDetailProvider.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/ItemDetailProvider.tsx
@@ -1,6 +1,4 @@
 import {
-    ActionIcon,
-    CopyButton,
     Group,
     Input,
     Paper,
@@ -8,9 +6,8 @@ import {
     Stack,
     Text,
     TextInput,
-    Tooltip,
 } from '@mantine/core';
-import { IconCheck, IconCopy, IconTable } from '@tabler/icons-react';
+import { IconTable } from '@tabler/icons-react';
 import { useCallback, type FC, type PropsWithChildren } from 'react';
 import {
     explorerActions,
@@ -19,6 +16,7 @@ import {
     useExplorerSelector,
 } from '../../../../features/explorer/store';
 import { getFieldColor } from '../../../../utils/fieldColors';
+import { CopyActionIcon } from '../../../common/CopyActionIcon';
 import FieldIcon from '../../../common/Filters/FieldIcon';
 import MantineIcon from '../../../common/MantineIcon';
 import MantineModal from '../../../common/MantineModal';
@@ -35,20 +33,12 @@ const CopyableInput: FC<{ label: string; value: string }> = ({
         size="xs"
         onFocus={(e) => e.currentTarget.select()}
         rightSection={
-            <CopyButton value={value} timeout={1500}>
-                {({ copied, copy }) => (
-                    <Tooltip label={copied ? 'Copied' : 'Copy'} position="left">
-                        <ActionIcon
-                            size="xs"
-                            color={copied ? 'teal' : 'gray'}
-                            onClick={copy}
-                            aria-label={`Copy ${label}`}
-                        >
-                            <MantineIcon icon={copied ? IconCheck : IconCopy} />
-                        </ActionIcon>
-                    </Tooltip>
-                )}
-            </CopyButton>
+            <CopyActionIcon
+                value={value}
+                tooltipPosition="left"
+                size="xs"
+                aria-label={`Copy ${label}`}
+            />
         }
     />
 );

--- a/packages/frontend/src/components/Explorer/ExplorerHeader/DevCopyChartDebugData.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorerHeader/DevCopyChartDebugData.tsx
@@ -1,34 +1,28 @@
-import { ActionIcon, CopyButton, Tooltip } from '@mantine/core';
-import { IconCheck, IconCode } from '@tabler/icons-react';
+import { IconCode } from '@tabler/icons-react';
 import {
     selectUnsavedChartVersion,
     useExplorerSelector,
 } from '../../../features/explorer/store';
 import useEchartsCartesianConfig from '../../../hooks/echarts/useEchartsCartesianConfig';
-import MantineIcon from '../../common/MantineIcon';
+import { CopyActionIcon } from '../../common/CopyActionIcon';
 
 export const DevCopyChartDebugData = () => {
     const unsavedChartVersion = useExplorerSelector(selectUnsavedChartVersion);
     const echartsOptions = useEchartsCartesianConfig();
 
     return (
-        <CopyButton
+        <CopyActionIcon
             value={JSON.stringify(
                 { unsavedChartVersion, echartsOptions },
                 null,
                 2,
             )}
-        >
-            {({ copied, copy }) => (
-                <Tooltip
-                    label={copied ? 'Copied!' : 'Copy chart debug data'}
-                    position="bottom"
-                >
-                    <ActionIcon onClick={copy} variant="default" size="md">
-                        <MantineIcon icon={copied ? IconCheck : IconCode} />
-                    </ActionIcon>
-                </Tooltip>
-            )}
-        </CopyButton>
+            icon={IconCode}
+            copyLabel="Copy chart debug data"
+            copiedLabel="Copied!"
+            tooltipPosition="bottom"
+            variant="default"
+            size="md"
+        />
     );
 };

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -44,8 +44,6 @@ import {
     IconPin,
     IconPinnedOff,
     IconSend,
-    IconStar,
-    IconStarFilled,
     IconTrash,
     IconUsers,
 } from '@tabler/icons-react';
@@ -124,6 +122,7 @@ import { ExplorerSection } from '../../../providers/Explorer/types';
 import useNativeFullscreenToggle from '../../../providers/Fullscreen/useNativeFullscreenToggle';
 import { TrackSection } from '../../../providers/Tracking/TrackingProvider';
 import { SectionName } from '../../../types/Events';
+import { FavoriteActionIcon } from '../../common/FavoriteActionIcon';
 import MantineIcon from '../../common/MantineIcon';
 import MantineModal from '../../common/MantineModal';
 const ChangeChartExploreModal = lazy(
@@ -658,25 +657,17 @@ const SavedChartsHeader: FC = () => {
                                     </Tooltip>
                                 )}
 
-                                <ActionIcon
+                                <FavoriteActionIcon
                                     size="xs"
                                     variant="transparent"
-                                    color={
-                                        isChartFavorited ? 'orange' : 'ldGray.6'
-                                    }
-                                    onClick={() => {
+                                    isFavorite={isChartFavorited}
+                                    onToggle={() => {
                                         toggleFavorite({
                                             contentType: ContentType.CHART,
                                             contentUuid: savedChart.uuid,
                                         });
                                     }}
-                                >
-                                    {isChartFavorited ? (
-                                        <IconStarFilled size={16} />
-                                    ) : (
-                                        <IconStar size={16} />
-                                    )}
-                                </ActionIcon>
+                                />
 
                                 {isEditMode && userCanManageChart && (
                                     <ActionIcon

--- a/packages/frontend/src/components/Explorer/SqlCard/SqlCard.tsx
+++ b/packages/frontend/src/components/Explorer/SqlCard/SqlCard.tsx
@@ -4,17 +4,9 @@ import {
     isCustomSqlDimension,
     isSqlTableCalculation,
 } from '@lightdash/common';
-import {
-    Box,
-    CopyButton,
-    Group,
-    Skeleton,
-    ActionIcon,
-    SegmentedControl,
-    Tooltip,
-} from '@mantine/core';
+import { Box, Group, Skeleton, SegmentedControl } from '@mantine/core';
 import { useHover } from '@mantine/hooks';
-import { IconCheck, IconClipboard } from '@tabler/icons-react';
+import { IconClipboard } from '@tabler/icons-react';
 import {
     lazy,
     memo,
@@ -41,7 +33,7 @@ import useApp from '../../../providers/App/useApp';
 import { ExplorerSection } from '../../../providers/Explorer/types';
 import Callout from '../../common/Callout';
 import CollapsableCard from '../../common/CollapsableCard/CollapsableCard';
-import MantineIcon from '../../common/MantineIcon';
+import { CopyActionIcon } from '../../common/CopyActionIcon';
 import { type SqlViewType } from '../../RenderedSql';
 import OpenInSqlRunnerButton from './OpenInSqlRunnerButton';
 
@@ -117,33 +109,13 @@ const SqlCard: FC<SqlCardProps> = memo(({ projectUuid }) => {
                 (hovered || sqlIsOpen) &&
                 data &&
                 isSuccess ? (
-                    <CopyButton value={formattedSql} timeout={2000}>
-                        {({ copied, copy }) => (
-                            <Tooltip
-                                label={
-                                    copied ? 'Copied to clipboard' : 'Copy SQL'
-                                }
-                                position="right"
-                                color={copied ? 'green' : 'dark'}
-                                fw={500}
-                            >
-                                <ActionIcon
-                                    color={copied ? 'teal' : 'gray'}
-                                    onClick={copy}
-                                >
-                                    {
-                                        <MantineIcon
-                                            icon={
-                                                copied
-                                                    ? IconCheck
-                                                    : IconClipboard
-                                            }
-                                        />
-                                    }
-                                </ActionIcon>
-                            </Tooltip>
-                        )}
-                    </CopyButton>
+                    <CopyActionIcon
+                        value={formattedSql}
+                        icon={IconClipboard}
+                        copyLabel="Copy SQL"
+                        copiedLabel="Copied to clipboard"
+                        tooltipPosition="right"
+                    />
                 ) : undefined
             }
             rightHeaderElement={

--- a/packages/frontend/src/components/JobDetailsDrawer/index.tsx
+++ b/packages/frontend/src/components/JobDetailsDrawer/index.tsx
@@ -7,13 +7,11 @@ import {
 import {
     Alert,
     Box,
-    CopyButton,
     Group,
     Loader,
     Stack,
     Text,
     Title,
-    ActionIcon,
     Drawer,
     type DefaultMantineColor,
 } from '@mantine/core';
@@ -21,9 +19,7 @@ import { useInterval } from '@mantine/hooks';
 import {
     IconAlertTriangle,
     IconAlertTriangleFilled,
-    IconCheck,
     IconCircleCheckFilled,
-    IconCopy,
 } from '@tabler/icons-react';
 import dayjs from 'dayjs';
 import duration from 'dayjs/plugin/duration';
@@ -35,6 +31,7 @@ import {
     runningStepsInfo,
 } from '../../hooks/useRefreshServer';
 import useActiveJob from '../../providers/ActiveJob/useActiveJob';
+import { CopyActionIcon } from '../common/CopyActionIcon';
 import MantineIcon from '../common/MantineIcon';
 import { NAVBAR_HEIGHT } from '../common/Page/constants';
 import ProjectCompileLog from './ProjectCompileLog';
@@ -205,7 +202,7 @@ const JobDetailsDrawer: FC = () => {
                                     pos="relative"
                                     gap="xs"
                                 >
-                                    <CopyButton
+                                    <CopyActionIcon
                                         value={
                                             step.stepError +
                                                 step.stepDbtLogs
@@ -217,27 +214,11 @@ const JobDetailsDrawer: FC = () => {
                                                     .map((log) => log.info.msg)
                                                     .join('\n') || ''
                                         }
-                                    >
-                                        {({ copied, copy }) => (
-                                            <ActionIcon
-                                                onClick={copy}
-                                                pos="absolute"
-                                                top={6}
-                                                right={4}
-                                                size="xs"
-                                            >
-                                                {copied ? (
-                                                    <MantineIcon
-                                                        icon={IconCheck}
-                                                    />
-                                                ) : (
-                                                    <MantineIcon
-                                                        icon={IconCopy}
-                                                    />
-                                                )}
-                                            </ActionIcon>
-                                        )}
-                                    </CopyButton>
+                                        pos="absolute"
+                                        top={6}
+                                        right={4}
+                                        size="xs"
+                                    />
                                     <Stack
                                         gap="xs"
                                         style={{

--- a/packages/frontend/src/components/ProjectConnection/DbtForms/DbtCloudForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtForms/DbtCloudForm.tsx
@@ -1,24 +1,17 @@
 import { DbtProjectType } from '@lightdash/common';
 import {
     TextInput,
-    ActionIcon,
     Alert,
     Anchor,
-    CopyButton,
     Group,
     Stack,
     PasswordInput,
     Text,
-    Tooltip,
 } from '@mantine/core';
-import {
-    IconCheck,
-    IconCopy,
-    IconInfoCircle,
-    IconPlus,
-} from '@tabler/icons-react';
+import { IconInfoCircle, IconPlus } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
 import useApp from '../../../providers/App/useApp';
+import { CopyActionIcon } from '../../common/CopyActionIcon';
 import MantineIcon from '../../common/MantineIcon';
 import { MultiSelectCombobox } from '../../common/MultiSelectCombobox/MultiSelectCombobox';
 import DocumentationHelpButton from '../../DocumentationHelpButton';
@@ -105,27 +98,12 @@ const DbtCloudForm: FC<{ disabled: boolean }> = ({ disabled }) => {
                     readOnly
                     rightSectionPointerEvents="all"
                     rightSection={
-                        <CopyButton value={webhookUrl}>
-                            {({ copied, copy }) => (
-                                <Tooltip
-                                    label={copied ? 'Copied' : 'Copy'}
-                                    position="left"
-                                >
-                                    <ActionIcon
-                                        aria-label="Copy webhook URL"
-                                        onMouseDown={(event) =>
-                                            event.preventDefault()
-                                        }
-                                        color={copied ? 'teal' : 'gray'}
-                                        onClick={copy}
-                                    >
-                                        <MantineIcon
-                                            icon={copied ? IconCheck : IconCopy}
-                                        />
-                                    </ActionIcon>
-                                </Tooltip>
-                            )}
-                        </CopyButton>
+                        <CopyActionIcon
+                            value={webhookUrl}
+                            tooltipPosition="left"
+                            aria-label="Copy webhook URL"
+                            onMouseDown={(event) => event.preventDefault()}
+                        />
                     }
                 />
             )}

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/PostgresForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/PostgresForm.tsx
@@ -1,19 +1,15 @@
 import { WarehouseTypes } from '@lightdash/common';
 import {
     TextInput,
-    CopyButton,
     Stack,
     Button,
-    ActionIcon,
     Anchor,
     Select,
     PasswordInput,
-    Tooltip,
 } from '@mantine/core';
-import { IconCheck, IconCopy } from '@tabler/icons-react';
 import React, { type FC, type ReactNode } from 'react';
 import { useToggle } from 'react-use';
-import MantineIcon from '../../common/MantineIcon';
+import { CopyActionIcon } from '../../common/CopyActionIcon';
 import { NumberInput } from '../../common/NumberInput';
 import FormCollapseButton from '../FormCollapseButton';
 import { useFormContext } from '../formContext';
@@ -370,43 +366,14 @@ const PostgresForm: FC<{
                                         rightSectionPointerEvents="all"
                                         rightSection={
                                             <>
-                                                <CopyButton
+                                                <CopyActionIcon
                                                     value={sshTunnelPublicKey}
-                                                >
-                                                    {({ copied, copy }) => (
-                                                        <Tooltip
-                                                            label={
-                                                                copied
-                                                                    ? 'Copied'
-                                                                    : 'Copy'
-                                                            }
-                                                            position="right"
-                                                        >
-                                                            <ActionIcon
-                                                                aria-label="Copy SSH tunnel public key"
-                                                                onMouseDown={(
-                                                                    event,
-                                                                ) =>
-                                                                    event.preventDefault()
-                                                                }
-                                                                color={
-                                                                    copied
-                                                                        ? 'teal'
-                                                                        : 'gray'
-                                                                }
-                                                                onClick={copy}
-                                                            >
-                                                                <MantineIcon
-                                                                    icon={
-                                                                        copied
-                                                                            ? IconCheck
-                                                                            : IconCopy
-                                                                    }
-                                                                />
-                                                            </ActionIcon>
-                                                        </Tooltip>
-                                                    )}
-                                                </CopyButton>
+                                                    tooltipPosition="right"
+                                                    aria-label="Copy SSH tunnel public key"
+                                                    onMouseDown={(event) =>
+                                                        event.preventDefault()
+                                                    }
+                                                />
                                             </>
                                         }
                                     />

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/RedshiftForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/RedshiftForm.tsx
@@ -1,19 +1,15 @@
 import { RedshiftAuthenticationType, WarehouseTypes } from '@lightdash/common';
 import {
     TextInput,
-    CopyButton,
     Stack,
     Button,
-    ActionIcon,
     Anchor,
     Select,
     PasswordInput,
-    Tooltip,
 } from '@mantine/core';
-import { IconCheck, IconCopy } from '@tabler/icons-react';
 import { useEffect, type FC, type ReactNode } from 'react';
 import { useToggle } from 'react-use';
-import MantineIcon from '../../common/MantineIcon';
+import { CopyActionIcon } from '../../common/CopyActionIcon';
 import { NumberInput } from '../../common/NumberInput';
 import FormCollapseButton from '../FormCollapseButton';
 import { useFormContext } from '../formContext';
@@ -365,43 +361,14 @@ const RedshiftForm: FC<{
                                         rightSectionPointerEvents="all"
                                         rightSection={
                                             <>
-                                                <CopyButton
+                                                <CopyActionIcon
                                                     value={sshTunnelPublicKey}
-                                                >
-                                                    {({ copied, copy }) => (
-                                                        <Tooltip
-                                                            label={
-                                                                copied
-                                                                    ? 'Copied'
-                                                                    : 'Copy'
-                                                            }
-                                                            position="right"
-                                                        >
-                                                            <ActionIcon
-                                                                aria-label="Copy SSH tunnel public key"
-                                                                onMouseDown={(
-                                                                    event,
-                                                                ) =>
-                                                                    event.preventDefault()
-                                                                }
-                                                                color={
-                                                                    copied
-                                                                        ? 'teal'
-                                                                        : 'gray'
-                                                                }
-                                                                onClick={copy}
-                                                            >
-                                                                <MantineIcon
-                                                                    icon={
-                                                                        copied
-                                                                            ? IconCheck
-                                                                            : IconCopy
-                                                                    }
-                                                                />
-                                                            </ActionIcon>
-                                                        </Tooltip>
-                                                    )}
-                                                </CopyButton>
+                                                    tooltipPosition="right"
+                                                    aria-label="Copy SSH tunnel public key"
+                                                    onMouseDown={(event) =>
+                                                        event.preventDefault()
+                                                    }
+                                                />
                                             </>
                                         }
                                     />

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionExamplesPanel.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionExamplesPanel.tsx
@@ -31,6 +31,7 @@ import { useConnectionSamples } from '../../../features/externalConnections/hook
 import { useDeleteConnectionSample } from '../../../features/externalConnections/hooks/useDeleteConnectionSample';
 import { useSaveConnectionSample } from '../../../features/externalConnections/hooks/useSaveConnectionSample';
 import { useTestConnection } from '../../../features/externalConnections/hooks/useTestConnection';
+import { ConfirmDeleteButton } from '../../common/ConfirmDeleteButton';
 import MantineIcon from '../../common/MantineIcon';
 
 const MAX_SAMPLE_PREVIEW_CHARS = 200;
@@ -123,7 +124,6 @@ const SampleRow: FC<SampleRowProps> = ({
     connectionUuid,
 }) => {
     const deleteMutation = useDeleteConnectionSample();
-    const [confirming, setConfirming] = useState(false);
 
     const label =
         sample.label ?? `${sample.request.method} ${sample.request.path}`;
@@ -138,18 +138,12 @@ const SampleRow: FC<SampleRowProps> = ({
         MAX_SAMPLE_PREVIEW_CHARS,
     );
 
-    const handleDelete = () => {
-        if (!confirming) {
-            setConfirming(true);
-            return;
-        }
+    const handleDelete = () =>
         deleteMutation.mutate({
             projectUuid,
             connectionUuid,
             sampleUuid: sample.sampleUuid,
         });
-        setConfirming(false);
-    };
 
     return (
         <Box
@@ -171,24 +165,16 @@ const SampleRow: FC<SampleRowProps> = ({
                         {responsePreview}
                     </Text>
                 </Stack>
-                <ActionIcon
-                    color={confirming ? 'red' : undefined}
-                    variant={confirming ? 'filled' : 'subtle'}
+                <ConfirmDeleteButton
                     size="sm"
                     loading={deleteMutation.isLoading}
-                    onClick={handleDelete}
-                    title={
-                        confirming ? 'Click again to confirm' : 'Delete sample'
-                    }
+                    aria-label="Delete sample"
+                    tooltip="Click again to confirm"
+                    onConfirm={handleDelete}
                 >
                     <MantineIcon icon={IconTrash} size="sm" />
-                </ActionIcon>
+                </ConfirmDeleteButton>
             </Group>
-            {confirming && (
-                <Text fz="xs" c="red" mt={4}>
-                    Click the trash icon again to confirm deletion
-                </Text>
-            )}
         </Box>
     );
 };

--- a/packages/frontend/src/components/Settings/SemanticLayerConnectionPanel/index.tsx
+++ b/packages/frontend/src/components/Settings/SemanticLayerConnectionPanel/index.tsx
@@ -1,7 +1,6 @@
 import { subject } from '@casl/ability';
 import { CommercialFeatureFlags } from '@lightdash/common';
 import {
-    ActionIcon,
     Anchor,
     Box,
     CopyButton,
@@ -12,7 +11,6 @@ import {
     Tabs,
     Text,
     Title,
-    Tooltip,
     UnstyledButton,
 } from '@mantine/core';
 import {
@@ -30,6 +28,7 @@ import { useProject } from '../../../hooks/useProject';
 import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../providers/App/useApp';
 import Callout from '../../common/Callout';
+import { CopyActionIcon } from '../../common/CopyActionIcon';
 import MantineIcon from '../../common/MantineIcon';
 import { SettingsCard } from '../../common/Settings/SettingsCard';
 import { GenerateTokenModal, type GeneratedToken } from './GenerateTokenModal';
@@ -73,18 +72,12 @@ const ConnectionChip: FC<{ label: string; value: string; span?: boolean }> = ({
                 {value}
             </Text>
         </Box>
-        <CopyButton value={value} timeout={2000}>
-            {({ copied, copy }) => (
-                <Tooltip label={copied ? 'Copied' : 'Copy'} position="left">
-                    <ActionIcon variant="default" size="sm" onClick={copy}>
-                        <MantineIcon
-                            icon={copied ? IconCheck : IconCopy}
-                            size="sm"
-                        />
-                    </ActionIcon>
-                </Tooltip>
-            )}
-        </CopyButton>
+        <CopyActionIcon
+            value={value}
+            tooltipPosition="left"
+            variant="default"
+            size="sm"
+        />
     </Box>
 );
 
@@ -126,18 +119,7 @@ const CodeBlock: FC<{ displayValue: ReactNode; copyValue: string }> = ({
     <Box className={`${classes.codeBlock} sentry-block ph-no-capture`}>
         {displayValue}
         <Box className={classes.codeBlockCopy}>
-            <CopyButton value={copyValue} timeout={2000}>
-                {({ copied, copy }) => (
-                    <Tooltip label={copied ? 'Copied' : 'Copy'} position="left">
-                        <ActionIcon
-                            color={copied ? 'teal' : 'gray'}
-                            onClick={copy}
-                        >
-                            <MantineIcon icon={copied ? IconCheck : IconCopy} />
-                        </ActionIcon>
-                    </Tooltip>
-                )}
-            </CopyButton>
+            <CopyActionIcon value={copyValue} tooltipPosition="left" />
         </Box>
     </Box>
 );

--- a/packages/frontend/src/components/SqlRunner/SqlEditorActions.tsx
+++ b/packages/frontend/src/components/SqlRunner/SqlEditorActions.tsx
@@ -1,12 +1,12 @@
-import { ActionIcon, CopyButton, Group, Tooltip } from '@mantine/core';
+import { ActionIcon, Group, Tooltip } from '@mantine/core';
 import {
-    IconCheck,
     IconClipboard,
     IconCode,
     IconTextWrap,
     IconTextWrapDisabled,
 } from '@tabler/icons-react';
 import { type FC } from 'react';
+import { CopyActionIcon } from '../common/CopyActionIcon';
 import MantineIcon from '../common/MantineIcon';
 
 export const SqlEditorActions: FC<{
@@ -48,27 +48,13 @@ export const SqlEditorActions: FC<{
                     )}
                 </ActionIcon>
             </Tooltip>
-            <CopyButton value={clipboardContent ?? ''} timeout={2000}>
-                {({ copied, copy }) => (
-                    <Tooltip
-                        label={copied ? 'Copied to clipboard!' : 'Copy'}
-                        position="right"
-                        color={copied ? 'green' : 'dark'}
-                    >
-                        <ActionIcon
-                            color={copied ? 'teal' : 'ldLight'}
-                            onClick={copy}
-                            variant="outline"
-                        >
-                            {copied ? (
-                                <IconCheck size="1rem" />
-                            ) : (
-                                <IconClipboard size="1rem" />
-                            )}
-                        </ActionIcon>
-                    </Tooltip>
-                )}
-            </CopyButton>
+            <CopyActionIcon
+                value={clipboardContent ?? ''}
+                icon={IconClipboard}
+                copiedLabel="Copied to clipboard!"
+                tooltipPosition="right"
+                variant="outline"
+            />
         </Group>
     );
 };

--- a/packages/frontend/src/components/UserSettings/AccessTokensPanel/CreateTokenModal.tsx
+++ b/packages/frontend/src/components/UserSettings/AccessTokensPanel/CreateTokenModal.tsx
@@ -1,20 +1,12 @@
 import { formatTimestamp } from '@lightdash/common';
-import {
-    ActionIcon,
-    Button,
-    CopyButton,
-    Select,
-    Stack,
-    TextInput,
-    Tooltip,
-} from '@mantine/core';
+import { Button, Select, Stack, TextInput } from '@mantine/core';
 import { useForm } from '@mantine/form';
-import { IconCheck, IconCopy, IconKey } from '@tabler/icons-react';
+import { IconKey } from '@tabler/icons-react';
 import { type FC } from 'react';
 import useHealth from '../../../hooks/health/useHealth';
 import { useCreateAccessToken } from '../../../hooks/useAccessToken';
 import Callout from '../../common/Callout';
-import MantineIcon from '../../common/MantineIcon';
+import { CopyActionIcon } from '../../common/CopyActionIcon';
 import MantineModal from '../../common/MantineModal';
 import { useExpireOptions } from './useExpireOptions';
 
@@ -106,27 +98,10 @@ export const CreateTokenModal: FC<{
                         className="sentry-block ph-no-capture"
                         value={data.token}
                         rightSection={
-                            <CopyButton value={data.token}>
-                                {({ copied, copy }) => (
-                                    <Tooltip
-                                        label={copied ? 'Copied' : 'Copy'}
-                                        position="right"
-                                    >
-                                        <ActionIcon
-                                            color={copied ? 'teal' : 'gray'}
-                                            onClick={copy}
-                                        >
-                                            <MantineIcon
-                                                icon={
-                                                    copied
-                                                        ? IconCheck
-                                                        : IconCopy
-                                                }
-                                            />
-                                        </ActionIcon>
-                                    </Tooltip>
-                                )}
-                            </CopyButton>
+                            <CopyActionIcon
+                                value={data.token}
+                                tooltipPosition="right"
+                            />
                         }
                     />
                     <TextInput
@@ -136,29 +111,10 @@ export const CreateTokenModal: FC<{
                         readOnly
                         value={`lightdash login ${health.data?.siteUrl} --token ${data.token}`}
                         rightSection={
-                            <CopyButton
+                            <CopyActionIcon
                                 value={`lightdash login ${health.data?.siteUrl} --token ${data.token}`}
-                            >
-                                {({ copied, copy }) => (
-                                    <Tooltip
-                                        label={copied ? 'Copied' : 'Copy'}
-                                        position="right"
-                                    >
-                                        <ActionIcon
-                                            color={copied ? 'teal' : 'gray'}
-                                            onClick={copy}
-                                        >
-                                            <MantineIcon
-                                                icon={
-                                                    copied
-                                                        ? IconCheck
-                                                        : IconCopy
-                                                }
-                                            />
-                                        </ActionIcon>
-                                    </Tooltip>
-                                )}
-                            </CopyButton>
+                                tooltipPosition="right"
+                            />
                         }
                     />
                     <Callout variant="info">

--- a/packages/frontend/src/components/UserSettings/AccessTokensPanel/TokensTable.tsx
+++ b/packages/frontend/src/components/UserSettings/AccessTokensPanel/TokensTable.tsx
@@ -6,7 +6,6 @@ import {
 import {
     ActionIcon,
     Button,
-    CopyButton,
     Group,
     Menu,
     Paper,
@@ -19,7 +18,6 @@ import {
 } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import {
-    IconCheck,
     IconCopy,
     IconDots,
     IconInfoCircle,
@@ -41,6 +39,7 @@ import {
     useRotateAccessToken,
 } from '../../../hooks/useAccessToken';
 import Callout from '../../common/Callout';
+import { CopyActionIcon } from '../../common/CopyActionIcon';
 import MantineIcon from '../../common/MantineIcon';
 import MantineModal from '../../common/MantineModal';
 import DocumentationHelpButton from '../../DocumentationHelpButton';
@@ -209,23 +208,10 @@ const RotateTokenForm: FC<{
                     className="sentry-block ph-no-capture"
                     value={rotatedTokenData.token}
                     rightSection={
-                        <CopyButton value={rotatedTokenData.token}>
-                            {({ copied, copy }) => (
-                                <Tooltip
-                                    label={copied ? 'Copied' : 'Copy'}
-                                    position="right"
-                                >
-                                    <ActionIcon
-                                        color={copied ? 'teal' : 'gray'}
-                                        onClick={copy}
-                                    >
-                                        <MantineIcon
-                                            icon={copied ? IconCheck : IconCopy}
-                                        />
-                                    </ActionIcon>
-                                </Tooltip>
-                            )}
-                        </CopyButton>
+                        <CopyActionIcon
+                            value={rotatedTokenData.token}
+                            tooltipPosition="right"
+                        />
                     }
                 />
 
@@ -375,25 +361,14 @@ export const TokensTable = () => {
                                 {tokenToCopy?.uuid}
                             </Text>
                         </Paper>
-                        <CopyButton value={tokenToCopy?.uuid ?? ''}>
-                            {({ copied, copy }) => (
-                                <Tooltip
-                                    label={copied ? 'Copied!' : 'Copy UUID'}
-                                    position="top"
-                                >
-                                    <ActionIcon
-                                        size="sm"
-                                        onClick={copy}
-                                        variant={copied ? 'filled' : 'light'}
-                                        color={copied ? 'teal' : 'blue'}
-                                    >
-                                        <MantineIcon
-                                            icon={copied ? IconCheck : IconCopy}
-                                        />
-                                    </ActionIcon>
-                                </Tooltip>
-                            )}
-                        </CopyButton>
+                        <CopyActionIcon
+                            value={tokenToCopy?.uuid ?? ''}
+                            copyLabel="Copy UUID"
+                            copiedLabel="Copied!"
+                            tooltipPosition="top"
+                            size="sm"
+                            variant="light"
+                        />
                     </Group>
                 </Stack>
             </MantineModal>

--- a/packages/frontend/src/components/UserSettings/EmailWhitelabel/EmailWhitelabelPanel.tsx
+++ b/packages/frontend/src/components/UserSettings/EmailWhitelabel/EmailWhitelabelPanel.tsx
@@ -3,10 +3,8 @@ import {
     type OrganizationEmailWhitelabel,
 } from '@lightdash/common';
 import {
-    ActionIcon,
     Badge,
     Button,
-    CopyButton,
     Group,
     Stack,
     Switch,
@@ -16,12 +14,7 @@ import {
     Tooltip,
 } from '@mantine/core';
 import { useForm } from '@mantine/form';
-import {
-    IconCheck,
-    IconCopy,
-    IconInfoCircle,
-    IconTrash,
-} from '@tabler/icons-react';
+import { IconInfoCircle, IconTrash } from '@tabler/icons-react';
 import { type FC } from 'react';
 import {
     useDeleteEmailWhitelabel,
@@ -30,6 +23,7 @@ import {
     useUpdateEmailWhitelabel,
     useVerifyEmailWhitelabel,
 } from '../../../hooks/organization/useEmailWhitelabel';
+import { CopyActionIcon } from '../../common/CopyActionIcon';
 import EmptyStateLoader from '../../common/EmptyStateLoader';
 import MantineIcon from '../../common/MantineIcon';
 import { SettingsCard } from '../../common/Settings/SettingsCard';
@@ -67,21 +61,7 @@ const CopyValue: FC<{ value: string }> = ({ value }) => (
         >
             {value}
         </Text>
-        <CopyButton value={value}>
-            {({ copied, copy }) => (
-                <Tooltip label={copied ? 'Copied' : 'Copy'}>
-                    <ActionIcon
-                        color={copied ? 'green' : 'gray'}
-                        onClick={copy}
-                    >
-                        <MantineIcon
-                            icon={copied ? IconCheck : IconCopy}
-                            size="sm"
-                        />
-                    </ActionIcon>
-                </Tooltip>
-            )}
-        </CopyButton>
+        <CopyActionIcon value={value} />
     </Group>
 );
 

--- a/packages/frontend/src/components/UserSettings/OAuthClientsPanel/CreateOAuthClientModal.tsx
+++ b/packages/frontend/src/components/UserSettings/OAuthClientsPanel/CreateOAuthClientModal.tsx
@@ -1,18 +1,10 @@
-import {
-    ActionIcon,
-    Button,
-    CopyButton,
-    Stack,
-    Textarea,
-    TextInput,
-    Tooltip,
-} from '@mantine/core';
+import { Button, Stack, Textarea, TextInput } from '@mantine/core';
 import { useForm } from '@mantine/form';
-import { IconCheck, IconCopy, IconPlug } from '@tabler/icons-react';
+import { IconPlug } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { useCreateOAuthClient } from '../../../hooks/useOAuthClients';
 import Callout from '../../common/Callout';
-import MantineIcon from '../../common/MantineIcon';
+import { CopyActionIcon } from '../../common/CopyActionIcon';
 import MantineModal from '../../common/MantineModal';
 
 export const CreateOAuthClientModal: FC<{
@@ -111,27 +103,10 @@ export const CreateOAuthClientModal: FC<{
                         readOnly
                         value={data?.clientId}
                         rightSection={
-                            <CopyButton value={data?.clientId ?? ''}>
-                                {({ copied, copy }) => (
-                                    <Tooltip
-                                        label={copied ? 'Copied' : 'Copy'}
-                                        position="right"
-                                    >
-                                        <ActionIcon
-                                            color={copied ? 'teal' : 'gray'}
-                                            onClick={copy}
-                                        >
-                                            <MantineIcon
-                                                icon={
-                                                    copied
-                                                        ? IconCheck
-                                                        : IconCopy
-                                                }
-                                            />
-                                        </ActionIcon>
-                                    </Tooltip>
-                                )}
-                            </CopyButton>
+                            <CopyActionIcon
+                                value={data?.clientId ?? ''}
+                                tooltipPosition="right"
+                            />
                         }
                     />
                     <TextInput
@@ -140,27 +115,10 @@ export const CreateOAuthClientModal: FC<{
                         className="sentry-block ph-no-capture"
                         value={data?.clientSecret}
                         rightSection={
-                            <CopyButton value={data?.clientSecret ?? ''}>
-                                {({ copied, copy }) => (
-                                    <Tooltip
-                                        label={copied ? 'Copied' : 'Copy'}
-                                        position="right"
-                                    >
-                                        <ActionIcon
-                                            color={copied ? 'teal' : 'gray'}
-                                            onClick={copy}
-                                        >
-                                            <MantineIcon
-                                                icon={
-                                                    copied
-                                                        ? IconCheck
-                                                        : IconCopy
-                                                }
-                                            />
-                                        </ActionIcon>
-                                    </Tooltip>
-                                )}
-                            </CopyButton>
+                            <CopyActionIcon
+                                value={data?.clientSecret ?? ''}
+                                tooltipPosition="right"
+                            />
                         }
                     />
                     <Callout variant="warning">

--- a/packages/frontend/src/components/UserSettings/OAuthClientsPanel/OAuthClientsTable.tsx
+++ b/packages/frontend/src/components/UserSettings/OAuthClientsPanel/OAuthClientsTable.tsx
@@ -1,24 +1,10 @@
 import { type OAuthClientSummary } from '@lightdash/common';
-import {
-    ActionIcon,
-    CopyButton,
-    Group,
-    Menu,
-    Paper,
-    Table,
-    Text,
-    Tooltip,
-} from '@mantine/core';
-import {
-    IconCheck,
-    IconCopy,
-    IconDots,
-    IconPencil,
-    IconTrash,
-} from '@tabler/icons-react';
+import { ActionIcon, Group, Menu, Paper, Table, Text } from '@mantine/core';
+import { IconDots, IconPencil, IconTrash } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
 import tableStyles from '../../../hooks/styles/tableStyles.module.css';
 import { useDeleteOAuthClient } from '../../../hooks/useOAuthClients';
+import { CopyActionIcon } from '../../common/CopyActionIcon';
 import MantineIcon from '../../common/MantineIcon';
 import MantineModal from '../../common/MantineModal';
 import { EditOAuthClientModal } from './EditOAuthClientModal';
@@ -49,25 +35,13 @@ const OAuthClientRow: FC<{
                         >
                             {client.clientId}
                         </Text>
-                        <CopyButton value={client.clientId}>
-                            {({ copied, copy }) => (
-                                <Tooltip
-                                    label={copied ? 'Copied' : 'Copy'}
-                                    position="right"
-                                >
-                                    <ActionIcon
-                                        size="xs"
-                                        onClick={copy}
-                                        variant="transparent"
-                                        color="ldGray.6"
-                                    >
-                                        <MantineIcon
-                                            icon={copied ? IconCheck : IconCopy}
-                                        />
-                                    </ActionIcon>
-                                </Tooltip>
-                            )}
-                        </CopyButton>
+                        <CopyActionIcon
+                            value={client.clientId}
+                            tooltipPosition="right"
+                            size="xs"
+                            variant="transparent"
+                            color="ldGray.6"
+                        />
                     </Group>
                 </Table.Td>
                 <Table.Td>

--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/InviteSuccess.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/InviteSuccess.tsx
@@ -1,18 +1,10 @@
 import { type InviteLink } from '@lightdash/common';
-import {
-    ActionIcon,
-    Alert,
-    CopyButton,
-    Stack,
-    Text,
-    TextInput,
-    Tooltip,
-} from '@mantine/core';
-import { IconCheck, IconCopy } from '@tabler/icons-react';
+import { Alert, Stack, Text, TextInput } from '@mantine/core';
+import { IconCheck } from '@tabler/icons-react';
 import React, { useMemo, type FC } from 'react';
 import { useToggle } from 'react-use';
 import useApp from '../../../providers/App/useApp';
-import MantineIcon from '../../common/MantineIcon';
+import { CopyActionIcon } from '../../common/CopyActionIcon';
 
 const InviteSuccess: FC<{
     invite: InviteLink;
@@ -69,23 +61,10 @@ const InviteSuccess: FC<{
                     className="sentry-block ph-no-capture"
                     value={invite.inviteUrl}
                     rightSection={
-                        <CopyButton value={invite.inviteUrl}>
-                            {({ copied, copy }) => (
-                                <Tooltip
-                                    label={copied ? 'Copied' : 'Copy'}
-                                    position="right"
-                                >
-                                    <ActionIcon
-                                        color={copied ? 'teal' : 'gray'}
-                                        onClick={copy}
-                                    >
-                                        <MantineIcon
-                                            icon={copied ? IconCheck : IconCopy}
-                                        />
-                                    </ActionIcon>
-                                </Tooltip>
-                            )}
-                        </CopyButton>
+                        <CopyActionIcon
+                            value={invite.inviteUrl}
+                            tooltipPosition="right"
+                        />
                     }
                 />
             </Stack>

--- a/packages/frontend/src/components/VisualizationConfigs/common/AccordionControl.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/common/AccordionControl.tsx
@@ -9,9 +9,9 @@ import {
 } from '@mantine/core';
 import { IconTrash } from '@tabler/icons-react';
 import { type FC } from 'react';
+import { ConfirmDeleteButton } from '../../common/ConfirmDeleteButton';
 import MantineIcon from '../../common/MantineIcon';
 import classes from './Accordion.module.css';
-import { ConfirmDeleteButton } from './ConfirmDeleteButton';
 
 type Props = {
     label: string;

--- a/packages/frontend/src/components/common/ConfirmDeleteButton.tsx
+++ b/packages/frontend/src/components/common/ConfirmDeleteButton.tsx
@@ -65,7 +65,7 @@ export const ConfirmDeleteButton: FC<Props> = ({
                 {...actionIconProps}
                 aria-label={ariaLabel}
                 aria-pressed={armed}
-                color={armed ? 'red' : 'gray'}
+                color={armed ? 'red' : undefined}
                 variant={armed ? 'filled' : 'subtle'}
                 onClick={handleClick}
                 onMouseLeave={disarm}

--- a/packages/frontend/src/components/common/CopyActionIcon.tsx
+++ b/packages/frontend/src/components/common/CopyActionIcon.tsx
@@ -1,0 +1,48 @@
+import {
+    ActionIcon,
+    CopyButton,
+    Tooltip,
+    type ActionIconProps,
+    type ElementProps,
+    type TooltipProps,
+} from '@mantine/core';
+import { IconCheck, IconCopy, type Icon } from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineIcon from './MantineIcon';
+
+type CopyActionIconProps = Omit<ActionIconProps, 'children'> &
+    Omit<ElementProps<'button'>, 'children' | 'color' | 'onClick' | 'value'> & {
+        value: string;
+        copyLabel?: string;
+        copiedLabel?: string;
+        icon?: Icon;
+        tooltipPosition?: TooltipProps['position'];
+    };
+
+export const CopyActionIcon: FC<CopyActionIconProps> = ({
+    value,
+    copyLabel = 'Copy',
+    copiedLabel = 'Copied',
+    icon = IconCopy,
+    tooltipPosition,
+    color,
+    ...rest
+}) => (
+    <CopyButton value={value}>
+        {({ copied, copy }) => (
+            <Tooltip
+                label={copied ? copiedLabel : copyLabel}
+                position={tooltipPosition}
+            >
+                <ActionIcon
+                    color={copied ? 'teal' : color}
+                    onClick={copy}
+                    aria-label={copyLabel}
+                    {...rest}
+                >
+                    <MantineIcon icon={copied ? IconCheck : icon} />
+                </ActionIcon>
+            </Tooltip>
+        )}
+    </CopyButton>
+);

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -42,8 +42,6 @@ import {
     IconPinnedOff,
     IconRefreshDot,
     IconSend,
-    IconStar,
-    IconStarFilled,
     IconTrash,
     IconUpload,
     IconUsers,
@@ -82,6 +80,7 @@ import { type TilePreAggregateStatus } from '../../../providers/Dashboard/types'
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
 import AddTileButton from '../../DashboardTiles/AddTileButton';
+import { FavoriteActionIcon } from '../FavoriteActionIcon';
 import MantineIcon from '../MantineIcon';
 import DashboardUpdateModal from '../modal/DashboardUpdateModal';
 import PageHeader from '../Page/PageHeader';
@@ -466,25 +465,16 @@ const DashboardHeader = memo(
                     )}
 
                     {dashboardUuid && (
-                        <ActionIcon
+                        <FavoriteActionIcon
                             size="md"
-                            color={isDashboardFavorited ? 'orange' : 'ldGray.6'}
-                            onClick={() => {
+                            isFavorite={isDashboardFavorited}
+                            onToggle={() => {
                                 toggleFavorite({
                                     contentType: ContentType.DASHBOARD,
                                     contentUuid: dashboardUuid,
                                 });
                             }}
-                        >
-                            <MantineIcon
-                                icon={
-                                    isDashboardFavorited
-                                        ? IconStarFilled
-                                        : IconStar
-                                }
-                                size={16}
-                            />
-                        </ActionIcon>
+                        />
                     )}
 
                     {isEditMode && userCanManageDashboard && (

--- a/packages/frontend/src/components/common/FavoriteActionIcon.tsx
+++ b/packages/frontend/src/components/common/FavoriteActionIcon.tsx
@@ -1,0 +1,36 @@
+import { ActionIcon, Tooltip, type ActionIconProps } from '@mantine/core';
+import { IconStar, IconStarFilled } from '@tabler/icons-react';
+import { type FC, type MouseEvent } from 'react';
+import MantineIcon from './MantineIcon';
+
+type Props = Omit<ActionIconProps, 'children' | 'color'> & {
+    isFavorite: boolean;
+    onToggle: (event: MouseEvent<HTMLButtonElement>) => void;
+    /** Shown in the tooltip and aria-label, e.g. "Remove <name> from favorites". */
+    name?: string;
+};
+
+export const FavoriteActionIcon: FC<Props> = ({
+    isFavorite,
+    onToggle,
+    name,
+    ...rest
+}) => {
+    const subject = name ? ` ${name}` : '';
+    const label = isFavorite
+        ? `Remove${subject} from favorites`
+        : `Add${subject} to favorites`;
+
+    return (
+        <Tooltip label={label}>
+            <ActionIcon
+                color={isFavorite ? 'orange' : undefined}
+                aria-label={label}
+                onClick={onToggle}
+                {...rest}
+            >
+                <MantineIcon icon={isFavorite ? IconStarFilled : IconStar} />
+            </ActionIcon>
+        </Tooltip>
+    );
+};

--- a/packages/frontend/src/components/common/JsonViewer/JsonCellViewer.tsx
+++ b/packages/frontend/src/components/common/JsonViewer/JsonCellViewer.tsx
@@ -1,5 +1,4 @@
 import {
-    ActionIcon,
     Box,
     Button,
     CopyButton,
@@ -9,12 +8,12 @@ import {
     Stack,
     Tabs,
     Text,
-    Tooltip,
 } from '@mantine/core';
 import { IconCheck, IconCode, IconCopy, IconEye } from '@tabler/icons-react';
 import { useMemo, useState, type FC } from 'react';
 import ReactJson, { type OnSelectProps } from 'react-json-view';
 import { useRjvTheme } from '../../../hooks/useRjvTheme';
+import { CopyActionIcon } from '../CopyActionIcon';
 import MantineIcon from '../MantineIcon';
 import MantineModal from '../MantineModal';
 import { type JsonCellValue } from './utils';
@@ -95,20 +94,11 @@ export const JsonCellModal: FC<ModalProps> = ({ value, opened, onClose }) => {
             cancelLabel={false}
             bodyScrollAreaMaxHeight="75vh"
             headerActions={
-                <CopyButton value={formattedJson} timeout={2000}>
-                    {({ copied, copy }) => (
-                        <Tooltip label={copied ? 'Copied JSON' : 'Copy JSON'}>
-                            <ActionIcon
-                                color={copied ? 'teal' : 'gray'}
-                                onClick={copy}
-                            >
-                                <MantineIcon
-                                    icon={copied ? IconCheck : IconCopy}
-                                />
-                            </ActionIcon>
-                        </Tooltip>
-                    )}
-                </CopyButton>
+                <CopyActionIcon
+                    value={formattedJson}
+                    copyLabel="Copy JSON"
+                    copiedLabel="Copied JSON"
+                />
             }
         >
             <Stack gap="sm">

--- a/packages/frontend/src/components/common/ShareLinkButton.tsx
+++ b/packages/frontend/src/components/common/ShareLinkButton.tsx
@@ -1,7 +1,6 @@
-import { ActionIcon, CopyButton, Tooltip } from '@mantine/core';
-import { IconCheck, IconLink } from '@tabler/icons-react';
+import { IconLink } from '@tabler/icons-react';
 import { type FC } from 'react';
-import MantineIcon from './MantineIcon';
+import { CopyActionIcon } from './CopyActionIcon';
 
 type ShareLinkButtonProps = {
     url: string;
@@ -13,27 +12,14 @@ export const ShareLinkButton: FC<ShareLinkButtonProps> = ({
     label = 'Copy link',
 }) => {
     return (
-        <CopyButton value={url} timeout={2000}>
-            {({ copied, copy }) => (
-                <Tooltip
-                    label={copied ? 'Link copied!' : label}
-                    position="bottom"
-                    openDelay={200}
-                    transitionProps={{ transition: 'fade', duration: 150 }}
-                >
-                    <ActionIcon
-                        variant="default"
-                        onClick={copy}
-                        size="md"
-                        aria-label={copied ? 'Link copied' : label}
-                    >
-                        <MantineIcon
-                            icon={copied ? IconCheck : IconLink}
-                            color={copied ? 'green' : undefined}
-                        />
-                    </ActionIcon>
-                </Tooltip>
-            )}
-        </CopyButton>
+        <CopyActionIcon
+            value={url}
+            icon={IconLink}
+            copyLabel={label}
+            copiedLabel="Link copied!"
+            tooltipPosition="bottom"
+            variant="default"
+            size="md"
+        />
     );
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
@@ -16,7 +16,6 @@ import {
     Box,
     Button,
     Code,
-    CopyButton,
     Group,
     Paper,
     Popover,
@@ -28,8 +27,6 @@ import {
 import { useDisclosure } from '@mantine/hooks';
 import {
     IconBug,
-    IconCheck,
-    IconCopy,
     IconExclamationCircle,
     IconMessageX,
     IconRefresh,
@@ -44,6 +41,7 @@ import { memo, useCallback, useMemo, useState, type FC } from 'react';
 import { Link } from 'react-router';
 import { type CustomRendererProps } from 'streamdown';
 import { AiMarkdown } from '../../../../../components/common/AiMarkdown';
+import { CopyActionIcon } from '../../../../../components/common/CopyActionIcon';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import {
     useRetryAiAgentThreadMessageMutation,
@@ -1157,19 +1155,11 @@ export const AssistantBubble: FC<Props> = memo(
                 )}
                 {isLoading ? null : (
                     <Group gap={0}>
-                        <CopyButton value={message.message ?? ''}>
-                            {({ copied, copy }) => (
-                                <ActionIcon
-                                    color="ldGray.9"
-                                    aria-label="copy"
-                                    onClick={copy}
-                                >
-                                    <MantineIcon
-                                        icon={copied ? IconCheck : IconCopy}
-                                    />
-                                </ActionIcon>
-                            )}
-                        </CopyButton>
+                        <CopyActionIcon
+                            value={message.message ?? ''}
+                            color="ldGray.9"
+                            aria-label="copy"
+                        />
 
                         {(!hasRating || upVoted) && (
                             <ActionIcon

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/ContentCard.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/ContentCard.tsx
@@ -4,15 +4,10 @@ import {
     type SummaryContent,
 } from '@lightdash/common';
 import { ActionIcon, Box, Group, Text, Tooltip } from '@mantine/core';
-import {
-    IconCircleCheckFilled,
-    IconEye,
-    IconStar,
-    IconStarFilled,
-    IconX,
-} from '@tabler/icons-react';
+import { IconCircleCheckFilled, IconEye, IconX } from '@tabler/icons-react';
 import { type FC, type PropsWithChildren } from 'react';
 import { Link } from 'react-router';
+import { FavoriteActionIcon } from '../../../../components/common/FavoriteActionIcon';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import { ResourceIcon } from '../../../../components/common/ResourceIcon';
 import { getResourceUrl } from '../../../../components/common/ResourceView/resourceUtils';
@@ -88,23 +83,15 @@ const CardActions: FC<Pick<Props, 'content' | 'onRemove' | 'star'>> = ({
 }) => (
     <>
         {star && (
-            <ActionIcon
-                color={star.isFavorite ? 'yellow' : 'ldGray.6'}
+            <FavoriteActionIcon
                 size="sm"
-                aria-label={
-                    star.isFavorite
-                        ? `Remove ${content.name} from favorites`
-                        : `Add ${content.name} to favorites`
-                }
-                onClick={(e) => {
+                isFavorite={star.isFavorite}
+                name={content.name}
+                onToggle={(e) => {
                     e.preventDefault();
                     star.onToggle();
                 }}
-            >
-                <MantineIcon
-                    icon={star.isFavorite ? IconStarFilled : IconStar}
-                />
-            </ActionIcon>
+            />
         )}
         {onRemove && (
             <ActionIcon

--- a/packages/frontend/src/ee/features/scim/components/ScimAccessTokensPanel/CreateTokenModal.tsx
+++ b/packages/frontend/src/ee/features/scim/components/ScimAccessTokensPanel/CreateTokenModal.tsx
@@ -1,18 +1,10 @@
 import { formatTimestamp } from '@lightdash/common';
-import {
-    ActionIcon,
-    Button,
-    CopyButton,
-    Select,
-    Stack,
-    TextInput,
-    Tooltip,
-} from '@mantine/core';
+import { Button, Select, Stack, TextInput } from '@mantine/core';
 import { useForm } from '@mantine/form';
-import { IconCheck, IconCopy, IconKey } from '@tabler/icons-react';
+import { IconKey } from '@tabler/icons-react';
 import { type FC } from 'react';
 import Callout from '../../../../../components/common/Callout';
-import MantineIcon from '../../../../../components/common/MantineIcon';
+import { CopyActionIcon } from '../../../../../components/common/CopyActionIcon';
 import MantineModal from '../../../../../components/common/MantineModal';
 import { useCreateScimToken } from '../../hooks/useScimAccessToken';
 
@@ -134,27 +126,10 @@ export const CreateTokenModal: FC<{
                         className="sentry-block ph-no-capture"
                         value={data.token}
                         rightSection={
-                            <CopyButton value={data.token}>
-                                {({ copied, copy }) => (
-                                    <Tooltip
-                                        label={copied ? 'Copied' : 'Copy'}
-                                        position="right"
-                                    >
-                                        <ActionIcon
-                                            color={copied ? 'teal' : 'gray'}
-                                            onClick={copy}
-                                        >
-                                            <MantineIcon
-                                                icon={
-                                                    copied
-                                                        ? IconCheck
-                                                        : IconCopy
-                                                }
-                                            />
-                                        </ActionIcon>
-                                    </Tooltip>
-                                )}
-                            </CopyButton>
+                            <CopyActionIcon
+                                value={data.token}
+                                tooltipPosition="right"
+                            />
                         }
                     />
                     <Callout

--- a/packages/frontend/src/ee/features/scim/components/ScimAccessTokensPanel/TokensTable.tsx
+++ b/packages/frontend/src/ee/features/scim/components/ScimAccessTokensPanel/TokensTable.tsx
@@ -3,21 +3,8 @@ import {
     formatTimestamp,
     type ServiceAccount,
 } from '@lightdash/common';
-import {
-    ActionIcon,
-    CopyButton,
-    Group,
-    Paper,
-    Table,
-    Text,
-    Tooltip,
-} from '@mantine/core';
-import {
-    IconCheck,
-    IconCopy,
-    IconInfoCircle,
-    IconTrash,
-} from '@tabler/icons-react';
+import { ActionIcon, Group, Paper, Table, Text, Tooltip } from '@mantine/core';
+import { IconInfoCircle, IconTrash } from '@tabler/icons-react';
 import {
     useEffect,
     useState,
@@ -25,6 +12,7 @@ import {
     type FC,
     type SetStateAction,
 } from 'react';
+import { CopyActionIcon } from '../../../../../components/common/CopyActionIcon';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import MantineModal from '../../../../../components/common/MantineModal';
 import tableStyles from '../../../../../hooks/styles/tableStyles.module.css';
@@ -91,25 +79,13 @@ const TokenItem: FC<{
                             ...{uuid.slice(-8)}
                         </Text>
                     </Tooltip>
-                    <CopyButton value={uuid}>
-                        {({ copied, copy }) => (
-                            <Tooltip
-                                label={copied ? 'Copied' : 'Copy'}
-                                position="right"
-                            >
-                                <ActionIcon
-                                    size="xs"
-                                    onClick={copy}
-                                    variant="transparent"
-                                    color="ldGray.6"
-                                >
-                                    <MantineIcon
-                                        icon={copied ? IconCheck : IconCopy}
-                                    />
-                                </ActionIcon>
-                            </Tooltip>
-                        )}
-                    </CopyButton>
+                    <CopyActionIcon
+                        value={uuid}
+                        tooltipPosition="right"
+                        size="xs"
+                        variant="transparent"
+                        color="ldGray.6"
+                    />
                 </Group>
             </Table.Td>
             <Table.Td w="1%">

--- a/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsCreateModal.tsx
+++ b/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsCreateModal.tsx
@@ -5,24 +5,21 @@ import {
     type RoleLevel,
 } from '@lightdash/common';
 import {
-    ActionIcon,
     Anchor,
     Button,
-    CopyButton,
     SegmentedControl,
     Select,
     Stack,
     Text,
     TextInput,
-    Tooltip,
 } from '@mantine/core';
 import { useForm } from '@mantine/form';
-import { IconCheck, IconCopy, IconKey } from '@tabler/icons-react';
+import { IconKey } from '@tabler/icons-react';
 import { addDays } from 'date-fns';
 import { useMemo, type FC } from 'react';
 import { Link } from 'react-router';
 import Callout from '../../../components/common/Callout';
-import MantineIcon from '../../../components/common/MantineIcon';
+import { CopyActionIcon } from '../../../components/common/CopyActionIcon';
 import MantineModal from '../../../components/common/MantineModal';
 import { useProjects } from '../../../hooks/useProjects';
 import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
@@ -358,27 +355,10 @@ export const ServiceAccountsCreateModal: FC<Props> = ({
                         className="sentry-block ph-no-capture"
                         value={token}
                         rightSection={
-                            <CopyButton value={token}>
-                                {({ copied, copy }) => (
-                                    <Tooltip
-                                        label={copied ? 'Copied' : 'Copy'}
-                                        position="right"
-                                    >
-                                        <ActionIcon
-                                            color={copied ? 'teal' : 'gray'}
-                                            onClick={copy}
-                                        >
-                                            <MantineIcon
-                                                icon={
-                                                    copied
-                                                        ? IconCheck
-                                                        : IconCopy
-                                                }
-                                            />
-                                        </ActionIcon>
-                                    </Tooltip>
-                                )}
-                            </CopyButton>
+                            <CopyActionIcon
+                                value={token}
+                                tooltipPosition="right"
+                            />
                         }
                     />
                     <Callout

--- a/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsRotateModal.tsx
+++ b/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsRotateModal.tsx
@@ -1,18 +1,10 @@
 import { type ServiceAccount } from '@lightdash/common';
-import {
-    ActionIcon,
-    Button,
-    CopyButton,
-    Select,
-    Stack,
-    TextInput,
-    Tooltip,
-} from '@mantine/core';
+import { Button, Select, Stack, TextInput } from '@mantine/core';
 import { useForm } from '@mantine/form';
-import { IconCheck, IconCopy, IconRefresh } from '@tabler/icons-react';
+import { IconRefresh } from '@tabler/icons-react';
 import { useCallback, useEffect, useState, type FC } from 'react';
 import Callout from '../../../components/common/Callout';
-import MantineIcon from '../../../components/common/MantineIcon';
+import { CopyActionIcon } from '../../../components/common/CopyActionIcon';
 import MantineModal from '../../../components/common/MantineModal';
 import { useExpireOptions } from '../../../components/UserSettings/AccessTokensPanel/useExpireOptions';
 import { useServiceAccounts } from './useServiceAccounts';
@@ -71,23 +63,10 @@ const RotateForm: FC<{
                     className="sentry-block ph-no-capture"
                     value={rotatedData.token}
                     rightSection={
-                        <CopyButton value={rotatedData.token}>
-                            {({ copied, copy }) => (
-                                <Tooltip
-                                    label={copied ? 'Copied' : 'Copy'}
-                                    position="right"
-                                >
-                                    <ActionIcon
-                                        color={copied ? 'teal' : 'gray'}
-                                        onClick={copy}
-                                    >
-                                        <MantineIcon
-                                            icon={copied ? IconCheck : IconCopy}
-                                        />
-                                    </ActionIcon>
-                                </Tooltip>
-                            )}
-                        </CopyButton>
+                        <CopyActionIcon
+                            value={rotatedData.token}
+                            tooltipPosition="right"
+                        />
                     }
                 />
 

--- a/packages/frontend/src/ee/pages/Roadmap.tsx
+++ b/packages/frontend/src/ee/pages/Roadmap.tsx
@@ -11,7 +11,6 @@ import {
     Badge,
     Box,
     Button,
-    CopyButton,
     Group,
     SegmentedControl,
     Stack,
@@ -25,8 +24,6 @@ import {
     IconAlertCircle,
     IconArrowUpRight,
     IconBrandGithub,
-    IconCheck,
-    IconCopy,
     IconFlag,
     IconGitPullRequest,
     IconLayoutKanban,
@@ -45,6 +42,7 @@ import {
     type ContentTableColumnDef,
     type ContentTableSortingState,
 } from '../../components/common/ContentTable';
+import { CopyActionIcon } from '../../components/common/CopyActionIcon';
 import EmptyStateLoader from '../../components/common/EmptyStateLoader';
 import FilterFacet from '../../components/common/FilterFacet';
 import MantineIcon from '../../components/common/MantineIcon';
@@ -207,38 +205,13 @@ const RoadmapDetailsModal: FC<{
                                     <Text className={styles.detailTicketId}>
                                         {item.ticketId}
                                     </Text>
-                                    <CopyButton value={item.ticketId}>
-                                        {({ copied, copy }) => (
-                                            <Tooltip
-                                                label={
-                                                    copied
-                                                        ? 'Copied'
-                                                        : 'Copy ticket ID'
-                                                }
-                                            >
-                                                <ActionIcon
-                                                    aria-label={
-                                                        copied
-                                                            ? 'Copied'
-                                                            : 'Copy ticket ID'
-                                                    }
-                                                    color="ldGray.6"
-                                                    onClick={copy}
-                                                    size="xs"
-                                                    variant="transparent"
-                                                >
-                                                    <MantineIcon
-                                                        icon={
-                                                            copied
-                                                                ? IconCheck
-                                                                : IconCopy
-                                                        }
-                                                        size={13}
-                                                    />
-                                                </ActionIcon>
-                                            </Tooltip>
-                                        )}
-                                    </CopyButton>
+                                    <CopyActionIcon
+                                        value={item.ticketId}
+                                        copyLabel="Copy ticket ID"
+                                        color="ldGray.6"
+                                        size="xs"
+                                        variant="transparent"
+                                    />
                                 </Group>
                             </RoadmapRailRow>
                             <RoadmapRailRow label="Created">

--- a/packages/frontend/src/features/apps/components/AppHeader.tsx
+++ b/packages/frontend/src/features/apps/components/AppHeader.tsx
@@ -4,9 +4,10 @@ import {
     type AppVersionStatus,
 } from '@lightdash/common';
 import { ActionIcon, Group, Popover, Title } from '@mantine/core';
-import { IconInfoCircle, IconStar, IconStarFilled } from '@tabler/icons-react';
+import { IconInfoCircle } from '@tabler/icons-react';
 import { useState, type FC, type ReactNode } from 'react';
 import { DASHBOARD_HEADER_HEIGHT } from '../../../components/common/Dashboard/dashboard.constants';
+import { FavoriteActionIcon } from '../../../components/common/FavoriteActionIcon';
 import MantineIcon from '../../../components/common/MantineIcon';
 import PageHeader from '../../../components/common/Page/PageHeader';
 import { useFavoriteMutation } from '../../../hooks/favorites/useFavoriteMutation';
@@ -95,16 +96,11 @@ const AppHeader: FC<Props> = ({ projectUuid, app, rightSection }) => {
                     </Popover.Dropdown>
                 </Popover>
 
-                <ActionIcon
+                <FavoriteActionIcon
                     size="md"
-                    color={isFavorited ? 'orange' : 'ldGray.6'}
+                    isFavorite={isFavorited}
                     disabled={favoriteMutation.isLoading}
-                    aria-label={
-                        isFavorited
-                            ? 'Remove from favorites'
-                            : 'Add to favorites'
-                    }
-                    onClick={() => {
+                    onToggle={() => {
                         // Personal apps must be filed in a space before they
                         // can be favorited.
                         if (!isFavorited && !app.spaceUuid) {
@@ -116,12 +112,7 @@ const AppHeader: FC<Props> = ({ projectUuid, app, rightSection }) => {
                             contentUuid: app.uuid,
                         });
                     }}
-                >
-                    <MantineIcon
-                        icon={isFavorited ? IconStarFilled : IconStar}
-                        size={16}
-                    />
-                </ActionIcon>
+                />
             </Group>
 
             <Group gap="sm" wrap="nowrap">

--- a/packages/frontend/src/features/sqlRunner/components/TableFields.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/TableFields.tsx
@@ -2,7 +2,6 @@ import {
     TextInput,
     Box,
     Center,
-    CopyButton,
     Group,
     Loader,
     Stack,
@@ -13,8 +12,9 @@ import {
     Tooltip,
 } from '@mantine/core';
 import { useDebouncedValue, useHover } from '@mantine/hooks';
-import { IconCopy, IconSearch, IconX } from '@tabler/icons-react';
+import { IconSearch, IconX } from '@tabler/icons-react';
 import { memo, useState, type FC } from 'react';
+import { CopyActionIcon } from '../../../components/common/CopyActionIcon';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { TableFieldIcon } from '../../../components/DataViz/Icons';
 import { useIsTruncated } from '../../../hooks/useIsTruncated';
@@ -36,26 +36,13 @@ const TableField: FC<{
         <Group gap={'xs'} wrap="nowrap" ref={hoverRef}>
             {hovered ? (
                 <Box display={hovered ? 'block' : 'none'}>
-                    <CopyButton value={`${activeTable}.${field.name}`}>
-                        {({ copied, copy }) => (
-                            <Tooltip
-                                label={copied ? 'Copied to clipboard' : 'Copy'}
-                                position="right"
-                            >
-                                <ActionIcon
-                                    size={16}
-                                    onClick={copy}
-                                    bg="ldGray.1"
-                                >
-                                    <MantineIcon
-                                        icon={IconCopy}
-                                        color={copied ? 'green' : 'blue'}
-                                        onClick={copy}
-                                    />
-                                </ActionIcon>
-                            </Tooltip>
-                        )}
-                    </CopyButton>
+                    <CopyActionIcon
+                        value={`${activeTable}.${field.name}`}
+                        copiedLabel="Copied to clipboard"
+                        tooltipPosition="right"
+                        size={16}
+                        bg="ldGray.1"
+                    />
                 </Box>
             ) : (
                 <TableFieldIcon fieldType={field.type} />

--- a/packages/frontend/src/features/sqlRunner/components/Tables.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Tables.tsx
@@ -3,7 +3,6 @@ import {
     TextInput,
     Box,
     Center,
-    CopyButton,
     Group,
     Loader,
     Stack,
@@ -19,7 +18,6 @@ import { useDebouncedValue, useHover } from '@mantine/hooks';
 import {
     IconChevronDown,
     IconChevronRight,
-    IconCopy,
     IconSearch,
     IconTable,
     IconX,
@@ -28,6 +26,7 @@ import dayjs from 'dayjs';
 import Fuse from 'fuse.js';
 import isEmpty from 'lodash/isEmpty';
 import { memo, useEffect, useMemo, useState, type FC } from 'react';
+import { CopyActionIcon } from '../../../components/common/CopyActionIcon';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { useIsTruncated } from '../../../hooks/useIsTruncated';
 import scrollAreaClasses from '../../../styles/ScrollArea.module.css';
@@ -139,21 +138,13 @@ const TableItem: FC<TableItemProps> = memo(
                     className={styles.copyButton}
                     display={hovered ? 'block' : 'none'}
                 >
-                    <CopyButton value={`${quotedTable}`}>
-                        {({ copied, copy }) => (
-                            <Tooltip
-                                label={copied ? 'Copied to clipboard' : 'Copy'}
-                                position="right"
-                            >
-                                <ActionIcon size="xs" onClick={copy} bg="body">
-                                    <MantineIcon
-                                        icon={IconCopy}
-                                        color={copied ? 'green' : undefined}
-                                    />
-                                </ActionIcon>
-                            </Tooltip>
-                        )}
-                    </CopyButton>
+                    <CopyActionIcon
+                        value={quotedTable}
+                        copiedLabel="Copied to clipboard"
+                        tooltipPosition="right"
+                        size="xs"
+                        bg="body"
+                    />
                 </Box>
             </Box>
         );

--- a/packages/frontend/src/hooks/toaster/ApiErrorDisplay.tsx
+++ b/packages/frontend/src/hooks/toaster/ApiErrorDisplay.tsx
@@ -1,6 +1,5 @@
 import { LightdashMode, type ApiErrorDetail } from '@lightdash/common';
 import {
-    ActionIcon,
     Anchor,
     Button,
     Code,
@@ -9,13 +8,13 @@ import {
     Modal,
     Stack,
     Text,
-    Tooltip,
     useComputedColorScheme,
 } from '@mantine/core';
 import { modals } from '@mantine/modals';
 import { IconCheck, IconCopy } from '@tabler/icons-react';
 import { defaultContext } from '@tanstack/react-query';
 import { useContext, useLayoutEffect, useRef, useState } from 'react';
+import { CopyActionIcon } from '../../components/common/CopyActionIcon';
 import MantineIcon from '../../components/common/MantineIcon';
 import { SnowflakeFormInput } from '../../components/UserSettings/MyWarehouseConnectionsPanel/WarehouseFormInputs';
 import SupportDrawerContent from '../../providers/SupportDrawer/SupportDrawerContent';
@@ -109,24 +108,15 @@ export const CopyErrorButton = ({
     value: string;
     color: string;
 }) => (
-    <CopyButton value={value}>
-        {({ copied, copy }) => (
-            <Tooltip label={copied ? 'Copied' : 'Copy error'} position="right">
-                <ActionIcon
-                    aria-label="Copy error details"
-                    color="ldGray.6"
-                    size="xs"
-                    onClick={copy}
-                    variant="transparent"
-                >
-                    <MantineIcon
-                        color={color}
-                        icon={copied ? IconCheck : IconCopy}
-                    />
-                </ActionIcon>
-            </Tooltip>
-        )}
-    </CopyButton>
+    <CopyActionIcon
+        value={value}
+        copyLabel="Copy error"
+        tooltipPosition="right"
+        aria-label="Copy error details"
+        color={color}
+        size="xs"
+        variant="transparent"
+    />
 );
 
 const CopyErrorIdButton = ({ value }: { value: string }) => (


### PR DESCRIPTION
Follow-up to the theme revamp stack (#28442 to #28447). No ticket; agreed with the developer.

## What changed
- `CopyActionIcon` (`components/common`) wraps `CopyButton` + `Tooltip` + `ActionIcon` + the check/copy icon swap that 33 call sites in 27 files spelled out by hand. It owns the copied colour (teal), so callers stop passing `copied ? 'teal' : 'gray'` toggles. Props: `value`, `copyLabel`, `copiedLabel`, `icon`, `tooltipPosition`, plus ActionIcon and button props.
- `FavoriteActionIcon` does the same for the four star toggles (one of which was yellow rather than orange).
- `ConfirmDeleteButton` moves from `VisualizationConfigs/common` to `components/common` and replaces the hand-rolled two-click delete on data-app connection samples. Its idle colour is the theme neutral rather than `gray`.

## Regression analysis
- Skipped sites (11 files) are Buttons with text labels, `UnstyledButton`/`Menu.Item`/`CodeHighlight.Control` children, and three ActionIcons with custom click logic (`stopPropagation`, an `onCopy` callback). They keep their current markup.
- Small behaviour notes: copy sites that set `timeout=2012` now use CopyButton's 1000 ms default; two copy icons gain a Copy/Copied tooltip they did not have; the sample-delete row loses its inline "click again" text in favour of the shared tooltip.

## Verified
- Typecheck, oxlint, oxfmt; the two test files touching migrated components pass (4 tests). No tests asserted on the old markup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Hr8bA9fzAkqy4yULJ6Qd9
