### PR TITLE
refactor(frontend): one hook picks editor themes from the colour scheme

### DIFF
--- a/packages/frontend/src/components/Explorer/CustomDimensionModal/CustomSqlDimensionModal.tsx
+++ b/packages/frontend/src/components/Explorer/CustomDimensionModal/CustomSqlDimensionModal.tsx
@@ -16,7 +16,6 @@ import {
     Stack,
     TextInput,
     Tooltip,
-    useComputedColorScheme,
 } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import {
@@ -41,6 +40,7 @@ import {
 } from '../../../features/explorer/store';
 import { SqlEditor } from '../../../features/tableCalculation/components/SqlForm';
 import useToaster from '../../../hooks/toaster/useToaster';
+import { useEditorTheme } from '../../../hooks/useEditorTheme';
 import { useCustomDimensionsAceEditorCompleter } from '../../../hooks/useExplorerAceEditorCompleter';
 import MantineIcon from '../../common/MantineIcon';
 import MantineModal from '../../common/MantineModal';
@@ -57,7 +57,7 @@ export const CustomSqlDimensionModal: FC<{
     table: string;
     item?: CustomSqlDimension;
 }> = ({ isEditing, table, item }) => {
-    const colorScheme = useComputedColorScheme();
+    const { ace: aceTheme } = useEditorTheme();
 
     const { showToastSuccess, showToastError } = useToaster();
     const { setAceEditor } = useCustomDimensionsAceEditorCompleter();
@@ -256,9 +256,7 @@ export const CustomSqlDimensionModal: FC<{
                     <SqlEditor
                         mode="sql"
                         placeholder="Enter SQL"
-                        theme={
-                            colorScheme === 'dark' ? 'tomorrow_night' : 'github'
-                        }
+                        theme={aceTheme}
                         width="100%"
                         maxLines={Infinity}
                         minLines={isExpanded ? 25 : 8}

--- a/packages/frontend/src/components/VisualizationConfigs/common/LabelEditor.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/common/LabelEditor.tsx
@@ -1,4 +1,4 @@
-import { Input, Paper, Text, useMantineColorScheme } from '@mantine/core';
+import { Input, Paper, Text } from '@mantine/core';
 import { useDebouncedValue } from '@mantine/hooks';
 import { type IDisposable, type languages } from 'monaco-editor';
 import {
@@ -12,6 +12,8 @@ import {
 } from 'react';
 import { useDeepCompareEffect } from 'react-use';
 import { getLightdashMonacoTheme } from '../../../features/sqlRunner/utils/monaco';
+import { useEditorTheme } from '../../../hooks/useEditorTheme';
+import '../../../styles/monaco.css';
 import {
     Editor,
     type BeforeMount,
@@ -19,7 +21,6 @@ import {
     type Monaco,
     type OnMount,
 } from '../../MonacoEditor';
-import '../../../styles/monaco.css';
 import styles from './LabelEditor.module.css';
 
 const MONACO_DEFAULT_OPTIONS: EditorProps['options'] = {
@@ -123,7 +124,7 @@ export const LabelEditor: FC<LabelEditorProps> = ({
         [reactId],
     );
 
-    const { colorScheme } = useMantineColorScheme();
+    const { monaco: monacoTheme } = useEditorTheme();
     const [localValue, setLocalValue] = useState(value);
     const [debouncedValue] = useDebouncedValue(localValue, 500);
     const contentDisposableRef = useRef<IDisposable | null>(null);
@@ -240,11 +241,7 @@ export const LabelEditor: FC<LabelEditorProps> = ({
                     language={languageId}
                     height={`${editorHeight}px`}
                     width="100%"
-                    theme={
-                        colorScheme === 'dark'
-                            ? 'lightdash-dark'
-                            : 'lightdash-light'
-                    }
+                    theme={monacoTheme}
                     wrapperProps={{
                         id: 'label-editor',
                     }}

--- a/packages/frontend/src/components/common/Filters/FilterGroupForm.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterGroupForm.tsx
@@ -26,7 +26,6 @@ import {
     Select,
     Stack,
     Text,
-    useMantineColorScheme,
 } from '@mantine/core';
 import { IconPlus } from '@tabler/icons-react';
 import React, { memo, useCallback, useMemo, useState, type FC } from 'react';
@@ -49,11 +48,10 @@ type Props = {
 const ALLOW_CONVERT_TO_GROUP_UP_TO_DEPTH = 2;
 
 const AddFilterButton: FC<{ onClick: () => void }> = ({ onClick }) => {
-    const { colorScheme } = useMantineColorScheme();
     return (
         <Box
             pos="relative"
-            bg={colorScheme === 'dark' ? 'ldDark.6' : 'white'}
+            bg="var(--mantine-color-body)"
             style={{
                 zIndex: 2,
             }}

--- a/packages/frontend/src/features/sourceCodeEditor/components/CodeEditorPane/index.tsx
+++ b/packages/frontend/src/features/sourceCodeEditor/components/CodeEditorPane/index.tsx
@@ -1,5 +1,5 @@
 import { lightdashDbtYamlSchema } from '@lightdash/common';
-import { Box, Loader, Stack, Text, useMantineColorScheme } from '@mantine/core';
+import { Box, Loader, Stack, Text } from '@mantine/core';
 import { IconFileOff } from '@tabler/icons-react';
 import type { editor } from 'monaco-editor';
 import { configureMonacoYaml } from 'monaco-yaml';
@@ -10,6 +10,7 @@ import Editor, {
     type Monaco,
     type OnMount,
 } from '../../../../components/MonacoEditor';
+import { useEditorTheme } from '../../../../hooks/useEditorTheme';
 import {
     getLightdashMonacoTheme,
     MONACO_DEFAULT_OPTIONS,
@@ -62,7 +63,7 @@ const CodeEditorPane: FC<CodeEditorPaneProps> = ({
     onSave,
     onCreatePR,
 }) => {
-    const { colorScheme } = useMantineColorScheme();
+    const { monaco: monacoTheme } = useEditorTheme();
     const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
     const monacoRef = useRef<Monaco | null>(null);
 
@@ -76,11 +77,10 @@ const CodeEditorPane: FC<CodeEditorPaneProps> = ({
     // Update Monaco theme when color scheme changes
     useEffect(() => {
         if (monacoRef.current) {
-            const themeName =
-                colorScheme === 'dark' ? 'lightdash-dark' : 'lightdash-light';
+            const themeName = monacoTheme;
             monacoRef.current.editor.setTheme(themeName);
         }
-    }, [colorScheme]);
+    }, [monacoTheme]);
 
     const handleBeforeMount: BeforeMount = useCallback((monaco) => {
         // Define both light and dark themes
@@ -167,11 +167,7 @@ const CodeEditorPane: FC<CodeEditorPaneProps> = ({
                         height="100%"
                         language={language}
                         value={content}
-                        theme={
-                            colorScheme === 'dark'
-                                ? 'lightdash-dark'
-                                : 'lightdash-light'
-                        }
+                        theme={monacoTheme}
                         options={editorOptions}
                         beforeMount={handleBeforeMount}
                         onMount={handleEditorMount}

--- a/packages/frontend/src/features/sqlRunner/components/SqlEditor.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/SqlEditor.tsx
@@ -1,4 +1,4 @@
-import { Center, Loader, useComputedColorScheme } from '@mantine/core';
+import { Center, Loader } from '@mantine/core';
 import { IconAlertCircle } from '@tabler/icons-react';
 import debounce from 'lodash/debounce';
 import isEmpty from 'lodash/isEmpty';
@@ -13,6 +13,7 @@ import Editor, {
 } from '../../../components/MonacoEditor';
 import { useParameters } from '../../../hooks/parameters/useParameters';
 import '../../../styles/monaco.css';
+import { useEditorTheme } from '../../../hooks/useEditorTheme';
 import { useDetectedTableFields } from '../hooks/useDetectedTableFields';
 import { useSqlEditorPreferences } from '../hooks/useSqlEditorPreferences';
 import { useTableFields } from '../hooks/useTableFields';
@@ -47,7 +48,7 @@ export const SqlEditor: FC<{
     highlightText?: MonacoHighlightLine;
     resetHighlightError?: () => void;
 }> = ({ onSubmit, highlightText, resetHighlightError }) => {
-    const colorScheme = useComputedColorScheme();
+    const { monaco: monacoTheme } = useEditorTheme();
     const sql = useAppSelector((state) => state.sqlRunner.sql);
     const dispatch = useAppDispatch();
     const quoteChar = useAppSelector((state) => state.sqlRunner.quoteChar);
@@ -292,9 +293,7 @@ export const SqlEditor: FC<{
             value={sql}
             onChange={onChange}
             options={MONACO_DEFAULT_OPTIONS}
-            theme={
-                colorScheme === 'dark' ? 'lightdash-dark' : 'lightdash-light'
-            }
+            theme={monacoTheme}
         />
     );
 };

--- a/packages/frontend/src/features/sqlRunner/components/SqlQueryHistory.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/SqlQueryHistory.tsx
@@ -7,7 +7,6 @@ import {
     HoverCard,
     Popover,
     Tooltip,
-    useComputedColorScheme,
 } from '@mantine/core';
 import { useHover } from '@mantine/hooks';
 import {
@@ -19,6 +18,7 @@ import dayjs from 'dayjs';
 import { type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { Editor } from '../../../components/MonacoEditor';
+import { useEditorTheme } from '../../../hooks/useEditorTheme';
 import { useTimeAgo } from '../../../hooks/useTimeAgo';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
 import { setSql } from '../store/sqlRunnerSlice';
@@ -31,16 +31,13 @@ type Props = {
 };
 
 const SqlQueryHistoryItem: FC<Props> = ({ timestamp, sql }) => {
-    const colorScheme = useComputedColorScheme();
+    const { monaco: monacoTheme } = useEditorTheme();
     const dispatch = useAppDispatch();
 
     const { hovered, ref: hoverRef } = useHover<HTMLButtonElement>();
     const timeAgo = useTimeAgo(new Date(timestamp));
 
     const formattedDate = dayjs(timestamp).format('YYYY-MM-DD HH:mm:ss');
-
-    const openInQueryEditorLinkColor =
-        colorScheme === 'dark' ? 'indigo.4' : 'indigo.6';
 
     return (
         <Stack w="100%">
@@ -64,7 +61,7 @@ const SqlQueryHistoryItem: FC<Props> = ({ timestamp, sql }) => {
                                 w={150}
                                 c={
                                     hovered
-                                        ? openInQueryEditorLinkColor
+                                        ? 'var(--mantine-color-indigo-light-color)'
                                         : 'ldGray.8'
                                 }
                             >
@@ -108,11 +105,7 @@ const SqlQueryHistoryItem: FC<Props> = ({ timestamp, sql }) => {
                             revealHorizontalRightPadding: 0,
                             roundedSelection: false,
                         }}
-                        theme={
-                            colorScheme === 'dark'
-                                ? 'lightdash-dark'
-                                : 'lightdash-light'
-                        }
+                        theme={monacoTheme}
                     />
                 </HoverCard.Dropdown>
             </HoverCard>

--- a/packages/frontend/src/features/tableCalculation/components/SqlForm.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/SqlForm.tsx
@@ -10,7 +10,6 @@ import {
     Flex,
     ScrollArea,
     Text,
-    useComputedColorScheme,
     useMantineTheme,
 } from '@mantine/core';
 import { useLocalStorage } from '@mantine/hooks';
@@ -24,13 +23,14 @@ import {
     AiTableCalculationInputBody,
 } from '../../../ee/features/ambientAi/components/tableCalculation';
 import { useAmbientAiEnabled } from '../../../ee/features/ambientAi/hooks/useAmbientAiEnabled';
+import { useEditorTheme } from '../../../hooks/useEditorTheme';
 import { useTableCalculationAceEditorCompleter } from '../../../hooks/useExplorerAceEditorCompleter';
 import { type TableCalculationForm } from '../types';
 import FormulaConversionPreviewBody from './FormulaConversionPreview';
-import classes from './SqlForm.module.css';
 import 'ace-builds/src-noconflict/mode-sql';
 import 'ace-builds/src-noconflict/theme-github';
 import 'ace-builds/src-noconflict/theme-tomorrow_night';
+import classes from './SqlForm.module.css';
 
 const SQL_PLACEHOLDER = '${table_name.field_name} + ${table_name.metric_name}';
 const SOFT_WRAP_LOCAL_STORAGE_KEY = 'lightdash-sql-form-soft-wrap';
@@ -105,7 +105,7 @@ export const SqlForm: FC<Props> = ({
     conversionState,
 }) => {
     const theme = useMantineTheme();
-    const colorScheme = useComputedColorScheme();
+    const { ace: aceTheme } = useEditorTheme();
     const [isSoftWrapEnabled, setSoftWrapEnabled] = useLocalStorage({
         key: SOFT_WRAP_LOCAL_STORAGE_KEY,
         defaultValue: true,
@@ -207,7 +207,7 @@ export const SqlForm: FC<Props> = ({
             >
                 <SqlEditor
                     mode="sql"
-                    theme={colorScheme === 'dark' ? 'tomorrow_night' : 'github'}
+                    theme={aceTheme}
                     width="100%"
                     placeholder={SQL_PLACEHOLDER}
                     maxLines={Infinity}

--- a/packages/frontend/src/hooks/useEditorTheme.ts
+++ b/packages/frontend/src/hooks/useEditorTheme.ts
@@ -1,0 +1,10 @@
+import { useComputedColorScheme } from '@mantine/core';
+
+/** Editor theme names that follow the app colour scheme. */
+export const useEditorTheme = () => {
+    const isDark = useComputedColorScheme('light') === 'dark';
+    return {
+        monaco: isDark ? 'lightdash-dark' : 'lightdash-light',
+        ace: isDark ? 'tomorrow_night' : 'github',
+    } as const;
+};


### PR DESCRIPTION
Follow-up to the theme revamp stack (#28442 to #28447). No ticket; agreed with the developer.

## What changed
- `useEditorTheme()` returns the Monaco (`lightdash-dark` / `lightdash-light`) and Ace (`tomorrow_night` / `github`) theme names from `useComputedColorScheme`. Six components that read the colour scheme only to pick those names use it instead.
- The last two colour ternaries become tokens: the filter group background is `var(--mantine-color-body)` and the SQL history link uses the indigo light-variant text colour.

## Regression analysis
- Same theme names in the same conditions; `useComputedColorScheme('light')` matches what four of the six callers already used. Unused `useMantineColorScheme` / `useComputedColorScheme` imports removed.

## Verified
- Typecheck, oxlint, oxfmt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Hr8bA9fzAkqy4yULJ6Qd9
