### PR TITLE
refactor(frontend): select option renderers are plain components

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileForms/AddChartTilesModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/AddChartTilesModal.tsx
@@ -21,7 +21,6 @@ import { useDebouncedValue } from '@mantine/hooks';
 import { IconChartAreaLine } from '@tabler/icons-react';
 import uniqBy from 'lodash/uniqBy';
 import React, {
-    forwardRef,
     useEffect,
     useLayoutEffect,
     useMemo,
@@ -48,56 +47,42 @@ type Props = {
     maxSelectedValues?: number;
 };
 
-interface ItemProps extends React.ComponentPropsWithoutRef<'div'> {
+type ItemProps = {
     label: string;
     chartKind: ChartKind;
     tooltipLabel?: string;
     disabled?: boolean;
     selected?: boolean;
-}
+};
 
-const SelectItem = forwardRef<HTMLDivElement, ItemProps>(
-    (
-        {
-            label,
-            tooltipLabel,
-            chartKind,
-            disabled,
-            selected,
-            ...others
-        }: ItemProps,
-        ref,
-    ) => (
-        <div ref={ref} {...others}>
-            <Stack gap="1">
-                <Tooltip
-                    label={tooltipLabel}
-                    disabled={!tooltipLabel}
-                    position="top-start"
+const SelectItem: FC<ItemProps> = ({
+    label,
+    tooltipLabel,
+    chartKind,
+    disabled,
+    selected,
+}) => (
+    <Stack gap="1">
+        <Tooltip
+            label={tooltipLabel}
+            disabled={!tooltipLabel}
+            position="top-start"
+        >
+            <Group gap="xs">
+                <ChartIcon
+                    chartKind={chartKind ?? ChartKind.VERTICAL_BAR}
+                    color={disabled ? 'ldGray.5' : undefined}
+                />
+                <Text
+                    c={disabled ? 'dimmed' : selected ? 'ldGray.9' : 'ldGray.8'}
+                    fw={500}
+                    fz="xs"
                 >
-                    <Group gap="xs">
-                        <ChartIcon
-                            chartKind={chartKind ?? ChartKind.VERTICAL_BAR}
-                            color={disabled ? 'ldGray.5' : undefined}
-                        />
-                        <Text
-                            c={
-                                disabled
-                                    ? 'dimmed'
-                                    : selected
-                                      ? 'ldGray.9'
-                                      : 'ldGray.8'
-                            }
-                            fw={500}
-                            fz="xs"
-                        >
-                            {label}
-                        </Text>
-                    </Group>
-                </Tooltip>
-            </Stack>
-        </div>
-    ),
+                    {label}
+                </Text>
+            </Group>
+        </Tooltip>
+    </Stack>
 );
 
 const AddChartTilesModal: FC<Props> = ({

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
@@ -28,7 +28,7 @@ import {
     IconSwitchHorizontal,
     type Icon,
 } from '@tabler/icons-react';
-import { forwardRef, type FC } from 'react';
+import { type FC } from 'react';
 import { getAxisTypeFromField } from '../../../../hooks/echarts/useEchartsCartesianConfig';
 import MantineIcon from '../../../common/MantineIcon';
 import { NumberInput } from '../../../common/NumberInput';
@@ -39,18 +39,19 @@ import { LabelEditor } from '../../common/LabelEditor';
 import { AxisMinInterval } from './AxisMinInterval';
 import { AxisMinMax } from './AxisMinMax';
 
-const XAxisSortSelectItem = forwardRef<
-    HTMLDivElement,
-    { icon: Icon; label: string; mirrorIcon?: boolean }
->(({ icon, label, mirrorIcon = false, ...others }, ref) => (
-    <Group ref={ref} gap="xs" {...others} wrap="nowrap">
+const XAxisSortSelectItem: FC<{
+    icon: Icon;
+    label: string;
+    mirrorIcon?: boolean;
+}> = ({ icon, label, mirrorIcon = false }) => (
+    <Group gap="xs" wrap="nowrap">
         <MantineIcon
             style={mirrorIcon ? { transform: 'rotateY(180deg)' } : undefined}
             icon={icon}
         />
         <Text fz="xs">{label}</Text>
     </Group>
-));
+);
 
 type Props = {
     itemsMap: ItemsMap | undefined;


### PR DESCRIPTION
Follow-up to the theme revamp stack (#28442 to #28447). No ticket; agreed with the developer.

## What changed
- The chart-tile picker `SelectItem` and the x-axis sort `XAxisSortSelectItem` were Mantine 6 style `forwardRef` item components that spread unknown props onto a wrapper `div`. Both are used only through Mantine 8's `renderOption`, which takes a plain function, so they drop `forwardRef`, the wrapper and the rest spread.

## Regression analysis
- Rendered markup loses one wrapper `div` per option; no props or handlers change. Typecheck covers the call sites.

## Verified
- Typecheck, oxlint, oxfmt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Hr8bA9fzAkqy4yULJ6Qd9
