### PR TITLE
refactor(frontend): neutral controls stop restating the dimmed shade

### DIFF
--- a/packages/frontend/src/components/DataViz/config/BigNumberConditionalFormatting.tsx
+++ b/packages/frontend/src/components/DataViz/config/BigNumberConditionalFormatting.tsx
@@ -118,7 +118,6 @@ export const BigNumberConditionalFormatting = ({
                         />
 
                         <ActionIcon
-                            color="ldGray.6"
                             aria-label="Remove rule"
                             onClick={() =>
                                 dispatch(removeConditionalFormattingRule(index))

--- a/packages/frontend/src/components/DataViz/config/BigNumberDisplayConfig.tsx
+++ b/packages/frontend/src/components/DataViz/config/BigNumberDisplayConfig.tsx
@@ -29,7 +29,6 @@ export const BigNumberDisplayConfig = () => {
                     <Config.Heading>Label</Config.Heading>
                     <Tooltip label={showLabel ? 'Hide label' : 'Show label'}>
                         <ActionIcon
-                            color="ldGray.6"
                             onClick={() => dispatch(setShowLabel(!showLabel))}
                         >
                             <MantineIcon

--- a/packages/frontend/src/components/DataViz/config/CartesianChartFieldConfiguration.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartFieldConfiguration.tsx
@@ -105,7 +105,6 @@ const YFieldsAxisConfig: FC<{
                             />
                             <Tooltip label="Remove Y axis">
                                 <ActionIcon
-                                    color="ldGray.6"
                                     onClick={() =>
                                         dispatch(
                                             actions.removeYAxisField(index),
@@ -180,7 +179,6 @@ const XFieldAxisConfig = ({
             />
             <Tooltip label="Remove X axis">
                 <ActionIcon
-                    color="ldGray.6"
                     onClick={() => dispatch(actions.removeXAxisField())}
                     data-testid="remove-x-axis-field"
                 >
@@ -317,7 +315,6 @@ export const CartesianChartFieldConfiguration = ({
                         <Config.Heading>{`Y-axis`}</Config.Heading>
                         <Tooltip label="Add Y axis">
                             <ActionIcon
-                                color="ldGray.6"
                                 onClick={() =>
                                     dispatch(actions.addYAxisField())
                                 }

--- a/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
@@ -477,7 +477,6 @@ const ColumnHeaderContextMenu: FC<HeaderProps> = ({ header }) => {
                                 size="xs"
                                 variant="light"
                                 bg="transparent"
-                                color="ldGray.6"
                                 aria-label="Context menu"
                             >
                                 <MantineIcon icon={IconDots} />

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -672,7 +672,6 @@ const SavedChartsHeader: FC = () => {
                                 {isEditMode && userCanManageChart && (
                                     <ActionIcon
                                         size="xs"
-                                        color="ldGray.6"
                                         disabled={updateSavedChart.isLoading}
                                         onClick={() => setIsRenamingChart(true)}
                                     >

--- a/packages/frontend/src/components/ExportSelector/index.tsx
+++ b/packages/frontend/src/components/ExportSelector/index.tsx
@@ -53,7 +53,6 @@ const ExportSelector: FC<
             return (
                 <>
                     <Button
-                        color="ldGray.6"
                         size="xs"
                         mb="xs"
                         leftSection={<MantineIcon icon={IconArrowLeft} />}

--- a/packages/frontend/src/components/Home/HomepageContentPanel/index.tsx
+++ b/packages/frontend/src/components/Home/HomepageContentPanel/index.tsx
@@ -122,7 +122,6 @@ export const HomepageContentPanel: FC<Props> = ({
                           title: 'Charts and Dashboards',
                           action: (
                               <MantineLinkButton
-                                  color="ldGray.6"
                                   size="compact-sm"
                                   variant="subtle"
                                   target="_blank"

--- a/packages/frontend/src/components/PinnedItemsPanel/index.tsx
+++ b/packages/frontend/src/components/PinnedItemsPanel/index.tsx
@@ -62,7 +62,6 @@ const PinnedItemsPanel: FC<Props> = ({ pinnedItems, isEnabled }) => {
                     target="_blank"
                     variant="subtle"
                     size="compact-sm"
-                    color="ldGray.6"
                 >
                     View docs
                 </MantineLinkButton>

--- a/packages/frontend/src/components/ProjectAccess/ProjectAccess.tsx
+++ b/packages/frontend/src/components/ProjectAccess/ProjectAccess.tsx
@@ -733,7 +733,7 @@ const ProjectAccess: FC<ProjectAccessProps> = ({ projectUuid }) => {
                         <Menu position="bottom-end">
                             <Menu.Target>
                                 <Tooltip label="View options">
-                                    <ActionIcon color="ldGray.6" size="sm">
+                                    <ActionIcon size="sm">
                                         <MantineIcon icon={IconDotsVertical} />
                                     </ActionIcon>
                                 </Tooltip>

--- a/packages/frontend/src/components/ProjectConnection/FormCollapseButton.tsx
+++ b/packages/frontend/src/components/ProjectConnection/FormCollapseButton.tsx
@@ -12,7 +12,6 @@ const FormCollapseButton: FC<
     return (
         <Button
             variant="subtle"
-            color="ldGray.6"
             size="compact-sm"
             style={{
                 alignSelf: 'end',

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionsTable.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionsTable.tsx
@@ -143,7 +143,6 @@ const ConnectionRow: FC<
                     <ActionIcon
                         variant="transparent"
                         size="sm"
-                        color="ldGray.6"
                         aria-label={`Actions for ${connection.name}`}
                     >
                         <MantineIcon icon={IconDots} />

--- a/packages/frontend/src/components/SortButton/SortItem.tsx
+++ b/packages/frontend/src/components/SortButton/SortItem.tsx
@@ -174,11 +174,7 @@ const SortItem = forwardRef<HTMLDivElement, SortItemProps>(
 
                     {isEditMode && (
                         <Tooltip label="Remove sort">
-                            <ActionIcon
-                                onClick={onRemoveSortField}
-                                size="xs"
-                                color="ldGray.6"
-                            >
+                            <ActionIcon onClick={onRemoveSortField} size="xs">
                                 <MantineIcon icon={IconMinus} />
                             </ActionIcon>
                         </Tooltip>

--- a/packages/frontend/src/components/SortButton/Sorting.tsx
+++ b/packages/frontend/src/components/SortButton/Sorting.tsx
@@ -257,11 +257,7 @@ const Sorting = forwardRef<HTMLDivElement, Props>(({ sorts, isEditMode }) => {
                                 comboboxProps={{ withinPortal: false }}
                             />
                             <Tooltip label="Cancel">
-                                <ActionIcon
-                                    size="xs"
-                                    color="ldGray.6"
-                                    onClick={resetAddState}
-                                >
+                                <ActionIcon size="xs" onClick={resetAddState}>
                                     <MantineIcon icon={IconMinus} />
                                 </ActionIcon>
                             </Tooltip>

--- a/packages/frontend/src/components/UserSettings/AccessTokensPanel/TokensTable.tsx
+++ b/packages/frontend/src/components/UserSettings/AccessTokensPanel/TokensTable.tsx
@@ -107,11 +107,7 @@ const TokenItem: FC<{
             <Table.Td w="1%">
                 <Menu position="bottom-end">
                     <Menu.Target>
-                        <ActionIcon
-                            variant="transparent"
-                            size="sm"
-                            color="ldGray.6"
-                        >
+                        <ActionIcon variant="transparent" size="sm">
                             <MantineIcon icon={IconDots} />
                         </ActionIcon>
                     </Menu.Target>

--- a/packages/frontend/src/components/UserSettings/MyAppsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/MyAppsPanel/index.tsx
@@ -271,11 +271,7 @@ const MyAppsPanel: FC<MyAppsPanelProps> = ({
                     return (
                         <Menu position="bottom-end">
                             <Menu.Target>
-                                <ActionIcon
-                                    variant="transparent"
-                                    color="ldGray.6"
-                                    size="sm"
-                                >
+                                <ActionIcon variant="transparent" size="sm">
                                     <MantineIcon icon={IconDots} size={16} />
                                 </ActionIcon>
                             </Menu.Target>

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/CredentialsTable.tsx
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/CredentialsTable.tsx
@@ -61,11 +61,7 @@ const CredentialsItem: FC<
         <Table.Td w="1%">
             <Menu position="bottom-end">
                 <Menu.Target>
-                    <ActionIcon
-                        variant="transparent"
-                        size="sm"
-                        color="ldGray.6"
-                    >
+                    <ActionIcon variant="transparent" size="sm">
                         <MantineIcon icon={IconDots} />
                     </ActionIcon>
                 </Menu.Target>

--- a/packages/frontend/src/components/UserSettings/OAuthClientsPanel/OAuthClientsTable.tsx
+++ b/packages/frontend/src/components/UserSettings/OAuthClientsPanel/OAuthClientsTable.tsx
@@ -40,7 +40,6 @@ const OAuthClientRow: FC<{
                             tooltipPosition="right"
                             size="xs"
                             variant="transparent"
-                            color="ldGray.6"
                         />
                     </Group>
                 </Table.Td>
@@ -55,11 +54,7 @@ const OAuthClientRow: FC<{
                 <Table.Td w="1%">
                     <Menu position="bottom-end">
                         <Menu.Target>
-                            <ActionIcon
-                                variant="transparent"
-                                size="sm"
-                                color="ldGray.6"
-                            >
+                            <ActionIcon variant="transparent" size="sm">
                                 <MantineIcon icon={IconDots} />
                             </ActionIcon>
                         </Menu.Target>

--- a/packages/frontend/src/components/UserSettings/UserAttributesPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/UserAttributesPanel/index.tsx
@@ -132,11 +132,7 @@ const UserAttributesPanel: FC = () => {
                         >
                             <Menu position="bottom-end">
                                 <Menu.Target>
-                                    <ActionIcon
-                                        variant="transparent"
-                                        size="sm"
-                                        color="ldGray.6"
-                                    >
+                                    <ActionIcon variant="transparent" size="sm">
                                         <MantineIcon icon={IconDots} />
                                     </ActionIcon>
                                 </Menu.Target>

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ColumnCellDisplay.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ColumnCellDisplay.tsx
@@ -170,7 +170,6 @@ export const ColumnCellDisplay: FC = () => {
                                             },
                                         );
                                     }}
-                                    color="ldGray.6"
                                     variant="light"
                                 >
                                     <MantineIcon

--- a/packages/frontend/src/components/VisualizationConfigs/common/EditableText.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/common/EditableText.tsx
@@ -86,7 +86,6 @@ export const EditableText: FC<Props> = ({
                                     <ActionIcon
                                         className={styles.action}
                                         size="xs"
-                                        color="ldGray.6"
                                     >
                                         <MantineIcon icon={IconVariable} />
                                     </ActionIcon>

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -433,7 +433,7 @@ const DashboardHeader = memo(
                         }}
                     >
                         <Popover.Target>
-                            <ActionIcon size="md" color="ldGray.6">
+                            <ActionIcon size="md">
                                 <MantineIcon icon={IconInfoCircle} />
                             </ActionIcon>
                         </Popover.Target>
@@ -480,7 +480,6 @@ const DashboardHeader = memo(
                     {isEditMode && userCanManageDashboard && (
                         <ActionIcon
                             size="md"
-                            color="ldGray.6"
                             disabled={isSaving}
                             onClick={handleEditClick}
                         >

--- a/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
@@ -389,7 +389,6 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
                             disabled={disabled}
                             aria-label="Menu"
                             data-testid={`ResourceViewActionMenu/${item.data.name}`}
-                            color="ldGray.6"
                         >
                             <IconDots size={16} />
                         </ActionIcon>

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -839,7 +839,6 @@ export const AgentChatInput = ({
             <Menu position="bottom-start" width={220}>
                 <Menu.Target>
                     <ActionIcon
-                        color="ldGray.6"
                         size={30}
                         radius="xl"
                         aria-label="Composer options"

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentVisualizationFilters.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentVisualizationFilters.tsx
@@ -93,7 +93,7 @@ const FilterGroupDisplay: FC<{
                         rule={rule as AiFilterRule}
                     />
                     {combinator === 'or' && index !== rules.length - 1 && (
-                        <Text fz="xs" color="ldGray.6" fw={500}>
+                        <Text fz="xs" c="dimmed" fw={500}>
                             OR
                         </Text>
                     )}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiArtifactPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiArtifactPanel.tsx
@@ -296,7 +296,6 @@ export const AiArtifactPanel: FC<AiArtifactPanelProps> = memo(
                         <Group gap={2} className={styles.headRight}>
                             <ActionIcon
                                 size="sm"
-                                color="ldGray.6"
                                 onClick={() => dispatch(clearPreview())}
                                 aria-label="Close"
                             >
@@ -434,7 +433,6 @@ export const AiArtifactPanel: FC<AiArtifactPanelProps> = memo(
                             />
                             <ActionIcon
                                 size="sm"
-                                color="ldGray.6"
                                 onClick={() => dispatch(clearPreview())}
                                 aria-label="Close"
                             >

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDataAppPreviewPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDataAppPreviewPanel.tsx
@@ -68,7 +68,6 @@ export const AiDataAppPreviewPanel: FC<Props> = ({ dataAppPreview }) => {
     const closeButton = (
         <ActionIcon
             size="sm"
-            color="ldGray.6"
             onClick={() => dispatch(clearPreview())}
             aria-label="Close"
         >
@@ -169,7 +168,6 @@ export const AiDataAppPreviewPanel: FC<Props> = ({ dataAppPreview }) => {
                                 <Tooltip label="More options">
                                     <ActionIcon
                                         size="sm"
-                                        color="ldGray.6"
                                         aria-label="More options"
                                     >
                                         <MantineIcon icon={IconDots} />

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiSavedChartPreviewPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiSavedChartPreviewPanel.tsx
@@ -67,7 +67,6 @@ export const AiSavedChartPreviewPanel: FC<Props> = ({ savedChartPreview }) => {
     const closeButton = (
         <ActionIcon
             size="sm"
-            color="ldGray.6"
             onClick={() => dispatch(clearPreview())}
             aria-label="Close"
         >
@@ -133,7 +132,6 @@ export const AiSavedChartPreviewPanel: FC<Props> = ({ savedChartPreview }) => {
                                 <Tooltip label="More options">
                                     <ActionIcon
                                         size="sm"
-                                        color="ldGray.6"
                                         aria-label="More options"
                                     >
                                         <MantineIcon icon={IconDots} />

--- a/packages/frontend/src/ee/features/customRoles/CustomRolesTable.tsx
+++ b/packages/frontend/src/ee/features/customRoles/CustomRolesTable.tsx
@@ -67,11 +67,7 @@ const TableRow: FC<{
             <Table.Td w="1%">
                 <Menu position="bottom-end">
                     <Menu.Target>
-                        <ActionIcon
-                            variant="transparent"
-                            size="sm"
-                            color="ldGray.6"
-                        >
+                        <ActionIcon variant="transparent" size="sm">
                             <MantineIcon icon={IconDots} />
                         </ActionIcon>
                     </Menu.Target>

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
@@ -460,26 +460,18 @@ const BlockCard: FC<BlockCardProps> = ({
                 </div>
                 <Group gap={2} className={classes.blockActions} wrap="nowrap">
                     <Tooltip label="Move up">
-                        <ActionIcon
-                            color="ldGray.6"
-                            disabled={!canUp}
-                            onClick={onUp}
-                        >
+                        <ActionIcon disabled={!canUp} onClick={onUp}>
                             <MantineIcon icon={IconArrowUp} />
                         </ActionIcon>
                     </Tooltip>
                     <Tooltip label="Move down">
-                        <ActionIcon
-                            color="ldGray.6"
-                            disabled={!canDown}
-                            onClick={onDown}
-                        >
+                        <ActionIcon disabled={!canDown} onClick={onDown}>
                             <MantineIcon icon={IconArrowDown} />
                         </ActionIcon>
                     </Tooltip>
                     {!definition.singleton && (
                         <Tooltip label="Duplicate">
-                            <ActionIcon color="ldGray.6" onClick={onDuplicate}>
+                            <ActionIcon onClick={onDuplicate}>
                                 <MantineIcon icon={IconCopy} />
                             </ActionIcon>
                         </Tooltip>

--- a/packages/frontend/src/ee/features/homepageBuilder/PublishModal.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/PublishModal.tsx
@@ -424,7 +424,6 @@ const PublishModalBody: FC<BodyProps> = ({
                                                     </Text>
                                                 </Box>
                                                 <ActionIcon
-                                                    color="ldGray.6"
                                                     size="sm"
                                                     disabled={index === 0}
                                                     aria-label={`Move ${assignment.groupName} up`}
@@ -441,7 +440,6 @@ const PublishModalBody: FC<BodyProps> = ({
                                                     />
                                                 </ActionIcon>
                                                 <ActionIcon
-                                                    color="ldGray.6"
                                                     size="sm"
                                                     disabled={
                                                         index ===

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/AnnouncementsBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/AnnouncementsBlock.tsx
@@ -407,7 +407,6 @@ const AnnouncementItemActions: FC<{
             {!announcement.published && (
                 <Tooltip label="Publish now">
                     <ActionIcon
-                        color="ldGray.6"
                         size="sm"
                         aria-label="Publish announcement now"
                         onClick={() => setConfirmingPublish(true)}
@@ -451,7 +450,6 @@ const AnnouncementItemActions: FC<{
             )}
             <Tooltip label={announcement.pinned ? 'Unpin' : 'Pin to top'}>
                 <ActionIcon
-                    color="ldGray.6"
                     size="sm"
                     aria-label={announcement.pinned ? 'Unpin' : 'Pin'}
                     onClick={() =>
@@ -468,7 +466,6 @@ const AnnouncementItemActions: FC<{
             </Tooltip>
             <Tooltip label="Edit">
                 <ActionIcon
-                    color="ldGray.6"
                     size="sm"
                     aria-label="Edit announcement"
                     onClick={() => onEdit(announcement)}

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/ContentCard.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/ContentCard.tsx
@@ -95,7 +95,6 @@ const CardActions: FC<Pick<Props, 'content' | 'onRemove' | 'star'>> = ({
         )}
         {onRemove && (
             <ActionIcon
-                color="ldGray.6"
                 size="sm"
                 aria-label={`Remove ${content.name} from collection`}
                 onClick={(e) => {

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/MetricsBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/MetricsBlock.tsx
@@ -363,7 +363,6 @@ export const MetricsBlockBuild: FC<BuildComponentProps> = ({
                                     </Text>
                                 </Box>
                                 <ActionIcon
-                                    color="ldGray.6"
                                     size="sm"
                                     aria-label={`Remove metric ${metricRef.label}`}
                                     onClick={() =>

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/QuickActionsBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/QuickActionsBlock.tsx
@@ -432,7 +432,6 @@ export const QuickActionsBlockBuild: FC<BuildComponentProps> = ({
                                         </ActionIcon>
                                     </Tooltip>
                                     <ActionIcon
-                                        color="ldGray.6"
                                         size="sm"
                                         disabled={index === 0}
                                         aria-label={`Move ${presentation.title} earlier`}
@@ -441,7 +440,6 @@ export const QuickActionsBlockBuild: FC<BuildComponentProps> = ({
                                         <MantineIcon icon={IconArrowLeft} />
                                     </ActionIcon>
                                     <ActionIcon
-                                        color="ldGray.6"
                                         size="sm"
                                         disabled={
                                             index ===
@@ -453,7 +451,6 @@ export const QuickActionsBlockBuild: FC<BuildComponentProps> = ({
                                         <MantineIcon icon={IconArrowRight} />
                                     </ActionIcon>
                                     <ActionIcon
-                                        color="ldGray.6"
                                         size="sm"
                                         aria-label={`Remove ${presentation.title}`}
                                         onClick={() =>

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.tsx
@@ -442,7 +442,6 @@ const BuildCard: FC<EditProps & { standalone: boolean }> = ({
                     onChange={(kind) => onPatch({ kind })}
                 />
                 <ActionIcon
-                    color="ldGray.6"
                     size="sm"
                     aria-label={`Remove ${item.title}`}
                     onClick={onRemove}
@@ -501,7 +500,6 @@ const BuildTile: FC<EditProps> = ({ item, projectUuid, onPatch, onRemove }) => (
             <KindControl item={item} onChange={(kind) => onPatch({ kind })} />
         )}
         <ActionIcon
-            color="ldGray.6"
             size="sm"
             aria-label={`Remove ${item.title}`}
             onClick={onRemove}
@@ -726,7 +724,6 @@ export const ResourcesBlockBuild: FC<BuildComponentProps> = ({
                     <Group gap={2} wrap="nowrap">
                         <Tooltip label="Add data app" openDelay={200}>
                             <ActionIcon
-                                color="ldGray.6"
                                 size="sm"
                                 aria-label="Add data app"
                                 onClick={() => setIsAppPickerOpen(true)}
@@ -736,7 +733,6 @@ export const ResourcesBlockBuild: FC<BuildComponentProps> = ({
                         </Tooltip>
                         <Tooltip label="Add link" openDelay={200}>
                             <ActionIcon
-                                color="ldGray.6"
                                 size="sm"
                                 aria-label="Add resource"
                                 onClick={() => startResolving(pasteValue)}

--- a/packages/frontend/src/ee/features/scim/components/ScimAccessTokensPanel/TokensTable.tsx
+++ b/packages/frontend/src/ee/features/scim/components/ScimAccessTokensPanel/TokensTable.tsx
@@ -84,7 +84,6 @@ const TokenItem: FC<{
                         tooltipPosition="right"
                         size="xs"
                         variant="transparent"
-                        color="ldGray.6"
                     />
                 </Group>
             </Table.Td>

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
@@ -270,7 +270,7 @@ const AiAgentNewThreadPage: FC = () => {
                             {agent.instruction && (
                                 <Popover withArrow>
                                     <Popover.Target>
-                                        <ActionIcon color="ldGray.6">
+                                        <ActionIcon>
                                             <MantineIcon
                                                 icon={IconInfoCircle}
                                             />

--- a/packages/frontend/src/ee/pages/Roadmap.tsx
+++ b/packages/frontend/src/ee/pages/Roadmap.tsx
@@ -208,7 +208,6 @@ const RoadmapDetailsModal: FC<{
                                     <CopyActionIcon
                                         value={item.ticketId}
                                         copyLabel="Copy ticket ID"
-                                        color="ldGray.6"
                                         size="xs"
                                         variant="transparent"
                                     />

--- a/packages/frontend/src/features/apps/components/AppBuilderSidebarToggle.tsx
+++ b/packages/frontend/src/features/apps/components/AppBuilderSidebarToggle.tsx
@@ -16,12 +16,7 @@ const AppBuilderSidebarToggle: FC<Props> = ({ collapsed, onToggle }) => {
 
     return (
         <Tooltip label={label} position="right">
-            <ActionIcon
-                size="sm"
-                color="ldGray.6"
-                onClick={onToggle}
-                aria-label={label}
-            >
+            <ActionIcon size="sm" onClick={onToggle} aria-label={label}>
                 <MantineIcon
                     icon={
                         collapsed

--- a/packages/frontend/src/features/apps/components/AppHeader.tsx
+++ b/packages/frontend/src/features/apps/components/AppHeader.tsx
@@ -77,7 +77,7 @@ const AppHeader: FC<Props> = ({ projectUuid, app, rightSection }) => {
                     }}
                 >
                     <Popover.Target>
-                        <ActionIcon size="md" color="ldGray.6">
+                        <ActionIcon size="md">
                             <MantineIcon icon={IconInfoCircle} />
                         </ActionIcon>
                     </Popover.Target>

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/FilterRequirementsButton.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/FilterRequirementsButton.tsx
@@ -103,7 +103,6 @@ const RuleCard: FC<RuleCardProps> = ({
             <Button
                 size="compact-xs"
                 variant="subtle"
-                color="ldGray.6"
                 ml="auto"
                 leftSection={<MantineIcon icon={IconTrash} />}
                 onClick={onDeleteRule}

--- a/packages/frontend/src/features/externalConnections/components/CustomHeadersField.tsx
+++ b/packages/frontend/src/features/externalConnections/components/CustomHeadersField.tsx
@@ -71,7 +71,6 @@ export const CustomHeadersField: FC<Props> = ({
                     />
                     <ActionIcon
                         aria-label="Remove header"
-                        color="ldGray.6"
                         mt={4}
                         disabled={disabled}
                         onClick={() =>

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumns.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumns.tsx
@@ -116,7 +116,6 @@ export const MetricsCatalogColumns: ContentTableColumnDef<CatalogField>[] = [
                     href={url.toString()}
                     target="_blank"
                     size="compact-xs"
-                    color="ldGray.6"
                     variant="subtle"
                     leftSection={<TableFilled />}
                     fz="sm"

--- a/packages/frontend/src/features/organizationDesigns/components/DesignListPage.tsx
+++ b/packages/frontend/src/features/organizationDesigns/components/DesignListPage.tsx
@@ -80,7 +80,6 @@ const DesignRow: FC<{
                     <ActionIcon
                         variant="transparent"
                         size="sm"
-                        color="ldGray.6"
                         aria-label="More actions"
                     >
                         <MantineIcon icon={IconDots} />

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/SchedulerFormFiltersTab.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/SchedulerFormFiltersTab.tsx
@@ -56,7 +56,7 @@ const FilterSummaryLabel: FC<
     if (isDisabled) {
         return (
             <Text fw={400} span>
-                <Text span color="ldGray.6">
+                <Text span c="dimmed">
                     is any value
                 </Text>
             </Text>
@@ -183,7 +183,7 @@ const FilterItem: FC<SchedulerFilterItemProps> = ({
                             fz="xs"
                             w={200}
                         >
-                            <Text fz="xs" color="ldGray.6" span>
+                            <Text fz="xs" c="dimmed" span>
                                 {`Applies to ${tilesWithFilter.length} tiles`}
                             </Text>
                         </Tooltip>
@@ -520,12 +520,12 @@ export const SchedulerFormFiltersTab: FC<SchedulerFiltersProps> = ({
             0 ? (
                 <Stack mb="sm">
                     {hasUnmetSingles && (
-                        <Text fz="xs" color="ldGray.6">
+                        <Text fz="xs" c="dimmed">
                             All required filters must have values
                         </Text>
                     )}
                     {hasUnmetGroups && (
-                        <Text fz="xs" color="ldGray.6">
+                        <Text fz="xs" c="dimmed">
                             Set a value for at least one filter in each
                             requirement group
                         </Text>
@@ -589,7 +589,7 @@ export const SchedulerFormFiltersTab: FC<SchedulerFiltersProps> = ({
                         },
                     )}
                     {savedFiltersNotInDashboard.length > 0 && (
-                        <Text fz="xs" color="ldGray.6" mt="xs">
+                        <Text fz="xs" c="dimmed" mt="xs">
                             The following filters are applied to this scheduled
                             delivery but no longer exist in the dashboard
                         </Text>

--- a/packages/frontend/src/features/virtualView/components/HeaderVirtualView.tsx
+++ b/packages/frontend/src/features/virtualView/components/HeaderVirtualView.tsx
@@ -204,7 +204,6 @@ const ChangesReviewModal: FC<
                                 <Button
                                     size="compact-xs"
                                     variant="subtle"
-                                    color="ldGray.6"
                                     onClick={() =>
                                         setShowAllDiffs(!showAllDiffs)
                                     }

--- a/packages/frontend/src/pages/Invite.tsx
+++ b/packages/frontend/src/pages/Invite.tsx
@@ -54,7 +54,7 @@ const WelcomeCard: FC<WelcomeCardProps> = ({ email, setReadyToJoin }) => {
                     {email}
                 </Text>
             )}
-            <Text color="ldGray.6" ta={textAlign}>
+            <Text c="dimmed" ta={textAlign}>
                 {`Your teammates ${
                     org?.name ? `at ${org.name}` : ''
                 } are using Lightdash to discover

--- a/packages/frontend/src/stories/WritebackPrCard.stories.tsx
+++ b/packages/frontend/src/stories/WritebackPrCard.stories.tsx
@@ -79,7 +79,7 @@ const CardShell: FC<{
                         <Text size="xs" fw={500}>
                             Edited semantic layer
                         </Text>
-                        <Text size="xs" c="ldGray.6">
+                        <Text size="xs" c="dimmed">
                             charliedowler/jaffle · 4c2a4e9
                         </Text>
                     </Stack>


### PR DESCRIPTION
Follow-up to the theme revamp stack (#28442 to #28447). No ticket; agreed with the developer.

## What changed
- The theme already renders subtle and transparent ActionIcons, subtle Buttons and link buttons in the dimmed neutral with a text-colour hover, so the 60-odd call sites passing `color="ldGray.6"` were restating the default. The prop is removed on ActionIcon, Button, `CopyActionIcon` and `MantineLinkButton`.
- `Text` that used the legacy `color` prop with that shade now says `c="dimmed"`, which resolves to the same value in both schemes.

## Regression analysis
- `ldGray-6` and `dimmed` are the same colour in light and dark, so nothing visible changes for subtle/transparent variants. Two `variant="light"` ActionIcons move from an `ldGray.6` light fill to the neutral light fill of the theme.
- Left untouched: `color="ldGray.6"` on Loader, TextInput, Badge, Select and Avatar.

## Verified
- Typecheck, oxlint, oxfmt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Hr8bA9fzAkqy4yULJ6Qd9
