### PR TITLE
refactor(frontend): single-rule inline styles become utility classes

### DIFF
--- a/packages/frontend/CLAUDE.md
+++ b/packages/frontend/CLAUDE.md
@@ -8,7 +8,8 @@ the [Frontend Style Guide](../../.cursor/rules/frontend.mdc). Key points:
 -   **Styling hierarchy**:
     1. Inline-style component props (≤3 simple layout props like `mt`, `p`, `w`)
     2. CSS modules (default choice when more than 3 inline-style props are needed or when component props aren't available)
-    3. Theme extensions for reusable styles
+    3. For a single layout rule Mantine has no prop for (`flex-shrink`, `align-self`, `overflow`, `cursor`, `white-space`), use the `ld-*` utility classes in `src/styles/global.css` (`ld-shrink-0`, `ld-grow`, `ld-self-center`, `ld-pointer`, `ld-nowrap`, ...) instead of a one-line module or an inline `style`
+    4. Theme extensions for reusable styles
 -   **NEVER use** `styles`(v8) or `sx`(v6) props or `style`(v6/v8)
 -   **Colors**: Prefer default component colors (auto-theme switching). For custom colors, use `ldGray.X` and `ldDark.X`, not standard `gray.X`
 -   **Prop changes** - `spacing` → `gap`, `noWrap` → `wrap="nowrap"`, `sx` → `style` (v6)

--- a/packages/frontend/src/components/DashboardTiles/TileBase/LoadingSkeletonOverlay.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/LoadingSkeletonOverlay.tsx
@@ -83,8 +83,8 @@ const LoadingSkeletonOverlay = ({
             gap="sm"
             style={{ zIndex: 1 }}
         >
-            {hasTitle && <Box h={28} style={{ flexShrink: 0 }} />}
-            <Box flex={1} mih={0} style={{ overflow: 'hidden' }}>
+            {hasTitle && <Box h={28} className="ld-shrink-0" />}
+            <Box flex={1} mih={0} className="ld-overflow-hidden">
                 {chartKind ? (
                     getSkeletonByChartKind(chartKind)
                 ) : (

--- a/packages/frontend/src/components/Explorer/CustomDimensionModal/CustomSqlDimensionModal.tsx
+++ b/packages/frontend/src/components/Explorer/CustomDimensionModal/CustomSqlDimensionModal.tsx
@@ -241,9 +241,7 @@ export const CustomSqlDimensionModal: FC<{
                             data-testid="CustomSqlDimensionModal/LabelInput"
                         />
                         <Select
-                            style={{
-                                alignSelf: 'flex-start',
-                            }}
+                            className="ld-self-start"
                             label="Dimension Type"
                             data={Object.values(DimensionType).map((type) => ({
                                 value: type,

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
@@ -379,7 +379,7 @@ const TreeSingleNodeComponent: FC<Props> = ({ node }) => {
                     <MantineIcon
                         icon={alertIcon}
                         color={color}
-                        style={{ flexShrink: 0 }}
+                        className="ld-shrink-0"
                     />
                 </Tooltip>
             );
@@ -445,7 +445,7 @@ const TreeSingleNodeComponent: FC<Props> = ({ node }) => {
                         offset={isCustomDimension(item) ? 36 : 70}
                     >
                         <HoverCard.Target>
-                            <Text truncate fz="sm" style={{ flexGrow: 1 }}>
+                            <Text truncate fz="sm" className="ld-grow">
                                 <Highlight
                                     component="span"
                                     highlight={searchQuery || ''}
@@ -488,7 +488,7 @@ const TreeSingleNodeComponent: FC<Props> = ({ node }) => {
                             <MantineIcon
                                 icon={IconHierarchyOff}
                                 color="dimmed"
-                                style={{ flexShrink: 0 }}
+                                className="ld-shrink-0"
                             />
                         </Tooltip>
                     )}
@@ -503,7 +503,7 @@ const TreeSingleNodeComponent: FC<Props> = ({ node }) => {
                             <ActionIcon onClick={handleFilterClick}>
                                 <MantineIcon
                                     icon={IconFilter}
-                                    style={{ flexShrink: 0 }}
+                                    className="ld-shrink-0"
                                 />
                             </ActionIcon>
                         </Tooltip>
@@ -513,7 +513,7 @@ const TreeSingleNodeComponent: FC<Props> = ({ node }) => {
                             <ActionIcon onClick={handleDeleteClick}>
                                 <MantineIcon
                                     icon={IconTrash}
-                                    style={{ flexShrink: 0 }}
+                                    className="ld-shrink-0"
                                 />
                             </ActionIcon>
                         </Tooltip>
@@ -523,7 +523,7 @@ const TreeSingleNodeComponent: FC<Props> = ({ node }) => {
                             <MantineIcon
                                 icon={IconAlertTriangle}
                                 color="yellow.9"
-                                style={{ flexShrink: 0 }}
+                                className="ld-shrink-0"
                             />
                         </Tooltip>
                     ) : null}

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualMissingField.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualMissingField.tsx
@@ -29,12 +29,12 @@ const VirtualMissingFieldComponent: FC<VirtualMissingFieldProps> = ({
             my="xs"
             gap="xs"
             wrap="nowrap"
-            style={{ overflow: 'hidden' }}
+            className="ld-overflow-hidden"
         >
             <MantineIcon
                 icon={IconAlertTriangle}
                 color="yellow.9"
-                style={{ flexShrink: 0 }}
+                className="ld-shrink-0"
             />
 
             <Text truncate size="sm" flex={1} miw={0}>
@@ -51,10 +51,10 @@ const VirtualMissingFieldComponent: FC<VirtualMissingFieldProps> = ({
             >
                 <ActionIcon
                     variant="transparent"
-                    style={{ flexShrink: 0 }}
+                    className="ld-shrink-0"
                     onClick={handleClick}
                 >
-                    <MantineIcon icon={IconTrash} style={{ flexShrink: 0 }} />
+                    <MantineIcon icon={IconTrash} className="ld-shrink-0" />
                 </ActionIcon>
             </Tooltip>
         </Group>

--- a/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResultsNonIdealStates.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResultsNonIdealStates.tsx
@@ -183,7 +183,7 @@ export const ExploreErrorState = ({
         title="Error loading results"
         description={
             <Fragment>
-                <Text style={{ whiteSpace: 'pre-wrap' }}>
+                <Text className="ld-pre-wrap">
                     {errorDetail?.message ||
                         'There was an error loading the results'}
                 </Text>

--- a/packages/frontend/src/components/Explorer/WriteBackModal/index.tsx
+++ b/packages/frontend/src/components/Explorer/WriteBackModal/index.tsx
@@ -397,12 +397,7 @@ const MultipleItemsModalContent = ({
                         {capitalize(texts[type].baseName)} YAML to be created:
                     </Text>
 
-                    <Paper
-                        h="100%"
-                        style={{
-                            overflowY: 'auto',
-                        }}
-                    >
+                    <Paper h="100%" className="ld-scroll-y">
                         <CodeBlock
                             code={error || previewCode}
                             language="yaml"

--- a/packages/frontend/src/components/LightdashVisualization/index.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/index.tsx
@@ -136,7 +136,7 @@ const LightdashVisualization = memo(
                             title="Unable to load visualization"
                             description={
                                 <Fragment>
-                                    <Text style={{ whiteSpace: 'pre-wrap' }}>
+                                    <Text className="ld-pre-wrap">
                                         {apiErrorDetail.message || ''}
                                     </Text>
                                     {apiErrorDetail.data.documentationUrl && (

--- a/packages/frontend/src/components/PreAggregateAudit/PreAggregateTopToolbar.tsx
+++ b/packages/frontend/src/components/PreAggregateAudit/PreAggregateTopToolbar.tsx
@@ -78,7 +78,7 @@ const PreAggregateTopToolbar: FC<Props> = ({
                     <ActionIcon
                         size="sm"
                         onClick={resetFilters}
-                        style={{ flexShrink: 0 }}
+                        className="ld-shrink-0"
                     >
                         <MantineIcon icon={IconFilterOff} />
                     </ActionIcon>

--- a/packages/frontend/src/components/ProjectAppearance/ProjectAppearance.tsx
+++ b/packages/frontend/src/components/ProjectAppearance/ProjectAppearance.tsx
@@ -100,7 +100,7 @@ const ProjectAppearance: FC<Props> = ({ projectUuid }) => {
                             leftSection={
                                 <MantineIcon icon={IconExternalLink} />
                             }
-                            style={{ alignSelf: 'flex-end' }}
+                            className="ld-self-end"
                         >
                             Manage organization palettes
                         </Button>

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/DatabricksForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/DatabricksForm.tsx
@@ -411,9 +411,7 @@ const DatabricksForm: FC<{
                                             gap="xs"
                                         >
                                             <TextInput
-                                                style={{
-                                                    flexGrow: 1,
-                                                }}
+                                                className="ld-grow"
                                                 size="xs"
                                                 {...form.getInputProps(
                                                     `warehouse.compute.${index}.name`,
@@ -422,9 +420,7 @@ const DatabricksForm: FC<{
                                                 required
                                             />
                                             <TextInput
-                                                style={{
-                                                    flexGrow: 1,
-                                                }}
+                                                className="ld-grow"
                                                 size="xs"
                                                 {...form.getInputProps(
                                                     `warehouse.compute.${index}.httpPath`,

--- a/packages/frontend/src/components/ProjectParameters/ProjectParameters.tsx
+++ b/packages/frontend/src/components/ProjectParameters/ProjectParameters.tsx
@@ -204,7 +204,7 @@ const ProjectParameters: FC<ProjectParametersProps> = ({ projectUuid }) => {
                     <Table.Thead>
                         <Table.Tr>
                             <Table.Th
-                                style={{ cursor: 'pointer' }}
+                                className="ld-pointer"
                                 onClick={() => handleSort('name')}
                             >
                                 <Group gap="xs">

--- a/packages/frontend/src/components/RefreshDbtButton/index.tsx
+++ b/packages/frontend/src/components/RefreshDbtButton/index.tsx
@@ -138,11 +138,7 @@ const RefreshDbtButton: FC<{
         return (
             <Popover withArrow width={300}>
                 <Popover.Target>
-                    <Box
-                        style={{
-                            cursor: 'pointer',
-                        }}
-                    >
+                    <Box className="ld-pointer">
                         <Button
                             size="xs"
                             variant="outline"

--- a/packages/frontend/src/components/SavedDashboards/AddTilesToDashboardModal.tsx
+++ b/packages/frontend/src/components/SavedDashboards/AddTilesToDashboardModal.tsx
@@ -367,7 +367,7 @@ const AddTilesToDashboardModal: FC<AddTilesToDashboardModalProps> = ({
                             placeholder="A few words to give your team some context"
                             autosize
                             maxRows={3}
-                            style={{ overflowY: 'auto' }}
+                            className="ld-scroll-y"
                             {...form.getInputProps('dashboardDescription')}
                         />
                         {!isLoadingSpaces && !showNewSpaceInput ? (

--- a/packages/frontend/src/components/SchedulersView/LogsTopToolbar.tsx
+++ b/packages/frontend/src/components/SchedulersView/LogsTopToolbar.tsx
@@ -92,9 +92,7 @@ export const LogsTopToolbar: FC<LogsTopToolbarProps> = memo(
                                 orientation="vertical"
                                 w={1}
                                 h={20}
-                                style={{
-                                    alignSelf: 'center',
-                                }}
+                                className="ld-self-center"
                             />
                         </>
                     )}
@@ -114,9 +112,7 @@ export const LogsTopToolbar: FC<LogsTopToolbarProps> = memo(
                                 orientation="vertical"
                                 w={1}
                                 h={20}
-                                style={{
-                                    alignSelf: 'center',
-                                }}
+                                className="ld-self-center"
                             />
                         </>
                     )}
@@ -149,7 +145,7 @@ export const LogsTopToolbar: FC<LogsTopToolbarProps> = memo(
                         <ActionIcon
                             size="sm"
                             onClick={resetFilters}
-                            style={{ flexShrink: 0 }}
+                            className="ld-shrink-0"
                         >
                             <MantineIcon icon={IconTrash} />
                         </ActionIcon>

--- a/packages/frontend/src/components/SchedulersView/RunDetailsModal.tsx
+++ b/packages/frontend/src/components/SchedulersView/RunDetailsModal.tsx
@@ -143,7 +143,7 @@ const JobTimingInfo: FC<{
                 <Text fz="xs" c="dimmed">
                     started
                 </Text>
-                <Text fz="xs" style={{ whiteSpace: 'nowrap' }}>
+                <Text fz="xs" className="ld-nowrap">
                     {startedAt ? formatTimeOnly(startedAt) : '-'}
                 </Text>
             </Stack>
@@ -151,7 +151,7 @@ const JobTimingInfo: FC<{
                 <Text fz="xs" c="dimmed">
                     {endLabel}
                 </Text>
-                <Text fz="xs" style={{ whiteSpace: 'nowrap' }}>
+                <Text fz="xs" className="ld-nowrap">
                     {completedAt ? formatTimeOnly(completedAt) : '-'}
                 </Text>
             </Stack>
@@ -159,7 +159,7 @@ const JobTimingInfo: FC<{
                 <Text fz="xs" c="dimmed">
                     duration
                 </Text>
-                <Text fz="xs" style={{ whiteSpace: 'nowrap' }}>
+                <Text fz="xs" className="ld-nowrap">
                     {startedAt && completedAt
                         ? formatDuration(startedAt, completedAt)
                         : '-'}

--- a/packages/frontend/src/components/SchedulersView/SchedulerTopToolbar.tsx
+++ b/packages/frontend/src/components/SchedulersView/SchedulerTopToolbar.tsx
@@ -86,9 +86,7 @@ export const SchedulerTopToolbar: FC<SchedulerTopToolbarProps> = memo(
                         orientation="vertical"
                         w={1}
                         h={20}
-                        style={{
-                            alignSelf: 'center',
-                        }}
+                        className="ld-self-center"
                     />
 
                     <ResourceTypeFilter
@@ -100,9 +98,7 @@ export const SchedulerTopToolbar: FC<SchedulerTopToolbarProps> = memo(
                         orientation="vertical"
                         w={1}
                         h={20}
-                        style={{
-                            alignSelf: 'center',
-                        }}
+                        className="ld-self-center"
                     />
 
                     <FormatFilter
@@ -130,7 +126,7 @@ export const SchedulerTopToolbar: FC<SchedulerTopToolbarProps> = memo(
                     />
                 </Group>
 
-                <Group gap="sm" wrap="nowrap" style={{ flexShrink: 0 }}>
+                <Group gap="sm" wrap="nowrap" className="ld-shrink-0">
                     {hasSelection && onBulkReassign && !hideBulkReassign && (
                         <>
                             <Text size="sm" c="dimmed">

--- a/packages/frontend/src/components/SchedulersView/SchedulersTable.tsx
+++ b/packages/frontend/src/components/SchedulersView/SchedulersTable.tsx
@@ -478,7 +478,7 @@ const SchedulersTable: FC<SchedulersTableProps> = ({
                                         size="xs"
                                     />
                                 }
-                                style={{ cursor: 'pointer' }}
+                                className="ld-pointer"
                                 onClick={() => {
                                     setSearchParams({
                                         tab: SchedulersViewTab.RUN_HISTORY,

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionExamplesPanel.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionExamplesPanel.tsx
@@ -357,7 +357,7 @@ export const ConnectionExamplesPanel: FC<Props> = ({
                     <TextInput
                         label="Path"
                         placeholder="/v1/endpoint"
-                        style={{ flexGrow: 1 }}
+                        className="ld-grow"
                         onPaste={handlePathPaste}
                         {...form.getInputProps('path')}
                     />
@@ -406,7 +406,7 @@ export const ConnectionExamplesPanel: FC<Props> = ({
                         variant="subtle"
                         size="compact-sm"
                         leftSection={<MantineIcon icon={IconPlus} />}
-                        style={{ alignSelf: 'flex-start' }}
+                        className="ld-self-start"
                         onClick={() =>
                             form.insertListItem('queryParams', {
                                 uuid: uuidv4(),

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionsTable.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionsTable.tsx
@@ -175,7 +175,7 @@ export const ConnectionsTable: FC<Props> = ({
     setConnectionToViewUsage,
 }) => {
     return (
-        <Paper style={{ overflow: 'hidden' }}>
+        <Paper className="ld-overflow-hidden">
             <Table
                 className={`${tableStyles.root} ${tableStyles.alignLastTdRight}`}
                 ta="left"

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/WizardTestStep.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/WizardTestStep.tsx
@@ -134,7 +134,7 @@ export const WizardTestStep: FC<Props> = ({
                     label="Path"
                     description="Relative to the base URL"
                     placeholder="/v1/endpoint"
-                    style={{ flexGrow: 1 }}
+                    className="ld-grow"
                     value={path}
                     onChange={(e) => setPath(e.currentTarget.value)}
                 />

--- a/packages/frontend/src/components/Settings/SemanticLayerConnectionPanel/index.tsx
+++ b/packages/frontend/src/components/Settings/SemanticLayerConnectionPanel/index.tsx
@@ -157,7 +157,7 @@ const TokenAddedCard: FC<{
                     fz="sm"
                     fw={500}
                     onClick={onReplace}
-                    style={{ flexShrink: 0 }}
+                    className="ld-shrink-0"
                 >
                     Replace
                 </Anchor>

--- a/packages/frontend/src/components/SettingsUsageAnalytics/index.tsx
+++ b/packages/frontend/src/components/SettingsUsageAnalytics/index.tsx
@@ -16,7 +16,7 @@ const SettingsUsageAnalytics: FC<ProjectUserAccessProps> = ({
             <Card
                 component={Link}
                 shadow="sm"
-                style={{ cursor: 'pointer' }}
+                className="ld-pointer"
                 to={`/projects/${projectUuid}/user-activity`}
             >
                 <Group>

--- a/packages/frontend/src/components/UserSettings/AccessTokensPanel/TokensTable.tsx
+++ b/packages/frontend/src/components/UserSettings/AccessTokensPanel/TokensTable.tsx
@@ -277,7 +277,7 @@ export const TokensTable = () => {
 
     return (
         <>
-            <Paper style={{ overflow: 'hidden' }}>
+            <Paper className="ld-overflow-hidden">
                 <Table
                     className={`${tableStyles.root} ${tableStyles.alignLastTdRight}`}
                 >

--- a/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/PaletteModalBase.tsx
+++ b/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/PaletteModalBase.tsx
@@ -158,7 +158,7 @@ export const PaletteModalBase: FC<PaletteModalBaseProps> = ({
                         <MantineIcon icon={IconChevronDown} size="xs" />
                     }
                     fullWidth
-                    style={{ alignSelf: 'flex-end' }}
+                    className="ld-self-end"
                 >
                     {showAllColors ? 'Show fewer colors' : 'Show all colors'}
                 </Button>

--- a/packages/frontend/src/components/UserSettings/GithubSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/GithubSettingsPanel/index.tsx
@@ -96,7 +96,7 @@ const GithubSettingsPanel: FC = () => {
                             Your GitHub integration has access to the following
                             repositories ({data.length}):
                         </Text>
-                        <Box mah={200} style={{ overflowY: 'auto' }}>
+                        <Box mah={200} className="ld-scroll-y">
                             <Text
                                 component="ul"
                                 fz="xs"

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/CredentialsTable.tsx
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/CredentialsTable.tsx
@@ -95,7 +95,7 @@ export const CredentialsTable: FC<CredentialsTableProps> = ({
     setWarehouseCredentialsToBeDeleted,
 }) => {
     return (
-        <Paper style={{ overflow: 'hidden' }}>
+        <Paper className="ld-overflow-hidden">
             <Table
                 className={`${tableStyles.root} ${tableStyles.alignLastTdRight}`}
             >

--- a/packages/frontend/src/components/UserSettings/OAuthClientsPanel/OAuthClientsTable.tsx
+++ b/packages/frontend/src/components/UserSettings/OAuthClientsPanel/OAuthClientsTable.tsx
@@ -115,7 +115,7 @@ export const OAuthClientsTable: FC<{
     clients: OAuthClientSummary[];
 }> = ({ clients }) => {
     return (
-        <Paper style={{ overflow: 'hidden' }}>
+        <Paper className="ld-overflow-hidden">
             <Table
                 className={`${tableStyles.root} ${tableStyles.alignLastTdRight}`}
             >

--- a/packages/frontend/src/components/UserSettings/OrganizationWarehouseCredentialsPanel/CredentialsTable.tsx
+++ b/packages/frontend/src/components/UserSettings/OrganizationWarehouseCredentialsPanel/CredentialsTable.tsx
@@ -67,7 +67,7 @@ export const CredentialsTable: FC<CredentialsTableProps> = ({
     setWarehouseCredentialsToBeDeleted,
 }) => {
     return (
-        <Paper style={{ overflow: 'hidden' }}>
+        <Paper className="ld-overflow-hidden">
             <Table
                 className={`${tableStyles.root} ${tableStyles.alignLastTdRight}`}
                 ta="left"

--- a/packages/frontend/src/components/UserSettings/ProjectManagementPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/ProjectManagementPanel/index.tsx
@@ -651,7 +651,7 @@ const ProjectManagementPanel: FC = () => {
                         orientation="vertical"
                         w={1}
                         h={20}
-                        style={{ alignSelf: 'center' }}
+                        className="ld-self-center"
                     />
 
                     <SegmentedControl
@@ -707,7 +707,7 @@ const ProjectManagementPanel: FC = () => {
                         orientation="vertical"
                         w={1}
                         h={20}
-                        style={{ alignSelf: 'center' }}
+                        className="ld-self-center"
                     />
 
                     {/* Warehouse filter */}
@@ -905,7 +905,7 @@ const ProjectManagementPanel: FC = () => {
                     )}
                 </Group>
 
-                <Group gap="sm" wrap="nowrap" style={{ flexShrink: 0 }}>
+                <Group gap="sm" wrap="nowrap" className="ld-shrink-0">
                     {hasActiveFilters && (
                         <Tooltip label="Clear all filters">
                             <ActionIcon size="sm" onClick={resetAllFilters}>

--- a/packages/frontend/src/components/UserSettings/UserAttributesPanel/UserAttributeModal.tsx
+++ b/packages/frontend/src/components/UserSettings/UserAttributesPanel/UserAttributeModal.tsx
@@ -312,7 +312,7 @@ const UserAttributeModal: FC<{
                             <Button
                                 size="xs"
                                 variant="default"
-                                style={{ alignSelf: 'flex-start' }}
+                                className="ld-self-start"
                                 leftSection={
                                     <MantineIcon icon={IconUserPlus} />
                                 }
@@ -402,7 +402,7 @@ const UserAttributeModal: FC<{
                                 <Button
                                     size="xs"
                                     variant="default"
-                                    style={{ alignSelf: 'flex-start' }}
+                                    className="ld-self-start"
                                     leftSection={
                                         <MantineIcon icon={IconUsersPlus} />
                                     }

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLine.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLine.tsx
@@ -435,7 +435,7 @@ export const ReferenceLine: FC<ReferenceLineProps> = ({
                             }}
                         />
                         <Group wrap="nowrap" flex="1" gap="sm">
-                            <Config.Label style={{ whiteSpace: 'nowrap' }}>
+                            <Config.Label className="ld-nowrap">
                                 Position
                             </Config.Label>
                             <SegmentedControl

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/TooltipConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/TooltipConfig.tsx
@@ -278,7 +278,7 @@ export const TooltipConfig: FC<Props> = ({ fields }) => {
                         size="md"
                         display="inline"
                         color="ldGray.5"
-                        style={{ cursor: 'pointer' }}
+                        className="ld-pointer"
                     />
                 </Tooltip>
                 <Switch

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/SingleSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/SingleSeriesConfiguration.tsx
@@ -79,13 +79,7 @@ const SingleSeriesConfiguration: FC<Props> = ({
     return (
         <Box>
             <Group justify="space-between">
-                <Group
-                    gap="two"
-                    ref={ref}
-                    style={{
-                        flexGrow: 1,
-                    }}
-                >
+                <Group gap="two" ref={ref} className="ld-grow">
                     {isGrouped && (
                         <GrabIcon
                             dragHandleProps={dragHandleProps}
@@ -126,11 +120,7 @@ const SingleSeriesConfiguration: FC<Props> = ({
                         />
                     )}
                     {!isSingle && isGrouped && (
-                        <Box
-                            style={{
-                                flexGrow: 1,
-                            }}
-                        >
+                        <Box className="ld-grow">
                             <EditableText
                                 disabled={series.hidden}
                                 defaultValue={seriesValue}

--- a/packages/frontend/src/components/VisualizationConfigs/GaugeConfig/GaugeDisplayConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/GaugeConfig/GaugeDisplayConfig.tsx
@@ -100,7 +100,7 @@ export const GaugeDisplayConfig: FC = memo(() => {
                                     );
                                 }}
                                 hasGrouping
-                                style={{ flex: 1 }}
+                                flex={1}
                             />
                         )}
                         <SegmentedControl

--- a/packages/frontend/src/components/VisualizationConfigs/MapConfig/MapFieldConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/MapConfig/MapFieldConfiguration.tsx
@@ -78,8 +78,8 @@ const MapFieldConfiguration: FC<MapFieldConfigurationProps> = ({ fieldId }) => {
     const isVisible = isFieldVisible(fieldId);
 
     return (
-        <Group gap="xs" wrap="nowrap" style={{ flexGrow: 1 }}>
-            <Box style={{ flexGrow: 1 }}>
+        <Group gap="xs" wrap="nowrap" className="ld-grow">
+            <Box className="ld-grow">
                 <MapFieldConfigurationInput
                     fieldId={fieldId}
                     defaultLabel={defaultLabel}

--- a/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/GroupItem.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/GroupItem.tsx
@@ -99,7 +99,7 @@ export const GroupItem = forwardRef<
                             onColorChange(defaultLabel, newColor)
                         }
                     />
-                    <Box style={{ flexGrow: 1 }}>
+                    <Box className="ld-grow">
                         <EditableText
                             placeholder={defaultLabel}
                             value={label}

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ColumnConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ColumnConfiguration.tsx
@@ -136,8 +136,8 @@ const ColumnConfiguration: FC<ColumnConfigurationProps> = ({
     };
 
     return (
-        <Group gap="xs" wrap="nowrap" style={{ flexGrow: 1 }}>
-            <Box style={{ flexGrow: 1 }}>
+        <Group gap="xs" wrap="nowrap" className="ld-grow">
+            <Box className="ld-grow">
                 <ColumnConfigurationInput
                     fieldId={fieldId}
                     chartConfig={visualizationConfig.chartConfig}

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -415,7 +415,7 @@ const DashboardHeader = memo(
                                 color="blue"
                                 variant="dot"
                                 size="sm"
-                                style={{ cursor: 'pointer' }}
+                                className="ld-pointer"
                             >
                                 {dashboard.draftsAwaitingReview} draft
                                 {dashboard.draftsAwaitingReview === 1

--- a/packages/frontend/src/components/common/FieldSelect/index.tsx
+++ b/packages/frontend/src/components/common/FieldSelect/index.tsx
@@ -246,7 +246,7 @@ const FieldSelectComponent = <T extends Item = Item>({
                     openDelay={500}
                 >
                     <Group wrap="nowrap" gap={rest.size} maw="100%">
-                        <FieldIcon style={{ flexShrink: 0 }} item={fieldItem} />
+                        <FieldIcon className="ld-shrink-0" item={fieldItem} />
                         <Text
                             span
                             fz="xs"

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
@@ -146,11 +146,7 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
                 if (coarseTimeFrame) {
                     return coarseTimeFrame === TimeFrames.WEEK ? (
                         <Flex align="center" gap="xs" w="100%">
-                            <Text
-                                c="dimmed"
-                                style={{ whiteSpace: 'nowrap' }}
-                                size="xs"
-                            >
+                            <Text c="dimmed" className="ld-nowrap" size="xs">
                                 week commencing
                             </Text>
 
@@ -181,7 +177,7 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
                             <Flex align="center" gap="xs" w="100%">
                                 <Text
                                     c="dimmed"
-                                    style={{ whiteSpace: 'nowrap' }}
+                                    className="ld-nowrap"
                                     size="xs"
                                 >
                                     week commencing

--- a/packages/frontend/src/components/common/Filters/index.tsx
+++ b/packages/frontend/src/components/common/Filters/index.tsx
@@ -288,7 +288,7 @@ const FiltersForm: FC<Props> = memo(({ filters, setFilters, isEditMode }) => {
     }, [andRootFilterGroupItems, orRootFilterGroups]);
 
     return (
-        <Stack gap="xs" pos="relative" m="sm" style={{ flexGrow: 1 }}>
+        <Stack gap="xs" pos="relative" m="sm" className="ld-grow">
             {totalFilterRules.length >= 1 &&
                 (showSimplifiedForm ? (
                     <SimplifiedFilterGroupForm

--- a/packages/frontend/src/components/common/JsonViewer/JsonCellViewer.tsx
+++ b/packages/frontend/src/components/common/JsonViewer/JsonCellViewer.tsx
@@ -160,7 +160,7 @@ export const JsonCellModal: FC<ModalProps> = ({ value, opened, onClose }) => {
                                 component="pre"
                                 fz="xs"
                                 m={0}
-                                style={{ whiteSpace: 'pre-wrap' }}
+                                className="ld-pre-wrap"
                             >
                                 {formattedJson}
                             </Box>

--- a/packages/frontend/src/components/common/PolymorphicPaperButton.tsx
+++ b/packages/frontend/src/components/common/PolymorphicPaperButton.tsx
@@ -15,7 +15,7 @@ export const PolymorphicPaperButton = createPolymorphicComponent<
 >(
     forwardRef<HTMLDivElement, PaperProps>(
         (props: PaperProps, ref: Ref<HTMLDivElement>) => (
-            <Paper ref={ref} {...props} style={{ cursor: 'pointer' }} />
+            <Paper ref={ref} {...props} className="ld-pointer" />
         ),
     ),
 );

--- a/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
+++ b/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
@@ -767,9 +767,7 @@ const InfiniteResourceTable = ({
                                         w={1}
                                         h={20}
                                         color="#DEE2E6"
-                                        style={{
-                                            alignSelf: 'center',
-                                        }}
+                                        className="ld-self-center"
                                     />
                                     <ContentTypeFilter
                                         value={selectedContentType}
@@ -808,9 +806,7 @@ const InfiniteResourceTable = ({
                                         w={1}
                                         h={20}
                                         color="#DEE2E6"
-                                        style={{
-                                            alignSelf: 'center',
-                                        }}
+                                        className="ld-self-center"
                                     />
                                     <Box w={220}>
                                         <UserSelect

--- a/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceModalContent.tsx
+++ b/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceModalContent.tsx
@@ -167,7 +167,7 @@ const UserAccessAuditList: FC<UserAccessAuditListProps> = ({
                     hasPreviousPage={page > 1}
                     onNextPage={handleNextPage}
                     onPreviousPage={handlePreviousPage}
-                    style={{ alignSelf: 'flex-end' }}
+                    className="ld-self-end"
                 />
             )}
         </Stack>

--- a/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceModalShared.tsx
+++ b/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceModalShared.tsx
@@ -224,7 +224,7 @@ export const UserAccessList: FC<UserAccessListProps> = ({
                     hasPreviousPage={page > 1}
                     onNextPage={handleNextPage}
                     onPreviousPage={handlePreviousPage}
-                    style={{ alignSelf: 'flex-end' }}
+                    className="ld-self-end"
                 />
             )}
         </Stack>
@@ -345,7 +345,7 @@ export const GroupsAccessList: FC<GroupAccessListProps> = ({
                     hasPreviousPage={page > 1}
                     onNextPage={handleNextPage}
                     onPreviousPage={handlePreviousPage}
-                    style={{ alignSelf: 'flex-end' }}
+                    className="ld-self-end"
                 />
             )}
         </Stack>

--- a/packages/frontend/src/components/common/Tree/TreeItem.tsx
+++ b/packages/frontend/src/components/common/Tree/TreeItem.tsx
@@ -101,14 +101,14 @@ const TreeItem: React.FC<Props> = ({
                 color="ldGray.7"
                 size="lg"
                 stroke={1.5}
-                style={{ flexShrink: 0 }}
+                className="ld-shrink-0"
             />
 
             <Highlight
                 truncate="end"
                 fz={rem(13)}
                 fw={500}
-                style={{ flexGrow: 1 }}
+                className="ld-grow"
                 highlight={matchHighlights}
                 highlightStyles={{
                     backgroundColor: 'transparent',
@@ -123,7 +123,7 @@ const TreeItem: React.FC<Props> = ({
                     icon={IconCheck}
                     size="lg"
                     color="blue.6"
-                    style={{ flexShrink: 0 }}
+                    className="ld-shrink-0"
                 />
             )}
         </Paper>

--- a/packages/frontend/src/ee/components/Home/AiSearchBox/AiSearchBox.tsx
+++ b/packages/frontend/src/ee/components/Home/AiSearchBox/AiSearchBox.tsx
@@ -185,7 +185,7 @@ const AiSearchBoxInner: FC<Props> = ({
         aiRouterConfigQuery.isLoading
     ) {
         return (
-            <Paper style={{ overflow: 'hidden' }} p="md">
+            <Paper className="ld-overflow-hidden" p="md">
                 <Group wrap="nowrap" align="center">
                     <Skeleton circle height={38} width={38} />
                     <Skeleton height={36} flex={1} />

--- a/packages/frontend/src/ee/components/Home/AiSearchBox/SearchDropdown.tsx
+++ b/packages/frontend/src/ee/components/Home/AiSearchBox/SearchDropdown.tsx
@@ -194,7 +194,7 @@ export const SearchDropdown: FC<Props> = ({
                     </ScrollArea.Autosize>
                 </Combobox.Options>
                 {footer && (
-                    <Combobox.Footer p={0} style={{ overflow: 'hidden' }}>
+                    <Combobox.Footer p={0} className="ld-overflow-hidden">
                         {footer}
                     </Combobox.Footer>
                 )}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminAgentsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminAgentsTable.tsx
@@ -579,9 +579,7 @@ const AiAgentAdminAgentsTable = () => {
                             orientation="vertical"
                             w={1}
                             h={20}
-                            style={{
-                                alignSelf: 'center',
-                            }}
+                            className="ld-self-center"
                         />
                         <ProjectsFilter
                             selectedProjectUuids={selectedProjectUuids}
@@ -595,9 +593,7 @@ const AiAgentAdminAgentsTable = () => {
                             orientation="vertical"
                             w={1}
                             h={20}
-                            style={{
-                                alignSelf: 'center',
-                            }}
+                            className="ld-self-center"
                         />
                         <Switch
                             size="xs"
@@ -616,9 +612,7 @@ const AiAgentAdminAgentsTable = () => {
                                     orientation="vertical"
                                     w={1}
                                     h={20}
-                                    style={{
-                                        alignSelf: 'center',
-                                    }}
+                                    className="ld-self-center"
                                 />
                                 <Button
                                     variant="subtle"

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminEvalsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminEvalsTable.tsx
@@ -366,7 +366,7 @@ const AiAgentAdminEvalsTable = ({
                             orientation="vertical"
                             w={1}
                             h={20}
-                            style={{ alignSelf: 'center' }}
+                            className="ld-self-center"
                         />
                         <ProjectsFilter
                             selectedProjectUuids={selectedProjectUuids}
@@ -377,7 +377,7 @@ const AiAgentAdminEvalsTable = ({
                             orientation="vertical"
                             w={1}
                             h={20}
-                            style={{ alignSelf: 'center' }}
+                            className="ld-self-center"
                         />
                         <AgentsFilter
                             selectedAgentUuids={selectedAgentUuids}
@@ -389,7 +389,7 @@ const AiAgentAdminEvalsTable = ({
                             orientation="vertical"
                             w={1}
                             h={20}
-                            style={{ alignSelf: 'center' }}
+                            className="ld-self-center"
                         />
                         <Switch
                             size="xs"
@@ -407,7 +407,7 @@ const AiAgentAdminEvalsTable = ({
                                     orientation="vertical"
                                     w={1}
                                     h={20}
-                                    style={{ alignSelf: 'center' }}
+                                    className="ld-self-center"
                                 />
                                 <Button
                                     variant="subtle"

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminTopToolbar.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminTopToolbar.tsx
@@ -97,9 +97,7 @@ export const AiAgentAdminTopToolbar: FC<AiAgentAdminTopToolbarProps> = memo(
                             orientation="vertical"
                             w={1}
                             h={20}
-                            style={{
-                                alignSelf: 'center',
-                            }}
+                            className="ld-self-center"
                         />
                         <ProjectsFilter
                             selectedProjectUuids={selectedProjectUuids}
@@ -111,9 +109,7 @@ export const AiAgentAdminTopToolbar: FC<AiAgentAdminTopToolbarProps> = memo(
                             orientation="vertical"
                             w={1}
                             h={20}
-                            style={{
-                                alignSelf: 'center',
-                            }}
+                            className="ld-self-center"
                         />
                         <AgentsFilter
                             selectedAgentUuids={selectedAgentUuids}
@@ -125,9 +121,7 @@ export const AiAgentAdminTopToolbar: FC<AiAgentAdminTopToolbarProps> = memo(
                             orientation="vertical"
                             w={1}
                             h={20}
-                            style={{
-                                alignSelf: 'center',
-                            }}
+                            className="ld-self-center"
                         />
                         <UsersFilter
                             selectedUserUuids={selectedUserUuids}
@@ -137,9 +131,7 @@ export const AiAgentAdminTopToolbar: FC<AiAgentAdminTopToolbarProps> = memo(
                             orientation="vertical"
                             w={1}
                             h={20}
-                            style={{
-                                alignSelf: 'center',
-                            }}
+                            className="ld-self-center"
                         />
                         <FeedbackFilter
                             selectedFeedback={selectedFeedback}
@@ -150,9 +142,7 @@ export const AiAgentAdminTopToolbar: FC<AiAgentAdminTopToolbarProps> = memo(
                             orientation="vertical"
                             w={1}
                             h={20}
-                            style={{
-                                alignSelf: 'center',
-                            }}
+                            className="ld-self-center"
                         />
                         <SourceFilter
                             selectedSource={selectedSource}
@@ -163,9 +153,7 @@ export const AiAgentAdminTopToolbar: FC<AiAgentAdminTopToolbarProps> = memo(
                             orientation="vertical"
                             w={1}
                             h={20}
-                            style={{
-                                alignSelf: 'center',
-                            }}
+                            className="ld-self-center"
                         />
                         <Switch
                             size="xs"
@@ -184,9 +172,7 @@ export const AiAgentAdminTopToolbar: FC<AiAgentAdminTopToolbarProps> = memo(
                                     orientation="vertical"
                                     w={1}
                                     h={20}
-                                    style={{
-                                        alignSelf: 'center',
-                                    }}
+                                    className="ld-self-center"
                                 />
                                 <Button
                                     variant="subtle"

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/EvalPreviewSidebar.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/EvalPreviewSidebar.tsx
@@ -154,7 +154,7 @@ export const EvalPreviewSidebar: FC<EvalPreviewSidebarProps> = ({
                                     c="ldGray.5"
                                     w={20}
                                     ta="right"
-                                    style={{ flexShrink: 0 }}
+                                    className="ld-shrink-0"
                                 >
                                     {index + 1}
                                 </Text>

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/McpActivityTopToolbar.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/McpActivityTopToolbar.tsx
@@ -67,7 +67,7 @@ export const McpActivityTopToolbar: FC<McpActivityTopToolbarProps> = memo(
                             orientation="vertical"
                             w={1}
                             h={20}
-                            style={{ alignSelf: 'center' }}
+                            className="ld-self-center"
                         />
                         <AgentsFilter
                             selectedAgentUuids={selectedAgentUuids}
@@ -78,7 +78,7 @@ export const McpActivityTopToolbar: FC<McpActivityTopToolbarProps> = memo(
                             orientation="vertical"
                             w={1}
                             h={20}
-                            style={{ alignSelf: 'center' }}
+                            className="ld-self-center"
                         />
                         <SegmentedControl
                             size="xs"
@@ -101,7 +101,7 @@ export const McpActivityTopToolbar: FC<McpActivityTopToolbarProps> = memo(
                                     orientation="vertical"
                                     w={1}
                                     h={20}
-                                    style={{ alignSelf: 'center' }}
+                                    className="ld-self-center"
                                 />
                                 <Button
                                     variant="subtle"

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ProjectContextDiffPreview.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ProjectContextDiffPreview.tsx
@@ -43,7 +43,7 @@ export const ProjectContextDiffPreview: FC<ProjectContextDiffPreviewProps> = ({
             poolOptions={PIERRE_POOL_OPTIONS}
             highlighterOptions={PIERRE_HIGHLIGHTER_OPTIONS}
         >
-            <Paper shadow="sm" radius="md" style={{ overflow: 'hidden' }}>
+            <Paper shadow="sm" radius="md" className="ld-overflow-hidden">
                 <Virtualizer style={viewportStyle}>
                     <MultiFileDiff
                         oldFile={{ name: fileName, contents: before }}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanCard.tsx
@@ -151,11 +151,7 @@ export const ReviewKanbanCard: FC<Props> = ({ item, isSelected, onSelect }) => {
                                     item.lastSeenAt,
                                 )}`}
                             >
-                                <Text
-                                    fz="xs"
-                                    c="dimmed"
-                                    style={{ whiteSpace: 'nowrap' }}
-                                >
+                                <Text fz="xs" c="dimmed" className="ld-nowrap">
                                     {formatRelativeReviewDate(item.lastSeenAt)}
                                 </Text>
                             </Tooltip>

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewPrDiffContent.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewPrDiffContent.tsx
@@ -65,7 +65,7 @@ export const ReviewPrDiffContent: FC<Props> = ({
                     <Paper
                         key={file.path}
                         radius="md"
-                        style={{ overflow: 'hidden' }}
+                        className="ld-overflow-hidden"
                     >
                         <Virtualizer style={viewportStyle}>
                             <MultiFileDiff

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ThreadPreviewSidebar.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ThreadPreviewSidebar.tsx
@@ -280,7 +280,7 @@ export const ThreadPreviewSidebar: FC<ThreadPreviewSidebarProps> = ({
             <Divider />
 
             {threadData && (
-                <Box mah="calc(100vh - 150px)" style={{ overflowY: 'auto' }}>
+                <Box mah="calc(100vh - 150px)" className="ld-scroll-y">
                     {selectedReviewItem ? (
                         <>
                             <Stack p="md" gap="md">

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiProvidersCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiProvidersCard.tsx
@@ -128,7 +128,7 @@ const ProviderRow: FC<ProviderRowProps> = ({
 
             <Group gap="xs" wrap="nowrap" align="flex-end">
                 <PasswordInput
-                    style={{ flex: 1 }}
+                    flex={1}
                     size="xs"
                     aria-label={label}
                     value={value}

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentKnowledgeDocumentModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentKnowledgeDocumentModal.tsx
@@ -194,7 +194,7 @@ const LoadedDocumentModal = ({
                     <Box
                         data-color-mode={colorScheme}
                         h="100%"
-                        style={{ overflowY: 'auto' }}
+                        className="ld-scroll-y"
                     >
                         <MDEditor.Markdown
                             source={form.values.content}

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentKnowledgeFilesSection.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentKnowledgeFilesSection.tsx
@@ -485,9 +485,7 @@ export const AiAgentKnowledgeFilesSection = ({
                                                                     IconFileText
                                                                 }
                                                                 color="dimmed"
-                                                                style={{
-                                                                    flexShrink: 0,
-                                                                }}
+                                                                className="ld-shrink-0"
                                                             />
                                                             <Stack
                                                                 gap={2}

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServersInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServersInput.tsx
@@ -1541,7 +1541,7 @@ export const AiAgentMcpServersInput = ({
                                         key={mcpServer.uuid}
                                         radius="md"
                                         p={0}
-                                        style={{ overflow: 'hidden' }}
+                                        className="ld-overflow-hidden"
                                     >
                                         <Group
                                             justify="space-between"

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.tsx
@@ -186,9 +186,9 @@ export const AgentChatDisplay: FC<PropsWithChildren<Props>> = ({
                     px={ChatElementsUtils.centeredElementProps.px}
                     pb="md"
                     gap="xl"
-                    style={{ flexGrow: 1 }}
+                    className="ld-grow"
                 >
-                    <Stack flex={1} style={{ flexGrow: 1 }}>
+                    <Stack flex={1} className="ld-grow">
                         {visibleMessages.map((message, i, xs) => (
                             <Fragment key={`${message.role}-${message.uuid}`}>
                                 {message.role === 'user' &&

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiVisualizationRenderer.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiVisualizationRenderer.tsx
@@ -355,7 +355,7 @@ export const AiVisualizationRenderer: FC<Props> = ({
                     </Box>
 
                     {displayDetails ? (
-                        <Stack gap="xs" style={{ flexShrink: 0 }}>
+                        <Stack gap="xs" className="ld-shrink-0">
                             <Flex align="center" justify="flex-start">
                                 <Button
                                     size="compact-xs"

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/StreamRecoveryAlert.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/StreamRecoveryAlert.tsx
@@ -28,7 +28,7 @@ export const StreamRecoveryAlert = () => {
                     aria-label="Connection lost. Reconnecting"
                     color="yellow.7"
                     size={14}
-                    style={{ flexShrink: 0 }}
+                    className="ld-shrink-0"
                 />
                 <Group gap={6} wrap="nowrap" flex={1} miw={0}>
                     <Text

--- a/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalAssessmentDisplay.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalAssessmentDisplay.tsx
@@ -83,11 +83,7 @@ export const EvalAssessmentDisplay: FC<EvalAssessmentDisplayProps> = ({
                     }
                 >
                     {assessment.reason && (
-                        <Text
-                            size="xs"
-                            style={{ whiteSpace: 'pre-wrap' }}
-                            mt="xs"
-                        >
+                        <Text size="xs" className="ld-pre-wrap" mt="xs">
                             {assessment.reason}
                         </Text>
                     )}
@@ -96,11 +92,7 @@ export const EvalAssessmentDisplay: FC<EvalAssessmentDisplayProps> = ({
                             <Text size="xs" fw={600} c="dimmed">
                                 Expected Response
                             </Text>
-                            <Text
-                                size="xs"
-                                style={{ whiteSpace: 'pre-wrap' }}
-                                fs="italic"
-                            >
+                            <Text size="xs" className="ld-pre-wrap" fs="italic">
                                 {expectedResponse}
                             </Text>
                         </Stack>

--- a/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalPromptThreadReference.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalPromptThreadReference.tsx
@@ -78,13 +78,7 @@ export const EvalPromptThreadReference: FC<Props> = ({
     );
 
     return (
-        <Card
-            p="sm"
-            style={{
-                cursor: 'pointer',
-            }}
-            onClick={handleOpenThread}
-        >
+        <Card p="sm" className="ld-pointer" onClick={handleOpenThread}>
             <Stack gap="xs">
                 <Group justify="space-between" align="flex-start">
                     <Group gap="xs" flex={1} align="flex-start">

--- a/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalSectionLayout.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalSectionLayout.tsx
@@ -136,7 +136,7 @@ export const EvalSectionLayout: FC<EvalSectionLayoutProps> = ({ children }) => {
                 key="evaluation"
                 size="lg"
                 onClick={handleNavigateToEvaluation}
-                style={{ cursor: 'pointer' }}
+                className="ld-pointer"
                 td="none"
                 fw={500}
             >

--- a/packages/frontend/src/ee/features/aiCopilot/components/PinnedContextCard/PinnedReviewEntityCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/PinnedContextCard/PinnedReviewEntityCard.tsx
@@ -117,7 +117,7 @@ const ReviewFindingRow: FC<{
             icon={IconSearch}
             right={
                 item.findingCount > 1 ? (
-                    <Text fz="xs" fw={600} c="dimmed" style={{ flexShrink: 0 }}>
+                    <Text fz="xs" fw={600} c="dimmed" className="ld-shrink-0">
                         {item.findingCount}×
                     </Text>
                 ) : undefined

--- a/packages/frontend/src/ee/features/customRoles/CustomRolesTable.tsx
+++ b/packages/frontend/src/ee/features/customRoles/CustomRolesTable.tsx
@@ -132,7 +132,7 @@ export const CustomRolesTable: FC<TableProps> = ({
 
     return (
         <>
-            <Paper style={{ overflow: 'hidden' }}>
+            <Paper className="ld-overflow-hidden">
                 <Table
                     className={`${tableStyles.root} ${tableStyles.alignLastTdRight}`}
                 >

--- a/packages/frontend/src/ee/features/customRoles/components/ScopeSelector/ScopeSelector.tsx
+++ b/packages/frontend/src/ee/features/customRoles/components/ScopeSelector/ScopeSelector.tsx
@@ -170,7 +170,7 @@ const ScopePanel: FC<{
 
     return (
         <Stack gap="md" h="100%" w="100%">
-            <Group justify="space-between" style={{ flexShrink: 0 }}>
+            <Group justify="space-between" className="ld-shrink-0">
                 <Title order={5}>{group.groupName}</Title>
                 <Group gap="xs">
                     <Text size="xs" fw={500}>
@@ -487,7 +487,7 @@ export const ScopeSelector: FC<ScopeSelectorProps> = ({
 
     return (
         <Stack gap="sm" h="100%">
-            <Stack gap="sm" style={{ flexShrink: 0 }}>
+            <Stack gap="sm" className="ld-shrink-0">
                 <Group justify="space-between">
                     <Stack gap="two">
                         <Title order={5}>Permissions</Title>
@@ -539,7 +539,7 @@ export const ScopeSelector: FC<ScopeSelectorProps> = ({
             </Stack>
 
             {filteredScopes.length === 0 ? (
-                <Paper p="xl" style={{ flexShrink: 0 }}>
+                <Paper p="xl" className="ld-shrink-0">
                     <Text ta="center" fz="sm">
                         No permissions found matching your search.
                     </Text>

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardFilterBar.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardFilterBar.tsx
@@ -117,7 +117,7 @@ const EmbedDashboardFilterBar: FC<Props> = ({
                 )}
             </Group>
 
-            <Group gap="xs" wrap="nowrap" style={{ flexShrink: 0 }}>
+            <Group gap="xs" wrap="nowrap" className="ld-shrink-0">
                 {dashboard.canDateZoom && (
                     <Box
                         className={embedContractClass('ld-dashboard-date-zoom')}

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -1057,7 +1057,7 @@ const DetailSidebar: FC<{
                     <TargetIcon
                         size={16}
                         color="var(--mantine-color-dimmed)"
-                        style={{ flexShrink: 0 }}
+                        className="ld-shrink-0"
                     />
                     <TruncatedText maxWidth={260} fz="sm" fw={600}>
                         {action.targetName}
@@ -1894,7 +1894,7 @@ const ActionRow: FC<{
                     <TargetIcon
                         size={14}
                         color="var(--mantine-color-dimmed)"
-                        style={{ flexShrink: 0 }}
+                        className="ld-shrink-0"
                     />
                     <TruncatedText maxWidth={220} fz="xs" fw={500}>
                         {action.targetName}

--- a/packages/frontend/src/ee/features/scim/components/ScimAccessTokensPanel/TokensTable.tsx
+++ b/packages/frontend/src/ee/features/scim/components/ScimAccessTokensPanel/TokensTable.tsx
@@ -117,7 +117,7 @@ export const TokensTable = () => {
 
     return (
         <>
-            <Paper style={{ overflow: 'hidden' }}>
+            <Paper className="ld-overflow-hidden">
                 <Table
                     className={`${tableStyles.root} ${tableStyles.alignLastTdRight}`}
                 >

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
@@ -285,9 +285,7 @@ const AiAgentNewThreadPage: FC = () => {
                                         >
                                             <Text
                                                 size="sm"
-                                                style={{
-                                                    whiteSpace: 'pre-wrap',
-                                                }}
+                                                className="ld-pre-wrap"
                                             >
                                                 {agent.instruction}
                                             </Text>
@@ -302,7 +300,7 @@ const AiAgentNewThreadPage: FC = () => {
                                 c="dimmed"
                                 ta="center"
                                 maw={600}
-                                style={{ whiteSpace: 'pre-wrap' }}
+                                className="ld-pre-wrap"
                             >
                                 {agent.description}
                             </Text>

--- a/packages/frontend/src/features/apps/ExternalRequestInspector.tsx
+++ b/packages/frontend/src/features/apps/ExternalRequestInspector.tsx
@@ -178,7 +178,7 @@ const ExternalRequestRow: FC<{ request: ExternalRequestEvent }> = ({
                             <Group
                                 gap={4}
                                 onClick={() => setJsonExpanded((v) => !v)}
-                                style={{ cursor: 'pointer' }}
+                                className="ld-pointer"
                             >
                                 <ActionIcon size="xs">
                                     {jsonExpanded ? (

--- a/packages/frontend/src/features/apps/QueryInspector.tsx
+++ b/packages/frontend/src/features/apps/QueryInspector.tsx
@@ -261,7 +261,7 @@ const QueryRow: FC<{
                             <Group
                                 gap={4}
                                 onClick={() => setJsonExpanded((v) => !v)}
-                                style={{ cursor: 'pointer' }}
+                                className="ld-pointer"
                             >
                                 <ActionIcon size="xs">
                                     {jsonExpanded ? (

--- a/packages/frontend/src/features/contentAsCode/components/ContentReviewPage.tsx
+++ b/packages/frontend/src/features/contentAsCode/components/ContentReviewPage.tsx
@@ -292,7 +292,7 @@ const ContentReviewPage: FC<ContentReviewPageProps> = ({ projectUuid }) => {
 
     return (
         <Group align="flex-start" gap="md" wrap="nowrap">
-            <Stack w={280} gap="sm" style={{ flexShrink: 0 }}>
+            <Stack w={280} gap="sm" className="ld-shrink-0">
                 <ScrollArea.Autosize mah="72vh">
                     <Stack gap="md">
                         {openDrafts.length > 0 && (
@@ -379,7 +379,7 @@ const ContentReviewPage: FC<ContentReviewPageProps> = ({ projectUuid }) => {
                             <Group
                                 gap="xs"
                                 wrap="nowrap"
-                                style={{ flexShrink: 0 }}
+                                className="ld-shrink-0"
                             >
                                 {active.prUrl ? (
                                     <Button
@@ -507,7 +507,7 @@ const ContentReviewPage: FC<ContentReviewPageProps> = ({ projectUuid }) => {
                             poolOptions={PIERRE_POOL_OPTIONS}
                             highlighterOptions={PIERRE_HIGHLIGHTER_OPTIONS}
                         >
-                            <Paper radius="md" style={{ overflow: 'hidden' }}>
+                            <Paper radius="md" className="ld-overflow-hidden">
                                 <Virtualizer
                                     key={active.uuid}
                                     style={viewportStyle}

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.tsx
@@ -604,7 +604,7 @@ const FilterConfiguration: FC<Props> = ({
             </Tabs>
 
             <Flex gap="sm">
-                <Box style={{ flexGrow: 1 }} />
+                <Box className="ld-grow" />
 
                 {!isTemporary &&
                     isFilterModified &&

--- a/packages/frontend/src/features/dashboardTabs/DeleteTabModal.tsx
+++ b/packages/frontend/src/features/dashboardTabs/DeleteTabModal.tsx
@@ -256,7 +256,7 @@ export const TabDeleteModal: FC<DeleteProps> = ({
                             <Box
                                 ref={scrollContainerRef}
                                 mah={150}
-                                style={{ overflowY: 'auto' }}
+                                className="ld-scroll-y"
                                 onScroll={onScroll}
                             >
                                 <List size="sm">

--- a/packages/frontend/src/features/dataAppActivity/components/DataAppActivityTopToolbar.tsx
+++ b/packages/frontend/src/features/dataAppActivity/components/DataAppActivityTopToolbar.tsx
@@ -145,7 +145,7 @@ export const DataAppActivityTopToolbar: FC<DataAppActivityTopToolbarProps> = ({
                         orientation="vertical"
                         w={1}
                         h={20}
-                        style={{ alignSelf: 'center' }}
+                        className="ld-self-center"
                     />
                     <FilterFacet
                         label="Users"
@@ -162,7 +162,7 @@ export const DataAppActivityTopToolbar: FC<DataAppActivityTopToolbarProps> = ({
                         orientation="vertical"
                         w={1}
                         h={20}
-                        style={{ alignSelf: 'center' }}
+                        className="ld-self-center"
                     />
                     <FilterFacet
                         label="Models"
@@ -176,7 +176,7 @@ export const DataAppActivityTopToolbar: FC<DataAppActivityTopToolbarProps> = ({
                         orientation="vertical"
                         w={1}
                         h={20}
-                        style={{ alignSelf: 'center' }}
+                        className="ld-self-center"
                     />
                     <SegmentedControl
                         size="xs"
@@ -195,7 +195,7 @@ export const DataAppActivityTopToolbar: FC<DataAppActivityTopToolbarProps> = ({
                         orientation="vertical"
                         w={1}
                         h={20}
-                        style={{ alignSelf: 'center' }}
+                        className="ld-self-center"
                     />
                     <SegmentedControl
                         size="xs"
@@ -214,7 +214,7 @@ export const DataAppActivityTopToolbar: FC<DataAppActivityTopToolbarProps> = ({
                                 orientation="vertical"
                                 w={1}
                                 h={20}
-                                style={{ alignSelf: 'center' }}
+                                className="ld-self-center"
                             />
                             <Button
                                 variant="subtle"

--- a/packages/frontend/src/features/externalConnections/components/CustomHeadersField.tsx
+++ b/packages/frontend/src/features/externalConnections/components/CustomHeadersField.tsx
@@ -52,7 +52,7 @@ export const CustomHeadersField: FC<Props> = ({
                     <TextInput
                         aria-label="Header name"
                         placeholder="anthropic-version"
-                        style={{ flexGrow: 1 }}
+                        className="ld-grow"
                         value={row.name}
                         disabled={disabled}
                         onChange={(e) =>
@@ -62,7 +62,7 @@ export const CustomHeadersField: FC<Props> = ({
                     <TextInput
                         aria-label="Header value"
                         placeholder="2023-06-01"
-                        style={{ flexGrow: 1 }}
+                        className="ld-grow"
                         value={row.value}
                         disabled={disabled}
                         onChange={(e) =>

--- a/packages/frontend/src/features/externalConnections/components/PathRulesField.tsx
+++ b/packages/frontend/src/features/externalConnections/components/PathRulesField.tsx
@@ -109,7 +109,7 @@ export const PathRulesField: FC<Props> = ({
                     variant="subtle"
                     size="compact-sm"
                     leftSection={<MantineIcon icon={IconPlus} />}
-                    style={{ alignSelf: 'flex-start' }}
+                    className="ld-self-start"
                     disabled={disabled}
                     onClick={() =>
                         onPrefixesChange([...prefixes, makePathPrefix()])

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogCategoryForm.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogCategoryForm.tsx
@@ -308,9 +308,7 @@ export const MetricsCatalogCategoryForm: FC<Props> = memo(
                             gap={2}
                             w="100%"
                             mah={140}
-                            style={{
-                                overflowY: 'auto',
-                            }}
+                            className="ld-scroll-y"
                         >
                             {filteredExistingCategories.map((category) => (
                                 <MetricCatalogCategoryFormItem

--- a/packages/frontend/src/features/organizationDesigns/components/DesignDetailPanel.tsx
+++ b/packages/frontend/src/features/organizationDesigns/components/DesignDetailPanel.tsx
@@ -70,14 +70,14 @@ const FileRow: FC<{
                 <Badge
                     color={KIND_COLORS[file.kind] ?? 'gray'}
                     size="sm"
-                    style={{ flexShrink: 0 }}
+                    className="ld-shrink-0"
                 >
                     {file.kind}
                 </Badge>
                 <Text size="sm" truncate>
                     {file.filename}
                 </Text>
-                <Text size="xs" c="dimmed" style={{ flexShrink: 0 }}>
+                <Text size="xs" c="dimmed" className="ld-shrink-0">
                     {formatBytes(file.sizeBytes)}
                 </Text>
             </Group>

--- a/packages/frontend/src/features/preview/components/PreviewAndCustomizeScreenshot.tsx
+++ b/packages/frontend/src/features/preview/components/PreviewAndCustomizeScreenshot.tsx
@@ -163,7 +163,7 @@ export const PreviewAndCustomizeScreenshot: FC<
                     onClick={() => setIsImageModalOpen(false)}
                     w="100%"
                     h="100%"
-                    style={{ cursor: 'pointer' }}
+                    className="ld-pointer"
                 />
             </Modal>
         </Box>

--- a/packages/frontend/src/features/projectGroupAccess/components/AddProjectGroupAccessModal.tsx
+++ b/packages/frontend/src/features/projectGroupAccess/components/AddProjectGroupAccessModal.tsx
@@ -135,7 +135,7 @@ const AddProjectGroupAccessModal: FC<AddProjectGroupAccessModalProps> = ({
                                     })) ?? []
                                 }
                                 {...form.getInputProps('groupUuid')}
-                                style={{ flexGrow: 1 }}
+                                className="ld-grow"
                             />
                             <Select
                                 data={organizationRoles}

--- a/packages/frontend/src/features/recentlyDeleted/components/ContentTypeFilter.tsx
+++ b/packages/frontend/src/features/recentlyDeleted/components/ContentTypeFilter.tsx
@@ -118,7 +118,7 @@ export const ContentTypeFilter: FC<ContentTypeFilterProps> = ({
                 orientation="vertical"
                 w={1}
                 h={20}
-                style={{ alignSelf: 'center' }}
+                className="ld-self-center"
             />
             <SegmentedControl
                 size="xs"

--- a/packages/frontend/src/features/sourceCodeEditor/components/SourceCodeEditorContent.tsx
+++ b/packages/frontend/src/features/sourceCodeEditor/components/SourceCodeEditorContent.tsx
@@ -357,7 +357,7 @@ const SourceCodeEditorContent: FC = () => {
     return (
         <>
             <Group gap={0} align="stretch" wrap="nowrap" h="100%" w="100%">
-                <Box w={300} style={{ flexShrink: 0 }}>
+                <Box w={300} className="ld-shrink-0">
                     <SourceCodeSidebar
                         projectUuid={projectUuid ?? ''}
                         branches={branches ?? []}

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
@@ -322,11 +322,7 @@ export const HeaderCreate: FC = () => {
                                             position="top"
                                             disabled={canSaveChart}
                                         >
-                                            <Group
-                                                style={{
-                                                    cursor: 'pointer',
-                                                }}
-                                            >
+                                            <Group className="ld-pointer">
                                                 <Menu.Item
                                                     disabled={!canSaveChart}
                                                     onClick={() => {
@@ -374,11 +370,7 @@ export const HeaderCreate: FC = () => {
                                             position="top"
                                             disabled={canCreateVirtualView}
                                         >
-                                            <Group
-                                                style={{
-                                                    cursor: 'pointer',
-                                                }}
-                                            >
+                                            <Group className="ld-pointer">
                                                 <Menu.Item
                                                     disabled={
                                                         !canCreateVirtualView
@@ -439,11 +431,7 @@ export const HeaderCreate: FC = () => {
                                                     );
                                             }}
                                         >
-                                            <Group
-                                                style={{
-                                                    cursor: 'pointer',
-                                                }}
-                                            >
+                                            <Group className="ld-pointer">
                                                 <Menu.Item
                                                     disabled={
                                                         writeBackDisabledMessage !==

--- a/packages/frontend/src/features/sqlRunner/components/WriteBackToDbtModal.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/WriteBackToDbtModal.tsx
@@ -171,7 +171,7 @@ export const WriteBackToDbtModal: FC<Props> = ({ opened, onClose }) => {
                                         'noopener,noreferrer',
                                     );
                                 }}
-                                style={{ cursor: 'pointer' }}
+                                className="ld-pointer"
                                 title={`Open "${writePreviewData?.url}" in new tab`}
                             >
                                 {writePreviewData?.repo}

--- a/packages/frontend/src/features/sync/components/SyncModalForm.tsx
+++ b/packages/frontend/src/features/sync/components/SyncModalForm.tsx
@@ -73,7 +73,7 @@ export const SyncModalForm: FC<Props> = ({
                         >
                             <TimeZonePicker
                                 size="sm"
-                                style={{ flexGrow: 1 }}
+                                className="ld-grow"
                                 placeholder={`Project Default ${
                                     projectDefaultOffsetString
                                         ? `(UTC ${projectDefaultOffsetString})`

--- a/packages/frontend/src/features/sync/components/SyncModalView.tsx
+++ b/packages/frontend/src/features/sync/components/SyncModalView.tsx
@@ -149,7 +149,7 @@ export const SyncModalView: FC<Props> = ({
             {schedulers.length > 0 ? (
                 <Box
                     mah={400}
-                    style={{ overflowY: 'auto' }}
+                    className="ld-scroll-y"
                     onScroll={
                         onScrollBottom
                             ? (e) => {
@@ -191,9 +191,7 @@ export const SyncModalView: FC<Props> = ({
                                 <Paper
                                     key={sync.schedulerUuid}
                                     p="sm"
-                                    style={{
-                                        overflow: 'hidden',
-                                    }}
+                                    className="ld-overflow-hidden"
                                 >
                                     <Group
                                         wrap="nowrap"

--- a/packages/frontend/src/features/tableCalculation/components/SqlForm.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/SqlForm.tsx
@@ -233,7 +233,7 @@ export const SqlForm: FC<Props> = ({
                 />
             </ScrollArea>
 
-            <Box style={{ flexShrink: 0 }}>
+            <Box className="ld-shrink-0">
                 {readOnly && !conversionState ? null : !isAmbientAiEnabled ? (
                     <Alert
                         radius={0}

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -1789,7 +1789,7 @@ const AppGenerate: FC = () => {
                                             void fetchNextPage();
                                         }
                                     }}
-                                    style={{ cursor: 'pointer' }}
+                                    className="ld-pointer"
                                 >
                                     {isFetchingNextPage ? (
                                         <Loader size="xs" />

--- a/packages/frontend/src/pages/DashboardVersionComparison.tsx
+++ b/packages/frontend/src/pages/DashboardVersionComparison.tsx
@@ -447,7 +447,7 @@ const ChartsTable = ({
                                 size="xs"
                                 c="blue"
                                 td="none"
-                                style={{ cursor: 'pointer' }}
+                                className="ld-pointer"
                             >
                                 {chartName}
                             </Text>

--- a/packages/frontend/src/providers/SupportDrawer/SupportDrawerContent.tsx
+++ b/packages/frontend/src/providers/SupportDrawer/SupportDrawerContent.tsx
@@ -166,11 +166,7 @@ const SupportDrawerContent: FC<SupportDrawerContentProps> = () => {
                 We will also share your Lightdash logs and your recent network
                 requests to help us investigate this issue.
             </Text>
-            <Button
-                mt="xs"
-                style={{ alignSelf: 'flex-end' }}
-                onClick={handleShare}
-            >
+            <Button mt="xs" className="ld-self-end" onClick={handleShare}>
                 Share
             </Button>
         </Stack>

--- a/packages/frontend/src/styles/global.css
+++ b/packages/frontend/src/styles/global.css
@@ -85,3 +85,44 @@ strong {
         opacity: 1;
     }
 }
+
+/* Layout utilities for the few rules Mantine has no style prop for. */
+.ld-shrink-0 {
+    flex-shrink: 0;
+}
+
+.ld-grow {
+    flex-grow: 1;
+}
+
+.ld-overflow-hidden {
+    overflow: hidden;
+}
+
+.ld-scroll-y {
+    overflow-y: auto;
+}
+
+.ld-self-center {
+    align-self: center;
+}
+
+.ld-self-end {
+    align-self: flex-end;
+}
+
+.ld-self-start {
+    align-self: flex-start;
+}
+
+.ld-pointer {
+    cursor: pointer;
+}
+
+.ld-nowrap {
+    white-space: nowrap;
+}
+
+.ld-pre-wrap {
+    white-space: pre-wrap;
+}


### PR DESCRIPTION
Follow-up to the theme revamp stack (#28442 to #28447). No ticket; agreed with the developer.

## What changed
- 162 `style={{ ... }}` objects carried a single layout rule Mantine has no prop for (`flex-shrink`, `flex-grow`, `align-self`, `overflow`, `overflow-y`, `cursor`, `white-space`) or one it does (`flex`, `height`). The former become `ld-*` utility classes in `src/styles/global.css` (`ld-shrink-0`, `ld-grow`, `ld-overflow-hidden`, `ld-scroll-y`, `ld-self-center`, `ld-self-end`, `ld-self-start`, `ld-pointer`, `ld-nowrap`, `ld-pre-wrap`); the latter the matching style prop.
- `packages/frontend/CLAUDE.md` documents the utilities as step 3 of the styling hierarchy.

## Regression analysis
- Only tags without an existing `className` were given a utility class, so no class merging was needed. Seven conversions to `h`/`flex` props on non-Mantine components (react-resizable-panels, ECharts, a chart wrapper) were reverted to their inline style after typecheck flagged them.
- Utility classes are global and unlayered; each holds one declaration with no specificity beyond a class.

## Verified
- Typecheck, oxlint, oxfmt; Explorer and Home render unchanged in light mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Hr8bA9fzAkqy4yULJ6Qd9
