### PR TITLE
feat(data-apps): org-scoped data app templates, storage + CLI upload

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -88,6 +88,12 @@ import {
     DashboardViewTable,
 } from '../database/entities/dashboards';
 import {
+    DataAppTemplateFilesTable,
+    DataAppTemplateFilesTableName,
+    DataAppTemplatesTable,
+    DataAppTemplatesTableName,
+} from '../database/entities/dataAppTemplates';
+import {
     DownloadAuditTable,
     DownloadAuditTableName,
 } from '../database/entities/downloadAudit';
@@ -781,6 +787,8 @@ declare module 'knex/types/tables' {
         [OrganizationColorPaletteTableName]: OrganizationColorPaletteTable;
         [OrganizationDesignsTableName]: OrganizationDesignsTable;
         [OrganizationDesignFilesTableName]: OrganizationDesignFilesTable;
+        [DataAppTemplatesTableName]: DataAppTemplatesTable;
+        [DataAppTemplateFilesTableName]: DataAppTemplateFilesTable;
         [OrganizationWarehouseCredentialsTableName]: OrganizationWarehouseCredentialsTable;
         [QueryHistoryTableName]: QueryHistoryTable;
         [PreAggregateDefinitionsTableName]: PreAggregateDefinitionsTable;

--- a/packages/backend/src/database/entities/dataAppTemplates.ts
+++ b/packages/backend/src/database/entities/dataAppTemplates.ts
@@ -1,0 +1,63 @@
+import { type TemplateQuestion } from '@lightdash/common';
+import { Knex } from 'knex';
+
+export const DataAppTemplatesTableName = 'data_app_templates';
+export const DataAppTemplateFilesTableName = 'data_app_template_files';
+
+export type DbDataAppTemplate = {
+    template_uuid: string;
+    organization_uuid: string;
+    slug: string;
+    name: string;
+    description: string;
+    category: string;
+    questions: TemplateQuestion[];
+    created_at: Date;
+    updated_at: Date;
+    created_by_user_uuid: string | null;
+};
+
+export type DbDataAppTemplateIn = Pick<
+    DbDataAppTemplate,
+    | 'template_uuid'
+    | 'organization_uuid'
+    | 'slug'
+    | 'name'
+    | 'description'
+    | 'category'
+    | 'created_by_user_uuid'
+> & { questions: string };
+
+export type DbDataAppTemplateUpdate = Partial<
+    Pick<
+        DbDataAppTemplate,
+        'name' | 'description' | 'category' | 'updated_at'
+    > & {
+        questions: string;
+    }
+>;
+
+export type DataAppTemplatesTable = Knex.CompositeTableType<
+    DbDataAppTemplate,
+    DbDataAppTemplateIn,
+    DbDataAppTemplateUpdate
+>;
+
+export type DbDataAppTemplateFile = {
+    file_uuid: string;
+    template_uuid: string;
+    filename: string;
+    size_bytes: number;
+    created_at: Date;
+};
+
+export type DbDataAppTemplateFileIn = Pick<
+    DbDataAppTemplateFile,
+    'template_uuid' | 'filename' | 'size_bytes'
+>;
+
+export type DataAppTemplateFilesTable = Knex.CompositeTableType<
+    DbDataAppTemplateFile,
+    DbDataAppTemplateFileIn,
+    never
+>;

--- a/packages/backend/src/database/migrations/20260902000100_create_data_app_templates.ts
+++ b/packages/backend/src/database/migrations/20260902000100_create_data_app_templates.ts
@@ -1,0 +1,66 @@
+import { Knex } from 'knex';
+
+const DataAppTemplatesTable = 'data_app_templates';
+const DataAppTemplateFilesTable = 'data_app_template_files';
+const OrganizationsTable = 'organizations';
+const UsersTable = 'users';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.createTable(DataAppTemplatesTable, (table) => {
+        table
+            .uuid('template_uuid')
+            .primary()
+            .notNullable()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+        table
+            .uuid('organization_uuid')
+            .notNullable()
+            .references('organization_uuid')
+            .inTable(OrganizationsTable)
+            .onDelete('CASCADE')
+            .index();
+        table.text('slug').notNullable();
+        table.text('name').notNullable();
+        table.text('description').notNullable();
+        table.text('category').notNullable();
+        // Declared questions from the manifest; the create-from-template
+        // form renders these and the answers travel as clarifications.
+        table.jsonb('questions').notNullable().defaultTo('[]');
+        table.timestamp('created_at').notNullable().defaultTo(knex.fn.now());
+        table.timestamp('updated_at').notNullable().defaultTo(knex.fn.now());
+        table
+            .uuid('created_by_user_uuid')
+            .nullable()
+            .references('user_uuid')
+            .inTable(UsersTable)
+            .onDelete('SET NULL')
+            .index();
+        table.unique(['organization_uuid', 'slug']);
+    });
+
+    // One row per authored file in the package; the bytes live in object
+    // storage under the template's prefix, keyed by filename.
+    await knex.schema.createTable(DataAppTemplateFilesTable, (table) => {
+        table
+            .uuid('file_uuid')
+            .primary()
+            .notNullable()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+        table
+            .uuid('template_uuid')
+            .notNullable()
+            .references('template_uuid')
+            .inTable(DataAppTemplatesTable)
+            .onDelete('CASCADE')
+            .index();
+        table.text('filename').notNullable();
+        table.integer('size_bytes').notNullable();
+        table.timestamp('created_at').notNullable().defaultTo(knex.fn.now());
+        table.unique(['template_uuid', 'filename']);
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists(DataAppTemplateFilesTable);
+    await knex.schema.dropTableIfExists(DataAppTemplatesTable);
+}

--- a/packages/backend/src/ee/controllers/DataAppTemplateController.ts
+++ b/packages/backend/src/ee/controllers/DataAppTemplateController.ts
@@ -1,0 +1,161 @@
+import {
+    ApiDataAppTemplateImportResponse,
+    ApiDataAppTemplateResponse,
+    ApiDataAppTemplatesResponse,
+    ApiErrorPayload,
+    ApiSuccessEmpty,
+    assertRegisteredAccount,
+    DATA_APP_TEMPLATE_PACKAGE_CONTENT_TYPE,
+    MAX_DATA_APP_TEMPLATE_PACKAGE_BYTES,
+    ParameterError,
+} from '@lightdash/common';
+import {
+    Delete,
+    Get,
+    Hidden,
+    Middlewares,
+    OperationId,
+    Path,
+    Put,
+    Request,
+    Response,
+    Route,
+    SuccessResponse,
+} from '@tsoa/runtime';
+import express from 'express';
+import {
+    allowApiKeyAuthentication,
+    isAuthenticated,
+    unauthorisedInDemo,
+} from '../../controllers/authentication';
+import { BaseController } from '../../controllers/baseController';
+import { DataAppTemplateService } from '../services/DataAppTemplateService/DataAppTemplateService';
+
+/**
+ * Org-level data app templates: packages uploaded with the CLI, stored per
+ * organization, and offered in the app builder's template gallery.
+ */
+@Route('/api/v1/org/data-app-templates')
+@Hidden()
+@Response<ApiErrorPayload>('default', 'Error')
+export class DataAppTemplateController extends BaseController {
+    /**
+     * List the organization's data app templates.
+     * @summary List data app templates
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/')
+    @OperationId('ListDataAppTemplates')
+    async listTemplates(
+        @Request() req: express.Request,
+    ): Promise<ApiDataAppTemplatesResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getDataAppTemplateService().list(req.account),
+        };
+    }
+
+    /**
+     * Upload a template package (uncompressed tar of `src/**` plus
+     * `AGENTS.md`) as the raw request body. Replaces the template with the
+     * same slug when the organization already has one.
+     * @summary Import data app template package
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Put('/package')
+    @OperationId('ImportDataAppTemplatePackage')
+    async importPackage(
+        @Request() req: express.Request,
+    ): Promise<ApiDataAppTemplateImportResponse> {
+        assertRegisteredAccount(req.account);
+        const contentType = req.headers['content-type']
+            ?.split(';')[0]
+            .trim()
+            .toLowerCase();
+        if (contentType !== DATA_APP_TEMPLATE_PACKAGE_CONTENT_TYPE) {
+            throw new ParameterError(
+                `Content-Type must be ${DATA_APP_TEMPLATE_PACKAGE_CONTENT_TYPE}`,
+            );
+        }
+        const contentLengthHeader = req.headers['content-length'];
+        if (!contentLengthHeader) {
+            throw new ParameterError('Content-Length header is required');
+        }
+        const contentLength = Number(contentLengthHeader);
+        if (
+            !Number.isSafeInteger(contentLength) ||
+            contentLength <= 0 ||
+            contentLength > MAX_DATA_APP_TEMPLATE_PACKAGE_BYTES
+        ) {
+            throw new ParameterError(
+                `Content-Length must be between 1 and ${MAX_DATA_APP_TEMPLATE_PACKAGE_BYTES}`,
+            );
+        }
+
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getDataAppTemplateService().importPackage(
+                req.account,
+                { body: req, contentLength },
+            ),
+        };
+    }
+
+    /**
+     * Get one of the organization's data app templates by slug.
+     * @summary Get data app template
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/{slug}')
+    @OperationId('GetDataAppTemplate')
+    async getTemplate(
+        @Request() req: express.Request,
+        @Path() slug: string,
+    ): Promise<ApiDataAppTemplateResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getDataAppTemplateService().get(
+                req.account,
+                slug,
+            ),
+        };
+    }
+
+    /**
+     * Delete a data app template and its stored files.
+     * @summary Delete data app template
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Delete('/{slug}')
+    @OperationId('DeleteDataAppTemplate')
+    async deleteTemplate(
+        @Request() req: express.Request,
+        @Path() slug: string,
+    ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
+        await this.getDataAppTemplateService().delete(req.account, slug);
+        this.setStatus(200);
+        return { status: 'ok', results: undefined };
+    }
+
+    protected getDataAppTemplateService() {
+        return this.services.getDataAppTemplateService<DataAppTemplateService>();
+    }
+}

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -44,6 +44,7 @@ import { AiWritebackRunModel } from './models/AiWritebackRunModel';
 import { AiWritebackThreadModel } from './models/AiWritebackThreadModel';
 import { CommercialFeatureFlagModel } from './models/CommercialFeatureFlagModel';
 import { CommercialSlackAuthenticationModel } from './models/CommercialSlackAuthenticationModel';
+import { DataAppTemplateModel } from './models/DataAppTemplateModel';
 import { EmbedModel } from './models/EmbedModel';
 import { ExternalConnectionModel } from './models/ExternalConnectionModel';
 import { ExternalSourceModel } from './models/ExternalSourceModel';
@@ -87,6 +88,7 @@ import { PreAggregationDuckDbClient } from './services/AsyncQueryService/PreAggr
 import { PreAggregationExternalResolver } from './services/AsyncQueryService/PreAggregationExternalResolver';
 import { CommercialCacheService } from './services/CommercialCacheService';
 import { CommercialSlackIntegrationService } from './services/CommercialSlackIntegrationService';
+import { DataAppTemplateService } from './services/DataAppTemplateService/DataAppTemplateService';
 import { EmbedService } from './services/EmbedService/EmbedService';
 import { ExternalConnectionCoderService } from './services/ExternalConnectionCoderService/ExternalConnectionCoderService';
 import { ExternalConnectionService } from './services/ExternalConnectionService/ExternalConnectionService';
@@ -443,6 +445,12 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     registry,
                 });
             },
+            dataAppTemplateService: ({ context, models }) =>
+                new DataAppTemplateService({
+                    lightdashConfig: context.lightdashConfig,
+                    dataAppTemplateModel:
+                        models.getDataAppTemplateModel<DataAppTemplateModel>(),
+                }),
             appGenerateService: ({ context, models, clients, repository }) =>
                 new AppGenerateService({
                     lightdashConfig: context.lightdashConfig,
@@ -1253,6 +1261,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                 }),
             projectHomepageModel: ({ database }) =>
                 new ProjectHomepageModel({ database }),
+            dataAppTemplateModel: ({ database }) =>
+                new DataAppTemplateModel({ database }),
             homepageRecommendedActionSkipsModel: ({ database }) =>
                 new HomepageRecommendedActionSkipsModel({ database }),
             aiAgentModel: ({ database, utils }) =>

--- a/packages/backend/src/ee/models/DataAppTemplateModel.ts
+++ b/packages/backend/src/ee/models/DataAppTemplateModel.ts
@@ -1,0 +1,156 @@
+import {
+    type DataAppTemplateSummary,
+    type TemplateQuestion,
+} from '@lightdash/common';
+import { type Knex } from 'knex';
+import {
+    DataAppTemplateFilesTableName,
+    DataAppTemplatesTableName,
+    type DbDataAppTemplate,
+    type DbDataAppTemplateFile,
+} from '../../database/entities/dataAppTemplates';
+
+export type DataAppTemplateWrite = {
+    organizationUuid: string;
+    slug: string;
+    name: string;
+    description: string;
+    category: string;
+    questions: TemplateQuestion[];
+    files: { filename: string; sizeBytes: number }[];
+    createdByUserUuid: string | null;
+};
+
+const toSummary = (
+    row: DbDataAppTemplate,
+    fileCount: number,
+): DataAppTemplateSummary => ({
+    templateUuid: row.template_uuid,
+    organizationUuid: row.organization_uuid,
+    slug: row.slug,
+    name: row.name,
+    description: row.description,
+    category: row.category,
+    questions: row.questions ?? [],
+    fileCount,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+});
+
+export class DataAppTemplateModel {
+    private readonly database: Knex;
+
+    constructor({ database }: { database: Knex }) {
+        this.database = database;
+    }
+
+    async listByOrganization(
+        organizationUuid: string,
+    ): Promise<DataAppTemplateSummary[]> {
+        const rows = await this.database(DataAppTemplatesTableName)
+            .where('organization_uuid', organizationUuid)
+            .orderBy('name', 'asc');
+        if (rows.length === 0) return [];
+        const counts = await this.database(DataAppTemplateFilesTableName)
+            .whereIn(
+                'template_uuid',
+                rows.map((r) => r.template_uuid),
+            )
+            .groupBy('template_uuid')
+            .select('template_uuid')
+            .count<{ template_uuid: string; count: string }[]>('* as count');
+        const countByUuid = new Map(
+            counts.map((c) => [c.template_uuid, Number(c.count)]),
+        );
+        return rows.map((row) =>
+            toSummary(row, countByUuid.get(row.template_uuid) ?? 0),
+        );
+    }
+
+    async findBySlug(
+        organizationUuid: string,
+        slug: string,
+    ): Promise<DataAppTemplateSummary | undefined> {
+        const row = await this.database(DataAppTemplatesTableName)
+            .where({ organization_uuid: organizationUuid, slug })
+            .first();
+        if (!row) return undefined;
+        const files = await this.listFiles(row.template_uuid);
+        return toSummary(row, files.length);
+    }
+
+    async listFiles(templateUuid: string): Promise<DbDataAppTemplateFile[]> {
+        return this.database(DataAppTemplateFilesTableName)
+            .where('template_uuid', templateUuid)
+            .orderBy('filename', 'asc');
+    }
+
+    /**
+     * Create the template, or replace it in place when the org already has
+     * the slug: metadata and the file list are swapped atomically so the
+     * template uuid (and its storage prefix) stay stable across uploads.
+     */
+    async upsert(
+        write: DataAppTemplateWrite,
+        templateUuid: string,
+    ): Promise<{ summary: DataAppTemplateSummary; created: boolean }> {
+        return this.database.transaction(async (trx) => {
+            const existing = await trx(DataAppTemplatesTableName)
+                .where({
+                    organization_uuid: write.organizationUuid,
+                    slug: write.slug,
+                })
+                .first();
+            const questions = JSON.stringify(write.questions);
+            let row: DbDataAppTemplate;
+            if (existing) {
+                [row] = await trx(DataAppTemplatesTableName)
+                    .where('template_uuid', existing.template_uuid)
+                    .update({
+                        name: write.name,
+                        description: write.description,
+                        category: write.category,
+                        questions,
+                        updated_at: new Date(),
+                    })
+                    .returning('*');
+                await trx(DataAppTemplateFilesTableName)
+                    .where('template_uuid', existing.template_uuid)
+                    .delete();
+            } else {
+                [row] = await trx(DataAppTemplatesTableName)
+                    .insert({
+                        template_uuid: templateUuid,
+                        organization_uuid: write.organizationUuid,
+                        slug: write.slug,
+                        name: write.name,
+                        description: write.description,
+                        category: write.category,
+                        questions,
+                        created_by_user_uuid: write.createdByUserUuid,
+                    })
+                    .returning('*');
+            }
+            if (write.files.length > 0) {
+                await trx(DataAppTemplateFilesTableName).insert(
+                    write.files.map((file) => ({
+                        template_uuid: row.template_uuid,
+                        filename: file.filename,
+                        size_bytes: file.sizeBytes,
+                    })),
+                );
+            }
+            return {
+                summary: toSummary(row, write.files.length),
+                created: !existing,
+            };
+        });
+    }
+
+    async delete(organizationUuid: string, slug: string): Promise<boolean> {
+        const deleted = await this.database(DataAppTemplatesTableName)
+            .where({ organization_uuid: organizationUuid, slug })
+            .delete();
+        return deleted > 0;
+    }
+}

--- a/packages/backend/src/ee/services/DataAppTemplateService/DataAppTemplateService.test.ts
+++ b/packages/backend/src/ee/services/DataAppTemplateService/DataAppTemplateService.test.ts
@@ -1,0 +1,179 @@
+import { PutObjectCommand, type S3Client } from '@aws-sdk/client-s3';
+import { ParameterError } from '@lightdash/common';
+import { Readable } from 'node:stream';
+import { pack as tarPack } from 'tar-stream';
+import { describe, expect, it, vi } from 'vitest';
+import { buildAccount } from '../../../auth/account/account.mock';
+import { lightdashConfigMock } from '../../../config/lightdashConfig.mock';
+import type { DataAppTemplateModel } from '../../models/DataAppTemplateModel';
+import { DataAppTemplateService } from './DataAppTemplateService';
+
+const packFiles = (files: Record<string, string>): Promise<Buffer> =>
+    new Promise((resolve, reject) => {
+        const packer = tarPack();
+        const chunks: Buffer[] = [];
+        packer.on('data', (c: Buffer) => chunks.push(c));
+        packer.on('end', () => resolve(Buffer.concat(chunks)));
+        packer.on('error', reject);
+        const entries = Object.entries(files);
+        const next = (i: number) => {
+            if (i >= entries.length) {
+                packer.finalize();
+                return;
+            }
+            const [name, contents] = entries[i];
+            packer.entry({ name }, Buffer.from(contents, 'utf-8'), (err) => {
+                if (err) reject(err);
+                else next(i + 1);
+            });
+        };
+        next(0);
+    });
+
+const MANIFEST = JSON.stringify({
+    templateVersion: 1,
+    template: {
+        id: 'forecaster',
+        name: 'Forecaster',
+        description: 'A live what-if forecast.',
+        category: 'Forecasting',
+    },
+    questions: [{ key: 'metric', label: 'What should we forecast?' }],
+    bindings: { history: { explore: 'orders' } },
+});
+
+const buildService = (overrides: Partial<DataAppTemplateModel> = {}) => {
+    const model = {
+        findBySlug: vi.fn().mockResolvedValue(undefined),
+        listFiles: vi.fn().mockResolvedValue([]),
+        upsert: vi.fn().mockImplementation(async (write, templateUuid) => ({
+            created: true,
+            summary: {
+                templateUuid,
+                organizationUuid: write.organizationUuid,
+                slug: write.slug,
+                name: write.name,
+                description: write.description,
+                category: write.category,
+                questions: write.questions,
+                fileCount: write.files.length,
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            },
+        })),
+        listByOrganization: vi.fn().mockResolvedValue([]),
+        delete: vi.fn().mockResolvedValue(true),
+        ...overrides,
+    } as unknown as DataAppTemplateModel;
+    const send = vi.fn(async (_command: unknown) => ({}));
+    const service = new DataAppTemplateService({
+        lightdashConfig: lightdashConfigMock,
+        dataAppTemplateModel: model,
+    });
+    (
+        service as unknown as {
+            getS3Client: () => { client: S3Client; bucket: string };
+            createAuditedAbility: () => { cannot: () => boolean };
+        }
+    ).getS3Client = () => ({
+        client: { send } as unknown as S3Client,
+        bucket: 'test-bucket',
+    });
+    // Ability rules are covered in common; the service tests stub authz
+    // the same way OrganizationDesignService's do.
+    (
+        service as unknown as {
+            createAuditedAbility: () => { cannot: () => boolean };
+        }
+    ).createAuditedAbility = () => ({ cannot: () => false });
+    return { service, model, send };
+};
+
+const importArchive = (service: DataAppTemplateService, archive: Buffer) =>
+    service.importPackage(buildAccount(), {
+        body: Readable.from(archive),
+        contentLength: archive.length,
+    });
+
+describe('DataAppTemplateService.importPackage', () => {
+    it('stores every authored file and registers the template from its manifest', async () => {
+        const { service, model, send } = buildService();
+        const archive = await packFiles({
+            'src/template.json': MANIFEST,
+            'src/App.jsx': 'export default () => null;',
+            'AGENTS.md': '# guardrails',
+        });
+
+        const result = await importArchive(service, archive);
+
+        expect(result.action).toBe('created');
+        expect(result.slug).toBe('forecaster');
+        expect(result.questions).toHaveLength(1);
+        expect(model.upsert).toHaveBeenCalledTimes(1);
+        const [write] = (model.upsert as ReturnType<typeof vi.fn>).mock
+            .calls[0];
+        expect(write.organizationUuid).toBe('test-org-uuid');
+        expect(
+            write.files.map((f: { filename: string }) => f.filename),
+        ).toEqual(['AGENTS.md', 'src/App.jsx', 'src/template.json']);
+        const puts = send.mock.calls.filter(
+            ([command]) => command instanceof PutObjectCommand,
+        );
+        expect(puts).toHaveLength(3);
+        const keys = puts.map(
+            ([command]) => (command as PutObjectCommand).input.Key,
+        );
+        expect(
+            keys.every((k) =>
+                k?.startsWith('data-app-templates/test-org-uuid/'),
+            ),
+        ).toBe(true);
+    });
+
+    it('rejects a package without a manifest', async () => {
+        const { service, model } = buildService();
+        const archive = await packFiles({ 'src/App.jsx': '// no manifest' });
+        await expect(importArchive(service, archive)).rejects.toThrow(
+            ParameterError,
+        );
+        expect(model.upsert).not.toHaveBeenCalled();
+    });
+
+    it('rejects scaffold and tooling files', async () => {
+        const { service, model } = buildService();
+        const archive = await packFiles({
+            'src/template.json': MANIFEST,
+            'package.json': '{}',
+        });
+        await expect(importArchive(service, archive)).rejects.toThrow(
+            /not allowed/,
+        );
+        expect(model.upsert).not.toHaveBeenCalled();
+    });
+
+    it('reports an update when the org already has the slug', async () => {
+        const existing = {
+            templateUuid: '00000000-0000-4000-8000-000000000001',
+            organizationUuid: 'test-org-uuid',
+            slug: 'forecaster',
+            name: 'Old',
+            description: 'Old',
+            category: 'Old',
+            questions: [],
+            fileCount: 1,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        };
+        const { service } = buildService({
+            findBySlug: vi.fn().mockResolvedValue(existing),
+            upsert: vi.fn().mockResolvedValue({
+                created: false,
+                summary: { ...existing, name: 'Forecaster' },
+            }),
+        } as unknown as Partial<DataAppTemplateModel>);
+        const archive = await packFiles({ 'src/template.json': MANIFEST });
+        const result = await importArchive(service, archive);
+        expect(result.action).toBe('updated');
+        expect(result.templateUuid).toBe(existing.templateUuid);
+    });
+});

--- a/packages/backend/src/ee/services/DataAppTemplateService/DataAppTemplateService.ts
+++ b/packages/backend/src/ee/services/DataAppTemplateService/DataAppTemplateService.ts
@@ -1,0 +1,425 @@
+import {
+    DeleteObjectsCommand,
+    PutObjectCommand,
+    S3Client,
+    type S3ClientConfig,
+} from '@aws-sdk/client-s3';
+import { subject } from '@casl/ability';
+import {
+    assertIsAccountWithOrg,
+    assertRegisteredAccount,
+    DATA_APP_TEMPLATE_GUARDRAILS_PATH,
+    DATA_APP_TEMPLATE_MANIFEST_PATH,
+    DataAppTemplatePackageError,
+    ForbiddenError,
+    MAX_DATA_APP_TEMPLATE_FILE_BYTES,
+    MAX_DATA_APP_TEMPLATE_FILES,
+    MAX_DATA_APP_TEMPLATE_PACKAGE_BYTES,
+    MissingConfigError,
+    NotFoundError,
+    ParameterError,
+    parseDataAppTemplateManifest,
+    validateDataAppTemplateEntryPath,
+    type Account,
+    type DataAppTemplateImportResult,
+    type DataAppTemplateSummary,
+} from '@lightdash/common';
+import { Readable } from 'node:stream';
+import { extract as tarExtract } from 'tar-stream';
+import { v4 as uuidv4 } from 'uuid';
+import { resolveS3Credentials } from '../../../clients/Aws/S3BaseClient';
+import { type LightdashConfig } from '../../../config/parseConfig';
+import { BaseService } from '../../../services/BaseService';
+import { type DataAppTemplateModel } from '../../models/DataAppTemplateModel';
+import { readS3ObjectAsBuffer } from '../AppGenerateService/s3Utils';
+
+type DataAppTemplateServiceArguments = {
+    lightdashConfig: LightdashConfig;
+    dataAppTemplateModel: DataAppTemplateModel;
+};
+
+export type DataAppTemplateSourceFile = {
+    filename: string;
+    contents: string;
+};
+
+const templateS3Prefix = (organizationUuid: string, templateUuid: string) =>
+    `data-app-templates/${organizationUuid}/${templateUuid}/`;
+
+const templateS3Key = (
+    organizationUuid: string,
+    templateUuid: string,
+    filename: string,
+) => `${templateS3Prefix(organizationUuid, templateUuid)}${filename}`;
+
+const bufferReadableWithLimit = async (
+    readable: Readable,
+    maxBytes: number,
+): Promise<Buffer> => {
+    const chunks: Buffer[] = [];
+    let total = 0;
+    for await (const chunk of readable) {
+        const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+        total += buffer.length;
+        if (total > maxBytes) {
+            throw new ParameterError(
+                `Template package must be at most ${maxBytes} bytes`,
+            );
+        }
+        chunks.push(buffer);
+    }
+    return Buffer.concat(chunks);
+};
+
+type PackageFile = { filename: string; body: Buffer };
+
+/**
+ * Unpacks a template package: only authored files (src/**, AGENTS.md) are
+ * accepted, sizes and counts are capped, and the manifest must be present.
+ */
+export const parseDataAppTemplatePackage = (
+    archive: Buffer,
+): Promise<PackageFile[]> =>
+    new Promise((resolve, reject) => {
+        const files: PackageFile[] = [];
+        const extractor = tarExtract();
+        extractor.on('entry', (header, stream, next) => {
+            const chunks: Buffer[] = [];
+            stream.on('data', (chunk: Buffer) => chunks.push(chunk));
+            stream.on('error', reject);
+            stream.on('end', () => {
+                try {
+                    if (header.type === 'file') {
+                        const filename = validateDataAppTemplateEntryPath(
+                            header.name,
+                        );
+                        const body = Buffer.concat(chunks);
+                        if (body.length > MAX_DATA_APP_TEMPLATE_FILE_BYTES) {
+                            throw new DataAppTemplatePackageError(
+                                `${filename} exceeds ${MAX_DATA_APP_TEMPLATE_FILE_BYTES} bytes`,
+                            );
+                        }
+                        files.push({ filename, body });
+                        if (files.length > MAX_DATA_APP_TEMPLATE_FILES) {
+                            throw new DataAppTemplatePackageError(
+                                `Template package has more than ${MAX_DATA_APP_TEMPLATE_FILES} files`,
+                            );
+                        }
+                    }
+                    next();
+                } catch (e) {
+                    reject(e);
+                }
+            });
+            stream.resume();
+        });
+        extractor.on('error', reject);
+        extractor.on('finish', () => resolve(files));
+        extractor.end(archive);
+    });
+
+export class DataAppTemplateService extends BaseService {
+    private readonly lightdashConfig: LightdashConfig;
+
+    private readonly dataAppTemplateModel: DataAppTemplateModel;
+
+    constructor({
+        lightdashConfig,
+        dataAppTemplateModel,
+    }: DataAppTemplateServiceArguments) {
+        super({ serviceName: 'DataAppTemplateService' });
+        this.lightdashConfig = lightdashConfig;
+        this.dataAppTemplateModel = dataAppTemplateModel;
+    }
+
+    private assertCanManage(account: Account): {
+        organizationUuid: string;
+        userUuid: string;
+    } {
+        assertRegisteredAccount(account);
+        assertIsAccountWithOrg(account);
+        const { organizationUuid } = account.organization;
+        // Permission placeholder (flagged for review): templates are org
+        // content packages with the same audience as themes-as-code, so they
+        // borrow the OrganizationDesign subject. A dedicated DataAppTemplate
+        // subject needs matching scopes + role-parity entries — follow-up.
+        const ability = this.createAuditedAbility(account);
+        if (
+            ability.cannot(
+                'manage',
+                subject('OrganizationDesign', { organizationUuid }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'Insufficient permissions to manage data app templates',
+            );
+        }
+        return { organizationUuid, userUuid: account.user.userUuid };
+    }
+
+    private assertCanView(account: Account): { organizationUuid: string } {
+        assertRegisteredAccount(account);
+        assertIsAccountWithOrg(account);
+        const { organizationUuid } = account.organization;
+        const ability = this.createAuditedAbility(account);
+        if (
+            ability.cannot(
+                'view',
+                subject('OrganizationDesign', { organizationUuid }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'Insufficient permissions to view data app templates',
+            );
+        }
+        return { organizationUuid };
+    }
+
+    /**
+     * Mirrors OrganizationDesignService.getS3Client — templates live in the
+     * same app-runtime bucket data apps use, under their own prefix, so
+     * self-hosted instances need no extra configuration.
+     */
+    private getS3Client(): { client: S3Client; bucket: string } {
+        const s3Config = this.lightdashConfig.appRuntime.s3;
+        if (!s3Config) {
+            throw new MissingConfigError(
+                'S3 is not configured for app runtime',
+            );
+        }
+        const config: S3ClientConfig = {
+            region: s3Config.region,
+            endpoint: s3Config.endpoint || undefined,
+            forcePathStyle: s3Config.forcePathStyle ?? false,
+        };
+        const credentials = resolveS3Credentials(s3Config);
+        if (credentials) {
+            config.credentials = credentials;
+        }
+        return { client: new S3Client(config), bucket: s3Config.bucket };
+    }
+
+    async importPackage(
+        account: Account,
+        input: { body: Readable; contentLength: number },
+    ): Promise<DataAppTemplateImportResult> {
+        const { organizationUuid, userUuid } = this.assertCanManage(account);
+        if (
+            input.contentLength <= 0 ||
+            input.contentLength > MAX_DATA_APP_TEMPLATE_PACKAGE_BYTES
+        ) {
+            throw new ParameterError(
+                `Template package must be between 1 and ${MAX_DATA_APP_TEMPLATE_PACKAGE_BYTES} bytes`,
+            );
+        }
+        const archive = await bufferReadableWithLimit(
+            input.body,
+            MAX_DATA_APP_TEMPLATE_PACKAGE_BYTES,
+        );
+        if (archive.length === 0) {
+            throw new ParameterError('Template package body is empty');
+        }
+
+        let files: PackageFile[];
+        try {
+            files = await parseDataAppTemplatePackage(archive);
+        } catch (e) {
+            if (e instanceof DataAppTemplatePackageError) {
+                throw new ParameterError(e.message);
+            }
+            throw e;
+        }
+        files.sort((a, b) => a.filename.localeCompare(b.filename));
+
+        const manifestFile = files.find(
+            (file) => file.filename === DATA_APP_TEMPLATE_MANIFEST_PATH,
+        );
+        if (!manifestFile) {
+            throw new ParameterError(
+                `Template package must contain ${DATA_APP_TEMPLATE_MANIFEST_PATH}`,
+            );
+        }
+        let manifest;
+        try {
+            manifest = parseDataAppTemplateManifest(
+                manifestFile.body.toString('utf-8'),
+            );
+        } catch (e) {
+            if (e instanceof DataAppTemplatePackageError) {
+                throw new ParameterError(e.message);
+            }
+            throw e;
+        }
+
+        const existing = await this.dataAppTemplateModel.findBySlug(
+            organizationUuid,
+            manifest.template.id,
+        );
+        const templateUuid = existing?.templateUuid ?? uuidv4();
+        const previousFiles = existing
+            ? await this.dataAppTemplateModel.listFiles(existing.templateUuid)
+            : [];
+
+        // Write the bytes before swapping metadata, so a failure mid-upload
+        // leaves the record pointing at its previous file list. Files that
+        // share a name with the previous package are overwritten in place;
+        // a versioned prefix would make re-uploads fully atomic (follow-up).
+        const { client, bucket } = this.getS3Client();
+        /* eslint-disable no-await-in-loop */
+        for (const file of files) {
+            await client.send(
+                new PutObjectCommand({
+                    Bucket: bucket,
+                    Key: templateS3Key(
+                        organizationUuid,
+                        templateUuid,
+                        file.filename,
+                    ),
+                    Body: file.body,
+                    ContentType: file.filename.endsWith('.json')
+                        ? 'application/json'
+                        : 'text/plain; charset=utf-8',
+                }),
+            );
+        }
+        /* eslint-enable no-await-in-loop */
+
+        const { summary, created } = await this.dataAppTemplateModel.upsert(
+            {
+                organizationUuid,
+                slug: manifest.template.id,
+                name: manifest.template.name,
+                description: manifest.template.description,
+                category: manifest.template.category,
+                questions: manifest.questions ?? [],
+                files: files.map((file) => ({
+                    filename: file.filename,
+                    sizeBytes: file.body.length,
+                })),
+                createdByUserUuid: userUuid,
+            },
+            templateUuid,
+        );
+
+        // Drop objects the new package no longer contains.
+        const keep = new Set(files.map((file) => file.filename));
+        const stale = previousFiles.filter((file) => !keep.has(file.filename));
+        if (stale.length > 0) {
+            await client.send(
+                new DeleteObjectsCommand({
+                    Bucket: bucket,
+                    Delete: {
+                        Objects: stale.map((file) => ({
+                            Key: templateS3Key(
+                                organizationUuid,
+                                templateUuid,
+                                file.filename,
+                            ),
+                        })),
+                    },
+                }),
+            );
+        }
+
+        this.logger.info(
+            `Data app template ${manifest.template.id} ${created ? 'created' : 'updated'} for organization ${organizationUuid} (${files.length} files)`,
+        );
+        return { ...summary, action: created ? 'created' : 'updated' };
+    }
+
+    async list(account: Account): Promise<DataAppTemplateSummary[]> {
+        const { organizationUuid } = this.assertCanView(account);
+        return this.dataAppTemplateModel.listByOrganization(organizationUuid);
+    }
+
+    async get(account: Account, slug: string): Promise<DataAppTemplateSummary> {
+        const { organizationUuid } = this.assertCanView(account);
+        const template = await this.dataAppTemplateModel.findBySlug(
+            organizationUuid,
+            slug,
+        );
+        if (!template) {
+            throw new NotFoundError(`Data app template "${slug}" not found`);
+        }
+        return template;
+    }
+
+    async delete(account: Account, slug: string): Promise<void> {
+        const { organizationUuid } = this.assertCanManage(account);
+        const template = await this.dataAppTemplateModel.findBySlug(
+            organizationUuid,
+            slug,
+        );
+        if (!template) {
+            throw new NotFoundError(`Data app template "${slug}" not found`);
+        }
+        const files = await this.dataAppTemplateModel.listFiles(
+            template.templateUuid,
+        );
+        await this.dataAppTemplateModel.delete(organizationUuid, slug);
+        if (files.length > 0) {
+            const { client, bucket } = this.getS3Client();
+            await client.send(
+                new DeleteObjectsCommand({
+                    Bucket: bucket,
+                    Delete: {
+                        Objects: files.map((file) => ({
+                            Key: templateS3Key(
+                                organizationUuid,
+                                template.templateUuid,
+                                file.filename,
+                            ),
+                        })),
+                    },
+                }),
+            );
+        }
+    }
+
+    /**
+     * The template's authored files, ready to seed into a sandbox: the
+     * storage-backed counterpart of the generated starter-source modules.
+     */
+    async getSourceFiles(
+        organizationUuid: string,
+        slug: string,
+    ): Promise<{
+        template: DataAppTemplateSummary;
+        files: DataAppTemplateSourceFile[];
+        guardrails: string | null;
+    }> {
+        const template = await this.dataAppTemplateModel.findBySlug(
+            organizationUuid,
+            slug,
+        );
+        if (!template) {
+            throw new NotFoundError(`Data app template "${slug}" not found`);
+        }
+        const rows = await this.dataAppTemplateModel.listFiles(
+            template.templateUuid,
+        );
+        const { client, bucket } = this.getS3Client();
+        const files: DataAppTemplateSourceFile[] = [];
+        /* eslint-disable no-await-in-loop */
+        for (const row of rows) {
+            const buffer = await readS3ObjectAsBuffer(
+                client,
+                bucket,
+                templateS3Key(
+                    organizationUuid,
+                    template.templateUuid,
+                    row.filename,
+                ),
+            );
+            files.push({
+                filename: row.filename,
+                contents: buffer.toString('utf-8'),
+            });
+        }
+        /* eslint-enable no-await-in-loop */
+        const guardrails =
+            files.find((f) => f.filename === DATA_APP_TEMPLATE_GUARDRAILS_PATH)
+                ?.contents ?? null;
+        return { template, files, guardrails };
+    }
+}

--- a/packages/backend/src/models/ModelRepository.ts
+++ b/packages/backend/src/models/ModelRepository.ts
@@ -173,6 +173,7 @@ export type ModelManifest = {
     projectParametersModel: ProjectParametersModel;
     /** An implementation signature for these models are not available at this stage */
     externalSourceModel: unknown;
+    dataAppTemplateModel: unknown;
     aiAgentMemoryModel: unknown;
     aiAgentModel: unknown;
     homepageRecommendedActionSkipsModel: unknown;
@@ -947,6 +948,10 @@ export class ModelRepository
 
     public getProjectHomepageModel<ModelImplT>(): ModelImplT {
         return this.getModel('projectHomepageModel');
+    }
+
+    public getDataAppTemplateModel<ModelImplT>(): ModelImplT {
+        return this.getModel('dataAppTemplateModel');
     }
 
     public getHomepageRecommendedActionSkipsModel<ModelImplT>(): ModelImplT {

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -177,6 +177,7 @@ interface ServiceManifest {
     previewDeploySetupService: unknown;
     appGenerateService: unknown;
     externalSourceService: unknown;
+    dataAppTemplateService: unknown;
     embedService: unknown;
     aiService: unknown;
     aiAgentCoderService: unknown;
@@ -1601,6 +1602,12 @@ export class ServiceRepository
         ExternalSourceServiceImplT,
     >(): ExternalSourceServiceImplT {
         return this.getService('externalSourceService');
+    }
+
+    public getDataAppTemplateService<
+        DataAppTemplateServiceImplT,
+    >(): DataAppTemplateServiceImplT {
+        return this.getService('dataAppTemplateService');
     }
 
     public getProjectContextService<

--- a/packages/cli/src/handlers/apps/templateUpload.test.ts
+++ b/packages/cli/src/handlers/apps/templateUpload.test.ts
@@ -1,0 +1,143 @@
+import { promises as fs } from 'fs';
+import { Response } from 'node-fetch';
+import * as os from 'os';
+import * as path from 'path';
+import { extract as tarExtract } from 'tar-stream';
+import { lightdashRawApi } from '../dbt/apiClient';
+import {
+    buildDataAppTemplatePackage,
+    uploadAppsAsTemplates,
+} from './templateUpload';
+
+vi.mock('../dbt/apiClient', () => ({
+    lightdashApi: vi.fn(),
+    lightdashRawApi: vi.fn(),
+}));
+
+const MANIFEST = JSON.stringify({
+    templateVersion: 1,
+    template: {
+        id: 'forecaster',
+        name: 'Forecaster',
+        description: 'A live what-if forecast.',
+        category: 'Forecasting',
+    },
+});
+
+const listTarEntries = (archive: Buffer): Promise<string[]> =>
+    new Promise((resolve, reject) => {
+        const names: string[] = [];
+        const extractor = tarExtract();
+        extractor.on('entry', (header, stream, next) => {
+            names.push(header.name);
+            stream.on('end', next);
+            stream.resume();
+        });
+        extractor.on('error', reject);
+        extractor.on('finish', () => resolve(names.sort()));
+        extractor.end(archive);
+    });
+
+const writeApp = async (root: string, slug: string) => {
+    const appDir = path.join(root, 'apps', slug);
+    await fs.mkdir(path.join(appDir, 'src', 'components'), {
+        recursive: true,
+    });
+    await fs.mkdir(path.join(appDir, 'node_modules', 'react'), {
+        recursive: true,
+    });
+    await fs.mkdir(path.join(appDir, '.lightdash', 'context'), {
+        recursive: true,
+    });
+    await fs.writeFile(path.join(appDir, 'lightdash-app.yml'), 'name: x\n');
+    await fs.writeFile(path.join(appDir, 'package.json'), '{}');
+    await fs.writeFile(path.join(appDir, 'AGENTS.md'), '# guardrails');
+    await fs.writeFile(path.join(appDir, 'src', 'template.json'), MANIFEST);
+    await fs.writeFile(path.join(appDir, 'src', 'App.jsx'), 'export {}');
+    await fs.writeFile(
+        path.join(appDir, 'src', 'components', 'Chart.jsx'),
+        'export {}',
+    );
+    await fs.writeFile(
+        path.join(appDir, 'node_modules', 'react', 'index.js'),
+        '',
+    );
+    await fs.writeFile(
+        path.join(appDir, '.lightdash', 'context', 'semantic-layer.yml'),
+        '',
+    );
+    return appDir;
+};
+
+describe('data app template upload', () => {
+    let root: string;
+
+    beforeEach(async () => {
+        vi.clearAllMocks();
+        root = await fs.mkdtemp(path.join(os.tmpdir(), 'template-upload-'));
+    });
+
+    afterEach(async () => {
+        await fs.rm(root, { recursive: true, force: true });
+    });
+
+    it('packs only the authored files: src/** and AGENTS.md', async () => {
+        const appDir = await writeApp(root, 'forecaster');
+        const archive = await buildDataAppTemplatePackage(appDir);
+        await expect(listTarEntries(archive)).resolves.toEqual([
+            'AGENTS.md',
+            'src/App.jsx',
+            'src/components/Chart.jsx',
+            'src/template.json',
+        ]);
+    });
+
+    it('rejects an app folder without src/template.json', async () => {
+        const appDir = await writeApp(root, 'plain');
+        await fs.rm(path.join(appDir, 'src', 'template.json'));
+        await expect(buildDataAppTemplatePackage(appDir)).rejects.toThrow(
+            /src\/template\.json/,
+        );
+    });
+
+    it('PUTs each selected app folder as a raw tar to the org templates endpoint', async () => {
+        await writeApp(root, 'forecaster');
+        vi.mocked(lightdashRawApi).mockResolvedValue(
+            new Response(
+                JSON.stringify({
+                    status: 'ok',
+                    results: {
+                        slug: 'forecaster',
+                        name: 'Forecaster',
+                        questions: [],
+                        action: 'created',
+                    },
+                }),
+            ) as never,
+        );
+
+        const summary = await uploadAppsAsTemplates({
+            customPath: root,
+            appRefs: ['forecaster'],
+        });
+
+        expect(summary).toEqual({ created: 1, updated: 0, failed: 0 });
+        expect(lightdashRawApi).toHaveBeenCalledTimes(1);
+        const [call] = vi.mocked(lightdashRawApi).mock.calls;
+        expect(call[0].method).toBe('PUT');
+        expect(call[0].url).toBe('/api/v1/org/data-app-templates/package');
+        expect(call[0].headers).toMatchObject({
+            'Content-Type': 'application/x-tar',
+        });
+        expect(Number(call[0].headers?.['Content-Length'])).toBe(
+            (call[0].body as Buffer).length,
+        );
+    });
+
+    it('fails fast when a selected folder does not exist', async () => {
+        await expect(
+            uploadAppsAsTemplates({ customPath: root, appRefs: ['missing'] }),
+        ).rejects.toThrow(/missing/);
+        expect(lightdashRawApi).not.toHaveBeenCalled();
+    });
+});

--- a/packages/cli/src/handlers/apps/templateUpload.ts
+++ b/packages/cli/src/handlers/apps/templateUpload.ts
@@ -1,0 +1,193 @@
+/* eslint-disable no-await-in-loop */
+import {
+    DATA_APP_TEMPLATE_GUARDRAILS_PATH,
+    DATA_APP_TEMPLATE_MANIFEST_PATH,
+    DATA_APP_TEMPLATE_PACKAGE_CONTENT_TYPE,
+    getErrorMessage,
+    MAX_DATA_APP_TEMPLATE_PACKAGE_BYTES,
+    ParameterError,
+    type ApiDataAppTemplateImportResponse,
+} from '@lightdash/common';
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import { pack as tarPack, type Headers } from 'tar-stream';
+import GlobalState from '../../globalState';
+import * as styles from '../../styles';
+import { getDownloadFolder } from '../contentAsCodePaths';
+import { lightdashRawApi } from '../dbt/apiClient';
+
+const TAR_EPOCH = new Date(0);
+
+export type TemplateUploadSummary = {
+    created: number;
+    updated: number;
+    failed: number;
+};
+
+const addTarEntry = (
+    packer: ReturnType<typeof tarPack>,
+    header: Headers,
+    body: Buffer,
+): Promise<void> =>
+    new Promise((resolve, reject) => {
+        packer.entry(header, body, (error) => {
+            if (error) reject(error);
+            else resolve();
+        });
+    });
+
+const collectFiles = async (
+    dir: string,
+    baseDir: string,
+): Promise<string[]> => {
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    const nested = await Promise.all(
+        entries.map(async (entry) => {
+            const entryPath = path.join(dir, entry.name);
+            if (entry.isDirectory()) return collectFiles(entryPath, baseDir);
+            if (!entry.isFile()) return [];
+            return [
+                path.relative(baseDir, entryPath).split(path.sep).join('/'),
+            ];
+        }),
+    );
+    return nested.flat();
+};
+
+/**
+ * Packs an app folder as a template package: the authored `src/**` tree
+ * plus `AGENTS.md` guardrails, as an uncompressed tar with fixed headers so
+ * the same folder always produces the same bytes. Scaffold and tooling
+ * files (`lightdash-app.yml`, `package.json`, `node_modules`, `.lightdash`)
+ * are never included — the server rebuilds against its own template.
+ */
+export const buildDataAppTemplatePackage = async (
+    appDir: string,
+): Promise<Buffer> => {
+    const manifestPath = path.join(appDir, DATA_APP_TEMPLATE_MANIFEST_PATH);
+    const hasManifest = await fs
+        .stat(manifestPath)
+        .then((s) => s.isFile())
+        .catch(() => false);
+    if (!hasManifest) {
+        throw new ParameterError(
+            `${appDir} is not a template: ${DATA_APP_TEMPLATE_MANIFEST_PATH} is missing`,
+        );
+    }
+
+    const files = await collectFiles(path.join(appDir, 'src'), appDir);
+    const guardrailsPath = path.join(appDir, DATA_APP_TEMPLATE_GUARDRAILS_PATH);
+    const hasGuardrails = await fs
+        .stat(guardrailsPath)
+        .then((s) => s.isFile())
+        .catch(() => false);
+    if (hasGuardrails) files.push(DATA_APP_TEMPLATE_GUARDRAILS_PATH);
+    files.sort();
+
+    return new Promise((resolve, reject) => {
+        const packer = tarPack();
+        const chunks: Buffer[] = [];
+        packer.on('data', (chunk: Buffer) => chunks.push(chunk));
+        packer.on('end', () => resolve(Buffer.concat(chunks)));
+        packer.on('error', reject);
+
+        void (async () => {
+            for (const filename of files) {
+                const body = await fs.readFile(path.join(appDir, filename));
+                await addTarEntry(
+                    packer,
+                    {
+                        name: filename,
+                        type: 'file',
+                        mode: 0o644,
+                        mtime: TAR_EPOCH,
+                        uid: 0,
+                        gid: 0,
+                    },
+                    body,
+                );
+            }
+            packer.finalize();
+        })().catch(reject);
+    });
+};
+
+/**
+ * `lightdash upload --apps <slug...> --as-template`: publishes each app
+ * folder as an organization data app template. Org-scoped, so no project
+ * is selected; refs must be folder names under `apps/`.
+ */
+export const uploadAppsAsTemplates = async ({
+    customPath,
+    appRefs,
+}: {
+    customPath?: string;
+    appRefs: string[];
+}): Promise<TemplateUploadSummary> => {
+    if (appRefs.length === 0) {
+        throw new ParameterError(
+            '--as-template requires --apps <slug...> naming the app folders to publish.',
+        );
+    }
+    const appsDir = path.join(getDownloadFolder(customPath), 'apps');
+    const summary: TemplateUploadSummary = {
+        created: 0,
+        updated: 0,
+        failed: 0,
+    };
+
+    for (const ref of appRefs) {
+        const appDir = path.join(appsDir, ref);
+        const exists = await fs
+            .stat(appDir)
+            .then((s) => s.isDirectory())
+            .catch(() => false);
+        if (!exists) {
+            throw new ParameterError(
+                `App folder "${ref}" not found in ${appsDir}. --as-template takes folder names under apps/.`,
+            );
+        }
+        try {
+            const archive = await buildDataAppTemplatePackage(appDir);
+            if (archive.length > MAX_DATA_APP_TEMPLATE_PACKAGE_BYTES) {
+                throw new ParameterError(
+                    `Template package for "${ref}" exceeds ${MAX_DATA_APP_TEMPLATE_PACKAGE_BYTES} bytes`,
+                );
+            }
+            const response = await lightdashRawApi({
+                method: 'PUT',
+                url: '/api/v1/org/data-app-templates/package',
+                body: archive,
+                headers: {
+                    'Content-Type': DATA_APP_TEMPLATE_PACKAGE_CONTENT_TYPE,
+                    'Content-Length': String(archive.length),
+                },
+            });
+            const result =
+                (await response.json()) as ApiDataAppTemplateImportResponse;
+            if (result.status !== 'ok') {
+                throw new Error('Template import returned an invalid response');
+            }
+            const { slug, name, questions, action } = result.results;
+            if (action === 'created') summary.created += 1;
+            else summary.updated += 1;
+            GlobalState.log(
+                styles.success(
+                    `✔ ${action === 'created' ? 'Published' : 'Updated'} template "${name}" (${slug}) with ${questions.length} question(s)`,
+                ),
+            );
+        } catch (error) {
+            summary.failed += 1;
+            GlobalState.log(
+                styles.error(
+                    `✖ Failed to publish "${ref}" as a template: ${getErrorMessage(error)}`,
+                ),
+            );
+        }
+    }
+
+    GlobalState.log(
+        `Templates: ${summary.created} created, ${summary.updated} updated, ${summary.failed} failed`,
+    );
+    return summary;
+};

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -105,6 +105,7 @@ import {
     uploadFilterMatches,
 } from './apps/appsDownload';
 import { loadTemplateDependencies } from './apps/scaffolding';
+import { uploadAppsAsTemplates } from './apps/templateUpload';
 import {
     createBuildLimitWaitState,
     withBuildLimitRetry,
@@ -185,6 +186,7 @@ export type DownloadHandlerOptions = {
     createNew?: boolean; // upload only: always create a new app instead of updating the manifest's app
     allowCustomDependencies?: boolean; // upload only: approve custom-dependency uploads without prompting
     appSpace?: string; // upload only: space (slug or uuid) for data apps this run creates
+    asTemplate?: boolean; // upload only: publish --apps folders as org data app templates
     force: boolean;
     path?: string; // New optional path parameter
     project?: string;
@@ -3664,6 +3666,16 @@ export const uploadHandler = async (
             customPath: contentPathOption,
             config,
             sendInvites: options.sendInvites,
+        });
+        return;
+    }
+
+    // Templates are organization content: pack and publish the named app
+    // folders without selecting a project or touching any other phase.
+    if (options.asTemplate) {
+        await uploadAppsAsTemplates({
+            customPath: contentPathOption,
+            appRefs: options.apps ?? [],
         });
         return;
     }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1168,6 +1168,11 @@ const uploadCommand = program
         false,
     )
     .option(
+        '--as-template',
+        'Publish the app folders named by --apps as organization data app templates (enterprise). Packs src/ and AGENTS.md; requires src/template.json. Org-scoped, no project is selected.',
+        false,
+    )
+    .option(
         '--organization',
         'upload all organization-scoped resources, including Data App themes, without selecting a project',
         false,

--- a/packages/common/src/ee/apps/templatePackage.test.ts
+++ b/packages/common/src/ee/apps/templatePackage.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import {
+    parseDataAppTemplateManifest,
+    validateDataAppTemplateEntryPath,
+} from './templatePackage';
+
+const validManifest = {
+    templateVersion: 1,
+    template: {
+        id: 'forecaster',
+        name: 'Forecaster',
+        description: 'A live what-if forecast.',
+        category: 'Forecasting',
+    },
+    questions: [
+        { key: 'metric', label: 'What should we forecast?', required: true },
+        { key: 'tiles', label: 'Which metrics?', kind: 'list' },
+    ],
+    bindings: { history: { explore: 'orders' } },
+};
+
+describe('validateDataAppTemplateEntryPath', () => {
+    it('accepts authored src files and the guardrails file', () => {
+        expect(validateDataAppTemplateEntryPath('src/App.jsx')).toBe(
+            'src/App.jsx',
+        );
+        expect(validateDataAppTemplateEntryPath('./src/template.json')).toBe(
+            'src/template.json',
+        );
+        expect(validateDataAppTemplateEntryPath('AGENTS.md')).toBe('AGENTS.md');
+    });
+
+    it('rejects scaffold, tooling, traversal and absolute paths', () => {
+        for (const bad of [
+            'package.json',
+            'lightdash-app.yml',
+            'dist/index.html',
+            '.claude/skills/x.md',
+            'src/../package.json',
+            '/src/App.jsx',
+            'src/node_modules/x.js',
+            'src//App.jsx',
+        ]) {
+            expect(() => validateDataAppTemplateEntryPath(bad)).toThrow();
+        }
+    });
+});
+
+describe('parseDataAppTemplateManifest', () => {
+    it('extracts identity and questions, ignoring the rest', () => {
+        const parsed = parseDataAppTemplateManifest(
+            JSON.stringify(validManifest),
+        );
+        expect(parsed.template.id).toBe('forecaster');
+        expect(parsed.template.name).toBe('Forecaster');
+        expect(parsed.questions).toHaveLength(2);
+        expect(parsed.questions?.[1].kind).toBe('list');
+        expect(parsed.questions?.[0].required).toBe(true);
+    });
+
+    it('defaults questions to an empty list', () => {
+        const parsed = parseDataAppTemplateManifest(
+            JSON.stringify({ ...validManifest, questions: undefined }),
+        );
+        expect(parsed.questions).toEqual([]);
+    });
+
+    it('rejects bad versions, ids, missing fields, and duplicate question keys', () => {
+        expect(() =>
+            parseDataAppTemplateManifest(
+                JSON.stringify({ ...validManifest, templateVersion: 2 }),
+            ),
+        ).toThrow(/templateVersion/);
+        expect(() =>
+            parseDataAppTemplateManifest(
+                JSON.stringify({
+                    ...validManifest,
+                    template: { ...validManifest.template, id: 'Not A Slug' },
+                }),
+            ),
+        ).toThrow(/slug/);
+        expect(() =>
+            parseDataAppTemplateManifest(
+                JSON.stringify({
+                    ...validManifest,
+                    template: { ...validManifest.template, description: '' },
+                }),
+            ),
+        ).toThrow(/description/);
+        expect(() =>
+            parseDataAppTemplateManifest(
+                JSON.stringify({
+                    ...validManifest,
+                    questions: [
+                        { key: 'a', label: 'A' },
+                        { key: 'a', label: 'B' },
+                    ],
+                }),
+            ),
+        ).toThrow(/duplicate/);
+        expect(() => parseDataAppTemplateManifest('{')).toThrow(/valid JSON/);
+    });
+});

--- a/packages/common/src/ee/apps/templatePackage.ts
+++ b/packages/common/src/ee/apps/templatePackage.ts
@@ -1,0 +1,238 @@
+import { type TemplateQuestion } from './templates';
+
+/**
+ * Org-scoped data app template packages.
+ *
+ * A template package is an app directory in the apps-as-code layout, packed as
+ * a tar: the authored `src/` tree (which must contain `src/template.json`, the
+ * manifest holding the fluid parts of the app) plus an optional `AGENTS.md`
+ * carrying the template's guardrails. Scaffold-owned files never travel: the
+ * sandbox image provides them. Uploaded with
+ * `lightdash upload --apps <slug> --as-template`, stored per organization, and
+ * seeded into the sandbox when a user creates an app from the template.
+ */
+export const DATA_APP_TEMPLATE_PACKAGE_CONTENT_TYPE = 'application/x-tar';
+export const DATA_APP_TEMPLATE_MANIFEST_PATH = 'src/template.json';
+export const DATA_APP_TEMPLATE_GUARDRAILS_PATH = 'AGENTS.md';
+export const MAX_DATA_APP_TEMPLATE_PACKAGE_BYTES = 5 * 1024 * 1024;
+export const MAX_DATA_APP_TEMPLATE_FILE_BYTES = 1024 * 1024;
+export const MAX_DATA_APP_TEMPLATE_FILES = 200;
+export const DATA_APP_TEMPLATE_SLUG_PATTERN = /^[a-z0-9][a-z0-9-]{1,63}$/;
+
+const MAX_NAME_LENGTH = 80;
+const MAX_DESCRIPTION_LENGTH = 300;
+const MAX_CATEGORY_LENGTH = 40;
+const MAX_QUESTIONS = 12;
+
+export type DataAppTemplateManifest = {
+    templateVersion: 1;
+    template: {
+        id: string;
+        name: string;
+        description: string;
+        category: string;
+    };
+    questions?: TemplateQuestion[];
+};
+
+export type DataAppTemplateSummary = {
+    templateUuid: string;
+    organizationUuid: string;
+    slug: string;
+    name: string;
+    description: string;
+    category: string;
+    questions: TemplateQuestion[];
+    fileCount: number;
+    createdAt: Date;
+    updatedAt: Date;
+};
+
+export type DataAppTemplateImportResult = DataAppTemplateSummary & {
+    action: 'created' | 'updated';
+};
+
+export type ApiDataAppTemplatesResponse = {
+    status: 'ok';
+    results: DataAppTemplateSummary[];
+};
+
+export type ApiDataAppTemplateResponse = {
+    status: 'ok';
+    results: DataAppTemplateSummary;
+};
+
+export type ApiDataAppTemplateImportResponse = {
+    status: 'ok';
+    results: DataAppTemplateImportResult;
+};
+
+export class DataAppTemplatePackageError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'DataAppTemplatePackageError';
+    }
+}
+
+/**
+ * Only authored files travel in a package: the `src/` tree and the
+ * guardrails file. Everything else in an app directory is scaffold, build
+ * output, or tooling and is rejected so a package can never smuggle config.
+ */
+export const validateDataAppTemplateEntryPath = (entryPath: string): string => {
+    const normalized = entryPath.replace(/^\.\//, '');
+    if (normalized.length === 0 || normalized.length > 512) {
+        throw new DataAppTemplatePackageError(
+            `Invalid package entry path "${entryPath}"`,
+        );
+    }
+    if (
+        normalized.startsWith('/') ||
+        normalized.includes('\\') ||
+        normalized
+            .split('/')
+            .some((segment) => segment === '..' || segment === '')
+    ) {
+        throw new DataAppTemplatePackageError(
+            `Package entry path "${entryPath}" must be relative and must not traverse directories`,
+        );
+    }
+    if (normalized.includes('node_modules/')) {
+        throw new DataAppTemplatePackageError(
+            `Package entry path "${entryPath}" must not include node_modules`,
+        );
+    }
+    if (
+        normalized !== DATA_APP_TEMPLATE_GUARDRAILS_PATH &&
+        !normalized.startsWith('src/')
+    ) {
+        throw new DataAppTemplatePackageError(
+            `Package entry path "${entryPath}" is not allowed: only src/ files and ${DATA_APP_TEMPLATE_GUARDRAILS_PATH} belong in a template package`,
+        );
+    }
+    return normalized;
+};
+
+const requireString = (
+    value: unknown,
+    field: string,
+    maxLength: number,
+): string => {
+    if (typeof value !== 'string' || value.trim().length === 0) {
+        throw new DataAppTemplatePackageError(
+            `${DATA_APP_TEMPLATE_MANIFEST_PATH}: ${field} is required`,
+        );
+    }
+    if (value.length > maxLength) {
+        throw new DataAppTemplatePackageError(
+            `${DATA_APP_TEMPLATE_MANIFEST_PATH}: ${field} must be at most ${maxLength} characters`,
+        );
+    }
+    return value.trim();
+};
+
+const parseQuestions = (value: unknown): TemplateQuestion[] => {
+    if (value === undefined) return [];
+    if (!Array.isArray(value)) {
+        throw new DataAppTemplatePackageError(
+            `${DATA_APP_TEMPLATE_MANIFEST_PATH}: questions must be an array`,
+        );
+    }
+    if (value.length > MAX_QUESTIONS) {
+        throw new DataAppTemplatePackageError(
+            `${DATA_APP_TEMPLATE_MANIFEST_PATH}: at most ${MAX_QUESTIONS} questions are allowed`,
+        );
+    }
+    const keys = new Set<string>();
+    return value.map((raw, index) => {
+        if (typeof raw !== 'object' || raw === null) {
+            throw new DataAppTemplatePackageError(
+                `${DATA_APP_TEMPLATE_MANIFEST_PATH}: questions[${index}] must be an object`,
+            );
+        }
+        const q = raw as Record<string, unknown>;
+        const key = requireString(q.key, `questions[${index}].key`, 64);
+        if (keys.has(key)) {
+            throw new DataAppTemplatePackageError(
+                `${DATA_APP_TEMPLATE_MANIFEST_PATH}: duplicate question key "${key}"`,
+            );
+        }
+        keys.add(key);
+        const label = requireString(q.label, `questions[${index}].label`, 200);
+        if (q.kind !== undefined && q.kind !== 'text' && q.kind !== 'list') {
+            throw new DataAppTemplatePackageError(
+                `${DATA_APP_TEMPLATE_MANIFEST_PATH}: questions[${index}].kind must be "text" or "list"`,
+            );
+        }
+        const question: TemplateQuestion = { key, label };
+        if (typeof q.placeholder === 'string')
+            question.placeholder = q.placeholder;
+        if (typeof q.default === 'string') question.default = q.default;
+        if (typeof q.required === 'boolean') question.required = q.required;
+        if (q.kind === 'list') question.kind = 'list';
+        return question;
+    });
+};
+
+/**
+ * Parses and validates `src/template.json`. Only the parts the platform
+ * needs are validated (identity + questions); the rest of the manifest is the
+ * template's own business and rides along untouched inside the package.
+ */
+export const parseDataAppTemplateManifest = (
+    contents: string,
+): DataAppTemplateManifest => {
+    let raw: unknown;
+    try {
+        raw = JSON.parse(contents);
+    } catch (e) {
+        throw new DataAppTemplatePackageError(
+            `${DATA_APP_TEMPLATE_MANIFEST_PATH} is not valid JSON`,
+        );
+    }
+    if (typeof raw !== 'object' || raw === null) {
+        throw new DataAppTemplatePackageError(
+            `${DATA_APP_TEMPLATE_MANIFEST_PATH} must be a JSON object`,
+        );
+    }
+    const manifest = raw as Record<string, unknown>;
+    if (manifest.templateVersion !== 1) {
+        throw new DataAppTemplatePackageError(
+            `${DATA_APP_TEMPLATE_MANIFEST_PATH}: unsupported templateVersion (expected 1)`,
+        );
+    }
+    if (typeof manifest.template !== 'object' || manifest.template === null) {
+        throw new DataAppTemplatePackageError(
+            `${DATA_APP_TEMPLATE_MANIFEST_PATH}: template block is required`,
+        );
+    }
+    const template = manifest.template as Record<string, unknown>;
+    const id = requireString(template.id, 'template.id', 64);
+    if (!DATA_APP_TEMPLATE_SLUG_PATTERN.test(id)) {
+        throw new DataAppTemplatePackageError(
+            `${DATA_APP_TEMPLATE_MANIFEST_PATH}: template.id must be a slug (lowercase letters, digits, hyphens; 2-64 characters)`,
+        );
+    }
+    return {
+        templateVersion: 1,
+        template: {
+            id,
+            name: requireString(
+                template.name,
+                'template.name',
+                MAX_NAME_LENGTH,
+            ),
+            description: requireString(
+                template.description,
+                'template.description',
+                MAX_DESCRIPTION_LENGTH,
+            ),
+            category: requireString(
+                template.category,
+                'template.category',
+                MAX_CATEGORY_LENGTH,
+            ),
+        },
+        questions: parseQuestions(manifest.questions),
+    };
+};

--- a/packages/common/src/ee/index.ts
+++ b/packages/common/src/ee/index.ts
@@ -15,6 +15,7 @@ export * from './apps/deliveryCapture';
 export * from './apps/sdkFeatures';
 export * from './apps/dataAppVizSchemaChanges';
 export * from './apps/templates';
+export * from './apps/templatePackage';
 export * from './apps/types';
 export * from './apps/code';
 export * from './apps/dataReferenceChecker';


### PR DESCRIPTION
Stacked on #28441. Slice 1 of CS-191: organizations upload their own data app templates; nothing template-specific ships in the product.

## What

- **common** `ee/apps/templatePackage.ts`: the package contract. `src/template.json` manifest parser (templateVersion 1, `template.{id,name,description,category}`, up to 12 declared `questions`), entry-path allowlist (`src/**` + `AGENTS.md` only, no traversal/absolute/node_modules), size caps (5MB package, 1MB file, 200 files), API response types.
- **backend**: `data_app_templates` + `data_app_template_files` tables (unique per org + slug), `DataAppTemplateModel`, `DataAppTemplateService` (tar parse, bytes stored in the app-runtime bucket under `data-app-templates/<org>/<templateUuid>/<file>`, re-upload keeps the template uuid stable and swaps metadata + file list in one transaction, delete cleans the bucket, `getSourceFiles` ready for the seeding slice), hidden controller:
  - `GET /api/v1/org/data-app-templates`
  - `GET /api/v1/org/data-app-templates/{slug}`
  - `PUT /api/v1/org/data-app-templates/package` (raw `application/x-tar`, same shape as `PUT /org/designs/package`)
  - `DELETE /api/v1/org/data-app-templates/{slug}`
- **cli**: `lightdash upload --apps <slug...> --as-template` packs `src/**` + `AGENTS.md` from each app folder as a deterministic uncompressed tar and PUTs it raw. Org-scoped, so no project is selected and every other upload phase is skipped.

## Verified on docker-dev (EE, MinIO)

- `upload --apps metric-forecaster kpi-scorecard --as-template` → 2 created; re-run → 2 updated with the same template uuids; questions from the manifests come back on `GET /{slug}`.
- Objects land in `lightdash-apps/data-app-templates/<org>/<templateUuid>/…`; `DELETE` removes them and the record (404 afterwards); re-publish creates a fresh uuid.
- Unit tests: manifest/path contract (common), import/replace/reject paths (backend), pack + upload (cli).

## Review notes

- **Permissions are a placeholder**: templates borrow `OrganizationDesign` (`view` for members, `manage` for org admins only), the same audience as themes-as-code. Templates are a guided build path, not an enforcement mechanism, so admin-only upload is the intended default. A dedicated `DataAppTemplate` subject needs scopes + role-parity entries, so it is left as a follow-up rather than added blind.
- Re-uploads overwrite same-named objects in place before the metadata swap; a versioned prefix would make that fully atomic. Fine for the PoC, called out in the code.
- Migration is additive; generated tsoa routes are not committed (regen locally with `pnpm -F backend generate-api`).

Next slices (same ticket): resolve a chosen org template from storage in the generate path (seed + questions + guardrails), gallery/form reading from this API, remove the embedded Forecaster/Scorecard sources, self-hosted smoke test.

## Evidence

Screenshots, the verification transcript and the review order for the whole stack: [Templated Data Apps Review](https://claude.ai/code/artifact/c906e241-f1aa-4dd3-8eea-858b0df20451#pr-28460) (section for this PR). Restacked onto main 2.82.2 on 2026-09-02; affected suites green after the restack (frontend 567, common 926, backend 379) and the end-to-end gallery flow passes 11/11 in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VU9L8WJ97vLUB4WJmaUKDa
