### PR TITLE
feat(authz): data app template scopes following the data app pattern

### DIFF
--- a/packages/backend/src/ee/models/DataAppTemplateModel.ts
+++ b/packages/backend/src/ee/models/DataAppTemplateModel.ts
@@ -33,6 +33,7 @@ const toSummary = (
     category: row.category,
     questions: row.questions ?? [],
     fileCount,
+    createdByUserUuid: row.created_by_user_uuid,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
 });

--- a/packages/backend/src/ee/services/DataAppTemplateService/DataAppTemplateService.test.ts
+++ b/packages/backend/src/ee/services/DataAppTemplateService/DataAppTemplateService.test.ts
@@ -1,5 +1,10 @@
 import { PutObjectCommand, type S3Client } from '@aws-sdk/client-s3';
-import { ParameterError } from '@lightdash/common';
+import {
+    defineUserAbility,
+    ForbiddenError,
+    OrganizationMemberRole,
+    ParameterError,
+} from '@lightdash/common';
 import { Readable } from 'node:stream';
 import { pack as tarPack } from 'tar-stream';
 import { describe, expect, it, vi } from 'vitest';
@@ -89,6 +94,30 @@ const buildService = (overrides: Partial<DataAppTemplateModel> = {}) => {
     return { service, model, send };
 };
 
+/**
+ * Runs the service against the real CASL rules for a role, so the tests
+ * exercise the create / manage@self / manage split rather than a stub.
+ */
+const withRole = (
+    service: DataAppTemplateService,
+    role: OrganizationMemberRole,
+) => {
+    const ability = defineUserAbility(
+        {
+            role,
+            organizationUuid: 'test-org-uuid',
+            userUuid: 'test-user-uuid',
+            roleUuid: undefined,
+        },
+        [],
+    );
+    const patched = service as unknown as {
+        createAuditedAbility: () => typeof ability;
+    };
+    patched.createAuditedAbility = () => ability;
+    return service;
+};
+
 const importArchive = (service: DataAppTemplateService, archive: Buffer) =>
     service.importPackage(buildAccount(), {
         body: Readable.from(archive),
@@ -128,6 +157,138 @@ describe('DataAppTemplateService.importPackage', () => {
                 k?.startsWith('data-app-templates/test-org-uuid/'),
             ),
         ).toBe(true);
+    });
+
+    it('gates a new slug on create:DataAppTemplate for the account organization', async () => {
+        const { service } = buildService();
+        const checks: { action: string; subjectType: string }[] = [];
+        (
+            service as unknown as {
+                createAuditedAbility: () => {
+                    cannot: (action: string, sub: unknown) => boolean;
+                };
+            }
+        ).createAuditedAbility = () => ({
+            cannot: (action, sub) => {
+                const subjectType = (sub as { __caslSubjectType__: string })
+                    .__caslSubjectType__;
+                checks.push({ action, subjectType });
+                return true;
+            },
+        });
+        const archive = await packFiles({ 'src/template.json': MANIFEST });
+
+        await expect(importArchive(service, archive)).rejects.toThrow(
+            ForbiddenError,
+        );
+        expect(checks).toEqual([
+            { action: 'create', subjectType: 'DataAppTemplate' },
+        ]);
+    });
+
+    it("lets an editor replace their own template but not a colleague's", async () => {
+        const existingOwn = {
+            templateUuid: '00000000-0000-4000-8000-000000000001',
+            organizationUuid: 'test-org-uuid',
+            slug: 'forecaster',
+            name: 'Old',
+            description: 'Old',
+            category: 'Old',
+            questions: [],
+            fileCount: 1,
+            createdByUserUuid: 'test-user-uuid',
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        };
+        const own = buildService({
+            findBySlug: vi.fn().mockResolvedValue(existingOwn),
+            upsert: vi.fn().mockResolvedValue({
+                created: false,
+                summary: { ...existingOwn, name: 'Forecaster' },
+            }),
+        } as unknown as Partial<DataAppTemplateModel>);
+        withRole(own.service, OrganizationMemberRole.EDITOR);
+        const archive = await packFiles({ 'src/template.json': MANIFEST });
+        await expect(
+            importArchive(own.service, archive),
+        ).resolves.toMatchObject({ action: 'updated' });
+
+        const colleagues = buildService({
+            findBySlug: vi.fn().mockResolvedValue({
+                ...existingOwn,
+                createdByUserUuid: 'another-user',
+            }),
+        } as unknown as Partial<DataAppTemplateModel>);
+        withRole(colleagues.service, OrganizationMemberRole.EDITOR);
+        await expect(
+            importArchive(colleagues.service, archive),
+        ).rejects.toThrow(ForbiddenError);
+        expect(colleagues.model.upsert).not.toHaveBeenCalled();
+        expect(colleagues.send).not.toHaveBeenCalled();
+    });
+
+    it('lets an admin delete any template, and an editor only their own', async () => {
+        const colleagueTemplate = {
+            templateUuid: '00000000-0000-4000-8000-000000000002',
+            organizationUuid: 'test-org-uuid',
+            slug: 'scorecard',
+            name: 'Scorecard',
+            description: 'x',
+            category: 'x',
+            questions: [],
+            fileCount: 0,
+            createdByUserUuid: 'another-user',
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        };
+        const admin = buildService({
+            findBySlug: vi.fn().mockResolvedValue(colleagueTemplate),
+        } as unknown as Partial<DataAppTemplateModel>);
+        withRole(admin.service, OrganizationMemberRole.ADMIN);
+        await expect(
+            admin.service.delete(buildAccount(), 'scorecard'),
+        ).resolves.toBeUndefined();
+        expect(admin.model.delete).toHaveBeenCalledWith(
+            'test-org-uuid',
+            'scorecard',
+        );
+
+        const editor = buildService({
+            findBySlug: vi.fn().mockResolvedValue(colleagueTemplate),
+        } as unknown as Partial<DataAppTemplateModel>);
+        withRole(editor.service, OrganizationMemberRole.EDITOR);
+        await expect(
+            editor.service.delete(buildAccount(), 'scorecard'),
+        ).rejects.toThrow(ForbiddenError);
+        expect(editor.model.delete).not.toHaveBeenCalled();
+
+        const owner = buildService({
+            findBySlug: vi.fn().mockResolvedValue({
+                ...colleagueTemplate,
+                createdByUserUuid: 'test-user-uuid',
+            }),
+        } as unknown as Partial<DataAppTemplateModel>);
+        withRole(owner.service, OrganizationMemberRole.EDITOR);
+        await expect(
+            owner.service.delete(buildAccount(), 'scorecard'),
+        ).resolves.toBeUndefined();
+        expect(owner.model.delete).toHaveBeenCalledTimes(1);
+    });
+
+    it('lets anyone who can build from templates browse them, and nobody below', async () => {
+        const viewer = withRole(
+            buildService().service,
+            OrganizationMemberRole.INTERACTIVE_VIEWER,
+        );
+        await expect(viewer.list(buildAccount())).rejects.toThrow(
+            ForbiddenError,
+        );
+
+        const editor = withRole(
+            buildService().service,
+            OrganizationMemberRole.EDITOR,
+        );
+        await expect(editor.list(buildAccount())).resolves.toEqual([]);
     });
 
     it('rejects a package without a manifest', async () => {

--- a/packages/backend/src/ee/services/DataAppTemplateService/DataAppTemplateService.ts
+++ b/packages/backend/src/ee/services/DataAppTemplateService/DataAppTemplateService.ts
@@ -132,42 +132,80 @@ export class DataAppTemplateService extends BaseService {
         this.dataAppTemplateModel = dataAppTemplateModel;
     }
 
-    private assertCanManage(account: Account): {
+    private accountContext(account: Account): {
         organizationUuid: string;
         userUuid: string;
     } {
         assertRegisteredAccount(account);
         assertIsAccountWithOrg(account);
-        const { organizationUuid } = account.organization;
-        // Permission placeholder (flagged for review): templates are org
-        // content packages with the same audience as themes-as-code, so they
-        // borrow the OrganizationDesign subject. A dedicated DataAppTemplate
-        // subject needs matching scopes + role-parity entries — follow-up.
+        return {
+            organizationUuid: account.organization.organizationUuid,
+            userUuid: account.user.userUuid,
+        };
+    }
+
+    /** create:DataAppTemplate — publishing a template the org does not have yet. */
+    private assertCanCreate(account: Account, organizationUuid: string) {
+        const ability = this.createAuditedAbility(account);
+        if (
+            ability.cannot(
+                'create',
+                subject('DataAppTemplate', { organizationUuid }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'Insufficient permissions to publish data app templates',
+            );
+        }
+    }
+
+    /**
+     * manage:DataAppTemplate(@self) — replacing or deleting an existing
+     * template. The subject carries the uploader so the @self rule can
+     * match; the org-wide rule ignores it.
+     */
+    private assertCanManageTemplate(
+        account: Account,
+        template: DataAppTemplateSummary,
+    ) {
         const ability = this.createAuditedAbility(account);
         if (
             ability.cannot(
                 'manage',
-                subject('OrganizationDesign', { organizationUuid }),
+                subject('DataAppTemplate', {
+                    organizationUuid: template.organizationUuid,
+                    createdByUserUuid: template.createdByUserUuid,
+                }),
             )
         ) {
             throw new ForbiddenError(
-                'Insufficient permissions to manage data app templates',
+                `Insufficient permissions to change data app template "${template.slug}"`,
             );
         }
-        return { organizationUuid, userUuid: account.user.userUuid };
     }
 
-    private assertCanView(account: Account): { organizationUuid: string } {
-        assertRegisteredAccount(account);
-        assertIsAccountWithOrg(account);
-        const { organizationUuid } = account.organization;
+    /**
+     * Browsing is part of building from a template
+     * (create:DataAppFromTemplate); template authors and curators can
+     * browse too, so they can see what they published.
+     */
+    private assertCanBrowse(account: Account): { organizationUuid: string } {
+        const { organizationUuid } = this.accountContext(account);
         const ability = this.createAuditedAbility(account);
-        if (
-            ability.cannot(
-                'view',
-                subject('OrganizationDesign', { organizationUuid }),
-            )
-        ) {
+        const canBrowse =
+            ability.can(
+                'create',
+                subject('DataAppFromTemplate', { organizationUuid }),
+            ) ||
+            ability.can(
+                'create',
+                subject('DataAppTemplate', { organizationUuid }),
+            ) ||
+            ability.can(
+                'manage',
+                subject('DataAppTemplate', { organizationUuid }),
+            );
+        if (!canBrowse) {
             throw new ForbiddenError(
                 'Insufficient permissions to view data app templates',
             );
@@ -203,7 +241,7 @@ export class DataAppTemplateService extends BaseService {
         account: Account,
         input: { body: Readable; contentLength: number },
     ): Promise<DataAppTemplateImportResult> {
-        const { organizationUuid, userUuid } = this.assertCanManage(account);
+        const { organizationUuid, userUuid } = this.accountContext(account);
         if (
             input.contentLength <= 0 ||
             input.contentLength > MAX_DATA_APP_TEMPLATE_PACKAGE_BYTES
@@ -255,6 +293,11 @@ export class DataAppTemplateService extends BaseService {
             organizationUuid,
             manifest.template.id,
         );
+        if (existing) {
+            this.assertCanManageTemplate(account, existing);
+        } else {
+            this.assertCanCreate(account, organizationUuid);
+        }
         const templateUuid = existing?.templateUuid ?? uuidv4();
         const previousFiles = existing
             ? await this.dataAppTemplateModel.listFiles(existing.templateUuid)
@@ -328,12 +371,12 @@ export class DataAppTemplateService extends BaseService {
     }
 
     async list(account: Account): Promise<DataAppTemplateSummary[]> {
-        const { organizationUuid } = this.assertCanView(account);
+        const { organizationUuid } = this.assertCanBrowse(account);
         return this.dataAppTemplateModel.listByOrganization(organizationUuid);
     }
 
     async get(account: Account, slug: string): Promise<DataAppTemplateSummary> {
-        const { organizationUuid } = this.assertCanView(account);
+        const { organizationUuid } = this.assertCanBrowse(account);
         const template = await this.dataAppTemplateModel.findBySlug(
             organizationUuid,
             slug,
@@ -345,7 +388,7 @@ export class DataAppTemplateService extends BaseService {
     }
 
     async delete(account: Account, slug: string): Promise<void> {
-        const { organizationUuid } = this.assertCanManage(account);
+        const { organizationUuid } = this.accountContext(account);
         const template = await this.dataAppTemplateModel.findBySlug(
             organizationUuid,
             slug,
@@ -353,6 +396,7 @@ export class DataAppTemplateService extends BaseService {
         if (!template) {
             throw new NotFoundError(`Data app template "${slug}" not found`);
         }
+        this.assertCanManageTemplate(account, template);
         const files = await this.dataAppTemplateModel.listFiles(
             template.templateUuid,
         );

--- a/packages/common/src/authorization/organizationMemberAbility.test.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.test.ts
@@ -125,6 +125,59 @@ describe('Organization member permissions', () => {
         ).toBe(false);
     });
 
+    describe('data app templates', () => {
+        const ownTemplate = subject('DataAppTemplate', {
+            organizationUuid: ORGANIZATION_EDITOR.organizationUuid,
+            createdByUserUuid: ORGANIZATION_EDITOR.userUuid,
+        });
+        const colleagueTemplate = subject('DataAppTemplate', {
+            organizationUuid: ORGANIZATION_EDITOR.organizationUuid,
+            createdByUserUuid: 'another-user',
+        });
+        const otherOrgTemplate = subject('DataAppTemplate', {
+            organizationUuid: 'another-organization',
+            createdByUserUuid: ORGANIZATION_EDITOR.userUuid,
+        });
+        const fromTemplate = subject('DataAppFromTemplate', {
+            organizationUuid: ORGANIZATION_EDITOR.organizationUuid,
+        });
+
+        it('lets editors publish templates, look after their own, and build from any', () => {
+            const ability =
+                defineAbilityForOrganizationMember(ORGANIZATION_EDITOR);
+            expect(ability.can('create', ownTemplate)).toBe(true);
+            expect(ability.can('manage', ownTemplate)).toBe(true);
+            expect(ability.can('manage', colleagueTemplate)).toBe(false);
+            expect(ability.can('create', otherOrgTemplate)).toBe(false);
+            expect(ability.can('create', fromTemplate)).toBe(true);
+        });
+
+        it('lets admins replace or delete any template in their organization', () => {
+            const ability =
+                defineAbilityForOrganizationMember(ORGANIZATION_ADMIN);
+            expect(ability.can('manage', colleagueTemplate)).toBe(true);
+            expect(ability.can('manage', otherOrgTemplate)).toBe(false);
+            expect(ability.can('create', fromTemplate)).toBe(true);
+        });
+
+        it('keeps developers on the editor grants: own templates only', () => {
+            const ability = defineAbilityForOrganizationMember(
+                ORGANIZATION_DEVELOPER,
+            );
+            expect(ability.can('create', ownTemplate)).toBe(true);
+            expect(ability.can('manage', colleagueTemplate)).toBe(false);
+        });
+
+        it('gives interactive viewers neither publishing nor building from templates', () => {
+            const ability = defineAbilityForOrganizationMember(
+                ORGANIZATION_INTERACTIVE_VIEWER,
+            );
+            expect(ability.can('create', ownTemplate)).toBe(false);
+            expect(ability.can('manage', ownTemplate)).toBe(false);
+            expect(ability.can('create', fromTemplate)).toBe(false);
+        });
+    });
+
     describe('Member permissions', () => {
         let ability = defineAbilityForOrganizationMember(ORGANIZATION_VIEWER);
         describe('when user is an organization admin', () => {

--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -255,6 +255,16 @@ export const applyOrganizationMemberStaticAbilities: Record<
         can('create', 'DataApp', {
             organizationUuid: member.organizationUuid,
         });
+        can('create', 'DataAppTemplate', {
+            organizationUuid: member.organizationUuid,
+        });
+        can('manage', 'DataAppTemplate', {
+            organizationUuid: member.organizationUuid,
+            createdByUserUuid: member.userUuid,
+        });
+        can('create', 'DataAppFromTemplate', {
+            organizationUuid: member.organizationUuid,
+        });
         can('manage', 'Space', {
             organizationUuid: member.organizationUuid,
             inheritsFromOrgOrProject: true,
@@ -453,6 +463,9 @@ export const applyOrganizationMemberStaticAbilities: Record<
         });
 
         can('manage', 'OrganizationDesign', {
+            organizationUuid: member.organizationUuid,
+        });
+        can('manage', 'DataAppTemplate', {
             organizationUuid: member.organizationUuid,
         });
 

--- a/packages/common/src/authorization/roleToScopeMapping.ts
+++ b/packages/common/src/authorization/roleToScopeMapping.ts
@@ -100,6 +100,9 @@ const BASE_ROLE_SCOPES = {
         'view:ContentAsCode',
         'create:ContentAsCode',
         'create:DataApp',
+        'create:DataAppTemplate', // Publish org templates
+        'manage:DataAppTemplate@self', // Replace/delete own templates
+        'create:DataAppFromTemplate', // Build from org templates
     ],
 
     [ProjectMemberRole.DEVELOPER]: [
@@ -168,6 +171,7 @@ const BASE_ROLE_SCOPES = {
         'manage:DataAppDependency', // Add custom npm deps (supply-chain capability)
         'manage:ExternalConnection',
         'manage:OrganizationDesign',
+        'manage:DataAppTemplate', // Replace/delete any org template
         'delete:Project', // Any project
         'view:Analytics',
         'manage:Dashboard', // All dashboards
@@ -285,6 +289,10 @@ export const getNonEnterpriseScopesForRole = (
         'manage:ExternalConnection',
         'view:OrganizationDesign',
         'manage:OrganizationDesign',
+        'create:DataAppTemplate',
+        'manage:DataAppTemplate@self',
+        'manage:DataAppTemplate',
+        'create:DataAppFromTemplate',
         'view:Roadmap',
         'manage:PersonalAccessToken',
         'manage:PreAggregation',

--- a/packages/common/src/authorization/roleToScopeParity.test.ts
+++ b/packages/common/src/authorization/roleToScopeParity.test.ts
@@ -138,6 +138,8 @@ const PROJECT_PARITY_IGNORE = new Set([
     '*:Organization',
     '*:OrganizationColorPalette',
     '*:OrganizationDesign',
+    '*:DataAppTemplate',
+    '*:DataAppFromTemplate',
     '*:Roadmap',
     '*:Group',
     '*:InviteLink',

--- a/packages/common/src/authorization/scopes.level.test.ts
+++ b/packages/common/src/authorization/scopes.level.test.ts
@@ -24,6 +24,10 @@ const ORG_ONLY_SCOPE_NAMES = [
     'impersonate:User',
     'view:OrganizationDesign',
     'manage:OrganizationDesign',
+    'create:DataAppTemplate',
+    'manage:DataAppTemplate@self',
+    'manage:DataAppTemplate',
+    'create:DataAppFromTemplate',
     'view:OrganizationAiAgent',
     'manage:OrganizationAiAgent',
 ];

--- a/packages/common/src/authorization/scopes.ts
+++ b/packages/common/src/authorization/scopes.ts
@@ -1590,6 +1590,70 @@ const scopes: Scope[] = [
         getConditions: addDefaultUuidCondition,
     },
 
+    // Data App Templates (org-uploaded starter apps offered in the
+    // builder's template gallery). Org-scoped resource following the data
+    // app pattern: create + manage@self for authors, manage for curators,
+    // and a separate capability for building from a template so each can
+    // be tiered independently in custom roles.
+    {
+        name: 'create:DataAppTemplate',
+        description: 'Upload new organization data app templates',
+        isEnterprise: false,
+        group: ScopeGroup.AI,
+        dependencies: [
+            {
+                name: 'manage:DataAppTemplate@self',
+                description: 'Replace or delete the templates you upload',
+            },
+        ],
+        level: 'organization',
+        getConditions: addDefaultUuidCondition,
+    },
+    {
+        name: 'manage:DataAppTemplate@self',
+        description:
+            'Replace and delete organization data app templates you uploaded',
+        isEnterprise: false,
+        group: ScopeGroup.AI,
+        dependencies: [
+            {
+                name: 'create:DataAppTemplate',
+                description: 'Upload the templates you look after',
+            },
+        ],
+        level: 'organization',
+        getConditions: (context) => [
+            {
+                ...addUuidCondition(context),
+                createdByUserUuid: context.userUuid || false,
+            },
+        ],
+    },
+    {
+        name: 'manage:DataAppTemplate',
+        description: 'Replace and delete any organization data app template',
+        isEnterprise: false,
+        group: ScopeGroup.AI,
+        dependencies: [],
+        level: 'organization',
+        getConditions: addDefaultUuidCondition,
+    },
+    {
+        name: 'create:DataAppFromTemplate',
+        description:
+            'Browse the template gallery and create data apps from organization templates',
+        isEnterprise: false,
+        group: ScopeGroup.AI,
+        dependencies: [
+            {
+                name: 'create:DataApp',
+                description: 'Build an app from the chosen template',
+            },
+        ],
+        level: 'organization',
+        getConditions: addDefaultUuidCondition,
+    },
+
     // Spotlight Scopes
     {
         name: 'manage:SpotlightTableConfig',

--- a/packages/common/src/authorization/serviceAccountAbility.ts
+++ b/packages/common/src/authorization/serviceAccountAbility.ts
@@ -352,6 +352,12 @@ const applyServiceAccountStaticAbilities: Record<
         can('manage', 'OrganizationDesign', {
             organizationUuid,
         });
+        can('manage', 'DataAppTemplate', {
+            organizationUuid,
+        });
+        can('create', 'DataAppFromTemplate', {
+            organizationUuid,
+        });
         can('manage', 'Dashboard', {
             organizationUuid,
         });

--- a/packages/common/src/authorization/types.ts
+++ b/packages/common/src/authorization/types.ts
@@ -37,6 +37,8 @@ export type CaslSubjectNames =
     | 'CustomSqlTableCalculations'
     | 'DataApp'
     | 'DataAppDependency'
+    | 'DataAppFromTemplate'
+    | 'DataAppTemplate'
     | 'Dashboard'
     | 'DeployProject'
     | 'DashboardComments'

--- a/packages/common/src/ee/apps/templatePackage.ts
+++ b/packages/common/src/ee/apps/templatePackage.ts
@@ -44,6 +44,8 @@ export type DataAppTemplateSummary = {
     category: string;
     questions: TemplateQuestion[];
     fileCount: number;
+    /** Uploader; the ownership condition behind manage:DataAppTemplate@self. */
+    createdByUserUuid: string | null;
     createdAt: Date;
     updatedAt: Date;
 };


### PR DESCRIPTION
Stacked on #28460. Replaces the `OrganizationDesign` permission placeholder with dedicated scopes that transpose the existing data-app pattern (`create:DataApp` / `manage:DataApp@self` / `manage:DataApp`) to templates, plus a separate capability for building from one. Organizations can tier each independently in custom roles.

## Scopes

| Scope | Grants | Default tier |
|---|---|---|
| `create:DataAppTemplate` | Upload new organization templates | Editor |
| `manage:DataAppTemplate@self` | Replace or delete the templates you uploaded (dependency of `create`) | Editor |
| `manage:DataAppTemplate` | Replace or delete any template in the organization | Admin |
| `create:DataAppFromTemplate` | Browse the template gallery and build apps from organization templates; building still needs the project's `create:DataApp` (listed as a dependency) | Editor |

All four are org-level (`level: 'organization'`, `ScopeGroup.AI`), so they appear in the custom-roles UI automatically. Templates are a guided build path, not an enforcement mechanism: someone without `create:DataAppFromTemplate` simply doesn't see the gallery.

## Wiring

- `CaslSubjectNames` gains `DataAppTemplate` and the capability subject `DataAppFromTemplate` (same idiom as `ExportCsv` / `UnderlyingData`).
- Member abilities: editor block grants `create` + `manage` (own, via `createdByUserUuid`) on templates and `create` on `DataAppFromTemplate`; admin block grants org-wide `manage`.
- `roleToScopeMapping`: editor / admin blocks, plus the non-enterprise exclusion set alongside the other data-app scopes.
- Service accounts: `ORG_ADMIN` gets `manage:DataAppTemplate` + `create:DataAppFromTemplate`; `SYSTEM_*` inherit from the member blocks.
- Golden lists: org-only scope set (`scopes.level.test.ts`) and project parity ignore (`*:DataAppTemplate`, `*:DataAppFromTemplate`).
- `DataAppTemplateSummary` now carries `createdByUserUuid` (the ownership condition; also useful to the gallery later).
- `DataAppTemplateService`: `create` for a new slug, `manage` on the specific template (with its uploader) for replace and delete, and any of the authoring/building grants for browsing.

## Tests

- Common: 677 authorization tests green (role parity, org-only golden list, mapping, member + service-account abilities, new template cases for editor / admin / developer / interactive viewer).
- Backend: 8 service tests, the ownership ones running against the real editor/admin abilities via `defineUserAbility` rather than a stub.
- Typecheck common/backend/cli/frontend; live re-upload and list on docker-dev with the admin PAT.

Slice 3 gates the From Template card on `create:DataAppFromTemplate`; slice 2 checks it in the generate path.

## Evidence

Screenshots, the verification transcript and the review order for the whole stack: [Templated Data Apps Review](https://claude.ai/code/artifact/c906e241-f1aa-4dd3-8eea-858b0df20451#pr-28462) (section for this PR). Restacked onto main 2.82.2 on 2026-09-02; affected suites green after the restack (frontend 567, common 926, backend 379) and the end-to-end gallery flow passes 11/11 in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VU9L8WJ97vLUB4WJmaUKDa
