### PR TITLE
fix(frontend): page sidebar hairline and even SQL runner padding

### DIFF
--- a/packages/frontend/src/components/common/Page/Sidebar.module.css
+++ b/packages/frontend/src/components/common/Page/Sidebar.module.css
@@ -167,6 +167,16 @@
     --sidebar-padding: 0px;
 }
 
+/* Only the edge that meets the content gets a hairline; the other sides sit
+   against the navbar and viewport, where a border reads as a stray box. */
+.sidebarPaper[data-position='left'] {
+    border-right: 1px solid var(--mantine-color-default-border);
+}
+
+.sidebarPaper[data-position='right'] {
+    border-left: 1px solid var(--mantine-color-default-border);
+}
+
 .sidebarContent {
     display: flex;
     flex-grow: 1;

--- a/packages/frontend/src/components/common/Page/Sidebar.tsx
+++ b/packages/frontend/src/components/common/Page/Sidebar.tsx
@@ -171,9 +171,11 @@ const Sidebar: FC<React.PropsWithChildren<Props>> = ({
                     {(style) => (
                         <>
                             <Paper
+                                withBorder={false}
                                 radius={0}
                                 className={classes.sidebarPaper}
                                 style={style}
+                                data-position={position}
                                 data-no-padding={noSidebarPadding}
                                 data-testid="common-sidebar"
                             >

--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -438,7 +438,7 @@ export const ContentPanel: FC = () => {
     } = useParameters(projectUuid, Array.from(parameterReferences ?? []));
 
     return (
-        <Stack gap={0} p="lg" pt="md" className={styles.root}>
+        <Stack gap={0} p="lg" className={styles.root}>
             <Tooltip.Group>
                 <PanelGroup
                     direction="vertical"


### PR DESCRIPTION
## Summary

Two small chrome fixes spotted on the SQL runner after the theme revamp.

- **Page sidebar borders.** The shared page sidebar Paper started picking up the theme's new Paper default (`withBorder: true`), so it drew a full box: a line under the navbar and one along the viewport bottom, on top of the hairline against the content. The Paper now opts out of the default border and the CSS draws only the edge that meets the content (`border-right` for a left sidebar, `border-left` for a right one, via a `data-position` attribute). This matches what the pinned collapsible variant already did.
- **SQL runner content padding.** The content stack had `p="lg" pt="md"`, so the top was 16px while the other sides were 20px. The override is dropped so all four sides match.

## Regression analysis

- The sidebar change touches every page rendered through `Page` with a non-collapsible sidebar (Explorer, SQL runner, dashboards, catalog). The visible difference is only the removal of the top and bottom lines; the content-facing hairline is unchanged in colour and width.
- No page passes `withSidebarBorder`, so there is no doubled line between the sidebar's border and the content's.
- The collapsible sidebar (Settings) is a separate code path and is untouched.
- No test ids, props or exports changed. Pre-commit lint, formatter and `ts-unused-exports` passed.

No ticket: follow-up polish to the theme revamp stack (#28443, #28444), which had none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLjR5QNLuFGPSB9GFdwFPS