### PR TITLE
feat: Learn backend proxy and wire types (CS-73 2/5)

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -135,6 +135,11 @@ export const lightdashConfigMock: LightdashConfig = {
     headway: {
         enabled: false,
     },
+    learn: {
+        contentBaseUrl: 'https://learn-content.test',
+        progressApiUrl: 'https://learn-progress.test',
+        serviceToken: null,
+    },
     lightdashSecret: 'look away this is a secret',
     lightdashSecrets: {
         active: 'look away this is a secret',

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1468,6 +1468,7 @@ export type LightdashConfig = {
     intercom: IntercomConfig;
     pylon: PylonConfig;
     headway: HeadwayConfig;
+    learn: LearnConfig;
     siteUrl: string;
     staticIp: string;
     signupUrl: string | undefined;
@@ -2124,6 +2125,13 @@ type PylonConfig = {
 
 type HeadwayConfig = {
     enabled: boolean;
+};
+
+export type LearnConfig = {
+    contentBaseUrl: string;
+    progressApiUrl: string;
+    /** Server-held bearer for the progress service; null ⇒ progress is client-local only. */
+    serviceToken: string | null;
 };
 
 export type RudderConfig = {
@@ -3043,6 +3051,17 @@ export const parseConfig = (): LightdashConfig => {
         },
         headway: {
             enabled: process.env.HEADWAY_ENABLED !== 'false',
+        },
+        learn: {
+            contentBaseUrl: (
+                process.env.LEARN_CONTENT_BASE_URL ||
+                'https://lu-content.onrender.com'
+            ).replace(/\/$/, ''),
+            progressApiUrl: (
+                process.env.LEARN_PROGRESS_API_URL ||
+                'https://lu-progress.onrender.com'
+            ).replace(/\/$/, ''),
+            serviceToken: process.env.LEARN_SERVICE_TOKEN || null,
         },
         siteUrl,
         helpMenuUrl: process.env.HELP_MENU_URL,

--- a/packages/backend/src/controllers/learnController.ts
+++ b/packages/backend/src/controllers/learnController.ts
@@ -1,0 +1,167 @@
+import {
+    assertRegisteredAccount,
+    type ApiErrorPayload,
+    type ApiLearnAskResponse,
+    type ApiLearnBadgesResponse,
+    type ApiLearnCatalogueResponse,
+    type ApiLearnCourseResponse,
+    type ApiLearnEventsResponse,
+    type ApiLearnProgressResponse,
+    type LearnAskRequest,
+    type LearnEventInput,
+} from '@lightdash/common';
+import {
+    Body,
+    Get,
+    Hidden,
+    Middlewares,
+    OperationId,
+    Path,
+    Post,
+    Request,
+    Response,
+    Route,
+    SuccessResponse,
+} from '@tsoa/runtime';
+import express from 'express';
+import { allowApiKeyAuthentication, isAuthenticated } from './authentication';
+import { BaseController } from './baseController';
+
+@Route('/api/v1/learn')
+// These endpoints are under development and susceptible to breaking changes.
+// Keep them hidden until the feature is GA.
+@Hidden()
+@Response<ApiErrorPayload>('default', 'Error')
+export class LearnController extends BaseController {
+    /**
+     * Get the Lightdash University course catalogue.
+     * @summary Get the Learn catalogue
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/catalogue')
+    @OperationId('getLearnCatalogue')
+    async getLearnCatalogue(
+        @Request() req: express.Request,
+    ): Promise<ApiLearnCatalogueResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getLearnService()
+                .getCatalogue(req.account),
+        };
+    }
+
+    /**
+     * Get a published course payload (lessons and quiz) by course id.
+     * @summary Get a Learn course
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/courses/{courseId}')
+    @OperationId('getLearnCourse')
+    async getLearnCourse(
+        @Request() req: express.Request,
+        @Path() courseId: string,
+    ): Promise<ApiLearnCourseResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getLearnService()
+                .getCourse(req.account, courseId),
+        };
+    }
+
+    /**
+     * Get the signed-in user's Learn progress rollups. `courses` is null when
+     * the instance has no Learn service token configured (client-local mode).
+     * @summary Get Learn progress
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/progress')
+    @OperationId('getLearnProgress')
+    async getLearnProgress(
+        @Request() req: express.Request,
+    ): Promise<ApiLearnProgressResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getLearnService()
+                .getProgress(req.account),
+        };
+    }
+
+    /**
+     * Append learning events for the signed-in user. The event source is
+     * always recorded as 'learn' server-side.
+     * @summary Record Learn events
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('/events')
+    @OperationId('recordLearnEvents')
+    async recordLearnEvents(
+        @Request() req: express.Request,
+        @Body() body: LearnEventInput[],
+    ): Promise<ApiLearnEventsResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getLearnService()
+                .recordEvents(req.account, body),
+        };
+    }
+
+    /**
+     * Get the signed-in user's per-module badge tiers. `badges` is null when
+     * the instance has no Learn service token configured.
+     * @summary Get Learn badges
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/badges')
+    @OperationId('getLearnBadges')
+    async getLearnBadges(
+        @Request() req: express.Request,
+    ): Promise<ApiLearnBadgesResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getLearnService()
+                .getBadges(req.account),
+        };
+    }
+
+    /**
+     * Search the Lightdash University library for lessons matching a question.
+     * @summary Search Learn content
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('/ask')
+    @OperationId('askLearn')
+    async askLearn(
+        @Request() req: express.Request,
+        @Body() body: LearnAskRequest,
+    ): Promise<ApiLearnAskResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getLearnService()
+                .ask(req.account, body),
+        };
+    }
+}

--- a/packages/backend/src/services/LearnService/LearnService.test.ts
+++ b/packages/backend/src/services/LearnService/LearnService.test.ts
@@ -1,0 +1,510 @@
+import {
+    ForbiddenError,
+    LEARN_ASK_QUERY_MAX_LENGTH,
+    NotFoundError,
+    ParameterError,
+    UnexpectedServerError,
+    type Account,
+} from '@lightdash/common';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { LightdashConfig } from '../../config/parseConfig';
+import { LearnService } from './LearnService';
+
+const buildAccount = (): Account =>
+    ({
+        authentication: { type: 'session', source: 'session-cookie' },
+        organization: {
+            organizationUuid: 'org-uuid',
+            name: 'Org',
+            createdAt: new Date(),
+        },
+        user: {
+            id: 'user-uuid',
+            userUuid: 'user-uuid',
+            userId: 1,
+            email: 'learner+test@example.com',
+            firstName: 'Test',
+            lastName: 'User',
+            role: 'admin',
+            type: 'registered',
+            isActive: true,
+            isTrackingAnonymized: false,
+            isMarketingOptedIn: false,
+            isSetupComplete: true,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            timezone: null,
+        },
+        isAnonymousUser: () => false,
+        isAuthenticated: () => true,
+        isJwtUser: () => false,
+        isOauthUser: () => false,
+        isPatUser: () => false,
+        isRegisteredUser: () => true,
+        isServiceAccount: () => false,
+        isSessionUser: () => true,
+    }) as Account;
+
+const catalogueEntry = {
+    id: 'viewer-fundamentals',
+    title: 'Viewer Fundamentals',
+    description: 'Learn to view.',
+    version: 1,
+    contentHash: 'abc123def456',
+    path: 'courses/viewer-fundamentals/abc123def456/course.json',
+    lessonCount: 2,
+    durationMinutes: 25,
+    tags: ['viewer'],
+    track: 'foundations',
+    scope: 'view:Project',
+    requires: [],
+    publishedAt: '2026-08-01T00:00:00.000Z',
+};
+
+const suggestion = {
+    query: 'How do I get a dashboard emailed to me every Monday?',
+    courseId: 'viewer-fundamentals',
+};
+
+const cataloguePayload = {
+    generatedAt: '2026-08-01T00:00:00.000Z',
+    courses: [catalogueEntry],
+    suggestions: [suggestion],
+};
+
+const coursePayload = {
+    id: 'viewer-fundamentals',
+    title: 'Viewer Fundamentals',
+    passingScore: 80,
+    lessons: [{ id: 'l1', title: 'Lesson One', html: '<p>hi</p>' }],
+    quiz: {
+        questions: [{ id: 'q1', prompt: 'Q?', choices: ['a', 'b'], answer: 1 }],
+    },
+    version: 1,
+    contentHash: 'abc123def456',
+    publishedAt: '2026-08-01T00:00:00.000Z',
+};
+
+const jsonResponse = (body: unknown, status = 200) =>
+    new Response(JSON.stringify(body), { status });
+
+const buildService = ({ flagEnabled = true, withToken = true } = {}) => {
+    const serviceToken = withToken ? 'service-token-1' : undefined;
+    const featureFlagService = {
+        get: vi.fn().mockResolvedValue({ enabled: flagEnabled }),
+    };
+    const lightdashConfig = {
+        learn: {
+            contentBaseUrl: 'https://content.test',
+            progressApiUrl: 'https://progress.test',
+            serviceToken,
+        },
+    } as LightdashConfig;
+    return {
+        service: new LearnService({ lightdashConfig, featureFlagService }),
+        featureFlagService,
+    };
+};
+
+describe('LearnService', () => {
+    let fetchMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+    });
+
+    describe('feature flag gate', () => {
+        it('throws ForbiddenError when the Learn flag is off', async () => {
+            const { service } = buildService({ flagEnabled: false });
+            await expect(service.getCatalogue(buildAccount())).rejects.toThrow(
+                ForbiddenError,
+            );
+            expect(fetchMock).not.toHaveBeenCalled();
+        });
+
+        it('gates the badges proxy on the flag', async () => {
+            const { service } = buildService({ flagEnabled: false });
+            await expect(service.getBadges(buildAccount())).rejects.toThrow(
+                ForbiddenError,
+            );
+            expect(fetchMock).not.toHaveBeenCalled();
+        });
+
+        it('gates the ask proxy on the flag', async () => {
+            const { service } = buildService({ flagEnabled: false });
+            await expect(
+                service.ask(buildAccount(), { query: 'anything' }),
+            ).rejects.toThrow(ForbiddenError);
+            expect(fetchMock).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('getCatalogue', () => {
+        it('returns the parsed catalogue from the content CDN', async () => {
+            const { service } = buildService();
+            fetchMock.mockResolvedValue(jsonResponse(cataloguePayload));
+            const catalogue = await service.getCatalogue(buildAccount());
+            expect(catalogue.courses).toHaveLength(1);
+            expect(fetchMock).toHaveBeenCalledWith(
+                'https://content.test/catalogue.json',
+                expect.anything(),
+            );
+        });
+
+        it('passes through unknown catalogue fields (forward compatibility)', async () => {
+            const { service } = buildService();
+            const withExtras = {
+                ...cataloguePayload,
+                courses: [
+                    {
+                        ...catalogueEntry,
+                        requires: [
+                            {
+                                id: 'ai-copilot',
+                                label: 'AI copilot',
+                                plan: 'enterprise',
+                            },
+                        ],
+                        docsUrl: 'https://docs.lightdash.com/x',
+                    },
+                ],
+            };
+            fetchMock.mockResolvedValue(jsonResponse(withExtras));
+            const catalogue = await service.getCatalogue(buildAccount());
+            expect(
+                (catalogue.courses[0] as Record<string, unknown>).docsUrl,
+            ).toBe('https://docs.lightdash.com/x');
+        });
+
+        it('defaults scope and requires for a catalogue published before them', async () => {
+            const { service } = buildService();
+            const { scope, requires, ...legacy } = catalogueEntry;
+            fetchMock.mockResolvedValue(
+                jsonResponse({ ...cataloguePayload, courses: [legacy] }),
+            );
+            const catalogue = await service.getCatalogue(buildAccount());
+            expect(catalogue.courses[0].scope).toBeNull();
+            expect(catalogue.courses[0].requires).toEqual([]);
+        });
+
+        it('maps upstream failures to UnexpectedServerError', async () => {
+            const { service } = buildService();
+            fetchMock.mockResolvedValue(jsonResponse({}, 502));
+            await expect(service.getCatalogue(buildAccount())).rejects.toThrow(
+                UnexpectedServerError,
+            );
+        });
+
+        it('maps invalid payloads to UnexpectedServerError', async () => {
+            const { service } = buildService();
+            fetchMock.mockResolvedValue(jsonResponse({ nope: true }));
+            await expect(service.getCatalogue(buildAccount())).rejects.toThrow(
+                UnexpectedServerError,
+            );
+        });
+
+        it('returns the curated ask suggestions', async () => {
+            const { service } = buildService();
+            fetchMock.mockResolvedValue(jsonResponse(cataloguePayload));
+            const catalogue = await service.getCatalogue(buildAccount());
+            expect(catalogue.suggestions).toEqual([suggestion]);
+        });
+
+        it('defaults suggestions for a catalogue published before them', async () => {
+            const { service } = buildService();
+            const { suggestions, ...legacy } = cataloguePayload;
+            fetchMock.mockResolvedValue(jsonResponse(legacy));
+            const catalogue = await service.getCatalogue(buildAccount());
+            expect(catalogue.suggestions).toEqual([]);
+        });
+    });
+
+    describe('getCourse', () => {
+        it('throws NotFoundError for a course missing from the catalogue', async () => {
+            const { service } = buildService();
+            fetchMock.mockResolvedValue(jsonResponse(cataloguePayload));
+            await expect(
+                service.getCourse(buildAccount(), 'not-a-course'),
+            ).rejects.toThrow(NotFoundError);
+        });
+
+        it('fetches the course payload and derives assetBaseUrl', async () => {
+            const { service } = buildService();
+            fetchMock
+                .mockResolvedValueOnce(jsonResponse(cataloguePayload))
+                .mockResolvedValueOnce(jsonResponse(coursePayload));
+            const course = await service.getCourse(
+                buildAccount(),
+                'viewer-fundamentals',
+            );
+            expect(course.assetBaseUrl).toBe(
+                'https://content.test/courses/viewer-fundamentals/abc123def456',
+            );
+            expect(fetchMock).toHaveBeenNthCalledWith(
+                2,
+                `https://content.test/${catalogueEntry.path}`,
+                expect.anything(),
+            );
+        });
+    });
+
+    describe('getProgress', () => {
+        it('reports serverSynced: false without a service token and never calls upstream', async () => {
+            const { service } = buildService({ withToken: false });
+            const result = await service.getProgress(buildAccount());
+            expect(result).toEqual({ courses: null, serverSynced: false });
+            expect(fetchMock).not.toHaveBeenCalled();
+        });
+
+        it('proxies with the server-held token and the session email', async () => {
+            const { service } = buildService();
+            fetchMock.mockResolvedValue(
+                jsonResponse({
+                    email: 'learner+test@example.com',
+                    courses: [],
+                }),
+            );
+            const result = await service.getProgress(buildAccount());
+            expect(result).toEqual({ courses: [], serverSynced: true });
+            const [url, init] = fetchMock.mock.calls[0];
+            expect(url).toBe(
+                'https://progress.test/api/v1/progress?email=learner%2Btest%40example.com',
+            );
+            expect((init.headers as Record<string, string>).authorization).toBe(
+                'Bearer service-token-1',
+            );
+        });
+    });
+
+    describe('recordEvents', () => {
+        const validEvent = {
+            verb: 'started',
+            object: { type: 'course', course: 'viewer-fundamentals' },
+            occurredAt: '2026-08-01T00:00:00.000Z',
+        };
+
+        it('rejects invalid payloads with ParameterError', async () => {
+            const { service } = buildService();
+            await expect(
+                service.recordEvents(buildAccount(), [{ nope: true }]),
+            ).rejects.toThrow(ParameterError);
+            await expect(
+                service.recordEvents(buildAccount(), []),
+            ).rejects.toThrow(ParameterError);
+            expect(fetchMock).not.toHaveBeenCalled();
+        });
+
+        it('rejects batches over 100 events', async () => {
+            const { service } = buildService();
+            const events = Array.from({ length: 101 }, () => validEvent);
+            await expect(
+                service.recordEvents(buildAccount(), events),
+            ).rejects.toThrow(ParameterError);
+        });
+
+        it('accepts and drops events when no service token is configured', async () => {
+            const { service } = buildService({ withToken: false });
+            const result = await service.recordEvents(buildAccount(), [
+                validEvent,
+            ]);
+            expect(result).toEqual({ accepted: 0 });
+            expect(fetchMock).not.toHaveBeenCalled();
+        });
+
+        it('stamps source: learn on every event before forwarding', async () => {
+            const { service } = buildService();
+            fetchMock.mockResolvedValue(jsonResponse({ accepted: 1 }));
+            const result = await service.recordEvents(buildAccount(), [
+                validEvent,
+            ]);
+            expect(result).toEqual({ accepted: 1 });
+            const [, init] = fetchMock.mock.calls[0];
+            const body = JSON.parse(init.body as string);
+            expect(body[0].source).toBe('learn');
+        });
+
+        it('maps upstream write failures to UnexpectedServerError', async () => {
+            const { service } = buildService();
+            fetchMock.mockResolvedValue(jsonResponse({}, 500));
+            await expect(
+                service.recordEvents(buildAccount(), [validEvent]),
+            ).rejects.toThrow(UnexpectedServerError);
+        });
+    });
+
+    describe('getBadges', () => {
+        it('reports badges: null without a service token and never calls upstream', async () => {
+            const { service } = buildService({ withToken: false });
+            const result = await service.getBadges(buildAccount());
+            expect(result).toEqual({ badges: null });
+            expect(fetchMock).not.toHaveBeenCalled();
+        });
+
+        it('proxies with the server-held token and the session email', async () => {
+            const { service } = buildService();
+            fetchMock.mockResolvedValue(
+                jsonResponse({
+                    badges: [
+                        { courseId: 'viewer-fundamentals', tier: 'silver' },
+                    ],
+                    unacknowledged: [],
+                }),
+            );
+            const result = await service.getBadges(buildAccount());
+            expect(result).toEqual({
+                badges: [{ courseId: 'viewer-fundamentals', tier: 'silver' }],
+            });
+            const [url, init] = fetchMock.mock.calls[0];
+            expect(url).toBe(
+                'https://progress.test/api/v1/badges?email=learner%2Btest%40example.com',
+            );
+            expect((init.headers as Record<string, string>).authorization).toBe(
+                'Bearer service-token-1',
+            );
+        });
+
+        it('maps upstream failures to UnexpectedServerError', async () => {
+            const { service } = buildService();
+            fetchMock.mockResolvedValue(jsonResponse({}, 500));
+            await expect(service.getBadges(buildAccount())).rejects.toThrow(
+                UnexpectedServerError,
+            );
+        });
+
+        it('drops per-badge fields the contract does not name', async () => {
+            const { service } = buildService();
+            fetchMock.mockResolvedValue(
+                jsonResponse({
+                    badges: [
+                        {
+                            courseId: 'viewer-fundamentals',
+                            tier: 'silver',
+                            earnedByEmail: 'learner+test@example.com',
+                        },
+                    ],
+                }),
+            );
+            const result = await service.getBadges(buildAccount());
+            expect(result.badges).toEqual([
+                { courseId: 'viewer-fundamentals', tier: 'silver' },
+            ]);
+        });
+
+        it('maps an unknown tier to UnexpectedServerError', async () => {
+            const { service } = buildService();
+            fetchMock.mockResolvedValue(
+                jsonResponse({
+                    badges: [{ courseId: 'viewer-fundamentals', tier: 'ruby' }],
+                }),
+            );
+            await expect(service.getBadges(buildAccount())).rejects.toThrow(
+                UnexpectedServerError,
+            );
+        });
+    });
+
+    describe('ask', () => {
+        it('rejects an invalid payload with ParameterError', async () => {
+            const { service } = buildService();
+            await expect(
+                service.ask(buildAccount(), { query: '' }),
+            ).rejects.toThrow(ParameterError);
+            expect(fetchMock).not.toHaveBeenCalled();
+        });
+
+        it('rejects a query over the published length cap', async () => {
+            const { service } = buildService();
+            await expect(
+                service.ask(buildAccount(), {
+                    query: 'x'.repeat(LEARN_ASK_QUERY_MAX_LENGTH + 1),
+                }),
+            ).rejects.toThrow(ParameterError);
+            expect(fetchMock).not.toHaveBeenCalled();
+        });
+
+        it('searches on an instance with no service token', async () => {
+            const { service } = buildService({ withToken: false });
+            fetchMock.mockResolvedValue(
+                jsonResponse({
+                    results: [
+                        {
+                            courseId: 'viewer-fundamentals',
+                            lessonId: 'l1',
+                            title: 'Lesson One',
+                            score: 0.72,
+                        },
+                    ],
+                }),
+            );
+            const result = await service.ask(buildAccount(), {
+                query: 'deliveries',
+            });
+            expect(result.matches).toHaveLength(1);
+            const [url, init] = fetchMock.mock.calls[0];
+            expect(url).toBe('https://progress.test/api/v1/ask');
+            expect(
+                (init.headers as Record<string, string>).authorization,
+            ).toBeUndefined();
+        });
+
+        it('forwards the query, normalises a missing lessonId and drops unknown per-match fields', async () => {
+            const { service } = buildService();
+            fetchMock.mockResolvedValue(
+                jsonResponse({
+                    results: [
+                        {
+                            courseId: 'viewer-fundamentals',
+                            lessonId: 'l1',
+                            title: 'Lesson One',
+                            score: 0.72,
+                            snippet: 'internal debugging text',
+                        },
+                        {
+                            courseId: 'deliveries',
+                            title: 'Deliveries',
+                            score: 0.51,
+                        },
+                    ],
+                }),
+            );
+            const result = await service.ask(buildAccount(), {
+                query: 'email me a dashboard',
+            });
+            expect(result.matches).toEqual([
+                {
+                    courseId: 'viewer-fundamentals',
+                    lessonId: 'l1',
+                    title: 'Lesson One',
+                    score: 0.72,
+                },
+                {
+                    courseId: 'deliveries',
+                    lessonId: null,
+                    title: 'Deliveries',
+                    score: 0.51,
+                },
+            ]);
+            const [url, init] = fetchMock.mock.calls[0];
+            // Upstream ask never reads the learner: no email in the URL or body.
+            expect(url).toBe('https://progress.test/api/v1/ask');
+            expect(init.method).toBe('POST');
+            expect(JSON.parse(init.body as string)).toEqual({
+                query: 'email me a dashboard',
+            });
+        });
+
+        it('maps a search outage to UnexpectedServerError', async () => {
+            const { service } = buildService();
+            fetchMock.mockResolvedValue(jsonResponse({}, 503));
+            await expect(
+                service.ask(buildAccount(), { query: 'anything' }),
+            ).rejects.toThrow(UnexpectedServerError);
+        });
+    });
+});

--- a/packages/backend/src/services/LearnService/LearnService.ts
+++ b/packages/backend/src/services/LearnService/LearnService.ts
@@ -1,0 +1,280 @@
+import {
+    assertRegisteredAccount,
+    FeatureFlags,
+    ForbiddenError,
+    LearnAskRequestSchema,
+    LearnAskResponseSchema,
+    LearnBadgesResponseSchema,
+    LearnCatalogueSchema,
+    LearnCourseSchema,
+    LearnEventInputSchema,
+    LearnProgressResponseSchema,
+    NotFoundError,
+    ParameterError,
+    UnexpectedServerError,
+    type Account,
+    type ApiLearnEventsResponse,
+    type LearnAskResults,
+    type LearnBadgesResults,
+    type LearnCatalogue,
+    type LearnCourse,
+    type LearnEventInput,
+    type LearnProgressResults,
+} from '@lightdash/common';
+import type { LightdashConfig } from '../../config/parseConfig';
+import { BaseService } from '../BaseService';
+import type { FeatureFlagService } from '../FeatureFlag/FeatureFlagService';
+
+const LEARN_REQUEST_TIMEOUT_MS = 10_000;
+const MAX_EVENTS_PER_REQUEST = 100;
+
+type Dependencies = {
+    lightdashConfig: LightdashConfig;
+    featureFlagService: Pick<FeatureFlagService, 'get'>;
+};
+
+export class LearnService extends BaseService {
+    private readonly lightdashConfig: LightdashConfig;
+
+    private readonly featureFlagService: Pick<FeatureFlagService, 'get'>;
+
+    constructor({ lightdashConfig, featureFlagService }: Dependencies) {
+        super();
+        this.lightdashConfig = lightdashConfig;
+        this.featureFlagService = featureFlagService;
+    }
+
+    private async assertLearnEnabled(account: Account): Promise<void> {
+        assertRegisteredAccount(account);
+        const flag = await this.featureFlagService.get({
+            user: {
+                userUuid: account.user.userUuid,
+                organizationUuid: account.organization?.organizationUuid,
+            },
+            featureFlagId: FeatureFlags.LearnSection,
+        });
+        if (!flag.enabled) {
+            throw new ForbiddenError('Learn is not available');
+        }
+    }
+
+    private async fetchUpstream(
+        url: string,
+        init: RequestInit = {},
+    ): Promise<Response> {
+        try {
+            return await fetch(url, {
+                ...init,
+                signal: AbortSignal.timeout(LEARN_REQUEST_TIMEOUT_MS),
+            });
+        } catch (error) {
+            this.logger.warn('Could not reach the Learn service', {
+                error: error instanceof Error ? error.message : String(error),
+            });
+            throw new UnexpectedServerError('Could not load Learn content');
+        }
+    }
+
+    private static async parseJson(response: Response): Promise<unknown> {
+        try {
+            return await response.json();
+        } catch {
+            throw new UnexpectedServerError('Could not load Learn content');
+        }
+    }
+
+    async getCatalogue(account: Account): Promise<LearnCatalogue> {
+        await this.assertLearnEnabled(account);
+        const response = await this.fetchUpstream(
+            `${this.lightdashConfig.learn.contentBaseUrl}/catalogue.json`,
+        );
+        if (!response.ok) {
+            this.logger.warn('Learn content service returned an error', {
+                statusCode: response.status,
+            });
+            throw new UnexpectedServerError('Could not load Learn content');
+        }
+        const parsed = LearnCatalogueSchema.safeParse(
+            await LearnService.parseJson(response),
+        );
+        if (!parsed.success) {
+            this.logger.warn('Learn catalogue failed validation', {
+                issueCount: parsed.error.issues.length,
+            });
+            throw new UnexpectedServerError('Could not load Learn content');
+        }
+        return parsed.data;
+    }
+
+    async getCourse(account: Account, courseId: string): Promise<LearnCourse> {
+        const catalogue = await this.getCatalogue(account);
+        const entry = catalogue.courses.find((c) => c.id === courseId);
+        if (!entry) {
+            throw new NotFoundError(`Course not found: ${courseId}`);
+        }
+        const { contentBaseUrl } = this.lightdashConfig.learn;
+        const response = await this.fetchUpstream(
+            `${contentBaseUrl}/${entry.path}`,
+        );
+        if (!response.ok) {
+            this.logger.warn('Learn course payload returned an error', {
+                statusCode: response.status,
+            });
+            throw new UnexpectedServerError('Could not load Learn content');
+        }
+        const parsed = LearnCourseSchema.safeParse(
+            await LearnService.parseJson(response),
+        );
+        if (!parsed.success) {
+            this.logger.warn('Learn course failed validation', {
+                issueCount: parsed.error.issues.length,
+            });
+            throw new UnexpectedServerError('Could not load Learn content');
+        }
+        return {
+            ...parsed.data,
+            assetBaseUrl: `${contentBaseUrl}/courses/${entry.id}/${entry.contentHash}`,
+        };
+    }
+
+    private progressRequest(
+        account: Account,
+        path: string,
+        init: RequestInit = {},
+    ): Promise<Response> {
+        const { progressApiUrl, serviceToken } = this.lightdashConfig.learn;
+        if (!serviceToken) {
+            throw new UnexpectedServerError('Learn progress is not configured');
+        }
+        const email = encodeURIComponent(account.user?.email ?? '');
+        return this.fetchUpstream(`${progressApiUrl}${path}?email=${email}`, {
+            ...init,
+            headers: {
+                'content-type': 'application/json',
+                authorization: `Bearer ${serviceToken}`,
+                ...(init.headers ?? {}),
+            },
+        });
+    }
+
+    async getProgress(account: Account): Promise<LearnProgressResults> {
+        await this.assertLearnEnabled(account);
+        if (!this.lightdashConfig.learn.serviceToken) {
+            return { courses: null, serverSynced: false };
+        }
+        const response = await this.progressRequest(
+            account,
+            '/api/v1/progress',
+        );
+        if (!response.ok) {
+            this.logger.warn('Learn progress service returned an error', {
+                statusCode: response.status,
+            });
+            throw new UnexpectedServerError('Could not load Learn progress');
+        }
+        const parsed = LearnProgressResponseSchema.safeParse(
+            await LearnService.parseJson(response),
+        );
+        if (!parsed.success) {
+            this.logger.warn('Learn progress failed validation', {
+                issueCount: parsed.error.issues.length,
+            });
+            throw new UnexpectedServerError('Could not load Learn progress');
+        }
+        return { courses: parsed.data.courses, serverSynced: true };
+    }
+
+    async getBadges(account: Account): Promise<LearnBadgesResults> {
+        await this.assertLearnEnabled(account);
+        if (!this.lightdashConfig.learn.serviceToken) {
+            return { badges: null };
+        }
+        const response = await this.progressRequest(account, '/api/v1/badges');
+        if (!response.ok) {
+            this.logger.warn('Learn badges service returned an error', {
+                statusCode: response.status,
+            });
+            throw new UnexpectedServerError('Could not load Learn badges');
+        }
+        const parsed = LearnBadgesResponseSchema.safeParse(
+            await LearnService.parseJson(response),
+        );
+        if (!parsed.success) {
+            this.logger.warn('Learn badges failed validation', {
+                issueCount: parsed.error.issues.length,
+            });
+            throw new UnexpectedServerError('Could not load Learn badges');
+        }
+        return { badges: parsed.data.badges };
+    }
+
+    async ask(account: Account, body: unknown): Promise<LearnAskResults> {
+        await this.assertLearnEnabled(account);
+        const request = LearnAskRequestSchema.safeParse(body);
+        if (!request.success) {
+            throw new ParameterError('Invalid Learn ask payload');
+        }
+        // Upstream search is unauthenticated and never reads the learner, so it
+        // carries neither the service token nor the email: it works unconfigured.
+        const { progressApiUrl } = this.lightdashConfig.learn;
+        const response = await this.fetchUpstream(
+            `${progressApiUrl}/api/v1/ask`,
+            {
+                method: 'POST',
+                headers: { 'content-type': 'application/json' },
+                body: JSON.stringify(request.data),
+            },
+        );
+        if (!response.ok) {
+            this.logger.warn('Learn ask service returned an error', {
+                statusCode: response.status,
+            });
+            throw new UnexpectedServerError('Could not search Learn content');
+        }
+        const parsed = LearnAskResponseSchema.safeParse(
+            await LearnService.parseJson(response),
+        );
+        if (!parsed.success) {
+            this.logger.warn('Learn ask results failed validation', {
+                issueCount: parsed.error.issues.length,
+            });
+            throw new UnexpectedServerError('Could not search Learn content');
+        }
+        return { matches: parsed.data.results };
+    }
+
+    async recordEvents(
+        account: Account,
+        events: unknown,
+    ): Promise<ApiLearnEventsResponse['results']> {
+        await this.assertLearnEnabled(account);
+        const parsed = LearnEventInputSchema.array()
+            .min(1)
+            .max(MAX_EVENTS_PER_REQUEST)
+            .safeParse(events);
+        if (!parsed.success) {
+            throw new ParameterError('Invalid Learn events payload');
+        }
+        if (!this.lightdashConfig.learn.serviceToken) {
+            // No server sync configured: accept and drop — the client also
+            // keeps local progress, so learners lose nothing they can see.
+            return { accepted: 0 };
+        }
+        const body: Array<LearnEventInput & { source: 'learn' }> =
+            parsed.data.map((event) => ({ ...event, source: 'learn' }));
+        const response = await this.progressRequest(account, '/api/v1/events', {
+            method: 'POST',
+            body: JSON.stringify(body),
+        });
+        if (!response.ok) {
+            this.logger.warn('Learn events write failed', {
+                statusCode: response.status,
+            });
+            throw new UnexpectedServerError('Could not save Learn progress');
+        }
+        const payload = (await LearnService.parseJson(response)) as {
+            accepted?: number;
+        };
+        return { accepted: payload.accepted ?? body.length };
+    }
+}

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -45,6 +45,7 @@ import { GitlabAppService } from './GitlabAppService/GitlabAppService';
 import { GroupsService } from './GroupService';
 import { HeadlessBrowserService } from './HeadlessBrowserService';
 import { HealthService } from './HealthService/HealthService';
+import { LearnService } from './LearnService/LearnService';
 import { LicenseService } from './LicenseService/LicenseService';
 import { LightdashAnalyticsService } from './LightdashAnalyticsService/LightdashAnalyticsService';
 import { LinearAppService } from './LinearAppService/LinearAppService';
@@ -134,6 +135,7 @@ interface ServiceManifest {
     pivotTableService: PivotTableService;
     projectService: ProjectService;
     promptService: PromptService;
+    learnService: LearnService;
     savedChartService: SavedChartService;
     schedulerService: SchedulerService;
     searchService: SearchService;
@@ -1105,6 +1107,17 @@ export class ServiceRepository
                     appGenerateService: this.providers.appGenerateService
                         ? this.getAppGenerateService<AppGenerateService>()
                         : undefined,
+                }),
+        );
+    }
+
+    public getLearnService(): LearnService {
+        return this.getService(
+            'learnService',
+            () =>
+                new LearnService({
+                    lightdashConfig: this.context.lightdashConfig,
+                    featureFlagService: this.getFeatureFlagService(),
                 }),
         );
     }

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -322,6 +322,7 @@ export * from './types/queryHistoryList';
 export * from './types/querySources';
 export * from './types/rename';
 export * from './types/resourceViewItem';
+export * from './types/learn';
 export * from './types/results';
 export * from './types/roadmap';
 export * from './types/roles';

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -222,6 +222,14 @@ import type {
     ApiGroupListResponse,
 } from './groups';
 import { type ApiImpersonationOrganizationSettingsResponse } from './impersonationOrganizationSettings';
+import {
+    type ApiLearnAskResponse,
+    type ApiLearnBadgesResponse,
+    type ApiLearnCatalogueResponse,
+    type ApiLearnCourseResponse,
+    type ApiLearnEventsResponse,
+    type ApiLearnProgressResponse,
+} from './learn';
 import type { LinearInstallation, LinearProject, LinearTeam } from './linear';
 import {
     type ApiCompiledMergeQueryResults,
@@ -1305,6 +1313,12 @@ type ApiResults =
     | ApiPaginatedValidateResponse['results']
     | ApiValidationSummaryResponse['results']
     | ApiRoadmapResponse['results']
+    | ApiLearnCatalogueResponse['results']
+    | ApiLearnCourseResponse['results']
+    | ApiLearnProgressResponse['results']
+    | ApiLearnEventsResponse['results']
+    | ApiLearnBadgesResponse['results']
+    | ApiLearnAskResponse['results']
     | ChartHistory
     | ChartVersion
     | DashboardHistory

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -109,6 +109,12 @@ export enum FeatureFlags {
     ExplorerChartGallery = 'explorer-chart-gallery',
 
     /**
+     * Show the Learn section (in-app Lightdash University training) and
+     * enable its content/progress proxy endpoints. Disabled by default.
+     */
+    LearnSection = 'learn-section',
+
+    /**
      * Per-organization gate for declaring custom npm dependencies in data
      * apps. Disabled by default; self-hosted instances can enable it globally
      * via LIGHTDASH_ENABLE_FEATURE_FLAGS.

--- a/packages/common/src/types/learn.ts
+++ b/packages/common/src/types/learn.ts
@@ -1,0 +1,409 @@
+import { z } from 'zod';
+
+export type LearnFeatureRequirement = {
+    id: string;
+    label: string;
+    plan: string;
+};
+
+export type LearnCatalogueEntry = {
+    id: string;
+    title: string;
+    description: string;
+    version: number;
+    contentHash: string;
+    path: string;
+    lessonCount: number;
+    durationMinutes: number | null;
+    tags: string[];
+    track: string | null;
+    /**
+     * Scope tag this module teaches: `action:Subject` or
+     * `action:Subject@global`; null = untagged. For a CS-169 scope-group
+     * module this is the ENTRY scope — the member whose minimum holding role
+     * is lowest — so pre-CS-169 consumers keep working unchanged.
+     */
+    scope: string | null;
+    /**
+     * CS-169 scope groups: the sorted unique set of the module's lesson
+     * scopes (singleton for a single-scope module, empty for an untagged
+     * one). Optional in the type — not just schema-defaulted like `scope` —
+     * so the board test fixtures shared byte-identically with the academy
+     * twin need not carry it; the schema default fills it on parse.
+     */
+    scopes?: string[];
+    /**
+     * One scope tag per lesson, in lesson order (null = untagged lesson).
+     * Empty for a pre-CS-169 catalogue. Optional for the same twin-fixture
+     * reason as `scopes`.
+     */
+    lessonScopes?: (string | null)[];
+    requires: LearnFeatureRequirement[];
+    publishedAt: string;
+};
+
+/** A curated Ask chip: the question, and the module that answers it. */
+export type LearnAskSuggestion = {
+    query: string;
+    courseId: string;
+};
+
+export type LearnCatalogue = {
+    generatedAt: string;
+    courses: LearnCatalogueEntry[];
+    suggestions: LearnAskSuggestion[];
+};
+
+const LearnFeatureRequirementSchema = z.object({
+    id: z.string().min(1),
+    label: z.string(),
+    plan: z.string(),
+});
+
+export const LearnCatalogueEntrySchema: z.ZodType<LearnCatalogueEntry> = z
+    .object({
+        id: z.string().min(1),
+        title: z.string().min(1),
+        description: z.string(),
+        version: z.number().int(),
+        contentHash: z.string().min(1),
+        path: z.string().min(1),
+        lessonCount: z.number().int(),
+        durationMinutes: z.number().nullable(),
+        tags: z.array(z.string()),
+        track: z.string().nullable(),
+        scope: z.string().nullable().default(null),
+        scopes: z.array(z.string()).default([]),
+        lessonScopes: z.array(z.string().nullable()).default([]),
+        requires: z.array(LearnFeatureRequirementSchema).default([]),
+        publishedAt: z.string(),
+    })
+    .passthrough() as unknown as z.ZodType<LearnCatalogueEntry>;
+
+const LearnAskSuggestionSchema = z.object({
+    query: z.string().min(1),
+    courseId: z.string().min(1),
+});
+
+export const LearnCatalogueSchema: z.ZodType<LearnCatalogue> = z
+    .object({
+        generatedAt: z.string(),
+        courses: z.array(LearnCatalogueEntrySchema),
+        suggestions: z.array(LearnAskSuggestionSchema).default([]),
+    })
+    .passthrough() as unknown as z.ZodType<LearnCatalogue>;
+
+export type LearnQuizQuestion = {
+    id: string;
+    prompt: string;
+    choices: string[];
+    answer: number;
+};
+
+export type LearnLesson = {
+    id: string;
+    title: string;
+    html: string;
+    /**
+     * CS-169: the scope this lesson teaches (null = untagged, always
+     * visible). Defaulted by the schema so a pre-CS-169 course.json —
+     * immutable per contentHash, never rewritten — still parses.
+     */
+    scope: string | null;
+};
+
+/** A clickable region on a demo step, as fractions of the image. */
+export type LearnDemoHotspot = {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+};
+
+export type LearnDemoStep = {
+    image: string;
+    caption: string;
+    hotspot: LearnDemoHotspot | null;
+};
+
+/** An interactive click-through demo a lesson mounts with `data-demo`. */
+export type LearnDemo = {
+    id: string;
+    title: string;
+    viewport: { width: number; height: number };
+    steps: LearnDemoStep[];
+};
+
+export type LearnCourse = {
+    id: string;
+    title: string;
+    passingScore: number;
+    logo?: string;
+    lessons: LearnLesson[];
+    quiz: { questions: LearnQuizQuestion[] };
+    demos: Record<string, LearnDemo>;
+    version: number;
+    contentHash: string;
+    publishedAt: string;
+    /** Absolute base URL lesson-relative `assets/…` refs resolve against. */
+    assetBaseUrl: string;
+};
+
+const LearnDemoSchema = z
+    .object({
+        id: z.string().min(1),
+        title: z.string(),
+        viewport: z.object({ width: z.number(), height: z.number() }),
+        steps: z.array(
+            z
+                .object({
+                    image: z.string().min(1),
+                    caption: z.string(),
+                    hotspot: z
+                        .object({
+                            x: z.number(),
+                            y: z.number(),
+                            width: z.number(),
+                            height: z.number(),
+                        })
+                        .nullish()
+                        .transform((value) => value ?? null),
+                })
+                .passthrough(),
+        ),
+    })
+    .passthrough();
+
+export const LearnCourseSchema = z
+    .object({
+        id: z.string().min(1),
+        title: z.string().min(1),
+        passingScore: z.number(),
+        logo: z.string().optional(),
+        demos: z.record(z.string(), LearnDemoSchema).default({}),
+        lessons: z.array(
+            z
+                .object({
+                    id: z.string().min(1),
+                    title: z.string().min(1),
+                    html: z.string(),
+                    scope: z.string().nullable().default(null),
+                })
+                .passthrough(),
+        ),
+        quiz: z
+            .object({
+                questions: z.array(
+                    z
+                        .object({
+                            id: z.string().min(1),
+                            prompt: z.string(),
+                            choices: z.array(z.string()),
+                            answer: z.number().int(),
+                        })
+                        .passthrough(),
+                ),
+            })
+            .passthrough(),
+        version: z.number().int(),
+        contentHash: z.string().min(1),
+        publishedAt: z.string(),
+    })
+    .passthrough();
+
+export type LearnCourseProgress = {
+    courseId: string;
+    startedAt: string | null;
+    completedAt: string | null;
+    lessonsCompleted: string[];
+    quiz: {
+        bestScore: number | null;
+        passed: boolean;
+        passedAt: string | null;
+    } | null;
+    lastEventAt: string | null;
+};
+
+export const LearnProgressResponseSchema = z
+    .object({
+        email: z.string(),
+        courses: z.array(
+            z
+                .object({
+                    courseId: z.string(),
+                    startedAt: z.string().nullable(),
+                    completedAt: z.string().nullable(),
+                    lessonsCompleted: z.array(z.string()),
+                    quiz: z
+                        .object({
+                            bestScore: z.number().nullable(),
+                            passed: z.boolean(),
+                            passedAt: z.string().nullable(),
+                        })
+                        .passthrough()
+                        .nullable(),
+                    lastEventAt: z.string().nullable(),
+                })
+                .passthrough(),
+        ),
+    })
+    .passthrough();
+
+export type LearnEventVerb =
+    | 'started'
+    | 'progressed'
+    | 'completed'
+    | 'passed'
+    | 'failed';
+
+/**
+ * A learning event as written by the Learn section. `source` is pinned
+ * server-side to 'learn' — the client never chooses the surface.
+ */
+export type LearnEventInput = {
+    verb: LearnEventVerb;
+    object: {
+        type: 'course' | 'lesson' | 'quiz';
+        course: string;
+        lesson?: string;
+        contentHash?: string;
+        version?: number;
+    };
+    result?: {
+        score?: number;
+        passed?: boolean;
+        completion?: boolean;
+    };
+    occurredAt: string;
+};
+
+export const LearnEventInputSchema: z.ZodType<LearnEventInput> = z
+    .object({
+        verb: z.enum([
+            'started',
+            'progressed',
+            'completed',
+            'passed',
+            'failed',
+        ]),
+        object: z
+            .object({
+                type: z.enum(['course', 'lesson', 'quiz']),
+                course: z.string().min(1),
+                lesson: z.string().optional(),
+                contentHash: z.string().optional(),
+                version: z.number().int().optional(),
+            })
+            .strict(),
+        result: z
+            .object({
+                score: z.number().min(0).max(100).optional(),
+                passed: z.boolean().optional(),
+                completion: z.boolean().optional(),
+            })
+            .strict()
+            .optional(),
+        occurredAt: z.string().datetime({ offset: true }),
+    })
+    .strict() as unknown as z.ZodType<LearnEventInput>;
+
+export type LearnProgressResults = {
+    /** Null when the instance has no Learn service token — progress is client-local. */
+    courses: LearnCourseProgress[] | null;
+    serverSynced: boolean;
+};
+
+export type ApiLearnCatalogueResponse = {
+    status: 'ok';
+    results: LearnCatalogue;
+};
+
+export type ApiLearnCourseResponse = {
+    status: 'ok';
+    results: LearnCourse;
+};
+
+export type ApiLearnProgressResponse = {
+    status: 'ok';
+    results: LearnProgressResults;
+};
+
+export type ApiLearnEventsResponse = {
+    status: 'ok';
+    results: { accepted: number };
+};
+
+export type LearnBadgeTier = 'bronze' | 'silver' | 'gold' | 'violet';
+
+export type LearnCourseBadge = {
+    courseId: string;
+    tier: LearnBadgeTier;
+};
+
+export type LearnBadgesResults = {
+    /** Null when the instance has no Learn service token: tiers are server-derived only. */
+    badges: LearnCourseBadge[] | null;
+};
+
+// The envelope passes unknown fields through for forward compatibility; each
+// badge is stripped to the contract, so a new upstream field never reaches a browser.
+export const LearnBadgesResponseSchema = z
+    .object({
+        badges: z.array(
+            z.object({
+                courseId: z.string().min(1),
+                tier: z.enum(['bronze', 'silver', 'gold', 'violet']),
+            }),
+        ),
+    })
+    .passthrough();
+
+export type LearnAskRequest = {
+    query: string;
+};
+
+/** The longest question the search accepts: shared by the schema and the input. */
+export const LEARN_ASK_QUERY_MAX_LENGTH = 500;
+
+export const LearnAskRequestSchema: z.ZodType<LearnAskRequest> = z
+    .object({
+        query: z.string().min(1).max(LEARN_ASK_QUERY_MAX_LENGTH),
+    })
+    .strict() as unknown as z.ZodType<LearnAskRequest>;
+
+export type LearnAskMatch = {
+    courseId: string;
+    lessonId: string | null;
+    title: string;
+    score: number;
+};
+
+export type LearnAskResults = {
+    matches: LearnAskMatch[];
+};
+
+export const LearnAskResponseSchema = z
+    .object({
+        results: z.array(
+            z.object({
+                courseId: z.string().min(1),
+                lessonId: z
+                    .string()
+                    .nullish()
+                    .transform((value) => value ?? null),
+                title: z.string(),
+                score: z.number(),
+            }),
+        ),
+    })
+    .passthrough();
+
+export type ApiLearnBadgesResponse = {
+    status: 'ok';
+    results: LearnBadgesResults;
+};
+
+export type ApiLearnAskResponse = {
+    status: 'ok';
+    results: LearnAskResults;
+};

--- a/packages/common/src/utils/sanitizeHtml.test.ts
+++ b/packages/common/src/utils/sanitizeHtml.test.ts
@@ -1,5 +1,6 @@
 import {
     HTML_SANITIZE_DEFAULT_RULES,
+    HTML_SANITIZE_LEARN_LESSON_RULES,
     HTML_SANITIZE_MARKDOWN_TILE_RULES,
     sanitizeHtml,
 } from './sanitizeHtml';
@@ -327,5 +328,59 @@ describe('sanitizeHtml', () => {
                 input,
             );
         });
+    });
+});
+
+describe('HTML_SANITIZE_LEARN_LESSON_RULES', () => {
+    const lesson =
+        '<p>Open Browse<a class="cit" href="#fig-1" data-hl="r1">1</a>.</p>' +
+        '<span class="figwrap" id="fig-1"><img src="https://x/y.png" alt="Spaces">' +
+        '<span class="hlbox below pl-l" data-r="r1" data-label="1 · Browse" style="left:10.5%;top:1.2%;width:7.5%;height:4%"></span></span>' +
+        '<figure class="shot" id="fig-2"><img src="https://x/z.png" alt=""><figcaption>Cap</figcaption></figure>';
+
+    test('keeps citation pins, figure ids and positioned highlight boxes', () => {
+        const out = sanitizeHtml(lesson, HTML_SANITIZE_LEARN_LESSON_RULES);
+        expect(out).toContain(
+            '<a class="cit" href="#fig-1" data-hl="r1">1</a>',
+        );
+        expect(out).toContain('<span class="figwrap" id="fig-1">');
+        expect(out).toContain('data-r="r1"');
+        expect(out).toContain('data-label="1 · Browse"');
+        expect(out).toContain('left:10.5%');
+        expect(out).toContain('height:4%');
+        expect(out).toContain('<figure class="shot" id="fig-2">');
+    });
+
+    test('still drops scripts, stylesheets and unsafe styles', () => {
+        const out = sanitizeHtml(
+            '<style>a{}</style><script>x()</script>' +
+                '<span class="hlbox" style="position:fixed;left:10%;background:url(x)"></span>',
+            HTML_SANITIZE_LEARN_LESSON_RULES,
+        );
+        expect(out).not.toContain('<style');
+        expect(out).not.toContain('<script');
+        expect(out).not.toContain('position');
+        expect(out).not.toContain('url(');
+        expect(out).toContain('left:10%');
+    });
+});
+
+describe('HTML_SANITIZE_LEARN_LESSON_RULES demo placeholders', () => {
+    test('keeps the data-demo mount point and nothing else on it', () => {
+        const out = sanitizeHtml(
+            '<div data-demo="save-chart" onclick="x()"></div>',
+            HTML_SANITIZE_LEARN_LESSON_RULES,
+        );
+        expect(out).toBe('<div data-demo="save-chart"></div>');
+    });
+});
+
+describe('HTML_SANITIZE_LEARN_LESSON_RULES frames', () => {
+    test('drops iframes even though markdown tiles allow them', () => {
+        const out = sanitizeHtml(
+            '<p>Before</p><iframe src="https://example.com/login" width="600" height="400"></iframe><p>After</p>',
+            HTML_SANITIZE_LEARN_LESSON_RULES,
+        );
+        expect(out).toBe('<p>Before</p><p>After</p>');
     });
 });

--- a/packages/common/src/utils/sanitizeHtml.ts
+++ b/packages/common/src/utils/sanitizeHtml.ts
@@ -127,6 +127,49 @@ export const HTML_SANITIZE_MARKDOWN_TILE_RULES: sanitize.IOptions = {
     ),
 };
 
+const percentRegex = /^\d+(?:\.\d+)?%$/;
+const tileAttributes =
+    HTML_SANITIZE_MARKDOWN_TILE_RULES.allowedAttributes || {};
+
+/**
+ * Rules for lesson HTML published by Lightdash University. Lessons carry
+ * citation pins (`a.cit` → `#fig-…`) and highlight boxes positioned by
+ * percentage over a figure; scripts and stylesheets are still dropped.
+ */
+export const HTML_SANITIZE_LEARN_LESSON_RULES: sanitize.IOptions = {
+    ...HTML_SANITIZE_MARKDOWN_TILE_RULES,
+    // Lessons never embed frames; a compromised content host must not either.
+    allowedTags: (HTML_SANITIZE_MARKDOWN_TILE_RULES.allowedTags || []).filter(
+        (tag) => tag !== 'iframe',
+    ),
+    allowedAttributes: {
+        ...Object.fromEntries(
+            Object.entries(tileAttributes).filter(([tag]) => tag !== 'iframe'),
+        ),
+        a: [...(tileAttributes.a ?? []), 'class', 'data-hl'],
+        span: [
+            ...(tileAttributes.span ?? []),
+            'class',
+            'id',
+            'data-r',
+            'data-label',
+        ],
+        figure: ['class', 'id'],
+        img: [...(tileAttributes.img ?? []), 'class'],
+        div: [...(tileAttributes.div ?? []), 'data-demo'],
+    },
+    allowedStyles: {
+        ...HTML_SANITIZE_MARKDOWN_TILE_RULES.allowedStyles,
+        span: {
+            ...allowedTextStylingProperties,
+            left: [percentRegex],
+            top: [percentRegex],
+            width: [...allowedTextStylingProperties.width, percentRegex],
+            height: [...allowedTextStylingProperties.height, percentRegex],
+        },
+    },
+};
+
 export const sanitizeHtml = (
     input: string,
     ruleSet: sanitize.IOptions = HTML_SANITIZE_DEFAULT_RULES,

--- a/packages/learn-ui/src/types/assignability.test.ts
+++ b/packages/learn-ui/src/types/assignability.test.ts
@@ -1,0 +1,35 @@
+import type {
+    LearnAskMatch as CommonAskMatch,
+    LearnCatalogue as CommonCatalogue,
+    LearnCatalogueEntry as CommonEntry,
+    LearnCourse as CommonCourse,
+    LearnCourseProgress as CommonProgress,
+    LearnEventInput as CommonEvent,
+} from '@lightdash/common';
+import { LEARN_ASK_QUERY_MAX_LENGTH } from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import { ASK_QUERY_MAX_LENGTH, type LearnAskMatch } from './ask';
+import type { LearnCatalogue, LearnCatalogueEntry } from './catalogue';
+import type { LearnCourse } from './course';
+import type { LearnCourseProgress, LearnEventInput } from './progress';
+
+// Common's zod-parsed types are the wire contract; the package types are the
+// subset the UI reads. If common drops or renames a field the UI depends on,
+// one of these assignments stops compiling.
+const entry = (e: CommonEntry): LearnCatalogueEntry => e;
+const catalogue = (c: CommonCatalogue): LearnCatalogue => c;
+const course = (c: CommonCourse): LearnCourse => c;
+const match = (m: CommonAskMatch): LearnAskMatch => m;
+const progress = (p: CommonProgress): LearnCourseProgress => p;
+const event = (e: CommonEvent): LearnEventInput => e;
+
+describe('type assignability from @lightdash/common', () => {
+    it('compiles', () => {
+        expect([entry, catalogue, course, match, progress, event]).toHaveLength(
+            6,
+        );
+    });
+    it('ask query limit matches the backend limit', () => {
+        expect(ASK_QUERY_MAX_LENGTH).toBe(LEARN_ASK_QUERY_MAX_LENGTH);
+    });
+});


### PR DESCRIPTION
Second of five. `@lightdash/common` gains the Learn wire types and zod schemas plus the lesson-HTML sanitiser rules; the backend gains a stateless validating proxy (`LearnService`) over the Lightdash University content host and progress service, exposed on `/api/v1/learn/*` (hidden, flag-gated by `LearnSection`). No database changes. Identical to the backend halves of the previous stack (#26660, #26662, #26663, #27884, #27887, #27902, #27966), consolidated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UMX8BRvEgNgP9x8rDya46E
