### PR TITLE
chore(timezone): remove NaiveTimestampFilterRebase feature flag

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -4251,22 +4251,6 @@ export class AsyncQueryService extends ProjectService {
             preloadedProjectTimezone,
         });
 
-        // Only meaningful with a non-UTC data timezone; skip the lookup otherwise.
-        const rebaseRawTimestampFilters =
-            columnTimezone && columnTimezone !== 'UTC'
-                ? (
-                      await this.featureFlagModel.get({
-                          featureFlagId:
-                              FeatureFlags.NaiveTimestampFilterRebase,
-                          user: {
-                              userUuid: account.user.id,
-                              organizationUuid:
-                                  account.organization.organizationUuid,
-                          },
-                      })
-                  ).enabled
-                : false;
-
         return new QueryComposer(
             { metricQuery, pivotConfiguration, totalConfiguration },
             {
@@ -4284,7 +4268,6 @@ export class AsyncQueryService extends ProjectService {
                 useTimezoneAwareDateTrunc,
                 columnTimezone,
                 dataTimezone,
-                rebaseRawTimestampFilters,
                 applyDateZoomToFilters,
                 displayTimezone,
                 queryExecutionContext: context,

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -7170,9 +7170,8 @@ describe('RAW time frame naive-column rebase', () => {
         expect(query).not.toContain('::timestamptz');
     });
 
-    // The filter LHS must be rebased like the SELECT — a bare predicate would
-    // compare the naive wall clock against the instant the SELECT displays.
-    // Flag-gated: the wrap defeats partition pruning.
+    // Filter LHS keeps the bare column (wrapping it defeats partition
+    // pruning); the literal side carries any conversion.
     const rawFilterQuery = (values: string[]): CompiledMetricQuery => ({
         ...rawQuery,
         filters: {
@@ -7190,47 +7189,6 @@ describe('RAW time frame naive-column rebase', () => {
         },
     });
 
-    test('RAW filter LHS is rebased to match the SELECT (Postgres)', () => {
-        const { query } = buildQuery({
-            explore: buildRawExplore(),
-            compiledMetricQuery: rawFilterQuery(['2024-01-15 02:00:00']),
-            warehouseSqlBuilder: warehouseClientMock,
-            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
-            timezone: 'Asia/Tokyo',
-            useTimezoneAwareDateTrunc: true,
-            columnTimezone: 'Asia/Tokyo',
-            rebaseRawTimestampFilters: true,
-        });
-        expect(query).toContain(
-            `("events".occurred_at)::timestamptz AS "events_occurred_at_raw"`,
-        );
-        const whereClause = query.slice(query.indexOf('WHERE'));
-        // LHS is the rebased instant; the offset literal now compares correctly.
-        expect(whereClause).toContain(
-            `(("events".occurred_at)::timestamptz) >`,
-        );
-        expect(whereClause).toContain(`('2024-01-15 02:00:00+00:00')`);
-    });
-
-    test('RAW filter LHS is rebased and the literal pinned to UTC (BigQuery)', () => {
-        const { query } = buildQuery({
-            explore: buildRawExplore(SupportedDbtAdapter.BIGQUERY),
-            compiledMetricQuery: rawFilterQuery(['2024-01-15 02:00:00']),
-            warehouseSqlBuilder: bigqueryClientMock,
-            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
-            timezone: 'Asia/Tokyo',
-            useTimezoneAwareDateTrunc: true,
-            columnTimezone: 'Asia/Tokyo',
-            rebaseRawTimestampFilters: true,
-        });
-        const whereClause = query.slice(query.indexOf('WHERE'));
-        expect(whereClause).toContain(`(TIMESTAMP("events".occurred_at)) >`);
-        // Offset-less literal pinned to UTC so the job time_zone can't shift it.
-        expect(whereClause).toContain(
-            `TIMESTAMP('2024-01-15 02:00:00', 'UTC')`,
-        );
-    });
-
     test('convert_timezone: false keeps the RAW filter bare (matches the bare SELECT)', () => {
         const { query } = buildQuery({
             explore: buildRawExplore(SupportedDbtAdapter.POSTGRES, true),
@@ -7240,12 +7198,11 @@ describe('RAW time frame naive-column rebase', () => {
             timezone: 'Asia/Tokyo',
             useTimezoneAwareDateTrunc: true,
             columnTimezone: 'Asia/Tokyo',
-            rebaseRawTimestampFilters: true,
         });
         expect(query).not.toContain('::timestamptz');
     });
 
-    test('flag off keeps the RAW filter bare while the SELECT is rebased', () => {
+    test('RAW filter stays bare while the SELECT is rebased', () => {
         const { query } = buildQuery({
             explore: buildRawExplore(),
             compiledMetricQuery: rawFilterQuery(['2024-01-15 02:00:00']),

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -53,7 +53,6 @@ import {
     MetricFilterRule,
     MetricQuery,
     MetricType,
-    naiveTimestampRebaseAdapters,
     parseAllReferences,
     parseTableCalculationFunctions,
     PivotConfiguration,
@@ -174,10 +173,6 @@ export type BuildQueryProps = {
      *  dimension columns to UTC while bare columns (aggregate inputs) remain
      *  in the data timezone. */
     dataTimezone?: string;
-    /** Rebase RAW timestamp filter columns to instants so predicates match the
-     *  SELECT. Gated behind NaiveTimestampFilterRebase (the wrap defeats
-     *  partition pruning). */
-    rebaseRawTimestampFilters?: boolean;
     queryExecutionContext?: QueryExecutionContext;
     /**
      * Turns this into a totals query: the builder collapses
@@ -855,17 +850,9 @@ export class MetricQueryBuilder {
             if (this.columnTimezone === 'UTC') {
                 return { sql: dimension.compiledSql, lhsMode: 'legacy' };
             }
-            // Filter LHS: a known domain keeps the bare column (the literal
-            // side carries the conversion, so predicates stay sargable); the
-            // flag-gated session wrap remains only as the unknown-domain
-            // fallback.
-            if (
-                !respectConvertTimezone &&
-                (timestampDomain !== undefined ||
-                    !this.args.rebaseRawTimestampFilters ||
-                    baseDimension.skipTimezoneConversion ||
-                    !naiveTimestampRebaseAdapters.has(adapterType))
-            ) {
+            // Filter LHS keeps the bare column — the literal side carries the
+            // conversion, so predicates stay sargable.
+            if (!respectConvertTimezone) {
                 return { sql: dimension.compiledSql, lhsMode: 'legacy' };
             }
             const { castToInstant, castNaiveToInstant, castAwareToInstant } =

--- a/packages/backend/src/utils/QueryBuilder/QueryComposer.ts
+++ b/packages/backend/src/utils/QueryBuilder/QueryComposer.ts
@@ -68,7 +68,6 @@ export type QueryComposerContext = {
     useTimezoneAwareDateTrunc?: boolean;
     columnTimezone?: string;
     dataTimezone?: string;
-    rebaseRawTimestampFilters?: boolean;
     applyDateZoomToFilters?: boolean;
     queryExecutionContext?: QueryExecutionContext;
     /**
@@ -131,7 +130,6 @@ export class QueryComposer {
             useTimezoneAwareDateTrunc,
             columnTimezone,
             dataTimezone,
-            rebaseRawTimestampFilters,
             applyDateZoomToFilters,
             queryExecutionContext,
         } = this.context;
@@ -195,7 +193,6 @@ export class QueryComposer {
             useTimezoneAwareDateTrunc,
             columnTimezone,
             dataTimezone,
-            rebaseRawTimestampFilters,
             totalConfiguration,
             queryExecutionContext,
         });

--- a/packages/common/src/featureFlags/previewFeatureFlags.ts
+++ b/packages/common/src/featureFlags/previewFeatureFlags.ts
@@ -11,7 +11,6 @@ const PREVIEW_EXCLUDED_FEATURE_FLAGS: ReadonlySet<string> = new Set<string>([
     FeatureFlags.OrganizationTrialBlock,
     FeatureFlags.OrganizationTrialWarning,
     // Changes query or compile semantics, so QA results would be misleading.
-    FeatureFlags.NaiveTimestampFilterRebase,
     FeatureFlags.CalculateSeriesColor,
     FeatureFlags.ReplaceCustomMetricsOnCompile,
     // Needs per-org worker queues that previews don't run.

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -14,16 +14,6 @@ export enum FeatureFlags {
     EnableTimezoneSupport = 'enable-timezone-support',
 
     /**
-     * Rebase RAW timestamp filter columns to instants when a data timezone is
-     * set, so sub-day filters return the rows the SELECT displays. Wrapping
-     * the filter column defeats partition pruning/index scans on BigQuery and
-     * Postgres-family warehouses, so this is off by default — enable per-org
-     * for data-timezone users who need filter correctness. Temporary: goes
-     * away once filters convert the literal into the column's domain instead.
-     */
-    NaiveTimestampFilterRebase = 'naive-timestamp-filter-rebase',
-
-    /**
      * Enable scheduler task that replaces custom metrics after project compile
      */
     ReplaceCustomMetricsOnCompile = 'replace-custom-metrics-on-compile',

--- a/packages/common/src/utils/timeFrames.ts
+++ b/packages/common/src/utils/timeFrames.ts
@@ -155,17 +155,6 @@ const postgresLikeCastToInstant = (sql: string) => `(${sql})::timestamptz`;
 const clickhouseCastToInstant = (sql: string) => `toTimeZone(${sql}, 'UTC')`;
 const identityCastToInstant = (sql: string) => sql;
 
-// Adapters whose castToInstant genuinely rebases a naive column at the SQL
-// level. Identity adapters keep filter columns bare; ClickHouse has no naive
-// type (its castToInstant only relabels an instant) so its filters stay bare.
-export const naiveTimestampRebaseAdapters: ReadonlySet<SupportedDbtAdapter> =
-    new Set([
-        SupportedDbtAdapter.BIGQUERY,
-        SupportedDbtAdapter.POSTGRES,
-        SupportedDbtAdapter.REDSHIFT,
-        SupportedDbtAdapter.DUCKDB,
-    ]);
-
 const bigqueryCastNaiveToInstant = (sql: string, z: string) =>
     `TIMESTAMP(${sql}, '${z}')`;
 // 3-arg CONVERT_TIMEZONE reads the NTZ wall clock in z and returns the UTC


### PR DESCRIPTION
Closes: GLITCH-740

### Description:
Removes the `NaiveTimestampFilterRebase` (`naive-timestamp-filter-rebase`) feature flag, which was never enabled for anyone. It was added as a temporary opt-in that wrapped the RAW timestamp filter LHS in a cast-to-instant expression so predicates match the rebased SELECT — at the cost of defeating partition pruning/index scans. Its own doc comment said it should go away once filter literals are rendered in the column's timestamp domain, which GLITCH-616 shipped.

**No behavior change**: the removed branch was only reachable with the flag on. With it gone, the filter LHS always keeps the bare column (as it does today) and the literal side carries any conversion.

Removed:
- the `FeatureFlags.NaiveTimestampFilterRebase` enum entry and its preview-environment exclusion
- the per-query feature-flag lookup in `AsyncQueryService`
- the `rebaseRawTimestampFilters` plumbing through `QueryComposer` / `MetricQueryBuilder`
- the unknown-domain session-wrap fallback on the RAW filter LHS and the `naiveTimestampRebaseAdapters` set it keyed on
- the tests that exercised the flag-on branch

### Risk assessment:

- [ ] This is a high-risk change