### PR TITLE
fix(sql-runner): editor top padding and unclipped, wider autocomplete

### DIFF
--- a/packages/frontend/src/features/sqlRunner/components/SqlEditor.module.css
+++ b/packages/frontend/src/features/sqlRunner/components/SqlEditor.module.css
@@ -1,0 +1,4 @@
+/* Fully qualified table names overflow Monaco's 430px suggest widget. */
+.editor :global(.monaco-editor .suggest-widget) {
+    min-width: rem(640px);
+}

--- a/packages/frontend/src/features/sqlRunner/components/SqlEditor.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/SqlEditor.tsx
@@ -8,6 +8,7 @@ import SuboptimalState from '../../../components/common/SuboptimalState/Suboptim
 import Editor, {
     useMonaco,
     type BeforeMount,
+    type EditorProps,
     type OnChange,
     type OnMount,
 } from '../../../components/MonacoEditor';
@@ -28,6 +29,7 @@ import {
     registerCustomCompletionProvider,
     registerMonacoLanguage,
 } from '../utils/monaco';
+import styles from './SqlEditor.module.css';
 
 // monaco highlight character
 export type MonacoHighlightChar = {
@@ -42,6 +44,13 @@ type MonacoHighlightLine = {
 };
 
 const DEBOUNCE_TIME = 500;
+
+// Widgets escape the card's overflow clipping; padding keeps line 1 off the toolbar.
+const SQL_RUNNER_MONACO_OPTIONS: EditorProps['options'] = {
+    ...MONACO_DEFAULT_OPTIONS,
+    padding: { top: 12, bottom: 12 },
+    fixedOverflowWidgets: true,
+};
 
 export const SqlEditor: FC<{
     onSubmit?: (sql: string) => void;
@@ -286,13 +295,14 @@ export const SqlEditor: FC<{
 
     return (
         <Editor
+            className={styles.editor}
             loading={<Loader color="gray" size="xs" />}
             beforeMount={beforeMount}
             onMount={onMount}
             language={language}
             value={sql}
             onChange={onChange}
-            options={MONACO_DEFAULT_OPTIONS}
+            options={SQL_RUNNER_MONACO_OPTIONS}
             theme={monacoTheme}
         />
     );


### PR DESCRIPTION
## Summary

Two pieces of SQL runner editor feedback:

- **Line 1 sat flush against the toolbar border.** The SQL editor now gets 12px top and bottom padding via Monaco's `padding` option. This is done in a SQL runner-specific options object so the shared `MONACO_DEFAULT_OPTIONS` used by the rendered-SQL viewer and chart config editors are untouched.
- **The autocomplete box kept cutting things off.** Two separate causes:
  - Monaco sizes the suggest widget against the whole page, but the editor card has `overflow: hidden`, so with a short editor pane the list was sliced off at the card edge. `fixedOverflowWidgets: true` lets the widget escape the card and overlay the results panel.
  - The widget defaults to 430px and only remembers a drag-resize in memory, so fully qualified names like `"db"."schema"."long_table_name"` were ellipsised on every reload. A scoped CSS module sets a 640px minimum width on the widget for the SQL runner editor only. Users can still drag it wider.

## Regression analysis

- Only `SqlEditor.tsx` changes behaviour. Other Monaco consumers keep the shared defaults.
- `fixedOverflowWidgets` also affects hover/parameter-hint widgets in this editor, which get the same escape-from-clipping benefit. Positioning still uses the widget's rendered width, so the widened list is kept inside the viewport near the right edge.
- The `min-width` rule does not use `!important`; it overrides Monaco's inline `width` through normal CSS precedence, so Monaco's own layout and resize sashes keep working.

## Verification

Checked in the running app: 12px gap above line 1, suggestion rows show full qualified table names, and with the editor pane shrunk the list renders over the results panel instead of being clipped at the card boundary. Frontend lint and typecheck pass.

Closes: PROD-10847

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012bUB5GnGwyBVmQghF13uMs
