### PR TITLE
fix(spotlight): keep the metric explore modal inside laptop viewports

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/MetricExploreModal/MetricExploreModal.module.css
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricExploreModal/MetricExploreModal.module.css
@@ -1,4 +1,10 @@
+/* Mantine caps the content at the viewport minus its y offset, so sizing
+   here (not on the body) keeps the modal off the page edges on laptops. */
 .modalContent {
+    --modal-content-height: 85dvh;
+    display: flex;
+    flex-direction: column;
+    min-height: rem(600px);
     overflow: hidden;
 }
 
@@ -21,6 +27,7 @@
 .modalBody {
     display: flex;
     flex: 1;
+    min-height: 0;
 }
 
 .sidebarContainer {

--- a/packages/frontend/src/features/metricsCatalog/components/MetricExploreModal/MetricExploreModal.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricExploreModal/MetricExploreModal.tsx
@@ -472,6 +472,7 @@ export const MetricExploreModal: FC<Props> = (props) => {
             onClose={handleClose}
             scrollAreaComponent={undefined}
             size="auto"
+            centered
         >
             <Modal.Overlay />
             <Modal.Content className={styles.modalContent} radius={12} w="100%">
@@ -558,13 +559,7 @@ export const MetricExploreModal: FC<Props> = (props) => {
                     </Group>
                 </Modal.Header>
 
-                <Modal.Body
-                    p={0}
-                    h="80vh"
-                    className={styles.modalBody}
-                    miw={800}
-                    mih={600}
-                >
+                <Modal.Body p={0} className={styles.modalBody} miw={800}>
                     <Stack w={460}>
                         <Box
                             px="lg"


### PR DESCRIPTION
## Summary

The metric explore modal in Spotlight sat 5dvh from the top of the page with a body fixed at `80vh` and a `600px` minimum. On laptop viewports (around 700px tall once browser chrome is accounted for) the content exceeded the viewport and was clipped at the bottom, and it read as glued to the top of the page.

- Sizing moves from `Modal.Body` to `Modal.Content`, where Mantine already caps height at `100dvh - 2 * y-offset`. The content is `85dvh` with a `600px` minimum and lays out as a flex column so the body takes the remainder.
- `centered` on `Modal.Root`, matching the theme default the rest of the app's modals get through `Modal` (which does not flow through to `Modal.Root`).

Measured in the running app:

| Viewport height | Before (top / bottom gap) | After (top / bottom gap) |
|---|---|---|
| 700px | 35px / clipped | 50px / 50px |
| 760px | 38px / 52px | 57px / 57px |
| 900px | 45px / 75px | 68px / 68px |

## Regression analysis

- Only `MetricExploreModal` changes. The min width, sidebar, and chart layout are untouched; the body still flexes to fill the modal.
- The body height shrinks slightly on tall screens because the header is now included in the `85dvh` (703px body at 900px tall vs 720px before). The chart container fills the body, so nothing depends on the exact number.
- `min-height: 600px` still wins over Mantine's cap below ~667px viewports, the same floor as before, so behaviour at very small heights is unchanged.

Closes: PROD-10848

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012bUB5GnGwyBVmQghF13uMs
