### PR TITLE
feat: Learn board logic in @lightdash/learn-ui (CS-73 3/5)

### DIFF
--- a/packages/learn-ui/src/index.ts
+++ b/packages/learn-ui/src/index.ts
@@ -1,4 +1,8 @@
-export { LearnUiProvider, useScopeSource } from './scope/context';
+export {
+    LearnUiProvider,
+    useScopeSource,
+    useLearnModel,
+} from './scope/context';
 export {
     OrganizationMemberRole,
     ProjectMemberRole,
@@ -16,3 +20,15 @@ export {
     type CardState,
     type Rollup,
 } from './model/rollup';
+export { createLearnModel, type LearnModel } from './model/learnModel';
+export * from './model/model';
+export * from './model/ask';
+export * from './model/askView';
+export * from './model/visibility';
+export * from './model/layout';
+export * from './model/motion';
+export * from './model/badges';
+export * from './model/badgesView';
+export * from './model/badgeArt';
+export * from './model/tokens';
+export * from './model/citations';

--- a/packages/learn-ui/src/model/ask.test.ts
+++ b/packages/learn-ui/src/model/ask.test.ts
@@ -1,0 +1,137 @@
+// Shared by the in-app Learn section and learn.lightdash.com via @lightdash/learn-ui.
+
+import { describe, expect, it } from 'vitest';
+import { ProjectMemberRole } from '../scope/types';
+import { createAskModel } from './ask';
+import { createBoardModel } from './model';
+import { commonScopeSource, entry } from './testFixtures';
+
+const library = [
+    entry({ id: 'foundation', scope: 'view:Project' }),
+    entry({ id: 'dashboards', scope: 'manage:Dashboard' }),
+    entry({ id: 'org', scope: 'manage:Organization' }),
+];
+const board = createBoardModel(commonScopeSource);
+const ask = createAskModel(board);
+const { askHighlights, lockedLabel, suggestionsFor } = ask;
+const viewer = board.roleScopes(ProjectMemberRole.VIEWER);
+const admin = board.roleScopes(ProjectMemberRole.ADMIN);
+
+const match = (courseId: string, score = 0.9) => ({
+    courseId,
+    title: courseId,
+    score,
+});
+
+describe('askHighlights', () => {
+    it('splits matches into the ones the role holds and the ones it does not', () => {
+        const { matched, locked } = askHighlights(
+            [match('foundation'), match('org')],
+            library,
+            viewer,
+        );
+        expect([...matched]).toEqual(['foundation']);
+        expect([...locked]).toEqual(['org']);
+    });
+
+    it('locks nothing for a role that holds everything', () => {
+        const { matched, locked } = askHighlights(
+            [match('foundation'), match('org')],
+            library,
+            admin,
+        );
+        expect([...matched].sort()).toEqual(['foundation', 'org']);
+        expect(locked.size).toBe(0);
+    });
+
+    it('drops results naming a module the catalogue does not have', () => {
+        const { matched, locked } = askHighlights(
+            [match('ghost')],
+            library,
+            admin,
+        );
+        expect(matched.size).toBe(0);
+        expect(locked.size).toBe(0);
+    });
+
+    it('de-duplicates lesson-level matches within one module', () => {
+        const { matched } = askHighlights(
+            [
+                {
+                    courseId: 'foundation',
+                    lessonId: '01',
+                    title: 'One',
+                    score: 0.9,
+                },
+                {
+                    courseId: 'foundation',
+                    lessonId: '02',
+                    title: 'Two',
+                    score: 0.8,
+                },
+            ],
+            library,
+            viewer,
+        );
+        expect([...matched]).toEqual(['foundation']);
+    });
+
+    it('highlights nothing for an empty result list', () => {
+        const { matched, locked } = askHighlights([], library, viewer);
+        expect(matched.size).toBe(0);
+        expect(locked.size).toBe(0);
+    });
+});
+
+describe('suggestionsFor', () => {
+    const suggestions = [
+        { query: 'Where do I find things?', courseId: 'foundation' },
+        { query: 'How do I run the org?', courseId: 'org' },
+        { query: 'Ghost', courseId: 'not-in-catalogue' },
+    ];
+
+    it('keeps only suggestions whose module the role holds', () => {
+        expect(
+            suggestionsFor(suggestions, library, viewer).map((s) => s.courseId),
+        ).toEqual(['foundation']);
+    });
+
+    it('keeps authored order for a role that holds more', () => {
+        expect(
+            suggestionsFor(suggestions, library, admin).map((s) => s.courseId),
+        ).toEqual(['foundation', 'org']);
+    });
+
+    it('caps the chips at one row of three, in authored order', () => {
+        const many = [1, 2, 3, 4, 5].map((n) => ({
+            query: `Question ${n}`,
+            courseId: 'foundation',
+        }));
+        expect(
+            suggestionsFor(many, library, viewer).map((s) => s.query),
+        ).toEqual(['Question 1', 'Question 2', 'Question 3']);
+    });
+
+    it('drops a suggestion naming a module the catalogue does not have', () => {
+        expect(
+            suggestionsFor(suggestions, library, admin).some(
+                (s) => s.courseId === 'not-in-catalogue',
+            ),
+        ).toBe(false);
+    });
+});
+
+describe('lockedLabel', () => {
+    it('names the lowest role that can open the module', () => {
+        expect(
+            lockedLabel(entry({ id: 'org', scope: 'manage:Organization' })),
+        ).toBe('admin and above');
+    });
+
+    it('is null when every system role holds it, so there is nothing to explain', () => {
+        expect(
+            lockedLabel(entry({ id: 'foundation', scope: 'view:Project' })),
+        ).toBeNull();
+        expect(lockedLabel(entry({ id: 'untagged', scope: null }))).toBeNull();
+    });
+});

--- a/packages/learn-ui/src/model/ask.ts
+++ b/packages/learn-ui/src/model/ask.ts
@@ -1,0 +1,97 @@
+// Shared by the in-app Learn section and learn.lightdash.com via @lightdash/learn-ui.
+
+import { type LearnCatalogueEntry } from '../types';
+import { ROLE_LABEL, SYSTEM_ROLES, type BoardModel } from './model';
+
+/** One lesson match from the ask API. */
+export type AskMatch = {
+    courseId: string;
+    lessonId?: string;
+    title: string;
+    score: number;
+};
+
+/** A curated chip, as published on the catalogue. */
+export type AskSuggestion = { query: string; courseId: string };
+
+export type AskHighlights = {
+    /** Modules the role holds that the query hit: these glow. */
+    matched: Set<string>;
+    /** Modules the query hit that the role cannot open: outlined, not hidden. */
+    locked: Set<string>;
+};
+
+/**
+ * Chips are offers, not answers, so an offer the role cannot take is worse than
+ * one fewer chip. Authored order is kept: the library curates which reads first.
+ */
+/** Chips stay on one row: the first few authored suggestions the role can use. */
+export const SUGGESTION_LIMIT = 3;
+
+export type AskModel = {
+    askHighlights: (
+        results: AskMatch[],
+        entries: LearnCatalogueEntry[],
+        held: Iterable<string>,
+    ) => AskHighlights;
+    suggestionsFor: (
+        suggestions: AskSuggestion[],
+        entries: LearnCatalogueEntry[],
+        held: Iterable<string>,
+    ) => AskSuggestion[];
+    lockedLabel: (entry: LearnCatalogueEntry) => string | null;
+};
+
+export const createAskModel = (board: BoardModel): AskModel => {
+    const { courseFor, heldBy, isUnlocked } = board;
+
+    /**
+     * A locked match is shown rather than filtered out: the answer existing is
+     * useful even when the learner cannot open it yet, and hiding it would make
+     * the board look like the library has no answer at all.
+     */
+    const askHighlights = (
+        results: AskMatch[],
+        entries: LearnCatalogueEntry[],
+        held: Iterable<string>,
+    ): AskHighlights => {
+        const heldList = Array.from(held);
+        const byId = new Map(entries.map((entry) => [entry.id, entry]));
+        const matched = new Set<string>();
+        const locked = new Set<string>();
+        for (const result of results) {
+            const entry = byId.get(result.courseId);
+            if (!entry) continue;
+            if (isUnlocked(entry, heldList)) matched.add(entry.id);
+            else locked.add(entry.id);
+        }
+        return { matched, locked };
+    };
+
+    const suggestionsFor = (
+        suggestions: AskSuggestion[],
+        entries: LearnCatalogueEntry[],
+        held: Iterable<string>,
+    ): AskSuggestion[] => {
+        const holdable = new Set(
+            courseFor(entries, held).map((entry) => entry.id),
+        );
+        return suggestions
+            .filter((s) => holdable.has(s.courseId))
+            .slice(0, SUGGESTION_LIMIT);
+    };
+
+    /**
+     * What to say beside a locked match. Null when every system role holds the
+     * module, because then the lock is not about the role and naming one would
+     * mislead.
+     */
+    const lockedLabel = (entry: LearnCatalogueEntry): string | null => {
+        const holders = heldBy(entry);
+        if (holders.length === 0 || holders.length === SYSTEM_ROLES.length)
+            return null;
+        return `${ROLE_LABEL[holders[0]]} and above`;
+    };
+
+    return { askHighlights, suggestionsFor, lockedLabel };
+};

--- a/packages/learn-ui/src/model/askView.test.ts
+++ b/packages/learn-ui/src/model/askView.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest';
+import { ProjectMemberRole } from '../scope/types';
+import { type LearnAskMatch } from '../types';
+import { createAskModel } from './ask';
+import {
+    ASK_RESULT_LIMIT,
+    askOpacity,
+    askScale,
+    createAskViewModel,
+    groupMatches,
+    nodeAskState,
+    resolveMatches,
+} from './askView';
+import { createBoardModel } from './model';
+import { commonScopeSource, entry } from './testFixtures';
+
+const entries = [
+    entry({ id: 'foundation', scope: 'view:Project' }),
+    entry({ id: 'dashboards', scope: 'manage:Dashboard' }),
+    entry({ id: 'spaces', scope: 'manage:Space' }),
+];
+
+const board = createBoardModel(commonScopeSource);
+const ask = createAskModel(board);
+const askView = createAskViewModel(board, ask);
+
+const viewerScopes = commonScopeSource.getAllScopesForRole(
+    ProjectMemberRole.VIEWER,
+);
+
+const match = (courseId: string, score: number): LearnAskMatch => ({
+    courseId,
+    lessonId: 'l1',
+    title: `${courseId} lesson`,
+    score,
+});
+
+describe('resolveMatches', () => {
+    it('drops matches naming a module this catalogue does not carry', () => {
+        expect(
+            resolveMatches(
+                [match('retired-module', 0.9), match('foundation', 0.8)],
+                entries,
+            ),
+        ).toEqual([match('foundation', 0.8)]);
+    });
+
+    it('caps the list once, so the board and the list light the same set', () => {
+        const many = Array.from({ length: 8 }, (_, i) =>
+            match('foundation', 1 - i / 10),
+        );
+        expect(resolveMatches(many, entries)).toHaveLength(ASK_RESULT_LIMIT);
+    });
+});
+
+describe('boardHighlights', () => {
+    it('splits held matches from locked ones', () => {
+        const highlights = askView.boardHighlights(
+            [match('foundation', 0.8), match('dashboards', 0.6)],
+            entries,
+            viewerScopes,
+        );
+        expect([...highlights.matched]).toEqual(['foundation']);
+        expect([...highlights.locked]).toEqual(['dashboards']);
+    });
+});
+
+describe('nodeAskState', () => {
+    const highlights = {
+        matched: new Set(['foundation']),
+        locked: new Set(['dashboards']),
+    };
+
+    it('is none when nothing is highlighted', () => {
+        expect(nodeAskState('foundation', null)).toBe('none');
+    });
+
+    it('marks matched, locked and dimmed nodes', () => {
+        expect(nodeAskState('foundation', highlights)).toBe('matched');
+        expect(nodeAskState('dashboards', highlights)).toBe('locked-match');
+        expect(nodeAskState('spaces', highlights)).toBe('dimmed');
+    });
+});
+
+describe('askOpacity / askScale', () => {
+    it('leaves untouched and matched nodes on their motion values', () => {
+        expect(askOpacity('none', 1)).toBe(1);
+        expect(askOpacity('matched', 1)).toBe(1);
+        expect(askScale('matched', 1)).toBe(1);
+    });
+
+    it('dims everything else to 40 percent of its motion opacity', () => {
+        expect(askOpacity('dimmed', 1)).toBe(0.4);
+        expect(askOpacity('dimmed', 0)).toBe(0);
+    });
+
+    it('surfaces a locked match that motion would have hidden', () => {
+        expect(askOpacity('locked-match', 0)).toBe(0.4);
+        expect(askScale('locked-match', 0.3)).toBe(1);
+    });
+});
+
+describe('groupMatches', () => {
+    it('groups by module and keeps first-seen order', () => {
+        expect(
+            groupMatches([
+                match('dashboards', 0.9),
+                match('foundation', 0.8),
+                { ...match('dashboards', 0.7), lessonId: 'l2' },
+            ]),
+        ).toEqual([
+            {
+                courseId: 'dashboards',
+                matches: [
+                    match('dashboards', 0.9),
+                    { ...match('dashboards', 0.7), lessonId: 'l2' },
+                ],
+            },
+            { courseId: 'foundation', matches: [match('foundation', 0.8)] },
+        ]);
+    });
+});
+
+describe('lockedNote', () => {
+    it('names the lowest role that holds the module', () => {
+        // 'manage:Dashboard' is held from interactive viewer up (the
+        // '@space' variant satisfies it, see model.test.ts), so this uses
+        // 'manage:Tags', which has no scoped lower-tier variant and is
+        // genuinely editor-and-above.
+        expect(
+            askView.lockedNote(entry({ id: 'tags', scope: 'manage:Tags' })),
+        ).toBe('editor and above');
+    });
+
+    it('says custom roles only when there is no system role to name', () => {
+        // An untagged module is held by every system role, so lockedLabel has
+        // nothing to name and the pane still needs a line.
+        expect(askView.lockedNote(entry({ id: 'x', scope: null }))).toBe(
+            'custom roles only',
+        );
+    });
+});

--- a/packages/learn-ui/src/model/askView.test.ts
+++ b/packages/learn-ui/src/model/askView.test.ts
@@ -22,7 +22,7 @@ const entries = [
 
 const board = createBoardModel(commonScopeSource);
 const ask = createAskModel(board);
-const askView = createAskViewModel(board, ask);
+const askView = createAskViewModel(ask);
 
 const viewerScopes = commonScopeSource.getAllScopesForRole(
     ProjectMemberRole.VIEWER,

--- a/packages/learn-ui/src/model/askView.ts
+++ b/packages/learn-ui/src/model/askView.ts
@@ -1,0 +1,130 @@
+// Shared by the in-app Learn section and learn.lightdash.com via @lightdash/learn-ui.
+
+import { type LearnAskMatch, type LearnCatalogueEntry } from '../types';
+import { type AskHighlights, type AskMatch, type AskModel } from './ask';
+import { type BoardModel } from './model';
+
+/** The results list stops at five: past that it stops reading as an answer. */
+export const ASK_RESULT_LIMIT = 5;
+
+const DIM_OPACITY = 0.4;
+
+export type NodeAskState = 'none' | 'matched' | 'locked-match' | 'dimmed';
+
+/**
+ * The search ranks embeddings and can name a module this catalogue does not
+ * carry. Resolve against the library and cap once, so the list and the lit
+ * nodes are the same set.
+ */
+export const resolveMatches = (
+    matches: LearnAskMatch[],
+    entries: LearnCatalogueEntry[],
+): LearnAskMatch[] => {
+    const known = new Set(entries.map((entry) => entry.id));
+    return matches
+        .filter((match) => known.has(match.courseId))
+        .slice(0, ASK_RESULT_LIMIT);
+};
+
+// The published match carries `lessonId: string | null` where the copied
+// AskMatch declares it optional; only the course id is read either way.
+const asAskMatch = ({ courseId, title, score }: LearnAskMatch): AskMatch => ({
+    courseId,
+    title,
+    score,
+});
+
+export const nodeAskState = (
+    id: string,
+    highlights: AskHighlights | null,
+): NodeAskState => {
+    if (highlights === null) return 'none';
+    if (highlights.matched.has(id)) return 'matched';
+    if (highlights.locked.has(id)) return 'locked-match';
+    return 'dimmed';
+};
+
+export const askOpacity = (
+    state: NodeAskState,
+    motionOpacity: number,
+): number => {
+    switch (state) {
+        case 'none':
+        case 'matched':
+            return motionOpacity;
+        case 'dimmed':
+            return motionOpacity * DIM_OPACITY;
+        case 'locked-match':
+            return DIM_OPACITY;
+        default:
+            return assertUnreachable(state, 'Unknown ask state');
+    }
+};
+
+export const askScale = (state: NodeAskState, motionScale: number): number => {
+    switch (state) {
+        case 'none':
+        case 'matched':
+        case 'dimmed':
+            return motionScale;
+        case 'locked-match':
+            return 1;
+        default:
+            return assertUnreachable(state, 'Unknown ask state');
+    }
+};
+
+export type AskGroup = {
+    courseId: string;
+    matches: LearnAskMatch[];
+};
+
+export const groupMatches = (matches: LearnAskMatch[]): AskGroup[] => {
+    const groups: AskGroup[] = [];
+    const byCourse = new Map<string, AskGroup>();
+    for (const result of matches) {
+        const existing = byCourse.get(result.courseId);
+        if (existing) {
+            existing.matches.push(result);
+            continue;
+        }
+        const group: AskGroup = {
+            courseId: result.courseId,
+            matches: [result],
+        };
+        byCourse.set(result.courseId, group);
+        groups.push(group);
+    }
+    return groups;
+};
+
+export type AskViewModel = {
+    boardHighlights: (
+        matches: LearnAskMatch[],
+        entries: LearnCatalogueEntry[],
+        held: string[],
+    ) => AskHighlights;
+    /** Who can reach a module the selected role cannot, for a locked match. */
+    lockedNote: (entry: LearnCatalogueEntry) => string;
+};
+
+export const createAskViewModel = (
+    board: BoardModel,
+    ask: AskModel,
+): AskViewModel => {
+    const boardHighlights = (
+        matches: LearnAskMatch[],
+        entries: LearnCatalogueEntry[],
+        held: string[],
+    ): AskHighlights =>
+        ask.askHighlights(matches.map(asAskMatch), entries, held);
+
+    const lockedNote = (entry: LearnCatalogueEntry): string =>
+        ask.lockedLabel(entry) ?? 'custom roles only';
+
+    return { boardHighlights, lockedNote };
+};
+
+const assertUnreachable = (value: never, message: string): never => {
+    throw new Error(`${message}: ${String(value)}`);
+};

--- a/packages/learn-ui/src/model/askView.ts
+++ b/packages/learn-ui/src/model/askView.ts
@@ -2,7 +2,6 @@
 
 import { type LearnAskMatch, type LearnCatalogueEntry } from '../types';
 import { type AskHighlights, type AskMatch, type AskModel } from './ask';
-import { type BoardModel } from './model';
 
 /** The results list stops at five: past that it stops reading as an answer. */
 export const ASK_RESULT_LIMIT = 5;
@@ -108,10 +107,7 @@ export type AskViewModel = {
     lockedNote: (entry: LearnCatalogueEntry) => string;
 };
 
-export const createAskViewModel = (
-    board: BoardModel,
-    ask: AskModel,
-): AskViewModel => {
+export const createAskViewModel = (ask: AskModel): AskViewModel => {
     const boardHighlights = (
         matches: LearnAskMatch[],
         entries: LearnCatalogueEntry[],

--- a/packages/learn-ui/src/model/badgeArt.ts
+++ b/packages/learn-ui/src/model/badgeArt.ts
@@ -1,0 +1,128 @@
+// Shared by the in-app Learn section and learn.lightdash.com via @lightdash/learn-ui.
+
+import { type BadgeRung } from './badgesView';
+
+// Slots read outline, body, highlight, inner mark. Slot 4 is near white so the
+// emblem's inner mark reads as a white counter; `locked` is deepened off near
+// white so it still shows on a light rail.
+const PALETTES: Record<BadgeRung, [string, string, string, string]> = {
+    violet: ['#3d22b8', '#6b46f0', '#9b83ff', '#f5f1ff'],
+    locked: ['#8e8e9a', '#a8a8b4', '#c4c4ce', '#ecedf0'],
+    bronze: ['#8c5a2b', '#b6763a', '#d6994f', '#fff7ec'],
+    silver: ['#5f6672', '#878e9b', '#b6bcc6', '#ffffff'],
+    gold: ['#8a6d1a', '#c9a02c', '#eac545', '#fffbe9'],
+};
+
+// Tier reads from the silhouette (orb, shield, diamond, gem, rosette), not from
+// the palette alone, so a badge stays legible at 16px and in monochrome.
+const TIER_MOTIFS: Record<BadgeRung, string[]> = {
+    locked: [
+        '................',
+        '................',
+        '................',
+        '................',
+        '......4444......',
+        '.....422224.....',
+        '....42144124....',
+        '...4214444124...',
+        '...4214444124...',
+        '...4214444124...',
+        '...1214444121...',
+        '....12144121....',
+        '.....122221.....',
+        '......1111......',
+        '................',
+        '................',
+    ],
+    bronze: [
+        '................',
+        '................',
+        '...1111111111...',
+        '...4333333334...',
+        '...4222222224...',
+        '...4212222124...',
+        '...4214444124...',
+        '...4214444124...',
+        '...3213443123...',
+        '...1221331221...',
+        '....12211221....',
+        '.....122221.....',
+        '......1221......',
+        '.......11.......',
+        '................',
+        '................',
+    ],
+    silver: [
+        '................',
+        '................',
+        '................',
+        '.......44.......',
+        '......4334......',
+        '.....431134.....',
+        '....43144134....',
+        '...4214444124...',
+        '...4214444124...',
+        '....22144122....',
+        '.....221122.....',
+        '......2222......',
+        '.......22.......',
+        '................',
+        '................',
+        '................',
+    ],
+    gold: [
+        '................',
+        '................',
+        '................',
+        '....44444444....',
+        '...4222222224...',
+        '..422111111224..',
+        '..421444444124..',
+        '..421444444124..',
+        '...2214444122...',
+        '....22144122....',
+        '.....221122.....',
+        '......2222......',
+        '.......22.......',
+        '................',
+        '................',
+        '................',
+    ],
+    violet: [
+        '................',
+        '................',
+        '................',
+        '.......44.......',
+        '.....442244.....',
+        '....42211224....',
+        '...4221441224...',
+        '...4214444124...',
+        '...4214444124...',
+        '...2221441222...',
+        '....22211222....',
+        '.....222222.....',
+        '......2222......',
+        '................',
+        '................',
+        '................',
+    ],
+};
+
+const badgeSvg = (motif: string[], rung: BadgeRung, cell: number): string => {
+    const rects: string[] = [];
+    motif.forEach((row, r) => {
+        for (let c = 0; c < row.length; c += 1) {
+            const ch = row[c];
+            if (ch === '.') continue;
+            const fill = PALETTES[rung][Number(ch) - 1];
+            rects.push(
+                `<rect x="${c * cell}" y="${r * cell}" width="${cell}" height="${cell}" fill="${fill}"/>`,
+            );
+        }
+    });
+    const size = 16 * cell;
+    return `<svg width="${size}" height="${size}" viewBox="0 0 ${size} ${size}" shape-rendering="crispEdges" aria-hidden="true">${rects.join('')}</svg>`;
+};
+
+export const tierBadgeSvg = (rung: BadgeRung, cell: number): string =>
+    badgeSvg(TIER_MOTIFS[rung], rung, cell);

--- a/packages/learn-ui/src/model/badges.test.ts
+++ b/packages/learn-ui/src/model/badges.test.ts
@@ -1,0 +1,106 @@
+// Shared by the in-app Learn section and learn.lightdash.com via @lightdash/learn-ui.
+
+import { describe, expect, it } from 'vitest';
+import { roleBadge, type Rung } from './badges';
+import { entry } from './testFixtures';
+
+const held = [entry({ id: 'a' }), entry({ id: 'b' }), entry({ id: 'c' })];
+const tiers = (pairs: [string, Rung][]): Map<string, Rung> => new Map(pairs);
+
+describe('roleBadge', () => {
+    it('sits at the lowest rung across the held modules', () => {
+        expect(
+            roleBadge(
+                held,
+                tiers([
+                    ['a', 'gold'],
+                    ['b', 'gold'],
+                    ['c', 'gold'],
+                ]),
+            ),
+        ).toMatchObject({ rung: 'gold', nextRung: 'violet' });
+        expect(
+            roleBadge(
+                held,
+                tiers([
+                    ['a', 'violet'],
+                    ['b', 'gold'],
+                    ['c', 'silver'],
+                ]),
+            ),
+        ).toMatchObject({ rung: 'silver', nextRung: 'gold' });
+    });
+
+    it('a module with no row pins the badge to locked', () => {
+        expect(
+            roleBadge(
+                held,
+                tiers([
+                    ['a', 'violet'],
+                    ['b', 'violet'],
+                ]),
+            ),
+        ).toMatchObject({ rung: 'locked', nextRung: 'bronze' });
+    });
+
+    it('counts how many held modules already cleared the next rung', () => {
+        expect(
+            roleBadge(
+                held,
+                tiers([
+                    ['a', 'gold'],
+                    ['b', 'bronze'],
+                ]),
+            ),
+        ).toEqual({
+            rung: 'locked',
+            nextRung: 'bronze',
+            at: 2,
+            of: 3,
+        });
+        expect(
+            roleBadge(
+                held,
+                tiers([
+                    ['a', 'gold'],
+                    ['b', 'silver'],
+                    ['c', 'silver'],
+                ]),
+            ),
+        ).toEqual({ rung: 'silver', nextRung: 'gold', at: 1, of: 3 });
+    });
+
+    it('tops out with no next rung once everything is violet', () => {
+        expect(
+            roleBadge(
+                held,
+                tiers([
+                    ['a', 'violet'],
+                    ['b', 'violet'],
+                    ['c', 'violet'],
+                ]),
+            ),
+        ).toEqual({ rung: 'violet', nextRung: null, at: 3, of: 3 });
+    });
+
+    it('a role holding nothing is locked with nothing to count', () => {
+        expect(roleBadge([], new Map())).toEqual({
+            rung: 'locked',
+            nextRung: 'bronze',
+            at: 0,
+            of: 0,
+        });
+    });
+
+    it('ignores tiers for modules the role does not hold', () => {
+        expect(
+            roleBadge(
+                [entry({ id: 'a' })],
+                tiers([
+                    ['a', 'bronze'],
+                    ['elsewhere', 'locked'],
+                ]),
+            ),
+        ).toMatchObject({ rung: 'bronze', of: 1 });
+    });
+});

--- a/packages/learn-ui/src/model/badges.ts
+++ b/packages/learn-ui/src/model/badges.ts
@@ -1,0 +1,58 @@
+// Shared by the in-app Learn section and learn.lightdash.com via @lightdash/learn-ui.
+
+import { type LearnCatalogueEntry } from '../types';
+
+/**
+ * One badge per role, not per module: a role badge is the honest summary of a
+ * course, and a shelf of per-module tiles only repeated the board underneath it.
+ *
+ * The badge sits at the WEAKEST held module, which is what makes it worth more
+ * than the modules it contains: gold means every module the role holds is gold.
+ * Per-module tiers are server-derived (docs/badges-contract.md); this is a
+ * client-side rollup over them, and it never invents a rung the server did not
+ * grant. A module the role does not hold is not in `held` at all, so role growth
+ * can lower the badge but never revokes a module's own tier.
+ */
+export type Rung = 'locked' | 'bronze' | 'silver' | 'gold' | 'violet';
+
+export const RUNG_LADDER: Rung[] = [
+    'locked',
+    'bronze',
+    'silver',
+    'gold',
+    'violet',
+];
+
+const rank = (rung: Rung): number => RUNG_LADDER.indexOf(rung);
+
+export type RoleBadge = {
+    /** Where the role stands now. */
+    rung: Rung;
+    /** The rung being worked toward, null once everything is violet. */
+    nextRung: Rung | null;
+    /** Held modules already at or above `nextRung`. */
+    at: number;
+    /** Held modules in total. */
+    of: number;
+};
+
+export const roleBadge = (
+    held: LearnCatalogueEntry[],
+    tiers: Map<string, Rung>,
+): RoleBadge => {
+    const of = held.length;
+    const earned = held.map((entry) => tiers.get(entry.id) ?? 'locked');
+    // A role with no modules is locked rather than violet: nothing was earned.
+    const rung =
+        earned.length === 0
+            ? 'locked'
+            : RUNG_LADDER[Math.min(...earned.map(rank))];
+    const nextRung = rung === 'violet' ? null : RUNG_LADDER[rank(rung) + 1];
+    if (nextRung === null) return { rung, nextRung: null, at: of, of };
+    return {
+        rung,
+        nextRung,
+        at: earned.filter((tier) => rank(tier) >= rank(nextRung)).length,
+        of,
+    };
+};

--- a/packages/learn-ui/src/model/badgesView.test.ts
+++ b/packages/learn-ui/src/model/badgesView.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { type RoleBadge } from './badges';
+import { badgeDetail } from './badgesView';
+
+const badge = (overrides: Partial<RoleBadge>): RoleBadge => ({
+    rung: 'bronze',
+    nextRung: 'silver',
+    at: 1,
+    of: 3,
+    ...overrides,
+});
+
+describe('badgeDetail', () => {
+    it('names what earns the next rung and how far along the role is', () => {
+        expect(badgeDetail(badge({}), true)).toBe(
+            'Pass every quiz for silver · 1 of 3 there',
+        );
+    });
+
+    it('says the role topped out, in the singular for one module', () => {
+        expect(
+            badgeDetail(
+                badge({ rung: 'violet', nextRung: null, at: 1, of: 1 }),
+                true,
+            ),
+        ).toBe('All 1 module at violet');
+        expect(
+            badgeDetail(
+                badge({ rung: 'violet', nextRung: null, at: 4, of: 4 }),
+                true,
+            ),
+        ).toBe('All 4 modules at violet');
+    });
+
+    it('says it cannot tell rather than Locked when badges did not load', () => {
+        expect(badgeDetail(badge({ rung: 'locked' }), false)).toBe(
+            'Badges unavailable right now',
+        );
+    });
+});

--- a/packages/learn-ui/src/model/badgesView.ts
+++ b/packages/learn-ui/src/model/badgesView.ts
@@ -1,5 +1,5 @@
-// Badge card copy over the copied badges.ts. Lightdash side only: nothing here
-// has a twin in lightdash-university.
+// Badge card copy over the copied badges.ts.
+// Shared by the in-app Learn section and learn.lightdash.com via @lightdash/learn-ui.
 
 import { type LearnBadgeTier } from '../types';
 import { RUNG_LADDER, type RoleBadge } from './badges';

--- a/packages/learn-ui/src/model/badgesView.ts
+++ b/packages/learn-ui/src/model/badgesView.ts
@@ -1,0 +1,56 @@
+// Badge card copy over the copied badges.ts. Lightdash side only: nothing here
+// has a twin in lightdash-university.
+
+import { type LearnBadgeTier } from '../types';
+import { RUNG_LADDER, type RoleBadge } from './badges';
+import { plural } from './model';
+
+/** The copied ladder, named against the published tier union. */
+export type BadgeRung = 'locked' | LearnBadgeTier;
+
+export const RUNG_WORD: Record<BadgeRung, string> = {
+    locked: 'Locked',
+    bronze: 'Bronze',
+    silver: 'Silver',
+    gold: 'Gold',
+    violet: 'Violet',
+};
+
+// What earns the next rung, so a locked badge is a goal rather than a blank.
+const RUNG_HINT: Record<BadgeRung, string> = {
+    locked: '',
+    bronze: 'Finish every module for bronze',
+    silver: 'Pass every quiz for silver',
+    gold: 'Score 90%+ on every quiz for gold',
+    violet: 'Ace every quiz for violet',
+};
+
+/** The full ladder, so a learner can read what each rung takes. */
+export const RUNG_REQ: Record<LearnBadgeTier, string> = {
+    bronze: 'Finish every module',
+    silver: 'Pass every quiz',
+    gold: 'Score 90% or more on every quiz',
+    violet: 'Ace every quiz (100%)',
+};
+
+/** The rungs a learner can earn, in ladder order: the copy owns the order. */
+export const EARNABLE: LearnBadgeTier[] = RUNG_LADDER.filter(
+    (rung): rung is LearnBadgeTier => rung !== 'locked',
+);
+
+/** Pending is not unavailable: an in-flight fetch says so and names no rung. */
+export const BADGE_PENDING_DETAIL = 'Loading badges';
+
+/**
+ * The line under the rung word. A failed badges fetch is not "nothing earned":
+ * saying Locked to a learner who holds gold reads as a revoked badge.
+ */
+export const badgeDetail = (badge: RoleBadge, available: boolean): string => {
+    if (!available) return 'Badges unavailable right now';
+    if (badge.nextRung === null) {
+        return `All ${plural(badge.of, 'module')} at ${RUNG_WORD[
+            badge.rung
+        ].toLowerCase()}`;
+    }
+    return `${RUNG_HINT[badge.nextRung]} · ${badge.at} of ${badge.of} there`;
+};

--- a/packages/learn-ui/src/model/citations.test.ts
+++ b/packages/learn-ui/src/model/citations.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { wireCitations } from './citations';
+
+const LESSON = `
+<p>Reach a space from Browse<a class="cit" href="#fig-1" data-hl="r1">1</a>.</p>
+<span class="figwrap" id="fig-1">
+  <img src="x.png" alt="">
+  <span class="hlbox" data-r="r1" data-label="1 · Browse" style="left:10.5%;top:1.2%;width:7.5%;height:4%"></span>
+  <span class="hlbox" data-r="r2" data-label="2 · Other" style="left:50%;top:1.2%;width:7.5%;height:4%"></span>
+</span>
+<p>Another<a class="cit" href="#fig-1" data-hl="r2">2</a>.</p>
+`;
+
+describe('wireCitations', () => {
+    let scope: HTMLElement;
+    let dispose: () => void;
+
+    beforeEach(() => {
+        scope = document.createElement('div');
+        scope.innerHTML = LESSON;
+        document.body.appendChild(scope);
+        Element.prototype.scrollIntoView = vi.fn();
+        dispose = wireCitations(scope);
+    });
+
+    afterEach(() => {
+        dispose();
+        scope.remove();
+    });
+
+    const pin = (n: number) =>
+        scope.querySelectorAll('a.cit')[n] as HTMLElement;
+    const box = (r: string) => scope.querySelector(`.hlbox[data-r="${r}"]`)!;
+
+    it('lights the matching box on hover and clears on mouseout', () => {
+        pin(0).dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+        expect(pin(0).classList.contains('active')).toBe(true);
+        expect(box('r1').classList.contains('active')).toBe(true);
+        expect(box('r2').classList.contains('active')).toBe(false);
+
+        pin(0).dispatchEvent(new MouseEvent('mouseout', { bubbles: true }));
+        expect(pin(0).classList.contains('active')).toBe(false);
+        expect(box('r1').classList.contains('active')).toBe(false);
+    });
+
+    it('moves the highlight between pins and follows focus', () => {
+        pin(0).dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+        expect(box('r1').classList.contains('active')).toBe(true);
+        pin(1).dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+        expect(box('r1').classList.contains('active')).toBe(false);
+        expect(box('r2').classList.contains('active')).toBe(true);
+    });
+
+    it('click keeps the highlight, scrolls to the figure and does not navigate', () => {
+        const event = new MouseEvent('click', {
+            bubbles: true,
+            cancelable: true,
+        });
+        pin(1).dispatchEvent(event);
+        expect(event.defaultPrevented).toBe(true);
+        expect(box('r2').classList.contains('active')).toBe(true);
+        expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
+
+        box('r2').dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        expect(box('r2').classList.contains('active')).toBe(false);
+    });
+
+    it('disposer removes the listeners and any active state', () => {
+        pin(0).dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+        dispose();
+        expect(box('r1').classList.contains('active')).toBe(false);
+        pin(0).dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+        expect(box('r1').classList.contains('active')).toBe(false);
+        dispose = () => {};
+    });
+});

--- a/packages/learn-ui/src/model/citations.ts
+++ b/packages/learn-ui/src/model/citations.ts
@@ -1,0 +1,83 @@
+// Citation pins in published lesson HTML (`a.cit` with `href="#fig-…"` and
+// `data-hl`) light the matching `.hlbox` on their figure. The lesson ships
+// this behaviour as an inline script, which never runs once the HTML is
+// injected, so the player wires it here with delegated listeners.
+
+const CLEAR_EVENTS = ['mouseout', 'focusout'] as const;
+const ACTIVATE_EVENTS = ['mouseover', 'focusin'] as const;
+
+const clearActive = (scope: HTMLElement): void => {
+    scope
+        .querySelectorAll('a.cit.active, .hlbox.active')
+        .forEach((el) => el.classList.remove('active'));
+};
+
+const activate = (scope: HTMLElement, pin: HTMLAnchorElement): void => {
+    clearActive(scope);
+    pin.classList.add('active');
+    const href = pin.getAttribute('href');
+    const region = pin.getAttribute('data-hl');
+    if (!href || !href.startsWith('#') || !region) return;
+    const figure = scope.querySelector(`[id="${CSS.escape(href.slice(1))}"]`);
+    const box = figure?.querySelector(`.hlbox[data-r="${CSS.escape(region)}"]`);
+    if (box) box.classList.add('active');
+};
+
+const pinFrom = (event: Event): HTMLAnchorElement | null => {
+    const target = event.target;
+    if (!(target instanceof Element)) return null;
+    return target.closest<HTMLAnchorElement>('a.cit');
+};
+
+/**
+ * Wire citation pins inside `scope`. Returns a disposer that removes the
+ * listeners; call it before the scope's HTML is replaced.
+ */
+export const wireCitations = (scope: HTMLElement): (() => void) => {
+    const onActivate = (event: Event) => {
+        const pin = pinFrom(event);
+        if (pin) activate(scope, pin);
+    };
+    const onClear = (event: Event) => {
+        if (pinFrom(event)) clearActive(scope);
+    };
+    const onClick = (event: Event) => {
+        const pin = pinFrom(event);
+        if (pin) {
+            event.preventDefault();
+            activate(scope, pin);
+            const href = pin.getAttribute('href');
+            const figure =
+                href && href.startsWith('#')
+                    ? scope.querySelector(`[id="${CSS.escape(href.slice(1))}"]`)
+                    : null;
+            const reduced = window.matchMedia?.(
+                '(prefers-reduced-motion: reduce)',
+            ).matches;
+            figure?.scrollIntoView({
+                behavior: reduced ? 'auto' : 'smooth',
+                block: 'center',
+            });
+            return;
+        }
+        const target = event.target;
+        if (target instanceof Element && target.closest('.figwrap')) {
+            clearActive(scope);
+        }
+    };
+
+    ACTIVATE_EVENTS.forEach((name) => scope.addEventListener(name, onActivate));
+    CLEAR_EVENTS.forEach((name) => scope.addEventListener(name, onClear));
+    scope.addEventListener('click', onClick);
+
+    return () => {
+        ACTIVATE_EVENTS.forEach((name) =>
+            scope.removeEventListener(name, onActivate),
+        );
+        CLEAR_EVENTS.forEach((name) =>
+            scope.removeEventListener(name, onClear),
+        );
+        scope.removeEventListener('click', onClick);
+        clearActive(scope);
+    };
+};

--- a/packages/learn-ui/src/model/layout.test.ts
+++ b/packages/learn-ui/src/model/layout.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from 'vitest';
+import { ScopeGroup } from '../scope/types';
+import { BOARD_WIDTH, buildLayout, seatMap, type LayoutModule } from './layout';
+
+const mod = (
+    id: string,
+    group: LayoutModule['group'],
+    unlocked = true,
+): LayoutModule => ({
+    id,
+    group,
+    unlocked,
+});
+
+const dist = (a: { x: number; y: number }, b: { x: number; y: number }) =>
+    Math.hypot(a.x - b.x, a.y - b.y);
+
+describe('buildLayout rows and columns', () => {
+    it('uses one row for up to three live groups and two rows beyond', () => {
+        const three = buildLayout([
+            mod('a', 'foundations'),
+            mod('b', ScopeGroup.CONTENT),
+            mod('c', ScopeGroup.DATA),
+        ]);
+        expect(three.height).toBe(60 + 320 + 40);
+        const four = buildLayout([
+            mod('a', 'foundations'),
+            mod('b', ScopeGroup.CONTENT),
+            mod('c', ScopeGroup.DATA),
+            mod('d', ScopeGroup.AI),
+        ]);
+        expect(four.height).toBe(60 + 2 * 320 + 40);
+        expect(four.width).toBe(BOARD_WIDTH);
+    });
+
+    it('ignores groups with nothing unlocked when counting live groups', () => {
+        const layout = buildLayout([
+            mod('a', 'foundations'),
+            mod('b', ScopeGroup.CONTENT, false),
+        ]);
+        expect(layout.captions.map((c) => c.group)).toEqual(['foundations']);
+        expect(layout.height).toBe(60 + 320 + 40);
+    });
+});
+
+describe('buildLayout seats', () => {
+    it('seats a single unlocked module at the cluster centre', () => {
+        const layout = buildLayout([mod('a', 'foundations')]);
+        const [node] = layout.nodes;
+        expect(node).toMatchObject({ x: BOARD_WIDTH / 2, y: 60 + 160 + 16 });
+    });
+
+    it('shares the ring evenly among unlocked modules with a 78px floor', () => {
+        const layout = buildLayout([
+            mod('a', 'foundations'),
+            mod('b', 'foundations'),
+            mod('c', 'foundations'),
+        ]);
+        const centre = { x: BOARD_WIDTH / 2, y: 60 + 160 + 16 };
+        layout.nodes.forEach((n) => expect(dist(n, centre)).toBeCloseTo(78, 5));
+        expect(layout.nodes[0].y).toBeCloseTo(centre.y - 78, 5);
+    });
+
+    it('grows the ring with many modules', () => {
+        const many = Array.from({ length: 12 }, (_, i) =>
+            mod(`m${i}`, 'foundations'),
+        );
+        const layout = buildLayout(many);
+        const centre = { x: BOARD_WIDTH / 2, y: 60 + 160 + 16 };
+        expect(dist(layout.nodes[0], centre)).toBeCloseTo(
+            (12 * 54) / (2 * Math.PI),
+            5,
+        );
+    });
+
+    it('parks locked modules at their cluster centre, dead groups at the board centre', () => {
+        const layout = buildLayout([
+            mod('a', 'foundations'),
+            mod('b', 'foundations', false),
+            mod('c', ScopeGroup.AI, false),
+        ]);
+        const byId = new Map(layout.nodes.map((n) => [n.id, n]));
+        expect(byId.get('b')).toMatchObject({
+            x: BOARD_WIDTH / 2,
+            y: 60 + 160 + 16,
+            unlocked: false,
+        });
+        expect(byId.get('c')).toMatchObject({
+            x: BOARD_WIDTH / 2,
+            y: 60 + 160,
+        });
+    });
+
+    it('seats exactly the unlocked modules on the ring', () => {
+        const modules = [
+            mod('a', 'foundations'),
+            mod('b', 'foundations'),
+            mod('c', 'foundations'),
+            mod('d', 'foundations', false),
+        ];
+        const layout = buildLayout(modules);
+        const centre = { x: BOARD_WIDTH / 2, y: 60 + 160 + 16 };
+        expect(layout.nodes.filter((n) => dist(n, centre) > 0)).toHaveLength(
+            modules.filter((m) => m.unlocked).length,
+        );
+    });
+
+    it('seatMap matches buildLayout seats', () => {
+        const modules = [mod('a', 'foundations'), mod('b', ScopeGroup.CONTENT)];
+        const seats = seatMap(modules);
+        buildLayout(modules).nodes.forEach((n) =>
+            expect(seats.get(n.id)).toEqual({ x: n.x, y: n.y }),
+        );
+    });
+});
+
+describe('buildLayout connectors and captions', () => {
+    it('ring links join consecutive unlocked nodes and skip locked ones', () => {
+        const layout = buildLayout([
+            mod('a', 'foundations'),
+            mod('b', 'foundations', false),
+            mod('c', 'foundations'),
+            mod('d', 'foundations'),
+        ]);
+        expect(layout.connectors.filter((c) => c.kind === 'ring')).toHaveLength(
+            3,
+        );
+    });
+
+    it('draws one ring link for a pair and none for a single node', () => {
+        expect(
+            buildLayout([
+                mod('a', 'foundations'),
+                mod('b', 'foundations'),
+            ]).connectors.filter((c) => c.kind === 'ring'),
+        ).toHaveLength(1);
+        expect(buildLayout([mod('a', 'foundations')]).connectors).toHaveLength(
+            0,
+        );
+    });
+
+    it('trunk links join horizontal neighbours plus the first and last column verticals', () => {
+        const groups: LayoutModule['group'][] = [
+            'foundations',
+            ScopeGroup.CONTENT,
+            ScopeGroup.DATA,
+            ScopeGroup.AI,
+            ScopeGroup.PROJECT_MANAGEMENT,
+            ScopeGroup.ORGANIZATION_MANAGEMENT,
+        ];
+        const layout = buildLayout(groups.map((g, i) => mod(`m${i}`, g)));
+        // 2 rows x 3 cols: 2 horizontal per row + 2 verticals
+        expect(
+            layout.connectors.filter((c) => c.kind === 'trunk'),
+        ).toHaveLength(6);
+    });
+
+    it('draws one horizontal trunk and no verticals for a 1x2 grid', () => {
+        const layout = buildLayout([
+            mod('a', 'foundations'),
+            mod('b', ScopeGroup.CONTENT),
+        ]);
+        const trunks = layout.connectors.filter((c) => c.kind === 'trunk');
+        expect(trunks).toHaveLength(1);
+        expect(trunks[0].y1).toBe(trunks[0].y2);
+    });
+
+    it('trims every connector by 22px at both ends', () => {
+        const layout = buildLayout([
+            mod('a', 'foundations'),
+            mod('b', 'foundations'),
+        ]);
+        const [ring] = layout.connectors;
+        expect(Math.hypot(ring.x2 - ring.x1, ring.y2 - ring.y1)).toBeCloseTo(
+            2 * 78 - 44,
+            5,
+        );
+    });
+
+    it('anchors the caption above the ring with unlocked / total counts', () => {
+        const layout = buildLayout([
+            mod('a', 'foundations'),
+            mod('b', 'foundations'),
+            mod('c', 'foundations', false),
+        ]);
+        const [cap] = layout.captions;
+        expect(cap).toMatchObject({
+            group: 'foundations',
+            unlocked: 2,
+            total: 3,
+        });
+        expect(cap.x).toBe(BOARD_WIDTH / 2 - 75);
+        expect(cap.y).toBe(60 + 160 + 16 - 78 - 22);
+    });
+});

--- a/packages/learn-ui/src/model/layout.ts
+++ b/packages/learn-ui/src/model/layout.ts
@@ -1,0 +1,251 @@
+// Shared by the in-app Learn section and learn.lightdash.com via @lightdash/learn-ui.
+
+import { GROUP_ORDER, type BoardGroup } from './model';
+
+export const BOARD_WIDTH = 1120;
+export const NODE_SIZE = 38;
+
+const GUTTER_X = 24;
+const GUTTER_Y = 60;
+const CELL_HEIGHT = 320;
+const BOTTOM_PAD = 40;
+const CLUSTER_Y_OFFSET = 16;
+const MIN_RADIUS = 78;
+const ARC_PER_NODE = 54;
+const MIN_TRUNK_RADIUS = 42;
+const CAPTION_HALF_WIDTH = 75;
+const CAPTION_GAP = 22;
+const TRIM = 22;
+
+export type LayoutModule = { id: string; group: BoardGroup; unlocked: boolean };
+export type Seat = { x: number; y: number };
+export type NodeSeat = Seat & { id: string; unlocked: boolean; index: number };
+export type Connector = {
+    x1: number;
+    y1: number;
+    x2: number;
+    y2: number;
+    kind: 'ring' | 'trunk';
+};
+export type Caption = {
+    group: BoardGroup;
+    x: number;
+    y: number;
+    unlocked: number;
+    total: number;
+};
+export type BoardLayout = {
+    width: number;
+    height: number;
+    nodes: NodeSeat[];
+    connectors: Connector[];
+    captions: Caption[];
+};
+
+type Grid = {
+    rows: number;
+    cols: number;
+    cellWidth: number;
+    height: number;
+    live: BoardGroup[];
+};
+
+type Cluster = {
+    group: BoardGroup;
+    cx: number;
+    cy: number;
+    radius: number;
+    visible: LayoutModule[];
+};
+
+const groupModules = (
+    modules: LayoutModule[],
+): Map<BoardGroup, LayoutModule[]> => {
+    const byGroup = new Map<BoardGroup, LayoutModule[]>();
+    for (const m of modules) {
+        const list = byGroup.get(m.group) ?? [];
+        list.push(m);
+        byGroup.set(m.group, list);
+    }
+    return new Map(
+        [...byGroup.entries()].sort(
+            ([a], [b]) => GROUP_ORDER.indexOf(a) - GROUP_ORDER.indexOf(b),
+        ),
+    );
+};
+
+const gridFor = (byGroup: Map<BoardGroup, LayoutModule[]>): Grid => {
+    const live = [...byGroup.entries()]
+        .filter(([, list]) => list.some((m) => m.unlocked))
+        .map(([group]) => group);
+    const rows = live.length <= 3 ? 1 : 2;
+    const cols = Math.ceil(Math.max(1, live.length) / rows);
+    return {
+        rows,
+        cols,
+        cellWidth: (BOARD_WIDTH - GUTTER_X * 2) / cols,
+        height: GUTTER_Y + rows * CELL_HEIGHT + BOTTOM_PAD,
+        live,
+    };
+};
+
+const ringRadius = (visibleCount: number): number =>
+    visibleCount > 1
+        ? Math.max(MIN_RADIUS, (visibleCount * ARC_PER_NODE) / (2 * Math.PI))
+        : 0;
+
+const clusterFor = (
+    group: BoardGroup,
+    list: LayoutModule[],
+    grid: Grid,
+): Cluster => {
+    const slot = grid.live.indexOf(group);
+    const visible = list.filter((m) => m.unlocked);
+    if (slot < 0) {
+        return {
+            group,
+            cx: BOARD_WIDTH / 2,
+            cy: GUTTER_Y + (grid.rows * CELL_HEIGHT) / 2,
+            radius: 0,
+            visible,
+        };
+    }
+    const col = slot % grid.cols;
+    const row = Math.floor(slot / grid.cols);
+    return {
+        group,
+        cx: GUTTER_X + col * grid.cellWidth + grid.cellWidth / 2,
+        cy: GUTTER_Y + row * CELL_HEIGHT + CELL_HEIGHT / 2 + CLUSTER_Y_OFFSET,
+        radius: ringRadius(visible.length),
+        visible,
+    };
+};
+
+const seatIn = (cluster: Cluster, visibleIndex: number): Seat => {
+    if (visibleIndex < 0 || cluster.radius === 0)
+        return { x: cluster.cx, y: cluster.cy };
+    const angle =
+        ((-90 + (visibleIndex * 360) / cluster.visible.length) * Math.PI) / 180;
+    return {
+        x: cluster.cx + cluster.radius * Math.cos(angle),
+        y: cluster.cy + cluster.radius * Math.sin(angle),
+    };
+};
+
+const trim = (
+    x1: number,
+    y1: number,
+    x2: number,
+    y2: number,
+    kind: Connector['kind'],
+): Connector => {
+    const dx = x2 - x1;
+    const dy = y2 - y1;
+    const length = Math.hypot(dx, dy) || 1;
+    const ux = (dx / length) * TRIM;
+    const uy = (dy / length) * TRIM;
+    return { x1: x1 + ux, y1: y1 + uy, x2: x2 - ux, y2: y2 - uy, kind };
+};
+
+export const seatMap = (modules: LayoutModule[]): Map<string, Seat> => {
+    const seats = new Map<string, Seat>();
+    const byGroup = groupModules(modules);
+    const grid = gridFor(byGroup);
+    for (const [group, list] of byGroup) {
+        const cluster = clusterFor(group, list, grid);
+        for (const m of list) {
+            seats.set(m.id, seatIn(cluster, cluster.visible.indexOf(m)));
+        }
+    }
+    return seats;
+};
+
+export const buildLayout = (modules: LayoutModule[]): BoardLayout => {
+    const byGroup = groupModules(modules);
+    const grid = gridFor(byGroup);
+    const nodes: NodeSeat[] = [];
+    const connectors: Connector[] = [];
+    const captions: Caption[] = [];
+    const liveClusters: Cluster[] = [];
+
+    for (const [group, list] of byGroup) {
+        const cluster = clusterFor(group, list, grid);
+        const seats = list.map((m) => ({
+            m,
+            seat: seatIn(cluster, cluster.visible.indexOf(m)),
+        }));
+        for (const { m, seat } of seats) {
+            nodes.push({
+                id: m.id,
+                unlocked: m.unlocked,
+                index: nodes.length,
+                ...seat,
+            });
+        }
+        const ring = seats
+            .filter(({ m }) => m.unlocked)
+            .map(({ seat }) => seat);
+        if (ring.length === 2) {
+            connectors.push(
+                trim(ring[0].x, ring[0].y, ring[1].x, ring[1].y, 'ring'),
+            );
+        } else if (ring.length > 2) {
+            ring.forEach((seat, i) => {
+                const next = ring[(i + 1) % ring.length];
+                connectors.push(trim(seat.x, seat.y, next.x, next.y, 'ring'));
+            });
+        }
+        if (cluster.visible.length > 0) {
+            const edge = Math.max(cluster.radius, MIN_TRUNK_RADIUS);
+            captions.push({
+                group,
+                x: cluster.cx - CAPTION_HALF_WIDTH,
+                y: cluster.cy - edge - CAPTION_GAP,
+                unlocked: cluster.visible.length,
+                total: list.length,
+            });
+            liveClusters.push(cluster);
+        }
+    }
+
+    const trunk = (a: Cluster, b: Cluster) => {
+        const ra = Math.max(a.radius, MIN_TRUNK_RADIUS);
+        const rb = Math.max(b.radius, MIN_TRUNK_RADIUS);
+        const dx = b.cx - a.cx;
+        const dy = b.cy - a.cy;
+        const length = Math.hypot(dx, dy) || 1;
+        connectors.push(
+            trim(
+                a.cx + (dx / length) * ra,
+                a.cy + (dy / length) * ra,
+                b.cx - (dx / length) * rb,
+                b.cy - (dy / length) * rb,
+                'trunk',
+            ),
+        );
+    };
+    liveClusters.forEach((cluster, i) => {
+        const col = i % grid.cols;
+        const row = Math.floor(i / grid.cols);
+        const right = liveClusters[i + 1];
+        if (
+            col < grid.cols - 1 &&
+            right &&
+            Math.floor((i + 1) / grid.cols) === row
+        ) {
+            trunk(cluster, right);
+        }
+        const below = liveClusters[i + grid.cols];
+        if (row === 0 && (col === 0 || col === grid.cols - 1) && below) {
+            trunk(cluster, below);
+        }
+    });
+
+    return {
+        width: BOARD_WIDTH,
+        height: grid.height,
+        nodes,
+        connectors,
+        captions,
+    };
+};

--- a/packages/learn-ui/src/model/learnModel.test.ts
+++ b/packages/learn-ui/src/model/learnModel.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { createLearnModel } from './learnModel';
+import { commonScopeSource, entry } from './testFixtures';
+
+describe('createLearnModel', () => {
+    const model = createLearnModel(commonScopeSource);
+    it('binds board, ask and visibility to one registry', () => {
+        const dashboards = entry({ id: 'd', scope: 'manage:Dashboard' });
+        const viewer = model.roleScopes('viewer');
+        expect(model.isUnlocked(dashboards, viewer)).toBe(false);
+        expect(model.lockedLabel(dashboards)).toBe(
+            'interactive viewer and above',
+        );
+        expect(model.lessonVisible('manage:Dashboard', viewer)).toBe(false);
+        expect(model.lessonVisible('manage:NotAThing', viewer)).toBe(true);
+    });
+});

--- a/packages/learn-ui/src/model/learnModel.ts
+++ b/packages/learn-ui/src/model/learnModel.ts
@@ -1,0 +1,19 @@
+import { type ScopeSource } from '../scope/types';
+import { createAskModel, type AskModel } from './ask';
+import { createAskViewModel, type AskViewModel } from './askView';
+import { createBoardModel, type BoardModel } from './model';
+import { createVisibilityModel, type VisibilityModel } from './visibility';
+
+export type LearnModel = BoardModel & AskModel & AskViewModel & VisibilityModel;
+
+/** Everything that reads the scope registry, bound to one ScopeSource. */
+export const createLearnModel = (source: ScopeSource): LearnModel => {
+    const board = createBoardModel(source);
+    const ask = createAskModel(board);
+    return {
+        ...board,
+        ...ask,
+        ...createAskViewModel(board, ask),
+        ...createVisibilityModel(board),
+    };
+};

--- a/packages/learn-ui/src/model/learnModel.ts
+++ b/packages/learn-ui/src/model/learnModel.ts
@@ -13,7 +13,7 @@ export const createLearnModel = (source: ScopeSource): LearnModel => {
     return {
         ...board,
         ...ask,
-        ...createAskViewModel(board, ask),
+        ...createAskViewModel(ask),
         ...createVisibilityModel(board),
     };
 };

--- a/packages/learn-ui/src/model/model.test.ts
+++ b/packages/learn-ui/src/model/model.test.ts
@@ -1,0 +1,403 @@
+import { describe, expect, it } from 'vitest';
+import {
+    OrganizationMemberRole,
+    ProjectMemberRole,
+    ScopeGroup,
+} from '../scope/types';
+import {
+    createBoardModel,
+    ctaLabel,
+    defaultRoleFor,
+    holds,
+    lessonsDone,
+    moduleDone,
+    moduleProgress,
+    parseScopeTag,
+    plural,
+    SYSTEM_ROLES,
+} from './model';
+import { emptyRollup, type Rollup } from './rollup';
+import { commonScopeSource, entry } from './testFixtures';
+
+const model = createBoardModel(commonScopeSource);
+const getAllScopesForRole = commonScopeSource.getAllScopesForRole;
+
+const rollup = (overrides: Partial<Rollup>): Rollup => ({
+    ...emptyRollup(),
+    ...overrides,
+});
+
+describe('parseScopeTag / holds', () => {
+    it('splits the @global marker off the base', () => {
+        expect(parseScopeTag('manage:ScheduledDeliveries@global')).toEqual({
+            base: 'manage:ScheduledDeliveries',
+            global: true,
+        });
+        expect(parseScopeTag('view:Project')).toEqual({
+            base: 'view:Project',
+            global: false,
+        });
+    });
+
+    it('a bare tag is held by the scope under any modifier', () => {
+        expect(holds(['manage:Dashboard@space'], 'manage:Dashboard')).toBe(
+            true,
+        );
+        expect(holds(['manage:Dashboard'], 'manage:Dashboard')).toBe(true);
+        expect(holds(['view:Dashboard'], 'manage:Dashboard')).toBe(false);
+        expect(holds([], 'manage:Dashboard')).toBe(false);
+    });
+
+    it('a @global tag is held only by the unmodified scope', () => {
+        expect(
+            holds(
+                ['manage:ScheduledDeliveries@self'],
+                'manage:ScheduledDeliveries@global',
+            ),
+        ).toBe(false);
+        expect(
+            holds(
+                ['manage:ScheduledDeliveries'],
+                'manage:ScheduledDeliveries@global',
+            ),
+        ).toBe(true);
+    });
+});
+
+describe('groupOf', () => {
+    it('regroups view:Project as foundations', () => {
+        expect(model.groupOf(entry({ id: 'a', scope: 'view:Project' }))).toBe(
+            'foundations',
+        );
+    });
+
+    it('uses the scope registry group otherwise', () => {
+        expect(
+            model.groupOf(entry({ id: 'b', scope: 'manage:Dashboard' })),
+        ).toBe(ScopeGroup.CONTENT);
+        expect(
+            model.groupOf(entry({ id: 'c', scope: 'manage:Organization' })),
+        ).toBe(ScopeGroup.ORGANIZATION_MANAGEMENT);
+    });
+
+    it('falls back to foundations for null or unknown scopes', () => {
+        expect(model.groupOf(entry({ id: 'd', scope: null }))).toBe(
+            'foundations',
+        );
+        expect(
+            model.groupOf(entry({ id: 'e', scope: 'manage:NotAThing' })),
+        ).toBe('foundations');
+    });
+});
+
+describe('courseFor / isUnlocked / heldBy', () => {
+    const library = [
+        entry({ id: 'foundation', scope: 'view:Project' }),
+        entry({ id: 'dashboards', scope: 'manage:Dashboard' }),
+        entry({ id: 'org', scope: 'manage:Organization' }),
+        entry({ id: 'untagged', scope: null }),
+    ];
+
+    it('a viewer gets the foundations and untagged modules only', () => {
+        const ids = model
+            .courseFor(library, getAllScopesForRole(ProjectMemberRole.VIEWER))
+            .map((e) => e.id);
+        expect(ids).toEqual(['foundation', 'untagged']);
+    });
+
+    it('an admin gets everything', () => {
+        expect(
+            model.courseFor(
+                library,
+                getAllScopesForRole(ProjectMemberRole.ADMIN),
+            ),
+        ).toHaveLength(4);
+    });
+
+    it('untagged modules are unlocked for everyone', () => {
+        expect(model.isUnlocked(entry({ id: 'x', scope: null }), [])).toBe(
+            true,
+        );
+    });
+
+    it('an unknown scope is unlocked for everyone, not vanished', () => {
+        const stale = entry({ id: 'stale', scope: 'manage:Nonexistent' });
+        expect(
+            SYSTEM_ROLES.every((role) =>
+                model.isUnlocked(stale, getAllScopesForRole(role)),
+            ),
+        ).toBe(true);
+        expect(
+            model.courseFor(
+                [stale],
+                getAllScopesForRole(ProjectMemberRole.VIEWER),
+            ),
+        ).toHaveLength(1);
+        expect(model.heldBy(stale)).toEqual(SYSTEM_ROLES);
+    });
+
+    it('lists the system roles that hold the module', () => {
+        expect(
+            model.heldBy(entry({ id: 'org', scope: 'manage:Organization' })),
+        ).toEqual([ProjectMemberRole.ADMIN]);
+        expect(
+            model.heldBy(entry({ id: 'f', scope: 'view:Project' })),
+        ).toHaveLength(5);
+    });
+});
+
+describe('the @global marker against the real role scope sets', () => {
+    const BASE = 'manage:ScheduledDeliveries';
+    const globalTagged = entry({ id: 'deliveries', scope: `${BASE}@global` });
+    const bareTagged = entry({ id: 'deliveries-bare', scope: BASE });
+    const unmodified = SYSTEM_ROLES.filter((role) =>
+        getAllScopesForRole(role).includes(BASE),
+    );
+    const modifiedOnly = SYSTEM_ROLES.filter((role) => {
+        const held = getAllScopesForRole(role);
+        return (
+            !held.includes(BASE) && held.some((s) => s.startsWith(`${BASE}@`))
+        );
+    });
+
+    it('is held by exactly the roles whose real scope set has the unmodified scope', () => {
+        expect(unmodified.length).toBeGreaterThan(0);
+        expect(unmodified.length).toBeLessThan(SYSTEM_ROLES.length);
+        expect(model.heldBy(globalTagged)).toEqual(unmodified);
+        unmodified.forEach((role) =>
+            expect(
+                model.isUnlocked(globalTagged, getAllScopesForRole(role)),
+            ).toBe(true),
+        );
+    });
+
+    it('a role holding only a modified variant holds the bare tag but not @global', () => {
+        expect(modifiedOnly.length).toBeGreaterThan(0);
+        modifiedOnly.forEach((role) => {
+            const held = getAllScopesForRole(role);
+            expect(model.isUnlocked(globalTagged, held)).toBe(false);
+            expect(model.isUnlocked(bareTagged, held)).toBe(true);
+        });
+    });
+});
+
+describe('scopePermits / defaultRoleFor', () => {
+    it('returns the registry description for a known scope', () => {
+        expect(
+            model.scopePermits(entry({ id: 'a', scope: 'manage:Dashboard' })),
+        ).toMatch(/dashboard/i);
+        expect(model.scopePermits(entry({ id: 'b', scope: null }))).toBeNull();
+    });
+
+    it('maps org roles onto the board roles, member and unknown to viewer', () => {
+        expect(defaultRoleFor(OrganizationMemberRole.EDITOR)).toBe(
+            ProjectMemberRole.EDITOR,
+        );
+        expect(defaultRoleFor(OrganizationMemberRole.MEMBER)).toBe(
+            ProjectMemberRole.VIEWER,
+        );
+        expect(defaultRoleFor(undefined)).toBe(ProjectMemberRole.VIEWER);
+    });
+});
+
+describe('moduleProgress / lessonsDone', () => {
+    const m = entry({ id: 'm', lessonCount: 4 });
+
+    it('is 0 without a rollup and 1 when completed regardless of lessons', () => {
+        expect(moduleProgress(m, undefined)).toBe(0);
+        expect(moduleProgress(m, rollup({ completed: true }))).toBe(1);
+        expect(lessonsDone(m, rollup({ completed: true }))).toBe(4);
+    });
+
+    it('is the completed-lesson fraction otherwise, capped at the lesson count', () => {
+        expect(
+            moduleProgress(
+                m,
+                rollup({ lessonsCompleted: new Set(['a', 'b']) }),
+            ),
+        ).toBe(0.5);
+        expect(
+            lessonsDone(
+                m,
+                rollup({
+                    lessonsCompleted: new Set(['a', 'b', 'c', 'd', 'e']),
+                }),
+            ),
+        ).toBe(4);
+    });
+
+    it('treats a zero-lesson module as not started', () => {
+        expect(
+            moduleProgress(
+                entry({ id: 'z', lessonCount: 0 }),
+                rollup({ started: true }),
+            ),
+        ).toBe(0);
+    });
+
+    it('stops one step short of 1 when every lesson is read but the quiz is not passed', () => {
+        const reachedQuiz = rollup({
+            lessonsCompleted: new Set(['a', 'b', 'c', 'd']),
+        });
+        expect(moduleProgress(m, reachedQuiz)).toBeCloseTo(4 / 5, 10);
+        expect(moduleDone(reachedQuiz)).toBe(false);
+    });
+
+    it('only the completed flag reads as done', () => {
+        expect(moduleDone(undefined)).toBe(false);
+        expect(moduleDone(rollup({ completed: true }))).toBe(true);
+    });
+});
+
+describe('railModel', () => {
+    const library = [
+        entry({ id: 'f1', scope: 'view:Project', lessonCount: 2 }),
+        entry({ id: 'f2', scope: 'view:Project', lessonCount: 2 }),
+        entry({ id: 'c1', scope: 'manage:Dashboard', lessonCount: 4 }),
+        entry({ id: 'c2', scope: 'manage:Dashboard', lessonCount: 4 }),
+        entry({ id: 'o1', scope: 'manage:Organization', lessonCount: 1 }),
+    ];
+    const rollups = new Map<string, Rollup>([
+        ['f1', rollup({ completed: true })],
+        ['c1', rollup({ lessonsCompleted: new Set(['x']) })],
+        ['c2', rollup({ lessonsCompleted: new Set(['x', 'y', 'z']) })],
+        ['o1', rollup({ completed: true })],
+    ]);
+
+    it('filters to the held course and orders by group', () => {
+        const rail = model.railModel(
+            library,
+            getAllScopesForRole(ProjectMemberRole.EDITOR),
+            rollups,
+        );
+        expect(rail.mine.map((m) => m.entry.id)).toEqual([
+            'f1',
+            'f2',
+            'c1',
+            'c2',
+        ]);
+    });
+
+    it('rolls up lessons and completed modules over the held course only', () => {
+        const rail = model.railModel(
+            library,
+            getAllScopesForRole(ProjectMemberRole.EDITOR),
+            rollups,
+        );
+        expect(rail.overall).toEqual({
+            doneLessons: 2 + 1 + 3,
+            totalLessons: 12,
+            pct: 50,
+            modulesComplete: 1,
+        });
+    });
+
+    it('queues in-flight modules by progress desc, then not-started', () => {
+        const rail = model.railModel(
+            library,
+            getAllScopesForRole(ProjectMemberRole.EDITOR),
+            rollups,
+        );
+        expect(rail.queue.map((m) => m.entry.id)).toEqual(['c2', 'c1', 'f2']);
+        expect(rail.nextUpId).toBe('c2');
+    });
+
+    it('caps the queue at four, in-flight first', () => {
+        const many = Array.from({ length: 6 }, (_, i) =>
+            entry({ id: `n${i}`, scope: 'view:Project', lessonCount: 2 }),
+        );
+        const rail = model.railModel(
+            many,
+            getAllScopesForRole(ProjectMemberRole.VIEWER),
+            new Map([['n5', rollup({ lessonsCompleted: new Set(['a']) })]]),
+        );
+        expect(rail.queue.map((m) => m.entry.id)).toEqual([
+            'n5',
+            'n0',
+            'n1',
+            'n2',
+        ]);
+    });
+
+    it('keeps a module whose lessons are all read but quiz unpassed in the queue', () => {
+        const lib = [
+            entry({ id: 'q1', scope: 'view:Project', lessonCount: 2 }),
+        ];
+        const rail = model.railModel(
+            lib,
+            getAllScopesForRole(ProjectMemberRole.VIEWER),
+            new Map([
+                ['q1', rollup({ lessonsCompleted: new Set(['a', 'b']) })],
+            ]),
+        );
+        expect(rail.mine[0].progress).toBeLessThan(1);
+        expect(rail.mine[0].done).toBe(false);
+        expect(rail.queue.map((m) => m.entry.id)).toEqual(['q1']);
+        expect(rail.completed).toEqual([]);
+        expect(rail.overall.modulesComplete).toBe(0);
+    });
+
+    it('marks a module done only on the completed flag', () => {
+        const lib = [
+            entry({ id: 'q1', scope: 'view:Project', lessonCount: 2 }),
+        ];
+        const rail = model.railModel(
+            lib,
+            getAllScopesForRole(ProjectMemberRole.VIEWER),
+            new Map([['q1', rollup({ completed: true })]]),
+        );
+        expect(rail.mine[0]).toMatchObject({ progress: 1, done: true });
+        expect(rail.completed.map((m) => m.entry.id)).toEqual(['q1']);
+        expect(rail.queue).toEqual([]);
+    });
+
+    it('keeps completed modules in the rail even when the role no longer holds them', () => {
+        const rail = model.railModel(
+            library,
+            getAllScopesForRole(ProjectMemberRole.EDITOR),
+            rollups,
+        );
+        expect(rail.completed.map((m) => m.entry.id)).toEqual(['f1', 'o1']);
+        const viewer = model.railModel(
+            library,
+            getAllScopesForRole(ProjectMemberRole.VIEWER),
+            rollups,
+        );
+        expect(viewer.mine.map((m) => m.entry.id)).toEqual(['f1', 'f2']);
+        expect(viewer.completed.map((m) => m.entry.id)).toEqual(['f1', 'o1']);
+        expect(viewer.overall.modulesComplete).toBe(1);
+    });
+
+    it('next up falls back to the first not-started, then to null', () => {
+        const fresh = model.railModel(
+            library,
+            getAllScopesForRole(ProjectMemberRole.VIEWER),
+            new Map(),
+        );
+        expect(fresh.nextUpId).toBe('f1');
+        const finished = model.railModel(
+            library,
+            getAllScopesForRole(ProjectMemberRole.VIEWER),
+            new Map([
+                ['f1', rollup({ completed: true })],
+                ['f2', rollup({ completed: true })],
+            ]),
+        );
+        expect(finished.nextUpId).toBeNull();
+        expect(model.railModel([], [], new Map()).nextUpId).toBeNull();
+    });
+});
+
+describe('labels', () => {
+    it('picks the CTA by done then progress', () => {
+        expect(ctaLabel(false, 0)).toBe('Start module');
+        expect(ctaLabel(false, 0.5)).toBe('Continue module');
+        expect(ctaLabel(false, 0.8)).toBe('Continue module');
+        expect(ctaLabel(true, 1)).toBe('Review module');
+    });
+
+    it('pluralises', () => {
+        expect(plural(1, 'lesson')).toBe('1 lesson');
+        expect(plural(3, 'module')).toBe('3 modules');
+    });
+});

--- a/packages/learn-ui/src/model/model.ts
+++ b/packages/learn-ui/src/model/model.ts
@@ -1,0 +1,291 @@
+// Shared by the in-app Learn section and learn.lightdash.com via @lightdash/learn-ui.
+
+import {
+    OrganizationMemberRole,
+    ProjectMemberRole,
+    ScopeGroup,
+    type Scope,
+    type ScopeSource,
+} from '../scope/types';
+import { type LearnCatalogueEntry } from '../types';
+import type { Rollup } from './rollup';
+
+export type BoardGroup = 'foundations' | ScopeGroup;
+
+export const GROUP_ORDER: BoardGroup[] = [
+    'foundations',
+    ScopeGroup.CONTENT,
+    ScopeGroup.SHARING,
+    ScopeGroup.DATA,
+    ScopeGroup.AI,
+    ScopeGroup.PROJECT_MANAGEMENT,
+    ScopeGroup.ORGANIZATION_MANAGEMENT,
+    ScopeGroup.SPOTLIGHT,
+];
+
+export const GROUP_LABEL: Record<BoardGroup, string> = {
+    foundations: 'Foundations',
+    [ScopeGroup.CONTENT]: 'Content',
+    [ScopeGroup.SHARING]: 'Sharing',
+    [ScopeGroup.DATA]: 'Data',
+    [ScopeGroup.AI]: 'AI',
+    [ScopeGroup.PROJECT_MANAGEMENT]: 'Project management',
+    [ScopeGroup.ORGANIZATION_MANAGEMENT]: 'Organization',
+    [ScopeGroup.SPOTLIGHT]: 'Spotlight',
+};
+
+export const SYSTEM_ROLES: ProjectMemberRole[] = [
+    ProjectMemberRole.VIEWER,
+    ProjectMemberRole.INTERACTIVE_VIEWER,
+    ProjectMemberRole.EDITOR,
+    ProjectMemberRole.DEVELOPER,
+    ProjectMemberRole.ADMIN,
+];
+
+export const ROLE_LABEL: Record<ProjectMemberRole, string> = {
+    [ProjectMemberRole.VIEWER]: 'viewer',
+    [ProjectMemberRole.INTERACTIVE_VIEWER]: 'interactive viewer',
+    [ProjectMemberRole.EDITOR]: 'editor',
+    [ProjectMemberRole.DEVELOPER]: 'developer',
+    [ProjectMemberRole.ADMIN]: 'admin',
+};
+
+const GLOBAL_SUFFIX = '@global';
+const FOUNDATION_SCOPE = 'view:Project';
+
+export const parseScopeTag = (
+    tag: string,
+): { base: string; global: boolean } => {
+    const global = tag.endsWith(GLOBAL_SUFFIX);
+    return {
+        base: global ? tag.slice(0, -GLOBAL_SUFFIX.length) : tag,
+        global,
+    };
+};
+
+const baseOf = (scopeName: string): string => scopeName.split('@')[0];
+
+export const holds = (held: Iterable<string>, tag: string): boolean => {
+    const { base, global } = parseScopeTag(tag);
+    for (const name of held) {
+        if (baseOf(name) !== base) continue;
+        if (!global || !name.includes('@')) return true;
+    }
+    return false;
+};
+
+const ORG_TO_BOARD_ROLE: Record<OrganizationMemberRole, ProjectMemberRole> = {
+    [OrganizationMemberRole.MEMBER]: ProjectMemberRole.VIEWER,
+    [OrganizationMemberRole.VIEWER]: ProjectMemberRole.VIEWER,
+    [OrganizationMemberRole.INTERACTIVE_VIEWER]:
+        ProjectMemberRole.INTERACTIVE_VIEWER,
+    [OrganizationMemberRole.EDITOR]: ProjectMemberRole.EDITOR,
+    [OrganizationMemberRole.DEVELOPER]: ProjectMemberRole.DEVELOPER,
+    [OrganizationMemberRole.ADMIN]: ProjectMemberRole.ADMIN,
+};
+
+export const defaultRoleFor = (
+    orgRole: OrganizationMemberRole | undefined,
+): ProjectMemberRole =>
+    orgRole === undefined
+        ? ProjectMemberRole.VIEWER
+        : ORG_TO_BOARD_ROLE[orgRole];
+
+export const lessonsDone = (
+    entry: LearnCatalogueEntry,
+    rollup: Rollup | undefined,
+): number => {
+    if (!rollup) return 0;
+    if (rollup.completed) return entry.lessonCount;
+    return Math.min(rollup.lessonsCompleted.size, entry.lessonCount);
+};
+
+export const moduleDone = (rollup: Rollup | undefined): boolean =>
+    rollup?.completed === true;
+
+export const moduleProgress = (
+    entry: LearnCatalogueEntry,
+    rollup: Rollup | undefined,
+): number => {
+    if (!rollup) return 0;
+    if (rollup.completed) return 1;
+    if (entry.lessonCount <= 0) return 0;
+    // The quiz is the last step, so reading every lesson stops one step short
+    // of 1; only a passed quiz (`completed`) reaches full.
+    return Math.min(
+        lessonsDone(entry, rollup) / entry.lessonCount,
+        entry.lessonCount / (entry.lessonCount + 1),
+    );
+};
+
+export type BoardModule = {
+    entry: LearnCatalogueEntry;
+    group: BoardGroup;
+    progress: number;
+    lessonsDone: number;
+    done: boolean;
+};
+
+export type RailModel = {
+    mine: BoardModule[];
+    nextUpId: string | null;
+    overall: {
+        pct: number;
+        doneLessons: number;
+        totalLessons: number;
+        modulesComplete: number;
+    };
+    queue: BoardModule[];
+    completed: BoardModule[];
+};
+
+const QUEUE_LIMIT = 4;
+const COMPLETED_LIMIT = 3;
+
+export const ctaLabel = (
+    done: boolean,
+    progress: number,
+): 'Start module' | 'Continue module' | 'Review module' => {
+    if (done) return 'Review module';
+    if (progress > 0) return 'Continue module';
+    return 'Start module';
+};
+
+export const plural = (n: number, word: string): string =>
+    `${n} ${word}${n === 1 ? '' : 's'}`;
+
+export type BoardModel = {
+    scopeKnown: (base: string) => boolean;
+    roleScopes: (role: ProjectMemberRole) => string[];
+    isUnlocked: (entry: LearnCatalogueEntry, held: Iterable<string>) => boolean;
+    groupOf: (entry: LearnCatalogueEntry) => BoardGroup;
+    courseFor: (
+        entries: LearnCatalogueEntry[],
+        held: Iterable<string>,
+    ) => LearnCatalogueEntry[];
+    heldBy: (entry: LearnCatalogueEntry) => ProjectMemberRole[];
+    scopePermits: (entry: LearnCatalogueEntry) => string | null;
+    railModel: (
+        entries: LearnCatalogueEntry[],
+        held: Iterable<string>,
+        rollups: Map<string, Rollup>,
+    ) => RailModel;
+};
+
+export const createBoardModel = (source: ScopeSource): BoardModel => {
+    const scopeMap = source.getAllScopeMap({ isEnterprise: true }) as Record<
+        string,
+        Scope | undefined
+    >;
+    const roleScopeCache = new Map<ProjectMemberRole, string[]>();
+
+    const scopeKnown = (base: string): boolean => scopeMap[base] !== undefined;
+
+    const roleScopes = (role: ProjectMemberRole): string[] => {
+        const cached = roleScopeCache.get(role);
+        if (cached) return cached;
+        const scopes = source.getAllScopesForRole(role);
+        roleScopeCache.set(role, scopes);
+        return scopes;
+    };
+
+    const isUnlocked = (
+        entry: LearnCatalogueEntry,
+        held: Iterable<string>,
+    ): boolean => {
+        if (entry.scope === null) return true;
+        const { base } = parseScopeTag(entry.scope);
+        if (scopeMap[base] === undefined) return true;
+        return holds(held, entry.scope);
+    };
+
+    const groupOf = (entry: LearnCatalogueEntry): BoardGroup => {
+        if (entry.scope === null) return 'foundations';
+        const { base } = parseScopeTag(entry.scope);
+        if (base === FOUNDATION_SCOPE) return 'foundations';
+        return scopeMap[base]?.group ?? 'foundations';
+    };
+
+    const courseFor = (
+        entries: LearnCatalogueEntry[],
+        held: Iterable<string>,
+    ): LearnCatalogueEntry[] => {
+        const heldList = Array.from(held);
+        return entries.filter((entry) => isUnlocked(entry, heldList));
+    };
+
+    const heldBy = (entry: LearnCatalogueEntry): ProjectMemberRole[] =>
+        SYSTEM_ROLES.filter((role) => isUnlocked(entry, roleScopes(role)));
+
+    const scopePermits = (entry: LearnCatalogueEntry): string | null => {
+        if (entry.scope === null) return null;
+        return scopeMap[parseScopeTag(entry.scope).base]?.description ?? null;
+    };
+
+    const railModel = (
+        entries: LearnCatalogueEntry[],
+        held: Iterable<string>,
+        rollups: Map<string, Rollup>,
+    ): RailModel => {
+        // Every module is scored; the held course filters the board, queue and
+        // totals, but completion is never revoked by a role change.
+        const everything: BoardModule[] = entries
+            .map((entry) => {
+                const rollup = rollups.get(entry.id);
+                return {
+                    entry,
+                    group: groupOf(entry),
+                    progress: moduleProgress(entry, rollup),
+                    lessonsDone: lessonsDone(entry, rollup),
+                    done: moduleDone(rollup),
+                };
+            })
+            .sort(
+                (a, b) =>
+                    GROUP_ORDER.indexOf(a.group) - GROUP_ORDER.indexOf(b.group),
+            );
+        const heldIds = new Set(
+            courseFor(entries, held).map((entry) => entry.id),
+        );
+        const mine = everything.filter((m) => heldIds.has(m.entry.id));
+
+        const inFlight = mine
+            .filter((m) => !m.done && m.progress > 0)
+            .sort((a, b) => b.progress - a.progress);
+        const notStarted = mine.filter((m) => !m.done && m.progress === 0);
+        const completed = everything.filter((m) => m.done);
+        const nextUp = inFlight[0] ?? notStarted[0] ?? null;
+
+        const doneLessons = mine.reduce((sum, m) => sum + m.lessonsDone, 0);
+        const totalLessons = mine.reduce(
+            (sum, m) => sum + m.entry.lessonCount,
+            0,
+        );
+
+        return {
+            mine,
+            nextUpId: nextUp ? nextUp.entry.id : null,
+            overall: {
+                pct: totalLessons
+                    ? Math.round((doneLessons / totalLessons) * 100)
+                    : 0,
+                doneLessons,
+                totalLessons,
+                modulesComplete: mine.filter((m) => m.done).length,
+            },
+            queue: [...inFlight, ...notStarted].slice(0, QUEUE_LIMIT),
+            completed: completed.slice(0, COMPLETED_LIMIT),
+        };
+    };
+
+    return {
+        scopeKnown,
+        roleScopes,
+        isUnlocked,
+        groupOf,
+        courseFor,
+        heldBy,
+        scopePermits,
+        railModel,
+    };
+};

--- a/packages/learn-ui/src/model/motion.test.ts
+++ b/packages/learn-ui/src/model/motion.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import { resolveMotion, staggerMs, type MotionInput } from './motion';
+
+const base: MotionInput = {
+    unlocked: true,
+    wasUnlocked: true,
+    seat: { x: 100, y: 100 },
+    prevSeat: { x: 80, y: 80 },
+    origin: { x: 10, y: 10 },
+    burst: false,
+    reducedMotion: false,
+};
+
+describe('resolveMotion', () => {
+    it('a settled unlocked node sits at its seat, fully visible, animated', () => {
+        expect(resolveMotion(base)).toEqual({
+            x: 100,
+            y: 100,
+            opacity: 1,
+            scale: 1,
+            animate: true,
+        });
+    });
+
+    it('a settled locked node is parked invisible and small', () => {
+        expect(
+            resolveMotion({ ...base, unlocked: false, wasUnlocked: false }),
+        ).toEqual({
+            x: 100,
+            y: 100,
+            opacity: 0,
+            scale: 0.3,
+            animate: true,
+        });
+    });
+
+    it('a newly unlocked node starts on the origin for the burst frame, then flies to its seat', () => {
+        const born = { ...base, wasUnlocked: false };
+        expect(resolveMotion({ ...born, burst: true })).toEqual({
+            x: 10,
+            y: 10,
+            opacity: 0.5,
+            scale: 0.25,
+            animate: false,
+        });
+        expect(resolveMotion(born)).toEqual({
+            x: 100,
+            y: 100,
+            opacity: 1,
+            scale: 1,
+            animate: true,
+        });
+    });
+
+    it('a newly locked node holds its previous seat for the burst frame, then collapses into the origin', () => {
+        const dying = { ...base, unlocked: false };
+        expect(resolveMotion({ ...dying, burst: true })).toEqual({
+            x: 80,
+            y: 80,
+            opacity: 1,
+            scale: 1,
+            animate: false,
+        });
+        expect(resolveMotion(dying)).toEqual({
+            x: 10,
+            y: 10,
+            opacity: 0,
+            scale: 0.2,
+            animate: true,
+        });
+    });
+
+    it('without an origin or under reduced motion nodes snap to their final state', () => {
+        expect(
+            resolveMotion({
+                ...base,
+                wasUnlocked: false,
+                burst: true,
+                origin: null,
+            }),
+        ).toEqual({
+            x: 100,
+            y: 100,
+            opacity: 1,
+            scale: 1,
+            animate: true,
+        });
+        expect(
+            resolveMotion({ ...base, unlocked: false, reducedMotion: true }),
+        ).toEqual({
+            x: 100,
+            y: 100,
+            opacity: 0,
+            scale: 0.3,
+            animate: false,
+        });
+    });
+});
+
+describe('staggerMs', () => {
+    it('cycles every ten nodes in 28ms steps', () => {
+        expect(staggerMs(0)).toBe(0);
+        expect(staggerMs(3)).toBe(84);
+        expect(staggerMs(10)).toBe(0);
+    });
+});

--- a/packages/learn-ui/src/model/motion.ts
+++ b/packages/learn-ui/src/model/motion.ts
@@ -1,0 +1,96 @@
+// Shared by the in-app Learn section and learn.lightdash.com via @lightdash/learn-ui.
+
+import type { Seat } from './layout';
+
+export const NODE_TRANSITION =
+    'opacity .3s ease-out, transform .34s ease-out, left .44s cubic-bezier(.2,.7,.3,1), top .44s cubic-bezier(.2,.7,.3,1)';
+
+const STAGGER_STEP_MS = 28;
+const STAGGER_CYCLE = 10;
+
+export const staggerMs = (index: number): number =>
+    (index % STAGGER_CYCLE) * STAGGER_STEP_MS;
+
+export type MotionInput = {
+    unlocked: boolean;
+    wasUnlocked: boolean;
+    seat: Seat;
+    prevSeat: Seat | null;
+    origin: Seat | null;
+    burst: boolean;
+    reducedMotion: boolean;
+};
+
+export type NodeMotion = {
+    x: number;
+    y: number;
+    opacity: number;
+    scale: number;
+    animate: boolean;
+};
+
+const LOCKED_SCALE = 0.3;
+const BORN_SCALE = 0.25;
+const DYING_SCALE = 0.2;
+
+export const resolveMotion = (input: MotionInput): NodeMotion => {
+    const {
+        unlocked,
+        wasUnlocked,
+        seat,
+        prevSeat,
+        origin,
+        burst,
+        reducedMotion,
+    } = input;
+    const settled: NodeMotion = unlocked
+        ? {
+              x: seat.x,
+              y: seat.y,
+              opacity: 1,
+              scale: 1,
+              animate: !reducedMotion,
+          }
+        : {
+              x: seat.x,
+              y: seat.y,
+              opacity: 0,
+              scale: LOCKED_SCALE,
+              animate: !reducedMotion,
+          };
+
+    if (reducedMotion || origin === null) return settled;
+
+    const born = unlocked && !wasUnlocked;
+    const dying = !unlocked && wasUnlocked;
+
+    if (born && burst) {
+        return {
+            x: origin.x,
+            y: origin.y,
+            opacity: 0.5,
+            scale: BORN_SCALE,
+            animate: false,
+        };
+    }
+    if (dying) {
+        if (burst) {
+            const from = prevSeat ?? origin;
+            return {
+                x: from.x,
+                y: from.y,
+                opacity: 1,
+                scale: 1,
+                animate: false,
+            };
+        }
+        return {
+            x: origin.x,
+            y: origin.y,
+            opacity: 0,
+            scale: DYING_SCALE,
+            animate: true,
+        };
+    }
+    return settled;
+};

--- a/packages/learn-ui/src/model/testFixtures.ts
+++ b/packages/learn-ui/src/model/testFixtures.ts
@@ -1,0 +1,33 @@
+import {
+    getAllScopeMap,
+    getAllScopesForRole,
+    type ProjectMemberRole as CommonProjectMemberRole,
+} from '@lightdash/common';
+import { type Scope, type ScopeSource } from '../scope/types';
+import { type LearnCatalogueEntry } from '../types';
+
+export const entry = (
+    overrides: Partial<LearnCatalogueEntry> & { id: string },
+): LearnCatalogueEntry => ({
+    title: overrides.id,
+    description: '',
+    version: 1,
+    contentHash: 'abc123',
+    path: `courses/${overrides.id}/abc123/course.json`,
+    lessonCount: 3,
+    durationMinutes: null,
+    tags: [],
+    track: null,
+    scope: null,
+    requires: [],
+    publishedAt: '2026-08-01T00:00:00.000Z',
+    ...overrides,
+});
+
+/** Test-only: the real registry, so the model tests keep their meaning. */
+export const commonScopeSource: ScopeSource = {
+    getAllScopeMap: (opts) =>
+        getAllScopeMap(opts) as unknown as Record<string, Scope>,
+    getAllScopesForRole: (role) =>
+        getAllScopesForRole(role as CommonProjectMemberRole),
+};

--- a/packages/learn-ui/src/model/tokens.ts
+++ b/packages/learn-ui/src/model/tokens.ts
@@ -1,0 +1,11 @@
+// Brand accent: hosts set --learn-accent (in-app: the Mantine ldBrandViolet-6
+// token); the fallback is Lightdash violet so the standalone academy needs no setup.
+export const LEARN_ACCENT = 'var(--learn-accent, #7262FF)';
+
+// No rgb-triplet custom property exists for the accent; the alpha ramp stays literal.
+const BRAND_VIOLET_RGB = '94, 76, 255';
+
+export const progressFill = (progress: number): string =>
+    progress >= 1
+        ? LEARN_ACCENT
+        : `rgba(${BRAND_VIOLET_RGB}, ${(0.07 + 0.55 * progress).toFixed(2)})`;

--- a/packages/learn-ui/src/model/visibility.test.ts
+++ b/packages/learn-ui/src/model/visibility.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from 'vitest';
+import { createBoardModel } from './model';
+import { commonScopeSource } from './testFixtures';
+import { createVisibilityModel } from './visibility';
+
+// Real registry scopes: the DashboardComments trio is the CS-169 reference
+// scope group (view held from interactive viewer, create from editor,
+// manage from developer).
+const VIEW = 'view:DashboardComments';
+const CREATE = 'create:DashboardComments';
+const MANAGE = 'manage:DashboardComments';
+
+const board = createBoardModel(commonScopeSource);
+const visibility = createVisibilityModel(board);
+const {
+    effectiveEntry,
+    effectiveRollup,
+    filterCourseForScopes,
+    lessonVisible,
+    visibleLessonCount,
+} = visibility;
+
+describe('lessonVisible', () => {
+    it('an untagged lesson (null or undefined) is always visible', () => {
+        expect(lessonVisible(null, [])).toBe(true);
+        expect(lessonVisible(undefined, [])).toBe(true);
+    });
+
+    it('a scope whose base the registry does not know is always visible (forward compat)', () => {
+        expect(board.scopeKnown('view:FluxCapacitor')).toBe(false);
+        expect(lessonVisible('view:FluxCapacitor', [])).toBe(true);
+    });
+
+    it('a known scope is visible only when held', () => {
+        expect(lessonVisible(VIEW, [VIEW])).toBe(true);
+        expect(lessonVisible(MANAGE, [VIEW])).toBe(false);
+    });
+
+    it('a bare tag is held under any modifier; @global only unmodified', () => {
+        expect(lessonVisible(MANAGE, [`${MANAGE}@space`])).toBe(true);
+        expect(lessonVisible(`${VIEW}@global`, [`${VIEW}@space`])).toBe(false);
+        expect(lessonVisible(`${VIEW}@global`, [VIEW])).toBe(true);
+    });
+});
+
+describe('visibleLessonCount', () => {
+    const entry = { lessonCount: 3, lessonScopes: [VIEW, null, MANAGE] };
+
+    it('counts lessons visible to the held scopes, nulls always counted', () => {
+        expect(visibleLessonCount(entry, [VIEW])).toBe(2);
+        expect(visibleLessonCount(entry, [VIEW, CREATE, MANAGE])).toBe(3);
+        expect(visibleLessonCount(entry, [])).toBe(1);
+    });
+
+    it('falls back to lessonCount when the catalogue has no lessonScopes', () => {
+        expect(visibleLessonCount({ lessonCount: 5 }, [])).toBe(5);
+    });
+});
+
+describe('effectiveEntry', () => {
+    it('replaces lessonCount with the visible count, leaving the original untouched', () => {
+        const entry = {
+            id: 'dashboard-comments',
+            lessonCount: 3,
+            lessonScopes: [VIEW, CREATE, MANAGE],
+        };
+        const eff = effectiveEntry(entry, [VIEW]);
+        expect(eff.lessonCount).toBe(1);
+        expect(eff.id).toBe('dashboard-comments');
+        expect(entry.lessonCount).toBe(3);
+    });
+
+    it('is the identity for an entry without lessonScopes (pre-CS-169 catalogue)', () => {
+        const entry = { id: 'legacy', lessonCount: 4 };
+        expect(effectiveEntry(entry, [])).toBe(entry);
+    });
+});
+
+describe('filterCourseForScopes', () => {
+    const course = {
+        title: 'Dashboard comments',
+        lessons: [
+            { id: '01-read', title: 'Read', html: '', scope: VIEW },
+            { id: '02-post', title: 'Post', html: '', scope: CREATE },
+            { id: '03-tidy', title: 'Tidy', html: '', scope: MANAGE },
+        ],
+        quiz: {
+            questions: [
+                {
+                    id: 'q1',
+                    prompt: 'a',
+                    choices: ['x', 'y'],
+                    answer: 0,
+                    lesson: '01-read',
+                },
+                {
+                    id: 'q2',
+                    prompt: 'b',
+                    choices: ['x', 'y'],
+                    answer: 1,
+                    lesson: '02-post',
+                },
+                {
+                    id: 'q3',
+                    prompt: 'c',
+                    choices: ['x', 'y'],
+                    answer: 0,
+                    lesson: '03-tidy',
+                },
+                { id: 'q4', prompt: 'd', choices: ['x', 'y'], answer: 1 },
+            ],
+        },
+    };
+
+    it('drops hidden lessons and their quiz questions, keeping questions without a lesson key', () => {
+        const filtered = filterCourseForScopes(course, [VIEW, CREATE]);
+        expect(filtered.lessons.map((l) => l.id)).toEqual([
+            '01-read',
+            '02-post',
+        ]);
+        expect(filtered.quiz.questions.map((q) => q.id)).toEqual([
+            'q1',
+            'q2',
+            'q4',
+        ]);
+    });
+
+    it('keeps untagged and unknown-scope lessons visible', () => {
+        const mixed = {
+            lessons: [
+                { id: 'a', scope: null },
+                { id: 'b' },
+                { id: 'c', scope: 'view:FluxCapacitor' },
+                { id: 'd', scope: MANAGE },
+            ],
+            quiz: { questions: [] },
+        };
+        expect(
+            filterCourseForScopes(mixed, []).lessons.map((l) => l.id),
+        ).toEqual(['a', 'b', 'c']);
+    });
+
+    it('returns the same course object when nothing is hidden (pre-CS-169 course.json)', () => {
+        const legacy = {
+            lessons: [
+                { id: 'l1', title: 'One', html: '' },
+                { id: 'l2', title: 'Two', html: '' },
+            ],
+            quiz: {
+                questions: [
+                    { id: 'q1', prompt: 'a', choices: ['x'], answer: 0 },
+                ],
+            },
+        };
+        expect(filterCourseForScopes(legacy, [])).toBe(legacy);
+        expect(filterCourseForScopes(course, [VIEW, CREATE, MANAGE])).toBe(
+            course,
+        );
+    });
+
+    it('does not mutate the original course', () => {
+        const filtered = filterCourseForScopes(course, [VIEW]);
+        expect(filtered).not.toBe(course);
+        expect(course.lessons).toHaveLength(3);
+        expect(course.quiz.questions).toHaveLength(4);
+        expect(filtered.lessons).toHaveLength(1);
+        expect(filtered.quiz.questions.map((q) => q.id)).toEqual(['q1', 'q4']);
+    });
+});
+
+describe('effectiveRollup', () => {
+    const entry = { lessonCount: 3, lessonScopes: [VIEW, CREATE, MANAGE] };
+    const completedTwo = {
+        completed: true,
+        passed: true,
+        lessonsCompleted: new Set(['l1', 'l2']),
+    };
+
+    it('re-opens a completed module when a role change unlocks a lesson', () => {
+        // Completed with 2 visible lessons as interactive viewer, then
+        // switched to editor: 3 visible, only 2 done — the module must stop
+        // reading as done.
+        const derived = effectiveRollup(entry, completedTwo, [
+            VIEW,
+            CREATE,
+            MANAGE,
+        ]);
+        expect(derived).toEqual({
+            completed: false,
+            passed: false,
+            lessonsCompleted: completedTwo.lessonsCompleted,
+        });
+    });
+
+    it('keeps done on a downgrade — everything the role can see is finished', () => {
+        // Completed all 3 as editor, then switched to viewer: 1 visible, 3 done.
+        const all = {
+            completed: true,
+            passed: true,
+            lessonsCompleted: new Set(['l1', 'l2', 'l3']),
+        };
+        expect(effectiveRollup(entry, all, [VIEW])).toBe(all);
+    });
+
+    it('is the identity for a module the role does not hold at all', () => {
+        const locked = { lessonCount: 2, lessonScopes: [MANAGE, MANAGE] };
+        expect(effectiveRollup(locked, completedTwo, [VIEW])).toBe(
+            completedTwo,
+        );
+    });
+
+    it('is the identity when the rollup is not completed, and for undefined', () => {
+        const open = {
+            completed: false,
+            passed: false,
+            lessonsCompleted: new Set<string>(),
+        };
+        expect(effectiveRollup(entry, open, [VIEW, CREATE, MANAGE])).toBe(open);
+        expect(effectiveRollup(entry, undefined, [VIEW])).toBeUndefined();
+    });
+});

--- a/packages/learn-ui/src/model/visibility.ts
+++ b/packages/learn-ui/src/model/visibility.ts
@@ -1,0 +1,159 @@
+/**
+ * CS-169 per-lesson scope visibility. Shared by the in-app Learn section and
+ * learn.lightdash.com via @lightdash/learn-ui. The panel maps catalogue
+ * entries through `effectiveEntry` BEFORE handing them to railModel /
+ * moduleProgress / lessonCount renders, so all board math sees visible
+ * counts without the twin model changing.
+ *
+ * Visibility rule mirrors `model.ts` `isUnlocked`: a null/untagged
+ * lesson is always visible, and a scope whose base the scope registry does
+ * not know is always visible (forward compat — an unknown scope never hides
+ * content).
+ */
+import { holds, parseScopeTag, type BoardModel } from './model';
+
+export type VisibilityModel = {
+    lessonVisible: (
+        scope: string | null | undefined,
+        held: string[],
+    ) => boolean;
+    visibleLessonCount: (entry: CountableEntry, held: string[]) => number;
+    effectiveEntry: <T extends CountableEntry>(entry: T, held: string[]) => T;
+    filterCourseForScopes: <T extends FilterableCourse>(
+        course: T,
+        held: string[],
+    ) => T;
+    effectiveRollup: <
+        R extends {
+            completed: boolean;
+            passed: boolean;
+            lessonsCompleted: Set<string>;
+        },
+    >(
+        entry: CountableEntry,
+        rollup: R | undefined,
+        held: string[],
+    ) => R | undefined;
+};
+
+export type CountableEntry = {
+    lessonCount: number;
+    lessonScopes?: (string | null)[];
+};
+
+export type FilterableCourse = {
+    lessons: { id: string; scope?: string | null }[];
+    quiz: { questions: { id: string; lesson?: string }[] };
+};
+
+export const createVisibilityModel = (board: BoardModel): VisibilityModel => {
+    /**
+     * Whether a lesson with this scope tag is visible to a learner holding
+     * `held`. null/undefined (untagged, or published before the field existed)
+     * and unknown-base tags are always visible, matching isUnlocked's
+     * forward-compat rule; otherwise the same holds() predicate the board uses
+     * for modules.
+     */
+    const lessonVisible = (
+        scope: string | null | undefined,
+        held: string[],
+    ): boolean => {
+        if (scope === null || scope === undefined) return true;
+        const { base } = parseScopeTag(scope);
+        if (!board.scopeKnown(base)) return true;
+        return holds(held, scope);
+    };
+
+    /**
+     * How many of the entry's lessons are visible to `held`. Derived from
+     * `lessonScopes` when the catalogue carries it (one tag per lesson, in
+     * lesson order); a pre-CS-169 catalogue has no per-lesson data, so the full
+     * lessonCount stands.
+     */
+    const visibleLessonCount = (
+        entry: CountableEntry,
+        held: string[],
+    ): number => {
+        if (!entry.lessonScopes) return entry.lessonCount;
+        return entry.lessonScopes.filter((scope) => lessonVisible(scope, held))
+            .length;
+    };
+
+    /**
+     * The entry with `lessonCount` replaced by the visible-lesson count. The
+     * panel maps entries through this before every model call and every
+     * lessonCount render, which is what keeps the board model byte-identical
+     * while its denominators become visible counts.
+     */
+    const effectiveEntry = <T extends CountableEntry>(
+        entry: T,
+        held: string[],
+    ): T => {
+        if (!entry.lessonScopes) return entry;
+        return { ...entry, lessonCount: visibleLessonCount(entry, held) };
+    };
+
+    /**
+     * The course with hidden lessons removed and the quiz filtered to questions
+     * whose `lesson` stem names a visible lesson (questions without a lesson key
+     * are kept — legacy quizzes predate the key, which reaches us through the
+     * schema's passthrough). Must run on the course object BEFORE the player
+     * builds its index-parallel answers array.
+     */
+    const filterCourseForScopes = <T extends FilterableCourse>(
+        course: T,
+        held: string[],
+    ): T => {
+        const lessons = course.lessons.filter((lesson) =>
+            lessonVisible(lesson.scope, held),
+        );
+        if (lessons.length === course.lessons.length) return course;
+        const visibleIds = new Set(lessons.map((lesson) => lesson.id));
+        const questions = course.quiz.questions.filter(
+            (q) => q.lesson === undefined || visibleIds.has(q.lesson),
+        );
+        return { ...course, lessons, quiz: { ...course.quiz, questions } };
+    };
+
+    /**
+     * Display-state derivation for a rollup against the currently visible lesson
+     * set (CS-169 §6: module "completed" is derived — a role change that unlocks
+     * new lessons re-opens the module, "2 of 3, new lessons unlocked"). The quiz
+     * pass and the completed event stay durable facts in the raw rollup; only
+     * the card/board doneness is derived here. Count-compare is exact for role
+     * upgrades because system role scope sets nest (previously visible lessons
+     * are a subset of now-visible ones); on a downgrade the completed size
+     * exceeds the visible count and the module stays done — the learner
+     * finished everything their role can see.
+     */
+    const effectiveRollup = <
+        R extends {
+            completed: boolean;
+            passed: boolean;
+            lessonsCompleted: Set<string>;
+        },
+    >(
+        entry: CountableEntry,
+        rollup: R | undefined,
+        held: string[],
+    ): R | undefined => {
+        // Legacy (pre-CS-169) entry: no per-lesson data, nothing to derive from.
+        if (!entry.lessonScopes) return rollup;
+        if (!rollup || (!rollup.completed && !rollup.passed)) return rollup;
+        // Covers downgrades and not-held modules (visible count 0): everything
+        // the role can see is finished, so the module stays done.
+        if (rollup.lessonsCompleted.size >= visibleLessonCount(entry, held))
+            return rollup;
+        // Derived copy only — the raw rollup (and server tiers) keep the durable
+        // quiz-pass and completed facts.
+        return { ...rollup, completed: false, passed: false };
+    };
+
+    return {
+        lessonVisible,
+        visibleLessonCount,
+        effectiveEntry,
+        filterCourseForScopes,
+        effectiveRollup,
+    };
+};

--- a/packages/learn-ui/src/model/visibility.ts
+++ b/packages/learn-ui/src/model/visibility.ts
@@ -2,8 +2,7 @@
  * CS-169 per-lesson scope visibility. Shared by the in-app Learn section and
  * learn.lightdash.com via @lightdash/learn-ui. The panel maps catalogue
  * entries through `effectiveEntry` BEFORE handing them to railModel /
- * moduleProgress / lessonCount renders, so all board math sees visible
- * counts without the twin model changing.
+ * moduleProgress / lessonCount renders, so all board math sees visible counts.
  *
  * Visibility rule mirrors `model.ts` `isUnlocked`: a null/untagged
  * lesson is always visible, and a scope whose base the scope registry does

--- a/packages/learn-ui/src/scope/context.tsx
+++ b/packages/learn-ui/src/scope/context.tsx
@@ -1,26 +1,40 @@
 import {
     createContext,
     useContext,
+    useMemo,
     type FC,
     type PropsWithChildren,
 } from 'react';
+import { createLearnModel, type LearnModel } from '../model/learnModel';
 import { type ScopeSource } from './types';
 
-const ScopeSourceContext = createContext<ScopeSource | null>(null);
+type LearnUiContextValue = { scopeSource: ScopeSource; model: LearnModel };
+const LearnUiContext = createContext<LearnUiContextValue | null>(null);
 
 export const LearnUiProvider: FC<
     PropsWithChildren<{ scopeSource: ScopeSource }>
-> = ({ scopeSource, children }) => (
-    <ScopeSourceContext.Provider value={scopeSource}>
-        {children}
-    </ScopeSourceContext.Provider>
-);
+> = ({ scopeSource, children }) => {
+    const value = useMemo(
+        () => ({ scopeSource, model: createLearnModel(scopeSource) }),
+        [scopeSource],
+    );
+    return (
+        <LearnUiContext.Provider value={value}>
+            {children}
+        </LearnUiContext.Provider>
+    );
+};
+
+const useLearnUi = (hook: string): LearnUiContextValue => {
+    const value = useContext(LearnUiContext);
+    if (value === null)
+        throw new Error(`${hook} must be used inside <LearnUiProvider>`);
+    return value;
+};
 
 // eslint-disable-next-line react/only-export-components -- hook co-located with its provider
-export const useScopeSource = (): ScopeSource => {
-    const source = useContext(ScopeSourceContext);
-    if (source === null) {
-        throw new Error('useScopeSource must be used inside <LearnUiProvider>');
-    }
-    return source;
-};
+export const useScopeSource = (): ScopeSource =>
+    useLearnUi('useScopeSource').scopeSource;
+// eslint-disable-next-line react/only-export-components -- hook co-located with its provider
+export const useLearnModel = (): LearnModel =>
+    useLearnUi('useLearnModel').model;

--- a/packages/learn-ui/src/test/setup.ts
+++ b/packages/learn-ui/src/test/setup.ts
@@ -23,5 +23,5 @@ beforeAll(() => {
         removeEventListener: () => {},
         dispatchEvent: () => false,
     })) as unknown as typeof window.matchMedia;
-    window.HTMLElement.prototype.scrollIntoView = () => {};
+    window.Element.prototype.scrollIntoView = () => {};
 });


### PR DESCRIPTION
Third of five. The board model, layout, motion, ask, badges, visibility (CS-169) and citations move from `packages/frontend/src/features/learn` into the package with their tests. The one behavioural change: functions that read the scope registry are produced by `createLearnModel(scopeSource)` instead of importing `@lightdash/common` at module scope, so learn.lightdash.com can bind them to its bundled scope manifest. Tests bind to the real registry through a test-only `commonScopeSource`.

Diff against the previous stack: `board/*.ts` in #27884, #27902, #27887 and `visibility.ts` in #27966.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UMX8BRvEgNgP9x8rDya46E
