### PR TITLE
fix: create preview modal crash on Mantine 8 grouped Select data

### DIFF
--- a/packages/frontend/src/components/NavBar/CreatePreviewProjectModal.tsx
+++ b/packages/frontend/src/components/NavBar/CreatePreviewProjectModal.tsx
@@ -21,6 +21,8 @@ import {
     Textarea,
     TextInput,
     Tooltip,
+    type ComboboxItem,
+    type ComboboxItemGroup,
 } from '@mantine/core';
 import {
     IconExternalLink,
@@ -243,42 +245,37 @@ const CreatePreviewModal: FC<Props> = ({
         [handleGeneratePreviewName],
     );
 
-    const regularProjectList = useMemo(() => {
+    const projectItems = useMemo(() => {
         if (isLoadingProjects || !projects || !user.data) return [];
 
         return projects
             .filter((p) => p.type === ProjectType.DEFAULT)
-            .map((project) => {
-                const userCannotCreatePreview = user.data.ability.cannot(
+            .map((project) => ({
+                value: project.projectUuid,
+                label: project.name,
+                disabled: user.data.ability.cannot(
                     'create',
                     subject('Project', {
                         organizationUuid: user.data.organizationUuid,
                         upstreamProjectUuid: project.projectUuid,
                         type: ProjectType.PREVIEW,
                     }),
-                );
-
-                const item: {
-                    value: string;
-                    label: string;
-                    disabled: boolean;
-                    group?: string;
-                } = {
-                    value: project.projectUuid,
-                    label: project.name,
-                    disabled: userCannotCreatePreview,
-                };
-
-                if (userCannotCreatePreview) {
-                    item.group = 'Requires Developer Access';
-                }
-
-                return item;
-            })
-            .sort((a, b) =>
-                a.disabled === b.disabled ? 0 : a.disabled ? 1 : -1,
-            );
+                ),
+            }));
     }, [isLoadingProjects, projects, user.data]);
+
+    const regularProjectList: (ComboboxItem | ComboboxItemGroup)[] =
+        useMemo(() => {
+            const available = projectItems.filter((item) => !item.disabled);
+            const restricted = projectItems.filter((item) => item.disabled);
+
+            return restricted.length > 0
+                ? [
+                      ...available,
+                      { group: 'Requires Developer Access', items: restricted },
+                  ]
+                : available;
+        }, [projectItems]);
 
     const { data: projectDetails } = useProject(
         selectedProjectUuid ?? undefined,
@@ -297,7 +294,7 @@ const CreatePreviewModal: FC<Props> = ({
             !selectedProjectUuid &&
             projects
         ) {
-            const initialProjectValue = regularProjectList.find(
+            const initialProjectValue = projectItems.find(
                 (project) => project.value === initialProjectUuid,
             );
 
@@ -312,7 +309,7 @@ const CreatePreviewModal: FC<Props> = ({
         handleGeneratePreviewName,
         isLoadingActiveProjectUuid,
         projects,
-        regularProjectList,
+        projectItems,
         selectedProjectUuid,
     ]);
 


### PR DESCRIPTION
## Problem

Opening the "Create preview" modal crashes the whole page with `TypeError: Cannot read properties of undefined (reading 'map')` for any user who lacks preview-creation access on at least one project in the org. Users who can create previews everywhere never hit it, so it looks intermittent/user-specific.

## Cause

The "Upstream Project" `Select` data still used the Mantine v6 flat-item shape, tagging restricted projects with a bare `group` property. Mantine 8's `getParsedComboboxData` treats any item containing a `group` key as a group container and calls `item.items.map(...)` — `items` is undefined for these flat items.

## Fix

Build the Mantine 8 grouped shape: available projects as flat items, restricted ones nested under `{ group: 'Requires Developer Access', items: [...] }`. This also restores the intended group heading in the dropdown. The initial-project lookup now uses the flat item list.

## Verification

Reproduced locally as an org viewer with developer access on one project only:

| Before | After |
|---|---|
| Click "Create preview" → error boundary page ("Something went wrong", TypeError) | Modal opens; restricted projects grouped under "Requires Developer Access" and disabled |

Also confirmed the parse crash directly against `@mantine/core` 8.3.18's `getParsedComboboxData` with the old flat `group` item shape.

Closes: PROD-9438
Closes: #26669

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JGzGSfgPeiZXMwStSKQbot