### PR TITLE
feat(backend): serve the mobile app association files

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -80,6 +80,10 @@ import PrometheusMetrics from './prometheus/PrometheusMetrics';
 import { apiV1Router } from './routers/apiV1Router';
 import { createAppPreviewRouter } from './routers/appPreviewRouter';
 import {
+    createAndroidAssetLinksHandler,
+    createAppleAppSiteAssociationHandler,
+} from './routers/mobileAppAssociation';
+import {
     oauthAuthorizationServerHandler,
     oauthProtectedResourceHandler,
 } from './routers/oauthRouter';
@@ -863,6 +867,25 @@ export default class App {
         expressApp.get(
             '/.well-known/oauth-protected-resource/api/v1/mcp',
             oauthProtectedResourceHandler,
+        );
+
+        const appleAppSiteAssociationHandler =
+            createAppleAppSiteAssociationHandler(
+                this.lightdashConfig.mobileAppAssociation,
+            );
+        expressApp.get(
+            '/.well-known/apple-app-site-association',
+            appleAppSiteAssociationHandler,
+        );
+        expressApp.get(
+            '/apple-app-site-association',
+            appleAppSiteAssociationHandler,
+        );
+        expressApp.get(
+            '/.well-known/assetlinks.json',
+            createAndroidAssetLinksHandler(
+                this.lightdashConfig.mobileAppAssociation,
+            ),
         );
 
         // OpenAI Apps domain verification: serves the portal-issued token so

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -91,6 +91,12 @@ export const lightdashConfigMock: LightdashConfig = {
         },
     },
     lightdashCloudInstance: 'test-instance',
+    mobileAppAssociation: {
+        appleTeamId: 'TEAMID',
+        appleBundleId: 'com.lightdash.mobile',
+        androidPackageName: 'com.lightdash.mobile',
+        androidCertificateFingerprints: [],
+    },
     openaiAppsChallengeToken: undefined,
     k8s: {
         podNamespace: undefined,

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1432,6 +1432,13 @@ export type MobilePushNotificationsConfig = {
         | undefined;
 };
 
+export type MobileAppAssociationConfig = {
+    appleTeamId: string;
+    appleBundleId: string;
+    androidPackageName: string;
+    androidCertificateFingerprints: string[];
+};
+
 export type LightdashConfig = {
     /** Always equals `lightdashSecrets.active`; kept for compatibility */
     lightdashSecret: string;
@@ -1459,6 +1466,7 @@ export type LightdashConfig = {
     mode: LightdashMode;
     mobile: HealthState['mobile'];
     mobilePushNotifications: MobilePushNotificationsConfig;
+    mobileAppAssociation: MobileAppAssociationConfig;
     license: {
         licenseKey: string | null;
         licenseCertificate: string | null;
@@ -2568,6 +2576,12 @@ const LEGACY_DISABLE_ENV_VARS: ReadonlyArray<
     // Add per migration; truthy env value disables the flag.
 ];
 
+const parseCertificateFingerprints = (value: string | undefined): string[] =>
+    (value ?? '')
+        .split(',')
+        .map((fingerprint) => fingerprint.trim())
+        .filter((fingerprint) => fingerprint.length > 0);
+
 const parseMobilePushCredential = (
     environment: 'SANDBOX' | 'PRODUCTION',
 ): MobilePushNotificationsConfig['sandbox'] => {
@@ -2782,6 +2796,17 @@ export const parseConfig = (): LightdashConfig => {
                     'LIGHTDASH_MOBILE_MINIMUM_IOS_VERSION',
                 ),
             },
+        },
+        mobileAppAssociation: {
+            appleTeamId: process.env.MOBILE_APPLE_TEAM_ID ?? 'AF5SF5H727',
+            appleBundleId:
+                process.env.MOBILE_APPLE_BUNDLE_ID ?? 'com.lightdash.mobile',
+            androidPackageName:
+                process.env.MOBILE_ANDROID_PACKAGE_NAME ??
+                'com.lightdash.mobile',
+            androidCertificateFingerprints: parseCertificateFingerprints(
+                process.env.MOBILE_ANDROID_CERT_FINGERPRINTS,
+            ),
         },
         mobilePushNotifications: {
             enabled:

--- a/packages/backend/src/routers/mobileAppAssociation.test.ts
+++ b/packages/backend/src/routers/mobileAppAssociation.test.ts
@@ -1,0 +1,143 @@
+import { type Request, type Response } from 'express';
+import { type MobileAppAssociationConfig } from '../config/parseConfig';
+import {
+    buildAndroidAssetLinks,
+    buildAppleAppSiteAssociation,
+    createAndroidAssetLinksHandler,
+    createAppleAppSiteAssociationHandler,
+} from './mobileAppAssociation';
+
+const config: MobileAppAssociationConfig = {
+    appleTeamId: 'AF5SF5H727',
+    appleBundleId: 'com.lightdash.mobile',
+    androidPackageName: 'com.lightdash.mobile',
+    androidCertificateFingerprints: [],
+};
+
+const createResponse = () => {
+    const response = {
+        type: vi.fn(() => response),
+        set: vi.fn(() => response),
+        send: vi.fn((body: unknown) => response),
+        redirect: vi.fn(() => response),
+        status: vi.fn(() => response),
+    };
+    return response;
+};
+
+const invoke = (
+    handler: (req: Request, res: Response) => void,
+    request: Partial<Request> = {},
+) => {
+    const response = createResponse();
+    handler(request as Request, response as unknown as Response);
+    return response;
+};
+
+const sentBody = (response: ReturnType<typeof createResponse>) =>
+    JSON.parse(String(response.send.mock.calls[0][0]));
+
+describe('buildAppleAppSiteAssociation', () => {
+    it('claims the team-prefixed app id', () => {
+        expect(
+            buildAppleAppSiteAssociation(config).applinks.details[0].appIDs,
+        ).toEqual(['AF5SF5H727.com.lightdash.mobile']);
+    });
+
+    it('claims only the paths the app routes', () => {
+        expect(
+            buildAppleAppSiteAssociation(config).applinks.details[0].components,
+        ).toEqual([
+            { '/': '/projects/*/saved/*' },
+            { '/': '/projects/*/dashboards/*' },
+            { '/': '/projects/*/dashboards/*/view' },
+            { '/': '/projects/*/spaces/*' },
+            { '/': '/projects/*/ai-agents/*/threads/*' },
+        ]);
+    });
+});
+
+describe('buildAndroidAssetLinks', () => {
+    it('returns an empty relation list when no fingerprint is configured', () => {
+        expect(buildAndroidAssetLinks(config)).toEqual([]);
+    });
+
+    it('delegates every url to the package for each configured fingerprint', () => {
+        expect(
+            buildAndroidAssetLinks({
+                ...config,
+                androidCertificateFingerprints: ['AA:BB', 'CC:DD'],
+            }),
+        ).toEqual([
+            {
+                relation: ['delegate_permission/common.handle_all_urls'],
+                target: {
+                    namespace: 'android_app',
+                    package_name: 'com.lightdash.mobile',
+                    sha256_cert_fingerprints: ['AA:BB', 'CC:DD'],
+                },
+            },
+        ]);
+    });
+});
+
+describe('createAppleAppSiteAssociationHandler', () => {
+    it('sends json without a redirect', () => {
+        const response = invoke(createAppleAppSiteAssociationHandler(config));
+
+        expect(response.type).toHaveBeenCalledWith('application/json');
+        expect(response.redirect).not.toHaveBeenCalled();
+        expect(response.status).not.toHaveBeenCalled();
+        expect(sentBody(response)).toEqual(
+            buildAppleAppSiteAssociation(config),
+        );
+    });
+
+    it('serves the same document to an unauthenticated request', () => {
+        const handler = createAppleAppSiteAssociationHandler(config);
+
+        expect(sentBody(invoke(handler, { user: undefined }))).toEqual(
+            sentBody(
+                invoke(handler, {
+                    user: { userUuid: 'a-user' },
+                } as Partial<Request>),
+            ),
+        );
+    });
+
+    it('marks the document cacheable', () => {
+        expect(
+            invoke(createAppleAppSiteAssociationHandler(config)).set,
+        ).toHaveBeenCalledWith('Cache-Control', 'public, max-age=3600');
+    });
+});
+
+describe('createAndroidAssetLinksHandler', () => {
+    it('sends json without a redirect', () => {
+        const response = invoke(
+            createAndroidAssetLinksHandler({
+                ...config,
+                androidCertificateFingerprints: ['AA:BB'],
+            }),
+        );
+
+        expect(response.type).toHaveBeenCalledWith('application/json');
+        expect(response.redirect).not.toHaveBeenCalled();
+        expect(sentBody(response)).toEqual([
+            {
+                relation: ['delegate_permission/common.handle_all_urls'],
+                target: {
+                    namespace: 'android_app',
+                    package_name: 'com.lightdash.mobile',
+                    sha256_cert_fingerprints: ['AA:BB'],
+                },
+            },
+        ]);
+    });
+
+    it('sends an empty json array when no fingerprint is configured', () => {
+        expect(
+            sentBody(invoke(createAndroidAssetLinksHandler(config))),
+        ).toEqual([]);
+    });
+});

--- a/packages/backend/src/routers/mobileAppAssociation.ts
+++ b/packages/backend/src/routers/mobileAppAssociation.ts
@@ -1,0 +1,77 @@
+import { type Request, type Response } from 'express';
+import { type MobileAppAssociationConfig } from '../config/parseConfig';
+
+export type AppleAppSiteAssociation = {
+    applinks: {
+        details: Array<{
+            appIDs: string[];
+            components: Array<{ '/': string }>;
+        }>;
+    };
+};
+
+export type AndroidAssetLinks = Array<{
+    relation: string[];
+    target: {
+        namespace: string;
+        package_name: string;
+        sha256_cert_fingerprints: string[];
+    };
+}>;
+
+const UNIVERSAL_LINK_PATHS = [
+    '/projects/*/saved/*',
+    '/projects/*/dashboards/*',
+    '/projects/*/dashboards/*/view',
+    '/projects/*/spaces/*',
+    '/projects/*/ai-agents/*/threads/*',
+];
+
+export const buildAppleAppSiteAssociation = (
+    config: MobileAppAssociationConfig,
+): AppleAppSiteAssociation => ({
+    applinks: {
+        details: [
+            {
+                appIDs: [`${config.appleTeamId}.${config.appleBundleId}`],
+                components: UNIVERSAL_LINK_PATHS.map((path) => ({
+                    '/': path,
+                })),
+            },
+        ],
+    },
+});
+
+export const buildAndroidAssetLinks = (
+    config: MobileAppAssociationConfig,
+): AndroidAssetLinks =>
+    config.androidCertificateFingerprints.length === 0
+        ? []
+        : [
+              {
+                  relation: ['delegate_permission/common.handle_all_urls'],
+                  target: {
+                      namespace: 'android_app',
+                      package_name: config.androidPackageName,
+                      sha256_cert_fingerprints:
+                          config.androidCertificateFingerprints,
+                  },
+              },
+          ];
+
+const createStaticJsonHandler = (document: unknown) => {
+    const body = JSON.stringify(document);
+    return (req: Request, res: Response) => {
+        res.type('application/json')
+            .set('Cache-Control', 'public, max-age=3600')
+            .send(body);
+    };
+};
+
+export const createAppleAppSiteAssociationHandler = (
+    config: MobileAppAssociationConfig,
+) => createStaticJsonHandler(buildAppleAppSiteAssociation(config));
+
+export const createAndroidAssetLinksHandler = (
+    config: MobileAppAssociationConfig,
+) => createStaticJsonHandler(buildAndroidAssetLinks(config));


### PR DESCRIPTION
## What breaks

A Lightdash chart or dashboard link opens the browser, not the app. Apple and Android both fetch an association file from the instance host before they let an app claim `https` links. The single-page-app catch-all answers those paths with `index.html` and `text/html`, so both platforms read it as no association at all.

Checked on 2026-09-01: all four Apple host and path combinations on the Cloud hosts returned `200 text/html`.

## What changes

The backend serves both association documents, registered above the SPA catch-all in `App.ts`:

| Route | Purpose |
| -- | -- |
| `GET /.well-known/apple-app-site-association` | iOS Universal Links |
| `GET /apple-app-site-association` | iOS Universal Links, legacy path |
| `GET /.well-known/assetlinks.json` | Android App Links |

Each document is built once from configuration and served from memory. Each route sends `application/json`. No route redirects and no route needs authentication.

The Apple document claims only the paths the iOS app routes today, read from `ContentLinkResolver.swift`:

- `/projects/*/saved/*`
- `/projects/*/dashboards/*` and `/projects/*/dashboards/*/view`
- `/projects/*/spaces/*`
- `/projects/*/ai-agents/*/threads/*`

The app also strips a leading `minimal` segment, but the `minimal` routes are the embed and screenshot surface, so this change does not claim them.

## Configuration

The Android release signing certificate fingerprints come from `MOBILE_ANDROID_CERT_FINGERPRINTS`, a comma separated list of SHA-256 fingerprints. When the variable is unset the route serves an empty relation list, so every instance answers the path and no instance claims links for a certificate it cannot prove.

**Cloud needs this variable set** with the Play release signing certificate fingerprint. Android App Links stay unverified until it is.

Three more variables have Lightdash defaults and only need setting to override them: `MOBILE_APPLE_TEAM_ID` (`AF5SF5H727`), `MOBILE_APPLE_BUNDLE_ID` and `MOBILE_ANDROID_PACKAGE_NAME` (both `com.lightdash.mobile`).

## Verification

Unit tests cover the document shape, the content type, the absence of a redirect, the identical response for an unauthenticated request, and the empty fingerprint case.

```
pnpm -F backend test src/routers/mobileAppAssociation.test.ts   9 passed
pnpm -F backend typecheck                                       clean
pnpm --filter backend run linter <touched paths>                clean
```

Linear: SPK-1679
Also serves the Android assetlinks for SPK-1773

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011j8Jti2ysa1f7vtCzDNsP8
