### PR TITLE
feat: Learn presentational components in @lightdash/learn-ui (CS-73 4/5)

### DIFF
--- a/packages/learn-ui/src/components/AskBar.test.tsx
+++ b/packages/learn-ui/src/components/AskBar.test.tsx
@@ -1,0 +1,178 @@
+import { fireEvent, screen } from '@testing-library/react';
+import { type ReactElement } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { commonScopeSource, entry } from '../model/testFixtures';
+import { LearnUiProvider } from '../scope/context';
+import { renderWithMantine } from '../test/render';
+import { type LearnAskMatch } from '../types';
+import { AskBar, type AskBarProps } from './AskBar';
+
+const renderBoard = (ui: ReactElement) =>
+    renderWithMantine(
+        <LearnUiProvider scopeSource={commonScopeSource}>{ui}</LearnUiProvider>,
+    );
+
+const entries = [
+    entry({ id: 'foundation', title: 'Getting around', scope: 'view:Project' }),
+    entry({
+        id: 'dashboards',
+        title: 'Building dashboards',
+        scope: 'manage:Dashboard',
+    }),
+];
+
+const match = (courseId: string, lessonId: string | null): LearnAskMatch => ({
+    courseId,
+    lessonId,
+    title: `${courseId} lesson`,
+    score: 0.7,
+});
+
+const renderBar = (overrides: Partial<AskBarProps> = {}) => {
+    const props: AskBarProps = {
+        entries,
+        suggestions: [
+            { query: 'Where do I find a chart?', courseId: 'foundation' },
+        ],
+        matches: null,
+        lockedIds: new Set<string>(),
+        isSearching: false,
+        isError: false,
+        onSubmit: vi.fn(),
+        onClear: vi.fn(),
+        onOpen: vi.fn(),
+        ...overrides,
+    };
+    renderBoard(<AskBar {...props} />);
+    return props;
+};
+
+describe('AskBar', () => {
+    it('submits the typed question', () => {
+        const props = renderBar();
+        fireEvent.change(screen.getByRole('searchbox'), {
+            target: { value: 'email me a dashboard' },
+        });
+        fireEvent.submit(screen.getByRole('search'));
+        expect(props.onSubmit).toHaveBeenCalledWith('email me a dashboard');
+    });
+
+    it('clears instead of searching when the box is empty', () => {
+        const props = renderBar();
+        fireEvent.submit(screen.getByRole('search'));
+        expect(props.onSubmit).not.toHaveBeenCalled();
+        expect(props.onClear).toHaveBeenCalled();
+    });
+
+    it('treats a whitespace-only question as a clear, box included', () => {
+        const props = renderBar();
+        fireEvent.change(screen.getByRole('searchbox'), {
+            target: { value: '   ' },
+        });
+        fireEvent.submit(screen.getByRole('search'));
+        expect(props.onSubmit).not.toHaveBeenCalled();
+        expect(props.onClear).toHaveBeenCalled();
+        expect(screen.getByRole('searchbox')).toHaveValue('');
+    });
+
+    it('caps the box at the length the request schema accepts', () => {
+        renderBar();
+        expect(screen.getByRole('searchbox')).toHaveAttribute(
+            'maxlength',
+            '500',
+        );
+    });
+
+    it('sends one request for a double submit of the same question', () => {
+        const props = renderBar({ matches: [match('foundation', 'l1')] });
+        fireEvent.change(screen.getByRole('searchbox'), {
+            target: { value: 'where are my charts' },
+        });
+        fireEvent.submit(screen.getByRole('search'));
+        fireEvent.submit(screen.getByRole('search'));
+        expect(props.onSubmit).toHaveBeenCalledTimes(1);
+    });
+
+    it('sends nothing while a search is already in flight', () => {
+        const props = renderBar({ isSearching: true });
+        fireEvent.change(screen.getByRole('searchbox'), {
+            target: { value: 'anything' },
+        });
+        fireEvent.submit(screen.getByRole('search'));
+        expect(props.onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('re-runs a question that failed', () => {
+        const props = renderBar({ isError: true });
+        fireEvent.change(screen.getByRole('searchbox'), {
+            target: { value: 'anything' },
+        });
+        fireEvent.submit(screen.getByRole('search'));
+        fireEvent.submit(screen.getByRole('search'));
+        expect(props.onSubmit).toHaveBeenCalledTimes(2);
+    });
+
+    it('runs a suggestion chip as a query', () => {
+        const props = renderBar();
+        fireEvent.click(
+            screen.getByRole('button', { name: 'Where do I find a chart?' }),
+        );
+        expect(props.onSubmit).toHaveBeenCalledWith('Where do I find a chart?');
+    });
+
+    it('groups results by module and opens the matched lesson', () => {
+        const props = renderBar({ matches: [match('foundation', 'l2')] });
+        expect(screen.getByText('Getting around')).toBeInTheDocument();
+        fireEvent.click(screen.getByRole('button', { name: 'Open' }));
+        expect(props.onOpen).toHaveBeenCalledWith('foundation', 'l2');
+    });
+
+    it('names the lowest holding role for a locked match instead of opening it', () => {
+        renderBar({
+            matches: [match('dashboards', 'l1')],
+            lockedIds: new Set(['dashboards']),
+        });
+        // manage:Dashboard is held from interactive viewer up via space access.
+        expect(
+            screen.getByText('interactive viewer and above'),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByRole('button', { name: 'Open' }),
+        ).not.toBeInTheDocument();
+    });
+
+    it('shows the empty copy when nothing matched', () => {
+        renderBar({ matches: [] });
+        expect(
+            screen.getByText('Nothing in the library matches that yet'),
+        ).toBeInTheDocument();
+    });
+
+    it('shows the failure copy when the search request failed', () => {
+        renderBar({ isError: true });
+        expect(
+            screen.getByText("Couldn't search right now"),
+        ).toBeInTheDocument();
+    });
+
+    it('clears the box and the board with the clear button', () => {
+        const props = renderBar({ matches: [match('foundation', 'l1')] });
+        fireEvent.change(screen.getByRole('searchbox'), {
+            target: { value: 'anything' },
+        });
+        fireEvent.click(screen.getByRole('button', { name: 'Clear search' }));
+        expect(screen.getByRole('searchbox')).toHaveValue('');
+        expect(props.onClear).toHaveBeenCalled();
+    });
+
+    it('leaves focus on the input when the clear button unmounts itself', () => {
+        renderBar({ matches: [match('foundation', 'l1')] });
+        fireEvent.change(screen.getByRole('searchbox'), {
+            target: { value: 'anything' },
+        });
+        const clear = screen.getByRole('button', { name: 'Clear search' });
+        clear.focus();
+        fireEvent.click(clear);
+        expect(screen.getByRole('searchbox')).toHaveFocus();
+    });
+});

--- a/packages/learn-ui/src/components/AskBar.tsx
+++ b/packages/learn-ui/src/components/AskBar.tsx
@@ -1,0 +1,195 @@
+import { Text } from '@mantine/core';
+import { useRef, useState, type FC, type FormEvent } from 'react';
+import { groupMatches } from '../model/askView';
+import { useLearnModel } from '../scope/context';
+import {
+    ASK_QUERY_MAX_LENGTH,
+    type LearnAskMatch,
+    type LearnAskSuggestion,
+    type LearnCatalogueEntry,
+} from '../types';
+import styles from './LearnBoard.module.css';
+
+export type AskBarProps = {
+    entries: LearnCatalogueEntry[];
+    suggestions: LearnAskSuggestion[];
+    matches: LearnAskMatch[] | null;
+    lockedIds: Set<string>;
+    isSearching: boolean;
+    isError: boolean;
+    onSubmit: (query: string) => void;
+    onClear: () => void;
+    onOpen: (courseId: string, lessonId: string | null) => void;
+};
+
+export const AskBar: FC<AskBarProps> = ({
+    entries,
+    suggestions,
+    matches,
+    lockedIds,
+    isSearching,
+    isError,
+    onSubmit,
+    onClear,
+    onOpen,
+}) => {
+    const { lockedNote } = useLearnModel();
+    const [value, setValue] = useState('');
+    const [submitted, setSubmitted] = useState<string | null>(null);
+    const inputRef = useRef<HTMLInputElement>(null);
+    const byId = new Map(entries.map((e) => [e.id, e]));
+
+    const clear = () => {
+        // Focus first: the × unmounts with the last character, and a focused
+        // button removed in the same commit drops focus to the body.
+        inputRef.current?.focus();
+        setValue('');
+        setSubmitted(null);
+        onClear();
+    };
+
+    // A request in flight, or the question already answered on screen, means
+    // there is nothing to send.
+    const run = (query: string) => {
+        if (isSearching) return;
+        if (query === submitted && matches !== null && !isError) return;
+        setSubmitted(query);
+        onSubmit(query);
+    };
+
+    const submit = (event: FormEvent) => {
+        event.preventDefault();
+        const query = value.trim();
+        if (query === '') {
+            clear();
+            return;
+        }
+        run(query);
+    };
+
+    const runSuggestion = (query: string) => {
+        setValue(query);
+        run(query);
+    };
+
+    return (
+        <div className={styles.ask}>
+            <form className={styles.askForm} role="search" onSubmit={submit}>
+                <input
+                    ref={inputRef}
+                    type="search"
+                    className={styles.askInput}
+                    aria-label="Ask the library"
+                    placeholder="Ask a question about Lightdash"
+                    maxLength={ASK_QUERY_MAX_LENGTH}
+                    value={value}
+                    onChange={(event) => setValue(event.target.value)}
+                />
+                {value !== '' && (
+                    <button
+                        type="button"
+                        className={styles.askClear}
+                        aria-label="Clear search"
+                        onClick={clear}
+                    >
+                        ×
+                    </button>
+                )}
+                <button
+                    type="submit"
+                    className={styles.askSubmit}
+                    disabled={isSearching}
+                >
+                    Ask
+                </button>
+            </form>
+
+            {suggestions.length > 0 && (
+                <div className={styles.askChips} data-testid="ask-chips">
+                    {suggestions.map((suggestion, index) => (
+                        <button
+                            key={`${suggestion.courseId}:${index}`}
+                            type="button"
+                            className={styles.askChip}
+                            disabled={isSearching}
+                            onClick={() => runSuggestion(suggestion.query)}
+                        >
+                            {suggestion.query}
+                        </button>
+                    ))}
+                </div>
+            )}
+
+            {isSearching && (
+                <Text size="sm" className={styles.muted}>
+                    Searching…
+                </Text>
+            )}
+            {isError && (
+                <Text size="sm" className={styles.muted}>
+                    Couldn&apos;t search right now
+                </Text>
+            )}
+            {!isError && matches !== null && matches.length === 0 && (
+                <Text size="sm" className={styles.muted}>
+                    Nothing in the library matches that yet
+                </Text>
+            )}
+
+            {!isError && matches !== null && matches.length > 0 && (
+                <ul className={styles.askResults}>
+                    {groupMatches(matches).map((group) => {
+                        const entry = byId.get(group.courseId);
+                        if (!entry) return null;
+                        const locked = lockedIds.has(group.courseId);
+                        return (
+                            <li
+                                key={group.courseId}
+                                className={styles.askGroup}
+                            >
+                                <span className={styles.askModule}>
+                                    {entry.title}
+                                </span>
+                                {/* A locked group names the role that holds it
+                                    once, in place of every row's Open. */}
+                                {locked && (
+                                    <Text
+                                        size="xs"
+                                        className={styles.muted}
+                                        data-testid="ask-locked-note"
+                                    >
+                                        {lockedNote(entry)}
+                                    </Text>
+                                )}
+                                {group.matches.map((result, index) => (
+                                    <span
+                                        key={`${group.courseId}:${index}`}
+                                        className={styles.askRow}
+                                    >
+                                        <span className={styles.askLesson}>
+                                            {result.title}
+                                        </span>
+                                        {!locked && (
+                                            <button
+                                                type="button"
+                                                className={styles.askOpen}
+                                                onClick={() =>
+                                                    onOpen(
+                                                        result.courseId,
+                                                        result.lessonId,
+                                                    )
+                                                }
+                                            >
+                                                Open
+                                            </button>
+                                        )}
+                                    </span>
+                                ))}
+                            </li>
+                        );
+                    })}
+                </ul>
+            )}
+        </div>
+    );
+};

--- a/packages/learn-ui/src/components/BoardNode.tsx
+++ b/packages/learn-ui/src/components/BoardNode.tsx
@@ -1,0 +1,79 @@
+import { type FC } from 'react';
+import { askOpacity, askScale, type NodeAskState } from '../model/askView';
+import { NODE_SIZE } from '../model/layout';
+import { plural } from '../model/model';
+import { NODE_TRANSITION, staggerMs, type NodeMotion } from '../model/motion';
+import { progressFill } from '../model/tokens';
+import styles from './LearnBoard.module.css';
+
+export type BoardNodeProps = {
+    id: string;
+    title: string;
+    lessonCount: number;
+    unlocked: boolean;
+    progress: number;
+    done: boolean;
+    selected: boolean;
+    nextUp: boolean;
+    index: number;
+    motion: NodeMotion;
+    askState: NodeAskState;
+    onSelect: (id: string) => void;
+};
+
+export const BoardNode: FC<BoardNodeProps> = ({
+    id,
+    title,
+    lessonCount,
+    unlocked,
+    progress,
+    done,
+    selected,
+    nextUp,
+    index,
+    motion,
+    askState,
+    onSelect,
+}) => {
+    const showPulse = nextUp && unlocked && !selected && askState === 'none';
+    // Ring/glow/label colour are enumerable states, so they live as CSS
+    // modifier classes; only continuous per-node values stay inline.
+    const className = [
+        styles.node,
+        !unlocked && styles.nodeLocked,
+        unlocked && done && styles.nodeDone,
+        selected && styles.nodeSelected,
+        showPulse && styles.nodeNextUp,
+        askState === 'matched' && styles.nodeMatched,
+        askState === 'locked-match' && styles.nodeLockedMatch,
+    ]
+        .filter(Boolean)
+        .join(' ');
+    return (
+        <button
+            type="button"
+            aria-label={`${title}, ${
+                unlocked && done ? 'complete' : plural(lessonCount, 'lesson')
+            }`}
+            aria-pressed={selected}
+            aria-hidden={!unlocked}
+            disabled={!unlocked}
+            tabIndex={unlocked ? 0 : -1}
+            className={className}
+            style={{
+                left: motion.x - NODE_SIZE / 2,
+                top: motion.y - NODE_SIZE / 2,
+                background: unlocked ? progressFill(progress) : undefined,
+                opacity: askOpacity(askState, motion.opacity),
+                transform: `scale(${askScale(askState, motion.scale)})`,
+                transition: motion.animate ? NODE_TRANSITION : 'none',
+                transitionDelay: motion.animate
+                    ? `${staggerMs(index)}ms`
+                    : '0ms',
+            }}
+            onClick={() => onSelect(id)}
+        >
+            {unlocked && done ? '✓' : lessonCount}
+        </button>
+    );
+};

--- a/packages/learn-ui/src/components/BoardRail.tsx
+++ b/packages/learn-ui/src/components/BoardRail.tsx
@@ -1,0 +1,177 @@
+import { Stack, Text } from '@mantine/core';
+import { type FC } from 'react';
+import { GROUP_LABEL, plural, type RailModel } from '../model/model';
+import { type Rollup } from '../model/rollup';
+import { type ProjectMemberRole } from '../scope/types';
+import {
+    type LearnBadgeTier,
+    type LearnCatalogueEntry,
+    type LearnCourse,
+} from '../types';
+import styles from './LearnBoard.module.css';
+import { ModulePane } from './ModulePane';
+import { RoleBadgeCard } from './RoleBadgeCard';
+
+type Props = {
+    rail: RailModel;
+    rollups: Map<string, Rollup>;
+    role: ProjectMemberRole;
+    /** The scope names the selected role holds — the pane filters its lesson list with them (CS-169). */
+    held: string[];
+    heldEntries: LearnCatalogueEntry[];
+    tiers: Map<string, LearnBadgeTier> | null;
+    tiersLoading: boolean;
+    selectedId: string | null;
+    onSelect: (id: string) => void;
+    onClearSelection: () => void;
+    onOpen: (courseId: string) => void;
+    selectedCourse: LearnCourse | undefined;
+    selectedCourseLoading: boolean;
+    selectedCourseError: boolean;
+};
+
+export const BoardRail: FC<Props> = ({
+    rail,
+    rollups,
+    role,
+    held,
+    heldEntries,
+    tiers,
+    tiersLoading,
+    selectedId,
+    onSelect,
+    onClearSelection,
+    onOpen,
+    selectedCourse,
+    selectedCourseLoading,
+    selectedCourseError,
+}) => {
+    // Completion is never revoked by a role change, so a Completed row can
+    // name a module absent from `rail.mine` once the held role changes.
+    const selected = selectedId
+        ? ([...rail.mine, ...rail.completed].find(
+              (m) => m.entry.id === selectedId,
+          ) ?? null)
+        : null;
+
+    return (
+        <aside className={styles.rail}>
+            <Stack gap={8}>
+                <span className={styles.overline}>Overall</span>
+                <span className={styles.bigPct}>{rail.overall.pct}%</span>
+                <div className={`${styles.bar} ${styles.barLg}`}>
+                    <div
+                        className={styles.barFill}
+                        style={{ width: `${rail.overall.pct}%` }}
+                    />
+                </div>
+                <Text size="xs" className={styles.muted}>
+                    {rail.overall.doneLessons} of{' '}
+                    {plural(rail.overall.totalLessons, 'lesson')} ·{' '}
+                    {plural(rail.overall.modulesComplete, 'module')} complete
+                </Text>
+            </Stack>
+
+            <RoleBadgeCard
+                role={role}
+                held={heldEntries}
+                tiers={tiers}
+                isLoading={tiersLoading}
+            />
+
+            {selected ? (
+                <ModulePane
+                    module={selected}
+                    held={held}
+                    rollup={rollups.get(selected.entry.id)}
+                    course={selectedCourse}
+                    courseLoading={selectedCourseLoading}
+                    courseError={selectedCourseError}
+                    onClose={onClearSelection}
+                    onOpen={onOpen}
+                />
+            ) : (
+                <>
+                    <Stack gap={10}>
+                        <span className={styles.overline}>
+                            Pick up where you left off
+                        </span>
+                        {rail.queue.map((m) => {
+                            const pct = Math.round(m.progress * 100);
+                            return (
+                                <button
+                                    key={m.entry.id}
+                                    type="button"
+                                    className={styles.queueCard}
+                                    onClick={() => onSelect(m.entry.id)}
+                                >
+                                    <Text size="sm" fw={600} component="span">
+                                        {m.entry.title}
+                                    </Text>
+                                    <span
+                                        className={`${styles.bar} ${styles.barSm}`}
+                                    >
+                                        <span
+                                            className={styles.barFill}
+                                            style={{ width: `${pct}%` }}
+                                        />
+                                    </span>
+                                    <Text
+                                        size="xs"
+                                        component="span"
+                                        className={styles.muted}
+                                    >
+                                        {m.progress > 0
+                                            ? `${pct}% · ${m.lessonsDone} of ${plural(m.entry.lessonCount, 'lesson')}`
+                                            : `${plural(m.entry.lessonCount, 'lesson')} · not started`}
+                                    </Text>
+                                </button>
+                            );
+                        })}
+                        {rail.queue.length === 0 && (
+                            <Text size="sm" className={styles.muted}>
+                                Nothing to resume
+                            </Text>
+                        )}
+                    </Stack>
+
+                    {rail.completed.length > 0 && (
+                        <Stack gap={8}>
+                            <span className={styles.overline}>Completed</span>
+                            {rail.completed.map((m) => (
+                                <button
+                                    key={m.entry.id}
+                                    type="button"
+                                    className={styles.completedRow}
+                                    onClick={() => onSelect(m.entry.id)}
+                                >
+                                    <span className={styles.checkDisc}>✓</span>
+                                    <Stack gap={2} component="span">
+                                        <Text
+                                            size="sm"
+                                            fw={500}
+                                            component="span"
+                                        >
+                                            {m.entry.title}
+                                        </Text>
+                                        <Text
+                                            size="xs"
+                                            component="span"
+                                            className={styles.muted}
+                                        >
+                                            {plural(
+                                                m.entry.lessonCount,
+                                                'lesson',
+                                            )}{' '}
+                                            · {GROUP_LABEL[m.group]}
+                                        </Text>
+                                    </Stack>
+                                </button>
+                            ))}
+                        </Stack>
+                    )}
+                </>
+            )}
+        </aside>
+    );
+};

--- a/packages/learn-ui/src/components/ClusterBoard.test.tsx
+++ b/packages/learn-ui/src/components/ClusterBoard.test.tsx
@@ -1,0 +1,131 @@
+import { screen } from '@testing-library/react';
+import { createRef, type ComponentProps } from 'react';
+import { describe, expect, it } from 'vitest';
+import { type Rollup } from '../model/rollup';
+import { commonScopeSource, entry } from '../model/testFixtures';
+import { LearnUiProvider } from '../scope/context';
+import { ProjectMemberRole } from '../scope/types';
+import { renderWithMantine } from '../test/render';
+import { ClusterBoard } from './ClusterBoard';
+
+const entries = [
+    entry({ id: 'foundation', title: 'Getting around', scope: 'view:Project' }),
+    // Untagged, so every role holds it: a second lit node with no scope guesswork.
+    entry({ id: 'sharing', title: 'Sharing your work', scope: null }),
+    entry({
+        id: 'dashboards',
+        title: 'Building dashboards',
+        scope: 'manage:Dashboard',
+    }),
+];
+
+type BoardOverrides = Partial<
+    Pick<
+        ComponentProps<typeof ClusterBoard>,
+        'prevHeld' | 'origin' | 'reducedMotion'
+    >
+>;
+
+const renderBoard = (
+    highlights: { matched: Set<string>; locked: Set<string> } | null,
+    nextUpId: string | null = null,
+    overrides: BoardOverrides = {},
+) =>
+    renderWithMantine(
+        <LearnUiProvider scopeSource={commonScopeSource}>
+            <ClusterBoard
+                entries={entries}
+                held={commonScopeSource.getAllScopesForRole(
+                    ProjectMemberRole.VIEWER,
+                )}
+                prevHeld={null}
+                rollups={new Map<string, Rollup>()}
+                selectedId={null}
+                nextUpId={nextUpId}
+                origin={null}
+                burst={false}
+                reducedMotion
+                highlights={highlights}
+                onSelect={() => {}}
+                boardRef={createRef<HTMLDivElement>()}
+                {...overrides}
+            />
+        </LearnUiProvider>,
+    );
+
+const nodeFor = (title: string): HTMLElement => {
+    const node = screen
+        .getByTestId('learn-board')
+        .querySelector<HTMLElement>(`[aria-label^="${title}"]`);
+    if (!node) throw new Error(`no node for ${title}`);
+    return node;
+};
+
+describe('ClusterBoard ask states', () => {
+    it('leaves every node at full opacity with no highlights', () => {
+        renderBoard(null);
+        expect(nodeFor('Getting around').style.opacity).toBe('1');
+        expect(nodeFor('Sharing your work').style.opacity).toBe('1');
+    });
+
+    it('dims the modules an answer did not match', () => {
+        renderBoard({
+            matched: new Set(['foundation']),
+            locked: new Set<string>(),
+        });
+        expect(nodeFor('Getting around').style.opacity).toBe('1');
+        expect(nodeFor('Sharing your work').style.opacity).toBe('0.4');
+    });
+
+    it('pulses the next-up module while nothing is lit', () => {
+        renderBoard(null, 'sharing');
+        expect(nodeFor('Sharing your work').className).toMatch(/nodeNextUp/);
+    });
+
+    it('drops the next-up pulse while an answer is lit', () => {
+        // Two highlights at once read as two answers, so the glow wins.
+        renderBoard(
+            { matched: new Set(['foundation']), locked: new Set<string>() },
+            'sharing',
+        );
+        expect(nodeFor('Sharing your work').className).not.toMatch(
+            /nodeNextUp/,
+        );
+    });
+
+    it('surfaces a locked match that would otherwise be invisible', () => {
+        renderBoard({
+            matched: new Set<string>(),
+            locked: new Set(['dashboards']),
+        });
+        const locked = nodeFor('Building dashboards');
+        expect(locked.style.opacity).toBe('0.4');
+        expect(locked.style.transform).toBe('scale(1)');
+    });
+
+    it('keeps a locked match at its seat through a role switch', () => {
+        const highlights = {
+            matched: new Set<string>(),
+            locked: new Set(['dashboards']),
+        };
+        const { unmount } = renderBoard(highlights);
+        const settled = nodeFor('Building dashboards');
+        const seat = { left: settled.style.left, top: settled.style.top };
+        unmount();
+
+        // Editor to viewer: dashboards flies out to the tab above the board,
+        // which is where the answer would otherwise paint its ring.
+        renderBoard(highlights, null, {
+            prevHeld: commonScopeSource.getAllScopesForRole(
+                ProjectMemberRole.EDITOR,
+            ),
+            origin: { x: 540, y: -60 },
+            reducedMotion: false,
+        });
+        const locked = nodeFor('Building dashboards');
+        expect(locked.style.left).toBe(seat.left);
+        expect(locked.style.top).toBe(seat.top);
+        expect(locked.style.transform).toBe('scale(1)');
+        expect(locked.style.opacity).toBe('0.4');
+    });
+});

--- a/packages/learn-ui/src/components/ClusterBoard.tsx
+++ b/packages/learn-ui/src/components/ClusterBoard.tsx
@@ -1,0 +1,213 @@
+import { useElementSize } from '@mantine/hooks';
+import { useMemo, type FC, type RefObject } from 'react';
+import { type AskHighlights } from '../model/ask';
+import { nodeAskState } from '../model/askView';
+import {
+    BOARD_WIDTH,
+    buildLayout,
+    seatMap,
+    type LayoutModule,
+    type Seat,
+} from '../model/layout';
+import {
+    GROUP_LABEL,
+    moduleDone,
+    moduleProgress,
+    type BoardGroup,
+} from '../model/model';
+import { resolveMotion } from '../model/motion';
+import { type Rollup } from '../model/rollup';
+import { useLearnModel } from '../scope/context';
+import { type LearnCatalogueEntry } from '../types';
+import { BoardNode } from './BoardNode';
+import styles from './LearnBoard.module.css';
+
+export type ClusterBoardProps = {
+    entries: LearnCatalogueEntry[];
+    held: string[];
+    prevHeld: string[] | null;
+    rollups: Map<string, Rollup>;
+    selectedId: string | null;
+    nextUpId: string | null;
+    origin: Seat | null;
+    burst: boolean;
+    reducedMotion: boolean;
+    highlights: AskHighlights | null;
+    onSelect: (id: string) => void;
+    boardRef: RefObject<HTMLDivElement | null>;
+};
+
+const toLayoutModules = (
+    entries: LearnCatalogueEntry[],
+    held: string[],
+    groupOf: (entry: LearnCatalogueEntry) => BoardGroup,
+    isUnlocked: (entry: LearnCatalogueEntry, held: Iterable<string>) => boolean,
+): LayoutModule[] =>
+    entries.map((entry) => ({
+        id: entry.id,
+        group: groupOf(entry),
+        unlocked: isUnlocked(entry, held),
+    }));
+
+export const ClusterBoard: FC<ClusterBoardProps> = ({
+    entries,
+    held,
+    prevHeld,
+    rollups,
+    selectedId,
+    nextUpId,
+    origin,
+    burst,
+    reducedMotion,
+    highlights,
+    onSelect,
+    boardRef,
+}) => {
+    const { groupOf, isUnlocked } = useLearnModel();
+    const layout = useMemo(
+        () => buildLayout(toLayoutModules(entries, held, groupOf, isUnlocked)),
+        [entries, held, groupOf, isUnlocked],
+    );
+    // The geometry is fixed at 1120px; scale it down when the column is narrower.
+    const { ref: viewportRef, width: viewportWidth } = useElementSize();
+    const scale =
+        viewportWidth > 0 ? Math.min(1, viewportWidth / BOARD_WIDTH) : 1;
+    const prevSeats = useMemo(
+        () =>
+            prevHeld
+                ? seatMap(
+                      toLayoutModules(entries, prevHeld, groupOf, isUnlocked),
+                  )
+                : null,
+        [entries, prevHeld, groupOf, isUnlocked],
+    );
+    const byId = useMemo(
+        () => new Map(entries.map((e) => [e.id, e])),
+        [entries],
+    );
+
+    const captionProgress = (group: string): number => {
+        const members = entries.filter(
+            (e) => groupOf(e) === group && isUnlocked(e, held),
+        );
+        if (members.length === 0) return 0;
+        const sum = members.reduce(
+            (acc, e) => acc + moduleProgress(e, rollups.get(e.id)),
+            0,
+        );
+        return Math.round((sum / members.length) * 100);
+    };
+
+    return (
+        <div
+            ref={viewportRef}
+            className={styles.boardViewport}
+            style={{ height: layout.height * scale }}
+        >
+            <div
+                ref={boardRef}
+                className={`${styles.board} ${styles.boardScaled}`}
+                style={{
+                    height: layout.height,
+                    transform: scale < 1 ? `scale(${scale})` : undefined,
+                }}
+                data-testid="learn-board"
+            >
+                <svg
+                    className={styles.connectors}
+                    width={layout.width}
+                    height={layout.height}
+                >
+                    {layout.connectors.map((c, i) => (
+                        <line
+                            key={i}
+                            x1={c.x1}
+                            y1={c.y1}
+                            x2={c.x2}
+                            y2={c.y2}
+                            className={
+                                c.kind === 'trunk'
+                                    ? styles.connectorTrunk
+                                    : styles.connectorRing
+                            }
+                        />
+                    ))}
+                </svg>
+                {layout.captions.map((caption) => {
+                    const pct = captionProgress(caption.group);
+                    return (
+                        <div
+                            key={caption.group}
+                            className={styles.caption}
+                            style={{ left: caption.x, top: caption.y }}
+                        >
+                            <span className={styles.captionName}>
+                                {GROUP_LABEL[caption.group]}
+                            </span>
+                            <div
+                                className={styles.captionBar}
+                                role="progressbar"
+                                aria-label={`${GROUP_LABEL[caption.group]} progress`}
+                                aria-valuenow={pct}
+                                aria-valuemin={0}
+                                aria-valuemax={100}
+                            >
+                                <div
+                                    className={styles.captionFill}
+                                    style={{ width: `${pct}%` }}
+                                />
+                            </div>
+                        </div>
+                    );
+                })}
+                {layout.nodes.map((node) => {
+                    const entry = byId.get(node.id);
+                    if (!entry) return null;
+                    const askState = nodeAskState(node.id, highlights);
+                    const flight = resolveMotion({
+                        unlocked: node.unlocked,
+                        wasUnlocked: prevHeld
+                            ? isUnlocked(entry, prevHeld)
+                            : node.unlocked,
+                        seat: { x: node.x, y: node.y },
+                        prevSeat: prevSeats?.get(node.id) ?? null,
+                        origin,
+                        burst,
+                        reducedMotion,
+                    });
+                    // A locked match is parked at its cluster centre: it shows
+                    // an answer, so it takes no part in the role-switch flight.
+                    const motion =
+                        askState === 'locked-match'
+                            ? {
+                                  ...flight,
+                                  x: node.x,
+                                  y: node.y,
+                                  animate: false,
+                              }
+                            : flight;
+                    return (
+                        <BoardNode
+                            key={node.id}
+                            id={node.id}
+                            title={entry.title}
+                            lessonCount={entry.lessonCount}
+                            unlocked={node.unlocked}
+                            progress={moduleProgress(
+                                entry,
+                                rollups.get(entry.id),
+                            )}
+                            done={moduleDone(rollups.get(entry.id))}
+                            selected={selectedId === node.id}
+                            nextUp={nextUpId === node.id}
+                            index={node.index}
+                            motion={motion}
+                            askState={askState}
+                            onSelect={onSelect}
+                        />
+                    );
+                })}
+            </div>
+        </div>
+    );
+};

--- a/packages/learn-ui/src/components/LearnBoard.module.css
+++ b/packages/learn-ui/src/components/LearnBoard.module.css
@@ -1,0 +1,595 @@
+/* Neutrals are the design README's literals (authoritative for tokens; the
+   ldGray ramp has no exact matches); brand purple uses the Mantine var. */
+.scroller {
+    width: 100%;
+    overflow-x: auto;
+}
+
+.card {
+    width: 100%;
+    max-width: 1440px;
+    margin: 0 auto;
+    background: #ffffff;
+    border-radius: 16px;
+    overflow: hidden;
+    box-shadow:
+        0 1px 2px rgba(10, 13, 18, 0.05),
+        0 0 0 1px #eceff3;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: stretch;
+}
+
+.boardColumn {
+    flex: 1 1 1120px;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+}
+
+/* Measures the column; the 1120px board scales down to fit inside it. */
+.boardViewport {
+    width: 100%;
+    overflow: hidden;
+}
+
+.boardScaled {
+    transform-origin: top left;
+}
+
+.header {
+    padding: 24px 28px 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.title {
+    margin: 0;
+    font-size: 32px;
+    line-height: 1;
+    letter-spacing: -0.02em;
+    font-weight: 500;
+}
+
+.sub {
+    font-size: 14px;
+    color: #818898;
+}
+
+.tabsRow {
+    padding: 4px 28px 10px;
+}
+
+.tabs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.tab {
+    height: 32px;
+    padding: 0 13px;
+    border-radius: 999px;
+    border: 0;
+    font: inherit;
+    font-size: 13px;
+    cursor: pointer;
+    background: #ffffff;
+    color: #818898;
+    box-shadow: inset 0 0 0 1px #e5e7eb;
+}
+
+.tabSelected {
+    background: #272835;
+    color: #ffffff;
+    box-shadow: inset 0 0 0 1px #272835;
+}
+
+.board {
+    position: relative;
+    width: 1120px;
+}
+
+.connectors {
+    position: absolute;
+    left: 0;
+    top: 0;
+    pointer-events: none;
+}
+
+.connectorTrunk {
+    stroke: #e5e7eb;
+    stroke-width: 1.5;
+    stroke-dasharray: 3 6;
+}
+
+.connectorRing {
+    stroke: var(--learn-accent, #7262FF);
+    stroke-width: 3;
+}
+
+.caption {
+    position: absolute;
+    width: 150px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+    transform: translateY(-100%);
+}
+
+.captionName {
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #272835;
+}
+
+.captionBar {
+    width: 96px;
+    height: 5px;
+    border-radius: 999px;
+    background: #f1f3f5;
+    overflow: hidden;
+}
+
+.captionFill {
+    height: 100%;
+    background: var(--learn-accent, #7262FF);
+}
+
+.node {
+    position: absolute;
+    width: 38px;
+    height: 38px;
+    border-radius: 50%;
+    border: 0;
+    padding: 0;
+    display: grid;
+    place-items: center;
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+    color: #272835;
+    /* Mantine exposes no rgb triplet variable for the accent; alpha shades stay literal. */
+    box-shadow: inset 0 0 0 1.5px rgba(94, 76, 255, 0.38);
+}
+
+.nodeLocked {
+    background: #ffffff;
+    color: #818898;
+    box-shadow: inset 0 0 0 1.5px #e5e7eb;
+    pointer-events: none;
+}
+
+.nodeDone {
+    color: #ffffff;
+    box-shadow:
+        inset 0 0 0 1.5px rgba(255, 255, 255, 0.85),
+        0 4px 14px rgba(94, 76, 255, 0.45);
+}
+
+.nodeSelected {
+    box-shadow:
+        inset 0 0 0 1.5px #272835,
+        0 0 0 4px rgba(39, 40, 53, 0.12);
+}
+
+.nodeNextUp {
+    animation: nudge 1.8s ease-in-out infinite;
+}
+
+@keyframes nudge {
+    0%,
+    100% {
+        box-shadow:
+            inset 0 0 0 2px var(--learn-accent, #7262FF),
+            0 0 0 0 rgba(94, 76, 255, 0.35);
+    }
+    50% {
+        box-shadow:
+            inset 0 0 0 2px var(--learn-accent, #7262FF),
+            0 0 0 10px rgba(94, 76, 255, 0);
+    }
+}
+
+/* Ask states. Dimming is the inline opacity from askOpacity(); these classes
+   carry only the ring treatment. */
+.nodeMatched {
+    box-shadow:
+        inset 0 0 0 2px var(--learn-accent, #7262FF),
+        0 0 0 8px rgba(94, 76, 255, 0.18);
+}
+
+.nodeLockedMatch {
+    background: #ffffff;
+    color: #818898;
+    box-shadow: inset 0 0 0 1.5px #818898;
+}
+
+.rail {
+    flex: 0 1 320px;
+    max-width: 100%;
+    min-width: 0;
+    border-left: 1px solid #eceff3;
+    background: #f8fafb;
+    padding: 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.overline {
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #818898;
+}
+
+.bigPct {
+    font-size: 44px;
+    line-height: 1;
+    letter-spacing: -0.02em;
+    font-weight: 500;
+}
+
+.bar {
+    display: block;
+    width: 100%;
+    border-radius: 999px;
+    background: #eceff3;
+    overflow: hidden;
+}
+
+.barSm {
+    height: 5px;
+}
+
+.barMd {
+    height: 6px;
+}
+
+.barLg {
+    height: 8px;
+}
+
+.barFill {
+    display: block;
+    height: 100%;
+    background: var(--learn-accent, #7262FF);
+}
+
+.queueCard {
+    text-align: left;
+    font: inherit;
+    cursor: pointer;
+    background: #ffffff;
+    border: 0;
+    border-radius: 16px;
+    padding: 14px;
+    box-shadow: 0 0 0 1px #eceff3;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    transition: box-shadow 120ms ease-out;
+}
+
+.queueCard:hover {
+    box-shadow:
+        0 0 0 1px #dfe1e7,
+        0 4px 12px rgba(10, 13, 18, 0.06);
+}
+
+.completedRow {
+    text-align: left;
+    font: inherit;
+    cursor: pointer;
+    background: transparent;
+    border: 0;
+    padding: 8px 0;
+    border-top: 1px solid #eceff3;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.checkDisc {
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background: var(--learn-accent, #7262FF);
+    color: #ffffff;
+    display: grid;
+    place-items: center;
+    font-size: 11px;
+    flex: none;
+}
+
+.paneTitle {
+    margin: 0;
+    font-size: 24px;
+    line-height: 1.1;
+    letter-spacing: -0.02em;
+    font-weight: 500;
+}
+
+.closeButton {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    border: 0;
+    background: #ffffff;
+    box-shadow: inset 0 0 0 1px #e5e7eb;
+    cursor: pointer;
+    font-size: 16px;
+    line-height: 1;
+}
+
+.scopeChip {
+    align-self: flex-start;
+    font-family: ui-monospace, Menlo, Consolas, monospace;
+    font-size: 12px;
+    background: #ffffff;
+    box-shadow: inset 0 0 0 1px #eceff3;
+    border-radius: 4px;
+    padding: 3px 8px;
+}
+
+.lessonRow {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+}
+
+.lessonDisc {
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    display: grid;
+    place-items: center;
+    font-size: 10px;
+    flex: none;
+    color: #ffffff;
+}
+
+.lessonDiscDone {
+    background: var(--learn-accent, #7262FF);
+    box-shadow: none;
+}
+
+.lessonDiscPending {
+    background: #ffffff;
+    box-shadow: inset 0 0 0 1px #dfe1e7;
+}
+
+.lessonLabel {
+    color: #272835;
+}
+
+.lessonLabelDone {
+    color: #818898;
+}
+
+.muted {
+    color: #818898;
+}
+
+.cta {
+    height: 38px;
+    border-radius: 999px;
+    border: 0;
+    background: var(--learn-accent, #7262FF);
+    color: #ffffff;
+    font: inherit;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 120ms ease-out;
+}
+
+.cta:hover {
+    /* No accent shade matches this hover tone; kept as a literal. */
+    background: #1200b2;
+}
+
+.ask {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin-top: 12px;
+}
+
+.askForm {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    background: #ffffff;
+    border-radius: 999px;
+    padding: 4px 4px 4px 16px;
+    box-shadow: inset 0 0 0 1px #e5e7eb;
+}
+
+.askInput {
+    flex: 1 1 auto;
+    min-width: 0;
+    height: 36px;
+    border: 0;
+    outline: none;
+    font: inherit;
+    font-size: 14px;
+    background: transparent;
+    color: #272835;
+}
+
+.askInput::placeholder {
+    color: #818898;
+}
+
+.askClear {
+    width: 24px;
+    height: 24px;
+    flex: none;
+    border: 0;
+    border-radius: 50%;
+    background: transparent;
+    color: #818898;
+    font-size: 16px;
+    line-height: 1;
+    cursor: pointer;
+}
+
+.askSubmit {
+    height: 36px;
+    flex: none;
+    padding: 0 18px;
+    border: 0;
+    border-radius: 999px;
+    background: var(--learn-accent, #7262FF);
+    color: #ffffff;
+    font: inherit;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+/* One row: the chip list is capped, so it never needs to wrap. */
+.askChips {
+    display: flex;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    gap: 6px;
+}
+
+.askChip {
+    height: 28px;
+    padding: 0 12px;
+    border: 0;
+    border-radius: 999px;
+    background: #ffffff;
+    color: #818898;
+    font: inherit;
+    font-size: 12px;
+    cursor: pointer;
+    box-shadow: inset 0 0 0 1px #eceff3;
+}
+
+.askResults {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.askGroup {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.askModule {
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #818898;
+}
+
+.askRow {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+}
+
+.askLesson {
+    color: #272835;
+}
+
+.askOpen {
+    border: 0;
+    background: transparent;
+    padding: 0;
+    font: inherit;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--learn-accent, #7262FF);
+    cursor: pointer;
+}
+
+.badgeHero {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.badgeEmblem {
+    display: inline-flex;
+    flex: none;
+    line-height: 0;
+}
+
+.badgeRung {
+    font-size: 20px;
+    line-height: 1.1;
+    letter-spacing: -0.01em;
+    font-weight: 500;
+}
+
+.badgeHowto {
+    font-size: 12px;
+}
+
+.badgeHowtoSummary {
+    cursor: pointer;
+    color: #818898;
+}
+
+.badgeHowtoList {
+    list-style: none;
+    margin: 8px 0 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.badgeHowtoRung {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    color: #818898;
+}
+
+.badgeHowtoEmblem {
+    display: inline-flex;
+    flex: none;
+    line-height: 0;
+}
+
+.badgeHowtoReq {
+    color: #818898;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .nodeNextUp {
+        animation: none;
+        box-shadow: inset 0 0 0 2px var(--learn-accent, #7262FF);
+    }
+    .queueCard,
+    .cta {
+        transition: none;
+    }
+}
+
+/* Below the card's two-column width the rail wraps under the board. */
+@media (max-width: 1100px) {
+    .rail {
+        border-left: 0;
+        border-top: 1px solid #eceff3;
+    }
+}

--- a/packages/learn-ui/src/components/LearnBoard.module.css
+++ b/packages/learn-ui/src/components/LearnBoard.module.css
@@ -1,5 +1,6 @@
 /* Neutrals are the design README's literals (authoritative for tokens; the
-   ldGray ramp has no exact matches); brand purple uses the Mantine var. */
+   ldGray ramp has no exact matches); the accent comes from the host-set
+   --learn-accent custom property, with a violet fallback. */
 .scroller {
     width: 100%;
     overflow-x: auto;

--- a/packages/learn-ui/src/components/LearnBoard.module.css
+++ b/packages/learn-ui/src/components/LearnBoard.module.css
@@ -105,7 +105,7 @@
 }
 
 .connectorRing {
-    stroke: var(--learn-accent, #7262FF);
+    stroke: var(--learn-accent, #7262ff);
     stroke-width: 3;
 }
 
@@ -137,7 +137,7 @@
 
 .captionFill {
     height: 100%;
-    background: var(--learn-accent, #7262FF);
+    background: var(--learn-accent, #7262ff);
 }
 
 .node {
@@ -185,12 +185,12 @@
     0%,
     100% {
         box-shadow:
-            inset 0 0 0 2px var(--learn-accent, #7262FF),
+            inset 0 0 0 2px var(--learn-accent, #7262ff),
             0 0 0 0 rgba(94, 76, 255, 0.35);
     }
     50% {
         box-shadow:
-            inset 0 0 0 2px var(--learn-accent, #7262FF),
+            inset 0 0 0 2px var(--learn-accent, #7262ff),
             0 0 0 10px rgba(94, 76, 255, 0);
     }
 }
@@ -199,7 +199,7 @@
    carry only the ring treatment. */
 .nodeMatched {
     box-shadow:
-        inset 0 0 0 2px var(--learn-accent, #7262FF),
+        inset 0 0 0 2px var(--learn-accent, #7262ff),
         0 0 0 8px rgba(94, 76, 255, 0.18);
 }
 
@@ -259,7 +259,7 @@
 .barFill {
     display: block;
     height: 100%;
-    background: var(--learn-accent, #7262FF);
+    background: var(--learn-accent, #7262ff);
 }
 
 .queueCard {
@@ -300,7 +300,7 @@
     width: 20px;
     height: 20px;
     border-radius: 50%;
-    background: var(--learn-accent, #7262FF);
+    background: var(--learn-accent, #7262ff);
     color: #ffffff;
     display: grid;
     place-items: center;
@@ -357,7 +357,7 @@
 }
 
 .lessonDiscDone {
-    background: var(--learn-accent, #7262FF);
+    background: var(--learn-accent, #7262ff);
     box-shadow: none;
 }
 
@@ -382,7 +382,7 @@
     height: 38px;
     border-radius: 999px;
     border: 0;
-    background: var(--learn-accent, #7262FF);
+    background: var(--learn-accent, #7262ff);
     color: #ffffff;
     font: inherit;
     font-weight: 600;
@@ -448,7 +448,7 @@
     padding: 0 18px;
     border: 0;
     border-radius: 999px;
-    background: var(--learn-accent, #7262FF);
+    background: var(--learn-accent, #7262ff);
     color: #ffffff;
     font: inherit;
     font-weight: 600;
@@ -517,7 +517,7 @@
     font: inherit;
     font-size: 13px;
     font-weight: 600;
-    color: var(--learn-accent, #7262FF);
+    color: var(--learn-accent, #7262ff);
     cursor: pointer;
 }
 
@@ -578,7 +578,7 @@
 @media (prefers-reduced-motion: reduce) {
     .nodeNextUp {
         animation: none;
-        box-shadow: inset 0 0 0 2px var(--learn-accent, #7262FF);
+        box-shadow: inset 0 0 0 2px var(--learn-accent, #7262ff);
     }
     .queueCard,
     .cta {

--- a/packages/learn-ui/src/components/LearnDemo.test.tsx
+++ b/packages/learn-ui/src/components/LearnDemo.test.tsx
@@ -1,0 +1,43 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { type LearnDemo as LearnDemoManifest } from '../types';
+import { LearnDemo } from './LearnDemo';
+
+const demo: LearnDemoManifest = {
+    id: 'save-chart',
+    title: 'Save a chart',
+    viewport: { width: 1440, height: 900 },
+    steps: [
+        {
+            image: 'save-1.png',
+            caption: 'Click Save.',
+            hotspot: { x: 0.8, y: 0.1, width: 0.1, height: 0.05 },
+        },
+        { image: 'save-2.png', caption: 'Name it.', hotspot: null },
+        { image: 'save-3.png', caption: 'Saved.', hotspot: null },
+    ],
+};
+
+describe('LearnDemo', () => {
+    it('walks the steps by hotspot, then Next, then Replay', () => {
+        render(<LearnDemo demo={demo} assetBaseUrl="https://cdn/x" />);
+        expect(screen.getByText('1/3')).toBeInTheDocument();
+        expect(screen.getByRole('img')).toHaveAttribute(
+            'src',
+            'https://cdn/x/assets/save-1.png',
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: 'Next step' }));
+        expect(screen.getByText('2/3')).toBeInTheDocument();
+        expect(
+            screen.queryByRole('button', { name: 'Next step' }),
+        ).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+        expect(screen.getByText('3/3')).toBeInTheDocument();
+        expect(screen.getByText('Saved.')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Replay' }));
+        expect(screen.getByText('1/3')).toBeInTheDocument();
+    });
+});

--- a/packages/learn-ui/src/components/LearnDemo.tsx
+++ b/packages/learn-ui/src/components/LearnDemo.tsx
@@ -1,0 +1,72 @@
+import { useState, type FC } from 'react';
+import { type LearnDemo as LearnDemoManifest } from '../types';
+import styles from './LearnLesson.module.css';
+
+type Props = {
+    demo: LearnDemoManifest;
+    assetBaseUrl: string;
+};
+
+const pct = (value: number): string => `${(value * 100).toFixed(2)}%`;
+
+/** Click-through demo: one screenshot per step, the hotspot advances it. */
+export const LearnDemo: FC<Props> = ({ demo, assetBaseUrl }) => {
+    const [step, setStep] = useState(0);
+    const current = demo.steps[step];
+    if (!current) return null;
+    const last = step === demo.steps.length - 1;
+
+    return (
+        <div className={styles.demo}>
+            <div
+                className={styles.demoStage}
+                style={{
+                    aspectRatio: `${demo.viewport.width} / ${demo.viewport.height}`,
+                }}
+            >
+                <img
+                    src={`${assetBaseUrl}/assets/${current.image}`}
+                    alt={`${demo.title}, step ${step + 1}`}
+                />
+                {current.hotspot && !last && (
+                    <button
+                        type="button"
+                        className={styles.demoHotspot}
+                        aria-label="Next step"
+                        style={{
+                            left: pct(current.hotspot.x),
+                            top: pct(current.hotspot.y),
+                            width: pct(current.hotspot.width),
+                            height: pct(current.hotspot.height),
+                        }}
+                        onClick={() => setStep(step + 1)}
+                    />
+                )}
+            </div>
+            <div className={styles.demoCaption}>
+                <span className={styles.demoStepCount}>
+                    {step + 1}/{demo.steps.length}
+                </span>
+                {current.caption}
+                {!current.hotspot && !last && (
+                    <button
+                        type="button"
+                        className={styles.demoButton}
+                        onClick={() => setStep(step + 1)}
+                    >
+                        Next
+                    </button>
+                )}
+                {last && (
+                    <button
+                        type="button"
+                        className={styles.demoButton}
+                        onClick={() => setStep(0)}
+                    >
+                        Replay
+                    </button>
+                )}
+            </div>
+        </div>
+    );
+};

--- a/packages/learn-ui/src/components/LearnLesson.module.css
+++ b/packages/learn-ui/src/components/LearnLesson.module.css
@@ -49,7 +49,7 @@
 }
 
 .lesson a {
-    color: var(--learn-accent, #7262FF);
+    color: var(--learn-accent, #7262ff);
 }
 
 /* Citation pins: a numbered dot after the sentence that describes a region of
@@ -61,7 +61,7 @@
     width: 15px;
     height: 15px;
     border-radius: 50%;
-    background: var(--learn-accent, #7262FF);
+    background: var(--learn-accent, #7262ff);
     color: #ffffff;
     font-size: 9px;
     font-weight: 700;
@@ -113,7 +113,7 @@
     pointer-events: none;
     opacity: 0;
     box-shadow:
-        0 0 0 2px var(--learn-accent, #7262FF),
+        0 0 0 2px var(--learn-accent, #7262ff),
         0 0 0 9999px rgba(39, 40, 53, 0.58);
     transition: opacity 0.18s ease;
 }
@@ -129,7 +129,7 @@
     transform: translateX(-50%);
     bottom: 100%;
     margin-bottom: 6px;
-    background: var(--learn-accent, #7262FF);
+    background: var(--learn-accent, #7262ff);
     color: #ffffff;
     font-size: 12px;
     font-weight: 500;
@@ -189,7 +189,7 @@
 .demoHotspot {
     position: absolute;
     background: transparent;
-    border: 2px solid var(--learn-accent, #7262FF);
+    border: 2px solid var(--learn-accent, #7262ff);
     border-radius: 6px;
     padding: 0;
     cursor: pointer;
@@ -219,7 +219,7 @@
 
 .demoStepCount {
     font-weight: 600;
-    color: var(--learn-accent, #7262FF);
+    color: var(--learn-accent, #7262ff);
     margin-right: 6px;
 }
 

--- a/packages/learn-ui/src/components/LearnLesson.module.css
+++ b/packages/learn-ui/src/components/LearnLesson.module.css
@@ -1,0 +1,241 @@
+/* Styles for the lesson HTML published by Lightdash University, which is
+   injected verbatim (sanitised) and carries no stylesheet of its own. The
+   citation and highlight rules mirror the lesson's own inline CSS, which the
+   sanitiser drops; their classes come from the lesson, hence :global(). */
+.lesson {
+    line-height: 1.6;
+    min-width: 0;
+    overflow-wrap: anywhere;
+}
+
+.lesson h1 {
+    font-size: 24px;
+    line-height: 1.2;
+    margin: 0 0 12px;
+}
+
+.lesson h2 {
+    font-size: 17px;
+    line-height: 1.3;
+    margin: 24px 0 8px;
+}
+
+.lesson p {
+    margin: 0 0 12px;
+}
+
+.lesson ul,
+.lesson ol {
+    margin: 0 0 12px;
+    padding-left: 22px;
+}
+
+.lesson img {
+    display: block;
+    max-width: 100%;
+    height: auto;
+    border-radius: 8px;
+    box-shadow: 0 0 0 1px #eceff3;
+}
+
+.lesson figure {
+    margin: 16px 0 20px;
+}
+
+.lesson figcaption {
+    margin-top: 8px;
+    font-size: 13px;
+    color: #818898;
+}
+
+.lesson a {
+    color: var(--learn-accent, #7262FF);
+}
+
+/* Citation pins: a numbered dot after the sentence that describes a region of
+   the figure below it. */
+.lesson :global(a.cit) {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 15px;
+    height: 15px;
+    border-radius: 50%;
+    background: var(--learn-accent, #7262FF);
+    color: #ffffff;
+    font-size: 9px;
+    font-weight: 700;
+    line-height: 1;
+    vertical-align: super;
+    margin: 0 1px 0 3px;
+    text-decoration: none;
+    cursor: pointer;
+    transition:
+        background 0.15s ease,
+        transform 0.15s ease;
+}
+
+.lesson :global(a.cit:hover),
+.lesson :global(a.cit:focus) {
+    background: #4536d6;
+    transform: translateY(-1px);
+    outline: none;
+}
+
+.lesson :global(a.cit.active) {
+    background: #1a1b25;
+}
+
+/* A figure that carries highlight regions. */
+.lesson :global(.figwrap) {
+    position: relative;
+    display: block;
+    overflow: hidden;
+    border: 1px solid #eceff3;
+    border-radius: 10px;
+    margin: 8px 0 20px;
+    line-height: 0;
+    scroll-margin-top: 28px;
+}
+
+.lesson :global(.figwrap) img {
+    width: 100%;
+    border-radius: 0;
+    box-shadow: none;
+    margin: 0;
+}
+
+/* Positioned by inline percentages from the lesson; the rest is here. The
+   huge spread shadow dims everything outside the box. */
+.lesson :global(.hlbox) {
+    position: absolute;
+    border-radius: 8px;
+    pointer-events: none;
+    opacity: 0;
+    box-shadow:
+        0 0 0 2px var(--learn-accent, #7262FF),
+        0 0 0 9999px rgba(39, 40, 53, 0.58);
+    transition: opacity 0.18s ease;
+}
+
+.lesson :global(.hlbox.active) {
+    opacity: 1;
+}
+
+.lesson :global(.hlbox)::after {
+    content: attr(data-label);
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    bottom: 100%;
+    margin-bottom: 6px;
+    background: var(--learn-accent, #7262FF);
+    color: #ffffff;
+    font-size: 12px;
+    font-weight: 500;
+    line-height: 1;
+    padding: 6px 9px;
+    border-radius: 999px;
+    white-space: nowrap;
+}
+
+.lesson :global(.hlbox.below)::after {
+    bottom: auto;
+    top: 100%;
+    margin-bottom: 0;
+    margin-top: 6px;
+}
+
+.lesson :global(.hlbox.pl-r)::after {
+    left: auto;
+    right: 0;
+    transform: none;
+}
+
+.lesson :global(.hlbox.pl-l)::after {
+    left: 0;
+    right: auto;
+    transform: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .lesson :global(a.cit),
+    .lesson :global(.hlbox) {
+        transition: none;
+    }
+}
+
+/* Click-through demos mounted where the lesson left a `data-demo` div. */
+.demo {
+    margin: 8px 0 20px;
+}
+
+.demoStage {
+    position: relative;
+    border: 1px solid #eceff3;
+    border-radius: 10px;
+    overflow: hidden;
+    line-height: 0;
+}
+
+.demoStage img {
+    display: block;
+    width: 100%;
+    border-radius: 0;
+    box-shadow: none;
+    margin: 0;
+}
+
+.demoHotspot {
+    position: absolute;
+    background: transparent;
+    border: 2px solid var(--learn-accent, #7262FF);
+    border-radius: 6px;
+    padding: 0;
+    cursor: pointer;
+    animation: demoPulse 1.6s ease-in-out infinite;
+}
+
+.demoHotspot:hover,
+.demoHotspot:focus-visible {
+    background: rgba(94, 76, 255, 0.12);
+}
+
+@keyframes demoPulse {
+    0%,
+    100% {
+        box-shadow: 0 0 0 0 rgba(94, 76, 255, 0.45);
+    }
+    50% {
+        box-shadow: 0 0 0 8px rgba(94, 76, 255, 0);
+    }
+}
+
+.demoCaption {
+    margin-top: 8px;
+    font-size: 14px;
+    color: #818898;
+}
+
+.demoStepCount {
+    font-weight: 600;
+    color: var(--learn-accent, #7262FF);
+    margin-right: 6px;
+}
+
+.demoButton {
+    margin-left: 8px;
+    padding: 3px 10px;
+    font: inherit;
+    font-size: 13px;
+    border-radius: 999px;
+    border: 1px solid #dfe1e7;
+    background: #ffffff;
+    cursor: pointer;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .demoHotspot {
+        animation: none;
+    }
+}

--- a/packages/learn-ui/src/components/LessonBody.test.tsx
+++ b/packages/learn-ui/src/components/LessonBody.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { LessonBody } from './LessonBody';
+
+describe('LessonBody', () => {
+    it('renders the html and mounts a demo into its placeholder', () => {
+        render(
+            <LessonBody
+                html='<p>Hello</p><div data-demo="tour"></div>'
+                demos={{
+                    tour: {
+                        id: 'tour',
+                        title: 'Tour',
+                        viewport: { width: 10, height: 10 },
+                        steps: [
+                            {
+                                image: 'a.png',
+                                caption: 'Step one',
+                                hotspot: null,
+                            },
+                        ],
+                    },
+                }}
+                assetBaseUrl="https://cdn.test/c"
+            />,
+        );
+        expect(screen.getByText('Hello')).toBeInTheDocument();
+        expect(screen.getByText('Step one')).toBeInTheDocument();
+    });
+    it('calls onMount with the root and runs its cleanup on html change', () => {
+        const cleanup = vi.fn();
+        const onMount = vi.fn(() => cleanup);
+        const { rerender } = render(
+            <LessonBody
+                html="<p>a</p>"
+                demos={{}}
+                assetBaseUrl=""
+                onMount={onMount}
+            />,
+        );
+        expect(onMount).toHaveBeenCalledTimes(1);
+        rerender(
+            <LessonBody
+                html="<p>b</p>"
+                demos={{}}
+                assetBaseUrl=""
+                onMount={onMount}
+            />,
+        );
+        expect(cleanup).toHaveBeenCalledTimes(1);
+        expect(onMount).toHaveBeenCalledTimes(2);
+    });
+});

--- a/packages/learn-ui/src/components/LessonBody.tsx
+++ b/packages/learn-ui/src/components/LessonBody.tsx
@@ -12,7 +12,11 @@ export type LessonBodyProps = {
     html: string;
     demos: Record<string, LearnDemoManifest>;
     assetBaseUrl: string;
-    /** Runs after every html change with the lesson root; defaults to citation wiring. */
+    /**
+     * Runs after every html change with the lesson root; defaults to citation
+     * wiring. Held in a ref, so an inline function is safe: the effect keys on
+     * `html` alone and a new callback identity never re-runs it.
+     */
     onMount?: (root: HTMLElement) => (() => void) | void;
 };
 
@@ -27,6 +31,8 @@ export const LessonBody: FC<LessonBodyProps> = ({
     const markup = useMemo(() => ({ __html: html }), [html]);
     const rootRef = useRef<HTMLDivElement>(null);
     const [mounts, setMounts] = useState<DemoMount[]>([]);
+    const onMountRef = useRef(onMount);
+    onMountRef.current = onMount;
 
     useEffect(() => {
         const el = rootRef.current;
@@ -42,8 +48,8 @@ export const LessonBody: FC<LessonBodyProps> = ({
                 }),
             ),
         );
-        return onMount(el) ?? undefined;
-    }, [html, onMount]);
+        return onMountRef.current(el) ?? undefined;
+    }, [html]);
 
     return (
         <>

--- a/packages/learn-ui/src/components/LessonBody.tsx
+++ b/packages/learn-ui/src/components/LessonBody.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useMemo, useRef, useState, type FC } from 'react';
+import { createPortal } from 'react-dom';
+import { wireCitations } from '../model/citations';
+import { type LearnDemo as LearnDemoManifest } from '../types';
+import { LearnDemo } from './LearnDemo';
+import styles from './LearnLesson.module.css';
+
+type DemoMount = { id: string; element: HTMLElement };
+
+export type LessonBodyProps = {
+    /** Sanitised lesson HTML; the host is responsible for sanitising. */
+    html: string;
+    demos: Record<string, LearnDemoManifest>;
+    assetBaseUrl: string;
+    /** Runs after every html change with the lesson root; defaults to citation wiring. */
+    onMount?: (root: HTMLElement) => (() => void) | void;
+};
+
+export const LessonBody: FC<LessonBodyProps> = ({
+    html,
+    demos,
+    assetBaseUrl,
+    onMount = wireCitations,
+}) => {
+    // One object per html string: a fresh { __html } each render would make
+    // React reset the injected HTML and wipe the demo portals mounted inside it.
+    const markup = useMemo(() => ({ __html: html }), [html]);
+    const rootRef = useRef<HTMLDivElement>(null);
+    const [mounts, setMounts] = useState<DemoMount[]>([]);
+
+    useEffect(() => {
+        const el = rootRef.current;
+        if (!el) {
+            setMounts([]);
+            return undefined;
+        }
+        setMounts(
+            Array.from(el.querySelectorAll<HTMLElement>('div[data-demo]')).map(
+                (element) => ({
+                    id: element.getAttribute('data-demo') ?? '',
+                    element,
+                }),
+            ),
+        );
+        return onMount(el) ?? undefined;
+    }, [html, onMount]);
+
+    return (
+        <>
+            {/* eslint-disable-next-line react/no-danger */}
+            <div
+                ref={rootRef}
+                className={styles.lesson}
+                dangerouslySetInnerHTML={markup}
+            />
+            {mounts.map(({ id, element }, index) => {
+                const demo = Object.prototype.hasOwnProperty.call(demos, id)
+                    ? demos[id]
+                    : undefined;
+                if (!demo || !element.isConnected) return null;
+                return createPortal(
+                    <LearnDemo demo={demo} assetBaseUrl={assetBaseUrl} />,
+                    element,
+                    `${index}-${id}`,
+                );
+            })}
+        </>
+    );
+};

--- a/packages/learn-ui/src/components/ModulePane.test.tsx
+++ b/packages/learn-ui/src/components/ModulePane.test.tsx
@@ -1,0 +1,73 @@
+import { screen } from '@testing-library/react';
+import { type ComponentProps } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { emptyRollup } from '../model/rollup';
+import { commonScopeSource, entry } from '../model/testFixtures';
+import { LearnUiProvider } from '../scope/context';
+import { renderWithMantine } from '../test/render';
+import { type LearnCourse } from '../types';
+import { ModulePane } from './ModulePane';
+
+const course: LearnCourse = {
+    id: 'dash',
+    title: 'Dashboards',
+    passingScore: 80,
+    lessons: [
+        { id: 'l1', title: 'Open one', html: '<p/>', scope: null },
+        {
+            id: 'l2',
+            title: 'Edit one',
+            html: '<p/>',
+            scope: 'manage:Dashboard',
+        },
+    ],
+    quiz: { questions: [] },
+    demos: {},
+    version: 1,
+    contentHash: 'h',
+    publishedAt: '2026-08-01T00:00:00.000Z',
+    assetBaseUrl: '',
+};
+const module = {
+    entry: entry({
+        id: 'dash',
+        scope: 'view:Dashboard',
+        lessonScopes: [null, 'manage:Dashboard'],
+    }),
+    group: 'content' as const,
+    progress: 0,
+    lessonsDone: 0,
+    done: false,
+};
+const render = (props: Partial<ComponentProps<typeof ModulePane>>) =>
+    renderWithMantine(
+        <LearnUiProvider scopeSource={commonScopeSource}>
+            <ModulePane
+                module={module}
+                held={commonScopeSource.getAllScopesForRole('viewer')}
+                rollup={emptyRollup()}
+                course={undefined}
+                courseLoading={false}
+                courseError={false}
+                onClose={vi.fn()}
+                onOpen={vi.fn()}
+                {...props}
+            />
+        </LearnUiProvider>,
+    );
+
+describe('ModulePane', () => {
+    it('shows the loading state from props', () => {
+        render({ courseLoading: true });
+        expect(screen.getByText('Loading lessons…')).toBeInTheDocument();
+    });
+    it('shows the error state from props', () => {
+        render({ courseError: true });
+        expect(screen.getByText('Lessons unavailable')).toBeInTheDocument();
+    });
+    it('lists only the lessons the held scopes can see', () => {
+        render({ course });
+        expect(screen.getByText(/Open one/)).toBeInTheDocument();
+        expect(screen.queryByText(/Edit one/)).not.toBeInTheDocument();
+    });
+});

--- a/packages/learn-ui/src/components/ModulePane.tsx
+++ b/packages/learn-ui/src/components/ModulePane.tsx
@@ -1,0 +1,149 @@
+import { Group, Stack, Text } from '@mantine/core';
+import { type FC } from 'react';
+import {
+    ctaLabel,
+    GROUP_LABEL,
+    parseScopeTag,
+    plural,
+    ROLE_LABEL,
+    type BoardModule,
+} from '../model/model';
+import { type Rollup } from '../model/rollup';
+import { useLearnModel } from '../scope/context';
+import { type LearnCourse } from '../types';
+import styles from './LearnBoard.module.css';
+
+type Props = {
+    module: BoardModule;
+    /** The scope names the selected role holds (CS-169 lesson filtering). */
+    held: string[];
+    rollup: Rollup | undefined;
+    course: LearnCourse | undefined;
+    courseLoading: boolean;
+    courseError: boolean;
+    onClose: () => void;
+    onOpen: (courseId: string) => void;
+};
+
+export const ModulePane: FC<Props> = ({
+    module,
+    held,
+    rollup,
+    course,
+    courseLoading,
+    courseError,
+    onClose,
+    onOpen,
+}) => {
+    const { entry, progress, group, done: moduleComplete } = module;
+    const { heldBy, isUnlocked, scopePermits, lessonVisible } = useLearnModel();
+    const pct = Math.round(progress * 100);
+    const holders = heldBy(entry).map((role) => ROLE_LABEL[role]);
+    const permits = scopePermits(entry);
+    const done = rollup?.lessonsCompleted ?? new Set<string>();
+    // CS-169: a held scope-group module lists only the lessons the selected
+    // role can see, matching the effective lessonCount the panel mapped in. A
+    // module the role does NOT hold (a completed row from another role) still
+    // describes the whole module, so its list stays unfiltered.
+    const lessons = (course?.lessons ?? []).filter(
+        (lesson) =>
+            !isUnlocked(entry, held) || lessonVisible(lesson.scope, held),
+    );
+
+    return (
+        <Stack gap={16}>
+            <Group justify="space-between" align="flex-start" gap={12}>
+                <Stack gap={6}>
+                    <span className={styles.overline}>
+                        {GROUP_LABEL[group]}
+                    </span>
+                    <h3 className={styles.paneTitle}>{entry.title}</h3>
+                </Stack>
+                <button
+                    type="button"
+                    className={styles.closeButton}
+                    aria-label="Close"
+                    onClick={onClose}
+                >
+                    ×
+                </button>
+            </Group>
+
+            <Stack gap={6}>
+                <div className={`${styles.bar} ${styles.barMd}`}>
+                    <div
+                        className={styles.barFill}
+                        style={{ width: `${pct}%` }}
+                    />
+                </div>
+                <Text size="xs" className={styles.muted}>
+                    {moduleComplete ? 'Complete' : `${pct}% complete`}
+                </Text>
+            </Stack>
+
+            {entry.scope !== null && (
+                <Stack gap={6}>
+                    <span className={styles.scopeChip}>
+                        {parseScopeTag(entry.scope).base}
+                    </span>
+                    {permits && (
+                        <Text size="sm" className={styles.muted}>
+                            {permits}
+                        </Text>
+                    )}
+                    <Text size="xs" className={styles.muted}>
+                        Held by{' '}
+                        {holders.length
+                            ? holders.join(', ')
+                            : 'custom roles only'}
+                    </Text>
+                </Stack>
+            )}
+
+            <Stack gap={8}>
+                {courseError && (
+                    <Text size="sm" className={styles.muted}>
+                        Lessons unavailable
+                    </Text>
+                )}
+                {courseLoading && !courseError && (
+                    <Text size="sm" className={styles.muted}>
+                        Loading lessons…
+                    </Text>
+                )}
+                {lessons.map((lesson, i) => {
+                    const finished = moduleComplete || done.has(lesson.id);
+                    return (
+                        <div key={lesson.id} className={styles.lessonRow}>
+                            <span
+                                className={`${styles.lessonDisc} ${finished ? styles.lessonDiscDone : styles.lessonDiscPending}`}
+                            >
+                                {finished ? '✓' : ''}
+                            </span>
+                            <span
+                                className={
+                                    finished
+                                        ? styles.lessonLabelDone
+                                        : styles.lessonLabel
+                                }
+                            >
+                                {String(i + 1).padStart(2, '0')} {lesson.title}
+                            </span>
+                        </div>
+                    );
+                })}
+            </Stack>
+
+            <button
+                type="button"
+                className={styles.cta}
+                onClick={() => onOpen(entry.id)}
+            >
+                {ctaLabel(moduleComplete, progress)}
+            </button>
+            <Text size="xs" className={styles.muted}>
+                {plural(entry.lessonCount, 'lesson')}
+            </Text>
+        </Stack>
+    );
+};

--- a/packages/learn-ui/src/components/RoleBadgeCard.test.tsx
+++ b/packages/learn-ui/src/components/RoleBadgeCard.test.tsx
@@ -1,0 +1,119 @@
+import { screen } from '@testing-library/react';
+import { type ReactElement } from 'react';
+import { describe, expect, it } from 'vitest';
+import { commonScopeSource, entry } from '../model/testFixtures';
+import { LearnUiProvider } from '../scope/context';
+import { ProjectMemberRole } from '../scope/types';
+import { renderWithMantine } from '../test/render';
+import { type LearnBadgeTier } from '../types';
+import { RoleBadgeCard } from './RoleBadgeCard';
+
+const renderBoard = (ui: ReactElement) =>
+    renderWithMantine(
+        <LearnUiProvider scopeSource={commonScopeSource}>{ui}</LearnUiProvider>,
+    );
+
+const held = [entry({ id: 'a' }), entry({ id: 'b' })];
+
+const tiers = (map: Record<string, LearnBadgeTier>) =>
+    new Map(Object.entries(map));
+
+describe('RoleBadgeCard', () => {
+    it('sits at the weakest held module and counts towards the next rung', () => {
+        renderBoard(
+            <RoleBadgeCard
+                role={ProjectMemberRole.VIEWER}
+                held={held}
+                tiers={tiers({ a: 'bronze', b: 'silver' })}
+                isLoading={false}
+            />,
+        );
+        expect(screen.getByText('viewer badge')).toBeInTheDocument();
+        // The rung word also appears in the disclosure, so pin the hero span.
+        expect(
+            screen.getByText('Bronze', { selector: 'span' }),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText(/Pass every quiz for silver/),
+        ).toBeInTheDocument();
+        expect(screen.getByText(/1 of 2 there/)).toBeInTheDocument();
+    });
+
+    it('says so when every held module is at the top rung', () => {
+        renderBoard(
+            <RoleBadgeCard
+                role={ProjectMemberRole.EDITOR}
+                held={held}
+                tiers={tiers({ a: 'violet', b: 'violet' })}
+                isLoading={false}
+            />,
+        );
+        expect(screen.getByText('editor badge')).toBeInTheDocument();
+        expect(screen.getByText('All 2 modules at violet')).toBeInTheDocument();
+    });
+
+    it('lists the four rungs in the How badges work disclosure', () => {
+        renderBoard(
+            <RoleBadgeCard
+                role={ProjectMemberRole.VIEWER}
+                held={held}
+                tiers={tiers({})}
+                isLoading={false}
+            />,
+        );
+        expect(screen.getByText('How badges work')).toBeInTheDocument();
+        expect(screen.getByText('Finish every module')).toBeInTheDocument();
+        expect(screen.getByText('Pass every quiz')).toBeInTheDocument();
+        expect(
+            screen.getByText('Score 90% or more on every quiz'),
+        ).toBeInTheDocument();
+        expect(screen.getByText('Ace every quiz (100%)')).toBeInTheDocument();
+    });
+
+    it('waits rather than calling a pending fetch unavailable', () => {
+        renderBoard(
+            <RoleBadgeCard
+                role={ProjectMemberRole.VIEWER}
+                held={held}
+                tiers={null}
+                isLoading
+            />,
+        );
+        expect(screen.getByText('Loading badges')).toBeInTheDocument();
+        expect(
+            screen.queryByText('Badges unavailable right now'),
+        ).not.toBeInTheDocument();
+        expect(
+            screen.queryByText('Locked', { selector: 'span' }),
+        ).not.toBeInTheDocument();
+    });
+
+    it('says badges could not be loaded rather than reading as revoked', () => {
+        renderBoard(
+            <RoleBadgeCard
+                role={ProjectMemberRole.VIEWER}
+                held={held}
+                tiers={null}
+                isLoading={false}
+            />,
+        );
+        expect(
+            screen.getByText('Badges unavailable right now'),
+        ).toBeInTheDocument();
+        expect(screen.getByText('viewer badge')).toBeInTheDocument();
+    });
+
+    it('renders nothing when the role holds no modules', () => {
+        renderBoard(
+            <div data-testid="mount">
+                <RoleBadgeCard
+                    role={ProjectMemberRole.VIEWER}
+                    held={[]}
+                    tiers={tiers({})}
+                    isLoading={false}
+                />
+            </div>,
+        );
+        expect(screen.getByTestId('mount')).toBeEmptyDOMElement();
+    });
+});

--- a/packages/learn-ui/src/components/RoleBadgeCard.tsx
+++ b/packages/learn-ui/src/components/RoleBadgeCard.tsx
@@ -1,0 +1,88 @@
+import { Stack, Text } from '@mantine/core';
+import { type FC } from 'react';
+import { tierBadgeSvg } from '../model/badgeArt';
+import { roleBadge } from '../model/badges';
+import {
+    BADGE_PENDING_DETAIL,
+    badgeDetail,
+    EARNABLE,
+    RUNG_REQ,
+    RUNG_WORD,
+} from '../model/badgesView';
+import { ROLE_LABEL } from '../model/model';
+import { type ProjectMemberRole } from '../scope/types';
+import { type LearnBadgeTier, type LearnCatalogueEntry } from '../types';
+import styles from './LearnBoard.module.css';
+
+export type RoleBadgeCardProps = {
+    role: ProjectMemberRole;
+    held: LearnCatalogueEntry[];
+    /** Null when badges could not be loaded, which is not the same as none earned. */
+    tiers: Map<string, LearnBadgeTier> | null;
+    /** True while the badges query is in flight, which is not unavailable either. */
+    isLoading: boolean;
+};
+
+export const RoleBadgeCard: FC<RoleBadgeCardProps> = ({
+    role,
+    held,
+    tiers,
+    isLoading,
+}) => {
+    // A role with nothing to learn has nothing to earn: no card rather than a
+    // badge reading "0 of 0 there" beside the empty state.
+    if (held.length === 0) return null;
+    const badge = roleBadge(held, tiers ?? new Map());
+    const detail = isLoading
+        ? BADGE_PENDING_DETAIL
+        : badgeDetail(badge, tiers !== null);
+
+    return (
+        <Stack gap={10}>
+            <span className={styles.overline}>{ROLE_LABEL[role]} badge</span>
+            <div className={styles.badgeHero}>
+                {/* Local constant markup from badgeArt, never remote content. */}
+                <span
+                    className={styles.badgeEmblem}
+                    dangerouslySetInnerHTML={{
+                        __html: tierBadgeSvg(
+                            isLoading ? 'locked' : badge.rung,
+                            4,
+                        ),
+                    }}
+                />
+                <Stack gap={2}>
+                    {!isLoading && (
+                        <span className={styles.badgeRung}>
+                            {RUNG_WORD[badge.rung]}
+                        </span>
+                    )}
+                    <Text size="xs" className={styles.muted}>
+                        {detail}
+                    </Text>
+                </Stack>
+            </div>
+            <details className={styles.badgeHowto}>
+                <summary className={styles.badgeHowtoSummary}>
+                    How badges work
+                </summary>
+                <ul className={styles.badgeHowtoList}>
+                    {EARNABLE.map((rung) => (
+                        <li key={rung} className={styles.badgeHowtoRung}>
+                            <span
+                                className={styles.badgeHowtoEmblem}
+                                dangerouslySetInnerHTML={{
+                                    __html: tierBadgeSvg(rung, 2),
+                                }}
+                            />
+                            <b>{RUNG_WORD[rung]}</b>
+                            <span className={styles.badgeHowtoReq}>
+                                {RUNG_REQ[rung]}
+                            </span>
+                        </li>
+                    ))}
+                </ul>
+            </details>
+        </Stack>
+    );
+};

--- a/packages/learn-ui/src/components/RoleTabs.tsx
+++ b/packages/learn-ui/src/components/RoleTabs.tsx
@@ -1,0 +1,57 @@
+import { type FC, type KeyboardEvent } from 'react';
+import { ROLE_LABEL, SYSTEM_ROLES } from '../model/model';
+import { type ProjectMemberRole } from '../scope/types';
+import styles from './LearnBoard.module.css';
+
+type Props = {
+    role: ProjectMemberRole;
+    onPick: (role: ProjectMemberRole, element: HTMLElement) => void;
+};
+
+// WAI-ARIA tabs: only the selected tab is tabbable, arrows move the selection.
+const nextIndex = (key: string, current: number): number | null => {
+    const last = SYSTEM_ROLES.length - 1;
+    if (key === 'ArrowRight') return current === last ? 0 : current + 1;
+    if (key === 'ArrowLeft') return current === 0 ? last : current - 1;
+    if (key === 'Home') return 0;
+    if (key === 'End') return last;
+    return null;
+};
+
+export const RoleTabs: FC<Props> = ({ role, onPick }) => {
+    const selectedIndex = SYSTEM_ROLES.indexOf(role);
+    const onKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+        const target = nextIndex(event.key, selectedIndex);
+        if (target === null) return;
+        event.preventDefault();
+        const tabs =
+            event.currentTarget.querySelectorAll<HTMLElement>('[role="tab"]');
+        const element = tabs[target];
+        if (!element) return;
+        element.focus();
+        onPick(SYSTEM_ROLES[target], element);
+    };
+
+    return (
+        <div
+            className={styles.tabs}
+            role="tablist"
+            aria-label="Preview a role"
+            onKeyDown={onKeyDown}
+        >
+            {SYSTEM_ROLES.map((candidate, index) => (
+                <button
+                    key={candidate}
+                    type="button"
+                    role="tab"
+                    aria-selected={candidate === role}
+                    tabIndex={index === selectedIndex ? 0 : -1}
+                    className={`${styles.tab} ${candidate === role ? styles.tabSelected : ''}`}
+                    onClick={(event) => onPick(candidate, event.currentTarget)}
+                >
+                    {ROLE_LABEL[candidate]}
+                </button>
+            ))}
+        </div>
+    );
+};

--- a/packages/learn-ui/src/index.test.ts
+++ b/packages/learn-ui/src/index.test.ts
@@ -1,0 +1,30 @@
+// Guards the package's public entry point: a re-export that goes missing (or a
+// value export that shadows a type, as `LearnDemo` once did) fails here rather
+// than in a downstream consumer.
+import { describe, expect, it } from 'vitest';
+import {
+    createLearnModel,
+    LearnDemo,
+    LearnUiProvider,
+    LessonBody,
+    type LearnDemoManifest,
+} from './index';
+
+describe('package entry point', () => {
+    it('exports the provider, the model factory and the lesson components', () => {
+        expect(typeof LearnUiProvider).toBe('function');
+        expect(typeof createLearnModel).toBe('function');
+        expect(typeof LessonBody).toBe('function');
+        expect(typeof LearnDemo).toBe('function');
+    });
+
+    it('exports the demo manifest type alongside the demo component', () => {
+        const manifest: LearnDemoManifest = {
+            id: 'x',
+            title: 'x',
+            viewport: { width: 1, height: 1 },
+            steps: [],
+        };
+        expect(manifest.id).toBe('x');
+    });
+});

--- a/packages/learn-ui/src/index.ts
+++ b/packages/learn-ui/src/index.ts
@@ -40,6 +40,9 @@ export {
     type ClusterBoardProps,
 } from './components/ClusterBoard';
 export { LearnDemo } from './components/LearnDemo';
+// The component export above shadows the star-exported `LearnDemo` manifest
+// type from './types'. Alias it so consumers can still name that type.
+export type { LearnDemo as LearnDemoManifest } from './types/course';
 export { LessonBody, type LessonBodyProps } from './components/LessonBody';
 export { ModulePane } from './components/ModulePane';
 export {

--- a/packages/learn-ui/src/index.ts
+++ b/packages/learn-ui/src/index.ts
@@ -32,3 +32,18 @@ export * from './model/badgesView';
 export * from './model/badgeArt';
 export * from './model/tokens';
 export * from './model/citations';
+export { AskBar, type AskBarProps } from './components/AskBar';
+export { BoardNode, type BoardNodeProps } from './components/BoardNode';
+export { BoardRail } from './components/BoardRail';
+export {
+    ClusterBoard,
+    type ClusterBoardProps,
+} from './components/ClusterBoard';
+export { LearnDemo } from './components/LearnDemo';
+export { LessonBody, type LessonBodyProps } from './components/LessonBody';
+export { ModulePane } from './components/ModulePane';
+export {
+    RoleBadgeCard,
+    type RoleBadgeCardProps,
+} from './components/RoleBadgeCard';
+export { RoleTabs } from './components/RoleTabs';


### PR DESCRIPTION
Fourth of five. The board and lesson components move into the package unchanged apart from three lifts: `ModulePane` takes the course as props instead of calling react-query; `ClusterBoard`/`AskBar` read registry functions from `useLearnModel()`; the brand colour becomes `--learn-accent` with a violet fallback. `LessonBody` is lifted out of the course player so the lesson HTML rendering (demo portals, citation wiring) is shared too. Sanitising stays with the host.

Diff against the previous stack: `board/components/*` and `components/LearnDemo.tsx` in #27884, #27901, #27902, #27887.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UMX8BRvEgNgP9x8rDya46E
