### PR TITLE
feat(backend): send agent run push notifications to Android

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -3411,6 +3411,7 @@ export type MobilePushNotificationEvent =
           properties: {
               organizationId: string;
               installationId: string;
+              platform: 'ios' | 'android';
               environment: 'sandbox' | 'production';
           };
       })
@@ -3439,6 +3440,7 @@ export type MobilePushNotificationEvent =
               promptId: string;
               installationId: string;
               liveActivityId: string;
+              platform: 'ios' | 'android';
               environment: 'sandbox' | 'production';
               state: 'working' | 'waiting_for_you' | 'idle';
               activityEvent: 'update' | 'end';
@@ -3456,6 +3458,7 @@ export type MobilePushNotificationEvent =
               promptId: string;
               installationId: string;
               liveActivityId: string;
+              platform: 'ios' | 'android';
               environment: 'sandbox' | 'production';
               outcome: 'sent' | 'invalid_token' | 'retryable' | 'failed';
           };

--- a/packages/backend/src/clients/Apns/ApnsClient.test.ts
+++ b/packages/backend/src/clients/Apns/ApnsClient.test.ts
@@ -16,6 +16,7 @@ const config: MobilePushNotificationsConfig = {
     teamId: 'TEAMID',
     sandbox: { keyId: 'SANDBOX', privateKey: 'sandbox-private-key' },
     production: { keyId: 'PRODUCTION', privateKey: 'production-private-key' },
+    fcm: undefined,
 };
 
 const createClient = (response: { status: number; body?: string }) => {

--- a/packages/backend/src/clients/Apns/ApnsClient.ts
+++ b/packages/backend/src/clients/Apns/ApnsClient.ts
@@ -6,6 +6,7 @@ import http2, {
 import { importPKCS8, SignJWT } from 'jose';
 import { type MobilePushNotificationsConfig } from '../../config/parseConfig';
 import { type MobilePushEnvironment } from '../../ee/database/entities/mobilePushNotifications';
+import { type MobilePushDeliveryResult } from '../MobilePush/mobilePushDelivery';
 
 export type LiveActivityPayload = {
     aps: {
@@ -67,11 +68,7 @@ export type AlertPayload = {
     promptUuid: string;
 };
 
-export type ApnsDeliveryResult =
-    | { status: 'sent' }
-    | { status: 'invalid_token'; reason: string | undefined }
-    | { status: 'retryable'; reason: string | undefined }
-    | { status: 'failed'; reason: string | undefined };
+export type ApnsDeliveryResult = MobilePushDeliveryResult;
 
 type ApnsHttpRequest = {
     origin: string;

--- a/packages/backend/src/clients/ClientRepository.ts
+++ b/packages/backend/src/clients/ClientRepository.ts
@@ -5,6 +5,7 @@ import { ApnsClient } from './Apns/ApnsClient';
 import { S3CacheClient } from './Aws/S3CacheClient';
 import { S3Client } from './Aws/S3Client';
 import EmailClient from './EmailClient/EmailClient';
+import { FcmClient } from './Fcm/FcmClient';
 import { type FileStorageClient } from './FileStorage/FileStorageClient';
 import { GoogleDriveClient } from './Google/GoogleDriveClient';
 import { GoogleChatClient } from './GoogleChat/GoogleChatClient';
@@ -20,6 +21,7 @@ import { SlackClient } from './Slack/SlackClient';
 
 export interface ClientManifest {
     apnsClient: ApnsClient;
+    fcmClient: FcmClient;
     natsClient: NatsClient;
     emailClient: EmailClient;
     googleDriveClient: GoogleDriveClient;
@@ -126,6 +128,17 @@ export class ClientRepository
             'apnsClient',
             () =>
                 new ApnsClient({
+                    config: this.context.lightdashConfig
+                        .mobilePushNotifications,
+                }),
+        );
+    }
+
+    public getFcmClient(): FcmClient {
+        return this.getClient(
+            'fcmClient',
+            () =>
+                new FcmClient({
                     config: this.context.lightdashConfig
                         .mobilePushNotifications,
                 }),

--- a/packages/backend/src/clients/Fcm/FcmClient.test.ts
+++ b/packages/backend/src/clients/Fcm/FcmClient.test.ts
@@ -1,0 +1,242 @@
+import { type MobilePushNotificationsConfig } from '../../config/parseConfig';
+import {
+    buildAgentRunAlertMessage,
+    buildAgentRunDataMessage,
+    FcmClient,
+    type FcmAccessTokenSource,
+    type FcmHttpTransport,
+} from './FcmClient';
+
+const config: MobilePushNotificationsConfig = {
+    enabled: true,
+    bundleId: 'com.lightdash.mobile',
+    teamId: 'TEAMID',
+    sandbox: undefined,
+    production: undefined,
+    fcm: {
+        projectId: 'lightdash-mobile',
+        clientEmail: 'push@lightdash-mobile.iam.gserviceaccount.com',
+        privateKey: 'private-key',
+    },
+};
+
+const dataMessage = buildAgentRunDataMessage({
+    state: 'working',
+    event: 'update',
+    liveActivityUuid: 'activity-uuid',
+    projectUuid: 'project-uuid',
+    agentUuid: 'agent-uuid',
+    threadUuid: 'thread-uuid',
+    promptUuid: 'prompt-uuid',
+    timestamp: new Date('2026-08-30T12:01:00.000Z'),
+    staleAt: new Date('2026-08-30T12:06:00.000Z'),
+});
+
+const createClient = (
+    response: { status: number; body?: string },
+    clientConfig: MobilePushNotificationsConfig = config,
+) => {
+    const transport = {
+        send: vi.fn(async () => response),
+    } satisfies FcmHttpTransport;
+    const accessTokenSource = {
+        getToken: vi.fn(async () => 'access-token'),
+    } satisfies FcmAccessTokenSource;
+
+    return {
+        client: new FcmClient({
+            config: clientConfig,
+            transport,
+            accessTokenSource,
+        }),
+        transport,
+        accessTokenSource,
+    };
+};
+
+describe('buildAgentRunDataMessage', () => {
+    it('sends the run state as string data with a collapse key', () => {
+        expect(dataMessage).toEqual({
+            data: {
+                type: 'agent_run',
+                state: 'working',
+                event: 'update',
+                liveActivityUuid: 'activity-uuid',
+                projectUuid: 'project-uuid',
+                agentUuid: 'agent-uuid',
+                threadUuid: 'thread-uuid',
+                promptUuid: 'prompt-uuid',
+                timestamp: '1788091260',
+                staleAt: '1788091560',
+            },
+            android: {
+                priority: 'high',
+                collapse_key: 'activity-uuid',
+                ttl: '300s',
+            },
+        });
+    });
+});
+
+describe('buildAgentRunAlertMessage', () => {
+    it('carries the alert text and the thread identifiers', () => {
+        expect(
+            buildAgentRunAlertMessage({
+                collapseId: 'activity-uuid',
+                alert: { title: 'Lightdash', body: 'Your agent finished.' },
+                projectUuid: 'project-uuid',
+                agentUuid: 'agent-uuid',
+                threadUuid: 'thread-uuid',
+                promptUuid: 'prompt-uuid',
+            }),
+        ).toEqual({
+            notification: {
+                title: 'Lightdash',
+                body: 'Your agent finished.',
+            },
+            data: {
+                type: 'agent_run_completed',
+                projectUuid: 'project-uuid',
+                agentUuid: 'agent-uuid',
+                threadUuid: 'thread-uuid',
+                promptUuid: 'prompt-uuid',
+            },
+            android: {
+                priority: 'high',
+                collapse_key: 'activity-uuid',
+            },
+        });
+    });
+});
+
+describe('FcmClient.sendAgentRunUpdate', () => {
+    it('posts the message to the project endpoint with a bearer token', async () => {
+        const { client, transport, accessTokenSource } = createClient({
+            status: 200,
+            body: '{"name":"projects/lightdash-mobile/messages/1"}',
+        });
+
+        const result = await client.sendAgentRunUpdate({
+            pushToken: 'registration-token',
+            payload: dataMessage,
+        });
+
+        expect(result).toEqual({ status: 'sent' });
+        expect(accessTokenSource.getToken).toHaveBeenCalledWith({
+            clientEmail: 'push@lightdash-mobile.iam.gserviceaccount.com',
+            privateKey: 'private-key',
+        });
+        expect(transport.send).toHaveBeenCalledWith({
+            url: 'https://fcm.googleapis.com/v1/projects/lightdash-mobile/messages:send',
+            headers: {
+                authorization: 'Bearer access-token',
+                'content-type': 'application/json',
+            },
+            body: JSON.stringify({
+                message: { token: 'registration-token', ...dataMessage },
+            }),
+        });
+    });
+
+    it('reports an unregistered token as invalid', async () => {
+        const { client } = createClient({
+            status: 404,
+            body: JSON.stringify({
+                error: {
+                    code: 404,
+                    status: 'NOT_FOUND',
+                    details: [{ errorCode: 'UNREGISTERED' }],
+                },
+            }),
+        });
+
+        expect(
+            await client.sendAgentRunUpdate({
+                pushToken: 'registration-token',
+                payload: dataMessage,
+            }),
+        ).toEqual({ status: 'invalid_token', reason: 'UNREGISTERED' });
+    });
+
+    it('reports a mismatched sender as invalid', async () => {
+        const { client } = createClient({
+            status: 403,
+            body: JSON.stringify({
+                error: {
+                    status: 'PERMISSION_DENIED',
+                    details: [{ errorCode: 'SENDER_ID_MISMATCH' }],
+                },
+            }),
+        });
+
+        expect(
+            await client.sendAgentRunUpdate({
+                pushToken: 'registration-token',
+                payload: dataMessage,
+            }),
+        ).toEqual({ status: 'invalid_token', reason: 'SENDER_ID_MISMATCH' });
+    });
+
+    it.each([429, 500, 503])('retries on status %i', async (status) => {
+        const { client } = createClient({ status });
+
+        expect(
+            await client.sendAgentRunUpdate({
+                pushToken: 'registration-token',
+                payload: dataMessage,
+            }),
+        ).toEqual({ status: 'retryable', reason: undefined });
+    });
+
+    it('fails on an unrecognised error', async () => {
+        const { client } = createClient({
+            status: 400,
+            body: JSON.stringify({ error: { status: 'FAILED_PRECONDITION' } }),
+        });
+
+        expect(
+            await client.sendAgentRunUpdate({
+                pushToken: 'registration-token',
+                payload: dataMessage,
+            }),
+        ).toEqual({ status: 'failed', reason: 'FAILED_PRECONDITION' });
+    });
+
+    it.each<MobilePushNotificationsConfig>([
+        { ...config, fcm: undefined },
+        { ...config, enabled: false },
+    ])('refuses to send without configuration', async (clientConfig) => {
+        const { client, transport } = createClient(
+            { status: 200 },
+            clientConfig,
+        );
+
+        expect(
+            await client.sendAgentRunUpdate({
+                pushToken: 'registration-token',
+                payload: dataMessage,
+            }),
+        ).toEqual({ status: 'failed', reason: 'fcm_not_configured' });
+        expect(transport.send).not.toHaveBeenCalled();
+    });
+
+    it('retries when the transport throws', async () => {
+        const transport = {
+            send: vi.fn(async () => {
+                throw new Error('boom');
+            }),
+        } satisfies FcmHttpTransport;
+        const client = new FcmClient({
+            config,
+            transport,
+            accessTokenSource: { getToken: vi.fn(async () => 'access-token') },
+        });
+
+        expect(
+            await client.sendAgentRunUpdate({
+                pushToken: 'registration-token',
+                payload: dataMessage,
+            }),
+        ).toEqual({ status: 'retryable', reason: 'Error' });
+    });
+});

--- a/packages/backend/src/clients/Fcm/FcmClient.ts
+++ b/packages/backend/src/clients/Fcm/FcmClient.ts
@@ -1,0 +1,365 @@
+import { importPKCS8, SignJWT } from 'jose';
+import { type MobilePushNotificationsConfig } from '../../config/parseConfig';
+import { type MobilePushDeliveryResult } from '../MobilePush/mobilePushDelivery';
+
+export type AgentRunDataMessage = {
+    data: {
+        type: 'agent_run';
+        state: 'working' | 'waiting_for_you' | 'idle';
+        event: 'update' | 'end';
+        liveActivityUuid: string;
+        projectUuid: string;
+        agentUuid: string;
+        threadUuid: string;
+        promptUuid: string;
+        timestamp: string;
+        staleAt: string;
+    };
+    android: {
+        priority: 'high';
+        collapse_key: string;
+        ttl: string;
+    };
+};
+
+export type AgentRunAlertMessage = {
+    notification: {
+        title: string;
+        body: string;
+    };
+    data: {
+        type: 'agent_run_completed';
+        projectUuid: string;
+        agentUuid: string;
+        threadUuid: string;
+        promptUuid: string;
+    };
+    android: {
+        priority: 'high';
+        collapse_key: string;
+    };
+};
+
+type FcmHttpRequest = {
+    url: string;
+    headers: Record<string, string>;
+    body: string;
+};
+
+export type FcmHttpTransport = {
+    send(request: FcmHttpRequest): Promise<{ status: number; body?: string }>;
+};
+
+type AccessTokenRequest = {
+    clientEmail: string;
+    privateKey: string;
+};
+
+export type FcmAccessTokenSource = {
+    getToken(request: AccessTokenRequest): Promise<string>;
+};
+
+export const FCM_REQUEST_TIMEOUT_MS = 30_000;
+
+export const FCM_MESSAGING_SCOPE =
+    'https://www.googleapis.com/auth/firebase.messaging';
+
+export const GOOGLE_TOKEN_ENDPOINT = 'https://oauth2.googleapis.com/token';
+
+const AGENT_RUN_TTL_SECONDS = 300;
+
+const INVALID_TOKEN_ERROR_CODES = new Set([
+    'UNREGISTERED',
+    'INVALID_ARGUMENT',
+    'SENDER_ID_MISMATCH',
+]);
+
+const RETRYABLE_ERROR_CODES = new Set([
+    'UNAVAILABLE',
+    'INTERNAL',
+    'QUOTA_EXCEEDED',
+]);
+
+class FcmRequestTimeoutError extends Error {
+    constructor() {
+        super('FCM request timed out');
+        this.name = 'FcmRequestTimeoutError';
+    }
+}
+
+type FcmClientDependencies = {
+    config: MobilePushNotificationsConfig;
+    transport?: FcmHttpTransport;
+    accessTokenSource?: FcmAccessTokenSource;
+};
+
+const readErrorCode = (value: unknown): string | undefined => {
+    if (typeof value !== 'object' || value === null || !('error' in value)) {
+        return undefined;
+    }
+    const { error } = value;
+    if (typeof error !== 'object' || error === null) return undefined;
+
+    if ('details' in error && Array.isArray(error.details)) {
+        const detail = error.details.find(
+            (candidate): candidate is { errorCode: string } =>
+                typeof candidate === 'object' &&
+                candidate !== null &&
+                'errorCode' in candidate &&
+                typeof candidate.errorCode === 'string',
+        );
+        if (detail !== undefined) return detail.errorCode;
+    }
+    if ('status' in error && typeof error.status === 'string') {
+        return error.status;
+    }
+    return undefined;
+};
+
+export const parseFcmErrorCode = (
+    body: string | undefined,
+): string | undefined => {
+    if (body === undefined) return undefined;
+    try {
+        return readErrorCode(JSON.parse(body));
+    } catch {
+        return undefined;
+    }
+};
+
+export const buildAgentRunDataMessage = (args: {
+    state: 'working' | 'waiting_for_you' | 'idle';
+    event: 'update' | 'end';
+    liveActivityUuid: string;
+    projectUuid: string;
+    agentUuid: string;
+    threadUuid: string;
+    promptUuid: string;
+    timestamp: Date;
+    staleAt: Date;
+}): AgentRunDataMessage => ({
+    data: {
+        type: 'agent_run',
+        state: args.state,
+        event: args.event,
+        liveActivityUuid: args.liveActivityUuid,
+        projectUuid: args.projectUuid,
+        agentUuid: args.agentUuid,
+        threadUuid: args.threadUuid,
+        promptUuid: args.promptUuid,
+        timestamp: String(Math.floor(args.timestamp.getTime() / 1000)),
+        staleAt: String(Math.floor(args.staleAt.getTime() / 1000)),
+    },
+    android: {
+        priority: 'high',
+        collapse_key: args.liveActivityUuid,
+        ttl: `${AGENT_RUN_TTL_SECONDS}s`,
+    },
+});
+
+export const buildAgentRunAlertMessage = (args: {
+    collapseId: string;
+    alert: { title: string; body: string };
+    projectUuid: string;
+    agentUuid: string;
+    threadUuid: string;
+    promptUuid: string;
+}): AgentRunAlertMessage => ({
+    notification: {
+        title: args.alert.title,
+        body: args.alert.body,
+    },
+    data: {
+        type: 'agent_run_completed',
+        projectUuid: args.projectUuid,
+        agentUuid: args.agentUuid,
+        threadUuid: args.threadUuid,
+        promptUuid: args.promptUuid,
+    },
+    android: {
+        priority: 'high',
+        collapse_key: args.collapseId,
+    },
+});
+
+export class NodeFcmHttpTransport implements FcmHttpTransport {
+    private readonly requestTimeoutMs: number;
+
+    constructor(requestTimeoutMs: number = FCM_REQUEST_TIMEOUT_MS) {
+        this.requestTimeoutMs = requestTimeoutMs;
+    }
+
+    async send(
+        request: FcmHttpRequest,
+    ): Promise<{ status: number; body?: string }> {
+        const controller = new AbortController();
+        const timeout = setTimeout(
+            () => controller.abort(),
+            this.requestTimeoutMs,
+        );
+        try {
+            const response = await fetch(request.url, {
+                method: 'POST',
+                headers: request.headers,
+                body: request.body,
+                signal: controller.signal,
+            });
+            const body = await response.text();
+            return {
+                status: response.status,
+                ...(body.length === 0 ? {} : { body }),
+            };
+        } catch (error) {
+            if (controller.signal.aborted) throw new FcmRequestTimeoutError();
+            throw error;
+        } finally {
+            clearTimeout(timeout);
+        }
+    }
+}
+
+export class GoogleFcmAccessTokenSource implements FcmAccessTokenSource {
+    private cached: { token: string; expiresAt: number } | undefined;
+
+    private readonly fetchToken: (
+        request: FcmHttpRequest,
+    ) => Promise<{ status: number; body?: string }>;
+
+    constructor(
+        fetchToken: (
+            request: FcmHttpRequest,
+        ) => Promise<{ status: number; body?: string }> = (request) =>
+            new NodeFcmHttpTransport().send(request),
+    ) {
+        this.fetchToken = fetchToken;
+    }
+
+    async getToken(request: AccessTokenRequest): Promise<string> {
+        const now = Date.now();
+        if (this.cached !== undefined && this.cached.expiresAt > now) {
+            return this.cached.token;
+        }
+
+        const privateKey = await importPKCS8(
+            request.privateKey.replace(/\\n/g, '\n'),
+            'RS256',
+        );
+        const assertion = await new SignJWT({ scope: FCM_MESSAGING_SCOPE })
+            .setProtectedHeader({ alg: 'RS256' })
+            .setIssuer(request.clientEmail)
+            .setAudience(GOOGLE_TOKEN_ENDPOINT)
+            .setIssuedAt(Math.floor(now / 1000))
+            .setExpirationTime(Math.floor(now / 1000) + 3600)
+            .sign(privateKey);
+
+        const response = await this.fetchToken({
+            url: GOOGLE_TOKEN_ENDPOINT,
+            headers: { 'content-type': 'application/x-www-form-urlencoded' },
+            body: new URLSearchParams({
+                grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+                assertion,
+            }).toString(),
+        });
+        if (response.status !== 200 || response.body === undefined) {
+            throw new Error('Unable to mint an FCM access token');
+        }
+
+        const parsed: unknown = JSON.parse(response.body);
+        if (
+            typeof parsed !== 'object' ||
+            parsed === null ||
+            !('access_token' in parsed) ||
+            typeof parsed.access_token !== 'string'
+        ) {
+            throw new Error('Unable to mint an FCM access token');
+        }
+
+        const expiresIn =
+            'expires_in' in parsed && typeof parsed.expires_in === 'number'
+                ? parsed.expires_in
+                : 3600;
+        this.cached = {
+            token: parsed.access_token,
+            expiresAt: now + Math.max(expiresIn - 300, 60) * 1000,
+        };
+        return this.cached.token;
+    }
+}
+
+export class FcmClient {
+    private readonly config: MobilePushNotificationsConfig;
+
+    private readonly transport: FcmHttpTransport;
+
+    private readonly accessTokenSource: FcmAccessTokenSource;
+
+    constructor(dependencies: FcmClientDependencies) {
+        this.config = dependencies.config;
+        this.transport = dependencies.transport ?? new NodeFcmHttpTransport();
+        this.accessTokenSource =
+            dependencies.accessTokenSource ?? new GoogleFcmAccessTokenSource();
+    }
+
+    private async send(args: {
+        token: string;
+        message: AgentRunDataMessage | AgentRunAlertMessage;
+    }): Promise<MobilePushDeliveryResult> {
+        const { fcm } = this.config;
+        if (!this.config.enabled || fcm === undefined) {
+            return { status: 'failed', reason: 'fcm_not_configured' };
+        }
+
+        try {
+            const accessToken = await this.accessTokenSource.getToken({
+                clientEmail: fcm.clientEmail,
+                privateKey: fcm.privateKey,
+            });
+            const response = await this.transport.send({
+                url: `https://fcm.googleapis.com/v1/projects/${fcm.projectId}/messages:send`,
+                headers: {
+                    authorization: `Bearer ${accessToken}`,
+                    'content-type': 'application/json',
+                },
+                body: JSON.stringify({
+                    message: { token: args.token, ...args.message },
+                }),
+            });
+            const reason = parseFcmErrorCode(response.body);
+
+            if (response.status === 200) return { status: 'sent' };
+            if (
+                response.status === 404 ||
+                (reason !== undefined && INVALID_TOKEN_ERROR_CODES.has(reason))
+            ) {
+                return { status: 'invalid_token', reason };
+            }
+            if (
+                response.status === 429 ||
+                response.status >= 500 ||
+                (reason !== undefined && RETRYABLE_ERROR_CODES.has(reason))
+            ) {
+                return { status: 'retryable', reason };
+            }
+            return { status: 'failed', reason };
+        } catch (error) {
+            return {
+                status: 'retryable',
+                reason: error instanceof Error ? error.name : undefined,
+            };
+        }
+    }
+
+    async sendAgentRunUpdate(args: {
+        pushToken: string;
+        payload: AgentRunDataMessage;
+    }): Promise<MobilePushDeliveryResult> {
+        return this.send({ token: args.pushToken, message: args.payload });
+    }
+
+    async sendAgentRunAlert(args: {
+        pushToken: string;
+        payload: AgentRunAlertMessage;
+    }): Promise<MobilePushDeliveryResult> {
+        return this.send({ token: args.pushToken, message: args.payload });
+    }
+}

--- a/packages/backend/src/clients/MobilePush/mobilePushDelivery.ts
+++ b/packages/backend/src/clients/MobilePush/mobilePushDelivery.ts
@@ -1,0 +1,5 @@
+export type MobilePushDeliveryResult =
+    | { status: 'sent' }
+    | { status: 'invalid_token'; reason: string | undefined }
+    | { status: 'retryable'; reason: string | undefined }
+    | { status: 'failed'; reason: string | undefined };

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -248,6 +248,7 @@ export const lightdashConfigMock: LightdashConfig = {
         teamId: undefined,
         sandbox: undefined,
         production: undefined,
+        fcm: undefined,
     },
     license: {
         licenseKey: null,

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1430,6 +1430,13 @@ export type MobilePushNotificationsConfig = {
               privateKey: string;
           }
         | undefined;
+    fcm:
+        | {
+              projectId: string;
+              clientEmail: string;
+              privateKey: string;
+          }
+        | undefined;
 };
 
 export type MobileAppAssociationConfig = {
@@ -2620,6 +2627,20 @@ const parseCertificateFingerprints = (value: string | undefined): string[] =>
         .map((fingerprint) => fingerprint.trim())
         .filter((fingerprint) => fingerprint.length > 0);
 
+const parseMobilePushFcmCredential = ():
+    | MobilePushNotificationsConfig['fcm']
+    | undefined => {
+    const projectId = process.env.MOBILE_PUSH_NOTIFICATIONS_FCM_PROJECT_ID;
+    const clientEmail = process.env.MOBILE_PUSH_NOTIFICATIONS_FCM_CLIENT_EMAIL;
+    const privateKey = process.env.MOBILE_PUSH_NOTIFICATIONS_FCM_PRIVATE_KEY;
+
+    return projectId === undefined ||
+        clientEmail === undefined ||
+        privateKey === undefined
+        ? undefined
+        : { projectId, clientEmail, privateKey };
+};
+
 const parseMobilePushCredential = (
     environment: 'SANDBOX' | 'PRODUCTION',
 ): MobilePushNotificationsConfig['sandbox'] => {
@@ -2767,6 +2788,7 @@ export const parseConfig = (): LightdashConfig => {
     const mobilePushSandbox = parseMobilePushCredential('SANDBOX');
     const mobilePushProduction = parseMobilePushCredential('PRODUCTION');
     const mobilePushTeamId = process.env.MOBILE_PUSH_NOTIFICATIONS_APNS_TEAM_ID;
+    const mobilePushFcm = parseMobilePushFcmCredential();
     const motherduckInstanceCache = {
         enabled: process.env.MOTHERDUCK_INSTANCE_CACHE_ENABLED === 'true',
         projectUuids: getArrayFromCommaSeparatedList(
@@ -2849,15 +2871,17 @@ export const parseConfig = (): LightdashConfig => {
         mobilePushNotifications: {
             enabled:
                 lightdashCloudInstance !== undefined &&
-                mobilePushTeamId !== undefined &&
-                (mobilePushSandbox !== undefined ||
-                    mobilePushProduction !== undefined),
+                ((mobilePushTeamId !== undefined &&
+                    (mobilePushSandbox !== undefined ||
+                        mobilePushProduction !== undefined)) ||
+                    mobilePushFcm !== undefined),
             bundleId:
                 process.env.MOBILE_PUSH_NOTIFICATIONS_APNS_BUNDLE_ID ??
                 'com.lightdash.mobile',
             teamId: mobilePushTeamId,
             sandbox: mobilePushSandbox,
             production: mobilePushProduction,
+            fcm: mobilePushFcm,
         },
         cookieSameSite: iframeEmbeddingEnabled ? 'none' : 'lax',
         license: {

--- a/packages/backend/src/ee/controllers/mobilePushNotificationController.ts
+++ b/packages/backend/src/ee/controllers/mobilePushNotificationController.ts
@@ -60,7 +60,7 @@ export class MobilePushNotificationController extends BaseController {
     @OperationId('registerMobilePushInstallation')
     async registerInstallation(
         @Request() req: express.Request,
-        @Path() installationUuid: string,
+        @Path() installationUuid: UUID,
         @Body() body: ApiMobilePushInstallationRequest,
     ): Promise<ApiMobilePushInstallationResponse> {
         assertRegisteredAccount(req.account);
@@ -100,7 +100,7 @@ export class MobilePushNotificationController extends BaseController {
     @OperationId('revokeMobilePushInstallation')
     async revokeInstallation(
         @Request() req: express.Request,
-        @Path() installationUuid: string,
+        @Path() installationUuid: UUID,
     ): Promise<ApiMobilePushInstallationResponse> {
         assertRegisteredAccount(req.account);
         await this.getMobilePushNotificationService().revokeInstallation({

--- a/packages/backend/src/ee/controllers/mobilePushNotificationController.ts
+++ b/packages/backend/src/ee/controllers/mobilePushNotificationController.ts
@@ -67,6 +67,7 @@ export class MobilePushNotificationController extends BaseController {
         await this.getMobilePushNotificationService().registerInstallation({
             user: toSessionUser(req.account),
             installationUuid,
+            platform: body.platform ?? 'ios',
             environment: body.environment,
             deviceToken: body.deviceToken,
         });

--- a/packages/backend/src/ee/database/entities/mobilePushNotifications.ts
+++ b/packages/backend/src/ee/database/entities/mobilePushNotifications.ts
@@ -8,6 +8,8 @@ export const AiAgentLiveActivityStartAttemptsTableName =
 
 export type MobilePushEnvironment = 'sandbox' | 'production';
 
+export type MobilePushPlatform = 'ios' | 'android';
+
 export type LiveActivityStartAttemptStatus =
     | 'excluded'
     | 'pending'
@@ -21,6 +23,7 @@ export type DbMobilePushInstallation = {
     installation_uuid: string;
     organization_uuid: string;
     user_uuid: string;
+    platform: MobilePushPlatform;
     environment: MobilePushEnvironment;
     encrypted_device_token: Buffer;
     device_token_fingerprint: string;

--- a/packages/backend/src/ee/database/migrations/20260902100000_add_mobile_push_installation_platform.ts
+++ b/packages/backend/src/ee/database/migrations/20260902100000_add_mobile_push_installation_platform.ts
@@ -1,0 +1,29 @@
+import type { Knex } from 'knex';
+
+export const classification = {
+    kind: 'safe',
+    reason: 'Adds a platform column with a default that matches every existing row',
+} as const;
+
+const installationsTable = 'mobile_push_installations';
+const platformCheckConstraint = 'mobile_push_installations_platform_check';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '5s'`);
+
+    await knex.schema.alterTable(installationsTable, (table) => {
+        table
+            .text('platform')
+            .notNullable()
+            .defaultTo('ios')
+            .checkIn(['ios', 'android'], platformCheckConstraint);
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '5s'`);
+
+    await knex.schema.alterTable(installationsTable, (table) => {
+        table.dropColumn('platform');
+    });
+}

--- a/packages/backend/src/ee/database/migrations/__tests__/20260902100000_add_mobile_push_installation_platform.test.ts
+++ b/packages/backend/src/ee/database/migrations/__tests__/20260902100000_add_mobile_push_installation_platform.test.ts
@@ -1,0 +1,55 @@
+import knex from 'knex';
+import { getTracker, MockClient, type Tracker } from 'knex-mock-client';
+import {
+    classification,
+    down,
+    up,
+} from '../20260902100000_add_mobile_push_installation_platform';
+
+describe('Mobile push installation platform migration', () => {
+    const database = knex({ client: MockClient, dialect: 'pg' });
+    let tracker: Tracker;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    afterEach(() => {
+        tracker.reset();
+    });
+
+    it('is safe for a rolling deployment', () => {
+        expect(classification).toEqual({
+            kind: 'safe',
+            reason: 'Adds a platform column with a default that matches every existing row',
+        });
+    });
+
+    it('defaults every existing installation to ios', async () => {
+        tracker.on.any(() => true).response({});
+
+        await up(database);
+
+        const migrationSql = tracker.history.all
+            .map(({ sql }) => sql)
+            .join('\n');
+        expect(migrationSql).toContain(`SET LOCAL lock_timeout = '5s'`);
+        expect(migrationSql).toContain(
+            `add column "platform" text not null default 'ios'`,
+        );
+        expect(migrationSql).toContain(
+            `constraint mobile_push_installations_platform_check check ("platform" in ('ios','android'))`,
+        );
+    });
+
+    it('reverses the column', async () => {
+        tracker.on.any(() => true).response({});
+
+        await down(database);
+
+        const migrationSql = tracker.history.all
+            .map(({ sql }) => sql)
+            .join('\n');
+        expect(migrationSql).toContain('drop column "platform"');
+    });
+});

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -177,6 +177,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     notificationStore,
                     threadStore,
                     apnsClient,
+                    fcmClient: clients.getFcmClient(),
                     scheduler,
                     analytics: context.lightdashAnalytics,
                     completionAlert: undefined,

--- a/packages/backend/src/ee/models/MobilePushNotificationModel.test.ts
+++ b/packages/backend/src/ee/models/MobilePushNotificationModel.test.ts
@@ -181,6 +181,45 @@ describe('MobilePushNotificationModel', () => {
         );
     });
 
+    it('releases a device token fingerprint held by the other platform', async () => {
+        tracker.on.any(/pg_advisory_xact_lock/).responseOnce([]);
+        tracker.on.select(MobilePushInstallationsTableName).responseOnce([]);
+        tracker.on.delete(MobilePushInstallationsTableName).responseOnce([]);
+        tracker.on.insert(MobilePushInstallationsTableName).responseOnce([
+            {
+                mobile_push_installation_uuid: 'stored-installation-uuid',
+                installation_uuid: 'android-installation-uuid',
+                organization_uuid: 'organization-uuid',
+                user_uuid: 'user-uuid',
+                platform: 'android',
+                environment: 'production',
+            },
+        ]);
+
+        await model.upsertInstallation({
+            installationUuid: 'android-installation-uuid',
+            organizationUuid: 'organization-uuid',
+            userUuid: 'user-uuid',
+            platform: 'android',
+            environment: 'production',
+            deviceToken: 'shared-device-token',
+        });
+
+        const cleanup = tracker.history.delete.find((query) =>
+            query.sql.includes(MobilePushInstallationsTableName),
+        );
+        expect(cleanup?.sql).toContain('"environment" = $');
+        expect(cleanup?.sql).toContain('"device_token_fingerprint" = $');
+        expect(cleanup?.sql).not.toContain('"platform"');
+        expect(cleanup?.bindings).toEqual(
+            expect.arrayContaining([
+                'production',
+                'android-installation-uuid',
+                expect.stringMatching(/^[a-f0-9]{64}$/),
+            ]),
+        );
+    });
+
     it('preserves pending, retryable, and sent attempts during same-installation token rotation', async () => {
         tracker.on.any(/pg_advisory_xact_lock/).response([]);
         tracker.on.select(MobilePushInstallationsTableName).responseOnce([

--- a/packages/backend/src/ee/models/MobilePushNotificationModel.test.ts
+++ b/packages/backend/src/ee/models/MobilePushNotificationModel.test.ts
@@ -49,6 +49,7 @@ describe('MobilePushNotificationModel', () => {
             installationUuid: 'installation-uuid',
             organizationUuid: 'organization-uuid',
             userUuid: 'user-uuid',
+            platform: 'ios',
             environment: 'sandbox',
             deviceToken: 'device-token',
         });
@@ -105,6 +106,7 @@ describe('MobilePushNotificationModel', () => {
             installationUuid: 'installation-uuid',
             organizationUuid: 'new-organization-uuid',
             userUuid: 'new-user-uuid',
+            platform: 'ios',
             environment: 'production',
             deviceToken: 'new-device-token',
         });
@@ -154,6 +156,7 @@ describe('MobilePushNotificationModel', () => {
             installationUuid: 'installation-uuid',
             organizationUuid: 'organization-uuid',
             userUuid: 'user-uuid',
+            platform: 'ios',
             environment: 'production',
             deviceToken: 'new-device-token',
         });

--- a/packages/backend/src/ee/models/MobilePushNotificationModel.ts
+++ b/packages/backend/src/ee/models/MobilePushNotificationModel.ts
@@ -12,6 +12,7 @@ import {
     type DbMobilePushInstallation,
     type LiveActivityStartAttemptStatus,
     type MobilePushEnvironment,
+    type MobilePushPlatform,
 } from '../database/entities/mobilePushNotifications';
 
 type MobilePushNotificationModelDependencies = {
@@ -24,6 +25,7 @@ export type MobilePushInstallation = {
     installationUuid: string;
     organizationUuid: string;
     userUuid: string;
+    platform: MobilePushPlatform;
     environment: MobilePushEnvironment;
 };
 
@@ -37,6 +39,7 @@ export type AiAgentLiveActivity = {
     agentUuid: string;
     threadUuid: string;
     promptUuid: string;
+    platform: MobilePushPlatform;
     environment: MobilePushEnvironment;
     deviceToken: string;
     pushToken: string;
@@ -93,6 +96,7 @@ export class MobilePushNotificationModel {
                 installationUuid: 'installation_uuid',
                 organizationUuid: 'organization_uuid',
                 userUuid: 'user_uuid',
+                platform: 'platform',
                 environment: 'environment',
             })
             .where('installation_uuid', installationUuid)
@@ -103,6 +107,7 @@ export class MobilePushNotificationModel {
         installationUuid: string;
         organizationUuid: string;
         userUuid: string;
+        platform: MobilePushPlatform;
         environment: MobilePushEnvironment;
         deviceToken: string;
     }): Promise<MobilePushInstallation> {
@@ -123,6 +128,7 @@ export class MobilePushNotificationModel {
                     'mobile_push_installation_uuid',
                     'organization_uuid',
                     'user_uuid',
+                    'platform',
                     'environment',
                 )
                 .where('installation_uuid', args.installationUuid)
@@ -135,7 +141,8 @@ export class MobilePushNotificationModel {
                     existing.user_uuid !== args.userUuid);
             const environmentChanged =
                 existing !== undefined &&
-                existing.environment !== args.environment;
+                (existing.environment !== args.environment ||
+                    existing.platform !== args.platform);
 
             if (ownershipChanged && existing !== undefined) {
                 await trx<DbAiAgentLiveActivity>(AiAgentLiveActivitiesTableName)
@@ -164,6 +171,7 @@ export class MobilePushNotificationModel {
                 MobilePushInstallationsTableName,
             )
                 .where({
+                    platform: args.platform,
                     environment: args.environment,
                     device_token_fingerprint: fingerprint,
                 })
@@ -177,6 +185,7 @@ export class MobilePushNotificationModel {
                     installation_uuid: args.installationUuid,
                     organization_uuid: args.organizationUuid,
                     user_uuid: args.userUuid,
+                    platform: args.platform,
                     environment: args.environment,
                     encrypted_device_token: encryptedDeviceToken,
                     device_token_fingerprint: fingerprint,
@@ -185,6 +194,7 @@ export class MobilePushNotificationModel {
                 .merge({
                     organization_uuid: args.organizationUuid,
                     user_uuid: args.userUuid,
+                    platform: args.platform,
                     environment: args.environment,
                     encrypted_device_token: encryptedDeviceToken,
                     device_token_fingerprint: fingerprint,
@@ -201,6 +211,7 @@ export class MobilePushNotificationModel {
                     'installation_uuid',
                     'organization_uuid',
                     'user_uuid',
+                    'platform',
                     'environment',
                 ]);
 
@@ -209,6 +220,7 @@ export class MobilePushNotificationModel {
                 installationUuid: row.installation_uuid,
                 organizationUuid: row.organization_uuid,
                 userUuid: row.user_uuid,
+                platform: row.platform,
                 environment: row.environment,
             };
         });
@@ -330,6 +342,7 @@ export class MobilePushNotificationModel {
                 .andWhere((candidates) => {
                     candidates.where((eligible) =>
                         eligible
+                            .where('platform', 'ios')
                             .whereIn('environment', args.environments)
                             .whereNotNull('encrypted_push_to_start_token')
                             .whereNotNull('push_to_start_token_fingerprint'),
@@ -426,6 +439,7 @@ export class MobilePushNotificationModel {
                     `${MobilePushInstallationsTableName}.user_uuid`,
                     args.userUuid,
                 )
+                .where(`${MobilePushInstallationsTableName}.platform`, 'ios')
                 .whereIn(
                     `${MobilePushInstallationsTableName}.environment`,
                     args.environments,
@@ -614,6 +628,7 @@ export class MobilePushNotificationModel {
                             ),
                     ),
             )
+            .where(`${MobilePushInstallationsTableName}.platform`, 'ios')
             .whereIn(
                 `${MobilePushInstallationsTableName}.environment`,
                 args.environments,
@@ -764,6 +779,7 @@ export class MobilePushNotificationModel {
                 agentUuid: `${AiAgentLiveActivitiesTableName}.agent_uuid`,
                 threadUuid: `${AiAgentLiveActivitiesTableName}.thread_uuid`,
                 promptUuid: `${AiAgentLiveActivitiesTableName}.prompt_uuid`,
+                platform: `${MobilePushInstallationsTableName}.platform`,
                 environment: `${MobilePushInstallationsTableName}.environment`,
                 encryptedDeviceToken: `${MobilePushInstallationsTableName}.encrypted_device_token`,
                 encryptedPushToken: `${AiAgentLiveActivitiesTableName}.encrypted_push_token`,
@@ -790,6 +806,7 @@ export class MobilePushNotificationModel {
             agentUuid: row.agentUuid,
             threadUuid: row.threadUuid,
             promptUuid: row.promptUuid,
+            platform: row.platform,
             environment: row.environment,
             deviceToken: this.encryptionUtil.decrypt(row.encryptedDeviceToken),
             pushToken: this.encryptionUtil.decrypt(row.encryptedPushToken),

--- a/packages/backend/src/ee/models/MobilePushNotificationModel.ts
+++ b/packages/backend/src/ee/models/MobilePushNotificationModel.ts
@@ -171,7 +171,6 @@ export class MobilePushNotificationModel {
                 MobilePushInstallationsTableName,
             )
                 .where({
-                    platform: args.platform,
                     environment: args.environment,
                     device_token_fingerprint: fingerprint,
                 })

--- a/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationReconciler.test.ts
+++ b/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationReconciler.test.ts
@@ -2,6 +2,7 @@ import {
     MobilePushNotificationReconciler,
     type AiAgentThreadLiveStateSignals,
     type MobilePushApnsClient,
+    type MobilePushFcmClient,
     type MobilePushReconciliationStore,
     type MobilePushReconciliationThreadStore,
     type ReconciliationActivity,
@@ -18,6 +19,7 @@ const activity: ReconciliationActivity = {
     agentUuid: 'agent-uuid',
     threadUuid: 'thread-uuid',
     promptUuid: 'prompt-uuid',
+    platform: 'ios' as const,
     environment: 'sandbox' as const,
     deviceToken: 'device-token',
     pushToken: 'activity-token',
@@ -72,6 +74,14 @@ const createDependencies = () => {
             status: 'sent',
         })),
     };
+    const fcmClient = {
+        sendAgentRunUpdate: vi.fn<MobilePushFcmClient['sendAgentRunUpdate']>(
+            async () => ({ status: 'sent' }),
+        ),
+        sendAgentRunAlert: vi.fn<MobilePushFcmClient['sendAgentRunAlert']>(
+            async () => ({ status: 'sent' }),
+        ),
+    };
     const scheduler = {
         mobilePushLiveActivity: vi.fn(async () => ({ jobId: 'job-uuid' })),
     };
@@ -85,6 +95,7 @@ const createDependencies = () => {
         notificationStore,
         threadStore,
         apnsClient,
+        fcmClient,
         scheduler,
         analytics,
         completionAlert,
@@ -148,6 +159,7 @@ describe('MobilePushNotificationReconciler.reconcileLiveActivity', () => {
                 promptId: 'prompt-uuid',
                 installationId: 'public-installation-uuid',
                 liveActivityId: 'activity-uuid',
+                platform: 'ios',
                 environment: 'sandbox',
                 state: 'working',
                 activityEvent: 'update',
@@ -305,7 +317,7 @@ describe('MobilePushNotificationReconciler.reconcileLiveActivity', () => {
 
         await expect(
             reconciler.reconcileLiveActivity(activity.liveActivityUuid),
-        ).rejects.toThrow('APNs alert delivery is retryable');
+        ).rejects.toThrow('Mobile push alert delivery is retryable');
 
         expect(dependencies.apnsClient.sendLiveActivity).not.toHaveBeenCalled();
         expect(
@@ -394,7 +406,9 @@ describe('MobilePushNotificationReconciler.reconcileLiveActivity', () => {
 
         await expect(
             reconciler.reconcileLiveActivity(activity.liveActivityUuid),
-        ).rejects.toThrow('APNs delivery is retryable: ServiceUnavailable');
+        ).rejects.toThrow(
+            'Mobile push delivery is retryable: ServiceUnavailable',
+        );
         expect(
             dependencies.notificationStore.markLiveActivityDelivered,
         ).not.toHaveBeenCalled();
@@ -444,5 +458,174 @@ describe('MobilePushNotificationReconciler.reconcileLiveActivity', () => {
             dependencies.notificationStore.deleteLiveActivity,
         ).toHaveBeenCalledWith({ liveActivityUuid: 'activity-uuid' });
         expect(dependencies.apnsClient.sendLiveActivity).not.toHaveBeenCalled();
+    });
+});
+
+describe('MobilePushNotificationReconciler platform routing', () => {
+    const androidActivity: ReconciliationActivity = {
+        ...activity,
+        platform: 'android',
+        deviceToken: 'fcm-registration-token',
+    };
+
+    it('keeps an ios activity on APNs and never calls FCM', async () => {
+        const dependencies = createDependencies();
+        const reconciler = new MobilePushNotificationReconciler(dependencies);
+
+        await reconciler.reconcileLiveActivity(activity.liveActivityUuid);
+
+        expect(dependencies.apnsClient.sendLiveActivity).toHaveBeenCalledTimes(
+            1,
+        );
+        expect(
+            dependencies.fcmClient.sendAgentRunUpdate,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('sends an android update to FCM with the device token', async () => {
+        const dependencies = createDependencies();
+        dependencies.notificationStore.findLiveActivity.mockResolvedValue(
+            androidActivity,
+        );
+        const reconciler = new MobilePushNotificationReconciler(dependencies);
+
+        await reconciler.reconcileLiveActivity(activity.liveActivityUuid);
+
+        expect(dependencies.apnsClient.sendLiveActivity).not.toHaveBeenCalled();
+        expect(dependencies.fcmClient.sendAgentRunUpdate).toHaveBeenCalledWith({
+            pushToken: 'fcm-registration-token',
+            payload: {
+                data: {
+                    type: 'agent_run',
+                    state: 'working',
+                    event: 'update',
+                    liveActivityUuid: 'activity-uuid',
+                    projectUuid: 'project-uuid',
+                    agentUuid: 'agent-uuid',
+                    threadUuid: 'thread-uuid',
+                    promptUuid: 'prompt-uuid',
+                    timestamp: '1788091260',
+                    staleAt: '1788091560',
+                },
+                android: {
+                    priority: 'high',
+                    collapse_key: 'activity-uuid',
+                    ttl: '300s',
+                },
+            },
+        });
+    });
+
+    it('records the platform on an android delivery', async () => {
+        const dependencies = createDependencies();
+        dependencies.notificationStore.findLiveActivity.mockResolvedValue(
+            androidActivity,
+        );
+        const reconciler = new MobilePushNotificationReconciler(dependencies);
+
+        await reconciler.reconcileLiveActivity(activity.liveActivityUuid);
+
+        expect(dependencies.analytics.track).toHaveBeenCalledWith(
+            expect.objectContaining({
+                event: 'mobile_push.live_activity_delivery',
+                properties: expect.objectContaining({
+                    platform: 'android',
+                    activityEvent: 'update',
+                    outcome: 'sent',
+                }),
+            }),
+        );
+    });
+
+    it('sends an android completion alert to FCM', async () => {
+        const dependencies = {
+            ...createDependencies(),
+            completionAlert: {
+                title: 'Approved title',
+                body: 'Approved body',
+            },
+        };
+        dependencies.notificationStore.findLiveActivity.mockResolvedValue({
+            ...androidActivity,
+            lastDeliveredState: 'idle',
+            endedAt: now,
+        });
+        const reconciler = new MobilePushNotificationReconciler(dependencies);
+
+        await reconciler.reconcileLiveActivity(activity.liveActivityUuid);
+
+        expect(dependencies.apnsClient.sendAlert).not.toHaveBeenCalled();
+        expect(dependencies.fcmClient.sendAgentRunAlert).toHaveBeenCalledWith({
+            pushToken: 'fcm-registration-token',
+            payload: {
+                notification: {
+                    title: 'Approved title',
+                    body: 'Approved body',
+                },
+                data: {
+                    type: 'agent_run_completed',
+                    projectUuid: 'project-uuid',
+                    agentUuid: 'agent-uuid',
+                    threadUuid: 'thread-uuid',
+                    promptUuid: 'prompt-uuid',
+                },
+                android: {
+                    priority: 'high',
+                    collapse_key: 'activity-uuid',
+                },
+            },
+        });
+        expect(
+            dependencies.notificationStore.markCompletionAlertCompleted,
+        ).toHaveBeenCalledWith('activity-uuid');
+    });
+
+    it('deletes the installation when FCM rejects the android token', async () => {
+        const dependencies = {
+            ...createDependencies(),
+            completionAlert: {
+                title: 'Approved title',
+                body: 'Approved body',
+            },
+        };
+        dependencies.notificationStore.findLiveActivity.mockResolvedValue({
+            ...androidActivity,
+            lastDeliveredState: 'idle',
+            endedAt: now,
+        });
+        dependencies.fcmClient.sendAgentRunAlert.mockResolvedValue({
+            status: 'invalid_token',
+            reason: 'UNREGISTERED',
+        });
+        const reconciler = new MobilePushNotificationReconciler(dependencies);
+
+        await reconciler.reconcileLiveActivity(activity.liveActivityUuid);
+
+        expect(
+            dependencies.notificationStore.deleteInstallation,
+        ).toHaveBeenCalledWith({
+            installationUuid: 'public-installation-uuid',
+            organizationUuid: 'organization-uuid',
+            userUuid: 'user-uuid',
+        });
+    });
+
+    it('surfaces a retryable android delivery to the job runner', async () => {
+        const dependencies = createDependencies();
+        dependencies.notificationStore.findLiveActivity.mockResolvedValue(
+            androidActivity,
+        );
+        dependencies.fcmClient.sendAgentRunUpdate.mockResolvedValue({
+            status: 'retryable',
+            reason: 'UNAVAILABLE',
+        });
+        const reconciler = new MobilePushNotificationReconciler(dependencies);
+
+        await expect(
+            reconciler.reconcileLiveActivity(activity.liveActivityUuid),
+        ).rejects.toThrow('Mobile push delivery is retryable: UNAVAILABLE');
+        expect(
+            dependencies.notificationStore.markLiveActivityDelivered,
+        ).not.toHaveBeenCalled();
     });
 });

--- a/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationReconciler.ts
+++ b/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationReconciler.ts
@@ -8,8 +8,18 @@ import {
     type ApnsDeliveryResult,
     type LiveActivityPayload,
 } from '../../../clients/Apns/ApnsClient';
+import {
+    buildAgentRunAlertMessage,
+    buildAgentRunDataMessage,
+    type AgentRunAlertMessage,
+    type AgentRunDataMessage,
+} from '../../../clients/Fcm/FcmClient';
+import { type MobilePushDeliveryResult } from '../../../clients/MobilePush/mobilePushDelivery';
 import Logger from '../../../logging/logger';
-import { type MobilePushEnvironment } from '../../database/entities/mobilePushNotifications';
+import {
+    type MobilePushEnvironment,
+    type MobilePushPlatform,
+} from '../../database/entities/mobilePushNotifications';
 import { deriveAiAgentThreadLiveStatus } from '../AiAgentService/aiAgentThreadLiveStatus';
 import { type AiAgentThreadLiveStateSignals } from '../AiAgentService/aiAgentThreadLiveStatus';
 
@@ -25,6 +35,7 @@ export type ReconciliationActivity = {
     agentUuid: string;
     threadUuid: string;
     promptUuid: string;
+    platform: MobilePushPlatform;
     environment: MobilePushEnvironment;
     deviceToken: string;
     pushToken: string;
@@ -92,10 +103,22 @@ export type MobilePushApnsClient = {
     }): Promise<ApnsDeliveryResult>;
 };
 
+export type MobilePushFcmClient = {
+    sendAgentRunUpdate(args: {
+        pushToken: string;
+        payload: AgentRunDataMessage;
+    }): Promise<MobilePushDeliveryResult>;
+    sendAgentRunAlert(args: {
+        pushToken: string;
+        payload: AgentRunAlertMessage;
+    }): Promise<MobilePushDeliveryResult>;
+};
+
 type ReconcilerDependencies = {
     notificationStore: MobilePushReconciliationStore;
     threadStore: MobilePushReconciliationThreadStore;
     apnsClient: MobilePushApnsClient;
+    fcmClient: MobilePushFcmClient;
     scheduler: {
         mobilePushLiveActivity(
             payload: {
@@ -123,6 +146,8 @@ export class MobilePushNotificationReconciler {
 
     private readonly apnsClient: MobilePushApnsClient;
 
+    private readonly fcmClient: MobilePushFcmClient;
+
     private readonly scheduler: ReconcilerDependencies['scheduler'];
 
     private readonly analytics: ReconcilerDependencies['analytics'];
@@ -135,6 +160,7 @@ export class MobilePushNotificationReconciler {
         this.notificationStore = dependencies.notificationStore;
         this.threadStore = dependencies.threadStore;
         this.apnsClient = dependencies.apnsClient;
+        this.fcmClient = dependencies.fcmClient;
         this.scheduler = dependencies.scheduler;
         this.analytics = dependencies.analytics;
         this.completionAlert = dependencies.completionAlert;
@@ -177,18 +203,32 @@ export class MobilePushNotificationReconciler {
             return 'completed';
         }
 
-        const result = await this.apnsClient.sendAlert({
-            environment: activity.environment,
-            deviceToken: activity.deviceToken,
-            collapseId: activity.liveActivityUuid,
-            payload: {
-                aps: { alert: this.completionAlert },
-                projectUuid: activity.projectUuid,
-                agentUuid: activity.agentUuid,
-                threadUuid: activity.threadUuid,
-                promptUuid: activity.promptUuid,
-            },
-        });
+        const alert = this.completionAlert;
+        const result =
+            activity.platform === 'android'
+                ? await this.fcmClient.sendAgentRunAlert({
+                      pushToken: activity.deviceToken,
+                      payload: buildAgentRunAlertMessage({
+                          collapseId: activity.liveActivityUuid,
+                          alert,
+                          projectUuid: activity.projectUuid,
+                          agentUuid: activity.agentUuid,
+                          threadUuid: activity.threadUuid,
+                          promptUuid: activity.promptUuid,
+                      }),
+                  })
+                : await this.apnsClient.sendAlert({
+                      environment: activity.environment,
+                      deviceToken: activity.deviceToken,
+                      collapseId: activity.liveActivityUuid,
+                      payload: {
+                          aps: { alert },
+                          projectUuid: activity.projectUuid,
+                          agentUuid: activity.agentUuid,
+                          threadUuid: activity.threadUuid,
+                          promptUuid: activity.promptUuid,
+                      },
+                  });
         this.track({
             event: 'mobile_push.completion_alert_delivery',
             userId: activity.userUuid,
@@ -200,6 +240,7 @@ export class MobilePushNotificationReconciler {
                 promptId: activity.promptUuid,
                 installationId: activity.installationUuid,
                 liveActivityId: activity.liveActivityUuid,
+                platform: activity.platform,
                 environment: activity.environment,
                 outcome: result.status,
             },
@@ -215,7 +256,7 @@ export class MobilePushNotificationReconciler {
         }
         if (result.status === 'retryable') {
             throw new Error(
-                `APNs alert delivery is retryable: ${result.reason ?? 'unknown'}`,
+                `Mobile push alert delivery is retryable: ${result.reason ?? 'unknown'}`,
             );
         }
 
@@ -300,22 +341,38 @@ export class MobilePushNotificationReconciler {
             liveStatus.stateChangedAt === null
                 ? deliveryTime
                 : new Date(liveStatus.stateChangedAt);
-        const payload = buildLiveActivityPayload({
-            state: liveStatus.state,
-            timestamp: deliveryTime,
-            staleAt,
-            dismissalAt,
-            event: liveStatus.state === 'idle' ? 'end' : 'update',
-            projectUuid: activity.projectUuid,
-            agentUuid: activity.agentUuid,
-            threadUuid: activity.threadUuid,
-            promptUuid: activity.promptUuid,
-        });
-        const result = await this.apnsClient.sendLiveActivity({
-            environment: activity.environment,
-            pushToken: activity.pushToken,
-            payload,
-        });
+        const activityEvent = liveStatus.state === 'idle' ? 'end' : 'update';
+        const result =
+            activity.platform === 'android'
+                ? await this.fcmClient.sendAgentRunUpdate({
+                      pushToken: activity.deviceToken,
+                      payload: buildAgentRunDataMessage({
+                          state: liveStatus.state,
+                          event: activityEvent,
+                          liveActivityUuid: activity.liveActivityUuid,
+                          projectUuid: activity.projectUuid,
+                          agentUuid: activity.agentUuid,
+                          threadUuid: activity.threadUuid,
+                          promptUuid: activity.promptUuid,
+                          timestamp: deliveryTime,
+                          staleAt,
+                      }),
+                  })
+                : await this.apnsClient.sendLiveActivity({
+                      environment: activity.environment,
+                      pushToken: activity.pushToken,
+                      payload: buildLiveActivityPayload({
+                          state: liveStatus.state,
+                          timestamp: deliveryTime,
+                          staleAt,
+                          dismissalAt,
+                          event: activityEvent,
+                          projectUuid: activity.projectUuid,
+                          agentUuid: activity.agentUuid,
+                          threadUuid: activity.threadUuid,
+                          promptUuid: activity.promptUuid,
+                      }),
+                  });
         this.track({
             event: 'mobile_push.live_activity_delivery',
             userId: activity.userUuid,
@@ -327,9 +384,10 @@ export class MobilePushNotificationReconciler {
                 promptId: activity.promptUuid,
                 installationId: activity.installationUuid,
                 liveActivityId: activity.liveActivityUuid,
+                platform: activity.platform,
                 environment: activity.environment,
                 state: liveStatus.state,
-                activityEvent: payload.aps.event,
+                activityEvent,
                 outcome: result.status,
             },
         });
@@ -346,7 +404,7 @@ export class MobilePushNotificationReconciler {
         }
         if (result.status === 'retryable') {
             throw new Error(
-                `APNs delivery is retryable: ${result.reason ?? 'unknown'}`,
+                `Mobile push delivery is retryable: ${result.reason ?? 'unknown'}`,
             );
         }
         if (result.status === 'failed') {

--- a/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationService.test.ts
+++ b/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationService.test.ts
@@ -30,6 +30,7 @@ const installation = {
     installationUuid,
     organizationUuid,
     userUuid,
+    platform: 'ios' as const,
     environment: 'sandbox' as const,
 };
 
@@ -132,6 +133,7 @@ const createDependencies = () => {
         teamId: 'TEAMID',
         sandbox: { keyId: 'KEYID', privateKey: 'private-key' },
         production: undefined,
+        fcm: undefined,
     };
 
     return {
@@ -1103,6 +1105,7 @@ describe('MobilePushNotificationService installation lifecycle', () => {
         expect(service.getStatus()).toEqual({
             enabled: true,
             environments: ['sandbox'],
+            platforms: ['ios'],
         });
     });
 
@@ -1113,6 +1116,7 @@ describe('MobilePushNotificationService installation lifecycle', () => {
         await service.registerInstallation({
             user: { userUuid, organizationUuid },
             installationUuid,
+            platform: 'ios',
             environment: 'sandbox',
             deviceToken: validDeviceToken,
         });
@@ -1123,6 +1127,7 @@ describe('MobilePushNotificationService installation lifecycle', () => {
             installationUuid,
             organizationUuid,
             userUuid,
+            platform: 'ios',
             environment: 'sandbox',
             deviceToken: validDeviceToken,
         });
@@ -1132,12 +1137,91 @@ describe('MobilePushNotificationService installation lifecycle', () => {
             properties: {
                 organizationId: organizationUuid,
                 installationId: installationUuid,
+                platform: 'ios',
                 environment: 'sandbox',
             },
         });
         expect(
             JSON.stringify(dependencies.analytics.track.mock.calls),
         ).not.toContain(validDeviceToken);
+    });
+
+    it('rejects an android registration when FCM is not configured', async () => {
+        const dependencies = createDependencies();
+        const service = new MobilePushNotificationService(dependencies);
+
+        await expect(
+            service.registerInstallation({
+                user: { userUuid, organizationUuid },
+                installationUuid,
+                platform: 'android',
+                environment: 'production',
+                deviceToken: 'fcm-registration:token_value',
+            }),
+        ).rejects.toBeInstanceOf(NotFoundError);
+        expect(
+            dependencies.mobilePushNotificationStore.upsertInstallation,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('registers an android installation against the FCM credential', async () => {
+        const dependencies = createDependencies();
+        dependencies.mobilePushNotificationsConfig.fcm = {
+            projectId: 'lightdash-mobile',
+            clientEmail: 'push@lightdash-mobile.iam.gserviceaccount.com',
+            privateKey: 'private-key',
+        };
+        const service = new MobilePushNotificationService(dependencies);
+
+        await service.registerInstallation({
+            user: { userUuid, organizationUuid },
+            installationUuid,
+            platform: 'android',
+            environment: 'production',
+            deviceToken: 'fcm-registration:token_value',
+        });
+
+        expect(
+            dependencies.mobilePushNotificationStore.upsertInstallation,
+        ).toHaveBeenCalledWith({
+            installationUuid,
+            organizationUuid,
+            userUuid,
+            platform: 'android',
+            environment: 'production',
+            deviceToken: 'fcm-registration:token_value',
+        });
+    });
+
+    it('reports android as available once FCM is configured', () => {
+        const dependencies = createDependencies();
+        dependencies.mobilePushNotificationsConfig.fcm = {
+            projectId: 'lightdash-mobile',
+            clientEmail: 'push@lightdash-mobile.iam.gserviceaccount.com',
+            privateKey: 'private-key',
+        };
+        const service = new MobilePushNotificationService(dependencies);
+
+        expect(service.getStatus().platforms).toEqual(['ios', 'android']);
+    });
+
+    it('rejects a push-to-start token on an android installation', async () => {
+        const dependencies = createDependencies();
+        dependencies.mobilePushNotificationStore.findInstallation.mockResolvedValue(
+            { ...installation, platform: 'android' },
+        );
+        const service = new MobilePushNotificationService(dependencies);
+
+        await expect(
+            service.registerPushToStartToken({
+                user: { userUuid, organizationUuid },
+                installationUuid,
+                pushToken: pushToStartToken,
+            }),
+        ).rejects.toBeInstanceOf(NotFoundError);
+        expect(
+            dependencies.mobilePushNotificationStore.registerPushToStartToken,
+        ).not.toHaveBeenCalled();
     });
 
     it.each(['', 'aa/bb', 'a'.repeat(513)])(
@@ -1150,6 +1234,7 @@ describe('MobilePushNotificationService installation lifecycle', () => {
                 service.registerInstallation({
                     user: { userUuid, organizationUuid },
                     installationUuid,
+                    platform: 'ios',
                     environment: 'sandbox',
                     deviceToken,
                 }),
@@ -1168,6 +1253,7 @@ describe('MobilePushNotificationService installation lifecycle', () => {
         await service.registerInstallation({
             user: { userUuid, organizationUuid },
             installationUuid,
+            platform: 'ios',
             environment: 'sandbox',
             deviceToken: 'device-token',
         });

--- a/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationService.ts
+++ b/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationService.ts
@@ -15,7 +15,10 @@ import {
 } from '../../../clients/Apns/ApnsClient';
 import { type MobilePushNotificationsConfig } from '../../../config/parseConfig';
 import Logger from '../../../logging/logger';
-import { type MobilePushEnvironment } from '../../database/entities/mobilePushNotifications';
+import {
+    type MobilePushEnvironment,
+    type MobilePushPlatform,
+} from '../../database/entities/mobilePushNotifications';
 import {
     type LiveActivityStartAttempt,
     type SchedulableLiveActivityStartAttempt,
@@ -31,6 +34,7 @@ type MobilePushInstallation = {
     installationUuid: string;
     organizationUuid: string;
     userUuid: string;
+    platform: MobilePushPlatform;
     environment: MobilePushEnvironment;
 };
 
@@ -85,6 +89,7 @@ export type MobilePushNotificationStore = {
         installationUuid: string;
         organizationUuid: string;
         userUuid: string;
+        platform: MobilePushPlatform;
         environment: MobilePushEnvironment;
         deviceToken: string;
     }): Promise<MobilePushInstallation>;
@@ -235,6 +240,23 @@ const validatePushToken = (pushToken: string): void => {
     }
 };
 
+const validateDeviceToken = (
+    platform: MobilePushPlatform,
+    deviceToken: string,
+): void => {
+    if (platform === 'ios') {
+        validatePushToken(deviceToken);
+        return;
+    }
+    if (
+        deviceToken.length === 0 ||
+        deviceToken.length > 4096 ||
+        !/^[A-Za-z0-9_:.%-]+$/.test(deviceToken)
+    ) {
+        throw new ParameterError('Push token is invalid');
+    }
+};
+
 const LIVE_ACTIVITY_START_STALE_AFTER_MS = 5 * 60 * 1000;
 const LIVE_ACTIVITY_START_PROCESSING_LEASE_MS = 5 * 60 * 1000;
 
@@ -284,16 +306,32 @@ export class MobilePushNotificationService {
     getStatus(): {
         enabled: boolean;
         environments: MobilePushEnvironment[];
+        platforms: MobilePushPlatform[];
     } {
         const environments: MobilePushEnvironment[] = [];
         if (this.config.sandbox !== undefined) environments.push('sandbox');
         if (this.config.production !== undefined)
             environments.push('production');
 
+        const platforms: MobilePushPlatform[] = [];
+        if (this.config.teamId !== undefined && environments.length > 0)
+            platforms.push('ios');
+        if (this.config.fcm !== undefined) platforms.push('android');
+
         return {
             enabled: this.config.enabled,
             environments: this.config.enabled ? environments : [],
+            platforms: this.config.enabled ? platforms : [],
         };
+    }
+
+    private isPlatformConfigured(
+        platform: MobilePushPlatform,
+        environment: MobilePushEnvironment,
+    ): boolean {
+        return platform === 'android'
+            ? this.config.fcm !== undefined
+            : this.config[environment] !== undefined;
     }
 
     private getConfiguredEnvironments(): MobilePushEnvironment[] {
@@ -370,15 +408,16 @@ export class MobilePushNotificationService {
     async registerInstallation(args: {
         user: MobilePushUser;
         installationUuid: string;
+        platform: MobilePushPlatform;
         environment: MobilePushEnvironment;
         deviceToken: string;
     }): Promise<void> {
         if (!this.config.enabled) return;
-        validatePushToken(args.deviceToken);
+        validateDeviceToken(args.platform, args.deviceToken);
         const { organizationUuid } = args.user;
         if (
             organizationUuid == null ||
-            this.config[args.environment] === undefined
+            !this.isPlatformConfigured(args.platform, args.environment)
         ) {
             throw new NotFoundError('Mobile push registration not found');
         }
@@ -387,6 +426,7 @@ export class MobilePushNotificationService {
             installationUuid: args.installationUuid,
             organizationUuid,
             userUuid: args.user.userUuid,
+            platform: args.platform,
             environment: args.environment,
             deviceToken: args.deviceToken,
         });
@@ -396,6 +436,7 @@ export class MobilePushNotificationService {
             properties: {
                 organizationId: organizationUuid,
                 installationId: args.installationUuid,
+                platform: args.platform,
                 environment: args.environment,
             },
         });
@@ -421,7 +462,8 @@ export class MobilePushNotificationService {
             );
         if (
             installation?.organizationUuid !== organizationUuid ||
-            installation.userUuid !== args.user.userUuid
+            installation.userUuid !== args.user.userUuid ||
+            installation.platform !== 'ios'
         ) {
             throw new NotFoundError('Mobile push registration not found');
         }
@@ -758,6 +800,7 @@ export class MobilePushNotificationService {
         if (
             installation?.organizationUuid !== organizationUuid ||
             installation.userUuid !== args.user.userUuid ||
+            installation.platform !== 'ios' ||
             (existingActivity !== undefined &&
                 (existingActivity.mobilePushInstallationUuid !==
                     installation.mobilePushInstallationUuid ||

--- a/packages/common/src/types/api/mobilePushNotifications.ts
+++ b/packages/common/src/types/api/mobilePushNotifications.ts
@@ -3,14 +3,18 @@ import { type UUID } from './uuid';
 
 export type MobilePushEnvironment = 'sandbox' | 'production';
 
+export type MobilePushPlatform = 'ios' | 'android';
+
 export type ApiMobilePushNotificationStatusResponse = ApiSuccess<{
     enabled: boolean;
     environments: MobilePushEnvironment[];
+    platforms: MobilePushPlatform[];
 }>;
 
 export type ApiMobilePushInstallationRequest = {
     environment: MobilePushEnvironment;
     deviceToken: string;
+    platform?: MobilePushPlatform;
 };
 
 export type ApiMobilePushInstallationResponse = ApiSuccessEmpty;

--- a/release-safety.declarations.json
+++ b/release-safety.declarations.json
@@ -8,6 +8,10 @@
         "mcp-run-metric-query-formula-only-table-calcs": {
             "reason": "The MCP run_metric_query tool no longer accepts template table calculations (running_total, percent_of_previous_value, etc.) in queryConfig.tableCalculations; only formula table calculations are accepted. MCP clients that send template-shaped payloads (scripted callers or agents replaying stored arguments) get an input validation error after upgrading and must switch to equivalent formulas. Agent-generated payloads self-correct because clients re-read the advertised schema.",
             "requiredStop": false
+        },
+        "mobile-push-installation-uuid-path-params": {
+            "reason": "PUT and DELETE /api/v1/mobile/push-notifications/installations/{installationUuid} now validate installationUuid as a UUID and reject other strings with a 400. Installation identifiers are server-generated UUIDs, and only the Lightdash mobile apps call these endpoints with the identifier they received, so no existing caller is affected.",
+            "requiredStop": false
         }
     }
 }


### PR DESCRIPTION
## What breaks

An agent run can take minutes. On iOS the app registers a device token and the server pushes the run state to a Live Activity, so a reader who locks the phone still sees it. An Android reader gets nothing, because the server can only reach Apple. The installation record has no platform, and there is no Firebase client to route to.

## What changes

This is the backend half of the Android push channel. The Android client work follows separately.

**The installation record gains a platform.** A migration adds a `platform` column to `mobile_push_installations`, defaulting to `ios`, which is what every existing row is. The registration endpoint accepts an optional `platform` in its body and defaults to `ios`, so the shipped iOS client keeps working without a change. `GET /status` now also reports the configured `platforms`, so a client can tell whether its own channel is available.

**An FCM client sits beside `ApnsClient`.** It mints a Google access token from a service account, posts to the FCM HTTP v1 endpoint, and maps the response to the same delivery result the APNs client already returns. Both clients now share one `MobilePushDeliveryResult` type, so the caller does not care which transport ran.

**`MobilePushNotificationReconciler` routes on the platform.** An iOS activity still goes to APNs as a Live Activity, with the same payload and headers as before. An Android activity goes to FCM as a high priority data message that carries the same run state, and the completion alert follows the same route. Everything after delivery is shared: an invalid token still deletes the installation, a retryable result still fails the job for the runner to retry, and the analytics events now carry the platform.

**Live Activity push-to-start stays Apple only.** It is an APNs concept with no Android equivalent, so the start attempt queries select iOS installations and a push-to-start token on an Android installation is refused.

## iOS behaviour

Unchanged. The routing test suite asserts that an iOS activity never reaches the FCM client, and the existing APNs payload and header tests pass untouched. Two internal job error strings say "Mobile push" instead of "APNs" because the sentence is no longer only about Apple.

## Configuration

Android push stays off until all three variables are set:

| Variable | Value |
| -- | -- |
| `MOBILE_PUSH_NOTIFICATIONS_FCM_PROJECT_ID` | Firebase project id |
| `MOBILE_PUSH_NOTIFICATIONS_FCM_CLIENT_EMAIL` | service account address |
| `MOBILE_PUSH_NOTIFICATIONS_FCM_PRIVATE_KEY` | service account private key |

With none of them set, the FCM client refuses every send and no Android installation can register, so an instance without Firebase behaves exactly as it does today.

## Verification

```
pnpm -F backend test src/clients src/ee/services/MobilePushNotificationService \
  src/ee/models/MobilePushNotificationModel.test.ts \
  src/ee/controllers/mobilePushNotificationController.test.ts \
  src/config/parseConfig.test.ts src/ee/database/migrations/__tests__ \
  src/scripts/rotate-lightdash-secret          26 files, 513 passed
pnpm -F backend typecheck                      clean
pnpm -F common typecheck                       clean
pnpm --filter backend run linter <touched>     clean
```

New tests cover the platform routing in the reconciler, the FCM delivery result mapping and message shape, the Android registration path, and the migration.

Linear: SPK-1770

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011j8Jti2ysa1f7vtCzDNsP8


## API note

allow-api-breaking-change: the `installationUuid` path parameter on the register and revoke endpoints is now typed as UUID. The column it maps to is UUID-typed, so a non-UUID value already failed with a 500; it now fails with a 422 at the boundary. No shipped client sends anything but a UUID.
