### PR TITLE
feat: in-app Learn section on @lightdash/learn-ui (CS-73 5/5)

### DIFF
--- a/packages/frontend/src/Routes.tsx
+++ b/packages/frontend/src/Routes.tsx
@@ -531,6 +531,41 @@ const SPACES_ROUTES: RouteObject[] = [
     },
 ];
 
+const LEARN_ROUTES: RouteObject[] = [
+    {
+        path: 'learn',
+        lazy: async () => {
+            const Learn = await loadLazyRouteDefault(
+                './pages/Learn',
+                () => import('./pages/Learn'),
+            );
+            return {
+                Component: () => (
+                    <TrackPage name={PageName.LEARN}>
+                        <Learn />
+                    </TrackPage>
+                ),
+            };
+        },
+    },
+    {
+        path: 'learn/courses/:courseId',
+        lazy: async () => {
+            const LearnCourse = await loadLazyRouteDefault(
+                './pages/LearnCourse',
+                () => import('./pages/LearnCourse'),
+            );
+            return {
+                Component: () => (
+                    <TrackPage name={PageName.LEARN_COURSE}>
+                        <LearnCourse />
+                    </TrackPage>
+                ),
+            };
+        },
+    },
+];
+
 const METRICS_ROUTES: RouteObject[] = [
     {
         path: 'metrics',
@@ -611,6 +646,7 @@ const PROJECT_LAYOUT_ROUTES: RouteObject[] = [
     ...DASHBOARD_LIST_ROUTES,
     ...SPACES_ROUTES,
     ...METRICS_ROUTES,
+    ...LEARN_ROUTES,
     {
         path: 'home',
         lazy: async () => {

--- a/packages/frontend/src/components/NavBar/BrowseMenu.tsx
+++ b/packages/frontend/src/components/NavBar/BrowseMenu.tsx
@@ -40,6 +40,7 @@ import scrollAreaClasses from '../../styles/ScrollArea.module.css';
 import MantineIcon from '../common/MantineIcon';
 import { PolymorphicGroupButton } from '../common/PolymorphicGroupButton';
 import TruncatedText from '../common/TruncatedText';
+import { LearnLink } from './LearnLink';
 import { MetricsLink } from './MetricsLink';
 
 interface Props {
@@ -191,6 +192,8 @@ const BrowseMenu: FC<Props> = ({ projectUuid }) => {
                 {!hasMetrics && (
                     <MetricsLink projectUuid={projectUuid} asMenu />
                 )}
+
+                <LearnLink projectUuid={projectUuid} asMenu />
 
                 {hasFavorites ? (
                     <>

--- a/packages/frontend/src/components/NavBar/LearnLink.module.css
+++ b/packages/frontend/src/components/NavBar/LearnLink.module.css
@@ -1,0 +1,14 @@
+/* The navbar search is absolutely centered from 75em up, so the left button
+   group must not grow past the search's left edge. Below this width the Learn
+   entry lives in the Browse menu instead of the top-level group. */
+.topLevel {
+    @media (max-width: 1550px) {
+        display: none;
+    }
+}
+
+.menuItem {
+    @media (min-width: 1551px) {
+        display: none;
+    }
+}

--- a/packages/frontend/src/components/NavBar/LearnLink.module.css
+++ b/packages/frontend/src/components/NavBar/LearnLink.module.css
@@ -8,7 +8,9 @@
 }
 
 .menuItem {
-    @media (min-width: 1551px) {
+    /* .01px past the max-width above: a fractional viewport width (browser
+       zoom, fractional DPI) must never match both queries. */
+    @media (min-width: 1550.01px) {
         display: none;
     }
 }

--- a/packages/frontend/src/components/NavBar/LearnLink.tsx
+++ b/packages/frontend/src/components/NavBar/LearnLink.tsx
@@ -1,0 +1,64 @@
+import { FeatureFlags } from '@lightdash/common';
+import { Button, Menu } from '@mantine/core';
+import { IconSchool } from '@tabler/icons-react';
+import { useCallback, type FC } from 'react';
+import { useNavigate } from 'react-router';
+import { useServerFeatureFlag } from '../../hooks/useServerOrClientFeatureFlag';
+import useApp from '../../providers/App/useApp';
+import useTracking from '../../providers/Tracking/useTracking';
+import { EventName } from '../../types/Events';
+import MantineIcon from '../common/MantineIcon';
+import classes from './LearnLink.module.css';
+
+interface Props {
+    projectUuid: string;
+    asMenu?: boolean;
+}
+
+export const LearnLink: FC<Props> = ({ projectUuid, asMenu }) => {
+    const { user } = useApp();
+    const navigate = useNavigate();
+    const { track } = useTracking();
+    const learnFlag = useServerFeatureFlag(FeatureFlags.LearnSection);
+
+    const handleLearnClick = useCallback(() => {
+        track({
+            name: EventName.LEARN_CLICKED,
+            properties: {
+                userId: user?.data?.userUuid,
+                organizationId: user?.data?.organizationUuid,
+                projectId: projectUuid,
+            },
+        });
+        void navigate(`/projects/${projectUuid}/learn`);
+    }, [track, user, navigate, projectUuid]);
+
+    if (learnFlag.isLoading || !learnFlag.data?.enabled) {
+        return null;
+    }
+
+    if (asMenu) {
+        return (
+            <Menu.Item
+                className={classes.menuItem}
+                leftSection={<MantineIcon icon={IconSchool} />}
+                onClick={handleLearnClick}
+            >
+                Learn
+            </Menu.Item>
+        );
+    }
+
+    return (
+        <Button
+            className={classes.topLevel}
+            variant="default"
+            size="xs"
+            fz="sm"
+            leftSection={<MantineIcon icon={IconSchool} color="ldGray.6" />}
+            onClick={handleLearnClick}
+        >
+            Learn
+        </Button>
+    );
+};

--- a/packages/frontend/src/components/NavBar/LearnLink.tsx
+++ b/packages/frontend/src/components/NavBar/LearnLink.tsx
@@ -55,7 +55,7 @@ export const LearnLink: FC<Props> = ({ projectUuid, asMenu }) => {
             variant="default"
             size="xs"
             fz="sm"
-            leftSection={<MantineIcon icon={IconSchool} color="ldGray.6" />}
+            leftSection={<MantineIcon icon={IconSchool} color="dimmed" />}
             onClick={handleLearnClick}
         >
             Learn

--- a/packages/frontend/src/components/NavBar/MainNavBarContent.tsx
+++ b/packages/frontend/src/components/NavBar/MainNavBarContent.tsx
@@ -11,6 +11,7 @@ import BrowseMenu from './BrowseMenu';
 import ExploreMenu from './ExploreMenu';
 import HeadwayMenuItem from './HeadwayMenuItem';
 import HelpMenu from './HelpMenu';
+import { LearnLink } from './LearnLink';
 import classes from './MainNavBarContent.module.css';
 import { MetricsLink } from './MetricsLink';
 import { NotificationsMenu } from './NotificationsMenu';
@@ -71,6 +72,7 @@ export const MainNavBarContent: FC<Props> = ({
                             {hasMetrics && (
                                 <MetricsLink projectUuid={activeProjectUuid} />
                             )}
+                            <LearnLink projectUuid={activeProjectUuid} />
                             <Suspense fallback={null}>
                                 <AiAgentsButton
                                     projectUuid={activeProjectUuid}

--- a/packages/frontend/src/features/learn/LearnUiRoot.tsx
+++ b/packages/frontend/src/features/learn/LearnUiRoot.tsx
@@ -1,0 +1,17 @@
+import { LearnUiProvider } from '@lightdash/learn-ui';
+import { type FC, type PropsWithChildren } from 'react';
+import { commonScopeSource } from './scopeSource';
+
+export const LearnUiRoot: FC<PropsWithChildren> = ({ children }) => (
+    <LearnUiProvider scopeSource={commonScopeSource}>
+        <div
+            style={{
+                display: 'contents',
+                ['--learn-accent' as string]:
+                    'var(--mantine-color-ldBrandViolet-6)',
+            }}
+        >
+            {children}
+        </div>
+    </LearnUiProvider>
+);

--- a/packages/frontend/src/features/learn/board/LearnBoardPanel.module.css
+++ b/packages/frontend/src/features/learn/board/LearnBoardPanel.module.css
@@ -1,0 +1,50 @@
+.scroller {
+    width: 100%;
+    overflow-x: auto;
+}
+
+.card {
+    width: 100%;
+    max-width: 1440px;
+    margin: 0 auto;
+    background: #ffffff;
+    border-radius: 16px;
+    overflow: hidden;
+    box-shadow:
+        0 1px 2px rgba(10, 13, 18, 0.05),
+        0 0 0 1px #eceff3;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: stretch;
+}
+
+.boardColumn {
+    flex: 1 1 1120px;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+}
+
+.header {
+    padding: 24px 28px 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.title {
+    margin: 0;
+    font-size: 32px;
+    line-height: 1;
+    letter-spacing: -0.02em;
+    font-weight: 500;
+}
+
+.sub {
+    font-size: 14px;
+    color: #818898;
+}
+
+.tabsRow {
+    padding: 4px 28px 10px;
+}

--- a/packages/frontend/src/features/learn/board/LearnBoardPanel.test.tsx
+++ b/packages/frontend/src/features/learn/board/LearnBoardPanel.test.tsx
@@ -1,0 +1,764 @@
+import {
+    OrganizationMemberRole,
+    type LearnAskMatch,
+    type LearnBadgesResults,
+} from '@lightdash/common';
+import { emptyRollup, SUGGESTION_LIMIT } from '@lightdash/learn-ui';
+import {
+    act,
+    fireEvent,
+    screen,
+    waitFor,
+    within,
+} from '@testing-library/react';
+import type * as ReactRouter from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import { LearnUiRoot } from '../LearnUiRoot';
+import { entry } from '../testFixtures';
+import { LearnBoardPanel } from './LearnBoardPanel';
+
+const navigate = vi.fn();
+vi.mock('react-router', async () => {
+    const actual = await vi.importActual<typeof ReactRouter>('react-router');
+    return {
+        ...actual,
+        useNavigate: () => navigate,
+        useParams: () => ({ projectUuid: 'project-1' }),
+    };
+});
+
+const catalogue = [
+    entry({
+        id: 'foundation',
+        title: 'Getting around',
+        scope: 'view:Project',
+        lessonCount: 2,
+    }),
+    // Untagged, so every role holds it.
+    entry({
+        id: 'sharing',
+        title: 'Sharing your work',
+        scope: null,
+        lessonCount: 2,
+    }),
+    entry({
+        id: 'dashboards',
+        title: 'Building dashboards',
+        scope: 'manage:Dashboard',
+        lessonCount: 2,
+    }),
+];
+
+// Swappable so a test can serve a differently shaped catalogue (CS-169).
+const catalogueState: { courses: typeof catalogue } = { courses: catalogue };
+
+const defaultRollups = () =>
+    new Map([
+        [
+            'foundation',
+            {
+                ...emptyRollup(),
+                started: true,
+                lessonsCompleted: new Set(['l1']),
+            },
+        ],
+    ]);
+// Swappable so a test can hand the board different progress (CS-169).
+const rollupsState = { map: defaultRollups() };
+
+type AskCallbacks = {
+    onSuccess?: (data: { matches: LearnAskMatch[] }) => void;
+    onError?: () => void;
+    onSettled?: () => void;
+};
+const askCalls: Array<{ query: string } & AskCallbacks> = [];
+const askMutate = vi.fn(
+    (variables: { query: string }, options: AskCallbacks = {}) => {
+        askCalls.push({ query: variables.query, ...options });
+    },
+);
+// Answers arrive through the mutation callbacks, so a test can settle two
+// requests in whichever order it likes.
+const answerWith = (matches: LearnAskMatch[], index = askCalls.length - 1) => {
+    const call = askCalls[index];
+    act(() => {
+        call.onSuccess?.({ matches });
+        call.onSettled?.();
+    });
+};
+const askState: { isLoading: boolean; isError: boolean } = {
+    isLoading: false,
+    isError: false,
+};
+const bronzeEverywhere: LearnBadgesResults = {
+    badges: [
+        { courseId: 'foundation', tier: 'bronze' },
+        { courseId: 'sharing', tier: 'bronze' },
+    ],
+};
+const badgesState: {
+    data: LearnBadgesResults | undefined;
+    isInitialLoading: boolean;
+} = {
+    data: bronzeEverywhere,
+    isInitialLoading: false,
+};
+// Hoisted: the mock factory reads this one eagerly, not from inside a closure.
+const setLessonBookmarkMock = vi.hoisted(() => vi.fn());
+
+// The pane's own useLearnCourse call (BoardRail/ModulePane now take the
+// selected course as props rather than fetching it themselves). Undefined by
+// default; a test that needs lesson-level content sets it before rendering.
+const defaultSelectedCourse = () => ({
+    data: undefined as
+        | { id: string; lessons: { id: string; title: string; html: string }[] }
+        | undefined,
+    isInitialLoading: false,
+    isError: false,
+});
+const selectedCourseState = { value: defaultSelectedCourse() };
+
+vi.mock('../hooks', () => ({
+    useLearnCatalogue: () => ({
+        data: {
+            generatedAt: '2026-08-01T00:00:00.000Z',
+            courses: catalogueState.courses,
+            suggestions: [
+                { query: 'Where do I find a chart?', courseId: 'foundation' },
+                { query: 'How do I build one?', courseId: 'dashboards' },
+                { query: 'How do I share it?', courseId: 'sharing' },
+                { query: 'Where does progress live?', courseId: 'foundation' },
+                { query: 'What is a space?', courseId: 'sharing' },
+            ],
+        },
+        isLoading: false,
+        isError: false,
+    }),
+    useLearnRollups: () => ({
+        rollups: rollupsState.map,
+        isLoading: false,
+        serverSynced: false,
+    }),
+    useLearnCourse: () => selectedCourseState.value,
+    useLearnBadges: () => badgesState,
+    useLearnAsk: () => ({
+        mutate: askMutate,
+        reset: () => {
+            askState.isError = false;
+        },
+        isLoading: askState.isLoading,
+        isError: askState.isError,
+    }),
+    setLessonBookmark: setLessonBookmarkMock,
+}));
+
+describe('LearnBoardPanel', () => {
+    beforeEach(() => {
+        navigate.mockClear();
+        askMutate.mockClear();
+        askCalls.length = 0;
+        setLessonBookmarkMock.mockClear();
+        askState.isLoading = false;
+        askState.isError = false;
+        badgesState.data = bronzeEverywhere;
+        badgesState.isInitialLoading = false;
+        catalogueState.courses = catalogue;
+        rollupsState.map = defaultRollups();
+        selectedCourseState.value = defaultSelectedCourse();
+    });
+
+    it('re-opens a completed module when a role change unlocks a lesson', async () => {
+        // Completed (quiz passed) with the 2 lessons visible to interactive
+        // viewer; the editor role holds all 3 — the module must leave the
+        // completed state and queue up as 2 of 3, not stay complete.
+        catalogueState.courses = [
+            entry({
+                id: 'comments',
+                title: 'Commenting on dashboards',
+                scope: 'view:DashboardComments',
+                lessonCount: 3,
+                lessonScopes: [
+                    'view:DashboardComments',
+                    'create:DashboardComments',
+                    'manage:DashboardComments',
+                ],
+            }),
+        ];
+        rollupsState.map = new Map([
+            [
+                'comments',
+                {
+                    ...emptyRollup(),
+                    started: true,
+                    passed: true,
+                    completed: true,
+                    lessonsCompleted: new Set(['l1', 'l2']),
+                },
+            ],
+        ]);
+        renderWithProviders(
+            <LearnUiRoot>
+                <LearnBoardPanel />
+            </LearnUiRoot>,
+            {
+                user: { role: OrganizationMemberRole.EDITOR },
+            },
+        );
+        await waitFor(() =>
+            expect(screen.getByRole('tab', { name: 'editor' })).toHaveAttribute(
+                'aria-selected',
+                'true',
+            ),
+        );
+        expect(screen.getByText(/1 module, 0 finished/)).toBeInTheDocument();
+        // The overall rail line and the queue card both count 2 of 3.
+        expect(screen.getAllByText(/2 of 3 lessons/).length).toBeGreaterThan(0);
+        // On the interactive viewer tab everything visible is done, so the
+        // module stays complete.
+        fireEvent.click(
+            screen.getByRole('tab', { name: 'interactive viewer' }),
+        );
+        expect(screen.getByText(/1 module, 1 finished/)).toBeInTheDocument();
+    });
+
+    it('counts only role-visible lessons for held modules and keeps full counts on locked ones', async () => {
+        // CS-169 scope-group module: a viewer holds view:DashboardComments
+        // but not create/manage, so 1 of 3 lessons is visible. The locked
+        // manage:Dashboard module keeps its full count — a locked node
+        // describes the whole module.
+        catalogueState.courses = [
+            entry({
+                id: 'comments',
+                title: 'Commenting on dashboards',
+                scope: 'view:DashboardComments',
+                lessonCount: 3,
+                lessonScopes: [
+                    'view:DashboardComments',
+                    'create:DashboardComments',
+                    'manage:DashboardComments',
+                ],
+            }),
+            entry({
+                id: 'dashboards',
+                title: 'Building dashboards',
+                scope: 'manage:Dashboard',
+                lessonCount: 3,
+                lessonScopes: ['manage:Dashboard', 'manage:Dashboard', null],
+            }),
+        ];
+        renderWithProviders(
+            <LearnUiRoot>
+                <LearnBoardPanel />
+            </LearnUiRoot>,
+            {
+                user: { role: OrganizationMemberRole.VIEWER },
+            },
+        );
+        await waitFor(() =>
+            expect(screen.getByRole('tab', { name: 'viewer' })).toHaveAttribute(
+                'aria-selected',
+                'true',
+            ),
+        );
+        const board = screen.getByTestId('learn-board');
+        expect(
+            board.querySelector(
+                '[aria-label="Commenting on dashboards, 1 lesson"]',
+            ),
+        ).not.toBeNull();
+        // Locked node: full lesson count, not the viewer-visible one.
+        expect(
+            board.querySelector(
+                '[aria-label="Building dashboards, 3 lessons"]',
+            ),
+        ).not.toBeNull();
+        // The rail totals sum visible lessons of held modules only.
+        expect(screen.getByText(/0 of 1 lesson ·/)).toBeInTheDocument();
+    });
+
+    it('defaults to the org role and lights only the held modules', async () => {
+        renderWithProviders(
+            <LearnUiRoot>
+                <LearnBoardPanel />
+            </LearnUiRoot>,
+            {
+                user: { role: OrganizationMemberRole.VIEWER },
+            },
+        );
+        await waitFor(() =>
+            expect(screen.getByRole('tab', { name: 'viewer' })).toHaveAttribute(
+                'aria-selected',
+                'true',
+            ),
+        );
+        expect(
+            screen.getByText(/Everything your viewer role unlocks/),
+        ).toBeInTheDocument();
+        // Locked nodes leave the accessibility tree, so query the DOM directly.
+        const locked = screen
+            .getByTestId('learn-board')
+            .querySelector('[aria-label^="Building dashboards"]');
+        expect(locked).toHaveAttribute('tabindex', '-1');
+        expect(locked).toHaveAttribute('aria-hidden', 'true');
+        expect(locked).toBeDisabled();
+    });
+
+    it('reads the org role once the user query resolves, even when it differs from the pre-resolution fallback', async () => {
+        renderWithProviders(
+            <LearnUiRoot>
+                <LearnBoardPanel />
+            </LearnUiRoot>,
+            {
+                user: { role: OrganizationMemberRole.ADMIN },
+            },
+        );
+        // Renders on the VIEWER fallback first, since `user` is still
+        // resolving; only settles on the admin tab once that query lands.
+        await waitFor(() =>
+            expect(screen.getByRole('tab', { name: 'admin' })).toHaveAttribute(
+                'aria-selected',
+                'true',
+            ),
+        );
+        expect(
+            screen.getByText(/Everything your admin role unlocks/),
+        ).toBeInTheDocument();
+    });
+
+    it('switching role unlocks more modules and selecting one opens the pane', async () => {
+        selectedCourseState.value = {
+            data: {
+                id: 'dashboards',
+                lessons: [
+                    { id: 'l1', title: 'Anatomy of a dashboard', html: '' },
+                    { id: 'l2', title: 'Filter a dashboard', html: '' },
+                ],
+            },
+            isInitialLoading: false,
+            isError: false,
+        };
+        renderWithProviders(
+            <LearnUiRoot>
+                <LearnBoardPanel />
+            </LearnUiRoot>,
+            {
+                user: { role: OrganizationMemberRole.VIEWER },
+            },
+        );
+        expect(await screen.findAllByRole('tab')).toHaveLength(5);
+        fireEvent.click(await screen.findByRole('tab', { name: 'editor' }));
+        const node = within(screen.getByTestId('learn-board')).getByRole(
+            'button',
+            { name: /Building dashboards/ },
+        );
+        await waitFor(() => expect(node).toHaveAttribute('tabindex', '0'));
+        fireEvent.click(node);
+        expect(screen.getByText('manage:Dashboard')).toBeInTheDocument();
+        expect(screen.getByText(/Anatomy of a dashboard/)).toBeInTheDocument();
+        fireEvent.click(screen.getByRole('button', { name: 'Start module' }));
+        expect(navigate).toHaveBeenCalledWith(
+            '/projects/project-1/learn/courses/dashboards',
+        );
+    });
+
+    it('hands focus back to the node when the pane closes', async () => {
+        renderWithProviders(
+            <LearnUiRoot>
+                <LearnBoardPanel />
+            </LearnUiRoot>,
+            {
+                user: { role: OrganizationMemberRole.VIEWER },
+            },
+        );
+        const node = within(await screen.findByTestId('learn-board')).getByRole(
+            'button',
+            { name: /Getting around/ },
+        );
+        fireEvent.click(node);
+        fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+        await waitFor(() => expect(node).toHaveFocus());
+    });
+
+    it('switching role clears the open module pane', async () => {
+        renderWithProviders(
+            <LearnUiRoot>
+                <LearnBoardPanel />
+            </LearnUiRoot>,
+            {
+                user: { role: OrganizationMemberRole.VIEWER },
+            },
+        );
+        fireEvent.click(await screen.findByRole('tab', { name: 'editor' }));
+        const node = within(screen.getByTestId('learn-board')).getByRole(
+            'button',
+            { name: /Building dashboards/ },
+        );
+        await waitFor(() => expect(node).toHaveAttribute('tabindex', '0'));
+        fireEvent.click(node);
+        expect(
+            screen.getByRole('button', { name: 'Close' }),
+        ).toBeInTheDocument();
+        fireEvent.click(screen.getByRole('tab', { name: 'admin' }));
+        await waitFor(() =>
+            expect(
+                screen.queryByRole('button', { name: 'Close' }),
+            ).not.toBeInTheDocument(),
+        );
+        expect(
+            screen.getByText('Pick up where you left off'),
+        ).toBeInTheDocument();
+    });
+
+    it('shows only the chips the selected role holds, capped at one row', async () => {
+        renderWithProviders(
+            <LearnUiRoot>
+                <LearnBoardPanel />
+            </LearnUiRoot>,
+            {
+                user: { role: OrganizationMemberRole.VIEWER },
+            },
+        );
+        expect(
+            await screen.findByRole('button', {
+                name: 'Where do I find a chart?',
+            }),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByRole('button', { name: 'How do I build one?' }),
+        ).not.toBeInTheDocument();
+        // 'What is a space?' is held too, but it is the fourth offer.
+        const chips = within(screen.getByTestId('ask-chips')).getAllByRole(
+            'button',
+        );
+        expect(chips).toHaveLength(SUGGESTION_LIMIT);
+        expect(chips.map((chip) => chip.textContent)).toEqual([
+            'Where do I find a chart?',
+            'How do I share it?',
+            'Where does progress live?',
+        ]);
+    });
+
+    it('puts the Ask bar above the role tabs', async () => {
+        renderWithProviders(
+            <LearnUiRoot>
+                <LearnBoardPanel />
+            </LearnUiRoot>,
+            {
+                user: { role: OrganizationMemberRole.VIEWER },
+            },
+        );
+        const search = await screen.findByRole('search');
+        const tabs = screen.getByRole('tablist');
+        expect(
+            search.compareDocumentPosition(tabs) &
+                Node.DOCUMENT_POSITION_FOLLOWING,
+        ).toBeTruthy();
+    });
+
+    it('treats an answer naming modules the catalogue lost as no answer', async () => {
+        renderWithProviders(
+            <LearnUiRoot>
+                <LearnBoardPanel />
+            </LearnUiRoot>,
+            {
+                user: { role: OrganizationMemberRole.VIEWER },
+            },
+        );
+        fireEvent.change(await screen.findByRole('searchbox'), {
+            target: { value: 'anything' },
+        });
+        fireEvent.submit(screen.getByRole('search'));
+        answerWith([
+            {
+                courseId: 'retired',
+                lessonId: 'l1',
+                title: 'Gone from the library',
+                score: 0.9,
+            },
+        ]);
+        expect(
+            await screen.findByText('Nothing in the library matches that yet'),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByText('Gone from the library'),
+        ).not.toBeInTheDocument();
+        const untouched = screen
+            .getByTestId('learn-board')
+            .querySelector<HTMLElement>('[aria-label^="Sharing your work"]');
+        expect(untouched?.style.opacity).not.toBe('0.4');
+    });
+
+    it('keeps the answer across a role change and re-derives the locked matches', async () => {
+        renderWithProviders(
+            <LearnUiRoot>
+                <LearnBoardPanel />
+            </LearnUiRoot>,
+            {
+                user: { role: OrganizationMemberRole.VIEWER },
+            },
+        );
+        fireEvent.change(await screen.findByRole('searchbox'), {
+            target: { value: 'filters' },
+        });
+        fireEvent.submit(screen.getByRole('search'));
+        answerWith([
+            {
+                courseId: 'dashboards',
+                lessonId: 'l1',
+                title: 'Filter a dashboard',
+                score: 0.9,
+            },
+        ]);
+        expect(
+            await screen.findByTestId('ask-locked-note'),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByRole('button', { name: 'Open' }),
+        ).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('tab', { name: 'editor' }));
+        await waitFor(() =>
+            expect(
+                screen.queryByTestId('ask-locked-note'),
+            ).not.toBeInTheDocument(),
+        );
+        expect(screen.getByText('Filter a dashboard')).toBeInTheDocument();
+        expect(
+            screen.getByRole('button', { name: 'Open' }),
+        ).toBeInTheDocument();
+    });
+
+    it('submitting a question searches and lights the matched module, and clearing restores the board', async () => {
+        renderWithProviders(
+            <LearnUiRoot>
+                <LearnBoardPanel />
+            </LearnUiRoot>,
+            {
+                user: { role: OrganizationMemberRole.VIEWER },
+            },
+        );
+        fireEvent.change(await screen.findByRole('searchbox'), {
+            target: { value: 'where are my charts' },
+        });
+        fireEvent.submit(screen.getByRole('search'));
+        expect(askMutate).toHaveBeenCalledWith(
+            { query: 'where are my charts' },
+            expect.anything(),
+        );
+
+        answerWith([
+            {
+                courseId: 'foundation',
+                lessonId: 'l2',
+                title: 'Finding saved charts',
+                score: 0.8,
+            },
+        ]);
+        expect(
+            await screen.findByText('Finding saved charts'),
+        ).toBeInTheDocument();
+        const dimmed = screen
+            .getByTestId('learn-board')
+            .querySelector<HTMLElement>('[aria-label^="Sharing your work"]');
+        expect(dimmed?.style.opacity).toBe('0.4');
+
+        fireEvent.click(screen.getByRole('button', { name: 'Clear search' }));
+        await waitFor(() => expect(dimmed?.style.opacity).toBe('1'));
+        expect(
+            screen.queryByText('Finding saved charts'),
+        ).not.toBeInTheDocument();
+    });
+
+    it('sends one request for a double submit and keeps the answer on a resubmit', async () => {
+        renderWithProviders(
+            <LearnUiRoot>
+                <LearnBoardPanel />
+            </LearnUiRoot>,
+            {
+                user: { role: OrganizationMemberRole.VIEWER },
+            },
+        );
+        fireEvent.change(await screen.findByRole('searchbox'), {
+            target: { value: 'where are my charts' },
+        });
+        fireEvent.submit(screen.getByRole('search'));
+        fireEvent.submit(screen.getByRole('search'));
+        expect(askMutate).toHaveBeenCalledTimes(1);
+
+        answerWith([
+            {
+                courseId: 'foundation',
+                lessonId: 'l2',
+                title: 'Finding saved charts',
+                score: 0.8,
+            },
+        ]);
+        expect(
+            await screen.findByText('Finding saved charts'),
+        ).toBeInTheDocument();
+        fireEvent.submit(screen.getByRole('search'));
+        expect(askMutate).toHaveBeenCalledTimes(1);
+    });
+
+    it('holds the answer while the next question runs and ignores the stale response', async () => {
+        renderWithProviders(
+            <LearnUiRoot>
+                <LearnBoardPanel />
+            </LearnUiRoot>,
+            {
+                user: { role: OrganizationMemberRole.VIEWER },
+            },
+        );
+        fireEvent.change(await screen.findByRole('searchbox'), {
+            target: { value: 'where are my charts' },
+        });
+        fireEvent.submit(screen.getByRole('search'));
+        answerWith([
+            {
+                courseId: 'foundation',
+                lessonId: 'l2',
+                title: 'Finding saved charts',
+                score: 0.8,
+            },
+        ]);
+        expect(
+            await screen.findByText('Finding saved charts'),
+        ).toBeInTheDocument();
+
+        fireEvent.change(screen.getByRole('searchbox'), {
+            target: { value: 'how do I share' },
+        });
+        fireEvent.submit(screen.getByRole('search'));
+        // The board must not flash back to undimmed while the answer reloads.
+        expect(screen.getByText('Finding saved charts')).toBeInTheDocument();
+        const dimmed = screen
+            .getByTestId('learn-board')
+            .querySelector<HTMLElement>('[aria-label^="Sharing your work"]');
+        expect(dimmed?.style.opacity).toBe('0.4');
+
+        answerWith([
+            {
+                courseId: 'sharing',
+                lessonId: 'l1',
+                title: 'Sharing basics',
+                score: 0.9,
+            },
+        ]);
+        expect(await screen.findByText('Sharing basics')).toBeInTheDocument();
+
+        // The first request answers late: the newer answer stands.
+        answerWith(
+            [
+                {
+                    courseId: 'foundation',
+                    lessonId: 'l2',
+                    title: 'Finding saved charts',
+                    score: 0.8,
+                },
+            ],
+            0,
+        );
+        expect(screen.getByText('Sharing basics')).toBeInTheDocument();
+        expect(
+            screen.queryByText('Finding saved charts'),
+        ).not.toBeInTheDocument();
+    });
+
+    it('opening a match bookmarks the lesson then navigates to the course', async () => {
+        renderWithProviders(
+            <LearnUiRoot>
+                <LearnBoardPanel />
+            </LearnUiRoot>,
+            {
+                user: { role: OrganizationMemberRole.VIEWER },
+            },
+        );
+        fireEvent.change(await screen.findByRole('searchbox'), {
+            target: { value: 'charts' },
+        });
+        fireEvent.submit(screen.getByRole('search'));
+        answerWith([
+            {
+                courseId: 'foundation',
+                lessonId: 'l2',
+                title: 'Finding saved charts',
+                score: 0.8,
+            },
+        ]);
+        fireEvent.click(await screen.findByRole('button', { name: 'Open' }));
+        expect(setLessonBookmarkMock).toHaveBeenCalledWith('foundation', 'l2');
+        expect(navigate).toHaveBeenCalledWith(
+            '/projects/project-1/learn/courses/foundation',
+        );
+    });
+
+    it('renders the role badge card from the badge tiers', async () => {
+        renderWithProviders(
+            <LearnUiRoot>
+                <LearnBoardPanel />
+            </LearnUiRoot>,
+            {
+                user: { role: OrganizationMemberRole.VIEWER },
+            },
+        );
+        expect(await screen.findByText('viewer badge')).toBeInTheDocument();
+        // The rung word also appears in the disclosure, so pin the hero span.
+        expect(
+            screen.getByText('Bronze', { selector: 'span' }),
+        ).toBeInTheDocument();
+    });
+
+    it('switches the badge when the role tab changes', async () => {
+        renderWithProviders(
+            <LearnUiRoot>
+                <LearnBoardPanel />
+            </LearnUiRoot>,
+            {
+                user: { role: OrganizationMemberRole.VIEWER },
+            },
+        );
+        expect(await screen.findByText('viewer badge')).toBeInTheDocument();
+        fireEvent.click(screen.getByRole('tab', { name: 'editor' }));
+        expect(await screen.findByText('editor badge')).toBeInTheDocument();
+        // Editor also holds the untiered dashboards module, so the role drops
+        // back to the lowest rung.
+        expect(
+            screen.getByText('Locked', { selector: 'span' }),
+        ).toBeInTheDocument();
+    });
+
+    it('waits for the badges query rather than calling it unavailable', async () => {
+        badgesState.data = undefined;
+        badgesState.isInitialLoading = true;
+        renderWithProviders(
+            <LearnUiRoot>
+                <LearnBoardPanel />
+            </LearnUiRoot>,
+            {
+                user: { role: OrganizationMemberRole.VIEWER },
+            },
+        );
+        expect(await screen.findByText('Loading badges')).toBeInTheDocument();
+        expect(
+            screen.queryByText('Badges unavailable right now'),
+        ).not.toBeInTheDocument();
+    });
+
+    it('says badges are unavailable rather than showing them as locked', async () => {
+        badgesState.data = { badges: null };
+        renderWithProviders(
+            <LearnUiRoot>
+                <LearnBoardPanel />
+            </LearnUiRoot>,
+            {
+                user: { role: OrganizationMemberRole.VIEWER },
+            },
+        );
+        expect(await screen.findByText('Overall')).toBeInTheDocument();
+        expect(screen.getByText('viewer badge')).toBeInTheDocument();
+        expect(
+            screen.getByText('Badges unavailable right now'),
+        ).toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/features/learn/board/LearnBoardPanel.test.tsx
+++ b/packages/frontend/src/features/learn/board/LearnBoardPanel.test.tsx
@@ -118,6 +118,9 @@ const defaultSelectedCourse = () => ({
     isError: false,
 });
 const selectedCourseState = { value: defaultSelectedCourse() };
+// Hoisted so the mock factory can hand it over directly: recording the argument
+// is what proves the panel passes `selectedId ?? undefined` down to the hook.
+const useLearnCourseMock = vi.hoisted(() => vi.fn());
 
 vi.mock('../hooks', () => ({
     useLearnCatalogue: () => ({
@@ -140,7 +143,7 @@ vi.mock('../hooks', () => ({
         isLoading: false,
         serverSynced: false,
     }),
-    useLearnCourse: () => selectedCourseState.value,
+    useLearnCourse: useLearnCourseMock,
     useLearnBadges: () => badgesState,
     useLearnAsk: () => ({
         mutate: askMutate,
@@ -159,6 +162,8 @@ describe('LearnBoardPanel', () => {
         askMutate.mockClear();
         askCalls.length = 0;
         setLessonBookmarkMock.mockClear();
+        useLearnCourseMock.mockReset();
+        useLearnCourseMock.mockImplementation(() => selectedCourseState.value);
         askState.isLoading = false;
         askState.isError = false;
         badgesState.data = bronzeEverywhere;
@@ -347,6 +352,10 @@ describe('LearnBoardPanel', () => {
             },
         );
         expect(await screen.findAllByRole('tab')).toHaveLength(5);
+        // Nothing selected yet: the hook is called with undefined, which is
+        // what disables the query.
+        expect(useLearnCourseMock).toHaveBeenCalled();
+        expect(useLearnCourseMock.mock.lastCall?.[0]).toBeUndefined();
         fireEvent.click(await screen.findByRole('tab', { name: 'editor' }));
         const node = within(screen.getByTestId('learn-board')).getByRole(
             'button',
@@ -354,6 +363,9 @@ describe('LearnBoardPanel', () => {
         );
         await waitFor(() => expect(node).toHaveAttribute('tabindex', '0'));
         fireEvent.click(node);
+        await waitFor(() =>
+            expect(useLearnCourseMock.mock.lastCall?.[0]).toBe('dashboards'),
+        );
         expect(screen.getByText('manage:Dashboard')).toBeInTheDocument();
         expect(screen.getByText(/Anatomy of a dashboard/)).toBeInTheDocument();
         fireEvent.click(screen.getByRole('button', { name: 'Start module' }));

--- a/packages/frontend/src/features/learn/board/LearnBoardPanel.tsx
+++ b/packages/frontend/src/features/learn/board/LearnBoardPanel.tsx
@@ -1,0 +1,329 @@
+import { type LearnAskMatch, type LearnBadgeTier } from '@lightdash/common';
+import {
+    AskBar,
+    BOARD_WIDTH,
+    BoardRail,
+    ClusterBoard,
+    defaultRoleFor,
+    plural,
+    resolveMatches,
+    ROLE_LABEL,
+    RoleTabs,
+    useLearnModel,
+    type ProjectMemberRole,
+    type Seat,
+} from '@lightdash/learn-ui';
+import { useReducedMotion } from '@mantine/hooks';
+import { IconSchool } from '@tabler/icons-react';
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    type FC,
+} from 'react';
+import { useNavigate, useParams } from 'react-router';
+import SuboptimalState from '../../../components/common/SuboptimalState/SuboptimalState';
+import useApp from '../../../providers/App/useApp';
+import {
+    setLessonBookmark,
+    useLearnAsk,
+    useLearnBadges,
+    useLearnCatalogue,
+    useLearnCourse,
+    useLearnRollups,
+} from '../hooks';
+import styles from './LearnBoardPanel.module.css';
+
+/** The answer on screen, kept while the next request is in flight. */
+type AskAnswer = { query: string; matches: LearnAskMatch[] };
+
+export const LearnBoardPanel: FC = () => {
+    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const navigate = useNavigate();
+    const { user } = useApp();
+    const {
+        roleScopes,
+        isUnlocked,
+        effectiveEntry,
+        effectiveRollup,
+        courseFor,
+        railModel,
+        suggestionsFor,
+        boardHighlights,
+    } = useLearnModel();
+    const catalogue = useLearnCatalogue();
+    const { rollups: rawRollups } = useLearnRollups();
+    const badges = useLearnBadges();
+    const ask = useLearnAsk();
+    const [answer, setAnswer] = useState<AskAnswer | null>(null);
+    const reducedMotion = useReducedMotion() ?? false;
+    const boardRef = useRef<HTMLDivElement>(null);
+    const tabsRef = useRef<HTMLDivElement>(null);
+    const frameRef = useRef<number | null>(null);
+    const askSeqRef = useRef(0);
+    const askInFlightRef = useRef(false);
+
+    // Not initialised from the org role: that query is still async at mount,
+    // so `picked` stays null until the learner overrides the derived default.
+    const [picked, setPicked] = useState<ProjectMemberRole | null>(null);
+    const role = picked ?? defaultRoleFor(user.data?.role);
+    const [prevRole, setPrevRole] = useState<ProjectMemberRole | null>(null);
+    const [origin, setOrigin] = useState<Seat | null>(null);
+    const [burst, setBurst] = useState(false);
+    const [selectedId, setSelectedId] = useState<string | null>(null);
+    const selectedCourse = useLearnCourse(selectedId ?? undefined);
+
+    useEffect(
+        () => () => {
+            if (frameRef.current !== null)
+                cancelAnimationFrame(frameRef.current);
+        },
+        [],
+    );
+
+    const { reset: resetAsk, mutate: runAsk } = ask;
+    // One request at a time, and re-asking the answer on screen is a no-op:
+    // every submit costs an upstream embedding. The pane is left open.
+    const submitAsk = useCallback(
+        (query: string) => {
+            if (askInFlightRef.current) return;
+            if (answer !== null && answer.query === query) return;
+            askSeqRef.current += 1;
+            askInFlightRef.current = true;
+            const seq = askSeqRef.current;
+            const current = () => seq === askSeqRef.current;
+            runAsk(
+                { query },
+                {
+                    onSuccess: (data) => {
+                        if (current())
+                            setAnswer({ query, matches: data.matches });
+                    },
+                    onError: () => {
+                        if (current()) setAnswer(null);
+                    },
+                    onSettled: () => {
+                        if (current()) askInFlightRef.current = false;
+                    },
+                },
+            );
+        },
+        [runAsk, answer],
+    );
+    const clearAsk = useCallback(() => {
+        // A response still in flight belongs to a question the learner dropped.
+        askSeqRef.current += 1;
+        askInFlightRef.current = false;
+        setAnswer(null);
+        resetAsk();
+    }, [resetAsk]);
+
+    const pickRole = useCallback(
+        (next: ProjectMemberRole, element: HTMLElement) => {
+            if (next === role) {
+                setPicked(next);
+                return;
+            }
+            if (frameRef.current !== null)
+                cancelAnimationFrame(frameRef.current);
+            const board = boardRef.current;
+            if (!reducedMotion && board) {
+                const b = board.getBoundingClientRect();
+                const t = element.getBoundingClientRect();
+                // The board may be scaled down to fit; seats are in board space.
+                const scale = b.width > 0 ? b.width / BOARD_WIDTH : 1;
+                setOrigin({
+                    x: (t.left + t.width / 2 - b.left) / scale,
+                    y: (t.top + t.height / 2 - b.top) / scale,
+                });
+            } else {
+                setOrigin(null);
+            }
+            setPrevRole(role);
+            setPicked(next);
+            setSelectedId(null);
+            // The answer is kept: the query has not changed, only which of its
+            // matches the new role can open, so the highlights re-derive.
+            setBurst(true);
+            frameRef.current = requestAnimationFrame(() => {
+                frameRef.current = requestAnimationFrame(() => setBurst(false));
+            });
+        },
+        [role, reducedMotion],
+    );
+
+    // Closing the pane unmounts the focused close button, so hand focus back
+    // to the node that opened it, else the selected role tab.
+    const clearSelection = useCallback(() => {
+        const node = boardRef.current?.querySelector<HTMLElement>(
+            'button[aria-pressed="true"]:not(:disabled)',
+        );
+        const tab = tabsRef.current?.querySelector<HTMLElement>(
+            '[role="tab"][aria-selected="true"]',
+        );
+        setSelectedId(null);
+        (node ?? tab)?.focus();
+    }, []);
+
+    const held = useMemo(() => roleScopes(role), [roleScopes, role]);
+    // CS-169: every lessonCount downstream of here — railModel/moduleProgress
+    // denominators, node numerals, rail and pane "N lessons" — is the count of
+    // lessons visible to the selected role, so the twin board model stays
+    // untouched while a scope-group module renders per-role counts.
+    // Visible-lesson counts only make sense for modules the selected role
+    // HOLDS. A locked ask-match or a completed row from a previous role still
+    // describes the whole module — showing '0 lessons' there would be a lie.
+    const entries = useMemo(
+        () =>
+            (catalogue.data?.courses ?? []).map((entry) =>
+                isUnlocked(entry, held) ? effectiveEntry(entry, held) : entry,
+            ),
+        [catalogue.data, held, isUnlocked, effectiveEntry],
+    );
+    // Doneness is derived too (CS-169 §6): a completed module whose visible
+    // lesson set grew re-opens. effectiveRollup is the identity for a module
+    // the role doesn't hold (visible count 0), so completed rows from other
+    // roles stay completed.
+    const rollups = useMemo(() => {
+        const derived = new Map(rawRollups);
+        for (const entry of entries) {
+            const rollup = effectiveRollup(
+                entry,
+                rawRollups.get(entry.id),
+                held,
+            );
+            if (rollup) derived.set(entry.id, rollup);
+        }
+        return derived;
+    }, [rawRollups, entries, held, effectiveRollup]);
+    const prevHeld = useMemo(
+        () => (prevRole ? roleScopes(prevRole) : null),
+        [prevRole, roleScopes],
+    );
+    const rail = useMemo(
+        () => railModel(entries, held, rollups),
+        [entries, held, rollups, railModel],
+    );
+    const heldEntries = useMemo(
+        () => courseFor(entries, held),
+        [entries, held, courseFor],
+    );
+    const tiers = useMemo((): Map<string, LearnBadgeTier> | null => {
+        const rows = badges.data?.badges;
+        if (!rows) return null;
+        return new Map(rows.map((badge) => [badge.courseId, badge.tier]));
+    }, [badges.data]);
+    const suggestions = useMemo(
+        () =>
+            catalogue.data
+                ? suggestionsFor(catalogue.data.suggestions, entries, held)
+                : [],
+        [catalogue.data, entries, held, suggestionsFor],
+    );
+    const matches = useMemo(
+        () =>
+            answer === null ? null : resolveMatches(answer.matches, entries),
+        [answer, entries],
+    );
+    const highlights = useMemo(
+        () =>
+            matches === null || matches.length === 0
+                ? null
+                : boardHighlights(matches, entries, held),
+        [matches, entries, held, boardHighlights],
+    );
+
+    const openCourse = (courseId: string) =>
+        navigate(
+            `/projects/${projectUuid}/learn/courses/${encodeURIComponent(courseId)}`,
+        );
+    const openMatch = (courseId: string, lessonId: string | null) => {
+        if (lessonId !== null) setLessonBookmark(courseId, lessonId);
+        void openCourse(courseId);
+    };
+
+    if (catalogue.isError) {
+        return (
+            <SuboptimalState
+                icon={IconSchool}
+                title="Learn is unavailable"
+                description="Learn content is fetched from Lightdash University. Check the instance can reach it, then retry."
+            />
+        );
+    }
+    if (catalogue.isLoading) {
+        return <SuboptimalState loading title="Loading your course" />;
+    }
+
+    return (
+        <div className={styles.scroller}>
+            <div className={styles.card}>
+                <div className={styles.boardColumn}>
+                    <div className={styles.header}>
+                        <h2 className={styles.title}>Your course</h2>
+                        <span className={styles.sub}>
+                            Everything your {ROLE_LABEL[role]} role unlocks:{' '}
+                            {plural(rail.mine.length, 'module')},{' '}
+                            {rail.overall.modulesComplete} finished.
+                        </span>
+                        <AskBar
+                            entries={entries}
+                            suggestions={suggestions}
+                            matches={matches}
+                            lockedIds={highlights?.locked ?? new Set<string>()}
+                            isSearching={ask.isLoading}
+                            isError={ask.isError}
+                            onSubmit={submitAsk}
+                            onClear={clearAsk}
+                            onOpen={openMatch}
+                        />
+                    </div>
+                    {/* The tabs sit next to the rings the nodes fly out of. */}
+                    <div className={styles.tabsRow} ref={tabsRef}>
+                        <RoleTabs role={role} onPick={pickRole} />
+                    </div>
+                    {rail.mine.length === 0 ? (
+                        <SuboptimalState
+                            icon={IconSchool}
+                            title="Nothing to learn yet"
+                            description="This role unlocks no modules in the current catalogue."
+                        />
+                    ) : (
+                        <ClusterBoard
+                            entries={entries}
+                            held={held}
+                            prevHeld={prevHeld}
+                            rollups={rollups}
+                            selectedId={selectedId}
+                            nextUpId={rail.nextUpId}
+                            origin={origin}
+                            burst={burst}
+                            reducedMotion={reducedMotion}
+                            highlights={highlights}
+                            onSelect={setSelectedId}
+                            boardRef={boardRef}
+                        />
+                    )}
+                </div>
+                <BoardRail
+                    rail={rail}
+                    rollups={rollups}
+                    role={role}
+                    held={held}
+                    heldEntries={heldEntries}
+                    tiers={tiers}
+                    tiersLoading={badges.isInitialLoading}
+                    selectedId={selectedId}
+                    onSelect={setSelectedId}
+                    onClearSelection={clearSelection}
+                    onOpen={openCourse}
+                    selectedCourse={selectedCourse.data}
+                    selectedCourseLoading={selectedCourse.isInitialLoading}
+                    selectedCourseError={selectedCourse.isError}
+                />
+            </div>
+        </div>
+    );
+};

--- a/packages/frontend/src/features/learn/components/LearnCoursePlayer.test.tsx
+++ b/packages/frontend/src/features/learn/components/LearnCoursePlayer.test.tsx
@@ -1,0 +1,172 @@
+import { OrganizationMemberRole, type LearnCourse } from '@lightdash/common';
+import { emptyRollup } from '@lightdash/learn-ui';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import type * as ReactRouter from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import { LearnUiRoot } from '../LearnUiRoot';
+import { LearnCoursePlayer } from './LearnCoursePlayer';
+
+vi.mock('react-router', async () => {
+    const actual = await vi.importActual<typeof ReactRouter>('react-router');
+    return {
+        ...actual,
+        useNavigate: () => vi.fn(),
+        useParams: () => ({
+            projectUuid: 'project-1',
+            courseId: 'saving-charts',
+        }),
+    };
+});
+
+const course: LearnCourse = {
+    id: 'saving-charts',
+    title: 'Saving charts',
+    passingScore: 80,
+    lessons: [
+        {
+            id: 'l1',
+            title: 'Save a chart',
+            scope: null,
+            html:
+                '<p>Open the chart<a class="cit" href="#fig-1" data-hl="r1">1</a>.</p>' +
+                '<div data-demo="save-chart"></div>' +
+                '<span class="figwrap" id="fig-1"><img src="assets/a.png" alt="">' +
+                '<span class="hlbox" data-r="r1" data-label="1 · Save" style="left:1%;top:2%;width:3%;height:4%"></span></span>',
+        },
+    ],
+    quiz: { questions: [] },
+    demos: {
+        'save-chart': {
+            id: 'save-chart',
+            title: 'Save a chart',
+            viewport: { width: 1440, height: 900 },
+            steps: [
+                {
+                    image: 'save-1.png',
+                    caption: 'Click Save.',
+                    hotspot: { x: 0.5, y: 0.5, width: 0.1, height: 0.1 },
+                },
+                { image: 'save-2.png', caption: 'Done.', hotspot: null },
+            ],
+        },
+    },
+    version: 1,
+    contentHash: 'abc',
+    publishedAt: '2026-08-01T00:00:00.000Z',
+    assetBaseUrl: 'https://cdn/courses/saving-charts/abc',
+};
+
+// Swappable so a test can serve a differently scoped course.
+const courseState: { data: LearnCourse } = { data: course };
+
+vi.mock('../hooks', () => ({
+    useLearnCatalogue: () => ({
+        data: {
+            generatedAt: '2026-08-01T00:00:00.000Z',
+            courses: [
+                {
+                    id: 'saving-charts',
+                    title: 'Saving charts',
+                    lessonCount: 1,
+                },
+            ],
+            suggestions: [],
+        },
+        isLoading: false,
+        isError: false,
+    }),
+    useLearnCourse: () => ({
+        data: courseState.data,
+        isInitialLoading: false,
+        isError: false,
+    }),
+    useLearnRollups: () => ({
+        rollups: new Map([['saving-charts', emptyRollup()]]),
+        isLoading: false,
+        serverSynced: false,
+    }),
+    useRecordLearnEvent: () => ({ record: vi.fn() }),
+    getLessonBookmark: () => null,
+    setLessonBookmark: vi.fn(),
+    setLastCourseId: vi.fn(),
+}));
+
+describe('LearnCoursePlayer', () => {
+    beforeEach(() => {
+        courseState.data = course;
+    });
+
+    it('renders an empty state instead of the player when the role holds none of the lesson scopes', async () => {
+        courseState.data = {
+            ...course,
+            lessons: [
+                {
+                    id: 'l1',
+                    title: 'Tidy the thread',
+                    scope: 'manage:DashboardComments',
+                    html: '<p>manage-only</p>',
+                },
+            ],
+            quiz: {
+                questions: [
+                    {
+                        id: 'q1',
+                        prompt: 'Q?',
+                        choices: ['a', 'b'],
+                        answer: 0,
+                    },
+                ],
+            },
+        };
+        // An org viewer maps to the viewer board role, which does not hold
+        // manage:DashboardComments.
+        renderWithProviders(
+            <LearnUiRoot>
+                <LearnCoursePlayer />
+            </LearnUiRoot>,
+            { user: { role: OrganizationMemberRole.VIEWER } },
+        );
+        await waitFor(() =>
+            expect(
+                screen.getByText(
+                    /None of this course's lessons are available to your role/,
+                ),
+            ).toBeInTheDocument(),
+        );
+        expect(screen.queryByText('manage-only')).not.toBeInTheDocument();
+        expect(screen.queryByText(/Lesson 1 of/)).not.toBeInTheDocument();
+    });
+
+    it('mounts a click-through demo where the lesson left its placeholder', async () => {
+        renderWithProviders(
+            <LearnUiRoot>
+                <LearnCoursePlayer />
+            </LearnUiRoot>,
+        );
+        await waitFor(() =>
+            expect(screen.getByText('Click Save.')).toBeInTheDocument(),
+        );
+        const placeholder = document.querySelector(
+            'div[data-demo="save-chart"]',
+        );
+        expect(placeholder?.textContent).toContain('1/2');
+        fireEvent.click(screen.getByRole('button', { name: 'Next step' }));
+        expect(screen.getByText('2/2')).toBeInTheDocument();
+    });
+
+    it('keeps the citation markup and resolves asset paths', async () => {
+        renderWithProviders(
+            <LearnUiRoot>
+                <LearnCoursePlayer />
+            </LearnUiRoot>,
+        );
+        await waitFor(() =>
+            expect(document.querySelector('a.cit')).toBeInTheDocument(),
+        );
+        expect(document.querySelector('.hlbox[data-r="r1"]')).not.toBeNull();
+        expect(
+            document.querySelector('.figwrap img')?.getAttribute('src'),
+        ).toBe('https://cdn/courses/saving-charts/abc/assets/a.png');
+    });
+});

--- a/packages/frontend/src/features/learn/components/LearnCoursePlayer.tsx
+++ b/packages/frontend/src/features/learn/components/LearnCoursePlayer.tsx
@@ -1,0 +1,400 @@
+import {
+    HTML_SANITIZE_LEARN_LESSON_RULES,
+    sanitizeHtml,
+    type LearnCourse,
+} from '@lightdash/common';
+import {
+    cardState,
+    defaultRoleFor,
+    emptyRollup,
+    LessonBody,
+    useLearnModel,
+} from '@lightdash/learn-ui';
+import {
+    Anchor,
+    Button,
+    Group,
+    Paper,
+    Progress,
+    Radio,
+    Stack,
+    Text,
+    Title,
+} from '@mantine/core';
+import { IconArrowLeft } from '@tabler/icons-react';
+import { useEffect, useMemo, useState, type FC } from 'react';
+import { useNavigate, useParams } from 'react-router';
+import MantineIcon from '../../../components/common/MantineIcon';
+import SuboptimalState from '../../../components/common/SuboptimalState/SuboptimalState';
+import useApp from '../../../providers/App/useApp';
+import {
+    getLessonBookmark,
+    setLastCourseId,
+    setLessonBookmark,
+    useLearnCatalogue,
+    useLearnCourse,
+    useLearnRollups,
+    useRecordLearnEvent,
+} from '../hooks';
+
+function scoreQuiz(
+    questions: LearnCourse['quiz']['questions'],
+    answers: ReadonlyArray<number | null>,
+): number {
+    const correct = questions.filter((q, i) => answers[i] === q.answer).length;
+    return Math.round((correct / questions.length) * 100);
+}
+
+function lessonHtml(course: LearnCourse, index: number): string {
+    const raw = course.lessons[index].html.replace(
+        /src="assets\//g,
+        `src="${course.assetBaseUrl}/assets/`,
+    );
+    return sanitizeHtml(raw, HTML_SANITIZE_LEARN_LESSON_RULES);
+}
+
+export const LearnCoursePlayer: FC = () => {
+    const { projectUuid, courseId } = useParams<{
+        projectUuid: string;
+        courseId: string;
+    }>();
+    const navigate = useNavigate();
+    const { user } = useApp();
+    const { roleScopes, filterCourseForScopes, effectiveRollup } =
+        useLearnModel();
+    const catalogue = useLearnCatalogue();
+    const course = useLearnCourse(courseId);
+    const { rollups } = useLearnRollups();
+    const { record } = useRecordLearnEvent();
+
+    // page ∈ [0, lessonCount-1] = lessons; page === lessonCount = quiz.
+    const [page, setPage] = useState<number | null>(null);
+    const [answers, setAnswers] = useState<(number | null)[]>([]);
+    const [quizResult, setQuizResult] = useState<number | null>(null);
+    const [started, setStarted] = useState(false);
+
+    useEffect(() => {
+        if (courseId) setLastCourseId(courseId);
+    }, [courseId]);
+
+    // CS-169: the course is filtered to the held scopes BEFORE the paging and
+    // the index-parallel quiz answers state are built, so a hidden lesson can
+    // never be paged to and a hidden lesson's quiz question is never scored.
+    // The board's role picker is component-local and not shared with this
+    // route, so the held scopes derive from the learner's org role the same
+    // way the board derives its default tab.
+    const held = useMemo(
+        () => roleScopes(defaultRoleFor(user.data?.role)),
+        [user.data?.role, roleScopes],
+    );
+    const data = useMemo(
+        () =>
+            course.data ? filterCourseForScopes(course.data, held) : undefined,
+        [course.data, held, filterCourseForScopes],
+    );
+
+    // Doneness is derived against the visible lesson set (CS-169 §6): a
+    // module completed under a smaller set re-opens when the role holds more
+    // lessons. The catalogue entry carries the per-lesson scopes; when the
+    // catalogue is unavailable the raw rollup stands (legacy behaviour).
+    const entry = catalogue.data?.courses.find((c) => c.id === courseId);
+    const baseRollup = courseId ? rollups.get(courseId) : undefined;
+    const derivedRollup = entry
+        ? effectiveRollup(entry, baseRollup, held)
+        : baseRollup;
+    const rollup = derivedRollup ?? emptyRollup();
+    const state = cardState(derivedRollup);
+
+    const eventObject = useMemo(
+        () =>
+            data && courseId
+                ? {
+                      course: courseId,
+                      contentHash: data.contentHash,
+                      version: data.version,
+                  }
+                : null,
+        [data, courseId],
+    );
+
+    useEffect(() => {
+        if (!data || page !== null || !courseId) return;
+        const bookmark = getLessonBookmark(courseId);
+        const bookmarkIndex = data.lessons.findIndex((l) => l.id === bookmark);
+        setPage(bookmarkIndex >= 0 ? bookmarkIndex : 0);
+        setAnswers(data.quiz.questions.map(() => null));
+    }, [data, page, courseId]);
+
+    useEffect(() => {
+        // A course with no visible lessons is never "started" — the learner
+        // only ever sees the empty state below.
+        if (!data || data.lessons.length === 0) return;
+        if (started || state !== 'open' || !eventObject) return;
+        setStarted(true);
+        record({
+            verb: 'started',
+            object: { type: 'course', ...eventObject },
+        });
+    }, [data, started, state, eventObject, record]);
+
+    // One object per lesson: a fresh string each render would make LessonBody
+    // reset the injected HTML and wipe the demo portals mounted inside it.
+    const lessonHtmlString = useMemo(
+        () =>
+            data && page !== null && page < data.lessons.length
+                ? lessonHtml(data, page)
+                : null,
+        [data, page],
+    );
+
+    if (course.isInitialLoading || (data && page === null)) {
+        return <SuboptimalState title="Loading course…" loading />;
+    }
+    if (course.isError || !data || page === null || !eventObject) {
+        return (
+            <SuboptimalState
+                title="Couldn't load this course"
+                description="It may have been unpublished, or the content service is unreachable."
+            />
+        );
+    }
+
+    // CS-169: a role that holds none of the course's lesson scopes would
+    // reach the player with zero lessons and a zero-question quiz (scored
+    // NaN). Render an honest empty state instead.
+    if (data.lessons.length === 0) {
+        return (
+            <Stack gap="md" py="lg" maw={760} w="100%" mx="auto">
+                <Anchor
+                    size="sm"
+                    onClick={() => navigate(`/projects/${projectUuid}/learn`)}
+                >
+                    <Group gap={4}>
+                        <MantineIcon icon={IconArrowLeft} />
+                        All courses
+                    </Group>
+                </Anchor>
+                <SuboptimalState
+                    title="No lessons for your role"
+                    description="None of this course's lessons are available to your role. Head back to the course board to see what your role unlocks."
+                />
+            </Stack>
+        );
+    }
+
+    const lessonCount = data.lessons.length;
+    // CS-169: the rollup can hold ids of lessons the role does not see, so
+    // the header count is the intersection with the visible lesson set.
+    const doneCount = data.lessons.filter((l) =>
+        rollup.lessonsCompleted.has(l.id),
+    ).length;
+    const onQuiz = page >= lessonCount;
+    const progressPct = Math.round(((page + 1) / (lessonCount + 1)) * 100);
+
+    const go = (next: number) => {
+        if (next > page && page < lessonCount) {
+            const lesson = data.lessons[page];
+            if (!rollup.lessonsCompleted.has(lesson.id)) {
+                record({
+                    verb: 'completed',
+                    object: {
+                        type: 'lesson',
+                        lesson: lesson.id,
+                        ...eventObject,
+                    },
+                });
+            }
+        }
+        const clamped = Math.max(0, Math.min(lessonCount, next));
+        if (clamped < lessonCount && courseId) {
+            setLessonBookmark(courseId, data.lessons[clamped].id);
+        }
+        setQuizResult(null);
+        setPage(clamped);
+    };
+
+    const submitQuiz = () => {
+        const score = scoreQuiz(data.quiz.questions, answers);
+        const passed = score >= data.passingScore;
+        record({
+            verb: passed ? 'passed' : 'failed',
+            object: { type: 'quiz', ...eventObject },
+            result: { score, passed },
+        });
+        if (passed && !rollup.completed) {
+            record({
+                verb: 'completed',
+                object: { type: 'course', ...eventObject },
+                result: { completion: true },
+            });
+        }
+        setQuizResult(score);
+    };
+
+    return (
+        <Stack gap="md" py="lg" maw={760} w="100%" mx="auto">
+            <Anchor
+                size="sm"
+                onClick={() => navigate(`/projects/${projectUuid}/learn`)}
+            >
+                <Group gap={4}>
+                    <MantineIcon icon={IconArrowLeft} />
+                    All courses
+                </Group>
+            </Anchor>
+
+            <Paper withBorder radius="md" p="lg">
+                <Stack gap={4}>
+                    <Title order={2}>{data.title}</Title>
+                    <Text size="sm" c="dimmed">
+                        {lessonCount} lessons · {doneCount} of {lessonCount}{' '}
+                        done
+                        {rollup.passed ? ' · Passed' : ''}
+                    </Text>
+                </Stack>
+            </Paper>
+
+            <Paper withBorder radius="md">
+                <Group justify="space-between" p="md" pb="xs">
+                    <Text fw={600}>{data.title}</Text>
+                    <Text size="sm" c="dimmed">
+                        {onQuiz
+                            ? 'Quiz'
+                            : `Lesson ${page + 1} of ${lessonCount}`}
+                    </Text>
+                </Group>
+                <Progress value={progressPct} size="xs" radius={0} />
+                <Stack p="lg" gap="md">
+                    {!onQuiz && lessonHtmlString !== null && (
+                        <LessonBody
+                            html={lessonHtmlString}
+                            demos={data.demos}
+                            assetBaseUrl={data.assetBaseUrl}
+                        />
+                    )}
+                    {onQuiz && quizResult === null && (
+                        <Stack gap="md">
+                            <Title order={3}>Quiz</Title>
+                            <Text size="sm" c="dimmed">
+                                Answer all questions. Passing score:{' '}
+                                {data.passingScore}%.
+                            </Text>
+                            {data.quiz.questions.map((q, qi) => (
+                                <Radio.Group
+                                    key={q.id}
+                                    label={`${qi + 1}. ${q.prompt}`}
+                                    value={
+                                        answers[qi] === null
+                                            ? null
+                                            : String(answers[qi])
+                                    }
+                                    onChange={(value) =>
+                                        setAnswers((prev) => {
+                                            const next = [...prev];
+                                            next[qi] = Number(value);
+                                            return next;
+                                        })
+                                    }
+                                >
+                                    <Stack gap={6} mt="xs">
+                                        {q.choices.map((choice, ci) => (
+                                            <Radio
+                                                key={choice}
+                                                value={String(ci)}
+                                                label={choice}
+                                            />
+                                        ))}
+                                    </Stack>
+                                </Radio.Group>
+                            ))}
+                            <Button onClick={submitQuiz}>Submit answers</Button>
+                        </Stack>
+                    )}
+                    {onQuiz && quizResult !== null && (
+                        <Stack gap="md">
+                            <Title order={3}>Your result: {quizResult}%</Title>
+                            <Text
+                                c={
+                                    quizResult >= data.passingScore
+                                        ? 'green'
+                                        : 'red'
+                                }
+                            >
+                                {quizResult >= data.passingScore
+                                    ? 'You passed — nice work!'
+                                    : `You need ${data.passingScore}% to pass.`}
+                            </Text>
+                            {data.quiz.questions.map((q, qi) => {
+                                const given = answers[qi];
+                                const correct = given === q.answer;
+                                return (
+                                    <Paper
+                                        key={q.id}
+                                        withBorder
+                                        radius="md"
+                                        p="sm"
+                                        style={{
+                                            borderColor: correct
+                                                ? 'var(--mantine-color-green-4)'
+                                                : 'var(--mantine-color-red-4)',
+                                        }}
+                                    >
+                                        <Text size="sm" fw={600}>
+                                            {qi + 1}. {q.prompt}
+                                        </Text>
+                                        <Text size="sm">
+                                            Your answer:{' '}
+                                            <strong>
+                                                {given === null
+                                                    ? '—'
+                                                    : q.choices[given]}
+                                            </strong>
+                                        </Text>
+                                        {!correct && (
+                                            <Text size="sm">
+                                                Correct answer:{' '}
+                                                <strong>
+                                                    {q.choices[q.answer]}
+                                                </strong>
+                                            </Text>
+                                        )}
+                                    </Paper>
+                                );
+                            })}
+                            {quizResult < data.passingScore && (
+                                <Button
+                                    variant="default"
+                                    onClick={() => {
+                                        setAnswers(
+                                            data.quiz.questions.map(() => null),
+                                        );
+                                        setQuizResult(null);
+                                    }}
+                                >
+                                    Try again
+                                </Button>
+                            )}
+                        </Stack>
+                    )}
+                </Stack>
+                {!onQuiz && (
+                    <Group justify="space-between" p="md" pt={0}>
+                        {page > 0 ? (
+                            <Button
+                                variant="default"
+                                onClick={() => go(page - 1)}
+                            >
+                                Back
+                            </Button>
+                        ) : (
+                            <span />
+                        )}
+                        <Button onClick={() => go(page + 1)}>
+                            {page === lessonCount - 1 ? 'Start quiz' : 'Next'}
+                        </Button>
+                    </Group>
+                )}
+            </Paper>
+        </Stack>
+    );
+};

--- a/packages/frontend/src/features/learn/hooks.test.tsx
+++ b/packages/frontend/src/features/learn/hooks.test.tsx
@@ -1,0 +1,51 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { type PropsWithChildren } from 'react';
+import { useRecordLearnEvent } from './hooks';
+
+const lightdashApi = vi.hoisted(() => vi.fn());
+
+vi.mock('../../api', () => ({ lightdashApi }));
+
+const renderWithClient = () => {
+    const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: PropsWithChildren) => (
+        <QueryClientProvider client={queryClient}>
+            {children}
+        </QueryClientProvider>
+    );
+
+    return {
+        queryClient,
+        ...renderHook(() => useRecordLearnEvent(), { wrapper }),
+    };
+};
+
+describe('useRecordLearnEvent', () => {
+    beforeEach(() => {
+        lightdashApi.mockReset();
+        localStorage.clear();
+    });
+
+    it('invalidates the badges as well as the progress once an event settles', async () => {
+        lightdashApi.mockResolvedValue({ accepted: 1 });
+        const { queryClient, result } = renderWithClient();
+        const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
+
+        act(() =>
+            result.current.record({
+                verb: 'completed',
+                object: { type: 'course', course: 'viewer-fundamentals' },
+            }),
+        );
+
+        await waitFor(() => {
+            expect(invalidateQueries).toHaveBeenCalledWith(['learn-progress']);
+            // Tiers are read-time on the server: a stale badge contradicts the
+            // rail sitting beside it.
+            expect(invalidateQueries).toHaveBeenCalledWith(['learn-badges']);
+        });
+    });
+});

--- a/packages/frontend/src/features/learn/hooks.ts
+++ b/packages/frontend/src/features/learn/hooks.ts
@@ -1,0 +1,194 @@
+import {
+    type ApiError,
+    type LearnAskRequest,
+    type LearnAskResults,
+    type LearnBadgesResults,
+    type LearnCatalogue,
+    type LearnCourse,
+    type LearnEventInput,
+    type LearnProgressResults,
+} from '@lightdash/common';
+import {
+    mergeRollups,
+    rollupFromEvents,
+    rollupFromServer,
+    type Rollup,
+} from '@lightdash/learn-ui';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useCallback, useMemo } from 'react';
+import { lightdashApi } from '../../api';
+
+const LOCAL_EVENTS_KEY = 'lightdash.learn.events.v1';
+const LAST_COURSE_KEY = 'lightdash.learn.lastCourse.v1';
+const LOCATION_PREFIX = 'lightdash.learn.location.';
+
+const getLearnCatalogue = async () =>
+    lightdashApi<LearnCatalogue>({
+        url: '/learn/catalogue',
+        method: 'GET',
+        body: undefined,
+    });
+
+const getLearnCourse = async (courseId: string) =>
+    lightdashApi<LearnCourse>({
+        url: `/learn/courses/${encodeURIComponent(courseId)}`,
+        method: 'GET',
+        body: undefined,
+    });
+
+const getLearnProgress = async () =>
+    lightdashApi<LearnProgressResults>({
+        url: '/learn/progress',
+        method: 'GET',
+        body: undefined,
+    });
+
+const postLearnEvents = async (events: LearnEventInput[]) =>
+    lightdashApi<{ accepted: number }>({
+        url: '/learn/events',
+        method: 'POST',
+        body: JSON.stringify(events),
+    });
+
+const getLearnBadges = async () =>
+    lightdashApi<LearnBadgesResults>({
+        url: '/learn/badges',
+        method: 'GET',
+        body: undefined,
+    });
+
+const postLearnAsk = async (body: LearnAskRequest) =>
+    lightdashApi<LearnAskResults>({
+        url: '/learn/ask',
+        method: 'POST',
+        body: JSON.stringify(body),
+    });
+
+export const useLearnCatalogue = () =>
+    useQuery<LearnCatalogue, ApiError>({
+        queryKey: ['learn-catalogue'],
+        queryFn: getLearnCatalogue,
+        staleTime: 5 * 60 * 1000,
+        retry: false,
+    });
+
+export const useLearnCourse = (courseId: string | undefined) =>
+    useQuery<LearnCourse, ApiError>({
+        queryKey: ['learn-course', courseId],
+        queryFn: () => getLearnCourse(courseId!),
+        enabled: courseId !== undefined,
+        staleTime: 5 * 60 * 1000,
+        retry: false,
+    });
+
+/** Per-module tiers. `badges` is null when the instance has no service token. */
+export const useLearnBadges = () =>
+    useQuery<LearnBadgesResults, ApiError>({
+        queryKey: ['learn-badges'],
+        queryFn: getLearnBadges,
+        staleTime: 5 * 60 * 1000,
+        retry: false,
+    });
+
+export const useLearnAsk = () =>
+    useMutation<LearnAskResults, ApiError, LearnAskRequest>({
+        mutationFn: postLearnAsk,
+    });
+
+const useLearnServerProgress = () =>
+    useQuery<LearnProgressResults, ApiError>({
+        queryKey: ['learn-progress'],
+        queryFn: getLearnProgress,
+        retry: false,
+    });
+
+function readLocalEvents(): LearnEventInput[] {
+    const raw = localStorage.getItem(LOCAL_EVENTS_KEY);
+    if (!raw) return [];
+    try {
+        return JSON.parse(raw) as LearnEventInput[];
+    } catch {
+        return [];
+    }
+}
+
+/**
+ * Rollups per course, merging server progress (when the instance syncs) with
+ * locally recorded events (always kept, so an unconfigured instance still has
+ * per-browser progress and a later-configured one back-fills nothing worse
+ * than what the learner already saw).
+ */
+export const useLearnRollups = () => {
+    const serverProgress = useLearnServerProgress();
+    const rollups = useMemo(() => {
+        const map = new Map<string, Rollup>();
+        const local = readLocalEvents();
+        for (const courseId of new Set(local.map((ev) => ev.object.course))) {
+            map.set(courseId, rollupFromEvents(local, courseId));
+        }
+        for (const course of serverProgress.data?.courses ?? []) {
+            const server = rollupFromServer(course);
+            const existing = map.get(course.courseId);
+            map.set(
+                course.courseId,
+                existing ? mergeRollups(server, existing) : server,
+            );
+        }
+        return map;
+    }, [serverProgress.data]);
+    return {
+        rollups,
+        isLoading: serverProgress.isInitialLoading,
+        serverSynced: serverProgress.data?.serverSynced ?? false,
+    };
+};
+
+export const useRecordLearnEvent = () => {
+    const queryClient = useQueryClient();
+    const mutation = useMutation<
+        { accepted: number },
+        ApiError,
+        LearnEventInput[]
+    >({
+        mutationFn: postLearnEvents,
+        // Tiers are derived server side at read time, so a finished module
+        // changes the badge as well as the progress the rail reads.
+        onSettled: async () => {
+            await Promise.all([
+                queryClient.invalidateQueries(['learn-progress']),
+                queryClient.invalidateQueries(['learn-badges']),
+            ]);
+        },
+    });
+    const { mutate } = mutation;
+    const record = useCallback(
+        (event: Omit<LearnEventInput, 'occurredAt'>) => {
+            const full: LearnEventInput = {
+                ...event,
+                occurredAt: new Date().toISOString(),
+            };
+            // Local copy first: progress must never depend on the network.
+            try {
+                const local = readLocalEvents();
+                local.push(full);
+                localStorage.setItem(LOCAL_EVENTS_KEY, JSON.stringify(local));
+            } catch {
+                // Storage full or unavailable — server sync still applies.
+            }
+            mutate([full]);
+        },
+        [mutate],
+    );
+    return { record, isRecording: mutation.isLoading };
+};
+
+export const setLastCourseId = (courseId: string): void => {
+    localStorage.setItem(LAST_COURSE_KEY, courseId);
+};
+
+export const getLessonBookmark = (courseId: string): string =>
+    localStorage.getItem(LOCATION_PREFIX + courseId) ?? '';
+
+export const setLessonBookmark = (courseId: string, lessonId: string): void => {
+    localStorage.setItem(LOCATION_PREFIX + courseId, lessonId);
+};

--- a/packages/frontend/src/features/learn/testFixtures.ts
+++ b/packages/frontend/src/features/learn/testFixtures.ts
@@ -1,0 +1,19 @@
+import { type LearnCatalogueEntry } from '@lightdash/common';
+
+export const entry = (
+    overrides: Partial<LearnCatalogueEntry> & { id: string },
+): LearnCatalogueEntry => ({
+    title: overrides.id,
+    description: '',
+    version: 1,
+    contentHash: 'abc123',
+    path: `courses/${overrides.id}/abc123/course.json`,
+    lessonCount: 3,
+    durationMinutes: null,
+    tags: [],
+    track: null,
+    scope: null,
+    requires: [],
+    publishedAt: '2026-08-01T00:00:00.000Z',
+    ...overrides,
+});

--- a/packages/frontend/src/pages/Learn.tsx
+++ b/packages/frontend/src/pages/Learn.tsx
@@ -1,0 +1,36 @@
+import { FeatureFlags } from '@lightdash/common';
+import { type FC } from 'react';
+import { Navigate, useParams } from 'react-router';
+import Page from '../components/common/Page/Page';
+import { LearnBoardPanel } from '../features/learn/board/LearnBoardPanel';
+import { LearnUiRoot } from '../features/learn/LearnUiRoot';
+import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
+
+const Learn: FC = () => {
+    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const learnFlag = useServerFeatureFlag(FeatureFlags.LearnSection);
+
+    if (!projectUuid || learnFlag.isLoading) {
+        return null;
+    }
+
+    if (!learnFlag.data?.enabled) {
+        return <Navigate to={`/projects/${projectUuid}/home`} replace />;
+    }
+
+    return (
+        <Page
+            title="Learn"
+            withCenteredRoot
+            withCenteredContent
+            withXLargePaddedContent
+            withLargeContent
+        >
+            <LearnUiRoot>
+                <LearnBoardPanel />
+            </LearnUiRoot>
+        </Page>
+    );
+};
+
+export default Learn;

--- a/packages/frontend/src/pages/LearnCourse.tsx
+++ b/packages/frontend/src/pages/LearnCourse.tsx
@@ -1,0 +1,36 @@
+import { FeatureFlags } from '@lightdash/common';
+import { type FC } from 'react';
+import { Navigate, useParams } from 'react-router';
+import Page from '../components/common/Page/Page';
+import { LearnCoursePlayer } from '../features/learn/components/LearnCoursePlayer';
+import { LearnUiRoot } from '../features/learn/LearnUiRoot';
+import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
+
+const LearnCourse: FC = () => {
+    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const learnFlag = useServerFeatureFlag(FeatureFlags.LearnSection);
+
+    if (!projectUuid || learnFlag.isLoading) {
+        return null;
+    }
+
+    if (!learnFlag.data?.enabled) {
+        return <Navigate to={`/projects/${projectUuid}/home`} replace />;
+    }
+
+    return (
+        <Page
+            title="Learn"
+            withCenteredRoot
+            withCenteredContent
+            withXLargePaddedContent
+            withLargeContent
+        >
+            <LearnUiRoot>
+                <LearnCoursePlayer />
+            </LearnUiRoot>
+        </Page>
+    );
+};
+
+export default LearnCourse;

--- a/packages/frontend/src/providers/Tracking/types.ts
+++ b/packages/frontend/src/providers/Tracking/types.ts
@@ -274,6 +274,15 @@ export type DashboardAutoRefreshUpdateEvent = {
     };
 };
 
+type LearnClickedEvent = {
+    name: EventName.LEARN_CLICKED;
+    properties: {
+        userId: string | undefined;
+        organizationId: string | undefined;
+        projectId: string;
+    };
+};
+
 type MetricsCatalogClickedEvent = {
     name: EventName.METRICS_CATALOG_CLICKED;
     properties: {
@@ -964,6 +973,7 @@ export type EventData =
     | ViewUnderlyingDataClickedEvent
     | DrillByClickedEvent
     | DashboardAutoRefreshUpdateEvent
+    | LearnClickedEvent
     | MetricsCatalogClickedEvent
     | MetricsCatalogChartUsageClickedEvent
     | MetricsCatalogExploreClickedEvent

--- a/packages/frontend/src/types/Events.ts
+++ b/packages/frontend/src/types/Events.ts
@@ -66,6 +66,8 @@ export enum PageName {
     METRICS_CATALOG = 'metrics_catalog',
     FUNNEL_BUILDER = 'funnel_builder',
     ROADMAP = 'roadmap',
+    LEARN = 'learn',
+    LEARN_COURSE = 'learn_course',
 }
 
 export enum CategoryName {
@@ -156,6 +158,7 @@ export enum EventName {
     DASHBOARD_AUTO_REFRESH_UPDATED = 'dashboard_auto_refresh.updated',
 
     // Metrics Catalog
+    LEARN_CLICKED = 'learn.clicked',
     METRICS_CATALOG_CLICKED = 'metrics_catalog.clicked',
     METRICS_CATALOG_SEARCH_APPLIED = 'metrics_catalog_search.applied',
     METRICS_CATALOG_CHART_USAGE_CLICKED = 'metrics_catalog_chart_usage.clicked',

--- a/packages/frontend/src/types/Events.ts
+++ b/packages/frontend/src/types/Events.ts
@@ -157,8 +157,10 @@ export enum EventName {
     NOTIFICATIONS_COMMENTS_ITEM_CLICKED = 'notifications_comments_item.clicked',
     DASHBOARD_AUTO_REFRESH_UPDATED = 'dashboard_auto_refresh.updated',
 
-    // Metrics Catalog
+    // Learn
     LEARN_CLICKED = 'learn.clicked',
+
+    // Metrics Catalog
     METRICS_CATALOG_CLICKED = 'metrics_catalog.clicked',
     METRICS_CATALOG_SEARCH_APPLIED = 'metrics_catalog_search.applied',
     METRICS_CATALOG_CHART_USAGE_CLICKED = 'metrics_catalog_chart_usage.clicked',

--- a/packages/learn-ui/src/components/LearnBoard.module.css
+++ b/packages/learn-ui/src/components/LearnBoard.module.css
@@ -1,32 +1,6 @@
 /* Neutrals are the design README's literals (authoritative for tokens; the
    ldGray ramp has no exact matches); the accent comes from the host-set
    --learn-accent custom property, with a violet fallback. */
-.scroller {
-    width: 100%;
-    overflow-x: auto;
-}
-
-.card {
-    width: 100%;
-    max-width: 1440px;
-    margin: 0 auto;
-    background: #ffffff;
-    border-radius: 16px;
-    overflow: hidden;
-    box-shadow:
-        0 1px 2px rgba(10, 13, 18, 0.05),
-        0 0 0 1px #eceff3;
-    display: flex;
-    flex-wrap: wrap;
-    align-items: stretch;
-}
-
-.boardColumn {
-    flex: 1 1 1120px;
-    min-width: 0;
-    display: flex;
-    flex-direction: column;
-}
 
 /* Measures the column; the 1120px board scales down to fit inside it. */
 .boardViewport {
@@ -36,30 +10,6 @@
 
 .boardScaled {
     transform-origin: top left;
-}
-
-.header {
-    padding: 24px 28px 12px;
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-}
-
-.title {
-    margin: 0;
-    font-size: 32px;
-    line-height: 1;
-    letter-spacing: -0.02em;
-    font-weight: 500;
-}
-
-.sub {
-    font-size: 14px;
-    color: #818898;
-}
-
-.tabsRow {
-    padding: 4px 28px 10px;
 }
 
 .tabs {


### PR DESCRIPTION
Last of five, and the first PR where Learn renders. Flag-gated nav link and routes, the board panel and course player as thin containers over the package (react-query hooks, router, org-role default, sanitising), local + server progress sync with rollup merge, badges tiers and the ask bar. Everything registry-dependent comes from `useLearnModel()` under `LearnUiRoot`, which binds the package to `@lightdash/common`'s scope registry and sets `--learn-accent`.

Replaces #26660, #26661 (graph dropped: #27884 deleted it), #26662, #26663, #27901, #27884, #27902, #27887, #27966.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UMX8BRvEgNgP9x8rDya46E
