### PR TITLE
chore(backend): stop reporting DeprecatedRouteError to Sentry

### DIFF
--- a/.claude/skills/deprecate-endpoint/SKILL.md
+++ b/.claude/skills/deprecate-endpoint/SKILL.md
@@ -9,8 +9,8 @@ allowed-tools: Read, Grep, Glob, Edit, Bash
 # Deprecate an HTTP Endpoint
 
 Checklist for deprecating a backend HTTP endpoint. The runtime behavior
-(warn→error logging, Sentry alerting, response headers) lives in one shared
-middleware — you only wire it on and supply a date + replacement hint.
+(warn→error logging, response headers) lives in one shared middleware — you
+only wire it on and supply a date + replacement hint.
 
 The authoritative policy is `packages/backend/src/controllers/CLAUDE.md` →
 "Deprecating Endpoints". This skill is the actionable checklist.
@@ -30,8 +30,8 @@ Read the handler before editing. It may already have some of the pieces
 
 **Only deprecate an endpoint once nothing first-party calls it anymore.** The
 frontend, CLI, EE code, and other internal consumers must already be migrated to
-the replacement. A deprecated route logs an error and reports to Sentry once past
-its deadline, so any straggler caller becomes noise/alerts.
+the replacement. A deprecated route logs an error once past its deadline, so
+any straggler caller becomes log noise.
 
 Verify before touching the controller — search every first-party surface for the
 route path and its API hooks, including EE and test suites:
@@ -43,7 +43,7 @@ grep -rn "<route-fragment>" packages/frontend/src packages/cli/src \
 
 Watch for version differences: a v2 call (`version: 'v2'` / `/api/v2/...`) to a
 similar path is the *replacement*, not a caller of the v1 route. A test that hits
-the route counts as a caller — it will trigger logs/Sentry once past sunset. If
+the route counts as a caller — it will trigger error logs once past sunset. If
 any first-party caller remains, migrate it first (or stop — it cannot be
 deprecated yet).
 
@@ -147,8 +147,9 @@ main (the docs site re-fetches swagger.json from main at build time).
 already does, per call:
 
 - `Deprecation`, `Sunset`, and legacy `Warning` response headers.
-- A warning log, escalating to an **error log + Sentry `DeprecatedRouteError`**
-  (`@lightdash/common`) once the sunset is within two weeks or has passed.
+- A warning log, escalating to an **error log** (GCP) once the sunset is
+  within two weeks or has passed. Do not report `DeprecatedRouteError` to
+  Sentry — it is in `IGNORE_ERRORS` and would burn quota on every call.
 
 Do not add per-endpoint logging/headers. (Some older routes also fire a
 `trackDeprecatedRouteCalled` analytics event — that's optional; the middleware is
@@ -156,6 +157,6 @@ the standard.)
 
 ## Later: removal
 
-Once the sunset passes (the route is now error-logging + Sentry-alerting on every
-call), the follow-up task is to delete the handler and its route, then
+Once the sunset passes (the route is now error-logging on every call), the
+follow-up task is to delete the handler and its route, then
 `pnpm generate-api` again. That's a separate change, not part of deprecating.

--- a/packages/backend/src/controllers/CLAUDE.md
+++ b/packages/backend/src/controllers/CLAUDE.md
@@ -156,8 +156,9 @@ keep `@summary` unchanged — the docs page URL is derived from it. Then
   date is within two weeks or has passed. Deprecated endpoints are not expected
   to be called by any first-party client, so any log line is a signal that
   something still depends on a route slated for removal.
-- When it escalates to an error, it also reports a `DeprecatedRouteError`
-  (`@lightdash/common`) to Sentry so overdue routes surface in alerting.
+- When it escalates to an error, it stays a GCP/log-only signal. Do not
+  report `DeprecatedRouteError` to Sentry — overdue routes fire once per
+  request and would dominate quota. The type is listed in `IGNORE_ERRORS`.
 - Responses carry `Deprecation` (deprecation date), `Sunset` (removal date), and
   a legacy `Warning` header.
 

--- a/packages/backend/src/controllers/authentication/deprecation.test.ts
+++ b/packages/backend/src/controllers/authentication/deprecation.test.ts
@@ -1,4 +1,3 @@
-import { DeprecatedRouteError } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
 import { Request, Response } from 'express';
 import Logger from '../../logging/logger';
@@ -101,7 +100,7 @@ describe('getDeprecatedRouteMiddleware', () => {
         expect(Sentry.captureException).not.toHaveBeenCalled();
     });
 
-    it('logs an error and reports a DeprecatedRouteError to Sentry when the removal date has passed', () => {
+    it('logs an error and does not report to Sentry when the removal date has passed', () => {
         const { res } = buildResponse();
         getDeprecatedRouteMiddleware(new Date('2020-01-01T00:00:00Z'), {
             removeOn: new Date('2020-04-01T00:00:00Z'),
@@ -109,9 +108,6 @@ describe('getDeprecatedRouteMiddleware', () => {
 
         expect(Logger.error).toHaveBeenCalledTimes(1);
         expect(Logger.warn).not.toHaveBeenCalled();
-        expect(Sentry.captureException).toHaveBeenCalledTimes(1);
-        expect(
-            (Sentry.captureException as import('vitest').Mock).mock.calls[0][0],
-        ).toBeInstanceOf(DeprecatedRouteError);
+        expect(Sentry.captureException).not.toHaveBeenCalled();
     });
 });

--- a/packages/backend/src/controllers/authentication/deprecation.test.ts
+++ b/packages/backend/src/controllers/authentication/deprecation.test.ts
@@ -91,11 +91,20 @@ describe('getDeprecatedRouteMiddleware', () => {
 
     it('logs a warning and does not report to Sentry when the removal date is far in the future', () => {
         const { res } = buildResponse();
-        getDeprecatedRouteMiddleware(new Date(Date.now()), {
-            removeOn: new Date(Date.now() + 365 * DAY_MS),
-        })(req, res, next);
+        const deprecatedOn = new Date(Date.now());
+        const removeOn = new Date(Date.now() + 365 * DAY_MS);
+        getDeprecatedRouteMiddleware(deprecatedOn, { removeOn })(
+            req,
+            res,
+            next,
+        );
 
         expect(Logger.warn).toHaveBeenCalledTimes(1);
+        expect(Logger.warn).toHaveBeenCalledWith('Deprecated endpoint called.', {
+            route: 'GET /api/v1/old',
+            deprecatedOn: deprecatedOn.toISOString(),
+            removeOn: removeOn.toISOString(),
+        });
         expect(Logger.error).not.toHaveBeenCalled();
         expect(Sentry.captureException).not.toHaveBeenCalled();
     });
@@ -104,9 +113,18 @@ describe('getDeprecatedRouteMiddleware', () => {
         const { res } = buildResponse();
         getDeprecatedRouteMiddleware(new Date('2020-01-01T00:00:00Z'), {
             removeOn: new Date('2020-04-01T00:00:00Z'),
+            suffixMessage: 'Use X instead.',
         })(req, res, next);
 
         expect(Logger.error).toHaveBeenCalledTimes(1);
+        expect(Logger.error).toHaveBeenCalledWith(
+            'Deprecated endpoint called. Use X instead.',
+            {
+                route: 'GET /api/v1/old',
+                deprecatedOn: '2020-01-01T00:00:00.000Z',
+                removeOn: '2020-04-01T00:00:00.000Z',
+            },
+        );
         expect(Logger.warn).not.toHaveBeenCalled();
         expect(Sentry.captureException).not.toHaveBeenCalled();
     });

--- a/packages/backend/src/controllers/authentication/deprecation.test.ts
+++ b/packages/backend/src/controllers/authentication/deprecation.test.ts
@@ -100,11 +100,14 @@ describe('getDeprecatedRouteMiddleware', () => {
         );
 
         expect(Logger.warn).toHaveBeenCalledTimes(1);
-        expect(Logger.warn).toHaveBeenCalledWith('Deprecated endpoint called.', {
-            route: 'GET /api/v1/old',
-            deprecatedOn: deprecatedOn.toISOString(),
-            removeOn: removeOn.toISOString(),
-        });
+        expect(Logger.warn).toHaveBeenCalledWith(
+            'Deprecated endpoint called.',
+            {
+                route: 'GET /api/v1/old',
+                deprecatedOn: deprecatedOn.toISOString(),
+                removeOn: removeOn.toISOString(),
+            },
+        );
         expect(Logger.error).not.toHaveBeenCalled();
         expect(Sentry.captureException).not.toHaveBeenCalled();
     });

--- a/packages/backend/src/controllers/authentication/deprecation.ts
+++ b/packages/backend/src/controllers/authentication/deprecation.ts
@@ -1,5 +1,3 @@
-import { DeprecatedRouteError } from '@lightdash/common';
-import * as Sentry from '@sentry/node';
 import { RequestHandler } from 'express';
 import Logger from '../../logging/logger';
 
@@ -46,14 +44,6 @@ export const getDeprecatedRouteMiddleware = (
         const message = `Deprecated endpoint called: ${req.method} ${req.path} (deprecated ${deprecatedOn.toISOString()}, removal ${removeOn.toISOString()}).${suffix}`;
         if (shouldEscalateToError(removeOn, new Date())) {
             Logger.error(message);
-            Sentry.captureException(
-                new DeprecatedRouteError(message, {
-                    method: req.method,
-                    path: req.path,
-                    deprecatedOn: deprecatedOn.toISOString(),
-                    removeOn: removeOn.toISOString(),
-                }),
-            );
         } else {
             Logger.warn(message);
         }

--- a/packages/backend/src/controllers/authentication/deprecation.ts
+++ b/packages/backend/src/controllers/authentication/deprecation.ts
@@ -41,11 +41,16 @@ export const getDeprecatedRouteMiddleware = (
             `299 - "This API endpoint is deprecated and will be removed after ${removeOn.toUTCString()}.${suffix}"`,
         );
 
-        const message = `Deprecated endpoint called: ${req.method} ${req.path} (deprecated ${deprecatedOn.toISOString()}, removal ${removeOn.toISOString()}).${suffix}`;
+        const message = `Deprecated endpoint called.${suffix}`;
+        const context = {
+            route: `${req.method} ${req.path}`,
+            deprecatedOn: deprecatedOn.toISOString(),
+            removeOn: removeOn.toISOString(),
+        };
         if (shouldEscalateToError(removeOn, new Date())) {
-            Logger.error(message);
+            Logger.error(message, context);
         } else {
-            Logger.warn(message);
+            Logger.warn(message, context);
         }
 
         next();

--- a/packages/backend/src/sentry.ts
+++ b/packages/backend/src/sentry.ts
@@ -96,6 +96,8 @@ export const IGNORE_ERRORS = [
     // dbt connection but the project uses "none") — surfaced to the user,
     // not a server bug.
     'ParameterError',
+    // Overdue deprecated routes fire once per request — keep GCP logs, drop Sentry.
+    'DeprecatedRouteError',
 ];
 
 const anrIntegrations = lightdashConfig.sentry.anr.enabled


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Relates: SPK-1568
Relates: #28306

### Description

Stop sending `DeprecatedRouteError` to Sentry. Overdue deprecated routes log once per request and were dominating error quota (including the retired results endpoint).

- Deprecation middleware still logs a warning, then an error after the sunset window — those lines keep going to GCP via Winston
- Logs now include structured `route`, `deprecatedOn`, and `removeOn` fields so leftover callers are queryable in GCP
- `DeprecatedRouteError` is added to `IGNORE_ERRORS` so any leftover capture is dropped
- Docs/skill updated so new deprecations do not reintroduce Sentry capture

This overlaps [#28306](https://github.com/lightdash/lightdash/pull/28306), which always logs as warn. This PR keeps the post-sunset error log so GCP still surfaces overdue routes at error severity.

### Risk assessment

- [ ] This is a high-risk change

Low risk: logging stays on (warn, then error after sunset); only Sentry reporting is removed.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://lightdash.slack.com/archives/C08HSS5JHJN/p1788340809046289?thread_ts=1788340809.046289&cid=C08HSS5JHJN)

<div><a href="https://cursor.com/agents/bc-53a2dd51-92b1-532d-83e7-6bbefd267272?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-53a2dd51-92b1-532d-83e7-6bbefd267272&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

