### PR TITLE
fix(embed): trim project and account responses for embedded sessions

### DIFF
--- a/packages/api-tests/tests/embedBootstrap.test.ts
+++ b/packages/api-tests/tests/embedBootstrap.test.ts
@@ -1,0 +1,164 @@
+import { CreateEmbedJwt, SEED_PROJECT, UpdateEmbed } from '@lightdash/common';
+import { ApiClient, Body } from '../helpers/api-client';
+import { login } from '../helpers/auth';
+
+const EMBED_API_PREFIX = `/api/v1/embed/${SEED_PROJECT.project_uuid}`;
+
+type EmbedConfig = {
+    dashboardUuids?: string[];
+    allowAllDashboards?: boolean;
+    chartUuids?: string[];
+    allowAllCharts?: boolean;
+};
+
+const embedHeaders = (token: string) => ({ 'Lightdash-Embed-Token': token });
+
+async function mintDashboardToken(
+    admin: ApiClient,
+    dashboardUuid: string,
+): Promise<string> {
+    const body: CreateEmbedJwt = {
+        user: { externalId: 'bootstrap-user@example.com' },
+        content: {
+            type: 'dashboard',
+            projectUuid: SEED_PROJECT.project_uuid,
+            dashboardUuid,
+            canExportCsv: false,
+            canExportImages: false,
+            canExportPagePdf: false,
+            canDateZoom: false,
+            canExplore: false,
+            canViewUnderlyingData: false,
+            dashboardFiltersInteractivity: { enabled: true },
+        },
+        expiresIn: '1 hour',
+    };
+    const resp = await admin.post<Body<{ url: string }>>(
+        `${EMBED_API_PREFIX}/get-embed-url`,
+        body,
+    );
+    expect(resp.status).toBe(200);
+    return resp.body.results.url.split('#')[1];
+}
+
+// The responses an embed loads on boot. Everything asserted as present here is
+// read by the current frontend or by a published SDK version, so removing it
+// breaks embeds that are already deployed; everything asserted as absent is
+// project or account metadata an embed viewer must not see.
+describe('Embed bootstrap responses', () => {
+    let admin: ApiClient;
+    let embedEnabled = true;
+    let token: string;
+
+    beforeAll(async () => {
+        admin = await login();
+
+        const configResp = await admin.get<Body<EmbedConfig>>(
+            `${EMBED_API_PREFIX}/config`,
+            { failOnStatusCode: false },
+        );
+        if (configResp.status === 403) {
+            embedEnabled = false;
+            return;
+        }
+        expect(configResp.status).toBe(200);
+        const config = configResp.body.results;
+
+        const dashboardsResp = await admin.get<
+            Body<Array<{ uuid: string; name: string }>>
+        >(`/api/v1/projects/${SEED_PROJECT.project_uuid}/dashboards`);
+        const seedDashboard = dashboardsResp.body.results.find(
+            (d) => d.name === 'Jaffle dashboard',
+        );
+        expect(seedDashboard).toBeDefined();
+        const dashboardUuid = seedDashboard!.uuid;
+
+        if (
+            !config.allowAllDashboards &&
+            !config.dashboardUuids?.includes(dashboardUuid)
+        ) {
+            const update: UpdateEmbed = {
+                dashboardUuids: [
+                    ...(config.dashboardUuids ?? []),
+                    dashboardUuid,
+                ],
+                allowAllDashboards: false,
+                chartUuids: config.chartUuids ?? [],
+                allowAllCharts: config.allowAllCharts ?? false,
+            };
+            const updateResp = await admin.patch(
+                `${EMBED_API_PREFIX}/config`,
+                update,
+            );
+            expect(updateResp.status).toBe(200);
+        }
+
+        token = await mintDashboardToken(admin, dashboardUuid);
+    });
+
+    beforeEach((ctx) => {
+        if (!embedEnabled) ctx.skip();
+    });
+
+    it('account response carries identity and permissions only', async () => {
+        const anonymous = new ApiClient();
+        const resp = await anonymous.get<Body<Record<string, unknown>>>(
+            `/api/v1/user/account?projectUuid=${SEED_PROJECT.project_uuid}`,
+            { headers: embedHeaders(token) },
+        );
+        expect(resp.status).toBe(200);
+        const account = resp.body.results;
+
+        expect(Object.keys(account).sort()).toEqual([
+            'authentication',
+            'organization',
+            'user',
+        ]);
+        expect(account.authentication).toEqual({ type: 'jwt' });
+
+        const organization = account.organization as Record<string, unknown>;
+        expect(organization.organizationUuid).toEqual(expect.any(String));
+
+        const user = account.user as Record<string, unknown>;
+        expect(user.type).toBe('anonymous');
+        expect(user.abilityRules).toEqual(expect.any(Array));
+        expect(user).not.toHaveProperty('ability');
+
+        expect(JSON.stringify(account)).not.toContain(token);
+    });
+
+    it('project response carries render settings only', async () => {
+        const anonymous = new ApiClient();
+        const resp = await anonymous.get<Body<Record<string, unknown>>>(
+            `/api/v1/projects/${SEED_PROJECT.project_uuid}`,
+            { headers: embedHeaders(token) },
+        );
+        expect(resp.status).toBe(200);
+        const project = resp.body.results;
+
+        expect(project.projectUuid).toBe(SEED_PROJECT.project_uuid);
+        expect(project.organizationUuid).toEqual(expect.any(String));
+        expect(project).toHaveProperty('queryTimezone');
+        expect(project).toHaveProperty('useProjectTimezoneInFilters');
+
+        expect(project.dbtConnection).toEqual({ type: 'none' });
+        const warehouseConnection = project.warehouseConnection as
+            | Record<string, unknown>
+            | undefined;
+        expect(warehouseConnection).toBeDefined();
+        expect(warehouseConnection!.type).toEqual(expect.any(String));
+        expect(
+            Object.keys(warehouseConnection!).every((key) =>
+                ['type', 'startOfWeek'].includes(key),
+            ),
+        ).toBe(true);
+
+        expect(project.createdByUserUuid).toBeNull();
+        expect(project.schedulerFailureContactOverride).toBeNull();
+        expect(project).not.toHaveProperty('upstreamProjectUuid');
+        expect(project).not.toHaveProperty(
+            'organizationWarehouseCredentialsUuid',
+        );
+        expect(project).not.toHaveProperty('pinnedListUuid');
+    });
+});

--- a/packages/backend/src/auth/account/index.ts
+++ b/packages/backend/src/auth/account/index.ts
@@ -8,3 +8,4 @@ export {
 } from './account';
 export type { AccountWriteContext } from './account';
 export { requestContextFromExpress } from './requestContext';
+export { serializeAccount } from './serializeAccount';

--- a/packages/backend/src/auth/account/serializeAccount.test.ts
+++ b/packages/backend/src/auth/account/serializeAccount.test.ts
@@ -1,0 +1,57 @@
+import { buildAccount } from './account.mock';
+import { serializeAccount } from './serializeAccount';
+
+describe('serializeAccount', () => {
+    test('embed account keeps only what the app needs to render', () => {
+        const account = buildAccount({ accountType: 'jwt' });
+        const { ability: _ability, ...user } = account.user;
+
+        const serialized = serializeAccount({
+            ...account,
+            embedWriteContext: {
+                canUpdateDashboard: true,
+                canUpdateSavedChart: false,
+                canCreateSavedChart: false,
+                canUseAiAgent: false,
+            },
+        });
+
+        expect(serialized).toEqual({
+            organization: account.organization,
+            authentication: { type: 'jwt' },
+            user,
+            embedWriteContext: {
+                canUpdateDashboard: true,
+                canUpdateSavedChart: false,
+                canCreateSavedChart: false,
+                canUseAiAgent: false,
+            },
+        });
+    });
+
+    test('embed account does not echo the token, the embed secret or the embed config', () => {
+        const account = buildAccount({ accountType: 'jwt' });
+
+        const serialized = serializeAccount(account);
+        const json = JSON.stringify(serialized);
+
+        expect(json).not.toContain(account.authentication.source);
+        expect(json).not.toContain(account.embed.encodedSecret);
+        expect(serialized).not.toHaveProperty('embed');
+        expect(serialized).not.toHaveProperty('access');
+        expect(serialized).not.toHaveProperty('requestContext');
+        expect(serialized).not.toHaveProperty('embedWriteUser');
+    });
+
+    test('session account does not echo the session cookie', () => {
+        const account = buildAccount({ accountType: 'session' });
+
+        const serialized = serializeAccount(account);
+
+        expect(serialized.authentication).toEqual({ type: 'session' });
+        expect(JSON.stringify(serialized)).not.toContain(
+            account.authentication.source,
+        );
+        expect(serialized.embedWriteContext).toBeUndefined();
+    });
+});

--- a/packages/backend/src/auth/account/serializeAccount.ts
+++ b/packages/backend/src/auth/account/serializeAccount.ts
@@ -1,0 +1,14 @@
+import { type Account, type SerializedAccount } from '@lightdash/common';
+
+export const serializeAccount = (account: Account): SerializedAccount => {
+    const { ability: _ability, ...user } = account.user;
+    return {
+        organization: account.organization,
+        authentication: { type: account.authentication.type },
+        user,
+        embedWriteContext:
+            'embedWriteContext' in account
+                ? account.embedWriteContext
+                : undefined,
+    };
+};

--- a/packages/backend/src/controllers/userController.ts
+++ b/packages/backend/src/controllers/userController.ts
@@ -54,7 +54,7 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
-import { toSessionUser } from '../auth/account';
+import { serializeAccount, toSessionUser } from '../auth/account';
 import Logger from '../logging/logger';
 import { UserModel } from '../models/UserModel';
 import {
@@ -814,15 +814,10 @@ export class UserController extends BaseController {
             throw new NotFoundError('Account not found');
         }
 
-        const { ability, ...userWithoutAbility } = req.account.user;
-
         this.setStatus(200);
         return {
             status: 'ok',
-            results: {
-                ...req.account,
-                user: userWithoutAbility,
-            },
+            results: serializeAccount(req.account),
         };
     }
 }

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -35,6 +35,7 @@ import {
     SnowflakeAuthenticationType,
     SupportedDbtAdapter,
     WarehouseTypes,
+    WeekDay,
     type ChartSummary,
     type CreateProject,
     type CreateWarehouseCredentials,
@@ -690,6 +691,42 @@ describe('ProjectService', () => {
             expect(result.dbtConnection).toHaveProperty('environment', [
                 { key: 'DBT_ENV_SECRET_PASSWORD', value: 'super-secret' },
             ]);
+        });
+
+        test('returns only render settings to embed tokens', async () => {
+            projectModel.get.mockResolvedValueOnce({
+                ...projectWithEnvironment,
+                warehouseConnection: {
+                    type: WarehouseTypes.SNOWFLAKE,
+                    account: 'acme-prod.eu-west-1',
+                    role: 'ANALYTICS_READER',
+                    database: 'PROD',
+                    warehouse: 'WH_SMALL',
+                    schema: 'REPORTING',
+                    startOfWeek: WeekDay.SUNDAY,
+                },
+            });
+            const jwtAccount = buildAccount({ accountType: 'jwt' });
+            const embedAccount = {
+                ...jwtAccount,
+                user: {
+                    ...jwtAccount.user,
+                    ability: new Ability<PossibleAbilities>([
+                        { subject: 'Project', action: ['update', 'view'] },
+                    ]),
+                },
+            } as typeof jwtAccount;
+
+            const result = await service.getProject(projectUuid, embedAccount);
+
+            expect(result.warehouseConnection).toEqual({
+                type: WarehouseTypes.SNOWFLAKE,
+                startOfWeek: WeekDay.SUNDAY,
+            });
+            expect(result.dbtConnection).toEqual({
+                type: DbtProjectType.NONE,
+            });
+            expect(result.createdByUserUuid).toBeNull();
         });
     });
 

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -334,6 +334,7 @@ import { runWorkerThread, wrapSentryTransaction } from '../../utils';
 import { buildCacheHash, getCacheUserUuid } from '../../utils/cacheUtils';
 import { metricQueryWithLimit as applyMetricQueryLimit } from '../../utils/csvLimitUtils';
 import { omitDbtEnvironment } from '../../utils/dbtProjectConfig';
+import { pickEmbedProject } from '../../utils/embedProject';
 import { EncryptionUtil } from '../../utils/EncryptionUtil/EncryptionUtil';
 import {
     applyMergeTerminalWrapper,
@@ -2553,6 +2554,10 @@ export class ProjectService extends BaseService {
         });
         if (auditedAbility.cannot('view', projectSubject)) {
             throw new ForbiddenError();
+        }
+
+        if (account.isJwtUser()) {
+            return pickEmbedProject(project);
         }
 
         if (auditedAbility.cannot('update', projectSubject)) {

--- a/packages/backend/src/utils/embedProject.test.ts
+++ b/packages/backend/src/utils/embedProject.test.ts
@@ -1,0 +1,107 @@
+import {
+    DbtProjectType,
+    ProjectType,
+    WarehouseTypes,
+    WeekDay,
+    type Project,
+} from '@lightdash/common';
+import { pickEmbedProject } from './embedProject';
+
+const project: Project = {
+    organizationUuid: 'org-uuid',
+    projectUuid: 'project-uuid',
+    slug: 'jaffle-shop',
+    name: 'Jaffle shop',
+    type: ProjectType.DEFAULT,
+    dbtConnection: {
+        type: DbtProjectType.GITHUB,
+        repository: 'acme/analytics',
+        branch: 'main',
+        project_sub_path: '/',
+        personal_access_token: 'ghp_secret',
+    },
+    warehouseConnection: {
+        type: WarehouseTypes.SNOWFLAKE,
+        account: 'acme-prod.eu-west-1',
+        role: 'ANALYTICS_READER',
+        database: 'PROD',
+        warehouse: 'WH_SMALL',
+        schema: 'REPORTING',
+        startOfWeek: WeekDay.SUNDAY,
+    },
+    pinnedListUuid: 'pinned-uuid',
+    upstreamProjectUuid: 'upstream-uuid',
+    dbtVersion: 'v1.11',
+    schedulerTimezone: 'UTC',
+    queryTimezone: 'Asia/Tokyo',
+    useProjectTimezoneInFilters: true,
+    schedulerFailureNotifyRecipients: true,
+    schedulerFailureIncludeContact: true,
+    schedulerFailureContactOverride: 'ops@acme.example',
+    createdByUserUuid: 'creator-uuid',
+    organizationWarehouseCredentialsUuid: 'org-creds-uuid',
+    hasDefaultUserSpaces: true,
+    projectDefaults: { column_totals: false },
+    colorPaletteUuid: 'palette-uuid',
+    expiresAt: null,
+    provisioningSource: 'terraform',
+    agentSqlScope: { schemas: ['reporting'] },
+};
+
+describe('pickEmbedProject', () => {
+    test('keeps the settings a dashboard needs to render', () => {
+        expect(pickEmbedProject(project)).toEqual({
+            organizationUuid: 'org-uuid',
+            projectUuid: 'project-uuid',
+            slug: 'jaffle-shop',
+            name: 'Jaffle shop',
+            type: ProjectType.DEFAULT,
+            dbtConnection: { type: DbtProjectType.NONE },
+            warehouseConnection: {
+                type: WarehouseTypes.SNOWFLAKE,
+                startOfWeek: WeekDay.SUNDAY,
+            },
+            dbtVersion: 'v1.11',
+            schedulerTimezone: 'UTC',
+            queryTimezone: 'Asia/Tokyo',
+            useProjectTimezoneInFilters: true,
+            schedulerFailureNotifyRecipients: false,
+            schedulerFailureIncludeContact: false,
+            schedulerFailureContactOverride: null,
+            createdByUserUuid: null,
+            hasDefaultUserSpaces: true,
+            projectDefaults: { column_totals: false },
+            colorPaletteUuid: 'palette-uuid',
+            expiresAt: null,
+            provisioningSource: null,
+            agentSqlScope: null,
+        });
+    });
+
+    test('drops warehouse identifiers, the dbt source and people', () => {
+        const json = JSON.stringify(pickEmbedProject(project));
+
+        [
+            'acme-prod.eu-west-1',
+            'ANALYTICS_READER',
+            'PROD',
+            'WH_SMALL',
+            'REPORTING',
+            'acme/analytics',
+            'ghp_secret',
+            'creator-uuid',
+            'ops@acme.example',
+            'upstream-uuid',
+            'pinned-uuid',
+            'org-creds-uuid',
+            'terraform',
+        ].forEach((secret) => expect(json).not.toContain(secret));
+    });
+
+    test('leaves the warehouse connection absent when the project has none', () => {
+        expect(
+            pickEmbedProject({ ...project, warehouseConnection: undefined })
+                .warehouseConnection,
+        ).toBeUndefined();
+    });
+});

--- a/packages/backend/src/utils/embedProject.test.ts
+++ b/packages/backend/src/utils/embedProject.test.ts
@@ -1,6 +1,7 @@
 import {
     DbtProjectType,
     ProjectType,
+    SupportedDbtVersions,
     WarehouseTypes,
     WeekDay,
     type Project,
@@ -15,6 +16,7 @@ const project: Project = {
     type: ProjectType.DEFAULT,
     dbtConnection: {
         type: DbtProjectType.GITHUB,
+        authorization_method: 'personal_access_token',
         repository: 'acme/analytics',
         branch: 'main',
         project_sub_path: '/',
@@ -31,7 +33,7 @@ const project: Project = {
     },
     pinnedListUuid: 'pinned-uuid',
     upstreamProjectUuid: 'upstream-uuid',
-    dbtVersion: 'v1.11',
+    dbtVersion: SupportedDbtVersions.V1_11,
     schedulerTimezone: 'UTC',
     queryTimezone: 'Asia/Tokyo',
     useProjectTimezoneInFilters: true,
@@ -61,7 +63,7 @@ describe('pickEmbedProject', () => {
                 type: WarehouseTypes.SNOWFLAKE,
                 startOfWeek: WeekDay.SUNDAY,
             },
-            dbtVersion: 'v1.11',
+            dbtVersion: SupportedDbtVersions.V1_11,
             schedulerTimezone: 'UTC',
             queryTimezone: 'Asia/Tokyo',
             useProjectTimezoneInFilters: true,

--- a/packages/backend/src/utils/embedProject.ts
+++ b/packages/backend/src/utils/embedProject.ts
@@ -1,0 +1,41 @@
+import {
+    DbtProjectType,
+    type Project,
+    type WarehouseCredentials,
+} from '@lightdash/common';
+
+// Embed viewers only need the connection's dialect and week settings; the
+// warehouse identifiers (account, host, database, role...) stay server-side.
+const pickEmbedWarehouseConnection = (
+    warehouseConnection: WarehouseCredentials,
+): WarehouseCredentials =>
+    ({
+        type: warehouseConnection.type,
+        startOfWeek: warehouseConnection.startOfWeek,
+    }) as WarehouseCredentials;
+
+export const pickEmbedProject = (project: Project): Project => ({
+    organizationUuid: project.organizationUuid,
+    projectUuid: project.projectUuid,
+    slug: project.slug,
+    name: project.name,
+    type: project.type,
+    dbtConnection: { type: DbtProjectType.NONE },
+    warehouseConnection: project.warehouseConnection
+        ? pickEmbedWarehouseConnection(project.warehouseConnection)
+        : undefined,
+    dbtVersion: project.dbtVersion,
+    schedulerTimezone: project.schedulerTimezone,
+    queryTimezone: project.queryTimezone,
+    useProjectTimezoneInFilters: project.useProjectTimezoneInFilters,
+    schedulerFailureNotifyRecipients: false,
+    schedulerFailureIncludeContact: false,
+    schedulerFailureContactOverride: null,
+    createdByUserUuid: null,
+    hasDefaultUserSpaces: project.hasDefaultUserSpaces,
+    projectDefaults: project.projectDefaults,
+    colorPaletteUuid: project.colorPaletteUuid,
+    expiresAt: project.expiresAt,
+    provisioningSource: null,
+    agentSqlScope: null,
+});

--- a/packages/common/src/types/account.ts
+++ b/packages/common/src/types/account.ts
@@ -1,9 +1,23 @@
-import { type Account, type AccountHelpers } from './auth';
+import {
+    type Account,
+    type AccountOrganization,
+    type AnonymousAccount,
+    type AuthType,
+} from './auth';
 
-// We omit AbilityRules because tsoa is very unforgiving. We'll still get this in the UI to apply abilities.
-// The same approach is taken for SessionUser from the UserController.
-export type SerializedAccount = Omit<Account, 'user' | keyof AccountHelpers> & {
+/**
+ * The account as returned by the API. Kept to what the app needs so a session
+ * never echoes its own credential (cookie, token, key) or, for embeds, the
+ * embed configuration behind the JWT.
+ *
+ * We omit AbilityRules because tsoa is very unforgiving. We'll still get this in the UI to apply abilities.
+ * The same approach is taken for SessionUser from the UserController.
+ */
+export type SerializedAccount = {
+    organization: AccountOrganization;
+    authentication: { type: AuthType };
     user: Omit<Account['user'], 'ability' | 'abilityRules'>;
+    embedWriteContext?: AnonymousAccount['embedWriteContext'];
 };
 
 export type ApiGetAccountResponse = {


### PR DESCRIPTION
Closes: #28414

Embedded sessions received the same project and account payloads as signed-in users, most of which the embed never reads. They now get just the settings a dashboard needs to render, and the account response is limited to the identity and permission fields the app uses. Verified the current frontend and the published SDK versions back to 0.2028 only read fields that are kept.

### Risk assessment:

- [ ] This is a high-risk change

High-risk changes require approval from a reviewer other than the author before merging.
