### PR TITLE
feat(data-apps): save a built app as an organization template

### DIFF
--- a/packages/backend/src/ee/controllers/DataAppTemplateController.ts
+++ b/packages/backend/src/ee/controllers/DataAppTemplateController.ts
@@ -8,14 +8,17 @@ import {
     DATA_APP_TEMPLATE_PACKAGE_CONTENT_TYPE,
     MAX_DATA_APP_TEMPLATE_PACKAGE_BYTES,
     ParameterError,
+    SaveAppAsTemplateRequest,
 } from '@lightdash/common';
 import {
+    Body,
     Delete,
     Get,
     Hidden,
     Middlewares,
     OperationId,
     Path,
+    Post,
     Put,
     Request,
     Response,
@@ -23,12 +26,14 @@ import {
     SuccessResponse,
 } from '@tsoa/runtime';
 import express from 'express';
+import { toSessionUser } from '../../auth/account';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,
     unauthorisedInDemo,
 } from '../../controllers/authentication';
 import { BaseController } from '../../controllers/baseController';
+import { AppGenerateService } from '../services/AppGenerateService/AppGenerateService';
 import { DataAppTemplateService } from '../services/DataAppTemplateService/DataAppTemplateService';
 
 /**
@@ -106,6 +111,43 @@ export class DataAppTemplateController extends BaseController {
             results: await this.getDataAppTemplateService().importPackage(
                 req.account,
                 { body: req, contentLength },
+            ),
+        };
+    }
+
+    /**
+     * Save a built data app as an organization template: its current source
+     * becomes the package, with the manifest identity and questions from the
+     * request. Needs view access to the app and create:DataAppTemplate.
+     * @summary Save app as data app template
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Post('/from-app')
+    @OperationId('SaveAppAsDataAppTemplate')
+    async saveAppAsTemplate(
+        @Request() req: express.Request,
+        @Body() body: SaveAppAsTemplateRequest,
+    ): Promise<ApiDataAppTemplateImportResponse> {
+        assertRegisteredAccount(req.account);
+        const code = await this.services
+            .getAppGenerateService<AppGenerateService>()
+            .getAppCode(
+                toSessionUser(req.account),
+                body.projectUuid,
+                body.appUuid,
+            );
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getDataAppTemplateService().importFromApp(
+                req.account,
+                body,
+                code.files,
             ),
         };
     }

--- a/packages/backend/src/ee/services/DataAppTemplateService/DataAppTemplateService.test.ts
+++ b/packages/backend/src/ee/services/DataAppTemplateService/DataAppTemplateService.test.ts
@@ -406,3 +406,91 @@ describe('DataAppTemplateService.importPackage', () => {
         expect(result.templateUuid).toBe(existing.templateUuid);
     });
 });
+
+describe('DataAppTemplateService.importFromApp', () => {
+    const b64 = (s: string) => Buffer.from(s, 'utf-8').toString('base64');
+    const APP_FILES = [
+        {
+            path: 'src/App.jsx',
+            contentBase64: b64('export default () => null;'),
+        },
+        {
+            path: 'src/template.json',
+            contentBase64: b64(
+                JSON.stringify({
+                    templateVersion: 1,
+                    template: {
+                        id: 'old',
+                        name: 'Old',
+                        description: 'o',
+                        category: 'o',
+                    },
+                    bindings: { history: { explore: 'orders' } },
+                }),
+            ),
+        },
+        { path: 'package.json', contentBase64: b64('{}') },
+    ];
+    const REQUEST = {
+        projectUuid: 'test-project-uuid',
+        appUuid: 'app-1',
+        template: {
+            id: 'revenue-forecaster',
+            name: 'Revenue Forecaster',
+            description: 'Forecasts revenue.',
+            category: 'Forecasting',
+        },
+        questions: [{ key: 'metric', label: 'What should we forecast?' }],
+        guardrails: 'Keep the monthly methodology.',
+    };
+
+    it("packages the app's src tree with a merged manifest and the guardrails as AGENTS.md", async () => {
+        const { service, model, send } = buildService();
+        const result = await service.importFromApp(
+            buildAccount(),
+            REQUEST,
+            APP_FILES,
+        );
+        expect(result.action).toBe('created');
+        expect(result.slug).toBe('revenue-forecaster');
+        const [write] = (model.upsert as ReturnType<typeof vi.fn>).mock
+            .calls[0];
+        expect(
+            write.files.map((f: { filename: string }) => f.filename),
+        ).toEqual(['AGENTS.md', 'src/App.jsx', 'src/template.json']);
+        const puts = send.mock.calls
+            .map(([command]) => command as PutObjectCommand)
+            .filter((command) => command instanceof PutObjectCommand);
+        const manifestPut = puts.find((c) =>
+            c.input.Key?.endsWith('src/template.json'),
+        );
+        const manifest = JSON.parse(String(manifestPut?.input.Body));
+        expect(manifest.template.id).toBe('revenue-forecaster');
+        expect(manifest.questions).toEqual(REQUEST.questions);
+        expect(manifest.bindings).toEqual({ history: { explore: 'orders' } });
+        const guardrailsPut = puts.find((c) =>
+            c.input.Key?.endsWith('AGENTS.md'),
+        );
+        expect(String(guardrailsPut?.input.Body)).toBe(
+            'Keep the monthly methodology.\n',
+        );
+    });
+
+    it('needs create:DataAppTemplate like any other publish', async () => {
+        const { service, model } = buildService();
+        withRole(service, OrganizationMemberRole.INTERACTIVE_VIEWER);
+        await expect(
+            service.importFromApp(buildAccount(), REQUEST, APP_FILES),
+        ).rejects.toThrow(ForbiddenError);
+        expect(model.upsert).not.toHaveBeenCalled();
+    });
+
+    it('rejects an app with no source files to package', async () => {
+        const { service } = buildService();
+        await expect(
+            service.importFromApp(buildAccount(), REQUEST, [
+                { path: 'package.json', contentBase64: b64('{}') },
+            ]),
+        ).rejects.toThrow(ParameterError);
+    });
+});

--- a/packages/backend/src/ee/services/DataAppTemplateService/DataAppTemplateService.ts
+++ b/packages/backend/src/ee/services/DataAppTemplateService/DataAppTemplateService.ts
@@ -8,6 +8,7 @@ import { subject } from '@casl/ability';
 import {
     assertIsAccountWithOrg,
     assertRegisteredAccount,
+    buildDataAppTemplateManifest,
     DATA_APP_TEMPLATE_GUARDRAILS_PATH,
     DATA_APP_TEMPLATE_MANIFEST_PATH,
     DataAppTemplatePackageError,
@@ -15,6 +16,7 @@ import {
     ForbiddenError,
     MAX_DATA_APP_TEMPLATE_FILE_BYTES,
     MAX_DATA_APP_TEMPLATE_FILES,
+    MAX_DATA_APP_TEMPLATE_GUARDRAILS_CHARS,
     MAX_DATA_APP_TEMPLATE_PACKAGE_BYTES,
     MAX_DATA_APP_TEMPLATES_PER_ORG,
     MissingConfigError,
@@ -23,8 +25,10 @@ import {
     parseDataAppTemplateManifest,
     validateDataAppTemplateEntryPath,
     type Account,
+    type DataAppCodeFile,
     type DataAppTemplateImportResult,
     type DataAppTemplateSummary,
+    type SaveAppAsTemplateRequest,
 } from '@lightdash/common';
 import { Readable } from 'node:stream';
 import { extract as tarExtract } from 'tar-stream';
@@ -274,7 +278,7 @@ export class DataAppTemplateService extends BaseService {
         account: Account,
         input: { body: Readable; contentLength: number },
     ): Promise<DataAppTemplateImportResult> {
-        const { organizationUuid, userUuid } = this.accountContext(account);
+        this.accountContext(account);
         await this.assertTemplatesEnabled(account);
         if (
             input.contentLength <= 0 ||
@@ -301,7 +305,109 @@ export class DataAppTemplateService extends BaseService {
             }
             throw e;
         }
-        files.sort((a, b) => a.filename.localeCompare(b.filename));
+        return this.importFiles(account, files);
+    }
+
+    /**
+     * Save-as-template from the UI: the app's current source (as returned
+     * by the app code read) becomes the package. Only the src tree travels;
+     * an existing manifest keeps its bindings while the request owns the
+     * identity block and questions; guardrails become AGENTS.md.
+     */
+    async importFromApp(
+        account: Account,
+        request: SaveAppAsTemplateRequest,
+        appFiles: DataAppCodeFile[],
+    ): Promise<DataAppTemplateImportResult> {
+        const guardrails = request.guardrails?.trim() ?? '';
+        if (guardrails.length > MAX_DATA_APP_TEMPLATE_GUARDRAILS_CHARS) {
+            throw new ParameterError(
+                `Guardrails must be at most ${MAX_DATA_APP_TEMPLATE_GUARDRAILS_CHARS} characters`,
+            );
+        }
+        // Scaffold, config and dependency files never belong in a package;
+        // the server rebuilds against its own template. Only the src tree
+        // travels, and an existing manifest is merged rather than copied.
+        const sourceFiles = appFiles
+            .map((file) => ({
+                filename: file.path.replace(/^\.\//, ''),
+                body: Buffer.from(file.contentBase64, 'base64'),
+            }))
+            .filter((file) => file.filename.startsWith('src/'));
+        const existingManifest = sourceFiles
+            .find((file) => file.filename === DATA_APP_TEMPLATE_MANIFEST_PATH)
+            ?.body.toString('utf-8');
+        const files: PackageFile[] = sourceFiles.filter(
+            (file) => file.filename !== DATA_APP_TEMPLATE_MANIFEST_PATH,
+        );
+        if (files.length === 0) {
+            throw new ParameterError(
+                'The app has no source files to save as a template',
+            );
+        }
+        let manifest: string;
+        try {
+            manifest = buildDataAppTemplateManifest({
+                existing: existingManifest,
+                template: request.template,
+                questions: request.questions ?? [],
+            });
+        } catch (e) {
+            if (e instanceof DataAppTemplatePackageError) {
+                throw new ParameterError(e.message);
+            }
+            throw e;
+        }
+        files.push({
+            filename: DATA_APP_TEMPLATE_MANIFEST_PATH,
+            body: Buffer.from(manifest, 'utf-8'),
+        });
+        if (guardrails.length > 0) {
+            files.push({
+                filename: DATA_APP_TEMPLATE_GUARDRAILS_PATH,
+                body: Buffer.from(`${guardrails}\n`, 'utf-8'),
+            });
+        }
+        return this.importFiles(account, files);
+    }
+
+    /**
+     * Shared publish path for a set of validated package files: manifest
+     * parse, permissions, caps, storage writes, record upsert.
+     */
+    private async importFiles(
+        account: Account,
+        input: PackageFile[],
+    ): Promise<DataAppTemplateImportResult> {
+        const { organizationUuid, userUuid } = this.accountContext(account);
+        await this.assertTemplatesEnabled(account);
+        let files: PackageFile[];
+        try {
+            files = input
+                .map((file) => ({
+                    filename: validateDataAppTemplateEntryPath(file.filename),
+                    body: file.body,
+                }))
+                .sort((a, b) => a.filename.localeCompare(b.filename));
+        } catch (e) {
+            if (e instanceof DataAppTemplatePackageError) {
+                throw new ParameterError(e.message);
+            }
+            throw e;
+        }
+        if (files.length > MAX_DATA_APP_TEMPLATE_FILES) {
+            throw new ParameterError(
+                `Template package has more than ${MAX_DATA_APP_TEMPLATE_FILES} files`,
+            );
+        }
+        const oversized = files.find(
+            (file) => file.body.length > MAX_DATA_APP_TEMPLATE_FILE_BYTES,
+        );
+        if (oversized) {
+            throw new ParameterError(
+                `${oversized.filename} exceeds ${MAX_DATA_APP_TEMPLATE_FILE_BYTES} bytes`,
+            );
+        }
 
         const manifestFile = files.find(
             (file) => file.filename === DATA_APP_TEMPLATE_MANIFEST_PATH,

--- a/packages/common/src/ee/apps/templatePackage.test.ts
+++ b/packages/common/src/ee/apps/templatePackage.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
+    buildDataAppTemplateManifest,
+    DataAppTemplatePackageError,
     parseDataAppTemplateManifest,
     validateDataAppTemplateEntryPath,
 } from './templatePackage';
@@ -99,5 +101,83 @@ describe('parseDataAppTemplateManifest', () => {
             ),
         ).toThrow(/duplicate/);
         expect(() => parseDataAppTemplateManifest('{')).toThrow(/valid JSON/);
+    });
+
+    describe('buildDataAppTemplateManifest', () => {
+        it("keeps an existing manifest's bindings and lets the request own metadata and questions", () => {
+            const existing = JSON.stringify({
+                templateVersion: 1,
+                template: {
+                    id: 'old',
+                    name: 'Old',
+                    description: 'Old',
+                    category: 'Old',
+                },
+                questions: [{ key: 'old', label: 'Old?' }],
+                bindings: { history: { explore: 'orders' } },
+                parameters: { horizon: { months: 24 } },
+            });
+            const merged = JSON.parse(
+                buildDataAppTemplateManifest({
+                    existing,
+                    template: {
+                        id: 'revenue-forecaster',
+                        name: 'Revenue Forecaster',
+                        description: 'Forecasts revenue.',
+                        category: 'Forecasting',
+                    },
+                    questions: [
+                        { key: 'metric', label: 'What should we forecast?' },
+                    ],
+                }),
+            );
+            expect(merged.bindings).toEqual({ history: { explore: 'orders' } });
+            expect(merged.parameters).toEqual({ horizon: { months: 24 } });
+            expect(merged.template.id).toBe('revenue-forecaster');
+            expect(merged.questions).toEqual([
+                { key: 'metric', label: 'What should we forecast?' },
+            ]);
+            expect(merged.templateVersion).toBe(1);
+        });
+
+        it('starts a fresh manifest when the app has none', () => {
+            const built = JSON.parse(
+                buildDataAppTemplateManifest({
+                    existing: undefined,
+                    template: {
+                        id: 'plain',
+                        name: 'Plain',
+                        description: 'd',
+                        category: 'c',
+                    },
+                    questions: [],
+                }),
+            );
+            expect(built).toEqual({
+                templateVersion: 1,
+                template: {
+                    id: 'plain',
+                    name: 'Plain',
+                    description: 'd',
+                    category: 'c',
+                },
+                questions: [],
+            });
+        });
+
+        it('rejects an existing manifest that is not valid JSON', () => {
+            expect(() =>
+                buildDataAppTemplateManifest({
+                    existing: '{not json',
+                    template: {
+                        id: 'x',
+                        name: 'x',
+                        description: 'x',
+                        category: 'x',
+                    },
+                    questions: [],
+                }),
+            ).toThrow(DataAppTemplatePackageError);
+        });
     });
 });

--- a/packages/common/src/ee/apps/templatePackage.ts
+++ b/packages/common/src/ee/apps/templatePackage.ts
@@ -239,3 +239,59 @@ export const parseDataAppTemplateManifest = (
         questions: parseQuestions(manifest.questions),
     };
 };
+
+export const MAX_DATA_APP_TEMPLATE_GUARDRAILS_CHARS = 20_000;
+
+/** Save-as-template from the UI: the app to package plus the manifest fields the modal collects. */
+export type SaveAppAsTemplateRequest = {
+    projectUuid: string;
+    appUuid: string;
+    template: DataAppTemplateManifest['template'];
+    questions?: TemplateQuestion[];
+    /** Optional guidance for the agent; becomes the package's AGENTS.md. */
+    guardrails?: string;
+};
+
+/**
+ * The manifest to write when an app is saved as a template. An app built
+ * from a template already carries a manifest whose bindings, parameters,
+ * labels and theme must survive; the request owns the identity block and
+ * the questions. Anything else in the existing manifest is kept as is.
+ */
+export const buildDataAppTemplateManifest = ({
+    existing,
+    template,
+    questions,
+}: {
+    existing: string | undefined;
+    template: DataAppTemplateManifest['template'];
+    questions: TemplateQuestion[];
+}): string => {
+    let base: Record<string, unknown> = {};
+    if (existing !== undefined) {
+        let parsed: unknown;
+        try {
+            parsed = JSON.parse(existing);
+        } catch {
+            throw new DataAppTemplatePackageError(
+                `The app's ${DATA_APP_TEMPLATE_MANIFEST_PATH} is not valid JSON`,
+            );
+        }
+        if (
+            parsed === null ||
+            typeof parsed !== 'object' ||
+            Array.isArray(parsed)
+        ) {
+            throw new DataAppTemplatePackageError(
+                `The app's ${DATA_APP_TEMPLATE_MANIFEST_PATH} must be a JSON object`,
+            );
+        }
+        base = parsed as Record<string, unknown>;
+    }
+    const { templateVersion: _v, template: _t, questions: _q, ...rest } = base;
+    return `${JSON.stringify(
+        { templateVersion: 1, template, questions, ...rest },
+        null,
+        2,
+    )}\n`;
+};

--- a/packages/frontend/src/features/apps/components/AppHeaderActions.tsx
+++ b/packages/frontend/src/features/apps/components/AppHeaderActions.tsx
@@ -18,6 +18,7 @@ import {
     IconCamera,
     IconCirclesRelation,
     IconCopy,
+    IconTemplate,
     IconDatabaseExport,
     IconDots,
     IconEdit,
@@ -56,10 +57,12 @@ import {
 import { useCanCreateDataApp } from '../hooks/useCanCreateDataApp';
 import { useCanEditDataApp } from '../hooks/useCanEditDataApp';
 import { useDuplicateApp } from '../hooks/useDuplicateApp';
+import { useCanSaveAppAsTemplate } from '../hooks/useSaveAppAsTemplate';
 import { type SdkUpgradeOffer } from '../hooks/useSdkUpgradeStatus';
 import AppUpgradeModal from './AppUpgradeModal';
 import { MoveAppToSpaceModal } from './MoveAppToSpaceModal';
 import { PromoteAppModal } from './PromoteAppModal';
+import { SaveAppAsTemplateModal } from './SaveAppAsTemplateModal';
 
 type Props = {
     projectUuid: string;
@@ -228,6 +231,8 @@ const AppHeaderActions: FC<Props> = ({
     const [isUpdateModalOpen, setIsUpdateModalOpen] = useState(false);
     const [isMoveToSpaceOpen, setIsMoveToSpaceOpen] = useState(false);
     const [isPromoteModalOpen, setIsPromoteModalOpen] = useState(false);
+    const [isSaveAsTemplateOpen, setIsSaveAsTemplateOpen] = useState(false);
+    const canSaveAsTemplate = useCanSaveAppAsTemplate();
     const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
     const [isDirectAccessModalOpen, setIsDirectAccessModalOpen] =
         useState(false);
@@ -435,6 +440,16 @@ const AppHeaderActions: FC<Props> = ({
                             Duplicate
                         </Menu.Item>
                     )}
+                    {canSaveAsTemplate && hasReadyVersion && (
+                        <Menu.Item
+                            leftSection={
+                                <MantineIcon icon={IconTemplate} size={14} />
+                            }
+                            onClick={() => setIsSaveAsTemplateOpen(true)}
+                        >
+                            Save as template
+                        </Menu.Item>
+                    )}
                     {canEdit && (
                         <>
                             <Menu.Item
@@ -566,6 +581,14 @@ const AppHeaderActions: FC<Props> = ({
                     onClose={() => setSyncModalOpen(false)}
                 />
             )}
+            <SaveAppAsTemplateModal
+                opened={isSaveAsTemplateOpen}
+                onClose={() => setIsSaveAsTemplateOpen(false)}
+                projectUuid={projectUuid}
+                appUuid={appUuid}
+                appName={appName}
+                appDescription={appDescription}
+            />
             {isPromoteModalOpen && (
                 <PromoteAppModal
                     projectUuid={projectUuid}

--- a/packages/frontend/src/features/apps/components/SaveAppAsTemplateModal.test.tsx
+++ b/packages/frontend/src/features/apps/components/SaveAppAsTemplateModal.test.tsx
@@ -1,0 +1,88 @@
+import { MantineProvider } from '@mantine/core';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { useSaveAppAsTemplate } from '../hooks/useSaveAppAsTemplate';
+import { SaveAppAsTemplateModal } from './SaveAppAsTemplateModal';
+
+vi.mock('../hooks/useSaveAppAsTemplate', () => ({
+    useSaveAppAsTemplate: vi.fn(),
+    useCanSaveAppAsTemplate: () => true,
+}));
+
+const setup = () => {
+    const mutate = vi.fn();
+    vi.mocked(useSaveAppAsTemplate).mockReturnValue({
+        mutate,
+        isLoading: false,
+    } as never);
+    render(
+        <MantineProvider env="test">
+            <SaveAppAsTemplateModal
+                opened
+                onClose={vi.fn()}
+                projectUuid="project-1"
+                appUuid="app-1"
+                appName="Revenue Forecaster"
+                appDescription="Monthly revenue with a live forecast."
+            />
+        </MantineProvider>,
+    );
+    return { mutate };
+};
+
+describe('SaveAppAsTemplateModal', () => {
+    it('pre-fills the identity from the app and publishes with the questions entered', () => {
+        const { mutate } = setup();
+        expect(screen.getByLabelText(/^Name/)).toHaveValue(
+            'Revenue Forecaster',
+        );
+        expect(screen.getByLabelText(/Template id/)).toHaveValue(
+            'revenue-forecaster',
+        );
+        fireEvent.click(screen.getByRole('button', { name: /Add question/i }));
+        fireEvent.change(screen.getByLabelText('Question'), {
+            target: { value: 'What should we forecast?' },
+        });
+        fireEvent.change(screen.getByLabelText('Default answer'), {
+            target: { value: 'Total order revenue' },
+        });
+        fireEvent.change(screen.getByLabelText(/Guidance for the agent/), {
+            target: { value: 'Keep the monthly methodology.' },
+        });
+        fireEvent.click(
+            screen.getByRole('button', { name: /Publish template/i }),
+        );
+        expect(mutate).toHaveBeenCalledTimes(1);
+        expect(mutate.mock.calls[0][0]).toEqual({
+            projectUuid: 'project-1',
+            appUuid: 'app-1',
+            template: {
+                id: 'revenue-forecaster',
+                name: 'Revenue Forecaster',
+                description: 'Monthly revenue with a live forecast.',
+                category: 'General',
+            },
+            questions: [
+                {
+                    key: 'what_should_we_forecast',
+                    label: 'What should we forecast?',
+                    default: 'Total order revenue',
+                },
+            ],
+            guardrails: 'Keep the monthly methodology.',
+        });
+    });
+
+    it('blocks publishing on an invalid template id', () => {
+        const { mutate } = setup();
+        fireEvent.change(screen.getByLabelText(/Template id/), {
+            target: { value: 'Not A Slug' },
+        });
+        expect(
+            screen.getByText(/Lowercase letters, numbers and dashes/),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole('button', { name: /Publish template/i }),
+        ).toBeDisabled();
+        expect(mutate).not.toHaveBeenCalled();
+    });
+});

--- a/packages/frontend/src/features/apps/components/SaveAppAsTemplateModal.tsx
+++ b/packages/frontend/src/features/apps/components/SaveAppAsTemplateModal.tsx
@@ -1,0 +1,287 @@
+import {
+    DATA_APP_TEMPLATE_SLUG_PATTERN,
+    generateSlug,
+    type TemplateQuestion,
+} from '@lightdash/common';
+import {
+    ActionIcon,
+    Button,
+    Checkbox,
+    Group,
+    Stack,
+    Text,
+    Textarea,
+    TextInput,
+} from '@mantine/core';
+import { IconPlus, IconTemplate, IconTrash } from '@tabler/icons-react';
+import { useEffect, useMemo, useState, type FC } from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
+import MantineModal from '../../../components/common/MantineModal';
+import { useSaveAppAsTemplate } from '../hooks/useSaveAppAsTemplate';
+
+type Props = {
+    opened: boolean;
+    onClose: () => void;
+    projectUuid: string;
+    appUuid: string;
+    appName: string;
+    appDescription: string | null;
+};
+
+type QuestionDraft = {
+    label: string;
+    defaultValue: string;
+    isList: boolean;
+};
+
+const toQuestions = (drafts: QuestionDraft[]): TemplateQuestion[] => {
+    const seen = new Set<string>();
+    return drafts
+        .filter((draft) => draft.label.trim().length > 0)
+        .map((draft) => {
+            let key = generateSlug(draft.label).replace(/-/g, '_');
+            let suffix = 2;
+            while (seen.has(key)) {
+                key = `${generateSlug(draft.label).replace(/-/g, '_')}_${suffix}`;
+                suffix += 1;
+            }
+            seen.add(key);
+            return {
+                key,
+                label: draft.label.trim(),
+                ...(draft.defaultValue.trim()
+                    ? { default: draft.defaultValue.trim() }
+                    : {}),
+                ...(draft.isList ? { kind: 'list' as const } : {}),
+            };
+        });
+};
+
+/**
+ * Save a built app as an organization template. The app's current source
+ * becomes the package; this form supplies the manifest's identity, the
+ * questions the builder will be asked, and optional guidance for the agent.
+ * An app built from a template keeps its bindings (the server merges).
+ */
+export const SaveAppAsTemplateModal: FC<Props> = ({
+    opened,
+    onClose,
+    projectUuid,
+    appUuid,
+    appName,
+    appDescription,
+}) => {
+    const [id, setId] = useState('');
+    const [name, setName] = useState('');
+    const [category, setCategory] = useState('General');
+    const [description, setDescription] = useState('');
+    const [guardrails, setGuardrails] = useState('');
+    const [questions, setQuestions] = useState<QuestionDraft[]>([]);
+    const { mutate, isLoading } = useSaveAppAsTemplate();
+
+    useEffect(() => {
+        if (!opened) return;
+        setId(generateSlug(appName));
+        setName(appName);
+        setDescription(appDescription ?? '');
+        setCategory('General');
+        setGuardrails('');
+        setQuestions([]);
+    }, [opened, appName, appDescription]);
+
+    const idError = useMemo(() => {
+        if (id.length === 0) return 'Required';
+        return DATA_APP_TEMPLATE_SLUG_PATTERN.test(id)
+            ? null
+            : 'Lowercase letters, numbers and dashes, 2 to 64 characters';
+    }, [id]);
+    const canSubmit =
+        !idError &&
+        name.trim().length > 0 &&
+        description.trim().length > 0 &&
+        category.trim().length > 0;
+
+    const handleConfirm = () => {
+        if (!canSubmit) return;
+        mutate(
+            {
+                projectUuid,
+                appUuid,
+                template: {
+                    id,
+                    name: name.trim(),
+                    description: description.trim(),
+                    category: category.trim(),
+                },
+                questions: toQuestions(questions),
+                ...(guardrails.trim() ? { guardrails: guardrails.trim() } : {}),
+            },
+            { onSuccess: onClose },
+        );
+    };
+
+    const updateQuestion = (index: number, patch: Partial<QuestionDraft>) =>
+        setQuestions((prev) =>
+            prev.map((q, i) => (i === index ? { ...q, ...patch } : q)),
+        );
+
+    return (
+        <MantineModal
+            opened={opened}
+            onClose={onClose}
+            title="Save as template"
+            icon={IconTemplate}
+            size="lg"
+            confirmLabel="Publish template"
+            confirmLoading={isLoading}
+            confirmDisabled={!canSubmit}
+            onConfirm={handleConfirm}
+        >
+            <Stack gap="sm">
+                <Text size="sm" c="dimmed">
+                    The app's current source becomes an organization template.
+                    Anyone who can build from templates will see it in the From
+                    Template gallery and be asked the questions below.
+                </Text>
+                <Group grow align="flex-start">
+                    <TextInput
+                        label="Name"
+                        required
+                        value={name}
+                        onChange={(e) => setName(e.currentTarget.value)}
+                        disabled={isLoading}
+                    />
+                    <TextInput
+                        label="Template id"
+                        description="Re-publishing with the same id replaces the template"
+                        required
+                        value={id}
+                        error={idError ?? undefined}
+                        onChange={(e) => setId(e.currentTarget.value)}
+                        disabled={isLoading}
+                    />
+                </Group>
+                <Group grow align="flex-start">
+                    <TextInput
+                        label="Category"
+                        required
+                        value={category}
+                        onChange={(e) => setCategory(e.currentTarget.value)}
+                        disabled={isLoading}
+                    />
+                </Group>
+                <Textarea
+                    label="Description"
+                    required
+                    autosize
+                    minRows={2}
+                    value={description}
+                    onChange={(e) => setDescription(e.currentTarget.value)}
+                    disabled={isLoading}
+                />
+                <Stack gap={6}>
+                    <Group justify="space-between">
+                        <div>
+                            <Text size="sm" fw={500}>
+                                Questions
+                            </Text>
+                            <Text size="xs" c="dimmed">
+                                Asked instead of a blank prompt when someone
+                                builds from this template.
+                            </Text>
+                        </div>
+                        <Button
+                            size="compact-xs"
+                            variant="light"
+                            leftSection={
+                                <MantineIcon icon={IconPlus} size={12} />
+                            }
+                            onClick={() =>
+                                setQuestions((prev) => [
+                                    ...prev,
+                                    {
+                                        label: '',
+                                        defaultValue: '',
+                                        isList: false,
+                                    },
+                                ])
+                            }
+                            disabled={isLoading}
+                        >
+                            Add question
+                        </Button>
+                    </Group>
+                    {questions.map((question, index) => (
+                        <Group
+                            // eslint-disable-next-line react/no-array-index-key
+                            key={index}
+                            gap="xs"
+                            align="flex-end"
+                            wrap="nowrap"
+                        >
+                            <TextInput
+                                label="Question"
+                                placeholder="What should we forecast?"
+                                value={question.label}
+                                onChange={(e) =>
+                                    updateQuestion(index, {
+                                        label: e.currentTarget.value,
+                                    })
+                                }
+                                style={{ flex: 2 }}
+                                disabled={isLoading}
+                            />
+                            <TextInput
+                                label="Default answer"
+                                value={question.defaultValue}
+                                onChange={(e) =>
+                                    updateQuestion(index, {
+                                        defaultValue: e.currentTarget.value,
+                                    })
+                                }
+                                style={{ flex: 1 }}
+                                disabled={isLoading}
+                            />
+                            <Checkbox
+                                label="List"
+                                checked={question.isList}
+                                onChange={(e) =>
+                                    updateQuestion(index, {
+                                        isList: e.currentTarget.checked,
+                                    })
+                                }
+                                pb={8}
+                                disabled={isLoading}
+                            />
+                            <ActionIcon
+                                variant="subtle"
+                                color="gray"
+                                aria-label="Remove question"
+                                mb={4}
+                                onClick={() =>
+                                    setQuestions((prev) =>
+                                        prev.filter((_, i) => i !== index),
+                                    )
+                                }
+                                disabled={isLoading}
+                            >
+                                <MantineIcon icon={IconTrash} size={14} />
+                            </ActionIcon>
+                        </Group>
+                    ))}
+                </Stack>
+                <Textarea
+                    label="Guidance for the agent"
+                    description="Optional. Saved as the template's AGENTS.md and shown to the agent on every build; builders can still override it."
+                    placeholder="Keep the monthly methodology; change bindings and labels in src/template.json rather than rewriting components."
+                    autosize
+                    minRows={2}
+                    maxRows={6}
+                    value={guardrails}
+                    onChange={(e) => setGuardrails(e.currentTarget.value)}
+                    disabled={isLoading}
+                />
+            </Stack>
+        </MantineModal>
+    );
+};

--- a/packages/frontend/src/features/apps/hooks/useOrgDataAppTemplates.ts
+++ b/packages/frontend/src/features/apps/hooks/useOrgDataAppTemplates.ts
@@ -6,7 +6,7 @@ import {
 import { useQuery } from '@tanstack/react-query';
 import { lightdashApi } from '../../../api';
 
-const ORG_DATA_APP_TEMPLATES_QUERY_KEY = 'org_data_app_templates';
+export const ORG_DATA_APP_TEMPLATES_QUERY_KEY = 'org_data_app_templates';
 
 const listOrgDataAppTemplatesApi = async () =>
     lightdashApi<ApiDataAppTemplatesResponse['results']>({

--- a/packages/frontend/src/features/apps/hooks/useSaveAppAsTemplate.ts
+++ b/packages/frontend/src/features/apps/hooks/useSaveAppAsTemplate.ts
@@ -1,0 +1,64 @@
+import {
+    FeatureFlags,
+    type ApiDataAppTemplateImportResponse,
+    type ApiError,
+    type DataAppTemplateImportResult,
+    type SaveAppAsTemplateRequest,
+} from '@lightdash/common';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { lightdashApi } from '../../../api';
+import useToaster from '../../../hooks/toaster/useToaster';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
+import useApp from '../../../providers/App/useApp';
+import { ORG_DATA_APP_TEMPLATES_QUERY_KEY } from './useOrgDataAppTemplates';
+
+const saveAppAsTemplateApi = async (request: SaveAppAsTemplateRequest) =>
+    lightdashApi<ApiDataAppTemplateImportResponse['results']>({
+        url: '/org/data-app-templates/from-app',
+        method: 'POST',
+        body: JSON.stringify(request),
+    });
+
+/**
+ * Whether the current user can publish templates from the UI: the
+ * templates feature is on and they hold create:DataAppTemplate.
+ */
+export const useCanSaveAppAsTemplate = (): boolean => {
+    const flag = useServerFeatureFlag(FeatureFlags.EnableDataAppTemplates);
+    const { user } = useApp();
+    return (
+        flag.data?.enabled === true &&
+        (user.data?.ability.can('create', 'DataAppTemplate') ?? false)
+    );
+};
+
+export const useSaveAppAsTemplate = () => {
+    const queryClient = useQueryClient();
+    const { showToastSuccess, showToastApiError } = useToaster();
+    return useMutation<
+        DataAppTemplateImportResult,
+        ApiError,
+        SaveAppAsTemplateRequest
+    >({
+        mutationFn: saveAppAsTemplateApi,
+        onSuccess: (result) => {
+            void queryClient.invalidateQueries({
+                queryKey: [ORG_DATA_APP_TEMPLATES_QUERY_KEY],
+            });
+            showToastSuccess({
+                title:
+                    result.action === 'created'
+                        ? `Template "${result.name}" published`
+                        : `Template "${result.name}" updated`,
+                subtitle:
+                    'It is now in the From Template gallery for your organization.',
+            });
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to save app as template',
+                apiError: error,
+            });
+        },
+    });
+};


### PR DESCRIPTION
Stacked on #28472. CS-201: publish a template from a built app without leaving the product.

## What

A **Save as template** item in a built app's menu (next to Duplicate). The modal pre-fills name and id from the app and collects the manifest identity, the questions builders will be asked (label, default, single value or one-per-line), and optional guidance for the agent, which becomes the package's `AGENTS.md`. Publishing uses the same import path as `lightdash upload --as-template`, so the template lands in the gallery immediately.

Gating: templates flag on, `create:DataAppTemplate`, and a ready version. Re-publishing with an existing id goes through the ownership rules from #28462 (`manage:DataAppTemplate@self` / `manage`).

## How

- `buildDataAppTemplateManifest` (common) merges an existing `src/template.json` with the request: bindings, parameters, labels and theme survive; the request owns `templateVersion`, `template` and `questions`. Invalid existing JSON is a 400.
- `POST /api/v1/org/data-app-templates/from-app` reads the app's latest ready source through `getAppCode` (so `view:DataApp` applies) and hands the `src/**` tree to `DataAppTemplateService.importFromApp`. `importPackage` (tar) and `importFromApp` now share `importFiles`: path allowlist, caps, manifest parse, permissions, storage writes, upsert.

## Verified on docker-dev

Recorder flow `cs-201-save-as-template` (5/5): menu item present, modal pre-filled from the app, publish toast, the template listed in From Template with its question. Then a build from that UI-saved template with a different answer: `seeded 42 files from org template ui-saved-…`, three `src/template.json` edits, rebound to `orders.total_order_amount`, ready in 71s. The merged manifest kept the original bindings (`fileCount` 43, same tree as the CLI-published package).

Tests: 3 new common (manifest merge), 3 new backend (package from app, scope refusal, no-source rejection; 14 in the service file), 2 new frontend (modal payload, id validation). Typecheck common/backend/frontend/cli, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VU9L8WJ97vLUB4WJmaUKDa
