### PR TITLE
docs: clarify MCP snapshot generation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,23 @@ pnpm generate:chart-as-code-schema
 pnpm check:chart-as-code-schema
 ```
 
+**MCP Tool Snapshot:**
+
+The committed `packages/common/src/schemas/json/mcp-tools-1.0.json` snapshot
+represents the stable/default MCP tool surface used by release-safety checks.
+Run the generator and commit the snapshot whenever a change affects an MCP
+tool's membership, name, title, description, annotations, input schema, or
+output schema, including changes to imported schemas:
+
+```bash
+pnpm generate:mcp-tools-snapshot
+```
+
+Do not regenerate it solely for a temporary runtime-selected rollout variant.
+Regenerate it when that variant becomes the default contract. If unsure whether
+a change affects the snapshot, run `pnpm check:mcp-tools-snapshot`. Running
+`pnpm generate-api` also regenerates the MCP tool snapshot through its post-hook.
+
 **Database Migrations:**
 
 ```bash

--- a/packages/backend/src/ee/services/McpService/AGENTS.md
+++ b/packages/backend/src/ee/services/McpService/AGENTS.md
@@ -2,5 +2,7 @@
 
 - MCP tool names are snake_case.
 - Keep tool descriptions, input schemas, output schemas, and prompt text stable unless the MCP-facing contract is intentionally changing.
-- Run `pnpm -F backend test src/ee/services/ai/tools/toolContracts.snapshot.test.ts` before and after shared tool-definition refactors.
-- If an MCP tool or prompt contract intentionally changes, update only the MCP snapshot entry and mention the contract change in review.
+- Run `pnpm -F backend test src/ee/services/McpService/mcpToolContracts.snapshot.test.ts` before and after shared tool-definition refactors.
+- If an MCP tool or prompt contract intentionally changes, update only the affected entry in the backend runtime contract snapshot and mention the contract change in review.
+- Separately, run `pnpm generate:mcp-tools-snapshot` and commit `packages/common/src/schemas/json/mcp-tools-1.0.json` whenever the stable/default MCP tool surface changes, including tool membership, metadata, input or output schemas, and imported schemas.
+- Do not regenerate the committed tool-surface snapshot solely for a temporary runtime-selected rollout variant. Regenerate it when the variant becomes the default; run `pnpm check:mcp-tools-snapshot` when unsure.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-10837

### Description:
Documents when agents should regenerate the committed MCP tool snapshot, including default versus rollout contracts and validation commands.
Clarifies the distinction from runtime contract snapshots and corrects the MCP contract test path.

### Risk assessment:

- [ ] This is a high-risk change

High-risk changes require approval from a reviewer other than the author before merging.