### PR TITLE
feat: uninstall official chart types from the library

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.registryInstall.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.registryInstall.test.ts
@@ -309,6 +309,7 @@ describe('AppGenerateService.listRegistryChartTypes', () => {
                     app_id: 'app-uuid-sankey',
                     registry_slug: 'sankey',
                     latest_ready_registry_version: '1.2.0',
+                    created_by_user_uuid: 'installer-user-uuid',
                 },
             ]),
         };
@@ -321,11 +322,13 @@ describe('AppGenerateService.listRegistryChartTypes', () => {
         expect(sankey?.state).toBe('update_available');
         expect(sankey?.installedAppUuid).toBe('app-uuid-sankey');
         expect(sankey?.installedRegistryVersion).toBe('1.2.0');
+        expect(sankey?.installedCreatedByUserUuid).toBe('installer-user-uuid');
 
         const radar = result.charts.find((c) => c.slug === 'radar');
         expect(radar?.state).toBe('not_installed');
         expect(radar?.installedAppUuid).toBeNull();
         expect(radar?.installedRegistryVersion).toBeNull();
+        expect(radar?.installedCreatedByUserUuid).toBeNull();
     });
 
     it('marks entries above the instance version incompatible', async () => {
@@ -344,6 +347,7 @@ describe('AppGenerateService.listRegistryChartTypes', () => {
         expect(result.charts).toHaveLength(1);
         expect(result.charts[0].state).toBe('incompatible');
         expect(result.charts[0].installedAppUuid).toBeNull();
+        expect(result.charts[0].installedCreatedByUserUuid).toBeNull();
     });
 });
 

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -8658,6 +8658,8 @@ export class AppGenerateService extends BaseService {
                     installedAppUuid: inst?.app_id ?? null,
                     installedRegistryVersion:
                         inst?.latest_ready_registry_version ?? null,
+                    installedCreatedByUserUuid:
+                        inst?.created_by_user_uuid ?? null,
                 };
             },
         );

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -1099,6 +1099,7 @@ export class AppModel {
             app_id: string;
             registry_slug: string;
             latest_ready_registry_version: string | null;
+            created_by_user_uuid: string | null;
         }>
     > {
         return this.joinLatestReadyVersion(this.database(AppsTableName))
@@ -1111,10 +1112,12 @@ export class AppModel {
                     app_id: string;
                     registry_slug: string;
                     latest_ready_registry_version: string | null;
+                    created_by_user_uuid: string | null;
                 }>
             >(
                 `${AppsTableName}.app_id`,
                 `${AppsTableName}.registry_slug`,
+                `${AppsTableName}.created_by_user_uuid`,
                 this.database
                     .ref(`${AppVersionsTableName}.registry_version`)
                     .as('latest_ready_registry_version'),

--- a/packages/common/src/ee/apps/registry.ts
+++ b/packages/common/src/ee/apps/registry.ts
@@ -121,6 +121,7 @@ export type RegistryChartTypeListItem = ChartRegistryEntry & {
     state: RegistryChartTypeState;
     installedAppUuid: string | null;
     installedRegistryVersion: string | null;
+    installedCreatedByUserUuid: string | null;
 };
 
 export type ApiListRegistryChartTypesResponse = ApiSuccess<{

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeLibraryDetailModal.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeLibraryDetailModal.tsx
@@ -88,50 +88,57 @@ const ChartTypeLibraryDetailModal: FC<Props> = ({
         </Button>
     );
 
-    const footerAction: ReactNode = (() => {
+    const footerProps = (() => {
         switch (item.state) {
             case 'not_installed':
-                return canInstallGate(
-                    <Button
-                        loading={installMutation.isLoading}
-                        onClick={handleInstall}
-                    >
-                        Install
-                    </Button>,
-                );
+                return {
+                    actions: canInstallGate(
+                        <Button
+                            loading={installMutation.isLoading}
+                            onClick={handleInstall}
+                        >
+                            Install
+                        </Button>,
+                    ),
+                };
             case 'update_available':
-                return (
-                    <Group gap="sm" wrap="nowrap">
-                        {uninstallButton}
-                        {canInstallGate(
-                            <Button
-                                loading={installMutation.isLoading}
-                                onClick={handleInstall}
-                            >
-                                Upgrade to v{item.version}
-                            </Button>,
-                        )}
-                    </Group>
-                );
+                return {
+                    actions: (
+                        <Group gap="sm" wrap="nowrap">
+                            {uninstallButton}
+                            {canInstallGate(
+                                <Button
+                                    loading={installMutation.isLoading}
+                                    onClick={handleInstall}
+                                >
+                                    Upgrade to v{item.version}
+                                </Button>,
+                            )}
+                        </Group>
+                    ),
+                };
             case 'installed':
-                return (
-                    <Group gap="sm" wrap="nowrap">
-                        {uninstallButton}
+                return {
+                    leftActions: uninstallButton,
+                    actions: (
                         <Button variant="default" onClick={onClose}>
                             View in gallery
                         </Button>
-                    </Group>
-                );
+                    ),
+                    cancelLabel: false as const,
+                };
             case 'incompatible':
-                return (
-                    <Group gap="sm" wrap="nowrap">
-                        <Text fz="xs" c="dimmed">
-                            Requires Lightdash v{item.minLightdashVersion} or
-                            later
-                        </Text>
-                        <Button disabled>Install</Button>
-                    </Group>
-                );
+                return {
+                    actions: (
+                        <Group gap="sm" wrap="nowrap">
+                            <Text fz="xs" c="dimmed">
+                                Requires Lightdash v{item.minLightdashVersion}{' '}
+                                or later
+                            </Text>
+                            <Button disabled>Install</Button>
+                        </Group>
+                    ),
+                };
             default:
                 return assertUnreachable(
                     item.state,
@@ -148,8 +155,7 @@ const ChartTypeLibraryDetailModal: FC<Props> = ({
                 title={item.name}
                 subtitle={`v${item.version}`}
                 bodyScrollAreaMaxHeight="calc(100vh - 200px)"
-                cancelLabel={item.state === 'installed' ? false : 'Cancel'}
-                actions={footerAction}
+                {...footerProps}
             >
                 <Stack gap="md">
                     {item.screenshots.length > 0 ? (

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeLibraryDetailModal.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeLibraryDetailModal.tsx
@@ -12,17 +12,19 @@ import {
     Stack,
     Text,
 } from '@mantine/core';
-import { IconPhoto } from '@tabler/icons-react';
-import { type FC, type ReactNode } from 'react';
+import { IconPhoto, IconTrash } from '@tabler/icons-react';
+import { useState, type FC, type ReactNode } from 'react';
 import Callout from '../../../components/common/Callout';
 import MantineIcon from '../../../components/common/MantineIcon';
 import MantineModal from '../../../components/common/MantineModal';
 import { useTimeAgo } from '../../../hooks/useTimeAgo';
 import { Can } from '../../../providers/Ability';
 import useApp from '../../../providers/App/useApp';
+import { useCanEditDataApp } from '../../apps/hooks/useCanEditDataApp';
 import { useInstallRegistryChartType } from '../hooks/useInstallRegistryChartType';
 import { registryAssetUrl } from '../utils/registryAssetUrl';
 import classes from './ChartTypeLibraryDetailModal.module.css';
+import ChartTypeUninstallModal from './ChartTypeUninstallModal';
 import DataAppVizFieldTypeBadge from './DataAppVizFieldTypeBadge';
 
 type Props = {
@@ -39,6 +41,13 @@ const ChartTypeLibraryDetailModal: FC<Props> = ({
     const { user } = useApp();
     const publishedAgo = useTimeAgo(item.publishedAt);
     const installMutation = useInstallRegistryChartType();
+    const [isUninstallModalOpen, setIsUninstallModalOpen] = useState(false);
+    // Registry apps are spaceless, so access is checked without a space, but
+    // the CASL self-rule still needs the real installing user for editors.
+    const canEdit = useCanEditDataApp(projectUuid, {
+        spaceUuid: null,
+        createdByUserUuid: item.installedCreatedByUserUuid,
+    });
 
     const handleInstall = () => {
         installMutation.mutate(
@@ -62,6 +71,23 @@ const ChartTypeLibraryDetailModal: FC<Props> = ({
         </Can>
     );
 
+    // Uninstall (app delete) uses the same permission as ChartTypeDetailModal's
+    // Delete button — install/upgrade use the separate DataApp create ability.
+    const canUninstall = canEdit && item.installedAppUuid !== null;
+    const uninstallButton = canUninstall && (
+        // The theme's subtle variant hardcodes gray text; c overrides it.
+        <Button
+            variant="subtle"
+            size="xs"
+            color="red"
+            c="red.7"
+            leftSection={<MantineIcon icon={IconTrash} />}
+            onClick={() => setIsUninstallModalOpen(true)}
+        >
+            Uninstall
+        </Button>
+    );
+
     const footerAction: ReactNode = (() => {
         switch (item.state) {
             case 'not_installed':
@@ -74,19 +100,27 @@ const ChartTypeLibraryDetailModal: FC<Props> = ({
                     </Button>,
                 );
             case 'update_available':
-                return canInstallGate(
-                    <Button
-                        loading={installMutation.isLoading}
-                        onClick={handleInstall}
-                    >
-                        Upgrade to v{item.version}
-                    </Button>,
+                return (
+                    <Group gap="sm" wrap="nowrap">
+                        {uninstallButton}
+                        {canInstallGate(
+                            <Button
+                                loading={installMutation.isLoading}
+                                onClick={handleInstall}
+                            >
+                                Upgrade to v{item.version}
+                            </Button>,
+                        )}
+                    </Group>
                 );
             case 'installed':
                 return (
-                    <Button variant="default" onClick={onClose}>
-                        View in gallery
-                    </Button>
+                    <Group gap="sm" wrap="nowrap">
+                        {uninstallButton}
+                        <Button variant="default" onClick={onClose}>
+                            View in gallery
+                        </Button>
+                    </Group>
                 );
             case 'incompatible':
                 return (
@@ -107,123 +141,135 @@ const ChartTypeLibraryDetailModal: FC<Props> = ({
     })();
 
     return (
-        <MantineModal
-            opened
-            onClose={onClose}
-            title={item.name}
-            subtitle={`v${item.version}`}
-            bodyScrollAreaMaxHeight="calc(100vh - 200px)"
-            cancelLabel={item.state === 'installed' ? false : 'Cancel'}
-            actions={footerAction}
-        >
-            <Stack gap="md">
-                {item.screenshots.length > 0 ? (
-                    <ScrollArea type="auto" offsetScrollbars>
-                        <Group
-                            gap="sm"
-                            wrap="nowrap"
-                            className={classes.screenshotRow}
-                        >
-                            {item.screenshots.map((path) => (
-                                <img
-                                    key={path}
-                                    src={registryAssetUrl(path)}
-                                    alt={item.name}
-                                    className={classes.screenshot}
-                                />
-                            ))}
-                        </Group>
-                    </ScrollArea>
-                ) : item.thumbnail ? (
-                    <Box className={classes.preview}>
-                        <img
-                            src={registryAssetUrl(item.thumbnail)}
-                            alt={item.name}
-                            className={classes.previewImage}
-                        />
-                    </Box>
-                ) : (
-                    <Box className={classes.preview}>
-                        <Stack
-                            align="center"
-                            justify="center"
-                            gap="xs"
-                            h="100%"
-                        >
-                            <MantineIcon
-                                icon={IconPhoto}
-                                size="xl"
-                                color="ldGray.5"
-                            />
-                        </Stack>
-                    </Box>
-                )}
-
-                <Text fz="sm" c="ldGray.7" lh={1.55}>
-                    {item.description || 'No description'}
-                </Text>
-
-                {item.state === 'update_available' && (
-                    <Callout
-                        variant="warning"
-                        title="Existing charts keep their pinned version"
-                    >
-                        Charts pinned to an earlier version keep rendering it
-                        until each chart is upgraded; charts without a pinned
-                        version switch to v{item.version} right away.
-                        {item.changelog && (
-                            <Text fz="sm" mt="xs">
-                                {item.changelog}
-                            </Text>
-                        )}
-                    </Callout>
-                )}
-
-                <Box>
-                    <Text fz={12} fw={600} c="ldGray.6" mb={4}>
-                        Fields
-                    </Text>
-                    <Group gap="sm">
-                        {item.vizSchema.fields.map((field) => (
-                            <Group key={field.name} gap={4} wrap="nowrap">
-                                <DataAppVizFieldTypeBadge type={field.type} />
-                                <Text fz="sm">{field.label}</Text>
+        <>
+            <MantineModal
+                opened
+                onClose={onClose}
+                title={item.name}
+                subtitle={`v${item.version}`}
+                bodyScrollAreaMaxHeight="calc(100vh - 200px)"
+                cancelLabel={item.state === 'installed' ? false : 'Cancel'}
+                actions={footerAction}
+            >
+                <Stack gap="md">
+                    {item.screenshots.length > 0 ? (
+                        <ScrollArea type="auto" offsetScrollbars>
+                            <Group
+                                gap="sm"
+                                wrap="nowrap"
+                                className={classes.screenshotRow}
+                            >
+                                {item.screenshots.map((path) => (
+                                    <img
+                                        key={path}
+                                        src={registryAssetUrl(path)}
+                                        alt={item.name}
+                                        className={classes.screenshot}
+                                    />
+                                ))}
                             </Group>
-                        ))}
-                    </Group>
-                </Box>
+                        </ScrollArea>
+                    ) : item.thumbnail ? (
+                        <Box className={classes.preview}>
+                            <img
+                                src={registryAssetUrl(item.thumbnail)}
+                                alt={item.name}
+                                className={classes.previewImage}
+                            />
+                        </Box>
+                    ) : (
+                        <Box className={classes.preview}>
+                            <Stack
+                                align="center"
+                                justify="center"
+                                gap="xs"
+                                h="100%"
+                            >
+                                <MantineIcon
+                                    icon={IconPhoto}
+                                    size="xl"
+                                    color="ldGray.5"
+                                />
+                            </Stack>
+                        </Box>
+                    )}
 
-                <SimpleGrid cols={2} className={classes.metaPanel}>
-                    <Box>
-                        <Text fz={12} fw={600} c="ldGray.6">
-                            Version
-                        </Text>
-                        <Text fz="sm" fw={500} c="ldGray.8">
-                            v{item.version}
-                        </Text>
-                    </Box>
-                    <Box>
-                        <Text fz={12} fw={600} c="ldGray.6">
-                            Published
-                        </Text>
-                        <Text fz="sm" fw={500} c="ldGray.8">
-                            {publishedAgo}
-                        </Text>
-                    </Box>
-                </SimpleGrid>
+                    <Text fz="sm" c="ldGray.7" lh={1.55}>
+                        {item.description || 'No description'}
+                    </Text>
 
-                {item.changelog && item.state !== 'update_available' && (
+                    {item.state === 'update_available' && (
+                        <Callout
+                            variant="warning"
+                            title="Existing charts keep their pinned version"
+                        >
+                            Charts pinned to an earlier version keep rendering
+                            it until each chart is upgraded; charts without a
+                            pinned version switch to v{item.version} right away.
+                            {item.changelog && (
+                                <Text fz="sm" mt="xs">
+                                    {item.changelog}
+                                </Text>
+                            )}
+                        </Callout>
+                    )}
+
                     <Box>
                         <Text fz={12} fw={600} c="ldGray.6" mb={4}>
-                            Changelog
+                            Fields
                         </Text>
-                        <Text fz="sm" c="ldGray.7">
-                            {item.changelog}
-                        </Text>
+                        <Group gap="sm">
+                            {item.vizSchema.fields.map((field) => (
+                                <Group key={field.name} gap={4} wrap="nowrap">
+                                    <DataAppVizFieldTypeBadge
+                                        type={field.type}
+                                    />
+                                    <Text fz="sm">{field.label}</Text>
+                                </Group>
+                            ))}
+                        </Group>
                     </Box>
-                )}
-            </Stack>
-        </MantineModal>
+
+                    <SimpleGrid cols={2} className={classes.metaPanel}>
+                        <Box>
+                            <Text fz={12} fw={600} c="ldGray.6">
+                                Version
+                            </Text>
+                            <Text fz="sm" fw={500} c="ldGray.8">
+                                v{item.version}
+                            </Text>
+                        </Box>
+                        <Box>
+                            <Text fz={12} fw={600} c="ldGray.6">
+                                Published
+                            </Text>
+                            <Text fz="sm" fw={500} c="ldGray.8">
+                                {publishedAgo}
+                            </Text>
+                        </Box>
+                    </SimpleGrid>
+
+                    {item.changelog && item.state !== 'update_available' && (
+                        <Box>
+                            <Text fz={12} fw={600} c="ldGray.6" mb={4}>
+                                Changelog
+                            </Text>
+                            <Text fz="sm" c="ldGray.7">
+                                {item.changelog}
+                            </Text>
+                        </Box>
+                    )}
+                </Stack>
+            </MantineModal>
+            {isUninstallModalOpen && item.installedAppUuid !== null && (
+                <ChartTypeUninstallModal
+                    projectUuid={projectUuid}
+                    appUuid={item.installedAppUuid}
+                    chartName={item.name}
+                    onClose={() => setIsUninstallModalOpen(false)}
+                />
+            )}
+        </>
     );
 };
 

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeLibrarySection.test.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeLibrarySection.test.tsx
@@ -7,6 +7,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import { defaultAbility } from '../../../providers/Ability/constants';
 import { renderWithProviders } from '../../../testing/testUtils';
+import { useCanEditDataApp } from '../../apps/hooks/useCanEditDataApp';
+import { useDeleteApp } from '../../apps/hooks/useDeleteApp';
 import { useRegistryChartTypes } from '../hooks/useRegistryChartTypes';
 import ChartTypeLibrarySection from './ChartTypeLibrarySection';
 
@@ -18,6 +20,14 @@ vi.mock('../hooks/useRegistryChartTypes', () => ({
     useRegistryChartTypes: vi.fn(),
 }));
 
+vi.mock('../../apps/hooks/useCanEditDataApp', () => ({
+    useCanEditDataApp: vi.fn(),
+}));
+
+vi.mock('../../apps/hooks/useDeleteApp', () => ({
+    useDeleteApp: vi.fn(),
+}));
+
 // Matches AppProviderMock's default user fixture (mockUserResponse) —
 // hardcoded rather than imported to avoid pulling in a __mocks__ file.
 const DEFAULT_ORG_UUID = '172a2270-000f-42be-9c68-c4752c23ae51';
@@ -25,6 +35,9 @@ const PROJECT_UUID = 'project-1';
 
 const mockedUseServerFeatureFlag = vi.mocked(useServerFeatureFlag);
 const mockedUseRegistryChartTypes = vi.mocked(useRegistryChartTypes);
+const mockedUseCanEditDataApp = vi.mocked(useCanEditDataApp);
+const mockedUseDeleteApp = vi.mocked(useDeleteApp);
+const mockedDeleteAppMutateAsync = vi.fn();
 
 const setFlag = (enabled: boolean, isLoading = false) => {
     mockedUseServerFeatureFlag.mockReturnValue({
@@ -62,6 +75,7 @@ const makeItem = (
     state: 'not_installed',
     installedAppUuid: null,
     installedRegistryVersion: null,
+    installedCreatedByUserUuid: null,
     ...overrides,
 });
 
@@ -84,6 +98,12 @@ describe('ChartTypeLibrarySection', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         defaultAbility.update([]);
+        mockedUseCanEditDataApp.mockReturnValue(false);
+        mockedDeleteAppMutateAsync.mockResolvedValue(undefined);
+        mockedUseDeleteApp.mockReturnValue({
+            mutateAsync: mockedDeleteAppMutateAsync,
+            isLoading: false,
+        } as unknown as ReturnType<typeof useDeleteApp>);
     });
 
     afterEach(() => {
@@ -285,5 +305,135 @@ describe('ChartTypeLibrarySection', () => {
         expect(
             await screen.findByRole('button', { name: 'View in gallery' }),
         ).toBeInTheDocument();
+    });
+
+    it('shows Uninstall for the installed state when the user can manage the app', async () => {
+        mockedUseCanEditDataApp.mockReturnValue(true);
+        setFlag(true);
+        setRegistryData([
+            makeItem({
+                slug: 'radial-gauge',
+                state: 'installed',
+                installedAppUuid: 'app-1',
+                installedRegistryVersion: '1.0.0',
+            }),
+        ]);
+        renderSection();
+
+        fireEvent.click(screen.getByText('Radial gauge'));
+
+        expect(
+            await screen.findByRole('button', { name: 'Uninstall' }),
+        ).toBeInTheDocument();
+    });
+
+    it('hides Uninstall for the installed state without manage permission', async () => {
+        mockedUseCanEditDataApp.mockReturnValue(false);
+        setFlag(true);
+        setRegistryData([
+            makeItem({
+                slug: 'radial-gauge',
+                state: 'installed',
+                installedAppUuid: 'app-1',
+                installedRegistryVersion: '1.0.0',
+            }),
+        ]);
+        renderSection();
+
+        fireEvent.click(screen.getByText('Radial gauge'));
+
+        expect(
+            await screen.findByRole('button', { name: 'View in gallery' }),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByRole('button', { name: 'Uninstall' }),
+        ).not.toBeInTheDocument();
+    });
+
+    it('shows Uninstall alongside Upgrade for the update_available state', async () => {
+        mockedUseCanEditDataApp.mockReturnValue(true);
+        defaultAbility.update([
+            {
+                action: 'create',
+                subject: 'DataApp',
+                conditions: {
+                    organizationUuid: DEFAULT_ORG_UUID,
+                    projectUuid: PROJECT_UUID,
+                },
+            },
+        ]);
+        setFlag(true);
+        setRegistryData([
+            makeItem({
+                slug: 'radial-gauge',
+                state: 'update_available',
+                installedAppUuid: 'app-1',
+                installedRegistryVersion: '0.9.0',
+            }),
+        ]);
+        renderSection();
+
+        fireEvent.click(screen.getByText('Radial gauge'));
+
+        expect(
+            await screen.findByRole('button', { name: /Upgrade to v/ }),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole('button', { name: 'Uninstall' }),
+        ).toBeInTheDocument();
+    });
+
+    it('confirms the uninstall modal and deletes the installed app', async () => {
+        mockedUseCanEditDataApp.mockReturnValue(true);
+        setFlag(true);
+        setRegistryData([
+            makeItem({
+                slug: 'radial-gauge',
+                state: 'installed',
+                installedAppUuid: 'app-1',
+                installedRegistryVersion: '1.0.0',
+            }),
+        ]);
+        renderSection();
+
+        fireEvent.click(screen.getByText('Radial gauge'));
+        fireEvent.click(
+            await screen.findByRole('button', { name: 'Uninstall' }),
+        );
+        fireEvent.click(
+            await screen.findByRole('button', { name: 'Uninstall chart type' }),
+        );
+
+        expect(mockedDeleteAppMutateAsync).toHaveBeenCalledWith({
+            projectUuid: PROJECT_UUID,
+            appUuid: 'app-1',
+            successTitle: 'Chart type uninstalled',
+        });
+    });
+
+    // useCanEditDataApp is mocked wholesale in this file (see the module mock
+    // above), so the CASL self-rule itself isn't exercised here — this pins
+    // that the real installing user is threaded through instead of a
+    // hardcoded null, which is what the self-rule needs to key off of.
+    it('threads the installed app creator through to the manage-permission check', async () => {
+        setFlag(true);
+        setRegistryData([
+            makeItem({
+                slug: 'radial-gauge',
+                state: 'installed',
+                installedAppUuid: 'app-1',
+                installedRegistryVersion: '1.0.0',
+                installedCreatedByUserUuid: 'installer-user-uuid',
+            }),
+        ]);
+        renderSection();
+
+        fireEvent.click(screen.getByText('Radial gauge'));
+
+        await screen.findByRole('button', { name: 'View in gallery' });
+        expect(mockedUseCanEditDataApp).toHaveBeenCalledWith(PROJECT_UUID, {
+            spaceUuid: null,
+            createdByUserUuid: 'installer-user-uuid',
+        });
     });
 });

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeUninstallModal.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeUninstallModal.tsx
@@ -1,0 +1,63 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { type FC } from 'react';
+import MantineModal from '../../../components/common/MantineModal';
+import useApp from '../../../providers/App/useApp';
+import { useDeleteApp } from '../../apps/hooks/useDeleteApp';
+
+type Props = {
+    projectUuid: string;
+    appUuid: string;
+    chartName: string;
+    onClose: () => void;
+};
+
+const ChartTypeUninstallModal: FC<Props> = ({
+    projectUuid,
+    appUuid,
+    chartName,
+    onClose,
+}) => {
+    const { health } = useApp();
+    const queryClient = useQueryClient();
+    const softDeleteEnabled = health.data?.softDelete.enabled;
+    const retentionDays = health.data?.softDelete.retentionDays;
+
+    const { mutateAsync: deleteApp, isLoading: isUninstalling } =
+        useDeleteApp();
+
+    const description = `${
+        softDeleteEnabled
+            ? `This chart type will be moved to Recently deleted and permanently removed after ${retentionDays} days.`
+            : 'This chart type and all of its versions will be permanently deleted, including any built artifacts in storage.'
+    } Saved charts using this chart type will stop rendering until it is reinstalled. You can reinstall it from the library at any time.`;
+
+    return (
+        <MantineModal
+            opened
+            onClose={onClose}
+            title="Uninstall chart type"
+            variant="delete"
+            resourceType="chart type"
+            resourceLabel={chartName}
+            description={description}
+            confirmLabel="Uninstall chart type"
+            onConfirm={async () => {
+                await deleteApp({
+                    projectUuid,
+                    appUuid,
+                    successTitle: 'Chart type uninstalled',
+                });
+                // useDeleteApp already invalidates data-app-vizs; the library
+                // catalog needs its own invalidation to flip back to Install.
+                void queryClient.invalidateQueries({
+                    queryKey: ['registry-chart-types', projectUuid],
+                });
+                onClose();
+            }}
+            confirmLoading={isUninstalling}
+            cancelDisabled={isUninstalling}
+        />
+    );
+};
+
+export default ChartTypeUninstallModal;


### PR DESCRIPTION
Follow-up to the installable chart types stack (all merged 🎉). The library detail modal's installed and update-available states now offer **Uninstall** — previously the only route was knowing that deleting the app from the regular Chart types section is the uninstall.

- New `ChartTypeUninstallModal`: soft-delete-aware confirm (mirrors the existing chart-type delete modal) plus a warning that saved charts using the type stop rendering until it's reinstalled.
- Permission matches the backend exactly: visible to project admins *and* the user who installed the chart type (the catalog now carries `installedCreatedByUserUuid` so the CASL self-rule can match — a hardcoded null would have hidden the button from installing editors the backend authorizes).
- After confirming, the catalog refetch flips the modal's state live back to Install.

Closes GLITCH-739

🤖 Generated with [Claude Code](https://claude.com/claude-code)