### PR TITLE
feat(data-apps): instructions-only org templates alongside seeded ones

### DIFF
--- a/packages/backend/src/ee/models/DataAppTemplateModel.ts
+++ b/packages/backend/src/ee/models/DataAppTemplateModel.ts
@@ -1,4 +1,6 @@
 import {
+    getDataAppTemplateKind,
+    type DataAppTemplateKind,
     type DataAppTemplateSummary,
     type TemplateQuestion,
 } from '@lightdash/common';
@@ -23,7 +25,7 @@ export type DataAppTemplateWrite = {
 
 const toSummary = (
     row: DbDataAppTemplate,
-    fileCount: number,
+    filenames: string[],
 ): DataAppTemplateSummary => ({
     templateUuid: row.template_uuid,
     organizationUuid: row.organization_uuid,
@@ -32,7 +34,8 @@ const toSummary = (
     description: row.description,
     category: row.category,
     questions: row.questions ?? [],
-    fileCount,
+    kind: getDataAppTemplateKind(filenames),
+    fileCount: filenames.length,
     createdByUserUuid: row.created_by_user_uuid,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
@@ -52,19 +55,20 @@ export class DataAppTemplateModel {
             .where('organization_uuid', organizationUuid)
             .orderBy('name', 'asc');
         if (rows.length === 0) return [];
-        const counts = await this.database(DataAppTemplateFilesTableName)
+        const files = await this.database(DataAppTemplateFilesTableName)
             .whereIn(
                 'template_uuid',
                 rows.map((r) => r.template_uuid),
             )
-            .groupBy('template_uuid')
-            .select('template_uuid')
-            .count<{ template_uuid: string; count: string }[]>('* as count');
-        const countByUuid = new Map(
-            counts.map((c) => [c.template_uuid, Number(c.count)]),
-        );
+            .select('template_uuid', 'filename');
+        const filenamesByUuid = new Map<string, string[]>();
+        files.forEach((file) => {
+            const list = filenamesByUuid.get(file.template_uuid) ?? [];
+            list.push(file.filename);
+            filenamesByUuid.set(file.template_uuid, list);
+        });
         return rows.map((row) =>
-            toSummary(row, countByUuid.get(row.template_uuid) ?? 0),
+            toSummary(row, filenamesByUuid.get(row.template_uuid) ?? []),
         );
     }
 
@@ -84,7 +88,10 @@ export class DataAppTemplateModel {
             .first();
         if (!row) return undefined;
         const files = await this.listFiles(row.template_uuid);
-        return toSummary(row, files.length);
+        return toSummary(
+            row,
+            files.map((file) => file.filename),
+        );
     }
 
     async listFiles(templateUuid: string): Promise<DbDataAppTemplateFile[]> {
@@ -149,7 +156,10 @@ export class DataAppTemplateModel {
                 );
             }
             return {
-                summary: toSummary(row, write.files.length),
+                summary: toSummary(
+                    row,
+                    write.files.map((file) => file.filename),
+                ),
                 created: !existing,
             };
         });

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.orgTemplate.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.orgTemplate.test.ts
@@ -27,6 +27,7 @@ const TEMPLATE = {
     description: 'x',
     category: 'Forecasting',
     questions: [],
+    kind: 'seeded',
     fileCount: 3,
     createdByUserUuid: 'someone',
     createdAt: new Date(),

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -230,6 +230,10 @@ import {
     CLARIFY_VIZ_SYSTEM_PROMPT,
 } from './clarifierPrompts';
 import {
+    buildClaudeAllowedTools,
+    type CodingAgentEditScope,
+} from './claudeAllowedTools';
+import {
     classifyClaudeCliFailure,
     ClaudeGenerationError,
 } from './claudeCliFailure';
@@ -2935,6 +2939,7 @@ export class AppGenerateService extends BaseService {
         dimensionCount: number;
         metricCount: number;
         yamlBytes: number;
+        editScope: CodingAgentEditScope;
     }> {
         const start = performance.now();
 
@@ -3000,12 +3005,16 @@ export class AppGenerateService extends BaseService {
         // src/components/ui, css) untouched. The package's AGENTS.md is not
         // a sandbox file; it travels as the template's prompt instructions.
         let orgTemplateInstructions: string | null = null;
+        let editScope: CodingAgentEditScope = 'source';
         if (orgTemplate) {
             const resolved = await this.dataAppTemplateService.getSourceFiles(
                 orgTemplate.organizationUuid,
                 orgTemplate.slug,
             );
-            if (orgTemplate.seed) {
+            // Instructions-only templates carry no source: nothing to seed,
+            // and AGENTS.md is the build prompt itself.
+            const isSeededKind = resolved.template.kind === 'seeded';
+            if (orgTemplate.seed && isSeededKind) {
                 const sourceFiles = resolved.files.filter((file) =>
                     file.filename.startsWith('src/'),
                 );
@@ -3033,8 +3042,18 @@ export class AppGenerateService extends BaseService {
             orgTemplateInstructions = buildOrgTemplateInstructions({
                 name: resolved.template.name,
                 guardrails: resolved.guardrails,
-                seeded: orgTemplate.seed,
+                seeded: orgTemplate.seed && isSeededKind,
+                kind: resolved.template.kind,
+                iteration: !orgTemplate.seed,
             });
+            // An app built from a seeded template stays an instance of that
+            // template: on every version the agent may only write the
+            // manifest. Changing what the template can do belongs to the
+            // template author; a user who wants a free copy duplicates the
+            // app or starts from scratch.
+            if (isSeededKind) {
+                editScope = 'manifest';
+            }
         }
 
         // Write chart reference files and prepend summary to prompt
@@ -3152,6 +3171,7 @@ export class AppGenerateService extends BaseService {
             dimensionCount,
             metricCount,
             yamlBytes: totalBytes,
+            editScope,
         };
     }
 
@@ -3533,6 +3553,7 @@ export class AppGenerateService extends BaseService {
         // for runs that don't collect a structured schema (metadata, builds).
         structuredOutputSchema: string | null,
         onTelemetry?: (telemetry: ClaudeGenerationTelemetry) => void,
+        editScope: CodingAgentEditScope = 'source',
     ): Promise<CodingAgentGenerationResult> {
         const start = performance.now();
         let telemetry = ZERO_CLAUDE_GENERATION_TELEMETRY;
@@ -3605,7 +3626,7 @@ export class AppGenerateService extends BaseService {
                         `--model ${claudeModel} ${effortFlag}` +
                         `--thinking-display summarized ` +
                         `--verbose --output-format stream-json --include-partial-messages ` +
-                        `--allowedTools "Read(//app/**),Read(//tmp/dbt-repo/**),Read(//tmp/images/**),Read(//tmp/uploads/**),Read(//tmp/metric-queries/**),Read(//tmp/dashboard/**),Read(//tmp/external-data/**),Write(//app/src/**),Edit(//app/src/**),Glob(//app/**),Glob(//tmp/dbt-repo/**),Glob(//tmp/uploads/**),Glob(//tmp/metric-queries/**),Glob(//tmp/dashboard/**),Glob(//tmp/external-data/**),Grep(//app/**),Grep(//tmp/dbt-repo/**),Grep(//tmp/uploads/**),Grep(//tmp/external-data/**)" ` +
+                        `--allowedTools "${buildClaudeAllowedTools(editScope)}" ` +
                         `${jsonSchemaFlag}--append-system-prompt-file ${AppGenerateService.EFFECTIVE_SKILL_PATH}`,
                     {
                         cwd: '/app',
@@ -4026,6 +4047,9 @@ export class AppGenerateService extends BaseService {
         reasoningEffort: DataAppClaudeEffort,
         structuredOutputSchema: string | null,
         onTelemetry?: (telemetry: ClaudeGenerationTelemetry) => void,
+        // Claude only: Codex keeps its own sandbox policy, so a seeded
+        // template build under Codex is guided by the prompt alone.
+        editScope: CodingAgentEditScope = 'source',
     ): Promise<CodingAgentGenerationResult> {
         if (this.dataAppCodingAgent === 'codex') {
             return this.runCodexGeneration(
@@ -4048,6 +4072,7 @@ export class AppGenerateService extends BaseService {
             reasoningEffort,
             structuredOutputSchema,
             onTelemetry,
+            editScope,
         );
     }
 
@@ -4229,6 +4254,7 @@ export class AppGenerateService extends BaseService {
         claudeModel: DataAppClaudeModel,
         claudeEffort: DataAppClaudeEffort,
         onTelemetry?: (telemetry: DataAppBuildFixTelemetry) => void,
+        editScope: CodingAgentEditScope = 'source',
     ): Promise<{
         buildMs: number;
         fixAttempts: number;
@@ -4347,6 +4373,7 @@ export class AppGenerateService extends BaseService {
                             AppGenerateService.elapsed(fixStart),
                     });
                 },
+                editScope,
             );
             fixGenerationMs += generation.durationMs;
             fixUsage = addClaudeUsage(fixUsage, generation.usage);
@@ -5061,6 +5088,9 @@ export class AppGenerateService extends BaseService {
             await AppGenerateService.prepareCodexProjectContext(sandbox);
         }
 
+        // Narrowed to the manifest by the catalog stage for a seeded
+        // template's first build; every other build writes anywhere in src.
+        let editScope: CodingAgentEditScope = 'source';
         let catalogStats = {
             tableCount: 0,
             dimensionCount: 0,
@@ -5165,6 +5195,7 @@ export class AppGenerateService extends BaseService {
                         : undefined,
                 );
                 durations.catalogMs = catalogResult.durationMs;
+                editScope = catalogResult.editScope;
                 catalogStats = {
                     tableCount: catalogResult.tableCount,
                     dimensionCount: catalogResult.dimensionCount,
@@ -5232,6 +5263,7 @@ export class AppGenerateService extends BaseService {
                     // structured output; other apps don't declare one.
                     isDataAppViz ? JSON.stringify(dataAppVizJsonSchema) : null,
                     captureMainGenerationTelemetry,
+                    editScope,
                 );
                 durations.generateMs = generation.durationMs;
                 responseText = generation.responseText;
@@ -5400,6 +5432,7 @@ export class AppGenerateService extends BaseService {
                             telemetry.usage,
                         );
                     },
+                    editScope,
                 );
                 durations.buildMs = buildResult.buildMs;
                 buildFixAttempts = buildResult.fixAttempts;

--- a/packages/backend/src/ee/services/AppGenerateService/claudeAllowedTools.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/claudeAllowedTools.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { buildClaudeAllowedTools } from './claudeAllowedTools';
+
+describe('buildClaudeAllowedTools', () => {
+    it('lets ordinary builds write anywhere under src', () => {
+        const tools = buildClaudeAllowedTools('source');
+        expect(tools).toContain('Write(//app/src/**)');
+        expect(tools).toContain('Edit(//app/src/**)');
+        expect(tools).toContain('Read(//tmp/dbt-repo/**)');
+    });
+
+    it('limits a seeded template build to the manifest', () => {
+        const tools = buildClaudeAllowedTools('manifest');
+        expect(tools).toContain('Edit(//app/src/template.json)');
+        expect(tools).toContain('Write(//app/src/template.json)');
+        expect(tools).not.toContain('src/**)');
+        // Reading and searching the whole app stays allowed: binding needs it.
+        expect(tools).toContain('Read(//app/**)');
+        expect(tools).toContain('Grep(//app/**)');
+    });
+});

--- a/packages/backend/src/ee/services/AppGenerateService/claudeAllowedTools.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/claudeAllowedTools.ts
@@ -1,0 +1,44 @@
+/**
+ * Which files the sandbox coding agent may write. `source` is every build's
+ * default: the app's src tree. `manifest` is the seeding build of a seeded
+ * organization template: only src/template.json is writable, so the agent
+ * binds the template and cannot reshape it. Anything else it wants to change
+ * needs approval it does not have, which is the point: it explains instead.
+ */
+export type CodingAgentEditScope = 'source' | 'manifest';
+
+const READ_TOOLS = [
+    'Read(//app/**)',
+    'Read(//tmp/dbt-repo/**)',
+    'Read(//tmp/images/**)',
+    'Read(//tmp/uploads/**)',
+    'Read(//tmp/metric-queries/**)',
+    'Read(//tmp/dashboard/**)',
+    'Read(//tmp/external-data/**)',
+];
+
+const SEARCH_TOOLS = [
+    'Glob(//app/**)',
+    'Glob(//tmp/dbt-repo/**)',
+    'Glob(//tmp/uploads/**)',
+    'Glob(//tmp/metric-queries/**)',
+    'Glob(//tmp/dashboard/**)',
+    'Glob(//tmp/external-data/**)',
+    'Grep(//app/**)',
+    'Grep(//tmp/dbt-repo/**)',
+    'Grep(//tmp/uploads/**)',
+    'Grep(//tmp/external-data/**)',
+];
+
+const WRITE_TOOLS: Record<CodingAgentEditScope, string[]> = {
+    source: ['Write(//app/src/**)', 'Edit(//app/src/**)'],
+    manifest: [
+        'Write(//app/src/template.json)',
+        'Edit(//app/src/template.json)',
+    ],
+};
+
+export const buildClaudeAllowedTools = (
+    editScope: CodingAgentEditScope,
+): string =>
+    [...READ_TOOLS, ...WRITE_TOOLS[editScope], ...SEARCH_TOOLS].join(',');

--- a/packages/backend/src/ee/services/AppGenerateService/templateSources.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/templateSources.test.ts
@@ -49,5 +49,27 @@ describe('template sources', () => {
             expect(instructions).toContain('Plain');
             expect(instructions).not.toContain('Template guardrails');
         });
+
+        it('turns an instructions-only template into the build prompt, on first build and on iteration', () => {
+            const first = buildOrgTemplateInstructions({
+                name: 'Executive Summary',
+                guardrails: 'One page. Three KPIs. A short narrative.',
+                seeded: false,
+                kind: 'instructions',
+            });
+            expect(first).toContain('Executive Summary');
+            expect(first).toContain('One page. Three KPIs.');
+            expect(first).not.toMatch(/src\/template\.json/);
+            expect(first).toMatch(/generate|build/i);
+            const later = buildOrgTemplateInstructions({
+                name: 'Executive Summary',
+                guardrails: 'One page. Three KPIs. A short narrative.',
+                seeded: false,
+                kind: 'instructions',
+                iteration: true,
+            });
+            expect(later).toContain('One page. Three KPIs.');
+            expect(later).not.toMatch(/src\/template\.json/);
+        });
     });
 });

--- a/packages/backend/src/ee/services/AppGenerateService/templateSources.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/templateSources.ts
@@ -1,3 +1,5 @@
+import { type DataAppTemplateKind } from '@lightdash/common';
+
 /**
  * Organization data app templates: uploaded packages whose source is seeded
  * into the sandbox so the agent binds the app (src/template.json edits
@@ -17,33 +19,56 @@ export const shouldSeedOrgTemplate = (context: {
 
 /**
  * Prompt block for an app built from an organization template. The
- * package's AGENTS.md is the template author's own guidance and travels
+ * package's AGENTS.md is the template author's own text and travels
  * verbatim: it is authoring guidance the builder can override, not an
- * enforcement mechanism. On the seeding build the agent is told to bind
- * the seeded app; on iterations only the guardrails remain.
+ * enforcement mechanism.
+ *
+ * Seeded templates: on the seeding build the agent is told to bind the
+ * seeded app; on iterations only the guardrails remain. Instructions-only
+ * templates have no source, so AGENTS.md is the build instruction itself,
+ * the org-authored counterpart of a built-in flavour.
  */
 export const buildOrgTemplateInstructions = ({
     name,
     guardrails,
     seeded,
+    kind = 'seeded',
+    iteration = false,
 }: {
     name: string;
     guardrails: string | null;
     seeded: boolean;
+    kind?: DataAppTemplateKind;
+    iteration?: boolean;
 }): string => {
+    const guidance = guardrails?.trim() ?? '';
+    if (kind === 'instructions') {
+        const header = iteration
+            ? `[Template: ${name} — organization template]
+This app was built from the "${name}" template. Keep to the template author's instructions below while making the requested change.`
+            : `[Template: ${name} — organization template]
+Build the app the template author describes below. These instructions define the app; resolve the user's request and any clarification answers within them.`;
+        return guidance.length > 0
+            ? `${header}
+
+Template instructions (from the template author's AGENTS.md):
+${guidance}`
+            : header;
+    }
     const header = seeded
         ? `[Template: ${name} — seeded organization template]
-The workspace already contains the finished "${name}" app: components under src/ and a src/template.json manifest holding everything that is meant to vary (data bindings, parameters, labels, theme). Your job is to BIND this app to the user's request, not to rebuild it:
+The workspace already contains the finished "${name}" app: components under src/ and a src/template.json manifest holding everything that is meant to vary (data bindings, parameters, labels, theme). Your job is to BIND this app to the user's request, not to rebuild it. In this build src/template.json is the only file you can write; component files are read-only.
 - Read src/template.json first. Resolve the user's request (and any clarification answers) against the real data models in /tmp/dbt-repo/models and set the manifest's bindings accordingly, using explore, metric, and dimension names exactly as declared in the YAML.
-- Adjust parameters, labels, and theme in src/template.json. Do not rewrite the components or the manifest loader: the deterministic starting point is the feature. Touch component code only for behavior the manifest cannot express, and keep changes minimal.
+- Adjust parameters, labels, and theme in src/template.json. Do not attempt to edit components or the manifest loader.
+- If part of the request needs something the manifest cannot express, do not work around it: say plainly what this template supports, bind the rest, and tell the user they can ask for the extra behaviour in a follow-up message once the app is built.
 - Verify every binding against the model YAML — a wrong field id fails loudly on the app page.`
         : `[Template: ${name} — organization template]
-This app was built from the "${name}" template: its src/template.json manifest holds the data bindings, parameters, labels, and theme. Prefer manifest edits over component rewrites when the request can be expressed there.`;
-    if (!guardrails || guardrails.trim().length === 0) {
+This app is an instance of the "${name}" template: its src/template.json manifest holds the data bindings, parameters, labels, and theme, and src/template.json is the only file you can write. Make the requested change there. If the request needs a component change, do not attempt it: explain that this app follows the template, that the change belongs to the template's author, and that the user can duplicate the app or start from scratch for a free copy.`;
+    if (guidance.length === 0) {
         return header;
     }
     return `${header}
 
 Template guardrails (from the template author's AGENTS.md):
-${guardrails.trim()}`;
+${guidance}`;
 };

--- a/packages/backend/src/ee/services/DataAppTemplateService/DataAppTemplateService.test.ts
+++ b/packages/backend/src/ee/services/DataAppTemplateService/DataAppTemplateService.test.ts
@@ -203,7 +203,10 @@ describe('DataAppTemplateService.importPackage', () => {
                 return true;
             },
         });
-        const archive = await packFiles({ 'src/template.json': MANIFEST });
+        const archive = await packFiles({
+            'src/template.json': MANIFEST,
+            'src/App.jsx': 'export {};',
+        });
 
         await expect(importArchive(service, archive)).rejects.toThrow(
             ForbiddenError,
@@ -235,7 +238,10 @@ describe('DataAppTemplateService.importPackage', () => {
             }),
         } as unknown as Partial<DataAppTemplateModel>);
         withRole(own.service, OrganizationMemberRole.EDITOR);
-        const archive = await packFiles({ 'src/template.json': MANIFEST });
+        const archive = await packFiles({
+            'src/template.json': MANIFEST,
+            'src/App.jsx': 'export {};',
+        });
         await expect(
             importArchive(own.service, archive),
         ).resolves.toMatchObject({ action: 'updated' });
@@ -318,7 +324,10 @@ describe('DataAppTemplateService.importPackage', () => {
         const { service, model, send } = buildService({
             countByOrganization: vi.fn().mockResolvedValue(50),
         } as unknown as Partial<DataAppTemplateModel>);
-        const archive = await packFiles({ 'src/template.json': MANIFEST });
+        const archive = await packFiles({
+            'src/template.json': MANIFEST,
+            'src/App.jsx': 'export {};',
+        });
         await expect(importArchive(service, archive)).rejects.toThrow(
             /at most 50/,
         );
@@ -329,7 +338,10 @@ describe('DataAppTemplateService.importPackage', () => {
     it('refuses uploads and browsing when the templates feature flag is off', async () => {
         const { service, featureFlagModel } = buildService();
         featureFlagModel.get.mockResolvedValue({ enabled: false });
-        const archive = await packFiles({ 'src/template.json': MANIFEST });
+        const archive = await packFiles({
+            'src/template.json': MANIFEST,
+            'src/App.jsx': 'export {};',
+        });
         await expect(importArchive(service, archive)).rejects.toThrow(
             ForbiddenError,
         );
@@ -357,6 +369,25 @@ describe('DataAppTemplateService.importPackage', () => {
             OrganizationMemberRole.EDITOR,
         );
         await expect(editor.list(buildAccount())).resolves.toEqual([]);
+    });
+
+    it('accepts an instructions-only package (manifest + AGENTS.md) and rejects one with nothing to build from', async () => {
+        const { service, model } = buildService();
+        const withGuidance = await packFiles({
+            'src/template.json': MANIFEST,
+            'AGENTS.md': 'Build a one-page executive summary.',
+        });
+        await expect(
+            importArchive(service, withGuidance),
+        ).resolves.toMatchObject({ action: 'created' });
+        expect(model.upsert).toHaveBeenCalledTimes(1);
+
+        const bare = buildService();
+        const manifestOnly = await packFiles({ 'src/template.json': MANIFEST });
+        await expect(importArchive(bare.service, manifestOnly)).rejects.toThrow(
+            /AGENTS\.md/,
+        );
+        expect(bare.model.upsert).not.toHaveBeenCalled();
     });
 
     it('rejects a package without a manifest', async () => {
@@ -400,7 +431,10 @@ describe('DataAppTemplateService.importPackage', () => {
                 summary: { ...existing, name: 'Forecaster' },
             }),
         } as unknown as Partial<DataAppTemplateModel>);
-        const archive = await packFiles({ 'src/template.json': MANIFEST });
+        const archive = await packFiles({
+            'src/template.json': MANIFEST,
+            'src/App.jsx': 'export {};',
+        });
         const result = await importArchive(service, archive);
         expect(result.action).toBe('updated');
         expect(result.templateUuid).toBe(existing.templateUuid);

--- a/packages/backend/src/ee/services/DataAppTemplateService/DataAppTemplateService.ts
+++ b/packages/backend/src/ee/services/DataAppTemplateService/DataAppTemplateService.ts
@@ -14,6 +14,7 @@ import {
     DataAppTemplatePackageError,
     FeatureFlags,
     ForbiddenError,
+    getDataAppTemplateKind,
     MAX_DATA_APP_TEMPLATE_FILE_BYTES,
     MAX_DATA_APP_TEMPLATE_FILES,
     MAX_DATA_APP_TEMPLATE_GUARDRAILS_CHARS,
@@ -415,6 +416,19 @@ export class DataAppTemplateService extends BaseService {
         if (!manifestFile) {
             throw new ParameterError(
                 `Template package must contain ${DATA_APP_TEMPLATE_MANIFEST_PATH}`,
+            );
+        }
+        // An instructions-only template has nothing to build from without
+        // AGENTS.md; a seeded one can omit it (the source is the template).
+        if (
+            getDataAppTemplateKind(files.map((file) => file.filename)) ===
+                'instructions' &&
+            !files.some(
+                (file) => file.filename === DATA_APP_TEMPLATE_GUARDRAILS_PATH,
+            )
+        ) {
+            throw new ParameterError(
+                `A template without source files must include ${DATA_APP_TEMPLATE_GUARDRAILS_PATH} with the instructions to build from`,
             );
         }
         let manifest;

--- a/packages/common/src/ee/apps/templatePackage.test.ts
+++ b/packages/common/src/ee/apps/templatePackage.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
     buildDataAppTemplateManifest,
     DataAppTemplatePackageError,
+    getDataAppTemplateKind,
     parseDataAppTemplateManifest,
     validateDataAppTemplateEntryPath,
 } from './templatePackage';
@@ -178,6 +179,24 @@ describe('parseDataAppTemplateManifest', () => {
                     questions: [],
                 }),
             ).toThrow(DataAppTemplatePackageError);
+        });
+    });
+
+    describe('getDataAppTemplateKind', () => {
+        it('is seeded when the package carries source beyond the manifest', () => {
+            expect(
+                getDataAppTemplateKind([
+                    'src/template.json',
+                    'src/App.jsx',
+                    'AGENTS.md',
+                ]),
+            ).toBe('seeded');
+        });
+
+        it('is instructions-only when only the manifest and AGENTS.md travel', () => {
+            expect(
+                getDataAppTemplateKind(['src/template.json', 'AGENTS.md']),
+            ).toBe('instructions');
         });
     });
 });

--- a/packages/common/src/ee/apps/templatePackage.ts
+++ b/packages/common/src/ee/apps/templatePackage.ts
@@ -36,6 +36,26 @@ export type DataAppTemplateManifest = {
     questions?: TemplateQuestion[];
 };
 
+/**
+ * How a template shapes a build. `seeded`: the package carries source, the
+ * sandbox is seeded with it and the agent binds the manifest. `instructions`:
+ * only the manifest and AGENTS.md travel, and AGENTS.md is the prompt the
+ * agent generates from (the same mechanism as the built-in flavours, but
+ * org-authored). Both live in the same gallery so they can be compared.
+ */
+export type DataAppTemplateKind = 'seeded' | 'instructions';
+
+export const getDataAppTemplateKind = (
+    filenames: string[],
+): DataAppTemplateKind =>
+    filenames.some(
+        (filename) =>
+            filename.startsWith('src/') &&
+            filename !== DATA_APP_TEMPLATE_MANIFEST_PATH,
+    )
+        ? 'seeded'
+        : 'instructions';
+
 export type DataAppTemplateSummary = {
     templateUuid: string;
     organizationUuid: string;
@@ -44,6 +64,7 @@ export type DataAppTemplateSummary = {
     description: string;
     category: string;
     questions: TemplateQuestion[];
+    kind: DataAppTemplateKind;
     fileCount: number;
     /** Uploader; the ownership condition behind manage:DataAppTemplate@self. */
     createdByUserUuid: string | null;

--- a/packages/frontend/src/features/apps/AppTemplatePicker.test.tsx
+++ b/packages/frontend/src/features/apps/AppTemplatePicker.test.tsx
@@ -17,6 +17,7 @@ const FORECASTER: DataAppTemplateSummary = {
     description: 'A live what-if forecast.',
     category: 'Forecasting',
     questions: [{ key: 'metric', label: 'What should we forecast?' }],
+    kind: 'seeded',
     fileCount: 3,
     createdByUserUuid: 'user-1',
     createdAt: new Date(),

--- a/packages/frontend/src/features/apps/TemplateGalleryModal.tsx
+++ b/packages/frontend/src/features/apps/TemplateGalleryModal.tsx
@@ -1,6 +1,7 @@
 import { type DataAppTemplateSummary } from '@lightdash/common';
 import {
     Badge,
+    Group,
     Modal,
     Paper,
     SimpleGrid,
@@ -73,9 +74,33 @@ const TemplateGalleryModal: FC<Props> = ({
                                 <Text fw={600} size="sm">
                                     {template.name}
                                 </Text>
-                                <Badge size="xs" variant="light" color="gray">
-                                    {template.category}
-                                </Badge>
+                                <Group gap={4}>
+                                    <Badge
+                                        size="xs"
+                                        variant="light"
+                                        color="gray"
+                                    >
+                                        {template.category}
+                                    </Badge>
+                                    <Badge
+                                        size="xs"
+                                        variant="outline"
+                                        color={
+                                            template.kind === 'seeded'
+                                                ? 'teal'
+                                                : 'grape'
+                                        }
+                                        title={
+                                            template.kind === 'seeded'
+                                                ? "Seeded: the app is built from the template's own source and bound to your data"
+                                                : "Prompt: the app is generated from the template author's instructions"
+                                        }
+                                    >
+                                        {template.kind === 'seeded'
+                                            ? 'Seeded'
+                                            : 'Prompt'}
+                                    </Badge>
+                                </Group>
                                 <Text size="xs" c="dimmed" lineClamp={3}>
                                     {template.description}
                                 </Text>


### PR DESCRIPTION
Stacked on #28482. Decision (Josh + Marshall, 2026-09-02): keep both template styles available so they can be compared on real asks, and drop one later if the comparison is clear.

## Two kinds, one mechanism

| Kind | Package | Build |
|---|---|---|
| **Seeded** | `src/**` + `src/template.json` (+ optional `AGENTS.md`) | Sandbox seeded with the source; on **every** version (build fixes included) the agent's write scope is `src/template.json` only (`--allowedTools`). A template user cannot reshape the template's components; the agent binds what the manifest expresses, explains the rest, and points to the template author or to duplicating the app for a free copy. Deterministic. |
| **Instructions** | `src/template.json` + `AGENTS.md` only | Nothing seeded; `AGENTS.md` is the build prompt. Same idea as the built-in PDF / Slide Show flavours, but org-authored, with questions, in the gallery. |

Kind is derived from the stored filenames (`getDataAppTemplateKind`), returned on the summary, and shown as a Seeded / Prompt badge in the gallery. Everything else is shared: upload (CLI and Save as template), scopes, questions, gallery, `templateSlug` on the build. An instructions-only package without `AGENTS.md` is rejected at import (nothing to build from). `buildOrgTemplateInstructions` now takes the kind and whether the build is an iteration.

## Restrictive by construction

Before this PR the seeded build's guidance allowed component edits "for behaviour the manifest cannot express", and the agent's call went both ways on the same ask ("12, 24, 36 months"): one build declined and offered, the next added a horizon lever. With the manifest-only scope the outcome is fixed. Verified: same ask, the agent bound the metric, set 24 months, wrote "One thing this template can't do: the horizon lever is a single fixed value in the manifest, not a runtime picker", and offered a follow-up. 85s, no component touched. Held on iteration too: asked a seeded-template app to "add a horizon selector", the agent wrote nothing, explained it can only edit the manifest and that the change belongs to the template author, and offered duplicate / from-scratch or a fixed value. 20s. The prompt kind stays unrestricted, which is the contrast we want to evaluate.

## First comparison, identical answers ("Total order revenue", no limit, "12, 24 or 36 months")

| | Seeded Metric Forecaster | Metric Forecaster (prompt) |
|---|---|---|
| Time | 149s (before the hard scope: the agent added a horizon lever, a component edit) | 192s |
| Result | Same authored design, growth fitted at 0.1%/mo as in every previous build | A different app ("Revenue Scenario Planning"), growth fitted at 10.6%/mo |
| Second prompt template | | Executive Summary (prompt), 191s: KPI cards show `NaN%` and zeros because it queried "last 90 days" on data ending Feb 2026; the seeded Scorecard avoids this with its latest-date anchor |

Both prompt packages live in the demo gardening repo (`apps/metric-forecaster-prompt`, `apps/executive-summary-prompt`); the first is the pre-seeding Forecaster instruction pack from #28420 verbatim, so the comparison is like for like.

Tests: kind helper (common), import rule + prompt text for the instructions kind (backend), picker/gallery fixtures (frontend); typecheck and lint clean across packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VU9L8WJ97vLUB4WJmaUKDa
