### PR TITLE
fix(frontend): dark text on white buttons in dark scheme

### DIFF
--- a/packages/frontend/src/theme/components/index.ts
+++ b/packages/frontend/src/theme/components/index.ts
@@ -132,6 +132,14 @@ export const themeComponents: MantineThemeOverride['components'] = {
                     'light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-4))';
                 root['--button-color'] = 'var(--mantine-color-text)';
             }
+            // White always paints a white fill. Default/primary ink is
+            // near-white in dark scheme (and the navbar is always dark).
+            if (
+                props.variant === 'white' &&
+                (props.color === undefined || props.color === 'primary')
+            ) {
+                root['--button-color'] = 'var(--mantine-color-black)';
+            }
             return { root };
         },
     }),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
No ticket; agreed with the developer.

### Description:
White-variant buttons inherit the theme primary for their label. Primary is near-white in dark scheme, and the navbar is always forced dark, so the Cancel control on the dashboard-explorer banner (and any other default `variant="white"` button) rendered near-white text on a white fill.

This pins default/primary white-variant labels to `--mantine-color-black`. Explicit colours on white buttons (for example orange on the impersonation banner) are unchanged.

Verified in the app: creating a chart from a dashboard shows dark Cancel text. DevTools reports `--button-color: var(--mantine-color-black)` and a near-black computed color.

[Dashboard explorer banner with dark Cancel text](https://cursor.com/agents/bc-02ea931d-0483-5423-8255-e5ce78feb3e8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbanner-cancel-dark-text.webp)

[DevTools computed color for Cancel](https://cursor.com/agents/bc-02ea931d-0483-5423-8255-e5ce78feb3e8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbanner-cancel-computed-color.webp)

[banner-cancel-button-dark-text.mp4](https://cursor.com/agents/bc-02ea931d-0483-5423-8255-e5ce78feb3e8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbanner-cancel-button-dark-text.mp4)

### Risk assessment:
- [ ] This is a high-risk change


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://lightdash.slack.com/archives/C04E1CCKN64/p1788333645870359?thread_ts=1788333645.870359&cid=C04E1CCKN64)

<div><a href="https://cursor.com/agents/bc-02ea931d-0483-5423-8255-e5ce78feb3e8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02ea931d-0483-5423-8255-e5ce78feb3e8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

