### PR TITLE
fix(frontend): save data app query chart into the app's project, not the route project

### DIFF
--- a/packages/frontend/src/features/apps/SaveQueryToLightdashModal.tsx
+++ b/packages/frontend/src/features/apps/SaveQueryToLightdashModal.tsx
@@ -27,7 +27,10 @@ const SaveQueryToLightdashModal: FC<Props> = ({
 }) => {
     const { data: spaces, isLoading: spacesLoading } =
         useSpaceSummaries(projectUuid);
-    const createChart = useCreateMutation({ redirectOnSuccess: false });
+    const createChart = useCreateMutation({
+        redirectOnSuccess: false,
+        projectUuid,
+    });
 
     const [name, setName] = useState(
         query.label || query.exploreName || 'Untitled query',

--- a/packages/frontend/src/hooks/useSavedQuery.test.tsx
+++ b/packages/frontend/src/hooks/useSavedQuery.test.tsx
@@ -1,4 +1,5 @@
 import {
+    type CreateSavedChart,
     type CreateSavedChartVersion,
     type Project,
     type SavedChart,
@@ -33,7 +34,7 @@ vi.mock('./useSearchParams', () => ({
 }));
 
 import { lightdashApi } from '../api';
-import { useAddVersionMutation } from './useSavedQuery';
+import { useAddVersionMutation, useCreateMutation } from './useSavedQuery';
 
 const createWrapper = () => {
     const queryClient = new QueryClient({
@@ -84,6 +85,51 @@ describe('useAddVersionMutation', () => {
 
         expect(navigate).toHaveBeenCalledWith(
             '/projects/jaffle-shop/saved/legacy-chart/view',
+        );
+    });
+});
+
+describe('useCreateMutation', () => {
+    const payload = { metricQuery: { filters: {} } } as CreateSavedChart;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(lightdashApi).mockResolvedValue({
+            uuid: 'chart-uuid',
+            slug: 'new-chart',
+            projectUuid: 'project-uuid',
+        } as SavedChart);
+    });
+
+    it('saves to the route project by default', async () => {
+        const { result } = renderHook(
+            () => useCreateMutation({ redirectOnSuccess: false }),
+            { wrapper: createWrapper() },
+        );
+
+        await act(() => result.current.mutateAsync(payload));
+
+        expect(lightdashApi).toHaveBeenCalledWith(
+            expect.objectContaining({ url: '/projects/project-uuid/saved' }),
+        );
+    });
+
+    it('saves to an explicit projectUuid over the route project', async () => {
+        const { result } = renderHook(
+            () =>
+                useCreateMutation({
+                    redirectOnSuccess: false,
+                    projectUuid: 'other-project-uuid',
+                }),
+            { wrapper: createWrapper() },
+        );
+
+        await act(() => result.current.mutateAsync(payload));
+
+        expect(lightdashApi).toHaveBeenCalledWith(
+            expect.objectContaining({
+                url: '/projects/other-project-uuid/saved',
+            }),
         );
     });
 });

--- a/packages/frontend/src/hooks/useSavedQuery.ts
+++ b/packages/frontend/src/hooks/useSavedQuery.ts
@@ -388,13 +388,17 @@ export const useCreateMutation = ({
     redirectOnSuccess = true,
     showToastOnSuccess = true,
     showViewChartAction = true,
+    projectUuid: explicitProjectUuid,
 }: {
     redirectOnSuccess?: boolean;
     showToastOnSuccess?: boolean;
     showViewChartAction?: boolean;
+    /** Overrides the route/embed project — for surfaces not mounted under a project route */
+    projectUuid?: string;
 } = {}) => {
     const navigate = useNavigate();
-    const projectUuid = useProjectUuid();
+    const routeProjectUuid = useProjectUuid();
+    const projectUuid = explicitProjectUuid ?? routeProjectUuid;
     const queryClient = useQueryClient();
     const { embedToken } = useEmbed();
     const isEmbedded = embedToken !== undefined;


### PR DESCRIPTION
## Summary

`SaveQueryToLightdashModal` (data app Query Inspector "Save to Lightdash") lists spaces from its `projectUuid` prop, but the save mutation ignored it: `useCreateMutation` resolved the project via `useProjectUuid()` (route param → embed context), so the POST went to `/projects/{routeProject}/saved`.

Latent today, but once the query inspector mounts in globally-mounted surfaces (AI agents launcher, ZAP-966):

- On another project's route the chart saved into the wrong project.
- On a non-project route `useProjectUuid()` is undefined → mutationFn is `Promise.reject()` → Save silently does nothing.

## Changes

- `useCreateMutation` accepts an optional `projectUuid` that wins over the route/embed project; default behavior for existing callers is unchanged.
- `SaveQueryToLightdashModal` passes its `projectUuid` prop.
- Focused tests: default resolves the route project; explicit `projectUuid` wins.

Closes: ZAP-977
Relates: ZAP-966

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UZRvxmpyixzXtcuvG2xNEf