### PR TITLE
fix(ai): tighten data app prompt copy for the thread agent

### DIFF
--- a/packages/backend/src/ee/services/ai/prompts/systemV2DataApps.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2DataApps.ts
@@ -3,7 +3,7 @@ import { DATA_APP_VIZ_LINE_FORMAT } from '@lightdash/common';
 export const GENERATE_DATA_APP_SECTION = `
 ## Data apps
 
-generateDataApp starts a build of a new data app — an interactive app, a slide show, or a PDF report — from a brief. iterateDataApp starts a build that adds a version to an existing app from a follow-up brief. Builds run in the background for several minutes; both calls return as soon as the build has started.
+generateDataApp starts a build of a new data app — an interactive app, a slide show, or a PDF report — from a brief. iterateDataApp starts a build that adds a version to an existing app from a follow-up brief.
 
 Pick the tool from the user's intent, not their wording:
 - A new app → generateDataApp. Pick the template from the user's words: "dashboard", "slideshow", "pdf", or "custom" (the default when none fits).
@@ -11,11 +11,10 @@ Pick the tool from the user's intent, not their wording:
 - A failed build the user wants fixed ("fix it", "try again") → iterateDataApp on the same app with a corrective brief that names what went wrong.
 - If a version is already building for the app, iterateDataApp returns an error saying so: tell the user to wait for the current build to finish, and do not retry.
 
-Briefs are for the coding agent, which sees the semantic layer — and, when iterating, the app's current source — but not this conversation. Make every brief self-contained:
-- generateDataApp: what the app shows, for whom, and how it behaves. Carry this thread's analysis in as a collection of visualizations — for each one, its title, a one-line description, and a metric query line \`${DATA_APP_VIZ_LINE_FORMAT}\`.
-- iterateDataApp: what to change and the outcome to expect, with a metric query line for each new visualization. Do not restate the parts of the app that stay the same.
-
+Briefs are for the coding agent, which explores the semantic layer itself — and, when iterating, works from the app's current source — but sees neither this conversation nor its query results:
+- generateDataApp: what the app shows, for whom, and how it behaves. The coding agent finds tables and fields on its own; when this thread has already settled the analysis, carry it over — for each visualization, its title, a one-line description, and a metric query line \`${DATA_APP_VIZ_LINE_FORMAT}\`.
+- iterateDataApp: what to change and the outcome to expect, with a metric query line for any visualization this thread already shaped. Do not restate the parts of the app that stay the same.
+- Carry analysis as queries, not numbers: a value pasted into the brief gets hardcoded into the app, while a metric query line stays live.
 - Reference existing content by slug (from findContent): dashboardSlug for a dashboard's layout and charts, chartSlugs for saved charts to build on. The source content stays unchanged. An unknown slug returns an error naming it and starts no build: look the content up with findContent and retry with the right slug, or ask the user which one they meant.
-- One request, one call: once the call returns, tell the user the build has started and will take a few minutes, then end your turn. Never wait, poll, or call the tool again for the same request. The outcome lands on this call's result for a later turn.
-- When the user later asks about the app, read the outcome from the earlier tool result: "success" carries the app name, slug, and the builder link (href) to share; "error" carries the failure message; "pending" means still building.
-- readContent (type data_app) reads a finished app; the content tools create and edit charts and dashboards, never data apps.`;
+
+When the user later asks about the app, read the outcome from the earlier tool result: "success" carries the app name, slug, and the builder link (href) to share; "error" carries the failure message; "pending" means still building. readContent (type data_app) reads a finished app; the content tools create and edit charts and dashboards, never data apps.`;

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -4025,7 +4025,7 @@ Parameters:
     },
   },
   {
-    "description": "Start building a new data app — an interactive application generated from a brief on top of this project's semantic layer. Use it when the user asks to build, make, or generate a data app (or an app, slide show, or PDF report); questions, charts, dashboards, and other saved content have their own tools. This tool always creates a new app: to change an app that already exists, use iterateDataApp instead. The build runs in the background for several minutes, so the call returns as soon as it has started (status: "pending"). One request, one call: tell the user the build has started and that you will link them to the app afterwards, then end your turn — never wait, poll, or call this tool again for the same request. A later turn sees the outcome on this call's result: "success" carries the app name and the builder link (href) to share; "error" carries the failure message.",
+    "description": "Start building a new data app — an interactive application generated from a brief on top of this project's semantic layer. Use it when the user asks to build, make, or generate a data app (or an app, slide show, or PDF report); questions, charts, dashboards, and other saved content have their own tools. This tool always creates a new app: to change an app that already exists, use iterateDataApp instead. The build runs in the background for several minutes, so the call returns as soon as it has started (status: "pending") and the outcome lands on this result for a later turn. One request, one call — never wait, poll, or call this tool again for the same request.",
     "inputSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": false,
@@ -4050,7 +4050,7 @@ Parameters:
           ],
         },
         "prompt": {
-          "description": "A self-contained brief for the coding agent that builds the app: what the app shows, for whom, and how it behaves. Carry this thread's analysis in as a collection of visualizations — for each one, its title, a one-line description, and a metric query line \`[viz title][explore; metrics; dimensions; filters; sort]\`. The coding agent sees the semantic layer but not this conversation, so include every detail it needs.",
+          "description": "A self-contained brief for the coding agent that builds the app: what the app shows, for whom, and how it behaves. The coding agent explores the semantic layer itself but sees neither this conversation nor its query results: when this thread has already settled the analysis, carry it over — for each visualization, its title, a one-line description, and a metric query line \`[viz title][explore; metrics; dimensions; filters; sort]\` — as queries, never pasted numbers, which would be hardcoded into the app.",
           "type": "string",
         },
         "template": {
@@ -4191,7 +4191,7 @@ Parameters:
     },
   },
   {
-    "description": "Start a build that adds a version to an existing data app from a follow-up brief. Use it when the user wants to change, fix, or extend a data app that already exists — one built earlier in this thread, or one found with findContent; use generateDataApp only for a brand-new app. The coding agent works from the app's current source, so the brief should describe the change, not restate the whole app. The build runs in the background for several minutes, so the call returns as soon as it has started (status: "pending"). One request, one call: tell the user the build has started, then end your turn — never wait, poll, or call this tool again for the same request. A later turn sees the outcome on this call's result: "success" carries the app name and the builder link (href) to share; "error" carries the failure message. While a version is already building for the app, the call fails — relay that the user should wait for the current build to finish.",
+    "description": "Start a build that adds a version to an existing data app from a follow-up brief. Use it when the user wants to change, fix, or extend a data app that already exists — one built earlier in this thread, or one found with findContent; use generateDataApp only for a brand-new app. The coding agent works from the app's current source, so the brief should describe the change, not restate the whole app. The build runs in the background for several minutes, so the call returns as soon as it has started (status: "pending") and the outcome lands on this result for a later turn. One request, one call — never wait, poll, or call this tool again for the same request. While a version is already building for the app, the call fails — relay that the user should wait for the current build to finish.",
     "inputSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": false,
@@ -4220,7 +4220,7 @@ Parameters:
           ],
         },
         "prompt": {
-          "description": "A self-contained brief of the change for the coding agent, which sees the app's current source and the semantic layer but not this conversation. Describe what to change and the outcome you expect, and include every detail from this thread the change depends on.",
+          "description": "A self-contained brief of the change for the coding agent, which works from the app's current source and explores the semantic layer itself, but sees neither this conversation nor its query results. Describe what to change and the outcome you expect; carry over any analysis this thread already settled as queries — a number pasted into the brief gets hardcoded into the app.",
           "type": "string",
         },
       },

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolGenerateDataAppArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolGenerateDataAppArgs.ts
@@ -27,15 +27,14 @@ export const TOOL_GENERATE_DATA_APP_DESCRIPTION = [
     "Start building a new data app — an interactive application generated from a brief on top of this project's semantic layer.",
     'Use it when the user asks to build, make, or generate a data app (or an app, slide show, or PDF report); questions, charts, dashboards, and other saved content have their own tools.',
     'This tool always creates a new app: to change an app that already exists, use iterateDataApp instead.',
-    'The build runs in the background for several minutes, so the call returns as soon as it has started (status: "pending"). One request, one call: tell the user the build has started and that you will link them to the app afterwards, then end your turn — never wait, poll, or call this tool again for the same request.',
-    'A later turn sees the outcome on this call\'s result: "success" carries the app name and the builder link (href) to share; "error" carries the failure message.',
+    'The build runs in the background for several minutes, so the call returns as soon as it has started (status: "pending") and the outcome lands on this result for a later turn. One request, one call — never wait, poll, or call this tool again for the same request.',
 ].join(' ');
 
 export const toolGenerateDataAppArgsSchema = z.object({
     prompt: z
         .string()
         .describe(
-            `A self-contained brief for the coding agent that builds the app: what the app shows, for whom, and how it behaves. Carry this thread's analysis in as a collection of visualizations — for each one, its title, a one-line description, and a metric query line \`${DATA_APP_VIZ_LINE_FORMAT}\`. The coding agent sees the semantic layer but not this conversation, so include every detail it needs.`,
+            `A self-contained brief for the coding agent that builds the app: what the app shows, for whom, and how it behaves. The coding agent explores the semantic layer itself but sees neither this conversation nor its query results: when this thread has already settled the analysis, carry it over — for each visualization, its title, a one-line description, and a metric query line \`${DATA_APP_VIZ_LINE_FORMAT}\` — as queries, never pasted numbers, which would be hardcoded into the app.`,
         ),
     template: z
         .enum(DATA_APP_BUILD_TEMPLATES)

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolIterateDataAppArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolIterateDataAppArgs.ts
@@ -10,8 +10,8 @@ export const TOOL_ITERATE_DATA_APP_DESCRIPTION = [
     'Start a build that adds a version to an existing data app from a follow-up brief.',
     'Use it when the user wants to change, fix, or extend a data app that already exists — one built earlier in this thread, or one found with findContent; use generateDataApp only for a brand-new app.',
     "The coding agent works from the app's current source, so the brief should describe the change, not restate the whole app.",
-    'The build runs in the background for several minutes, so the call returns as soon as it has started (status: "pending"). One request, one call: tell the user the build has started, then end your turn — never wait, poll, or call this tool again for the same request.',
-    'A later turn sees the outcome on this call\'s result: "success" carries the app name and the builder link (href) to share; "error" carries the failure message. While a version is already building for the app, the call fails — relay that the user should wait for the current build to finish.',
+    'The build runs in the background for several minutes, so the call returns as soon as it has started (status: "pending") and the outcome lands on this result for a later turn. One request, one call — never wait, poll, or call this tool again for the same request.',
+    'While a version is already building for the app, the call fails — relay that the user should wait for the current build to finish.',
 ].join(' ');
 
 export const toolIterateDataAppArgsSchema = z.object({
@@ -23,7 +23,7 @@ export const toolIterateDataAppArgsSchema = z.object({
     prompt: z
         .string()
         .describe(
-            "A self-contained brief of the change for the coding agent, which sees the app's current source and the semantic layer but not this conversation. Describe what to change and the outcome you expect, and include every detail from this thread the change depends on.",
+            "A self-contained brief of the change for the coding agent, which works from the app's current source and explores the semantic layer itself, but sees neither this conversation nor its query results. Describe what to change and the outcome you expect; carry over any analysis this thread already settled as queries — a number pasted into the brief gets hardcoded into the app.",
         ),
     dashboardSlug: z
         .string()


### PR DESCRIPTION
Copy-only pass over the thread agent's data-app prompt surfaces (system section, generateDataApp/iterateDataApp tool contracts), reviewed for agent-facing writing:

- **Dedupe mechanics**: the one-request-one-call / outcome-later guidance was stated three times (system section, both tool descriptions, and the runtime result string). Each meaning now lives in its strongest placement: "tell the user and end your turn" only in the tool result (arrives at the exact moment it applies), "never wait/poll/re-call" at the call site, outcome-reading once in the system section.
- **Builder has no data access**: clarify the coding agent explores the semantic layer itself but never sees the thread's conversation or query results — so briefs stay at the level of intent, carry the thread's analysis over as metric query lines only when it's already settled, and never paste numbers (they'd be hardcoded into the app).

No behavior changes; agent tool contract snapshot regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XKvcqvthpKmS6DjQrTzhGk