### PR TITLE
feat: add opt-in OpenTelemetry tracing for Knex queries

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -89,6 +89,7 @@
         "@opentelemetry/exporter-trace-otlp-http": "0.219.0",
         "@opentelemetry/instrumentation-express": "0.60.0",
         "@opentelemetry/instrumentation-http": "0.219.0",
+        "@opentelemetry/instrumentation-knex": "0.63.0",
         "@opentelemetry/resources": "2.8.0",
         "@opentelemetry/sdk-metrics": "2.8.0",
         "@opentelemetry/sdk-node": "0.219.0",

--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -1,4 +1,4 @@
-import './sentry'; // Sentry has to be initialized before anything else
+import './tracing/bootstrap'; // Must run before modules that can load Knex
 import {
     AnyType,
     ApiError,

--- a/packages/backend/src/NatsWorkerApp.ts
+++ b/packages/backend/src/NatsWorkerApp.ts
@@ -1,3 +1,4 @@
+import './tracing/bootstrap'; // Must run before modules that can load Knex
 import { createTerminus } from '@godaddy/terminus';
 import { MotherduckInstanceCache } from '@lightdash/warehouses';
 import * as Sentry from '@sentry/node';

--- a/packages/backend/src/SchedulerApp.ts
+++ b/packages/backend/src/SchedulerApp.ts
@@ -1,3 +1,4 @@
+import './tracing/bootstrap'; // Must run before modules that can load Knex
 import { createTerminus } from '@godaddy/terminus';
 import { MotherduckInstanceCache } from '@lightdash/warehouses';
 import * as Sentry from '@sentry/node';

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -1,3 +1,4 @@
+import './tracing/bootstrap'; // Must run before modules that can load Knex
 import { getErrorMessage } from '@lightdash/common';
 import App from './App';
 import { lightdashConfig } from './config/lightdashConfig';

--- a/packages/backend/src/natsWorker.ts
+++ b/packages/backend/src/natsWorker.ts
@@ -1,3 +1,4 @@
+import './tracing/bootstrap'; // Must run before modules that can load Knex
 import { z } from 'zod';
 import { lightdashConfig } from './config/lightdashConfig';
 import { getEnterpriseAppArguments } from './ee';

--- a/packages/backend/src/scheduler.ts
+++ b/packages/backend/src/scheduler.ts
@@ -1,3 +1,4 @@
+import './tracing/bootstrap'; // Must run before modules that can load Knex
 import { lightdashConfig } from './config/lightdashConfig';
 import { getEnterpriseAppArguments } from './ee';
 import knexConfig from './knexfile';

--- a/packages/backend/src/tracing/bootstrap.ts
+++ b/packages/backend/src/tracing/bootstrap.ts
@@ -1,0 +1,4 @@
+import '../sentry';
+import { initOtelTracing } from './tracing';
+
+initOtelTracing();

--- a/packages/backend/src/tracing/tracing.test.ts
+++ b/packages/backend/src/tracing/tracing.test.ts
@@ -11,9 +11,11 @@ import Logger from '../logging/logger';
 import {
     AlwaysSampleAiRootsSampler,
     configureOtelTraceExport,
+    createOtelInstrumentations,
     initOtelTracing,
     installRedactingOtelDiagnostics,
     LightdashTraceContextPropagator,
+    otelDatabaseTracingEnabled,
     otelTracingEnabled,
     sanitizeOtelDiagnosticArguments,
     sentryTraceToTraceparent,
@@ -36,6 +38,61 @@ describe('otelTracingEnabled', () => {
         vi.stubEnv('OTEL_TRACES_EXPORTER', 'none');
 
         expect(otelTracingEnabled()).toBe(true);
+    });
+});
+
+describe('otelDatabaseTracingEnabled', () => {
+    it('requires both OTel tracing and database tracing to be enabled', () => {
+        vi.stubEnv('OTEL_SDK_DISABLED', undefined);
+        vi.stubEnv('LIGHTDASH_OTEL_TRACES_ENABLED', 'true');
+        vi.stubEnv('LIGHTDASH_OTEL_DB_TRACES_ENABLED', 'true');
+
+        expect(otelDatabaseTracingEnabled()).toBe(true);
+
+        vi.stubEnv('LIGHTDASH_OTEL_DB_TRACES_ENABLED', undefined);
+        expect(otelDatabaseTracingEnabled()).toBe(false);
+
+        vi.stubEnv('LIGHTDASH_OTEL_DB_TRACES_ENABLED', 'true');
+        vi.stubEnv('LIGHTDASH_OTEL_TRACES_ENABLED', undefined);
+        expect(otelDatabaseTracingEnabled()).toBe(false);
+    });
+
+    it('stays disabled when the OTel SDK is disabled', () => {
+        vi.stubEnv('LIGHTDASH_OTEL_TRACES_ENABLED', 'true');
+        vi.stubEnv('LIGHTDASH_OTEL_DB_TRACES_ENABLED', 'true');
+        vi.stubEnv('OTEL_SDK_DISABLED', 'true');
+
+        expect(otelDatabaseTracingEnabled()).toBe(false);
+    });
+
+    it('adds parent-scoped Knex instrumentation', () => {
+        vi.stubEnv('LIGHTDASH_OTEL_TRACES_ENABLED', 'true');
+        vi.stubEnv('LIGHTDASH_OTEL_DB_TRACES_ENABLED', 'true');
+        vi.stubEnv('OTEL_SDK_DISABLED', undefined);
+
+        const knexInstrumentation = createOtelInstrumentations().find(
+            ({ instrumentationName }) =>
+                instrumentationName === '@opentelemetry/instrumentation-knex',
+        );
+
+        expect(knexInstrumentation?.getConfig()).toMatchObject({
+            requireParentSpan: true,
+            maxQueryLength: 1022,
+        });
+    });
+
+    it('omits Knex instrumentation by default', () => {
+        vi.stubEnv('LIGHTDASH_OTEL_TRACES_ENABLED', 'true');
+        vi.stubEnv('LIGHTDASH_OTEL_DB_TRACES_ENABLED', undefined);
+        vi.stubEnv('OTEL_SDK_DISABLED', undefined);
+
+        expect(
+            createOtelInstrumentations().some(
+                ({ instrumentationName }) =>
+                    instrumentationName ===
+                    '@opentelemetry/instrumentation-knex',
+            ),
+        ).toBe(false);
     });
 });
 

--- a/packages/backend/src/tracing/tracing.test.ts
+++ b/packages/backend/src/tracing/tracing.test.ts
@@ -12,6 +12,7 @@ import {
     AlwaysSampleAiRootsSampler,
     configureOtelTraceExport,
     createOtelInstrumentations,
+    getOtelDatabaseTraceMaxQueryLength,
     initOtelTracing,
     installRedactingOtelDiagnostics,
     LightdashTraceContextPropagator,
@@ -68,6 +69,7 @@ describe('otelDatabaseTracingEnabled', () => {
     it('adds parent-scoped Knex instrumentation', () => {
         vi.stubEnv('LIGHTDASH_OTEL_TRACES_ENABLED', 'true');
         vi.stubEnv('LIGHTDASH_OTEL_DB_TRACES_ENABLED', 'true');
+        vi.stubEnv('LIGHTDASH_OTEL_DB_TRACES_MAX_QUERY_LENGTH', '2048');
         vi.stubEnv('OTEL_SDK_DISABLED', undefined);
 
         const knexInstrumentation = createOtelInstrumentations().find(
@@ -77,8 +79,21 @@ describe('otelDatabaseTracingEnabled', () => {
 
         expect(knexInstrumentation?.getConfig()).toMatchObject({
             requireParentSpan: true,
-            maxQueryLength: 1022,
+            maxQueryLength: 2048,
         });
+    });
+
+    it.each([
+        [undefined, 1022],
+        ['2048', 2048],
+        ['0', 0],
+        ['-1', 1022],
+        ['1.5', 1022],
+        ['invalid', 1022],
+    ])('uses max query length %s as %i', (configured, expected) => {
+        vi.stubEnv('LIGHTDASH_OTEL_DB_TRACES_MAX_QUERY_LENGTH', configured);
+
+        expect(getOtelDatabaseTraceMaxQueryLength()).toBe(expected);
     });
 
     it('omits Knex instrumentation by default', () => {

--- a/packages/backend/src/tracing/tracing.ts
+++ b/packages/backend/src/tracing/tracing.ts
@@ -32,6 +32,7 @@ import {
 import {
     CompositePropagator,
     diagLogLevelFromString,
+    getNumberFromEnv,
     getStringFromEnv,
     getStringListFromEnv,
     W3CBaggagePropagator,
@@ -184,6 +185,25 @@ export const otelTracingEnabled = () =>
 export const otelDatabaseTracingEnabled = () =>
     otelTracingEnabled() &&
     parseBoolean(process.env.LIGHTDASH_OTEL_DB_TRACES_ENABLED);
+
+const DEFAULT_OTEL_DB_TRACES_MAX_QUERY_LENGTH = 1022;
+
+export const getOtelDatabaseTraceMaxQueryLength = () => {
+    const configured = getNumberFromEnv(
+        'LIGHTDASH_OTEL_DB_TRACES_MAX_QUERY_LENGTH',
+    );
+    if (configured === undefined)
+        return DEFAULT_OTEL_DB_TRACES_MAX_QUERY_LENGTH;
+
+    if (!Number.isInteger(configured) || configured < 0) {
+        diag.warn(
+            `LIGHTDASH_OTEL_DB_TRACES_MAX_QUERY_LENGTH must be a non-negative integer; using ${DEFAULT_OTEL_DB_TRACES_MAX_QUERY_LENGTH}`,
+        );
+        return DEFAULT_OTEL_DB_TRACES_MAX_QUERY_LENGTH;
+    }
+
+    return configured;
+};
 
 const SUPPORTED_TRACE_EXPORTERS = new Set(['console', 'otlp', 'zipkin']);
 const SUPPORTED_OTLP_PROTOCOLS = new Set([
@@ -515,7 +535,7 @@ export const createOtelInstrumentations = () => [
         ? [
               new KnexInstrumentation({
                   requireParentSpan: true,
-                  maxQueryLength: 1022,
+                  maxQueryLength: getOtelDatabaseTraceMaxQueryLength(),
               }),
           ]
         : []),

--- a/packages/backend/src/tracing/tracing.ts
+++ b/packages/backend/src/tracing/tracing.ts
@@ -42,6 +42,7 @@ import {
     ExpressLayerType,
 } from '@opentelemetry/instrumentation-express';
 import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
+import { KnexInstrumentation } from '@opentelemetry/instrumentation-knex';
 import {
     defaultResource,
     resourceFromAttributes,
@@ -179,6 +180,10 @@ export const installRedactingOtelDiagnostics = (): (() => void) => {
 export const otelTracingEnabled = () =>
     parseBoolean(process.env.LIGHTDASH_OTEL_TRACES_ENABLED) &&
     process.env.OTEL_SDK_DISABLED !== 'true';
+
+export const otelDatabaseTracingEnabled = () =>
+    otelTracingEnabled() &&
+    parseBoolean(process.env.LIGHTDASH_OTEL_DB_TRACES_ENABLED);
 
 const SUPPORTED_TRACE_EXPORTERS = new Set(['console', 'otlp', 'zipkin']);
 const SUPPORTED_OTLP_PROTOCOLS = new Set([
@@ -493,6 +498,29 @@ const isIgnoredIncomingRequest = (
     );
 };
 
+export const createOtelInstrumentations = () => [
+    new HttpInstrumentation({
+        ignoreIncomingRequestHook: (req) =>
+            isIgnoredIncomingRequest(req.url ?? '', req.headers['user-agent']),
+    }),
+    new ExpressInstrumentation({
+        // A span per middleware layer floods traces; the request handler layer
+        // alone still names the HTTP span with the resolved route.
+        ignoreLayersType: [
+            ExpressLayerType.MIDDLEWARE,
+            ExpressLayerType.ROUTER,
+        ],
+    }),
+    ...(otelDatabaseTracingEnabled()
+        ? [
+              new KnexInstrumentation({
+                  requireParentSpan: true,
+                  maxQueryLength: 1022,
+              }),
+          ]
+        : []),
+];
+
 class OtelTracingStrategy implements TracingStrategy {
     private readonly isEnabled = otelTracingEnabled;
 
@@ -531,24 +559,7 @@ class OtelTracingStrategy implements TracingStrategy {
                         new W3CBaggagePropagator(),
                     ],
                 }),
-                instrumentations: [
-                    new HttpInstrumentation({
-                        ignoreIncomingRequestHook: (req) =>
-                            isIgnoredIncomingRequest(
-                                req.url ?? '',
-                                req.headers['user-agent'],
-                            ),
-                    }),
-                    new ExpressInstrumentation({
-                        // A span per middleware layer floods traces; the request
-                        // handler layer alone still names the HTTP span with the
-                        // resolved route.
-                        ignoreLayersType: [
-                            ExpressLayerType.MIDDLEWARE,
-                            ExpressLayerType.ROUTER,
-                        ],
-                    }),
-                ],
+                instrumentations: createOtelInstrumentations(),
             });
         } finally {
             restoreOtelLogLevel();
@@ -564,8 +575,11 @@ class OtelTracingStrategy implements TracingStrategy {
             process.env.LIGHTDASH_OTEL_ALWAYS_SAMPLE_AI_TRACES === 'false'
                 ? ''
                 : '; AI/agent roots are always sampled';
+        const databaseTracing = otelDatabaseTracingEnabled()
+            ? '; database traces enabled'
+            : '';
         Logger.info(
-            `OpenTelemetry tracing configured; trace exporters: ${exporters}${protocol}; Lightdash sampling ratio: ${getSampleRate()}${aiSampling}; OTEL_TRACES_SAMPLER and OTEL_TRACES_SAMPLER_ARG are overridden by Lightdash; exporter connectivity has not been validated. Set OTEL_LOG_LEVEL=DEBUG for OpenTelemetry SDK/exporter diagnostics`,
+            `OpenTelemetry tracing configured; trace exporters: ${exporters}${protocol}; Lightdash sampling ratio: ${getSampleRate()}${aiSampling}${databaseTracing}; OTEL_TRACES_SAMPLER and OTEL_TRACES_SAMPLER_ARG are overridden by Lightdash; exporter connectivity has not been validated. Set OTEL_LOG_LEVEL=DEBUG for OpenTelemetry SDK/exporter diagnostics`,
         );
     }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -240,6 +240,9 @@ importers:
       '@opentelemetry/instrumentation-http':
         specifier: 0.219.0
         version: 0.219.0(@opentelemetry/api@1.9.0)(supports-color@5.5.0)
+      '@opentelemetry/instrumentation-knex':
+        specifier: 0.63.0
+        version: 0.63.0(@opentelemetry/api@1.9.0)(supports-color@5.5.0)
       '@opentelemetry/resources':
         specifier: 2.8.0
         version: 2.8.0(@opentelemetry/api@1.9.0)
@@ -4857,6 +4860,12 @@ packages:
   '@opentelemetry/instrumentation-knex@0.44.1':
     resolution: {integrity: sha512-U4dQxkNhvPexffjEmGwCq68FuftFK15JgUF05y/HlK3M6W/G2iEaACIfXdSnwVNe9Qh0sPfw8LbOPxrWzGWGMQ==}
     engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-knex@0.63.0':
+    resolution: {integrity: sha512-XrpRahI/9vTrfSUfkhy8jGX8KMRKecQIPU9GyEZ8gkR030iJwQYsMmKGO5TK9R80cQGUopXwDvV55zmVNEkcPg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
@@ -20472,6 +20481,14 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)(supports-color@5.5.0)
+      '@opentelemetry/semantic-conventions': 1.41.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-knex@0.63.0(@opentelemetry/api@1.9.0)(supports-color@5.5.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.219.0(@opentelemetry/api@1.9.0)(supports-color@5.5.0)
       '@opentelemetry/semantic-conventions': 1.41.1
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-10856
Closes: #28497

### Description:

Adds opt-in internal database spans when `LIGHTDASH_OTEL_DB_TRACES_ENABLED=true` and OpenTelemetry tracing is enabled.
The Knex instrumentation requires a parent span and defaults exported SQL text to 1,022 characters, configurable with `LIGHTDASH_OTEL_DB_TRACES_MAX_QUERY_LENGTH` (`0` omits SQL text).
Tracing now bootstraps before Knex can load in the API, scheduler, and NATS worker processes.
Validated with focused tracing tests, backend typechecking, linting, formatting, and a runtime instrumentation patch check.

### Risk assessment:

- [ ] This is a high-risk change

Low risk: the feature is disabled by default and only affects explicitly opted-in tracing deployments.

High-risk changes require approval from a reviewer other than the author before merging.
