### PR TITLE
feat(frontend): add any explore field to the query from chart config pickers

### DIFF
--- a/packages/frontend/src/components/LightdashVisualization/VisualizationConfigCartesian.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationConfigCartesian.tsx
@@ -15,6 +15,7 @@ const VisualizationCartesianConfig: FC<VisualizationCartesianConfigProps> = ({
     colorPalette,
     children,
     tableCalculationsMetadata,
+    unsavedMetricQuery,
 }) => {
     const cartesianConfig = useCartesianChartConfig({
         initialChartConfig,
@@ -26,6 +27,7 @@ const VisualizationCartesianConfig: FC<VisualizationCartesianConfigProps> = ({
         cartesianType,
         colorPalette,
         tableCalculationsMetadata,
+        unsavedMetricQuery,
     });
 
     useEffect(() => {

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationConfigPie.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationConfigPie.tsx
@@ -18,6 +18,7 @@ const VisualizationPieConfig: FC<VisualizationConfigPieProps> = ({
     children,
     tableCalculationsMetadata,
     parameters,
+    unsavedMetricQuery,
 }) => {
     const { dimensions, numericMetrics } = useMemo(() => {
         const metrics = getMetricsFromItemsMap(itemsMap ?? {}, isNumericItem);
@@ -37,6 +38,7 @@ const VisualizationPieConfig: FC<VisualizationConfigPieProps> = ({
         colorPalette,
         tableCalculationsMetadata,
         parameters,
+        unsavedMetricQuery,
     );
 
     useEffect(() => {

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
@@ -385,6 +385,7 @@ const VisualizationProvider: FC<
                     colorPalette={colorPalette}
                     tableCalculationsMetadata={tableCalculationsMetadata}
                     parameters={parameters}
+                    unsavedMetricQuery={unsavedMetricQuery}
                 >
                     {({ visualizationConfig }) => (
                         <Context.Provider
@@ -405,6 +406,7 @@ const VisualizationProvider: FC<
                     colorPalette={colorPalette}
                     tableCalculationsMetadata={tableCalculationsMetadata}
                     parameters={parameters}
+                    unsavedMetricQuery={unsavedMetricQuery}
                 >
                     {({ visualizationConfig }) => (
                         <Context.Provider

--- a/packages/frontend/src/components/LightdashVisualization/types.ts
+++ b/packages/frontend/src/components/LightdashVisualization/types.ts
@@ -89,6 +89,7 @@ export type VisualizationCartesianConfigProps =
         >;
         colorPalette: string[];
         tableCalculationsMetadata?: TableCalculationMetadata[];
+        unsavedMetricQuery?: MetricQuery;
     };
 
 // Funnel
@@ -134,6 +135,7 @@ export type VisualizationConfigPieProps =
         itemsMap: ItemsMap | undefined;
         colorPalette: string[];
         tableCalculationsMetadata?: TableCalculationMetadata[];
+        unsavedMetricQuery?: MetricQuery;
     };
 
 // Table

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Layout/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Layout/index.tsx
@@ -30,6 +30,7 @@ import { useVisualizationContext } from '../../../LightdashVisualization/useVisu
 import { AddButton } from '../../common/AddButton';
 import { Config } from '../../common/Config';
 import { RowLimitControls } from '../../common/RowLimitControls';
+import { useAddFieldsToQuery } from '../../common/useAddFieldsToQuery';
 import { MAX_PIVOTS } from '../../TableConfigPanel/constants';
 
 type Props = {
@@ -39,9 +40,18 @@ type Props = {
 export const Layout: FC<Props> = ({ items }) => {
     const { visualizationConfig, pivotDimensions, setPivotDimensions } =
         useVisualizationContext();
+    const { addableItems, addFieldToQuery, isFieldPending } =
+        useAddFieldsToQuery();
 
     const isCartesianChart =
         isCartesianVisualizationConfig(visualizationConfig);
+
+    // Whether picking this option must first put its field on the query.
+    const isAddableField = useCallback(
+        (value: Field | TableCalculation | CustomDimension) =>
+            !items.some((i) => getItemId(i) === getItemId(value)),
+        [items],
+    );
 
     const cartesianType = isCartesianChart
         ? visualizationConfig.chartConfig.dirtyChartType
@@ -79,8 +89,11 @@ export const Layout: FC<Props> = ({ items }) => {
         if (!isCartesianChart) return undefined;
         const { dirtyLayout } = visualizationConfig.chartConfig;
 
-        return items.find((item) => getItemId(item) === dirtyLayout?.xField);
-    }, [items, isCartesianChart, visualizationConfig]);
+        return (
+            items.find((item) => getItemId(item) === dirtyLayout?.xField) ??
+            addableItems.find((item) => getItemId(item) === dirtyLayout?.xField)
+        );
+    }, [items, addableItems, isCartesianChart, visualizationConfig]);
 
     const isXAxisFieldNumeric = useMemo(
         () => isNumericItem(xAxisField),
@@ -97,9 +110,12 @@ export const Layout: FC<Props> = ({ items }) => {
 
     const yActiveField = useCallback(
         (field: string) => {
-            return items.find((item) => getItemId(item) === field);
+            return (
+                items.find((item) => getItemId(item) === field) ??
+                addableItems.find((item) => getItemId(item) === field)
+            );
         },
-        [items],
+        [items, addableItems],
     );
 
     const availableYFields = useMemo(() => {
@@ -111,6 +127,11 @@ export const Layout: FC<Props> = ({ items }) => {
             (item) => !dirtyLayout?.yField?.includes(getItemId(item)),
         );
     }, [isCartesianChart, items, visualizationConfig]);
+
+    const addableYItems = useMemo(
+        () => addableItems.filter((item) => !yFields.includes(getItemId(item))),
+        [addableItems, yFields],
+    );
 
     // Group series logic
     const availableDimensions = useMemo(() => {
@@ -151,13 +172,42 @@ export const Layout: FC<Props> = ({ items }) => {
         ],
     );
 
+    const addableDimensions = useMemo(
+        () =>
+            addableItems.filter(
+                (item) => isDimension(item) || isCustomDimension(item),
+            ),
+        [addableItems],
+    );
+
+    const addableGroupByDimensions = useMemo(
+        () =>
+            addableDimensions.filter(
+                (item) =>
+                    !pivotDimensions?.includes(getItemId(item)) &&
+                    (!isCartesianChart ||
+                        getItemId(item) !==
+                            visualizationConfig.chartConfig.dirtyLayout
+                                ?.xField),
+            ),
+        [
+            addableDimensions,
+            visualizationConfig.chartConfig,
+            isCartesianChart,
+            pivotDimensions,
+        ],
+    );
+
     const canAddPivot = useMemo(
         () =>
             chartHasMetricOrTableCalc &&
-            availableGroupByDimensions.length > 0 &&
+            availableGroupByDimensions.length +
+                addableGroupByDimensions.length >
+                0 &&
             (!pivotDimensions || pivotDimensions.length < MAX_PIVOTS),
         [
             availableGroupByDimensions.length,
+            addableGroupByDimensions.length,
             pivotDimensions,
             chartHasMetricOrTableCalc,
         ],
@@ -167,6 +217,10 @@ export const Layout: FC<Props> = ({ items }) => {
         (newValue: Field | TableCalculation | CustomDimension | undefined) => {
             if (!isCartesianChart) return;
             const { setXField, setStacking } = visualizationConfig.chartConfig;
+
+            if (newValue && isAddableField(newValue)) {
+                addFieldToQuery(newValue);
+            }
 
             const fieldId = newValue ? getItemId(newValue) : undefined;
             setXField(fieldId ?? undefined);
@@ -180,7 +234,13 @@ export const Layout: FC<Props> = ({ items }) => {
                 setCurrentStackMode(StackType.NONE);
             }
         },
-        [isCartesianChart, visualizationConfig, currentStackMode],
+        [
+            isCartesianChart,
+            visualizationConfig,
+            currentStackMode,
+            isAddableField,
+            addFieldToQuery,
+        ],
     );
 
     if (!isCartesianChart) return null;
@@ -229,17 +289,33 @@ export const Layout: FC<Props> = ({ items }) => {
                             </Tooltip>
                             {dirtyLayout?.xField === EMPTY_X_AXIS &&
                                 (() => {
-                                    const availableXField = items.find(
-                                        (item) =>
-                                            !pivotDimensions?.includes(
-                                                getItemId(item),
-                                            ),
-                                    );
+                                    const availableXField =
+                                        items.find(
+                                            (item) =>
+                                                !pivotDimensions?.includes(
+                                                    getItemId(item),
+                                                ),
+                                        ) ??
+                                        addableItems.find(
+                                            (item) =>
+                                                !pivotDimensions?.includes(
+                                                    getItemId(item),
+                                                ),
+                                        );
                                     return (
                                         <AddButton
                                             disabled={!availableXField}
                                             onClick={() => {
                                                 if (availableXField) {
+                                                    if (
+                                                        isAddableField(
+                                                            availableXField,
+                                                        )
+                                                    ) {
+                                                        addFieldToQuery(
+                                                            availableXField,
+                                                        );
+                                                    }
                                                     setXField(
                                                         getItemId(
                                                             availableXField,
@@ -257,6 +333,8 @@ export const Layout: FC<Props> = ({ items }) => {
                             data-testid="x-axis-field-select"
                             item={xAxisField}
                             items={items}
+                            addItems={addableItems}
+                            loading={isFieldPending(dirtyLayout?.xField)}
                             inactiveItemIds={pivotDimensions}
                             onChange={handleOnChangeOfXAxisField}
                             rightSection={
@@ -280,13 +358,18 @@ export const Layout: FC<Props> = ({ items }) => {
                         <Config.Heading>{`${
                             validConfig?.layout.flipAxes ? 'X' : 'Y'
                         }-axis`}</Config.Heading>
-                        {availableYFields.length > 0 && (
+                        {(availableYFields.length > 0 ||
+                            addableYItems.length > 0) && (
                             <AddButton
-                                onClick={() =>
-                                    addSingleSeries(
-                                        getItemId(availableYFields[0]),
-                                    )
-                                }
+                                onClick={() => {
+                                    const nextYField =
+                                        availableYFields[0] ?? addableYItems[0];
+                                    if (!nextYField) return;
+                                    if (isAddableField(nextYField)) {
+                                        addFieldToQuery(nextYField);
+                                    }
+                                    addSingleSeries(getItemId(nextYField));
+                                }}
                             />
                         )}
                     </Config.Group>
@@ -302,7 +385,12 @@ export const Layout: FC<Props> = ({ items }) => {
                                 data-testid="y-axis-field-select"
                                 item={activeField}
                                 items={yFieldsOptions}
+                                addItems={addableYItems}
+                                loading={isFieldPending(field)}
                                 onChange={(newValue) => {
+                                    if (newValue && isAddableField(newValue)) {
+                                        addFieldToQuery(newValue);
+                                    }
                                     updateYField(
                                         index,
                                         newValue ? getItemId(newValue) : '',
@@ -335,14 +423,19 @@ export const Layout: FC<Props> = ({ items }) => {
                             </Group>
                             {canAddPivot && (
                                 <AddButton
-                                    onClick={() =>
+                                    onClick={() => {
+                                        const nextGroupField =
+                                            availableGroupByDimensions[0] ??
+                                            addableGroupByDimensions[0];
+                                        if (!nextGroupField) return;
+                                        if (isAddableField(nextGroupField)) {
+                                            addFieldToQuery(nextGroupField);
+                                        }
                                         setPivotDimensions([
                                             ...(pivotDimensions || []),
-                                            getItemId(
-                                                availableGroupByDimensions[0],
-                                            ),
-                                        ])
-                                    }
+                                            getItemId(nextGroupField),
+                                        ]);
+                                    }}
                                 />
                             )}
                         </Config.Group>
@@ -363,6 +456,9 @@ export const Layout: FC<Props> = ({ items }) => {
                                 // Group series logic
                                 const groupSelectedField =
                                     availableDimensions.find(
+                                        (item) => getItemId(item) === pivotKey,
+                                    ) ??
+                                    addableDimensions.find(
                                         (item) => getItemId(item) === pivotKey,
                                     );
                                 const activeField = chartHasMetricOrTableCalc
@@ -411,11 +507,16 @@ export const Layout: FC<Props> = ({ items }) => {
                                             placeholder="Select a field to group by"
                                             item={activeField}
                                             items={availableDimensions}
+                                            addItems={addableDimensions}
+                                            loading={isFieldPending(pivotKey)}
                                             inactiveItemIds={inactiveItemIds.filter(
                                                 (id) => id !== pivotKey,
                                             )} // keep current value enabled
                                             onChange={(newValue) => {
                                                 if (!newValue) return;
+                                                if (isAddableField(newValue)) {
+                                                    addFieldToQuery(newValue);
+                                                }
                                                 setPivotDimensions(
                                                     pivotDimensions
                                                         ? replaceStringInArray(

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.test.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.test.tsx
@@ -66,25 +66,43 @@ const {
 
 // The picker routes project-type selection through the Redux-based
 // useSelectProjectChartType hook; assert on what it dispatches.
-vi.mock('../../../features/explorer/store', () => ({
-    useExplorerDispatch: () => dispatch,
-    useExplorerSelector: () => authoringState.current,
-    selectChartTypeAuthoring: () => null,
-    explorerActions: {
-        setChartType: (payload: unknown) => ({ type: 'setChartType', payload }),
-        setChartConfig: (payload: unknown) => ({
-            type: 'setChartConfig',
-            payload,
-        }),
-        setPivotConfig: (payload: unknown) => ({
-            type: 'setPivotConfig',
-            payload,
-        }),
-        startChartTypeAuthoring: (payload: unknown) => ({
-            type: 'startChartTypeAuthoring',
-            payload,
-        }),
-    },
+vi.mock('../../../features/explorer/store', () => {
+    const selectTableName = vi.fn();
+    const selectMetricQuery = vi.fn();
+    return {
+        useExplorerDispatch: () => dispatch,
+        useExplorerSelector: (selector: unknown) =>
+            selector === selectTableName
+                ? 'orders'
+                : selector === selectMetricQuery
+                  ? { dimensions: [], metrics: [], tableCalculations: [] }
+                  : authoringState.current,
+        selectTableName,
+        selectMetricQuery,
+        selectChartTypeAuthoring: () => null,
+        explorerActions: {
+            setChartType: (payload: unknown) => ({
+                type: 'setChartType',
+                payload,
+            }),
+            setChartConfig: (payload: unknown) => ({
+                type: 'setChartConfig',
+                payload,
+            }),
+            setPivotConfig: (payload: unknown) => ({
+                type: 'setPivotConfig',
+                payload,
+            }),
+            startChartTypeAuthoring: (payload: unknown) => ({
+                type: 'startChartTypeAuthoring',
+                payload,
+            }),
+        },
+    };
+});
+// The add-to-query pool reads the explore; not under test here.
+vi.mock('../../../hooks/useExplore', () => ({
+    useExplore: () => ({ data: undefined }),
 }));
 vi.mock('../CustomChartType/CustomChartTypePicker', () => ({
     default: (props: PickerProps) => {

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
@@ -64,9 +64,8 @@ export const ConfigTabs: FC = memo(() => {
     const selectProjectChartType = useSelectProjectChartType();
     const dispatch = useExplorerDispatch();
 
-    // The results' columns plus fields the current query selects but whose
-    // run hasn't landed. Reconciling against this keeps a just-assigned
-    // binding from being stripped before its results arrive.
+    // Results' columns plus pending (not-yet-run) query fields, so a
+    // just-assigned binding isn't stripped before its results land.
     const effectiveItemsMap = useMemo<ItemsMap>(() => {
         const pendingEntries = addableItems.flatMap((item) => {
             const id = getItemId(item);

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
@@ -5,6 +5,7 @@ import {
     FeatureFlags,
     getAppDisplayName,
     getEffectiveOptionValues,
+    getItemId,
     pruneDataAppVizOptionValues,
     type ItemsMap,
 } from '@lightdash/common';
@@ -35,6 +36,7 @@ import { useIsInsideChartGallery } from '../../common/ChartGallery/ChartGalleryC
 import { isDataAppVizVisualizationConfig } from '../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
 import { ColorPaletteSection } from '../common/ColorPaletteSection';
+import { useAddFieldsToQuery } from '../common/useAddFieldsToQuery';
 import { type CustomChartTypeOption } from '../CustomChartType/customChartTypeOption';
 import CustomChartTypeSection from '../CustomChartType/CustomChartTypeSection';
 import { useSelectProjectChartType } from '../CustomChartType/useSelectProjectChartType';
@@ -58,8 +60,21 @@ export const ConfigTabs: FC = memo(() => {
     const navigate = useNavigate();
     const { visualizationConfig, itemsMap, setChartType, setPivotDimensions } =
         useVisualizationContext();
+    const { addableItems, isFieldPending } = useAddFieldsToQuery();
     const selectProjectChartType = useSelectProjectChartType();
     const dispatch = useExplorerDispatch();
+
+    // The results' columns plus fields the current query selects but whose
+    // run hasn't landed. Reconciling against this keeps a just-assigned
+    // binding from being stripped before its results arrive.
+    const effectiveItemsMap = useMemo<ItemsMap>(() => {
+        const pendingEntries = addableItems.flatMap((item) => {
+            const id = getItemId(item);
+            return isFieldPending(id) ? [[id, item] as const] : [];
+        });
+        if (pendingEntries.length === 0) return itemsMap ?? NO_COLUMNS;
+        return { ...itemsMap, ...Object.fromEntries(pendingEntries) };
+    }, [itemsMap, addableItems, isFieldPending]);
     const authoring = useExplorerSelector(selectChartTypeAuthoring);
     const isAuthoring = authoring !== null;
 
@@ -138,8 +153,8 @@ export const ConfigTabs: FC = memo(() => {
     // Auto-binding cannot run without columns, and it only runs once, at pick
     // time — so picking now would leave the slots empty for good.
     const { dimensions, metrics } = useMemo(
-        () => getDataAppVizFieldItems(itemsMap ?? NO_COLUMNS),
-        [itemsMap],
+        () => getDataAppVizFieldItems(effectiveItemsMap),
+        [effectiveItemsMap],
     );
     const hasColumns = dimensions.length > 0 || metrics.length > 0;
 
@@ -168,7 +183,7 @@ export const ConfigTabs: FC = memo(() => {
         // show the saved mapping reconciled the way the renderer does.
         const effectiveMapping = reconcileDataAppVizFieldMapping(
             fields,
-            itemsMap ?? NO_COLUMNS,
+            effectiveItemsMap,
             selectedViz.fieldMapping,
         );
 
@@ -195,7 +210,7 @@ export const ConfigTabs: FC = memo(() => {
             if (!upgradeTarget) return;
             const nextMapping = reconcileDataAppVizFieldMapping(
                 upgradeTarget.schema.fields,
-                itemsMap ?? NO_COLUMNS,
+                effectiveItemsMap,
                 selectedViz.fieldMapping,
             );
             upgradeDataAppVizVersion(
@@ -228,7 +243,7 @@ export const ConfigTabs: FC = memo(() => {
                     </Callout>
                 )}
                 <DataAppVizSettings
-                    itemsMap={itemsMap ?? NO_COLUMNS}
+                    itemsMap={effectiveItemsMap}
                     fields={fields}
                     fieldMapping={effectiveMapping}
                     onFieldChange={handleFieldChange}
@@ -307,10 +322,7 @@ export const ConfigTabs: FC = memo(() => {
                         hasColumns={hasColumns}
                         onSelectVega={() => setChartType(ChartType.CUSTOM)}
                         onSelectProjectType={(picked) =>
-                            selectProjectChartType(
-                                picked,
-                                itemsMap ?? NO_COLUMNS,
-                            )
+                            selectProjectChartType(picked, effectiveItemsMap)
                         }
                         onClear={() => {
                             clearDataAppViz();

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizSettings.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizSettings.tsx
@@ -1,5 +1,9 @@
 import {
     getItemId,
+    isCustomDimension,
+    isDimension,
+    isMetric,
+    isTableCalculation,
     type DataAppVizField,
     type DataAppVizFieldMapping,
     type Item,
@@ -11,6 +15,7 @@ import { poolKeyForSlot } from '../../../features/chartTypes/utils/autoMapDataAp
 import { getDataAppVizFieldItems } from '../../../features/chartTypes/utils/getDataAppVizFieldItems';
 import FieldSelect from '../../common/FieldSelect';
 import { Config } from '../common/Config';
+import { useAddFieldsToQuery } from '../common/useAddFieldsToQuery';
 
 type Props = {
     itemsMap: ItemsMap;
@@ -33,9 +38,24 @@ const DataAppVizSettings: FC<Props> = ({
     fieldMapping,
     onFieldChange,
 }) => {
+    const { addableItems, addFieldToQuery, isFieldPending } =
+        useAddFieldsToQuery();
+
     const { dimensions, metrics } = useMemo(
         () => getDataAppVizFieldItems(itemsMap),
         [itemsMap],
+    );
+    // The hook already drops hidden fields, mirroring the in-query pools.
+    const addPools = useMemo(
+        () => ({
+            dimension: addableItems.filter(
+                (item) => isDimension(item) || isCustomDimension(item),
+            ),
+            metric: addableItems.filter(
+                (item) => isMetric(item) || isTableCalculation(item),
+            ),
+        }),
+        [addableItems],
     );
     const itemPools = { dimension: dimensions, metric: metrics };
     const fieldItems = (field: DataAppVizField): Item[] =>
@@ -51,9 +71,11 @@ const DataAppVizSettings: FC<Props> = ({
 
             {fields.map((field) => {
                 const items = fieldItems(field);
+                const addItems = addPools[poolKeyForSlot(field)];
                 const selectedId = fieldMapping[field.name];
                 const selectedItem = selectedId
-                    ? items.find((i) => getItemId(i) === selectedId)
+                    ? (items.find((i) => getItemId(i) === selectedId) ??
+                      addItems.find((i) => getItemId(i) === selectedId))
                     : undefined;
                 return (
                     <Config key={field.name}>
@@ -65,19 +87,33 @@ const DataAppVizSettings: FC<Props> = ({
                                 // own; the placeholder names what the chart is
                                 // missing, as the cartesian layout does.
                                 placeholder={
-                                    items.length === 0
+                                    items.length === 0 && addItems.length === 0
                                         ? `You need at least one ${poolKeyForSlot(field)} in your chart to set this field`
                                         : `Select ${field.label.toLowerCase()}`
                                 }
-                                disabled={items.length === 0}
+                                disabled={
+                                    items.length === 0 && addItems.length === 0
+                                }
                                 item={selectedItem}
                                 items={items}
-                                onChange={(newField) =>
+                                addItems={addItems}
+                                loading={isFieldPending(selectedId)}
+                                onChange={(newField) => {
+                                    if (
+                                        newField &&
+                                        !items.some(
+                                            (i) =>
+                                                getItemId(i) ===
+                                                getItemId(newField),
+                                        )
+                                    ) {
+                                        addFieldToQuery(newField);
+                                    }
                                     onFieldChange(
                                         field.name,
                                         newField ? getItemId(newField) : null,
-                                    )
-                                }
+                                    );
+                                }}
                                 clearable={!field.required}
                                 hasGrouping
                             />

--- a/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/PieChartLayoutConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/PieChartLayoutConfig.tsx
@@ -3,6 +3,8 @@ import {
     isCustomDimension,
     isDimension,
     isField,
+    isMetric,
+    isNumericItem,
     isTableCalculation,
     type CustomDimension,
     type Dimension,
@@ -10,14 +12,36 @@ import {
     type TableCalculation,
 } from '@lightdash/common';
 import { Box, Group, Stack, SegmentedControl, Tooltip } from '@mantine/core';
+import { useMemo } from 'react';
 import FieldSelect from '../../common/FieldSelect';
 import { isPieVisualizationConfig } from '../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
 import { AddButton } from '../common/AddButton';
 import { Config } from '../common/Config';
+import { useAddFieldsToQuery } from '../common/useAddFieldsToQuery';
 
 export const Layout: React.FC = () => {
     const { visualizationConfig, itemsMap } = useVisualizationContext();
+    const { addableItems, addFieldToQuery, isFieldPending } =
+        useAddFieldsToQuery();
+
+    const addableDimensions = useMemo(
+        () =>
+            addableItems.filter(
+                (item): item is Dimension | CustomDimension =>
+                    isDimension(item) || isCustomDimension(item),
+            ),
+        [addableItems],
+    );
+
+    const addableNumericMetrics = useMemo(
+        () =>
+            addableItems.filter(
+                (item): item is Metric =>
+                    isField(item) && isMetric(item) && isNumericItem(item),
+            ),
+        [addableItems],
+    );
 
     if (!isPieVisualizationConfig(visualizationConfig)) return null;
 
@@ -30,12 +54,22 @@ export const Layout: React.FC = () => {
         groupChange,
         groupRemove,
 
+        metricId,
         selectedMetric,
         metricChange,
 
         isDonut,
         toggleDonut,
     } = visualizationConfig.chartConfig;
+
+    const unusedAddableDimensions = addableDimensions.filter(
+        (item) => !groupFieldIds.includes(getItemId(item)),
+    );
+    const hasAnyDimension =
+        dimensions.length > 0 || addableDimensions.length > 0;
+    const allDimensionsGrouped =
+        groupFieldIds.length ===
+        dimensions.length + unusedAddableDimensions.length;
 
     return (
         <Stack>
@@ -45,47 +79,64 @@ export const Layout: React.FC = () => {
                         <Config.Heading>Groups</Config.Heading>
                         <Tooltip
                             disabled={
-                                !(
-                                    dimensions.length === 0 ||
-                                    groupFieldIds.length === dimensions.length
-                                )
+                                !(!hasAnyDimension || allDimensionsGrouped)
                             }
                             label={
-                                dimensions.length === 0
+                                !hasAnyDimension
                                     ? 'You must select at least one dimension to create a pie chart'
-                                    : dimensions.length === groupFieldIds.length
-                                      ? 'To add more groups you need to add more dimensions to your query'
+                                    : allDimensionsGrouped
+                                      ? 'All dimensions are already used as groups'
                                       : undefined
                             }
                         >
                             <AddButton
-                                onClick={groupAdd}
+                                onClick={() => {
+                                    const hasUnusedInQueryDimension =
+                                        dimensions.some(
+                                            (item) =>
+                                                !groupFieldIds.includes(
+                                                    getItemId(item),
+                                                ),
+                                        );
+                                    if (hasUnusedInQueryDimension) {
+                                        groupAdd();
+                                        return;
+                                    }
+                                    const nextDimension =
+                                        unusedAddableDimensions[0];
+                                    if (!nextDimension) return;
+                                    addFieldToQuery(nextDimension);
+                                    groupAdd(getItemId(nextDimension));
+                                }}
                                 disabled={
-                                    dimensions.length === 0 ||
-                                    groupFieldIds.length === dimensions.length
+                                    !hasAnyDimension || allDimensionsGrouped
                                 }
                             />
                         </Tooltip>
                     </Config.Group>
 
                     {groupFieldIds.map((dimensionId, index) => {
-                        if (!itemsMap || !dimensionId) return null;
+                        if (!dimensionId) return null;
 
-                        const dimension = itemsMap[dimensionId];
+                        const dimension = itemsMap?.[dimensionId];
 
                         const selectedDimension =
                             isDimension(dimension) ||
                             isCustomDimension(dimension)
                                 ? dimension
-                                : undefined;
+                                : addableDimensions.find(
+                                      (item) => getItemId(item) === dimensionId,
+                                  );
                         return (
                             <FieldSelect<CustomDimension | Dimension>
                                 key={index}
-                                disabled={dimensions.length === 0}
+                                disabled={!hasAnyDimension}
                                 clearable={index !== 0}
                                 placeholder="Select dimension"
                                 item={selectedDimension}
                                 items={dimensions}
+                                addItems={addableDimensions}
+                                loading={isFieldPending(dimensionId)}
                                 inactiveItemIds={groupFieldIds
                                     .filter((id): id is string => !!id)
                                     .filter((id) => id !== dimensionId)}
@@ -95,6 +146,15 @@ export const Layout: React.FC = () => {
                                     if (newField) {
                                         const newFieldId = getItemId(newField);
                                         if (newFieldId !== dimensionId) {
+                                            if (
+                                                !dimensions.some(
+                                                    (item) =>
+                                                        getItemId(item) ===
+                                                        newFieldId,
+                                                )
+                                            ) {
+                                                addFieldToQuery(newField);
+                                            }
                                             groupChange(
                                                 dimensionId,
                                                 newFieldId,
@@ -116,16 +176,39 @@ export const Layout: React.FC = () => {
                     <Config.Heading>Metric</Config.Heading>
 
                     <Tooltip
-                        disabled={numericMetrics && numericMetrics.length > 0}
+                        disabled={
+                            numericMetrics.length > 0 ||
+                            addableNumericMetrics.length > 0
+                        }
                         label="You must select at least one numeric metric to create a pie chart"
                     >
                         <Box>
                             <FieldSelect<Metric | TableCalculation>
                                 placeholder="Select metric"
-                                disabled={numericMetrics.length === 0}
-                                item={selectedMetric}
+                                disabled={
+                                    numericMetrics.length === 0 &&
+                                    addableNumericMetrics.length === 0
+                                }
+                                item={
+                                    selectedMetric ??
+                                    addableNumericMetrics.find(
+                                        (item) => getItemId(item) === metricId,
+                                    )
+                                }
                                 items={numericMetrics}
+                                addItems={addableNumericMetrics}
+                                loading={isFieldPending(metricId)}
                                 onChange={(newField) => {
+                                    if (
+                                        newField &&
+                                        !numericMetrics.some(
+                                            (item) =>
+                                                getItemId(item) ===
+                                                getItemId(newField),
+                                        )
+                                    ) {
+                                        addFieldToQuery(newField);
+                                    }
                                     if (newField && isField(newField))
                                         metricChange(getItemId(newField));
                                     else if (

--- a/packages/frontend/src/components/VisualizationConfigs/common/useAddFieldsToQuery.ts
+++ b/packages/frontend/src/components/VisualizationConfigs/common/useAddFieldsToQuery.ts
@@ -1,0 +1,81 @@
+import {
+    getItemId,
+    getItemMap,
+    isCustomDimension,
+    isDimension,
+    isField,
+    isTableCalculation,
+    type Item,
+} from '@lightdash/common';
+import { useCallback, useMemo } from 'react';
+import {
+    explorerActions,
+    selectMetricQuery,
+    selectTableName,
+    useExplorerDispatch,
+    useExplorerSelector,
+} from '../../../features/explorer/store';
+import { useExplore } from '../../../hooks/useExplore';
+import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
+
+/**
+ * The pool behind a config picker's "Add to query" group: every visible field
+ * of the current explore (plus the query's custom dimensions, additional
+ * metrics and table calculations) that the last run's results don't already
+ * offer. Picking one adds it to the query and re-runs, so a chart slot can use
+ * it without a round trip through the sidebar.
+ *
+ * Explorer-only: the config panels always render inside the explorer store.
+ */
+export const useAddFieldsToQuery = () => {
+    const { itemsMap } = useVisualizationContext();
+    const dispatch = useExplorerDispatch();
+    const tableName = useExplorerSelector(selectTableName);
+    const metricQuery = useExplorerSelector(selectMetricQuery);
+    const { data: explore } = useExplore(tableName, { refetchOnMount: false });
+
+    const addableItems = useMemo(() => {
+        if (!explore) return [];
+        const allItems = getItemMap(
+            explore,
+            metricQuery.additionalMetrics,
+            metricQuery.tableCalculations,
+            metricQuery.customDimensions,
+        );
+        return Object.entries(allItems).flatMap(([id, item]) =>
+            (itemsMap && id in itemsMap) || (isField(item) && item.hidden)
+                ? []
+                : [item],
+        );
+    }, [explore, metricQuery, itemsMap]);
+
+    // Selected in the query but missing from the last results: the run this
+    // field's add action requested hasn't landed yet.
+    const isFieldPending = useCallback(
+        (fieldId: string | null | undefined): boolean =>
+            !!fieldId &&
+            !(itemsMap && fieldId in itemsMap) &&
+            (metricQuery.dimensions.includes(fieldId) ||
+                metricQuery.metrics.includes(fieldId) ||
+                metricQuery.tableCalculations.some(
+                    (tc) => tc.name === fieldId,
+                )),
+        [itemsMap, metricQuery],
+    );
+
+    const addFieldToQuery = useCallback(
+        (item: Item) => {
+            if (isDimension(item) || isCustomDimension(item)) {
+                dispatch(explorerActions.addDimensionToQuery(getItemId(item)));
+            } else if (isTableCalculation(item)) {
+                // Always part of the query; only the run is missing.
+                dispatch(explorerActions.requestQueryExecution());
+            } else {
+                dispatch(explorerActions.addMetricToQuery(getItemId(item)));
+            }
+        },
+        [dispatch],
+    );
+
+    return { addableItems, addFieldToQuery, isFieldPending };
+};

--- a/packages/frontend/src/components/VisualizationConfigs/common/useAddFieldsToQuery.ts
+++ b/packages/frontend/src/components/VisualizationConfigs/common/useAddFieldsToQuery.ts
@@ -19,13 +19,9 @@ import { useExplore } from '../../../hooks/useExplore';
 import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
 
 /**
- * The pool behind a config picker's "Add to query" group: every visible field
- * of the current explore (plus the query's custom dimensions, additional
- * metrics and table calculations) that the last run's results don't already
- * offer. Picking one adds it to the query and re-runs, so a chart slot can use
- * it without a round trip through the sidebar.
- *
- * Explorer-only: the config panels always render inside the explorer store.
+ * The pool behind a config picker's "Add to query" group: visible explore
+ * fields the last run's results don't offer. Picking one adds it to the query
+ * and re-runs. Explorer-only — the config panels render inside its store.
  */
 export const useAddFieldsToQuery = () => {
     const { itemsMap } = useVisualizationContext();

--- a/packages/frontend/src/components/common/FieldSelect/index.tsx
+++ b/packages/frontend/src/components/common/FieldSelect/index.tsx
@@ -81,7 +81,8 @@ type FieldSelectProps<T extends Item = Item> = Omit<
     /** Fields not in the query yet, offered under an "Add to query" group.
      *  Picking one reaches `onChange` like any other item. */
     addItems?: T[];
-    /** Shows a spinner while the slot waits on a query run. */
+    /** Shows a spinner while the slot waits on a query run, replacing any
+     *  `rightSection` for the duration. */
     loading?: boolean;
     inactiveItemIds?: string[];
     onChange: (value: T | undefined) => void;

--- a/packages/frontend/src/components/common/FieldSelect/index.tsx
+++ b/packages/frontend/src/components/common/FieldSelect/index.tsx
@@ -19,6 +19,8 @@ import {
     Text,
     Tooltip,
     type ComboboxItem,
+    type ComboboxParsedItem,
+    type OptionsFilter,
     type SelectProps,
 } from '@mantine/core';
 import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
@@ -30,9 +32,45 @@ interface FieldSelectItem extends ComboboxItem {
     item: Item;
     description?: string;
     size?: SelectProps['size'];
+    /** Dimmed table context rendered before the label; the "Add to query"
+     *  group has no per-table headers to carry it. */
+    tablePrefix?: string;
 }
 
 const ADD_TO_QUERY_GROUP_LABEL = 'Add to query';
+
+// Mantine's default filter only sees `label`, which no longer carries the
+// table name for "Add to query" options — match the prefix too, so searching
+// "orders amount" still finds them.
+const optionsFilter: OptionsFilter = ({ options, search, limit }) => {
+    const words = search.toLowerCase().trim().split(/\s+/);
+    const matches = (option: ComboboxItem) => {
+        const { label, tablePrefix } = option as FieldSelectItem;
+        const haystack = `${tablePrefix ?? ''} ${label}`.toLowerCase();
+        return words.every((word) => haystack.includes(word));
+    };
+
+    const result: ComboboxParsedItem[] = [];
+    let count = 0;
+    for (const item of options) {
+        if (count >= limit) break;
+        if ('group' in item) {
+            const kept: ComboboxItem[] = [];
+            for (const option of item.items) {
+                if (count >= limit) break;
+                if (matches(option)) {
+                    kept.push(option);
+                    count += 1;
+                }
+            }
+            if (kept.length > 0) result.push({ ...item, items: kept });
+        } else if (matches(item)) {
+            result.push(item);
+            count += 1;
+        }
+    }
+    return result;
+};
 
 type FieldSelectProps<T extends Item = Item> = Omit<
     SelectProps,
@@ -232,12 +270,20 @@ const FieldSelectComponent = <T extends Item = Item>({
             }),
         );
 
-        // Not-in-query fields sit in one trailing group; full labels keep
-        // same-named fields from different tables distinguishable.
+        // Not-in-query fields sit in one trailing group. The label matches
+        // the in-query options (and the input once picked); the dimmed
+        // tablePrefix keeps same-named fields from different tables readable.
         const addEntries: FieldSelectItem[] = sortedAddItems.map((i) => ({
             item: i,
             value: getItemId(i),
-            label: getItemLabel(i),
+            label: getLabel(i, hasGrouping),
+            tablePrefix: hasGrouping
+                ? isField(i) && !isCustomDimension(i)
+                    ? i.tableLabel
+                    : isCustomDimension(i)
+                      ? tableLabelMap.get(i.table)
+                      : undefined
+                : undefined,
             description: isField(i) ? i.description : undefined,
             disabled: inactiveItemIds.includes(getItemId(i)),
         }));
@@ -282,6 +328,11 @@ const FieldSelectComponent = <T extends Item = Item>({
                             size={rest.size}
                             style={{ wordBreak: 'normal' }}
                         >
+                            {fieldOption.tablePrefix && (
+                                <Text span inherit c="dimmed">
+                                    {fieldOption.tablePrefix}{' '}
+                                </Text>
+                            )}
                             {fieldOption.label}
                         </Text>
                         {checked && (
@@ -299,6 +350,7 @@ const FieldSelectComponent = <T extends Item = Item>({
     return (
         <Select
             limit={FILTER_SELECT_LIMIT}
+            filter={optionsFilter}
             ref={inputRef}
             w="100%"
             miw={250}

--- a/packages/frontend/src/components/common/FieldSelect/index.tsx
+++ b/packages/frontend/src/components/common/FieldSelect/index.tsx
@@ -14,6 +14,7 @@ import {
     Box,
     CheckIcon,
     Group,
+    Loader,
     Select,
     Text,
     Tooltip,
@@ -31,12 +32,19 @@ interface FieldSelectItem extends ComboboxItem {
     size?: SelectProps['size'];
 }
 
+const ADD_TO_QUERY_GROUP_LABEL = 'Add to query';
+
 type FieldSelectProps<T extends Item = Item> = Omit<
     SelectProps,
     'value' | 'data' | 'onChange'
 > & {
     item?: T;
     items: T[];
+    /** Fields not in the query yet, offered under an "Add to query" group.
+     *  Picking one reaches `onChange` like any other item. */
+    addItems?: T[];
+    /** Shows a spinner while the slot waits on a query run. */
+    loading?: boolean;
     inactiveItemIds?: string[];
     onChange: (value: T | undefined) => void;
     onClosed?: () => void;
@@ -54,6 +62,8 @@ const getLabel = (item: Item, hasGrouping: boolean) => {
 const FieldSelectComponent = <T extends Item = Item>({
     item,
     items,
+    addItems,
+    loading = false,
     onChange,
     onClosed,
     inactiveItemIds = [],
@@ -74,7 +84,7 @@ const FieldSelectComponent = <T extends Item = Item>({
         }
     }, [focusOnRender]);
 
-    const [tableLabelMap, sortedItems] = useMemo(() => {
+    const [tableLabelMap, sortedItems, sortedAddItems] = useMemo(() => {
         const map = new Map<string, string>();
 
         const getTypePriority = (i: Item): number => {
@@ -96,77 +106,73 @@ const FieldSelectComponent = <T extends Item = Item>({
             return i.name;
         };
 
-        return [
-            map,
-            [...items].sort((a, b) => {
-                /**
-                 * Sorting logic:
-                 * Sorts by table first
-                 * Then sorts by type
-                 * 1. Dimensions & Custom dimensions (interval-type dimensions are sorted by time frame, instead of label)
-                 * 2. Metrics & Additional metrics
-                 * 3. Table calculations
-                 * Then sorts by label
-                 */
-                if (
-                    isField(a) &&
-                    !isCustomDimension(a) &&
-                    a.table &&
-                    a.tableLabel
-                ) {
-                    map.set(a.table, a.tableLabel);
-                }
-                if (
-                    isField(b) &&
-                    !isCustomDimension(b) &&
-                    b.table &&
-                    b.tableLabel
-                ) {
-                    map.set(b.table, b.tableLabel);
-                }
+        /**
+         * Sorting logic:
+         * Sorts by table first
+         * Then sorts by type
+         * 1. Dimensions & Custom dimensions (interval-type dimensions are sorted by time frame, instead of label)
+         * 2. Metrics & Additional metrics
+         * 3. Table calculations
+         * Then sorts by label
+         */
+        const compare = (a: T, b: T): number => {
+            // Prioritise items from the base table
+            if (baseTable) {
+                const aIsInTable = 'table' in a && a.table === baseTable;
+                const bIsInTable = 'table' in b && b.table === baseTable;
+                if (aIsInTable !== bIsInTable) return aIsInTable ? -1 : 1;
+            }
 
-                // Prioritise items from the base table
-                if (baseTable) {
-                    const aIsInTable = 'table' in a && a.table === baseTable;
-                    const bIsInTable = 'table' in b && b.table === baseTable;
-                    if (aIsInTable !== bIsInTable) return aIsInTable ? -1 : 1;
-                }
+            // Sort by table label for items from different tables
+            if (isField(a) && isField(b) && a.table !== b.table) {
+                return (a.tableLabel || '').localeCompare(b.tableLabel || '');
+            }
 
-                // Sort by table label for items from different tables
-                if (isField(a) && isField(b) && a.table !== b.table) {
-                    return (a.tableLabel || '').localeCompare(
-                        b.tableLabel || '',
-                    );
-                }
+            // Sort by item type priority (dimensions + custom dimensions > metrics + custom metrics > table calculations)
+            const priorityDiff = getTypePriority(a) - getTypePriority(b);
+            if (priorityDiff !== 0) return priorityDiff;
 
-                // Sort by item type priority (dimensions + custom dimensions > metrics + custom metrics > table calculations)
-                const priorityDiff = getTypePriority(a) - getTypePriority(b);
-                if (priorityDiff !== 0) return priorityDiff;
+            // Sort by group (timeIntervalBaseDimensionName or name)
+            const groupComparison = getGroupKey(a).localeCompare(
+                getGroupKey(b),
+            );
+            if (groupComparison !== 0) return groupComparison;
 
-                // Sort by group (timeIntervalBaseDimensionName or name)
-                const groupComparison = getGroupKey(a).localeCompare(
-                    getGroupKey(b),
-                );
-                if (groupComparison !== 0) return groupComparison;
+            // Within the same group, sort time-based dimensions by their time interval
+            if (
+                isDimension(a) &&
+                isDimension(b) &&
+                'timeInterval' in a &&
+                'timeInterval' in b &&
+                a.timeInterval &&
+                b.timeInterval
+            ) {
+                return sortTimeFrames(a.timeInterval, b.timeInterval);
+            }
 
-                // Within the same group, sort time-based dimensions by their time interval
-                if (
-                    isDimension(a) &&
-                    isDimension(b) &&
-                    'timeInterval' in a &&
-                    'timeInterval' in b &&
-                    a.timeInterval &&
-                    b.timeInterval
-                ) {
-                    return sortTimeFrames(a.timeInterval, b.timeInterval);
-                }
+            return getLabel(a, hasGrouping).localeCompare(
+                getLabel(b, hasGrouping),
+            );
+        };
 
-                return getLabel(a, hasGrouping).localeCompare(
-                    getLabel(b, hasGrouping),
-                );
-            }),
-        ];
-    }, [items, baseTable, hasGrouping]);
+        const itemIds = new Set(items.map(getItemId));
+        const dedupedAddItems = (addItems ?? []).filter(
+            (i) => !itemIds.has(getItemId(i)),
+        );
+
+        [...items, ...dedupedAddItems].forEach((i) => {
+            if (
+                isField(i) &&
+                !isCustomDimension(i) &&
+                i.table &&
+                i.tableLabel
+            ) {
+                map.set(i.table, i.tableLabel);
+            }
+        });
+
+        return [map, [...items].sort(compare), dedupedAddItems.sort(compare)];
+    }, [items, addItems, baseTable, hasGrouping]);
 
     const selectedItemId = useMemo(() => {
         return item ? getItemId(item) : null;
@@ -175,11 +181,12 @@ const FieldSelectComponent = <T extends Item = Item>({
     const handleChange = useCallback(
         (value: string | null) => {
             const selectedField = value
-                ? items.find((f) => getItemId(f) === value)
+                ? (items.find((f) => getItemId(f) === value) ??
+                  sortedAddItems.find((f) => getItemId(f) === value))
                 : undefined;
             onChange(selectedField);
         },
-        [items, onChange],
+        [items, sortedAddItems, onChange],
     );
 
     const selectData = useMemo(() => {
@@ -225,8 +232,30 @@ const FieldSelectComponent = <T extends Item = Item>({
             }),
         );
 
-        return [...ungrouped, ...groupedData];
-    }, [sortedItems, hasGrouping, tableLabelMap, inactiveItemIds]);
+        // Not-in-query fields sit in one trailing group; full labels keep
+        // same-named fields from different tables distinguishable.
+        const addEntries: FieldSelectItem[] = sortedAddItems.map((i) => ({
+            item: i,
+            value: getItemId(i),
+            label: getItemLabel(i),
+            description: isField(i) ? i.description : undefined,
+            disabled: inactiveItemIds.includes(getItemId(i)),
+        }));
+
+        return [
+            ...ungrouped,
+            ...groupedData,
+            ...(addEntries.length > 0
+                ? [{ group: ADD_TO_QUERY_GROUP_LABEL, items: addEntries }]
+                : []),
+        ];
+    }, [
+        sortedItems,
+        sortedAddItems,
+        hasGrouping,
+        tableLabelMap,
+        inactiveItemIds,
+    ]);
 
     const renderOption = useCallback(
         ({ option, checked }: { option: ComboboxItem; checked?: boolean }) => {
@@ -285,6 +314,10 @@ const FieldSelectComponent = <T extends Item = Item>({
                 rest.clearable || rest.rightSection ? 'all' : 'none'
             }
             {...rest}
+            {...(loading && {
+                rightSection: <Loader size="xs" />,
+                rightSectionPointerEvents: 'none' as const,
+            })}
             value={selectedItemId}
             data={selectData}
             onChange={handleChange}

--- a/packages/frontend/src/features/explorer/store/explorerSlice.ts
+++ b/packages/frontend/src/features/explorer/store/explorerSlice.ts
@@ -79,6 +79,65 @@ const removePivotValuesFromSorts = (sorts: SortField[]): SortField[] => {
     }, []);
 };
 
+const applyToggleDimension = (state: ExplorerSliceState, fieldId: FieldId) => {
+    const currentDimensions = state.unsavedChartVersion.metricQuery.dimensions;
+
+    state.unsavedChartVersion.metricQuery.dimensions = toggleArrayValue(
+        currentDimensions,
+        fieldId,
+    );
+
+    state.unsavedChartVersion.metricQuery.sorts =
+        state.unsavedChartVersion.metricQuery.sorts.filter(
+            (s) => s.fieldId !== fieldId,
+        );
+
+    const dimensionIds = state.unsavedChartVersion.metricQuery.dimensions;
+    const metricIds = state.unsavedChartVersion.metricQuery.metrics;
+    const calcIds = state.unsavedChartVersion.metricQuery.tableCalculations.map(
+        ({ name }) => name,
+    );
+
+    state.unsavedChartVersion.tableConfig.columnOrder = calcColumnOrder(
+        state.unsavedChartVersion.tableConfig.columnOrder,
+        [...dimensionIds, ...metricIds, ...calcIds],
+        dimensionIds,
+    );
+};
+
+const applyToggleMetric = (state: ExplorerSliceState, fieldId: FieldId) => {
+    const currentMetrics = state.unsavedChartVersion.metricQuery.metrics;
+
+    state.unsavedChartVersion.metricQuery.metrics = toggleArrayValue(
+        currentMetrics,
+        fieldId,
+    );
+
+    state.unsavedChartVersion.metricQuery.sorts =
+        state.unsavedChartVersion.metricQuery.sorts.filter(
+            (s) => s.fieldId !== fieldId,
+        );
+
+    state.unsavedChartVersion.metricQuery.metricOverrides = Object.fromEntries(
+        Object.entries(
+            state.unsavedChartVersion.metricQuery.metricOverrides || {},
+        ).filter(([key]) =>
+            state.unsavedChartVersion.metricQuery.metrics.includes(key),
+        ),
+    );
+
+    const dimensionIds = state.unsavedChartVersion.metricQuery.dimensions;
+    const metricIds = state.unsavedChartVersion.metricQuery.metrics;
+    const calcIds = state.unsavedChartVersion.metricQuery.tableCalculations.map(
+        ({ name }) => name,
+    );
+
+    state.unsavedChartVersion.tableConfig.columnOrder = calcColumnOrder(
+        state.unsavedChartVersion.tableConfig.columnOrder,
+        [...dimensionIds, ...metricIds, ...calcIds],
+    );
+};
+
 const explorerSlice = createSlice({
     name: 'explorer',
     initialState,
@@ -148,74 +207,36 @@ const explorerSlice = createSlice({
         },
 
         toggleDimension: (state, action: PayloadAction<FieldId>) => {
-            const fieldId = action.payload;
-            const currentDimensions =
-                state.unsavedChartVersion.metricQuery.dimensions;
-
-            state.unsavedChartVersion.metricQuery.dimensions = toggleArrayValue(
-                currentDimensions,
-                fieldId,
-            );
-
-            state.unsavedChartVersion.metricQuery.sorts =
-                state.unsavedChartVersion.metricQuery.sorts.filter(
-                    (s) => s.fieldId !== fieldId,
-                );
-
-            const dimensionIds =
-                state.unsavedChartVersion.metricQuery.dimensions;
-            const metricIds = state.unsavedChartVersion.metricQuery.metrics;
-            const calcIds =
-                state.unsavedChartVersion.metricQuery.tableCalculations.map(
-                    ({ name }) => name,
-                );
-
-            state.unsavedChartVersion.tableConfig.columnOrder = calcColumnOrder(
-                state.unsavedChartVersion.tableConfig.columnOrder,
-                [...dimensionIds, ...metricIds, ...calcIds],
-                dimensionIds,
-            );
+            applyToggleDimension(state, action.payload);
         },
 
         toggleMetric: (state, action: PayloadAction<FieldId>) => {
-            const fieldId = action.payload;
-            const currentMetrics =
-                state.unsavedChartVersion.metricQuery.metrics;
+            applyToggleMetric(state, action.payload);
+        },
 
-            state.unsavedChartVersion.metricQuery.metrics = toggleArrayValue(
-                currentMetrics,
-                fieldId,
-            );
+        // Config-panel "Add to query" pickers: never deselect, and always run
+        // the query — itemsMap only refreshes from results, even when
+        // auto-fetch is off.
+        addDimensionToQuery: (state, action: PayloadAction<FieldId>) => {
+            if (
+                !state.unsavedChartVersion.metricQuery.dimensions.includes(
+                    action.payload,
+                )
+            ) {
+                applyToggleDimension(state, action.payload);
+            }
+            state.queryExecution.pendingFetch = true;
+        },
 
-            state.unsavedChartVersion.metricQuery.sorts =
-                state.unsavedChartVersion.metricQuery.sorts.filter(
-                    (s) => s.fieldId !== fieldId,
-                );
-
-            state.unsavedChartVersion.metricQuery.metricOverrides =
-                Object.fromEntries(
-                    Object.entries(
-                        state.unsavedChartVersion.metricQuery.metricOverrides ||
-                            {},
-                    ).filter(([key]) =>
-                        state.unsavedChartVersion.metricQuery.metrics.includes(
-                            key,
-                        ),
-                    ),
-                );
-
-            const dimensionIds =
-                state.unsavedChartVersion.metricQuery.dimensions;
-            const metricIds = state.unsavedChartVersion.metricQuery.metrics;
-            const calcIds =
-                state.unsavedChartVersion.metricQuery.tableCalculations.map(
-                    ({ name }) => name,
-                );
-
-            state.unsavedChartVersion.tableConfig.columnOrder = calcColumnOrder(
-                state.unsavedChartVersion.tableConfig.columnOrder,
-                [...dimensionIds, ...metricIds, ...calcIds],
-            );
+        addMetricToQuery: (state, action: PayloadAction<FieldId>) => {
+            if (
+                !state.unsavedChartVersion.metricQuery.metrics.includes(
+                    action.payload,
+                )
+            ) {
+                applyToggleMetric(state, action.payload);
+            }
+            state.queryExecution.pendingFetch = true;
         },
 
         removeField: (state, action: PayloadAction<FieldId>) => {

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
@@ -978,9 +978,8 @@ const useCartesianChartConfig = ({
             ];
         }, [resultsData, sortedDimensions]);
 
-    // Fields the current (not-yet-run) query selects. `availableFields` only
-    // knows the last run, so without this a field just added from a config
-    // picker would be stripped from the layout before its results land.
+    // `availableFields` only knows the last run; a field just added from a
+    // config picker must not be stripped before its results land.
     const pendingFieldIds = useMemo(
         () =>
             unsavedMetricQuery

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
@@ -68,6 +68,9 @@ type Args = {
     cartesianType: CartesianTypeOptions | undefined;
     colorPalette: string[];
     tableCalculationsMetadata?: TableCalculationMetadata[];
+    /** The not-yet-run metric query; its fields count as valid layout
+     *  references so a just-added field survives until results land. */
+    unsavedMetricQuery?: MetricQuery;
 };
 
 const getReferenceLineKey = ({ fieldId, fieldRef, data }: ReferenceLineField) =>
@@ -322,6 +325,7 @@ const useCartesianChartConfig = ({
     stacking,
     cartesianType,
     tableCalculationsMetadata,
+    unsavedMetricQuery,
 }: Args) => {
     const [columnLimit, setColumnLimit] = useState<number | undefined>(
         initialChartConfig?.columnLimit,
@@ -974,6 +978,23 @@ const useCartesianChartConfig = ({
             ];
         }, [resultsData, sortedDimensions]);
 
+    // Fields the current (not-yet-run) query selects. `availableFields` only
+    // knows the last run, so without this a field just added from a config
+    // picker would be stripped from the layout before its results land.
+    const pendingFieldIds = useMemo(
+        () =>
+            unsavedMetricQuery
+                ? new Set([
+                      ...unsavedMetricQuery.dimensions,
+                      ...unsavedMetricQuery.metrics,
+                      ...unsavedMetricQuery.tableCalculations.map(
+                          ({ name }) => name,
+                      ),
+                  ])
+                : undefined,
+        [unsavedMetricQuery],
+    );
+
     /**
      * Is valid when the field is a table calculation in the metadata with the current name
      */
@@ -1049,18 +1070,17 @@ const useCartesianChartConfig = ({
                 const xField = getXField(prev?.xField);
                 const yFields = getYFields(prev?.yField);
 
+                const isValidFieldReference = (fieldId: string) =>
+                    availableFields.includes(fieldId) ||
+                    isFieldValidTableCalculation(fieldId) ||
+                    pendingFieldIds?.has(fieldId) === true;
+
                 const isCurrentXFieldValid: boolean =
                     xField === EMPTY_X_AXIS ||
-                    (!!xField &&
-                        (availableFields.includes(xField) ||
-                            isFieldValidTableCalculation(xField)));
+                    (!!xField && isValidFieldReference(xField));
 
                 const currentValidYFields = yFields
-                    ? yFields.filter(
-                          (y) =>
-                              availableFields.includes(y) ||
-                              isFieldValidTableCalculation(y),
-                      )
+                    ? yFields.filter(isValidFieldReference)
                     : [];
 
                 const isCurrentYFieldsValid: boolean =
@@ -1196,6 +1216,7 @@ const useCartesianChartConfig = ({
         getXField,
         getYFields,
         isFieldValidTableCalculation,
+        pendingFieldIds,
         itemsMap,
     ]);
 

--- a/packages/frontend/src/hooks/usePieChartConfig.ts
+++ b/packages/frontend/src/hooks/usePieChartConfig.ts
@@ -10,6 +10,7 @@ import {
     type Dimension,
     type ItemsMap,
     type Metric,
+    type MetricQuery,
     type ParametersValuesMap,
     type PieChart,
     type PieChartLegendPosition,
@@ -33,7 +34,7 @@ type PieChartConfig = {
     validConfig: PieChart;
 
     groupFieldIds: (string | null)[];
-    groupAdd: () => void;
+    groupAdd: (dimensionId?: string) => void;
     groupChange: (prevDimensionId: string, newDimensionId: string) => void;
     groupRemove: (dimensionId: string) => void;
 
@@ -96,6 +97,9 @@ export type PieChartConfigFn = (
     colorPalette: string[],
     tableCalculationsMetadata?: TableCalculationMetadata[],
     parameters?: ParametersValuesMap,
+    /** The not-yet-run metric query; its fields count as valid group/metric
+     *  references so a just-added field survives until results land. */
+    unsavedMetricQuery?: MetricQuery,
 ) => PieChartConfig;
 
 const usePieChartConfig: PieChartConfigFn = (
@@ -107,6 +111,7 @@ const usePieChartConfig: PieChartConfigFn = (
     colorPalette,
     tableCalculationsMetadata,
     parameters,
+    unsavedMetricQuery,
 ) => {
     const [groupFieldIds, setGroupFieldIds] = useState(
         pieChartConfig?.groupFieldIds ?? [],
@@ -187,11 +192,25 @@ const usePieChartConfig: PieChartConfigFn = (
 
     const isLoading = !resultsData;
 
+    // Fields the current (not-yet-run) query selects. The pools above only
+    // know the last run, so without this a field just added from the config
+    // picker would be dropped before its results land.
+    const pendingDimensionIds = useMemo(
+        () => new Set(unsavedMetricQuery?.dimensions),
+        [unsavedMetricQuery?.dimensions],
+    );
+    const pendingMetricIds = useMemo(
+        () => new Set(unsavedMetricQuery?.metrics),
+        [unsavedMetricQuery?.metrics],
+    );
+
     useEffect(() => {
         if (isLoading || dimensionIds.length === 0) return;
 
-        const newGroupFieldIds = groupFieldIds.filter((id) =>
-            dimensionIds.includes(id),
+        const newGroupFieldIds = groupFieldIds.filter(
+            (id) =>
+                dimensionIds.includes(id) ||
+                (!!id && pendingDimensionIds.has(id)),
         );
 
         const firstDimensionId = dimensionIds[0];
@@ -203,11 +222,22 @@ const usePieChartConfig: PieChartConfigFn = (
         if (isEqual(newGroupFieldIds, groupFieldIds)) return;
 
         setGroupFieldIds(newGroupFieldIds);
-    }, [isLoading, dimensionIds, groupFieldIds, pieChartConfig?.groupFieldIds]);
+    }, [
+        isLoading,
+        dimensionIds,
+        groupFieldIds,
+        pendingDimensionIds,
+        pieChartConfig?.groupFieldIds,
+    ]);
 
     useEffect(() => {
         if (isLoading || allNumericMetricIds.length === 0) return;
-        if (metricId && allNumericMetricIds.includes(metricId)) return;
+        if (
+            metricId &&
+            (allNumericMetricIds.includes(metricId) ||
+                pendingMetricIds.has(metricId))
+        )
+            return;
 
         /**
          * When table calculations update, their name changes, so we need to update the selected fields
@@ -225,7 +255,13 @@ const usePieChartConfig: PieChartConfigFn = (
         }
 
         setMetricId(allNumericMetricIds[0] ?? null);
-    }, [allNumericMetricIds, isLoading, metricId, tableCalculationsMetadata]);
+    }, [
+        allNumericMetricIds,
+        isLoading,
+        metricId,
+        pendingMetricIds,
+        tableCalculationsMetadata,
+    ]);
 
     const isValueLabelOverriden = useMemo(() => {
         return Object.values(groupValueOptionOverrides).some(
@@ -349,16 +385,21 @@ const usePieChartConfig: PieChartConfigFn = (
         [],
     );
 
-    const handleGroupAdd = useCallback(() => {
-        setGroupFieldIds((prev) => {
-            const nextId = dimensionIds.find((id) => !prev.includes(id));
-            if (!nextId) return prev;
+    const handleGroupAdd = useCallback(
+        (dimensionId?: string) => {
+            setGroupFieldIds((prev) => {
+                const nextId =
+                    dimensionId ??
+                    dimensionIds.find((id) => !prev.includes(id));
+                if (!nextId) return prev;
 
-            const newSet = new Set(prev);
-            newSet.add(nextId);
-            return [...newSet.values()];
-        });
-    }, [dimensionIds]);
+                const newSet = new Set(prev);
+                newSet.add(nextId);
+                return [...newSet.values()];
+            });
+        },
+        [dimensionIds],
+    );
 
     const handleRemoveGroup = useCallback((dimensionId: string) => {
         setGroupFieldIds((prev) => {

--- a/packages/frontend/src/hooks/usePieChartConfig.ts
+++ b/packages/frontend/src/hooks/usePieChartConfig.ts
@@ -192,9 +192,8 @@ const usePieChartConfig: PieChartConfigFn = (
 
     const isLoading = !resultsData;
 
-    // Fields the current (not-yet-run) query selects. The pools above only
-    // know the last run, so without this a field just added from the config
-    // picker would be dropped before its results land.
+    // The pools above only know the last run; a field just added from the
+    // config picker must not be dropped before its results land.
     const pendingDimensionIds = useMemo(
         () => new Set(unsavedMetricQuery?.dimensions),
         [unsavedMetricQuery?.dimensions],


### PR DESCRIPTION
## Summary

Every chart-config field picker used to offer only the fields already in the query (`itemsMap` from the last run), so putting a new field on an axis meant a round trip through the sidebar: find it, add it, run, come back. This PR lets you pick any visible field of the current explore directly in the config dropdowns — following the pattern the merge-join bar already established.

**What changed**

- **`FieldSelect`** gains an optional `addItems` pool rendered as a trailing **"Add to query"** group (full labels, deduped against the in-query pool) and a `loading` prop that shows a spinner on a slot while its run is in flight.
- **New explorer actions `addDimensionToQuery` / `addMetricToQuery`** — toggle semantics but never toggle-off, and they set `pendingFetch` so the query runs even with auto-fetch disabled (itemsMap only refreshes from results, so without a run the chart could never plot the field).
- **New shared hook `useAddFieldsToQuery`** builds the addable pool from the explore (`getItemMap` + the query's custom dimensions/additional metrics/table calcs, hidden fields excluded), dispatches the right add action per item type, and reports per-slot pending state.
- **Reconciler guards**: the cartesian "fallout layout" effect, the pie group/metric effects, and the data-app-viz `reconcileDataAppVizFieldMapping` call now treat fields of the current *not-yet-run* metric query as valid, so a just-assigned field is not stripped before its results land.
- **Wired into**: cartesian layout (X, Y, Group — including the Add buttons, which fall back to the explore pool when every in-query field is used), pie layout (groups + metric), and the custom chart type field mapping (both slot pools keep the hidden-field filtering from GLITCH-607).
- **Empty states updated**: the pie "to add more groups you need to add more dimensions to your query" tooltip and the data-app-viz "you need at least one dimension in your chart" placeholder now only appear when the *explore* genuinely has nothing to offer.

Out of scope (per ticket): table config, removing fields from the config panel, other viz types (sankey/map/funnel/…) — fast-follow once this pattern is proven.

## Validation

- E2E in the local app with auto-fetch off: cartesian Y-metric pick from "Add to query" (field added to query, query auto-ran, chart updated), Group add pulling a dimension from the explore pool (pivot survived the reconcilers through the in-flight window), pie group add + metric swap to a not-in-query metric (guards held `groupFieldIds`/`metricId`).
- Custom chart type: selected the official KPI Delta type from the project gallery, picked a not-in-query metric for its Comparison value slot from “Add to query” — the metric was added to the query, the mapping kept the binding through the in-flight run, and the viz re-rendered with the delta.
- `pnpm -F frontend typecheck`, package linter on changed files, and the explorer-slice / cartesian-config / visualization-interaction test suites all pass.

Closes: PROD-10458

🤖 Generated with [Claude Code](https://claude.com/claude-code)
