### PR TITLE
fix(ai): match active data app card to active artifact card

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/DataAppBuildCard.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/DataAppBuildCard.module.css
@@ -4,11 +4,24 @@
     --card-icon-size: 22px;
 }
 
+/* Same active treatment as AiArtifactButton, so an open app and an open
+   artifact read the same in the thread. */
 .cardActive {
-    border-color: var(--mantine-color-ldDark-9);
     background-color: light-dark(
-        var(--mantine-color-ldGray-0),
-        var(--mantine-color-ldDark-7)
+        color-mix(
+            in srgb,
+            var(--mantine-color-indigo-6) 3.5%,
+            var(--mantine-color-white)
+        ),
+        var(--mantine-color-dark-6)
+    );
+    border-color: light-dark(
+        color-mix(
+            in srgb,
+            var(--mantine-color-indigo-6) 18%,
+            var(--mantine-color-ldGray-2)
+        ),
+        var(--mantine-color-ldGray-3)
     );
 }
 

--- a/packages/frontend/src/stories/DataAppBuildCard.stories.tsx
+++ b/packages/frontend/src/stories/DataAppBuildCard.stories.tsx
@@ -44,6 +44,7 @@ const meta: Meta<typeof DataAppBuildCard> = {
     component: DataAppBuildCard,
     args: {
         compact: false,
+        isActive: false,
         onOpenBuilder: fn(),
         onView: fn(),
     },
@@ -101,6 +102,11 @@ export const CompactReady: Story = {
 
 export const CompactFailed: Story = {
     args: { state: states.failed, compact: true },
+};
+
+/** Open in the preview panel — should match an active artifact card. */
+export const CompactReadyActive: Story = {
+    args: { state: states.ready, compact: true, isActive: true },
 };
 
 /** Every state at a phone-width column; nothing should overflow. */


### PR DESCRIPTION
### Description:

The active data app build card used a heavy black border (`ldDark-9`) plus a grey fill, while an active artifact card uses the subtle indigo-tinted surface and hairline indigo border. `.cardActive` now uses the same declarations as `AiArtifactButton`'s `[data-artifact-open='true']`, so an open app and an open artifact read the same in a thread.

I read the acceptance criteria's "navigation affordance" as the existing `View`/menu controls, and left them alone — the artifact card's chevron is its whole-card click target, which the app card intentionally doesn't have. Happy to change that if the intent was to make the card itself clickable.

Also added a `CompactReadyActive` story (and `isActive` to the story args, which was previously missing a required prop) so the state is reviewable in Storybook.

No screenshot: there's no Chrome in this environment to render the story.

### Risk assessment:

- [ ] This is a high-risk change

CSS-only change to one card's active state.
