### PR TITLE
feat(onboarding): graduate coding agent rollout flag

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -947,7 +947,6 @@ type OnboardingHomepageProvisionedEvent = BaseTrack & {
         homepageUuid: string;
         onboardingFlow: OnboardingFlow;
         homepageBuilderEnablement: HomepageBuilderEnablement | null;
-        codingAgentOnboardingEnablement: CodingAgentOnboardingEnablement | null;
     };
 };
 
@@ -989,7 +988,6 @@ type OnboardingHomepageSkippedEvent = BaseTrack & {
         projectId: string;
         onboardingFlow: OnboardingFlow;
         homepageBuilderEnablement: HomepageBuilderEnablement | null;
-        codingAgentOnboardingEnablement: CodingAgentOnboardingEnablement | null;
         reason: OnboardingHomepageSkippedReason;
     };
 };
@@ -1002,7 +1000,6 @@ type OnboardingHomepageFailedEvent = BaseTrack & {
         projectId: string;
         onboardingFlow: OnboardingFlow;
         homepageBuilderEnablement: HomepageBuilderEnablement | null;
-        codingAgentOnboardingEnablement: CodingAgentOnboardingEnablement | null;
         errorType: string;
     };
 };
@@ -1014,15 +1011,10 @@ type OnboardingOrgFlagsProvisionedEvent = BaseTrack & {
         organizationId: string;
         onboardingFlow: OnboardingFlow;
         homepageBuilderEnablement: HomepageBuilderEnablement;
-        codingAgentOnboardingEnablement: CodingAgentOnboardingEnablement;
     };
 };
 
 export type HomepageBuilderEnablement =
-    | EnsureOrganizationOverrideOutcome
-    | 'failed';
-
-export type CodingAgentOnboardingEnablement =
     | EnsureOrganizationOverrideOutcome
     | 'failed';
 

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -378,6 +378,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     userService: repository.getUserService(),
                     schedulerClient:
                         clients.getSchedulerClient() as CommercialSchedulerClient,
+                    featureFlagService: repository.getFeatureFlagService(),
                 }),
             previewDeploySetupService: ({ context, models }) =>
                 new PreviewDeploySetupService({

--- a/packages/backend/src/ee/services/OnboardingAgentService/OnboardingAgentService.test.ts
+++ b/packages/backend/src/ee/services/OnboardingAgentService/OnboardingAgentService.test.ts
@@ -1,0 +1,114 @@
+import { Ability } from '@casl/ability';
+import {
+    FeatureFlags,
+    ForbiddenError,
+    OrganizationMemberRole,
+    type PossibleAbilities,
+    type SessionUser,
+} from '@lightdash/common';
+import { type LightdashConfig } from '../../../config/parseConfig';
+import { type ProjectModel } from '../../../models/ProjectModel/ProjectModel';
+import { type PersonalAccessTokenService } from '../../../services/PersonalAccessTokenService';
+import { type PromptService } from '../../../services/PromptService/PromptService';
+import { type UserService } from '../../../services/UserService';
+import { type AgentOnboardingRunModel } from '../../models/AgentOnboardingRunModel';
+import { type SandboxRegistryModel } from '../../models/SandboxRegistryModel';
+import { type CommercialSchedulerClient } from '../../scheduler/SchedulerClient';
+import { type OnboardingAgentFileStore } from './OnboardingAgentFileStore';
+import { OnboardingAgentService } from './OnboardingAgentService';
+
+const ORGANIZATION_UUID = '00000000-0000-0000-0000-000000000001';
+const PROJECT_UUID = '00000000-0000-0000-0000-000000000002';
+const USER_UUID = '00000000-0000-0000-0000-000000000003';
+const NOW = new Date('2026-09-02T10:00:00.000Z');
+
+const user: SessionUser = {
+    userUuid: USER_UUID,
+    email: 'admin@example.com',
+    firstName: 'Admin',
+    lastName: 'User',
+    organizationUuid: ORGANIZATION_UUID,
+    organizationName: 'Organization',
+    organizationCreatedAt: NOW,
+    userId: 1,
+    role: OrganizationMemberRole.ADMIN,
+    isTrackingAnonymized: false,
+    isMarketingOptedIn: false,
+    avatarUrl: null,
+    avatarGradient: null,
+    isSetupComplete: true,
+    isActive: true,
+    createdAt: NOW,
+    updatedAt: NOW,
+    timezone: null,
+    abilityRules: [],
+    ability: new Ability<PossibleAbilities>([
+        { action: 'view', subject: 'Project' },
+    ]),
+};
+
+const buildService = (codingAgentEnabled: boolean) => {
+    const getFeatureFlag = vi.fn().mockResolvedValue({
+        id: FeatureFlags.CodingAgent,
+        enabled: codingAgentEnabled,
+    });
+    const getProjectSummary = vi.fn().mockResolvedValue({
+        organizationUuid: ORGANIZATION_UUID,
+    });
+    const findActiveRunForProject = vi.fn().mockResolvedValue(undefined);
+
+    const dependencies = {
+        lightdashConfig: {} as LightdashConfig,
+        agentOnboardingRunModel: {
+            findActiveRunForProject,
+        } as unknown as AgentOnboardingRunModel,
+        sandboxRegistryModel: {} as SandboxRegistryModel,
+        projectModel: {
+            getSummary: getProjectSummary,
+        } as unknown as ProjectModel,
+        personalAccessTokenService: {} as PersonalAccessTokenService,
+        promptService: {} as PromptService,
+        userService: {} as UserService,
+        schedulerClient: {} as CommercialSchedulerClient,
+        fileStore: {} as OnboardingAgentFileStore,
+        featureFlagService: { get: getFeatureFlag },
+    };
+
+    return {
+        service: new OnboardingAgentService(dependencies),
+        getFeatureFlag,
+        getProjectSummary,
+        findActiveRunForProject,
+    };
+};
+
+describe('OnboardingAgentService entitlement', () => {
+    it('allows entitled organizations to access agent onboarding runs', async () => {
+        const mocks = buildService(true);
+
+        await expect(
+            mocks.service.getActiveRun(user, PROJECT_UUID),
+        ).resolves.toBeNull();
+
+        expect(mocks.getFeatureFlag).toHaveBeenCalledExactlyOnceWith({
+            user,
+            featureFlagId: FeatureFlags.CodingAgent,
+        });
+        expect(mocks.findActiveRunForProject).toHaveBeenCalledExactlyOnceWith(
+            PROJECT_UUID,
+        );
+    });
+
+    it('blocks organizations without coding-agent entitlement from starting a run', async () => {
+        const mocks = buildService(false);
+
+        await expect(
+            mocks.service.createRun({ user, projectUuid: PROJECT_UUID }),
+        ).rejects.toThrow(
+            new ForbiddenError('Coding agent onboarding is not available'),
+        );
+
+        expect(mocks.getProjectSummary).not.toHaveBeenCalled();
+        expect(mocks.findActiveRunForProject).not.toHaveBeenCalled();
+    });
+});

--- a/packages/backend/src/ee/services/OnboardingAgentService/OnboardingAgentService.ts
+++ b/packages/backend/src/ee/services/OnboardingAgentService/OnboardingAgentService.ts
@@ -1,5 +1,6 @@
 import { subject } from '@casl/ability';
 import {
+    FeatureFlags,
     ForbiddenError,
     getConnectionDefaults,
     getErrorMessage,
@@ -20,6 +21,7 @@ import { fromSession } from '../../../auth/account';
 import { type LightdashConfig } from '../../../config/parseConfig';
 import { type ProjectModel } from '../../../models/ProjectModel/ProjectModel';
 import { BaseService } from '../../../services/BaseService';
+import { type FeatureFlagService } from '../../../services/FeatureFlag/FeatureFlagService';
 import { type PersonalAccessTokenService } from '../../../services/PersonalAccessTokenService';
 import { type PromptService } from '../../../services/PromptService/PromptService';
 import { type UserService } from '../../../services/UserService';
@@ -88,6 +90,7 @@ type Dependencies = {
     promptService: PromptService;
     userService: UserService;
     schedulerClient: CommercialSchedulerClient;
+    featureFlagService: Pick<FeatureFlagService, 'get'>;
     sandboxManager?: SandboxManager;
     fileStore?: OnboardingAgentFileStore;
 };
@@ -134,6 +137,8 @@ export class OnboardingAgentService extends BaseService {
 
     private readonly schedulerClient: CommercialSchedulerClient;
 
+    private readonly featureFlagService: Pick<FeatureFlagService, 'get'>;
+
     private readonly fileStore: OnboardingAgentFileStore;
 
     private sandboxManager: SandboxManager | undefined;
@@ -149,12 +154,25 @@ export class OnboardingAgentService extends BaseService {
         this.promptService = dependencies.promptService;
         this.userService = dependencies.userService;
         this.schedulerClient = dependencies.schedulerClient;
+        this.featureFlagService = dependencies.featureFlagService;
         this.fileStore =
             dependencies.fileStore ??
             new OnboardingAgentFileStore({
                 lightdashConfig: dependencies.lightdashConfig,
             });
         this.sandboxManager = dependencies.sandboxManager;
+    }
+
+    private async assertCodingAgentEnabled(user: SessionUser): Promise<void> {
+        const { enabled } = await this.featureFlagService.get({
+            user,
+            featureFlagId: FeatureFlags.CodingAgent,
+        });
+        if (!enabled) {
+            throw new ForbiddenError(
+                'Coding agent onboarding is not available',
+            );
+        }
     }
 
     private async assertCanViewProject(
@@ -199,6 +217,7 @@ export class OnboardingAgentService extends BaseService {
         if (!isUserWithOrg(args.user)) {
             throw new ForbiddenError('User is not part of an organization');
         }
+        await this.assertCodingAgentEnabled(args.user);
         const { organizationUuid } = await this.assertCanManageProject(
             args.user,
             args.projectUuid,
@@ -248,6 +267,7 @@ export class OnboardingAgentService extends BaseService {
         user: SessionUser,
         projectUuid: string,
     ): Promise<AgentOnboardingRun | null> {
+        await this.assertCodingAgentEnabled(user);
         await this.assertCanViewProject(user, projectUuid);
         const run =
             await this.agentOnboardingRunModel.findActiveRunForProject(
@@ -279,6 +299,7 @@ export class OnboardingAgentService extends BaseService {
         projectUuid: string,
         agentOnboardingRunUuid: string,
     ): Promise<DbAgentOnboardingRun> {
+        await this.assertCodingAgentEnabled(user);
         const run = await this.findOrganizationScopedRun(
             user,
             agentOnboardingRunUuid,

--- a/packages/backend/src/ee/services/OrganizationService/provisionOnboardingOrgFlags.test.ts
+++ b/packages/backend/src/ee/services/OrganizationService/provisionOnboardingOrgFlags.test.ts
@@ -90,13 +90,10 @@ describe('provisionOnboardingOrgFlags', () => {
         vi.restoreAllMocks();
     });
 
-    it('enables both flags and tracks their outcomes', async () => {
+    it('enables the homepage builder and tracks the outcome', async () => {
         const mocks = buildArguments();
-        mocks.ensureOrganizationOverrideEnabled.mockImplementation(
-            async ({ featureFlagId }) =>
-                featureFlagId === CommercialFeatureFlags.HomepageBuilder
-                    ? 'already_enabled'
-                    : 'kept_disabled',
+        mocks.ensureOrganizationOverrideEnabled.mockResolvedValue(
+            'already_enabled',
         );
 
         await provisionOnboardingOrgFlags(mocks.args);
@@ -105,16 +102,11 @@ describe('provisionOnboardingOrgFlags', () => {
             user,
             featureFlagId: FeatureFlags.NewOnboarding,
         });
-        expect(mocks.ensureOrganizationOverrideEnabled).toHaveBeenCalledTimes(
-            2,
-        );
-        expect(mocks.ensureOrganizationOverrideEnabled).toHaveBeenCalledWith({
+        expect(
+            mocks.ensureOrganizationOverrideEnabled,
+        ).toHaveBeenCalledExactlyOnceWith({
             user,
             featureFlagId: CommercialFeatureFlags.HomepageBuilder,
-        });
-        expect(mocks.ensureOrganizationOverrideEnabled).toHaveBeenCalledWith({
-            user,
-            featureFlagId: FeatureFlags.CodingAgentOnboarding,
         });
         expect(mocks.track).toHaveBeenCalledExactlyOnceWith({
             event: 'onboarding_org_flags.provisioned',
@@ -123,7 +115,6 @@ describe('provisionOnboardingOrgFlags', () => {
                 organizationId: ORGANIZATION_UUID,
                 onboardingFlow: 'new',
                 homepageBuilderEnablement: 'already_enabled',
-                codingAgentOnboardingEnablement: 'kept_disabled',
             },
         });
     });
@@ -147,22 +138,13 @@ describe('provisionOnboardingOrgFlags', () => {
             .spyOn(Logger, 'error')
             .mockImplementation(() => Logger);
         const mocks = buildArguments();
-        mocks.ensureOrganizationOverrideEnabled.mockImplementation(
-            async ({ featureFlagId }) => {
-                if (featureFlagId === CommercialFeatureFlags.HomepageBuilder) {
-                    throw error;
-                }
-                return 'enabled';
-            },
-        );
+        mocks.ensureOrganizationOverrideEnabled.mockRejectedValue(error);
 
         await expect(
             provisionOnboardingOrgFlags(mocks.args),
         ).resolves.toBeUndefined();
 
-        expect(mocks.ensureOrganizationOverrideEnabled).toHaveBeenCalledTimes(
-            2,
-        );
+        expect(mocks.ensureOrganizationOverrideEnabled).toHaveBeenCalledOnce();
         expect(Sentry.captureException).toHaveBeenCalledExactlyOnceWith(error);
         expect(errorSpy).toHaveBeenCalledOnce();
         expect(mocks.track).toHaveBeenCalledExactlyOnceWith({
@@ -172,7 +154,6 @@ describe('provisionOnboardingOrgFlags', () => {
                 organizationId: ORGANIZATION_UUID,
                 onboardingFlow: 'new',
                 homepageBuilderEnablement: 'failed',
-                codingAgentOnboardingEnablement: 'enabled',
             },
         });
     });

--- a/packages/backend/src/ee/services/OrganizationService/provisionOnboardingOrgFlags.ts
+++ b/packages/backend/src/ee/services/OrganizationService/provisionOnboardingOrgFlags.ts
@@ -5,7 +5,6 @@ import {
 } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
 import {
-    type CodingAgentOnboardingEnablement,
     type HomepageBuilderEnablement,
     type LightdashAnalytics,
 } from '../../../analytics/LightdashAnalytics';
@@ -53,23 +52,6 @@ export const provisionOnboardingOrgFlags = async ({
         homepageBuilderEnablement = 'failed';
     }
 
-    let codingAgentOnboardingEnablement: CodingAgentOnboardingEnablement;
-    try {
-        codingAgentOnboardingEnablement =
-            await featureFlagService.ensureOrganizationOverrideEnabled({
-                user,
-                featureFlagId: FeatureFlags.CodingAgentOnboarding,
-            });
-    } catch (error) {
-        Sentry.captureException(error);
-        Logger.error(
-            `Failed to enable coding agent onboarding for organization ${organizationUuid}: ${
-                error instanceof Error ? error.message : String(error)
-            }`,
-        );
-        codingAgentOnboardingEnablement = 'failed';
-    }
-
     analytics.track({
         event: 'onboarding_org_flags.provisioned',
         userId: user.userUuid,
@@ -77,7 +59,6 @@ export const provisionOnboardingOrgFlags = async ({
             organizationId: organizationUuid,
             onboardingFlow: 'new',
             homepageBuilderEnablement,
-            codingAgentOnboardingEnablement,
         },
     });
 };

--- a/packages/backend/src/ee/services/ProjectService/provisionOnboardingHomepage.test.ts
+++ b/packages/backend/src/ee/services/ProjectService/provisionOnboardingHomepage.test.ts
@@ -11,7 +11,6 @@ import {
     type ProjectHomepage,
     type SessionUser,
 } from '@lightdash/common';
-import Logger from '../../../logging/logger';
 import {
     provisionOnboardingHomepage,
     type ProvisionOnboardingHomepageArguments,
@@ -167,16 +166,11 @@ describe('provisionOnboardingHomepage', () => {
 
         await provisionOnboardingHomepage(mocks.args);
 
-        expect(mocks.ensureOrganizationOverrideEnabled).toHaveBeenCalledTimes(
-            2,
-        );
-        expect(mocks.ensureOrganizationOverrideEnabled).toHaveBeenCalledWith({
+        expect(
+            mocks.ensureOrganizationOverrideEnabled,
+        ).toHaveBeenCalledExactlyOnceWith({
             user,
             featureFlagId: CommercialFeatureFlags.HomepageBuilder,
-        });
-        expect(mocks.ensureOrganizationOverrideEnabled).toHaveBeenCalledWith({
-            user,
-            featureFlagId: FeatureFlags.CodingAgentOnboarding,
         });
         expect(mocks.listHomepages).not.toHaveBeenCalled();
         expect(mocks.createHomepage).not.toHaveBeenCalled();
@@ -189,7 +183,6 @@ describe('provisionOnboardingHomepage', () => {
                 projectId: PROJECT_UUID,
                 onboardingFlow: 'new',
                 homepageBuilderEnablement: 'kept_disabled',
-                codingAgentOnboardingEnablement: 'kept_disabled',
                 reason: 'homepage_builder_flag_disabled',
             },
         });
@@ -217,7 +210,6 @@ describe('provisionOnboardingHomepage', () => {
                 projectId: PROJECT_UUID,
                 onboardingFlow: 'new',
                 homepageBuilderEnablement: 'failed',
-                codingAgentOnboardingEnablement: 'failed',
                 reason: 'homepage_builder_flag_disabled',
             },
         });
@@ -245,7 +237,6 @@ describe('provisionOnboardingHomepage', () => {
                 projectId: PROJECT_UUID,
                 onboardingFlow: 'legacy',
                 homepageBuilderEnablement: null,
-                codingAgentOnboardingEnablement: null,
                 reason: 'new_onboarding_flag_disabled',
             },
         });
@@ -267,7 +258,6 @@ describe('provisionOnboardingHomepage', () => {
                 projectId: PROJECT_UUID,
                 onboardingFlow: 'new',
                 homepageBuilderEnablement: 'enabled',
-                codingAgentOnboardingEnablement: 'enabled',
                 reason: 'homepage_already_exists',
             },
         });
@@ -294,7 +284,6 @@ describe('provisionOnboardingHomepage', () => {
                 projectId: PROJECT_UUID,
                 onboardingFlow: 'new',
                 homepageBuilderEnablement: null,
-                codingAgentOnboardingEnablement: null,
                 reason: 'not_first_project',
             },
         });
@@ -330,7 +319,6 @@ describe('provisionOnboardingHomepage', () => {
                 homepageUuid: HOMEPAGE_UUID,
                 onboardingFlow: 'new',
                 homepageBuilderEnablement: 'enabled',
-                codingAgentOnboardingEnablement: 'enabled',
             },
         });
     });
@@ -367,7 +355,6 @@ describe('provisionOnboardingHomepage', () => {
                 projectId: PROJECT_UUID,
                 onboardingFlow: 'new',
                 homepageBuilderEnablement: 'enabled',
-                codingAgentOnboardingEnablement: 'enabled',
                 errorType: 'Error',
             },
         });
@@ -389,7 +376,6 @@ describe('provisionOnboardingHomepage', () => {
                 projectId: PROJECT_UUID,
                 onboardingFlow: 'new',
                 homepageBuilderEnablement: 'enabled',
-                codingAgentOnboardingEnablement: 'enabled',
                 errorType: 'Error',
             },
         });
@@ -404,16 +390,11 @@ describe('provisionOnboardingHomepage', () => {
             user,
             featureFlagId: FeatureFlags.NewOnboarding,
         });
-        expect(mocks.ensureOrganizationOverrideEnabled).toHaveBeenCalledTimes(
-            2,
-        );
-        expect(mocks.ensureOrganizationOverrideEnabled).toHaveBeenCalledWith({
+        expect(
+            mocks.ensureOrganizationOverrideEnabled,
+        ).toHaveBeenCalledExactlyOnceWith({
             user,
             featureFlagId: CommercialFeatureFlags.HomepageBuilder,
-        });
-        expect(mocks.ensureOrganizationOverrideEnabled).toHaveBeenCalledWith({
-            user,
-            featureFlagId: FeatureFlags.CodingAgentOnboarding,
         });
         expect(mocks.getFeatureFlag).toHaveBeenCalledWith({
             user,
@@ -441,7 +422,6 @@ describe('provisionOnboardingHomepage', () => {
                 homepageUuid: HOMEPAGE_UUID,
                 onboardingFlow: 'new',
                 homepageBuilderEnablement: 'enabled',
-                codingAgentOnboardingEnablement: 'enabled',
             },
         });
     });
@@ -483,71 +463,6 @@ describe('provisionOnboardingHomepage', () => {
                 homepageUuid: HOMEPAGE_UUID,
                 onboardingFlow: 'new',
                 homepageBuilderEnablement: 'already_enabled',
-                codingAgentOnboardingEnablement: 'already_enabled',
-            },
-        });
-    });
-
-    it('provisions when coding agent onboarding enablement fails', async () => {
-        const errorSpy = vi
-            .spyOn(Logger, 'error')
-            .mockImplementation(() => Logger);
-        try {
-            const mocks = buildArguments();
-            mocks.ensureOrganizationOverrideEnabled.mockImplementation(
-                async ({ featureFlagId }) => {
-                    if (featureFlagId === FeatureFlags.CodingAgentOnboarding) {
-                        throw new Error('Enable failed');
-                    }
-                    return 'enabled';
-                },
-            );
-
-            await provisionOnboardingHomepage(mocks.args);
-
-            expect(mocks.createHomepage).toHaveBeenCalled();
-            expect(mocks.publishHomepage).toHaveBeenCalled();
-            expect(mocks.track).toHaveBeenCalledExactlyOnceWith({
-                event: 'onboarding_homepage.provisioned',
-                userId: USER_UUID,
-                properties: {
-                    organizationId: ORGANIZATION_UUID,
-                    projectId: PROJECT_UUID,
-                    homepageUuid: HOMEPAGE_UUID,
-                    onboardingFlow: 'new',
-                    homepageBuilderEnablement: 'enabled',
-                    codingAgentOnboardingEnablement: 'failed',
-                },
-            });
-            expect(errorSpy).toHaveBeenCalled();
-        } finally {
-            errorSpy.mockRestore();
-        }
-    });
-
-    it('provisions when coding agent onboarding remains disabled', async () => {
-        const mocks = buildArguments();
-        mocks.ensureOrganizationOverrideEnabled.mockImplementation(
-            async ({ featureFlagId }) =>
-                featureFlagId === FeatureFlags.CodingAgentOnboarding
-                    ? 'kept_disabled'
-                    : 'enabled',
-        );
-
-        await provisionOnboardingHomepage(mocks.args);
-
-        expect(mocks.createHomepage).toHaveBeenCalled();
-        expect(mocks.publishHomepage).toHaveBeenCalled();
-        expect(mocks.track).toHaveBeenCalledExactlyOnceWith({
-            event: 'onboarding_homepage.provisioned',
-            userId: USER_UUID,
-            properties: {
-                organizationId: ORGANIZATION_UUID,
-                projectId: PROJECT_UUID,
-                homepageUuid: HOMEPAGE_UUID,
-                onboardingFlow: 'new',
-                homepageBuilderEnablement: 'enabled',
-                codingAgentOnboardingEnablement: 'kept_disabled',
             },
         });
     });

--- a/packages/backend/src/ee/services/ProjectService/provisionOnboardingHomepage.ts
+++ b/packages/backend/src/ee/services/ProjectService/provisionOnboardingHomepage.ts
@@ -7,7 +7,6 @@ import {
 } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
 import {
-    type CodingAgentOnboardingEnablement,
     type HomepageBuilderEnablement,
     type LightdashAnalytics,
     type OnboardingFlow,
@@ -58,8 +57,6 @@ export const provisionOnboardingHomepage = async ({
         ? 'new'
         : 'legacy';
     let homepageBuilderEnablement: HomepageBuilderEnablement | null = null;
-    let codingAgentOnboardingEnablement: CodingAgentOnboardingEnablement | null =
-        null;
     const trackSkipped = (reason: OnboardingHomepageSkippedReason) => {
         analytics.track({
             event: 'onboarding_homepage.skipped',
@@ -69,7 +66,6 @@ export const provisionOnboardingHomepage = async ({
                 projectId: projectUuid,
                 onboardingFlow,
                 homepageBuilderEnablement,
-                codingAgentOnboardingEnablement,
                 reason,
             },
         });
@@ -106,22 +102,6 @@ export const provisionOnboardingHomepage = async ({
                 }`,
             );
             homepageBuilderEnablement = 'failed';
-        }
-
-        try {
-            codingAgentOnboardingEnablement =
-                await featureFlagService.ensureOrganizationOverrideEnabled({
-                    user,
-                    featureFlagId: FeatureFlags.CodingAgentOnboarding,
-                });
-        } catch (error) {
-            Sentry.captureException(error);
-            Logger.error(
-                `Failed to enable coding agent onboarding for organization ${organizationUuid}: ${
-                    error instanceof Error ? error.message : String(error)
-                }`,
-            );
-            codingAgentOnboardingEnablement = 'failed';
         }
 
         const homepageBuilderFlag = await featureFlagService.get({
@@ -167,7 +147,6 @@ export const provisionOnboardingHomepage = async ({
                 homepageUuid: homepage.homepageUuid,
                 onboardingFlow,
                 homepageBuilderEnablement,
-                codingAgentOnboardingEnablement,
             },
         });
     } catch (error) {
@@ -179,7 +158,6 @@ export const provisionOnboardingHomepage = async ({
                 projectId: projectUuid,
                 onboardingFlow,
                 homepageBuilderEnablement,
-                codingAgentOnboardingEnablement,
                 errorType: error instanceof Error ? error.name : 'Unknown',
             },
         });

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -224,12 +224,6 @@ export enum FeatureFlags {
     CodingAgent = 'ai-coding-agent',
 
     /**
-     * Show the coding-agent project onboarding flow. This gates only the UI;
-     * the CLI, APIs, and installed skills remain available independently.
-     */
-    CodingAgentOnboarding = 'coding-agent-onboarding',
-
-    /**
      * Allow storing long-lived GitHub personal access tokens as GitHub MCP
      * credentials (guided connect flow and generic bearer endpoints targeting
      * the hosted GitHub MCP URL). Off by default — orgs should authenticate

--- a/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/SelectConnectMethod.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/SelectConnectMethod.tsx
@@ -21,14 +21,14 @@ import { ConnectMethod } from './types';
 
 interface SelectConnectMethodProps {
     isCreatingFirstProject: boolean;
-    isCodingAgentOnboardingEnabled: boolean;
+    isCodingAgentEnabled: boolean;
     onBack: () => void;
     onSelect: (method: ConnectMethod) => void;
 }
 
 const SelectConnectMethod: FC<SelectConnectMethodProps> = ({
     isCreatingFirstProject,
-    isCodingAgentOnboardingEnabled,
+    isCodingAgentEnabled,
     onSelect,
     onBack,
 }) => {
@@ -66,7 +66,7 @@ const SelectConnectMethod: FC<SelectConnectMethodProps> = ({
                     </Text>
 
                     <Stack>
-                        {isCodingAgentOnboardingEnabled && (
+                        {isCodingAgentEnabled && (
                             <OnboardingButton
                                 onClick={() => {
                                     track({

--- a/packages/frontend/src/ee/features/agentOnboarding/AgentOnboardingStartPage.test.tsx
+++ b/packages/frontend/src/ee/features/agentOnboarding/AgentOnboardingStartPage.test.tsx
@@ -1,3 +1,4 @@
+import { FeatureFlags } from '@lightdash/common';
 import { MantineProvider } from '@mantine/core';
 import { render, screen } from '@testing-library/react';
 import { type PropsWithChildren } from 'react';
@@ -5,7 +6,7 @@ import { MemoryRouter, Route, Routes } from 'react-router';
 import AgentOnboardingStartPage from './AgentOnboardingStartPage';
 
 const state = vi.hoisted(() => ({
-    isFlagEnabled: true,
+    isCodingAgentEntitled: true,
     project: {
         projectUuid: 'project-uuid',
         warehouseConnection: { type: 'postgres' },
@@ -17,8 +18,12 @@ vi.mock('../../../hooks/useProject', () => ({
 }));
 
 vi.mock('../../../hooks/useServerOrClientFeatureFlag', () => ({
-    useServerFeatureFlag: () => ({
-        data: { enabled: state.isFlagEnabled },
+    useServerFeatureFlag: (featureFlag: FeatureFlags) => ({
+        data: {
+            enabled:
+                featureFlag === FeatureFlags.CodingAgent &&
+                state.isCodingAgentEntitled,
+        },
         isInitialLoading: false,
     }),
 }));
@@ -73,7 +78,7 @@ const renderPage = () =>
 
 describe('AgentOnboardingStartPage', () => {
     beforeEach(() => {
-        state.isFlagEnabled = true;
+        state.isCodingAgentEntitled = true;
         state.project = {
             projectUuid: 'project-uuid',
             warehouseConnection: { type: 'postgres' },
@@ -89,8 +94,8 @@ describe('AgentOnboardingStartPage', () => {
         expect(screen.getByText('Run it for me')).toBeInTheDocument();
     });
 
-    it('redirects to project settings when the flag is disabled', () => {
-        state.isFlagEnabled = false;
+    it('redirects to project settings without coding-agent entitlement', () => {
+        state.isCodingAgentEntitled = false;
 
         renderPage();
 

--- a/packages/frontend/src/ee/features/agentOnboarding/AgentOnboardingStartPage.tsx
+++ b/packages/frontend/src/ee/features/agentOnboarding/AgentOnboardingStartPage.tsx
@@ -16,12 +16,10 @@ const AgentOnboardingStartPage: FC = () => {
     const { health } = useApp();
     const { data: project, isInitialLoading: isLoadingProject } =
         useProject(projectUuid);
-    const codingAgentOnboardingFlag = useServerFeatureFlag(
-        FeatureFlags.CodingAgentOnboarding,
-    );
+    const codingAgentFlag = useServerFeatureFlag(FeatureFlags.CodingAgent);
 
     if (
-        codingAgentOnboardingFlag.isInitialLoading ||
+        codingAgentFlag.isInitialLoading ||
         isLoadingProject ||
         health.isInitialLoading
     ) {
@@ -29,7 +27,7 @@ const AgentOnboardingStartPage: FC = () => {
     }
 
     if (
-        codingAgentOnboardingFlag.data?.enabled !== true ||
+        codingAgentFlag.data?.enabled !== true ||
         !project ||
         !project.warehouseConnection ||
         !health.data

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.test.tsx
@@ -404,7 +404,7 @@ describe('useRecommendedActions', () => {
             ).toStrictEqual('Resume');
         });
 
-        it('keeps the settings link when coding-agent onboarding is disabled', () => {
+        it('keeps the settings link without coding-agent entitlement', () => {
             vi.mocked(useServerFeatureFlag).mockImplementation(
                 (flag) =>
                     settled({
@@ -427,7 +427,7 @@ describe('useRecommendedActions', () => {
             vi.mocked(useServerFeatureFlag).mockImplementation(
                 (flag) =>
                     settled({
-                        enabled: flag === FeatureFlags.CodingAgentOnboarding,
+                        enabled: flag === FeatureFlags.CodingAgent,
                     }) as ReturnType<typeof useServerFeatureFlag>,
             );
 

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.tsx
@@ -225,13 +225,11 @@ const useActionStatuses = (
     const githubConfigQuery = useGithubConfig();
     const slackQuery = useGetSlack();
     const newOnboardingFlag = useServerFeatureFlag(FeatureFlags.NewOnboarding);
-    const codingAgentOnboardingFlag = useServerFeatureFlag(
-        FeatureFlags.CodingAgentOnboarding,
-    );
+    const codingAgentFlag = useServerFeatureFlag(FeatureFlags.CodingAgent);
     const areFlagsSettled =
-        newOnboardingFlag.isFetched && codingAgentOnboardingFlag.isFetched;
+        newOnboardingFlag.isFetched && codingAgentFlag.isFetched;
     const hasAgentSemanticLayerEntry =
-        isFlagOn(newOnboardingFlag) && isFlagOn(codingAgentOnboardingFlag);
+        isFlagOn(newOnboardingFlag) && isFlagOn(codingAgentFlag);
 
     const activeAgentRunQuery = useActiveAgentOnboardingRun(
         projectUuid ?? undefined,

--- a/packages/frontend/src/pages/CreateProject.tsx
+++ b/packages/frontend/src/pages/CreateProject.tsx
@@ -33,9 +33,7 @@ const CreateProject: FC = () => {
 
     const { method } = useParams<{ method: ConnectMethod }>();
     const projectUuid = useSearchParams('projectUuid');
-    const codingAgentOnboardingFlag = useServerFeatureFlag(
-        FeatureFlags.CodingAgentOnboarding,
-    );
+    const codingAgentFlag = useServerFeatureFlag(FeatureFlags.CodingAgent);
 
     const [warehouse, setWarehouse] = useState<SelectedWarehouse>();
 
@@ -44,15 +42,14 @@ const CreateProject: FC = () => {
         !health ||
         isLoadingOrganization ||
         !organization ||
-        codingAgentOnboardingFlag.isInitialLoading
+        codingAgentFlag.isInitialLoading
     ) {
         return <PageSpinner />;
     }
 
-    const isCodingAgentOnboardingEnabled =
-        codingAgentOnboardingFlag.data?.enabled === true;
+    const isCodingAgentEnabled = codingAgentFlag.data?.enabled === true;
 
-    if (method === ConnectMethod.AGENT && !isCodingAgentOnboardingEnabled) {
+    if (method === ConnectMethod.AGENT && !isCodingAgentEnabled) {
         return <Navigate to="/createProject" replace />;
     }
 
@@ -86,8 +83,8 @@ const CreateProject: FC = () => {
                                         isCreatingFirstProject={
                                             isCreatingFirstProject
                                         }
-                                        isCodingAgentOnboardingEnabled={
-                                            isCodingAgentOnboardingEnabled
+                                        isCodingAgentEnabled={
+                                            isCodingAgentEnabled
                                         }
                                         onSelect={(newMethod) => {
                                             void navigate(

--- a/release-safety.declarations.json
+++ b/release-safety.declarations.json
@@ -8,6 +8,10 @@
         "mcp-run-metric-query-formula-only-table-calcs": {
             "reason": "The MCP run_metric_query tool no longer accepts template table calculations (running_total, percent_of_previous_value, etc.) in queryConfig.tableCalculations; only formula table calculations are accepted. MCP clients that send template-shaped payloads (scripted callers or agents replaying stored arguments) get an input validation error after upgrading and must switch to equivalent formulas. Agent-generated payloads self-correct because clients re-read the advertised schema.",
             "requiredStop": false
+        },
+        "coding-agent-onboarding-feature-flag-removed": {
+            "reason": "The graduated CodingAgentOnboarding member is removed from the public FeatureFlags enum. Downstream TypeScript consumers that still reference this rollout-only member must remove that reference and use CodingAgent for coding-agent availability checks.",
+            "requiredStop": false
         }
     }
 }


### PR DESCRIPTION
## What changed

## Summary

- Remove the graduated `coding-agent-onboarding` flag, provisioning hooks, and obsolete analytics fields.
- Gate project creation, guided semantic-layer setup, recommended actions, and onboarding-run APIs with the underlying coding-agent entitlement.
- Add entitled and non-entitled frontend/backend coverage and declare the exported enum removal for release safety.

### Validation

- `pnpm -F frontend test src/ee/features/agentOnboarding/AgentOnboardingStartPage.test.tsx` — passed (3 tests).
- `pnpm -F backend test src/ee/services/OnboardingAgentService/OnboardingAgentService.test.ts` — passed (2 tests).
- `validate_changes` targeted mode — passed for backend, common, frontend, and reverse-dependent packages.
- `validate_changes` final mode at tree `c140e2f2ce716c4922d5357680320af211a3f078` — passed formatting, lint, typecheck, and related tests.
- The harness identified pre-existing, unchanged failures in `pnpm -F api-tests run --if-present typecheck`, `pnpm -F cli run --if-present typecheck`, and `pnpm -F query-sdk run --if-present typecheck`; baseline comparison confirmed they are non-blocking.

## Proof of work

🟢 **PASS** — The repository change graduates the rollout flag, retains coding-agent onboarding for entitled organizations, and blocks non-entitled access in both frontend and backend. Console rollout state and deployment sequencing were not inferred because they are operational constraints outside this checkout.

Revision: `8047e27aeb5801696b0f57090971b51721c188a0`

### Eligible organization retains the coding-agent project-creation option

- Expected: After choosing a warehouse, an organization with coding-agent availability sees the enabled coding-agent connection method.
- Observed: The authenticated capture reached /createProject after selecting PostgreSQL and displayed the connection-method screen with the coding-agent setup option. The inspected text-rendering h3 selector had one visible match at the required 1280×720 viewport.
- Evidence:
  - Screenshot: https://ld-linear-agent-v2.exe.xyz/evidence/a81eeb08c9f509df1b2955297c9ef834657af85aa4839f71f526357fb5d519ab.png
  - Structured screenshot observation: final URL /createProject; viewport 1280×720; selector h3 matchCount=1 and visible=true.

![Lightdash development environment screenshot](https://ld-linear-agent-v2.exe.xyz/evidence/a81eeb08c9f509df1b2955297c9ef834657af85aa4839f71f526357fb5d519ab.png)

### Entitled organization can access the guided semantic-layer setup page

- Expected: With FeatureFlags.CodingAgent enabled and a warehouse connection present, the guided setup page renders its launch panel and action.
- Observed: The focused frontend test rendered “Let Lightdash build it for you” and “Run it for me” for the entitled outcome.
- Evidence:
  - Command: pnpm -F frontend test src/ee/features/agentOnboarding/AgentOnboardingStartPage.test.tsx src/ee/features/homepageBuilder/blocks/useRecommendedActions.test.tsx
  - Result: 2 test files passed, 21 tests passed; includes the entitled guided-page and agent semantic-layer destination cases.

### Organizations without coding-agent entitlement cannot access onboarding

- Expected: The frontend redirects away from the guided onboarding page and the backend refuses to start an onboarding run when FeatureFlags.CodingAgent is disabled.
- Observed: The frontend test redirected to project settings without entitlement. The backend test rejected createRun with ForbiddenError before project lookup or active-run lookup occurred.
- Evidence:
  - Frontend command: pnpm -F frontend test src/ee/features/agentOnboarding/AgentOnboardingStartPage.test.tsx src/ee/features/homepageBuilder/blocks/useRecommendedActions.test.tsx — 2 files and 21 tests passed.
  - Backend command: pnpm -F backend test src/ee/services/OnboardingAgentService/OnboardingAgentService.test.ts src/ee/services/OrganizationService/provisionOnboardingOrgFlags.test.ts src/ee/services/ProjectService/provisionOnboardingHomepage.test.ts — 3 files and 17 tests passed.
  - Backend negative case verified ForbiddenError("Coding agent onboarding is not available") and that project/run model lookups were not called.

### Rollout-only feature flag is absent from application and test code

- Expected: Application and test code contain no coding-agent-onboarding or CodingAgentOnboarding references.
- Observed: The fixed revision search returned no matches outside the intentionally retained release-safety declaration and excluded changelog.
- Evidence:
  - Command: git grep -n -E 'coding-agent-onboarding|CodingAgentOnboarding' 8047e27aeb5801696b0f57090971b51721c188a0 -- ':!CHANGELOG.md' ':!release-safety.declarations.json' || true
  - Result: no output.

### Rollout provisioning and obsolete analytics outcomes are removed

- Expected: Organization/project onboarding provisions only the remaining homepage-builder behavior and no longer tracks coding-agent-onboarding enablement outcomes.
- Observed: Focused provisioning tests passed with exactly one homepage-builder override operation and analytics payloads containing no obsolete coding-agent-onboarding enablement field.
- Evidence:
  - Command: pnpm -F backend test src/ee/services/OnboardingAgentService/OnboardingAgentService.test.ts src/ee/services/OrganizationService/provisionOnboardingOrgFlags.test.ts src/ee/services/ProjectService/provisionOnboardingHomepage.test.ts
  - Result: 3 test files passed, 17 tests passed, including 3 organization provisioning and 12 homepage provisioning cases.

## Development environment

[Open the public Lightdash development environment](https://ld-runner-prod-10851-77aad14f3a0e.exe.xyz) (anyone with the URL can access it)

Login: `demo@lightdash.com` / `demo_password!`

## References

Closes: PROD-10851

