### PR TITLE
fix(data-apps): restore template card fan layout

### DIFF
--- a/packages/frontend/src/features/apps/AppTemplatePicker.module.css
+++ b/packages/frontend/src/features/apps/AppTemplatePicker.module.css
@@ -122,7 +122,7 @@
 }
 
 /* Narrow widths can't hold the arch — stack the cards vertically. */
-@media (max-width: 880px) {
+@media (max-width: 760px) {
     .fan {
         height: auto;
         display: flex;


### PR DESCRIPTION
## What changed

## Summary

- Restores the four-card template fan at medium viewport widths so the final “From scratch” option remains visible.
- Keeps the existing vertical card layout for genuinely narrow screens.

### Validation

- `pnpm -F 'frontend' run --if-present typecheck` — passed.
- `pnpm -F 'frontend' exec vitest related 'src/features/apps/AppTemplatePicker.module.css' --run --passWithNoTests` — passed.
- `pnpm -F 'frontend' run --if-present lint` — passed.
- Sealed visual proof was blocked because the development-environment replay could not reliably reach the Data App creation screen.

### Review notes

- Chose the exact 760px threshold previously used by the four-card layout to preserve its measured responsive boundary. A shared Mantine breakpoint would improve token consistency but slightly change that boundary; reviewer input is useful on which tradeoff to prefer.

## Proof of work

🟠 **BLOCKED** — The required creation-screen visual evidence could not be captured: the initial login replay timed out, and the focused replacement could not find the Data App creation link after opening the New menu.

Revision: `d3c798fd237abb9ff80062adc3f353b7501b9c1b`

### Data App creation template cards render in the intended layout

- Expected: All four template cards are visible in the fanned creation-screen layout, and the final From scratch option is unobscured and accessible.
- Observed: Required visual evidence was not obtained. The initial capture failed waiting for input[name="email"] for 15000ms. The focused replacement reached the New control but failed waiting for a[href$="/apps/generate"] for 15000ms after opening the menu.
- Evidence:
  - Initial capture failure: Walkthrough recorder exited with 1: step 1 (waitFor) failed: locator.waitFor: Timeout 15000ms exceeded.
  - Focused replacement failure: Walkthrough recorder exited with 1: step 3 (waitFor) failed: locator.waitFor: Timeout 15000ms exceeded.

## Development environment

[Open the public Lightdash development environment](https://ld-runner-prod-10858-b61f979afbbb.exe.xyz) (anyone with the URL can access it)

Login: `demo@lightdash.com` / `demo_password!`

## References

Closes: PROD-10858

