### PR TITLE
feat(jira): add OAuth integration

### DIFF
--- a/packages/backend/src/@types/express-session.d.ts
+++ b/packages/backend/src/@types/express-session.d.ts
@@ -14,6 +14,11 @@ declare module 'express-session' {
                 codeVerifier: string;
                 redirectUri: string;
             };
+            jira?: {
+                redirectUri: string;
+                clientId: string;
+                clientSecret: string;
+            };
             isPopup?: boolean | undefined;
             databricks?: {
                 projectUuid?: string | undefined;

--- a/packages/backend/src/@types/express-session.d.ts
+++ b/packages/backend/src/@types/express-session.d.ts
@@ -17,7 +17,7 @@ declare module 'express-session' {
             jira?: {
                 redirectUri: string;
                 clientId: string;
-                clientSecret: string;
+                encryptedClientSecret: string;
             };
             isPopup?: boolean | undefined;
             databricks?: {

--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -152,6 +152,10 @@ import {
     InviteLinkTableName,
 } from '../database/entities/inviteLinks';
 import {
+    JiraAppInstallationTable,
+    JiraAppInstallationTableName,
+} from '../database/entities/jiraAppInstallation';
+import {
     JobsTable,
     JobsTableName,
     JobStepsTable,
@@ -522,6 +526,8 @@ import {
     AiEvalTableName,
 } from '../ee/database/entities/aiEvals';
 import {
+    AiReviewJiraDestinationTable,
+    AiReviewJiraDestinationTableName,
     AiReviewLinearDestinationTable,
     AiReviewLinearDestinationTableName,
     AiReviewNotificationLogTable,
@@ -715,6 +721,7 @@ declare module 'knex/types/tables' {
         [DownloadAuditTableName]: DownloadAuditTable;
         [GithubAppInstallationTableName]: GithubAppInstallationTable;
         [GitlabAppInstallationTableName]: GitlabAppInstallationTable;
+        [JiraAppInstallationTableName]: JiraAppInstallationTable;
         [LinearAppInstallationTableName]: LinearAppInstallationTable;
         [GitUserCredentialsTableName]: GitUserCredentialsTable;
         [UserOAuthGrantsTableName]: UserOAuthGrantsTable;
@@ -773,6 +780,7 @@ declare module 'knex/types/tables' {
         [NotificationsTableName]: NotificationsTable;
         [AiReviewNotificationLogTableName]: AiReviewNotificationLogTable;
         [AiReviewNotificationSettingsTableName]: AiReviewNotificationSettingsTable;
+        [AiReviewJiraDestinationTableName]: AiReviewJiraDestinationTable;
         [AiReviewLinearDestinationTableName]: AiReviewLinearDestinationTable;
         [CatalogTableName]: CatalogTable;
         [SlackChannelProjectMappingsTableName]: SlackChannelProjectMappingsTable;

--- a/packages/backend/src/clients/jira/Jira.test.ts
+++ b/packages/backend/src/clients/jira/Jira.test.ts
@@ -1,0 +1,171 @@
+import { ForbiddenError } from '@lightdash/common'; // pragma: allowlist secret
+import {
+    createJiraIssue,
+    exchangeJiraCodeForToken,
+    getJiraAuthorizationUrl,
+    getJiraIssueTypes,
+    getJiraProjects,
+    getJiraSites,
+    linkJiraIssueUrl,
+} from './Jira';
+
+describe('Jira client', () => {
+    afterEach(() => vi.unstubAllGlobals());
+
+    it('builds the Atlassian authorization URL with offline access', () => {
+        const url = new URL(
+            getJiraAuthorizationUrl(
+                'client-1',
+                'https://app.example.com/api/v1/jira/oauth/callback',
+                'state-1',
+            ),
+        );
+        expect(url.origin + url.pathname).toBe(
+            'https://auth.atlassian.com/authorize',
+        );
+        expect(url.searchParams.get('audience')).toBe('api.atlassian.com');
+        expect(url.searchParams.get('scope')).toContain('write:jira-work');
+        expect(url.searchParams.get('scope')).toContain('offline_access');
+        expect(url.searchParams.get('state')).toBe('state-1');
+    });
+
+    it('exchanges a code and records token expiry', async () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-09-02T10:00:00Z'));
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                access_token: 'access-1',
+                refresh_token: 'refresh-1',
+                expires_in: 3600,
+            }),
+        });
+        vi.stubGlobal('fetch', fetchMock);
+        await expect(
+            exchangeJiraCodeForToken(
+                'code-1',
+                'client-1',
+                'secret-1',
+                'https://app.example.com/callback',
+            ),
+        ).resolves.toEqual({
+            token: 'access-1',
+            refreshToken: 'refresh-1',
+            expiresAt: new Date('2026-09-02T11:00:00Z'),
+        });
+        expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toMatchObject({
+            client_secret: 'secret-1',
+            grant_type: 'authorization_code',
+        });
+        vi.useRealTimers();
+    });
+
+    it('rejects a token response without an access token', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }),
+        );
+        await expect(
+            exchangeJiraCodeForToken('code', 'client', 'secret', 'callback'),
+        ).rejects.toBeInstanceOf(ForbiddenError);
+    });
+
+    it('filters accessible resources to Jira sites', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn().mockResolvedValue({
+                ok: true,
+                json: async () => [
+                    {
+                        id: 'jira-1',
+                        name: 'Acme',
+                        url: 'https://acme.atlassian.net',
+                        scopes: ['read:jira-work'],
+                    },
+                    {
+                        id: 'confluence-1',
+                        name: 'Docs',
+                        url: 'https://acme.atlassian.net/wiki',
+                        scopes: ['read:confluence-content.all'],
+                    },
+                ],
+            }),
+        );
+        await expect(getJiraSites('token')).resolves.toEqual([
+            {
+                id: 'jira-1',
+                name: 'Acme',
+                url: 'https://acme.atlassian.net',
+            },
+        ]);
+    });
+
+    it('paginates projects and returns non-subtask issue types', async () => {
+        const fetchMock = vi.fn().mockImplementation(async (url: string) => ({
+            ok: true,
+            json: async () =>
+                url.includes('/statuses')
+                    ? [
+                          { id: '1', name: 'Task', subtask: false },
+                          { id: '2', name: 'Subtask', subtask: true },
+                      ]
+                    : {
+                          values: [{ id: '10', key: 'DATA', name: 'Data' }],
+                          startAt: 0,
+                          maxResults: 100,
+                          total: 1,
+                      },
+        }));
+        vi.stubGlobal('fetch', fetchMock);
+        await expect(getJiraProjects('token', 'site-1')).resolves.toEqual([
+            { id: '10', key: 'DATA', name: 'Data' },
+        ]);
+        await expect(
+            getJiraIssueTypes('token', 'site-1', '10'),
+        ).resolves.toEqual([{ id: '1', name: 'Task', subtask: false }]);
+    });
+
+    it('creates an issue with ADF and links it back to Lightdash', async () => {
+        const fetchMock = vi
+            .fn()
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({ id: '100', key: 'DATA-42' }),
+            })
+            .mockResolvedValueOnce({ ok: true });
+        vi.stubGlobal('fetch', fetchMock);
+        await expect(
+            createJiraIssue(
+                'token',
+                {
+                    id: 'site-1',
+                    name: 'Acme',
+                    url: 'https://acme.atlassian.net',
+                },
+                {
+                    title: 'Broken metric',
+                    description: 'Needs review',
+                    projectId: '10',
+                    issueTypeId: '1',
+                },
+            ),
+        ).resolves.toEqual({
+            id: '100',
+            key: 'DATA-42',
+            url: 'https://acme.atlassian.net/browse/DATA-42',
+        });
+        const createBody = JSON.parse(fetchMock.mock.calls[0][1].body);
+        expect(createBody.fields.description).toMatchObject({
+            type: 'doc',
+            version: 1,
+        });
+        await expect(
+            linkJiraIssueUrl('token', 'site-1', {
+                issueIdOrKey: 'DATA-42',
+                url: 'https://app.example.com/reviews',
+                title: 'Open in Lightdash', // pragma: allowlist secret
+            }),
+        ).resolves.toBeUndefined();
+        expect(fetchMock.mock.calls[1][0]).toContain('/DATA-42/remotelink');
+    });
+});

--- a/packages/backend/src/clients/jira/Jira.ts
+++ b/packages/backend/src/clients/jira/Jira.ts
@@ -1,0 +1,270 @@
+import {
+    ForbiddenError,
+    getErrorMessage,
+    LightdashError, // pragma: allowlist secret
+    NotFoundError,
+    UnexpectedServerError,
+    type JiraCreatedIssue,
+    type JiraIssueType,
+    type JiraProject,
+    type JiraSite,
+} from '@lightdash/common'; // pragma: allowlist secret
+
+const JIRA_AUTHORIZE_URL = 'https://auth.atlassian.com/authorize';
+const JIRA_TOKEN_URL = 'https://auth.atlassian.com/oauth/token';
+const JIRA_RESOURCES_URL =
+    'https://api.atlassian.com/oauth/token/accessible-resources';
+const JIRA_API_URL = 'https://api.atlassian.com/ex/jira';
+const JIRA_SCOPES = ['read:jira-work', 'write:jira-work', 'offline_access'];
+const PAGE_SIZE = 100;
+
+export class JiraApiError extends LightdashError {
+    // pragma: allowlist secret
+    constructor(message: string, statusCode: number = 500) {
+        super({ message, name: 'JiraApiError', statusCode, data: {} });
+    }
+}
+
+export type JiraTokens = {
+    token: string;
+    refreshToken: string | null;
+    expiresAt: Date;
+};
+
+type JiraTokenResponse = {
+    access_token?: string;
+    refresh_token?: string;
+    expires_in?: number;
+};
+
+const parseTokenResponse = async (response: Response): Promise<JiraTokens> => {
+    const body = (await response.json()) as JiraTokenResponse;
+    if (!response.ok || !body.access_token) {
+        throw new ForbiddenError('Invalid Jira authentication token');
+    }
+
+    return {
+        token: body.access_token,
+        refreshToken: body.refresh_token ?? null,
+        expiresAt: new Date(Date.now() + (body.expires_in ?? 3600) * 1000),
+    };
+};
+
+const requestJiraToken = async (
+    body: Record<string, string>,
+): Promise<JiraTokens> => {
+    try {
+        const response = await fetch(JIRA_TOKEN_URL, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+        });
+        return await parseTokenResponse(response);
+    } catch (error) {
+        if (error instanceof LightdashError) throw error;
+        throw new UnexpectedServerError(getErrorMessage(error));
+    }
+};
+
+export const getJiraAuthorizationUrl = (
+    clientId: string,
+    redirectUri: string,
+    state: string,
+): string => {
+    const params = new URLSearchParams({
+        audience: 'api.atlassian.com',
+        client_id: clientId,
+        scope: JIRA_SCOPES.join(' '),
+        redirect_uri: redirectUri,
+        state,
+        response_type: 'code',
+        prompt: 'consent',
+    });
+    return `${JIRA_AUTHORIZE_URL}?${params.toString()}`;
+};
+
+export const exchangeJiraCodeForToken = (
+    code: string,
+    clientId: string,
+    clientSecret: string,
+    redirectUri: string,
+): Promise<JiraTokens> =>
+    requestJiraToken({
+        grant_type: 'authorization_code',
+        client_id: clientId,
+        client_secret: clientSecret,
+        code,
+        redirect_uri: redirectUri,
+    });
+
+export const refreshJiraToken = (
+    refreshToken: string,
+    clientId: string,
+    clientSecret: string,
+): Promise<JiraTokens> =>
+    requestJiraToken({
+        grant_type: 'refresh_token',
+        client_id: clientId,
+        client_secret: clientSecret,
+        refresh_token: refreshToken,
+    });
+
+const parseJiraResponse = async <T>(response: Response): Promise<T> => {
+    if (response.status === 401) {
+        throw new ForbiddenError('Invalid Jira access token');
+    }
+    if (response.status === 403) {
+        throw new ForbiddenError('Insufficient permissions for Jira');
+    }
+    if (response.status === 404) {
+        throw new NotFoundError('Jira resource not found');
+    }
+    if (!response.ok) {
+        throw new JiraApiError(
+            `Jira API error: ${response.status} ${await response.text()}`,
+            response.status,
+        );
+    }
+    return (await response.json()) as T;
+};
+
+export const getJiraSites = async (token: string): Promise<JiraSite[]> => {
+    const response = await fetch(JIRA_RESOURCES_URL, {
+        headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: 'application/json',
+        },
+    });
+    const sites =
+        await parseJiraResponse<Array<JiraSite & { scopes?: string[] }>>(
+            response,
+        );
+    return sites
+        .filter((site) => site.scopes?.some((scope) => scope.includes('jira')))
+        .map(({ id, name, url }) => ({ id, name, url }));
+};
+
+const jiraRequest = async <T>(
+    token: string,
+    siteId: string,
+    path: string,
+    init?: RequestInit,
+): Promise<T> => {
+    const response = await fetch(
+        `${JIRA_API_URL}/${encodeURIComponent(siteId)}/rest/api/3${path}`,
+        {
+            ...init,
+            headers: {
+                Authorization: `Bearer ${token}`,
+                Accept: 'application/json',
+                ...(init?.body ? { 'Content-Type': 'application/json' } : {}),
+                ...init?.headers,
+            },
+        },
+    );
+    return parseJiraResponse<T>(response);
+};
+
+export const getJiraProjects = async (
+    token: string,
+    siteId: string,
+): Promise<JiraProject[]> => {
+    const projects: JiraProject[] = [];
+    let startAt = 0;
+    let total = 0;
+    do {
+        // eslint-disable-next-line no-await-in-loop
+        const page = await jiraRequest<{
+            values: JiraProject[];
+            startAt: number;
+            maxResults: number;
+            total: number;
+        }>(
+            token,
+            siteId,
+            `/project/search?startAt=${startAt}&maxResults=${PAGE_SIZE}&orderBy=name`,
+        );
+        projects.push(
+            ...page.values.map(({ id, key, name }) => ({ id, key, name })),
+        );
+        startAt = page.startAt + page.maxResults;
+        total = page.total;
+    } while (startAt < total);
+    return projects;
+};
+
+export const getJiraIssueTypes = async (
+    token: string,
+    siteId: string,
+    projectId: string,
+): Promise<JiraIssueType[]> => {
+    const issueTypes = await jiraRequest<
+        Array<JiraIssueType & { statuses?: unknown[] }>
+    >(token, siteId, `/project/${encodeURIComponent(projectId)}/statuses`);
+    return issueTypes
+        .filter((issueType) => !issueType.subtask)
+        .map(({ id, name, subtask }) => ({ id, name, subtask }));
+};
+
+const toAdf = (description: string) => ({
+    type: 'doc',
+    version: 1,
+    content: description.split('\n').map((line) => ({
+        type: 'paragraph',
+        content: line ? [{ type: 'text', text: line }] : [],
+    })),
+});
+
+export const createJiraIssue = async (
+    token: string,
+    site: JiraSite,
+    input: {
+        title: string;
+        description: string;
+        projectId: string;
+        issueTypeId: string;
+    },
+): Promise<JiraCreatedIssue> => {
+    const issue = await jiraRequest<{ id: string; key: string }>(
+        token,
+        site.id,
+        '/issue',
+        {
+            method: 'POST',
+            body: JSON.stringify({
+                fields: {
+                    project: { id: input.projectId },
+                    issuetype: { id: input.issueTypeId },
+                    summary: input.title,
+                    description: toAdf(input.description),
+                },
+            }),
+        },
+    );
+    return {
+        ...issue,
+        url: `${site.url.replace(/\/$/, '')}/browse/${issue.key}`,
+    };
+};
+
+export const linkJiraIssueUrl = async (
+    token: string,
+    siteId: string,
+    input: { issueIdOrKey: string; url: string; title: string },
+): Promise<void> => {
+    const response = await fetch(
+        `${JIRA_API_URL}/${encodeURIComponent(siteId)}/rest/api/3/issue/${encodeURIComponent(input.issueIdOrKey)}/remotelink`,
+        {
+            method: 'POST',
+            headers: {
+                Authorization: `Bearer ${token}`,
+                Accept: 'application/json',
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+                object: { url: input.url, title: input.title },
+            }),
+        },
+    );
+    if (!response.ok) await parseJiraResponse(response);
+};

--- a/packages/backend/src/controllers/jiraController.ts
+++ b/packages/backend/src/controllers/jiraController.ts
@@ -1,0 +1,230 @@
+import {
+    assertRegisteredAccount,
+    ParameterError,
+    type ApiJiraInstallUrlResponse,
+    type ApiSuccessEmpty,
+    type JiraInstallation,
+    type JiraIssueType,
+    type JiraOAuthCredentials,
+    type JiraProject,
+    type JiraSite,
+} from '@lightdash/common'; // pragma: allowlist secret
+import {
+    Body,
+    Delete,
+    Get,
+    Middlewares,
+    OperationId,
+    Post,
+    Put,
+    Query,
+    Request,
+    Route,
+    SuccessResponse,
+    Tags,
+} from '@tsoa/runtime';
+import express from 'express';
+import { toSessionUser } from '../auth/account';
+import { isAuthenticated, unauthorisedInDemo } from './authentication';
+import { BaseController } from './baseController';
+
+@Route('/api/v1/jira')
+@Tags('Integrations')
+export class JiraController extends BaseController {
+    /**
+     * Start Jira OAuth with the organization's own Atlassian OAuth 2.0 app
+     * @summary Connect Jira
+     */
+    @Middlewares([isAuthenticated, unauthorisedInDemo])
+    @SuccessResponse('200')
+    @Post('/install')
+    @OperationId('installJiraIntegration')
+    async installJiraIntegration(
+        @Request() req: express.Request,
+        @Body() body: JiraOAuthCredentials,
+    ): Promise<ApiJiraInstallUrlResponse> {
+        assertRegisteredAccount(req.account);
+        const context = await this.services
+            .getJiraAppService()
+            .installRedirect(toSessionUser(req.account), body);
+        req.session.oauth = {
+            returnTo: context.returnToUrl,
+            state: context.state,
+            jira: context.jira,
+        };
+        return {
+            status: 'ok',
+            results: { installUrl: context.installUrl },
+        };
+    }
+
+    /**
+     * Restart Jira OAuth with the credentials already saved for the organization
+     * @summary Reconnect Jira
+     */
+    @Middlewares([isAuthenticated, unauthorisedInDemo])
+    @SuccessResponse('302', 'Redirect to Jira OAuth')
+    @Get('/install')
+    @OperationId('reconnectJiraIntegration')
+    async reconnectJiraIntegration(
+        @Request() req: express.Request,
+    ): Promise<void> {
+        assertRegisteredAccount(req.account);
+        const context = await this.services
+            .getJiraAppService()
+            .installRedirect(toSessionUser(req.account), null);
+        req.session.oauth = {
+            returnTo: context.returnToUrl,
+            state: context.state,
+            jira: context.jira,
+        };
+        this.setStatus(302);
+        this.setHeader('Location', context.installUrl);
+    }
+
+    /**
+     * Finish Jira OAuth and return to Ask AI settings
+     * @summary Jira OAuth callback
+     */
+    @Get('/oauth/callback')
+    @OperationId('jiraOauthCallback')
+    async jiraOauthCallback(
+        @Request() req: express.Request,
+        @Query() code?: string,
+        @Query() state?: string,
+    ): Promise<void> {
+        assertRegisteredAccount(req.account);
+        if (!state || state !== req.session.oauth?.state) {
+            this.setStatus(400);
+            throw new ParameterError('State does not match');
+        }
+        const redirectUrl = await this.services
+            .getJiraAppService()
+            .installCallback(
+                toSessionUser(req.account),
+                req.session.oauth,
+                code,
+                state,
+            );
+        this.setStatus(302);
+        this.setHeader('Location', redirectUrl);
+    }
+
+    /**
+     * Get the Jira site connected to the organization
+     * @summary Get Jira installation
+     */
+    @Middlewares([isAuthenticated, unauthorisedInDemo])
+    @SuccessResponse('200')
+    @Get('/')
+    @OperationId('getJiraInstallation')
+    async getJiraInstallation(@Request() req: express.Request): Promise<{
+        status: 'ok';
+        results: JiraInstallation;
+    }> {
+        assertRegisteredAccount(req.account);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getJiraAppService()
+                .getInstallation(toSessionUser(req.account)),
+        };
+    }
+
+    /**
+     * List Jira sites available through the connection
+     * @summary List Jira sites
+     */
+    @Middlewares([isAuthenticated, unauthorisedInDemo])
+    @Get('/sites')
+    @OperationId('getJiraSites')
+    async getJiraSites(@Request() req: express.Request): Promise<{
+        status: 'ok';
+        results: JiraSite[];
+    }> {
+        assertRegisteredAccount(req.account);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getJiraAppService()
+                .getSites(toSessionUser(req.account)),
+        };
+    }
+
+    /**
+     * Select the Jira site used by the organization
+     * @summary Select Jira site
+     */
+    @Middlewares([isAuthenticated, unauthorisedInDemo])
+    @Put('/site')
+    @OperationId('selectJiraSite')
+    async selectJiraSite(
+        @Request() req: express.Request,
+        @Body() body: { siteId: string },
+    ): Promise<{ status: 'ok'; results: JiraInstallation }> {
+        assertRegisteredAccount(req.account);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getJiraAppService()
+                .selectSite(toSessionUser(req.account), body.siteId),
+        };
+    }
+
+    /**
+     * List Jira projects accessible through the connection
+     * @summary List Jira projects
+     */
+    @Middlewares([isAuthenticated, unauthorisedInDemo])
+    @Get('/projects')
+    @OperationId('getJiraProjects')
+    async getJiraProjects(@Request() req: express.Request): Promise<{
+        status: 'ok';
+        results: JiraProject[];
+    }> {
+        assertRegisteredAccount(req.account);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getJiraAppService()
+                .getProjects(toSessionUser(req.account)),
+        };
+    }
+
+    /**
+     * List Jira issue types available in a project
+     * @summary List Jira issue types
+     */
+    @Middlewares([isAuthenticated, unauthorisedInDemo])
+    @Get('/issue-types')
+    @OperationId('getJiraIssueTypes')
+    async getJiraIssueTypes(
+        @Request() req: express.Request,
+        @Query() projectId: string,
+    ): Promise<{ status: 'ok'; results: JiraIssueType[] }> {
+        assertRegisteredAccount(req.account);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getJiraAppService()
+                .getIssueTypes(toSessionUser(req.account), projectId),
+        };
+    }
+
+    /**
+     * Uninstall Jira integration from the organization
+     * @summary Uninstall Jira integration
+     */
+    @Middlewares([isAuthenticated, unauthorisedInDemo])
+    @Delete('/uninstall')
+    @OperationId('uninstallJiraIntegration')
+    async uninstallJiraIntegration(
+        @Request() req: express.Request,
+    ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
+        await this.services
+            .getJiraAppService()
+            .deleteAppInstallation(toSessionUser(req.account));
+        return { status: 'ok', results: undefined };
+    }
+}

--- a/packages/backend/src/database/entities/jiraAppInstallation.ts
+++ b/packages/backend/src/database/entities/jiraAppInstallation.ts
@@ -1,0 +1,48 @@
+import { type Knex } from 'knex';
+
+export const JiraAppInstallationTableName = 'jira_app_installations';
+
+export type DbJiraAppInstallation = {
+    jira_app_installation_uuid: string;
+    organization_uuid: string;
+    oauth_client_id: string;
+    encrypted_oauth_client_secret: Buffer;
+    encrypted_access_token: Buffer;
+    encrypted_refresh_token: Buffer | null;
+    token_expires_at: Date;
+    jira_site_id: string | null;
+    jira_site_name: string | null;
+    jira_site_url: string | null;
+    created_at: Date;
+    created_by_user_uuid: string | null;
+    updated_at: Date;
+    updated_by_user_uuid: string | null;
+};
+
+type DbJiraAppInstallationIn = Pick<
+    DbJiraAppInstallation,
+    | 'organization_uuid'
+    | 'oauth_client_id'
+    | 'encrypted_oauth_client_secret'
+    | 'encrypted_access_token'
+    | 'encrypted_refresh_token'
+    | 'token_expires_at'
+    | 'jira_site_id'
+    | 'jira_site_name'
+    | 'jira_site_url'
+    | 'created_by_user_uuid'
+    | 'updated_by_user_uuid'
+>;
+
+type DbJiraAppInstallationUpdate = Partial<
+    Omit<
+        DbJiraAppInstallationIn,
+        'organization_uuid' | 'created_by_user_uuid'
+    > & { updated_at: Date }
+>;
+
+export type JiraAppInstallationTable = Knex.CompositeTableType<
+    DbJiraAppInstallation,
+    DbJiraAppInstallationIn,
+    DbJiraAppInstallationUpdate
+>;

--- a/packages/backend/src/database/migrations/20260902100000_add_jira_app_installations.ts
+++ b/packages/backend/src/database/migrations/20260902100000_add_jira_app_installations.ts
@@ -1,0 +1,64 @@
+import { type Knex } from 'knex';
+
+export const classification = {
+    kind: 'safe',
+    reason: 'Creates a new empty Jira installation table without reading or rewriting existing rows',
+} as const;
+
+const tableName = 'jira_app_installations';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '5s'`);
+
+    if (!(await knex.schema.hasTable(tableName))) {
+        await knex.schema.createTable(tableName, (table) => {
+            table
+                .uuid('jira_app_installation_uuid')
+                .defaultTo(knex.raw('uuid_generate_v4()'))
+                .primary();
+            table
+                .uuid('organization_uuid')
+                .unique()
+                .notNullable()
+                .references('organization_uuid')
+                .inTable('organizations')
+                .onDelete('CASCADE')
+                .index();
+            table.string('oauth_client_id').notNullable();
+            table.binary('encrypted_oauth_client_secret').notNullable();
+            table.binary('encrypted_access_token').notNullable();
+            table.binary('encrypted_refresh_token').nullable();
+            table.timestamp('token_expires_at', { useTz: false }).notNullable();
+            table.string('jira_site_id').nullable();
+            table.string('jira_site_name').nullable();
+            table.string('jira_site_url').nullable();
+            table
+                .timestamp('created_at', { useTz: false })
+                .notNullable()
+                .defaultTo(knex.fn.now());
+            table
+                .uuid('created_by_user_uuid')
+                .nullable()
+                .references('user_uuid')
+                .inTable('users')
+                .onDelete('SET NULL')
+                .index();
+            table
+                .timestamp('updated_at', { useTz: false })
+                .notNullable()
+                .defaultTo(knex.fn.now());
+            table
+                .uuid('updated_by_user_uuid')
+                .nullable()
+                .references('user_uuid')
+                .inTable('users')
+                .onDelete('SET NULL')
+                .index();
+        });
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '5s'`);
+    await knex.schema.dropTableIfExists(tableName);
+}

--- a/packages/backend/src/models/JiraAppInstallations/JiraAppInstallationsModel.ts
+++ b/packages/backend/src/models/JiraAppInstallations/JiraAppInstallationsModel.ts
@@ -1,0 +1,188 @@
+import {
+    NotFoundError,
+    UnexpectedServerError,
+    type JiraInstallation,
+    type JiraSite,
+    type LightdashUserWithOrg, // pragma: allowlist secret
+} from '@lightdash/common'; // pragma: allowlist secret
+import { type Knex } from 'knex';
+import { JiraAppInstallationTableName } from '../../database/entities/jiraAppInstallation';
+import { type EncryptionUtil } from '../../utils/EncryptionUtil/EncryptionUtil';
+
+type Arguments = { database: Knex; encryptionUtil: EncryptionUtil };
+
+export type JiraAuth = {
+    clientId: string;
+    clientSecret: string;
+    token: string;
+    refreshToken: string | null;
+    expiresAt: Date;
+    site: JiraSite | null;
+};
+
+export class JiraAppInstallationsModel {
+    readonly database: Knex;
+
+    readonly encryptionUtil: EncryptionUtil;
+
+    constructor(args: Arguments) {
+        this.database = args.database;
+        this.encryptionUtil = args.encryptionUtil;
+    }
+
+    async transaction<T>(run: (trx: Knex.Transaction) => Promise<T>) {
+        return this.database.transaction(run);
+    }
+
+    private decrypt(value: Buffer, label: string): string {
+        try {
+            return this.encryptionUtil.decrypt(value);
+        } catch {
+            throw new UnexpectedServerError(`Failed to decrypt Jira ${label}`);
+        }
+    }
+
+    async findInstallation(
+        organizationUuid: string,
+    ): Promise<JiraInstallation | undefined> {
+        const row = await this.database(JiraAppInstallationTableName)
+            .where({ organization_uuid: organizationUuid })
+            .first();
+        if (!row) return undefined;
+        return {
+            organizationUuid: row.organization_uuid,
+            clientId: row.oauth_client_id,
+            siteId: row.jira_site_id,
+            siteName: row.jira_site_name,
+            siteUrl: row.jira_site_url,
+            requiresSiteSelection: row.jira_site_id === null,
+        };
+    }
+
+    async getInstallation(organizationUuid: string): Promise<JiraInstallation> {
+        const installation = await this.findInstallation(organizationUuid);
+        if (!installation)
+            throw new NotFoundError('Jira installation not found');
+        return installation;
+    }
+
+    async upsertInstallation(
+        user: LightdashUserWithOrg, // pragma: allowlist secret
+        args: {
+            clientId: string;
+            clientSecret: string;
+            token: string;
+            refreshToken: string | null;
+            expiresAt: Date;
+            site: JiraSite | null;
+        },
+        database: Knex = this.database,
+    ): Promise<void> {
+        const credentials = {
+            oauth_client_id: args.clientId,
+            encrypted_oauth_client_secret: this.encryptionUtil.encrypt(
+                args.clientSecret,
+            ),
+        };
+        await database(JiraAppInstallationTableName)
+            .insert({
+                organization_uuid: user.organizationUuid,
+                ...credentials,
+                encrypted_access_token: this.encryptionUtil.encrypt(args.token),
+                encrypted_refresh_token: args.refreshToken
+                    ? this.encryptionUtil.encrypt(args.refreshToken)
+                    : null,
+                token_expires_at: args.expiresAt,
+                jira_site_id: args.site?.id ?? null,
+                jira_site_name: args.site?.name ?? null,
+                jira_site_url: args.site?.url ?? null,
+                created_by_user_uuid: user.userUuid,
+                updated_by_user_uuid: user.userUuid,
+            })
+            .onConflict('organization_uuid')
+            .merge({
+                ...credentials,
+                encrypted_access_token: this.encryptionUtil.encrypt(args.token),
+                encrypted_refresh_token: args.refreshToken
+                    ? this.encryptionUtil.encrypt(args.refreshToken)
+                    : null,
+                token_expires_at: args.expiresAt,
+                jira_site_id: args.site?.id ?? null,
+                jira_site_name: args.site?.name ?? null,
+                jira_site_url: args.site?.url ?? null,
+                updated_by_user_uuid: user.userUuid,
+                updated_at: new Date(),
+            });
+    }
+
+    async setSite(
+        organizationUuid: string,
+        site: JiraSite,
+        database: Knex = this.database,
+    ): Promise<void> {
+        await database(JiraAppInstallationTableName)
+            .where({ organization_uuid: organizationUuid })
+            .update({
+                jira_site_id: site.id,
+                jira_site_name: site.name,
+                jira_site_url: site.url,
+                updated_at: new Date(),
+            });
+    }
+
+    async getAuth(organizationUuid: string): Promise<JiraAuth> {
+        const row = await this.database(JiraAppInstallationTableName)
+            .where({ organization_uuid: organizationUuid })
+            .first();
+        if (!row) {
+            throw new NotFoundError(
+                `Unable to find Jira authentication for organization ${organizationUuid}`,
+            );
+        }
+        return {
+            clientId: row.oauth_client_id,
+            clientSecret: this.decrypt(
+                row.encrypted_oauth_client_secret,
+                'client secret',
+            ),
+            token: this.decrypt(row.encrypted_access_token, 'access token'),
+            refreshToken: row.encrypted_refresh_token
+                ? this.decrypt(row.encrypted_refresh_token, 'refresh token')
+                : null,
+            expiresAt: row.token_expires_at,
+            site:
+                row.jira_site_id && row.jira_site_name && row.jira_site_url
+                    ? {
+                          id: row.jira_site_id,
+                          name: row.jira_site_name,
+                          url: row.jira_site_url,
+                      }
+                    : null,
+        };
+    }
+
+    async updateAuth(
+        organizationUuid: string,
+        args: Pick<JiraAuth, 'token' | 'refreshToken' | 'expiresAt'>,
+    ): Promise<void> {
+        await this.database(JiraAppInstallationTableName)
+            .where({ organization_uuid: organizationUuid })
+            .update({
+                encrypted_access_token: this.encryptionUtil.encrypt(args.token),
+                encrypted_refresh_token: args.refreshToken
+                    ? this.encryptionUtil.encrypt(args.refreshToken)
+                    : null,
+                token_expires_at: args.expiresAt,
+                updated_at: new Date(),
+            });
+    }
+
+    async deleteInstallation(
+        organizationUuid: string,
+        database: Knex = this.database,
+    ): Promise<void> {
+        await database(JiraAppInstallationTableName)
+            .where({ organization_uuid: organizationUuid })
+            .delete();
+    }
+}

--- a/packages/backend/src/models/ModelRepository.ts
+++ b/packages/backend/src/models/ModelRepository.ts
@@ -31,6 +31,7 @@ import { GitUserCredentialsModel } from './GitUserCredentials/GitUserCredentials
 import { GroupsModel } from './GroupsModel';
 import { HeadlessBrowserLoginGrantModel } from './HeadlessBrowserLoginGrantModel';
 import { InviteLinkModel } from './InviteLinkModel';
+import { JiraAppInstallationsModel } from './JiraAppInstallations/JiraAppInstallationsModel';
 import { JobModel } from './JobModel/JobModel';
 import { LinearAppInstallationsModel } from './LinearAppInstallations/LinearAppInstallationsModel';
 import { McpContextModel } from './McpContextModel';
@@ -108,6 +109,7 @@ export type ModelManifest = {
     githubAppInstallationsModel: GithubAppInstallationsModel;
     gitUserCredentialsModel: GitUserCredentialsModel;
     gitlabAppInstallationsModel: GitlabAppInstallationsModel;
+    jiraAppInstallationsModel: JiraAppInstallationsModel;
     linearAppInstallationsModel: LinearAppInstallationsModel;
     groupsModel: GroupsModel;
     headlessBrowserLoginGrantModel: HeadlessBrowserLoginGrantModel;
@@ -440,6 +442,17 @@ export class ModelRepository
             'linearAppInstallationsModel',
             () =>
                 new LinearAppInstallationsModel({
+                    database: this.database,
+                    encryptionUtil: this.utils.getEncryptionUtil(),
+                }),
+        );
+    }
+
+    public getJiraAppInstallationsModel(): JiraAppInstallationsModel {
+        return this.getModel(
+            'jiraAppInstallationsModel',
+            () =>
+                new JiraAppInstallationsModel({
                     database: this.database,
                     encryptionUtil: this.utils.getEncryptionUtil(),
                 }),

--- a/packages/backend/src/services/HealthService/HealthService.mock.ts
+++ b/packages/backend/src/services/HealthService/HealthService.mock.ts
@@ -36,6 +36,7 @@ export const BaseResponse: HealthState = {
     hasMicrosoftTeams: false,
     hasGithub: false,
     hasGitlab: false,
+    hasJira: false,
     hasLinear: true,
     hasHeadlessBrowser: false,
     hasSlack: false,

--- a/packages/backend/src/services/HealthService/HealthService.mock.ts
+++ b/packages/backend/src/services/HealthService/HealthService.mock.ts
@@ -36,7 +36,7 @@ export const BaseResponse: HealthState = {
     hasMicrosoftTeams: false,
     hasGithub: false,
     hasGitlab: false,
-    hasJira: false,
+    hasJira: true,
     hasLinear: true,
     hasHeadlessBrowser: false,
     hasSlack: false,

--- a/packages/backend/src/services/HealthService/HealthService.ts
+++ b/packages/backend/src/services/HealthService/HealthService.ts
@@ -184,6 +184,7 @@ export class HealthService extends BaseService {
             hasGitlab:
                 this.lightdashConfig.gitlab.clientId !== undefined &&
                 this.lightdashConfig.gitlab.clientSecret !== undefined,
+            hasJira: true,
             hasLinear: true,
             auth: {
                 disablePasswordAuthentication:

--- a/packages/backend/src/services/JiraAppService/JiraAppService.test.ts
+++ b/packages/backend/src/services/JiraAppService/JiraAppService.test.ts
@@ -1,0 +1,232 @@
+import { Ability } from '@casl/ability';
+import {
+    OrganizationMemberRole,
+    type PossibleAbilities,
+    type SessionUser,
+} from '@lightdash/common'; // pragma: allowlist secret
+import {
+    exchangeJiraCodeForToken,
+    getJiraAuthorizationUrl,
+    getJiraSites,
+    refreshJiraToken,
+} from '../../clients/jira/Jira';
+import { JiraAppService } from './JiraAppService';
+
+vi.mock('../../clients/jira/Jira', () => ({
+    createJiraIssue: vi.fn(),
+    exchangeJiraCodeForToken: vi.fn(),
+    getJiraAuthorizationUrl: vi.fn(),
+    getJiraIssueTypes: vi.fn(),
+    getJiraProjects: vi.fn(),
+    getJiraSites: vi.fn(),
+    linkJiraIssueUrl: vi.fn(),
+    refreshJiraToken: vi.fn(),
+}));
+
+const ORGANIZATION_UUID = '00000000-0000-0000-0000-000000000001';
+const NOW = new Date('2026-09-02T10:00:00Z');
+const user = {
+    userUuid: 'user-1',
+    organizationUuid: ORGANIZATION_UUID,
+    organizationName: 'Acme',
+    organizationCreatedAt: NOW,
+    role: OrganizationMemberRole.ADMIN,
+    ability: new Ability<PossibleAbilities>([
+        { action: 'manage', subject: 'Organization' },
+    ]),
+} as SessionUser;
+
+const CREDENTIALS = { clientId: 'client-1', clientSecret: 'secret-1' };
+
+const makeService = () => {
+    const trx = {};
+    const model = {
+        transaction: vi.fn().mockImplementation((run) => run(trx)),
+        findInstallation: vi.fn().mockResolvedValue(undefined),
+        getInstallation: vi.fn().mockResolvedValue({
+            organizationUuid: ORGANIZATION_UUID,
+            clientId: 'client-1',
+            siteId: 'site-1',
+            siteName: 'Acme',
+            siteUrl: 'https://acme.atlassian.net',
+            requiresSiteSelection: false,
+        }),
+        getAuth: vi.fn().mockResolvedValue({
+            ...CREDENTIALS,
+            token: 'access-1',
+            refreshToken: 'refresh-1',
+            expiresAt: new Date(Date.now() + 60_000),
+            site: {
+                id: 'site-1',
+                name: 'Acme',
+                url: 'https://acme.atlassian.net',
+            },
+        }),
+        upsertInstallation: vi.fn(),
+        updateAuth: vi.fn(),
+        setSite: vi.fn(),
+        deleteInstallation: vi.fn(),
+    };
+    const onWorkspaceChanged = vi.fn();
+    const service = new JiraAppService({
+        jiraAppInstallationsModel: model,
+        lightdashConfig: { siteUrl: 'https://app.example.com' },
+        analytics: { track: vi.fn() },
+        onWorkspaceChanged,
+    } as unknown as ConstructorParameters<typeof JiraAppService>[0]);
+    return { service, model, trx, onWorkspaceChanged };
+};
+
+describe('JiraAppService', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(getJiraAuthorizationUrl).mockReturnValue(
+            'https://auth.atlassian.com/authorize?test',
+        );
+    });
+
+    it('starts OAuth with the credentials supplied by the organization', async () => {
+        const { service, model } = makeService();
+        const context = await service.installRedirect(user, {
+            clientId: ' client-1 ',
+            clientSecret: 'secret-1',
+        });
+        expect(getJiraAuthorizationUrl).toHaveBeenCalledWith(
+            'client-1',
+            'https://app.example.com/api/v1/jira/oauth/callback',
+            context.state,
+        );
+        expect(context.jira).toEqual({
+            redirectUri: 'https://app.example.com/api/v1/jira/oauth/callback',
+            clientId: 'client-1',
+            clientSecret: 'secret-1',
+        });
+        expect(context.returnToUrl).toBe(
+            'https://app.example.com/generalSettings/ai/general',
+        );
+        expect(model.getAuth).not.toHaveBeenCalled();
+    });
+
+    it('rejects blank credentials', async () => {
+        const { service } = makeService();
+        await expect(
+            service.installRedirect(user, {
+                clientId: 'client-1',
+                clientSecret: '   ',
+            }),
+        ).rejects.toThrow('Jira OAuth client secret is invalid');
+        expect(getJiraAuthorizationUrl).not.toHaveBeenCalled();
+    });
+
+    it('reconnects with the credentials stored for the organization', async () => {
+        const { service, model } = makeService();
+        const context = await service.installRedirect(user, null);
+        expect(model.getAuth).toHaveBeenCalledWith(ORGANIZATION_UUID);
+        expect(getJiraAuthorizationUrl).toHaveBeenCalledWith(
+            'client-1',
+            'https://app.example.com/api/v1/jira/oauth/callback',
+            context.state,
+        );
+        expect(context.jira).toMatchObject(CREDENTIALS);
+    });
+
+    it('stores tokens and auto-selects the only Jira site', async () => {
+        const { service, model, trx } = makeService();
+        vi.mocked(exchangeJiraCodeForToken).mockResolvedValue({
+            token: 'access-2',
+            refreshToken: 'refresh-2',
+            expiresAt: NOW,
+        });
+        vi.mocked(getJiraSites).mockResolvedValue([
+            {
+                id: 'site-1',
+                name: 'Acme',
+                url: 'https://acme.atlassian.net',
+            },
+        ]);
+        await service.installCallback(
+            user,
+            {
+                state: 'state-1',
+                returnTo: 'https://app.example.com/generalSettings/ai/general',
+                jira: {
+                    redirectUri: 'https://app.example.com/callback',
+                    ...CREDENTIALS,
+                },
+            },
+            'code-1',
+            'state-1',
+        );
+        expect(exchangeJiraCodeForToken).toHaveBeenCalledWith(
+            'code-1',
+            'client-1',
+            'secret-1',
+            'https://app.example.com/callback',
+        );
+        expect(model.upsertInstallation).toHaveBeenCalledWith(
+            user,
+            {
+                ...CREDENTIALS,
+                token: 'access-2',
+                refreshToken: 'refresh-2',
+                expiresAt: NOW,
+                site: {
+                    id: 'site-1',
+                    name: 'Acme',
+                    url: 'https://acme.atlassian.net',
+                },
+            },
+            trx,
+        );
+    });
+
+    it('clears routing when selecting a different site', async () => {
+        const { service, model, trx, onWorkspaceChanged } = makeService();
+        vi.mocked(getJiraSites).mockResolvedValue([
+            {
+                id: 'site-2',
+                name: 'Other',
+                url: 'https://other.atlassian.net',
+            },
+        ]);
+        await service.selectSite(user, 'site-2');
+        expect(model.setSite).toHaveBeenCalledWith(
+            ORGANIZATION_UUID,
+            expect.objectContaining({ id: 'site-2' }),
+            trx,
+        );
+        expect(onWorkspaceChanged).toHaveBeenCalledWith(ORGANIZATION_UUID, trx);
+    });
+
+    it('refreshes an expired token before calling Jira', async () => {
+        const { service, model } = makeService();
+        model.getAuth.mockResolvedValue({
+            clientId: 'client-9',
+            clientSecret: 'secret-9',
+            token: 'expired',
+            refreshToken: 'refresh-1',
+            expiresAt: new Date(0),
+            site: {
+                id: 'site-1',
+                name: 'Acme',
+                url: 'https://acme.atlassian.net',
+            },
+        });
+        vi.mocked(refreshJiraToken).mockResolvedValue({
+            token: 'access-2',
+            refreshToken: 'refresh-2',
+            expiresAt: NOW,
+        });
+        vi.mocked(getJiraSites).mockResolvedValue([]);
+        await service.getSites(user);
+        expect(refreshJiraToken).toHaveBeenCalledWith(
+            'refresh-1',
+            'client-9',
+            'secret-9',
+        );
+        expect(model.updateAuth).toHaveBeenCalledWith(
+            ORGANIZATION_UUID,
+            expect.objectContaining({ token: 'access-2' }),
+        );
+    });
+});

--- a/packages/backend/src/services/JiraAppService/JiraAppService.test.ts
+++ b/packages/backend/src/services/JiraAppService/JiraAppService.test.ts
@@ -37,6 +37,7 @@ const user = {
 } as SessionUser;
 
 const CREDENTIALS = { clientId: 'client-1', clientSecret: 'secret-1' };
+const ENCRYPTED_SECRET = Buffer.from('enc:secret-1').toString('base64');
 
 const makeService = () => {
     const trx = {};
@@ -68,8 +69,15 @@ const makeService = () => {
         deleteInstallation: vi.fn(),
     };
     const onWorkspaceChanged = vi.fn();
+    const encryptionUtil = {
+        encrypt: vi.fn((message: string) => Buffer.from(`enc:${message}`)),
+        decrypt: vi.fn((encrypted: Buffer) =>
+            encrypted.toString().replace(/^enc:/, ''),
+        ),
+    };
     const service = new JiraAppService({
         jiraAppInstallationsModel: model,
+        encryptionUtil,
         lightdashConfig: { siteUrl: 'https://app.example.com' },
         analytics: { track: vi.fn() },
         onWorkspaceChanged,
@@ -99,7 +107,7 @@ describe('JiraAppService', () => {
         expect(context.jira).toEqual({
             redirectUri: 'https://app.example.com/api/v1/jira/oauth/callback',
             clientId: 'client-1',
-            clientSecret: 'secret-1',
+            encryptedClientSecret: ENCRYPTED_SECRET,
         });
         expect(context.returnToUrl).toBe(
             'https://app.example.com/generalSettings/ai/general',
@@ -127,7 +135,10 @@ describe('JiraAppService', () => {
             'https://app.example.com/api/v1/jira/oauth/callback',
             context.state,
         );
-        expect(context.jira).toMatchObject(CREDENTIALS);
+        expect(context.jira).toMatchObject({
+            clientId: 'client-1',
+            encryptedClientSecret: ENCRYPTED_SECRET,
+        });
     });
 
     it('stores tokens and auto-selects the only Jira site', async () => {
@@ -151,7 +162,8 @@ describe('JiraAppService', () => {
                 returnTo: 'https://app.example.com/generalSettings/ai/general',
                 jira: {
                     redirectUri: 'https://app.example.com/callback',
-                    ...CREDENTIALS,
+                    clientId: 'client-1',
+                    encryptedClientSecret: ENCRYPTED_SECRET,
                 },
             },
             'code-1',

--- a/packages/backend/src/services/JiraAppService/JiraAppService.ts
+++ b/packages/backend/src/services/JiraAppService/JiraAppService.ts
@@ -1,0 +1,362 @@
+import { subject } from '@casl/ability';
+import {
+    AuthorizationError,
+    ForbiddenError,
+    getErrorMessage,
+    isUserWithOrg,
+    NotFoundError,
+    ParameterError,
+    type JiraCreatedIssue,
+    type JiraInstallation,
+    type JiraIssueType,
+    type JiraOAuthCredentials,
+    type JiraProject,
+    type JiraSite,
+    type LightdashUserWithOrg,
+    type SessionUser,
+} from '@lightdash/common'; // pragma: allowlist secret
+import { type SessionData } from 'express-session';
+import { type Knex } from 'knex';
+import { nanoid } from 'nanoid';
+import { type LightdashAnalytics } from '../../analytics/LightdashAnalytics'; // pragma: allowlist secret
+import {
+    createJiraIssue,
+    exchangeJiraCodeForToken,
+    getJiraAuthorizationUrl,
+    getJiraIssueTypes,
+    getJiraProjects,
+    getJiraSites,
+    linkJiraIssueUrl,
+    refreshJiraToken,
+} from '../../clients/jira/Jira';
+import { type LightdashConfig } from '../../config/parseConfig'; // pragma: allowlist secret
+import { type JiraAppInstallationsModel } from '../../models/JiraAppInstallations/JiraAppInstallationsModel';
+import { BaseService } from '../BaseService';
+
+type Arguments = {
+    jiraAppInstallationsModel: JiraAppInstallationsModel;
+    lightdashConfig: LightdashConfig; // pragma: allowlist secret
+    analytics: LightdashAnalytics; // pragma: allowlist secret
+    onWorkspaceChanged?: (
+        organizationUuid: string,
+        trx: Knex.Transaction,
+    ) => Promise<void>;
+    onInstallationDeleted?: (
+        organizationUuid: string,
+        trx: Knex.Transaction,
+    ) => Promise<void>;
+};
+
+const MAX_CREDENTIAL_LENGTH = 255;
+
+export class JiraAppService extends BaseService {
+    private readonly model: JiraAppInstallationsModel;
+
+    private readonly config: LightdashConfig; // pragma: allowlist secret
+
+    private readonly analytics: LightdashAnalytics; // pragma: allowlist secret
+
+    private readonly onWorkspaceChanged: NonNullable<
+        Arguments['onWorkspaceChanged']
+    >;
+
+    private readonly onInstallationDeleted: NonNullable<
+        Arguments['onInstallationDeleted']
+    >;
+
+    constructor(args: Arguments) {
+        super();
+        this.model = args.jiraAppInstallationsModel;
+        this.config = args.lightdashConfig;
+        this.analytics = args.analytics;
+        this.onWorkspaceChanged =
+            args.onWorkspaceChanged ?? (() => Promise.resolve());
+        this.onInstallationDeleted =
+            args.onInstallationDeleted ?? (() => Promise.resolve());
+    }
+
+    private canManageOrg(
+        user: SessionUser,
+    ): asserts user is SessionUser & LightdashUserWithOrg {
+        if (!isUserWithOrg(user))
+            throw new Error('User is not part of an organization');
+        if (
+            !this.createAuditedAbility(user).can(
+                'manage',
+                subject('Organization', {
+                    organizationUuid: user.organizationUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'User does not have permission to manage organization',
+            );
+        }
+    }
+
+    private static validateCredentials(
+        credentials: JiraOAuthCredentials,
+    ): JiraOAuthCredentials {
+        const clientId = credentials.clientId.trim();
+        const clientSecret = credentials.clientSecret.trim();
+        if (!clientId || clientId.length > MAX_CREDENTIAL_LENGTH) {
+            throw new ParameterError('Jira OAuth client ID is invalid');
+        }
+        if (!clientSecret || clientSecret.length > MAX_CREDENTIAL_LENGTH) {
+            throw new ParameterError('Jira OAuth client secret is invalid');
+        }
+        return { clientId, clientSecret };
+    }
+
+    private async getStoredCredentials(
+        organizationUuid: string,
+    ): Promise<JiraOAuthCredentials> {
+        const { clientId, clientSecret } =
+            await this.model.getAuth(organizationUuid);
+        return { clientId, clientSecret };
+    }
+
+    private getRedirectUri() {
+        return new URL(
+            '/api/v1/jira/oauth/callback',
+            this.config.siteUrl, // pragma: allowlist secret
+        ).href;
+    }
+
+    async installRedirect(
+        user: SessionUser,
+        credentials: JiraOAuthCredentials | null,
+    ) {
+        this.canManageOrg(user);
+        const { clientId, clientSecret } = credentials
+            ? JiraAppService.validateCredentials(credentials)
+            : await this.getStoredCredentials(user.organizationUuid);
+        const state = nanoid();
+        const redirectUri = this.getRedirectUri();
+        this.analytics.track({
+            event: 'jira_install.started',
+            userId: user.userUuid,
+            properties: { organizationId: user.organizationUuid },
+        });
+        return {
+            installUrl: getJiraAuthorizationUrl(clientId, redirectUri, state),
+            returnToUrl: new URL(
+                '/generalSettings/ai/general',
+                this.config.siteUrl, // pragma: allowlist secret
+            ).href,
+            state,
+            jira: { redirectUri, clientId, clientSecret },
+        };
+    }
+
+    async installCallback(
+        user: SessionUser,
+        oauth: SessionData['oauth'],
+        code?: string,
+        state?: string,
+    ): Promise<string> {
+        this.canManageOrg(user);
+        try {
+            if (!state || state !== oauth?.state) {
+                throw new AuthorizationError('State does not match');
+            }
+            if (!code) throw new ParameterError('Code not provided');
+            if (!oauth.jira) {
+                throw new ParameterError('Jira OAuth session not found');
+            }
+            const { clientId, clientSecret, redirectUri } = oauth.jira;
+            const tokens = await exchangeJiraCodeForToken(
+                code,
+                clientId,
+                clientSecret,
+                redirectUri,
+            );
+            const sites = await getJiraSites(tokens.token);
+            if (sites.length === 0) {
+                throw new NotFoundError('No Jira sites are available');
+            }
+            const existing = await this.model.findInstallation(
+                user.organizationUuid,
+            );
+            const previousSite = existing?.siteId
+                ? (sites.find((site) => site.id === existing.siteId) ?? null)
+                : null;
+            const site = previousSite ?? (sites.length === 1 ? sites[0] : null);
+            const workspaceChanged =
+                existing?.siteId != null && existing.siteId !== site?.id;
+
+            await this.model.transaction(async (trx) => {
+                await this.model.upsertInstallation(
+                    user,
+                    { ...tokens, site, clientId, clientSecret },
+                    trx,
+                );
+                if (workspaceChanged) {
+                    await this.onWorkspaceChanged(user.organizationUuid, trx);
+                }
+            });
+            this.analytics.track({
+                event: 'jira_install.completed',
+                userId: user.userUuid,
+                properties: { organizationId: user.organizationUuid },
+            });
+            return new URL(
+                oauth.returnTo ?? this.config.siteUrl, // pragma: allowlist secret
+            ).href;
+        } catch (error) {
+            this.analytics.track({
+                event: 'jira_install.error',
+                userId: user.userUuid,
+                properties: {
+                    organizationId: user.organizationUuid,
+                    error: getErrorMessage(error),
+                },
+            });
+            throw error;
+        }
+    }
+
+    async getInstallation(user: SessionUser): Promise<JiraInstallation> {
+        this.canManageOrg(user);
+        return this.model.getInstallation(user.organizationUuid);
+    }
+
+    async deleteAppInstallation(user: SessionUser): Promise<void> {
+        this.canManageOrg(user);
+        await this.model.transaction(async (trx) => {
+            await this.model.deleteInstallation(user.organizationUuid, trx);
+            await this.onInstallationDeleted(user.organizationUuid, trx);
+        });
+        this.analytics.track({
+            event: 'jira_install.uninstalled',
+            userId: user.userUuid,
+            properties: { organizationId: user.organizationUuid },
+        });
+    }
+
+    async getSites(user: SessionUser): Promise<JiraSite[]> {
+        this.canManageOrg(user);
+        return this.withValidToken(user.organizationUuid, (token) =>
+            getJiraSites(token),
+        );
+    }
+
+    async selectSite(
+        user: SessionUser,
+        siteId: string,
+    ): Promise<JiraInstallation> {
+        this.canManageOrg(user);
+        const sites = await this.withValidToken(
+            user.organizationUuid,
+            (token) => getJiraSites(token),
+        );
+        const site = sites.find((candidate) => candidate.id === siteId);
+        if (!site) throw new NotFoundError('Jira site not found');
+        const current = await this.model.getInstallation(user.organizationUuid);
+        await this.model.transaction(async (trx) => {
+            await this.model.setSite(user.organizationUuid, site, trx);
+            if (current.siteId !== site.id) {
+                await this.onWorkspaceChanged(user.organizationUuid, trx);
+            }
+        });
+        return this.model.getInstallation(user.organizationUuid);
+    }
+
+    async getProjects(user: SessionUser): Promise<JiraProject[]> {
+        this.canManageOrg(user);
+        return this.withSite(user.organizationUuid, (token, site) =>
+            getJiraProjects(token, site.id),
+        );
+    }
+
+    async getIssueTypes(
+        user: SessionUser,
+        projectId: string,
+    ): Promise<JiraIssueType[]> {
+        this.canManageOrg(user);
+        return this.withSite(user.organizationUuid, (token, site) =>
+            getJiraIssueTypes(token, site.id, projectId),
+        );
+    }
+
+    async createIssueForOrganization(
+        organizationUuid: string,
+        input: {
+            title: string;
+            description: string;
+            projectId: string;
+            issueTypeId: string;
+        },
+    ): Promise<JiraCreatedIssue> {
+        return this.withSite(organizationUuid, (token, site) =>
+            createJiraIssue(token, site, input),
+        );
+    }
+
+    async linkIssueUrlForOrganization(
+        organizationUuid: string,
+        input: { issueIdOrKey: string; url: string; title: string },
+    ): Promise<void> {
+        return this.withSite(organizationUuid, (token, site) =>
+            linkJiraIssueUrl(token, site.id, input),
+        );
+    }
+
+    private async withSite<T>(
+        organizationUuid: string,
+        run: (token: string, site: JiraSite) => Promise<T>,
+    ): Promise<T> {
+        const auth = await this.getValidAuth(organizationUuid);
+        if (!auth.site) {
+            throw new ParameterError('Select a Jira site before using Jira');
+        }
+        try {
+            return await run(auth.token, auth.site);
+        } catch (error) {
+            if (!(error instanceof ForbiddenError)) throw error;
+            const refreshed = await this.refreshAuth(organizationUuid, auth);
+            return run(refreshed.token, auth.site);
+        }
+    }
+
+    private async withValidToken<T>(
+        organizationUuid: string,
+        run: (token: string) => Promise<T>,
+    ): Promise<T> {
+        const auth = await this.getValidAuth(organizationUuid);
+        try {
+            return await run(auth.token);
+        } catch (error) {
+            if (!(error instanceof ForbiddenError)) throw error;
+            const refreshed = await this.refreshAuth(organizationUuid, auth);
+            return run(refreshed.token);
+        }
+    }
+
+    private async getValidAuth(organizationUuid: string) {
+        const auth = await this.model.getAuth(organizationUuid);
+        if (auth.expiresAt.getTime() > Date.now() + 30_000) return auth;
+        return this.refreshAuth(organizationUuid, auth);
+    }
+
+    private async refreshAuth(
+        organizationUuid: string,
+        auth: Awaited<ReturnType<JiraAppInstallationsModel['getAuth']>>,
+    ) {
+        if (!auth.refreshToken) {
+            throw new ForbiddenError('Jira connection must be renewed');
+        }
+        const refreshed = await refreshJiraToken(
+            auth.refreshToken,
+            auth.clientId,
+            auth.clientSecret,
+        );
+        const next = {
+            ...auth,
+            ...refreshed,
+            refreshToken: refreshed.refreshToken ?? auth.refreshToken,
+        };
+        await this.model.updateAuth(organizationUuid, next);
+        return next;
+    }
+}

--- a/packages/backend/src/services/JiraAppService/JiraAppService.ts
+++ b/packages/backend/src/services/JiraAppService/JiraAppService.ts
@@ -31,10 +31,12 @@ import {
 } from '../../clients/jira/Jira';
 import { type LightdashConfig } from '../../config/parseConfig'; // pragma: allowlist secret
 import { type JiraAppInstallationsModel } from '../../models/JiraAppInstallations/JiraAppInstallationsModel';
+import { type EncryptionUtil } from '../../utils/EncryptionUtil/EncryptionUtil';
 import { BaseService } from '../BaseService';
 
 type Arguments = {
     jiraAppInstallationsModel: JiraAppInstallationsModel;
+    encryptionUtil: EncryptionUtil;
     lightdashConfig: LightdashConfig; // pragma: allowlist secret
     analytics: LightdashAnalytics; // pragma: allowlist secret
     onWorkspaceChanged?: (
@@ -52,6 +54,8 @@ const MAX_CREDENTIAL_LENGTH = 255;
 export class JiraAppService extends BaseService {
     private readonly model: JiraAppInstallationsModel;
 
+    private readonly encryptionUtil: EncryptionUtil;
+
     private readonly config: LightdashConfig; // pragma: allowlist secret
 
     private readonly analytics: LightdashAnalytics; // pragma: allowlist secret
@@ -67,6 +71,7 @@ export class JiraAppService extends BaseService {
     constructor(args: Arguments) {
         super();
         this.model = args.jiraAppInstallationsModel;
+        this.encryptionUtil = args.encryptionUtil;
         this.config = args.lightdashConfig;
         this.analytics = args.analytics;
         this.onWorkspaceChanged =
@@ -145,7 +150,14 @@ export class JiraAppService extends BaseService {
                 this.config.siteUrl, // pragma: allowlist secret
             ).href,
             state,
-            jira: { redirectUri, clientId, clientSecret },
+            jira: {
+                redirectUri,
+                clientId,
+                // The secret round-trips through the session store, so never in plaintext
+                encryptedClientSecret: this.encryptionUtil
+                    .encrypt(clientSecret)
+                    .toString('base64'),
+            },
         };
     }
 
@@ -164,7 +176,10 @@ export class JiraAppService extends BaseService {
             if (!oauth.jira) {
                 throw new ParameterError('Jira OAuth session not found');
             }
-            const { clientId, clientSecret, redirectUri } = oauth.jira;
+            const { clientId, redirectUri } = oauth.jira;
+            const clientSecret = this.encryptionUtil.decrypt(
+                Buffer.from(oauth.jira.encryptedClientSecret, 'base64'),
+            );
             const tokens = await exchangeJiraCodeForToken(
                 code,
                 clientId,
@@ -315,7 +330,7 @@ export class JiraAppService extends BaseService {
         } catch (error) {
             if (!(error instanceof ForbiddenError)) throw error;
             const refreshed = await this.refreshAuth(organizationUuid, auth);
-            return run(refreshed.token, auth.site);
+            return run(refreshed.token, refreshed.site ?? auth.site);
         }
     }
 

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -45,6 +45,7 @@ import { GitlabAppService } from './GitlabAppService/GitlabAppService';
 import { GroupsService } from './GroupService';
 import { HeadlessBrowserService } from './HeadlessBrowserService';
 import { HealthService } from './HealthService/HealthService';
+import { JiraAppService } from './JiraAppService/JiraAppService';
 import { LicenseService } from './LicenseService/LicenseService';
 import { LightdashAnalyticsService } from './LightdashAnalyticsService/LightdashAnalyticsService';
 import { LinearAppService } from './LinearAppService/LinearAppService';
@@ -111,6 +112,7 @@ interface ServiceManifest {
     pullRequestsService: PullRequestsService;
     githubAppService: GithubAppService;
     gitlabAppService: GitlabAppService;
+    jiraAppService: JiraAppService;
     linearAppService: LinearAppService;
     gdriveService: GdriveService;
     groupService: GroupsService;
@@ -578,6 +580,19 @@ export class ServiceRepository
                 new LinearAppService({
                     linearAppInstallationsModel:
                         this.models.getLinearAppInstallationsModel(),
+                    lightdashConfig: this.context.lightdashConfig,
+                    analytics: this.context.lightdashAnalytics, // pragma: allowlist secret
+                }),
+        );
+    }
+
+    public getJiraAppService(): JiraAppService {
+        return this.getService(
+            'jiraAppService',
+            () =>
+                new JiraAppService({
+                    jiraAppInstallationsModel:
+                        this.models.getJiraAppInstallationsModel(),
                     lightdashConfig: this.context.lightdashConfig,
                     analytics: this.context.lightdashAnalytics, // pragma: allowlist secret
                 }),

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -593,6 +593,7 @@ export class ServiceRepository
                 new JiraAppService({
                     jiraAppInstallationsModel:
                         this.models.getJiraAppInstallationsModel(),
+                    encryptionUtil: this.utils.getEncryptionUtil(),
                     lightdashConfig: this.context.lightdashConfig,
                     analytics: this.context.lightdashAnalytics, // pragma: allowlist secret
                 }),

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -152,6 +152,7 @@ export * from './types/funnel';
 export * from './types/gdrive';
 export * from './types/gitIntegration';
 export * from './types/groups';
+export * from './types/jira';
 export * from './types/linear';
 export * from './types/job';
 export * from './types/knex-paginate';

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -231,6 +231,13 @@ import type {
     ApiGroupListResponse,
 } from './groups';
 import { type ApiImpersonationOrganizationSettingsResponse } from './impersonationOrganizationSettings';
+import type {
+    JiraInstallation,
+    JiraInstallUrl,
+    JiraIssueType,
+    JiraProject,
+    JiraSite,
+} from './jira';
 import { type KnexPaginatedData } from './knex-paginate';
 import type { LinearInstallation, LinearProject, LinearTeam } from './linear';
 import {
@@ -710,6 +717,7 @@ export type HealthState = {
     hasSlack: boolean;
     hasGithub: boolean;
     hasGitlab: boolean;
+    hasJira: boolean;
     hasLinear: boolean;
     hasHeadlessBrowser: boolean;
     hasExtendedUsageAnalytics: boolean;
@@ -1334,6 +1342,11 @@ type ApiResults =
     | ApiGitFileContent
     | GitIntegrationConfiguration
     | GithubUserCredential
+    | JiraInstallation
+    | JiraInstallUrl
+    | Array<JiraSite>
+    | Array<JiraProject>
+    | Array<JiraIssueType>
     | LinearInstallation
     | Array<LinearTeam>
     | Array<LinearProject>

--- a/packages/common/src/types/jira.test.ts
+++ b/packages/common/src/types/jira.test.ts
@@ -1,0 +1,16 @@
+import { getJiraIssueIdentifier } from './jira';
+
+describe('getJiraIssueIdentifier', () => {
+    it('reads an issue key from a Jira browse URL', () => {
+        expect(
+            getJiraIssueIdentifier('https://acme.atlassian.net/browse/DATA-42'),
+        ).toBe('DATA-42');
+    });
+
+    it('returns null for invalid and non-issue URLs', () => {
+        expect(getJiraIssueIdentifier('not-a-url')).toBeNull();
+        expect(
+            getJiraIssueIdentifier('https://acme.atlassian.net/projects/DATA'),
+        ).toBeNull();
+    });
+});

--- a/packages/common/src/types/jira.ts
+++ b/packages/common/src/types/jira.ts
@@ -1,0 +1,60 @@
+import { type ApiSuccess } from './api/success';
+
+export type JiraOAuthCredentials = {
+    clientId: string;
+    clientSecret: string;
+};
+
+export type JiraInstallation = {
+    organizationUuid: string;
+    clientId: string;
+    siteId: string | null;
+    siteName: string | null;
+    siteUrl: string | null;
+    requiresSiteSelection: boolean;
+};
+
+export type JiraSite = {
+    id: string;
+    name: string;
+    url: string;
+};
+
+export type JiraProject = {
+    id: string;
+    key: string;
+    name: string;
+};
+
+export type JiraIssueType = {
+    id: string;
+    name: string;
+    subtask: boolean;
+};
+
+export type JiraCreatedIssue = {
+    id: string;
+    key: string;
+    url: string;
+};
+
+export type JiraInstallUrl = {
+    installUrl: string;
+};
+
+export type ApiJiraInstallUrlResponse = ApiSuccess<JiraInstallUrl>;
+export type ApiJiraInstallationResponse = ApiSuccess<JiraInstallation>;
+export type ApiJiraSitesResponse = ApiSuccess<JiraSite[]>;
+export type ApiJiraProjectsResponse = ApiSuccess<JiraProject[]>;
+export type ApiJiraIssueTypesResponse = ApiSuccess<JiraIssueType[]>;
+
+const JIRA_ISSUE_KEY_IN_URL = /\/browse\/([A-Za-z][A-Za-z0-9_]*-\d+)/;
+
+export const getJiraIssueIdentifier = (url: string): string | null => {
+    try {
+        const { pathname } = new URL(url);
+        return pathname.match(JIRA_ISSUE_KEY_IN_URL)?.[1] ?? null;
+    } catch {
+        return null;
+    }
+};

--- a/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
+++ b/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
@@ -111,6 +111,7 @@ export default function mockHealthResponse(
         hasExtendedUsageAnalytics: false,
         hasGithub: false,
         hasGitlab: false,
+        hasJira: false,
         hasLinear: false,
         hasCacheAutocompleResults: false,
         hasMicrosoftTeams: false,


### PR DESCRIPTION
## Summary

- add organization-level Atlassian OAuth with multi-site selection
- encrypt refresh tokens at rest and rotate them during API use
- the client secret only crosses the OAuth session encrypted with the app secret
- expose Jira projects, issue types, and connection health

## Verification

- common, backend, and frontend typechecks
- focused Jira client, service, and common type tests
- core migration applied locally

Part of PROD-10122 and ZAP-491 (closed by the last PR of the stack).

## Risk assessment

- [ ] This is a high-risk change