### PR TITLE
feat(ai-reviews): export findings to Jira

### DIFF
--- a/packages/backend/src/ee/controllers/AiAgentAdminController.ts
+++ b/packages/backend/src/ee/controllers/AiAgentAdminController.ts
@@ -20,6 +20,9 @@ import {
     ApiAiAgentSummaryResponse,
     ApiAiAgentThreadDumpResponse,
     ApiAiOrganizationSettingsResponse,
+    ApiAiReviewJiraBackfillResponse,
+    ApiAiReviewJiraDestinationResponse,
+    ApiAiReviewJiraRoutingResponse,
     ApiAiReviewLinearBackfillResponse,
     ApiAiReviewLinearDestinationResponse,
     ApiAiReviewLinearRoutingResponse,
@@ -42,6 +45,8 @@ import {
     UpdateAiAgentReviewItemPriority,
     UpdateAiAgentReviewItemStatus,
     UpdateAiOrganizationSettings,
+    UpdateAiReviewJiraDestination,
+    UpdateAiReviewJiraRouting,
     UpdateAiReviewLinearDestination,
     UpdateAiReviewLinearRouting,
     UpdateAiReviewNotificationSettings,
@@ -1107,6 +1112,125 @@ export class AiAgentAdminController extends BaseController {
             status: 'ok',
             results:
                 await this.getAiAgentAdminService().updateReviewLinearDestination(
+                    toSessionUser(req.account),
+                    projectUuid,
+                    body,
+                ),
+        };
+    }
+
+    /**
+     * Get Jira routing for AI review issues
+     * @summary Get AI review Jira routing
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @Get('/review-jira-routing')
+    @OperationId('getAiReviewJiraRouting')
+    async getReviewJiraRouting(
+        @Request() req: express.Request,
+    ): Promise<ApiAiReviewJiraRoutingResponse> {
+        assertRegisteredAccount(req.account);
+        return {
+            status: 'ok',
+            results: await this.getAiAgentAdminService().getReviewJiraRouting(
+                toSessionUser(req.account),
+            ),
+        };
+    }
+
+    /**
+     * Update Jira routing for AI review issues
+     * @summary Update AI review Jira routing
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @Put('/review-jira-routing')
+    @OperationId('updateAiReviewJiraRouting')
+    async updateReviewJiraRouting(
+        @Request() req: express.Request,
+        @Body() body: UpdateAiReviewJiraRouting,
+    ): Promise<ApiAiReviewJiraRoutingResponse> {
+        assertRegisteredAccount(req.account);
+        return {
+            status: 'ok',
+            results:
+                await this.getAiAgentAdminService().updateReviewJiraRouting(
+                    toSessionUser(req.account),
+                    body,
+                ),
+        };
+    }
+
+    /**
+     * Create Jira issues for existing open AI review findings
+     * @summary Backfill AI review Jira issues
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @Post('/review-jira-issues/backfill')
+    @OperationId('backfillAiReviewJiraIssues')
+    async backfillReviewJiraIssues(
+        @Request() req: express.Request,
+    ): Promise<ApiAiReviewJiraBackfillResponse> {
+        assertRegisteredAccount(req.account);
+        return {
+            status: 'ok',
+            results:
+                await this.getAiAgentAdminService().backfillReviewJiraIssues(
+                    toSessionUser(req.account),
+                ),
+        };
+    }
+
+    /**
+     * Get a project's Jira destination for AI reviews
+     * @summary Get AI review Jira destination
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @Get('/review-jira-destination/{projectUuid}')
+    @OperationId('getAiReviewJiraDestination')
+    async getReviewJiraDestination(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+    ): Promise<ApiAiReviewJiraDestinationResponse> {
+        assertRegisteredAccount(req.account);
+        return {
+            status: 'ok',
+            results:
+                await this.getAiAgentAdminService().getReviewJiraDestination(
+                    toSessionUser(req.account),
+                    projectUuid,
+                ),
+        };
+    }
+
+    /**
+     * Update a project's Jira destination for AI reviews
+     * @summary Update AI review Jira destination
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @Put('/review-jira-destination/{projectUuid}')
+    @OperationId('updateAiReviewJiraDestination')
+    async updateReviewJiraDestination(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+        @Body() body: UpdateAiReviewJiraDestination,
+    ): Promise<ApiAiReviewJiraDestinationResponse> {
+        assertRegisteredAccount(req.account);
+        return {
+            status: 'ok',
+            results:
+                await this.getAiAgentAdminService().updateReviewJiraDestination(
                     toSessionUser(req.account),
                     projectUuid,
                     body,

--- a/packages/backend/src/ee/database/entities/aiAgentReviewClassifier.ts
+++ b/packages/backend/src/ee/database/entities/aiAgentReviewClassifier.ts
@@ -276,6 +276,7 @@ export type DbAiAgentReviewItem = {
     dismissed_reason: AiAgentReviewItemDismissedReason | null;
     assigned_to_user_uuid: string | null;
     linked_issue_url: string | null;
+    jira_linked_issue_url: string | null;
     linked_pr_url: string | null;
     pr_writeback_thread_uuid: string | null;
     pr_state: AiAgentReviewItemPrState | null;

--- a/packages/backend/src/ee/database/entities/aiReviewNotifications.ts
+++ b/packages/backend/src/ee/database/entities/aiReviewNotifications.ts
@@ -10,6 +10,8 @@ export const AiReviewNotificationSettingsTableName =
     'ai_agent_review_notification_settings';
 export const AiReviewLinearDestinationTableName =
     'ai_agent_review_linear_destinations';
+export const AiReviewJiraDestinationTableName =
+    'ai_agent_review_jira_destinations';
 
 export type DbAiReviewNotificationSettings = {
     organization_uuid: string;
@@ -19,6 +21,10 @@ export type DbAiReviewNotificationSettings = {
     linear_team_id: string | null;
     linear_project_id: string | null;
     linear_apply_to_all_projects: boolean | null;
+    jira_enabled: boolean;
+    jira_project_id: string | null;
+    jira_issue_type_id: string | null;
+    jira_apply_to_all_projects: boolean | null;
     created_at: Date;
     updated_at: Date;
 };
@@ -49,6 +55,17 @@ export type DbAiReviewLinearDestination = {
     updated_at: Date;
 };
 
+export type DbAiReviewJiraDestination = {
+    ai_review_jira_destination_uuid: string;
+    organization_uuid: string;
+    project_uuid: string;
+    enabled: boolean;
+    jira_project_id: string | null;
+    jira_issue_type_id: string | null;
+    created_at: Date;
+    updated_at: Date;
+};
+
 export type AiReviewNotificationSettingsTable = Knex.CompositeTableType<
     DbAiReviewNotificationSettings,
     Pick<
@@ -63,7 +80,13 @@ export type AiReviewNotificationSettingsTable = Knex.CompositeTableType<
         Partial<
             Pick<
                 DbAiReviewNotificationSettings,
-                'linear_apply_to_all_projects' | 'created_at' | 'updated_at'
+                | 'linear_apply_to_all_projects'
+                | 'jira_enabled'
+                | 'jira_project_id'
+                | 'jira_issue_type_id'
+                | 'jira_apply_to_all_projects'
+                | 'created_at'
+                | 'updated_at'
             >
         >,
     Partial<
@@ -75,6 +98,10 @@ export type AiReviewNotificationSettingsTable = Knex.CompositeTableType<
             | 'linear_team_id'
             | 'linear_project_id'
             | 'linear_apply_to_all_projects'
+            | 'jira_enabled'
+            | 'jira_project_id'
+            | 'jira_issue_type_id'
+            | 'jira_apply_to_all_projects'
             | 'updated_at'
         >
     >
@@ -130,6 +157,30 @@ export type AiReviewLinearDestinationTable = Knex.CompositeTableType<
         Pick<
             DbAiReviewLinearDestination,
             'enabled' | 'linear_team_id' | 'linear_project_id' | 'updated_at'
+        >
+    >
+>;
+
+export type AiReviewJiraDestinationTable = Knex.CompositeTableType<
+    DbAiReviewJiraDestination,
+    Pick<
+        DbAiReviewJiraDestination,
+        | 'organization_uuid'
+        | 'project_uuid'
+        | 'enabled'
+        | 'jira_project_id'
+        | 'jira_issue_type_id'
+    > &
+        Partial<
+            Pick<
+                DbAiReviewJiraDestination,
+                'ai_review_jira_destination_uuid' | 'created_at' | 'updated_at'
+            >
+        >,
+    Partial<
+        Pick<
+            DbAiReviewJiraDestination,
+            'enabled' | 'jira_project_id' | 'jira_issue_type_id' | 'updated_at'
         >
     >
 >;

--- a/packages/backend/src/ee/database/migrations/20260902101000_add_jira_to_ai_reviews.ts
+++ b/packages/backend/src/ee/database/migrations/20260902101000_add_jira_to_ai_reviews.ts
@@ -1,0 +1,89 @@
+import { type Knex } from 'knex';
+
+export const classification = {
+    kind: 'safe',
+    reason: 'Adds nullable Jira review routing and link storage without rewriting existing review data',
+} as const;
+
+const settingsTable = 'ai_agent_review_notification_settings';
+const destinationTable = 'ai_agent_review_jira_destinations';
+const reviewItemTable = 'ai_agent_review_item';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '5s'`);
+
+    if (!(await knex.schema.hasColumn(settingsTable, 'jira_enabled'))) {
+        await knex.schema.alterTable(settingsTable, (table) => {
+            table.boolean('jira_enabled').notNullable().defaultTo(false);
+            table.string('jira_project_id').nullable();
+            table.string('jira_issue_type_id').nullable();
+            table
+                .boolean('jira_apply_to_all_projects')
+                .notNullable()
+                .defaultTo(false);
+        });
+    }
+
+    if (!(await knex.schema.hasTable(destinationTable))) {
+        await knex.schema.createTable(destinationTable, (table) => {
+            table
+                .uuid('ai_review_jira_destination_uuid')
+                .defaultTo(knex.raw('uuid_generate_v4()'))
+                .primary();
+            table
+                .uuid('organization_uuid')
+                .notNullable()
+                .references('organization_uuid')
+                .inTable('organizations')
+                .onDelete('CASCADE')
+                .index();
+            table
+                .uuid('project_uuid')
+                .notNullable()
+                .unique()
+                .references('project_uuid')
+                .inTable('projects')
+                .onDelete('CASCADE')
+                .index();
+            table.boolean('enabled').notNullable().defaultTo(false);
+            table.string('jira_project_id').nullable();
+            table.string('jira_issue_type_id').nullable();
+            table
+                .timestamp('created_at', { useTz: false })
+                .notNullable()
+                .defaultTo(knex.fn.now());
+            table
+                .timestamp('updated_at', { useTz: false })
+                .notNullable()
+                .defaultTo(knex.fn.now());
+        });
+    }
+
+    if (
+        !(await knex.schema.hasColumn(reviewItemTable, 'jira_linked_issue_url'))
+    ) {
+        await knex.schema.alterTable(reviewItemTable, (table) => {
+            table.text('jira_linked_issue_url').nullable();
+        });
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '5s'`);
+    if (await knex.schema.hasColumn(reviewItemTable, 'jira_linked_issue_url')) {
+        await knex.schema.alterTable(reviewItemTable, (table) => {
+            table.dropColumn('jira_linked_issue_url');
+        });
+    }
+    await knex.schema.dropTableIfExists(destinationTable);
+    if (await knex.schema.hasColumn(settingsTable, 'jira_enabled')) {
+        await knex.schema.alterTable(settingsTable, (table) => {
+            table.dropColumns(
+                'jira_enabled',
+                'jira_project_id',
+                'jira_issue_type_id',
+                'jira_apply_to_all_projects',
+            );
+        });
+    }
+}

--- a/packages/backend/src/ee/database/migrations/20260902101000_add_jira_to_ai_reviews.ts
+++ b/packages/backend/src/ee/database/migrations/20260902101000_add_jira_to_ai_reviews.ts
@@ -2,7 +2,7 @@ import { type Knex } from 'knex';
 
 export const classification = {
     kind: 'safe',
-    reason: 'Adds nullable Jira review routing and link storage without rewriting existing review data',
+    reason: 'Adds Jira review routing columns with constant defaults, a new destinations table, and a nullable link column; no existing rows are rewritten',
 } as const;
 
 const settingsTable = 'ai_agent_review_notification_settings';

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -18,6 +18,7 @@ import { registerPreAggregateStream } from '../nats/natsConfig';
 import { AsyncQueryService } from '../services/AsyncQueryService/AsyncQueryService';
 import { DeployService } from '../services/DeployService';
 import { InstanceConfigurationService } from '../services/InstanceConfigurationService/InstanceConfigurationService';
+import { JiraAppService } from '../services/JiraAppService/JiraAppService';
 import { LinearAppService } from '../services/LinearAppService/LinearAppService';
 import { OrganizationService } from '../services/OrganizationService/OrganizationService';
 import { ProjectService } from '../services/ProjectService/ProjectService';
@@ -211,6 +212,26 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         ),
                     onInstallationDeleted: (organizationUuid, trx) =>
                         aiAgentReviewNotificationModel.clearLinearDestinations(
+                            organizationUuid,
+                            trx,
+                        ),
+                });
+            },
+            jiraAppService: ({ models, context }) => {
+                const aiAgentReviewNotificationModel =
+                    models.getAiAgentReviewNotificationModel<AiAgentReviewNotificationModel>();
+                return new JiraAppService({
+                    jiraAppInstallationsModel:
+                        models.getJiraAppInstallationsModel(),
+                    lightdashConfig: context.lightdashConfig,
+                    analytics: context.lightdashAnalytics,
+                    onWorkspaceChanged: (organizationUuid, trx) =>
+                        aiAgentReviewNotificationModel.clearJiraDestinations(
+                            organizationUuid,
+                            trx,
+                        ),
+                    onInstallationDeleted: (organizationUuid, trx) =>
+                        aiAgentReviewNotificationModel.clearJiraDestinations(
                             organizationUuid,
                             trx,
                         ),
@@ -1442,6 +1463,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     context.models.getAiOrganizationSettingsModel<AiOrganizationSettingsModel>(),
                 aiAgentReviewNotificationService:
                     context.serviceRepository.getAiAgentReviewNotificationService<AiAgentReviewNotificationService>(),
+                jiraAppService: context.serviceRepository.getJiraAppService(),
                 linearAppService:
                     context.serviceRepository.getLinearAppService(),
                 aiAgentAdminService:

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -217,7 +217,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         ),
                 });
             },
-            jiraAppService: ({ models, context }) => {
+            jiraAppService: ({ models, context, utils }) => {
                 const aiAgentReviewNotificationModel =
                     models.getAiAgentReviewNotificationModel<AiAgentReviewNotificationModel>();
                 return new JiraAppService({
@@ -225,6 +225,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         models.getJiraAppInstallationsModel(),
                     lightdashConfig: context.lightdashConfig,
                     analytics: context.lightdashAnalytics,
+                    encryptionUtil: utils.getEncryptionUtil(),
                     onWorkspaceChanged: (organizationUuid, trx) =>
                         aiAgentReviewNotificationModel.clearJiraDestinations(
                             organizationUuid,

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
@@ -1417,6 +1417,7 @@ export class AiAgentReviewClassifierModel {
                     statusUpdatedByUserUuid:
                         item?.status_updated_by_user_uuid ?? null,
                     linkedIssueUrl: item?.linked_issue_url ?? null,
+                    linkedJiraIssueUrl: item?.jira_linked_issue_url ?? null,
                     linkedPrUrl: item?.linked_pr_url ?? null,
                     prState: item?.pr_state ?? null,
                     prWritebackStatus: writebackStale
@@ -1593,6 +1594,7 @@ export class AiAgentReviewClassifierModel {
                     statusUpdatedAt: row.status_updated_at ?? row.updated_at,
                     statusUpdatedByUserUuid: row.status_updated_by_user_uuid,
                     linkedIssueUrl: row.linked_issue_url,
+                    linkedJiraIssueUrl: row.jira_linked_issue_url,
                     linkedPrUrl: row.linked_pr_url,
                     prState: row.pr_state,
                     prWritebackStatus: writebackStale
@@ -2578,6 +2580,34 @@ export class AiAgentReviewClassifierModel {
         );
     }
 
+    async listUnlinkedReviewItemsForJiraExport(args: {
+        organizationUuid: string;
+        projectUuids: string[] | null;
+    }): Promise<Array<{ fingerprint: string; projectUuid: string }>> {
+        if (args.projectUuids && args.projectUuids.length === 0) return [];
+        const query = this.database<AiAgentReviewItemTable>(
+            AiAgentReviewItemTableName,
+        )
+            .select('fingerprint', 'project_uuid')
+            .where('organization_uuid', args.organizationUuid)
+            .whereNull('jira_linked_issue_url')
+            .whereNotNull('project_uuid')
+            .whereIn('status', ['triage', 'open', 'in_progress']);
+        const rows = await (args.projectUuids
+            ? query.whereIn('project_uuid', args.projectUuids)
+            : query);
+        return rows.flatMap((row) =>
+            row.project_uuid
+                ? [
+                      {
+                          fingerprint: row.fingerprint,
+                          projectUuid: row.project_uuid,
+                      },
+                  ]
+                : [],
+        );
+    }
+
     // Holds a row lock while the external issue is created so concurrent jobs
     // for the same item cannot each create one.
     async withReviewItemLinkedIssueLock<T>(
@@ -2607,6 +2637,39 @@ export class AiAgentReviewClassifierModel {
                         .where('organization_uuid', args.organizationUuid)
                         .update({
                             linked_issue_url: linkedIssueUrl,
+                            updated_at: trx.fn.now() as never,
+                        });
+                },
+            );
+        });
+    }
+
+    async withReviewItemJiraLinkedIssueLock<T>(
+        args: { fingerprint: string; organizationUuid: string },
+        run: (
+            linkedIssueUrl: string | null,
+            setLinkedIssueUrl: (linkedIssueUrl: string) => Promise<void>,
+        ) => Promise<T>,
+    ): Promise<T> {
+        return this.database.transaction(async (trx) => {
+            const row = await trx<AiAgentReviewItemTable>(
+                AiAgentReviewItemTableName,
+            )
+                .select('jira_linked_issue_url')
+                .where('fingerprint', args.fingerprint)
+                .where('organization_uuid', args.organizationUuid)
+                .forUpdate()
+                .first();
+            return run(
+                row?.jira_linked_issue_url ?? null,
+                async (linkedIssueUrl) => {
+                    await trx<AiAgentReviewItemTable>(
+                        AiAgentReviewItemTableName,
+                    )
+                        .where('fingerprint', args.fingerprint)
+                        .where('organization_uuid', args.organizationUuid)
+                        .update({
+                            jira_linked_issue_url: linkedIssueUrl,
                             updated_at: trx.fn.now() as never,
                         });
                 },
@@ -3011,6 +3074,7 @@ export class AiAgentReviewClassifierModel {
                         .whereIn('status', ['triage', 'open'])
                         .whereNull('assigned_to_user_uuid')
                         .whereNull('linked_issue_url')
+                        .whereNull('jira_linked_issue_url')
                         .whereNull('linked_pr_url')
                         .whereNull('pr_writeback_thread_uuid')
                         .whereNull('status_updated_by_user_uuid')

--- a/packages/backend/src/ee/models/AiAgentReviewNotificationModel.test.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewNotificationModel.test.ts
@@ -35,6 +35,9 @@ describe('AiAgentReviewNotificationModel', () => {
             linearEnabled: false,
             linearTeamId: null,
             linearProjectId: null,
+            jiraEnabled: false,
+            jiraProjectId: null,
+            jiraIssueTypeId: null,
         });
     });
 

--- a/packages/backend/src/ee/models/AiAgentReviewNotificationModel.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewNotificationModel.ts
@@ -1,17 +1,22 @@
 import {
+    AiReviewJiraDestination,
+    AiReviewJiraRouting,
     AiReviewLinearDestination,
     AiReviewLinearRouting,
     AiReviewNotificationChannel,
     AiReviewNotificationEvent,
     AiReviewNotificationSettings,
     AiReviewNotificationStatus,
+    resolveAiReviewJiraDestination,
     resolveAiReviewLinearDestination,
 } from '@lightdash/common';
 import { type Knex } from 'knex';
 import {
+    AiReviewJiraDestinationTableName,
     AiReviewLinearDestinationTableName,
     AiReviewNotificationLogTableName,
     AiReviewNotificationSettingsTableName,
+    type DbAiReviewJiraDestination,
     type DbAiReviewLinearDestination,
     type DbAiReviewNotificationSettings,
 } from '../database/entities/aiReviewNotifications';
@@ -46,6 +51,9 @@ export class AiAgentReviewNotificationModel {
             linearEnabled: row.linear_enabled,
             linearTeamId: row.linear_team_id,
             linearProjectId: row.linear_project_id,
+            jiraEnabled: row.jira_enabled ?? false,
+            jiraProjectId: row.jira_project_id ?? null,
+            jiraIssueTypeId: row.jira_issue_type_id ?? null,
         };
     }
 
@@ -64,6 +72,9 @@ export class AiAgentReviewNotificationModel {
                 linearEnabled: false,
                 linearTeamId: null,
                 linearProjectId: null,
+                jiraEnabled: false,
+                jiraProjectId: null,
+                jiraIssueTypeId: null,
             };
         }
 
@@ -81,6 +92,9 @@ export class AiAgentReviewNotificationModel {
                 linear_enabled: settings.linearEnabled,
                 linear_team_id: settings.linearTeamId,
                 linear_project_id: settings.linearProjectId,
+                jira_enabled: settings.jiraEnabled,
+                jira_project_id: settings.jiraProjectId,
+                jira_issue_type_id: settings.jiraIssueTypeId,
                 updated_at: new Date(),
             })
             .onConflict('organization_uuid')
@@ -90,6 +104,9 @@ export class AiAgentReviewNotificationModel {
                 linear_enabled: settings.linearEnabled,
                 linear_team_id: settings.linearTeamId,
                 linear_project_id: settings.linearProjectId,
+                jira_enabled: settings.jiraEnabled,
+                jira_project_id: settings.jiraProjectId,
+                jira_issue_type_id: settings.jiraIssueTypeId,
                 updated_at: new Date(),
             })
             .returning('*');
@@ -191,6 +208,9 @@ export class AiAgentReviewNotificationModel {
                   linearEnabled: false,
                   linearTeamId: null,
                   linearProjectId: null,
+                  jiraEnabled: false,
+                  jiraProjectId: null,
+                  jiraIssueTypeId: null,
               };
         const destinations = await this.listLinearDestinations(
             organizationUuid,
@@ -360,6 +380,250 @@ export class AiAgentReviewNotificationModel {
                 linear_team_id: null,
                 linear_project_id: null,
                 linear_apply_to_all_projects: false,
+                updated_at: new Date(),
+            });
+    }
+
+    private static mapJiraDestination(
+        row: DbAiReviewJiraDestination,
+    ): AiReviewJiraDestination {
+        return {
+            organizationUuid: row.organization_uuid,
+            projectUuid: row.project_uuid,
+            enabled: row.enabled,
+            jiraProjectId: row.jira_project_id,
+            jiraIssueTypeId: row.jira_issue_type_id,
+        };
+    }
+
+    async listJiraDestinations(
+        organizationUuid: string,
+        database: Knex = this.database,
+    ): Promise<AiReviewJiraDestination[]> {
+        const rows = await database(AiReviewJiraDestinationTableName).where({
+            organization_uuid: organizationUuid,
+        });
+        return rows.map(AiAgentReviewNotificationModel.mapJiraDestination);
+    }
+
+    async getJiraDestination(
+        organizationUuid: string,
+        projectUuid: string,
+    ): Promise<AiReviewJiraDestination> {
+        const settingsRow = await this.getSettingsRow(organizationUuid);
+        const settings = settingsRow
+            ? AiAgentReviewNotificationModel.mapSettings(settingsRow)
+            : await this.getSettings(organizationUuid);
+        const destinationRow = await this.database(
+            AiReviewJiraDestinationTableName,
+        )
+            .where({
+                organization_uuid: organizationUuid,
+                project_uuid: projectUuid,
+            })
+            .first();
+        let hasProjectDestinations = !!destinationRow;
+        if (
+            !(settingsRow?.jira_apply_to_all_projects ?? false) &&
+            !destinationRow
+        ) {
+            hasProjectDestinations = !!(await this.database(
+                AiReviewJiraDestinationTableName,
+            )
+                .where({ organization_uuid: organizationUuid })
+                .first());
+        }
+        return resolveAiReviewJiraDestination({
+            organizationUuid,
+            projectUuid,
+            applyToAllProjects:
+                settingsRow?.jira_apply_to_all_projects ?? false,
+            settings,
+            destination: destinationRow
+                ? AiAgentReviewNotificationModel.mapJiraDestination(
+                      destinationRow,
+                  )
+                : null,
+            hasProjectDestinations,
+        });
+    }
+
+    async getJiraRouting(
+        organizationUuid: string,
+        database: Knex = this.database,
+    ): Promise<AiReviewJiraRouting> {
+        const settingsRow = await this.getSettingsRow(
+            organizationUuid,
+            database,
+        );
+        const settings = settingsRow
+            ? AiAgentReviewNotificationModel.mapSettings(settingsRow)
+            : await this.getSettings(organizationUuid);
+        const destinations = await this.listJiraDestinations(
+            organizationUuid,
+            database,
+        );
+        const applyToAllProjects =
+            settingsRow?.jira_apply_to_all_projects ?? false;
+
+        if (applyToAllProjects) {
+            return {
+                organizationUuid,
+                applyToAllProjects: true,
+                projectUuids: [],
+                enabled: settings.jiraEnabled,
+                jiraProjectId: settings.jiraProjectId,
+                jiraIssueTypeId: settings.jiraIssueTypeId,
+            };
+        }
+        if (destinations.length > 0) {
+            const enabled = destinations.filter(
+                (destination) => destination.enabled,
+            );
+            const first = enabled[0] ?? destinations[0];
+            return {
+                organizationUuid,
+                applyToAllProjects: false,
+                projectUuids: (enabled.length > 0 ? enabled : destinations).map(
+                    (destination) => destination.projectUuid,
+                ),
+                enabled: enabled.length > 0,
+                jiraProjectId: first.jiraProjectId,
+                jiraIssueTypeId: first.jiraIssueTypeId,
+            };
+        }
+        if (settings.jiraProjectId) {
+            return {
+                organizationUuid,
+                applyToAllProjects: true,
+                projectUuids: [],
+                enabled: settings.jiraEnabled,
+                jiraProjectId: settings.jiraProjectId,
+                jiraIssueTypeId: settings.jiraIssueTypeId,
+            };
+        }
+        return {
+            organizationUuid,
+            applyToAllProjects: true,
+            projectUuids: [],
+            enabled: false,
+            jiraProjectId: null,
+            jiraIssueTypeId: null,
+        };
+    }
+
+    async upsertJiraDestination(
+        destination: AiReviewJiraDestination,
+    ): Promise<AiReviewJiraDestination> {
+        const [row] = await this.database(AiReviewJiraDestinationTableName)
+            .insert({
+                organization_uuid: destination.organizationUuid,
+                project_uuid: destination.projectUuid,
+                enabled: destination.enabled,
+                jira_project_id: destination.jiraProjectId,
+                jira_issue_type_id: destination.jiraIssueTypeId,
+                updated_at: new Date(),
+            })
+            .onConflict('project_uuid')
+            .merge({
+                enabled: destination.enabled,
+                jira_project_id: destination.jiraProjectId,
+                jira_issue_type_id: destination.jiraIssueTypeId,
+                updated_at: new Date(),
+            })
+            .returning('*');
+        await this.database(AiReviewNotificationSettingsTableName)
+            .where({ organization_uuid: destination.organizationUuid })
+            .update({
+                jira_apply_to_all_projects: false,
+                updated_at: new Date(),
+            });
+        return AiAgentReviewNotificationModel.mapJiraDestination(row);
+    }
+
+    async upsertJiraRouting(
+        routing: AiReviewJiraRouting,
+    ): Promise<AiReviewJiraRouting> {
+        return this.database.transaction(async (trx) => {
+            const current = await this.getSettingsRow(
+                routing.organizationUuid,
+                trx,
+            );
+            await trx(AiReviewNotificationSettingsTableName)
+                .insert({
+                    organization_uuid: routing.organizationUuid,
+                    enabled: current?.enabled ?? false,
+                    slack_channel_id: current?.slack_channel_id ?? null,
+                    linear_enabled: current?.linear_enabled ?? false,
+                    linear_team_id: current?.linear_team_id ?? null,
+                    linear_project_id: current?.linear_project_id ?? null,
+                    linear_apply_to_all_projects:
+                        current?.linear_apply_to_all_projects ?? false,
+                    jira_enabled: routing.enabled,
+                    jira_project_id: routing.jiraProjectId,
+                    jira_issue_type_id: routing.jiraIssueTypeId,
+                    jira_apply_to_all_projects: routing.applyToAllProjects,
+                    updated_at: new Date(),
+                })
+                .onConflict('organization_uuid')
+                .merge({
+                    jira_enabled: routing.enabled,
+                    jira_project_id: routing.jiraProjectId,
+                    jira_issue_type_id: routing.jiraIssueTypeId,
+                    jira_apply_to_all_projects: routing.applyToAllProjects,
+                    updated_at: new Date(),
+                });
+
+            if (
+                routing.applyToAllProjects ||
+                routing.projectUuids.length === 0
+            ) {
+                await trx(AiReviewJiraDestinationTableName)
+                    .where({ organization_uuid: routing.organizationUuid })
+                    .delete();
+            } else {
+                await trx(AiReviewJiraDestinationTableName)
+                    .where({ organization_uuid: routing.organizationUuid })
+                    .whereNotIn('project_uuid', routing.projectUuids)
+                    .delete();
+                const now = new Date();
+                await trx(AiReviewJiraDestinationTableName)
+                    .insert(
+                        routing.projectUuids.map((projectUuid) => ({
+                            organization_uuid: routing.organizationUuid,
+                            project_uuid: projectUuid,
+                            enabled: routing.enabled,
+                            jira_project_id: routing.jiraProjectId,
+                            jira_issue_type_id: routing.jiraIssueTypeId,
+                            updated_at: now,
+                        })),
+                    )
+                    .onConflict('project_uuid')
+                    .merge({
+                        enabled: routing.enabled,
+                        jira_project_id: routing.jiraProjectId,
+                        jira_issue_type_id: routing.jiraIssueTypeId,
+                        updated_at: now,
+                    });
+            }
+            return this.getJiraRouting(routing.organizationUuid, trx);
+        });
+    }
+
+    async clearJiraDestinations(
+        organizationUuid: string,
+        database: Knex = this.database,
+    ): Promise<void> {
+        await database(AiReviewJiraDestinationTableName)
+            .where({ organization_uuid: organizationUuid })
+            .delete();
+        await database(AiReviewNotificationSettingsTableName)
+            .where({ organization_uuid: organizationUuid })
+            .update({
+                jira_enabled: false,
+                jira_project_id: null,
+                jira_issue_type_id: null,
+                jira_apply_to_all_projects: false,
                 updated_at: new Date(),
             });
     }

--- a/packages/backend/src/ee/models/AiAgentReviewNotificationModel.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewNotificationModel.ts
@@ -614,18 +614,20 @@ export class AiAgentReviewNotificationModel {
         organizationUuid: string,
         database: Knex = this.database,
     ): Promise<void> {
-        await database(AiReviewJiraDestinationTableName)
-            .where({ organization_uuid: organizationUuid })
-            .delete();
-        await database(AiReviewNotificationSettingsTableName)
-            .where({ organization_uuid: organizationUuid })
-            .update({
-                jira_enabled: false,
-                jira_project_id: null,
-                jira_issue_type_id: null,
-                jira_apply_to_all_projects: false,
-                updated_at: new Date(),
-            });
+        await database.transaction(async (trx) => {
+            await trx(AiReviewJiraDestinationTableName)
+                .where({ organization_uuid: organizationUuid })
+                .delete();
+            await trx(AiReviewNotificationSettingsTableName)
+                .where({ organization_uuid: organizationUuid })
+                .update({
+                    jira_enabled: false,
+                    jira_project_id: null,
+                    jira_issue_type_id: null,
+                    jira_apply_to_all_projects: false,
+                    updated_at: new Date(),
+                });
+        });
     }
 
     async recordSent(args: LogArgs): Promise<string> {

--- a/packages/backend/src/ee/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.ts
@@ -23,6 +23,7 @@ import {
     SchedulerWorkerArguments,
 } from '../../scheduler/SchedulerWorker';
 import { TypedEETaskList } from '../../scheduler/types';
+import { type JiraAppService } from '../../services/JiraAppService/JiraAppService';
 import { type LinearAppService } from '../../services/LinearAppService/LinearAppService';
 import { type AiAgentReviewClassifierModel } from '../models/AiAgentReviewClassifierModel';
 import { type AiAgentReviewNotificationModel } from '../models/AiAgentReviewNotificationModel';
@@ -43,6 +44,7 @@ import { type MobilePushNotificationService } from '../services/MobilePushNotifi
 import { type OnboardingAgentService } from '../services/OnboardingAgentService/OnboardingAgentService';
 import { ProjectContextService } from '../services/ProjectContextService/ProjectContextService';
 import type { ProjectHomepageService } from '../services/ProjectHomepageService';
+import { createReviewJiraIssue } from './tasks/createReviewJiraIssue';
 import { createReviewLinearIssue } from './tasks/createReviewLinearIssue';
 import { sendContentReviewNotification } from './tasks/sendContentReviewNotification';
 import { sendReviewNotification } from './tasks/sendReviewNotification';
@@ -121,6 +123,7 @@ type CommercialSchedulerWorkerArguments = SchedulerWorkerArguments & {
     aiAgentReviewNotificationModel: AiAgentReviewNotificationModel;
     aiOrganizationSettingsModel: AiOrganizationSettingsModel;
     aiAgentReviewNotificationService: AiAgentReviewNotificationService;
+    jiraAppService: JiraAppService;
     linearAppService: LinearAppService;
     aiAgentAdminService: AiAgentAdminService;
     embedService: EmbedService;
@@ -170,6 +173,8 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
 
     protected readonly aiAgentReviewNotificationService: AiAgentReviewNotificationService;
 
+    protected readonly jiraAppService: JiraAppService;
+
     protected readonly linearAppService: LinearAppService;
 
     protected readonly aiAgentAdminService: AiAgentAdminService;
@@ -217,6 +222,7 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
         this.aiOrganizationSettingsModel = args.aiOrganizationSettingsModel;
         this.aiAgentReviewNotificationService =
             args.aiAgentReviewNotificationService;
+        this.jiraAppService = args.jiraAppService;
         this.linearAppService = args.linearAppService;
         this.aiAgentAdminService = args.aiAgentAdminService;
         this.embedService = args.embedService;
@@ -1073,6 +1079,19 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                         this.aiAgentReviewClassifierModel,
                     projectModel: this.projectModel,
                     linearAppService: this.linearAppService,
+                    analytics: this.analytics,
+                })(payload);
+            },
+            [EE_SCHEDULER_TASKS.CREATE_REVIEW_JIRA_ISSUE]: async (payload) => {
+                await createReviewJiraIssue({
+                    siteUrl: this.lightdashConfig.siteUrl, // pragma: allowlist secret
+                    model: this.aiAgentReviewNotificationModel,
+                    aiOrganizationSettingsModel:
+                        this.aiOrganizationSettingsModel,
+                    aiAgentReviewClassifierModel:
+                        this.aiAgentReviewClassifierModel,
+                    projectModel: this.projectModel,
+                    jiraAppService: this.jiraAppService,
                     analytics: this.analytics,
                 })(payload);
             },

--- a/packages/backend/src/ee/scheduler/tasks/createReviewJiraIssue.test.ts
+++ b/packages/backend/src/ee/scheduler/tasks/createReviewJiraIssue.test.ts
@@ -1,0 +1,187 @@
+import { type Mock } from 'vitest';
+import {
+    buildJiraIssueDescription,
+    createReviewJiraIssue,
+} from './createReviewJiraIssue';
+
+type Deps = Parameters<typeof createReviewJiraIssue>[0];
+
+const payload = {
+    organizationUuid: 'org-1',
+    projectUuid: 'project-1',
+    fingerprints: ['fp-1'],
+    reviewRunUuid: 'run-1',
+};
+
+const makeDeps = (overrides: Record<string, unknown> = {}) => {
+    const createIssueForOrganization = vi.fn().mockResolvedValue({
+        id: '100',
+        key: 'DATA-42',
+        url: 'https://acme.atlassian.net/browse/DATA-42',
+    });
+    const setLinkedIssueUrl = vi.fn().mockResolvedValue(undefined);
+    return {
+        siteUrl: 'https://app.example.com',
+        model: {
+            getJiraDestination: vi.fn().mockResolvedValue({
+                organizationUuid: 'org-1',
+                projectUuid: 'project-1',
+                enabled: true,
+                jiraProjectId: '10',
+                jiraIssueTypeId: '1',
+            }),
+        },
+        aiOrganizationSettingsModel: {
+            findByOrganizationUuid: vi.fn().mockResolvedValue({
+                aiAgentReviewsEnabled: true,
+            }),
+        },
+        aiAgentReviewClassifierModel: {
+            getReviewItem: vi.fn().mockResolvedValue({
+                title: 'Broken metric',
+                description: 'Count is wrong',
+                primaryRootCause: 'semantic_layer',
+                priority: 'high',
+                findingCount: 3,
+                targetRefs: [
+                    {
+                        type: 'metric',
+                        modelName: 'orders',
+                        metricName: 'count_orders',
+                    },
+                ],
+                linkedIssueUrl: null,
+                linkedJiraIssueUrl: null,
+                latestFinding: null,
+                agentUuid: null,
+            }),
+            withReviewItemJiraLinkedIssueLock: vi
+                .fn()
+                .mockImplementation(
+                    (
+                        _args: unknown,
+                        run: (
+                            url: string | null,
+                            setUrl: (url: string) => Promise<void>,
+                        ) => Promise<void>,
+                    ) => run(null, setLinkedIssueUrl),
+                ),
+        },
+        projectModel: {
+            get: vi.fn().mockResolvedValue({ name: 'Jaffle shop' }),
+        },
+        jiraAppService: {
+            createIssueForOrganization,
+            linkIssueUrlForOrganization: vi.fn().mockResolvedValue(undefined),
+        },
+        analytics: { track: vi.fn() },
+        createIssueForOrganization,
+        setLinkedIssueUrl,
+        ...overrides,
+    } as unknown as Deps & {
+        createIssueForOrganization: Mock;
+        setLinkedIssueUrl: Mock;
+    };
+};
+
+describe('createReviewJiraIssue', () => {
+    it('creates a Jira issue and stores its URL', async () => {
+        const deps = makeDeps();
+        await createReviewJiraIssue(deps)(payload);
+        expect(deps.createIssueForOrganization).toHaveBeenCalledWith(
+            'org-1',
+            expect.objectContaining({
+                title: 'Broken metric',
+                projectId: '10',
+                issueTypeId: '1',
+                description: expect.stringContaining('Priority: high'),
+            }),
+        );
+        expect(deps.setLinkedIssueUrl).toHaveBeenCalledWith(
+            'https://acme.atlassian.net/browse/DATA-42',
+        );
+        expect(
+            deps.jiraAppService.linkIssueUrlForOrganization,
+        ).toHaveBeenCalledWith('org-1', {
+            issueIdOrKey: 'DATA-42',
+            url: expect.stringContaining('/generalSettings/ai/reviews'),
+            title: 'Open in Lightdash', // pragma: allowlist secret
+        });
+    });
+
+    it('does nothing when Jira routing is disabled', async () => {
+        const deps = makeDeps({
+            model: {
+                getJiraDestination: vi.fn().mockResolvedValue({
+                    enabled: false,
+                    jiraProjectId: '10',
+                    jiraIssueTypeId: '1',
+                }),
+            },
+        });
+        await createReviewJiraIssue(deps)(payload);
+        expect(deps.createIssueForOrganization).not.toHaveBeenCalled();
+    });
+
+    it('uses the locked Jira URL to prevent duplicate issues', async () => {
+        const deps = makeDeps({
+            aiAgentReviewClassifierModel: {
+                getReviewItem: vi.fn().mockResolvedValue({
+                    title: 'Broken metric',
+                    description: 'Count is wrong',
+                    primaryRootCause: 'semantic_layer',
+                    priority: 'high',
+                    findingCount: 1,
+                    targetRefs: [],
+                }),
+                withReviewItemJiraLinkedIssueLock: vi
+                    .fn()
+                    .mockImplementation(
+                        (
+                            _args: unknown,
+                            run: (url: string | null) => Promise<void>,
+                        ) => run('https://acme.atlassian.net/browse/DATA-42'),
+                    ),
+            },
+        });
+        await createReviewJiraIssue(deps)(payload);
+        expect(deps.createIssueForOrganization).not.toHaveBeenCalled();
+    });
+
+    it('fails the job so transient Jira errors are retried', async () => {
+        const deps = makeDeps({
+            jiraAppService: {
+                createIssueForOrganization: vi
+                    .fn()
+                    .mockRejectedValue(new Error('Jira is down')),
+            },
+        });
+        await expect(createReviewJiraIssue(deps)(payload)).rejects.toThrow(
+            'fp-1',
+        );
+        expect(deps.setLinkedIssueUrl).not.toHaveBeenCalled();
+    });
+});
+
+describe('buildJiraIssueDescription', () => {
+    it('includes review metadata and affected objects', () => {
+        const description = buildJiraIssueDescription({
+            description: 'Count is wrong',
+            rootCause: 'semantic_layer',
+            priority: 'high',
+            findingCount: 3,
+            targetRefs: [
+                {
+                    type: 'metric',
+                    modelName: 'orders',
+                    metricName: 'count_orders',
+                },
+            ],
+            projectName: 'Jaffle shop',
+            reviewUrl: 'https://app.example.com/reviews',
+        });
+        expect(description).toContain('Occurrences: 3');
+        expect(description).toContain('- orders / count_orders');
+        expect(description).toContain('Open in Lightdash:');
+    });
+});

--- a/packages/backend/src/ee/scheduler/tasks/createReviewJiraIssue.ts
+++ b/packages/backend/src/ee/scheduler/tasks/createReviewJiraIssue.ts
@@ -1,0 +1,201 @@
+import {
+    getErrorMessage,
+    type AiAgentReviewItemSummary,
+    type AiAgentTargetRef,
+    type AiReviewJiraDestination,
+    type CreateReviewJiraIssuePayload,
+} from '@lightdash/common'; // pragma: allowlist secret
+import { type LightdashAnalytics } from '../../../analytics/LightdashAnalytics'; // pragma: allowlist secret
+import Logger from '../../../logging/logger';
+import { type ProjectModel } from '../../../models/ProjectModel/ProjectModel';
+import { type JiraAppService } from '../../../services/JiraAppService/JiraAppService';
+import { type AiAgentReviewClassifierModel } from '../../models/AiAgentReviewClassifierModel';
+import { type AiAgentReviewNotificationModel } from '../../models/AiAgentReviewNotificationModel';
+import { type AiOrganizationSettingsModel } from '../../models/AiOrganizationSettingsModel';
+import {
+    buildReviewDrawerSearchParams,
+    REVIEWS_BOARD_PATH,
+} from '../../services/AiAgentReviewNotificationService';
+
+type Dependencies = {
+    siteUrl: string;
+    model: AiAgentReviewNotificationModel;
+    aiOrganizationSettingsModel: AiOrganizationSettingsModel;
+    aiAgentReviewClassifierModel: AiAgentReviewClassifierModel;
+    projectModel: ProjectModel;
+    jiraAppService: JiraAppService;
+    analytics: LightdashAnalytics; // pragma: allowlist secret
+};
+
+const formatTargetRef = (targetRef: AiAgentTargetRef): string =>
+    Object.entries(targetRef)
+        .filter(([key, value]) => key !== 'type' && value)
+        .map(([, value]) => String(value))
+        .join(' / ') || targetRef.type;
+
+export const buildJiraIssueDescription = (args: {
+    description: string;
+    rootCause: string;
+    priority: string;
+    findingCount: number;
+    targetRefs: AiAgentTargetRef[];
+    projectName: string;
+    reviewUrl: string;
+}): string => {
+    const lines = [
+        args.description.trim(),
+        '',
+        `Priority: ${args.priority}`,
+        `Root cause: ${args.rootCause}`,
+        `Project: ${args.projectName}`,
+        `Occurrences: ${args.findingCount}`,
+    ];
+    const affected = args.targetRefs.map(formatTargetRef);
+    if (affected.length > 0) {
+        lines.push(
+            '',
+            'Affected objects',
+            ...affected.map((ref) => `- ${ref}`),
+        );
+    }
+    lines.push('', `Open in Lightdash: ${args.reviewUrl}`); // pragma: allowlist secret
+    return lines.join('\n');
+};
+
+const exportReviewItem = async (
+    deps: Dependencies,
+    args: {
+        payload: CreateReviewJiraIssuePayload;
+        fingerprint: string;
+        reviewItem: AiAgentReviewItemSummary;
+        destination: AiReviewJiraDestination & {
+            jiraProjectId: string;
+            jiraIssueTypeId: string;
+        };
+        projectName: string;
+    },
+): Promise<void> => {
+    const { payload, fingerprint, reviewItem, destination } = args;
+    const reviewUrl = `${deps.siteUrl}${REVIEWS_BOARD_PATH}?${buildReviewDrawerSearchParams(
+        payload.projectUuid,
+        fingerprint,
+        reviewItem,
+    )}`;
+    await deps.aiAgentReviewClassifierModel.withReviewItemJiraLinkedIssueLock(
+        { organizationUuid: payload.organizationUuid, fingerprint },
+        async (linkedIssueUrl, setLinkedIssueUrl) => {
+            if (linkedIssueUrl !== null) return;
+            const created =
+                await deps.jiraAppService.createIssueForOrganization(
+                    payload.organizationUuid,
+                    {
+                        title: reviewItem.title,
+                        description: buildJiraIssueDescription({
+                            description: reviewItem.description,
+                            rootCause: reviewItem.primaryRootCause,
+                            priority: reviewItem.priority,
+                            findingCount: reviewItem.findingCount,
+                            targetRefs: reviewItem.targetRefs,
+                            projectName: args.projectName,
+                            reviewUrl,
+                        }),
+                        projectId: destination.jiraProjectId,
+                        issueTypeId: destination.jiraIssueTypeId,
+                    },
+                );
+            await setLinkedIssueUrl(created.url);
+            try {
+                await deps.jiraAppService.linkIssueUrlForOrganization(
+                    payload.organizationUuid,
+                    {
+                        issueIdOrKey: created.key,
+                        url: reviewUrl,
+                        title: 'Open in Lightdash', // pragma: allowlist secret
+                    },
+                );
+            } catch (error) {
+                Logger.warn(
+                    `Failed to attach review URL to Jira issue ${created.key}: ${getErrorMessage(
+                        error,
+                    )}`,
+                );
+            }
+            deps.analytics.track({
+                event: 'ai_review_jira_issue.created',
+                anonymousId: payload.organizationUuid,
+                properties: {
+                    organizationId: payload.organizationUuid,
+                    projectId: payload.projectUuid,
+                },
+            });
+        },
+    );
+};
+
+export const createReviewJiraIssue =
+    (deps: Dependencies) =>
+    async (payload: CreateReviewJiraIssuePayload): Promise<void> => {
+        const settings =
+            await deps.aiOrganizationSettingsModel.findByOrganizationUuid(
+                payload.organizationUuid,
+            );
+        if (!settings?.aiAgentReviewsEnabled) return;
+        const destination = await deps.model.getJiraDestination(
+            payload.organizationUuid,
+            payload.projectUuid,
+        );
+        const { jiraProjectId, jiraIssueTypeId } = destination;
+        if (!destination.enabled || !jiraProjectId || !jiraIssueTypeId) return;
+        const project = await deps.projectModel.get(payload.projectUuid);
+        const failures: string[] = [];
+        /* eslint-disable no-await-in-loop */
+        for (const fingerprint of payload.fingerprints) {
+            try {
+                const reviewItem =
+                    await deps.aiAgentReviewClassifierModel.getReviewItem(
+                        payload.organizationUuid,
+                        fingerprint,
+                    );
+                if (!reviewItem) {
+                    Logger.warn(
+                        'Skipping Jira issue creation for missing review item',
+                        { fingerprint },
+                    );
+                } else {
+                    await exportReviewItem(deps, {
+                        payload,
+                        fingerprint,
+                        reviewItem,
+                        destination: {
+                            ...destination,
+                            jiraProjectId,
+                            jiraIssueTypeId,
+                        },
+                        projectName: project.name,
+                    });
+                }
+            } catch (error) {
+                failures.push(fingerprint);
+                Logger.error(
+                    `Failed to create Jira issue for review item ${fingerprint}: ${getErrorMessage(
+                        error,
+                    )}`,
+                );
+                deps.analytics.track({
+                    event: 'ai_review_jira_issue.errored',
+                    anonymousId: payload.organizationUuid,
+                    properties: {
+                        organizationId: payload.organizationUuid,
+                        projectId: payload.projectUuid,
+                        error: getErrorMessage(error),
+                    },
+                });
+            }
+        }
+        /* eslint-enable no-await-in-loop */
+        if (failures.length > 0) {
+            throw new Error(
+                `Failed to create Jira issues for review items: ${failures.join(', ')}`,
+            );
+        }
+    };

--- a/packages/backend/src/ee/services/AiAgentAdminService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.test.ts
@@ -515,6 +515,7 @@ const makeService = ({
         aiAgentReviewNotificationService: {
             notifyAssigned: vi.fn().mockResolvedValue(undefined),
             createLinearIssues: vi.fn().mockResolvedValue(undefined),
+            createJiraIssues: vi.fn().mockResolvedValue(undefined),
             ...aiAgentReviewNotificationService,
         },
         slackClient: {
@@ -622,6 +623,52 @@ describe('AiAgentAdminService review access', () => {
             }),
         ).rejects.toThrow('not an available issue category');
         expect(createManualReviewItem).not.toHaveBeenCalled();
+    });
+
+    it('queues Linear and Jira exports for an issue created by hand', async () => {
+        const createLinearIssues = vi.fn().mockResolvedValue(undefined);
+        const createJiraIssues = vi.fn().mockResolvedValue(undefined);
+        const service = makeService({
+            aiAgentReviewClassifierModel: {
+                createManualReviewItem: vi.fn().mockResolvedValue(
+                    makeReviewItem({
+                        fingerprint: 'fp-manual',
+                        organizationUuid: ORGANIZATION_UUID,
+                        projectUuid: PROJECT_UUID,
+                    }),
+                ),
+            },
+            projectModel: {
+                get: vi
+                    .fn()
+                    .mockResolvedValue({ organizationUuid: ORGANIZATION_UUID }),
+            },
+            aiAgentReviewNotificationService: {
+                createLinearIssues,
+                createJiraIssues,
+            },
+        });
+
+        await service.createReviewItem(makeAdminUser(), {
+            title: 'Revenue metric double counts refunds',
+            description: null,
+            projectUuid: PROJECT_UUID,
+            agentUuid: null,
+            assignedToUserUuid: null,
+            primaryRootCause: 'semantic_layer',
+            priority: 'high',
+            targetRefs: [],
+        });
+
+        const exportArgs = {
+            organizationUuid: ORGANIZATION_UUID,
+            projectUuid: PROJECT_UUID,
+            fingerprints: ['fp-manual'],
+            reviewRunUuid: null,
+            userUuid: USER_UUID,
+        };
+        expect(createLinearIssues).toHaveBeenCalledWith(exportArgs);
+        expect(createJiraIssues).toHaveBeenCalledWith(exportArgs);
     });
 
     it('forbids starting writeback without manage:SourceCode', async () => {

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -24,6 +24,9 @@ import {
     AiAgentReviewWritebackJobPayload,
     AiAgentSummary,
     AiAgentThreadDump,
+    AiReviewJiraBackfillResult,
+    AiReviewJiraDestination,
+    AiReviewJiraRouting,
     AiReviewLinearBackfillResult,
     AiReviewLinearDestination,
     AiReviewLinearRouting,
@@ -60,6 +63,8 @@ import {
     toolEditDbtProjectOutputSchema,
     UpdateAiAgentReviewItemPriority,
     UpdateAiAgentReviewItemStatus,
+    UpdateAiReviewJiraDestination,
+    UpdateAiReviewJiraRouting,
     UpdateAiReviewLinearDestination,
     UpdateAiReviewLinearRouting,
     UpdateAiReviewNotificationSettings,
@@ -1068,6 +1073,14 @@ export class AiAgentAdminService extends BaseService {
                 'A Linear team is required to create review issues',
             );
         }
+        if (
+            updatedSettings.jiraEnabled &&
+            (!updatedSettings.jiraProjectId || !updatedSettings.jiraIssueTypeId)
+        ) {
+            throw new ParameterError(
+                'A Jira project and issue type are required to create review issues',
+            );
+        }
 
         const updated =
             await this.aiAgentReviewNotificationModel.upsertSettings(
@@ -1266,6 +1279,165 @@ export class AiAgentAdminService extends BaseService {
         }
 
         return queuedCount;
+    }
+
+    async getReviewJiraDestination(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<AiReviewJiraDestination> {
+        const { organizationUuid } = user;
+        if (!organizationUuid)
+            throw new ForbiddenError('Organization not found');
+        this.checkReviewAccess(user, organizationUuid);
+        const project = await this.projectModel.get(projectUuid);
+        if (project.organizationUuid !== organizationUuid) {
+            throw new NotFoundError('Project not found');
+        }
+        return this.aiAgentReviewNotificationModel.getJiraDestination(
+            organizationUuid,
+            projectUuid,
+        );
+    }
+
+    async updateReviewJiraDestination(
+        user: SessionUser,
+        projectUuid: string,
+        destination: UpdateAiReviewJiraDestination,
+    ): Promise<AiReviewJiraDestination> {
+        const { organizationUuid } = user;
+        if (!organizationUuid)
+            throw new ForbiddenError('Organization not found');
+        this.checkOrganizationAdminAccess(user);
+        const project = await this.projectModel.get(projectUuid);
+        if (project.organizationUuid !== organizationUuid) {
+            throw new NotFoundError('Project not found');
+        }
+        if (
+            destination.enabled &&
+            (!destination.jiraProjectId || !destination.jiraIssueTypeId)
+        ) {
+            throw new ParameterError(
+                'A Jira project and issue type are required to create review issues',
+            );
+        }
+        return this.aiAgentReviewNotificationModel.upsertJiraDestination({
+            organizationUuid,
+            projectUuid,
+            ...destination,
+        });
+    }
+
+    async getReviewJiraRouting(
+        user: SessionUser,
+    ): Promise<AiReviewJiraRouting> {
+        const { organizationUuid } = user;
+        if (!organizationUuid)
+            throw new ForbiddenError('Organization not found');
+        this.checkReviewAccess(user, organizationUuid);
+        return this.aiAgentReviewNotificationModel.getJiraRouting(
+            organizationUuid,
+        );
+    }
+
+    async updateReviewJiraRouting(
+        user: SessionUser,
+        routing: UpdateAiReviewJiraRouting,
+    ): Promise<AiReviewJiraRouting> {
+        const { organizationUuid } = user;
+        if (!organizationUuid)
+            throw new ForbiddenError('Organization not found');
+        this.checkOrganizationAdminAccess(user);
+        if (
+            routing.enabled &&
+            (!routing.jiraProjectId || !routing.jiraIssueTypeId)
+        ) {
+            throw new ParameterError(
+                'A Jira project and issue type are required to create review issues',
+            );
+        }
+        if (
+            routing.enabled &&
+            !routing.applyToAllProjects &&
+            routing.projectUuids.length === 0
+        ) {
+            throw new ParameterError(
+                'Select at least one project or apply Jira issues to all projects',
+            );
+        }
+        if (!routing.applyToAllProjects && routing.projectUuids.length > 0) {
+            const projects =
+                await this.projectModel.getAllByOrganizationUuid(
+                    organizationUuid,
+                );
+            const validProjectUuids = new Set(
+                projects.map((project) => project.projectUuid),
+            );
+            if (
+                routing.projectUuids.some(
+                    (projectUuid) => !validProjectUuids.has(projectUuid),
+                )
+            ) {
+                throw new NotFoundError('Project not found');
+            }
+        }
+        return this.aiAgentReviewNotificationModel.upsertJiraRouting({
+            organizationUuid,
+            ...routing,
+        });
+    }
+
+    async backfillReviewJiraIssues(
+        user: SessionUser,
+    ): Promise<AiReviewJiraBackfillResult> {
+        const { organizationUuid } = user;
+        if (!organizationUuid)
+            throw new ForbiddenError('Organization not found');
+        this.checkOrganizationAdminAccess(user);
+        const routing =
+            await this.aiAgentReviewNotificationModel.getJiraRouting(
+                organizationUuid,
+            );
+        if (
+            !routing.enabled ||
+            !routing.jiraProjectId ||
+            !routing.jiraIssueTypeId
+        ) {
+            throw new ParameterError(
+                'Enable Jira issues and choose a project and issue type before exporting existing findings',
+            );
+        }
+        const items =
+            await this.aiAgentReviewClassifierModel.listUnlinkedReviewItemsForJiraExport(
+                {
+                    organizationUuid,
+                    projectUuids: routing.applyToAllProjects
+                        ? null
+                        : routing.projectUuids,
+                },
+            );
+        const fingerprintsByProject = new Map<string, string[]>();
+        for (const item of items) {
+            const fingerprints =
+                fingerprintsByProject.get(item.projectUuid) ?? [];
+            fingerprints.push(item.fingerprint);
+            fingerprintsByProject.set(item.projectUuid, fingerprints);
+        }
+        let queuedCount = 0;
+        for (const [projectUuid, fingerprints] of fingerprintsByProject) {
+            for (let index = 0; index < fingerprints.length; index += 25) {
+                const batch = fingerprints.slice(index, index + 25);
+                // eslint-disable-next-line no-await-in-loop
+                await this.aiAgentReviewNotificationService.createJiraIssues({
+                    organizationUuid,
+                    projectUuid,
+                    fingerprints: batch,
+                    reviewRunUuid: null,
+                    userUuid: user.userUuid,
+                });
+                queuedCount += batch.length;
+            }
+        }
+        return { queuedCount };
     }
 
     async listReviewItems(

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -1618,13 +1618,19 @@ export class AiAgentAdminService extends BaseService {
         });
 
         if (item.projectUuid) {
-            await this.aiAgentReviewNotificationService.createLinearIssues({
+            const exportArgs = {
                 organizationUuid,
                 projectUuid: item.projectUuid,
                 fingerprints: [item.fingerprint],
                 reviewRunUuid: null,
                 userUuid: user.userUuid,
-            });
+            };
+            await this.aiAgentReviewNotificationService.createLinearIssues(
+                exportArgs,
+            );
+            await this.aiAgentReviewNotificationService.createJiraIssues(
+                exportArgs,
+            );
         }
 
         return item;

--- a/packages/backend/src/ee/services/AiAgentReviewNotificationService.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewNotificationService.ts
@@ -187,6 +187,12 @@ export class AiAgentReviewNotificationService {
             fingerprints: args.fingerprints,
             reviewRunUuid: args.reviewRunUuid,
         });
+        await this.createJiraIssues({
+            organizationUuid: args.organizationUuid,
+            projectUuid: args.projectUuid,
+            fingerprints: args.fingerprints,
+            reviewRunUuid: args.reviewRunUuid,
+        });
     }
 
     async createLinearIssues(args: {
@@ -202,6 +208,26 @@ export class AiAgentReviewNotificationService {
 
         await this.schedulerClient.scheduleTask(
             EE_SCHEDULER_TASKS.CREATE_REVIEW_LINEAR_ISSUE,
+            {
+                organizationUuid: args.organizationUuid,
+                projectUuid: args.projectUuid,
+                fingerprints: args.fingerprints,
+                reviewRunUuid: args.reviewRunUuid,
+                userUuid: args.userUuid,
+            },
+        );
+    }
+
+    async createJiraIssues(args: {
+        organizationUuid: string;
+        projectUuid: string;
+        fingerprints: string[];
+        reviewRunUuid: string | null;
+        userUuid?: string;
+    }): Promise<void> {
+        if (args.fingerprints.length === 0) return;
+        await this.schedulerClient.scheduleTask(
+            EE_SCHEDULER_TASKS.CREATE_REVIEW_JIRA_ISSUE,
             {
                 organizationUuid: args.organizationUuid,
                 projectUuid: args.projectUuid,

--- a/packages/backend/src/scheduler/SchedulerTaskTracer.ts
+++ b/packages/backend/src/scheduler/SchedulerTaskTracer.ts
@@ -223,6 +223,12 @@ const getTagsForTask: {
         'content_review_request.uuid': payload.requestUuid,
     }),
 
+    [SCHEDULER_TASKS.CREATE_REVIEW_JIRA_ISSUE]: (payload) => ({
+        'organization.uuid': payload.organizationUuid,
+        'project.uuid': payload.projectUuid,
+        'user.uuid': payload.userUuid ?? '',
+    }),
+
     [SCHEDULER_TASKS.CREATE_REVIEW_LINEAR_ISSUE]: (payload) => ({
         'organization.uuid': payload.organizationUuid,
         'project.uuid': payload.projectUuid,

--- a/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
+++ b/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
@@ -761,6 +761,7 @@ export type AiAgentReviewItem = {
     statusUpdatedAt: Date;
     statusUpdatedByUserUuid: string | null;
     linkedIssueUrl: string | null;
+    linkedJiraIssueUrl?: string | null;
     linkedPrUrl: string | null;
     prState: AiAgentReviewItemPrState | null;
     prWritebackStatus: AiAgentReviewItemWritebackStatus | null;

--- a/packages/common/src/ee/types/aiReviewNotification.test.ts
+++ b/packages/common/src/ee/types/aiReviewNotification.test.ts
@@ -1,12 +1,59 @@
 import {
     AiReviewNotificationChannel,
     AiReviewNotificationEvent,
+    resolveAiReviewJiraDestination,
     resolveAiReviewLinearDestination,
 } from './aiReviewNotification';
 
 test('event and channel enums expose stable string values', () => {
     expect(AiReviewNotificationEvent.NeedsReview).toBe('needs_review');
     expect(AiReviewNotificationChannel.SlackDm).toBe('slack_dm');
+});
+
+describe('resolveAiReviewJiraDestination', () => {
+    const settings = {
+        jiraEnabled: true,
+        jiraProjectId: 'jira-project-1',
+        jiraIssueTypeId: 'type-1',
+    };
+
+    it('uses organization routing for all projects', () => {
+        expect(
+            resolveAiReviewJiraDestination({
+                organizationUuid: 'org-1',
+                projectUuid: 'project-1',
+                applyToAllProjects: true,
+                settings,
+                destination: null,
+                hasProjectDestinations: false,
+            }),
+        ).toEqual({
+            organizationUuid: 'org-1',
+            projectUuid: 'project-1',
+            enabled: true,
+            jiraProjectId: 'jira-project-1',
+            jiraIssueTypeId: 'type-1',
+        });
+    });
+
+    it('disables unselected projects', () => {
+        expect(
+            resolveAiReviewJiraDestination({
+                organizationUuid: 'org-1',
+                projectUuid: 'project-2',
+                applyToAllProjects: false,
+                settings,
+                destination: null,
+                hasProjectDestinations: true,
+            }),
+        ).toEqual({
+            organizationUuid: 'org-1',
+            projectUuid: 'project-2',
+            enabled: false,
+            jiraProjectId: null,
+            jiraIssueTypeId: null,
+        });
+    });
 });
 
 describe('resolveAiReviewLinearDestination', () => {

--- a/packages/common/src/ee/types/aiReviewNotification.ts
+++ b/packages/common/src/ee/types/aiReviewNotification.ts
@@ -25,6 +25,9 @@ export type AiReviewNotificationSettings = {
     linearEnabled: boolean;
     linearTeamId: string | null;
     linearProjectId: string | null;
+    jiraEnabled: boolean;
+    jiraProjectId: string | null;
+    jiraIssueTypeId: string | null;
 };
 
 export type UpdateAiReviewNotificationSettings = {
@@ -33,6 +36,9 @@ export type UpdateAiReviewNotificationSettings = {
     linearEnabled?: boolean;
     linearTeamId?: string | null;
     linearProjectId?: string | null;
+    jiraEnabled?: boolean;
+    jiraProjectId?: string | null;
+    jiraIssueTypeId?: string | null;
 };
 
 export type ApiAiReviewNotificationSettingsResponse =
@@ -80,6 +86,45 @@ export type AiReviewLinearBackfillResult = {
 
 export type ApiAiReviewLinearBackfillResponse =
     ApiSuccess<AiReviewLinearBackfillResult>;
+
+export type AiReviewJiraDestination = {
+    organizationUuid: string;
+    projectUuid: string;
+    enabled: boolean;
+    jiraProjectId: string | null;
+    jiraIssueTypeId: string | null;
+};
+
+export type UpdateAiReviewJiraDestination = Pick<
+    AiReviewJiraDestination,
+    'enabled' | 'jiraProjectId' | 'jiraIssueTypeId'
+>;
+
+export type ApiAiReviewJiraDestinationResponse =
+    ApiSuccess<AiReviewJiraDestination>;
+
+export type AiReviewJiraRouting = {
+    organizationUuid: string;
+    applyToAllProjects: boolean;
+    projectUuids: string[];
+    enabled: boolean;
+    jiraProjectId: string | null;
+    jiraIssueTypeId: string | null;
+};
+
+export type UpdateAiReviewJiraRouting = Omit<
+    AiReviewJiraRouting,
+    'organizationUuid'
+>;
+
+export type ApiAiReviewJiraRoutingResponse = ApiSuccess<AiReviewJiraRouting>;
+
+export type AiReviewJiraBackfillResult = {
+    queuedCount: number;
+};
+
+export type ApiAiReviewJiraBackfillResponse =
+    ApiSuccess<AiReviewJiraBackfillResult>;
 
 export const resolveAiReviewLinearDestination = ({
     organizationUuid,
@@ -130,6 +175,55 @@ export const resolveAiReviewLinearDestination = ({
         enabled: false,
         linearTeamId: null,
         linearProjectId: null,
+    };
+};
+
+export const resolveAiReviewJiraDestination = ({
+    organizationUuid,
+    projectUuid,
+    applyToAllProjects,
+    settings,
+    destination,
+    hasProjectDestinations,
+}: {
+    organizationUuid: string;
+    projectUuid: string;
+    applyToAllProjects: boolean;
+    settings: Pick<
+        AiReviewNotificationSettings,
+        'jiraEnabled' | 'jiraProjectId' | 'jiraIssueTypeId'
+    >;
+    destination: AiReviewJiraDestination | null;
+    hasProjectDestinations: boolean;
+}): AiReviewJiraDestination => {
+    if (applyToAllProjects) {
+        return {
+            organizationUuid,
+            projectUuid,
+            enabled: settings.jiraEnabled,
+            jiraProjectId: settings.jiraProjectId,
+            jiraIssueTypeId: settings.jiraIssueTypeId,
+        };
+    }
+
+    if (destination) return destination;
+
+    if (!hasProjectDestinations && settings.jiraProjectId) {
+        return {
+            organizationUuid,
+            projectUuid,
+            enabled: settings.jiraEnabled,
+            jiraProjectId: settings.jiraProjectId,
+            jiraIssueTypeId: settings.jiraIssueTypeId,
+        };
+    }
+
+    return {
+        organizationUuid,
+        projectUuid,
+        enabled: false,
+        jiraProjectId: null,
+        jiraIssueTypeId: null,
     };
 };
 

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -1044,3 +1044,5 @@ export type CreateReviewLinearIssuePayload = {
     schedulerUuid?: string;
     userUuid?: string;
 };
+
+export type CreateReviewJiraIssuePayload = CreateReviewLinearIssuePayload;

--- a/packages/common/src/types/schedulerTaskList.test.ts
+++ b/packages/common/src/types/schedulerTaskList.test.ts
@@ -12,6 +12,12 @@ test('CREATE_REVIEW_LINEAR_ISSUE task is registered', () => {
     );
 });
 
+test('CREATE_REVIEW_JIRA_ISSUE task is registered', () => {
+    expect(EE_SCHEDULER_TASKS.CREATE_REVIEW_JIRA_ISSUE).toBe(
+        'createReviewJiraIssue',
+    );
+});
+
 test('AI_DEEP_RESEARCH tasks are registered', () => {
     expect(EE_SCHEDULER_TASKS.AI_DEEP_RESEARCH).toBe('aiDeepResearch');
     expect(EE_SCHEDULER_TASKS.SWEEP_STALE_AI_DEEP_RESEARCH_RUNS).toBe(

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -27,6 +27,7 @@ import { type RenameResourcesPayload } from './rename';
 import {
     type BackfillDefaultUserSpacesPayload,
     type CompileProjectPayload,
+    type CreateReviewJiraIssuePayload,
     type CreateReviewLinearIssuePayload,
     type DownloadAsyncQueryResultsPayload,
     type EmailBatchNotificationPayload,
@@ -180,6 +181,7 @@ export const EE_SCHEDULER_TASKS = {
     AI_AGENT_REVIEW_REMEDIATION_RUN: 'aiAgentReviewRemediationRun',
     SEND_REVIEW_NOTIFICATION: 'sendReviewNotification',
     SEND_CONTENT_REVIEW_NOTIFICATION: 'sendContentReviewNotification',
+    CREATE_REVIEW_JIRA_ISSUE: 'createReviewJiraIssue',
     CREATE_REVIEW_LINEAR_ISSUE: 'createReviewLinearIssue',
     EMBED_ARTIFACT_VERSION: 'embedArtifactVersion',
     GENERATE_ARTIFACT_QUESTION: 'generateArtifactQuestion',
@@ -305,6 +307,7 @@ export interface TaskPayloadMap {
     [SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_RUN]: AiAgentReviewRemediationRunJobPayload;
     [SCHEDULER_TASKS.SEND_REVIEW_NOTIFICATION]: SendReviewNotificationPayload;
     [SCHEDULER_TASKS.SEND_CONTENT_REVIEW_NOTIFICATION]: SendContentReviewNotificationPayload;
+    [SCHEDULER_TASKS.CREATE_REVIEW_JIRA_ISSUE]: CreateReviewJiraIssuePayload;
     [SCHEDULER_TASKS.CREATE_REVIEW_LINEAR_ISSUE]: CreateReviewLinearIssuePayload;
     [SCHEDULER_TASKS.EMBED_ARTIFACT_VERSION]: EmbedArtifactVersionJobPayload;
     [SCHEDULER_TASKS.GENERATE_ARTIFACT_QUESTION]: GenerateArtifactQuestionJobPayload;
@@ -344,6 +347,7 @@ export interface EETaskPayloadMap {
     [EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_RUN]: AiAgentReviewRemediationRunJobPayload;
     [EE_SCHEDULER_TASKS.SEND_REVIEW_NOTIFICATION]: SendReviewNotificationPayload;
     [EE_SCHEDULER_TASKS.SEND_CONTENT_REVIEW_NOTIFICATION]: SendContentReviewNotificationPayload;
+    [EE_SCHEDULER_TASKS.CREATE_REVIEW_JIRA_ISSUE]: CreateReviewJiraIssuePayload;
     [EE_SCHEDULER_TASKS.CREATE_REVIEW_LINEAR_ISSUE]: CreateReviewLinearIssuePayload;
     [EE_SCHEDULER_TASKS.EMBED_ARTIFACT_VERSION]: EmbedArtifactVersionJobPayload;
     [EE_SCHEDULER_TASKS.GENERATE_ARTIFACT_QUESTION]: GenerateArtifactQuestionJobPayload;


### PR DESCRIPTION
## Summary

- add organization-level Jira routing for AI review findings
- create issues automatically or by backfill through an idempotent scheduler task
- persist Jira issue links alongside existing Linear links
- issues created by hand queue a Jira export too, matching the review-run path (previously only Linear was queued from `createReviewItem`; the Linear call is unchanged, so existing Linear behaviour is not affected)

## Verification

- common, backend, and frontend typechecks
- focused routing, scheduler, service, and model tests
- EE migration up/down verified locally

Part of PROD-10122 and ZAP-491 (closed by the last PR of the stack).

## Risk assessment

- [ ] This is a high-risk change