### PR TITLE
fix(data-apps): separate template cards from prompt

### DIFF
--- a/packages/frontend/src/features/apps/AppTemplatePicker.module.css
+++ b/packages/frontend/src/features/apps/AppTemplatePicker.module.css
@@ -2,7 +2,7 @@
     position: relative;
     width: 100%;
     max-width: 920px;
-    height: 260px;
+    height: 280px;
     margin: 0 auto;
 }
 


### PR DESCRIPTION
## What changed

## Summary

- Increase the fanned template picker’s reserved height so rotated cards and their shadows clear the prompt composer.
- Preserve the existing intrinsic-height stacked layout at narrow viewport widths.

### Validation

- `pnpm -F 'frontend' run --if-present typecheck` — passed
- `pnpm -F 'frontend' exec vitest related 'src/features/apps/AppTemplatePicker.module.css' --run --passWithNoTests` — passed
- `pnpm -F 'frontend' run --if-present lint` — passed

### Review notes

- Chose a minimal increase to the picker’s existing fixed fan height, matching the component’s current pixel-based card geometry. An alternative is to introduce geometry variables and derive the height with `calc()` or restructure the fan for intrinsic sizing; reviewer input is useful if that broader maintainability change is preferred over the narrow layout fix.

## Proof of work

🟢 **PASS** — The data app creation page renders all four app type cards above the prompt composer without overlap.

Revision: `c818b6113371d93bde41b29838309963d750e93c`

### App type cards remain separate from the prompt input

- Expected: On the seeded Jaffle shop data app creation page, all four app type cards are visible in their dedicated area above the visible prompt composer and do not overlap it.
- Observed: The captured page remained on the requested data app creation route at 1280×720. Direct inspection of the persisted PNG shows all four cards fully above the prompt composer with clear vertical separation and no overlap. Structured inspection found exactly one visible 710px-wide, 280px-high card area; each of button[data-pos="0"] through button[data-pos="3"] matched once and was visible; and the contenteditable prompt matched once and was visible at 700px by 80px.
- Evidence:
  - Preflight authoritatively confirmed revision c818b6113371d93bde41b29838309963d750e93c and worktree "clean".
  - Persisted and inspected screenshot: https://ld-linear-agent-v2.exe.xyz/evidence/4893ecae81673a1bb609570dc1736fe947c8229777b716a6a4726d6e9d0e9734.png
  - Final product URL: https://ld-runner-zap-981-d2f72eaa00c2.exe.xyz/projects/3675b69e-8324-4110-bdca-059031aa8da3/apps/generate
  - Page observation viewport: 1280×720, deviceScaleFactor 1.
  - Card-area observation: matchCount 1, visible true, display block, position relative, width 710px, height 280px, visibility visible.
  - Card observations: data-pos 0–3 each had matchCount 1, visible true, display block, and visibility visible.
  - Prompt observation: matchCount 1, visible true, display block, position relative, width 700px, height 80px, visibility visible.

![Lightdash development environment screenshot](https://ld-linear-agent-v2.exe.xyz/evidence/4893ecae81673a1bb609570dc1736fe947c8229777b716a6a4726d6e9d0e9734.png)

## Development environment

[Open the public Lightdash development environment](https://ld-runner-zap-981-d2f72eaa00c2.exe.xyz) (anyone with the URL can access it)

Login: `demo@lightdash.com` / `demo_password!`

## References

Closes: ZAP-981

