### PR TITLE
feat(ai): query inspector in the thread's data app preview panel

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AiAgentPageLayout.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AiAgentPageLayout.tsx
@@ -45,7 +45,9 @@ const renderPreviewPanel = (preview: AiPreview) => {
         case 'savedChart':
             return <AiSavedChartPreviewPanel savedChartPreview={preview} />;
         case 'dataApp':
-            return <AiDataAppPreviewPanel dataAppPreview={preview} />;
+            return (
+                <AiDataAppPreviewPanel dataAppPreview={preview} showInspector />
+            );
         default:
             return assertUnreachable(preview, 'Unknown preview type');
     }

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiArtifactPanel.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiArtifactPanel.module.css
@@ -49,6 +49,13 @@
     min-height: 0;
 }
 
+/* Positioned so the app inspector can overlay the preview's bottom edge. */
+.previewBody {
+    flex: 1;
+    min-height: 0;
+    position: relative;
+}
+
 .head {
     display: flex;
     align-items: center;

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDataAppPreviewPanel.inspector.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDataAppPreviewPanel.inspector.test.tsx
@@ -1,0 +1,152 @@
+import { act, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { QueryEvent } from '../../../../../features/apps/hooks/useAppSdkBridge';
+import { renderWithProviders } from '../../../../../testing/testUtils';
+
+type IframePreviewProps = {
+    onQueryEvent?: (event: QueryEvent) => void;
+};
+
+const mocks = vi.hoisted(() => ({
+    iframePreview: vi.fn((_props: IframePreviewProps) => null),
+    latestReadyVersion: 3,
+    tokenLoading: false,
+}));
+
+vi.mock('../../../../../features/apps/AppIframePreview', () => ({
+    default: mocks.iframePreview,
+}));
+
+vi.mock('../../../../../features/apps/hooks/useAppPreviewToken', () => ({
+    useAppPreviewToken: () => ({
+        data: mocks.tokenLoading ? undefined : 'preview-token',
+        isLoading: mocks.tokenLoading,
+        error: undefined,
+    }),
+}));
+
+vi.mock('../../../../../features/apps/hooks/useGetApp', () => ({
+    useGetApp: () => ({
+        data: {
+            pages: [
+                {
+                    name: 'Sales app',
+                    description: null,
+                    latestReadyVersion: mocks.latestReadyVersion,
+                    versions: [{ status: 'ready' }],
+                },
+            ],
+        },
+        isLoading: false,
+        error: undefined,
+    }),
+}));
+
+vi.mock('../../../../../features/apps/previewOrigin', () => ({
+    usePreviewOrigin: () => 'https://preview.example.com',
+}));
+
+vi.mock('../../store/hooks', () => ({
+    useAiAgentStoreDispatch: () => vi.fn(),
+}));
+
+// eslint-disable-next-line import/first
+import { AiDataAppPreviewPanel } from './AiDataAppPreviewPanel';
+
+const dataAppPreview = {
+    appUuid: 'app-uuid',
+    messageUuid: 'message-uuid',
+    threadUuid: 'thread-uuid',
+    projectUuid: 'project-uuid',
+    agentUuid: 'agent-uuid',
+};
+
+const latestIframeProps = (): IframePreviewProps => {
+    const { calls } = mocks.iframePreview.mock;
+    return calls[calls.length - 1][0];
+};
+
+const readyQuery = (id: string): QueryEvent => ({
+    id,
+    timestamp: 0,
+    label: 'Revenue',
+    exploreName: 'orders',
+    dimensions: [],
+    metrics: [],
+    filters: {},
+    sorts: [],
+    tableCalculations: [],
+    additionalMetrics: [],
+    limit: 0,
+    queryUuid: `${id}-uuid`,
+    status: 'ready',
+    rowCount: 1,
+    durationMs: 10,
+    error: null,
+    rawMetricQuery: null,
+});
+
+const panel = (showInspector: boolean) => (
+    <AiDataAppPreviewPanel
+        dataAppPreview={dataAppPreview}
+        showInspector={showInspector}
+    />
+);
+
+// A new ready version refetches the preview token, so the iframe briefly
+// gives way to a loader before the new bundle mounts.
+const landNewVersion = (
+    rerender: (ui: React.ReactElement) => void,
+    version: number,
+) => {
+    mocks.latestReadyVersion = version;
+    mocks.tokenLoading = true;
+    rerender(panel(true));
+    mocks.tokenLoading = false;
+    rerender(panel(true));
+};
+
+describe('AiDataAppPreviewPanel inspector', () => {
+    beforeEach(() => {
+        mocks.latestReadyVersion = 3;
+        mocks.tokenLoading = false;
+        window.localStorage.clear();
+    });
+
+    it('surfaces the query inspector once the app issues a query', () => {
+        renderWithProviders(panel(true));
+        expect(screen.queryByText(/Queries \(/)).not.toBeInTheDocument();
+
+        act(() => latestIframeProps().onQueryEvent?.(readyQuery('r1')));
+
+        expect(screen.getByText('Queries (1)')).toBeInTheDocument();
+    });
+
+    it('clears the log when a new version lands', () => {
+        const { rerender } = renderWithProviders(panel(true));
+        act(() => latestIframeProps().onQueryEvent?.(readyQuery('r1')));
+        expect(screen.getByText('Queries (1)')).toBeInTheDocument();
+
+        landNewVersion(rerender, 4);
+
+        expect(screen.queryByText(/Queries \(/)).not.toBeInTheDocument();
+        act(() => latestIframeProps().onQueryEvent?.(readyQuery('r2')));
+        expect(screen.getByText('Queries (1)')).toBeInTheDocument();
+    });
+
+    it('keeps the log across versions when Persist is on', () => {
+        window.localStorage.setItem('data-apps:persist-logs', 'true');
+        const { rerender } = renderWithProviders(panel(true));
+        act(() => latestIframeProps().onQueryEvent?.(readyQuery('r1')));
+
+        landNewVersion(rerender, 4);
+        act(() => latestIframeProps().onQueryEvent?.(readyQuery('r2')));
+
+        expect(screen.getByText('Queries (2)')).toBeInTheDocument();
+    });
+
+    it('leaves the launcher preview without inspector wiring', () => {
+        renderWithProviders(panel(false));
+        expect(latestIframeProps().onQueryEvent).toBeUndefined();
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDataAppPreviewPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDataAppPreviewPanel.tsx
@@ -15,7 +15,9 @@ import { type FC, type ReactNode } from 'react';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import TruncatedText from '../../../../../components/common/TruncatedText';
 import AppIframePreview from '../../../../../features/apps/AppIframePreview';
+import AppInspectorPanel from '../../../../../features/apps/AppInspectorPanel';
 import { getVisiblePreviewTokenError } from '../../../../../features/apps/hooks/previewTokenQueryOptions';
+import { useAppInspector } from '../../../../../features/apps/hooks/useAppInspector';
 import { useAppPreviewToken } from '../../../../../features/apps/hooks/useAppPreviewToken';
 import { useGetApp } from '../../../../../features/apps/hooks/useGetApp';
 import { usePreviewOrigin } from '../../../../../features/apps/previewOrigin';
@@ -28,9 +30,15 @@ import artifactStyles from './AiArtifactPanel.module.css';
 
 type Props = {
     dataAppPreview: DataAppPreviewData;
+    /** Only the full-page thread panel hosts the query inspector; the
+     *  floating launcher preview is too small for it. */
+    showInspector: boolean;
 };
 
-export const AiDataAppPreviewPanel: FC<Props> = ({ dataAppPreview }) => {
+export const AiDataAppPreviewPanel: FC<Props> = ({
+    dataAppPreview,
+    showInspector,
+}) => {
     const dispatch = useAiAgentStoreDispatch();
     const { appUuid, projectUuid } = dataAppPreview;
 
@@ -41,6 +49,10 @@ export const AiDataAppPreviewPanel: FC<Props> = ({ dataAppPreview }) => {
     // Authoritative across ALL versions — the ready version may be older than
     // the fetched page of versions, so never scan `versions` for it.
     const latestReadyVersion = app?.latestReadyVersion ?? undefined;
+    const identityKey = `${appUuid}:${latestReadyVersion}`;
+    // Lives here, not next to the iframe, so logs and dismissal survive the
+    // token reload between versions. Only wired in when `showInspector`.
+    const inspector = useAppInspector({ identityKey, defaultHidden: false });
 
     const {
         data: token,
@@ -133,15 +145,24 @@ export const AiDataAppPreviewPanel: FC<Props> = ({ dataAppPreview }) => {
         );
     } else {
         body = (
-            <AppIframePreview
-                src={previewUrl}
-                previewToken={token}
-                expectedPreviewOrigin={previewOrigin}
-                projectUuid={projectUuid}
-                appUuid={appUuid}
-                identityKey={`${appUuid}:${latestReadyVersion}`}
-                capabilities={{ gsheetExport: true }}
-            />
+            <>
+                <AppIframePreview
+                    src={previewUrl}
+                    previewToken={token}
+                    expectedPreviewOrigin={previewOrigin}
+                    projectUuid={projectUuid}
+                    appUuid={appUuid}
+                    identityKey={identityKey}
+                    capabilities={{ gsheetExport: true }}
+                    {...(showInspector ? inspector.iframeProps : {})}
+                />
+                {showInspector && !inspector.hidden && (
+                    <AppInspectorPanel
+                        projectUuid={projectUuid}
+                        {...inspector.panelProps}
+                    />
+                )}
+            </>
         );
     }
 
@@ -195,9 +216,7 @@ export const AiDataAppPreviewPanel: FC<Props> = ({ dataAppPreview }) => {
                     </Group>
                 </Box>
 
-                <Box flex={1} mih={0}>
-                    {body}
-                </Box>
+                <Box className={artifactStyles.previewBody}>{body}</Box>
             </Box>
         </Box>
     );

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/AiAgentsLauncher.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/AiAgentsLauncher.tsx
@@ -221,6 +221,7 @@ const AiAgentsLauncherInner: FC = () => {
                         >
                             <AiDataAppPreviewPanel
                                 dataAppPreview={transitionDataAppPreview}
+                                showInspector={false}
                             />
                         </Box>
                     )}

--- a/packages/frontend/src/features/apps/hooks/useAppInspector.test.tsx
+++ b/packages/frontend/src/features/apps/hooks/useAppInspector.test.tsx
@@ -1,0 +1,168 @@
+import { MantineProvider } from '@mantine/core';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { type FC } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import AppInspectorPanel from '../AppInspectorPanel';
+import { useAppInspector, type UseAppInspectorResult } from './useAppInspector';
+import type { ExternalRequestEvent, QueryEvent } from './useAppSdkBridge';
+
+// Stands in for the SDK bridge: the harness publishes the callbacks the hook
+// hands to `AppIframePreview`, and tests feed events through them.
+let inspector: UseAppInspectorResult;
+
+const Host: FC<{ identityKey: string }> = ({ identityKey }) => {
+    inspector = useAppInspector({ identityKey, defaultHidden: false });
+    if (inspector.hidden) return null;
+    return <AppInspectorPanel projectUuid="p-1" {...inspector.panelProps} />;
+};
+
+const renderHost = (identityKey = 'app:1') =>
+    render(
+        <MantineProvider env="test">
+            <Host identityKey={identityKey} />
+        </MantineProvider>,
+    );
+
+const rerenderHost = (
+    rerender: (ui: React.ReactElement) => void,
+    identityKey: string,
+) =>
+    rerender(
+        <MantineProvider env="test">
+            <Host identityKey={identityKey} />
+        </MantineProvider>,
+    );
+
+const queryEvent = (
+    overrides: Partial<QueryEvent> & Pick<QueryEvent, 'id' | 'status'>,
+): QueryEvent => ({
+    timestamp: 0,
+    label: 'Revenue',
+    exploreName: 'orders',
+    dimensions: [],
+    metrics: ['orders_revenue'],
+    filters: {},
+    sorts: [],
+    tableCalculations: [],
+    additionalMetrics: [],
+    limit: 20,
+    queryUuid: null,
+    rowCount: null,
+    durationMs: null,
+    error: null,
+    rawMetricQuery: null,
+    ...overrides,
+});
+
+const externalRequestEvent: ExternalRequestEvent = {
+    id: 'ext-1',
+    timestamp: 0,
+    alias: 'stripe',
+    method: 'GET',
+    path: '/v1/charges',
+    query: null,
+    requestBody: null,
+    status: 'ready',
+    httpStatus: 200,
+    contentType: 'application/json',
+    responseBody: { ok: true },
+    truncated: false,
+    durationMs: 42,
+    error: null,
+};
+
+const emitQuery = (event: QueryEvent) =>
+    act(() => inspector.iframeProps.onQueryEvent(event));
+
+describe('useAppInspector', () => {
+    beforeEach(() => {
+        window.localStorage.clear();
+        // jsdom has no scrollIntoView; the focused row calls it.
+        Element.prototype.scrollIntoView = vi.fn();
+    });
+
+    it('stays out of the way until the app issues its first query', () => {
+        renderHost();
+        expect(screen.queryByText(/Queries \(/)).not.toBeInTheDocument();
+
+        emitQuery(queryEvent({ id: 'r1', status: 'pending' }));
+
+        expect(screen.getByText('Queries (1)')).toBeInTheDocument();
+        expect(screen.getByText('pending')).toBeInTheDocument();
+    });
+
+    it('rolls a query row through its status transitions', () => {
+        renderHost();
+        emitQuery(queryEvent({ id: 'r1', status: 'pending' }));
+        emitQuery(
+            queryEvent({
+                id: 'r1',
+                status: 'ready',
+                queryUuid: 'q-1',
+                rowCount: 3,
+                durationMs: 20,
+            }),
+        );
+
+        expect(screen.getByText('Queries (1)')).toBeInTheDocument();
+        expect(screen.getByText('ready')).toBeInTheDocument();
+        expect(screen.getByText('3 rows')).toBeInTheDocument();
+        expect(inspector.readyQueryCount).toBe(1);
+    });
+
+    it('counts external-connection requests on the Requests tab', () => {
+        renderHost();
+        act(() =>
+            inspector.iframeProps.onExternalRequestEvent(externalRequestEvent),
+        );
+        expect(screen.getByText('Requests (1)')).toBeInTheDocument();
+    });
+
+    it('clears the log when a new app version lands, dropping late events from the old one', () => {
+        const { rerender } = renderHost('app:1');
+        emitQuery(queryEvent({ id: 'r1', status: 'pending' }));
+        act(() =>
+            inspector.iframeProps.onExternalRequestEvent(externalRequestEvent),
+        );
+
+        rerenderHost(rerender, 'app:2');
+        expect(screen.queryByText(/Queries \(/)).not.toBeInTheDocument();
+
+        emitQuery(queryEvent({ id: 'r1', status: 'ready', queryUuid: 'q-1' }));
+        expect(screen.queryByText(/Queries \(/)).not.toBeInTheDocument();
+        expect(inspector.readyQueryCount).toBe(0);
+    });
+
+    it('keeps the log across versions when Persist is on, interrupting in-flight rows', () => {
+        const { rerender } = renderHost('app:1');
+        emitQuery(queryEvent({ id: 'r0', status: 'ready', queryUuid: 'q-0' }));
+        emitQuery(queryEvent({ id: 'r1', status: 'pending' }));
+        // The switch lives in the expanded title bar.
+        fireEvent.click(screen.getByText('Queries (2)'));
+        fireEvent.click(screen.getByLabelText('Persist'));
+
+        rerenderHost(rerender, 'app:2');
+
+        expect(screen.getByText('Queries (2)')).toBeInTheDocument();
+        expect(screen.getByText('error')).toBeInTheDocument();
+        // Only queries since the version switch count towards the live gate.
+        expect(inspector.readyQueryCount).toBe(0);
+        emitQuery(queryEvent({ id: 'r2', status: 'ready', queryUuid: 'q-2' }));
+        expect(inspector.readyQueryCount).toBe(1);
+    });
+
+    it('re-opens the panel and focuses the row when the app reports a lineage selection', () => {
+        renderHost();
+        emitQuery(queryEvent({ id: 'r1', status: 'ready', queryUuid: 'q-1' }));
+        fireEvent.click(screen.getByLabelText('Close inspector panel'));
+        expect(screen.queryByText(/Queries \(/)).not.toBeInTheDocument();
+
+        act(() =>
+            inspector.iframeProps.onLineageSelected({ queryUuid: 'q-1' }),
+        );
+
+        const row = document.querySelector('[data-query-uuid="q-1"]')!;
+        expect(row.className).toMatch(/queryRowFocused/);
+        expect(inspector.iframeProps.lineageHighlightQueryUuid).toBe('q-1');
+    });
+});

--- a/packages/frontend/src/features/apps/hooks/useAppInspector.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppInspector.ts
@@ -1,0 +1,205 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type {
+    ExternalRequestEvent,
+    QueryEvent,
+    SdkManifest,
+} from './useAppSdkBridge';
+import {
+    countReadyQueriesSinceBoundary,
+    useTrackedAppQueries,
+} from './useTrackedAppQueries';
+import { useTrackedExternalRequests } from './useTrackedExternalRequests';
+
+/** Bridge callbacks and lineage state to spread onto `AppIframePreview`. */
+export type AppInspectorIframeProps = {
+    onQueryEvent: (event: QueryEvent) => void;
+    onExternalRequestEvent: (event: ExternalRequestEvent) => void;
+    onSdkManifest: (manifest: SdkManifest) => void;
+    lineageEnabled: boolean;
+    onLineageAvailabilityChange: (available: boolean) => void;
+    onLineageSelected: (event: { queryUuid: string }) => void;
+    lineageHighlightQueryUuid: string | null;
+    onLineageCancelled: () => void;
+};
+
+/** Tracked logs, actions and lineage state to spread onto `AppInspectorPanel`. */
+export type AppInspectorPanelProps = {
+    queries: QueryEvent[];
+    onClearQueries: () => void;
+    externalRequests: ExternalRequestEvent[];
+    onClearExternalRequests: () => void;
+    persistLogs: boolean;
+    onPersistLogsChange: (value: boolean) => void;
+    onHoverQuery: (queryUuid: string | null) => void;
+    focusedQueryUuid: string | null;
+    lineageEnabled: boolean;
+    lineageAvailable: boolean;
+    lineageSupportedBySdk: boolean;
+    onToggleLineage: () => void;
+    onDismiss: () => void;
+};
+
+export type UseAppInspectorResult = {
+    /** Parent-owned visibility: the panel's X hides it, `show` re-opens it. */
+    hidden: boolean;
+    show: () => void;
+    /** Persist-aware rollover for a host-triggered iframe reload (manual
+     *  refresh). Version switches roll over via `identityKey`. */
+    rolloverLogs: () => void;
+    /** `ready` queries since the last version switch, unaffected by rows
+     *  Persist carried over from a previous bundle. */
+    readyQueryCount: number;
+    iframeProps: AppInspectorIframeProps;
+    panelProps: AppInspectorPanelProps;
+};
+
+/**
+ * Inspector wiring for an app preview host: tracks bridge query and
+ * external-request events, owns lineage ("Inspect data") state and rolls the
+ * logs over when the served bundle changes. Shared by the app viewer page and
+ * the AI thread preview; the builder keeps its own wiring.
+ *
+ * @param identityKey - app uuid + version of the served bundle, the same value
+ * as `AppIframePreview`'s `identityKey`. A change rolls the logs over: cleared
+ * by default, kept with in-flight rows interrupted when Persist is on. Never
+ * rolls over on mount.
+ */
+export const useAppInspector = ({
+    identityKey,
+    defaultHidden,
+}: {
+    identityKey: string;
+    defaultHidden: boolean;
+}): UseAppInspectorResult => {
+    const {
+        queries,
+        persistLogs,
+        setPersistLogs,
+        handleQueryEvent,
+        clearQueries,
+        resetQueries,
+        interruptInFlightQueries,
+    } = useTrackedAppQueries();
+    const {
+        externalRequests,
+        handleExternalRequestEvent,
+        clearExternalRequests,
+        interruptInFlightRequests,
+    } = useTrackedExternalRequests();
+
+    const [hidden, setHidden] = useState(defaultHidden);
+    const [lineageEnabled, setLineageEnabled] = useState(false);
+    const [lineageAvailable, setLineageAvailable] = useState(false);
+    const [sdkManifest, setSdkManifest] = useState<SdkManifest | null>(null);
+    const [hoveredQueryUuid, setHoveredQueryUuid] = useState<string | null>(
+        null,
+    );
+    const [focusedQueryUuid, setFocusedQueryUuid] = useState<string | null>(
+        null,
+    );
+    const [readyQueryBoundary, setReadyQueryBoundary] = useState(0);
+
+    const queriesRef = useRef(queries);
+    queriesRef.current = queries;
+
+    // Matches the builder: a version switch moves the ready-count boundary so
+    // persisted rows from the old bundle don't count; a manual refresh doesn't.
+    const rollover = useCallback(
+        (newBundle: boolean) => {
+            setFocusedQueryUuid(null);
+            if (persistLogs) {
+                interruptInFlightQueries();
+                interruptInFlightRequests();
+                if (newBundle) {
+                    setReadyQueryBoundary(
+                        queriesRef.current.filter((q) => q.status === 'ready')
+                            .length,
+                    );
+                }
+                return;
+            }
+            // resetQueries (not clearQueries) so a late terminal event from
+            // the still-running parent-owned fetch can't land as a phantom row.
+            resetQueries();
+            clearExternalRequests();
+            setReadyQueryBoundary(0);
+        },
+        [
+            persistLogs,
+            interruptInFlightQueries,
+            interruptInFlightRequests,
+            resetQueries,
+            clearExternalRequests,
+        ],
+    );
+    const rolloverLogs = useCallback(() => rollover(false), [rollover]);
+
+    // The iframe is an external system: a new bundle means new logs and a
+    // fresh manifest. Skips mount so queries fired during initial load stay.
+    const previousIdentityKeyRef = useRef(identityKey);
+    useEffect(() => {
+        if (previousIdentityKeyRef.current === identityKey) return;
+        previousIdentityKeyRef.current = identityKey;
+        setSdkManifest(null);
+        rollover(true);
+    }, [identityKey, rollover]);
+
+    const show = useCallback(() => setHidden(false), []);
+    const hide = useCallback(() => setHidden(true), []);
+
+    const handleToggleLineage = useCallback(() => {
+        setLineageEnabled((v) => !v);
+        setFocusedQueryUuid(null);
+    }, []);
+    const handleLineageSelected = useCallback(
+        (event: { queryUuid: string }) => {
+            setHidden(false);
+            // Re-clicking the selected element deselects it.
+            setFocusedQueryUuid((prev) =>
+                prev === event.queryUuid ? null : event.queryUuid,
+            );
+        },
+        [],
+    );
+    const handleLineageCancelled = useCallback(() => {
+        setLineageEnabled(false);
+        setFocusedQueryUuid(null);
+    }, []);
+
+    return {
+        hidden,
+        show,
+        rolloverLogs,
+        readyQueryCount: countReadyQueriesSinceBoundary(
+            queries,
+            readyQueryBoundary,
+        ),
+        iframeProps: {
+            onQueryEvent: handleQueryEvent,
+            onExternalRequestEvent: handleExternalRequestEvent,
+            onSdkManifest: setSdkManifest,
+            lineageEnabled,
+            onLineageAvailabilityChange: setLineageAvailable,
+            onLineageSelected: handleLineageSelected,
+            // Hover overrides the persistent click-selection.
+            lineageHighlightQueryUuid: hoveredQueryUuid ?? focusedQueryUuid,
+            onLineageCancelled: handleLineageCancelled,
+        },
+        panelProps: {
+            queries,
+            onClearQueries: clearQueries,
+            externalRequests,
+            onClearExternalRequests: clearExternalRequests,
+            persistLogs,
+            onPersistLogsChange: setPersistLogs,
+            onHoverQuery: setHoveredQueryUuid,
+            focusedQueryUuid,
+            lineageEnabled,
+            lineageAvailable,
+            lineageSupportedBySdk:
+                sdkManifest?.features.includes('lineage') ?? false,
+            onToggleLineage: handleToggleLineage,
+            onDismiss: hide,
+        },
+    };
+};

--- a/packages/frontend/src/features/apps/hooks/useTrackedAppQueries.ts
+++ b/packages/frontend/src/features/apps/hooks/useTrackedAppQueries.ts
@@ -33,12 +33,8 @@ export const countReadyQueriesSinceBoundary = (
  * single timeline entry per query, plus the "interrupted by reload" recovery
  * used by the builder when the preview iframe restarts mid-query.
  *
- * Shared between the builder (`AppGenerate`) where the queries panel is
- * always-on, and the preview (`AppPreviewTest`) where it's opt-in via a menu.
- * Preview uses only `queries`, `handleQueryEvent`, `clearQueries`, and
- * `resetKey` — the persist/interrupt machinery is builder-specific (the
- * builder handles its own version-switch reset because it must choose
- * between clearing and interrupting based on "Persist").
+ * Used directly by the builder (`AppGenerate`) and through `useAppInspector`
+ * by the viewer page and the AI thread preview.
  *
  * @param resetKey - When this changes (e.g. the previewed app version),
  * queries are reset automatically (see resetQueries). Omit to manage resets

--- a/packages/frontend/src/pages/AppPreviewTest.tsx
+++ b/packages/frontend/src/pages/AppPreviewTest.tsx
@@ -14,14 +14,10 @@ import AppHeader from '../features/apps/components/AppHeader';
 import AppHeaderActions from '../features/apps/components/AppHeaderActions';
 import { getVisiblePreviewTokenError } from '../features/apps/hooks/previewTokenQueryOptions';
 import { useAppBuildPoller } from '../features/apps/hooks/useAppBuildPoller';
+import { useAppInspector } from '../features/apps/hooks/useAppInspector';
 import { useAppPreviewToken } from '../features/apps/hooks/useAppPreviewToken';
 import { useCanEditDataApp } from '../features/apps/hooks/useCanEditDataApp';
 import { useGetApp } from '../features/apps/hooks/useGetApp';
-import {
-    countReadyQueriesSinceBoundary,
-    useTrackedAppQueries,
-} from '../features/apps/hooks/useTrackedAppQueries';
-import { useTrackedExternalRequests } from '../features/apps/hooks/useTrackedExternalRequests';
 import { usePreviewOrigin } from '../features/apps/previewOrigin';
 import { useProjectUuid } from '../hooks/useProjectUuid';
 import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
@@ -91,33 +87,11 @@ export default function AppPreviewTest() {
         error: tokenError,
     } = useAppPreviewToken(projectUuid, appUuid, version);
 
-    const [networkPanelHidden, setNetworkPanelHidden] = useState(true);
-
-    // Data-lineage ("Inspect data"): click a value to reveal the query behind
-    // it; hover a query row to highlight where it renders.
-    const [lineageEnabled, setLineageEnabled] = useState(false);
-    const [lineageAvailable, setLineageAvailable] = useState(false);
-    const [hoveredQueryUuid, setHoveredQueryUuid] = useState<string | null>(
-        null,
-    );
-    const [focusedQueryUuid, setFocusedQueryUuid] = useState<string | null>(
-        null,
-    );
-
-    // Query tracking from the preview iframe. The panel is opt-in (hidden by
-    // default in preview because most viewers aren't technical), but we wire
-    // up the SDK bridge callback unconditionally so queries that run before
-    // the user opens the panel are still captured. `version` as the reset key
-    // clears stale entries on version navigation — this component re-renders
-    // rather than remounting, so without it a previous version's queries
-    // would survive and corrupt the live capturedQueryCount gate.
-    const { queries, handleQueryEvent, clearQueries, resetQueries } =
-        useTrackedAppQueries(version);
-    const {
-        externalRequests,
-        handleExternalRequestEvent,
-        clearExternalRequests,
-    } = useTrackedExternalRequests();
+    // Panel is opt-in here (most viewers aren't technical), but bridge events
+    // are captured regardless so earlier queries show once it's opened.
+    const identityKey = `${appUuid}:${version}`;
+    const inspector = useAppInspector({ identityKey, defaultHidden: true });
+    const { rolloverLogs } = inspector;
 
     // Manual refresh: bumping the counter changes the iframe URL, forcing a
     // reload so the app's metric queries re-fire. `invalidateCache` latches on
@@ -128,32 +102,8 @@ export default function AppPreviewTest() {
     const handleRefresh = useCallback(() => {
         setRefreshKey((k) => k + 1);
         setInvalidateCache(true);
-        // resetQueries (not clearQueries): the reload doesn't tear down the
-        // parent-owned fetch/poll, so an in-flight query's late terminal event
-        // would otherwise land as a phantom row.
-        resetQueries();
-        clearExternalRequests();
-    }, [resetQueries, clearExternalRequests]);
-
-    const handleToggleLineage = useCallback(() => {
-        setLineageEnabled((v) => !v);
-        setFocusedQueryUuid(null);
-    }, []);
-    const handleLineageSelected = useCallback(
-        (event: { queryUuid: string }) => {
-            setNetworkPanelHidden(false);
-            // Selection persists (row highlight + in-app element outline);
-            // re-clicking the selected element deselects it.
-            setFocusedQueryUuid((prev) =>
-                prev === event.queryUuid ? null : event.queryUuid,
-            );
-        },
-        [],
-    );
-    const handleLineageCancelled = useCallback(() => {
-        setLineageEnabled(false);
-        setFocusedQueryUuid(null);
-    }, []);
+        rolloverLogs();
+    }, [rolloverLogs]);
 
     const previewOrigin = usePreviewOrigin();
 
@@ -273,38 +223,19 @@ export default function AppPreviewTest() {
                     expectedPreviewOrigin={previewOrigin}
                     projectUuid={projectUuid}
                     appUuid={appUuid}
-                    identityKey={`${appUuid}:${version}`}
+                    identityKey={identityKey}
                     onScreenshotAvailabilityChange={setScreenshotAvailable}
                     invalidateCache={invalidateCache}
-                    onQueryEvent={handleQueryEvent}
-                    onExternalRequestEvent={handleExternalRequestEvent}
                     urlStateSync
                     capabilities={{ gsheetExport: true }}
-                    lineageEnabled={lineageEnabled}
-                    onLineageAvailabilityChange={setLineageAvailable}
-                    onLineageSelected={handleLineageSelected}
-                    lineageHighlightQueryUuid={
-                        // Hover overrides; falls back to the persistent
-                        // click-selection.
-                        hoveredQueryUuid ?? focusedQueryUuid
-                    }
-                    onLineageCancelled={handleLineageCancelled}
+                    {...inspector.iframeProps}
                 />
-                {!networkPanelHidden && !isFullscreen && (
+                {!inspector.hidden && !isFullscreen && (
                     <AppInspectorPanel
-                        queries={queries}
                         projectUuid={projectUuid}
-                        onClearQueries={clearQueries}
-                        externalRequests={externalRequests}
-                        onClearExternalRequests={clearExternalRequests}
                         defaultCollapsed={false}
                         hideWhenEmpty={false}
-                        onDismiss={() => setNetworkPanelHidden(true)}
-                        onHoverQuery={setHoveredQueryUuid}
-                        focusedQueryUuid={focusedQueryUuid}
-                        lineageEnabled={lineageEnabled}
-                        lineageAvailable={lineageAvailable}
-                        onToggleLineage={handleToggleLineage}
+                        {...inspector.panelProps}
                     />
                 )}
             </>
@@ -339,12 +270,7 @@ export default function AppPreviewTest() {
                     }}
                     rightSection={
                         <AppHeaderActions
-                            // Boundary 0: no persist mode here, and
-                            // useTrackedAppQueries(version) resets on switch.
-                            capturedQueryCount={countReadyQueriesSinceBoundary(
-                                queries,
-                                0,
-                            )}
+                            capturedQueryCount={inspector.readyQueryCount}
                             fullscreenToggle={
                                 isFullscreenFeatureEnabled &&
                                 document.fullscreenEnabled ? (
@@ -390,7 +316,7 @@ export default function AppPreviewTest() {
                                     ? capturePreviewScreenshot
                                     : null
                             }
-                            onViewNetwork={() => setNetworkPanelHidden(false)}
+                            onViewNetwork={inspector.show}
                             onDeleted={() => {
                                 void navigate(`/projects/${projectUuid}/home`);
                             }}


### PR DESCRIPTION
The AI thread's full-page data app preview now shows the same query inspector as the builder and viewer, so users can verify what an agent-built app actually queries.

```diff
 <AiDataAppPreviewPanel showInspector>       # page layout: true · floating launcher: false
+  useAppInspector({ identityKey: `${appUuid}:${latestReadyVersion}` })
   <AppIframePreview {...inspector.iframeProps} />
+  <AppInspectorPanel {...inspector.panelProps} />   # hidden until first query, boots collapsed
```

The wiring that the viewer page and builder each hand-rolled is now one module in the apps feature, adopted by the viewer page and the thread preview so the two cannot drift:

```text
useAppInspector({ identityKey, defaultHidden })
  useTrackedAppQueries()            # Persist pref (localStorage, shared with the builder)
  useTrackedExternalRequests()
  lineage: enabled · available · hovered · focused · SDK manifest
  on identityKey change:  persist ? interrupt in-flight + move ready boundary : reset both
  → iframeProps   bridge callbacks + lineage highlight
  → panelProps    logs, per-tab clear, Persist, lineage toggle, dismiss
```

**Behaviour**

- Inspector is hidden until the app issues its first query, then appears as a collapsed title bar at the bottom of the preview. Expand, resize, tabs, Open in Explore, Save to Lightdash, lineage and Persist all inherit from `AppInspectorPanel`.
- A new ready version clears the log unless Persist is on. The hook lives at panel level so logs and dismissal survive the preview-token reload between versions.
- Viewer page (`AppPreviewTest`) migrated onto the hook. It gains the Persist switch and SDK-aware lineage tooltip; its `capturedQueryCount` export gate uses the hook's ready count.
- Launcher preview and builder page untouched.

**Tests**

- `useAppInspector.test.tsx`: renders the panel through the hook and feeds bridge events through `iframeProps`. Covers hidden-while-empty, status transitions, tab counts, reset on identity change, Persist honored, lineage reveal.
- `AiDataAppPreviewPanel.inspector.test.tsx`: first-query reveal, reset and Persist across a version change through the token-loading state, launcher gets no inspector wiring.

Verified in the browser against a local app: real metric query through the SDK bridge shows the collapsed bar, expands to a ready row, and the viewer's "View network" still works.

Closes: ZAP-966
Relates: ZAP-977
