### PR TITLE
fix(frontend): stop PolymorphicPaperButton dropping the caller's className

### DIFF
--- a/packages/frontend/src/components/common/PolymorphicPaperButton.tsx
+++ b/packages/frontend/src/components/common/PolymorphicPaperButton.tsx
@@ -3,6 +3,7 @@ import {
     Paper,
     type PaperProps,
 } from '@mantine/core';
+import { clsx } from 'clsx';
 import { forwardRef, type Ref } from 'react';
 
 /**
@@ -14,8 +15,12 @@ export const PolymorphicPaperButton = createPolymorphicComponent<
     PaperProps
 >(
     forwardRef<HTMLDivElement, PaperProps>(
-        (props: PaperProps, ref: Ref<HTMLDivElement>) => (
-            <Paper ref={ref} {...props} className="ld-pointer" />
+        ({ className, ...props }: PaperProps, ref: Ref<HTMLDivElement>) => (
+            <Paper
+                ref={ref}
+                {...props}
+                className={clsx('ld-pointer', className)}
+            />
         ),
     ),
 );

--- a/packages/frontend/src/features/apps/AppTemplatePicker.test.tsx
+++ b/packages/frontend/src/features/apps/AppTemplatePicker.test.tsx
@@ -2,6 +2,7 @@
 import { MantineProvider } from '@mantine/core';
 import { fireEvent, render, screen } from '@testing-library/react';
 import AppTemplatePicker from './AppTemplatePicker';
+import classes from './AppTemplatePicker.module.css';
 
 const setup = (
     selected:
@@ -65,6 +66,13 @@ describe('AppTemplatePicker', () => {
         const { onSelectedChange } = setup(null);
         fireEvent.click(screen.getByRole('button', { name: /From scratch/i }));
         expect(onSelectedChange).toHaveBeenCalledWith('custom');
+    });
+
+    it('keeps the card layout class on each button', () => {
+        setup(null);
+        expect(screen.getByRole('button', { name: /Dashboard/i })).toHaveClass(
+            classes.card,
+        );
     });
 
     it('clicking the selected card deselects it', () => {


### PR DESCRIPTION
Closes:

### Description:

`PolymorphicPaperButton` applied `className="ld-pointer"` *after* the props spread (introduced in #28457, replacing an inline `style` that had the same ordering but no caller to clash with), so it replaced whatever className the caller passed.

On the data app creation page that dropped `AppTemplatePicker`'s `.card` class: the cards lost their absolute positioning and fell back into normal flow, overflowing the fan's fixed 260px height and overlapping the prompt input. Merging the classes instead restores the arch — and also the styling of the other five call sites (chart type gallery/library cards, format form, AI suggested questions, memory sources).

Added a test asserting the card class survives; it fails on `main`.

### Risk assessment:

- [ ] This is a high-risk change
