### PR TITLE
fix(backend): allow adding warehouse credentials to a project created without them

### DIFF
--- a/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
@@ -8,6 +8,7 @@ import {
     CreateDuckdbMotherduckCredentials,
     CreatePostgresCredentials,
     CreateSnowflakeCredentials,
+    CreateWarehouseCredentials,
     DatabricksAuthenticationType,
     DbtCloudIDEProjectConfig,
     DbtGithubProjectConfig,
@@ -351,6 +352,37 @@ describe('ProjectModel', () => {
             'md:analytics?motherduck_token=previous-token&saas_mode=true',
             'credentials_updated',
         );
+    });
+
+    test('updates a project that was created without warehouse credentials', async () => {
+        vi.spyOn(model, 'getWarehouseCredentialsForProject').mockRejectedValue(
+            new NotFoundError('Cannot find any warehouse credentials'),
+        );
+        const invalidate = vi
+            .spyOn(MotherduckInstanceCache, 'invalidateByConnectionString')
+            .mockImplementation(() => undefined);
+        tracker.on
+            .update(({ sql }) => sql.includes('projects'))
+            .response([{ project_id: 1 }]);
+        tracker.on
+            .insert(({ sql }) => sql.includes('warehouse_credentials'))
+            .response([]);
+
+        await model.update(projectUuid, {
+            name: expectedProject.name,
+            dbtConnection: expectedProject.dbtConnection,
+            dbtVersion: expectedProject.dbtVersion,
+            warehouseConnection: {
+                type: WarehouseTypes.BIGQUERY,
+            } as CreateWarehouseCredentials,
+        });
+
+        expect(
+            tracker.history.insert.some(({ sql }) =>
+                sql.includes('warehouse_credentials'),
+            ),
+        ).toBe(true);
+        expect(invalidate).not.toHaveBeenCalled();
     });
 
     test('checks project membership without requiring an email row', async () => {

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -928,9 +928,15 @@ export class ProjectModel {
     }
 
     async update(projectUuid: string, data: UpdateProject): Promise<void> {
-        const previousConnectionString = getMotherduckConnectionString(
-            await this.getWarehouseCredentialsForProject(projectUuid),
-        );
+        let previousConnectionString: string | undefined;
+        try {
+            previousConnectionString = getMotherduckConnectionString(
+                await this.getWarehouseCredentialsForProject(projectUuid),
+            );
+        } catch (e) {
+            // Projects created without warehouse credentials have none to invalidate
+            if (!(e instanceof NotFoundError)) throw e;
+        }
         const nextConnectionString = getMotherduckConnectionString(
             data.warehouseConnection,
         );


### PR DESCRIPTION
## Problem

Projects created without warehouse credentials (dbt-free / lightdash-yml deploys, `--no-warehouse-credentials`, Spark auto-detection) could never have a connection added afterwards: `PATCH /api/v1/projects/:uuid` failed with `NotFoundError: Cannot find any warehouse credentials for project.`

`ProjectModel.update` unconditionally fetched the project's current credentials — only to snapshot the previous MotherDuck connection string for cache invalidation — and `getWarehouseCredentialsForProject` throws when no `warehouse_credentials` row exists. The request died before reaching `upsertWarehouseConnection`, which handles the first-time insert fine.

## Fix

Tolerate the missing row when snapshotting the previous connection string: a project with no stored credentials has no MotherDuck instance to invalidate, so the `NotFoundError` is swallowed and the update proceeds to the upsert. Any other error still propagates.

## Testing

- New unit test: updating a credential-less project succeeds, inserts the credentials, and performs no MotherDuck invalidation.
- Manually verified: created a dbt-free project via `lightdash deploy --create` (no credentials row), then added a BigQuery connection through the UI — previously 404ed, now saves and queries work.

Closes: PROD-10867