### PR TITLE
chore(dashboard): add dashboard custom metrics feature flag

### DIFF
--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -334,6 +334,13 @@ export enum FeatureFlags {
      * chart types from the configured chart registry. Default: off.
      */
     ChartTypeRegistry = 'chart-type-registry',
+
+    /**
+     * Custom metrics created while building a chart inside a dashboard are
+     * kept on the dashboard and offered when building later charts there.
+     * Off by default.
+     */
+    DashboardCustomMetrics = 'dashboard-custom-metrics',
 }
 
 export type FeatureFlag = {


### PR DESCRIPTION
Closes: GLITCH-723

### Description:

Adds `FeatureFlags.DashboardCustomMetrics` (`'dashboard-custom-metrics'`), off by default.

It will gate the entry points for dashboard-scoped custom metrics — the in-dashboard chart builder, registry seeding, and the per-field indicator. Nothing consumes it yet.

Deliberately **not** added to `PREVIEW_EXCLUDED_FEATURE_FLAGS`: it changes no query or compile semantics, so preview environments should pick it up automatically.

### Risk assessment:

- [ ] This is a high-risk change
