### PR TITLE
feat(backend): accept Android installations for agent run activities

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -3465,6 +3465,7 @@ export type MobilePushNotificationEvent =
               promptId: string;
               installationId: string;
               liveActivityId: string;
+              platform: 'ios' | 'android';
               environment: 'sandbox' | 'production';
           };
       })

--- a/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationReconciler.test.ts
+++ b/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationReconciler.test.ts
@@ -516,6 +516,21 @@ describe('MobilePushNotificationReconciler platform routing', () => {
         });
     });
 
+    it('sends to the installation device token, not the stored activity token', async () => {
+        const dependencies = createDependencies();
+        dependencies.notificationStore.findLiveActivity.mockResolvedValue({
+            ...androidActivity,
+            pushToken: 'a-stale-registration-token',
+        });
+        const reconciler = new MobilePushNotificationReconciler(dependencies);
+
+        await reconciler.reconcileLiveActivity(activity.liveActivityUuid);
+
+        expect(dependencies.fcmClient.sendAgentRunUpdate).toHaveBeenCalledWith(
+            expect.objectContaining({ pushToken: 'fcm-registration-token' }),
+        );
+    });
+
     it('records the platform on an android delivery', async () => {
         const dependencies = createDependencies();
         dependencies.notificationStore.findLiveActivity.mockResolvedValue(

--- a/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationService.test.ts
+++ b/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationService.test.ts
@@ -24,6 +24,8 @@ const pushToStartToken =
     'ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789';
 const validDeviceToken =
     'fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210';
+const androidRegistrationToken =
+    'fMEQ_p9nS0m:APA91bH-lightdash.mobile_registration-token';
 
 const installation = {
     mobilePushInstallationUuid: installationUuid,
@@ -219,6 +221,7 @@ describe('MobilePushNotificationService.registerLiveActivity', () => {
                 promptId: promptUuid,
                 installationId: installationUuid,
                 liveActivityId: liveActivityUuid,
+                platform: 'ios',
                 environment: 'sandbox',
             },
         });
@@ -339,6 +342,81 @@ describe('MobilePushNotificationService.registerLiveActivity', () => {
         const service = new MobilePushNotificationService(dependencies);
 
         await expect(register(service)).rejects.toBeInstanceOf(NotFoundError);
+        expect(
+            dependencies.mobilePushNotificationStore.upsertLiveActivity,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('registers an activity for an android installation', async () => {
+        const dependencies = createDependencies();
+        dependencies.mobilePushNotificationStore.findInstallation.mockResolvedValue(
+            { ...installation, platform: 'android', environment: 'production' },
+        );
+        const service = new MobilePushNotificationService(dependencies);
+
+        await register(service, { pushToken: androidRegistrationToken });
+
+        expect(
+            dependencies.mobilePushNotificationStore.upsertLiveActivity,
+        ).toHaveBeenCalledWith({
+            liveActivityUuid,
+            mobilePushInstallationUuid: installationUuid,
+            organizationUuid,
+            userUuid,
+            projectUuid,
+            agentUuid,
+            threadUuid,
+            promptUuid,
+            pushToken: androidRegistrationToken,
+        });
+        expect(dependencies.analytics.track).toHaveBeenCalledWith(
+            expect.objectContaining({
+                event: 'mobile_push.live_activity_registered',
+                properties: expect.objectContaining({ platform: 'android' }),
+            }),
+        );
+        expect(
+            dependencies.scheduler.mobilePushLiveActivity,
+        ).toHaveBeenCalledWith({
+            liveActivityUuid,
+            organizationUuid,
+            projectUuid,
+            userUuid,
+        });
+    });
+
+    it.each(['', 'has spaces', 'a'.repeat(4097)])(
+        'rejects an invalid android registration token',
+        async (pushToken) => {
+            const dependencies = createDependencies();
+            dependencies.mobilePushNotificationStore.findInstallation.mockResolvedValue(
+                {
+                    ...installation,
+                    platform: 'android',
+                    environment: 'production',
+                },
+            );
+            const service = new MobilePushNotificationService(dependencies);
+
+            await expect(
+                register(service, { pushToken }),
+            ).rejects.toBeInstanceOf(ParameterError);
+            expect(
+                dependencies.threadStore.findThreadOwnership,
+            ).not.toHaveBeenCalled();
+            expect(
+                dependencies.mobilePushNotificationStore.upsertLiveActivity,
+            ).not.toHaveBeenCalled();
+        },
+    );
+
+    it('still rejects an android registration token on an ios installation', async () => {
+        const dependencies = createDependencies();
+        const service = new MobilePushNotificationService(dependencies);
+
+        await expect(
+            register(service, { pushToken: androidRegistrationToken }),
+        ).rejects.toBeInstanceOf(ParameterError);
         expect(
             dependencies.mobilePushNotificationStore.upsertLiveActivity,
         ).not.toHaveBeenCalled();

--- a/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationService.ts
+++ b/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationService.ts
@@ -776,31 +776,35 @@ export class MobilePushNotificationService {
 
     async registerLiveActivity(args: RegisterLiveActivity): Promise<void> {
         if (!this.config.enabled) return;
-        validatePushToken(args.pushToken);
         const { organizationUuid } = args.user;
         if (organizationUuid == null) {
             throw new NotFoundError('Mobile push registration not found');
         }
 
-        const [installation, existingActivity, ownership, prompt] =
-            await Promise.all([
-                this.mobilePushNotificationStore.findInstallation(
-                    args.installationUuid,
-                ),
-                this.mobilePushNotificationStore.findLiveActivityOwner(
-                    args.liveActivityUuid,
-                ),
-                this.threadStore.findThreadOwnership({
-                    organizationUuid,
-                    threadUuid: args.threadUuid,
-                }),
-                this.threadStore.findWebAppPrompt(args.promptUuid),
-            ]);
-
+        const installation =
+            await this.mobilePushNotificationStore.findInstallation(
+                args.installationUuid,
+            );
         if (
             installation?.organizationUuid !== organizationUuid ||
-            installation.userUuid !== args.user.userUuid ||
-            installation.platform !== 'ios' ||
+            installation.userUuid !== args.user.userUuid
+        ) {
+            throw new NotFoundError('Mobile push registration not found');
+        }
+        validateDeviceToken(installation.platform, args.pushToken);
+
+        const [existingActivity, ownership, prompt] = await Promise.all([
+            this.mobilePushNotificationStore.findLiveActivityOwner(
+                args.liveActivityUuid,
+            ),
+            this.threadStore.findThreadOwnership({
+                organizationUuid,
+                threadUuid: args.threadUuid,
+            }),
+            this.threadStore.findWebAppPrompt(args.promptUuid),
+        ]);
+
+        if (
             (existingActivity !== undefined &&
                 (existingActivity.mobilePushInstallationUuid !==
                     installation.mobilePushInstallationUuid ||
@@ -847,6 +851,7 @@ export class MobilePushNotificationService {
                 promptId: args.promptUuid,
                 installationId: args.installationUuid,
                 liveActivityId: args.liveActivityUuid,
+                platform: installation.platform,
                 environment: installation.environment,
             },
         });


### PR DESCRIPTION
Follow-up to #28477.

## What breaks

An Android installation can register a device token, but it never receives a push.

`registerLiveActivity` refuses any installation whose platform is not `ios`, and it validates the push token with the APNs hex rule, which no FCM registration token passes. `upsertLiveActivity` has no other caller. No activity row can exist for an Android installation, so the FCM route added in #28477 is unreachable.

## What changes

`registerLiveActivity` accepts an Android installation. It validates the push token against the platform of the installation: hex for iOS, the FCM registration token character set for Android. For Android the push token is the FCM registration token.

The installation lookup now runs before the token check, because the platform decides which token rule applies. Its two ownership checks move ahead of the other three lookups and throw the same `NotFoundError` as before. Every other ownership check is unchanged, in the same order, with the same error.

The `mobile_push.live_activity_registered` event now carries the platform, so registrations can be split by platform. The other two mobile push events already carry it.

Live Activity push-to-start stays iOS only. It is an APNs concept and this change does not touch it.

## Which token the reconciler sends to

The Android send path reads the device token from the installation, not the token stored on the activity row. The installation row is rewritten on every re-registration, so it is the fresher of the two. A test pins this: an activity holding a stale token still delivers to the installation token.

The activity token still matters for Android. `upsertLiveActivity` deletes any other activity holding the same token fingerprint, so one device follows one run at a time and a new registration replaces the previous one.

## iOS unchanged

An iOS registration takes the same path, stores the same row and emits the same events. An FCM-shaped token on an iOS installation is still rejected. The reconciler test that asserts an iOS activity never reaches the FCM client still passes.

## Verification

```
pnpm -F backend exec vitest run src/ee/services/MobilePushNotificationService \
  src/ee/models/MobilePushNotificationModel.test.ts \
  src/ee/controllers/mobilePushNotificationController.test.ts \
  src/clients/Fcm src/clients/Apns src/config/parseConfig.test.ts \
  src/ee/database/migrations/__tests__            11 files, 355 passed
pnpm -F backend typecheck                         clean
pnpm -F common typecheck                          clean
pnpm --filter backend run linter <touched paths>  clean
```

New tests: an Android installation registers an activity and schedules it; an invalid Android registration token is rejected before the ownership lookups; an FCM-shaped token on an iOS installation is still rejected; the Android send path uses the installation device token.

`pnpm generate-api` reports no change from this diff. The generated files on `main` are behind #28477 and the release workflow regenerates them.

Linear: SPK-1770

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011j8Jti2ysa1f7vtCzDNsP8
