### PR TITLE
feat: translate embedded parameter labels

### DIFF
--- a/packages/common/src/utils/i18n/types.ts
+++ b/packages/common/src/utils/i18n/types.ts
@@ -1,6 +1,14 @@
 import { type ChartAsCodeLanguageMap } from './chartAsCode';
 import { type DashboardAsCodeLanguageMap } from './dashboardAsCode';
 
+export type ParameterLanguageMap = {
+    [parameterName: string]: {
+        label: string;
+    };
+};
+
 export type LanguageMap = Partial<
     ChartAsCodeLanguageMap & DashboardAsCodeLanguageMap
->;
+> & {
+    parameters?: ParameterLanguageMap;
+};

--- a/packages/common/src/utils/i18n/uiStrings.ts
+++ b/packages/common/src/utils/i18n/uiStrings.ts
@@ -39,6 +39,7 @@ export const DEFAULT_UI_STRINGS = {
     'filters.summary.filterPlural': 'filters',
     'filters.summary.parameterSingular': 'parameter',
     'filters.summary.parameterPlural': 'parameters',
+    'parameters.is': 'is',
     'filters.summary.dateZoomLabel': 'Date Zoom:',
     'filters.summary.default': 'Default',
     'filters.summary.showFilters': 'Show filters',

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardParameters.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardParameters.tsx
@@ -6,6 +6,7 @@ import FilterGroupSeparator from '../../../../../features/dashboardFilters/Filte
 import { Parameters } from '../../../../../features/parameters';
 import useDashboardContext from '../../../../../providers/Dashboard/useDashboardContext';
 import useDashboardTileStatusContext from '../../../../../providers/Dashboard/useDashboardTileStatusContext';
+import { useUiStrings } from '../../../../providers/Embed/useUiStrings';
 import { embedContractClass } from '../../styles/embedClassContract';
 
 const parametersSeparator: ReactNode = (
@@ -31,6 +32,7 @@ type Props = {
 };
 
 const EmbedDashboardParameters: FC<Props> = ({ parameters }) => {
+    const getUiString = useUiStrings();
     const parameterValues = useDashboardContext((c) => c.parameterValues);
     const handleParameterChange = useDashboardContext((c) => c.setParameter);
     const clearAllParameters = useDashboardContext((c) => c.clearAllParameters);
@@ -60,6 +62,7 @@ const EmbedDashboardParameters: FC<Props> = ({ parameters }) => {
                     'ld-dashboard-parameter-dropdown',
                 )}
                 separator={parametersSeparator}
+                getUiString={getUiString}
             />
         </Group>
     );

--- a/packages/frontend/src/ee/pages/EmbedDashboard.tsx
+++ b/packages/frontend/src/ee/pages/EmbedDashboard.tsx
@@ -15,7 +15,11 @@ const EmbedDashboardPage: FC<{
 }> = ({ containerStyles, initialDashboard, isEditMode, onEditModeChange }) => {
     const projectUuidFromParams = useProjectUuid();
 
-    const { embedToken, projectUuid: projectUuidFromEmbed } = useEmbed();
+    const {
+        embedToken,
+        languageMap,
+        projectUuid: projectUuidFromEmbed,
+    } = useEmbed();
 
     const projectUuid = projectUuidFromEmbed ?? projectUuidFromParams;
 
@@ -31,7 +35,11 @@ const EmbedDashboardPage: FC<{
     }
 
     return (
-        <DashboardProvider embedToken={embedToken} projectUuid={projectUuid}>
+        <DashboardProvider
+            embedToken={embedToken}
+            projectUuid={projectUuid}
+            parameterLabelOverrides={languageMap?.parameters}
+        >
             <EmbedDashboard
                 containerStyles={containerStyles}
                 initialDashboard={initialDashboard}

--- a/packages/frontend/src/features/parameters/components/Parameter.test.tsx
+++ b/packages/frontend/src/features/parameters/components/Parameter.test.tsx
@@ -1,0 +1,28 @@
+import { DEFAULT_UI_STRINGS } from '@lightdash/common';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import Parameter from './Parameter';
+
+describe('Parameter', () => {
+    it('uses the supplied UI string between the label and value', () => {
+        const { getByRole } = renderWithProviders(
+            <Parameter
+                paramKey="metric_type"
+                parameter={{ label: 'Metric Type', default: 'count' }}
+                value={null}
+                parameterValues={{}}
+                openPopoverId={undefined}
+                onPopoverOpen={vi.fn()}
+                onPopoverClose={vi.fn()}
+                onParameterChange={vi.fn()}
+                getUiString={(key) =>
+                    key === 'parameters.is' ? 'es' : DEFAULT_UI_STRINGS[key]
+                }
+            />,
+        );
+
+        expect(
+            getByRole('button', { name: 'Metric Type es count' }),
+        ).toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/features/parameters/components/Parameter.tsx
+++ b/packages/frontend/src/features/parameters/components/Parameter.tsx
@@ -1,10 +1,12 @@
 import {
+    DEFAULT_UI_STRINGS,
     formatDate,
     parseDate,
     TimeFrames,
     type LightdashProjectParameter,
     type ParametersValuesMap,
     type ParameterValue,
+    type UiStringResolver,
 } from '@lightdash/common';
 import {
     ActionIcon,
@@ -39,6 +41,7 @@ type Props = {
     triggerClassName?: string;
     dropdownClassName?: string;
     shadowedReservedNames?: string[];
+    getUiString?: UiStringResolver;
 };
 
 const Parameter: FC<Props> = ({
@@ -56,11 +59,15 @@ const Parameter: FC<Props> = ({
     triggerClassName,
     dropdownClassName,
     shadowedReservedNames = [],
+    getUiString,
 }) => {
     const popoverId = useId();
     const isPopoverOpen = openPopoverId === popoverId;
 
     const displayLabel = parameter.label || paramKey;
+    const isLabel = getUiString
+        ? getUiString('parameters.is')
+        : DEFAULT_UI_STRINGS['parameters.is'];
 
     const displayValue = useMemo(() => {
         if (value === null || value === undefined || value === '') {
@@ -190,8 +197,7 @@ const Parameter: FC<Props> = ({
                                     {displayLabel}
                                 </Text>
                                 <Text span c="gray.6">
-                                    {' '}
-                                    is{' '}
+                                    {` ${isLabel} `}
                                 </Text>
                                 <Text span>{displayValue}</Text>
                             </Text>

--- a/packages/frontend/src/features/parameters/components/Parameters.tsx
+++ b/packages/frontend/src/features/parameters/components/Parameters.tsx
@@ -4,6 +4,7 @@ import {
     type ParameterDefinitions,
     type ParametersValuesMap,
     type ParameterValue,
+    type UiStringResolver,
 } from '@lightdash/common';
 import { Group, Skeleton } from '@mantine/core';
 import { useCallback, useMemo, useState, type FC, type ReactNode } from 'react';
@@ -33,6 +34,7 @@ type Props = {
     triggerClassName?: string;
     dropdownClassName?: string;
     shadowedReservedNames?: string[];
+    getUiString?: UiStringResolver;
 };
 
 export const Parameters: FC<Props> = ({
@@ -48,6 +50,7 @@ export const Parameters: FC<Props> = ({
     triggerClassName,
     dropdownClassName,
     shadowedReservedNames = [],
+    getUiString,
 }) => {
     const projectUuid = useProjectUuid();
     const [openPopoverId, setOpenPopoverId] = useState<string | undefined>();
@@ -150,6 +153,7 @@ export const Parameters: FC<Props> = ({
                                 isEditMode={isEditMode}
                                 isDraggable={isEditMode}
                                 shadowedReservedNames={shadowedReservedNames}
+                                getUiString={getUiString}
                             />
                         </DraggableItem>
                     </DroppableArea>

--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -27,6 +27,7 @@ import {
     type DateZoomConfig,
     type FilterableDimension,
     type InteractivityOptions,
+    type LanguageMap,
     type Metric,
     type ParameterDefinitions,
     type ParametersValuesMap,
@@ -80,6 +81,7 @@ import {
 } from './dashboardParametersUrl';
 import DashboardTileStatusProvider from './DashboardTileStatusProvider';
 import { getActiveTabForTabs } from './getActiveTabForTabs';
+import { applyParameterLabelOverrides } from './parameterLabelOverrides';
 import useDashboardContext from './useDashboardContext';
 import useDashboardTileStatusContext from './useDashboardTileStatusContext';
 
@@ -100,6 +102,7 @@ type DashboardProviderProps = React.PropsWithChildren<{
     dashboardCommentsCheck?: ReturnType<typeof useDashboardCommentsCheck>;
     defaultInvalidateCache?: boolean;
     sdkFilters?: SdkFilter[];
+    parameterLabelOverrides?: LanguageMap['parameters'];
     // Interactive dashboard page only. The /minimal render used for exports
     // and scheduled deliveries must leave this off so a viewer's unpublished
     // draft never reaches a delivered image, PDF or spreadsheet.
@@ -117,6 +120,7 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
     dashboardCommentsCheck,
     defaultInvalidateCache,
     includeUnpublishedDraft = false,
+    parameterLabelOverrides,
     children,
 }) => {
     const { search, pathname } = useLocation();
@@ -293,6 +297,15 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
 
     const [parameterDefinitions, setParameterDefinitions] =
         useState<ParameterDefinitions>({});
+
+    const translatedParameterDefinitions = useMemo(
+        () =>
+            applyParameterLabelOverrides(
+                parameterDefinitions,
+                parameterLabelOverrides,
+            ),
+        [parameterDefinitions, parameterLabelOverrides],
+    );
 
     const addParameterDefinitions = useCallback(
         (parameters: ParameterDefinitions) => {
@@ -763,9 +776,13 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         return getMissingRequiredParameters(
             Array.from(dashboardParameterReferences),
             dashboardParameterValues,
-            parameterDefinitions,
+            translatedParameterDefinitions,
         );
-    }, [dashboardParameterReferences, parameters, parameterDefinitions]);
+    }, [
+        dashboardParameterReferences,
+        parameters,
+        translatedParameterDefinitions,
+    ]);
 
     const [tilesWithDateZoomApplied, setTilesWithDateZoomApplied] =
         useState<Set<string>>();
@@ -1867,7 +1884,7 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         parameterValues,
         selectedParametersCount,
         setParameter,
-        parameterDefinitions,
+        parameterDefinitions: translatedParameterDefinitions,
         clearAllParameters,
         dashboardParameterReferences,
         addParameterReferences,

--- a/packages/frontend/src/providers/Dashboard/parameterLabelOverrides.test.ts
+++ b/packages/frontend/src/providers/Dashboard/parameterLabelOverrides.test.ts
@@ -1,0 +1,68 @@
+import { type ParameterDefinitions } from '@lightdash/common';
+import { applyParameterLabelOverrides } from './parameterLabelOverrides';
+
+const parameterDefinitions: ParameterDefinitions = {
+    order_region: {
+        label: 'Order region',
+        description: 'Region where the order was placed',
+        default: 'EU',
+        options: ['EU', 'US'],
+    },
+    min_order_total: {
+        label: 'Minimum order total',
+        type: 'number',
+        allow_custom_values: true,
+    },
+};
+
+describe('applyParameterLabelOverrides', () => {
+    it('translates labels by parameter name and leaves other fields untouched', () => {
+        const result = applyParameterLabelOverrides(parameterDefinitions, {
+            order_region: { label: 'Región del pedido' },
+            min_order_total: { label: 'Pedido mínimo' },
+        });
+
+        expect(result.order_region).toEqual({
+            ...parameterDefinitions.order_region,
+            label: 'Región del pedido',
+        });
+        expect(result.min_order_total).toEqual({
+            ...parameterDefinitions.min_order_total,
+            label: 'Pedido mínimo',
+        });
+        expect(parameterDefinitions.order_region.label).toBe('Order region');
+    });
+
+    it('ignores overrides for parameters that are not defined', () => {
+        const result = applyParameterLabelOverrides(parameterDefinitions, {
+            another_parameter: { label: 'Otro parámetro' },
+        });
+
+        expect(result).toBe(parameterDefinitions);
+    });
+
+    it('returns definitions unchanged when there are no overrides', () => {
+        expect(
+            applyParameterLabelOverrides(parameterDefinitions, undefined),
+        ).toBe(parameterDefinitions);
+    });
+
+    it('ignores empty-string labels', () => {
+        const result = applyParameterLabelOverrides(parameterDefinitions, {
+            order_region: { label: '' },
+        });
+
+        expect(result).toBe(parameterDefinitions);
+    });
+
+    it('only applies string labels from SDK input', () => {
+        const result = applyParameterLabelOverrides(parameterDefinitions, {
+            order_region: {
+                // A host can pass untyped contentOverrides at runtime.
+                label: 42 as unknown as string,
+            },
+        });
+
+        expect(result).toBe(parameterDefinitions);
+    });
+});

--- a/packages/frontend/src/providers/Dashboard/parameterLabelOverrides.ts
+++ b/packages/frontend/src/providers/Dashboard/parameterLabelOverrides.ts
@@ -1,0 +1,32 @@
+import { type LanguageMap, type ParameterDefinitions } from '@lightdash/common';
+
+export type ParameterLabelOverrides = LanguageMap['parameters'];
+
+export const applyParameterLabelOverrides = (
+    parameterDefinitions: ParameterDefinitions,
+    overrides: ParameterLabelOverrides,
+): ParameterDefinitions => {
+    if (!overrides) return parameterDefinitions;
+
+    let translatedDefinitions: ParameterDefinitions | undefined;
+
+    Object.entries(parameterDefinitions).forEach(([name, definition]) => {
+        const override = overrides[name];
+        const translatedLabel =
+            override && typeof override.label === 'string'
+                ? override.label
+                : undefined;
+
+        if (!translatedLabel || translatedLabel === definition.label) {
+            return;
+        }
+
+        translatedDefinitions ??= { ...parameterDefinitions };
+        translatedDefinitions[name] = {
+            ...definition,
+            label: translatedLabel,
+        };
+    });
+
+    return translatedDefinitions ?? parameterDefinitions;
+};

--- a/packages/sdk-test-app/generate-embed-token.ts
+++ b/packages/sdk-test-app/generate-embed-token.ts
@@ -209,6 +209,9 @@ async function main() {
                     // map filter labels) can be exercised in the test app
                     hidden: false,
                 },
+                parameterInteractivity: {
+                    enabled: true,
+                },
                 canExportCsv: false,
                 canExportImages: false,
                 isPreview: false,

--- a/packages/sdk-test-app/public/locales/en/translation.json
+++ b/packages/sdk-test-app/public/locales/en/translation.json
@@ -1,4 +1,9 @@
 {
+    "parameters": {
+        "metric_type": {
+            "label": "Metric Type"
+        }
+    },
     "dashboard": {
         "jaffle-dashboard": {
             "name": "Jaffle dashboard",
@@ -81,5 +86,7 @@
             ]
         }
     },
-    "uiOverrides": {}
+    "uiOverrides": {
+        "parameters.is": "is"
+    }
 }

--- a/packages/sdk-test-app/public/locales/es/translation.json
+++ b/packages/sdk-test-app/public/locales/es/translation.json
@@ -1,4 +1,9 @@
 {
+    "parameters": {
+        "metric_type": {
+            "label": "Tipo de métrica"
+        }
+    },
     "dashboard": {
         "jaffle-dashboard": {
             "name": "Tablero de Jaffle",
@@ -82,6 +87,7 @@
         }
     },
     "uiOverrides": {
+        "parameters.is": "es",
         "tileMenu.exploreFromHere": "Explorar desde aquí",
         "tileMenu.downloadData": "Descargar datos",
         "tileMenu.exportImage": "Exportar imagen",

--- a/packages/sdk-test-app/public/locales/ka/translation.json
+++ b/packages/sdk-test-app/public/locales/ka/translation.json
@@ -1,4 +1,9 @@
 {
+    "parameters": {
+        "metric_type": {
+            "label": "მეტრიკის ტიპი"
+        }
+    },
     "dashboard": {
         "jaffle-dashboard": {
             "name": "Jaffle-ის დაფა",
@@ -82,6 +87,7 @@
         }
     },
     "uiOverrides": {
+        "parameters.is": "არის",
         "tileMenu.exploreFromHere": "გამოიკვლიეთ აქედან",
         "tileMenu.downloadData": "მონაცემების ჩამოტვირთვა",
         "tileMenu.exportImage": "სურათის ექსპორტი",


### PR DESCRIPTION
Closes: PROD-10860

### Description:

- Adds parameter label overrides to the SDK contentOverrides language map, keyed by parameter name.
- Applies translated labels when dashboard parameter definitions are resolved, covering parameter pills, popovers, pinned controls, and required-parameter UI.
- Adds parameters.is to SDK uiOverrides so the separator between a parameter label and value is translatable.
- Updates the SDK i18n example and token fixture with a parameter-referencing chart flow.
- Keeps v1 label-only: descriptions and option labels are unchanged.

### Verification:

- Focused frontend tests: 6 passed.
- Common UI-string tests: 7 passed.
- Frontend and common typechecks passed.
- Common build and SDK test-app build passed.
- Touched-file lint and formatting passed.
- Browser verified English: Metric Type is count.
- Browser verified Spanish: Tipo de métrica es count.
- Browser verified Georgian: მეტრიკის ტიპი არის count.

### Risk assessment:

- [ ] This is a high-risk change

Low risk: the new SDK overrides are optional, additive, and fall back to existing English labels.