### PR TITLE
fix(backend): keep mobile push installations with their owner

### DIFF
--- a/packages/backend/src/ee/models/MobilePushNotificationModel.test.ts
+++ b/packages/backend/src/ee/models/MobilePushNotificationModel.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto';
 import knex, { type Knex } from 'knex';
 import { getTracker, MockClient, type Tracker } from 'knex-mock-client';
 import { EncryptionUtil } from '../../utils/EncryptionUtil/EncryptionUtil';
@@ -13,6 +14,9 @@ const encryptionUtil = {
     decrypt: (value: Buffer): string =>
         value.toString('utf8').replace(/^encrypted:/, ''),
 } as unknown as EncryptionUtil;
+
+const fingerprintOf = (token: string): string =>
+    createHash('sha256').update(token).digest('hex');
 
 const database = knex({ client: MockClient, dialect: 'pg' });
 const model = new MobilePushNotificationModel({
@@ -85,6 +89,7 @@ describe('MobilePushNotificationModel', () => {
                 organization_uuid: 'old-organization-uuid',
                 user_uuid: 'old-user-uuid',
                 environment: 'sandbox',
+                device_token_fingerprint: fingerprintOf('new-device-token'),
             },
         ]);
         tracker.on.delete(AiAgentLiveActivitiesTableName).responseOnce([]);
@@ -126,6 +131,141 @@ describe('MobilePushNotificationModel', () => {
         expect(insert?.bindings.filter((value) => value === null)).toHaveLength(
             2,
         );
+    });
+
+    it('refuses to reassign an installation to a caller with a different device token', async () => {
+        tracker.on.any(/pg_advisory_xact_lock/).responseOnce([]);
+        tracker.on.select(MobilePushInstallationsTableName).responseOnce([
+            {
+                mobile_push_installation_uuid: 'stored-installation-uuid',
+                organization_uuid: 'owner-organization-uuid',
+                user_uuid: 'owner-user-uuid',
+                platform: 'ios',
+                environment: 'sandbox',
+                device_token_fingerprint: fingerprintOf('owner-device-token'),
+            },
+        ]);
+
+        await expect(
+            model.upsertInstallation({
+                installationUuid: 'installation-uuid',
+                organizationUuid: 'other-organization-uuid',
+                userUuid: 'other-user-uuid',
+                platform: 'ios',
+                environment: 'sandbox',
+                deviceToken: 'guessed-device-token',
+            }),
+        ).resolves.toEqual({ status: 'owner_mismatch' });
+
+        expect(tracker.history.delete).toHaveLength(0);
+        expect(tracker.history.insert).toHaveLength(0);
+        expect(tracker.history.update).toHaveLength(0);
+    });
+
+    it('reassigns an installation when the caller sends the stored device token', async () => {
+        tracker.on.any(/pg_advisory_xact_lock/).responseOnce([]);
+        tracker.on.select(MobilePushInstallationsTableName).responseOnce([
+            {
+                mobile_push_installation_uuid: 'stored-installation-uuid',
+                organization_uuid: 'owner-organization-uuid',
+                user_uuid: 'owner-user-uuid',
+                platform: 'ios',
+                environment: 'sandbox',
+                device_token_fingerprint: fingerprintOf('owner-device-token'),
+            },
+        ]);
+        tracker.on.delete(AiAgentLiveActivitiesTableName).responseOnce([]);
+        tracker.on
+            .delete(AiAgentLiveActivityStartAttemptsTableName)
+            .responseOnce([]);
+        tracker.on.delete(MobilePushInstallationsTableName).responseOnce([]);
+        tracker.on.insert(MobilePushInstallationsTableName).responseOnce([
+            {
+                mobile_push_installation_uuid: 'stored-installation-uuid',
+                installation_uuid: 'installation-uuid',
+                organization_uuid: 'next-organization-uuid',
+                user_uuid: 'next-user-uuid',
+                platform: 'ios',
+                environment: 'sandbox',
+            },
+        ]);
+
+        await expect(
+            model.upsertInstallation({
+                installationUuid: 'installation-uuid',
+                organizationUuid: 'next-organization-uuid',
+                userUuid: 'next-user-uuid',
+                platform: 'ios',
+                environment: 'sandbox',
+                deviceToken: 'owner-device-token',
+            }),
+        ).resolves.toEqual({
+            status: 'stored',
+            installation: {
+                mobilePushInstallationUuid: 'stored-installation-uuid',
+                installationUuid: 'installation-uuid',
+                organizationUuid: 'next-organization-uuid',
+                userUuid: 'next-user-uuid',
+                platform: 'ios',
+                environment: 'sandbox',
+            },
+        });
+
+        expect(
+            tracker.history.delete.some((query) =>
+                query.sql.includes(AiAgentLiveActivitiesTableName),
+            ),
+        ).toBe(true);
+        expect(
+            tracker.history.delete.some((query) =>
+                query.sql.includes(AiAgentLiveActivityStartAttemptsTableName),
+            ),
+        ).toBe(true);
+    });
+
+    it('rotates a device token for the same owner', async () => {
+        tracker.on.any(/pg_advisory_xact_lock/).responseOnce([]);
+        tracker.on.select(MobilePushInstallationsTableName).responseOnce([
+            {
+                mobile_push_installation_uuid: 'stored-installation-uuid',
+                organization_uuid: 'organization-uuid',
+                user_uuid: 'user-uuid',
+                platform: 'ios',
+                environment: 'sandbox',
+                device_token_fingerprint: fingerprintOf('previous-token'),
+            },
+        ]);
+        tracker.on.delete(MobilePushInstallationsTableName).responseOnce([]);
+        tracker.on.insert(MobilePushInstallationsTableName).responseOnce([
+            {
+                mobile_push_installation_uuid: 'stored-installation-uuid',
+                installation_uuid: 'installation-uuid',
+                organization_uuid: 'organization-uuid',
+                user_uuid: 'user-uuid',
+                platform: 'ios',
+                environment: 'sandbox',
+            },
+        ]);
+
+        const result = await model.upsertInstallation({
+            installationUuid: 'installation-uuid',
+            organizationUuid: 'organization-uuid',
+            userUuid: 'user-uuid',
+            platform: 'ios',
+            environment: 'sandbox',
+            deviceToken: 'rotated-token',
+        });
+
+        expect(result.status).toBe('stored');
+        expect(
+            tracker.history.delete.some((query) =>
+                query.sql.includes(AiAgentLiveActivitiesTableName),
+            ),
+        ).toBe(false);
+        const insert = tracker.history.insert.find((query) =>
+            query.sql.includes(MobilePushInstallationsTableName),
+        );
+        expect(insert?.bindings).toContain(fingerprintOf('rotated-token'));
     });
 
     it('clears push-to-start state when the installation environment changes', async () => {

--- a/packages/backend/src/ee/models/MobilePushNotificationModel.ts
+++ b/packages/backend/src/ee/models/MobilePushNotificationModel.ts
@@ -29,6 +29,10 @@ export type MobilePushInstallation = {
     environment: MobilePushEnvironment;
 };
 
+export type UpsertInstallationResult =
+    | { status: 'stored'; installation: MobilePushInstallation }
+    | { status: 'owner_mismatch' };
+
 export type AiAgentLiveActivity = {
     liveActivityUuid: string;
     mobilePushInstallationUuid: string;
@@ -110,7 +114,7 @@ export class MobilePushNotificationModel {
         platform: MobilePushPlatform;
         environment: MobilePushEnvironment;
         deviceToken: string;
-    }): Promise<MobilePushInstallation> {
+    }): Promise<UpsertInstallationResult> {
         const fingerprint = tokenFingerprint(args.deviceToken);
         const encryptedDeviceToken = this.encryptionUtil.encrypt(
             args.deviceToken,
@@ -130,6 +134,7 @@ export class MobilePushNotificationModel {
                     'user_uuid',
                     'platform',
                     'environment',
+                    'device_token_fingerprint',
                 )
                 .where('installation_uuid', args.installationUuid)
                 .forUpdate()
@@ -139,6 +144,14 @@ export class MobilePushNotificationModel {
                 existing !== undefined &&
                 (existing.organization_uuid !== args.organizationUuid ||
                     existing.user_uuid !== args.userUuid);
+
+            if (
+                ownershipChanged &&
+                existing.device_token_fingerprint !== fingerprint
+            ) {
+                return { status: 'owner_mismatch' };
+            }
+
             const environmentChanged =
                 existing !== undefined &&
                 (existing.environment !== args.environment ||
@@ -215,12 +228,16 @@ export class MobilePushNotificationModel {
                 ]);
 
             return {
-                mobilePushInstallationUuid: row.mobile_push_installation_uuid,
-                installationUuid: row.installation_uuid,
-                organizationUuid: row.organization_uuid,
-                userUuid: row.user_uuid,
-                platform: row.platform,
-                environment: row.environment,
+                status: 'stored',
+                installation: {
+                    mobilePushInstallationUuid:
+                        row.mobile_push_installation_uuid,
+                    installationUuid: row.installation_uuid,
+                    organizationUuid: row.organization_uuid,
+                    userUuid: row.user_uuid,
+                    platform: row.platform,
+                    environment: row.environment,
+                },
             };
         });
     }

--- a/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationService.test.ts
+++ b/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationService.test.ts
@@ -84,7 +84,9 @@ const createDependencies = () => {
         findLiveActivityOwner: vi.fn<
             MobilePushNotificationStore['findLiveActivityOwner']
         >(async () => undefined),
-        upsertInstallation: vi.fn(async () => installation),
+        upsertInstallation: vi.fn<
+            MobilePushNotificationStore['upsertInstallation']
+        >(async () => ({ status: 'stored', installation })),
         registerPushToStartToken: vi.fn<
             MobilePushNotificationStore['registerPushToStartToken']
         >(async () => true),
@@ -1222,6 +1224,25 @@ describe('MobilePushNotificationService installation lifecycle', () => {
         expect(
             JSON.stringify(dependencies.analytics.track.mock.calls),
         ).not.toContain(validDeviceToken);
+    });
+
+    it('reports a refused reassignment as not found', async () => {
+        const dependencies = createDependencies();
+        dependencies.mobilePushNotificationStore.upsertInstallation.mockResolvedValue(
+            { status: 'owner_mismatch' },
+        );
+        const service = new MobilePushNotificationService(dependencies);
+
+        await expect(
+            service.registerInstallation({
+                user: { userUuid, organizationUuid },
+                installationUuid,
+                platform: 'ios',
+                environment: 'sandbox',
+                deviceToken: validDeviceToken,
+            }),
+        ).rejects.toBeInstanceOf(NotFoundError);
+        expect(dependencies.analytics.track).not.toHaveBeenCalled();
     });
 
     it('rejects an android registration when FCM is not configured', async () => {

--- a/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationService.ts
+++ b/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationService.ts
@@ -38,6 +38,10 @@ type MobilePushInstallation = {
     environment: MobilePushEnvironment;
 };
 
+type UpsertInstallationResult =
+    | { status: 'stored'; installation: MobilePushInstallation }
+    | { status: 'owner_mismatch' };
+
 type MobilePushThreadOwnership = {
     threadUuid: string;
     projectUuid: string;
@@ -92,7 +96,7 @@ export type MobilePushNotificationStore = {
         platform: MobilePushPlatform;
         environment: MobilePushEnvironment;
         deviceToken: string;
-    }): Promise<MobilePushInstallation>;
+    }): Promise<UpsertInstallationResult>;
     registerPushToStartToken(args: {
         installationUuid: string;
         organizationUuid: string;
@@ -422,14 +426,18 @@ export class MobilePushNotificationService {
             throw new NotFoundError('Mobile push registration not found');
         }
 
-        await this.mobilePushNotificationStore.upsertInstallation({
-            installationUuid: args.installationUuid,
-            organizationUuid,
-            userUuid: args.user.userUuid,
-            platform: args.platform,
-            environment: args.environment,
-            deviceToken: args.deviceToken,
-        });
+        const result =
+            await this.mobilePushNotificationStore.upsertInstallation({
+                installationUuid: args.installationUuid,
+                organizationUuid,
+                userUuid: args.user.userUuid,
+                platform: args.platform,
+                environment: args.environment,
+                deviceToken: args.deviceToken,
+            });
+        if (result.status === 'owner_mismatch') {
+            throw new NotFoundError('Mobile push registration not found');
+        }
         this.track({
             event: 'mobile_push.installation_registered',
             userId: args.user.userUuid,


### PR DESCRIPTION
## What changes

An installation row in `mobile_push_installations` records which account a device belongs to. Registering an installation UUID that already exists moved the row to the caller. It also deleted the previous owner's live activities and start attempts, and cleared the push-to-start token. The caller needed only the UUID.

Installation registration now checks the existing owner before reassigning a row. When the owner differs, the caller must send the device token the row already holds.

## How the check works

`upsertInstallation` already reads the existing row under an advisory lock with `SELECT ... FOR UPDATE`. It now also reads the stored device token fingerprint and compares it with the fingerprint of the incoming token. A mismatch returns `owner_mismatch` before any delete or insert runs, so the row, its live activities and its start attempts stay as they were.

The comparison happens inside the transaction that performs the write, so a concurrent registration cannot land between the read and the upsert.

`registerInstallation` maps `owner_mismatch` to `NotFoundError('Mobile push registration not found')`. That is the same error and the same message the other guards on this route already use, so the response says nothing about whether the row exists. A refused call emits no registration event.

## The two working paths are unchanged

The same owner rotating a device token still stores it, and still keeps its live activities.

The same device signing in as another account still transfers the row, because the app re-registers with the same installation UUID and the same device token. That path also still clears the previous account's live activities, start attempts and push-to-start token, exactly as before.

## Verification

```
pnpm -F backend exec vitest run src/ee/services/MobilePushNotificationService \
  src/ee/models/MobilePushNotificationModel.test.ts \
  src/ee/controllers/mobilePushNotificationController.test.ts \
  src/clients/Fcm src/clients/Apns src/ee/database/migrations/__tests__ \
  src/config/parseConfig.test.ts                  11 files, 359 passed
pnpm -F backend typecheck                         clean
pnpm -F common typecheck                          clean
pnpm --filter backend run linter <touched paths>  clean
```

New tests cover a reassignment with a different device token, a reassignment with the stored device token, a token rotation by the same owner, and the not-found result the service returns.

No migration. No API change.

Linear: SPK-1725

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011j8Jti2ysa1f7vtCzDNsP8
