### PR TITLE
fix(auth): designed error when SSO login collides with an existing pending account

### DIFF
--- a/packages/backend/src/controllers/authentication/strategies/googleStrategy.test.ts
+++ b/packages/backend/src/controllers/authentication/strategies/googleStrategy.test.ts
@@ -89,6 +89,36 @@ describe('googleStrategyVerify', () => {
         expect(done).toHaveBeenCalledWith(null, user);
     });
 
+    it('rejects a Google profile whose email is not verified before logging in', async () => {
+        const userService = createUserService();
+        const done = vi.fn<VerifyCallback>();
+        const req = {
+            ip: '127.0.0.1',
+            get: vi.fn(() => 'test-agent'),
+            session: { oauth: {} },
+            services: { getUserService: () => userService },
+        } as unknown as Express.Request;
+        const unverifiedProfile = {
+            ...profile,
+            emails: [{ value: 'shared@example.com', verified: false }],
+        } as unknown as Profile;
+
+        await googleStrategyVerify(
+            req,
+            'access-token',
+            'refresh-token',
+            params,
+            unverifiedProfile,
+            done,
+        );
+
+        expect(userService.loginWithOpenId).not.toHaveBeenCalled();
+        expect(done).toHaveBeenCalledWith(null, undefined, {
+            message:
+                'Authentication failed: email is not verified in Google profile.',
+        });
+    });
+
     it('stores the grant separately after a login flow', async () => {
         const userService = createUserService();
         const done = vi.fn<VerifyCallback>();

--- a/packages/backend/src/controllers/authentication/strategies/googleStrategy.ts
+++ b/packages/backend/src/controllers/authentication/strategies/googleStrategy.ts
@@ -17,6 +17,14 @@ import { URL } from 'url';
 import { lightdashConfig } from '../../../config/lightdashConfig';
 import Logger from '../../../logging/logger';
 
+// The typings declare the claim as 'true' | 'false' but Google's userinfo sends a boolean
+const parseEmailVerifiedClaim = (claim: unknown): boolean | undefined => {
+    if (typeof claim === 'boolean') return claim;
+    if (claim === 'true') return true;
+    if (claim === 'false') return false;
+    return undefined;
+};
+
 export const googleStrategyVerify = async (
     req: Express.Request,
     _accessToken: string,
@@ -28,11 +36,22 @@ export const googleStrategyVerify = async (
     try {
         const issuer = 'https://accounts.google.com';
         const { inviteCode, intent } = req.session.oauth || {};
-        const [{ value: email }] = profile.emails || [];
+        const [{ value: email, verified: emailVerifiedClaim }] =
+            profile.emails || [];
         const { id: subject } = profile;
         if (!(email && subject)) {
             return done(null, undefined, {
                 message: 'Could not parse authentication token',
+            });
+        }
+
+        if (parseEmailVerifiedClaim(emailVerifiedClaim) === false) {
+            Logger.warn(
+                `Authentication failed: email ${email} is not verified in Google profile.`,
+            );
+            return done(null, undefined, {
+                message:
+                    'Authentication failed: email is not verified in Google profile.',
             });
         }
 

--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -102,7 +102,9 @@ const userModel = {
     createPendingUser: vi.fn<UserModel['createPendingUser']>(
         async () => newUser,
     ),
-    findSessionUserByPrimaryEmail: vi.fn(async () => sessionUser),
+    findSessionUserByPrimaryEmail: vi.fn<
+        UserModel['findSessionUserByPrimaryEmail']
+    >(async () => sessionUser),
     findSessionUserByPersonalAccessToken: vi.fn<
         UserModel['findSessionUserByPersonalAccessToken']
     >(async () => undefined),
@@ -3537,6 +3539,9 @@ describe('UserService', () => {
             );
         });
         test('should create user', async () => {
+            userModel.findSessionUserByPrimaryEmail.mockResolvedValueOnce(
+                undefined,
+            );
             await userService.loginWithOpenId(openIdUser, undefined, undefined);
             expect(
                 openIdIdentityModel.updateIdentityByOpenId as import('vitest').Mock,
@@ -3703,6 +3708,85 @@ describe('UserService', () => {
             expect(
                 userModel.createUser as import('vitest').Mock,
             ).toHaveBeenCalledTimes(0);
+        });
+        describe('when an account with the same email already exists and is not linked', () => {
+            const unverifiedEmail = {
+                email: openIdUser.openId.email,
+                isVerified: false,
+            };
+
+            test('tells a pending user to activate with a one-time code or an invite', async () => {
+                emailModel.getPrimaryEmailStatus.mockResolvedValueOnce(
+                    unverifiedEmail,
+                );
+
+                await expect(
+                    userService.loginWithOpenId(
+                        openIdUser,
+                        undefined,
+                        undefined,
+                    ),
+                ).rejects.toThrowError(
+                    new ForbiddenError(
+                        'An account for test@test.com is waiting to be activated. Sign in with your email to get a one-time code, or ask your admin for an invite link. After that, SSO sign-in will be enabled.',
+                    ),
+                );
+
+                expect(userModel.createUser).not.toHaveBeenCalled();
+                expect(
+                    openIdIdentityModel.createIdentity,
+                ).not.toHaveBeenCalled();
+            });
+
+            test('tells a pending user to get an invite when one-time-code login is unavailable', async () => {
+                const service = createUserService({
+                    ...lightdashConfigMock,
+                    auth: {
+                        ...lightdashConfigMock.auth,
+                        disablePasswordAuthentication: true,
+                    },
+                });
+                emailModel.getPrimaryEmailStatus.mockResolvedValueOnce(
+                    unverifiedEmail,
+                );
+
+                await expect(
+                    service.loginWithOpenId(openIdUser, undefined, undefined),
+                ).rejects.toThrowError(
+                    new ForbiddenError(
+                        "An account for test@test.com already exists but hasn't been activated. Ask your admin for an invite link. After that, SSO sign-in will be enabled.",
+                    ),
+                );
+
+                expect(userModel.createUser).not.toHaveBeenCalled();
+                expect(
+                    openIdIdentityModel.createIdentity,
+                ).not.toHaveBeenCalled();
+            });
+
+            test('tells a verified user to sign in with email when linking by email is disabled', async () => {
+                emailModel.getPrimaryEmailStatus.mockResolvedValueOnce({
+                    email: openIdUser.openId.email,
+                    isVerified: true,
+                });
+
+                await expect(
+                    userService.loginWithOpenId(
+                        openIdUser,
+                        undefined,
+                        undefined,
+                    ),
+                ).rejects.toThrowError(
+                    new ForbiddenError(
+                        'An account for test@test.com already exists. Sign in with your email, then connect this sign-in method from your account settings, or ask your admin to enable linking SSO logins by email.',
+                    ),
+                );
+
+                expect(userModel.createUser).not.toHaveBeenCalled();
+                expect(
+                    openIdIdentityModel.createIdentity,
+                ).not.toHaveBeenCalled();
+            });
         });
         test('rejects a link flow when the identity belongs to another user', async () => {
             const currentUser: SessionUser = {

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -1246,21 +1246,19 @@ export class UserService extends BaseService {
         }
 
         // Link the new openid identity to an existing user if they already
-        // have the same verified primary email. Allowed instance-wide via env
-        // OR per-org via organization_settings — resolve the candidate user,
-        // then check the effective toggle for their org.
+        // have the same verified primary email (instance env OR per-org
+        // organization_settings). Otherwise, fail closed without an invite.
         if (!authenticatedUser) {
             const userWithSameEmail =
                 await this.userModel.findSessionUserByPrimaryEmail(
                     openIdUser.openId.email,
                 );
 
-            if (
-                userWithSameEmail &&
-                (await this.isOidcToEmailLinkingEnabledForOrg(
-                    userWithSameEmail.organizationUuid,
-                ))
-            ) {
+            if (userWithSameEmail) {
+                const isLinkingEnabled =
+                    await this.isOidcToEmailLinkingEnabledForOrg(
+                        userWithSameEmail.organizationUuid,
+                    );
                 const emailStatus = await this.emailModel.getPrimaryEmailStatus(
                     userWithSameEmail.userUuid,
                 );
@@ -1268,7 +1266,7 @@ export class UserService extends BaseService {
                     `Email status for user ${userWithSameEmail.userUuid} - Is verified: ${emailStatus.isVerified}`,
                 );
 
-                if (emailStatus.isVerified) {
+                if (isLinkingEnabled && emailStatus.isVerified) {
                     if (
                         this.lightdashConfig.groups.enabled === true &&
                         this.lightdashConfig.auth.enableGroupSync === true &&
@@ -1293,6 +1291,18 @@ export class UserService extends BaseService {
                         userWithSameEmail,
                         openIdUser,
                         refreshToken,
+                    );
+                }
+
+                // Without an invite the fallthrough would collide with this
+                // account in createUser; fail closed with the next step instead.
+                if (!inviteCode) {
+                    throw new ForbiddenError(
+                        await this.getSsoLoginCollisionMessage(
+                            userWithSameEmail,
+                            openIdUser.openId.email,
+                            emailStatus.isVerified,
+                        ),
                     );
                 }
             }
@@ -2329,24 +2339,50 @@ export class UserService extends BaseService {
         return !hasPassword && !hasOpenIdIdentity;
     }
 
+    private async isEmailOtpLoginAvailable(
+        user: LightdashUser,
+        email: string,
+    ): Promise<boolean> {
+        if (!user.isActive) {
+            return false;
+        }
+        const [isStrictlyPasswordlessUser, isEmailOtpLoginAllowed] =
+            await Promise.all([
+                this.isStrictlyPasswordlessUser(user),
+                this.isLoginMethodAllowed(
+                    email.toLowerCase(),
+                    LocalIssuerTypes.EMAIL_OTP,
+                ),
+            ]);
+        return isStrictlyPasswordlessUser && isEmailOtpLoginAllowed;
+    }
+
+    // Shown to an SSO user who provably owns the mailbox; never reveal org,
+    // role, groups or admin identities here.
+    private async getSsoLoginCollisionMessage(
+        user: LightdashUser,
+        email: string,
+        isEmailVerified: boolean,
+    ): Promise<string> {
+        if (isEmailVerified) {
+            return `An account for ${email} already exists. Sign in with your email, then connect this sign-in method from your account settings, or ask your admin to enable linking SSO logins by email.`;
+        }
+        if (await this.isEmailOtpLoginAvailable(user, email)) {
+            return `An account for ${email} is waiting to be activated. Sign in with your email to get a one-time code, or ask your admin for an invite link. After that, SSO sign-in will be enabled.`;
+        }
+        return `An account for ${email} already exists but hasn't been activated. Ask your admin for an invite link. After that, SSO sign-in will be enabled.`;
+    }
+
     // OTP login is deliberately NOT gated on the NewOnboarding flag: accounts
     // enrolled as strictly passwordless have no other way to sign in, so a
     // flag rollback must not strand them. The flag gates enrollment only.
     async requestEmailOtpLogin(email: string): Promise<void> {
         const normalizedEmail = email.toLowerCase();
         const user = await this.userModel.findUserByEmail(normalizedEmail);
-        if (!user || !user.isActive) {
-            return;
-        }
-        const [isStrictlyPasswordlessUser, isEmailLoginAllowed] =
-            await Promise.all([
-                this.isStrictlyPasswordlessUser(user),
-                this.isLoginMethodAllowed(
-                    normalizedEmail,
-                    LocalIssuerTypes.EMAIL_OTP,
-                ),
-            ]);
-        if (!isStrictlyPasswordlessUser || !isEmailLoginAllowed) {
+        if (
+            !user ||
+            !(await this.isEmailOtpLoginAvailable(user, normalizedEmail))
+        ) {
             return;
         }
         const emailStatus = await this.emailModel.getPrimaryEmailStatus(


### PR DESCRIPTION
Users pre-created through users-as-code (`sendInvite=false`) have an unverified primary email. On their first Google/OIDC sign-in the email-linking branch is skipped, the login falls through to "create user", and `UserModel.createUser` throws the raw `AlreadyExistsError: Email x already in use`, which lands as a toast on `/login` with no way forward.

This PR keeps the fail-closed behaviour and replaces the incidental error with a designed one that tells the user the next step. No activation, no linking, no state change.

```mermaid
flowchart TD
  A[SSO callback → loginWithOpenId] --> B{identity for iss+sub?}
  B -- yes --> B1[log in]
  B -- no --> C{user with same primary email?}
  C -- no --> H[register new user]
  C -- yes --> D{org linking on AND email verified?}
  D -- yes --> F[link identity, same uuid]
  D -- no, invite code --> I[invite activation, unchanged]
  D -- no --> X[ForbiddenError with next step]
  X -.->|before| Y[createUser → AlreadyExistsError toast]
```

**Messages** (email + next step only, never org, role, groups or admins):

- Email unverified, one-time-code login available: `An account for x is waiting to be activated. Sign in with your email to get a one-time code, or ask your admin for an invite link. After that, SSO sign-in will be enabled.`
- Email unverified, one-time-code login not available: `An account for x already exists but hasn't been activated. Ask your admin for an invite link. After that, SSO sign-in will be enabled.`
- Email verified but org linking off: `An account for x already exists. Sign in with your email, then connect this sign-in method from your account settings, or ask your admin to enable linking SSO logins by email.`

"One-time-code login available" reuses the same gates as `requestEmailOtpLogin` via a new `isEmailOtpLoginAvailable` helper, so the hint only appears when that flow would work.

**Also**: `googleStrategy` now rejects profiles with `email_verified: false`, mirroring `oidcStrategy`. This guarantees the detailed message is only ever shown to someone who provably controls the mailbox.

**Not in scope**: activating a pending user on SSO login. That needs the declared-issuer trust decision in the ticket.

## Tests

- `UserService.test.ts`: pending + code available, pending + code unavailable, verified + linking off. Each asserts the exact message and that `createUser` / `createIdentity` are not called. Existing verified + linking on tests still pass.
- `googleStrategy.test.ts`: `verified: false` fails without calling `loginWithOpenId`.

Reproduced end to end locally before the change: users-as-code user → `loginWithOpenId` with a Google identity → `AlreadyExistsError` with the org toggle on or off; verified email + toggle on links with the same uuid.

Relates: PROD-10804
Relates: #28368

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FEqrbUZMZFBNvSr7btfdDS
