### PR TITLE
fix(ai): pivot grouped deep research report charts on refresh

### DIFF
--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.test.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.test.ts
@@ -2416,6 +2416,7 @@ describe('AiDeepResearchService', () => {
                 projectUuid: 'project-1',
                 metricQuery: refreshQueryHistory.metricQuery,
                 context: QueryExecutionContext.AI,
+                pivotConfiguration: undefined,
             });
             expect(result).toEqual({
                 source: 'semantic',
@@ -2436,6 +2437,87 @@ describe('AiDeepResearchService', () => {
                     description: null,
                 },
             });
+        });
+
+        it('pivots the refreshed query by the chart group-by dimension', async () => {
+            const groupedChartConfig = {
+                ...chart.chartConfig,
+                yAxisMetrics: ['orders_unique_order_count'],
+                groupBy: ['orders_status'],
+            };
+            const groupedMetricQuery = {
+                ...refreshQueryHistory.metricQuery,
+                dimensions: ['orders_order_month', 'orders_status'],
+                metrics: ['orders_unique_order_count'],
+            };
+            const { service, asyncQueryService } = buildService({
+                model: {
+                    findByUuidScoped: vi
+                        .fn()
+                        .mockResolvedValue(
+                            runRow({ result_markdown: chartReportMarkdown }),
+                        ),
+                },
+                aiAgentModel: {
+                    getToolCallsAndResultsForPrompt: vi.fn().mockResolvedValue([
+                        {
+                            ...chartProvenance()[0],
+                            toolCall: {
+                                ...chartProvenance()[0].toolCall,
+                                toolArgs: {
+                                    ...chartToolArgs,
+                                    queryConfig: {
+                                        ...chartToolArgs.queryConfig,
+                                        dimensions:
+                                            groupedMetricQuery.dimensions,
+                                        metrics: groupedMetricQuery.metrics,
+                                    },
+                                    chartConfig: groupedChartConfig,
+                                },
+                            },
+                        },
+                    ]),
+                },
+                queryHistoryModel: {
+                    getByQueryUuid: vi.fn().mockResolvedValue({
+                        ...refreshQueryHistory,
+                        metricQuery: groupedMetricQuery,
+                    }),
+                },
+                asyncQueryService: {
+                    executeAsyncMetricQuery: vi.fn().mockResolvedValue({
+                        queryUuid: 'query-2',
+                        cacheMetadata: { cacheHit: true },
+                        metricQuery: groupedMetricQuery,
+                        fields: {},
+                        warnings: [],
+                    }),
+                },
+            });
+
+            await service.refreshChart({
+                account: {} as AnyType,
+                user: userWithProjectAccess(),
+                projectUuid: 'project-1',
+                aiDeepResearchRunUuid: 'run-1',
+                chartKey: chart.queryUuid,
+            });
+
+            expect(
+                asyncQueryService.executeAsyncMetricQuery,
+            ).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    metricQuery: groupedMetricQuery,
+                    pivotConfiguration: expect.objectContaining({
+                        groupByColumns: [{ reference: 'orders_status' }],
+                        valuesColumns: [
+                            expect.objectContaining({
+                                reference: 'orders_unique_order_count',
+                            }),
+                        ],
+                    }),
+                }),
+            );
         });
 
         it('rejects a chart key that is not part of the persisted report', async () => {

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
@@ -9,10 +9,14 @@ import {
     aiDeepResearchWorkerFindingsInputSchema,
     AiResultType,
     applyDeepResearchChartRefsWithAdjustments,
+    buildDeepResearchVizConfig,
     ConflictError,
+    derivePivotConfigurationFromChart,
     findDeepResearchChartRefs,
     ForbiddenError,
     getErrorMessage,
+    getGroupByDimensions,
+    getWebAiChartConfig,
     isAiDeepResearchEvidencePackEmpty,
     isAiDeepResearchRunTerminal,
     isUserWithOrg,
@@ -44,6 +48,7 @@ import {
     type AiDeepResearchTerminalStatus,
     type AiDeepResearchWarehouseChart,
     type ApiAiAgentThreadMessageVizQuery,
+    type PivotConfiguration,
     type SessionUser,
 } from '@lightdash/common';
 import { validate as isValidUuid } from 'uuid';
@@ -1068,6 +1073,7 @@ export class AiDeepResearchService extends BaseService {
             projectUuid: args.projectUuid,
             metricQuery: chart.metricQuery,
             context: QueryExecutionContext.AI,
+            pivotConfiguration: this.getChartPivotConfiguration(chart),
         });
 
         return {
@@ -1089,6 +1095,37 @@ export class AiDeepResearchService extends BaseService {
                 description: null,
             },
         };
+    }
+
+    // Grouped charts expect server-pivoted results, matching the chat viz path.
+    private getChartPivotConfiguration(
+        chart: AiDeepResearchChartData,
+    ): PivotConfiguration | undefined {
+        try {
+            const webAiChartConfig = getWebAiChartConfig({
+                vizConfig: buildDeepResearchVizConfig(chart),
+                metricQuery: chart.metricQuery,
+                fieldsMap: chart.fields,
+                overrideChartType: chart.chartConfig.defaultVizType,
+            });
+            const groupByDimensions = getGroupByDimensions(webAiChartConfig);
+            if (!groupByDimensions?.length) {
+                return undefined;
+            }
+            return derivePivotConfigurationFromChart(
+                {
+                    chartConfig: webAiChartConfig.echartsConfig,
+                    pivotConfig: { columns: groupByDimensions },
+                },
+                chart.metricQuery,
+                chart.fields,
+            );
+        } catch (error) {
+            this.logger.warn(
+                `Deep Research chart ${chart.queryUuid} refresh falls back to unpivoted results: ${getErrorMessage(error)}`,
+            );
+            return undefined;
+        }
     }
 
     async getChart(args: {

--- a/packages/common/src/ee/aiDeepResearch/vizConfig.ts
+++ b/packages/common/src/ee/aiDeepResearch/vizConfig.ts
@@ -1,0 +1,27 @@
+import { type ToolRunQueryArgs } from '../AiAgent/schemas/tools/toolRunQueryArgs';
+import { type AiDeepResearchChartData } from './types';
+
+export const buildDeepResearchVizConfig = (
+    chart: AiDeepResearchChartData,
+): ToolRunQueryArgs => {
+    const { metricQuery } = chart;
+    return {
+        title: chart.title,
+        description: '',
+        queryConfig: {
+            exploreName: metricQuery.exploreName,
+            dimensions: metricQuery.dimensions,
+            metrics: metricQuery.metrics,
+            sorts: metricQuery.sorts.map((sort) => ({
+                ...sort,
+                nullsFirst: sort.nullsFirst ?? null,
+            })),
+            limit: metricQuery.limit,
+            parameters: null,
+            customMetrics: null,
+            tableCalculations: null,
+            filters: null,
+        },
+        chartConfig: chart.chartConfig,
+    };
+};

--- a/packages/common/src/ee/index.ts
+++ b/packages/common/src/ee/index.ts
@@ -3,6 +3,7 @@ export * from './agentOnboarding/types';
 export * from './aiDeepResearch/evidence';
 export * from './aiDeepResearch/markdown';
 export * from './aiDeepResearch/types';
+export * from './aiDeepResearch/vizConfig';
 export * from './aiDeepResearch/workers';
 export * from './aiWriteback/mcpTask';
 export * from './aiWriteback/types';

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchChartTile.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchChartTile.tsx
@@ -1,5 +1,6 @@
 import {
     type AiDeepResearchChartData,
+    buildDeepResearchVizConfig,
     isApiError,
     isWarehouseResourceLimitError,
     type ToolRunQueryArgs,
@@ -16,10 +17,7 @@ import AgentVisualizationFilters from '../ChatElements/AgentVisualizationFilters
 import { AiVisualizationRenderer } from '../ChatElements/AiVisualizationRenderer';
 import { shouldDisplayVisualizationFilters } from '../ChatElements/AiVisualizationRenderer.utils';
 import styles from './DeepResearchReport.module.css';
-import {
-    buildDeepResearchVizConfig,
-    useDeepResearchOpenInExploreUrl,
-} from './useDeepResearchExploreUrl';
+import { useDeepResearchOpenInExploreUrl } from './useDeepResearchExploreUrl';
 
 type Props = {
     chartKey: string;

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/useDeepResearchExploreUrl.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/useDeepResearchExploreUrl.ts
@@ -1,36 +1,11 @@
 import {
+    buildDeepResearchVizConfig,
     getGroupByDimensions,
     getWebAiChartConfig,
     type AiDeepResearchChartData,
-    type ToolRunQueryArgs,
 } from '@lightdash/common';
 import { useMemo } from 'react';
 import { getOpenInExploreUrl } from '../../../../../utils/getOpenInExploreUrl';
-
-export const buildDeepResearchVizConfig = (
-    chart: AiDeepResearchChartData,
-): ToolRunQueryArgs => {
-    const metricQuery = chart.metricQuery;
-    return {
-        title: chart.title,
-        description: '',
-        queryConfig: {
-            exploreName: metricQuery.exploreName,
-            dimensions: metricQuery.dimensions,
-            metrics: metricQuery.metrics,
-            sorts: metricQuery.sorts.map((sort) => ({
-                ...sort,
-                nullsFirst: sort.nullsFirst ?? null,
-            })),
-            limit: metricQuery.limit,
-            parameters: null,
-            customMetrics: null,
-            tableCalculations: null,
-            filters: null,
-        },
-        chartConfig: chart.chartConfig,
-    };
-};
 
 export const useDeepResearchOpenInExploreUrl = (
     chart: AiDeepResearchChartData | undefined,


### PR DESCRIPTION
## Problem

Deep Research report charts with a group-by dimension render blank: month labels on the x-axis, no series, legend, or y-axis. "Open in Explore" shows the data fine.

## Why

The report tile refresh endpoint re-runs the chart's metric query without a `pivotConfiguration`, so results arrive unpivoted while the tile renders with `pivotDimensions` and expects server-pivoted columns.

```text
DeepResearchChartTile
  POST …/charts/{key}/refresh
    AiDeepResearchService.refreshChart
      executeAsyncMetricQuery({ metricQuery })      ← no pivotConfiguration
  ← rows {month, status, count}, pivotDetails: null
  VisualizationProvider(pivotDimensions=[status])
    expects count_completed / count_shipped … → 0 series
```

Explore sends `pivotConfiguration` with the query and the chat viz endpoint derives it from the chart's group-by (#23827). The Deep Research refresh endpoint (#25754) shipped without it.

## Fix

```diff
 async refreshChart(...) {
   const chart = await this.getRunChart(run, args.chartKey);
   const query = await this.asyncQueryService.executeAsyncMetricQuery({
       ..., metricQuery: chart.metricQuery, context: QueryExecutionContext.AI,
+      pivotConfiguration: this.getChartPivotConfiguration(chart),
   });
```

- `getChartPivotConfiguration` mirrors the chat path: `getWebAiChartConfig` → `getGroupByDimensions` → `derivePivotConfigurationFromChart`; `undefined` when there is no group-by, and falls back to unpivoted results (warn log) rather than failing the refresh.
- `buildDeepResearchVizConfig` moved from the frontend into `@lightdash/common` so backend and frontend build the same viz config.

## Verification

Real local Deep Research run with 4 charts:

| Chart | Before | After |
|---|---|---|
| single dimension (×2) | draws | draws |
| month + status (×2) | axes only, 6 SVG paths | 3 series + legend, 33/34 SVG paths |

Tests: `refreshChart` asserts `pivotConfiguration` is `undefined` for ungrouped charts and carries `groupByColumns: [{ reference: 'orders_status' }]` for grouped ones.

Closes: PROD-10765
Closes: #28298
