### PR TITLE
fix(frontend): render the config panel when deep-linked open without the gallery

### DIFF
--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationConfigPortal.test.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationConfigPortal.test.tsx
@@ -84,6 +84,30 @@ describe('VisualizationConfigPortal', () => {
         );
     });
 
+    it('finds a host that mounts after the config opens', async () => {
+        renderWithProviders(
+            <Page withNavbar={false} isRightSidebarOpen={false}>
+                <PortalProducer isOpen />
+            </Page>,
+        );
+        expect(
+            document.getElementById(VisualizationConfigPortalId),
+        ).toBeNull();
+
+        const lateHost = document.createElement('div');
+        lateHost.id = VisualizationConfigPortalId;
+        document.body.appendChild(lateHost);
+
+        expect(
+            await screen.findByText('Configure content'),
+        ).toBeInTheDocument();
+        expect(lateHost).toContainElement(
+            screen.getByText('Configure content'),
+        );
+
+        lateHost.remove();
+    });
+
     it('keeps the original target when not following the host', async () => {
         renderWithProviders(
             <Page

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationConfigPortal.test.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationConfigPortal.test.tsx
@@ -90,9 +90,7 @@ describe('VisualizationConfigPortal', () => {
                 <PortalProducer isOpen />
             </Page>,
         );
-        expect(
-            document.getElementById(VisualizationConfigPortalId),
-        ).toBeNull();
+        expect(document.getElementById(VisualizationConfigPortalId)).toBeNull();
 
         const lateHost = document.createElement('div');
         lateHost.id = VisualizationConfigPortalId;

--- a/packages/frontend/src/components/Explorer/VisualizationCard/useVisualizationConfigPortalTarget.ts
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/useVisualizationConfigPortalTarget.ts
@@ -31,13 +31,16 @@ const useVisualizationConfigPortalTarget = (
 
         updateTarget();
 
-        if (!followHost) return;
+        // On a fresh page load with the config already open, the host mounts
+        // after this lookup — keep watching until one is found. Only the
+        // gallery host keeps being followed across replacements after that.
+        if (!followHost && target !== null) return;
 
         const observer = new MutationObserver(updateTarget);
         observer.observe(document.body, { childList: true, subtree: true });
 
         return () => observer.disconnect();
-    }, [isOpen, followHost]);
+    }, [isOpen, followHost, target]);
 
     return target;
 };


### PR DESCRIPTION
## Summary

With the `explorer-chart-gallery` flag off, loading an explore URL that already carries `chartSidebar=configure` left the explorer's left panel blank — neither the field tree nor the config panel rendered until the user closed and reopened Configure.

`useVisualizationConfigPortalTarget` looks up the portal host element once when the panel opens, and outside gallery mode it attached no observer. On a fresh page load with the config open from the URL, the host mounts *after* that one-shot lookup, so the target stayed `null` forever.

The fix keeps the `MutationObserver` running until a host is found in both modes, then drops it outside gallery mode — so the pinned `followHost: false` semantics (keep the original target when the host is *replaced* while open) are unchanged, and only the late-mount race is fixed. Added a regression test for the late-mounting host alongside the four existing pinned behaviors.

## Validation

- `VisualizationConfigPortal.test.tsx`: 5/5 pass (4 pre-existing pinned behaviors + new late-mount test).
- Reproduced the blank panel on a fresh deep-linked load with the gallery flag off in the local app, then confirmed the panel renders on the same load path with this fix.

Found while validating PROD-10458 in legacy-sidebar mode; reproduces without those changes.

Closes: PROD-10868
Relates: PROD-10458

🤖 Generated with [Claude Code](https://claude.com/claude-code)