### PR TITLE
fix(query): avoid duplicate snowflake timestamp rebase

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -7536,6 +7536,22 @@ describe('Naive timestamp domain — explicit, session-independent conversion', 
         ],
     };
 
+    const snowflakeWrappedDimensionSql = `TO_TIMESTAMP_NTZ(CONVERT_TIMEZONE('UTC', \${TABLE}.occurred_at))`;
+    const snowflakeWrappedSql = `TO_TIMESTAMP_NTZ(CONVERT_TIMEZONE('UTC', "events".occurred_at))`;
+    const buildSnowflakeNormalizedExplore = () => {
+        const explore = buildNaiveExplore(
+            SupportedDbtAdapter.SNOWFLAKE,
+            'naive',
+        );
+        ['occurred_at', 'occurred_at_raw'].forEach((dimensionName) => {
+            const dimension = explore.tables.events.dimensions[dimensionName];
+            dimension.sql = snowflakeWrappedDimensionSql;
+            dimension.compiledSql = snowflakeWrappedSql;
+            dimension.isTimestampNormalizedToUtc = true;
+        });
+        return explore;
+    };
+
     test('MIN/MAX over a known-naive TIMESTAMP base converts the aggregate operand (Postgres)', () => {
         const { query } = buildQuery({
             explore: buildNaiveExplore(SupportedDbtAdapter.POSTGRES, 'naive'),
@@ -7628,6 +7644,154 @@ describe('Naive timestamp domain — explicit, session-independent conversion', 
         });
         expect(query).toContain(
             `MAX(CONVERT_TIMEZONE('Asia/Tokyo', 'UTC', "events".occurred_at)) AS "events_max_ts"`,
+        );
+    });
+
+    test('MIN/MAX inherited from a Snowflake timestamp dimension keeps its normalized instant', () => {
+        const snowflakeClientMock = {
+            ...warehouseClientMock,
+            getAdapterType: () => SupportedDbtAdapter.SNOWFLAKE,
+        };
+        const explore = buildSnowflakeNormalizedExplore();
+        const queryWithInheritedMetric: CompiledMetricQuery = {
+            ...maxNaiveQuery,
+            dimensions: ['events_occurred_at_raw'],
+            additionalMetrics: maxNaiveQuery.additionalMetrics?.map(
+                (metric) => ({
+                    ...metric,
+                    sql: snowflakeWrappedDimensionSql,
+                }),
+            ),
+            compiledAdditionalMetrics:
+                maxNaiveQuery.compiledAdditionalMetrics?.map((metric) => ({
+                    ...metric,
+                    sql: snowflakeWrappedDimensionSql,
+                    compiledSql: `MAX(${snowflakeWrappedSql})`,
+                })),
+        };
+
+        const { query } = buildQuery({
+            explore,
+            compiledMetricQuery: queryWithInheritedMetric,
+            warehouseSqlBuilder: snowflakeClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: 'Asia/Tokyo',
+            useTimezoneAwareDateTrunc: true,
+            columnTimezone: 'UTC',
+            dataTimezone: 'Asia/Tokyo',
+        });
+
+        expect(query).toContain(
+            `${snowflakeWrappedSql} AS "events_occurred_at_raw"`,
+        );
+        expect(query).toContain(
+            `MAX(${snowflakeWrappedSql}) AS "events_max_ts"`,
+        );
+        expect(query).not.toContain(
+            `CONVERT_TIMEZONE('Asia/Tokyo', 'UTC', ${snowflakeWrappedSql})`,
+        );
+    });
+
+    test('Snowflake filtered MIN/MAX distinguishes inherited dimension SQL from an explicit bare column', () => {
+        const snowflakeClientMock = {
+            ...warehouseClientMock,
+            getAdapterType: () => SupportedDbtAdapter.SNOWFLAKE,
+        };
+        const filters = [
+            {
+                id: 'f1',
+                target: { fieldRef: 'events.occurred_at' },
+                operator: FilterOperator.NOT_NULL,
+                values: [],
+            },
+        ];
+        const inheritedFilteredSql = `MAX(CASE WHEN "events".occurred_at IS NOT NULL THEN ${snowflakeWrappedSql} ELSE NULL END)`;
+        const explicitFilteredSql = `MAX(CASE WHEN "events".occurred_at IS NOT NULL THEN "events".occurred_at ELSE NULL END)`;
+        const inheritedQuery: CompiledMetricQuery = {
+            ...maxNaiveQuery,
+            additionalMetrics: maxNaiveQuery.additionalMetrics?.map(
+                (metric) => ({
+                    ...metric,
+                    sql: snowflakeWrappedDimensionSql,
+                }),
+            ),
+            compiledAdditionalMetrics:
+                maxNaiveQuery.compiledAdditionalMetrics?.map((metric) => ({
+                    ...metric,
+                    sql: snowflakeWrappedDimensionSql,
+                    filters,
+                    compiledSql: inheritedFilteredSql,
+                })),
+        };
+        const explicitQuery: CompiledMetricQuery = {
+            ...maxNaiveQuery,
+            compiledAdditionalMetrics:
+                maxNaiveQuery.compiledAdditionalMetrics?.map((metric) => ({
+                    ...metric,
+                    filters,
+                    compiledSql: explicitFilteredSql,
+                })),
+        };
+        const build = (compiledMetricQuery: CompiledMetricQuery) =>
+            buildQuery({
+                explore: buildSnowflakeNormalizedExplore(),
+                compiledMetricQuery,
+                warehouseSqlBuilder: snowflakeClientMock,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+                timezone: 'Asia/Tokyo',
+                useTimezoneAwareDateTrunc: true,
+                columnTimezone: 'UTC',
+                dataTimezone: 'Asia/Tokyo',
+            }).query;
+
+        expect(build(inheritedQuery)).toContain(
+            `${inheritedFilteredSql} AS "events_max_ts"`,
+        );
+        expect(build(explicitQuery)).toContain(
+            `CONVERT_TIMEZONE('Asia/Tokyo', 'UTC', ${explicitFilteredSql}) AS "events_max_ts"`,
+        );
+    });
+
+    test('Snowflake non-normalized timestamp expressions still receive the data-timezone rebase', () => {
+        const snowflakeClientMock = {
+            ...warehouseClientMock,
+            getAdapterType: () => SupportedDbtAdapter.SNOWFLAKE,
+        };
+        const dimensionSql = `COALESCE(\${TABLE}.occurred_at, \${TABLE}.occurred_at)`;
+        const compiledDimensionSql = `COALESCE("events".occurred_at, "events".occurred_at)`;
+        const explore = buildNaiveExplore(
+            SupportedDbtAdapter.SNOWFLAKE,
+            'naive',
+        );
+        explore.tables.events.dimensions.occurred_at.sql = dimensionSql;
+        explore.tables.events.dimensions.occurred_at.compiledSql =
+            compiledDimensionSql;
+        const queryWithExpression: CompiledMetricQuery = {
+            ...maxNaiveQuery,
+            additionalMetrics: maxNaiveQuery.additionalMetrics?.map(
+                (metric) => ({ ...metric, sql: dimensionSql }),
+            ),
+            compiledAdditionalMetrics:
+                maxNaiveQuery.compiledAdditionalMetrics?.map((metric) => ({
+                    ...metric,
+                    sql: dimensionSql,
+                    compiledSql: `MAX(${compiledDimensionSql})`,
+                })),
+        };
+
+        const { query } = buildQuery({
+            explore,
+            compiledMetricQuery: queryWithExpression,
+            warehouseSqlBuilder: snowflakeClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: 'Asia/Tokyo',
+            useTimezoneAwareDateTrunc: true,
+            columnTimezone: 'UTC',
+            dataTimezone: 'Asia/Tokyo',
+        });
+
+        expect(query).toContain(
+            `MAX(CONVERT_TIMEZONE('Asia/Tokyo', 'UTC', ${compiledDimensionSql})) AS "events_max_ts"`,
         );
     });
 

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -1180,6 +1180,14 @@ export class MetricQueryBuilder {
                 metric,
             );
             if (baseDimension?.skipTimezoneConversion) return baseSql;
+            // Inherited Snowflake dimension SQL is already normalized to UTC;
+            // explicit metric SQL still needs the data-timezone rebase below.
+            if (
+                baseDimension?.isTimestampNormalizedToUtc &&
+                metric.sql === baseDimension.sql
+            ) {
+                return baseSql;
+            }
             const {
                 castToInstant,
                 castNaiveAggregateToInstant,

--- a/packages/common/src/compiler/translator.mock.ts
+++ b/packages/common/src/compiler/translator.mock.ts
@@ -917,6 +917,7 @@ export const LIGHTDASH_TABLE_WITH_DEFAULT_TIME_INTERVAL_DIMENSIONS_SNOWFLAKE: Om
             colors: undefined,
             index: 0,
             isIntervalBase: true,
+            isTimestampNormalizedToUtc: true,
         },
         user_created_raw: {
             fieldType: FieldType.DIMENSION,
@@ -942,6 +943,7 @@ export const LIGHTDASH_TABLE_WITH_DEFAULT_TIME_INTERVAL_DIMENSIONS_SNOWFLAKE: Om
             colors: undefined,
             index: 0,
             isIntervalBase: false,
+            isTimestampNormalizedToUtc: true,
         },
         user_created_day: {
             fieldType: FieldType.DIMENSION,

--- a/packages/common/src/compiler/translator.test.ts
+++ b/packages/common/src/compiler/translator.test.ts
@@ -237,6 +237,29 @@ describe('timestamp domain', () => {
         );
     });
 
+    it('should mark Snowflake timestamp dimensions normalized to UTC', () => {
+        const snowflake = convertTable(
+            SupportedDbtAdapter.SNOWFLAKE,
+            MODEL_WITH_TIMESTAMP_DOMAIN,
+            DEFAULT_SPOTLIGHT_CONFIG,
+        );
+        const postgres = convertTable(
+            SupportedDbtAdapter.POSTGRES,
+            MODEL_WITH_TIMESTAMP_DOMAIN,
+            DEFAULT_SPOTLIGHT_CONFIG,
+        );
+
+        expect(
+            snowflake.dimensions.user_created.isTimestampNormalizedToUtc,
+        ).toBe(true);
+        expect(
+            snowflake.dimensions.user_created_raw.isTimestampNormalizedToUtc,
+        ).toBe(true);
+        expect(postgres.dimensions.user_created).not.toHaveProperty(
+            'isTimestampNormalizedToUtc',
+        );
+    });
+
     it('should prefer the YAML timestamp_domain over the catalog', () => {
         const result = convertTable(
             SupportedDbtAdapter.POSTGRES,

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -232,6 +232,10 @@ const convertDimension = (
     let name = meta.dimension?.name || column.name;
     let sql = meta.dimension?.sql || defaultSql(column.name);
     let label = meta.dimension?.label || friendlyName(name);
+    const isTimestampNormalizedToUtc =
+        type === DimensionType.TIMESTAMP &&
+        !disableTimestampConversion &&
+        targetWarehouse === SupportedDbtAdapter.SNOWFLAKE;
     if (type === DimensionType.TIMESTAMP && !disableTimestampConversion) {
         sql = convertTimezone(sql, 'UTC', 'UTC', targetWarehouse);
     }
@@ -343,6 +347,9 @@ const convertDimension = (
             ? { skipTimezoneConversion: true }
             : {}),
         ...(timestampDomain ? { timestampDomain } : {}),
+        ...(isTimestampNormalizedToUtc && type === DimensionType.TIMESTAMP
+            ? { isTimestampNormalizedToUtc: true as const }
+            : {}),
         groups,
         isIntervalBase,
         ...(meta.dimension && meta.dimension.tags

--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -811,6 +811,8 @@ export interface Dimension extends Field {
     isAdditionalDimension?: boolean;
     skipTimezoneConversion?: boolean;
     timestampDomain?: TimestampDomain;
+    /** True when compilation normalized the timestamp expression to UTC. */
+    isTimestampNormalizedToUtc?: true;
     colors?: Record<string, string>;
     isIntervalBase?: boolean;
     aiHint?: string | string[];


### PR DESCRIPTION
## What changed

## Summary

Prevent Snowflake Min/Max metrics inherited from timezone-normalized timestamp dimensions from applying a second data-timezone conversion. The compiler now records UTC normalization explicitly, while bare-column and non-normalized metric expressions continue through the existing rebase path, including filtered metrics.

### Validation

- `pnpm -F backend exec oxfmt 'src/utils/QueryBuilder/MetricQueryBuilder.test.ts' 'src/utils/QueryBuilder/MetricQueryBuilder.ts' --check` — passed
- `pnpm -F common exec oxfmt 'src/compiler/translator.mock.ts' 'src/compiler/translator.test.ts' 'src/compiler/translator.ts' 'src/types/field.ts' --check` — passed
- `pnpm -F backend lint` — passed
- `pnpm -F common lint` — passed
- `pnpm -F backend typecheck` — passed
- `pnpm -F common typecheck` — passed
- `pnpm -F e2e typecheck` — passed
- `pnpm -F frontend typecheck` — passed
- `pnpm -F warehouses typecheck` — passed
- `pnpm -F backend exec vitest related 'src/utils/QueryBuilder/MetricQueryBuilder.test.ts' 'src/utils/QueryBuilder/MetricQueryBuilder.ts' --run --passWithNoTests` — passed
- `pnpm -F common exec vitest related 'src/compiler/translator.mock.ts' 'src/compiler/translator.test.ts' 'src/compiler/translator.ts' 'src/types/field.ts' --run --passWithNoTests` — passed
- `pnpm -F backend test src/utils/QueryBuilder/MetricQueryBuilder.test.ts -t "MIN/MAX inherited from a Snowflake timestamp dimension keeps its normalized instant|Snowflake filtered MIN/MAX distinguishes inherited dimension SQL from an explicit bare column|Snowflake non-normalized timestamp expressions still receive the data-timezone rebase"` — 3 tests passed
- `pnpm -F common test src/compiler/translator.test.ts -t "should mark Snowflake timestamp dimensions normalized to UTC"` — 1 test passed
- `pnpm -F api-tests typecheck`, `pnpm -F cli typecheck`, and `pnpm -F query-sdk typecheck` — non-blocking failures reproduced unchanged on the base revision

### Review notes

The implementation uses optional true-only normalization metadata for compatibility with existing compiled explores and identifies inheritance through the exact source-SQL copy used by both UI and YAML metric creation paths. A broader alternative is a required metric provenance enum across the shared contract; reviewer input is useful if that larger contract change is preferred.

## Proof of work

🟢 **PASS** — Production QueryBuilder invocation confirms Snowflake TIMESTAMP_NTZ Min and Max metrics inherited through both UI-custom and YAML paths reuse the dimension's UTC-normalized expression without a second timezone conversion, while explicit bare-column metrics retain the Asia/Tokyo-to-UTC rebase.

Revision: `2662b68ff8d41722c91d7b18ce6a00789c1cf33f`

### UI custom Min and Max metrics inherit normalized Snowflake timestamp SQL

- Expected: With timezone-aware truncation enabled, column timezone UTC, and data/project timezone Asia/Tokyo, both metrics and the selected raw dimension use TO_TIMESTAMP_NTZ(CONVERT_TIMEZONE('UTC', "events".occurred_at)) without an outer Asia/Tokyo-to-UTC conversion.
- Observed: A direct MetricQueryBuilder invocation asserted the identical normalized dimension operand for UI Max and UI Min and asserted that the second CONVERT_TIMEZONE was absent.
- Evidence:
  - Production invocation: LIGHTDASH_SECRET='synthetic-proof-only-not-a-credential' S3_ENDPOINT='http://127.0.0.1:9000' S3_BUCKET='synthetic-proof' S3_REGION='local' pnpm exec tsx /tmp/prod10850-proof.ts; result reported ui-max and ui-min with dimensionAndMetricShareNormalizedExpression=true and doubleConversionAbsent=true under the requested four timezone settings.
  - pnpm -F backend test src/utils/QueryBuilder/MetricQueryBuilder.test.ts -t "MIN/MAX inherited from a Snowflake timestamp dimension keeps its normalized instant|Snowflake filtered MIN/MAX distinguishes inherited dimension SQL from an explicit bare column|Snowflake non-normalized timestamp expressions still receive the data-timezone rebase" — 1 test file passed, 3 tests passed.

### YAML column-level Min and Max metrics inherit normalized Snowflake timestamp SQL

- Expected: YAML metrics resolved through dimensionReference preserve the normalized timestamp operand for both Min and Max and do not apply a second timezone conversion.
- Observed: The direct production invocation exercised YAML dimensionReference metrics for both aggregate types; each shared the selected dimension's normalized expression and omitted the second conversion.
- Evidence:
  - Production invocation result reported yaml-max and yaml-min with dimensionAndMetricShareNormalizedExpression=true and doubleConversionAbsent=true.
  - pnpm -F backend test src/utils/QueryBuilder/MetricQueryBuilder.test.ts -t "a YAML MIN/MAX metric \(dimensionReference\) gets the same rebase" — 1 test file passed, 1 test passed, confirming the YAML dimensionReference resolution path.

### Explicit bare-column Min and Max metrics retain data-timezone rebasing

- Expected: A metric explicitly using ${TABLE}.occurred_at still compiles its operand as CONVERT_TIMEZONE('Asia/Tokyo', 'UTC', "events".occurred_at).
- Observed: Direct production invocation asserted the expected Asia/Tokyo-to-UTC operand conversion for explicit bare-column Max and Min. Focused tests also retained rebasing for filtered explicit and non-normalized expressions.
- Evidence:
  - Production invocation result reported explicit-bare-max and explicit-bare-min with dataTimezoneRebaseRetained=true.
  - The focused backend command passed the explicit filtered-column and non-normalized-expression rebase cases alongside the inherited-expression case: 3 tests passed.

### Snowflake timestamp compilation identifies UTC-normalized dimensions

- Expected: Snowflake base and raw timestamp dimensions receiving compile-time timezone normalization are marked for downstream QueryBuilder handling, while PostgreSQL dimensions are not.
- Observed: The focused common compiler test passed, confirming both Snowflake timestamp dimensions are marked and the PostgreSQL counterpart remains unmarked.
- Evidence:
  - pnpm -F common test src/compiler/translator.test.ts -t "should mark Snowflake timestamp dimensions normalized to UTC" — 1 test file passed, 1 test passed.

## Development environment

[Open the public Lightdash development environment](https://ld-runner-prod-10850-da2b5ecd6c8b.exe.xyz) (anyone with the URL can access it)

Login: `demo@lightdash.com` / `demo_password!`

## References

Closes: PROD-10850

