### PR TITLE
feat(ai): element picker in the thread's data app preview panel

### DIFF
--- a/packages/frontend/src/components/common/PromptComposer/PromptComposer.module.css
+++ b/packages/frontend/src/components/common/PromptComposer/PromptComposer.module.css
@@ -266,20 +266,27 @@
 
 /* --- inline editor surface --- */
 
-.inlineEditorWrap {
+/* Editor stacked above the attachment row; wrapped pills must never share
+ * the editor's row or they squeeze the text into a single column. */
+.inlineMain {
     /* Single source of truth for where inline text begins. The caret sits at
        the ProseMirror padding edge, and the placeholder overlay has to land on
        exactly the same pixel — binding both to this var stops them drifting. */
     --composer-inline-inset: rem(22px);
-    position: relative;
+    display: flex;
+    flex-direction: column;
     flex: 1;
     min-width: 0;
 }
 
 /* The root's 4px gap plus this inset matches its 10px horizontal padding,
  * keeping a leading action visually centered between the border and text. */
-.inlineActions + .inlineEditorWrap {
+.inlineActions + .inlineMain {
     --composer-inline-inset: rem(6px);
+}
+
+.inlineEditorWrap {
+    position: relative;
 }
 
 .inlineEditorContent {
@@ -341,6 +348,10 @@
 
 .root[data-size='md'] .attachments {
     padding: 0 rem(12px);
+}
+
+.root[data-variant='inline'] .attachments {
+    padding: 0 var(--mantine-spacing-xs) rem(4px) var(--composer-inline-inset);
 }
 
 .toolbar {

--- a/packages/frontend/src/components/common/PromptComposer/PromptComposer.tsx
+++ b/packages/frontend/src/components/common/PromptComposer/PromptComposer.tsx
@@ -235,22 +235,29 @@ const PromptComposer = forwardRef<PromptComposerHandle, Props>(
                 )}
 
                 {isInline ? (
-                    <Box className={classes.inlineEditorWrap}>
-                        {editorSurface}
-                        {isEmpty && placeholder && (
-                            <Text
-                                aria-hidden
-                                className={classes.inlinePlaceholder}
-                            >
-                                {placeholder}
-                            </Text>
+                    <Box className={classes.inlineMain}>
+                        <Box className={classes.inlineEditorWrap}>
+                            {editorSurface}
+                            {isEmpty && placeholder && (
+                                <Text
+                                    aria-hidden
+                                    className={classes.inlinePlaceholder}
+                                >
+                                    {placeholder}
+                                </Text>
+                            )}
+                        </Box>
+                        {attachments && (
+                            <Box className={classes.attachments}>
+                                {attachments}
+                            </Box>
                         )}
                     </Box>
                 ) : (
                     editorSurface
                 )}
 
-                {attachments && (
+                {!isInline && attachments && (
                     <Box className={classes.attachments}>{attachments}</Box>
                 )}
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -66,7 +66,17 @@ import {
     useCreateAiAgentThreadMessageSteerMutation,
     useInterruptAiAgentThreadMessageMutation,
 } from '../../hooks/useProjectAiAgents';
+import {
+    clearThreadElementReferences,
+    removeThreadElementReference,
+    selectThreadElementReferences,
+    type ThreadElementReference,
+} from '../../store/aiAgentThreadElementRefsSlice';
 import { isAiAgentThreadStreamActive } from '../../store/aiAgentThreadStreamSlice';
+import {
+    useAiAgentStoreDispatch,
+    useAiAgentStoreSelector,
+} from '../../store/hooks';
 import { useAiAgentThreadStreamQuery } from '../../streaming/useAiAgentThreadStreamQuery';
 import { AgentSelector } from '../AgentSelector';
 import { type Agent } from '../AgentSelector/AgentSelectorUtils';
@@ -88,6 +98,66 @@ import {
 import { getAgentSuggestionModes } from './suggestionModes';
 
 const SUGGESTION_CHIP_MENTION_NAME = 'suggestionChip';
+
+type SubmitContext = {
+    context?: AiPromptContextInput;
+    optimisticContext?: AiPromptContextItem[];
+};
+
+/** Context the composer submits with a prompt; keys are omitted when empty. */
+const buildSubmitContext = ({
+    mentionContext,
+    externalSources,
+    elementReferences,
+}: {
+    mentionContext: SubmitContext;
+    externalSources: ExternalSourceAttachment[];
+    elementReferences: ThreadElementReference[];
+}): SubmitContext => {
+    const context: AiPromptContextItemInput[] = [
+        ...(mentionContext.context ?? []),
+        ...externalSources.map(({ sourceUuid }) => ({
+            type: 'external_source' as const,
+            sourceUuid,
+        })),
+        ...elementReferences.map(({ appUuid, version, tag, text, loc }) => ({
+            type: 'data_app_element' as const,
+            appUuid,
+            version,
+            tag,
+            text,
+            loc,
+        })),
+    ];
+    const optimisticContext: AiPromptContextItem[] = [
+        ...(mentionContext.optimisticContext ?? []),
+        ...externalSources,
+        ...elementReferences.map(
+            ({
+                appUuid,
+                appSlug,
+                appDisplayName,
+                version,
+                tag,
+                text,
+                loc,
+            }) => ({
+                type: 'data_app_element' as const,
+                appUuid,
+                version,
+                tag,
+                text,
+                loc,
+                appSlug,
+                displayName: appDisplayName,
+            }),
+        ),
+    ];
+    return {
+        ...(context.length > 0 ? { context } : {}),
+        ...(optimisticContext.length > 0 ? { optimisticContext } : {}),
+    };
+};
 const ACTIVE_DEEP_RESEARCH_DISABLED_REASON =
     'Only one deep research run can be active in a thread at a time.';
 
@@ -113,11 +183,9 @@ const SuggestionChipMention = Mention.extend({
     },
 });
 
-type SubmitArgs = {
+type SubmitArgs = SubmitContext & {
     message: string;
     toolHints: string[];
-    context?: AiPromptContextInput;
-    optimisticContext?: AiPromptContextItem[];
 };
 
 interface AgentChatInputProps {
@@ -207,6 +275,16 @@ export const AgentChatInput = ({
     const [externalSourceAttachments, setExternalSourceAttachments] = useState<
         ExternalSourceAttachment[]
     >([]);
+    // Picked in the thread's data app preview panel.
+    const storeDispatch = useAiAgentStoreDispatch();
+    const elementReferences = useAiAgentStoreSelector(
+        selectThreadElementReferences(threadUuid),
+    );
+    const clearElementReferences = useCallback(() => {
+        if (threadUuid) {
+            storeDispatch(clearThreadElementReferences({ threadUuid }));
+        }
+    }, [storeDispatch, threadUuid]);
     const resetCsvFileInputRef = useRef<() => void>(null);
     const { data: externalSourcesFlag } = useServerFeatureFlag(
         FeatureFlags.ExternalSources,
@@ -485,22 +563,17 @@ export const AgentChatInput = ({
             onSubmitRef.current({
                 message: chip.label,
                 toolHints: [chip.tool],
-                ...(externalSourceAttachments.length > 0
-                    ? {
-                          context: externalSourceAttachments.map(
-                              ({ sourceUuid }) => ({
-                                  type: 'external_source' as const,
-                                  sourceUuid,
-                              }),
-                          ),
-                          optimisticContext: externalSourceAttachments,
-                      }
-                    : {}),
+                ...buildSubmitContext({
+                    mentionContext: {},
+                    externalSources: externalSourceAttachments,
+                    elementReferences,
+                }),
             });
             if (clearOnSubmitRef.current) {
                 editor?.commands.clearContent();
                 setValueState('');
                 setExternalSourceAttachments([]);
+                clearElementReferences();
             }
             trackClick();
         },
@@ -515,6 +588,8 @@ export const AgentChatInput = ({
             emptyStateMode,
             navigate,
             externalSourceAttachments,
+            elementReferences,
+            clearElementReferences,
             isPreparingCsv,
             retainCsvSources,
         ],
@@ -640,34 +715,23 @@ export const AgentChatInput = ({
             dismissDeepResearchNudgeForSession();
             setNudgeState('done');
         }
-        const mentionContext = extractContentMentionContext(ed);
-        const context = [
-            ...(mentionContext.context ?? []),
-            ...externalSourceAttachments.map(
-                ({ sourceUuid }) =>
-                    ({
-                        type: 'external_source',
-                        sourceUuid,
-                    }) satisfies AiPromptContextItemInput,
-            ),
-        ];
-        const optimisticContext = [
-            ...(mentionContext.optimisticContext ?? []),
-            ...externalSourceAttachments,
-        ];
         retainCsvSources(
             externalSourceAttachments.map(({ sourceUuid }) => sourceUuid),
         );
         onSubmitRef.current({
             message: text,
             toolHints: extractToolHints(ed),
-            ...(context.length > 0 ? { context } : {}),
-            ...(optimisticContext.length > 0 ? { optimisticContext } : {}),
+            ...buildSubmitContext({
+                mentionContext: extractContentMentionContext(ed),
+                externalSources: externalSourceAttachments,
+                elementReferences,
+            }),
         });
         if (clearOnSubmitRef.current) {
             ed.commands.clearContent();
             setValueState('');
             setExternalSourceAttachments([]);
+            clearElementReferences();
         }
     };
 
@@ -929,11 +993,13 @@ export const AgentChatInput = ({
     };
 
     const renderedAttachments =
-        externalSourceAttachments.length > 0 || pendingCsvFiles.length > 0 ? (
+        externalSourceAttachments.length > 0 ||
+        pendingCsvFiles.length > 0 ||
+        elementReferences.length > 0 ? (
             <PromptAttachments
                 externalSources={externalSourceAttachments}
                 pendingCsvFiles={pendingCsvFiles}
-                elementRefs={[]}
+                elementRefs={elementReferences}
                 onRemoveExternalSource={(sourceUuid) => {
                     setExternalSourceAttachments((attachments) =>
                         attachments.filter(
@@ -943,7 +1009,15 @@ export const AgentChatInput = ({
                     );
                     void discardCsvSource(sourceUuid);
                 }}
-                onRemoveElementRef={() => {}}
+                onRemoveElementRef={(reference) => {
+                    if (!threadUuid) return;
+                    storeDispatch(
+                        removeThreadElementReference({
+                            threadUuid,
+                            reference,
+                        }),
+                    );
+                }}
             />
         ) : undefined;
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDataAppPreviewPanel.picker.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDataAppPreviewPanel.picker.test.tsx
@@ -1,0 +1,257 @@
+import { act, fireEvent, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ElementSelectedEvent } from '../../../../../features/apps/hooks/useAppSdkBridge';
+import { renderWithProviders } from '../../../../../testing/testUtils';
+import { store } from '../../store';
+import {
+    clearThreadElementReferences,
+    selectThreadElementReferences,
+} from '../../store/aiAgentThreadElementRefsSlice';
+
+type IframePreviewProps = {
+    inspectorEnabled?: boolean;
+    onElementSelected?: (event: ElementSelectedEvent) => void;
+    onInspectorAvailabilityChange?: (available: boolean) => void;
+    onInspectorCancelled?: () => void;
+};
+
+const mocks = vi.hoisted(() => ({
+    iframePreview: vi.fn((_props: IframePreviewProps) => null),
+    latestReadyVersion: 3,
+}));
+
+vi.mock('../../../../../features/apps/AppIframePreview', () => ({
+    default: mocks.iframePreview,
+}));
+
+vi.mock('../../../../../features/apps/hooks/useAppPreviewToken', () => ({
+    useAppPreviewToken: () => ({
+        data: 'preview-token',
+        isLoading: false,
+        error: undefined,
+    }),
+}));
+
+vi.mock('../../../../../features/apps/hooks/useGetApp', () => ({
+    useGetApp: () => ({
+        data: {
+            pages: [
+                {
+                    appUuid: 'app-uuid',
+                    name: 'Sales app',
+                    slug: 'sales-app',
+                    description: null,
+                    latestReadyVersion: mocks.latestReadyVersion,
+                    versions: [{ status: 'ready' }],
+                },
+            ],
+        },
+        isLoading: false,
+        error: undefined,
+    }),
+}));
+
+vi.mock('../../../../../features/apps/previewOrigin', () => ({
+    usePreviewOrigin: () => 'https://preview.example.com',
+}));
+
+vi.mock('../../hooks/useDeepResearch', () => ({
+    useHasActiveDeepResearchRun: vi.fn(() => false),
+}));
+
+vi.mock('../../../../../hooks/useServerOrClientFeatureFlag', () => ({
+    useServerFeatureFlag: vi.fn(() => ({ data: { enabled: false } })),
+}));
+
+// eslint-disable-next-line import/first
+import { AgentChatInput } from './AgentChatInput';
+// eslint-disable-next-line import/first
+import { AiDataAppPreviewPanel } from './AiDataAppPreviewPanel';
+
+const THREAD_UUID = 'thread-uuid';
+
+const dataAppPreview = {
+    appUuid: 'app-uuid',
+    messageUuid: 'message-uuid',
+    threadUuid: THREAD_UUID,
+    projectUuid: 'project-uuid',
+    agentUuid: 'agent-uuid',
+};
+
+const latestIframeProps = (): IframePreviewProps => {
+    const { calls } = mocks.iframePreview.mock;
+    return calls[calls.length - 1][0];
+};
+
+const announcePicker = () =>
+    act(() => latestIframeProps().onInspectorAvailabilityChange?.(true));
+
+const pickElement = (label: string) =>
+    act(() => latestIframeProps().onElementSelected?.({ label }));
+
+const pickerToggle = () => screen.queryByLabelText('Toggle element picker');
+
+const HEADING_LABEL = '[h1 "Revenue" @src/App.jsx:14]';
+const HEADING_PILL = '<h1> Revenue';
+
+/** Panel and composer side by side, as the full-page thread layout has them. */
+const renderThread = (showInspector: boolean) => {
+    const onSubmit = vi.fn();
+    const view = renderWithProviders(
+        <Provider store={store}>
+            <MemoryRouter>
+                <AiDataAppPreviewPanel
+                    dataAppPreview={dataAppPreview}
+                    showInspector={showInspector}
+                />
+                <AgentChatInput
+                    onSubmit={onSubmit}
+                    projectUuid="project-uuid"
+                    agentUuid="agent-uuid"
+                    threadUuid={THREAD_UUID}
+                    defaultValue="make it bigger"
+                    showSuggestions={false}
+                />
+            </MemoryRouter>
+        </Provider>,
+    );
+    return { ...view, onSubmit };
+};
+
+describe('AiDataAppPreviewPanel element picker', () => {
+    beforeEach(() => {
+        mocks.latestReadyVersion = 3;
+        window.localStorage.clear();
+        store.dispatch(
+            clearThreadElementReferences({ threadUuid: THREAD_UUID }),
+        );
+    });
+
+    it('shows the toggle only once the app announces the picker', () => {
+        renderThread(true);
+        expect(pickerToggle()).not.toBeInTheDocument();
+
+        announcePicker();
+
+        expect(pickerToggle()).toBeInTheDocument();
+    });
+
+    it('never shows the toggle in the launcher preview', () => {
+        renderThread(false);
+        expect(
+            latestIframeProps().onInspectorAvailabilityChange,
+        ).toBeUndefined();
+        expect(pickerToggle()).not.toBeInTheDocument();
+    });
+
+    it('adds picked elements to the composer as element references, collapsing duplicates', () => {
+        renderThread(true);
+        announcePicker();
+        fireEvent.click(pickerToggle()!);
+        expect(latestIframeProps().inspectorEnabled).toBe(true);
+
+        pickElement(HEADING_LABEL);
+        pickElement(HEADING_LABEL);
+        pickElement('[button "Export"]');
+
+        expect(screen.getAllByText(HEADING_PILL)).toHaveLength(1);
+        expect(screen.getByText('<button> Export')).toBeInTheDocument();
+        // Stays on across clicks.
+        expect(latestIframeProps().inspectorEnabled).toBe(true);
+    });
+
+    it('removes an element reference from the composer', () => {
+        renderThread(true);
+        announcePicker();
+        fireEvent.click(pickerToggle()!);
+        pickElement(HEADING_LABEL);
+
+        fireEvent.click(screen.getByLabelText(`Remove ${HEADING_PILL}`));
+
+        expect(screen.queryByText(HEADING_PILL)).not.toBeInTheDocument();
+    });
+
+    it('keeps element references when the panel closes and a new version lands', () => {
+        const { rerender } = renderThread(true);
+        announcePicker();
+        fireEvent.click(pickerToggle()!);
+        pickElement(HEADING_LABEL);
+
+        mocks.latestReadyVersion = 4;
+        rerender(
+            <Provider store={store}>
+                <MemoryRouter>
+                    <AgentChatInput
+                        onSubmit={vi.fn()}
+                        projectUuid="project-uuid"
+                        agentUuid="agent-uuid"
+                        threadUuid={THREAD_UUID}
+                        showSuggestions={false}
+                    />
+                </MemoryRouter>
+            </Provider>,
+        );
+
+        expect(screen.getByText(HEADING_PILL)).toBeInTheDocument();
+        expect(
+            selectThreadElementReferences(THREAD_UUID)(store.getState()),
+        ).toEqual([
+            {
+                appUuid: 'app-uuid',
+                appSlug: 'sales-app',
+                appDisplayName: 'Sales app',
+                version: 3,
+                tag: 'h1',
+                text: 'Revenue',
+                loc: 'src/App.jsx:14',
+            },
+        ]);
+    });
+
+    it('sends the element references as context and clears them', () => {
+        const { onSubmit } = renderThread(true);
+        announcePicker();
+        fireEvent.click(pickerToggle()!);
+        pickElement(HEADING_LABEL);
+
+        fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Enter' });
+
+        expect(onSubmit).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: 'make it bigger',
+                context: [
+                    {
+                        type: 'data_app_element',
+                        appUuid: 'app-uuid',
+                        version: 3,
+                        tag: 'h1',
+                        text: 'Revenue',
+                        loc: 'src/App.jsx:14',
+                    },
+                ],
+                optimisticContext: [
+                    expect.objectContaining({
+                        type: 'data_app_element',
+                        appSlug: 'sales-app',
+                        displayName: 'Sales app',
+                    }),
+                ],
+            }),
+        );
+        expect(screen.queryByText(HEADING_PILL)).not.toBeInTheDocument();
+    });
+
+    it('leaves the picker on Esc and keeps the element references', () => {
+        renderThread(true);
+        announcePicker();
+        fireEvent.click(pickerToggle()!);
+        pickElement(HEADING_LABEL);
+
+        act(() => latestIframeProps().onInspectorCancelled?.());
+
+        expect(latestIframeProps().inspectorEnabled).toBe(false);
+        expect(screen.getByText(HEADING_PILL)).toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDataAppPreviewPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDataAppPreviewPanel.tsx
@@ -16,16 +16,20 @@ import {
     IconExternalLink,
     IconX,
 } from '@tabler/icons-react';
-import { type FC, type ReactNode, useState } from 'react';
+import { useCallback, useState, type FC, type ReactNode } from 'react';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import TruncatedText from '../../../../../components/common/TruncatedText';
 import AppIframePreview from '../../../../../features/apps/AppIframePreview';
 import AppInspectorPanel from '../../../../../features/apps/AppInspectorPanel';
+import { ElementPickerButton } from '../../../../../features/apps/components/ElementPickerButton';
 import { getVisiblePreviewTokenError } from '../../../../../features/apps/hooks/previewTokenQueryOptions';
 import { useAppInspector } from '../../../../../features/apps/hooks/useAppInspector';
 import { useAppPreviewToken } from '../../../../../features/apps/hooks/useAppPreviewToken';
+import { useElementPicker } from '../../../../../features/apps/hooks/useElementPicker';
 import { useGetApp } from '../../../../../features/apps/hooks/useGetApp';
 import { usePreviewOrigin } from '../../../../../features/apps/previewOrigin';
+import { type ElementRef } from '../../../../../features/apps/utils/elementRefs';
+import { addThreadElementReference } from '../../store/aiAgentThreadElementRefsSlice';
 import {
     clearPreview,
     type DataAppPreviewData,
@@ -35,8 +39,8 @@ import artifactStyles from './AiArtifactPanel.module.css';
 
 type Props = {
     dataAppPreview: DataAppPreviewData;
-    /** Only the full-page thread panel hosts the query inspector; the
-     *  floating launcher preview is too small for it. */
+    /** Only the full-page thread panel hosts the network inspector and the
+     *  element picker; the floating launcher preview is too small for them. */
     showInspector: boolean;
 };
 
@@ -45,7 +49,7 @@ export const AiDataAppPreviewPanel: FC<Props> = ({
     showInspector,
 }) => {
     const dispatch = useAiAgentStoreDispatch();
-    const { appUuid, projectUuid } = dataAppPreview;
+    const { appUuid, projectUuid, threadUuid } = dataAppPreview;
 
     const previewOrigin = usePreviewOrigin();
     const appQuery = useGetApp(projectUuid, appUuid);
@@ -75,6 +79,47 @@ export const AiDataAppPreviewPanel: FC<Props> = ({
             setInspectorPinned(true);
             inspector.show();
         }
+    };
+    const { onLineageCancelled } = inspector.iframeProps;
+
+    // Picked references go to the thread's composer state, not the hook's own
+    // list, so they outlive closing the panel and the next version.
+    const appSlug = app?.slug;
+    const appName = app?.name;
+    const handlePick = useCallback(
+        (ref: ElementRef) => {
+            if (
+                appSlug === undefined ||
+                appName === undefined ||
+                latestReadyVersion === undefined
+            ) {
+                return;
+            }
+            dispatch(
+                addThreadElementReference({
+                    threadUuid,
+                    reference: {
+                        appUuid,
+                        appSlug,
+                        appDisplayName: getAppDisplayName(appName, appUuid),
+                        version: latestReadyVersion,
+                        ...ref,
+                    },
+                }),
+            );
+        },
+        [dispatch, threadUuid, appUuid, appSlug, appName, latestReadyVersion],
+    );
+    // Picker and lineage both claim clicks in the preview: one at a time.
+    const picker = useElementPicker({
+        identityKey,
+        onEnabled: onLineageCancelled,
+        onPick: handlePick,
+    });
+    const { lineageEnabled, onToggleLineage } = inspector.panelProps;
+    const handleToggleLineage = () => {
+        if (!lineageEnabled) picker.cancel();
+        onToggleLineage();
     };
 
     const {
@@ -177,13 +222,16 @@ export const AiDataAppPreviewPanel: FC<Props> = ({
                     appUuid={appUuid}
                     identityKey={identityKey}
                     capabilities={{ gsheetExport: true }}
-                    {...(showInspector ? inspector.iframeProps : {})}
+                    {...(showInspector
+                        ? { ...inspector.iframeProps, ...picker.iframeProps }
+                        : {})}
                 />
                 {showInspector && !inspector.hidden && (
                     <AppInspectorPanel
                         projectUuid={projectUuid}
                         hideWhenEmpty={!inspectorPinned}
                         {...inspector.panelProps}
+                        onToggleLineage={handleToggleLineage}
                     />
                 )}
             </>
@@ -251,6 +299,12 @@ export const AiDataAppPreviewPanel: FC<Props> = ({
                                 )}
                             </Menu.Dropdown>
                         </Menu>
+                        {showInspector && picker.available && (
+                            <ElementPickerButton
+                                enabled={picker.enabled}
+                                onToggle={picker.toggle}
+                            />
+                        )}
                         {closeButton}
                     </Group>
                 </Box>

--- a/packages/frontend/src/ee/features/aiCopilot/store/aiAgentThreadElementRefsSlice.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/store/aiAgentThreadElementRefsSlice.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+import {
+    addThreadElementReference,
+    aiAgentThreadElementRefsSlice,
+    clearThreadElementReferences,
+    removeThreadElementReference,
+    selectThreadElementReferences,
+    type ThreadElementReference,
+} from './aiAgentThreadElementRefsSlice';
+
+const { reducer } = aiAgentThreadElementRefsSlice;
+
+const wrap = (aiAgentThreadElementRefs: ReturnType<typeof reducer>) => ({
+    aiAgentThreadElementRefs,
+});
+
+const heading: ThreadElementReference = {
+    appUuid: 'app-1',
+    appSlug: 'f1-standings',
+    appDisplayName: 'F1 standings',
+    version: 3,
+    tag: 'h1',
+    text: 'FORMULA 1',
+    loc: 'src/App.jsx:14',
+};
+
+const button: ThreadElementReference = {
+    ...heading,
+    tag: 'button',
+    text: 'Send',
+    loc: '',
+};
+
+const reduce = (...actions: Parameters<typeof reducer>[1][]) =>
+    actions.reduce(reducer, reducer(undefined, { type: '@@init' }));
+
+describe('aiAgentThreadElementRefsSlice', () => {
+    it('has no references for an unknown thread', () => {
+        const state = wrap(reduce());
+        expect(selectThreadElementReferences('t1')(state)).toEqual([]);
+    });
+
+    it('adds references in pick order, per thread', () => {
+        const state = wrap(
+            reduce(
+                addThreadElementReference({
+                    threadUuid: 't1',
+                    reference: heading,
+                }),
+                addThreadElementReference({
+                    threadUuid: 't1',
+                    reference: button,
+                }),
+                addThreadElementReference({
+                    threadUuid: 't2',
+                    reference: button,
+                }),
+            ),
+        );
+        expect(selectThreadElementReferences('t1')(state)).toEqual([
+            heading,
+            button,
+        ]);
+        expect(selectThreadElementReferences('t2')(state)).toEqual([button]);
+    });
+
+    it('collapses the same element picked twice from the same version', () => {
+        const state = wrap(
+            reduce(
+                addThreadElementReference({
+                    threadUuid: 't1',
+                    reference: heading,
+                }),
+                addThreadElementReference({
+                    threadUuid: 't1',
+                    reference: { ...heading, appDisplayName: 'renamed' },
+                }),
+            ),
+        );
+        expect(selectThreadElementReferences('t1')(state)).toEqual([heading]);
+    });
+
+    it('keeps the same element picked from another version', () => {
+        const state = wrap(
+            reduce(
+                addThreadElementReference({
+                    threadUuid: 't1',
+                    reference: heading,
+                }),
+                addThreadElementReference({
+                    threadUuid: 't1',
+                    reference: { ...heading, version: 4 },
+                }),
+            ),
+        );
+        expect(selectThreadElementReferences('t1')(state)).toHaveLength(2);
+    });
+
+    it('removes one reference and leaves the rest', () => {
+        const state = wrap(
+            reduce(
+                addThreadElementReference({
+                    threadUuid: 't1',
+                    reference: heading,
+                }),
+                addThreadElementReference({
+                    threadUuid: 't1',
+                    reference: button,
+                }),
+                removeThreadElementReference({
+                    threadUuid: 't1',
+                    reference: heading,
+                }),
+            ),
+        );
+        expect(selectThreadElementReferences('t1')(state)).toEqual([button]);
+    });
+
+    it('clears only the given thread', () => {
+        const state = wrap(
+            reduce(
+                addThreadElementReference({
+                    threadUuid: 't1',
+                    reference: heading,
+                }),
+                addThreadElementReference({
+                    threadUuid: 't2',
+                    reference: heading,
+                }),
+                clearThreadElementReferences({ threadUuid: 't1' }),
+            ),
+        );
+        expect(selectThreadElementReferences('t1')(state)).toEqual([]);
+        expect(selectThreadElementReferences('t2')(state)).toEqual([heading]);
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/store/aiAgentThreadElementRefsSlice.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/store/aiAgentThreadElementRefsSlice.ts
@@ -1,0 +1,76 @@
+// Per-thread element references waiting for the next prompt; kept outside the
+// preview panel so they survive closing it and a new app version landing.
+
+import { dataAppElementContextKey } from '@lightdash/common';
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+
+export type ThreadElementReference = {
+    appUuid: string;
+    appSlug: string;
+    appDisplayName: string;
+    /** The ready version the reference was picked from. */
+    version: number;
+    tag: string;
+    text: string;
+    loc: string;
+};
+
+type State = Record<string, ThreadElementReference[]>;
+
+const initialState: State = {};
+
+const NO_REFERENCES: ThreadElementReference[] = [];
+
+const referenceKey = dataAppElementContextKey;
+
+export const aiAgentThreadElementRefsSlice = createSlice({
+    name: 'aiAgentThreadElementRefs',
+    initialState,
+    reducers: {
+        addThreadElementReference: (
+            state,
+            action: PayloadAction<{
+                threadUuid: string;
+                reference: ThreadElementReference;
+            }>,
+        ) => {
+            const { threadUuid, reference } = action.payload;
+            const existing = state[threadUuid] ?? [];
+            const key = referenceKey(reference);
+            if (existing.some((r) => referenceKey(r) === key)) return;
+            state[threadUuid] = [...existing, reference];
+        },
+        removeThreadElementReference: (
+            state,
+            action: PayloadAction<{
+                threadUuid: string;
+                reference: ThreadElementReference;
+            }>,
+        ) => {
+            const { threadUuid, reference } = action.payload;
+            const existing = state[threadUuid];
+            if (!existing) return;
+            const key = referenceKey(reference);
+            state[threadUuid] = existing.filter((r) => referenceKey(r) !== key);
+        },
+        clearThreadElementReferences: (
+            state,
+            action: PayloadAction<{ threadUuid: string }>,
+        ) => {
+            delete state[action.payload.threadUuid];
+        },
+    },
+});
+
+export const {
+    addThreadElementReference,
+    removeThreadElementReference,
+    clearThreadElementReferences,
+} = aiAgentThreadElementRefsSlice.actions;
+
+/** Only a thread composer carries references; a new-thread composer has none. */
+export const selectThreadElementReferences =
+    (threadUuid: string | undefined) =>
+    (state: { aiAgentThreadElementRefs: State }): ThreadElementReference[] =>
+        (threadUuid && state.aiAgentThreadElementRefs[threadUuid]) ||
+        NO_REFERENCES;

--- a/packages/frontend/src/ee/features/aiCopilot/store/index.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/store/index.ts
@@ -1,5 +1,6 @@
 import { configureStore } from '@reduxjs/toolkit';
 import { aiAgentLauncherSlice } from './aiAgentLauncherSlice';
+import { aiAgentThreadElementRefsSlice } from './aiAgentThreadElementRefsSlice';
 import { aiAgentThreadModeSlice } from './aiAgentThreadModeSlice';
 import { aiAgentThreadStreamSlice } from './aiAgentThreadStreamSlice';
 import { aiArtifactSlice } from './aiArtifactSlice';
@@ -9,6 +10,7 @@ export const store = configureStore({
     reducer: {
         aiAgentThreadStream: aiAgentThreadStreamSlice.reducer,
         aiAgentThreadMode: aiAgentThreadModeSlice.reducer,
+        aiAgentThreadElementRefs: aiAgentThreadElementRefsSlice.reducer,
         aiArtifact: aiArtifactSlice.reducer,
         aiAgentLauncher: aiAgentLauncherSlice.reducer,
         createIssue: createIssueSlice.reducer,


### PR DESCRIPTION
## Summary

Top of the ZAP-976 stack. A user with a data app open in the AI agent thread's full-page preview panel toggles the **element picker** from the panel header, clicks elements in the running app, and each click adds an **element reference** pill to the message composer. Sending attaches the references as `data_app_element` context and clears the pills.

- Picker toggle sits right of the more-options button, only in the full-page layout (same gate as the network inspector) and only after the SDK announces availability. Picker on turns lineage off and vice versa; Esc leaves the picker.
- References live in a per-thread redux slice tagged with the app's uuid, slug, and the version they were picked from, so they survive closing the panel and a new version landing. Same element twice yields one pill; pills are removable.
- Composer renders them in the attachment row next to CSV attachments, requires non-empty text to send, attaches them as context, and clears them after send. The sent bubble shows a pill per reference, also after reload.

Out of scope: launcher preview, clicking a sent pill to scroll the preview, clearing pills when a new version lands.

## Test plan

- [x] panel render test: toggle absent until the SDK announces and when `showInspector` is false; a selected event produces a reference in the composer
- [x] slice reducer tests
- [x] proof of work on a local instance of this branch (`.local/proofs/ZAP-976/proof.md`, untracked): picker gating in full-page vs launcher and with an older SDK, dedupe, Esc, removal, panel close, send disabled without text, send + reload, agent brief verbatim, build started, 403 for a user without app access, builder picker unchanged

Closes: ZAP-976
Closes: ZAP-984

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYqCC1cLQv5apggPng7HgQ