### PR TITLE
feat(ai): show/hide network inspector from data app preview menu

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDataAppPreviewPanel.inspector.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDataAppPreviewPanel.inspector.test.tsx
@@ -1,4 +1,5 @@
 import { act, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { QueryEvent } from '../../../../../features/apps/hooks/useAppSdkBridge';
 import { renderWithProviders } from '../../../../../testing/testUtils';
@@ -143,6 +144,33 @@ describe('AiDataAppPreviewPanel inspector', () => {
         act(() => latestIframeProps().onQueryEvent?.(readyQuery('r2')));
 
         expect(screen.getByText('Queries (2)')).toBeInTheDocument();
+    });
+
+    it('re-opens a dismissed inspector from the menu', async () => {
+        const user = userEvent.setup();
+        renderWithProviders(panel(true));
+        act(() => latestIframeProps().onQueryEvent?.(readyQuery('r1')));
+        expect(screen.getByText('Queries (1)')).toBeInTheDocument();
+
+        await user.click(screen.getByLabelText('Close inspector panel'));
+        expect(screen.queryByText('Queries (1)')).not.toBeInTheDocument();
+
+        await user.click(screen.getByLabelText('More options'));
+        await user.click(await screen.findByText('Show network'));
+        expect(screen.getByText('Queries (1)')).toBeInTheDocument();
+
+        await user.click(screen.getByLabelText('More options'));
+        expect(await screen.findByText('Hide network')).toBeInTheDocument();
+    });
+
+    it('shows the inspector from the menu before the first query', async () => {
+        const user = userEvent.setup();
+        renderWithProviders(panel(true));
+        expect(screen.queryByText(/Queries \(/)).not.toBeInTheDocument();
+
+        await user.click(screen.getByLabelText('More options'));
+        await user.click(await screen.findByText('Show network'));
+        expect(screen.getByText('Queries (0)')).toBeInTheDocument();
     });
 
     it('leaves the launcher preview without inspector wiring', () => {

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDataAppPreviewPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDataAppPreviewPanel.tsx
@@ -10,8 +10,13 @@ import {
     Text,
     Tooltip,
 } from '@mantine/core';
-import { IconDots, IconExternalLink, IconX } from '@tabler/icons-react';
-import { type FC, type ReactNode } from 'react';
+import {
+    IconArrowsUpDown,
+    IconDots,
+    IconExternalLink,
+    IconX,
+} from '@tabler/icons-react';
+import { type FC, type ReactNode, useState } from 'react';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import TruncatedText from '../../../../../components/common/TruncatedText';
 import AppIframePreview from '../../../../../features/apps/AppIframePreview';
@@ -53,6 +58,24 @@ export const AiDataAppPreviewPanel: FC<Props> = ({
     // Lives here, not next to the iframe, so logs and dismissal survive the
     // token reload between versions. Only wired in when `showInspector`.
     const inspector = useAppInspector({ identityKey, defaultHidden: false });
+    // Opened from the menu: keep the panel visible (collapsed bar) even before
+    // the app issues its first query.
+    const [inspectorPinned, setInspectorPinned] = useState(false);
+    const hasInspectorLogs =
+        inspector.panelProps.queries.length > 0 ||
+        inspector.panelProps.externalRequests.length > 0;
+    const isInspectorVisible =
+        showInspector &&
+        !inspector.hidden &&
+        (inspectorPinned || hasInspectorLogs);
+    const toggleInspector = () => {
+        if (isInspectorVisible) {
+            inspector.hide();
+        } else {
+            setInspectorPinned(true);
+            inspector.show();
+        }
+    };
 
     const {
         data: token,
@@ -159,6 +182,7 @@ export const AiDataAppPreviewPanel: FC<Props> = ({
                 {showInspector && !inspector.hidden && (
                     <AppInspectorPanel
                         projectUuid={projectUuid}
+                        hideWhenEmpty={!inspectorPinned}
                         {...inspector.panelProps}
                     />
                 )}
@@ -210,6 +234,21 @@ export const AiDataAppPreviewPanel: FC<Props> = ({
                                 >
                                     Open in new tab
                                 </Menu.Item>
+                                {showInspector && (
+                                    <Menu.Item
+                                        leftSection={
+                                            <MantineIcon
+                                                icon={IconArrowsUpDown}
+                                                size="sm"
+                                            />
+                                        }
+                                        onClick={toggleInspector}
+                                    >
+                                        {isInspectorVisible
+                                            ? 'Hide network'
+                                            : 'Show network'}
+                                    </Menu.Item>
+                                )}
                             </Menu.Dropdown>
                         </Menu>
                         {closeButton}

--- a/packages/frontend/src/features/apps/hooks/useAppInspector.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppInspector.ts
@@ -40,9 +40,11 @@ export type AppInspectorPanelProps = {
 };
 
 export type UseAppInspectorResult = {
-    /** Parent-owned visibility: the panel's X hides it, `show` re-opens it. */
+    /** Parent-owned visibility: the panel's X (or `hide`) hides it, `show`
+     *  re-opens it. */
     hidden: boolean;
     show: () => void;
+    hide: () => void;
     /** Persist-aware rollover for a host-triggered iframe reload (manual
      *  refresh). Version switches roll over via `identityKey`. */
     rolloverLogs: () => void;
@@ -169,6 +171,7 @@ export const useAppInspector = ({
     return {
         hidden,
         show,
+        hide,
         rolloverLogs,
         readyQueryCount: countReadyQueriesSinceBoundary(
             queries,


### PR DESCRIPTION
The AI thread's data app preview shows a query inspector, but its X hid it for good: the hook's `hidden` flag was parent-owned and the thread panel never called `show`. The viewer page had a "View network" menu item; the thread panel did not.

```diff
 <Menu.Dropdown>
   Open in new tab
+  Show network / Hide network      # toggles inspector.hide() / inspector.show()
 </Menu.Dropdown>
```

**Behaviour**

- Three-dots menu gets a "Show network" / "Hide network" item, same icon as the viewer's item.
- Label reflects actual visibility: while the inspector is auto-hidden for being empty it reads "Show network", not "Hide".
- Opening from the menu pins the panel so it stays as a collapsed title bar even before the app issues its first query (`hideWhenEmpty={false}`). Auto-reveal on first query is unchanged.
- `useAppInspector` exposes `hide` alongside `show`; the launcher preview still gets no inspector wiring.

**Tests** (`AiDataAppPreviewPanel.inspector.test.tsx`)

- dismiss via X, reopen from the menu, label flips to "Hide network"
- open from the menu before any query shows the empty collapsed bar

Relates: ZAP-966

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016rDeCRxvGteApzHDPa782R
