### PR TITLE
fix(feature-flags): fail closed for anonymous AI copilot flag checks

### DIFF
--- a/packages/backend/src/ee/models/CommercialFeatureFlagModel.test.ts
+++ b/packages/backend/src/ee/models/CommercialFeatureFlagModel.test.ts
@@ -82,3 +82,45 @@ describe('CommercialFeatureFlagModel direct access', () => {
         });
     });
 });
+
+describe('CommercialFeatureFlagModel AI copilot', () => {
+    let tracker: Tracker;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    afterEach(() => {
+        tracker.reset();
+    });
+
+    const createGatedModel = () =>
+        new CommercialFeatureFlagModel({
+            database,
+            lightdashConfig: {
+                ...lightdashConfigMock,
+                enabledFeatureFlags: new Set<string>(),
+                disabledFeatureFlags: new Set<string>(),
+                ai: {
+                    ...lightdashConfigMock.ai,
+                    copilot: {
+                        ...lightdashConfigMock.ai.copilot,
+                        enabled: true,
+                        requiresFeatureFlag: true,
+                    },
+                },
+            },
+        });
+
+    it('fails closed without a user when the flag is org-gated', async () => {
+        await expect(
+            createGatedModel().get({
+                featureFlagId: CommercialFeatureFlags.AiCopilot,
+            }),
+        ).resolves.toEqual({
+            id: CommercialFeatureFlags.AiCopilot,
+            enabled: false,
+        });
+        expect(tracker.history.select).toHaveLength(0);
+    });
+});

--- a/packages/backend/src/ee/models/CommercialFeatureFlagModel.ts
+++ b/packages/backend/src/ee/models/CommercialFeatureFlagModel.ts
@@ -58,10 +58,10 @@ export class CommercialFeatureFlagModel extends FeatureFlagModel {
             return { id: featureFlagId, enabled: copilotConfigEnabled };
         }
 
+        // Anonymous and embed callers have no organization to resolve
+        // overrides against, so the per-org gate fails closed.
         if (!user) {
-            throw new Error(
-                'User is required to check if AI copilot is enabled',
-            );
+            return { id: featureFlagId, enabled: false };
         }
 
         const dbResult = await this.tryGetFromDatabase({ user, featureFlagId });


### PR DESCRIPTION
## Problem

`GET /api/v2/feature-flag/:featureFlagId` has no auth middleware, so it is called by logged-out pages and embed (JWT) viewers with no session user. For `ai-copilot` on shared tenants (where `requiresFeatureFlag` is on), the commercial flag handler threw a plain `Error('User is required to check if AI copilot is enabled')`. That is a 500 for the caller and a Sentry error event on every hit. Sentry shows this as one of the highest-volume unhandled issues, with most events carrying an empty user.

## Fix

Return `{ enabled: false }` when there is no user, matching the direct-access and homepage-builder flags in the same model. There is no organization to resolve an override against without a user, so failing closed is the only correct answer anyway.

## Regression analysis

- Authenticated callers are unaffected: the `user` branch and the DB override lookup are unchanged.
- Dedicated instances (`requiresFeatureFlag` off) are unaffected: they return early before the user check, as before.
- Anonymous and embed callers previously got a 500. They now get `enabled: false`, which is what the frontend already treats a failed flag query as. No UI that gates on this flag was reachable for those callers.
- Added a unit test pinning the fail-closed behaviour and asserting no flag queries are issued.

Closes: PROD-10871

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017DuyysYdtgJXJdrQy63van
