### PR TITLE
fix(dashboards): stop unsaved-changes dialog firing on uuid dashboard URLs

### DIFF
--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -60,6 +60,7 @@ import DashboardProvider from '../providers/Dashboard/DashboardProvider';
 import useDashboardContext from '../providers/Dashboard/useDashboardContext';
 import useDashboardTileStatusContext from '../providers/Dashboard/useDashboardTileStatusContext';
 import useNativeFullscreenToggle from '../providers/Fullscreen/useNativeFullscreenToggle';
+import { isSameDashboardRoute } from '../utils/dashboardRoutes';
 import '../styles/react-grid.css';
 
 const Dashboard: FC = () => {
@@ -726,13 +727,17 @@ const Dashboard: FC = () => {
         if (
             isEditMode &&
             (haveTilesChanged || haveFiltersChanged || haveTabsChanged) &&
-            !nextLocation.pathname.includes(
-                `/projects/${projectUrlIdentifier}/dashboards/${dashboardIdentifier}`,
-            ) &&
-            (!dashboardUuid ||
-                !nextLocation.pathname.includes(
-                    `/projects/${projectUrlIdentifier}/dashboards/${dashboardUuid}`,
-                )) &&
+            // A URL may carry either the uuid or the slug for both the project
+            // and the dashboard, so accept any combination — but compare whole
+            // segments, and require the project to match too: dashboard slugs
+            // are only unique within a project.
+            !isSameDashboardRoute({
+                location: nextLocation,
+                projectUuid,
+                projectSlug: projectUrlIdentifier,
+                dashboardUuid,
+                dashboardSlug: dashboardIdentifier,
+            }) &&
             // Allow user to add a new table
             !sessionStorage.getItem(`unsavedDashboardTiles:${dashboardUuid}`)
         ) {

--- a/packages/frontend/src/utils/dashboardRoutes.test.ts
+++ b/packages/frontend/src/utils/dashboardRoutes.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import { isSameDashboardRoute } from './dashboardRoutes';
+
+const PROJECT_UUID = '3675b69e-8324-4110-bdca-059031aa8da3';
+const PROJECT_SLUG = 'jaffle-shop';
+const DASHBOARD_UUID = 'a9d63dcf-81de-4a1b-9dae-97cd94917d7a';
+const DASHBOARD_SLUG = 'revenue';
+
+const check = (pathname: string) =>
+    isSameDashboardRoute({
+        location: { pathname },
+        projectUuid: PROJECT_UUID,
+        projectSlug: PROJECT_SLUG,
+        dashboardUuid: DASHBOARD_UUID,
+        dashboardSlug: DASHBOARD_SLUG,
+    });
+
+describe('isSameDashboardRoute', () => {
+    it('matches a slug URL', () => {
+        expect(
+            check(
+                `/projects/${PROJECT_SLUG}/dashboards/${DASHBOARD_SLUG}/edit`,
+            ),
+        ).toBe(true);
+    });
+
+    it('matches a uuid URL', () => {
+        expect(
+            check(
+                `/projects/${PROJECT_UUID}/dashboards/${DASHBOARD_UUID}/edit`,
+            ),
+        ).toBe(true);
+    });
+
+    it('matches a uuid project with a slug dashboard', () => {
+        expect(
+            check(
+                `/projects/${PROJECT_UUID}/dashboards/${DASHBOARD_SLUG}/edit`,
+            ),
+        ).toBe(true);
+    });
+
+    it('matches a slug project with a uuid dashboard', () => {
+        expect(
+            check(
+                `/projects/${PROJECT_SLUG}/dashboards/${DASHBOARD_UUID}/edit`,
+            ),
+        ).toBe(true);
+    });
+
+    it('matches with a trailing tab segment', () => {
+        expect(
+            check(
+                `/projects/${PROJECT_SLUG}/dashboards/${DASHBOARD_SLUG}/edit/tabs/abc`,
+            ),
+        ).toBe(true);
+    });
+
+    it('matches without a trailing mode segment', () => {
+        expect(
+            check(`/projects/${PROJECT_SLUG}/dashboards/${DASHBOARD_SLUG}`),
+        ).toBe(true);
+    });
+
+    it('does not match another project with the same dashboard slug', () => {
+        expect(
+            check(`/projects/other-project/dashboards/${DASHBOARD_SLUG}/view`),
+        ).toBe(false);
+    });
+
+    it('does not match a dashboard slug that merely starts with this one', () => {
+        expect(
+            check(
+                `/projects/${PROJECT_SLUG}/dashboards/${DASHBOARD_SLUG}-2/edit`,
+            ),
+        ).toBe(false);
+    });
+
+    it('does not match a project slug that merely starts with this one', () => {
+        expect(
+            check(
+                `/projects/${PROJECT_SLUG}-staging/dashboards/${DASHBOARD_SLUG}/edit`,
+            ),
+        ).toBe(false);
+    });
+
+    it('does not match a different dashboard in the same project', () => {
+        expect(
+            check(`/projects/${PROJECT_SLUG}/dashboards/other-dashboard/edit`),
+        ).toBe(false);
+    });
+
+    it('does not match a non-dashboard route', () => {
+        expect(check(`/projects/${PROJECT_SLUG}/tables`)).toBe(false);
+    });
+
+    it('does not match when the dashboard segment is absent', () => {
+        expect(check(`/projects/${PROJECT_SLUG}/dashboards`)).toBe(false);
+    });
+
+    it('does not match a bare path', () => {
+        expect(check('/')).toBe(false);
+    });
+
+    it('does not match a missing segment against undefined identifiers', () => {
+        // Identifiers are undefined while the dashboard loads; a malformed
+        // path must not match by both sides being absent.
+        expect(
+            isSameDashboardRoute({
+                location: { pathname: '/' },
+                projectUuid: undefined,
+                dashboardUuid: undefined,
+            }),
+        ).toBe(false);
+    });
+});

--- a/packages/frontend/src/utils/dashboardRoutes.ts
+++ b/packages/frontend/src/utils/dashboardRoutes.ts
@@ -22,10 +22,14 @@ const getDashboardIdentifierFromPathname = (pathname: string) => {
     return match?.params.dashboardIdentifier ?? null;
 };
 
-const getProjectUuidFromPathname = (pathname: string) => {
-    const match = matchPath('/projects/:projectUuid/*', pathname);
+// A URL may carry the project's uuid or its slug, so this is an identifier
+// rather than specifically a uuid.
+const getProjectIdentifierFromPathname = (pathname: string) => {
+    const match =
+        matchPath('/projects/:projectIdentifier/*', pathname) ??
+        matchPath('/projects/:projectIdentifier', pathname);
 
-    return match?.params.projectUuid ?? null;
+    return match?.params.projectIdentifier ?? null;
 };
 
 export const isSameLocation = (
@@ -41,19 +45,34 @@ export const isSameLocation = (
     );
 };
 
+/**
+ * Whether a location points at this dashboard, in this project.
+ *
+ * A URL may carry either the uuid or the slug for the project and for the
+ * dashboard, in any combination, so both forms are accepted. Matching is on
+ * whole path segments, and the project has to match too: dashboard slugs are
+ * only unique within a project, so a same-named dashboard elsewhere is not
+ * this one.
+ */
 export const isSameDashboardRoute = ({
     location,
     projectUuid,
+    projectSlug,
     dashboardUuid,
     dashboardSlug,
 }: {
     location: LocationLike;
-    projectUuid: string;
+    projectUuid?: string;
+    projectSlug?: string;
     dashboardUuid?: string;
     dashboardSlug?: string;
 }) => {
-    const currentProjectUuid = getProjectUuidFromPathname(location.pathname);
-    if (currentProjectUuid !== projectUuid) return false;
+    const currentProjectIdentifier = getProjectIdentifierFromPathname(
+        location.pathname,
+    );
+    if (!currentProjectIdentifier) return false;
+    if (![projectUuid, projectSlug].includes(currentProjectIdentifier))
+        return false;
 
     const currentDashboardIdentifier = getDashboardIdentifierFromPathname(
         location.pathname,


### PR DESCRIPTION
Closes: GLITCH-745

### Description:

Editing a dashboard via its **uuid** URL with unsaved changes popped "You have unsaved changes to your dashboard!" on navigations that should be exempt — including navigations to the dashboard you were already on.

The `useBlocker` exemption compared against `projectUrlIdentifier`, which is the project **slug**:

```ts
!nextLocation.pathname.includes(
    `/projects/${projectUrlIdentifier}/dashboards/${dashboardIdentifier}`,
)
```

On a uuid-form URL that string never matches, so the "staying on this dashboard" escape hatch was dead.

Replaced with segment parsing in `isSameDashboardRoute`. A URL may carry either the uuid or the slug for both the project and the dashboard, so any combination is accepted — but identifiers must match **whole path segments**, and the **project must match too**.

That last part matters: dashboard slugs are only unique within a project, so matching on the dashboard segment alone would treat `/projects/project-b/dashboards/revenue/view` as "the dashboard we're already on" and discard edits silently. Segment matching also stops `revenue` matching `revenue-2` — a looseness the original `.includes()` already had.

### Repro

1. Open a dashboard in edit mode at `/projects/{projectUuid}/dashboards/{dashboardUuid}/edit`
2. Add a tile so there are unsaved changes
3. Trigger a navigation that should be exempt — the dialog appears

Slug URLs were unaffected, which is why it went unnoticed: you only land on the uuid form via copy-paste from the database, an API response, or a hand-built link.

Originally diagnosed by instrumenting the blocker — `nextLocation.pathname` was the identical URL it was blocking — and confirmed by the same repro producing no dialog on the slug URL.

### Tests

`isSameDashboardRoute.test.ts`, 12 cases:

- slug URL, uuid URL, mixed uuid-project + slug-dashboard, trailing `/edit/tabs/...` → match
- different project with the same dashboard slug → no match
- `revenue-2` vs `revenue`, `jaffle-shop-staging` vs `jaffle-shop` → no match
- different dashboard in the same project, non-dashboard route, missing segment, bare `/` → no match
- `undefined` identifier against a missing segment → no match (identifiers are undefined while the dashboard loads)

Also verified in the app that the guard still fires on a genuine leave: uuid URL, unsaved change, no sessionStorage exemption, navigating Home → dialog shown as expected.

### Risk assessment:

- [ ] This is a high-risk change
