### PR TITLE
feat(dashboard): build charts in a modal without leaving the dashboard

### DIFF
--- a/packages/common/src/featureFlags/previewFeatureFlags.ts
+++ b/packages/common/src/featureFlags/previewFeatureFlags.ts
@@ -29,6 +29,10 @@ const PREVIEW_EXCLUDED_FEATURE_FLAGS: ReadonlySet<string> = new Set<string>([
     // gallery replaces; keep previews on the shipped path until it has its
     // own coverage. QA can still turn it on with a feature_flag_overrides row.
     FeatureFlags.ExplorerChartGallery,
+    // Same reason: the dashboard E2E specs drive the navigate-away "New chart"
+    // flow, which the in-dashboard modal replaces. Opt-in POC — keep previews
+    // on the shipped path until it has its own coverage.
+    FeatureFlags.DashboardCustomMetrics,
     // Derived from instance configuration: left to their config handler so a
     // preview never advertises a feature whose backend isn't configured.
     CommercialFeatureFlags.AiCopilot,

--- a/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
+++ b/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
@@ -163,6 +163,9 @@ const AddTileButton: FC<Props> = ({
                             <Menu.Item
                                 onClick={() => {
                                     if (onNewChart) {
+                                        // Modal supplies the dashboard via
+                                        // context; sessionStorage would also
+                                        // show the navbar's edit banner.
                                         onNewChart();
                                         return;
                                     }

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartEditorModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartEditorModal.tsx
@@ -1,0 +1,182 @@
+import {
+    ChartType,
+    type AdditionalMetric,
+    type SavedChart,
+} from '@lightdash/common';
+import { IconChartBar } from '@tabler/icons-react';
+import { useCallback, useMemo, useState, type FC } from 'react';
+import { Provider } from 'react-redux';
+import {
+    buildInitialExplorerState,
+    createExplorerStore,
+} from '../../features/explorer/store';
+import { MergeProvider } from '../../features/mergeQuery/context/MergeContext';
+import { useExplore } from '../../hooks/useExplore';
+import { useExplorerQueryEffects } from '../../hooks/useExplorerQueryEffects';
+import { ExplorerSection } from '../../providers/Explorer/types';
+import { ModalHostedContext } from '../../providers/Explorer/useIsModalHosted';
+import MantineModal from '../common/MantineModal';
+import Page from '../common/Page/Page';
+import Explorer from '../Explorer';
+import ExploreSideBar from '../Explorer/ExploreSideBar';
+
+type ContentProps = {
+    exploreId: string;
+    editChart?: SavedChart;
+    seededMetrics: AdditionalMetric[];
+    onExploreSelect: (exploreName: string) => void;
+    onBackToTables: () => void;
+};
+
+const DashboardChartEditorContent: FC<ContentProps> = ({
+    exploreId,
+    editChart,
+    seededMetrics,
+    onExploreSelect,
+    onBackToTables,
+}) => {
+    const { data } = useExplore(exploreId);
+
+    // Store initializes once; the parent key remounts it per session.
+    // No useExplorerRoute — it would rewrite the dashboard URL from the modal.
+    const [store] = useState(() =>
+        createExplorerStore({
+            explorer: buildInitialExplorerState({
+                isEditMode: true,
+                initialState: {
+                    expandedSections: [
+                        ExplorerSection.FILTERS,
+                        ExplorerSection.VISUALIZATION,
+                        ExplorerSection.RESULTS,
+                    ],
+                    savedChart: editChart,
+                    unsavedChartVersion: {
+                        tableName: exploreId,
+                        metricQuery: editChart?.metricQuery ?? {
+                            exploreName: exploreId,
+                            dimensions: [],
+                            metrics: [],
+                            filters: {},
+                            sorts: [],
+                            limit: 500,
+                            tableCalculations: [],
+                            additionalMetrics: seededMetrics,
+                            timezone: undefined,
+                        },
+                        chartConfig: editChart?.chartConfig ?? {
+                            type: ChartType.CARTESIAN,
+                            config: {
+                                layout: { xField: '', yField: [] },
+                                eChartsConfig: { series: [] },
+                            },
+                        },
+                        tableConfig: editChart?.tableConfig ?? {
+                            columnOrder: [],
+                        },
+                        pivotConfig: editChart?.pivotConfig ?? { columns: [] },
+                    },
+                },
+                defaultLimit: 500,
+            }),
+        }),
+    );
+
+    return (
+        <Provider store={store}>
+            <ExplorerEffects />
+            <Page
+                withContainerHeight
+                title={data ? data.label : 'Tables'}
+                sidebar={
+                    <ExploreSideBar
+                        onExploreClick={(explore) =>
+                            onExploreSelect(explore.name)
+                        }
+                        onBackToTables={onBackToTables}
+                    />
+                }
+                isSidebarOpen
+                withFullHeight
+                withPaddedContent
+            >
+                <MergeProvider>
+                    <Explorer />
+                </MergeProvider>
+            </Page>
+        </Provider>
+    );
+};
+
+// Query effects must run inside the store Provider.
+const ExplorerEffects: FC = () => {
+    useExplorerQueryEffects();
+    return null;
+};
+
+type Props = {
+    opened: boolean;
+    dashboardUuid: string;
+    dashboardName: string;
+    editChart?: SavedChart;
+    seededMetrics?: AdditionalMetric[];
+    onChartSaved: (chart: SavedChart) => void;
+    onClose: () => void;
+};
+
+/**
+ * Full-screen Explorer over a dashboard, so authors build a chart without
+ * leaving the page. Modelled on the embedded dashboard's chart editor.
+ */
+const DashboardChartEditorModal: FC<Props> = ({
+    opened,
+    dashboardUuid,
+    dashboardName,
+    editChart,
+    seededMetrics = [],
+    onChartSaved,
+    onClose,
+}) => {
+    const [pickedExploreId, setPickedExploreId] = useState<string>();
+    const exploreId = editChart ? editChart.tableName : pickedExploreId;
+
+    const modalHostValue = useMemo(
+        () => ({
+            isModalHosted: true,
+            onChartSaved,
+            dashboard: { uuid: dashboardUuid, name: dashboardName },
+        }),
+        [onChartSaved, dashboardUuid, dashboardName],
+    );
+
+    const handleClose = useCallback(() => {
+        setPickedExploreId(undefined);
+        onClose();
+    }, [onClose]);
+
+    return (
+        <MantineModal
+            opened={opened}
+            onClose={handleClose}
+            title={editChart ? 'Edit chart' : 'New chart'}
+            icon={IconChartBar}
+            fullScreen
+            cancelLabel={false}
+            modalBodyProps={{ px: 0, py: 0 }}
+        >
+            <ModalHostedContext.Provider value={modalHostValue}>
+                <DashboardChartEditorContent
+                    key={`${dashboardUuid}-${exploreId ?? 'picker'}-${
+                        editChart?.uuid ?? 'new'
+                    }`}
+                    exploreId={exploreId ?? ''}
+                    editChart={editChart}
+                    seededMetrics={seededMetrics}
+                    onExploreSelect={setPickedExploreId}
+                    onBackToTables={() => setPickedExploreId(undefined)}
+                />
+            </ModalHostedContext.Provider>
+        </MantineModal>
+    );
+};
+
+export default DashboardChartEditorModal;

--- a/packages/frontend/src/components/Explorer/SaveChartButton/index.tsx
+++ b/packages/frontend/src/components/Explorer/SaveChartButton/index.tsx
@@ -32,6 +32,10 @@ import {
     useUpdateMutation,
 } from '../../../hooks/useSavedQuery';
 import useSearchParams from '../../../hooks/useSearchParams';
+import {
+    useIsModalHosted,
+    useModalHostedChartSaved,
+} from '../../../providers/Explorer/useIsModalHosted';
 import MantineIcon from '../../common/MantineIcon';
 import MantineModal from '../../common/MantineModal';
 import ChartCreateModal from '../../common/modal/ChartCreateModal';
@@ -46,6 +50,10 @@ const SaveChartButton: FC<{
     const isAmbientAiEnabled = useAmbientAiEnabled();
     const embed = useEmbed();
     const isEmbedded = embed.embedToken !== undefined;
+    const isModalHosted = useIsModalHosted();
+    const onModalHostChartSaved = useModalHostedChartSaved();
+    // Both mean the Explorer is not the page, so saving must not navigate away.
+    const suppressNavigation = isEmbedded || isModalHosted;
     const projectUuid = useProjectUuid();
     const unsavedChartVersion = useExplorerSelector(selectUnsavedChartVersion);
     // For saving: enriched with map extent (only subscribes here to avoid re-renders elsewhere)
@@ -98,7 +106,9 @@ const SaveChartButton: FC<{
         setIsQueryModalOpen(true);
     };
 
-    const update = useAddVersionMutation({ redirectOnSuccess: !isEmbedded });
+    const update = useAddVersionMutation({
+        redirectOnSuccess: !suppressNavigation,
+    });
     const updateMetadata = useUpdateMutation(
         savedChart?.dashboardUuid ?? undefined,
         savedChart?.uuid,
@@ -240,7 +250,7 @@ const SaveChartButton: FC<{
                         // Trigger metadata generation on mouse enter if available
                         onMouseEnter={() => {
                             if (savedChart) return;
-                            if (isEmbedded) return;
+                            if (suppressNavigation) return;
                             if (!isAmbientAiEnabled) return;
                             triggerMetadataGeneration();
                         }}
@@ -301,13 +311,14 @@ const SaveChartButton: FC<{
                         setIsQueryModalOpen(false);
                         setIsSaveAsModal(false);
                         embed.onChartSaved?.(saved, 'created');
+                        onModalHostChartSaved?.(saved);
                     }}
                     defaultSpaceUuid={spaceUuid ?? undefined}
                     chartMetadata={generatedMetadata ?? undefined}
                     forceSpaceOrDashboardChoice={isSaveAsModal}
                     isSaveAs={isSaveAsModal}
-                    redirectOnSuccess={!isEmbedded}
-                    showViewChartAction={!isEmbedded}
+                    redirectOnSuccess={!suppressNavigation}
+                    showViewChartAction={!suppressNavigation}
                     forcedSpaceUuid={
                         isEmbedded ? embed.writeActions?.spaceUuid : undefined
                     }

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -125,6 +125,9 @@ type DashboardHeaderProps = {
         // Map of new tile UUID → source tile UUID, so dashboard filter `tileTargets` are copied from the source.
         tileUuidMapping?: Record<string, string>,
     ) => void;
+    // Overrides the default "New chart" navigation so the chart is built in
+    // a modal over the dashboard instead of on the Explorer page.
+    onNewChart?: () => void;
     onCancel: () => void;
     onSaveDashboard: () => void;
     onDelete: () => void;
@@ -155,6 +158,7 @@ const DashboardHeader = memo(
         dashboardTabs,
         dashboardTiles,
         onAddTiles,
+        onNewChart,
         onCancel,
         onSaveDashboard,
         onDelete,
@@ -610,6 +614,7 @@ const DashboardHeader = memo(
                             setAddingTab={setAddingTab}
                             activeTabUuid={activeTabUuid}
                             dashboardTabs={dashboardTabs}
+                            onNewChart={onNewChart}
                             radius="md"
                         />
 

--- a/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToDashboard.tsx
+++ b/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToDashboard.tsx
@@ -21,6 +21,10 @@ import useDashboardStorage from '../../../../hooks/dashboard/useDashboardStorage
 import useToaster from '../../../../hooks/toaster/useToaster';
 import { useOptionalProjectRoute } from '../../../../hooks/useProjectRoute';
 import { useCreateMutation } from '../../../../hooks/useSavedQuery';
+import {
+    useIsModalHosted,
+    useModalHostedChartSaved,
+} from '../../../../providers/Explorer/useIsModalHosted';
 import classes from './ChartCreateModal.module.css';
 import { DEFAULT_CHART_METADATA, type ChartMetadata } from './types';
 
@@ -89,6 +93,8 @@ export const SaveToDashboard: FC<Props> = ({
 
     const { showToastSuccess } = useToaster();
     const navigate = useNavigate();
+    const isModalHosted = useIsModalHosted();
+    const onModalHostChartSaved = useModalHostedChartSaved();
 
     const { mutateAsync: createChart } = useCreateMutation({
         redirectOnSuccess: false,
@@ -131,6 +137,16 @@ export const SaveToDashboard: FC<Props> = ({
                 },
                 ...getDefaultChartTileSize(savedData.chartConfig?.type),
             };
+            // Modal-hosted: delegate to host, skip dashboard storage and navigation.
+            if (isModalHosted) {
+                onModalHostChartSaved?.(chart);
+                showToastSuccess({
+                    title: `Success! ${values.name} was added to ${dashboardName}`,
+                });
+                onClose();
+                return;
+            }
+
             const unsavedDashboardTiles =
                 getUnsavedDashboardTiles(dashboardUuid);
             const existingTiles =
@@ -168,6 +184,9 @@ export const SaveToDashboard: FC<Props> = ({
             dashboardName,
             selectedDashboard?.tiles,
             selectedDashboard?.slug,
+            isModalHosted,
+            onModalHostChartSaved,
+            onClose,
         ],
     );
     return (

--- a/packages/frontend/src/components/common/modal/ChartCreateModal/index.tsx
+++ b/packages/frontend/src/components/common/modal/ChartCreateModal/index.tsx
@@ -6,6 +6,7 @@ import { IconChartBar } from '@tabler/icons-react';
 import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
 import useDashboardStorage from '../../../../hooks/dashboard/useDashboardStorage';
 import { useProjectUuid } from '../../../../hooks/useProjectUuid';
+import { useModalHostedDashboard } from '../../../../providers/Explorer/useIsModalHosted';
 import MantineModal, { type MantineModalProps } from '../../MantineModal';
 import { SaveToDashboard } from './SaveToDashboard';
 import { SaveToSpaceOrDashboard } from './SaveToSpaceOrDashboard';
@@ -61,8 +62,23 @@ const ChartCreateModal: FC<ChartCreateModalProps> = ({
     const [spaceUuid] = useState(defaultSpaceUuid);
 
     const { getEditingDashboardInfo } = useDashboardStorage();
-    const [editingDashboardInfo, setEditingDashboardInfo] = useState(() =>
+    const hostDashboard = useModalHostedDashboard();
+    const [storedDashboardInfo, setEditingDashboardInfo] = useState(() =>
         getEditingDashboardInfo(),
+    );
+    // A modal host supplies the dashboard directly; sessionStorage is only for
+    // the navigate-away flow.
+    const editingDashboardInfo = useMemo(
+        () =>
+            hostDashboard
+                ? {
+                      name: hostDashboard.name,
+                      dashboardUuid: hostDashboard.uuid,
+                      dashboardSlug: null,
+                      activeTabUuid: null,
+                  }
+                : storedDashboardInfo,
+        [hostDashboard, storedDashboardInfo],
     );
 
     useEffect(() => {

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -2,17 +2,22 @@ import { subject } from '@casl/ability';
 import {
     copyDateZoomTileTargets,
     excludeTilesFromTabScopedFilters,
+    getDefaultChartTileSize,
     getShadowedReservedNames,
     isEmptyDateZoomConfig,
     normalizeDateZoomConfig,
     pruneDateZoomConfig,
     removeDateZoomTileTargets,
+    ChartType,
     ContentType,
+    DashboardTileTypes,
     DateGranularity,
+    FeatureFlags,
     type DashboardFilterRule,
     type UpdateDashboard,
     type DashboardTile,
     type Dashboard as IDashboard,
+    type SavedChart,
 } from '@lightdash/common';
 import { Button, Group, Text } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
@@ -24,6 +29,7 @@ import { IconAlertCircle, IconCircleCheckFilled } from '@tabler/icons-react';
 import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
 import { type Layout } from 'react-grid-layout';
 import { useBlocker, useNavigate, useParams } from 'react-router';
+import { v4 as uuid4 } from 'uuid';
 import styles from '../components/common/Dashboard/Dashboard.module.css';
 import DashboardHeader from '../components/common/Dashboard/DashboardHeader';
 import ErrorState from '../components/common/ErrorState';
@@ -32,6 +38,7 @@ import DashboardDeleteModal from '../components/common/modal/DashboardDeleteModa
 import DashboardDuplicateModal from '../components/common/modal/DashboardDuplicateModal';
 import { DashboardExportModal } from '../components/common/modal/DashboardExportModal';
 import Page from '../components/common/Page/Page';
+import DashboardChartEditorModal from '../components/DashboardTiles/DashboardChartEditorModal';
 import PageSpinner from '../components/PageSpinner';
 import { useDashboardCommentsCheck } from '../features/comments';
 import DismissedDraftAlert from '../features/contentAsCode/components/DismissedDraftAlert';
@@ -54,6 +61,7 @@ import useToaster from '../hooks/toaster/useToaster';
 import { useContentAction } from '../hooks/useContent';
 import { useProjectUrlIdentifier } from '../hooks/useProjectRoute';
 import { useProjectUuid } from '../hooks/useProjectUuid';
+import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
 import useApp from '../providers/App/useApp';
 import DashboardAiAgentContextBridge from '../providers/Dashboard/DashboardAiAgentContextBridge';
 import DashboardProvider from '../providers/Dashboard/DashboardProvider';
@@ -773,6 +781,44 @@ const Dashboard: FC = () => {
         (c) => c.hasTilesThatSupportFilters,
     );
 
+    const dashboardCustomMetricsFlag = useServerFeatureFlag(
+        FeatureFlags.DashboardCustomMetrics,
+    );
+    const isDashboardCustomMetricsEnabled =
+        dashboardCustomMetricsFlag.data?.enabled === true;
+    const [isNewChartOpen, setIsNewChartOpen] = useState(false);
+    const [chartToEdit, setChartToEdit] = useState<SavedChart | undefined>();
+
+    const handleChartEditorSaved = useCallback(
+        (chart: SavedChart) => {
+            // New uuid means a brand-new chart; an existing tile refreshes
+            // itself via the update mutation's query cache reset.
+            if (chart.uuid !== chartToEdit?.uuid) {
+                void handleAddTiles([
+                    {
+                        uuid: uuid4(),
+                        type: DashboardTileTypes.SAVED_CHART,
+                        properties: {
+                            // Created against this dashboard, so the tile owns it.
+                            belongsToDashboard: true,
+                            savedChartUuid: chart.uuid,
+                            chartName: chart.name,
+                            hideTitle:
+                                chart.chartConfig.type === ChartType.BIG_NUMBER
+                                    ? true
+                                    : undefined,
+                        },
+                        tabUuid: activeTab?.uuid,
+                        ...getDefaultChartTileSize(chart.chartConfig.type),
+                    },
+                ]);
+            }
+            setChartToEdit(undefined);
+            setIsNewChartOpen(false);
+        },
+        [chartToEdit, handleAddTiles, activeTab?.uuid],
+    );
+
     if (isDashboardLoading) {
         return <PageSpinner />;
     }
@@ -906,6 +952,10 @@ const Dashboard: FC = () => {
             hasDefaultDateZoomGranularityChanged ||
             hasDateZoomConfigChanged,
         onAddTiles: handleAddTiles,
+        onNewChart:
+            isDashboardCustomMetricsEnabled && isEditMode
+                ? () => setIsNewChartOpen(true)
+                : undefined,
         onSaveDashboard: () => {
             if (shouldShowVerificationSaveOptions) {
                 saveVerificationModalHandlers.open();
@@ -1028,6 +1078,20 @@ const Dashboard: FC = () => {
             >
                 <div>
                     <DashboardHeader {...dashboardHeaderProps} />
+
+                    {isDashboardCustomMetricsEnabled && dashboard.uuid ? (
+                        <DashboardChartEditorModal
+                            opened={isNewChartOpen || chartToEdit !== undefined}
+                            dashboardUuid={dashboard.uuid}
+                            dashboardName={dashboard.name}
+                            editChart={chartToEdit}
+                            onChartSaved={handleChartEditorSaved}
+                            onClose={() => {
+                                setIsNewChartOpen(false);
+                                setChartToEdit(undefined);
+                            }}
+                        />
+                    ) : null}
 
                     {dashboard.draftOverlayError ? (
                         <DraftOverlayFailureAlert

--- a/packages/frontend/src/providers/Explorer/useIsModalHosted.ts
+++ b/packages/frontend/src/providers/Explorer/useIsModalHosted.ts
@@ -1,0 +1,26 @@
+import { type SavedChart } from '@lightdash/common';
+import { createContext, useContext } from 'react';
+
+type ModalHostedValue = {
+    /** True when Explorer is inside a modal; saving must not navigate away. */
+    isModalHosted: boolean;
+    /** Hands the saved chart back to the host so it can stage a tile. */
+    onChartSaved?: (chart: SavedChart) => void;
+    /** Dashboard context for the save dialog, bypassing sessionStorage. */
+    dashboard?: { uuid: string; name: string };
+};
+
+export const ModalHostedContext = createContext<ModalHostedValue>({
+    isModalHosted: false,
+});
+
+export const useIsModalHosted = (): boolean =>
+    useContext(ModalHostedContext).isModalHosted;
+
+export const useModalHostedChartSaved = ():
+    | ((chart: SavedChart) => void)
+    | undefined => useContext(ModalHostedContext).onChartSaved;
+
+export const useModalHostedDashboard = ():
+    | { uuid: string; name: string }
+    | undefined => useContext(ModalHostedContext).dashboard;


### PR DESCRIPTION
Closes: GLITCH-722

### Description:

Adds a full-screen Explorer over the dashboard so authors build a chart in place instead of being sent to the Explorer page and back. Behind the `dashboard-custom-metrics` flag; with the flag off, "New chart" uses the existing navigation unchanged.

Saving creates a dashboard-owned chart and stages its tile without the page navigating.

### Notes for review

Two things are less obvious than they look:

**The dashboard reaches the save dialog via context, not sessionStorage.** The `fromDashboard` / `dashboardUuid` keys also drive the navbar's "editing a dashboard chart" banner, whose Cancel button navigates away — exactly what this modal exists to avoid. They can't be used for one without the other, so the modal supplies the dashboard through a `ModalHostedContext` instead and leaves sessionStorage to the navigate-away flow.

**`SaveToDashboard` needed a modal-hosted branch.** It takes only `onClose`, never `onConfirm`, and calls `navigate()` itself with no `redirectOnSuccess` guard. When hosted in a modal it now hands the chart back to the host and closes, skipping both the navigate and its own sessionStorage tile write — the latter matters because the host stages the tile in React state, and doing both would surface it twice.

`SaveChartButton` generalises its existing embed-only navigation suppression to cover any modal host.

### Verified in the app

- Modal opens over the dashboard; Explore loads; chart saves; URL never changes
- Save dialog defaults to the current dashboard with no picker
- Tile is staged exactly once; "Save changes" enables
- With the flag off, "New chart" navigates to the tables page as before

Edit-in-place is deliberately out of scope and tracked separately.

### Risk assessment:

- [ ] This is a high-risk change
