### PR TITLE
fix(backend): include the explore base table in underlying data columns

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -248,6 +248,7 @@ import {
 } from '../UserAttributesService/UserAttributeUtils';
 import { getValidatedDashboardSorts } from './dashboardSorts';
 import { getPivotedColumns } from './getPivotedColumns';
+import { getUnderlyingDataAvailableTables } from './getUnderlyingDataAvailableTables';
 import { getUnpivotedColumns } from './getUnpivotedColumns';
 import {
     applyMergeExportLimit,
@@ -6584,16 +6585,10 @@ export class AsyncQueryService extends ProjectService {
             ? metricQueryFields[underlyingDataItemId]
             : undefined;
 
-        const joinedTables = explore.joinedTables.map(
-            (joinedTable) => joinedTable.table,
+        const availableTables = getUnderlyingDataAvailableTables(
+            explore,
+            metricQueryFields,
         );
-
-        const availableTables = new Set([
-            ...joinedTables,
-            ...Object.values(metricQueryFields)
-                .filter(isField)
-                .map((field) => field.table),
-        ]);
 
         const itemShowUnderlyingValues =
             isField(underlyingDataItem) && isMetric(underlyingDataItem)

--- a/packages/backend/src/services/AsyncQueryService/getUnderlyingDataAvailableTables.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/getUnderlyingDataAvailableTables.test.ts
@@ -1,0 +1,76 @@
+import {
+    DimensionType,
+    FieldType,
+    MetricType,
+    type Explore,
+    type ItemsMap,
+} from '@lightdash/common';
+import { getUnderlyingDataAvailableTables } from './getUnderlyingDataAvailableTables';
+
+const explore: Pick<Explore, 'baseTable' | 'joinedTables'> = {
+    baseTable: 'customers',
+    joinedTables: [
+        { table: 'orders' },
+        { table: 'payments' },
+    ] as Explore['joinedTables'],
+};
+
+const ordersCount: ItemsMap = {
+    orders_count: {
+        fieldType: FieldType.METRIC,
+        type: MetricType.COUNT,
+        name: 'count',
+        label: 'Count',
+        table: 'orders',
+        tableLabel: 'Orders',
+        sql: '${TABLE}.order_id',
+        hidden: false,
+    },
+};
+
+describe('getUnderlyingDataAvailableTables', () => {
+    it('includes the base table even when no queried field belongs to it', () => {
+        // A chart on the `customers` explore that only queries `orders.count`
+        // must still be able to show `customers.*` underlying columns.
+        const tables = getUnderlyingDataAvailableTables(explore, ordersCount);
+
+        expect(tables.has('customers')).toBe(true);
+    });
+
+    it('includes every joined table of the explore', () => {
+        const tables = getUnderlyingDataAvailableTables(explore, ordersCount);
+
+        expect(tables.has('orders')).toBe(true);
+        expect(tables.has('payments')).toBe(true);
+    });
+
+    it('includes tables of the queried fields', () => {
+        const tables = getUnderlyingDataAvailableTables(explore, {
+            ...ordersCount,
+            extra_dim: {
+                fieldType: FieldType.DIMENSION,
+                type: DimensionType.STRING,
+                name: 'dim',
+                label: 'Dim',
+                table: 'extra',
+                tableLabel: 'Extra',
+                sql: '${TABLE}.dim',
+                hidden: false,
+            },
+        });
+
+        expect(tables.has('extra')).toBe(true);
+    });
+
+    it('ignores non-field items such as table calculations', () => {
+        const tables = getUnderlyingDataAvailableTables(explore, {
+            calc: {
+                name: 'calc',
+                displayName: 'Calc',
+                sql: '1',
+            },
+        } as unknown as ItemsMap);
+
+        expect([...tables]).toEqual(['customers', 'orders', 'payments']);
+    });
+});

--- a/packages/backend/src/services/AsyncQueryService/getUnderlyingDataAvailableTables.ts
+++ b/packages/backend/src/services/AsyncQueryService/getUnderlyingDataAvailableTables.ts
@@ -1,0 +1,22 @@
+import { isField, type Explore, type ItemsMap } from '@lightdash/common';
+
+/**
+ * Tables whose fields may appear in an "underlying data" query.
+ *
+ * The base table is always part of the FROM clause, and every joined table
+ * is reachable through the explore's join graph, so both are always
+ * available. Tables of the fields in the source query are included too, so
+ * a table that is neither the base nor a declared join (e.g. an additional
+ * metric's table) is not dropped.
+ */
+export const getUnderlyingDataAvailableTables = (
+    explore: Pick<Explore, 'baseTable' | 'joinedTables'>,
+    metricQueryFields: ItemsMap,
+): Set<string> =>
+    new Set([
+        explore.baseTable,
+        ...explore.joinedTables.map((joinedTable) => joinedTable.table),
+        ...Object.values(metricQueryFields)
+            .filter(isField)
+            .map((field) => field.table),
+    ]);


### PR DESCRIPTION
Closes: #28536

### Description:

`executeAsyncUnderlyingDataQuery` decides which tables may contribute columns to the underlying-data query from the explore's joined tables plus the tables of the fields in the source query. The base table was never added, so a chart whose only field is a metric on a joined table lost every `show_underlying_values` entry that pointed at the base table (e.g. `customers.first_name` on `orders.fulfillment_rate` when the chart is built on the `customers` explore).

This PR

- extracts that rule into `getUnderlyingDataAvailableTables(explore, metricQueryFields)` and includes `explore.baseTable`, which is always part of the `FROM` clause;
- adds unit tests covering the base table, joined tables, queried-field tables and non-field items.

Verified against the `full-jaffle-shop-demo` project: with no dimensions and only `orders.fulfillment_rate` on the `customers` explore, "View underlying data" now returns `customers_first_name` alongside the two `orders` columns. Before the change the column was absent.

Risk: low. The change only widens the candidate set by the base table; the explicit `show_underlying_values` list (or the 50-dimension cap when there is none) still governs what is selected.
