### PR TITLE
refactor(apps): share element picker, pill and attachment row between builder and thread

### DIFF
--- a/docs/data-apps/CONTEXT.md
+++ b/docs/data-apps/CONTEXT.md
@@ -163,6 +163,21 @@ Metadata the coding agent emits at build time linking each query to the
 data points rendered from it. Powers Inspect data in the network inspector.
 _Avoid_: provenance, data references (a different, static set)
 
+**Element picker**:
+The mode, toggled from a preview's header, in which clicking an element of
+the running app produces an element reference instead of interacting with
+the app. Stays on across clicks; Esc leaves it. Available in the builder and
+in the AI agent thread's full-page preview panel.
+_Avoid_: inspector, inspect mode, click-to-edit, selection mode
+
+**Element reference**:
+A pointer to one rendered element of a data app, picked with the element
+picker: its tag, visible text, source location, and the app and version it
+was picked from. Attached to a prompt so the user can say "make this
+bigger" without describing "this"; the coding agent resolves it by source
+location, falling back to the visible text.
+_Avoid_: element ref (outside code), selection, pick (as a noun), pill
+
 **Data references**:
 The statically extracted set of data calls a version makes — explores,
 fields, filters, parameters, linked charts, external hosts — plus how much

--- a/packages/common/src/ee/apps/elementReference.test.ts
+++ b/packages/common/src/ee/apps/elementReference.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import {
+    dataAppElementContextKey,
+    elementReferenceToWireString,
+} from './elementReference';
+
+describe('elementReferenceToWireString', () => {
+    it('serializes full, text-only, loc-only, and tag-only forms', () => {
+        expect(
+            elementReferenceToWireString({
+                tag: 'h1',
+                text: 'FORMULA 1',
+                loc: 'src/App.jsx:14',
+            }),
+        ).toBe('[h1 "FORMULA 1" @src/App.jsx:14]');
+        expect(
+            elementReferenceToWireString({
+                tag: 'button',
+                text: 'Send',
+                loc: '',
+            }),
+        ).toBe('[button "Send"]');
+        expect(
+            elementReferenceToWireString({
+                tag: 'path',
+                text: '',
+                loc: 'src/App.jsx:14',
+            }),
+        ).toBe('[path @src/App.jsx:14]');
+        expect(
+            elementReferenceToWireString({ tag: 'div', text: '', loc: '' }),
+        ).toBe('[div]');
+    });
+});
+
+describe('dataAppElementContextKey', () => {
+    it('scopes the wire string to app and version', () => {
+        expect(
+            dataAppElementContextKey({
+                appUuid: 'app-1',
+                version: 3,
+                tag: 'h1',
+                text: 'FORMULA 1',
+                loc: 'src/App.jsx:14',
+            }),
+        ).toBe('data_app_element:app-1:3:[h1 "FORMULA 1" @src/App.jsx:14]');
+    });
+});

--- a/packages/common/src/ee/apps/elementReference.ts
+++ b/packages/common/src/ee/apps/elementReference.ts
@@ -1,0 +1,33 @@
+/**
+ * An element reference picked with the element picker: one rendered element
+ * of a data app, identified by tag, visible text, and build-time source
+ * location (`path:line`, empty when unavailable).
+ */
+export type DataAppElementReference = {
+    tag: string;
+    text: string;
+    loc: string;
+};
+
+/**
+ * Bracket wire format the coding agent resolves, e.g.
+ * `[h1 "FORMULA 1" @src/App.jsx:14]`, `[button "Send"]`, `[div @src/App.jsx:14]`, `[div]`.
+ */
+export const elementReferenceToWireString = ({
+    tag,
+    text,
+    loc,
+}: DataAppElementReference): string => {
+    const head = text ? `${tag} "${text}"` : tag;
+    return loc ? `[${head} @${loc}]` : `[${head}]`;
+};
+
+/** Identity of an element reference as prompt context: app, version, element. */
+export const dataAppElementContextKey = ({
+    appUuid,
+    version,
+    tag,
+    text,
+    loc,
+}: DataAppElementReference & { appUuid: string; version: number }): string =>
+    `data_app_element:${appUuid}:${version}:${elementReferenceToWireString({ tag, text, loc })}`;

--- a/packages/common/src/ee/index.ts
+++ b/packages/common/src/ee/index.ts
@@ -13,6 +13,7 @@ export * from './externalConnections/types';
 export * from './AiRouter';
 export * from './apps/customChartTypeSerializer';
 export * from './apps/deliveryCapture';
+export * from './apps/elementReference';
 export * from './apps/sdkFeatures';
 export * from './apps/dataAppVizSchemaChanges';
 export * from './apps/types';

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -14,10 +14,8 @@ import {
     Box,
     FileButton,
     Group,
-    Loader,
     Menu,
     Paper,
-    Pill,
     Text,
 } from '@mantine/core';
 import {
@@ -83,6 +81,10 @@ import {
     type ContentMentionMenuState,
     type ContentMentionSuggestionItem,
 } from './contentMentions';
+import {
+    PromptAttachments,
+    type ExternalSourceAttachment,
+} from './PromptAttachments';
 import { getAgentSuggestionModes } from './suggestionModes';
 
 const SUGGESTION_CHIP_MENTION_NAME = 'suggestionChip';
@@ -117,11 +119,6 @@ type SubmitArgs = {
     context?: AiPromptContextInput;
     optimisticContext?: AiPromptContextItem[];
 };
-
-type ExternalSourceAttachment = Extract<
-    AiPromptContextItem,
-    { type: 'external_source' }
->;
 
 interface AgentChatInputProps {
     onSubmit: (args: SubmitArgs) => void;
@@ -933,39 +930,21 @@ export const AgentChatInput = ({
 
     const renderedAttachments =
         externalSourceAttachments.length > 0 || pendingCsvFiles.length > 0 ? (
-            <Pill.Group>
-                {externalSourceAttachments.map((attachment) => (
-                    <Pill
-                        key={attachment.sourceUuid}
-                        withRemoveButton
-                        onRemove={() => {
-                            setExternalSourceAttachments((attachments) =>
-                                attachments.filter(
-                                    ({ sourceUuid }) =>
-                                        sourceUuid !== attachment.sourceUuid,
-                                ),
-                            );
-                            void discardCsvSource(attachment.sourceUuid);
-                        }}
-                    >
-                        {attachment.displayName}
-                        {attachment.tables.length > 1
-                            ? ` · ${attachment.tables.length} tables`
-                            : ''}
-                    </Pill>
-                ))}
-                {pendingCsvFiles.map((file) => (
-                    <Pill key={file.id}>
-                        <Group gap={6} wrap="nowrap">
-                            {file.status === 'preparing' && (
-                                <Loader size={10} />
-                            )}
-                            {file.status === 'queued' ? 'Queued' : 'Preparing'}{' '}
-                            {file.filename}
-                        </Group>
-                    </Pill>
-                ))}
-            </Pill.Group>
+            <PromptAttachments
+                externalSources={externalSourceAttachments}
+                pendingCsvFiles={pendingCsvFiles}
+                elementRefs={[]}
+                onRemoveExternalSource={(sourceUuid) => {
+                    setExternalSourceAttachments((attachments) =>
+                        attachments.filter(
+                            (attachment) =>
+                                attachment.sourceUuid !== sourceUuid,
+                        ),
+                    );
+                    void discardCsvSource(sourceUuid);
+                }}
+                onRemoveElementRef={() => {}}
+            />
         ) : undefined;
 
     const renderComposerAction = (size: 'sm' | 'lg') => {

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/PromptAttachments.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/PromptAttachments.tsx
@@ -1,0 +1,63 @@
+import { type AiPromptContextItem } from '@lightdash/common';
+import { Group, Loader, Pill } from '@mantine/core';
+import { ElementRefPill } from '../../../../../features/apps/components/ElementRefPill';
+import {
+    elementRefKey,
+    type ElementRef,
+} from '../../../../../features/apps/utils/elementRefs';
+import { type PendingCsvSource } from '../../hooks/useCsvSourceAttachment';
+
+export type ExternalSourceAttachment = Extract<
+    AiPromptContextItem,
+    { type: 'external_source' }
+>;
+
+type Props<T extends ElementRef> = {
+    externalSources: ExternalSourceAttachment[];
+    onRemoveExternalSource: (sourceUuid: string) => void;
+    pendingCsvFiles: PendingCsvSource[];
+    elementRefs: T[];
+    /** Called with the same object from `elementRefs`, so hosts that tag
+     *  references with extra fields (app, version) get them back intact. */
+    onRemoveElementRef: (ref: T) => void;
+};
+
+/** The row of context attached to a prompt, shown between editor and toolbar. */
+export const PromptAttachments = <T extends ElementRef>({
+    externalSources,
+    onRemoveExternalSource,
+    pendingCsvFiles,
+    elementRefs,
+    onRemoveElementRef,
+}: Props<T>) => (
+    <Pill.Group>
+        {externalSources.map((attachment) => (
+            <Pill
+                key={attachment.sourceUuid}
+                withRemoveButton
+                onRemove={() => onRemoveExternalSource(attachment.sourceUuid)}
+            >
+                {attachment.displayName}
+                {attachment.tables.length > 1
+                    ? ` · ${attachment.tables.length} tables`
+                    : ''}
+            </Pill>
+        ))}
+        {pendingCsvFiles.map((file) => (
+            <Pill key={file.id}>
+                <Group gap={6} wrap="nowrap">
+                    {file.status === 'preparing' && <Loader size={10} />}
+                    {file.status === 'queued' ? 'Queued' : 'Preparing'}{' '}
+                    {file.filename}
+                </Group>
+            </Pill>
+        ))}
+        {elementRefs.map((ref) => (
+            <ElementRefPill
+                key={elementRefKey(ref)}
+                elementRef={ref}
+                onRemove={() => onRemoveElementRef(ref)}
+            />
+        ))}
+    </Pill.Group>
+);

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useCsvSourceAttachment.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useCsvSourceAttachment.ts
@@ -13,7 +13,7 @@ import {
 } from '../../../../features/externalSources/hooks/useExternalSources';
 import useToaster from '../../../../hooks/toaster/useToaster';
 
-type PendingCsvSource = {
+export type PendingCsvSource = {
     id: number;
     filename: string;
     status: 'queued' | 'preparing';

--- a/packages/frontend/src/features/apps/AppResourcePicker.tsx
+++ b/packages/frontend/src/features/apps/AppResourcePicker.tsx
@@ -33,7 +33,6 @@ import {
     IconCamera,
     IconChartBar,
     IconCheck,
-    IconClick,
     IconDatabase,
     IconDatabasePlus,
     IconFileDescription,
@@ -133,43 +132,6 @@ export const ScreenshotButton: FC<{
             aria-label="Capture screenshot"
         >
             <MantineIcon icon={IconCamera} size={16} />
-        </ActionIcon>
-    </Tooltip>
-);
-
-/**
- * Toggle button that activates the iframe-side element inspector.
- * While enabled, clicks inside the preview iframe are intercepted and
- * inserted as bracketed references at the textarea cursor (e.g.
- * `[button "Total Revenue"]: `), so the user can compose targeted edits.
- *
- * Rendered only once the iframe SDK has announced inspector support, for the
- * same reason as the screenshot button.
- */
-export const InspectButton: FC<{
-    enabled: boolean;
-    onToggle: () => void;
-    disabled?: boolean;
-}> = ({ enabled, onToggle, disabled }) => (
-    <Tooltip
-        label={
-            enabled
-                ? 'Inspect mode on - click any element in the preview'
-                : 'Point at an element in the preview to reference it'
-        }
-        position="top"
-    >
-        <ActionIcon
-            variant={enabled ? 'light' : 'subtle'}
-            color={enabled ? 'indigo' : 'gray'}
-            size="md"
-            radius="xl"
-            onClick={onToggle}
-            disabled={disabled}
-            aria-label="Toggle element inspector"
-            aria-pressed={enabled}
-        >
-            <MantineIcon icon={IconClick} size={16} />
         </ActionIcon>
     </Tooltip>
 );

--- a/packages/frontend/src/features/apps/components/ElementPickerButton.tsx
+++ b/packages/frontend/src/features/apps/components/ElementPickerButton.tsx
@@ -1,0 +1,36 @@
+import { ActionIcon, Tooltip } from '@mantine/core';
+import { IconClick } from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
+
+/**
+ * Toggles the element picker on a preview. Render it only once the preview's
+ * SDK has announced picker availability.
+ */
+export const ElementPickerButton: FC<{
+    enabled: boolean;
+    onToggle: () => void;
+    disabled?: boolean;
+}> = ({ enabled, onToggle, disabled }) => (
+    <Tooltip
+        label={
+            enabled
+                ? 'Element picker on – click an element in the preview'
+                : 'Pick an element in the preview to reference it'
+        }
+        position="top"
+    >
+        <ActionIcon
+            variant={enabled ? 'light' : 'subtle'}
+            color={enabled ? 'indigo' : 'gray'}
+            size="md"
+            radius="xl"
+            onClick={onToggle}
+            disabled={disabled}
+            aria-label="Toggle element picker"
+            aria-pressed={enabled}
+        >
+            <MantineIcon icon={IconClick} size={16} />
+        </ActionIcon>
+    </Tooltip>
+);

--- a/packages/frontend/src/features/apps/components/ElementRefPill.module.css
+++ b/packages/frontend/src/features/apps/components/ElementRefPill.module.css
@@ -1,0 +1,26 @@
+/* Element reference pill — tinted violet to mark element references apart from chart/dashboard pills. */
+.pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 1px 2px 1px 6px;
+    border-radius: 999px;
+    height: 22px;
+    max-width: 240px;
+    min-width: 0;
+    background-color: light-dark(
+        var(--mantine-color-violet-0),
+        var(--mantine-color-violet-9)
+    );
+}
+
+.pillStatic {
+    padding-right: 6px;
+}
+
+.label {
+    min-width: 0;
+    flex: 0 1 auto;
+    font-size: 11px;
+    line-height: 1;
+}

--- a/packages/frontend/src/features/apps/components/ElementRefPill.tsx
+++ b/packages/frontend/src/features/apps/components/ElementRefPill.tsx
@@ -1,0 +1,44 @@
+import { ActionIcon, Box, Text, Tooltip } from '@mantine/core';
+import { IconClick, IconX } from '@tabler/icons-react';
+import { clsx } from 'clsx';
+import { type FC } from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
+import { elementRefChipLabel, type ElementRef } from '../utils/elementRefs';
+import classes from './ElementRefPill.module.css';
+
+/**
+ * An element reference picked from a preview. Removable in the composer;
+ * without `onRemove` it renders read-only, e.g. in a sent message.
+ */
+export const ElementRefPill: FC<{
+    elementRef: ElementRef;
+    onRemove?: () => void;
+}> = ({ elementRef, onRemove }) => {
+    const label = elementRefChipLabel(elementRef);
+    return (
+        <Tooltip
+            position="top-start"
+            disabled={!elementRef.loc}
+            label={`Source: ${elementRef.loc}`}
+        >
+            <Box
+                className={clsx(classes.pill, !onRemove && classes.pillStatic)}
+            >
+                <MantineIcon icon={IconClick} size={12} color="violet.6" />
+                <Text fw={500} truncate className={classes.label}>
+                    {label}
+                </Text>
+                {onRemove && (
+                    <ActionIcon
+                        size="xs"
+                        radius="xl"
+                        onClick={onRemove}
+                        aria-label={`Remove ${label}`}
+                    >
+                        <MantineIcon icon={IconX} size={10} />
+                    </ActionIcon>
+                )}
+            </Box>
+        </Tooltip>
+    );
+};

--- a/packages/frontend/src/features/apps/hooks/useElementPicker.test.tsx
+++ b/packages/frontend/src/features/apps/hooks/useElementPicker.test.tsx
@@ -1,0 +1,150 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useElementPicker } from './useElementPicker';
+
+const renderPicker = (identityKey = 'app:1', onEnabled?: () => void) =>
+    renderHook(({ key }) => useElementPicker({ identityKey: key, onEnabled }), {
+        initialProps: { key: identityKey },
+    });
+
+const h1Label = '[h1 "Revenue" @src/App.jsx:14]';
+
+describe('useElementPicker', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('is unavailable until the served bundle announces the picker', () => {
+        const { result } = renderPicker();
+        expect(result.current.available).toBe(false);
+
+        act(() =>
+            result.current.iframeProps.onInspectorAvailabilityChange(true),
+        );
+
+        expect(result.current.available).toBe(true);
+    });
+
+    it('turns on from the toggle and tells the host so lineage can be switched off', () => {
+        const onEnabled = vi.fn();
+        const { result } = renderPicker('app:1', onEnabled);
+
+        act(() => result.current.toggle());
+        expect(result.current.enabled).toBe(true);
+        expect(result.current.iframeProps.inspectorEnabled).toBe(true);
+        expect(onEnabled).toHaveBeenCalledTimes(1);
+
+        act(() => result.current.toggle());
+        expect(result.current.enabled).toBe(false);
+        expect(onEnabled).toHaveBeenCalledTimes(1);
+    });
+
+    it('collects one reference per picked element, collapsing repeat clicks', () => {
+        const { result } = renderPicker();
+
+        act(() =>
+            result.current.iframeProps.onElementSelected({ label: h1Label }),
+        );
+        act(() =>
+            result.current.iframeProps.onElementSelected({ label: h1Label }),
+        );
+        act(() =>
+            result.current.iframeProps.onElementSelected({
+                label: '[button "Send"]',
+            }),
+        );
+
+        expect(result.current.refs).toEqual([
+            { tag: 'h1', text: 'Revenue', loc: 'src/App.jsx:14' },
+            { tag: 'button', text: 'Send', loc: '' },
+        ]);
+    });
+
+    it('warns and ignores a label it does not recognise', () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const { result } = renderPicker();
+
+        act(() => result.current.select({ label: 'not a reference' }));
+
+        expect(result.current.refs).toEqual([]);
+        expect(warn).toHaveBeenCalledWith(
+            expect.stringContaining('element picker label'),
+            'not a reference',
+        );
+    });
+
+    it('hands picked references to onPick instead of keeping them', () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const onPick = vi.fn();
+        const { result } = renderHook(() =>
+            useElementPicker({ identityKey: 'app:1', onPick }),
+        );
+
+        act(() => result.current.select({ label: h1Label }));
+        act(() => result.current.select({ label: 'not a reference' }));
+
+        expect(onPick).toHaveBeenCalledTimes(1);
+        expect(onPick).toHaveBeenCalledWith({
+            tag: 'h1',
+            text: 'Revenue',
+            loc: 'src/App.jsx:14',
+        });
+        expect(result.current.refs).toEqual([]);
+        expect(warn).toHaveBeenCalledTimes(1);
+    });
+
+    it('removes a single reference', () => {
+        const { result } = renderPicker();
+        act(() => result.current.select({ label: h1Label }));
+        act(() => result.current.select({ label: '[button "Send"]' }));
+
+        act(() =>
+            result.current.remove({
+                tag: 'h1',
+                text: 'Revenue',
+                loc: 'src/App.jsx:14',
+            }),
+        );
+
+        expect(result.current.refs).toEqual([
+            { tag: 'button', text: 'Send', loc: '' },
+        ]);
+    });
+
+    it('leaves picker mode on Esc but keeps what was picked', () => {
+        const { result } = renderPicker();
+        act(() => result.current.toggle());
+        act(() => result.current.select({ label: h1Label }));
+
+        act(() => result.current.iframeProps.onInspectorCancelled());
+
+        expect(result.current.enabled).toBe(false);
+        expect(result.current.refs).toHaveLength(1);
+    });
+
+    it('clears every reference without touching picker mode', () => {
+        const { result } = renderPicker();
+        act(() => result.current.toggle());
+        act(() => result.current.select({ label: h1Label }));
+
+        act(() => result.current.clear());
+
+        expect(result.current.refs).toEqual([]);
+        expect(result.current.enabled).toBe(true);
+    });
+
+    it('forgets availability and leaves picker mode when a new bundle lands', () => {
+        const { result, rerender } = renderPicker('app:1');
+        act(() =>
+            result.current.iframeProps.onInspectorAvailabilityChange(true),
+        );
+        act(() => result.current.toggle());
+        act(() => result.current.select({ label: h1Label }));
+
+        rerender({ key: 'app:2' });
+
+        expect(result.current.available).toBe(false);
+        expect(result.current.enabled).toBe(false);
+        expect(result.current.refs).toHaveLength(1);
+    });
+});

--- a/packages/frontend/src/features/apps/hooks/useElementPicker.ts
+++ b/packages/frontend/src/features/apps/hooks/useElementPicker.ts
@@ -1,0 +1,118 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+    elementRefKey,
+    parseElementRefLabel,
+    type ElementRef,
+} from '../utils/elementRefs';
+import type { ElementSelectedEvent } from './useAppSdkBridge';
+
+/** Picker state and bridge callbacks to spread onto `AppIframePreview`. */
+export type ElementPickerIframeProps = {
+    inspectorEnabled: boolean;
+    onElementSelected: (event: ElementSelectedEvent) => void;
+    onInspectorAvailabilityChange: (available: boolean) => void;
+    onInspectorCancelled: () => void;
+};
+
+export type UseElementPickerResult = {
+    /** Picker mode is on: clicks in the preview produce element references. */
+    enabled: boolean;
+    /** The served bundle's SDK announced the picker; older SDKs never do. */
+    available: boolean;
+    refs: ElementRef[];
+    toggle: () => void;
+    select: (event: ElementSelectedEvent) => void;
+    remove: (ref: ElementRef) => void;
+    /** Leave picker mode (Esc); keeps the references picked so far. */
+    cancel: () => void;
+    /** Drop every picked reference; picker mode is untouched. */
+    clear: () => void;
+    iframeProps: ElementPickerIframeProps;
+};
+
+/**
+ * Element picker wiring for an app preview host. A change of `identityKey`
+ * (the same value passed as `AppIframePreview`'s) leaves picker mode and
+ * forgets availability until the new bundle announces it.
+ */
+export const useElementPicker = ({
+    identityKey,
+    onEnabled,
+    onPick,
+}: {
+    identityKey: string;
+    /** The picker was turned on; hosts use it to leave lineage mode. */
+    onEnabled?: () => void;
+    /** Receives each picked reference instead of the hook keeping `refs`. */
+    onPick?: (ref: ElementRef) => void;
+}): UseElementPickerResult => {
+    const [enabled, setEnabled] = useState(false);
+    const [available, setAvailable] = useState(false);
+    const [refs, setRefs] = useState<ElementRef[]>([]);
+
+    const onEnabledRef = useRef(onEnabled);
+    onEnabledRef.current = onEnabled;
+    const onPickRef = useRef(onPick);
+    onPickRef.current = onPick;
+
+    const previousIdentityKeyRef = useRef(identityKey);
+    useEffect(() => {
+        if (previousIdentityKeyRef.current === identityKey) return;
+        previousIdentityKeyRef.current = identityKey;
+        setEnabled(false);
+        setAvailable(false);
+    }, [identityKey]);
+
+    const toggle = useCallback(() => {
+        const next = !enabled;
+        setEnabled(next);
+        if (next) onEnabledRef.current?.();
+    }, [enabled]);
+
+    const select = useCallback((event: ElementSelectedEvent) => {
+        const ref = parseElementRefLabel(event.label);
+        if (!ref) {
+            console.warn(
+                '[apps] Ignoring unrecognised element picker label:',
+                event.label,
+            );
+            return;
+        }
+        if (onPickRef.current) {
+            onPickRef.current(ref);
+            return;
+        }
+        setRefs((prev) =>
+            prev.some((r) => elementRefKey(r) === elementRefKey(ref))
+                ? prev
+                : [...prev, ref],
+        );
+    }, []);
+
+    const remove = useCallback((ref: ElementRef) => {
+        setRefs((prev) =>
+            prev.filter((r) => elementRefKey(r) !== elementRefKey(ref)),
+        );
+    }, []);
+
+    // Stable: `AppIframePreview` re-attaches its Esc listener when it changes.
+    const cancel = useCallback(() => setEnabled(false), []);
+    const clear = useCallback(() => setRefs([]), []);
+
+    return {
+        enabled,
+        available,
+        refs,
+        toggle,
+        select,
+        remove,
+        cancel,
+        clear,
+        iframeProps: {
+            inspectorEnabled: enabled,
+            onElementSelected: select,
+            onInspectorAvailabilityChange: setAvailable,
+            onInspectorCancelled: cancel,
+        },
+    };
+};

--- a/packages/frontend/src/features/apps/utils/elementRefs.ts
+++ b/packages/frontend/src/features/apps/utils/elementRefs.ts
@@ -1,18 +1,10 @@
-/**
- * Element references picked from the iframe inspector. They render as
- * removable pills alongside the other prompt attachments and serialize to the
- * bracketed wire format (`[h1 "FORMULA 1" @src/App.jsx:14]`) appended to the
- * prompt, so the agent receives the same text it always has.
- */
+import {
+    elementReferenceToWireString,
+    type DataAppElementReference,
+} from '@lightdash/common';
 
-export type ElementRef = {
-    /** Rendered HTML tag (e.g. `h1`, `div`, `button`). */
-    tag: string;
-    /** Visible text content of the clicked element, possibly truncated. */
-    text: string;
-    /** Build-time source location `path:line`. Empty when unavailable. */
-    loc: string;
-};
+/** An element reference picked from the iframe inspector. */
+export type ElementRef = DataAppElementReference;
 
 /**
  * Parse `[tag "text" @loc]` (or `[tag @loc]`, `[tag "text"]`, `[tag]`) from
@@ -32,10 +24,7 @@ export function parseElementRefLabel(label: string): ElementRef | null {
 }
 
 /** Serialize back to the wire format the agent receives in the prompt. */
-export function refToWireString({ tag, text, loc }: ElementRef): string {
-    const head = text ? `${tag} "${text}"` : tag;
-    return loc ? `[${head} @${loc}]` : `[${head}]`;
-}
+export const refToWireString = elementReferenceToWireString;
 
 /** Stable identity for dedupe and React keys. */
 export function elementRefKey(ref: ElementRef): string {

--- a/packages/frontend/src/pages/AppGenerate.module.css
+++ b/packages/frontend/src/pages/AppGenerate.module.css
@@ -509,33 +509,3 @@
     margin-top: var(--mantine-spacing-xs);
     opacity: 0.9;
 }
-
-/* Inspector element-ref pill — same shape as the picker's selectedQueryItem,
- * tinted violet to mark inspector picks apart from chart/dashboard pills. */
-.elementRefChip {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-    padding: 1px 2px 1px 6px;
-    border-radius: 999px;
-    border: 1px solid;
-    height: 22px;
-    max-width: 240px;
-    min-width: 0;
-
-    @mixin light {
-        background-color: var(--mantine-color-violet-0);
-        border-color: var(--mantine-color-violet-3);
-    }
-    @mixin dark {
-        background-color: var(--mantine-color-violet-9);
-        border-color: var(--mantine-color-violet-7);
-    }
-}
-
-.elementRefChipName {
-    min-width: 0;
-    flex: 0 1 auto;
-    font-size: 11px;
-    line-height: 1;
-}

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -14,7 +14,6 @@ import {
     type DataAppVizContext,
 } from '@lightdash/common';
 import {
-    ActionIcon,
     Badge,
     Box,
     Button,
@@ -39,11 +38,9 @@ import {
     IconLayoutDashboard,
     IconLink,
     IconPackage,
-    IconClick,
     IconPlayerStop,
     IconRestore,
     IconPlugConnected,
-    IconX,
 } from '@tabler/icons-react';
 import { useQueryClient } from '@tanstack/react-query';
 import {
@@ -80,7 +77,6 @@ import { type AppIframePreviewHandle } from '../features/apps/AppIframePreview';
 import AppInspectorPanel from '../features/apps/AppInspectorPanel';
 import {
     AttachButton,
-    InspectButton,
     ModelPicker,
     ScreenshotButton,
     SelectedAttachmentSection,
@@ -100,6 +96,8 @@ import AppPreview from '../features/apps/components/AppPreview';
 import AppVersionNarration from '../features/apps/components/AppVersionNarration';
 import ClarificationQuestionList from '../features/apps/components/ClarificationQuestionList';
 import ConnectionChip from '../features/apps/components/ConnectionChip';
+import { ElementPickerButton } from '../features/apps/components/ElementPickerButton';
+import { ElementRefPill } from '../features/apps/components/ElementRefPill';
 import LoadingDots from '../features/apps/components/LoadingDots';
 import RecentAppSuggestions from '../features/apps/components/RecentAppSuggestions';
 import { useAppBuildPoller } from '../features/apps/hooks/useAppBuildPoller';
@@ -110,6 +108,7 @@ import { useBuildNotification } from '../features/apps/hooks/useBuildNotificatio
 import { useCancelAppVersion } from '../features/apps/hooks/useCancelAppVersion';
 import { useClarificationRound } from '../features/apps/hooks/useClarificationRound';
 import { useDataAppModelSelection } from '../features/apps/hooks/useDataAppModelSelection';
+import { useElementPicker } from '../features/apps/hooks/useElementPicker';
 import { useGenerateApp } from '../features/apps/hooks/useGenerateApp';
 import { useGetApp } from '../features/apps/hooks/useGetApp';
 import { useIterateApp } from '../features/apps/hooks/useIterateApp';
@@ -139,11 +138,8 @@ import {
     type ChatMessage,
 } from '../features/apps/utils/chatMessage';
 import {
-    elementRefChipLabel,
     elementRefKey,
-    parseElementRefLabel,
     refToWireString,
-    type ElementRef,
 } from '../features/apps/utils/elementRefs';
 import { getVersionNarration } from '../features/apps/utils/versionNarration';
 import { versionsToChatMessages } from '../features/apps/utils/versionsToChatMessages';
@@ -264,37 +260,6 @@ const ThemeChip: FC<{
     </Menu>
 );
 
-/** A removable pill for an element picked with the inspector. Matches the
- *  chart/dashboard pill shape, violet-tinted to mark inspector picks. */
-const ElementRefChip: FC<{ elementRef: ElementRef; onRemove: () => void }> = ({
-    elementRef,
-    onRemove,
-}) => {
-    const label = elementRefChipLabel(elementRef);
-    return (
-        <Tooltip
-            position="top-start"
-            disabled={!elementRef.loc}
-            label={`Source: ${elementRef.loc}`}
-        >
-            <Box className={classes.elementRefChip}>
-                <MantineIcon icon={IconClick} size={12} color="violet.6" />
-                <Text fw={500} truncate className={classes.elementRefChipName}>
-                    {label}
-                </Text>
-                <ActionIcon
-                    size="xs"
-                    radius="xl"
-                    onClick={onRemove}
-                    aria-label={`Remove ${label}`}
-                >
-                    <MantineIcon icon={IconX} size={10} />
-                </ActionIcon>
-            </Box>
-        </Tooltip>
-    );
-};
-
 /** A small informational badge shown on assistant bubbles for versions that
  *  were uploaded with a custom dependency set. Lists `name@version` per line
  *  in the tooltip so the author can confirm what was installed. */
@@ -404,15 +369,6 @@ const AppGenerate: FC = () => {
     const [selectedConnections, setSelectedConnections] = useState<
         SelectedConnection[]
     >([]);
-    // Click-to-edit ("Inspect") mode. While on, the iframe overlays a hover
-    // outline and intercepts clicks; each click inserts an element-reference
-    // pill at the editor cursor so the user can compose targeted edits.
-    // Stays on across multiple clicks; the user toggles off when done.
-    const [inspectorEnabled, setInspectorEnabled] = useState(false);
-    // Capability flag — flipped to true when the iframe SDK announces the
-    // inspector. Existing apps in resumed sandboxes may have an older SDK
-    // that never announces, in which case the toggle stays hidden.
-    const [inspectorAvailable, setInspectorAvailable] = useState(false);
     // Same handshake for screenshot capture. Older templates (resumed
     // sandboxes built before this feature shipped) never announce, so the
     // Screenshot button stays hidden — they keep working as before.
@@ -454,31 +410,6 @@ const AppGenerate: FC = () => {
     // consistency. Defaults to visible because the builder is the technical
     // workflow where seeing queries as they fire is the point.
     const [networkPanelHidden, setNetworkPanelHidden] = useState(false);
-    // Inspected elements attach as removable pills like the other prompt
-    // resources; the wire format is appended to the prompt at submit time.
-    const [selectedElementRefs, setSelectedElementRefs] = useState<
-        ElementRef[]
-    >([]);
-    const handleElementSelected = useCallback((event: { label: string }) => {
-        const ref = parseElementRefLabel(event.label);
-        if (!ref) {
-            console.warn(
-                '[apps] Ignoring unrecognized inspector label:',
-                event.label,
-            );
-            return;
-        }
-        setSelectedElementRefs((prev) =>
-            prev.some((r) => elementRefKey(r) === elementRefKey(ref))
-                ? prev
-                : [...prev, ref],
-        );
-    }, []);
-    // Stable so AppIframePreview's keydown listener doesn't re-attach on
-    // every render of this page.
-    const handleInspectorCancelled = useCallback(() => {
-        setInspectorEnabled(false);
-    }, []);
     const handleLineageSelected = useCallback(
         (event: { queryUuid: string }) => {
             setNetworkPanelHidden(false);
@@ -496,14 +427,6 @@ const AppGenerate: FC = () => {
         setFocusedQueryUuid(null);
     }, []);
 
-    const handleToggleLineage = useCallback(() => {
-        setLineageEnabled((v) => {
-            const next = !v;
-            if (next) setInspectorEnabled(false);
-            return next;
-        });
-        setFocusedQueryUuid(null);
-    }, []);
     const [localMessages, setLocalMessages] = useState<ChatMessage[]>([]);
     // Maps prompt text → image preview URL so the thumbnail survives the
     // local→server message transition (localMessages get cleared when server
@@ -525,6 +448,20 @@ const AppGenerate: FC = () => {
     const [activeAppUuid, setActiveAppUuid] = useState<string | undefined>(
         isUuidString(urlAppUuid ?? '') ? urlAppUuid : undefined,
     );
+    // Element references travel as wire-string lines appended to the prompt
+    // at submit time. Picker and lineage modes are mutually exclusive.
+    const elementPicker = useElementPicker({
+        identityKey: activeAppUuid ?? '',
+        onEnabled: handleLineageCancelled,
+    });
+    const cancelElementPicker = elementPicker.cancel;
+    const clearElementRefs = elementPicker.clear;
+    const handleToggleLineage = useCallback(() => {
+        const next = !lineageEnabled;
+        setLineageEnabled(next);
+        if (next) cancelElementPicker();
+        setFocusedQueryUuid(null);
+    }, [lineageEnabled, cancelElementPicker]);
     // Connections already linked to this app — shown as an "available" pill so
     // the user knows what the generated app can call via client.externalFetch.
     const { data: availableConnectionLinks = [] } = useAppExternalConnections(
@@ -573,7 +510,8 @@ const AppGenerate: FC = () => {
         setSelectedCharts([]);
         setSelectedDashboard(null);
         setSelectedConnections([]);
-        setSelectedElementRefs([]);
+        clearElementRefs();
+        cancelElementPicker();
         setFileAttachments([]);
         setLocalMessages([]);
         setPin(null);
@@ -581,8 +519,6 @@ const AppGenerate: FC = () => {
         // parent-owned fetch/poll of an in-flight query.
         resetQueries();
         clearExternalRequests();
-        setInspectorEnabled(false);
-        setInspectorAvailable(false);
         setScreenshotAvailable(false);
         setIsCapturingScreenshot(false);
         setLineageEnabled(false);
@@ -601,7 +537,13 @@ const AppGenerate: FC = () => {
         );
         sentImagesByPrompt.current.clear();
         sentFilesByPrompt.current.clear();
-    }, [resetQueries, clearExternalRequests, resetClarification]);
+    }, [
+        resetQueries,
+        clearExternalRequests,
+        resetClarification,
+        clearElementRefs,
+        cancelElementPicker,
+    ]);
     useEffect(() => {
         const prev = prevUrlAppUuid.current;
         prevUrlAppUuid.current = urlAppUuid;
@@ -1488,14 +1430,14 @@ const AppGenerate: FC = () => {
     const handleSubmit = async () => {
         const typed = (promptEditorRef.current?.getText() ?? '').trim();
         if (
-            (!typed && selectedElementRefs.length === 0) ||
+            (!typed && elementPicker.refs.length === 0) ||
             isLoading ||
             isSubmittingRef.current
         )
             return;
-        // Inspector references travel as their own lines after the typed text —
+        // Element references travel as their own lines after the typed text —
         // the same bracketed wire format the agent has always received.
-        const trimmed = [typed, ...selectedElementRefs.map(refToWireString)]
+        const trimmed = [typed, ...elementPicker.refs.map(refToWireString)]
             .filter(Boolean)
             .join('\n');
 
@@ -1662,7 +1604,7 @@ const AppGenerate: FC = () => {
             setSelectedCharts([]);
             setSelectedDashboard(null);
             setSelectedConnections([]);
-            setSelectedElementRefs([]);
+            clearElementRefs();
             resetGenerate();
             resetIterate();
 
@@ -2502,20 +2444,19 @@ const AppGenerate: FC = () => {
                                                 selectedDashboard ||
                                                 selectedConnections.length >
                                                     0 ||
-                                                selectedElementRefs.length >
-                                                    0 ||
+                                                elementPicker.refs.length > 0 ||
                                                 fileAttachments.length > 0) && (
                                                 <Box
                                                     className={
                                                         classes.attachedResources
                                                     }
                                                 >
-                                                    {selectedElementRefs.length >
+                                                    {elementPicker.refs.length >
                                                         0 && (
                                                         <Group gap={4}>
-                                                            {selectedElementRefs.map(
+                                                            {elementPicker.refs.map(
                                                                 (ref) => (
-                                                                    <ElementRefChip
+                                                                    <ElementRefPill
                                                                         key={elementRefKey(
                                                                             ref,
                                                                         )}
@@ -2523,21 +2464,8 @@ const AppGenerate: FC = () => {
                                                                             ref
                                                                         }
                                                                         onRemove={() =>
-                                                                            setSelectedElementRefs(
-                                                                                (
-                                                                                    prev,
-                                                                                ) =>
-                                                                                    prev.filter(
-                                                                                        (
-                                                                                            r,
-                                                                                        ) =>
-                                                                                            elementRefKey(
-                                                                                                r,
-                                                                                            ) !==
-                                                                                            elementRefKey(
-                                                                                                ref,
-                                                                                            ),
-                                                                                    ),
+                                                                            elementPicker.remove(
+                                                                                ref,
                                                                             )
                                                                         }
                                                                     />
@@ -2798,31 +2726,14 @@ const AppGenerate: FC = () => {
                                                             }
                                                         />
                                                     )}
-                                                {inspectorAvailable && (
-                                                    <InspectButton
+                                                {elementPicker.available && (
+                                                    <ElementPickerButton
                                                         enabled={
-                                                            inspectorEnabled
+                                                            elementPicker.enabled
                                                         }
-                                                        onToggle={() => {
-                                                            setInspectorEnabled(
-                                                                (v) => {
-                                                                    const next =
-                                                                        !v;
-                                                                    if (next)
-                                                                        setLineageEnabled(
-                                                                            false,
-                                                                        );
-                                                                    return next;
-                                                                },
-                                                            );
-                                                            // Entering inspector
-                                                            // mode force-disables
-                                                            // lineage — drop its
-                                                            // selection too.
-                                                            setFocusedQueryUuid(
-                                                                null,
-                                                            );
-                                                        }}
+                                                        onToggle={
+                                                            elementPicker.toggle
+                                                        }
                                                     />
                                                 )}
                                                 {newAppLanding && (
@@ -2923,7 +2834,9 @@ const AppGenerate: FC = () => {
                                                         }
                                                         disabled={
                                                             (isPromptEmpty &&
-                                                                selectedElementRefs.length ===
+                                                                elementPicker
+                                                                    .refs
+                                                                    .length ===
                                                                     0) ||
                                                             isLoading
                                                         }
@@ -3116,18 +3029,9 @@ const AppGenerate: FC = () => {
                                         onExternalRequestEvent={
                                             handleExternalRequestEvent
                                         }
-                                        inspectorEnabled={inspectorEnabled}
-                                        onElementSelected={
-                                            handleElementSelected
-                                        }
-                                        onInspectorAvailabilityChange={
-                                            setInspectorAvailable
-                                        }
+                                        {...elementPicker.iframeProps}
                                         onScreenshotAvailabilityChange={
                                             setScreenshotAvailable
-                                        }
-                                        onInspectorCancelled={
-                                            handleInspectorCancelled
                                         }
                                         lineageEnabled={lineageEnabled}
                                         onLineageAvailabilityChange={

--- a/packages/frontend/src/stories/PromptAttachments.stories.tsx
+++ b/packages/frontend/src/stories/PromptAttachments.stories.tsx
@@ -1,0 +1,138 @@
+import { ExternalSourceType } from '@lightdash/common';
+import { Paper, Stack } from '@mantine/core';
+import '@mantine/core/styles.css';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState, type ComponentProps } from 'react';
+import { fn } from 'storybook/test';
+import {
+    PromptAttachments,
+    type ExternalSourceAttachment,
+} from '../ee/features/aiCopilot/components/ChatElements/PromptAttachments';
+import {
+    elementRefKey,
+    type ElementRef,
+} from '../features/apps/utils/elementRefs';
+import MantineBaseProvider from '../providers/MantineBaseProvider';
+
+const singleTableCsv: ExternalSourceAttachment = {
+    type: 'external_source',
+    sourceUuid: 'src-1',
+    displayName: 'orders.csv',
+    sourceType: ExternalSourceType.CSV,
+    tables: [{ tableUuid: 't-1', tableName: 'orders', displayName: 'Orders' }],
+};
+
+const multiTableCsv: ExternalSourceAttachment = {
+    type: 'external_source',
+    sourceUuid: 'src-2',
+    displayName: 'finance-export.xlsx',
+    sourceType: ExternalSourceType.CSV,
+    tables: [
+        { tableUuid: 't-2', tableName: 'revenue', displayName: 'Revenue' },
+        { tableUuid: 't-3', tableName: 'costs', displayName: 'Costs' },
+        { tableUuid: 't-4', tableName: 'headcount', displayName: 'Headcount' },
+    ],
+};
+
+const heading: ElementRef = {
+    tag: 'h1',
+    text: 'Revenue by region',
+    loc: 'src/App.jsx:14',
+};
+const buttonWithoutLoc: ElementRef = { tag: 'button', text: 'Send', loc: '' };
+const longText: ElementRef = {
+    tag: 'p',
+    text: 'Weekly revenue over the last twenty-six weeks, split by re…',
+    loc: 'src/pages/Overview/RevenueTrend.tsx:128',
+};
+const bareTag: ElementRef = { tag: 'svg', text: '', loc: 'src/Chart.tsx:9' };
+
+type Args = ComponentProps<typeof PromptAttachments>;
+
+/** Owns removal so pills disappear when clicked; the actions log each removal. */
+const Scenario = (args: Args) => {
+    const [externalSources, setExternalSources] = useState(
+        args.externalSources,
+    );
+    const [elementRefs, setElementRefs] = useState(args.elementRefs);
+    return (
+        <PromptAttachments
+            {...args}
+            externalSources={externalSources}
+            onRemoveExternalSource={(sourceUuid) => {
+                args.onRemoveExternalSource(sourceUuid);
+                setExternalSources((prev) =>
+                    prev.filter((s) => s.sourceUuid !== sourceUuid),
+                );
+            }}
+            elementRefs={elementRefs}
+            onRemoveElementRef={(ref) => {
+                args.onRemoveElementRef(ref);
+                setElementRefs((prev) =>
+                    prev.filter((r) => elementRefKey(r) !== elementRefKey(ref)),
+                );
+            }}
+        />
+    );
+};
+
+const meta: Meta<typeof Scenario> = {
+    title: 'AI Copilot/Prompt Attachments',
+    component: Scenario,
+    args: {
+        externalSources: [],
+        pendingCsvFiles: [],
+        elementRefs: [],
+        onRemoveExternalSource: fn(),
+        onRemoveElementRef: fn(),
+    },
+    decorators: [
+        (renderStory) => (
+            <MantineBaseProvider>
+                <Stack w={560} p="md">
+                    <Paper p="sm">{renderStory()}</Paper>
+                </Stack>
+            </MantineBaseProvider>
+        ),
+    ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Scenario>;
+
+export const CsvSingleTable: Story = {
+    args: { externalSources: [singleTableCsv] },
+};
+
+export const CsvMultiTable: Story = {
+    args: { externalSources: [multiTableCsv] },
+};
+
+export const CsvPending: Story = {
+    args: {
+        externalSources: [singleTableCsv],
+        pendingCsvFiles: [
+            { id: 1, filename: 'customers.csv', status: 'preparing' },
+            { id: 2, filename: 'products.csv', status: 'queued' },
+        ],
+    },
+};
+
+export const ElementReferences: Story = {
+    args: { elementRefs: [heading, buttonWithoutLoc, bareTag] },
+};
+
+export const ElementReferenceLongText: Story = {
+    args: { elementRefs: [longText] },
+};
+
+export const Mixed: Story = {
+    args: {
+        externalSources: [singleTableCsv, multiTableCsv],
+        pendingCsvFiles: [
+            { id: 1, filename: 'customers.csv', status: 'preparing' },
+        ],
+        elementRefs: [heading, buttonWithoutLoc, longText],
+    },
+};


### PR DESCRIPTION
## Summary

Prefactor for element references in the AI agent thread (ZAP-976). Moves the data apps **element picker** out of the builder page into `features/apps` so the builder and the thread share one implementation. Builder behaviour is unchanged.

- `useElementPicker` owns picker state (enabled, available, references) and the iframe props to spread onto the preview; resets on identity key change; `onEnabled` lets the host turn lineage off; `onPick` hands references to a host that stores them elsewhere.
- `ElementRefPill` (violet builder styling, `<tag> text` label, source location tooltip, optional remove) and `ElementPickerButton` moved to `features/apps/components`.
- `PromptAttachments` extracted from the thread composer: CSV attachments plus element reference pills, with a Storybook story covering CSV states, pills with and without a location, long text, and removal.
- Element reference wire string and context key helpers added to `@lightdash/common`.
- Glossary entries for element picker and element reference in the data apps CONTEXT.

## Test plan

- [x] `useElementPicker` renderHook tests: handshake, select and dedupe, unrecognised label, remove, Esc cancel, clear, identity reset, `onPick`
- [x] existing element reference parse/serialise tests
- [x] builder picker verified in the browser (proof bundle on the top PR)

Closes: ZAP-982
Relates: ZAP-976

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYqCC1cLQv5apggPng7HgQ