### PR TITLE
fix(oauth): send an OAuth error when the account has no organization

### DIFF
--- a/packages/backend/src/routers/oauthRouter.test.ts
+++ b/packages/backend/src/routers/oauthRouter.test.ts
@@ -9,10 +9,14 @@ import oauthRouter from './oauthRouter';
 vi.mock('../logging/logger', () => ({
     default: {
         error: vi.fn(),
+        warn: vi.fn(),
     },
 }));
 
-type OAuthServiceStub = Pick<OAuthService, 'authorize' | 'validateRedirectUri'>;
+type OAuthServiceStub = Pick<
+    OAuthService,
+    'authorize' | 'validateRedirectUri' | 'getClientDisplayName' | 'getSiteUrl'
+>;
 
 const getRedirectUrl = (body: string): string => {
     const match = /<meta http-equiv="refresh" content="0;url=([^"]+)" \/>/.exec(
@@ -33,12 +37,30 @@ const getRedirectUrl = (body: string): string => {
 const createOAuthService = () => ({
     authorize: vi.fn<OAuthServiceStub['authorize']>(),
     validateRedirectUri: vi.fn<OAuthServiceStub['validateRedirectUri']>(),
+    getClientDisplayName: vi
+        .fn<OAuthServiceStub['getClientDisplayName']>()
+        .mockResolvedValue('Lightdash Mobile'),
+    getSiteUrl: vi
+        .fn<OAuthServiceStub['getSiteUrl']>()
+        .mockReturnValue('https://eu1.lightdash.cloud'),
 });
 
 const authenticatedUser = {
     userId: 1,
     organizationUuid: 'organization-uuid',
+    firstName: 'Test',
+    lastName: 'User',
+    email: 'test@lightdash.com',
+    organizationName: 'Test organization',
 } as Express.User;
+
+const userWithoutOrganization = {
+    ...authenticatedUser,
+    organizationUuid: undefined,
+} as Express.User;
+
+const missingOrganizationMessage =
+    'Your account is not a member of an organization on eu1.lightdash.cloud. Sign in to the Lightdash instance where you were invited.';
 
 const requestAuthorize = async ({
     body,
@@ -127,6 +149,61 @@ const requestAuthorizationLoginRedirect = async (path: string) => {
                     response.on('end', () =>
                         resolve({
                             headers: response.headers,
+                            status: response.statusCode ?? 0,
+                        }),
+                    );
+                },
+            );
+            request.on('error', reject);
+            request.end();
+        });
+    } finally {
+        await new Promise<void>((resolve, reject) => {
+            server.close((error) => (error ? reject(error) : resolve()));
+        });
+    }
+};
+
+const requestAuthorizePage = async ({
+    query,
+    oauthService,
+    user = authenticatedUser,
+}: {
+    query: Record<string, string>;
+    oauthService: ReturnType<typeof createOAuthService>;
+    user?: Express.User;
+}): Promise<{ body: string; status: number }> => {
+    const app = express();
+    app.use(express.json());
+    app.use((request, _response, next) => {
+        request.user = user;
+        request.services = {
+            getOauthService: () => oauthService as unknown as OAuthService,
+        } as Express.Request['services'];
+        next();
+    });
+    app.use('/api/v1/oauth', oauthRouter);
+
+    const server = app.listen(0, '127.0.0.1');
+    await once(server, 'listening');
+
+    try {
+        return await new Promise((resolve, reject) => {
+            const request = httpRequest(
+                {
+                    hostname: '127.0.0.1',
+                    method: 'GET',
+                    path: `/api/v1/oauth/authorize?${new URLSearchParams(
+                        query,
+                    ).toString()}`,
+                    port: (server.address() as AddressInfo).port,
+                },
+                (response) => {
+                    const chunks: Buffer[] = [];
+                    response.on('data', (chunk: Buffer) => chunks.push(chunk));
+                    response.on('end', () =>
+                        resolve({
+                            body: Buffer.concat(chunks).toString('utf8'),
                             status: response.statusCode ?? 0,
                         }),
                     );
@@ -292,6 +369,76 @@ describe('OAuth authorize redirects', () => {
         } finally {
             redirectSpy.mockRestore();
         }
+    });
+
+    it('sends an OAuth error instead of the approve page when the user has no organization', async () => {
+        const oauthService = createOAuthService();
+        oauthService.validateRedirectUri.mockResolvedValue(true);
+
+        const response = await requestAuthorizePage({
+            query: {
+                client_id: 'client-id',
+                redirect_uri: 'https://registered.example/callback',
+                state: 'request-state',
+            },
+            oauthService,
+            user: userWithoutOrganization,
+        });
+
+        expect(response.status).toBe(200);
+        const location = new URL(getRedirectUrl(response.body));
+        expect(location.searchParams.get('error')).toBe('access_denied');
+        expect(location.searchParams.get('error_description')).toBe(
+            missingOrganizationMessage,
+        );
+        expect(location.searchParams.get('state')).toBe('request-state');
+        expect(oauthService.getClientDisplayName).not.toHaveBeenCalled();
+    });
+
+    it('renders the approve page when the user has an organization', async () => {
+        const oauthService = createOAuthService();
+
+        const response = await requestAuthorizePage({
+            query: {
+                client_id: 'client-id',
+                redirect_uri: 'https://registered.example/callback',
+                state: 'request-state',
+            },
+            oauthService,
+        });
+
+        expect(response.status).toBe(200);
+        expect(response.body).toContain('Lightdash Mobile');
+        expect(response.body).toContain('action="/api/v1/oauth/authorize"');
+        expect(oauthService.getClientDisplayName).toHaveBeenCalledWith(
+            'client-id',
+        );
+    });
+
+    it('sends an OAuth error when an approval comes from a user with no organization', async () => {
+        const oauthService = createOAuthService();
+        oauthService.validateRedirectUri.mockResolvedValue(true);
+
+        const response = await requestAuthorize({
+            body: {
+                approve: 'true',
+                client_id: 'client-id',
+                redirect_uri: 'https://registered.example/callback',
+                state: 'request-state',
+            },
+            oauthService,
+            user: userWithoutOrganization,
+        });
+
+        expect(response.status).toBe(200);
+        expect(response.headers['content-type']).toContain('text/html');
+        const location = new URL(getRedirectUrl(response.body));
+        expect(location.searchParams.get('error')).toBe('access_denied');
+        expect(location.searchParams.get('error_description')).toBe(
+            missingOrganizationMessage,
+        );
+        expect(location.searchParams.get('state')).toBe('request-state');
+        expect(oauthService.authorize).not.toHaveBeenCalled();
     });
 
     it('checks authentication before handling a denial', async () => {

--- a/packages/backend/src/routers/oauthRouter.ts
+++ b/packages/backend/src/routers/oauthRouter.ts
@@ -30,9 +30,9 @@ function getOAuthService(req: express.Request): OAuthService {
 
 const getValidatedRedirectUrl = async (
     req: express.Request,
+    params: { clientId: unknown; redirectUri: unknown },
 ): Promise<URL | null> => {
-    const clientId = req.body.client_id;
-    const redirectUri = req.body.redirect_uri;
+    const { clientId, redirectUri } = params;
     if (typeof clientId !== 'string' || typeof redirectUri !== 'string') {
         return null;
     }
@@ -72,6 +72,61 @@ const sendOAuthRedirectResponse = (
     );
 };
 
+type OAuthIdentity =
+    | { missingField: string }
+    | { userId: number; organizationUuid: string };
+
+const resolveOAuthIdentity = (user: Express.User): OAuthIdentity => {
+    if (!user.userId) return { missingField: 'userId' };
+    if (!user.organizationUuid) return { missingField: 'organizationUuid' };
+    return {
+        userId: user.userId,
+        organizationUuid: user.organizationUuid,
+    };
+};
+
+const getInstanceHost = (req: express.Request): string => {
+    const siteUrl = getOAuthService(req).getSiteUrl();
+    try {
+        return new URL(siteUrl).host;
+    } catch {
+        return siteUrl;
+    }
+};
+
+const sendMissingOrganizationResponse = async (
+    req: express.Request,
+    res: express.Response,
+    params: {
+        missingField: string;
+        clientId: unknown;
+        redirectUri: unknown;
+        state: unknown;
+    },
+) => {
+    Logger.warn(
+        `OAuth authorize rejected: the session user is missing ${params.missingField}`,
+    );
+
+    const redirectUrl = await getValidatedRedirectUrl(req, {
+        clientId: params.clientId,
+        redirectUri: params.redirectUri,
+    });
+    if (!redirectUrl) {
+        return sendInvalidRedirectResponse(res);
+    }
+
+    const message = `Your account is not a member of an organization on ${getInstanceHost(
+        req,
+    )}. Sign in to the Lightdash instance where you were invited.`;
+    redirectUrl.searchParams.set('error', 'access_denied');
+    redirectUrl.searchParams.set('error_description', message);
+    if (typeof params.state === 'string' && params.state !== '') {
+        redirectUrl.searchParams.set('state', params.state);
+    }
+    return sendOAuthRedirectResponse(res, redirectUrl, message);
+};
+
 // Get authorization - use OAuth2Server
 oauthRouter.get('/authorize', async (req, res, next) => {
     const loginUrl = `/login?redirect=${encodeURIComponent(
@@ -90,6 +145,16 @@ oauthRouter.get('/authorize', async (req, res, next) => {
     } = req.query;
     if (!client_id || !redirect_uri) {
         return res.status(400).send('Missing required parameters');
+    }
+
+    const identity = resolveOAuthIdentity(req.user);
+    if ('missingField' in identity) {
+        return sendMissingOrganizationResponse(req, res, {
+            missingField: identity.missingField,
+            clientId: client_id,
+            redirectUri: redirect_uri,
+            state,
+        });
     }
 
     // Render authorize page using Handlebars template
@@ -152,11 +217,20 @@ oauthRouter.post('/authorize', async (req, res) => {
     if (!req.user) {
         return res.status(401).send('Unauthorized');
     }
-    if (!req.user.userId || !req.user.organizationUuid) {
-        return res.status(400).send('Missing userUuid or organizationUuid');
+    const identity = resolveOAuthIdentity(req.user);
+    if ('missingField' in identity) {
+        return sendMissingOrganizationResponse(req, res, {
+            missingField: identity.missingField,
+            clientId: req.body.client_id,
+            redirectUri: req.body.redirect_uri,
+            state: req.body.state,
+        });
     }
 
-    const redirectUrl = await getValidatedRedirectUrl(req);
+    const redirectUrl = await getValidatedRedirectUrl(req, {
+        clientId: req.body.client_id,
+        redirectUri: req.body.redirect_uri,
+    });
     if (!redirectUrl) {
         return sendInvalidRedirectResponse(res);
     }
@@ -189,8 +263,8 @@ oauthRouter.post('/authorize', async (req, res) => {
             oauthReq,
             oauthRes,
             {
-                userId: req.user.userId,
-                organizationUuid: req.user.organizationUuid,
+                userId: identity.userId,
+                organizationUuid: identity.organizationUuid,
             },
         );
         redirectUrl.searchParams.set(


### PR DESCRIPTION
## What breaks

A person signs in to the mobile app on an instance where their account has no organisation. The app shows the approve page. After Approve, the web view shows the plain text `Missing userUuid or organizationUuid` and stops. There is no way forward.

## What changes

- `GET /api/v1/oauth/authorize` checks the organisation before it renders the approve page.
- Both `GET` and `POST` send the failure through the OAuth redirect with `error=access_denied` and a message a person can read. The message names the host and says the account is not a member of an organisation there.
- The rejection logs which field is missing.
- When the redirect URI cannot be validated, the router falls back to the existing invalid-redirect response.

## Verification

- `oauthRouter.test.ts`: a session user with no `organizationUuid` gets the OAuth error redirect on `GET` and on `POST`; a user with an organisation still gets the approve page and the code redirect; `state` is echoed on the error redirect.
- Typecheck, touched tests and lint on the touched paths pass.

Not verified on a live instance.

Client handling, read from source:
- iOS parses `error` and `error_description` from the callback URL (`OAuthService.swift`) and shows the description as the sign-in message.
- Android receives the redirect through AppAuth as an `AuthorizationException`, so the web view closes and control returns to the app. Whether the app shows `error_description` for `access_denied` is tracked separately (SPK-1837).

Linear: SPK-1728

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HYWMPV2jQeF2cfoZvcrjfR

