### PR TITLE
fix(backend): treat a blank FCM push credential as unset

### DIFF
--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -151,6 +151,84 @@ describe('mobile push notification config', () => {
 
         expect(lightdashConfig.mobilePushNotifications.enabled).toBe(false);
     });
+
+    describe('FCM credential', () => {
+        afterEach(() => {
+            vi.restoreAllMocks();
+        });
+
+        it('is absent when all FCM variables are blank', () => {
+            process.env.LIGHTDASH_CLOUD_INSTANCE = 'cloud-instance';
+            process.env.MOBILE_PUSH_NOTIFICATIONS_FCM_PROJECT_ID = '';
+            process.env.MOBILE_PUSH_NOTIFICATIONS_FCM_CLIENT_EMAIL = '';
+            process.env.MOBILE_PUSH_NOTIFICATIONS_FCM_PRIVATE_KEY = '';
+
+            expect(parseConfig().mobilePushNotifications).toEqual({
+                enabled: false,
+                bundleId: 'com.lightdash.mobile',
+                teamId: undefined,
+                sandbox: undefined,
+                production: undefined,
+                fcm: undefined,
+            });
+        });
+
+        it('is absent when all FCM variables are whitespace only', () => {
+            process.env.LIGHTDASH_CLOUD_INSTANCE = 'cloud-instance';
+            process.env.MOBILE_PUSH_NOTIFICATIONS_FCM_PROJECT_ID = '   ';
+            process.env.MOBILE_PUSH_NOTIFICATIONS_FCM_CLIENT_EMAIL = '\t';
+            process.env.MOBILE_PUSH_NOTIFICATIONS_FCM_PRIVATE_KEY = '  \n ';
+
+            expect(parseConfig().mobilePushNotifications.fcm).toBeUndefined();
+        });
+
+        it('is present with trimmed values when all FCM variables are set', () => {
+            process.env.LIGHTDASH_CLOUD_INSTANCE = 'cloud-instance';
+            process.env.MOBILE_PUSH_NOTIFICATIONS_FCM_PROJECT_ID =
+                '  project-id  ';
+            process.env.MOBILE_PUSH_NOTIFICATIONS_FCM_CLIENT_EMAIL =
+                ' client@example.com\n';
+            process.env.MOBILE_PUSH_NOTIFICATIONS_FCM_PRIVATE_KEY =
+                '\tprivate-key';
+
+            expect(parseConfig().mobilePushNotifications).toEqual({
+                enabled: true,
+                bundleId: 'com.lightdash.mobile',
+                teamId: undefined,
+                sandbox: undefined,
+                production: undefined,
+                fcm: {
+                    projectId: 'project-id',
+                    clientEmail: 'client@example.com',
+                    privateKey: 'private-key',
+                },
+            });
+        });
+
+        it('warns once and stays absent when only some FCM variables are set', () => {
+            const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            process.env.LIGHTDASH_CLOUD_INSTANCE = 'cloud-instance';
+            process.env.MOBILE_PUSH_NOTIFICATIONS_FCM_PROJECT_ID = 'project-id';
+            process.env.MOBILE_PUSH_NOTIFICATIONS_FCM_CLIENT_EMAIL = '   ';
+
+            const config = parseConfig();
+
+            expect(config.mobilePushNotifications.fcm).toBeUndefined();
+            expect(warn).toHaveBeenCalledTimes(1);
+            expect(warn).toHaveBeenCalledWith(
+                'Mobile push FCM credential is missing: MOBILE_PUSH_NOTIFICATIONS_FCM_CLIENT_EMAIL, MOBILE_PUSH_NOTIFICATIONS_FCM_PRIVATE_KEY',
+            );
+        });
+
+        it('does not warn when all FCM variables are absent', () => {
+            const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            process.env.LIGHTDASH_CLOUD_INSTANCE = 'cloud-instance';
+
+            parseConfig();
+
+            expect(warn).not.toHaveBeenCalled();
+        });
+    });
 });
 
 describe('license config', () => {

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -2627,18 +2627,53 @@ const parseCertificateFingerprints = (value: string | undefined): string[] =>
         .map((fingerprint) => fingerprint.trim())
         .filter((fingerprint) => fingerprint.length > 0);
 
+const normalizeCredentialEnvironmentVariable = (
+    value: string | undefined,
+): string | undefined => {
+    if (value === undefined) {
+        return undefined;
+    }
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+};
+
 const parseMobilePushFcmCredential = ():
     | MobilePushNotificationsConfig['fcm']
     | undefined => {
-    const projectId = process.env.MOBILE_PUSH_NOTIFICATIONS_FCM_PROJECT_ID;
-    const clientEmail = process.env.MOBILE_PUSH_NOTIFICATIONS_FCM_CLIENT_EMAIL;
-    const privateKey = process.env.MOBILE_PUSH_NOTIFICATIONS_FCM_PRIVATE_KEY;
+    const projectId = normalizeCredentialEnvironmentVariable(
+        process.env.MOBILE_PUSH_NOTIFICATIONS_FCM_PROJECT_ID,
+    );
+    const clientEmail = normalizeCredentialEnvironmentVariable(
+        process.env.MOBILE_PUSH_NOTIFICATIONS_FCM_CLIENT_EMAIL,
+    );
+    const privateKey = normalizeCredentialEnvironmentVariable(
+        process.env.MOBILE_PUSH_NOTIFICATIONS_FCM_PRIVATE_KEY,
+    );
 
-    return projectId === undefined ||
-        clientEmail === undefined ||
-        privateKey === undefined
-        ? undefined
-        : { projectId, clientEmail, privateKey };
+    if (
+        projectId !== undefined &&
+        clientEmail !== undefined &&
+        privateKey !== undefined
+    ) {
+        return { projectId, clientEmail, privateKey };
+    }
+
+    const missingVariables = [
+        projectId === undefined && 'MOBILE_PUSH_NOTIFICATIONS_FCM_PROJECT_ID',
+        clientEmail === undefined &&
+            'MOBILE_PUSH_NOTIFICATIONS_FCM_CLIENT_EMAIL',
+        privateKey === undefined && 'MOBILE_PUSH_NOTIFICATIONS_FCM_PRIVATE_KEY',
+    ].filter((name): name is string => name !== false);
+
+    if (missingVariables.length < 3) {
+        console.warn(
+            `Mobile push FCM credential is missing: ${missingVariables.join(
+                ', ',
+            )}`,
+        );
+    }
+
+    return undefined;
 };
 
 const parseMobilePushCredential = (


### PR DESCRIPTION
## Summary

A mobile push FCM secret with a blank value read as configured. `parseMobilePushFcmCredential` only checked for `undefined`, not an empty or whitespace-only string. The backend then advertised `android` push support and every send failed as retryable.

## Change

- Trim each of the three FCM env vars. A blank or whitespace-only value now counts as absent, same as an unset one.
- When some but not all three are set, log one warning naming the missing variable names (never values).
- APNs parsing is unchanged.

## Test plan

- [x] `pnpm -F backend exec vitest run src/config/parseConfig.test.ts` (221 passed)
- [x] `pnpm -F backend typecheck`
- [x] `pnpm --filter backend run linter src/config/parseConfig.ts src/config/parseConfig.test.ts`

Linear: SPK-1835

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XTVY8hhJAdob79yob9y5No
