### PR TITLE
feat: only ask the org creator "how did you hear about us?"

### DIFF
--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -650,10 +650,9 @@ describe('UserService', () => {
             });
         });
 
-        test('does not track an absent answer', async () => {
+        test('does not track when the referral answer is omitted (invited member)', async () => {
             await userService.completeUserSetup(sessionUser, {
                 jobTitle: '',
-                howDidYouHearAboutUs: 'a podcast',
                 enableEmailDomainAccess: false,
                 isMarketingOptedIn: true,
                 isTrackingAnonymized: false,
@@ -666,19 +665,14 @@ describe('UserService', () => {
                     isSetupComplete: true,
                     isTrackingAnonymized: false,
                     isMarketingOptedIn: true,
-                    howDidYouHearAboutUs: 'a podcast',
+                    howDidYouHearAboutUs: undefined,
                 },
             );
-            expect(vi.mocked(analyticsMock.track)).toHaveBeenCalledWith({
-                event: 'hear_about_us.submitted',
-                userId: sessionUser.userUuid,
-                properties: {
-                    organizationId: sessionUser.organizationUuid,
-                    onboardingFlow: 'legacy',
-                    answered: true,
-                    answer: 'a podcast',
-                },
-            });
+            expect(vi.mocked(analyticsMock.track)).not.toHaveBeenCalledWith(
+                expect.objectContaining({
+                    event: 'hear_about_us.submitted',
+                }),
+            );
         });
     });
 

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -668,11 +668,14 @@ export const hasSpecialCharacters = (text: string) => /[^a-zA-Z ]/g.test(text);
 export const CompleteUserSchema = z.object({
     organizationName: getOrganizationNameSchema().optional(),
     jobTitle: z.string().min(0),
+    // Only collected from the person creating the organization; invited
+    // members skip it (their onboarding omits this field from the schema).
     howDidYouHearAboutUs: z
         .string()
         .trim()
         .min(1, 'Please let us know how you heard about Lightdash')
-        .max(1000),
+        .max(1000)
+        .optional(),
     enableEmailDomainAccess: z.boolean().default(false),
     isMarketingOptedIn: z.boolean().default(true),
     isTrackingAnonymized: z.boolean().default(false),

--- a/packages/e2e/cypress/e2e/app/space.cy.ts
+++ b/packages/e2e/cypress/e2e/app/space.cy.ts
@@ -134,9 +134,6 @@ describe('Space', () => {
                 // Complete user onboarding
                 cy.findByPlaceholderText('Select your role').click();
                 cy.contains('Product').click();
-                cy.findByPlaceholderText(
-                    'Google, a colleague, a podcast...',
-                ).type('Cypress');
                 cy.contains('Next').click();
 
                 // Don't show private spaces in navbar

--- a/packages/frontend/src/components/UserCompletionModal/UserCompletionModal.test.tsx
+++ b/packages/frontend/src/components/UserCompletionModal/UserCompletionModal.test.tsx
@@ -349,6 +349,12 @@ describe('UserCompletionModal', () => {
         });
         expect(emailDomainCheckbox).not.toBeInTheDocument();
 
+        // invited members do not see the referral question
+        const referralInput = screen.queryByRole('textbox', {
+            name: /How did you hear about us/,
+        });
+        expect(referralInput).not.toBeInTheDocument();
+
         // select role
         const roleSelect =
             await screen.findByPlaceholderText('Select your role');
@@ -357,19 +363,13 @@ describe('UserCompletionModal', () => {
         const roleOption = await screen.findByText('Software Engineer');
         await user.click(roleOption);
 
-        const referralInput = await screen.findByRole('textbox', {
-            name: /How did you hear about us/,
-        });
-        await user.type(referralInput, 'a podcast');
-
         // submit button should be enabled now
         expect(submitButton).toBeEnabled();
 
-        // mock api call
+        // mock api call — no referral answer for invited members
         const scope = nock(BASE_API_URL)
             .patch('/api/v1/user/me/complete', {
                 jobTitle: 'Software Engineer',
-                howDidYouHearAboutUs: 'a podcast',
                 enableEmailDomainAccess: false,
                 isMarketingOptedIn: true,
                 isTrackingAnonymized: false,
@@ -384,11 +384,11 @@ describe('UserCompletionModal', () => {
         await waitFor(() => expect(scope.isDone()).toBe(true));
     });
 
-    it('should render the how did you hear about us input', async () => {
+    it('should render the how did you hear about us input for the org creator', async () => {
         renderModal({
             user: {
                 isSetupComplete: false,
-                organizationName: 'test organization',
+                organizationName: '',
             },
         });
 
@@ -400,9 +400,7 @@ describe('UserCompletionModal', () => {
         ).toBeInTheDocument();
     });
 
-    it('should submit the trimmed how did you hear about us answer', async () => {
-        const user = userEvent.setup();
-
+    it('should not render the how did you hear about us input for invited members', async () => {
         renderModal({
             user: {
                 isSetupComplete: false,
@@ -410,9 +408,31 @@ describe('UserCompletionModal', () => {
             },
         });
 
+        const welcomeModal = await screen.findByRole('dialog');
+        expect(
+            within(welcomeModal).queryByRole('textbox', {
+                name: /How did you hear about us/,
+            }),
+        ).not.toBeInTheDocument();
+    });
+
+    it('should submit the trimmed how did you hear about us answer', async () => {
+        const user = userEvent.setup();
+
+        renderModal({
+            user: {
+                isSetupComplete: false,
+                organizationName: '',
+            },
+        });
+
         const submitButton = await screen.findByRole('button', {
             name: 'Next',
         });
+
+        const nameInput =
+            await screen.findByPlaceholderText('Enter company name');
+        await user.type(nameInput, 'test organization');
 
         const roleSelect =
             await screen.findByPlaceholderText('Select your role');
@@ -427,6 +447,7 @@ describe('UserCompletionModal', () => {
 
         const scope = nock(BASE_API_URL)
             .patch('/api/v1/user/me/complete', {
+                organizationName: 'test organization',
                 jobTitle: 'Software Engineer',
                 howDidYouHearAboutUs: 'a podcast',
                 enableEmailDomainAccess: false,
@@ -447,13 +468,17 @@ describe('UserCompletionModal', () => {
         renderModal({
             user: {
                 isSetupComplete: false,
-                organizationName: 'test organization',
+                organizationName: '',
             },
         });
 
         const submitButton = await screen.findByRole('button', {
             name: 'Next',
         });
+
+        const nameInput =
+            await screen.findByPlaceholderText('Enter company name');
+        await user.type(nameInput, 'test organization');
 
         const roleSelect =
             await screen.findByPlaceholderText('Select your role');

--- a/packages/frontend/src/components/UserCompletionModal/UserCompletionModal.test.tsx
+++ b/packages/frontend/src/components/UserCompletionModal/UserCompletionModal.test.tsx
@@ -450,7 +450,8 @@ describe('UserCompletionModal', () => {
                 organizationName: 'test organization',
                 jobTitle: 'Software Engineer',
                 howDidYouHearAboutUs: 'a podcast',
-                enableEmailDomainAccess: false,
+                // org creator on a custom domain: enabled by default
+                enableEmailDomainAccess: true,
                 isMarketingOptedIn: true,
                 isTrackingAnonymized: false,
             })

--- a/packages/frontend/src/components/UserCompletionModal/UserCompletionModal.tsx
+++ b/packages/frontend/src/components/UserCompletionModal/UserCompletionModal.tsx
@@ -29,9 +29,13 @@ const UserCompletionModal: FC = () => {
             zodResolver(
                 canEnterOrganizationName
                     ? CompleteUserSchema
-                    : // User is not creating org, just accepting invite
-                      // They cannot input org name so don't validate it for backwards compat reasons
-                      CompleteUserSchema.omit({ organizationName: true }),
+                    : // User is not creating org, just accepting invite: they
+                      // cannot input org name (backwards compat) and we only
+                      // ask the org creator how they heard about us.
+                      CompleteUserSchema.omit({
+                          organizationName: true,
+                          howDidYouHearAboutUs: true,
+                      }),
             ),
         [canEnterOrganizationName],
     );
@@ -51,10 +55,12 @@ const UserCompletionModal: FC = () => {
     const { isLoading, mutate, isSuccess } = useUserCompleteMutation();
 
     const handleSubmit = form.onSubmit((data) => {
-        const payload = {
-            ...data,
-            howDidYouHearAboutUs: data.howDidYouHearAboutUs?.trim() ?? '',
-        };
+        // Only the org creator answers "how did you hear about us?"; drop it
+        // for invited members so we don't collect (or track) their answer.
+        const howDidYouHearAboutUs = canEnterOrganizationName
+            ? data.howDidYouHearAboutUs?.trim() || undefined
+            : undefined;
+        const payload = { ...data, howDidYouHearAboutUs };
         if (user.data?.organizationName) {
             const { organizationName, ...rest } = payload;
             mutate(rest);
@@ -113,7 +119,8 @@ const UserCompletionModal: FC = () => {
                         !(
                             form.values.organizationName &&
                             form.values.jobTitle &&
-                            form.values.howDidYouHearAboutUs.trim()
+                            (!canEnterOrganizationName ||
+                                form.values.howDidYouHearAboutUs?.trim())
                         )
                     }
                 >
@@ -150,13 +157,15 @@ const UserCompletionModal: FC = () => {
                         {...form.getInputProps('jobTitle')}
                     />
 
-                    <TextInput
-                        label="How did you hear about us?"
-                        placeholder="Google, a colleague, a podcast..."
-                        disabled={isLoading}
-                        required
-                        {...form.getInputProps('howDidYouHearAboutUs')}
-                    />
+                    {canEnterOrganizationName && (
+                        <TextInput
+                            label="How did you hear about us?"
+                            placeholder="Google, a colleague, a podcast..."
+                            disabled={isLoading}
+                            required
+                            {...form.getInputProps('howDidYouHearAboutUs')}
+                        />
+                    )}
 
                     <Stack gap="xs">
                         {canEnableEmailDomainAccess && (

--- a/packages/frontend/src/pages/OrganizationSetup.test.tsx
+++ b/packages/frontend/src/pages/OrganizationSetup.test.tsx
@@ -57,7 +57,7 @@ describe('OrganizationSetup', () => {
         } as ReturnType<typeof useServerFeatureFlag>);
     });
 
-    it('submits an empty referral answer when a user joining an existing organization skips it', async () => {
+    it('does not ask invited members how they heard about us', async () => {
         const user = userEvent.setup();
 
         mockOrgApi('test organization');
@@ -77,10 +77,12 @@ describe('OrganizationSetup', () => {
             screen.queryByPlaceholderText('Acme Analytics'),
         ).not.toBeInTheDocument();
 
-        const referralInput = await screen.findByRole('textbox', {
-            name: /How did you hear about us/,
-        });
-        expect(referralInput).toBeInTheDocument();
+        // invited members do not see the referral question
+        expect(
+            screen.queryByRole('textbox', {
+                name: /How did you hear about us/,
+            }),
+        ).not.toBeInTheDocument();
 
         const submitButton = await screen.findByRole('button', {
             name: 'Finish',
@@ -92,17 +94,12 @@ describe('OrganizationSetup', () => {
         const scope = nock(BASE_API_URL)
             .patch('/api/v1/user/me/complete', {
                 jobTitle: 'Software Engineer',
-                howDidYouHearAboutUs: 'a podcast',
                 enableEmailDomainAccess: false,
                 isMarketingOptedIn: true,
                 isTrackingAnonymized: false,
             })
             .reply(200);
 
-        const referralInputCreate = await screen.findByRole('textbox', {
-            name: /How did you hear about us/,
-        });
-        await user.type(referralInputCreate, 'a podcast');
         expect(submitButton).toBeEnabled();
 
         await user.click(submitButton);
@@ -186,17 +183,18 @@ describe('OrganizationSetup', () => {
         const scope = nock(BASE_API_URL)
             .patch('/api/v1/user/me/complete', {
                 jobTitle: 'Software Engineer',
-                howDidYouHearAboutUs: 'a podcast',
                 enableEmailDomainAccess: false,
                 isMarketingOptedIn: true,
                 isTrackingAnonymized: false,
             })
             .reply(200);
 
-        const referralInput = await screen.findByRole('textbox', {
-            name: /How did you hear about us/,
-        });
-        await user.type(referralInput, 'a podcast');
+        // invited members do not see the referral question
+        expect(
+            screen.queryByRole('textbox', {
+                name: /How did you hear about us/,
+            }),
+        ).not.toBeInTheDocument();
 
         await user.click(await screen.findByRole('button', { name: 'Finish' }));
 

--- a/packages/frontend/src/pages/OrganizationSetup.tsx
+++ b/packages/frontend/src/pages/OrganizationSetup.tsx
@@ -150,7 +150,12 @@ const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
         validate: zodResolver(
             canEnterOrganizationName
                 ? CompleteUserSchema
-                : CompleteUserSchema.omit({ organizationName: true }),
+                : // Invited members join an existing org: no org name to set,
+                  // and we only ask the org creator how they heard about us.
+                  CompleteUserSchema.omit({
+                      organizationName: true,
+                      howDidYouHearAboutUs: true,
+                  }),
         ),
     });
 
@@ -262,7 +267,6 @@ const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
             // rights to change), so don't attempt to save it.
             completeMutation.mutate({
                 jobTitle: values.jobTitle,
-                howDidYouHearAboutUs: values.howDidYouHearAboutUs.trim(),
                 enableEmailDomainAccess: values.enableEmailDomainAccess,
                 isMarketingOptedIn: values.isMarketingOptedIn,
                 isTrackingAnonymized: values.isTrackingAnonymized,
@@ -451,15 +455,17 @@ const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
                                     {...form.getInputProps('jobTitle')}
                                 />
 
-                                <TextInput
-                                    label="How did you hear about us?"
-                                    placeholder="Google, a colleague, a podcast..."
-                                    size="md"
-                                    required
-                                    {...form.getInputProps(
-                                        'howDidYouHearAboutUs',
-                                    )}
-                                />
+                                {canEnterOrganizationName && (
+                                    <TextInput
+                                        label="How did you hear about us?"
+                                        placeholder="Google, a colleague, a podcast..."
+                                        size="md"
+                                        required
+                                        {...form.getInputProps(
+                                            'howDidYouHearAboutUs',
+                                        )}
+                                    />
+                                )}
 
                                 <Stack gap="xs">
                                     {canEnableEmailDomainAccess && (


### PR DESCRIPTION
Closes: <!-- no linked issue -->

### Description:

The "How did you hear about us?" onboarding question was required of **every** user completing setup — including people invited into an existing org. For internal onboarding that's an annoying speed bump, and the answers from invitees are mostly noise ("my boss told me"). We only care about the referral source of whoever created the organization.

This moves the question to the org-creator path only:

- `howDidYouHearAboutUs` is now `optional()` in `CompleteUserSchema` (still non-empty when present). Invited members omit it from validation **and** the request payload, so nothing is stored and no `hear_about_us.submitted` analytics event fires for them.
- Both onboarding surfaces render and require the field only when the user is creating the org (`canEnterOrganizationName`):
  - legacy `UserCompletionModal`
  - new `OrganizationSetup` page (behind the `NewOnboarding` flag)
- Backend `completeUserSetup` already tolerated an absent answer — no change needed there; the test that claimed to cover the "absent" case now actually does.

Tests updated across `UserCompletionModal.test.tsx`, `OrganizationSetup.test.tsx`, and `UserService.test.ts`.

### Risk assessment:

- [ ] This is a high-risk change

Low risk: onboarding-only UX change, backwards-compatible schema loosening (input becomes optional), no data migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EwCqobkXjiVcByKdyktHcT

---
_Generated by [Claude Code](https://claude.ai/code/session_01EwCqobkXjiVcByKdyktHcT)_