### PR TITLE
fix(ai): track input tokens inclusive of cache + make keyManagement unmissable

### DIFF
--- a/packages/backend/src/analytics/aiUsage.test.ts
+++ b/packages/backend/src/analytics/aiUsage.test.ts
@@ -18,7 +18,7 @@ vi.mock('../logging/logger', () => ({
 }));
 
 describe('languageModelUsageToTokens', () => {
-    it('maps AI SDK usage to token classes', () => {
+    it('maps AI SDK usage to token classes, keeping input inclusive of cache', () => {
         expect(
             languageModelUsageToTokens({
                 inputTokens: 1000,
@@ -35,7 +35,9 @@ describe('languageModelUsageToTokens', () => {
                 totalTokens: 1200,
             }),
         ).toEqual({
-            inputTokens: 150,
+            // inclusive of cache (150 uncached + 800 read + 50 write), NOT the
+            // uncached slice — the warehouse subtracts the cache classes itself
+            inputTokens: 1000,
             outputTokens: 200,
             cacheReadTokens: 800,
             cacheWriteTokens: 50,
@@ -44,7 +46,7 @@ describe('languageModelUsageToTokens', () => {
         });
     });
 
-    it('derives non-cached input only when every input class is reported', () => {
+    it('passes the inclusive input through regardless of which cache classes are reported', () => {
         expect(
             languageModelUsageToTokens({
                 inputTokens: 1_000,
@@ -60,7 +62,7 @@ describe('languageModelUsageToTokens', () => {
                 },
                 totalTokens: 1_200,
             }).inputTokens,
-        ).toBe(150);
+        ).toBe(1_000);
 
         expect(
             languageModelUsageToTokens({
@@ -77,7 +79,7 @@ describe('languageModelUsageToTokens', () => {
                 },
                 totalTokens: 1_200,
             }).inputTokens,
-        ).toBeNull();
+        ).toBe(1_000);
     });
 
     it('maps unreported token classes to null', () => {

--- a/packages/backend/src/analytics/aiUsage.test.ts
+++ b/packages/backend/src/analytics/aiUsage.test.ts
@@ -35,8 +35,9 @@ describe('languageModelUsageToTokens', () => {
                 totalTokens: 1200,
             }),
         ).toEqual({
-            // inclusive of cache (150 uncached + 800 read + 50 write), NOT the
-            // uncached slice — the warehouse subtracts the cache classes itself
+            // The value includes the cache tokens (150 uncached + 800 read +
+            // 50 write). It is not the uncached part. The warehouse subtracts
+            // the cache tokens.
             inputTokens: 1000,
             outputTokens: 200,
             cacheReadTokens: 800,

--- a/packages/backend/src/analytics/aiUsage.ts
+++ b/packages/backend/src/analytics/aiUsage.ts
@@ -58,6 +58,12 @@ const parseKeyManagement = (value: string | null): AiKeyManagement | null =>
  * Token counts for a single AI call, normalized across providers and call
  * kinds (LLM text/object generation, embeddings). Null means the provider
  * did not report that class of tokens.
+ *
+ * `inputTokens` is the total prompt tokens INCLUSIVE of cache reads and
+ * writes. The warehouse `ai_token_usage` model derives uncached input by
+ * subtracting the cache classes (`input_tokens - cache_read - cache_write`),
+ * so every producer must keep this inclusive — emitting the uncached slice
+ * here undercounts input and zeroes out the derived uncached column.
  */
 export type AiUsageTokens = {
     inputTokens: number | null;
@@ -72,28 +78,17 @@ export type AiUsageTokens = {
 // usage, and a missing field must never throw into the AI call path.
 export const languageModelUsageToTokens = (
     usage: LanguageModelUsage,
-): AiUsageTokens => {
-    const inputTokens = usage?.inputTokens ?? null;
-    const cacheReadTokens = usage?.inputTokenDetails?.cacheReadTokens ?? null;
-    const cacheWriteTokens = usage?.inputTokenDetails?.cacheWriteTokens ?? null;
-    const noCacheTokens = usage?.inputTokenDetails?.noCacheTokens ?? null;
-    const normalizedInputTokens =
-        noCacheTokens ??
-        (inputTokens !== null &&
-        cacheReadTokens !== null &&
-        cacheWriteTokens !== null
-            ? inputTokens - cacheReadTokens - cacheWriteTokens
-            : null);
-
-    return {
-        inputTokens: normalizedInputTokens,
-        outputTokens: usage?.outputTokens ?? null,
-        cacheReadTokens,
-        cacheWriteTokens,
-        reasoningTokens: usage?.outputTokenDetails?.reasoningTokens ?? null,
-        totalTokens: usage?.totalTokens ?? null,
-    };
-};
+): AiUsageTokens => ({
+    // AI SDK `inputTokens` is the total input, inclusive of cache reads and
+    // writes (`inputTokenDetails` breaks out the classes). Keep it inclusive —
+    // the warehouse derives uncached input by subtracting the cache classes.
+    inputTokens: usage?.inputTokens ?? null,
+    outputTokens: usage?.outputTokens ?? null,
+    cacheReadTokens: usage?.inputTokenDetails?.cacheReadTokens ?? null,
+    cacheWriteTokens: usage?.inputTokenDetails?.cacheWriteTokens ?? null,
+    reasoningTokens: usage?.outputTokenDetails?.reasoningTokens ?? null,
+    totalTokens: usage?.totalTokens ?? null,
+});
 
 export const embeddingModelUsageToTokens = (
     usage: EmbeddingModelUsage,

--- a/packages/backend/src/analytics/aiUsage.ts
+++ b/packages/backend/src/analytics/aiUsage.ts
@@ -59,11 +59,12 @@ const parseKeyManagement = (value: string | null): AiKeyManagement | null =>
  * kinds (LLM text/object generation, embeddings). Null means the provider
  * did not report that class of tokens.
  *
- * `inputTokens` is the total prompt tokens INCLUSIVE of cache reads and
- * writes. The warehouse `ai_token_usage` model derives uncached input by
- * subtracting the cache classes (`input_tokens - cache_read - cache_write`),
- * so every producer must keep this inclusive — emitting the uncached slice
- * here undercounts input and zeroes out the derived uncached column.
+ * `inputTokens` is the total number of prompt tokens. This total includes the
+ * cache-read tokens and the cache-write tokens. The warehouse model
+ * `ai_token_usage` calculates the uncached input tokens. To do this, it
+ * subtracts the cache tokens (`input_tokens - cache_read - cache_write`). Each
+ * producer must keep this total. If a producer records only the uncached part,
+ * the input count becomes too low. The uncached column then becomes zero.
  */
 export type AiUsageTokens = {
     inputTokens: number | null;
@@ -79,9 +80,10 @@ export type AiUsageTokens = {
 export const languageModelUsageToTokens = (
     usage: LanguageModelUsage,
 ): AiUsageTokens => ({
-    // AI SDK `inputTokens` is the total input, inclusive of cache reads and
-    // writes (`inputTokenDetails` breaks out the classes). Keep it inclusive —
-    // the warehouse derives uncached input by subtracting the cache classes.
+    // The AI SDK `inputTokens` is the total input. It includes the cache-read
+    // tokens and the cache-write tokens. `inputTokenDetails` gives each class.
+    // Keep this total. The warehouse calculates the uncached input. To do this,
+    // it subtracts the cache tokens.
     inputTokens: usage?.inputTokens ?? null,
     outputTokens: usage?.outputTokens ?? null,
     cacheReadTokens: usage?.inputTokenDetails?.cacheReadTokens ?? null,

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.ts
@@ -733,6 +733,7 @@ export class AiAgentMemoryService extends BaseService {
                 projectUuid: memory.project_uuid,
                 agentUuid: memory.agent_uuid,
                 recordIO: copilotConfig.telemetryEnabled,
+                keyManagement: model.keyManagement,
                 ...getLanguageModelAttribution(model.model),
             }),
         });
@@ -1721,6 +1722,7 @@ export class AiAgentMemoryService extends BaseService {
                     projectUuid: args.partition.projectUuid,
                     userUuid: args.partition.ownerUserUuid,
                     recordIO: copilotConfig.telemetryEnabled,
+                    keyManagement: model.keyManagement,
                     ...getLanguageModelAttribution(model.model),
                 }),
                 messages: [
@@ -2031,6 +2033,7 @@ export class AiAgentMemoryService extends BaseService {
                 agentUuid: args.thread.agentUuid,
                 threadUuid: args.thread.threadUuid,
                 recordIO: copilotConfig.telemetryEnabled,
+                keyManagement: model.keyManagement,
                 ...getLanguageModelAttribution(model.model),
             }),
             messages: [

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
@@ -1559,6 +1559,7 @@ export class AiAgentReviewClassifierService extends BaseService {
             agentUuid: candidate.subject.agentUuid,
             threadUuid: candidate.subject.threadUuid,
             promptUuid: candidate.subject.assistantPromptUuid,
+            keyManagement: model.keyManagement,
             ...getLanguageModelAttribution(model.model),
         });
         const result = await generateObject({
@@ -1724,6 +1725,7 @@ Existing review items — dedup rules. The evidence packet field existingReviewI
             agentUuid: candidate.subject.agentUuid,
             threadUuid: candidate.subject.threadUuid,
             promptUuid: candidate.subject.assistantPromptUuid,
+            keyManagement: model.keyManagement,
             ...getLanguageModelAttribution(model.model),
         });
         try {

--- a/packages/backend/src/ee/services/AiService/AiService.ts
+++ b/packages/backend/src/ee/services/AiService/AiService.ts
@@ -143,8 +143,9 @@ export class AiService extends BaseService {
                 ...getAnthropicModel(anthropicConfig, preset, {
                     enableReasoning: false,
                 }),
-                // getAnthropicModel bypasses getModel's withKeyManagement, so
-                // stamp it here or ambient calls log a null key origin.
+                // getAnthropicModel does not use getModel and withKeyManagement.
+                // Set keyManagement here. If you do not, the ambient calls
+                // record a null key origin.
                 keyManagement: resolveKeyManagement(copilotConfig, 'anthropic'),
                 telemetry: attribution,
             };

--- a/packages/backend/src/ee/services/AiService/AiService.ts
+++ b/packages/backend/src/ee/services/AiService/AiService.ts
@@ -50,7 +50,11 @@ import {
     sanitizeCustomFormat,
 } from '../ai/agents/tableCalculationGenerator';
 import { generateTooltip as generateTooltipFromContext } from '../ai/agents/tooltipGenerator';
-import { getModel, pickAmbientAnthropicPreset } from '../ai/models';
+import {
+    getModel,
+    pickAmbientAnthropicPreset,
+    resolveKeyManagement,
+} from '../ai/models';
 import { getAnthropicModel } from '../ai/models/anthropic-claude';
 import { OrgAiCopilotConfigResolver } from '../ai/OrgAiCopilotConfigResolver';
 import { AiCallAttribution } from '../ai/utils/aiCallTelemetry';
@@ -139,6 +143,9 @@ export class AiService extends BaseService {
                 ...getAnthropicModel(anthropicConfig, preset, {
                     enableReasoning: false,
                 }),
+                // getAnthropicModel bypasses getModel's withKeyManagement, so
+                // stamp it here or ambient calls log a null key origin.
+                keyManagement: resolveKeyManagement(copilotConfig, 'anthropic'),
                 telemetry: attribution,
             };
         }

--- a/packages/backend/src/ee/services/ai/agents/agentSelector.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentSelector.ts
@@ -161,6 +161,7 @@ export async function selectAgent({
         feature: 'agent-selector',
         ...getLanguageModelAttribution(model),
         ...telemetry,
+        keyManagement: telemetry?.keyManagement ?? null,
     });
     const result = await generateObject({
         model,

--- a/packages/backend/src/ee/services/ai/agents/agentV2.test.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.test.ts
@@ -468,7 +468,7 @@ describe('recordAgentStepUsage', () => {
             event: 'ai.usage',
             properties: {
                 feature: 'agent',
-                // inclusive of cache: 10 uncached + 4 read + 2 write
+                // The total includes the cache tokens: 10 uncached + 4 read + 2 write.
                 inputTokens: 16,
                 outputTokens: 7,
                 cacheReadTokens: 4,
@@ -529,7 +529,7 @@ describe('recordAgentStepUsage', () => {
             runUuid: 'run-1',
             phase: 'investigating',
             tokens: {
-                // inclusive of cache: 10 uncached + 4 read + 2 write
+                // The total includes the cache tokens: 10 uncached + 4 read + 2 write.
                 inputTokens: 16,
                 outputTokens: 7,
                 cacheReadTokens: 4,

--- a/packages/backend/src/ee/services/ai/agents/agentV2.test.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.test.ts
@@ -468,7 +468,8 @@ describe('recordAgentStepUsage', () => {
             event: 'ai.usage',
             properties: {
                 feature: 'agent',
-                inputTokens: 10,
+                // inclusive of cache: 10 uncached + 4 read + 2 write
+                inputTokens: 16,
                 outputTokens: 7,
                 cacheReadTokens: 4,
                 cacheWriteTokens: 2,
@@ -528,7 +529,8 @@ describe('recordAgentStepUsage', () => {
             runUuid: 'run-1',
             phase: 'investigating',
             tokens: {
-                inputTokens: 10,
+                // inclusive of cache: 10 uncached + 4 read + 2 write
+                inputTokens: 16,
                 outputTokens: 7,
                 cacheReadTokens: 4,
                 cacheWriteTokens: 2,

--- a/packages/backend/src/ee/services/ai/agents/embeddingGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/embeddingGenerator.ts
@@ -88,6 +88,8 @@ export async function generateEmbedding(
         ...attribution,
         model: modelName,
         provider,
+        // Embeddings run on an instance-only path where key origin isn't tracked.
+        keyManagement: null,
         extra,
     });
     const result = await embed({

--- a/packages/backend/src/ee/services/ai/agents/embeddingGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/embeddingGenerator.ts
@@ -88,7 +88,8 @@ export async function generateEmbedding(
         ...attribution,
         model: modelName,
         provider,
-        // Embeddings run on an instance-only path where key origin isn't tracked.
+        // The embeddings use an instance-only path. This path does not record
+        // the key origin.
         keyManagement: null,
         extra,
     });

--- a/packages/backend/src/ee/services/ai/agents/projectRouter.ts
+++ b/packages/backend/src/ee/services/ai/agents/projectRouter.ts
@@ -54,6 +54,7 @@ export async function routeProjectForSlack(
         feature: 'project-router',
         ...getLanguageModelAttribution(model),
         ...telemetry,
+        keyManagement: telemetry?.keyManagement ?? null,
     });
     const result = await generateObject({
         model,

--- a/packages/backend/src/ee/services/ai/models/types.ts
+++ b/packages/backend/src/ee/services/ai/models/types.ts
@@ -38,14 +38,9 @@ export type GeneratorModelOptions = {
     // construction point where that context is in scope; read via
     // getGeneratorTelemetry. See utils/aiCallTelemetry.
     telemetry?: AiCallAttribution;
-    // This field shows the key that the model uses. The key is a
-    // Lightdash-managed key or a self-managed (BYO) key. This field is
-    // necessary. It can be null. The model builder sets it. The value stays
-    // with the builder result when you spread that result into modelOptions.
-    // This field is necessary, not optional. If a construction site does not
-    // use the builder, it can record null. The call then does not show in the
-    // managed-key reports. Because the field is necessary, this is a compile
-    // error, not a silent gap. getGeneratorTelemetry reads the field. Use null
-    // only for a path that does not record the key origin.
+    // The key origin for the model: a Lightdash-managed key or a self-managed
+    // (BYO) key. This field is necessary, but it can be null. The model builder
+    // sets it. getGeneratorTelemetry reads it. Use null only for a path that
+    // does not record the key origin.
     keyManagement: AiKeyManagement | null;
 };

--- a/packages/backend/src/ee/services/ai/models/types.ts
+++ b/packages/backend/src/ee/services/ai/models/types.ts
@@ -39,7 +39,11 @@ export type GeneratorModelOptions = {
     // getGeneratorTelemetry. See utils/aiCallTelemetry.
     telemetry?: AiCallAttribution;
     // Whether the model runs on a Lightdash-managed or self-managed (BYO) key.
-    // Stamped by the model builder and rides along when the builder result is
-    // spread into modelOptions; read by getGeneratorTelemetry.
-    keyManagement?: AiKeyManagement | null;
+    // REQUIRED (nullable): stamped by the model builder and carried when the
+    // builder result is spread into modelOptions. Required — not optional — so a
+    // construction site that bypasses the builder (and would otherwise log null,
+    // dropping the call out of managed-key reporting) is a compile error rather
+    // than a silent gap. Read by getGeneratorTelemetry. null only for paths
+    // where key origin genuinely isn't tracked.
+    keyManagement: AiKeyManagement | null;
 };

--- a/packages/backend/src/ee/services/ai/models/types.ts
+++ b/packages/backend/src/ee/services/ai/models/types.ts
@@ -38,12 +38,14 @@ export type GeneratorModelOptions = {
     // construction point where that context is in scope; read via
     // getGeneratorTelemetry. See utils/aiCallTelemetry.
     telemetry?: AiCallAttribution;
-    // Whether the model runs on a Lightdash-managed or self-managed (BYO) key.
-    // REQUIRED (nullable): stamped by the model builder and carried when the
-    // builder result is spread into modelOptions. Required — not optional — so a
-    // construction site that bypasses the builder (and would otherwise log null,
-    // dropping the call out of managed-key reporting) is a compile error rather
-    // than a silent gap. Read by getGeneratorTelemetry. null only for paths
-    // where key origin genuinely isn't tracked.
+    // This field shows the key that the model uses. The key is a
+    // Lightdash-managed key or a self-managed (BYO) key. This field is
+    // necessary. It can be null. The model builder sets it. The value stays
+    // with the builder result when you spread that result into modelOptions.
+    // This field is necessary, not optional. If a construction site does not
+    // use the builder, it can record null. The call then does not show in the
+    // managed-key reports. Because the field is necessary, this is a compile
+    // error, not a silent gap. getGeneratorTelemetry reads the field. Use null
+    // only for a path that does not record the key origin.
     keyManagement: AiKeyManagement | null;
 };

--- a/packages/backend/src/ee/services/ai/projectContext/authorMemoryProjectContextEntry.test.ts
+++ b/packages/backend/src/ee/services/ai/projectContext/authorMemoryProjectContextEntry.test.ts
@@ -20,6 +20,7 @@ const model = getModel(lightdashConfigMock.ai.copilot, {
 const telemetry = getAiCallTelemetry({
     functionId: 'memoryProjectContextEntryAuthoringTest',
     feature: 'ai-agent-memory',
+    keyManagement: model.keyManagement,
 });
 const memory = {
     title: 'Revenue convention',

--- a/packages/backend/src/ee/services/ai/projectContext/authorProjectContextEntry.test.ts
+++ b/packages/backend/src/ee/services/ai/projectContext/authorProjectContextEntry.test.ts
@@ -94,6 +94,7 @@ const model = getModel(lightdashConfigMock.ai.copilot, {
 const telemetry = getAiCallTelemetry({
     functionId: 'projectContextEntryAuthoringTest',
     feature: 'review-classifier',
+    keyManagement: model.keyManagement,
 });
 
 describe('authorProjectContextEntry', () => {

--- a/packages/backend/src/ee/services/ai/utils/aiCallTelemetry.ts
+++ b/packages/backend/src/ee/services/ai/utils/aiCallTelemetry.ts
@@ -61,13 +61,15 @@ export type AiCallTelemetryOptions = AiCallAttribution & {
     functionId: string;
     feature: AiCallFeature;
     /**
-     * Required (nullable), unlike the optional `keyManagement` on
-     * AiCallAttribution: every emitter must state whether the call ran on a
-     * Lightdash-managed key, a self-managed (BYO) key, or a path where key
-     * origin isn't tracked (`null`, e.g. embeddings / instance-only evals).
-     * Forgetting it is then a compile error rather than a silent `null` that
-     * drops the call out of managed-key reporting — which is how several
-     * features (review-classifier on Haiku included) went missing before.
+     * This field is necessary. It can be null. The `keyManagement` field on
+     * AiCallAttribution is optional, but this field is not. Each emitter must
+     * show the key that the call used. The key is a Lightdash-managed key, a
+     * self-managed (BYO) key, or null. Use null for a path that does not record
+     * the key origin. Examples are embeddings and internal evaluations. If an
+     * emitter does not set this field, the code does not compile. Before this
+     * change, an emitter could set null by mistake. The call then did not show
+     * in the managed-key reports. Several features were absent because of this,
+     * for example the review-classifier, which uses the Haiku model.
      */
     keyManagement: AiKeyManagement | null;
     /**
@@ -159,7 +161,8 @@ export const getGeneratorTelemetry = (
             ? getLanguageModelAttribution(modelOptions.model)
             : {}),
         ...(modelOptions.telemetry ?? {}),
-        // Always set (last so it wins): the model builder is the source of
-        // truth for key origin, and the required field must be present.
+        // Always set this field. Set it last so that it is the final value.
+        // The model builder is the correct source for the key origin. This
+        // necessary field must be present.
         keyManagement: modelOptions.keyManagement ?? null,
     });

--- a/packages/backend/src/ee/services/ai/utils/aiCallTelemetry.ts
+++ b/packages/backend/src/ee/services/ai/utils/aiCallTelemetry.ts
@@ -61,6 +61,16 @@ export type AiCallTelemetryOptions = AiCallAttribution & {
     functionId: string;
     feature: AiCallFeature;
     /**
+     * Required (nullable), unlike the optional `keyManagement` on
+     * AiCallAttribution: every emitter must state whether the call ran on a
+     * Lightdash-managed key, a self-managed (BYO) key, or a path where key
+     * origin isn't tracked (`null`, e.g. embeddings / instance-only evals).
+     * Forgetting it is then a compile error rather than a silent `null` that
+     * drops the call out of managed-key reporting — which is how several
+     * features (review-classifier on Haiku included) went missing before.
+     */
+    keyManagement: AiKeyManagement | null;
+    /**
      * Record the prompt/response content on the span. Gated separately from span
      * emission because content can contain user data — emission (token usage +
      * attribution) is always on, content capture is opt-in.
@@ -148,8 +158,8 @@ export const getGeneratorTelemetry = (
         ...(modelOptions.model != null
             ? getLanguageModelAttribution(modelOptions.model)
             : {}),
-        ...(modelOptions.keyManagement != null
-            ? { keyManagement: modelOptions.keyManagement }
-            : {}),
         ...(modelOptions.telemetry ?? {}),
+        // Always set (last so it wins): the model builder is the source of
+        // truth for key origin, and the required field must be present.
+        keyManagement: modelOptions.keyManagement ?? null,
     });

--- a/packages/backend/src/ee/services/ai/utils/aiCallTelemetry.ts
+++ b/packages/backend/src/ee/services/ai/utils/aiCallTelemetry.ts
@@ -61,15 +61,10 @@ export type AiCallTelemetryOptions = AiCallAttribution & {
     functionId: string;
     feature: AiCallFeature;
     /**
-     * This field is necessary. It can be null. The `keyManagement` field on
-     * AiCallAttribution is optional, but this field is not. Each emitter must
-     * show the key that the call used. The key is a Lightdash-managed key, a
-     * self-managed (BYO) key, or null. Use null for a path that does not record
-     * the key origin. Examples are embeddings and internal evaluations. If an
-     * emitter does not set this field, the code does not compile. Before this
-     * change, an emitter could set null by mistake. The call then did not show
-     * in the managed-key reports. Several features were absent because of this,
-     * for example the review-classifier, which uses the Haiku model.
+     * The key origin for the call. This field is necessary, unlike the optional
+     * `keyManagement` on AiCallAttribution. Use a Lightdash-managed key, a
+     * self-managed (BYO) key, or null. Use null only for a path that does not
+     * record the key origin, for example embeddings or internal evaluations.
      */
     keyManagement: AiKeyManagement | null;
     /**

--- a/packages/backend/src/ee/services/ai/utils/llmAsAJudge.ts
+++ b/packages/backend/src/ee/services/ai/utils/llmAsAJudge.ts
@@ -194,6 +194,7 @@ export async function llmAsAJudge({
                 feature: 'llm-judge',
                 ...getLanguageModelAttribution(judge),
                 ...telemetry,
+                keyManagement: telemetry?.keyManagement ?? null,
             });
             const result = await generateObject({
                 model: judge,
@@ -284,6 +285,7 @@ ${
                 feature: 'llm-judge',
                 ...getLanguageModelAttribution(judge),
                 ...telemetry,
+                keyManagement: telemetry?.keyManagement ?? null,
             });
             const result = await generateObject({
                 model: judge,

--- a/packages/backend/src/ee/services/ai/utils/llmAsJudgeForTools.ts
+++ b/packages/backend/src/ee/services/ai/utils/llmAsJudgeForTools.ts
@@ -302,6 +302,8 @@ export const evaluateToolCallSequence = async (
         functionId: 'evaluateToolCallSequence',
         feature: 'llm-judge',
         ...getLanguageModelAttribution(judge),
+        // Instance-only eval path — key origin isn't tracked for this call.
+        keyManagement: null,
     });
     const result = await generateObject({
         model: judge,

--- a/packages/backend/src/ee/services/ai/utils/llmAsJudgeForTools.ts
+++ b/packages/backend/src/ee/services/ai/utils/llmAsJudgeForTools.ts
@@ -302,7 +302,8 @@ export const evaluateToolCallSequence = async (
         functionId: 'evaluateToolCallSequence',
         feature: 'llm-judge',
         ...getLanguageModelAttribution(judge),
-        // Instance-only eval path — key origin isn't tracked for this call.
+        // This is an instance-only evaluation path. It does not record the
+        // key origin.
         keyManagement: null,
     });
     const result = await generateObject({


### PR DESCRIPTION
Closes: <!-- no linked ticket — investigation into the AI token-spend vs Anthropic-console difference -->

### Description:

_This description uses ASD-STE100 Simplified Technical English._

The AI token usage in our logs was different from the Anthropic console bill. This change corrects two separate faults.

**Fault 1 — the input tokens did not include the cache tokens.**

`languageModelUsageToTokens` recorded only the uncached tokens as `inputTokens`. But the warehouse model `ai_token_usage` includes the cache-read tokens and the cache-write tokens in `input_tokens`. The warehouse model calculates the uncached tokens. To do this, it subtracts the cache tokens.

Because of this fault, each AI-SDK feature recorded too few input tokens. The number of missing tokens was equal to its cache tokens. This is the largest part of the monthly difference of approximately 6 billion tokens.

The data-app path was already correct. It recorded the total with the cache tokens included. The fault was only in the AI-SDK path.

The fix records the total with the cache tokens included. The cache tokens stay in their own fields, as before.

**Fault 2 — the code did not always record `keyManagement`.**

Some background paths and classifier paths made the telemetry without `keyManagement`. These calls recorded a null key origin. As a result, the reports for the Lightdash-managed key did not count them. One example is the review-classifier. It uses the Haiku model. This is the reason the Haiku totals looked approximately one half too low.

`keyManagement` is now a necessary field on `AiCallTelemetryOptions` and on `GeneratorModelOptions`. If a caller does not set it, the code does not compile. The value `null` is correct only for a path that does not record the key origin. Examples are embeddings and internal evaluations.

This change sets `keyManagement` at these call sites:
- review-classifier
- ai-agent-memory
- projectRouter
- agentSelector
- llmAsAJudge
- llmAsJudgeForTools
- embeddingGenerator
- the ambient-model path for a customer key (`getAmbientAiModel`). This path used `getAnthropicModel` directly. It did not get `keyManagement` from `withKeyManagement`.

A related change in the analytics repository removes the `greatest(…, 0)` limit on `uncached_input_tokens`. This limit hid the fault. See lightdash/analytics#191 (merged).

### Risk assessment:

- [ ] This is a high-risk change

The risk is low. The change affects only analytics and attribution. It does not change model selection, request behavior, or a customer-facing function. The token counts change only for new data. The warehouse keeps the old rows until a backfill. The compiler makes `keyManagement` necessary. A call site that does not set it fails at compile time. It does not fail without a message.

The local build tools did not work in the authoring environment. CI did the verification and passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GVHUEcxKHvXNNC53qUrYtA