### PR TITLE
fix(query-history): correct cache-hit totals, trigger counts and metric-card trigger

### DIFF
--- a/packages/backend/src/models/QueryHistoryModel/QueryHistoryModel.ts
+++ b/packages/backend/src/models/QueryHistoryModel/QueryHistoryModel.ts
@@ -700,11 +700,13 @@ export class QueryHistoryModel {
         windows: Record<QueryHistoryWindow, number>;
         warehouseTimeMsLast7Days: number;
     }> {
+        // Trigger totals span every window, so the tabs keep their counts as
+        // the page's window sections load.
         const triggerCountsQuery = this.buildUserHistoryQuery(
             projectUuid,
             userUuid,
             filters,
-            { skipTrigger: true },
+            { skipTrigger: true, skipWindow: true },
         )
             .select(`${QueryHistoryTableName}.context`)
             .count(`${QueryHistoryTableName}.query_uuid as count`)

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -21,6 +21,8 @@ import {
     QueryExecutionContext,
     QueryHistory,
     QueryHistoryStatus,
+    QueryHistoryWindow,
+    QueryTrigger,
     ResultColumns,
     VizAggregationOptions,
     VizIndexType,
@@ -5357,5 +5359,59 @@ describe('checkDashboardChartQueryPermissions', () => {
                 spaceUuid: chartSpace.uuid,
             },
         );
+    });
+});
+
+describe('getQueryHistoryList', () => {
+    const buildService = (
+        counts: Awaited<ReturnType<QueryHistoryModel['getUserHistoryCounts']>>,
+    ) =>
+        getMockedAsyncQueryService(lightdashConfigMock, {
+            featureFlagModel: {
+                get: vi.fn(async ({ featureFlagId }: AnyType) => ({
+                    id: featureFlagId,
+                    enabled: featureFlagId === FeatureFlags.QueryHistory,
+                })),
+            } as unknown as FeatureFlagModel,
+            queryHistoryModel: {
+                findUserHistory: vi.fn(async () => ({
+                    data: [],
+                    pagination: {
+                        page: 1,
+                        pageSize: 10,
+                        totalPageCount: 0,
+                        totalResults: 0,
+                    },
+                })),
+                getUserHistoryCounts: vi.fn(async () => counts),
+            } as unknown as QueryHistoryModel,
+        } as never);
+
+    it('totals across every trigger, not just the filtered one', async () => {
+        const service = buildService({
+            triggers: {
+                [QueryTrigger.INTERACTIVE]: 218,
+                [QueryTrigger.APPS]: 129,
+                [QueryTrigger.SCHEDULED]: 0,
+            },
+            // Windows keep the trigger filter, so they only cover interactive.
+            windows: {
+                [QueryHistoryWindow.LAST_FEW_MINUTES]: 0,
+                [QueryHistoryWindow.LAST_HOUR]: 8,
+                [QueryHistoryWindow.LAST_24_HOURS]: 20,
+                [QueryHistoryWindow.LAST_7_DAYS]: 28,
+                [QueryHistoryWindow.LAST_30_DAYS]: 162,
+            },
+            warehouseTimeMsLast7Days: 13331,
+        });
+
+        const { counts } = await service.getQueryHistoryList({
+            account: buildAccount(),
+            projectUuid: projectSummary.projectUuid,
+            filters: { trigger: QueryTrigger.INTERACTIVE },
+            paginateArgs: { page: 1, pageSize: 10 },
+        });
+
+        expect(counts.total).toBe(347);
     });
 });

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -1249,7 +1249,9 @@ export class AsyncQueryService extends ProjectService {
             pagination,
             counts: {
                 ...counts,
-                total: Object.values(counts.windows).reduce(
+                // The "All" tab ignores the trigger filter, so it sums the
+                // per-trigger totals rather than the trigger-filtered windows.
+                total: Object.values(counts.triggers).reduce(
                     (sum, count) => sum + count,
                     0,
                 ),

--- a/packages/common/src/types/queryHistoryList.ts
+++ b/packages/common/src/types/queryHistoryList.ts
@@ -32,7 +32,6 @@ export const QUERY_TRIGGER_BY_CONTEXT: Record<
     [QueryExecutionContext.CHART_HISTORY]: QueryTrigger.INTERACTIVE,
     [QueryExecutionContext.SQL_CHART]: QueryTrigger.INTERACTIVE,
     [QueryExecutionContext.VIEW_UNDERLYING_DATA]: QueryTrigger.INTERACTIVE,
-    [QueryExecutionContext.METRICS_EXPLORER]: QueryTrigger.INTERACTIVE,
     [QueryExecutionContext.CALCULATE_TOTAL]: QueryTrigger.INTERACTIVE,
     [QueryExecutionContext.CALCULATE_SUBTOTAL]: QueryTrigger.INTERACTIVE,
     // api/cli/ai/mcp are executed by the user, just through another door.
@@ -43,6 +42,9 @@ export const QUERY_TRIGGER_BY_CONTEXT: Record<
     [QueryExecutionContext.MCP_RUN_SQL]: QueryTrigger.INTERACTIVE,
     [QueryExecutionContext.MCP_SEARCH_FIELD_VALUES]: QueryTrigger.INTERACTIVE,
     [QueryExecutionContext.DASHBOARD]: QueryTrigger.APPS,
+    // Metric cards render themselves on load — homepage KPI blocks and the
+    // metrics catalog, not a person hitting run.
+    [QueryExecutionContext.METRICS_EXPLORER]: QueryTrigger.APPS,
     [QueryExecutionContext.AUTOREFRESHED_DASHBOARD]: QueryTrigger.APPS,
     [QueryExecutionContext.FILTER_AUTOCOMPLETE]: QueryTrigger.APPS,
     [QueryExecutionContext.DATA_APP_SAMPLE]: QueryTrigger.APPS,

--- a/packages/common/src/utils/queryHistoryList.test.ts
+++ b/packages/common/src/utils/queryHistoryList.test.ts
@@ -37,6 +37,10 @@ describe('query trigger taxonomy', () => {
         expect(getQueryTrigger(QueryExecutionContext.DASHBOARD)).toBe(
             QueryTrigger.APPS,
         );
+        // Metric cards run themselves on load, not because a person hit run.
+        expect(getQueryTrigger(QueryExecutionContext.METRICS_EXPLORER)).toBe(
+            QueryTrigger.APPS,
+        );
         expect(getQueryTrigger(QueryExecutionContext.EMBED)).toBe(
             QueryTrigger.APPS,
         );

--- a/packages/frontend/src/features/queryHistory/components/QueryHistoryDetailPanel.tsx
+++ b/packages/frontend/src/features/queryHistory/components/QueryHistoryDetailPanel.tsx
@@ -23,6 +23,7 @@ import { useQueryResultsPreview } from '../hooks/useQueryResultsPreview';
 import { useRerunQuery, canRerunQuery } from '../hooks/useRerunQuery';
 import styles from '../QueryHistory.module.css';
 import { formatRunTime, formatWhen, getTriggerLabel } from '../utils/format';
+import { getQueryTimings } from '../utils/timings';
 
 const SQL_PREVIEW_LINES = 12;
 const RESULTS_PREVIEW_COLUMNS = 6;
@@ -72,27 +73,7 @@ export const QueryHistoryDetailPanel: FC<Props> = ({
     const rerunMutation = useRerunQuery(projectUuid);
     const { mutate: cancelQuery } = useCancelQuery(projectUuid, item.queryUuid);
 
-    // Queued/warehouse/fetch add up to the total: time before the worker
-    // picked the job up, time in the warehouse, and everything after
-    // (writing + serving the results file).
-    const timings = useMemo(() => {
-        const endedAt = failed ? item.erroredAt : item.resultsUpdatedAt;
-        const totalMs = endedAt
-            ? dayjs(endedAt).diff(dayjs(item.createdAt))
-            : null;
-        const queuedMs = item.processingStartedAt
-            ? Math.max(
-                  dayjs(item.processingStartedAt).diff(dayjs(item.createdAt)),
-                  0,
-              )
-            : null;
-        const warehouseMs = item.warehouseExecutionTimeMs;
-        const fetchMs =
-            totalMs !== null && queuedMs !== null && warehouseMs !== null
-                ? Math.max(totalMs - queuedMs - warehouseMs, 0)
-                : null;
-        return { totalMs, queuedMs, warehouseMs, fetchMs };
-    }, [item, failed]);
+    const timings = useMemo(() => getQueryTimings(item), [item]);
 
     const exploreUrl = useMemo(() => {
         if (!item.metricQuery || !item.exploreName) return null;

--- a/packages/frontend/src/features/queryHistory/utils/timings.test.ts
+++ b/packages/frontend/src/features/queryHistory/utils/timings.test.ts
@@ -1,0 +1,100 @@
+import {
+    QueryExecutionContext,
+    QueryHistoryStatus,
+    QueryLanguage,
+    QueryTrigger,
+    type QueryHistoryListItem,
+} from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import { getQueryTimings } from './timings';
+
+const buildItem = (
+    overrides: Partial<QueryHistoryListItem>,
+): QueryHistoryListItem =>
+    ({
+        queryUuid: 'queryUuid',
+        createdAt: new Date('2026-09-02T12:00:00.000Z'),
+        projectUuid: 'projectUuid',
+        context: QueryExecutionContext.EXPLORE,
+        trigger: QueryTrigger.INTERACTIVE,
+        language: QueryLanguage.SEMANTIC,
+        status: QueryHistoryStatus.READY,
+        title: 'title',
+        subline: 'subline',
+        error: null,
+        exploreName: 'explore',
+        metricQuery: null,
+        requestParameters: {},
+        chartName: null,
+        chartUuid: null,
+        savedSqlUuid: null,
+        dashboardName: null,
+        dashboardUuid: null,
+        compiledSql: 'select 1',
+        totalRowCount: 1,
+        warehouseExecutionTimeMs: 0,
+        cacheHit: false,
+        resultsExpiresAt: null,
+        processingStartedAt: null,
+        resultsUpdatedAt: null,
+        erroredAt: null,
+        ...overrides,
+    }) as QueryHistoryListItem;
+
+describe('getQueryTimings', () => {
+    it('splits a fresh run into queued, warehouse and fetch', () => {
+        const timings = getQueryTimings(
+            buildItem({
+                processingStartedAt: new Date('2026-09-02T12:00:00.100Z'),
+                warehouseExecutionTimeMs: 400,
+                resultsUpdatedAt: new Date('2026-09-02T12:00:01.000Z'),
+            }),
+        );
+
+        expect(timings).toEqual({
+            totalMs: 1000,
+            queuedMs: 100,
+            warehouseMs: 400,
+            fetchMs: 500,
+        });
+    });
+
+    it('reports no total for a cache hit, whose results predate the run', () => {
+        const timings = getQueryTimings(
+            buildItem({
+                cacheHit: true,
+                processingStartedAt: new Date('2026-09-02T12:00:00.010Z'),
+                warehouseExecutionTimeMs: 0,
+                // The cached file was written by an earlier run, an hour ago.
+                resultsUpdatedAt: new Date('2026-09-02T11:00:00.000Z'),
+            }),
+        );
+
+        expect(timings.totalMs).toBeNull();
+        expect(timings.fetchMs).toBeNull();
+        expect(timings.queuedMs).toBe(10);
+        expect(timings.warehouseMs).toBe(0);
+    });
+
+    it('ends a failed run at its error time', () => {
+        const timings = getQueryTimings(
+            buildItem({
+                status: QueryHistoryStatus.ERROR,
+                error: 'boom',
+                erroredAt: new Date('2026-09-02T12:00:02.000Z'),
+                resultsUpdatedAt: null,
+            }),
+        );
+
+        expect(timings.totalMs).toBe(2000);
+    });
+
+    it('reports no total while a run is still going', () => {
+        const timings = getQueryTimings(
+            buildItem({ status: QueryHistoryStatus.EXECUTING }),
+        );
+
+        expect(timings.totalMs).toBeNull();
+        expect(timings.fetchMs).toBeNull();
+    });
+});

--- a/packages/frontend/src/features/queryHistory/utils/timings.ts
+++ b/packages/frontend/src/features/queryHistory/utils/timings.ts
@@ -1,0 +1,44 @@
+import {
+    QueryHistoryStatus,
+    type QueryHistoryListItem,
+} from '@lightdash/common';
+import dayjs from 'dayjs';
+
+export type QueryTimings = {
+    totalMs: number | null;
+    queuedMs: number | null;
+    warehouseMs: number | null;
+    fetchMs: number | null;
+};
+
+/**
+ * Queued/warehouse/fetch add up to the total: time before the worker picked
+ * the job up, time in the warehouse, and everything after (writing + serving
+ * the results file).
+ *
+ * A cache hit copies the cached file's timestamps onto this run, so
+ * `resultsUpdatedAt` predates `createdAt` and can't end it — such a run has no
+ * recorded finish time and its total is unknown.
+ */
+export const getQueryTimings = (item: QueryHistoryListItem): QueryTimings => {
+    const endedAt =
+        item.status === QueryHistoryStatus.ERROR
+            ? item.erroredAt
+            : item.resultsUpdatedAt;
+    const elapsedMs = endedAt
+        ? dayjs(endedAt).diff(dayjs(item.createdAt))
+        : null;
+    const totalMs = elapsedMs !== null && elapsedMs >= 0 ? elapsedMs : null;
+    const queuedMs = item.processingStartedAt
+        ? Math.max(
+              dayjs(item.processingStartedAt).diff(dayjs(item.createdAt)),
+              0,
+          )
+        : null;
+    const warehouseMs = item.warehouseExecutionTimeMs;
+    const fetchMs =
+        totalMs !== null && queuedMs !== null && warehouseMs !== null
+            ? Math.max(totalMs - queuedMs - warehouseMs, 0)
+            : null;
+    return { totalMs, queuedMs, warehouseMs, fetchMs };
+};


### PR DESCRIPTION
Three defects on the "My query history" page, found while investigating why an explore was appearing in history that nobody had knowingly queried.

### 1. Cache hits rendered a hugely negative "Total"

The detail panel derived `totalMs` from `resultsUpdatedAt - createdAt`. On a cache hit `AsyncQueryService` copies the *cached file's* timestamps onto the new row (`results_updated_at: resultsCache.updatedAt`), so the end time predates the run by however old the cache entry is and the panel showed e.g. `Total −52.84s`.

This is not an edge case — on our internal instance **38,952 of 78,094 rows (49.9%) in the last 30 days** have `results_updated_at < created_at`, i.e. every cache hit.

A cache hit has no recorded finish time, so its total is genuinely unknown and now renders as `—` rather than a negative number. The timing maths moves out of the component into `getQueryTimings` so the case is covered by a unit test.

### 2. Trigger tab counts followed whichever window loaded last

`getUserHistoryCounts` built the trigger counts with `{ skipTrigger: true }` but not `skipWindow`, so they inherited the window filter. Each window section requests its own counts and pushes them up, so the toolbar showed whichever section resolved last: `Interactive 8 · Apps 0 · Scheduled 0` where the real numbers were `218 / 129 / 0`.

`total` also summed the window counts, which still carry the trigger filter — so the "All" tab was counting only the selected trigger. It now sums the (unfiltered) per-trigger totals.

### 3. Homepage KPI cards were classified as Interactive

Homepage metric blocks fire two queries per card on every page load, logged as `context = 'metricsExplorer'`, which mapped to **Interactive** — so users saw history entries for explores they never opened. Metric cards render themselves on load, so `metricsExplorer` moves to **Apps**, alongside dashboards, embeds and filter autocomplete.

### Testing

- `getQueryTimings` unit tests cover the fresh run, the cache hit, the failed run and the still-running case.
- New `getQueryHistoryList` test pins the "All" total to the sum of triggers.
- Existing trigger-taxonomy test extended with `metricsExplorer`.
- Lint + typecheck pass on common, backend and frontend.

Closes: PROD-10876

https://claude.ai/code/session_01XfPWHVLJeaX3DZsJtFtcN1
