### PR TITLE
perf: index the warehouse catalog for type attachment

### DIFF
--- a/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.ts
@@ -30,6 +30,7 @@ import {
     ParseError,
     SupportedDbtAdapter,
     SupportedDbtVersions,
+    type AttachTypesDiagnostics,
     type LightdashProjectConfig,
     type ProjectContextEntry,
 } from '@lightdash/common';
@@ -308,12 +309,17 @@ export class DbtBaseProjectAdapter implements ProjectAdapter {
                     {},
                 );
             }
-            Logger.info(`Attach types to ${validModels.length} models`);
             const lazyTypedModels = attachTypesToModels(
                 validModels,
                 this.cachedWarehouse.warehouseCatalog,
                 true,
                 adapterType !== 'snowflake',
+                (diagnostics) =>
+                    DbtBaseProjectAdapter.logAttachTypesPhase(
+                        'cached_catalog',
+                        trackingParams,
+                        diagnostics,
+                    ),
             );
             Logger.info('Convert explores');
             const disableTimestampConversion =
@@ -342,12 +348,17 @@ export class DbtBaseProjectAdapter implements ProjectAdapter {
                 );
                 const modelCatalog =
                     getSchemaStructureFromDbtModels(validModels);
-                Logger.info(
-                    `Fetching table metadata for ${modelCatalog.length} tables`,
-                );
-
+                const catalogFetchStartedAt = Date.now();
                 const warehouseCatalog =
                     await this.warehouseClient.getCatalog(modelCatalog);
+                Logger.info('dbt.compile.warehouseCatalogFetch', {
+                    event: 'dbt.compile.warehouseCatalogFetch',
+                    projectUuid: trackingParams?.projectUuid ?? null,
+                    jobUuid: trackingParams?.jobUuid ?? null,
+                    warehouseType: this.warehouseClient.credentials.type,
+                    requestedTables: modelCatalog.length,
+                    durationMs: Date.now() - catalogFetchStartedAt,
+                });
                 // Clients only create the sidecar when they classify a column;
                 // stamp it (possibly empty) so the staleness check above can't
                 // refetch again on domain-less warehouses.
@@ -356,15 +367,18 @@ export class DbtBaseProjectAdapter implements ProjectAdapter {
                     warehouseCatalog,
                 );
 
-                Logger.info(
-                    'Attach types to models after missing catalog error',
-                );
                 // Some types were missing so refresh the schema and try again
                 const typedModels = attachTypesToModels(
                     validModels,
                     warehouseCatalog,
                     false,
                     adapterType !== 'snowflake',
+                    (diagnostics) =>
+                        DbtBaseProjectAdapter.logAttachTypesPhase(
+                            'refetched_catalog',
+                            trackingParams,
+                            diagnostics,
+                        ),
                 );
                 Logger.info('Convert explores after missing catalog error');
                 const disableTimestampConversion =
@@ -391,6 +405,28 @@ export class DbtBaseProjectAdapter implements ProjectAdapter {
             }
             throw e;
         }
+    }
+
+    private static logAttachTypesPhase(
+        catalogSource: 'cached_catalog' | 'refetched_catalog',
+        trackingParams: TrackingParams | undefined,
+        diagnostics: AttachTypesDiagnostics,
+    ) {
+        Logger.info('dbt.compile.attachTypes', {
+            event: 'dbt.compile.attachTypes',
+            projectUuid: trackingParams?.projectUuid ?? null,
+            jobUuid: trackingParams?.jobUuid ?? null,
+            catalogSource,
+            durationMs: diagnostics.durationMs,
+            modelCount: diagnostics.modelCount,
+            columnCount: diagnostics.columnCount,
+            catalogTableCount: diagnostics.catalogTableCount,
+            distinctSchemaCount: diagnostics.schemaPairs.length,
+            schemaPairs: diagnostics.schemaPairs.slice(0, 20),
+            exactLookups: diagnostics.exactLookups,
+            caseInsensitiveLookups: diagnostics.caseInsensitiveLookups,
+            missingLookups: diagnostics.missingLookups,
+        });
     }
 
     static _validateDbtModel(

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -3925,6 +3925,7 @@ export class ProjectService extends BaseService {
                                 projectUuid,
                                 organizationUuid: user.organizationUuid,
                                 userUuid: user.userUuid,
+                                jobUuid: job.jobUuid,
                             };
                             timings.compileExplores.start = performance.now();
                             const explores =
@@ -8279,6 +8280,7 @@ export class ProjectService extends BaseService {
         user: Pick<SessionUser, 'userUuid'>,
         projectUuid: string,
         requestMethod: RequestMethod,
+        jobUuid?: string,
     ): Promise<{
         explores: (Explore | ExploreError)[];
         lightdashProjectConfig: LightdashProjectConfig;
@@ -8354,6 +8356,7 @@ export class ProjectService extends BaseService {
                 projectUuid,
                 organizationUuid: project.organizationUuid,
                 userUuid: user.userUuid,
+                jobUuid,
             };
             const explores = await adapter.compileAllExplores(
                 trackingParams,
@@ -8868,6 +8871,7 @@ export class ProjectService extends BaseService {
                             user,
                             projectUuid,
                             requestMethod,
+                            job.jobUuid,
                         );
 
                         timings.yaml.start = performance.now();

--- a/packages/backend/src/types.ts
+++ b/packages/backend/src/types.ts
@@ -12,6 +12,7 @@ export type TrackingParams = {
     userUuid: string;
     organizationUuid: string;
     projectUuid: string;
+    jobUuid?: string;
 };
 
 export interface ProjectAdapter {

--- a/packages/common/src/compiler/translator.test.ts
+++ b/packages/common/src/compiler/translator.test.ts
@@ -238,6 +238,32 @@ describe('attachTypesToModels', () => {
         ).not.toThrow();
         expect(diagnostics[0].catalogTableCount).toEqual(1);
     });
+    it('should count an exact table with a case-insensitive column as case-insensitive', async () => {
+        // The table key matches exactly and only the column needs folding. This is the
+        // combination that a table-level-only classification gets wrong.
+        const diagnostics: AttachTypesDiagnostics[] = [];
+        attachTypesToModels(
+            [model],
+            warehouseSchemaWithUpperCaseColumn,
+            true,
+            false,
+            (d) => diagnostics.push(d),
+        );
+        expect(diagnostics[0].caseInsensitiveLookups).toEqual(1);
+        expect(diagnostics[0].exactLookups).toEqual(0);
+    });
+    it('should count a case-insensitive table as case-insensitive', async () => {
+        const diagnostics: AttachTypesDiagnostics[] = [];
+        attachTypesToModels(
+            [model],
+            warehouseSchemaWithAllUpperCaseKeys,
+            true,
+            false,
+            (d) => diagnostics.push(d),
+        );
+        expect(diagnostics[0].caseInsensitiveLookups).toEqual(1);
+        expect(diagnostics[0].exactLookups).toEqual(0);
+    });
     it('should report diagnostics for the phase', async () => {
         const diagnostics: AttachTypesDiagnostics[] = [];
         attachTypesToModels([model], warehouseSchema, false, true, (d) =>

--- a/packages/common/src/compiler/translator.test.ts
+++ b/packages/common/src/compiler/translator.test.ts
@@ -12,12 +12,17 @@ import {
 } from '../types/field';
 import { DEFAULT_SPOTLIGHT_CONFIG } from '../types/lightdashProjectConfig';
 import { TimeFrames } from '../types/timeFrames';
+import {
+    WAREHOUSE_TIMESTAMP_DOMAINS_KEY,
+    type WarehouseCatalog,
+} from '../types/warehouse';
 import { warehouseClientMock } from './exploreCompiler.mock';
 import { getExploreParameterDefinitions } from './parameters';
 import {
     attachTypesToModels,
     convertExplores,
     convertTable,
+    type AttachTypesDiagnostics,
 } from './translator';
 import {
     expectedModelWithTimestampDomain,
@@ -186,6 +191,69 @@ describe('attachTypesToModels', () => {
                 false,
             )[0],
         ).toEqual(expectedModelWithType);
+    });
+    it('should keep the first catalog entry when two fold to the same name', async () => {
+        // Neither key matches exactly, so both can only be reached case-insensitively.
+        const collidingCatalog: WarehouseCatalog = {
+            myDatabase: {
+                mySchema: {
+                    MYTABLE: { myColumnName: DimensionType.NUMBER },
+                    MyTable: { myColumnName: DimensionType.STRING },
+                },
+            },
+        };
+        expect(
+            attachTypesToModels([model], collidingCatalog, true, false)[0]
+                .columns.myColumnName.data_type,
+        ).toEqual(DimensionType.NUMBER);
+    });
+    it('should prefer an exact match over a case-insensitive one', async () => {
+        const collidingCatalog: WarehouseCatalog = {
+            myDatabase: {
+                mySchema: {
+                    MYTABLE: { myColumnName: DimensionType.NUMBER },
+                    myTable: { myColumnName: DimensionType.STRING },
+                },
+            },
+        };
+        expect(
+            attachTypesToModels([model], collidingCatalog, true, false)[0]
+                .columns.myColumnName.data_type,
+        ).toEqual(DimensionType.STRING);
+    });
+    it('should not treat the timestamp-domain sidecar as a database', async () => {
+        const catalogWithSidecar = {
+            ...warehouseSchema,
+            [WAREHOUSE_TIMESTAMP_DOMAINS_KEY]: {
+                myDatabase: {
+                    mySchema: { myTable: { myColumnName: 'utc' } },
+                },
+            },
+        } as unknown as WarehouseCatalog;
+        const diagnostics: AttachTypesDiagnostics[] = [];
+        expect(() =>
+            attachTypesToModels([model], catalogWithSidecar, true, true, (d) =>
+                diagnostics.push(d),
+            ),
+        ).not.toThrow();
+        expect(diagnostics[0].catalogTableCount).toEqual(1);
+    });
+    it('should report diagnostics for the phase', async () => {
+        const diagnostics: AttachTypesDiagnostics[] = [];
+        attachTypesToModels([model], warehouseSchema, false, true, (d) =>
+            diagnostics.push(d),
+        );
+        expect(diagnostics).toHaveLength(1);
+        expect(diagnostics[0].modelCount).toEqual(1);
+        expect(diagnostics[0].columnCount).toEqual(
+            Object.keys(model.columns).length,
+        );
+        expect(diagnostics[0].catalogTableCount).toEqual(1);
+        expect(diagnostics[0].exactLookups).toEqual(1);
+        expect(diagnostics[0].caseInsensitiveLookups).toEqual(0);
+        expect(diagnostics[0].schemaPairs).toEqual([
+            { databaseSchema: 'myDatabase.mySchema', models: 1 },
+        ]);
     });
 });
 

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -52,8 +52,10 @@ import { OrderFieldsByStrategy, type FieldGroupType } from '../types/table';
 import { type TimeFrames } from '../types/timeFrames';
 import {
     getCatalogTimestampDomain,
+    WAREHOUSE_TIMESTAMP_DOMAINS_KEY,
     type WarehouseCatalog,
     type WarehouseSqlBuilder,
+    type WarehouseTableSchema,
 } from '../types/warehouse';
 import assertUnreachable from '../utils/assertUnreachable';
 import {
@@ -1553,44 +1555,119 @@ export const convertExplores = async (
     return [...explores, ...exploreErrors];
 };
 
+export type AttachTypesDiagnostics = {
+    durationMs: number;
+    modelCount: number;
+    columnCount: number;
+    catalogTableCount: number;
+    schemaPairs: { databaseSchema: string; models: number }[];
+    exactLookups: number;
+    caseInsensitiveLookups: number;
+    missingLookups: number;
+};
+
 export const attachTypesToModels = (
     models: DbtModelNode[],
     warehouseCatalog: WarehouseCatalog,
     throwOnMissingCatalogEntry: boolean = true,
     caseSensitiveMatching: boolean = true,
+    onDiagnostics?: (diagnostics: AttachTypesDiagnostics) => void,
 ): DbtModelNode[] => {
+    const startedAt = Date.now();
+    let exactLookups = 0;
+    let caseInsensitiveLookups = 0;
+    let missingLookups = 0;
+    let columnCount = 0;
+
+    // Indexed once instead of rescanning Object.keys() at three catalog levels for every
+    // column of every model, which made the cost models x columns x tables-in-schema.
+    const exactIndex = new Map<string, WarehouseTableSchema>();
+    const foldedIndex = new Map<string, WarehouseTableSchema>();
+    const exactLocation = new Map<
+        string,
+        { database: string; schema: string; table: string }
+    >();
+    const foldedLocation = new Map<
+        string,
+        { database: string; schema: string; table: string }
+    >();
+    const key = (database: string, schema: string, table: string) =>
+        `${database}\u0000${schema}\u0000${table}`;
+    const foldedKey = (database: string, schema: string, table: string) =>
+        key(database.toLowerCase(), schema.toLowerCase(), table.toLowerCase());
+
+    let catalogTableCount = 0;
+    Object.keys(warehouseCatalog).forEach((database) => {
+        // The reserved timestamp-domain sidecar sits beside the database keys and is not one.
+        if (database === WAREHOUSE_TIMESTAMP_DOMAINS_KEY) return;
+        const schemas = warehouseCatalog[database];
+        if (schemas === undefined || schemas === null) return;
+        Object.keys(schemas).forEach((schema) => {
+            const tables = schemas[schema];
+            if (tables === undefined || tables === null) return;
+            Object.keys(tables).forEach((table) => {
+                const columns = tables[table];
+                if (columns === undefined || columns === null) return;
+                catalogTableCount += 1;
+                const location = { database, schema, table };
+                const exact = key(database, schema, table);
+                // Object.keys() yields insertion order and the replaced code took the FIRST
+                // match, so only absent keys are set — that preserves which duplicate wins.
+                if (!exactIndex.has(exact)) {
+                    exactIndex.set(exact, columns);
+                    exactLocation.set(exact, location);
+                }
+                const folded = foldedKey(database, schema, table);
+                if (!foldedIndex.has(folded)) {
+                    foldedIndex.set(folded, columns);
+                    foldedLocation.set(folded, location);
+                }
+            });
+        });
+    });
+
+    const lookup = (
+        database: string,
+        schema: string,
+        table: string,
+    ):
+        | {
+              columns: WarehouseTableSchema;
+              location: { database: string; schema: string; table: string };
+              caseInsensitive: boolean;
+          }
+        | undefined => {
+        const exact = key(database, schema, table);
+        const exactHit = exactIndex.get(exact);
+        if (exactHit !== undefined) {
+            return {
+                columns: exactHit,
+                location: exactLocation.get(exact)!,
+                caseInsensitive: false,
+            };
+        }
+        if (caseSensitiveMatching) return undefined;
+        const folded = foldedKey(database, schema, table);
+        const foldedHit = foldedIndex.get(folded);
+        if (foldedHit !== undefined) {
+            return {
+                columns: foldedHit,
+                location: foldedLocation.get(folded)!,
+                caseInsensitive: true,
+            };
+        }
+        return undefined;
+    };
+
     // Check that all models appear in the warehouse
     models.forEach(({ database, schema, name }) => {
-        const databaseMatch = Object.keys(warehouseCatalog).find((db) =>
-            caseSensitiveMatching
-                ? db === database
-                : db.toLowerCase() === database.toLowerCase(),
-        );
-        // Explicit undefined checks: a matched key can be the empty string
-        // (ClickHouse table_catalog), which is falsy but a real match.
-        const schemaMatch =
-            databaseMatch !== undefined
-                ? Object.keys(warehouseCatalog[databaseMatch]).find((s) =>
-                      caseSensitiveMatching
-                          ? s === schema
-                          : s.toLowerCase() === schema.toLowerCase(),
-                  )
-                : undefined;
-        const tableMatch =
-            databaseMatch !== undefined && schemaMatch !== undefined
-                ? Object.keys(
-                      warehouseCatalog[databaseMatch][schemaMatch],
-                  ).find((t) =>
-                      caseSensitiveMatching
-                          ? t === name
-                          : t.toLowerCase() === name.toLowerCase(),
-                  )
-                : undefined;
-        if (tableMatch === undefined && throwOnMissingCatalogEntry) {
-            throw new MissingCatalogEntryError(
-                `Model "${name}" was expected in your target warehouse at "${database}.${schema}.${name}". Does the table exist in your target data warehouse?`,
-                {},
-            );
+        if (lookup(database, schema, name) === undefined) {
+            if (throwOnMissingCatalogEntry) {
+                throw new MissingCatalogEntryError(
+                    `Model "${name}" was expected in your target warehouse at "${database}.${schema}.${name}". Does the table exist in your target data warehouse?`,
+                    {},
+                );
+            }
         }
     });
 
@@ -1601,60 +1678,32 @@ export const attachTypesToModels = (
         | { type: DimensionType; timestampDomain: TimestampDomain | undefined }
         | undefined => {
         const tableName = alias || name;
-        const databaseMatch = Object.keys(warehouseCatalog).find((db) =>
-            caseSensitiveMatching
-                ? db === database
-                : db.toLowerCase() === database.toLowerCase(),
-        );
-        const schemaMatch =
-            databaseMatch !== undefined
-                ? Object.keys(warehouseCatalog[databaseMatch]).find((s) =>
-                      caseSensitiveMatching
-                          ? s === schema
-                          : s.toLowerCase() === schema.toLowerCase(),
-                  )
-                : undefined;
-        const tableMatch =
-            databaseMatch !== undefined && schemaMatch !== undefined
-                ? Object.keys(
-                      warehouseCatalog[databaseMatch][schemaMatch],
-                  ).find((t) =>
-                      caseSensitiveMatching
-                          ? t === tableName
-                          : t.toLowerCase() === tableName.toLowerCase(),
-                  )
-                : undefined;
-        const columnMatch =
-            databaseMatch !== undefined &&
-            schemaMatch !== undefined &&
-            tableMatch !== undefined
-                ? Object.keys(
-                      warehouseCatalog[databaseMatch][schemaMatch][tableMatch],
-                  ).find((c) =>
-                      caseSensitiveMatching
-                          ? c === columnName
-                          : c.toLowerCase() === columnName.toLowerCase(),
-                  )
-                : undefined;
-        if (
-            databaseMatch !== undefined &&
-            schemaMatch !== undefined &&
-            tableMatch !== undefined &&
-            columnMatch !== undefined
-        ) {
-            return {
-                type: warehouseCatalog[databaseMatch][schemaMatch][tableMatch][
-                    columnMatch
-                ],
-                timestampDomain: getCatalogTimestampDomain(
-                    warehouseCatalog,
-                    databaseMatch,
-                    schemaMatch,
-                    tableMatch,
-                    columnMatch,
-                ),
-            };
+        const hit = lookup(database, schema, tableName);
+        if (hit !== undefined) {
+            const columnMatch = Object.keys(hit.columns).find((column) =>
+                caseSensitiveMatching
+                    ? column === columnName
+                    : column.toLowerCase() === columnName.toLowerCase(),
+            );
+            if (columnMatch !== undefined) {
+                if (hit.caseInsensitive) {
+                    caseInsensitiveLookups += 1;
+                } else {
+                    exactLookups += 1;
+                }
+                return {
+                    type: hit.columns[columnMatch],
+                    timestampDomain: getCatalogTimestampDomain(
+                        warehouseCatalog,
+                        hit.location.database,
+                        hit.location.schema,
+                        hit.location.table,
+                        columnMatch,
+                    ),
+                };
+            }
         }
+        missingLookups += 1;
         if (throwOnMissingCatalogEntry) {
             throw new MissingCatalogEntryError(
                 `Column "${columnName}" from model "${tableName}" does not exist.\n "${tableName}.${columnName}" was not found in your target warehouse at ${database}.${schema}.${tableName}. Try rerunning dbt to update your warehouse.`,
@@ -1665,10 +1714,11 @@ export const attachTypesToModels = (
     };
 
     // Update the dbt models with type info
-    return models.map((model) => ({
+    const typedModels = models.map((model) => ({
         ...model,
         columns: Object.fromEntries(
             Object.entries(model.columns).map(([column_name, column]) => {
+                columnCount += 1;
                 const columnType = getColumnType(model, column_name);
                 return [
                     column_name,
@@ -1685,6 +1735,31 @@ export const attachTypesToModels = (
             }),
         ),
     }));
+
+    if (onDiagnostics) {
+        const modelsByPair = new Map<string, number>();
+        models.forEach(({ database, schema }) => {
+            const pair = `${database}.${schema}`;
+            modelsByPair.set(pair, (modelsByPair.get(pair) ?? 0) + 1);
+        });
+        onDiagnostics({
+            durationMs: Date.now() - startedAt,
+            modelCount: models.length,
+            columnCount,
+            catalogTableCount,
+            schemaPairs: [...modelsByPair.entries()]
+                .map(([databaseSchema, count]) => ({
+                    databaseSchema,
+                    models: count,
+                }))
+                .sort((a, b) => b.models - a.models),
+            exactLookups,
+            caseInsensitiveLookups,
+            missingLookups,
+        });
+    }
+
+    return typedModels;
 };
 
 export const getSchemaStructureFromDbtModels = (

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -1686,7 +1686,8 @@ export const attachTypesToModels = (
                     : column.toLowerCase() === columnName.toLowerCase(),
             );
             if (columnMatch !== undefined) {
-                if (hit.caseInsensitive) {
+                // A lookup is only exact when BOTH the table and the column matched exactly.
+                if (hit.caseInsensitive || columnMatch !== columnName) {
                     caseInsensitiveLookups += 1;
                 } else {
                     exactLookups += 1;

--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
@@ -1701,27 +1701,39 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
             table: string;
         }[],
     ) {
+        const startedAt = Date.now();
         const tablesMetadata = await processPromisesInBatches(
             config,
             DEFAULT_BATCH_SIZE,
             async ({ database, schema, table }) =>
                 this.runTableCatalogQuery(database, schema, table),
         );
+        const fetchedAt = Date.now();
 
-        return tablesMetadata.reduce<WarehouseCatalog>((acc, tableMetadata) => {
-            if (tableMetadata) {
-                tableMetadata.rows.forEach((row) => {
-                    const match = config.find(
-                        ({ database, schema, table }) =>
-                            database.toLowerCase() ===
-                                row.database_name.toLowerCase() &&
-                            schema.toLowerCase() ===
-                                row.schema_name.toLowerCase() &&
-                            table.toLowerCase() ===
-                                row.table_name.toLowerCase(),
-                    );
-                    // Unquoted identifiers will always be
-                    if (row.kind === 'COLUMN' && !!match) {
+        // Indexed once instead of scanning the whole request list, with three toLowerCase
+        // compares per candidate, for every column row returned.
+        const requestByKey = new Map<string, (typeof config)[number]>();
+        config.forEach((request) => {
+            const key = `${request.database.toLowerCase()}\u0000${request.schema.toLowerCase()}\u0000${request.table.toLowerCase()}`;
+            // config.find took the first match, so only absent keys are set.
+            if (!requestByKey.has(key)) requestByKey.set(key, request);
+        });
+
+        let columnRows = 0;
+        let unmatchedRows = 0;
+        const catalog = tablesMetadata.reduce<WarehouseCatalog>(
+            (acc, tableMetadata) => {
+                if (tableMetadata) {
+                    tableMetadata.rows.forEach((row) => {
+                        if (row.kind !== 'COLUMN') return;
+                        columnRows += 1;
+                        const match = requestByKey.get(
+                            `${row.database_name.toLowerCase()}\u0000${row.schema_name.toLowerCase()}\u0000${row.table_name.toLowerCase()}`,
+                        );
+                        if (!match) {
+                            unmatchedRows += 1;
+                            return;
+                        }
                         acc[match.database] = acc[match.database] || {};
                         acc[match.database][match.schema] =
                             acc[match.database][match.schema] || {};
@@ -1740,11 +1752,29 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
                             row.column_name,
                             getSnowflakeTimestampDomain(rawType),
                         );
-                    }
-                });
-            }
-            return acc;
-        }, {});
+                    });
+                }
+                return acc;
+            },
+            {},
+        );
+
+        const finishedAt = Date.now();
+        console.info(
+            JSON.stringify({
+                event: 'warehouse.getCatalog',
+                warehouse: 'snowflake',
+                requestedTables: config.length,
+                respondedTables: tablesMetadata.filter(Boolean).length,
+                columnRows,
+                unmatchedRows,
+                batchSize: DEFAULT_BATCH_SIZE,
+                fetchDurationMs: fetchedAt - startedAt,
+                indexDurationMs: finishedAt - fetchedAt,
+                durationMs: finishedAt - startedAt,
+            }),
+        );
+        return catalog;
     }
 
     async getAllTables() {


### PR DESCRIPTION
Linear: SPK-1861

## What changed

`attachTypesToModels` resolved a column's database, schema and table with
`Object.keys(...).find(...)` at three catalog levels, once per column of every model. The
table-level scan covered every table in the schema, so the cost was
`models x columns x tables-in-schema`. This change indexes the catalog into a `Map` once and
looks up per column.

`SnowflakeWarehouseClient.getCatalog` had the same shape. Its reducer called `config.find` with
three `toLowerCase` compares per candidate, for every column row returned. It now indexes the
request list once.

The lookup semantics are unchanged:

- An exact match still wins over a case-insensitive one.
- When two catalog entries fold to the same name, the first one still wins. The index only sets
  absent keys, and `Object.keys` yields insertion order.
- The empty-string database key (ClickHouse `table_catalog`) still matches.
- The reserved `__lightdashTimestampDomains` sidecar is excluded from the index, so it is never
  treated as a database.

## Observability

Two wide events, one per phase, each carrying the whole context on a single event.

`dbt.compile.attachTypes` carries `projectUuid`, `jobUuid`, `catalogSource`
(`cached_catalog` or `refetched_catalog`), `durationMs`, `modelCount`, `columnCount`,
`catalogTableCount`, `distinctSchemaCount`, `schemaPairs` (the `database.schema` pairs with a
model count each, top 20), `exactLookups`, `caseInsensitiveLookups` and `missingLookups`.

`dbt.compile.warehouseCatalogFetch` carries `projectUuid`, `jobUuid`, `warehouseType`,
`requestedTables` and `durationMs`.

`warehouse.getCatalog` (Snowflake, in the warehouses package, which has no project context)
carries `requestedTables`, `respondedTables`, `columnRows`, `unmatchedRows`, `batchSize`,
`fetchDurationMs`, `indexDurationMs` and `durationMs`.

`schemaPairs` is the field that answers the sizing question directly. This term is quadratic in
models per schema, so a project whose models all land in one schema pays it and a project whose
repos use dbt custom-schema configs does not. Today nothing in the logs says which case an
instance is in.

`jobUuid` is new on `TrackingParams` and is threaded from `compileProject` and
`testAndCompileProject`. Where a caller has no job, the field is an explicit `null` rather than
absent.

## Measured

Rig calibrated to a large self-hosted project: 3,382 explores, 214,997 dimensions, 43,336
metrics, one shared warehouse schema. 8 vCPU, Node v24.18.1, whole run in a cgroup v2 scope.

**Arm C, customer-calibrated, 3,382 explores, one schema, 8 vCPU:**

| | Before | After |
|---|---:|---:|
| `attachTypesToModels` | 24,026 ms | **135 ms** |
| Whole compile, wall | 69,655 ms | **41,977 ms** |
| CPU used | 230.4 s | 200.6 s |
| Peak memory, whole process tree | 4,341 MB | 4,241 MB |
| Explores compiled / errors | 3,382 / 0 | 3,382 / 0 |

**Arm A prime, 6,020 explores with joins, one schema, 8 vCPU:**

| | Before | After |
|---|---:|---:|
| `attachTypesToModels` | 108,176 ms | **205 ms** |
| Whole compile, wall | 194,554 ms | **92,778 ms** |
| CPU used | 408.9 s | 299.9 s |
| Peak memory, whole process tree | 7,370 MB | 7,554 MB |
| Explores compiled / errors | 6,020 / 0 | 6,020 / 0 |

Read the memory column as unchanged, not improved or worsened. These are single repetitions per
arm and the index itself is about 1 MB of `Map` entries holding references to objects that
already exist. The duration and CPU columns are the result.

The Snowflake reducer, replayed at 3,382 tables and 216,448 column rows with output asserted
identical: **32,128 ms to 116 ms**. At 5,955 tables and 238,200 rows: 66,329 ms to 131 ms.

Output equivalence is checked by sha256 over the compiled explores sorted by name, plus a
sha256 of the collision list. Both are byte-identical before and after on both arms.

## What is still unmeasured

The Snowflake numbers above are for the row-matching reducer only. `getCatalog` also opens a
connection, runs `SHOW COLUMNS IN TABLE` and destroys the connection **once per table**, 100 at
a time. That per-table round trip is untouched by this change and is not measured here, because
the rig has no Snowflake. The same shape against local Postgres, where a connection costs
nothing, takes 6.7 s for 3,382 tables; a real Snowflake connection costs far more than nothing.
The new `fetchDurationMs` field is what will tell us, from a real instance, whether that term
matters.

The 24 s figure assumes every model resolves into one warehouse schema. Measured separately,
the same arm with models spread across 14 schemas spends 1.3 s in this phase before the change.
The fix is justified either way at this cost, and the new `schemaPairs` field removes the guess.
