### PR TITLE
chore(rainbow): enable preview feature flags and wire the EE licence

### DIFF
--- a/docs/preview-feature-flags.md
+++ b/docs/preview-feature-flags.md
@@ -36,6 +36,12 @@ need an app runtime). Those surfaces render but won't work end to end.
 This is controlled by `LIGHTDASH_PREVIEW_FEATURE_FLAGS_ENABLED`, which defaults
 to `true` in PR mode. Set it to `false` for production-like flag resolution.
 
+Rainbow previews are not PR mode: they run the repo's own dev scripts, and
+`packages/backend`'s `dev` pins `LIGHTDASH_MODE=development`. They set the
+variable outright instead, in `rainbow.toml`'s `[env]` table. Anything touching
+that table or the services needs the Rainbow base image recompiled before it
+takes effect.
+
 ## Managing flags at runtime
 
 The management endpoints require an organization admin and only work when

--- a/rainbow.toml
+++ b/rainbow.toml
@@ -23,6 +23,14 @@ memory = "8gb"                      # a starting guess; the measured working set
 # packageManager field, and postgresql-16 from [datastores] below. Add
 # [runtime] only to override a pin or to list an OS package nothing else owns.
 
+# Previews exist to exercise unreleased work, so they enable the curated preview
+# flag set (PREVIEW_ENABLED_FEATURE_FLAGS) and the flag-management API that lets
+# an admin toggle a flag at runtime — see docs/preview-feature-flags.md. Okteto
+# previews got this from LIGHTDASH_MODE=pr; here the backend's dev script pins
+# LIGHTDASH_MODE=development, so it has to be set outright.
+[env]
+LIGHTDASH_PREVIEW_FEATURE_FLAGS_ENABLED = "true"
+
 [datastores]
 postgres = true                    # provisioned, localhost, seeded once
 
@@ -70,6 +78,13 @@ watch = ["**"]                     # Vite HMR / tsx watch notice the write; bott
 vars = ["SITE_URL"]
 patch = [{ path = "/api/v1/health", field = "results.siteUrl" }]
 
+# Names, not values: the platform holds what they resolve to. The licence pair
+# is the offline (ed25519-signed) form Okteto previews use, so it verifies
+# locally without reaching api.keygen.sh. Until both are provisioned in the
+# platform's store these two resolve to nothing and previews stay OSS-only —
+# an unprovisioned name injects no variable rather than failing the fork.
 [secrets]
 LIGHTDASH_SECRET = "app-secret"
 PGPASSWORD = "postgres-password"
+LIGHTDASH_LICENSE_KEY = "lightdash-license-key"
+LIGHTDASH_LICENSE_CERTIFICATE = "lightdash-license-certificate"


### PR DESCRIPTION
Rainbow PR previews resolve **every** feature flag to `false` and carry no enterprise licence, so anything behind a flag — query history, data apps, the chart gallery — or behind EE is invisible in a preview. Okteto previews had both.

Verified live on the preview for #28550:

```
LIGHTDASH_LOG_LEVEL=info
LIGHTDASH_MODE=development
LIGHTDASH_SECRET=not-very-secret        <- the complete LIGHTDASH_* set

/api/v2/feature-flag/query-history          -> {"enabled": false}
/api/v2/feature-flag/enable-data-apps       -> {"enabled": false}
/api/v2/feature-flag/explorer-chart-gallery -> {"enabled": false}
/api/v1/health .license -> {hasLicenseKey: false, valid: false}
```

### Why both mechanisms miss

1. `LIGHTDASH_ENABLE_FEATURE_FLAGS` — what `/docker-dev` writes into `.env.development.local` from `scripts/dev-profiles.json` — reaches the process only because `ecosystem.config.js` dotenv-loads `.env.development` + `.env.development.local` for pm2. Rainbow runs `pnpm -F backend dev` directly and the backend loads no env file of its own. Confirmed by `LIGHTDASH_LOG_LEVEL=info` in the guest, where `.env.development` sets `debug`.
2. The preview auto-enable path (`previewFeatureFlags.enabled` → `PREVIEW_ENABLED_FEATURE_FLAGS`, whose exclusion list does *not* contain `query-history`) keys off `LIGHTDASH_MODE=pr`. `packages/backend`'s `dev` script pins `LIGHTDASH_MODE=development`, so it never fires.

The licence is separate: `docker/docker-compose.preview.yml` injects `LIGHTDASH_LICENSE_KEY` + `LIGHTDASH_LICENSE_CERTIFICATE` from Okteto's admin variables. Nothing equivalent existed in `rainbow.toml`.

### Change

`[env]` sets `LIGHTDASH_PREVIEW_FEATURE_FLAGS_ENABLED = "true"`, and `[secrets]` names the offline licence pair. `docs/preview-feature-flags.md` claimed previews are PR-mode only; it now covers the Rainbow case.

### Two platform actions still needed

Landing this file is safe but not sufficient:

- **Recompile the base**: any change touching services or `[env]` is gated on `rainbow image compile -repo lightdash/lightdash -install -cold` — the current base runs a hand-built `lightdash.service` unit rather than the compiler's `rainbow-<service>` units. Until that runs, the `[env]` line has no effect.
- **Provision the licence secrets**: `[secrets]` maps an env var to a *platform secret name*; values live with the platform, never in this repo — it is public. An unprovisioned name is silently accepted and injects nothing (verified: the env forked fine with no `LIGHTDASH_LICENSE_KEY` in the process), so these lines are inert rather than broken until the values exist.

### Schema notes, probed against the live platform

None of this is documented in the repo, so for the record:

- `[[app.service]]` does **not** accept an `env` table — `unknown key(s): app.service.env`. A top-level `[env]` table is valid.
- Changes to `[secrets]` alone do not trip the recompile gate; changes to services or `[env]` do.

Closes: PROD-10879

https://claude.ai/code/session_01XfPWHVLJeaX3DZsJtFtcN1
