### PR TITLE
feat: bound the dbt source fetch

### DIFF
--- a/packages/backend/src/config/dbtSourceFetchConcurrency.test.ts
+++ b/packages/backend/src/config/dbtSourceFetchConcurrency.test.ts
@@ -1,0 +1,83 @@
+import { resolveDbtSourceFetchConcurrency } from './dbtSourceFetchConcurrency';
+
+const GIB = 1024 * 1024 * 1024;
+
+const runtime = (cores: number, memoryBytes: number | undefined) => ({
+    availableParallelism: () => cores,
+    constrainedMemory: () => memoryBytes,
+});
+
+describe('resolveDbtSourceFetchConcurrency', () => {
+    it('uses cores when memory is unconstrained', () => {
+        const result = resolveDbtSourceFetchConcurrency(
+            undefined,
+            runtime(4, undefined),
+        );
+        expect(result.chosen).toEqual(4);
+        expect(result.memoryDerivedLimit).toBeNull();
+    });
+
+    it('caps at eight however many cores are reported', () => {
+        expect(
+            resolveDbtSourceFetchConcurrency(undefined, runtime(64, undefined))
+                .chosen,
+        ).toEqual(8);
+    });
+
+    it('takes the memory bound when it is lower than cores', () => {
+        // 8 GiB - 3 GiB reserve = 5 GiB, at 1 GiB per source
+        const result = resolveDbtSourceFetchConcurrency(
+            undefined,
+            runtime(8, 8 * GIB),
+        );
+        expect(result.memoryDerivedLimit).toEqual(5);
+        expect(result.chosen).toEqual(5);
+    });
+
+    it('takes the core bound when it is lower than memory', () => {
+        const result = resolveDbtSourceFetchConcurrency(
+            undefined,
+            runtime(2, 32 * GIB),
+        );
+        expect(result.memoryDerivedLimit).toEqual(29);
+        expect(result.chosen).toEqual(2);
+    });
+
+    it('never drops below one, however small the limit', () => {
+        const result = resolveDbtSourceFetchConcurrency(
+            undefined,
+            runtime(8, 2 * GIB),
+        );
+        expect(result.memoryDerivedLimit).toBeLessThanOrEqual(0);
+        expect(result.chosen).toEqual(1);
+    });
+
+    it('lets the override win over both bounds', () => {
+        const result = resolveDbtSourceFetchConcurrency(
+            14,
+            runtime(2, 4 * GIB),
+        );
+        expect(result.chosen).toEqual(14);
+        expect(result.override).toEqual(14);
+    });
+
+    it('clamps a non-positive override to one', () => {
+        expect(
+            resolveDbtSourceFetchConcurrency(0, runtime(8, undefined)).chosen,
+        ).toEqual(1);
+    });
+
+    it('reports every input that produced the decision', () => {
+        const result = resolveDbtSourceFetchConcurrency(
+            undefined,
+            runtime(8, 8 * GIB),
+        );
+        expect(result).toEqual({
+            override: undefined,
+            availableParallelism: 8,
+            constrainedMemoryBytes: 8 * GIB,
+            memoryDerivedLimit: 5,
+            chosen: 5,
+        });
+    });
+});

--- a/packages/backend/src/config/dbtSourceFetchConcurrency.test.ts
+++ b/packages/backend/src/config/dbtSourceFetchConcurrency.test.ts
@@ -43,10 +43,30 @@ describe('resolveDbtSourceFetchConcurrency', () => {
         expect(result.chosen).toEqual(2);
     });
 
-    it('never drops below one, however small the limit', () => {
+    it('floors the memory bound at two, however small the limit', () => {
+        // Below 1 buys no memory: at every concurrency at or below 4 the peak already sits
+        // after the fetch phase, so 1 costs wall clock and saves nothing.
         const result = resolveDbtSourceFetchConcurrency(
             undefined,
             runtime(8, 2 * GIB),
+        );
+        // reported raw, before the floor, so the sizing arithmetic stays legible
+        expect(result.memoryDerivedLimit).toBeLessThanOrEqual(0);
+        expect(result.chosen).toEqual(2);
+    });
+
+    it('lets a single core still serialise', () => {
+        const result = resolveDbtSourceFetchConcurrency(
+            undefined,
+            runtime(1, 32 * GIB),
+        );
+        expect(result.chosen).toEqual(1);
+    });
+
+    it('does not let the memory floor override the core bound', () => {
+        const result = resolveDbtSourceFetchConcurrency(
+            undefined,
+            runtime(1, 2 * GIB),
         );
         expect(result.memoryDerivedLimit).toBeLessThanOrEqual(0);
         expect(result.chosen).toEqual(1);

--- a/packages/backend/src/config/dbtSourceFetchConcurrency.ts
+++ b/packages/backend/src/config/dbtSourceFetchConcurrency.ts
@@ -3,6 +3,12 @@ import os from 'os';
 export const DBT_SOURCE_FETCH_MEMORY_RESERVE_BYTES = 3 * 1024 * 1024 * 1024;
 export const DBT_SOURCE_FETCH_MEMORY_PER_SOURCE_BYTES = 1024 * 1024 * 1024;
 export const DBT_SOURCE_FETCH_MAX_CONCURRENCY = 8;
+/**
+ * The memory bound never drops below this. Measured: at every concurrency at or below 4 the peak
+ * already sits after the fetch phase, so 1 has the same peak as 2 and only costs wall clock.
+ * Without this floor any pod at or below 4 GiB would serialise every source parse for no gain.
+ */
+export const DBT_SOURCE_FETCH_MIN_MEMORY_CONCURRENCY = 2;
 
 export type DbtSourceFetchConcurrencyInputs = {
     override: number | undefined;
@@ -22,6 +28,10 @@ export type DbtSourceFetchConcurrencyInputs = {
  * The memory reserve is the measured Node save-path floor plus margin. The per-source figure is
  * an estimate for real repositories, measured at 251 MB against a fixture; it is the constant to
  * tighten with evidence from a real instance.
+ *
+ * The memory-derived bound floors at DBT_SOURCE_FETCH_MIN_MEMORY_CONCURRENCY; the core bound does
+ * not, because a single-core pod genuinely cannot parallelise. `memoryDerivedLimit` is reported
+ * raw, before the floor, so a support log still shows what the memory arithmetic produced.
  */
 export const resolveDbtSourceFetchConcurrency = (
     override: number | undefined,
@@ -61,7 +71,12 @@ export const resolveDbtSourceFetchConcurrency = (
 
     const bounded = Math.min(
         availableParallelism,
-        memoryDerivedLimit ?? Number.POSITIVE_INFINITY,
+        memoryDerivedLimit === null
+            ? Number.POSITIVE_INFINITY
+            : Math.max(
+                  DBT_SOURCE_FETCH_MIN_MEMORY_CONCURRENCY,
+                  memoryDerivedLimit,
+              ),
     );
     const chosen = Math.min(
         DBT_SOURCE_FETCH_MAX_CONCURRENCY,

--- a/packages/backend/src/config/dbtSourceFetchConcurrency.ts
+++ b/packages/backend/src/config/dbtSourceFetchConcurrency.ts
@@ -1,0 +1,78 @@
+import os from 'os';
+
+export const DBT_SOURCE_FETCH_MEMORY_RESERVE_BYTES = 3 * 1024 * 1024 * 1024;
+export const DBT_SOURCE_FETCH_MEMORY_PER_SOURCE_BYTES = 1024 * 1024 * 1024;
+export const DBT_SOURCE_FETCH_MAX_CONCURRENCY = 8;
+
+export type DbtSourceFetchConcurrencyInputs = {
+    override: number | undefined;
+    availableParallelism: number;
+    constrainedMemoryBytes: number | undefined;
+    memoryDerivedLimit: number | null;
+    chosen: number;
+};
+
+/**
+ * How many dbt sources may be fetched at once.
+ *
+ * Bounded by cores and by memory, because each source runs its own dbt process whose memory is
+ * additive to the Node heap. Concurrency above the CPU quota buys no wall clock — total dbt CPU
+ * is fixed and the processes only time-slice — while memory rises linearly with it.
+ *
+ * The memory reserve is the measured Node save-path floor plus margin. The per-source figure is
+ * an estimate for real repositories, measured at 251 MB against a fixture; it is the constant to
+ * tighten with evidence from a real instance.
+ */
+export const resolveDbtSourceFetchConcurrency = (
+    override: number | undefined,
+    // injectable for tests only
+    runtime: {
+        availableParallelism: () => number;
+        constrainedMemory: () => number | undefined;
+    } = {
+        availableParallelism: () => os.availableParallelism(),
+        constrainedMemory: () =>
+            typeof process.constrainedMemory === 'function'
+                ? process.constrainedMemory()
+                : undefined,
+    },
+): DbtSourceFetchConcurrencyInputs => {
+    const availableParallelism = Math.max(1, runtime.availableParallelism());
+    const constrainedMemoryBytes = runtime.constrainedMemory();
+
+    const memoryDerivedLimit =
+        constrainedMemoryBytes !== undefined && constrainedMemoryBytes > 0
+            ? Math.floor(
+                  (constrainedMemoryBytes -
+                      DBT_SOURCE_FETCH_MEMORY_RESERVE_BYTES) /
+                      DBT_SOURCE_FETCH_MEMORY_PER_SOURCE_BYTES,
+              )
+            : null;
+
+    if (override !== undefined) {
+        return {
+            override,
+            availableParallelism,
+            constrainedMemoryBytes,
+            memoryDerivedLimit,
+            chosen: Math.max(1, Math.floor(override)),
+        };
+    }
+
+    const bounded = Math.min(
+        availableParallelism,
+        memoryDerivedLimit ?? Number.POSITIVE_INFINITY,
+    );
+    const chosen = Math.min(
+        DBT_SOURCE_FETCH_MAX_CONCURRENCY,
+        Math.max(1, bounded),
+    );
+
+    return {
+        override,
+        availableParallelism,
+        constrainedMemoryBytes,
+        memoryDerivedLimit,
+        chosen,
+    };
+};

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -117,6 +117,7 @@ export const lightdashConfigMock: LightdashConfig = {
     },
     dbt: {
         environmentVariableAllowlist: [],
+        sourceFetchConcurrency: undefined,
     },
     dashboard: {
         maxTilesPerTab: 50,

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1513,6 +1513,7 @@ export type LightdashConfig = {
     };
     dbt: {
         environmentVariableAllowlist: string[];
+        sourceFetchConcurrency: number | undefined;
     };
     database: {
         connectionUri: string | undefined;
@@ -3218,6 +3219,9 @@ export const parseConfig = (): LightdashConfig => {
         dbt: {
             environmentVariableAllowlist: getArrayFromCommaSeparatedList(
                 'ALLOW_DBT_COMMANDS_ACCESS_TO_ENV_VARS',
+            ),
+            sourceFetchConcurrency: getIntegerFromEnvironmentVariable(
+                'DBT_SOURCE_FETCH_CONCURRENCY',
             ),
         },
         allowMultiOrgs: process.env.ALLOW_MULTIPLE_ORGS === 'true',

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -271,6 +271,7 @@ import { Readable } from 'stream';
 import { URL } from 'url';
 import { promisify } from 'util';
 import { v4 as uuidv4 } from 'uuid';
+import v8 from 'v8';
 import { Worker } from 'worker_threads';
 import { gzip } from 'zlib';
 import {
@@ -283,6 +284,7 @@ import { S3CacheClient } from '../../clients/Aws/S3CacheClient';
 import EmailClient from '../../clients/EmailClient/EmailClient';
 import { type FileStorageClient } from '../../clients/FileStorage/FileStorageClient';
 import type { INatsClient } from '../../clients/NatsClient';
+import { resolveDbtSourceFetchConcurrency } from '../../config/dbtSourceFetchConcurrency';
 import { LightdashConfig } from '../../config/parseConfig';
 import { normalizeDatabricksHostLenient } from '../../controllers/authentication/strategies/databricksStrategy';
 import type { DbProjectParameter } from '../../database/entities/projectParameters';
@@ -344,6 +346,7 @@ import {
 import { PivotQueryBuilder } from '../../utils/QueryBuilder/PivotQueryBuilder';
 import { QueryComposer } from '../../utils/QueryBuilder/QueryComposer';
 import { applyLimitToSqlQuery } from '../../utils/QueryBuilder/utils';
+import { runWithConcurrency } from '../../utils/runWithConcurrency';
 import { SubtotalsCalculator } from '../../utils/SubtotalsCalculator';
 import { AdminNotificationService } from '../AdminNotificationService/AdminNotificationService';
 import { BaseService } from '../BaseService';
@@ -4784,9 +4787,11 @@ export class ProjectService extends BaseService {
         primary,
         sources,
         manifestFetchAdapters,
+        jobUuid,
     }: {
         projectUuid: string;
         organizationUuid: string | undefined;
+        jobUuid?: string;
         primary: {
             adapter: ProjectAdapter;
             warehouseCredentials: CreateWarehouseCredentials;
@@ -4866,8 +4871,28 @@ export class ProjectService extends BaseService {
                 );
             });
 
-        const built = await Promise.all(
-            compilableSources.map(async (source) => {
+        const concurrencyDecision = resolveDbtSourceFetchConcurrency(
+            this.lightdashConfig.dbt.sourceFetchConcurrency,
+        );
+        this.logger.info('dbt.compile.sourceFetchStart', {
+            event: 'dbt.compile.sourceFetchStart',
+            projectUuid,
+            jobUuid: jobUuid ?? null,
+            sourceCount: compilableSources.length,
+            concurrency: concurrencyDecision.chosen,
+            envOverride: concurrencyDecision.override ?? null,
+            availableParallelism: concurrencyDecision.availableParallelism,
+            constrainedMemoryBytes:
+                concurrencyDecision.constrainedMemoryBytes ?? null,
+            memoryDerivedLimit: concurrencyDecision.memoryDerivedLimit,
+            nodeHeapLimitBytes: v8.getHeapStatistics().heap_size_limit,
+        });
+
+        const sourceFetchStartedAt = Date.now();
+        const built = await runWithConcurrency(
+            compilableSources,
+            concurrencyDecision.chosen,
+            async (source) => {
                 // Name the source (and repo) in any failure so the user can tell
                 // which one to fix — the raw git error only mentions a temp dir.
                 const repoSuffix =
@@ -4875,6 +4900,7 @@ export class ProjectService extends BaseService {
                     source.dbtConnection.repository
                         ? ` (${source.dbtConnection.repository})`
                         : '';
+                const sourceStartedAt = Date.now();
                 let sourceAdapter: ProjectAdapter;
                 try {
                     sourceAdapter = await this.buildSourceAdapter(
@@ -4920,6 +4946,18 @@ export class ProjectService extends BaseService {
                             ),
                         ),
                     };
+                    this.logger.info('dbt.compile.sourceFetched', {
+                        event: 'dbt.compile.sourceFetched',
+                        projectUuid,
+                        jobUuid: jobUuid ?? null,
+                        sourceName: source.name,
+                        durationMs: Date.now() - sourceStartedAt,
+                        modelCount: Object.values(manifest.nodes).filter(
+                            (node) => node.resource_type === 'model',
+                        ).length,
+                        selectedModelCount:
+                            sourceSelectedModelIds?.length ?? null,
+                    });
                     return {
                         name: source.name,
                         precedence: source.precedence,
@@ -4933,8 +4971,18 @@ export class ProjectService extends BaseService {
                         )}`,
                     );
                 }
-            }),
+            },
         );
+        this.logger.info('dbt.compile.sourceFetchComplete', {
+            event: 'dbt.compile.sourceFetchComplete',
+            projectUuid,
+            jobUuid: jobUuid ?? null,
+            sourceCount: compilableSources.length,
+            concurrency: concurrencyDecision.chosen,
+            durationMs: Date.now() - sourceFetchStartedAt,
+            nodeRssBytes: process.memoryUsage().rss,
+            nodeHeapUsedBytes: process.memoryUsage().heapUsed,
+        });
 
         const manifestSources: ManifestSource[] = [
             {
@@ -5039,10 +5087,12 @@ export class ProjectService extends BaseService {
         primary,
         manifestFetchAdapters,
         onDbtSourceCount,
+        jobUuid,
     }: {
         projectUuid: string;
         organizationUuid: string | undefined;
         userUuid: string;
+        jobUuid?: string;
         primary: {
             adapter: ProjectAdapter;
             warehouseCredentials: CreateWarehouseCredentials;
@@ -5076,6 +5126,7 @@ export class ProjectService extends BaseService {
             primary,
             sources,
             manifestFetchAdapters,
+            jobUuid,
         });
     }
 

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -4874,19 +4874,30 @@ export class ProjectService extends BaseService {
         const concurrencyDecision = resolveDbtSourceFetchConcurrency(
             this.lightdashConfig.dbt.sourceFetchConcurrency,
         );
-        this.logger.info('dbt.compile.sourceFetchStart', {
-            event: 'dbt.compile.sourceFetchStart',
-            projectUuid,
-            jobUuid: jobUuid ?? null,
-            sourceCount: compilableSources.length,
-            concurrency: concurrencyDecision.chosen,
-            envOverride: concurrencyDecision.override ?? null,
-            availableParallelism: concurrencyDecision.availableParallelism,
-            constrainedMemoryBytes:
-                concurrencyDecision.constrainedMemoryBytes ?? null,
-            memoryDerivedLimit: concurrencyDecision.memoryDerivedLimit,
-            nodeHeapLimitBytes: v8.getHeapStatistics().heap_size_limit,
-        });
+        // The default log format renders the message and drops metadata, so the decisive
+        // values ride in both. Typed fields stay for instances on the json format.
+        this.logger.info(
+            `dbt.compile.sourceFetchStart projectUuid=${projectUuid} sources=${
+                compilableSources.length
+            } concurrency=${concurrencyDecision.chosen} cores=${
+                concurrencyDecision.availableParallelism
+            } memoryDerivedLimit=${
+                concurrencyDecision.memoryDerivedLimit ?? 'none'
+            } envOverride=${concurrencyDecision.override ?? 'none'}`,
+            {
+                event: 'dbt.compile.sourceFetchStart',
+                projectUuid,
+                jobUuid: jobUuid ?? null,
+                sourceCount: compilableSources.length,
+                concurrency: concurrencyDecision.chosen,
+                envOverride: concurrencyDecision.override ?? null,
+                availableParallelism: concurrencyDecision.availableParallelism,
+                constrainedMemoryBytes:
+                    concurrencyDecision.constrainedMemoryBytes ?? null,
+                memoryDerivedLimit: concurrencyDecision.memoryDerivedLimit,
+                nodeHeapLimitBytes: v8.getHeapStatistics().heap_size_limit,
+            },
+        );
 
         const sourceFetchStartedAt = Date.now();
         const built = await runWithConcurrency(
@@ -4946,18 +4957,23 @@ export class ProjectService extends BaseService {
                             ),
                         ),
                     };
-                    this.logger.info('dbt.compile.sourceFetched', {
-                        event: 'dbt.compile.sourceFetched',
-                        projectUuid,
-                        jobUuid: jobUuid ?? null,
-                        sourceName: source.name,
-                        durationMs: Date.now() - sourceStartedAt,
-                        modelCount: Object.values(manifest.nodes).filter(
-                            (node) => node.resource_type === 'model',
-                        ).length,
-                        selectedModelCount:
-                            sourceSelectedModelIds?.length ?? null,
-                    });
+                    const sourceDurationMs = Date.now() - sourceStartedAt;
+                    const sourceModelCount = Object.values(
+                        manifest.nodes,
+                    ).filter((node) => node.resource_type === 'model').length;
+                    this.logger.info(
+                        `dbt.compile.sourceFetched projectUuid=${projectUuid} sourceName=${source.name} durationMs=${sourceDurationMs} models=${sourceModelCount}`,
+                        {
+                            event: 'dbt.compile.sourceFetched',
+                            projectUuid,
+                            jobUuid: jobUuid ?? null,
+                            sourceName: source.name,
+                            durationMs: sourceDurationMs,
+                            modelCount: sourceModelCount,
+                            selectedModelCount:
+                                sourceSelectedModelIds?.length ?? null,
+                        },
+                    );
                     return {
                         name: source.name,
                         precedence: source.precedence,
@@ -4973,16 +4989,27 @@ export class ProjectService extends BaseService {
                 }
             },
         );
-        this.logger.info('dbt.compile.sourceFetchComplete', {
-            event: 'dbt.compile.sourceFetchComplete',
-            projectUuid,
-            jobUuid: jobUuid ?? null,
-            sourceCount: compilableSources.length,
-            concurrency: concurrencyDecision.chosen,
-            durationMs: Date.now() - sourceFetchStartedAt,
-            nodeRssBytes: process.memoryUsage().rss,
-            nodeHeapUsedBytes: process.memoryUsage().heapUsed,
-        });
+        const sourceFetchDurationMs = Date.now() - sourceFetchStartedAt;
+        const memoryAfterFetch = process.memoryUsage();
+        this.logger.info(
+            `dbt.compile.sourceFetchComplete projectUuid=${projectUuid} sources=${
+                compilableSources.length
+            } concurrency=${
+                concurrencyDecision.chosen
+            } durationMs=${sourceFetchDurationMs} nodeRssMb=${Math.round(
+                memoryAfterFetch.rss / 1024 / 1024,
+            )}`,
+            {
+                event: 'dbt.compile.sourceFetchComplete',
+                projectUuid,
+                jobUuid: jobUuid ?? null,
+                sourceCount: compilableSources.length,
+                concurrency: concurrencyDecision.chosen,
+                durationMs: sourceFetchDurationMs,
+                nodeRssBytes: memoryAfterFetch.rss,
+                nodeHeapUsedBytes: memoryAfterFetch.heapUsed,
+            },
+        );
 
         const manifestSources: ManifestSource[] = [
             {

--- a/packages/backend/src/utils/runWithConcurrency.test.ts
+++ b/packages/backend/src/utils/runWithConcurrency.test.ts
@@ -1,0 +1,92 @@
+import { runWithConcurrency } from './runWithConcurrency';
+
+const delay = (ms: number) =>
+    new Promise<void>((resolve) => {
+        setTimeout(resolve, ms);
+    });
+
+describe('runWithConcurrency', () => {
+    it('returns results in input order when tasks finish out of order', async () => {
+        const items = [50, 10, 40, 0, 30];
+        const results = await runWithConcurrency(items, 2, async (item) => {
+            await delay(item);
+            return item;
+        });
+        expect(results).toEqual(items);
+    });
+
+    it('never exceeds the concurrency limit', async () => {
+        let inFlight = 0;
+        let maxInFlight = 0;
+        await runWithConcurrency(
+            Array.from({ length: 14 }, (_, index) => index),
+            3,
+            async () => {
+                inFlight += 1;
+                maxInFlight = Math.max(maxInFlight, inFlight);
+                await delay(5);
+                inFlight -= 1;
+            },
+        );
+        expect(maxInFlight).toEqual(3);
+    });
+
+    it('matches unbounded scheduling when the limit is at least the item count', async () => {
+        let inFlight = 0;
+        let maxInFlight = 0;
+        await runWithConcurrency(
+            Array.from({ length: 6 }, (_, index) => index),
+            6,
+            async () => {
+                inFlight += 1;
+                maxInFlight = Math.max(maxInFlight, inFlight);
+                await delay(5);
+                inFlight -= 1;
+            },
+        );
+        expect(maxInFlight).toEqual(6);
+    });
+
+    it('starts no further task after the first rejection and propagates it', async () => {
+        const started: number[] = [];
+        const failure = new Error('source two failed');
+        // Item 1 fails while item 0 still holds the other slot, so every later item is
+        // admitted only after the failure is already recorded.
+        await expect(
+            runWithConcurrency(
+                Array.from({ length: 10 }, (_, index) => index),
+                2,
+                async (item) => {
+                    started.push(item);
+                    if (item === 1) throw failure;
+                    await delay(50);
+                    return item;
+                },
+            ),
+        ).rejects.toThrow('source two failed');
+
+        expect(started).toEqual([0, 1]);
+    });
+
+    it('reports the first error when several tasks fail', async () => {
+        const first = new Error('first');
+        await expect(
+            runWithConcurrency([1, 2, 3, 4], 1, async (item) => {
+                if (item === 1) throw first;
+                throw new Error(`later ${item}`);
+            }),
+        ).rejects.toThrow('first');
+    });
+
+    it('treats a non-positive limit as one', async () => {
+        let inFlight = 0;
+        let maxInFlight = 0;
+        await runWithConcurrency([1, 2, 3], 0, async () => {
+            inFlight += 1;
+            maxInFlight = Math.max(maxInFlight, inFlight);
+            await delay(1);
+            inFlight -= 1;
+        });
+        expect(maxInFlight).toEqual(1);
+    });
+});

--- a/packages/backend/src/utils/runWithConcurrency.ts
+++ b/packages/backend/src/utils/runWithConcurrency.ts
@@ -1,0 +1,37 @@
+import pLimit from 'p-limit';
+
+/**
+ * Run tasks over `items` with at most `concurrency` in flight, preserving input order.
+ *
+ * Fails fast: after the first rejection, queued tasks throw that error instead of starting.
+ * p-limit on its own keeps draining its queue after a rejection, so a plain `pLimit` wrapper
+ * would still start every remaining task once one has already failed.
+ */
+export const runWithConcurrency = async <T, R>(
+    items: readonly T[],
+    concurrency: number,
+    task: (item: T, index: number) => Promise<R>,
+): Promise<R[]> => {
+    const limit = pLimit(Math.max(1, Math.floor(concurrency)));
+    let hasFailed = false;
+    let firstError: unknown;
+
+    return Promise.all(
+        items.map((item, index) =>
+            limit(async () => {
+                if (hasFailed) {
+                    throw firstError;
+                }
+                try {
+                    return await task(item, index);
+                } catch (error) {
+                    if (!hasFailed) {
+                        hasFailed = true;
+                        firstError = error;
+                    }
+                    throw error;
+                }
+            }),
+        ),
+    );
+};


### PR DESCRIPTION
Linear: SPK-1862

**Base**: this branch sits on top of `feature/spk-1861` (PR #28553), which is not merged yet. The
first two commits here are that PR. Review the third commit, `feat: bound the dbt source fetch`.

## What changed

`buildMergedManifestAdapter` fetched every dbt source with an uncapped `Promise.all`, so a
project with N sources started N dbt processes at once in the worker container. Their memory is
additive to the Node heap, which is meanwhile holding the manifests of every source that has
already finished.

The fetch now runs through a bounded pool. Concurrency comes from both bounds, because Node
reads the cgroup:

```
cMem    = constrainedMemory() > 0 ? floor((limit - 3 GiB) / 1 GiB) : Infinity
default = clamp(min(availableParallelism(), max(2, cMem)), 1, 8)
```

`DBT_SOURCE_FETCH_CONCURRENCY` overrides both.

**The memory bound floors at 2; the core bound does not.** Without the floor, any pod at or
below 4 GiB defaults to concurrency 1, and the measurements below say that buys nothing: at every
concurrency at or below 4 the peak already sits after the fetch phase, so `c=1` has the same peak
as `c=2` (3,380 against 3,362 MB on 8 vCPU) and only pays wall clock. On a 2 vCPU 4 GiB pod — a
common real shape — the un-floored default would serialise every source parse for no memory gain.
A single-core pod still gets 1, because one core genuinely cannot parallelise.

`memoryDerivedLimit` is reported raw in the log line, before the floor is applied, so the sizing
decision stays legible.

`runWithConcurrency` wraps each task in a shared failed flag, because p-limit on its own keeps
draining its queue after a rejection — queued tasks would still start after one source had
already failed. Six unit tests cover order preservation under shuffled completion, the in-flight
ceiling, equivalence with unbounded scheduling when the limit is at least the item count, and
fail-fast.

Invariants held: result order follows declared source order, each adapter is registered before
its own fetch starts, the `Failed to load dbt source "<name>"` message shape is unchanged, and
with concurrency at or above N the scheduling matches today.

## Observability

`dbt.compile.sourceFetchStart` carries `projectUuid`, `jobUuid`, `sourceCount`, the chosen
`concurrency`, and every input that produced it: `envOverride`, `availableParallelism`,
`constrainedMemoryBytes`, `memoryDerivedLimit`, and `nodeHeapLimitBytes`.

This is the line that answers "what memory limit do I need" from a support log, without anyone
reproducing anything. `nodeHeapLimitBytes` is there because of a trap found while measuring:
**Node sizes its default old-space from the cgroup limit, and it moves in plateaus rather than
as a fraction.** On the published image, 4, 6.8, 8 and 12 GiB limits all give exactly 2,240 MB;
4,288 MB appears only at 15 GiB and above. Reading the pod limit alone does not tell an operator
what the heap will be, and raising the limit often does not change it. SPK-1867 fixes the heap
sizing itself; this field makes the current value visible either way.

`dbt.compile.sourceFetched` carries `projectUuid`, `jobUuid`, `sourceName`, `durationMs`,
`modelCount` and `selectedModelCount`. A slow source can now be named; today it cannot.

`dbt.compile.sourceFetchComplete` carries the phase `durationMs`, the concurrency used, and the
Node process RSS and heap at the end of the fetch.

The ticket also asked for the source name on the existing clone, deps and `dbt ls` lines. Those
sit in `dbtGitProjectAdapter` and `DbtCliClient`, which have no project or source context, and
tagging them means threading a label through every adapter constructor. The wide
`sourceFetched` event carries the same attribution on one event instead, which is the preferred
shape. Threading the label is left as a follow-up.

## Measured

Arm calibrated to a large self-hosted project: 3,382 explores, 214,997 dimensions, 43,336
metrics, one shared warehouse schema, 14 sources. Each run in its own cgroup v2 scope with a
16 GiB ceiling, swap zero, no ceiling hits, medians of two repetitions interleaved across
concurrency levels.

**These runs all carry SPK-1861**, so `attachTypesToModels` is about 0.1 s in every one of them.
Wall clock is therefore not comparable to the pre-1861 baseline. Fetch duration, CPU seconds and
peak memory are. The `c=14` row is the control: it is this branch with the cap effectively off.

### 8 vCPU

| concurrency | fetch | wall | CPU | tree peak | anon peak | peak sits in | explores | fingerprint |
|---:|---:|---:|---:|---:|---:|---|---:|---|
| 1 | 181.1 s | 199.5 s | 199.3 s | 3,380 MB | 2,797 MB | post-fetch | 3,382 | `7a64e37a3767` |
| 2 | 91.1 s | 109.6 s | 198.9 s | 3,362 MB | 2,772 MB | post-fetch | 3,382 | `7a64e37a3767` |
| 4 | 52.3 s | 69.9 s | 198.3 s | 3,023 MB | 2,443 MB | post-fetch | 3,382 | `7a64e37a3767` |
| 14 (control) | 26.2 s | 45.0 s | 205.8 s | 4,288 MB | 3,823 MB | **fetch** | 3,382 | `7a64e37a3767` |

### 2 vCPU

The arm closest to a real pod. `c=14` is again the control.

| concurrency | fetch | wall | CPU | tree peak | peak sits in | explores | fingerprint |
|---:|---:|---:|---:|---:|---|---:|---|
| 2 | **99.1 s** | 133.6 s | **200.3 s** | 3,110 MB | post-fetch | 3,382 | `7a64e37a3767` |
| 14 (control) | 170.2 s | 191.0 s | 366.3 s | 3,757 MB | **fetch** | 3,382 | `7a64e37a3767` |

**This is the headline result of the change.** On two cores, capping to 2 makes the fetch **42%
faster** and uses **45% fewer CPU seconds** for byte-identical output. Fourteen dbt parses
contending for two cores were not merely slower, they were doing measurably more work.

That also settles the open question about which effect was at play. If the extra CPU had been
quota throttling, fetch would have stayed near its uncapped duration at `c=2` and the cap would
be a memory-only change on constrained pods. It did not: fetch fell from 170.2 s to 99.1 s and
CPU fell with it. The cost is oversubscription, and bounding concurrency recovers it.

## Predictions against measurements

The predictions were written before the run, so they can fail. Two did.

| Prediction | Outcome |
|---|---|
| `c=14` reproduces the uncapped baseline peak (4,341 MB) within noise | **Confirmed.** 4,288 MB. |
| The peak relocates from fetch into the save path as concurrency drops | **Confirmed.** Fetch at `c=14`, post-fetch at every `c` at or below 4. |
| CPU seconds stay within about 5% across all concurrencies | **Confirmed.** 198.3 to 205.8 s, a 3.8% spread. No work was skipped. |
| Output identical at every concurrency | **Confirmed.** Same explores fingerprint and 3,382 explores in every run. |
| Tree peak is about `max(2.6 GiB, 0.7 GiB + 0.25 GiB x c)` | **Wrong on magnitude.** The measured floor is 2.95 to 3.31 GiB, not 2.6 to 2.7, and the slope between `c=4` and `c=14` is about 105 MB per source rather than 250 MB. |
| `c=2` on 2 vCPU: fetch 100–115 s | **Confirmed**, 99.1 s, marginally better than the band. |
| `c=2` on 2 vCPU: wall 150–165 s, CPU 240–280 s | **Better than predicted** on both: 133.6 s and 200.3 s. Part of the wall gain is SPK-1861 removing ~25 s of type attachment from this arm. |
| `c=2` on 2 vCPU: tree peak about 2,700 MB | **Wrong.** 3,110 MB. |
| `c=1` worse than uncapped on 8 vCPU | **Confirmed.** Fetch 181.1 s against 26.2 s uncapped. |

### The 2 vCPU `c=1` arm, measured against predictions recorded before the run

This is the arm the floor-of-2 decision rests on. Predictions were written into this body before
the run started. Two repetitions of each concurrency, interleaved, same rig, same 16 GiB scope,
2 vCPU, no ceiling hits.

| arm | reps | fetch | wall | CPU | tree peak | anon peak | peak sits in | explores | fingerprint |
|---|---:|---:|---:|---:|---:|---:|---|---:|---|
| `c=1` | 2 | 182.9 s | 224.6 s | 222.2 s | 3,453 MB | 2,912 MB | post-fetch | 3,382 | `7a64e37a3767` |
| `c=2` (control) | 2 | 92.8 s | 136.6 s | 224.4 s | 3,195 MB | 2,617 MB | post-fetch | 3,382 | `7a64e37a3767` |

Per repetition, `(fetch, wall, CPU, tree peak)`:

- `c=1`: (181.0 s, 222.4 s, 219.5 s, 3,447 MB) and (184.8 s, 226.8 s, 224.9 s, 3,459 MB)
- `c=2`: (91.6 s, 133.5 s, 220.5 s, 3,146 MB) and (94.1 s, 139.7 s, 228.3 s, 3,244 MB)

| Prediction | Measured | Verdict |
|---|---:|---|
| fetch 185–205 s | 182.9 s | just under, by 1% |
| wall 215–240 s | 224.6 s | held |
| CPU 195–210 s | 222.2 s | **over by 6%** — but the reasoning held exactly: `c=2` measured 224.4 s, so `c=1` and `c=2` do the same CPU work. The band was low for both, not the claim |
| tree peak 3.0–3.4 GB | 3,453 MB | **just over, by 1.6%** |
| peak sits post-fetch | post-fetch | held |
| `c=1` about 2x slower than `c=2` | fetch 1.97x, wall 1.64x | held on fetch |
| `c=1` 10–20% slower on wall than uncapped | 1.18x | held |
| **no memory gain over `c=2`** | 3,453 against 3,195 MB, a difference inside this rig's run-to-run spread | held |
| fingerprint and explore count | `7a64e37a3767`, 3,382 | held |

**`c=1` gives no memory back over `c=2`** (3,453 against 3,195 MB, inside the run-to-run spread
seen on this rig, which reached 768 MB between identical `c=4` repetitions) **and costs 1.97x the
fetch and 1.64x the wall.** Nothing on this arm favours it. Against uncapped, `c=1` gives back
304 MB of peak for 1.18x the wall, where `c=2` gives back 562 MB for 0.71x the wall.

That is the evidence for flooring the memory-derived bound at 2.

The fingerprint also confirms the fixture: these repositories were regenerated from the
deterministic generator after a disk sweep removed the working trees, and they compile to the
same `7a64e37a3767` as every earlier arm.

The second failure is the informative one. Once concurrency is at or below 4 the fetch phase is
no longer the peak at all — the maximum has moved into the compile and save phases, which do not
depend on concurrency. The remaining differences between `c=1`, `2` and `4` are variance in that
later phase, not a concurrency effect. One `c=4` repetition came in at 2,638 MB and another at
3,406 MB, a 768 MB spread at identical settings, which is the size of the noise.

So the honest claim is narrower than the prediction: **bounding the fetch removes about 1 GiB
from the peak and moves the maximum out of the fetch phase, after which further reduction needs
a different change.** It does not drive the peak down proportionally with concurrency.

The cost is wall clock, and on a machine with spare cores it is real: `c=4` doubles the fetch
phase (26.2 s to 52.3 s) and `c=1` is seven times slower. That is why the default is bounded by
cores as well as by memory, and why it never drops below 1.

## What is still unmeasured

**The 1 GiB per source constant is a guess.** The fixtures parse at 251 MB per source and carry
no packages, no macros and no tests; a real repository of the same model count is heavier. That
constant sets the memory bound, so it decides the default on a memory-constrained pod. The thing
that would replace it is the `dbt.compile.sourceFetched` and `sourceFetchComplete` events from a
real instance: source count, per-source duration and model count beside the Node RSS at the end
of the fetch give the real per-source figure directly. Until then, treat the memory bound as
conservative rather than accurate.

Peak memory here is the whole process tree in a cgroup, so it includes the dbt subprocesses.
Summed per-process RSS overstates that by about 8% through shared pages, which is why the tree
figure is used.
