### PR TITLE
feat: make a stuck refresh say what happened

### DIFF
--- a/packages/backend/src/models/JobModel/JobModel.ts
+++ b/packages/backend/src/models/JobModel/JobModel.ts
@@ -339,6 +339,24 @@ export class JobModel {
             .andWhere('step_status', JobStepStatusType.PENDING);
     }
 
+    /**
+     * Mark every still-running step of a job as failed with `error`.
+     *
+     * The stuck-job reaper sets `job_status` only, which leaves the drawer rendering a red
+     * error title above a step that is still spinning with no message, because the drawer
+     * renders `stepError` and nothing writes it.
+     */
+    async failRunningSteps(jobUuid: string, error: string): Promise<void> {
+        await this.database(JobStepsTableName)
+            .update({
+                step_status: JobStepStatusType.ERROR,
+                step_error: error,
+                updated_at: new Date(),
+            })
+            .where('job_uuid', jobUuid)
+            .andWhere('step_status', JobStepStatusType.RUNNING);
+    }
+
     async tryJobStep<T>(
         jobUuid: string,
         jobStepType: JobStepType,

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -2049,6 +2049,42 @@ export class ProjectModel {
         });
     }
 
+    /**
+     * Who holds the compile lock for a project, and for how long.
+     *
+     * A retry blocked by a zombie compile otherwise reads "Compilation is already in progress"
+     * about a job the server has already declared failed, with nothing to identify the holder.
+     */
+    async getProjectLockHolder(projectUuid: string): Promise<{
+        heldForSeconds: number;
+        backendPid: number;
+        applicationName: string | null;
+    } | null> {
+        const result = await this.database.raw(
+            `
+            SELECT a.pid,
+                   a.application_name,
+                   EXTRACT(EPOCH FROM (now() - a.xact_start)) AS held_for_seconds
+            FROM pg_locks l
+            JOIN pg_stat_activity a ON a.pid = l.pid
+            JOIN projects p ON p.project_uuid = ?
+            WHERE l.locktype = 'advisory'
+              AND l.classid = ?
+              AND l.objid = p.project_id
+              AND l.granted
+            ORDER BY a.xact_start ASC
+            LIMIT 1`,
+            [projectUuid, CACHED_EXPLORES_PG_LOCK_NAMESPACE],
+        );
+        const row = result.rows[0];
+        if (!row) return null;
+        return {
+            heldForSeconds: Math.round(Number(row.held_for_seconds ?? 0)),
+            backendPid: Number(row.pid),
+            applicationName: row.application_name ?? null,
+        };
+    }
+
     async getWarehouseFromCache(
         projectUuid: string,
     ): Promise<WarehouseCatalog | undefined> {

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -4784,9 +4784,11 @@ export class ProjectService extends BaseService {
         primary,
         sources,
         manifestFetchAdapters,
+        jobUuid,
     }: {
         projectUuid: string;
         organizationUuid: string | undefined;
+        jobUuid?: string;
         primary: {
             adapter: ProjectAdapter;
             warehouseCredentials: CreateWarehouseCredentials;
@@ -4951,6 +4953,57 @@ export class ProjectService extends BaseService {
 
         const { manifest: mergedManifest, collisions } =
             combineManifestSources(manifestSources);
+
+        // One line that says whether type attachment is a factor for this project: the cost is
+        // quadratic in models per warehouse schema, and nothing today reports how they spread.
+        const modelsBySchema = new Map<string, number>();
+        let mergedColumnCount = 0;
+        Object.values(mergedManifest.nodes).forEach((node) => {
+            if (node.resource_type !== 'model' && node.resource_type !== 'seed')
+                return;
+            const model = node as DbtRawModelNode;
+            const pair = `${model.database}.${model.schema}`;
+            modelsBySchema.set(pair, (modelsBySchema.get(pair) ?? 0) + 1);
+            mergedColumnCount += Object.keys(model.columns ?? {}).length;
+        });
+        this.logger.info(
+            `dbt.compile.mergedManifestShape projectUuid=${projectUuid} sources=${
+                manifestSources.length
+            } models=${[...modelsBySchema.values()].reduce(
+                (sum, count) => sum + count,
+                0,
+            )} columns=${mergedColumnCount} distinctSchemas=${
+                modelsBySchema.size
+            }`,
+            {
+                event: 'dbt.compile.mergedManifestShape',
+                projectUuid,
+                jobUuid: jobUuid ?? null,
+                sourceCount: manifestSources.length,
+                modelsPerSource: manifestSources.map((source) => ({
+                    sourceName: source.name,
+                    models: Object.values(source.manifest.nodes).filter(
+                        (node) =>
+                            node.resource_type === 'model' ||
+                            node.resource_type === 'seed',
+                    ).length,
+                })),
+                totalModels: [...modelsBySchema.values()].reduce(
+                    (sum, count) => sum + count,
+                    0,
+                ),
+                totalColumns: mergedColumnCount,
+                distinctSchemaCount: modelsBySchema.size,
+                schemaPairs: [...modelsBySchema.entries()]
+                    .map(([databaseSchema, models]) => ({
+                        databaseSchema,
+                        models,
+                    }))
+                    .sort((a, b) => b.models - a.models)
+                    .slice(0, 20),
+                collisions: collisions.length,
+            },
+        );
         if (collisions.length > 0) {
             this.logger.warn(
                 `Merged ${manifestSources.length} dbt sources for project ${projectUuid} with ${collisions.length} name collision(s)`,
@@ -5039,10 +5092,12 @@ export class ProjectService extends BaseService {
         primary,
         manifestFetchAdapters,
         onDbtSourceCount,
+        jobUuid,
     }: {
         projectUuid: string;
         organizationUuid: string | undefined;
         userUuid: string;
+        jobUuid?: string;
         primary: {
             adapter: ProjectAdapter;
             warehouseCredentials: CreateWarehouseCredentials;
@@ -5076,6 +5131,7 @@ export class ProjectService extends BaseService {
             primary,
             sources,
             manifestFetchAdapters,
+            jobUuid,
         });
     }
 
@@ -8839,11 +8895,32 @@ export class ProjectService extends BaseService {
         };
 
         const onLockFailed = async () => {
+            const holder = await this.projectModel
+                .getProjectLockHolder(projectUuid)
+                .catch(() => null);
+            const heldFor = holder
+                ? ` The compile holding it started ${Math.round(
+                      holder.heldForSeconds / 60,
+                  )} minutes ago.`
+                : '';
+            this.logger.warn(
+                `dbt.compile.lockBlocked projectUuid=${projectUuid} jobUuid=${
+                    job.jobUuid
+                } lockHeldForSeconds=${holder?.heldForSeconds ?? 'unknown'}`,
+                {
+                    event: 'dbt.compile.lockBlocked',
+                    projectUuid,
+                    jobUuid: job.jobUuid,
+                    lockHeldForSeconds: holder?.heldForSeconds ?? null,
+                    lockHolderBackendPid: holder?.backendPid ?? null,
+                    lockHolderApplicationName: holder?.applicationName ?? null,
+                },
+            );
             await this.jobModel.updateJobStep(
                 job.jobUuid,
                 JobStepStatusType.ERROR,
                 JobStepType.COMPILING,
-                'Compilation is already in progress for this project',
+                `Compilation is already in progress for this project.${heldFor}`,
             );
         };
 
@@ -8958,14 +9035,40 @@ export class ProjectService extends BaseService {
                 });
             }
         };
+        let compileFailed = false;
         await this.projectModel
             .tryAcquireProjectLock(projectUuid, onLockAcquired, onLockFailed)
             .catch((e) => {
+                compileFailed = true;
                 if (!(e instanceof LightdashError)) {
                     Sentry.captureException(e);
                 }
+                // The default log format renders the message only and drops metadata, so the
+                // decisive numbers ride in the message too. Typed fields stay for json format.
                 this.logger.error(
-                    `Background job failed:${e instanceof Error ? e.stack : e}`,
+                    `dbt.compile.failed projectUuid=${projectUuid} jobUuid=${
+                        job.jobUuid
+                    } elapsedMs=${Math.round(
+                        performance.now() - totalStartTime,
+                    )} error=${getErrorMessage(e)}`,
+                    {
+                        event: 'dbt.compile.failed',
+                        projectUuid,
+                        jobUuid: job.jobUuid,
+                        organizationUuid,
+                        error: getErrorMessage(e),
+                        stack: e instanceof Error ? e.stack : undefined,
+                        elapsedMs: performance.now() - totalStartTime,
+                        sections: {
+                            yamlMs: timings.yaml.end - timings.yaml.start,
+                            parametersMs:
+                                timings.parameters.end -
+                                timings.parameters.start,
+                            cacheExploresMs:
+                                timings.cacheExplores.end -
+                                timings.cacheExplores.start,
+                        },
+                    },
                 );
             });
         const totalTime = performance.now() - totalStartTime;
@@ -8976,8 +9079,17 @@ export class ProjectService extends BaseService {
             timings.cacheExplores.end - timings.cacheExplores.start;
 
         this.logger.info(
-            `compileProject completed in ${totalTime.toFixed(2)}`,
+            `compileProject ${
+                compileFailed ? 'failed after' : 'completed in'
+            } ${totalTime.toFixed(2)}ms projectUuid=${projectUuid} jobUuid=${
+                job.jobUuid
+            }`,
             {
+                event: compileFailed
+                    ? 'dbt.compile.end.failed'
+                    : 'dbt.compile.end.ok',
+                projectUuid,
+                jobUuid: job.jobUuid,
                 totalTimeMs: totalTime,
                 sections: {
                     yamlMs: durationYaml.toFixed(2),

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -2278,6 +2278,17 @@ export class SchedulerService extends BaseService {
         return { reassignedCount };
     }
 
+    private static stuckJobError(
+        taskIdentifier: string,
+        durationMinutes: number | undefined,
+    ): string {
+        const ran =
+            durationMinutes === undefined
+                ? ''
+                : ` It ran for ${durationMinutes} minutes.`;
+        return `This ${taskIdentifier} job took longer than expected and was stopped after 1 hour.${ran} Please try again. If the issue persists, contact support.`;
+    }
+
     async checkForStuckJobs(): Promise<{
         runningCount: number;
         warningCount: number;
@@ -2313,7 +2324,14 @@ export class SchedulerService extends BaseService {
             if (durationMs >= ONE_HOUR_MS) {
                 // Over 1 hour: log error and schedule for DB logging
                 this.logger.error(
-                    `Stuck job detected (over 1 hour): ${job.taskIdentifier} (job ${job.id}) running for ${durationMinutes} min`,
+                    `Stuck job detected (over 1 hour): ${job.taskIdentifier} graphileJobId=${
+                        job.id
+                    } lightdashJobUuid=${
+                        getLightdashJobUuid(job.payload) ?? 'none'
+                    } projectUuid=${
+                        (job.payload.projectUuid as string | undefined) ??
+                        'none'
+                    } durationMinutes=${durationMinutes}`,
                     logContext,
                 );
                 jobsToLog.push({ job, durationMinutes });
@@ -2339,7 +2357,15 @@ export class SchedulerService extends BaseService {
                     scheduledTime: job.runAt,
                     status: SchedulerJobStatus.ERROR,
                     details: {
-                        error: 'This job took longer than expected and was stopped after 1 hour—please try again. If the issue persists, contact support.',
+                        error: SchedulerService.stuckJobError(
+                            job.taskIdentifier,
+                            durationMinutes,
+                        ),
+                        durationMinutes,
+                        graphileJobId: job.id,
+                        taskIdentifier: job.taskIdentifier,
+                        lightdashJobUuid:
+                            getLightdashJobUuid(job.payload) ?? null,
                         lockedAt: job.lockedAt.toISOString(),
                         lockedBy: job.lockedBy,
                         projectUuid: job.payload.projectUuid as
@@ -2375,11 +2401,23 @@ export class SchedulerService extends BaseService {
 
         // Update Lightdash job status to ERROR for tasks that track a Lightdash job row
         await Promise.all(
-            lightdashJobUuids.map((jobUuid) =>
-                this.jobModel.update(jobUuid, {
+            lightdashJobUuids.map(async (jobUuid) => {
+                const stuck = jobsToLog.find(
+                    ({ job }) => getLightdashJobUuid(job.payload) === jobUuid,
+                );
+                await this.jobModel.update(jobUuid, {
                     jobStatus: JobStatusType.ERROR,
-                }),
-            ),
+                });
+                // The drawer renders stepError, so the job row alone shows an error title
+                // above a step that is still spinning with nothing to read.
+                await this.jobModel.failRunningSteps(
+                    jobUuid,
+                    SchedulerService.stuckJobError(
+                        stuck?.job.taskIdentifier ?? 'compileProject',
+                        stuck?.durationMinutes,
+                    ),
+                );
+            }),
         );
 
         // Remove stuck jobs from graphile queue to prevent indefinite running


### PR DESCRIPTION
Linear: SPK-1864

**Base**: `main`. Independent of SPK-1861 and SPK-1862.

## What changed

A refresh that runs past an hour currently ends with an error title above a spinner and no
message anywhere the operator can reach. Five changes, all on the diagnostic path, none changing
what the compile does.

1. **The failure is written onto the step, not only the job.** New
   `JobModel.failRunningSteps(jobUuid, error)` beside `setPendingJobsToSkipped`, called from
   `checkForStuckJobs`. The drawer already renders `stepError`; nothing was writing it.
2. **The reaper sentence names the job.** Task name, elapsed minutes, graphile job id and the
   Lightdash job uuid, in the message and as typed fields.
3. **A failed compile logs its failure and its partial timings.** The `compileProject` catch
   block previously logged a bare stack with no identifiers and then fell through to a line that
   said `compileProject completed`. A failed compile now says failed, and carries the error and
   the section timings it had already collected.
4. **The merged manifest shape is logged at compile start**: source count, models per source,
   total columns, and the distinct `database.schema` pairs with a model count each. Type
   attachment is quadratic in models per schema, so this single line decides whether that term
   is a factor for a given project.
5. **A blocked retry names the lock holder** and how long it has held the lock, from `pg_locks`
   joined to `pg_stat_activity`.

Cancelling a running compile is deliberately not here. See the ticket.

## A finding that affects every wide event we are adding

`printMessage` in `packages/backend/src/logging/winston.ts` renders `info.message` and **drops
the metadata object entirely**. The default format is `pretty`, and `plain` behaves the same.
Only `LIGHTDASH_LOG_FORMAT=json` emits structured fields.

So a metadata-only event is invisible on a default-configured instance, which would have
defeated the point of this work. Every event here therefore carries its decisive values in the
message string as well as in typed fields. Operators on `json` get the fields; everyone else can
still grep the line.

**SPK-1861 and SPK-1862 have the same exposure** and their events are metadata-only. Either they
need the same treatment or those instances need `LIGHTDASH_LOG_FORMAT=json`.

## Evidence: what an operator sees

Reproduced on a live instance by starting a real compile, backdating the graphile lock to 65
minutes, and running `checkForStuckJobs`. Same procedure before and after. Captures in
`logs/stuck-job-before/` and `logs/stuck-job-after/`.

**The job the drawer renders**, from `GET /api/v1/jobs/:uuid`:

| | Before | After |
|---|---|---|
| `jobStatus` | `ERROR` | `ERROR` |
| step `stepStatus` | **`RUNNING`** | **`ERROR`** |
| step `stepError` | **`null`** | `This compileProject job took longer than expected and was stopped after 1 hour. It ran for 65 minutes. Please try again. If the issue persists, contact support.` |

Before, the drawer draws a red error title over a spinning step with nothing to read. After, it
draws the message. No UI change was needed.

**What reaches `scheduler_log`:**

Before — the sentence names nothing, and the details carry no job uuid and no duration:

```
"error": "This job took longer than expected and was stopped after 1 hour—please try again. ..."
"lockedAt": "...", "lockedBy": "...", "projectUuid": "...", "organizationUuid": "...", "createdByUserUuid": "..."
```

After — the sentence names the task and the elapsed time, and the details gain the identifiers:

```
"error": "This compileProject job took longer than expected and was stopped after 1 hour. It ran for 65 minutes. ..."
"graphileJobId": "21", "taskIdentifier": "compileProject", "durationMinutes": 65,
"lightdashJobUuid": "3bb93314-194f-433b-bafc-86699de7dc9c", "lockedAt": "...", "lockedBy": "...", ...
```

**What a blocked retry says:**

| Before | After |
|---|---|
| `Compilation is already in progress for this project` | `Compilation is already in progress for this project. The compile holding it started 0 minutes ago.` |

The zero is correct for the reproduction, where the holder had just started. On the real path
the holder is the zombie compile and the number is its true age, which is the whole point: it
distinguishes a genuine concurrent deploy from a compile the server already declared failed.

## What is verified live and what is not

Verified on a running instance, before and after: the step error, the reaper identifiers, and
the lock-holder message.

Code-only, not exercised by this reproduction: the `compileProject` catch-block log needs a
compile that throws, and the merged-manifest-shape line only runs on the multi-source path,
which the single-source development project does not take. Both typecheck and both are on the
same code path as changes that were exercised, but neither has a captured before and after.

## Not measured

This change makes a long refresh self-diagnosing. It does not make it shorter, and it does not
touch why a refresh runs long in the first place.
