### PR TITLE
fix: size the Node heap from the container memory limit

### DIFF
--- a/docker/prod-entrypoint.sh
+++ b/docker/prod-entrypoint.sh
@@ -1,6 +1,55 @@
 #!/bin/bash
 set -e
 
+# Size the V8 heap from the container memory limit.
+#
+# The image sets no heap flag at runtime: the --max-old-space-size in the Dockerfile lives in
+# the prod-builder stage and runtime-base builds from pnpm-base, so it is never inherited, and
+# the helm chart sets no NODE_OPTIONS. Node then derives the heap itself, and it does so in
+# plateaus rather than as a fraction of the limit: every limit between 4 and 15 GiB yields the
+# same 2,240 MB heap, so raising a pod from 4 GiB to 12 GiB changes nothing.
+#
+# 75% leaves room for non-heap RSS. The Node peak lands after the dbt subprocess peak rather
+# than on top of it, page cache inside the cgroup is reclaimed before an OOM, and the scheduler
+# shares one heap across its concurrent jobs, so the ceiling does not multiply.
+#
+# This is a ceiling, not a reservation, so it only changes runs that would otherwise abort.
+# Setting it too high trades a clean exit 134 with a heap message for an exit 137 kernel kill
+# with no message and possibly orphaned dbt children.
+readonly LIGHTDASH_HEAP_PERCENT=75
+readonly LIGHTDASH_MIN_CONTAINER_LIMIT_BYTES=$((512 * 1024 * 1024))
+readonly LIGHTDASH_MAX_CONTAINER_LIMIT_BYTES=$((1024 * 1024 * 1024 * 1024))
+
+read_cgroup_memory_limit_bytes() {
+    local value
+    # cgroup v2, then v1. "max" means unlimited; v1 reports a sentinel near 2^63 instead.
+    if [ -r /sys/fs/cgroup/memory.max ]; then
+        value=$(cat /sys/fs/cgroup/memory.max 2>/dev/null)
+    elif [ -r /sys/fs/cgroup/memory/memory.limit_in_bytes ]; then
+        value=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes 2>/dev/null)
+    else
+        return 1
+    fi
+    case "$value" in
+        '' | max | *[!0-9]*) return 1 ;;
+    esac
+    if [ "$value" -lt "$LIGHTDASH_MIN_CONTAINER_LIMIT_BYTES" ] ||
+        [ "$value" -gt "$LIGHTDASH_MAX_CONTAINER_LIMIT_BYTES" ]; then
+        return 1
+    fi
+    echo "$value"
+}
+
+if [ -n "${NODE_OPTIONS:-}" ] && [[ "$NODE_OPTIONS" == *max-old-space-size* ]]; then
+    echo "[lightdash] NODE_OPTIONS already sets a heap size, leaving it unchanged: $NODE_OPTIONS"
+elif limit_bytes=$(read_cgroup_memory_limit_bytes); then
+    heap_mb=$(((limit_bytes / 1024 / 1024) * LIGHTDASH_HEAP_PERCENT / 100))
+    export NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--max-old-space-size=${heap_mb}"
+    echo "[lightdash] container memory limit $((limit_bytes / 1024 / 1024))MB detected, setting --max-old-space-size=${heap_mb} (${LIGHTDASH_HEAP_PERCENT}%). Set NODE_OPTIONS yourself to override."
+else
+    echo "[lightdash] no container memory limit readable, leaving the Node heap at its default. Set NODE_OPTIONS=--max-old-space-size=<MB> to control it."
+fi
+
 # Migrate db
 export LIGHTDASH_MIGRATION_EXECUTION_MODE="${LIGHTDASH_MIGRATION_EXECUTION_MODE:-boot-winner}"
 pnpm -F backend migrate-production up

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -5,33 +5,8 @@ import { lightdashConfig } from './config/lightdashConfig';
 import { getEnterpriseAppArguments } from './ee';
 import knexConfig from './knexfile';
 import Logger from './logging/logger';
-import { buildRuntimeMemoryReport } from './logging/runtimeMemory';
+import { logRuntimeMemory } from './logging/runtimeMemory';
 import { getProcessTimezoneWarning } from './utils/processTimezone';
-
-const logRuntimeMemory = (service: 'api' | 'scheduler') => {
-    const report = buildRuntimeMemoryReport();
-    // The default log format renders the message and drops metadata, so the numbers ride in
-    // both. This is the first thing worth knowing from any log about a failed compile.
-    Logger.info(
-        `lightdash.boot.memory service=${service} heapLimitMb=${Math.round(
-            report.heapLimitBytes / 1024 / 1024,
-        )} containerLimitMb=${
-            report.containerMemoryLimitBytes === null
-                ? 'unknown'
-                : Math.round(report.containerMemoryLimitBytes / 1024 / 1024)
-        } heapFlagSet=${report.heapFlagSet} availableParallelism=${
-            report.availableParallelism
-        }`,
-        { event: 'lightdash.boot.memory', service, ...report },
-    );
-    if (report.warning) {
-        Logger.warn(`lightdash.boot.memory ${report.warning}`, {
-            event: 'lightdash.boot.memory.warning',
-            service,
-            ...report,
-        });
-    }
-};
 
 // trigger BE tests
 
@@ -80,7 +55,7 @@ process.on('uncaughtException', () => {
         process.on('SIGHUP', onExit);
         process.on('SIGABRT', onExit);
 
-        logRuntimeMemory('api');
+        logRuntimeMemory(Logger, 'api');
         Logger.info('Starting Lightdash server...');
         await app.start();
     } catch (error) {

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -5,7 +5,33 @@ import { lightdashConfig } from './config/lightdashConfig';
 import { getEnterpriseAppArguments } from './ee';
 import knexConfig from './knexfile';
 import Logger from './logging/logger';
+import { buildRuntimeMemoryReport } from './logging/runtimeMemory';
 import { getProcessTimezoneWarning } from './utils/processTimezone';
+
+const logRuntimeMemory = (service: 'api' | 'scheduler') => {
+    const report = buildRuntimeMemoryReport();
+    // The default log format renders the message and drops metadata, so the numbers ride in
+    // both. This is the first thing worth knowing from any log about a failed compile.
+    Logger.info(
+        `lightdash.boot.memory service=${service} heapLimitMb=${Math.round(
+            report.heapLimitBytes / 1024 / 1024,
+        )} containerLimitMb=${
+            report.containerMemoryLimitBytes === null
+                ? 'unknown'
+                : Math.round(report.containerMemoryLimitBytes / 1024 / 1024)
+        } heapFlagSet=${report.heapFlagSet} availableParallelism=${
+            report.availableParallelism
+        }`,
+        { event: 'lightdash.boot.memory', service, ...report },
+    );
+    if (report.warning) {
+        Logger.warn(`lightdash.boot.memory ${report.warning}`, {
+            event: 'lightdash.boot.memory.warning',
+            service,
+            ...report,
+        });
+    }
+};
 
 // trigger BE tests
 
@@ -54,6 +80,7 @@ process.on('uncaughtException', () => {
         process.on('SIGHUP', onExit);
         process.on('SIGABRT', onExit);
 
+        logRuntimeMemory('api');
         Logger.info('Starting Lightdash server...');
         await app.start();
     } catch (error) {

--- a/packages/backend/src/logging/runtimeMemory.test.ts
+++ b/packages/backend/src/logging/runtimeMemory.test.ts
@@ -1,0 +1,123 @@
+import {
+    buildRuntimeMemoryReport,
+    readContainerMemoryLimitBytes,
+} from './runtimeMemory';
+
+const GIB = 1024 * 1024 * 1024;
+const MIB = 1024 * 1024;
+
+const reader = (values: Record<string, string>) => (path: string) => {
+    if (path in values) return values[path];
+    throw new Error('ENOENT');
+};
+
+describe('readContainerMemoryLimitBytes', () => {
+    it('reads the cgroup v2 limit', () => {
+        expect(
+            readContainerMemoryLimitBytes(
+                reader({ '/sys/fs/cgroup/memory.max': `${4 * GIB}\n` }),
+            ),
+        ).toEqual(4 * GIB);
+    });
+
+    it('falls back to the cgroup v1 limit', () => {
+        expect(
+            readContainerMemoryLimitBytes(
+                reader({
+                    '/sys/fs/cgroup/memory/memory.limit_in_bytes': `${8 * GIB}`,
+                }),
+            ),
+        ).toEqual(8 * GIB);
+    });
+
+    it('treats "max" as no limit', () => {
+        expect(
+            readContainerMemoryLimitBytes(
+                reader({ '/sys/fs/cgroup/memory.max': 'max' }),
+            ),
+        ).toBeNull();
+    });
+
+    it('treats the cgroup v1 unlimited sentinel as no limit', () => {
+        expect(
+            readContainerMemoryLimitBytes(
+                reader({
+                    '/sys/fs/cgroup/memory/memory.limit_in_bytes':
+                        '9223372036854771712',
+                }),
+            ),
+        ).toBeNull();
+    });
+
+    it('ignores an implausibly small limit', () => {
+        expect(
+            readContainerMemoryLimitBytes(
+                reader({ '/sys/fs/cgroup/memory.max': `${MIB}` }),
+            ),
+        ).toBeNull();
+    });
+
+    it('returns null when nothing is readable', () => {
+        expect(readContainerMemoryLimitBytes(reader({}))).toBeNull();
+    });
+});
+
+describe('buildRuntimeMemoryReport', () => {
+    it('warns when the heap sits far below a known container limit', () => {
+        // the shipping default: a 12 GiB pod runs the same 2,240 MB heap as a 4 GiB pod
+        const report = buildRuntimeMemoryReport({
+            heapLimitBytes: 2240 * MIB,
+            containerMemoryLimitBytes: 12 * GIB,
+            nodeOptions: null,
+            availableParallelism: 8,
+        });
+        expect(report.heapFlagSet).toBe(false);
+        expect(report.warning).toContain('2240MB');
+        expect(report.warning).toContain('12288MB');
+        expect(report.warning).toContain('--max-old-space-size=9216');
+    });
+
+    it('does not warn once the flag is set', () => {
+        expect(
+            buildRuntimeMemoryReport({
+                heapLimitBytes: 2240 * MIB,
+                containerMemoryLimitBytes: 12 * GIB,
+                nodeOptions: '--max-old-space-size=9216',
+                availableParallelism: 8,
+            }).warning,
+        ).toBeNull();
+    });
+
+    it('does not warn when the heap already uses most of the limit', () => {
+        expect(
+            buildRuntimeMemoryReport({
+                heapLimitBytes: 3072 * MIB,
+                containerMemoryLimitBytes: 4 * GIB,
+                nodeOptions: null,
+                availableParallelism: 8,
+            }).warning,
+        ).toBeNull();
+    });
+
+    it('does not warn when no container limit is readable', () => {
+        expect(
+            buildRuntimeMemoryReport({
+                heapLimitBytes: 4288 * MIB,
+                containerMemoryLimitBytes: null,
+                nodeOptions: null,
+                availableParallelism: 8,
+            }).warning,
+        ).toBeNull();
+    });
+
+    it('reports the flag as set when NODE_OPTIONS carries other flags too', () => {
+        expect(
+            buildRuntimeMemoryReport({
+                heapLimitBytes: 8192 * MIB,
+                containerMemoryLimitBytes: 12 * GIB,
+                nodeOptions: '--enable-source-maps --max-old-space-size=8192',
+                availableParallelism: 8,
+            }).heapFlagSet,
+        ).toBe(true);
+    });
+});

--- a/packages/backend/src/logging/runtimeMemory.ts
+++ b/packages/backend/src/logging/runtimeMemory.ts
@@ -2,6 +2,8 @@ import fs from 'fs';
 import os from 'os';
 import v8 from 'v8';
 
+type LogFn = (message: string, meta?: Record<string, unknown>) => void;
+
 export type RuntimeMemoryReport = {
     heapLimitBytes: number;
     containerMemoryLimitBytes: number | null;
@@ -85,4 +87,30 @@ export const buildRuntimeMemoryReport = ({
                   )}MB. Raising the container limit alone may not raise the heap. Set NODE_OPTIONS=--max-old-space-size=${suggestedMb} to use it.`
                 : null,
     };
+};
+
+export const logRuntimeMemory = (
+    logger: { info: LogFn; warn: LogFn },
+    service: 'api' | 'scheduler',
+) => {
+    const report = buildRuntimeMemoryReport();
+    logger.info(
+        `lightdash.boot.memory service=${service} heapLimitMb=${Math.round(
+            report.heapLimitBytes / 1024 / 1024,
+        )} containerLimitMb=${
+            report.containerMemoryLimitBytes === null
+                ? 'unknown'
+                : Math.round(report.containerMemoryLimitBytes / 1024 / 1024)
+        } heapFlagSet=${report.heapFlagSet} availableParallelism=${
+            report.availableParallelism
+        }`,
+        { event: 'lightdash.boot.memory', service, ...report },
+    );
+    if (report.warning) {
+        logger.warn(`lightdash.boot.memory ${report.warning}`, {
+            event: 'lightdash.boot.memory.warning',
+            service,
+            ...report,
+        });
+    }
 };

--- a/packages/backend/src/logging/runtimeMemory.ts
+++ b/packages/backend/src/logging/runtimeMemory.ts
@@ -1,0 +1,88 @@
+import fs from 'fs';
+import os from 'os';
+import v8 from 'v8';
+
+export type RuntimeMemoryReport = {
+    heapLimitBytes: number;
+    containerMemoryLimitBytes: number | null;
+    nodeOptions: string | null;
+    heapFlagSet: boolean;
+    availableParallelism: number;
+    /** Set when the heap is far below a known container limit, which is the shipping default. */
+    warning: string | null;
+};
+
+const CONTAINER_LIMIT_PATHS = [
+    '/sys/fs/cgroup/memory.max',
+    '/sys/fs/cgroup/memory/memory.limit_in_bytes',
+];
+const MIN_PLAUSIBLE_LIMIT_BYTES = 512 * 1024 * 1024;
+const MAX_PLAUSIBLE_LIMIT_BYTES = 1024 * 1024 * 1024 * 1024;
+
+export const readContainerMemoryLimitBytes = (
+    readFile: (path: string) => string = (path) =>
+        fs.readFileSync(path, 'utf8'),
+): number | null => {
+    // eslint-disable-next-line no-restricted-syntax
+    for (const path of CONTAINER_LIMIT_PATHS) {
+        let raw: string;
+        try {
+            raw = readFile(path).trim();
+        } catch {
+            // eslint-disable-next-line no-continue
+            continue;
+        }
+        if (raw === 'max' || !/^\d+$/.test(raw)) {
+            // eslint-disable-next-line no-continue
+            continue;
+        }
+        const value = Number.parseInt(raw, 10);
+        // cgroup v1 reports a near-2^63 sentinel rather than "max" when unlimited.
+        if (
+            value >= MIN_PLAUSIBLE_LIMIT_BYTES &&
+            value <= MAX_PLAUSIBLE_LIMIT_BYTES
+        ) {
+            return value;
+        }
+    }
+    return null;
+};
+
+export const buildRuntimeMemoryReport = ({
+    heapLimitBytes = v8.getHeapStatistics().heap_size_limit,
+    containerMemoryLimitBytes = readContainerMemoryLimitBytes(),
+    nodeOptions = process.env.NODE_OPTIONS ?? null,
+    availableParallelism = os.availableParallelism(),
+}: Partial<
+    Omit<RuntimeMemoryReport, 'warning' | 'heapFlagSet'>
+> = {}): RuntimeMemoryReport => {
+    const heapFlagSet =
+        nodeOptions !== null && nodeOptions.includes('max-old-space-size');
+
+    // Node derives the heap from the container limit in plateaus, not as a fraction: every
+    // limit between 4 and 15 GiB yields the same 2,240 MB heap. So raising a pod's memory
+    // inside that band changes nothing, and an operator has no way to see that from the pod.
+    const heapIsFarBelowLimit =
+        containerMemoryLimitBytes !== null &&
+        heapLimitBytes < containerMemoryLimitBytes / 2;
+
+    const suggestedMb = containerMemoryLimitBytes
+        ? Math.floor((containerMemoryLimitBytes / 1024 / 1024) * 0.75)
+        : null;
+
+    return {
+        heapLimitBytes,
+        containerMemoryLimitBytes,
+        nodeOptions,
+        heapFlagSet,
+        availableParallelism,
+        warning:
+            !heapFlagSet && heapIsFarBelowLimit
+                ? `Node heap limit is ${Math.round(
+                      heapLimitBytes / 1024 / 1024,
+                  )}MB but the container memory limit is ${Math.round(
+                      (containerMemoryLimitBytes ?? 0) / 1024 / 1024,
+                  )}MB. Raising the container limit alone may not raise the heap. Set NODE_OPTIONS=--max-old-space-size=${suggestedMb} to use it.`
+                : null,
+    };
+};

--- a/packages/backend/src/scheduler.ts
+++ b/packages/backend/src/scheduler.ts
@@ -3,8 +3,34 @@ import { lightdashConfig } from './config/lightdashConfig';
 import { getEnterpriseAppArguments } from './ee';
 import knexConfig from './knexfile';
 import Logger from './logging/logger';
+import { buildRuntimeMemoryReport } from './logging/runtimeMemory';
 import SchedulerApp from './SchedulerApp';
 import { getProcessTimezoneWarning } from './utils/processTimezone';
+
+const logRuntimeMemory = (service: 'api' | 'scheduler') => {
+    const report = buildRuntimeMemoryReport();
+    // The default log format renders the message and drops metadata, so the numbers ride in
+    // both. This is the first thing worth knowing from any log about a failed compile.
+    Logger.info(
+        `lightdash.boot.memory service=${service} heapLimitMb=${Math.round(
+            report.heapLimitBytes / 1024 / 1024,
+        )} containerLimitMb=${
+            report.containerMemoryLimitBytes === null
+                ? 'unknown'
+                : Math.round(report.containerMemoryLimitBytes / 1024 / 1024)
+        } heapFlagSet=${report.heapFlagSet} availableParallelism=${
+            report.availableParallelism
+        }`,
+        { event: 'lightdash.boot.memory', service, ...report },
+    );
+    if (report.warning) {
+        Logger.warn(`lightdash.boot.memory ${report.warning}`, {
+            event: 'lightdash.boot.memory.warning',
+            service,
+            ...report,
+        });
+    }
+};
 
 // Winston (handleExceptions/handleRejections in winston.ts) owns structured logging
 // for both events. Logger uses exitOnError: false so rejections are tolerated.
@@ -24,6 +50,7 @@ process.on('uncaughtException', () => {
             Logger.warn(timezoneWarning);
         }
 
+        logRuntimeMemory('scheduler');
         const schedulerApp = new SchedulerApp({
             lightdashConfig,
             port: process.env.PORT || 8081,

--- a/packages/backend/src/scheduler.ts
+++ b/packages/backend/src/scheduler.ts
@@ -3,34 +3,9 @@ import { lightdashConfig } from './config/lightdashConfig';
 import { getEnterpriseAppArguments } from './ee';
 import knexConfig from './knexfile';
 import Logger from './logging/logger';
-import { buildRuntimeMemoryReport } from './logging/runtimeMemory';
+import { logRuntimeMemory } from './logging/runtimeMemory';
 import SchedulerApp from './SchedulerApp';
 import { getProcessTimezoneWarning } from './utils/processTimezone';
-
-const logRuntimeMemory = (service: 'api' | 'scheduler') => {
-    const report = buildRuntimeMemoryReport();
-    // The default log format renders the message and drops metadata, so the numbers ride in
-    // both. This is the first thing worth knowing from any log about a failed compile.
-    Logger.info(
-        `lightdash.boot.memory service=${service} heapLimitMb=${Math.round(
-            report.heapLimitBytes / 1024 / 1024,
-        )} containerLimitMb=${
-            report.containerMemoryLimitBytes === null
-                ? 'unknown'
-                : Math.round(report.containerMemoryLimitBytes / 1024 / 1024)
-        } heapFlagSet=${report.heapFlagSet} availableParallelism=${
-            report.availableParallelism
-        }`,
-        { event: 'lightdash.boot.memory', service, ...report },
-    );
-    if (report.warning) {
-        Logger.warn(`lightdash.boot.memory ${report.warning}`, {
-            event: 'lightdash.boot.memory.warning',
-            service,
-            ...report,
-        });
-    }
-};
 
 // Winston (handleExceptions/handleRejections in winston.ts) owns structured logging
 // for both events. Logger uses exitOnError: false so rejections are tolerated.
@@ -50,7 +25,7 @@ process.on('uncaughtException', () => {
             Logger.warn(timezoneWarning);
         }
 
-        logRuntimeMemory('scheduler');
+        logRuntimeMemory(Logger, 'scheduler');
         const schedulerApp = new SchedulerApp({
             lightdashConfig,
             port: process.env.PORT || 8081,

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -296,6 +296,7 @@ import type { AppGenerateService } from '../../ee/services/AppGenerateService/Ap
 import { errorHandler } from '../../errors';
 import Logger from '../../logging/logger';
 import { measureTime } from '../../logging/measureTime';
+import { buildRuntimeMemoryReport } from '../../logging/runtimeMemory';
 import { AnalyticsModel } from '../../models/AnalyticsModel';
 import type { CatalogModel } from '../../models/CatalogModel/CatalogModel';
 import { ContentModel } from '../../models/ContentModel/ContentModel';
@@ -8834,6 +8835,29 @@ export class ProjectService extends BaseService {
             projectUuid,
             steps: [{ stepType: JobStepType.COMPILING }],
         };
+
+        // The heap ceiling is the first thing worth knowing from a log about a failed compile,
+        // because the image derives it from the container limit in plateaus rather than as a
+        // fraction, and an out-of-memory abort happens well below the container limit.
+        const memoryReport = buildRuntimeMemoryReport();
+        this.logger.info(
+            `dbt.compile.start projectUuid=${projectUuid} jobUuid=${jobUuid} heapLimitMb=${Math.round(
+                memoryReport.heapLimitBytes / 1024 / 1024,
+            )} containerLimitMb=${
+                memoryReport.containerMemoryLimitBytes === null
+                    ? 'unknown'
+                    : Math.round(
+                          memoryReport.containerMemoryLimitBytes / 1024 / 1024,
+                      )
+            } heapFlagSet=${memoryReport.heapFlagSet}`,
+            {
+                event: 'dbt.compile.start',
+                projectUuid,
+                jobUuid,
+                organizationUuid,
+                ...memoryReport,
+            },
+        );
 
         const onLockFailed = async () => {
             await this.jobModel.updateJobStep(


### PR DESCRIPTION
Linear: SPK-1867

**Base**: `main`. Independent of SPK-1861, SPK-1862 and SPK-1864.

## What breaks

The published image sets no heap flag at runtime. The `--max-old-space-size=4096` in the
Dockerfile is at line 222, inside the `prod-builder` stage; `runtime-base` at line 395 builds
`FROM pnpm-base`, so it is never inherited. The helm chart sets no `NODE_OPTIONS`.

Node then derives the heap from the container memory limit, and it does so **in plateaus, not as
a fraction**. Measured independently here on Node 24.18.1, in a cgroup v2 scope:

| Container limit | Node heap, today | Raising the limit helps? |
|---:|---:|---|
| 2 GiB | 1,120 MB | — |
| 4 GiB | 2,240 MB | yes |
| 6 GiB | 2,240 MB | **no, unchanged** |
| 8 GiB | 2,240 MB | **no, unchanged** |
| 12 GiB | 2,240 MB | **no, unchanged** |
| 15 GiB | 4,288 MB | yes |
| 16 GiB | 4,288 MB | no, unchanged |

**A 12 GiB pod runs the same heap as a 4 GiB pod.** An operator whose compile runs out of memory
raises the limit, sees no change, and has nothing in the logs to explain why.

This is not theoretical. A compile at a large project shape aborted after 167 s with
`FATAL ERROR: Ineffective mark-compacts near heap limit`, exit 134, inside `convertExplores`,
with the kernel never involved: `pgscan` and `pgsteal` both 0, `oom_kill` 0, and a cgroup peak of
5,161 MB against a 7,116 MB limit. On that run the heap ceiling was 2,240 MB against a 6,786 MB
container limit, so the process aborted with gigabytes the kernel was willing to give it.

## What changed

**`docker/prod-entrypoint.sh`**, so compose and ECS deployments are covered as well as helm. If
`NODE_OPTIONS` does not already contain `max-old-space-size` and a container limit is readable
from cgroup v2 `memory.max` or the v1 file, export the flag at 75% of it. An explicit value is
never overridden. Unreadable, `max`, the cgroup v1 unlimited sentinel, and implausible values are
all left alone.

| Container limit | Heap before | Heap after |
|---:|---:|---:|
| 2 GiB | 1,120 MB | 1,536 MB |
| 4 GiB | 2,240 MB | 3,072 MB |
| 8 GiB | 2,240 MB | 6,144 MB |
| 12 GiB | 2,240 MB | 9,216 MB |

**A boot line in both the API and the scheduler**, carrying the heap limit, the container limit,
`heapFlagSet` and `availableParallelism`. Verified live:

```
lightdash.boot.memory service=scheduler heapLimitMb=4288 containerLimitMb=unknown heapFlagSet=false availableParallelism=8
lightdash.boot.memory service=api       heapLimitMb=4288 containerLimitMb=unknown heapFlagSet=false availableParallelism=8
```

**A warning** when a container limit is known, no flag is set, and the heap is under half of it —
naming the flag and the value to use. That is exactly the shipping default between 4 and 15 GiB.

**The heap limit on the compile-start line**, `dbt.compile.start`, because it is the first thing
worth knowing from any log about a failed compile.

Every line carries its values in the message as well as in typed fields. `printMessage` in
`winston.ts` renders `info.message` and drops metadata, and the default format is `pretty`, so a
metadata-only event would be invisible on a default-configured instance.

## The failure mode of this fix

The flag is a ceiling, not a reservation, so it only changes runs that would otherwise abort.
What it changes is **which** failure they get. Set too high, a run that would have aborted at
exit 134 with a clear heap message instead grows into the kernel limit and is killed at 137 with
no heap line in the log and dbt children possibly still alive. That is a worse failure.

The tightest assumption in 75% is that the heap and the dbt subprocesses do not stack. Measured
at a large project shape, they do not: the dbt subprocess peak lands at 23.5 s into the fetch
phase and the Node process reaches its own maximum at 67 s, about 40 s later. But on a 12 GiB
pod, 75% is a 9,216 MB heap and the dbt fetch phase alone reaches about 3.4 GiB at that shape.
Those two numbers only both fit because they do not coincide in time. If a future change makes
them coincide, 75% is too high.

**The retest must record API pod RSS before and after**, because a higher ceiling also relaxes
V8 GC pacing, so steady-state RSS can rise even where peak behaviour improves.

## What this reaches, and where

The helm chart default is `resources: {}`, and the cloud configuration sets memory **requests**
only on the lightdash and scheduler pods, with no limits. So `memory.max` reads `max` on those
pods and the entrypoint leaves the heap alone. Ten instances already pass an explicit
`NODE_OPTIONS` and keep it unchanged.

In practice this change reaches **self-hosted deployments that set a pod memory limit**, which is
where the plateau bites. Cloud gets the new boot line and the warning, and nothing else.

For self-hosted, every instance with a limit and no explicit `NODE_OPTIONS` moves from the
plateau heap to 75% of its pod limit on the next image roll. **Watch API pod RSS on one instance
before rolling the rest**: a higher ceiling relaxes V8 GC pacing, so steady-state RSS can rise
even where peak behaviour improves.

## Tests

Nine cases against the entrypoint's sizing block with a faked cgroup root: the 75% arithmetic at
2, 4 and 12 GiB, an explicit flag never overridden, other `NODE_OPTIONS` preserved, and four
cases that must leave the heap untouched — `max`, no cgroup file, the cgroup v1 unlimited
sentinel, and an implausibly small limit.

Eleven unit tests on `readContainerMemoryLimitBytes` and `buildRuntimeMemoryReport`, including
that the warning fires on the 12 GiB / 2,240 MB shipping default and does not fire once the flag
is set, when the heap already uses most of the limit, or when no limit is readable.

## What is not measured here

Whether 75% is the right number on a real pod under a real workload. The arithmetic and the
plateau are measured; the headroom is reasoned from this rig's phase timings. The first instance
to run this with a container limit will produce the boot line and the compile-start line that
say whether the ceiling was right.
