### PR TITLE
feat(ai): Ask AI for data apps as pinned context

### DIFF
--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -12,5 +12,6 @@ collisions with other contexts' or repo-wide meanings.
 
 - [Data apps](./docs/data-apps/CONTEXT.md) — AI-generated interactive apps built on the semantic layer by a coding agent in a sandbox, versioned per prompt, found and read by the AI agent
 - [Pre-aggregates](./docs/pre-aggregates/CONTEXT.md) — user-defined, pre-computed summaries of explores that serve matching queries from materialized files instead of the warehouse
+- [AI agent](./docs/ai-agent/CONTEXT.md) — the in-app conversational agent (Ask AI), what users pin to its prompts, and where it opens from
 - [AI agent memory](./docs/ai-agent-memory/CONTEXT.md) — per-user, per-project knowledge the AI agent distills from a user's threads and recalls on their future threads
 - [External sources](./docs/external-sources/CONTEXT.md) — uploaded CSVs and connected Google Sheets ingested to typed parquet and queried as explores on the DuckDB engine

--- a/docs/ai-agent/CONTEXT.md
+++ b/docs/ai-agent/CONTEXT.md
@@ -1,0 +1,47 @@
+# AI agent
+
+Lightdash's in-app conversational agent, surfaced as Ask AI. A user asks
+questions in a thread; the agent answers with tools that read and query the
+project. Users can attach project content to a prompt so the agent knows what
+they are looking at. Not the coding agent that writes data apps, and not an
+external agent reaching Lightdash through MCP.
+
+## Language
+
+**Ask AI**:
+The entry point that opens the AI agent from a piece of content — a chart,
+dashboard, dashboard tile, data app, or listing row — with that content
+already pinned to the new prompt.
+_Avoid_: ask agent, open copilot, AI button
+
+**Pinned context**:
+The set of content a user attaches to one AI agent prompt: charts,
+dashboards, data apps, previous conversations, dbt files, repositories,
+external sources. Stored with the prompt and shown to the agent as names and
+slugs; the agent reads the content itself with its tools. Outside this
+context, qualify as "AI agent pinned context"; it is not data-app **Context**,
+which is what the coding agent receives.
+_Avoid_: context (unqualified), attachments, references, mentions (for the
+set)
+
+**Mention**:
+Attaching content to a prompt by typing `@` and picking it from search, the
+current page, or the tiles of a pinned dashboard. A mention is one way to
+add pinned context; Ask AI is the other.
+_Avoid_: tag, link, reference
+
+**Runtime overrides**:
+The live state a chart or dashboard had when it was pinned — dashboard
+filters, parameter values, date zoom, active tab — recorded so the agent
+queries what the user saw rather than the saved state.
+_Avoid_: filters (unqualified), page state, snapshot
+
+**Launcher**:
+The docked panel that hosts the AI agent on content pages. Ask AI opens it;
+a thread can expand from it to the full page and collapse back.
+_Avoid_: sidebar, widget, chat panel
+
+**Preview panel**:
+The in-thread panel that renders a data app the agent built or the user
+pinned, so it can be inspected without leaving the thread.
+_Avoid_: iframe, side panel, viewer

--- a/docs/data-apps/CONTEXT.md
+++ b/docs/data-apps/CONTEXT.md
@@ -101,8 +101,9 @@ _Avoid_: follow-ups, Q&A, refinements
 **Context**:
 Everything a user attaches to a prompt for the coding agent: saved charts,
 dashboards, images, screenshots of the running app, files, sample data, and
-external connections. Kept with the version.
-_Avoid_: attachments, resources (unqualified)
+external connections. Kept with the version. Not the AI agent's **pinned
+context**, which is what a user attaches to an Ask AI prompt.
+_Avoid_: attachments, resources (unqualified), pinned context
 
 **Generate from**:
 To create a new data app with existing charts or dashboards attached as

--- a/packages/backend/src/ee/database/entities/ai.ts
+++ b/packages/backend/src/ee/database/entities/ai.ts
@@ -467,7 +467,8 @@ export type AiPromptContextEntityType =
     | 'proposed_change'
     | 'review_finding'
     | 'preview_environment'
-    | 'data_app_element';
+    | 'data_app_element'
+    | 'data_app';
 
 // Element reference snapshot stored in runtime_overrides; entity_ref holds the
 // natural key so one prompt can reference several elements of the same app.
@@ -477,6 +478,12 @@ export type AiPromptDataAppElementSnapshot = {
     tag: string;
     text: string;
     loc: string;
+};
+
+// Latest ready version number at attach time; app versions are integers, so
+// pinned_version_uuid stays null.
+export type AiPromptDataAppSnapshot = {
+    version: number | null;
 };
 
 export type DbAiPromptContext = {
@@ -496,6 +503,7 @@ export type DbAiPromptContext = {
         | AiDashboardRuntimeOverrides
         | AiPromptExternalSourceSnapshot
         | AiPromptDataAppElementSnapshot
+        | AiPromptDataAppSnapshot
         | null;
     created_at: Date;
 };

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -6992,12 +6992,25 @@ export class AiAgentModel {
                 await this.database(AppsTableName)
                     .whereIn('app_id', appUuids)
                     .whereNull('deleted_at')
-                    .select<{ app_id: string; slug: string; name: string }[]>(
-                        'app_id',
-                        'slug',
-                        'name',
-                    )
-            ).map((r) => [r.app_id, { slug: r.slug, name: r.name }] as const),
+                    .select<
+                        {
+                            app_id: string;
+                            slug: string;
+                            name: string;
+                            space_uuid: string | null;
+                        }[]
+                    >('app_id', 'slug', 'name', 'space_uuid')
+            ).map(
+                (r) =>
+                    [
+                        r.app_id,
+                        {
+                            slug: r.slug,
+                            name: r.name,
+                            spaceUuid: r.space_uuid,
+                        },
+                    ] as const,
+            ),
         );
 
         const previewProjectUuids = rows
@@ -7077,7 +7090,10 @@ export class AiAgentModel {
         dashboardSlugByUuid: Map<string, string>,
         reviewItem: AiAgentReviewItemSummary | null,
         projectNameByUuid: Map<string, string>,
-        appDataByUuid: Map<string, { slug: string; name: string }>,
+        appDataByUuid: Map<
+            string,
+            { slug: string; name: string; spaceUuid: string | null }
+        >,
     ): AiPromptContextItem {
         // chart/dashboard/thread are uuid-keyed: entity_uuid is a non-null
         // invariant (only file/repository leave it null, using entity_ref).
@@ -7214,6 +7230,7 @@ export class AiAgentModel {
                         ? getAppDisplayName(app.name, appUuid)
                         : row.display_name,
                     pinnedVersion: snapshot?.version ?? null,
+                    isPersonal: app !== undefined && app.spaceUuid === null,
                 };
             }
             default:

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -146,6 +146,7 @@ import {
     AiPromptContextEntityType,
     AiPromptContextTableName,
     AiPromptDataAppElementSnapshot,
+    AiPromptDataAppSnapshot,
     AiPromptInterruptTableName,
     AiPromptSteerTableName,
     AiPromptTableName,
@@ -6506,7 +6507,9 @@ export class AiAgentModel {
             c.type === 'dashboard' ? [c.dashboardUuid] : [],
         );
         const appUuids = context.flatMap((c) =>
-            c.type === 'data_app_element' ? [c.appUuid] : [],
+            c.type === 'data_app_element' || c.type === 'data_app'
+                ? [c.appUuid]
+                : [],
         );
 
         const appNameByUuid = new Map(
@@ -6519,6 +6522,22 @@ export class AiAgentModel {
                         'name',
                     )
             ).map((r) => [r.app_id, r.name] as const),
+        );
+
+        const pinnedAppUuids = context.flatMap((c) =>
+            c.type === 'data_app' ? [c.appUuid] : [],
+        );
+        const latestReadyVersionByAppUuid = new Map(
+            (
+                await trx(AppVersionsTableName)
+                    .whereIn('app_id', pinnedAppUuids)
+                    .where('status', 'ready')
+                    .groupBy('app_id')
+                    .select<{ app_id: string; version: number }[]>(
+                        'app_id',
+                        trx.raw('max(version) as version'),
+                    )
+            ).map((r) => [r.app_id, r.version] as const),
         );
 
         const chartLookup = new Map(
@@ -6803,6 +6822,23 @@ export class AiAgentModel {
                         } satisfies AiPromptDataAppElementSnapshot,
                     };
                 }
+                case 'data_app': {
+                    const appName = appNameByUuid.get(ctx.appUuid);
+                    return {
+                        ai_prompt_uuid: promptUuid,
+                        entity_type: 'data_app' as AiPromptContextEntityType,
+                        entity_uuid: ctx.appUuid,
+                        display_name:
+                            appName === undefined
+                                ? null
+                                : getAppDisplayName(appName, ctx.appUuid),
+                        runtime_overrides: {
+                            version:
+                                latestReadyVersionByAppUuid.get(ctx.appUuid) ??
+                                null,
+                        } satisfies AiPromptDataAppSnapshot,
+                    };
+                }
                 default:
                     return assertUnreachable(
                         ctx,
@@ -6939,14 +6975,18 @@ export class AiAgentModel {
             }),
         );
 
-        const appUuids = rows.flatMap((r) =>
-            r.entity_type === 'data_app_element'
-                ? [
-                      (r.runtime_overrides as AiPromptDataAppElementSnapshot)
-                          .appUuid,
-                  ]
-                : [],
-        );
+        const appUuids = rows.flatMap((r) => {
+            if (r.entity_type === 'data_app_element') {
+                return [
+                    (r.runtime_overrides as AiPromptDataAppElementSnapshot)
+                        .appUuid,
+                ];
+            }
+            if (r.entity_type === 'data_app' && r.entity_uuid !== null) {
+                return [r.entity_uuid];
+            }
+            return [];
+        });
         const appDataByUuid = new Map(
             (
                 await this.database(AppsTableName)
@@ -7159,6 +7199,21 @@ export class AiAgentModel {
                     displayName: app
                         ? getAppDisplayName(app.name, snapshot.appUuid)
                         : row.display_name,
+                };
+            }
+            case 'data_app': {
+                const appUuid = requireEntityUuid();
+                const app = appDataByUuid.get(appUuid);
+                const snapshot =
+                    row.runtime_overrides as AiPromptDataAppSnapshot | null;
+                return {
+                    type: 'data_app',
+                    appUuid,
+                    appSlug: app?.slug ?? null,
+                    displayName: app
+                        ? getAppDisplayName(app.name, appUuid)
+                        : row.display_name,
+                    pinnedVersion: snapshot?.version ?? null,
                 };
             }
             default:

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -1165,7 +1165,7 @@ export class AiAgentService extends BaseService {
                         app.template === DATA_APP_VIZ_TEMPLATE
                     ) {
                         throw new ParameterError(
-                            'Chart types cannot be pinned as context',
+                            'Project chart types cannot be pinned context',
                         );
                     }
                     if (

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -60,6 +60,8 @@ import {
     CommercialFeatureFlags,
     ConflictError,
     ContentType,
+    DATA_APP_VIZ_TEMPLATE,
+    dataAppContextKey,
     dataAppElementContextKey,
     dataAppVizSchema,
     DbtProjectType,
@@ -1066,6 +1068,9 @@ export class AiAgentService extends BaseService {
                 case 'data_app_element':
                     key = dataAppElementContextKey(item);
                     break;
+                case 'data_app':
+                    key = dataAppContextKey(item.appUuid);
+                    break;
                 default:
                     return assertUnreachable(
                         item,
@@ -1147,10 +1152,21 @@ export class AiAgentService extends BaseService {
                     return;
                 }
 
-                if (item.type === 'data_app_element') {
+                if (
+                    item.type === 'data_app_element' ||
+                    item.type === 'data_app'
+                ) {
                     const app = await this.appModel.findAppByUuid(item.appUuid);
                     if (!app || app.project_uuid !== agent.projectUuid) {
                         throw new NotFoundError('Data app not found');
+                    }
+                    if (
+                        item.type === 'data_app' &&
+                        app.template === DATA_APP_VIZ_TEMPLATE
+                    ) {
+                        throw new ParameterError(
+                            'Chart types cannot be pinned as context',
+                        );
                     }
                     if (
                         !(await this.appGenerateService.canViewApp(user, app))
@@ -8727,6 +8743,11 @@ Use them as a reference, but do all the due dilligence and follow the instructio
                     const status = item.status ? ` — ${item.status}` : '';
                     return `- Preview environment${name}${status} — test the fix in this preview project.`;
                 }
+                case 'data_app': {
+                    const name = item.displayName ?? '(name unavailable)';
+                    const slugText = item.appSlug ?? '(slug unavailable)';
+                    return `- Data app "${name}" (dataAppSlug: ${slugText})`;
+                }
                 case 'data_app_element': {
                     const name = item.displayName ?? '(name unavailable)';
                     const slugText = item.appSlug ?? '(slug unavailable)';
@@ -8746,7 +8767,7 @@ Use them as a reference, but do all the due dilligence and follow the instructio
 The user attached the following to this message as context:
 ${lines.join('\n')}
 
-Use your existing tools to inspect them when relevant to the user's question. When runtime overrides are listed, apply them on top of the chart's saved state when querying.`,
+Use your existing tools to inspect them when relevant to the user's question (readContent for charts, dashboards, and data apps). When runtime overrides are listed, apply them on top of the chart's saved state when querying.`,
         } satisfies UserModelMessage;
     }
 

--- a/packages/backend/src/ee/services/AiAgentService/pinnedContextMessage.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/pinnedContextMessage.test.ts
@@ -339,6 +339,7 @@ describe('AiAgentService.createPinnedContextMessage data app pins', () => {
                 appSlug: 'f1-standings',
                 displayName: 'F1 standings',
                 pinnedVersion: 3,
+                isPersonal: false,
             },
         ]);
 
@@ -365,6 +366,7 @@ describe('AiAgentService.createPinnedContextMessage data app pins', () => {
                 appSlug: 'f1-standings',
                 displayName: 'F1 standings',
                 pinnedVersion: null,
+                isPersonal: false,
             },
             {
                 type: 'chart',

--- a/packages/backend/src/ee/services/AiAgentService/pinnedContextMessage.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/pinnedContextMessage.test.ts
@@ -329,3 +329,61 @@ describe('AiAgentService.createPinnedContextMessage review pins', () => {
         );
     });
 });
+
+describe('AiAgentService.createPinnedContextMessage data app pins', () => {
+    it('renders a data app by name and slug only', () => {
+        const content = buildMessage([
+            {
+                type: 'data_app',
+                appUuid: 'app-1',
+                appSlug: 'f1-standings',
+                displayName: 'F1 standings',
+                pinnedVersion: 3,
+            },
+        ]);
+
+        expect(content).toContain(
+            '- Data app "F1 standings" (dataAppSlug: f1-standings)',
+        );
+        expect(content).not.toContain('version 3');
+        expect(content).toContain('readContent');
+    });
+
+    it('keeps mixed items in their pinned order', () => {
+        const content = buildMessage([
+            {
+                type: 'dashboard',
+                dashboardUuid: 'dashboard-1',
+                dashboardSlug: 'exec-dashboard',
+                displayName: 'Executive dashboard',
+                pinnedVersionUuid: null,
+                runtimeOverrides: null,
+            },
+            {
+                type: 'data_app',
+                appUuid: 'app-1',
+                appSlug: 'f1-standings',
+                displayName: 'F1 standings',
+                pinnedVersion: null,
+            },
+            {
+                type: 'chart',
+                chartUuid: 'chart-1',
+                chartSlug: 'revenue',
+                displayName: 'Revenue',
+                pinnedVersionUuid: null,
+                runtimeOverrides: null,
+                chartKind: null,
+            },
+        ]);
+
+        const dashboardAt = content.indexOf(
+            '- Dashboard "Executive dashboard"',
+        );
+        const appAt = content.indexOf('- Data app "F1 standings"');
+        const chartAt = content.indexOf('- Chart "Revenue"');
+        expect(dashboardAt).toBeGreaterThan(-1);
+        expect(appAt).toBeGreaterThan(dashboardAt);
+        expect(chartAt).toBeGreaterThan(appAt);
+    });
+});

--- a/packages/backend/src/ee/services/AiAgentService/promptContextAccess.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/promptContextAccess.test.ts
@@ -1,0 +1,148 @@
+import {
+    ForbiddenError,
+    NotFoundError,
+    ParameterError,
+    type AiAgent,
+    type AiPromptContextInput,
+    type SessionUser,
+} from '@lightdash/common';
+import { AiAgentService } from './AiAgentService';
+
+vi.mock('../ai/AiAgentMcpRuntimeClient', () => ({
+    AiAgentMcpRuntimeClient: vi
+        .fn()
+        // eslint-disable-next-line prefer-arrow-callback
+        .mockImplementation(function MockAiAgentMcpRuntimeClient() {
+            return {};
+        }),
+}));
+
+const PROJECT_UUID = 'project-uuid';
+const USER_UUID = 'user-uuid';
+
+const user = { userUuid: USER_UUID } as SessionUser;
+const agent = {
+    uuid: 'agent-uuid',
+    organizationUuid: 'org-uuid',
+    projectUuid: PROJECT_UUID,
+} as AiAgent;
+
+type App = {
+    app_id: string;
+    project_uuid: string;
+    space_uuid: string | null;
+    created_by_user_uuid: string;
+    template: string | null;
+    organization_uuid: string;
+};
+
+const sharedApp: App = {
+    app_id: 'app-shared',
+    project_uuid: PROJECT_UUID,
+    space_uuid: 'space-1',
+    created_by_user_uuid: 'someone-else',
+    template: 'dashboard',
+    organization_uuid: 'org-uuid',
+};
+
+const otherUsersPersonalApp: App = {
+    ...sharedApp,
+    app_id: 'app-personal',
+    space_uuid: null,
+};
+
+const chartTypeApp: App = {
+    ...sharedApp,
+    app_id: 'app-viz',
+    template: 'data_app_viz',
+};
+
+const buildService = (apps: App[]) => {
+    const appModel = {
+        findAppByUuid: vi
+            .fn()
+            .mockImplementation(async (appUuid: string) =>
+                apps.find((a) => a.app_id === appUuid),
+            ),
+    };
+    // Personal apps (no space) are viewable only by their creator.
+    const appGenerateService = {
+        canViewApp: vi
+            .fn()
+            .mockImplementation(
+                async (u: SessionUser, app: App) =>
+                    app.space_uuid !== null ||
+                    app.created_by_user_uuid === u.userUuid,
+            ),
+    };
+    const service = new AiAgentService({
+        appModel,
+        appGenerateService,
+        analytics: { track: vi.fn() },
+        lightdashConfig: { ai: { copilot: {} } },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    const validate = (context: AiPromptContextInput) =>
+        (
+            service as unknown as {
+                validatePromptContextAccess: (
+                    u: SessionUser,
+                    a: AiAgent,
+                    c: AiPromptContextInput,
+                ) => Promise<AiPromptContextInput | undefined>;
+            }
+        ).validatePromptContextAccess(user, agent, context);
+    return { validate, appModel, appGenerateService };
+};
+
+describe('validatePromptContextAccess for data apps', () => {
+    it('accepts a data app the user can view', async () => {
+        const { validate } = buildService([sharedApp]);
+        const context: AiPromptContextInput = [
+            { type: 'data_app', appUuid: 'app-shared', appSlug: 'shared' },
+        ];
+
+        await expect(validate(context)).resolves.toEqual(context);
+    });
+
+    it("rejects another user's personal app", async () => {
+        const { validate } = buildService([otherUsersPersonalApp]);
+
+        await expect(
+            validate([{ type: 'data_app', appUuid: 'app-personal' }]),
+        ).rejects.toThrow(ForbiddenError);
+    });
+
+    it('rejects a project chart type', async () => {
+        const { validate, appGenerateService } = buildService([chartTypeApp]);
+
+        await expect(
+            validate([{ type: 'data_app', appUuid: 'app-viz' }]),
+        ).rejects.toThrow(ParameterError);
+        expect(appGenerateService.canViewApp).not.toHaveBeenCalled();
+    });
+
+    it('rejects an app from another project as not found', async () => {
+        const { validate } = buildService([
+            { ...sharedApp, project_uuid: 'other-project' },
+        ]);
+
+        await expect(
+            validate([{ type: 'data_app', appUuid: 'app-shared' }]),
+        ).rejects.toThrow(NotFoundError);
+    });
+
+    it('collapses the same app pinned twice into one item', async () => {
+        const { validate, appModel } = buildService([sharedApp]);
+
+        await expect(
+            validate([
+                { type: 'data_app', appUuid: 'app-shared', appSlug: 'shared' },
+                { type: 'data_app', appUuid: 'app-shared' },
+            ]),
+        ).resolves.toEqual([
+            { type: 'data_app', appUuid: 'app-shared', appSlug: 'shared' },
+        ]);
+        expect(appModel.findAppByUuid).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/backend/src/ee/services/AiAgentService/promptContextAccess.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/promptContextAccess.test.ts
@@ -116,9 +116,11 @@ describe('validatePromptContextAccess for data apps', () => {
     it('rejects a project chart type', async () => {
         const { validate, appGenerateService } = buildService([chartTypeApp]);
 
-        await expect(
-            validate([{ type: 'data_app', appUuid: 'app-viz' }]),
-        ).rejects.toThrow(ParameterError);
+        const result = validate([{ type: 'data_app', appUuid: 'app-viz' }]);
+        await expect(result).rejects.toThrow(ParameterError);
+        await expect(result).rejects.toThrow(
+            'Project chart types cannot be pinned context',
+        );
         expect(appGenerateService.canViewApp).not.toHaveBeenCalled();
     });
 

--- a/packages/backend/src/ee/services/ai/compaction.test.ts
+++ b/packages/backend/src/ee/services/ai/compaction.test.ts
@@ -320,6 +320,7 @@ describe('AI context compaction helpers', () => {
                         appSlug: 'f1-standings',
                         displayName: 'F1 standings',
                         pinnedVersion: 3,
+                        isPersonal: false,
                     },
                 ],
                 steers: [],

--- a/packages/backend/src/ee/services/ai/compaction.test.ts
+++ b/packages/backend/src/ee/services/ai/compaction.test.ts
@@ -303,6 +303,33 @@ describe('AI context compaction helpers', () => {
             'element reference [button "Send"] in data app F1 standings (app-1, version 3',
         );
     });
+
+    it('serializes a pinned data app by name and slug', () => {
+        const serialized = Compaction.serializeConversation([
+            {
+                role: 'user',
+                uuid: 'prompt-1',
+                threadUuid: 'thread-1',
+                message: 'What data does this app use?',
+                createdAt: new Date().toISOString(),
+                user: { uuid: 'user-1', name: 'Test User' },
+                context: [
+                    {
+                        type: 'data_app',
+                        appUuid: 'app-1',
+                        appSlug: 'f1-standings',
+                        displayName: 'F1 standings',
+                        pinnedVersion: 3,
+                    },
+                ],
+                steers: [],
+                hidden: false,
+            },
+        ]);
+
+        expect(serialized).toContain('data app F1 standings (f1-standings)');
+    });
+
     it('filters raw prompt rows after the latest compaction boundary', () => {
         const filtered = Compaction.filterThreadMessagesAfterCompaction(
             [

--- a/packages/backend/src/ee/services/ai/compaction.ts
+++ b/packages/backend/src/ee/services/ai/compaction.ts
@@ -234,6 +234,8 @@ export class Compaction {
                 return `preview environment${
                     item.projectName ? ` (${item.projectName})` : ''
                 }${item.status ? ` — ${item.status}` : ''}`;
+            case 'data_app':
+                return `data app ${item.displayName ?? item.appUuid} (${item.appSlug ?? item.appUuid})`;
             case 'data_app_element':
                 return `element reference ${elementReferenceToWireString(item)} in data app ${item.displayName ?? item.appUuid} (${item.appUuid}, version ${item.version}; copy it verbatim into the iterateDataApp brief)`;
             default:

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -229,11 +229,15 @@ export type AiAgentSummary = Pick<
 >;
 
 // An empty spaceAccess list means the agent is unrestricted (all spaces).
+export const isSpaceRestrictedAgent = (
+    agent: Pick<AiAgent, 'spaceAccess'>,
+): boolean => agent.spaceAccess.length > 0;
+
 export const hasAiAgentAccessToSpace = (
     agent: Pick<AiAgent, 'spaceAccess'>,
     spaceUuid: string,
 ): boolean =>
-    agent.spaceAccess.length === 0 || agent.spaceAccess.includes(spaceUuid);
+    !isSpaceRestrictedAgent(agent) || agent.spaceAccess.includes(spaceUuid);
 
 export type AiAgentUser = {
     uuid: string;

--- a/packages/common/src/ee/AiAgent/requestTypes.ts
+++ b/packages/common/src/ee/AiAgent/requestTypes.ts
@@ -245,6 +245,13 @@ export type AiPromptContextItemInput =
           tag: string;
           text: string;
           loc: string;
+      }
+    | {
+          // A data app the user pinned; the server snapshots its name and
+          // latest ready version number at attach time.
+          type: 'data_app';
+          appUuid: string;
+          appSlug?: string | null;
       };
 
 export type AiPromptContextInput = AiPromptContextItemInput[];
@@ -344,6 +351,13 @@ export type AiPromptContextItem =
           loc: string;
           appSlug: string | null;
           displayName: string | null;
+      }
+    | {
+          type: 'data_app';
+          appUuid: string;
+          appSlug: string | null;
+          displayName: string | null;
+          pinnedVersion: number | null;
       };
 
 export type AiPromptContext = AiPromptContextItem[];

--- a/packages/common/src/ee/AiAgent/requestTypes.ts
+++ b/packages/common/src/ee/AiAgent/requestTypes.ts
@@ -358,6 +358,8 @@ export type AiPromptContextItem =
           appSlug: string | null;
           displayName: string | null;
           pinnedVersion: number | null;
+          // Personal apps have no space; space-restricted agents cannot read them.
+          isPersonal: boolean;
       };
 
 export type AiPromptContext = AiPromptContextItem[];

--- a/packages/common/src/ee/apps/elementReference.ts
+++ b/packages/common/src/ee/apps/elementReference.ts
@@ -31,3 +31,7 @@ export const dataAppElementContextKey = ({
     loc,
 }: DataAppElementReference & { appUuid: string; version: number }): string =>
     `data_app_element:${appUuid}:${version}:${elementReferenceToWireString({ tag, text, loc })}`;
+
+/** Identity of a pinned data app as prompt context. */
+export const dataAppContextKey = (appUuid: string): string =>
+    `data_app:${appUuid}`;

--- a/packages/frontend/src/Routes.tsx
+++ b/packages/frontend/src/Routes.tsx
@@ -750,7 +750,6 @@ const PROJECT_LAYOUT_ROUTES: RouteObject[] = [
     },
     {
         path: 'apps/:appUuid/versions/:version/view',
-        handle: { hideAILauncher: true },
         lazy: async () => {
             const AppPreviewTest = await loadLazyRouteDefault(
                 './pages/AppPreviewTest',
@@ -761,7 +760,6 @@ const PROJECT_LAYOUT_ROUTES: RouteObject[] = [
     },
     {
         path: 'apps/:appUuid/view',
-        handle: { hideAILauncher: true },
         lazy: async () => {
             const AppPreviewTest = await loadLazyRouteDefault(
                 './pages/AppPreviewTest',

--- a/packages/frontend/src/components/DashboardTiles/DashboardDataAppTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardDataAppTile.tsx
@@ -21,6 +21,7 @@ import {
 } from '@mantine/core';
 import { IconAppsOff, IconCode, IconFilter } from '@tabler/icons-react';
 import React, { useMemo, useState, type FC } from 'react';
+import { AskAiAgentButton } from '../../ee/features/aiCopilot/components/AskAiAgentMenuItem/AskAiAgentButton';
 import AppIframePreview from '../../features/apps/AppIframePreview';
 import { getVisiblePreviewTokenError } from '../../features/apps/hooks/previewTokenQueryOptions';
 import { useAppPreviewToken } from '../../features/apps/hooks/useAppPreviewToken';
@@ -125,6 +126,7 @@ const DataAppTile: FC<Props> = (props) => {
         },
     } = props;
     const projectUuid = useProjectUuid();
+    const dashboardUuid = useDashboardContext((c) => c.dashboard?.uuid);
 
     const [isCommentsMenuOpen, setIsCommentsMenuOpen] = useState(false);
     const showComments = useDashboardContext(
@@ -281,6 +283,14 @@ const DataAppTile: FC<Props> = (props) => {
     return (
         <TileBase
             title={title}
+            titleLeftIcon={
+                <AskAiAgentButton
+                    projectUuid={projectUuid}
+                    dataAppUuid={appUuid}
+                    dashboardUuid={dashboardUuid}
+                    clickedFrom="dashboard_data_app_tile"
+                />
+            }
             lockHeaderVisibility={isCommentsMenuOpen}
             visibleHeaderElement={
                 tileHasComments ? dashboardComments : undefined

--- a/packages/frontend/src/components/UserSettings/MyAppsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/MyAppsPanel/index.tsx
@@ -22,6 +22,7 @@ import {
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useMemo, useState, type FC } from 'react';
 import { Link } from 'react-router';
+import { AskAiAgentMenuItem } from '../../../ee/features/aiCopilot/components/AskAiAgentMenuItem/AskAiAgentMenuItem';
 import AppThumbnailHoverCard from '../../../features/apps/components/AppThumbnailHoverCard';
 import { MoveAppToSpaceModal as SharedMoveAppToSpaceModal } from '../../../features/apps/components/MoveAppToSpaceModal';
 import { useMyApps } from '../../../features/apps/hooks/useMyApps';
@@ -276,6 +277,13 @@ const MyAppsPanel: FC<MyAppsPanelProps> = ({
                                 </ActionIcon>
                             </Menu.Target>
                             <Menu.Dropdown>
+                                <AskAiAgentMenuItem
+                                    projectUuid={app.projectUuid}
+                                    dataAppUuid={app.appUuid}
+                                    clickedFrom="data_app_my_apps_menu"
+                                    mode="navigate"
+                                    withDivider
+                                />
                                 {hasReadyVersion(app) && (
                                     <Menu.Item
                                         component={Link}

--- a/packages/frontend/src/components/UserSettings/MyAppsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/MyAppsPanel/index.tsx
@@ -22,7 +22,6 @@ import {
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useMemo, useState, type FC } from 'react';
 import { Link } from 'react-router';
-import { AskAiAgentMenuItem } from '../../../ee/features/aiCopilot/components/AskAiAgentMenuItem/AskAiAgentMenuItem';
 import AppThumbnailHoverCard from '../../../features/apps/components/AppThumbnailHoverCard';
 import { MoveAppToSpaceModal as SharedMoveAppToSpaceModal } from '../../../features/apps/components/MoveAppToSpaceModal';
 import { useMyApps } from '../../../features/apps/hooks/useMyApps';
@@ -277,13 +276,6 @@ const MyAppsPanel: FC<MyAppsPanelProps> = ({
                                 </ActionIcon>
                             </Menu.Target>
                             <Menu.Dropdown>
-                                <AskAiAgentMenuItem
-                                    projectUuid={app.projectUuid}
-                                    dataAppUuid={app.appUuid}
-                                    clickedFrom="data_app_my_apps_menu"
-                                    mode="navigate"
-                                    withDivider
-                                />
                                 {hasReadyVersion(app) && (
                                     <Menu.Item
                                         component={Link}

--- a/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
@@ -4,6 +4,7 @@ import {
     ChartSourceType,
     ContentReviewContentType,
     DirectAccessResourceType,
+    isResourceViewDataAppItem,
     isResourceViewItemChart,
     isResourceViewItemDashboard,
     ResourceViewItemType,
@@ -457,6 +458,14 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
                             />
                             {/* TODO: add a create-issue entry point once the issues flow is finalized */}
                         </>
+                    )}
+
+                    {isResourceViewDataAppItem(item) && (
+                        <AskAiAgentMenuItem
+                            projectUuid={projectUuid}
+                            dataAppUuid={item.data.uuid}
+                            clickedFrom="data_app_resource_action_menu"
+                        />
                     )}
 
                     {(userCanManage || canDuplicateDataApp) &&

--- a/packages/frontend/src/ee/features/aiCopilot/components/AskAiAgentMenuItem/AskAiAgentButton.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AskAiAgentMenuItem/AskAiAgentButton.tsx
@@ -8,6 +8,7 @@ type Props = {
     projectUuid: string | undefined;
     chartUuid?: string;
     dashboardUuid?: string;
+    dataAppUuid?: string;
     clickedFrom: AiAgentAskClickedSource;
     variant?: ActionIconProps['variant'];
     size?: ActionIconProps['size'];
@@ -24,6 +25,7 @@ export const AskAiAgentButton: FC<Props> = ({
     projectUuid,
     chartUuid,
     dashboardUuid,
+    dataAppUuid,
     clickedFrom,
     variant = 'subtle',
     size = 'sm',
@@ -34,6 +36,7 @@ export const AskAiAgentButton: FC<Props> = ({
         projectUuid,
         chartUuid,
         dashboardUuid,
+        dataAppUuid,
         clickedFrom,
     });
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/AskAiAgentMenuItem/AskAiAgentMenuItem.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AskAiAgentMenuItem/AskAiAgentMenuItem.tsx
@@ -8,6 +8,7 @@ type Props = {
     projectUuid: string | undefined;
     chartUuid?: string;
     dashboardUuid?: string;
+    dataAppUuid?: string;
     clickedFrom: AiAgentAskClickedSource;
     /**
      * Render a `<Menu.Divider />` after the item. The divider is only rendered
@@ -25,6 +26,7 @@ export const AskAiAgentMenuItem: FC<Props> = ({
     projectUuid,
     chartUuid,
     dashboardUuid,
+    dataAppUuid,
     clickedFrom,
     withDivider = false,
 }) => {
@@ -32,6 +34,7 @@ export const AskAiAgentMenuItem: FC<Props> = ({
         projectUuid,
         chartUuid,
         dashboardUuid,
+        dataAppUuid,
         clickedFrom,
     });
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/AskAiAgentMenuItem/AskAiAgentMenuItem.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AskAiAgentMenuItem/AskAiAgentMenuItem.tsx
@@ -2,7 +2,10 @@ import { Menu } from '@mantine/core';
 import { type FC } from 'react';
 import { type AiAgentAskClickedSource } from '../../../../../providers/Tracking/types';
 import { AiAgentIcon } from '../AiAgentIcon';
-import { useAskAiAgentAction } from './useAskAiAgentAction';
+import {
+    useAskAiAgentAction,
+    type AskAiAgentMode,
+} from './useAskAiAgentAction';
 
 type Props = {
     projectUuid: string | undefined;
@@ -10,6 +13,7 @@ type Props = {
     dashboardUuid?: string;
     dataAppUuid?: string;
     clickedFrom: AiAgentAskClickedSource;
+    mode?: AskAiAgentMode;
     /**
      * Render a `<Menu.Divider />` after the item. The divider is only rendered
      * when the item itself is visible, so callers don't need to gate it.
@@ -18,7 +22,7 @@ type Props = {
 };
 
 /**
- * Menu item that opens the AI agent launcher panel for a new conversation.
+ * Menu item that starts a new AI agent conversation (panel or full page).
  * Renders nothing when AI agents are not enabled, the user lacks permission,
  * or no default agent can be resolved.
  */
@@ -28,6 +32,7 @@ export const AskAiAgentMenuItem: FC<Props> = ({
     dashboardUuid,
     dataAppUuid,
     clickedFrom,
+    mode,
     withDivider = false,
 }) => {
     const { canAsk, handleClick } = useAskAiAgentAction({
@@ -36,6 +41,7 @@ export const AskAiAgentMenuItem: FC<Props> = ({
         dashboardUuid,
         dataAppUuid,
         clickedFrom,
+        mode,
     });
 
     if (!canAsk) return null;

--- a/packages/frontend/src/ee/features/aiCopilot/components/AskAiAgentMenuItem/useAskAiAgentAction.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AskAiAgentMenuItem/useAskAiAgentAction.ts
@@ -1,3 +1,5 @@
+import { FeatureFlags } from '@lightdash/common';
+import { useServerFeatureFlag } from '../../../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../../../providers/App/useApp';
 import { type AiAgentAskClickedSource } from '../../../../../providers/Tracking/types';
 import useTracking from '../../../../../providers/Tracking/useTracking';
@@ -11,6 +13,7 @@ type Args = {
     projectUuid: string | undefined;
     chartUuid?: string;
     dashboardUuid?: string;
+    dataAppUuid?: string;
     clickedFrom: AiAgentAskClickedSource;
 };
 
@@ -18,23 +21,28 @@ type Args = {
  * Shared logic for the "Ask AI Agent" entry points: resolves whether the action
  * should be shown and opens the launcher panel for a new conversation on click.
  * `canAsk` is false when AI agents are disabled, the user lacks permission, or
- * no default agent can be resolved.
+ * no default agent can be resolved. Data app context additionally requires
+ * data apps to be enabled.
  */
 export const useAskAiAgentAction = ({
     projectUuid,
     chartUuid,
     dashboardUuid,
+    dataAppUuid,
     clickedFrom,
 }: Args) => {
     const isVisible = useAiAgentButtonVisibility();
     const { agents } = useDefaultAiAgent(projectUuid);
     const { user } = useApp();
     const { track } = useTracking();
+    const dataAppsFlag = useServerFeatureFlag(FeatureFlags.EnableDataApps);
+    const dataAppsEnabled = dataAppsFlag.data?.enabled === true;
 
-    const canAsk = isVisible && agents.length > 0;
+    const canAsk =
+        isVisible && agents.length > 0 && (!dataAppUuid || dataAppsEnabled);
 
     const handleClick = () => {
-        if (agents.length === 0) return;
+        if (!canAsk) return;
         track({
             name: EventName.AI_AGENT_ASK_CLICKED,
             properties: {
@@ -45,7 +53,9 @@ export const useAskAiAgentAction = ({
             },
         });
         const pendingContext =
-            chartUuid || dashboardUuid ? { chartUuid, dashboardUuid } : null;
+            chartUuid || dashboardUuid || dataAppUuid
+                ? { chartUuid, dashboardUuid, dataAppUuid }
+                : null;
         aiAgentStore.dispatch(openDefaultAgentPanel({ pendingContext }));
     };
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/AskAiAgentMenuItem/useAskAiAgentAction.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AskAiAgentMenuItem/useAskAiAgentAction.ts
@@ -1,4 +1,5 @@
-import { FeatureFlags } from '@lightdash/common';
+import { assertUnreachable, FeatureFlags } from '@lightdash/common';
+import { useNavigate } from 'react-router';
 import { useServerFeatureFlag } from '../../../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../../../providers/App/useApp';
 import { type AiAgentAskClickedSource } from '../../../../../providers/Tracking/types';
@@ -7,7 +8,14 @@ import { EventName } from '../../../../../types/Events';
 import { useAiAgentButtonVisibility } from '../../hooks/useAiAgentsButtonVisibility';
 import { store as aiAgentStore } from '../../store';
 import { openDefaultAgentPanel } from '../../store/aiAgentLauncherSlice';
+import { buildNewThreadUrl } from '../Launcher/newThreadUrl';
 import { useDefaultAiAgent } from '../Launcher/useDefaultAiAgent';
+
+/**
+ * `panel` opens the docked launcher; `navigate` goes to the full-page
+ * new-thread route for surfaces where the launcher is hidden (app builder).
+ */
+export type AskAiAgentMode = 'panel' | 'navigate';
 
 type Args = {
     projectUuid: string | undefined;
@@ -15,11 +23,12 @@ type Args = {
     dashboardUuid?: string;
     dataAppUuid?: string;
     clickedFrom: AiAgentAskClickedSource;
+    mode?: AskAiAgentMode;
 };
 
 /**
  * Shared logic for the "Ask AI Agent" entry points: resolves whether the action
- * should be shown and opens the launcher panel for a new conversation on click.
+ * should be shown and starts a new conversation on click.
  * `canAsk` is false when AI agents are disabled, the user lacks permission, or
  * no default agent can be resolved. Data app context additionally requires
  * data apps to be enabled.
@@ -30,11 +39,13 @@ export const useAskAiAgentAction = ({
     dashboardUuid,
     dataAppUuid,
     clickedFrom,
+    mode = 'panel',
 }: Args) => {
     const isVisible = useAiAgentButtonVisibility();
-    const { agents } = useDefaultAiAgent(projectUuid);
+    const { agents, selectedAgent } = useDefaultAiAgent(projectUuid);
     const { user } = useApp();
     const { track } = useTracking();
+    const navigate = useNavigate();
     const dataAppsFlag = useServerFeatureFlag(FeatureFlags.EnableDataApps);
     const dataAppsEnabled = dataAppsFlag.data?.enabled === true;
 
@@ -56,7 +67,25 @@ export const useAskAiAgentAction = ({
             chartUuid || dashboardUuid || dataAppUuid
                 ? { chartUuid, dashboardUuid, dataAppUuid }
                 : null;
-        aiAgentStore.dispatch(openDefaultAgentPanel({ pendingContext }));
+        switch (mode) {
+            case 'panel':
+                aiAgentStore.dispatch(
+                    openDefaultAgentPanel({ pendingContext }),
+                );
+                return;
+            case 'navigate':
+                if (!projectUuid || !selectedAgent) return;
+                void navigate(
+                    buildNewThreadUrl({
+                        projectUuid,
+                        agent: selectedAgent,
+                        pendingContext,
+                    }),
+                );
+                return;
+            default:
+                return assertUnreachable(mode, 'Unknown ask AI mode');
+        }
     };
 
     return { canAsk, handleClick };

--- a/packages/frontend/src/ee/features/aiCopilot/components/AskAiAgentMenuItem/useAskAiAgentAction.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AskAiAgentMenuItem/useAskAiAgentAction.ts
@@ -13,7 +13,7 @@ import { useDefaultAiAgent } from '../Launcher/useDefaultAiAgent';
 
 /**
  * `panel` opens the docked launcher; `navigate` goes to the full-page
- * new-thread route for surfaces where the launcher is hidden (app builder).
+ * new-thread route for surfaces where the launcher is hidden (My apps).
  */
 export type AskAiAgentMode = 'panel' | 'navigate';
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/AskAiAgentMenuItem/useAskAiAgentAction.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AskAiAgentMenuItem/useAskAiAgentAction.ts
@@ -49,8 +49,13 @@ export const useAskAiAgentAction = ({
     const dataAppsFlag = useServerFeatureFlag(FeatureFlags.EnableDataApps);
     const dataAppsEnabled = dataAppsFlag.data?.enabled === true;
 
+    // Navigate mode needs the resolved agent for the URL before it can act.
+    const canNavigate = !!projectUuid && !!selectedAgent;
     const canAsk =
-        isVisible && agents.length > 0 && (!dataAppUuid || dataAppsEnabled);
+        isVisible &&
+        agents.length > 0 &&
+        (!dataAppUuid || dataAppsEnabled) &&
+        (mode !== 'navigate' || canNavigate);
 
     const handleClick = () => {
         if (!canAsk) return;

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.tsx
@@ -218,6 +218,7 @@ export const AgentChatDisplay: FC<PropsWithChildren<Props>> = ({
                                     <UserBubble
                                         message={message}
                                         projectUuid={projectUuid}
+                                        agentUuid={agentUuid}
                                     />
                                 ) : (
                                     <ErrorBoundary>

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.module.css
@@ -288,6 +288,13 @@
         linear-gradient(currentColor 0 0) 7px 6px / 4px 5px no-repeat;
 }
 
+.contentMentionIcon[data-icon-type='data_app']::before {
+    background:
+        linear-gradient(currentColor 0 0) 1px 1px / 10px 10px no-repeat,
+        linear-gradient(var(--mantine-color-body) 0 0) 2px 4px / 8px 6px
+            no-repeat;
+}
+
 .contentMentionIcon[data-rendered-icon='true']::before {
     content: none;
 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -2,6 +2,7 @@ import { subject } from '@casl/ability';
 import {
     FeatureFlags,
     getExternalSourceDisplayName,
+    isSpaceRestrictedAgent,
     type AgentSuggestion,
     type AiPromptContextInput,
     type AiPromptContextItem,
@@ -356,7 +357,8 @@ export const AgentChatInput = ({
     // A space-restricted agent cannot read personal data apps, so @ hides them.
     const { data: agent } = useProjectAiAgent(projectUuid, agentUuid);
     const hidePersonalDataAppsRef = useRef(false);
-    hidePersonalDataAppsRef.current = (agent?.spaceAccess.length ?? 0) > 0;
+    hidePersonalDataAppsRef.current =
+        agent !== undefined && isSpaceRestrictedAgent(agent);
     // What the @-mention dropdown is doing, sourced from the suggestion render
     // lifecycle — the plugin's own `active` flag alone can't tell an open
     // menu from a dismissed or empty one.

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -65,6 +65,7 @@ import { useDeepResearchComposer } from '../../hooks/useDeepResearchComposer';
 import {
     useCreateAiAgentThreadMessageSteerMutation,
     useInterruptAiAgentThreadMessageMutation,
+    useProjectAiAgent,
 } from '../../hooks/useProjectAiAgents';
 import {
     clearThreadElementReferences,
@@ -352,6 +353,10 @@ export const AgentChatInput = ({
     projectUuidRef.current = projectUuid;
     const contentMentionPriorityItemsRef = useRef(contentMentionPriorityItems);
     contentMentionPriorityItemsRef.current = contentMentionPriorityItems;
+    // A space-restricted agent cannot read personal data apps, so @ hides them.
+    const { data: agent } = useProjectAiAgent(projectUuid, agentUuid);
+    const hidePersonalDataAppsRef = useRef(false);
+    hidePersonalDataAppsRef.current = (agent?.spaceAccess.length ?? 0) > 0;
     // What the @-mention dropdown is doing, sourced from the suggestion render
     // lifecycle — the plugin's own `active` flag alone can't tell an open
     // menu from a dismissed or empty one.
@@ -463,6 +468,7 @@ export const AgentChatInput = ({
             createContentMentionExtension({
                 getProjectUuid: () => projectUuidRef.current,
                 getPriorityItems: () => contentMentionPriorityItemsRef.current,
+                getHidePersonalDataApps: () => hidePersonalDataAppsRef.current,
                 onMenuStateChange: (state) => {
                     contentMentionMenuRef.current = state;
                 },

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatUserBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatUserBubble.tsx
@@ -103,6 +103,16 @@ export const UserBubble: FC<Props> = ({
                                     key={`${getPromptContextItemKey(item)}-${idx}`}
                                     item={item}
                                     projectUuid={projectUuid}
+                                    previewScope={
+                                        agentUuid
+                                            ? {
+                                                  messageUuid: message.uuid,
+                                                  threadUuid:
+                                                      message.threadUuid,
+                                                  agentUuid,
+                                              }
+                                            : undefined
+                                    }
                                 />
                             ))}
                         </Group>

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatUserBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatUserBubble.tsx
@@ -24,6 +24,8 @@ type Props = {
     // Explicit for routes where projectUuid isn't a URL param (the review
     // remediation workspace); falls back to params for the normal agent chat.
     projectUuid?: string;
+    // Explicit for the docked launcher, where the route is the host page.
+    agentUuid?: string;
 };
 
 const getVisibleUserName = (name: string) => {
@@ -39,10 +41,12 @@ export const UserBubble: FC<Props> = ({
     message,
     isActive = false,
     projectUuid: projectUuidProp,
+    agentUuid: agentUuidProp,
 }) => {
-    const { agentUuid } = useParams();
+    const { agentUuid: paramsAgentUuid } = useParams();
     const paramsProjectUuid = useProjectUuid();
     const projectUuid = projectUuidProp ?? paramsProjectUuid;
+    const agentUuid = agentUuidProp ?? paramsAgentUuid;
     const timeAgo = useTimeAgo(message.createdAt);
     const name = getVisibleUserName(message.user.name);
     const app = useApp();
@@ -111,7 +115,7 @@ export const UserBubble: FC<Props> = ({
                                                       message.threadUuid,
                                                   agentUuid,
                                               }
-                                            : undefined
+                                            : null
                                     }
                                 />
                             ))}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentLink.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentLink.tsx
@@ -12,27 +12,18 @@ import {
 import { type FC, type MouseEvent, type ReactNode } from 'react';
 import { Link, createPath, useLocation, useNavigate } from 'react-router';
 import MantineIcon from '../../../../../components/common/MantineIcon';
-import { selectPreview, setPreview } from '../../store/aiArtifactSlice';
-import {
-    useAiAgentStoreDispatch,
-    useAiAgentStoreSelector,
-} from '../../store/hooks';
 import styles from './ContentLink.module.css';
 import { ContentReferenceLink } from './ContentReferenceLink';
 import { type ContentType } from './rehypeContentLinks';
+import {
+    isPlainLeftClick,
+    useDataAppPreviewLink,
+} from './useDataAppPreviewLink';
 
 export type SqlRunnerLinkState = {
     sql: string;
     limit?: number;
 };
-
-const isPlainLeftClick = (e: MouseEvent<HTMLAnchorElement>) =>
-    !e.defaultPrevented &&
-    e.button === 0 &&
-    !e.metaKey &&
-    !e.altKey &&
-    !e.ctrlKey &&
-    !e.shiftKey;
 
 const REFERENCE_LINK_KINDS = {
     'dashboard-link': 'dashboard',
@@ -65,8 +56,16 @@ export const ContentLink: FC<ContentLinkProps> = ({
     const location = useLocation();
     const resourceHref = typeof props.href === 'string' ? props.href : '';
     const title = typeof props.title === 'string' ? props.title : undefined;
-    const dispatch = useAiAgentStoreDispatch();
-    const currentPreview = useAiAgentStoreSelector(selectPreview);
+    const dataAppUuid =
+        'data-app-uuid' in props && typeof props['data-app-uuid'] === 'string'
+            ? props['data-app-uuid']
+            : null;
+    const dataAppPreviewLink = useDataAppPreviewLink(dataAppUuid, {
+        messageUuid: message.uuid,
+        threadUuid: message.threadUuid,
+        projectUuid,
+        agentUuid,
+    });
 
     const handleResourceClick = (e: MouseEvent<HTMLAnchorElement>) => {
         if (!resourceHref || !isPlainLeftClick(e)) {
@@ -112,43 +111,13 @@ export const ContentLink: FC<ContentLinkProps> = ({
                 </ContentReferenceLink>
             );
 
-        case 'data-app-link': {
-            const appUuid =
-                'data-app-uuid' in props &&
-                typeof props['data-app-uuid'] === 'string'
-                    ? props['data-app-uuid']
-                    : undefined;
-            const isActive =
-                !!appUuid &&
-                currentPreview?.type === 'dataApp' &&
-                currentPreview.appUuid === appUuid;
-
-            // Modified clicks fall through to the anchor and open the full
-            // page in a new tab.
-            const handleDataAppClick = (e: MouseEvent<HTMLAnchorElement>) => {
-                if (!appUuid || !isPlainLeftClick(e)) {
-                    return;
-                }
-
-                e.preventDefault();
-                dispatch(
-                    setPreview({
-                        type: 'dataApp',
-                        appUuid,
-                        messageUuid: message.uuid,
-                        threadUuid: message.threadUuid,
-                        projectUuid,
-                        agentUuid,
-                    }),
-                );
-            };
-
+        case 'data-app-link':
             return (
                 <ContentReferenceLink
                     to={resourceHref || undefined}
                     kind={REFERENCE_LINK_KINDS[contentType]}
-                    data-app-active={isActive || undefined}
-                    onClick={handleDataAppClick}
+                    data-app-active={dataAppPreviewLink.isActive || undefined}
+                    onClick={dataAppPreviewLink.onClick}
                     target="_blank"
                     rel="noreferrer"
                     title={title}
@@ -156,7 +125,6 @@ export const ContentLink: FC<ContentLinkProps> = ({
                     {children}
                 </ContentReferenceLink>
             );
-        }
 
         case 'chart-link': {
             const chartUuid =

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentLink.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentLink.tsx
@@ -12,6 +12,11 @@ import {
 import { type FC, type MouseEvent, type ReactNode } from 'react';
 import { Link, createPath, useLocation, useNavigate } from 'react-router';
 import MantineIcon from '../../../../../components/common/MantineIcon';
+import { selectPreview, setPreview } from '../../store/aiArtifactSlice';
+import {
+    useAiAgentStoreDispatch,
+    useAiAgentStoreSelector,
+} from '../../store/hooks';
 import styles from './ContentLink.module.css';
 import { ContentReferenceLink } from './ContentReferenceLink';
 import { type ContentType } from './rehypeContentLinks';
@@ -54,6 +59,8 @@ export const ContentLink: FC<ContentLinkProps> = ({
 }) => {
     const navigate = useNavigate();
     const location = useLocation();
+    const dispatch = useAiAgentStoreDispatch();
+    const currentPreview = useAiAgentStoreSelector(selectPreview);
     const resourceHref = typeof props.href === 'string' ? props.href : '';
     const title = typeof props.title === 'string' ? props.title : undefined;
     const dataAppUuid =

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentMentionNodeView.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentMentionNodeView.tsx
@@ -1,14 +1,10 @@
 import { ContentType, type ChartKind } from '@lightdash/common';
-import {
-    IconBrandGithub,
-    IconFile,
-    IconLayoutDashboard,
-} from '@tabler/icons-react';
+import { IconBrandGithub, IconFile } from '@tabler/icons-react';
 import { NodeViewWrapper, type NodeViewProps } from '@tiptap/react';
 import MantineIcon from '../../../../../components/common/MantineIcon';
-import { getChartIcon } from '../../../../../components/common/ResourceIcon/utils';
 import TruncatedText from '../../../../../components/common/TruncatedText';
 import styles from './AgentChatInput.module.css';
+import { getContentMentionIcon } from './contentMentionIcon';
 
 // File and repository mentions reuse this node so they get the same pill chrome;
 // they're distinguished by their contentType and carry the path / `owner/repo`
@@ -19,30 +15,22 @@ const REPOSITORY_CONTENT_TYPE = 'repository';
 const getContentMentionContentType = (value: unknown) => {
     if (value === FILE_CONTENT_TYPE) return FILE_CONTENT_TYPE;
     if (value === REPOSITORY_CONTENT_TYPE) return REPOSITORY_CONTENT_TYPE;
-    return value === ContentType.DASHBOARD
-        ? ContentType.DASHBOARD
-        : ContentType.CHART;
+    if (value === ContentType.DASHBOARD) return ContentType.DASHBOARD;
+    if (value === ContentType.DATA_APP) return ContentType.DATA_APP;
+    return ContentType.CHART;
 };
 
 export const ContentMentionNodeView = ({ node }: NodeViewProps) => {
     const contentType = getContentMentionContentType(node.attrs.contentType);
     const isFile = contentType === FILE_CONTENT_TYPE;
     const isRepository = contentType === REPOSITORY_CONTENT_TYPE;
-    const Icon = isFile
-        ? IconFile
-        : isRepository
-          ? IconBrandGithub
-          : contentType === ContentType.DASHBOARD
-            ? IconLayoutDashboard
-            : getChartIcon(
-                  (node.attrs.chartKind as ChartKind | null) ?? undefined,
-              );
-    const iconColor =
+    const { icon: Icon, color: iconColor } =
         isFile || isRepository
-            ? 'ldGray.6'
-            : contentType === ContentType.DASHBOARD
-              ? 'green.7'
-              : 'blue.7';
+            ? { icon: isFile ? IconFile : IconBrandGithub, color: 'ldGray.6' }
+            : getContentMentionIcon(
+                  contentType,
+                  (node.attrs.chartKind as ChartKind | null) ?? null,
+              );
     const label = typeof node.attrs.label === 'string' ? node.attrs.label : '';
 
     return (

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentMentionNodeView.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentMentionNodeView.tsx
@@ -1,29 +1,20 @@
-import { ContentType, type ChartKind } from '@lightdash/common';
+import { type ChartKind } from '@lightdash/common';
 import { IconBrandGithub, IconFile } from '@tabler/icons-react';
 import { NodeViewWrapper, type NodeViewProps } from '@tiptap/react';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import TruncatedText from '../../../../../components/common/TruncatedText';
 import styles from './AgentChatInput.module.css';
+import {
+    FILE_MENTION_CONTENT_TYPE,
+    getContentMentionContentType,
+    REPOSITORY_MENTION_CONTENT_TYPE,
+} from './contentMentionContentType';
 import { getContentMentionIcon } from './contentMentionIcon';
-
-// File and repository mentions reuse this node so they get the same pill chrome;
-// they're distinguished by their contentType and carry the path / `owner/repo`
-// in `label`.
-const FILE_CONTENT_TYPE = 'file';
-const REPOSITORY_CONTENT_TYPE = 'repository';
-
-const getContentMentionContentType = (value: unknown) => {
-    if (value === FILE_CONTENT_TYPE) return FILE_CONTENT_TYPE;
-    if (value === REPOSITORY_CONTENT_TYPE) return REPOSITORY_CONTENT_TYPE;
-    if (value === ContentType.DASHBOARD) return ContentType.DASHBOARD;
-    if (value === ContentType.DATA_APP) return ContentType.DATA_APP;
-    return ContentType.CHART;
-};
 
 export const ContentMentionNodeView = ({ node }: NodeViewProps) => {
     const contentType = getContentMentionContentType(node.attrs.contentType);
-    const isFile = contentType === FILE_CONTENT_TYPE;
-    const isRepository = contentType === REPOSITORY_CONTENT_TYPE;
+    const isFile = contentType === FILE_MENTION_CONTENT_TYPE;
+    const isRepository = contentType === REPOSITORY_MENTION_CONTENT_TYPE;
     const { icon: Icon, color: iconColor } =
         isFile || isRepository
             ? { icon: isFile ? IconFile : IconBrandGithub, color: 'ldGray.6' }

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentionContentType.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentionContentType.ts
@@ -1,0 +1,16 @@
+import { ContentType } from '@lightdash/common';
+
+// `contentType` values marking a content-mention node as a file or repository
+// (vs chart / dashboard / data app). Those nodes carry the path / `owner/repo`
+// in `label` and no context payload.
+export const FILE_MENTION_CONTENT_TYPE = 'file';
+export const REPOSITORY_MENTION_CONTENT_TYPE = 'repository';
+
+export const getContentMentionContentType = (value: unknown) => {
+    if (value === FILE_MENTION_CONTENT_TYPE) return FILE_MENTION_CONTENT_TYPE;
+    if (value === REPOSITORY_MENTION_CONTENT_TYPE)
+        return REPOSITORY_MENTION_CONTENT_TYPE;
+    if (value === ContentType.DASHBOARD) return ContentType.DASHBOARD;
+    if (value === ContentType.DATA_APP) return ContentType.DATA_APP;
+    return ContentType.CHART;
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentionIcon.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentionIcon.ts
@@ -1,0 +1,27 @@
+import { ContentType, type ChartKind } from '@lightdash/common';
+import {
+    IconAppWindow,
+    IconLayoutDashboard,
+    type Icon,
+} from '@tabler/icons-react';
+import { getChartIcon } from '../../../../../components/common/ResourceIcon/utils';
+
+export const getContentMentionIcon = (
+    contentType:
+        | ContentType.CHART
+        | ContentType.DASHBOARD
+        | ContentType.DATA_APP,
+    chartKind: ChartKind | null,
+): { icon: Icon; color: string } => {
+    switch (contentType) {
+        case ContentType.DASHBOARD:
+            return { icon: IconLayoutDashboard, color: 'green.7' };
+        case ContentType.DATA_APP:
+            return { icon: IconAppWindow, color: 'orange.6' };
+        case ContentType.CHART:
+            return {
+                icon: getChartIcon(chartKind ?? undefined),
+                color: 'blue.7',
+            };
+    }
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentionIcon.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentionIcon.ts
@@ -1,4 +1,8 @@
-import { ContentType, type ChartKind } from '@lightdash/common';
+import {
+    assertUnreachable,
+    ContentType,
+    type ChartKind,
+} from '@lightdash/common';
 import {
     IconAppWindow,
     IconLayoutDashboard,
@@ -23,5 +27,10 @@ export const getContentMentionIcon = (
                 icon: getChartIcon(chartKind ?? undefined),
                 color: 'blue.7',
             };
+        default:
+            return assertUnreachable(
+                contentType,
+                'Unknown content mention type',
+            );
     }
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.test.ts
@@ -164,6 +164,29 @@ describe('contentMentions', () => {
             expect(items.map((item) => item.uuid)).toEqual(['app-1']);
         });
 
+        it('hides personal apps offered by priority groups when the agent is space-restricted', async () => {
+            mockContentSearch([dataAppResult({ uuid: 'app-1' })]);
+
+            const items = await buildContentMentionSuggestionItems({
+                projectUuid: 'project-uuid',
+                query: 'app',
+                priorityItems: [
+                    {
+                        id: 'current:data_app:app-personal',
+                        label: 'App scratch',
+                        contentType: ContentType.DATA_APP,
+                        uuid: 'app-personal',
+                        slug: 'scratch',
+                        isPersonalDataApp: true,
+                        group: 'current',
+                    },
+                ],
+                hidePersonalDataApps: true,
+            });
+
+            expect(items.map((item) => item.uuid)).toEqual(['app-1']);
+        });
+
         it('dedupes an already mentioned app against search results by uuid', async () => {
             mockContentSearch([
                 dataAppResult({ uuid: 'app-1', name: 'F1 standings' }),
@@ -179,6 +202,7 @@ describe('contentMentions', () => {
                         contentType: ContentType.DATA_APP,
                         uuid: 'app-1',
                         slug: 'f1-standings',
+                        isPersonalDataApp: false,
                         group: 'thread',
                     },
                 ],
@@ -198,6 +222,7 @@ describe('contentMentions', () => {
                             appSlug: 'f1-standings',
                             displayName: 'F1 standings',
                             pinnedVersion: 3,
+                            isPersonal: false,
                         },
                     ],
                     'thread',
@@ -209,6 +234,7 @@ describe('contentMentions', () => {
                     contentType: ContentType.DATA_APP,
                     uuid: 'app-1',
                     slug: 'f1-standings',
+                    isPersonalDataApp: false,
                     group: 'thread',
                 },
             ]);
@@ -245,6 +271,7 @@ describe('contentMentions', () => {
                         appSlug: 'f1-standings',
                         displayName: 'F1 standings',
                         pinnedVersion: null,
+                        isPersonal: false,
                     },
                 ],
             });
@@ -377,6 +404,7 @@ describe('contentMentions', () => {
             contentType: ContentType.CHART,
             uuid: 'chart-1',
             slug: 'revenue-chart',
+            isPersonalDataApp: false,
             group: 'thread',
         };
         const tileChart: ContentMentionSuggestionItem = {
@@ -385,6 +413,7 @@ describe('contentMentions', () => {
             contentType: ContentType.CHART,
             uuid: 'chart-1',
             slug: 'revenue-chart',
+            isPersonalDataApp: false,
             group: 'dashboardTile',
         };
         const tileChart2: ContentMentionSuggestionItem = {
@@ -393,6 +422,7 @@ describe('contentMentions', () => {
             contentType: ContentType.CHART,
             uuid: 'chart-2',
             slug: 'active-users',
+            isPersonalDataApp: false,
             group: 'dashboardTile',
         };
 
@@ -428,6 +458,7 @@ describe('contentMentions', () => {
                 uuid: 'chart-1',
                 slug: 'revenue-chart',
                 chartKind: ChartKind.VERTICAL_BAR,
+                isPersonalDataApp: false,
                 group: 'thread',
             },
         ]);
@@ -445,6 +476,7 @@ describe('contentMentions', () => {
                         contentType: ContentType.DASHBOARD,
                         uuid: 'dashboard-1',
                         slug: 'exec-dashboard',
+                        isPersonalDataApp: false,
                         group: 'current',
                     },
                     {
@@ -453,6 +485,7 @@ describe('contentMentions', () => {
                         contentType: ContentType.CHART,
                         uuid: 'chart-1',
                         slug: 'revenue-by-month',
+                        isPersonalDataApp: false,
                         group: 'dashboardTile',
                     },
                 ],
@@ -464,6 +497,7 @@ describe('contentMentions', () => {
                 contentType: ContentType.CHART,
                 uuid: 'chart-1',
                 slug: 'revenue-by-month',
+                isPersonalDataApp: false,
                 group: 'dashboardTile',
             },
         ]);

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.test.ts
@@ -1,10 +1,21 @@
-import { ChartKind, ContentType } from '@lightdash/common';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+    ChartKind,
+    ContentType,
+    type ApiContentResponse,
+    type DataAppContent,
+} from '@lightdash/common';
+import { Editor } from '@tiptap/core';
+import Document from '@tiptap/extension-document';
+import Paragraph from '@tiptap/extension-paragraph';
+import Text from '@tiptap/extension-text';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { lightdashApi } from '../../../../../api';
 import {
     buildContentMentionSuggestionItems,
     contentMentionMenuOwnsEnter,
     contextItemsToContentMentionSuggestions,
+    createContentMentionExtension,
+    extractContentMentionContext,
     fuzzyContentMentionLabelMatch,
     getContentMentionEmptyMessage,
     mergeAiPromptContextInput,
@@ -18,9 +29,226 @@ vi.mock('../../../../../api', () => ({
 
 const mockedLightdashApi = vi.mocked(lightdashApi);
 
+const dataAppResult = (
+    overrides: Partial<DataAppContent> & Pick<DataAppContent, 'uuid'>,
+): DataAppContent =>
+    ({
+        contentType: ContentType.DATA_APP,
+        name: `App ${overrides.uuid}`,
+        slug: overrides.uuid,
+        space: { uuid: 'space-1', name: 'Shared' },
+        template: 'dashboard',
+        ...overrides,
+    }) as DataAppContent;
+
+const mockContentSearch = (data: DataAppContent[]) => {
+    mockedLightdashApi.mockResolvedValue({
+        data,
+    } as unknown as ApiContentResponse['results']);
+};
+
+// Undestroyed editors leave DOMObserver timers behind that fire after jsdom
+// teardown.
+const editors: Editor[] = [];
+
+afterEach(() => {
+    editors.splice(0).forEach((editor) => editor.destroy());
+});
+
+const buildMentionEditor = (mentions: Record<string, unknown>[]) => {
+    const editor = new Editor({
+        extensions: [
+            Document,
+            Paragraph,
+            Text,
+            createContentMentionExtension({
+                getProjectUuid: () => 'project-uuid',
+                getPriorityItems: () => [],
+            }),
+        ],
+        content: {
+            type: 'doc',
+            content: [
+                {
+                    type: 'paragraph',
+                    content: mentions.map((attrs) => ({
+                        type: 'contentMention',
+                        attrs,
+                    })),
+                },
+            ],
+        },
+    });
+    editors.push(editor);
+    return editor;
+};
+
 describe('contentMentions', () => {
     beforeEach(() => {
         mockedLightdashApi.mockReset();
+    });
+
+    describe('data app mentions', () => {
+        it('requests data apps, including personal ones, without chart types', async () => {
+            mockContentSearch([]);
+
+            await buildContentMentionSuggestionItems({
+                projectUuid: 'project-uuid',
+                query: 'f1',
+                priorityItems: [],
+            });
+
+            const url = new URL(
+                mockedLightdashApi.mock.calls[0][0].url,
+                'http://localhost',
+            );
+            expect(url.searchParams.getAll('contentTypes')).toEqual([
+                ContentType.CHART,
+                ContentType.DASHBOARD,
+                ContentType.DATA_APP,
+            ]);
+            expect(url.searchParams.get('includePersonalDataApps')).toBe(
+                'true',
+            );
+            expect(url.searchParams.get('dataAppVizsFilter')).toBe('exclude');
+        });
+
+        it('drops project chart type results and labels personal apps', async () => {
+            mockContentSearch([
+                dataAppResult({ uuid: 'app-1', name: 'F1 standings' }),
+                dataAppResult({ uuid: 'viz-1', template: 'data_app_viz' }),
+                dataAppResult({
+                    uuid: 'app-personal',
+                    name: 'My scratch app',
+                    space: null,
+                }),
+            ]);
+
+            const items = await buildContentMentionSuggestionItems({
+                projectUuid: 'project-uuid',
+                query: 'app',
+                priorityItems: [],
+            });
+
+            expect(items.map((item) => item.uuid)).toEqual([
+                'app-1',
+                'app-personal',
+            ]);
+            expect(items[0]).toMatchObject({
+                contentType: ContentType.DATA_APP,
+                label: 'F1 standings',
+                slug: 'app-1',
+                spaceName: 'Shared',
+                isPersonalDataApp: false,
+                group: 'search',
+            });
+            expect(items[1]).toMatchObject({
+                spaceName: null,
+                isPersonalDataApp: true,
+            });
+        });
+
+        it('hides personal apps when the agent is space-restricted', async () => {
+            mockContentSearch([
+                dataAppResult({ uuid: 'app-1' }),
+                dataAppResult({ uuid: 'app-personal', space: null }),
+            ]);
+
+            const items = await buildContentMentionSuggestionItems({
+                projectUuid: 'project-uuid',
+                query: 'app',
+                priorityItems: [],
+                hidePersonalDataApps: true,
+            });
+
+            expect(items.map((item) => item.uuid)).toEqual(['app-1']);
+        });
+
+        it('dedupes an already mentioned app against search results by uuid', async () => {
+            mockContentSearch([
+                dataAppResult({ uuid: 'app-1', name: 'F1 standings' }),
+            ]);
+
+            const items = await buildContentMentionSuggestionItems({
+                projectUuid: 'project-uuid',
+                query: 'f1',
+                priorityItems: [
+                    {
+                        id: 'thread:data_app:app-1',
+                        label: 'F1 standings',
+                        contentType: ContentType.DATA_APP,
+                        uuid: 'app-1',
+                        slug: 'f1-standings',
+                        group: 'thread',
+                    },
+                ],
+            });
+
+            expect(items).toHaveLength(1);
+            expect(items[0].group).toBe('thread');
+        });
+
+        it('maps pinned data apps into "Already mentioned" suggestions', () => {
+            expect(
+                contextItemsToContentMentionSuggestions(
+                    [
+                        {
+                            type: 'data_app',
+                            appUuid: 'app-1',
+                            appSlug: 'f1-standings',
+                            displayName: 'F1 standings',
+                            pinnedVersion: 3,
+                        },
+                    ],
+                    'thread',
+                ),
+            ).toEqual([
+                {
+                    id: 'thread:data_app:app-1',
+                    label: 'F1 standings',
+                    contentType: ContentType.DATA_APP,
+                    uuid: 'app-1',
+                    slug: 'f1-standings',
+                    group: 'thread',
+                },
+            ]);
+        });
+
+        it('extracts a data app mention as a data_app context item, deduped by uuid', () => {
+            const editor = buildMentionEditor([
+                {
+                    contentType: ContentType.DATA_APP,
+                    uuid: 'app-1',
+                    slug: 'f1-standings',
+                    label: 'F1 standings',
+                },
+                {
+                    contentType: ContentType.DATA_APP,
+                    uuid: 'app-1',
+                    slug: 'f1-standings',
+                    label: 'F1 standings',
+                },
+            ]);
+
+            expect(extractContentMentionContext(editor)).toEqual({
+                context: [
+                    {
+                        type: 'data_app',
+                        appUuid: 'app-1',
+                        appSlug: 'f1-standings',
+                    },
+                ],
+                optimisticContext: [
+                    {
+                        type: 'data_app',
+                        appUuid: 'app-1',
+                        appSlug: 'f1-standings',
+                        displayName: 'F1 standings',
+                        pinnedVersion: null,
+                    },
+                ],
+            });
+        });
     });
 
     it('dedupes prompt context preserving first occurrence', () => {

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.tsx
@@ -3,8 +3,6 @@ import {
     ChartSourceType,
     ContentType,
     DATA_APP_VIZ_TEMPLATE,
-    dataAppContextKey,
-    dataAppElementContextKey,
     type AiPromptContextInput,
     type AiPromptContextItem,
     type ApiContentResponse,
@@ -41,9 +39,17 @@ import {
 import suggestionStyles from '../../../../../components/common/SuggestionList/SuggestionList.module.css';
 import TruncatedText from '../../../../../components/common/TruncatedText';
 import styles from './AgentChatInput.module.css';
+import {
+    FILE_MENTION_CONTENT_TYPE,
+    getContentMentionContentType,
+    REPOSITORY_MENTION_CONTENT_TYPE,
+} from './contentMentionContentType';
 import { getContentMentionIcon } from './contentMentionIcon';
 import { ContentMentionNodeView } from './ContentMentionNodeView';
-import { getPromptContextItemKey } from './contentReferenceUtils';
+import {
+    getDataAppContextItemName,
+    getPromptContextItemKey,
+} from './contentReferenceUtils';
 
 const CONTENT_MENTION_NAME = 'contentMention';
 const MIN_CONTENT_SEARCH_QUERY_LENGTH = 2;
@@ -85,9 +91,6 @@ export type ContentMentionSuggestionItem = SuggestionItem & {
 };
 
 const FILE_MENTION_GROUP = 'file';
-// `contentType` value marking a content-mention node as a file (vs chart /
-// dashboard). The node carries the path in `label`; no context payload.
-const FILE_MENTION_CONTENT_TYPE = 'file';
 const MAX_FILE_SUGGESTIONS = 8;
 
 // A dbt source file the user can `@`-mention. Unlike content mentions it carries
@@ -100,10 +103,6 @@ export type FileMentionSuggestionItem = SuggestionItem & {
 };
 
 const REPOSITORY_MENTION_GROUP = 'repository';
-// `contentType` value marking a content-mention node as a repository (vs chart /
-// dashboard / file). The node carries `owner/repo` in `label`; no context
-// payload — the agent reads the repo via its exploreRepo tool.
-const REPOSITORY_MENTION_CONTENT_TYPE = 'repository';
 const MAX_REPOSITORY_SUGGESTIONS = 8;
 
 // A GitHub or GitLab repository the org's installation can access. Like file
@@ -286,15 +285,6 @@ export const contentMentionMenuOwnsEnter = (
     }
 };
 
-const getContentMentionContentType = (value: unknown) => {
-    if (value === FILE_MENTION_CONTENT_TYPE) return FILE_MENTION_CONTENT_TYPE;
-    if (value === REPOSITORY_MENTION_CONTENT_TYPE)
-        return REPOSITORY_MENTION_CONTENT_TYPE;
-    if (value === ContentType.DASHBOARD) return ContentType.DASHBOARD;
-    if (value === ContentType.DATA_APP) return ContentType.DATA_APP;
-    return ContentType.CHART;
-};
-
 const getContentMentionIconSpec = (contentType: string): DOMOutputSpec => [
     'span',
     {
@@ -303,40 +293,6 @@ const getContentMentionIconSpec = (contentType: string): DOMOutputSpec => [
         'data-icon-type': contentType,
     },
 ];
-
-const getContextKey = (item: AiPromptContextInput[number]) => {
-    switch (item.type) {
-        case 'chart':
-            return `chart:${item.chartUuid}`;
-        case 'dashboard':
-            return `dashboard:${item.dashboardUuid}`;
-        case 'thread':
-            return `thread:${item.threadUuid}`;
-        case 'file':
-            return `file:${item.path}`;
-        case 'repository':
-            return `repository:${item.fullName}`;
-        case 'external_source':
-            return `external_source:${item.sourceUuid}`;
-        case 'pull_request':
-            return `pull_request:${item.prUrl}`;
-        case 'proposed_change':
-            return `proposed_change:${item.fingerprint}`;
-        case 'review_finding':
-            return `review_finding:${item.fingerprint}`;
-        case 'preview_environment':
-            return `preview_environment:${item.previewProjectUuid}`;
-        case 'data_app_element':
-            return dataAppElementContextKey(item);
-        case 'data_app':
-            return dataAppContextKey(item.appUuid);
-        default:
-            return assertUnreachable(
-                item,
-                'Unknown AiPromptContextItemInput type',
-            );
-    }
-};
 
 const normalizeSearchText = (value: string) =>
     value
@@ -376,7 +332,7 @@ export const mergeAiPromptContextInput = (
     contextGroups
         .flatMap((context) => context ?? [])
         .forEach((item) => {
-            const key = getContextKey(item);
+            const key = getPromptContextItemKey(item);
             if (seen.has(key)) {
                 return;
             }
@@ -447,7 +403,7 @@ export const contextItemsToContentMentionSuggestions = (
         if (item.type === 'data_app') {
             return {
                 id: `${group}:data_app:${item.appUuid}`,
-                label: item.displayName ?? item.appSlug ?? 'Data app',
+                label: getDataAppContextItemName(item),
                 contentType: ContentType.DATA_APP,
                 uuid: item.appUuid,
                 slug: item.appSlug,

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.tsx
@@ -82,7 +82,7 @@ export type ContentMentionSuggestionItem = SuggestionItem & {
     chartKind?: ChartKind | null;
     spaceName?: string | null;
     // Personal data apps have no space; agents restricted to spaces hide them.
-    isPersonalDataApp?: boolean;
+    isPersonalDataApp: boolean;
     group: ContentMentionGroup;
     dashboardUuid?: string | null;
     dashboardSlug?: string | null;
@@ -387,6 +387,7 @@ export const contextItemsToContentMentionSuggestions = (
                 uuid: item.chartUuid,
                 slug: item.chartSlug,
                 chartKind: item.chartKind,
+                isPersonalDataApp: false,
                 group,
             };
         }
@@ -397,6 +398,7 @@ export const contextItemsToContentMentionSuggestions = (
                 contentType: ContentType.DASHBOARD,
                 uuid: item.dashboardUuid,
                 slug: item.dashboardSlug,
+                isPersonalDataApp: false,
                 group,
             };
         }
@@ -407,6 +409,7 @@ export const contextItemsToContentMentionSuggestions = (
                 contentType: ContentType.DATA_APP,
                 uuid: item.appUuid,
                 slug: item.appSlug,
+                isPersonalDataApp: item.isPersonal,
                 group,
             };
         }
@@ -427,6 +430,7 @@ const summaryContentToSuggestion = (
             slug: item.slug,
             chartKind: item.chartKind,
             spaceName: item.space.name,
+            isPersonalDataApp: false,
             group: 'search',
             verified: item.verification !== null,
         };
@@ -440,6 +444,7 @@ const summaryContentToSuggestion = (
             uuid: item.uuid,
             slug: item.slug,
             spaceName: item.space.name,
+            isPersonalDataApp: false,
             group: 'search',
             verified: item.verification !== null,
         };
@@ -509,15 +514,13 @@ export const buildContentMentionSuggestionItems = async ({
     const matchingPriorityItems = priorityItems.filter((item) =>
         fuzzyContentMentionLabelMatch(item.label, query),
     );
-    const allSearchItems = projectUuid
+    const searchItems = projectUuid
         ? await getSearchSuggestions(projectUuid, query)
         : [];
-    const searchItems = hidePersonalDataApps
-        ? allSearchItems.filter((item) => !item.isPersonalDataApp)
-        : allSearchItems;
 
     const seen = new Set<string>();
     return [...matchingPriorityItems, ...searchItems].filter((item) => {
+        if (hidePersonalDataApps && item.isPersonalDataApp) return false;
         const key = `${item.contentType}:${item.uuid}`;
         if (seen.has(key)) return false;
         seen.add(key);
@@ -725,6 +728,7 @@ const generateContentMentionSuggestion = ({
             uuid: null,
             slug: null,
             chartKind: null,
+            isPersonalDataApp: false,
             dashboardUuid: null,
             dashboardSlug: null,
             dashboardName: null,
@@ -754,6 +758,7 @@ const generateContentMentionSuggestion = ({
                 slug: item.slug,
                 label: item.label,
                 chartKind: item.chartKind ?? null,
+                isPersonalDataApp: item.isPersonalDataApp,
                 dashboardUuid: item.dashboardUuid ?? null,
                 dashboardSlug: item.dashboardSlug ?? null,
                 dashboardName: item.dashboardName ?? null,
@@ -873,6 +878,7 @@ export const createContentMentionExtension = ({
                 slug: { default: null },
                 label: { default: null },
                 chartKind: { default: null },
+                isPersonalDataApp: { default: false },
                 dashboardUuid: { default: null },
                 dashboardSlug: { default: null },
                 dashboardName: { default: null },
@@ -959,6 +965,7 @@ export const extractContentMentionContext = (
             slug?: string | null;
             label?: string | null;
             chartKind?: ChartKind | null;
+            isPersonalDataApp?: boolean;
             dashboardUuid?: string | null;
             dashboardSlug?: string | null;
             dashboardName?: string | null;
@@ -1027,6 +1034,7 @@ export const extractContentMentionContext = (
                 appSlug: attrs.slug ?? null,
                 displayName: attrs.label ?? null,
                 pinnedVersion: null,
+                isPersonal: attrs.isPersonalDataApp === true,
             });
             return;
         }

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.tsx
@@ -2,6 +2,8 @@ import {
     assertUnreachable,
     ChartSourceType,
     ContentType,
+    DATA_APP_VIZ_TEMPLATE,
+    dataAppContextKey,
     dataAppElementContextKey,
     type AiPromptContextInput,
     type AiPromptContextItem,
@@ -18,7 +20,6 @@ import {
     IconBrandGitlab,
     IconCircleCheck,
     IconFile,
-    IconLayoutDashboard,
 } from '@tabler/icons-react';
 import Mention, { type MentionOptions } from '@tiptap/extension-mention';
 import { type DOMOutputSpec } from '@tiptap/pm/model';
@@ -32,7 +33,6 @@ import tippy, { type Instance as TippyInstance } from 'tippy.js';
 import { lightdashApi } from '../../../../../api';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import { PolymorphicGroupButton } from '../../../../../components/common/PolymorphicGroupButton';
-import { getChartIcon } from '../../../../../components/common/ResourceIcon/utils';
 import {
     SuggestionList,
     type SuggestionItem,
@@ -41,6 +41,7 @@ import {
 import suggestionStyles from '../../../../../components/common/SuggestionList/SuggestionList.module.css';
 import TruncatedText from '../../../../../components/common/TruncatedText';
 import styles from './AgentChatInput.module.css';
+import { getContentMentionIcon } from './contentMentionIcon';
 import { ContentMentionNodeView } from './ContentMentionNodeView';
 import { getPromptContextItemKey } from './contentReferenceUtils';
 
@@ -66,11 +67,16 @@ const DOM_RECT_FALLBACK: DOMRect = {
 type ContentMentionGroup = 'thread' | 'current' | 'dashboardTile' | 'search';
 
 export type ContentMentionSuggestionItem = SuggestionItem & {
-    contentType: ContentType.CHART | ContentType.DASHBOARD;
+    contentType:
+        | ContentType.CHART
+        | ContentType.DASHBOARD
+        | ContentType.DATA_APP;
     uuid: string;
     slug: string | null;
     chartKind?: ChartKind | null;
     spaceName?: string | null;
+    // Personal data apps have no space; agents restricted to spaces hide them.
+    isPersonalDataApp?: boolean;
     group: ContentMentionGroup;
     dashboardUuid?: string | null;
     dashboardSlug?: string | null;
@@ -284,9 +290,9 @@ const getContentMentionContentType = (value: unknown) => {
     if (value === FILE_MENTION_CONTENT_TYPE) return FILE_MENTION_CONTENT_TYPE;
     if (value === REPOSITORY_MENTION_CONTENT_TYPE)
         return REPOSITORY_MENTION_CONTENT_TYPE;
-    return value === ContentType.DASHBOARD
-        ? ContentType.DASHBOARD
-        : ContentType.CHART;
+    if (value === ContentType.DASHBOARD) return ContentType.DASHBOARD;
+    if (value === ContentType.DATA_APP) return ContentType.DATA_APP;
+    return ContentType.CHART;
 };
 
 const getContentMentionIconSpec = (contentType: string): DOMOutputSpec => [
@@ -322,6 +328,8 @@ const getContextKey = (item: AiPromptContextInput[number]) => {
             return `preview_environment:${item.previewProjectUuid}`;
         case 'data_app_element':
             return dataAppElementContextKey(item);
+        case 'data_app':
+            return dataAppContextKey(item.appUuid);
         default:
             return assertUnreachable(
                 item,
@@ -436,6 +444,16 @@ export const contextItemsToContentMentionSuggestions = (
                 group,
             };
         }
+        if (item.type === 'data_app') {
+            return {
+                id: `${group}:data_app:${item.appUuid}`,
+                label: item.displayName ?? item.appSlug ?? 'Data app',
+                contentType: ContentType.DATA_APP,
+                uuid: item.appUuid,
+                slug: item.appSlug,
+                group,
+            };
+        }
         // Threads are reference-only context — not mentionable content.
         return [];
     });
@@ -471,6 +489,22 @@ const summaryContentToSuggestion = (
         };
     }
 
+    // Project chart types are data apps under the hood but not content the
+    // agent reads, so they never show up as mentions.
+    if (item.contentType === ContentType.DATA_APP) {
+        if (item.template === DATA_APP_VIZ_TEMPLATE) return null;
+        return {
+            id: `search:data_app:${item.uuid}`,
+            label: item.name,
+            contentType: ContentType.DATA_APP,
+            uuid: item.uuid,
+            slug: item.slug,
+            spaceName: item.space?.name ?? null,
+            isPersonalDataApp: item.space === null,
+            group: 'search',
+        };
+    }
+
     return null;
 };
 
@@ -485,6 +519,9 @@ const getSearchSuggestions = async (
     params.append('projectUuids', projectUuid);
     params.append('contentTypes', ContentType.CHART);
     params.append('contentTypes', ContentType.DASHBOARD);
+    params.append('contentTypes', ContentType.DATA_APP);
+    params.set('includePersonalDataApps', 'true');
+    params.set('dataAppVizsFilter', 'exclude');
     params.set('pageSize', '20');
     params.set('page', '1');
     params.set('search', trimmedQuery);
@@ -505,17 +542,23 @@ export const buildContentMentionSuggestionItems = async ({
     projectUuid,
     query,
     priorityItems,
+    hidePersonalDataApps = false,
 }: {
     projectUuid: string | undefined;
     query: string;
     priorityItems: ContentMentionSuggestionItem[];
+    // A space-restricted agent cannot read personal apps, so don't offer them.
+    hidePersonalDataApps?: boolean;
 }) => {
     const matchingPriorityItems = priorityItems.filter((item) =>
         fuzzyContentMentionLabelMatch(item.label, query),
     );
-    const searchItems = projectUuid
+    const allSearchItems = projectUuid
         ? await getSearchSuggestions(projectUuid, query)
         : [];
+    const searchItems = hidePersonalDataApps
+        ? allSearchItems.filter((item) => !item.isPersonalDataApp)
+        : allSearchItems;
 
     const seen = new Set<string>();
     return [...matchingPriorityItems, ...searchItems].filter((item) => {
@@ -628,12 +671,10 @@ const renderContentMentionItem = (
     if (isRepositoryMentionItem(item)) {
         return renderRepositoryMentionItem(item, isSelected, onClick);
     }
-    const Icon =
-        item.contentType === ContentType.DASHBOARD
-            ? IconLayoutDashboard
-            : getChartIcon(item.chartKind ?? undefined);
-    const iconColor =
-        item.contentType === ContentType.DASHBOARD ? 'green.7' : 'blue.7';
+    const { icon: Icon, color: iconColor } = getContentMentionIcon(
+        item.contentType,
+        item.chartKind ?? null,
+    );
     const detail = item.spaceName ?? groupLabels[item.group];
 
     return (
@@ -679,11 +720,13 @@ const renderContentMentionItem = (
 const generateContentMentionSuggestion = ({
     getProjectUuid,
     getPriorityItems,
+    getHidePersonalDataApps,
     onMenuStateChange,
     includeFilesAndRepositories,
 }: {
     getProjectUuid: () => string | undefined;
     getPriorityItems: () => ContentMentionSuggestionItem[];
+    getHidePersonalDataApps: () => boolean;
     onMenuStateChange?: (state: ContentMentionMenuState) => void;
     includeFilesAndRepositories: boolean;
 }): MentionOptions['suggestion'] => ({
@@ -699,6 +742,7 @@ const generateContentMentionSuggestion = ({
                 projectUuid,
                 query,
                 priorityItems: getPriorityItems(),
+                hidePersonalDataApps: getHidePersonalDataApps(),
             });
         }
         // Fetch all three in parallel so files/repos don't wait on content.
@@ -707,6 +751,7 @@ const generateContentMentionSuggestion = ({
                 projectUuid,
                 query,
                 priorityItems: getPriorityItems(),
+                hidePersonalDataApps: getHidePersonalDataApps(),
             }),
             getProjectFileSuggestions(projectUuid, query),
             getRepositorySuggestions(projectUuid, query),
@@ -852,11 +897,13 @@ const generateContentMentionSuggestion = ({
 export const createContentMentionExtension = ({
     getProjectUuid,
     getPriorityItems,
+    getHidePersonalDataApps = () => false,
     onMenuStateChange,
     includeFilesAndRepositories = true,
 }: {
     getProjectUuid: () => string | undefined;
     getPriorityItems: () => ContentMentionSuggestionItem[];
+    getHidePersonalDataApps?: () => boolean;
     onMenuStateChange?: (state: ContentMentionMenuState) => void;
     includeFilesAndRepositories?: boolean;
 }) =>
@@ -905,6 +952,7 @@ export const createContentMentionExtension = ({
         suggestion: generateContentMentionSuggestion({
             getProjectUuid,
             getPriorityItems,
+            getHidePersonalDataApps,
             onMenuStateChange,
             includeFilesAndRepositories,
         }),
@@ -1007,6 +1055,22 @@ export const extractContentMentionContext = (
                 displayName: attrs.label ?? null,
                 pinnedVersionUuid: null,
                 runtimeOverrides: null,
+            });
+            return;
+        }
+
+        if (attrs.contentType === ContentType.DATA_APP && attrs.uuid) {
+            context.push({
+                type: 'data_app',
+                appUuid: attrs.uuid,
+                appSlug: attrs.slug ?? null,
+            });
+            optimisticContext.push({
+                type: 'data_app',
+                appUuid: attrs.uuid,
+                appSlug: attrs.slug ?? null,
+                displayName: attrs.label ?? null,
+                pinnedVersion: null,
             });
             return;
         }

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentReferenceUtils.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentReferenceUtils.test.ts
@@ -2,6 +2,8 @@ import { ChartKind } from '@lightdash/common';
 import { describe, expect, it } from 'vitest';
 import {
     buildContentReferenceSegments,
+    getDataAppContextItemLabel,
+    getPromptContextItemHref,
     getPromptContextItemKey,
 } from './contentReferenceUtils';
 
@@ -206,6 +208,25 @@ describe('contentReferenceUtils', () => {
         expect(result.matchedKeys.size).toBe(0);
         expect(getPromptContextItemKey(item)).toBe(
             'data_app_element:app-1:3:[h1 "FORMULA 1" @src/App.jsx:14]',
+        );
+    });
+
+    it('resolves key, chip label with pinned version, and href for a data app', () => {
+        const item = {
+            type: 'data_app' as const,
+            appUuid: 'app-1',
+            appSlug: 'f1-standings',
+            displayName: 'F1 standings',
+            pinnedVersion: 3,
+        };
+
+        expect(getPromptContextItemKey(item)).toBe('data_app:app-1');
+        expect(getDataAppContextItemLabel(item)).toBe('F1 standings v3');
+        expect(
+            getDataAppContextItemLabel({ ...item, pinnedVersion: null }),
+        ).toBe('F1 standings');
+        expect(getPromptContextItemHref(item, 'project-1')).toBe(
+            '/projects/project-1/apps/app-1/view',
         );
     });
 });

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentReferenceUtils.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentReferenceUtils.test.ts
@@ -218,6 +218,7 @@ describe('contentReferenceUtils', () => {
             appSlug: 'f1-standings',
             displayName: 'F1 standings',
             pinnedVersion: 3,
+            isPersonal: false,
         };
 
         expect(getPromptContextItemKey(item)).toBe('data_app:app-1');

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentReferenceUtils.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentReferenceUtils.ts
@@ -1,5 +1,6 @@
 import {
     assertUnreachable,
+    dataAppContextKey,
     dataAppElementContextKey,
     type AiPromptContextItem,
 } from '@lightdash/common';
@@ -50,9 +51,21 @@ export const getPromptContextItemKey = (item: AiPromptContextItem) => {
             return `preview_environment:${item.previewProjectUuid}`;
         case 'data_app_element':
             return dataAppElementContextKey(item);
+        case 'data_app':
+            return dataAppContextKey(item.appUuid);
         default:
             return assertUnreachable(item, 'Unknown AiPromptContextItem type');
     }
+};
+
+// Chip label: the app's name plus the version it was pinned at.
+export const getDataAppContextItemLabel = (
+    item: Extract<AiPromptContextItem, { type: 'data_app' }>,
+): string => {
+    const name = item.displayName ?? item.appSlug ?? 'Data app';
+    return item.pinnedVersion === null
+        ? name
+        : `${name} v${item.pinnedVersion}`;
 };
 
 const getProposedChangeLabel = (
@@ -84,10 +97,15 @@ const getPromptContextItemLabel = (item: InlineReferenceItem) => {
             return item.title;
         case 'preview_environment':
             return item.projectName ?? 'Preview environment';
+        case 'data_app':
+            return item.displayName ?? item.appSlug ?? 'Data app';
         default:
             return assertUnreachable(item, 'Unknown AiPromptContextItem type');
     }
 };
+
+export const getDataAppHref = (projectUuid: string, appUuid: string) =>
+    `/projects/${projectUuid}/apps/${appUuid}/view`;
 
 export const getPromptContextItemHref = (
     item: AiPromptContextItem,
@@ -121,6 +139,8 @@ export const getPromptContextItemHref = (
         // An element reference points inside a running app, not at a route.
         case 'data_app_element':
             return null;
+        case 'data_app':
+            return getDataAppHref(projectUuid, item.appUuid);
         default:
             return assertUnreachable(item, 'Unknown AiPromptContextItem type');
     }

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentReferenceUtils.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentReferenceUtils.ts
@@ -2,8 +2,10 @@ import {
     assertUnreachable,
     dataAppContextKey,
     dataAppElementContextKey,
+    type AiPromptContextInput,
     type AiPromptContextItem,
 } from '@lightdash/common';
+import { dataAppHref } from '../../../../../features/apps/utils/appUrls';
 
 // Element references never render inline; they always show as pills.
 type InlineReferenceItem = Exclude<
@@ -27,7 +29,9 @@ export type ContentReferenceSegment =
           label: string;
       };
 
-export const getPromptContextItemKey = (item: AiPromptContextItem) => {
+export const getPromptContextItemKey = (
+    item: AiPromptContextItem | AiPromptContextInput[number],
+) => {
     switch (item.type) {
         case 'chart':
             return `chart:${item.chartUuid}`;
@@ -58,11 +62,17 @@ export const getPromptContextItemKey = (item: AiPromptContextItem) => {
     }
 };
 
-// Chip label: the app's name plus the version it was pinned at.
+export const getDataAppContextItemName = (
+    item: Pick<
+        Extract<AiPromptContextItem, { type: 'data_app' }>,
+        'displayName' | 'appSlug'
+    >,
+): string => item.displayName ?? item.appSlug ?? 'Data app';
+
 export const getDataAppContextItemLabel = (
     item: Extract<AiPromptContextItem, { type: 'data_app' }>,
 ): string => {
-    const name = item.displayName ?? item.appSlug ?? 'Data app';
+    const name = getDataAppContextItemName(item);
     return item.pinnedVersion === null
         ? name
         : `${name} v${item.pinnedVersion}`;
@@ -98,14 +108,11 @@ const getPromptContextItemLabel = (item: InlineReferenceItem) => {
         case 'preview_environment':
             return item.projectName ?? 'Preview environment';
         case 'data_app':
-            return item.displayName ?? item.appSlug ?? 'Data app';
+            return getDataAppContextItemName(item);
         default:
             return assertUnreachable(item, 'Unknown AiPromptContextItem type');
     }
 };
-
-export const getDataAppHref = (projectUuid: string, appUuid: string) =>
-    `/projects/${projectUuid}/apps/${appUuid}/view`;
 
 export const getPromptContextItemHref = (
     item: AiPromptContextItem,
@@ -140,7 +147,7 @@ export const getPromptContextItemHref = (
         case 'data_app_element':
             return null;
         case 'data_app':
-            return getDataAppHref(projectUuid, item.appUuid);
+            return dataAppHref(projectUuid, item.appUuid);
         default:
             return assertUnreachable(item, 'Unknown AiPromptContextItem type');
     }

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/useDataAppPreviewLink.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/useDataAppPreviewLink.ts
@@ -1,0 +1,43 @@
+import { type MouseEvent } from 'react';
+import { selectDataAppPreview, setPreview } from '../../store/aiArtifactSlice';
+import {
+    useAiAgentStoreDispatch,
+    useAiAgentStoreSelector,
+} from '../../store/hooks';
+
+export const isPlainLeftClick = (e: MouseEvent<HTMLAnchorElement>) =>
+    !e.defaultPrevented &&
+    e.button === 0 &&
+    !e.metaKey &&
+    !e.altKey &&
+    !e.ctrlKey &&
+    !e.shiftKey;
+
+export type DataAppPreviewScope = {
+    messageUuid: string;
+    threadUuid: string;
+    projectUuid: string;
+    agentUuid: string;
+};
+
+// Plain click opens the app in the in-thread preview panel; modified clicks
+// fall through to the anchor and open the full page in a new tab.
+export const useDataAppPreviewLink = (
+    appUuid: string | null,
+    scope: DataAppPreviewScope | null,
+) => {
+    const dispatch = useAiAgentStoreDispatch();
+    const currentPreview = useAiAgentStoreSelector(selectDataAppPreview);
+    const isActive =
+        appUuid !== null &&
+        currentPreview !== null &&
+        currentPreview.appUuid === appUuid;
+
+    const onClick = (e: MouseEvent<HTMLAnchorElement>) => {
+        if (!appUuid || !scope || !isPlainLeftClick(e)) return;
+        e.preventDefault();
+        dispatch(setPreview({ type: 'dataApp', appUuid, ...scope }));
+    };
+
+    return { isActive, onClick };
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/AiAgentsLauncher.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/AiAgentsLauncher.tsx
@@ -69,6 +69,9 @@ const AiAgentsLauncherInner: FC = () => {
     const currentDashboard = useAiAgentStoreSelector(
         (state) => state.aiAgentLauncher.currentDashboard,
     );
+    const currentDataApp = useAiAgentStoreSelector(
+        (state) => state.aiAgentLauncher.currentDataApp,
+    );
     const { dock } = useLauncherDock(activeProjectUuid);
 
     const prevProjectUuidRef = useRef(activeProjectUuid);
@@ -165,13 +168,15 @@ const AiAgentsLauncherInner: FC = () => {
     }
     const transitionDataAppPreview =
         activeDataAppPreview ?? lastDataAppPreviewRef.current;
-    const isDashboardPage = currentDashboard?.projectUuid === activeProjectUuid;
+    const isContentPage =
+        currentDashboard?.projectUuid === activeProjectUuid ||
+        currentDataApp?.projectUuid === activeProjectUuid;
 
     if (!isAllowed || !activeProjectUuid) return null;
     if (
         !isPanelOpenSafe &&
         dock.length === 0 &&
-        (!selectedAgent || !isDashboardPage)
+        (!selectedAgent || !isContentPage)
     ) {
         return null;
     }

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherDock.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherDock.tsx
@@ -44,6 +44,9 @@ export const LauncherDock: FC<Props> = ({
     const currentDashboard = useAiAgentStoreSelector(
         (state) => state.aiAgentLauncher.currentDashboard,
     );
+    const currentDataApp = useAiAgentStoreSelector(
+        (state) => state.aiAgentLauncher.currentDataApp,
+    );
 
     const agentsByUuid = useMemo(
         () => new Map(agents.map((a) => [a.uuid, a])),
@@ -86,10 +89,10 @@ export const LauncherDock: FC<Props> = ({
         if (!agentUuid) return;
         const pendingContext =
             currentDashboard?.projectUuid === projectUuid
-                ? {
-                      dashboardUuid: currentDashboard.uuid,
-                  }
-                : null;
+                ? { dashboardUuid: currentDashboard.uuid }
+                : currentDataApp?.projectUuid === projectUuid
+                  ? { dataAppUuid: currentDataApp.uuid }
+                  : null;
         dispatch(
             openPanel({
                 threadId: null,

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
@@ -140,6 +140,7 @@ const NewThreadPanel: FC<{
 
     const chartUuid = pendingContext?.chartUuid;
     const dashboardUuid = pendingContext?.dashboardUuid;
+    const dataAppUuid = pendingContext?.dataAppUuid;
 
     const { addItem: addDockItem } = useLauncherDock(projectUuid);
     const isAuto = isLauncherAutoAgent(agent);
@@ -155,6 +156,7 @@ const NewThreadPanel: FC<{
         projectUuid,
         chartUuidOrSlug: chartUuid,
         dashboardUuidOrSlug: dashboardUuid,
+        dataAppUuidOrSlug: dataAppUuid,
     });
     const { curateContext } = useDashboardPageContextCuration({
         previousContext: contextInput,

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
@@ -379,6 +379,7 @@ const NewThreadPanel: FC<{
                                     key={getPromptContextItemKey(item)}
                                     item={item}
                                     projectUuid={projectUuid}
+                                    previewScope={null}
                                 />
                             ))}
                         </Group>

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/PanelHeader.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/PanelHeader.tsx
@@ -23,10 +23,6 @@ import {
     useAiAgentStoreDispatch,
     useAiAgentStoreSelector,
 } from '../../store/hooks';
-import {
-    AI_ROUTING_AUTO_VALUE,
-    AI_ROUTING_SEARCH_PARAM,
-} from '../AgentSelector/AgentSelectorUtils';
 import styles from './AiAgentsLauncher.module.css';
 import {
     getConcreteLauncherAgent,
@@ -34,6 +30,7 @@ import {
     LAUNCHER_AUTO_AGENT,
 } from './launcherAgentSelection';
 import { launcherSession } from './launcherSession';
+import { buildNewThreadUrl } from './newThreadUrl';
 
 type Props = {
     projectUuid: string;
@@ -88,25 +85,7 @@ export const PanelHeader: FC<Props> = ({
             if (isAuto) return;
             target = `/projects/${projectUuid}/ai-agents/${agent.uuid}/threads/${threadId}`;
         } else {
-            const params = new URLSearchParams();
-            if (pendingContext?.chartUuid) {
-                params.set('chartUuid', pendingContext.chartUuid);
-            }
-            if (pendingContext?.dashboardUuid) {
-                params.set('dashboardUuid', pendingContext.dashboardUuid);
-            }
-            if (pendingContext?.dataAppUuid) {
-                params.set('dataAppUuid', pendingContext.dataAppUuid);
-            }
-            if (isAuto) {
-                params.set(AI_ROUTING_SEARCH_PARAM, AI_ROUTING_AUTO_VALUE);
-            }
-            const search = params.toString();
-            target = isAuto
-                ? `/projects/${projectUuid}/ai-agents${search ? `?${search}` : ''}`
-                : `/projects/${projectUuid}/ai-agents/${agent.uuid}/threads${
-                      search ? `?${search}` : ''
-                  }`;
+            target = buildNewThreadUrl({ projectUuid, agent, pendingContext });
         }
         dispatch(closePanel());
         void navigate(target);

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/PanelHeader.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/PanelHeader.tsx
@@ -95,6 +95,9 @@ export const PanelHeader: FC<Props> = ({
             if (pendingContext?.dashboardUuid) {
                 params.set('dashboardUuid', pendingContext.dashboardUuid);
             }
+            if (pendingContext?.dataAppUuid) {
+                params.set('dataAppUuid', pendingContext.dataAppUuid);
+            }
             if (isAuto) {
                 params.set(AI_ROUTING_SEARCH_PARAM, AI_ROUTING_AUTO_VALUE);
             }

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/newThreadUrl.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/newThreadUrl.test.ts
@@ -1,0 +1,50 @@
+import { type AiAgentSummary } from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import { LAUNCHER_AUTO_AGENT } from './launcherAgentSelection';
+import { buildNewThreadUrl } from './newThreadUrl';
+
+const agent = { uuid: 'agent-1' } as AiAgentSummary;
+
+describe('buildNewThreadUrl', () => {
+    it('targets the agent thread route with the data app query param', () => {
+        expect(
+            buildNewThreadUrl({
+                projectUuid: 'p1',
+                agent,
+                pendingContext: { dataAppUuid: 'app-1' },
+            }),
+        ).toBe('/projects/p1/ai-agents/agent-1/threads?dataAppUuid=app-1');
+    });
+
+    it('carries chart and dashboard params', () => {
+        expect(
+            buildNewThreadUrl({
+                projectUuid: 'p1',
+                agent,
+                pendingContext: { chartUuid: 'c1', dashboardUuid: 'd1' },
+            }),
+        ).toBe(
+            '/projects/p1/ai-agents/agent-1/threads?chartUuid=c1&dashboardUuid=d1',
+        );
+    });
+
+    it('omits the query string without context', () => {
+        expect(
+            buildNewThreadUrl({
+                projectUuid: 'p1',
+                agent,
+                pendingContext: null,
+            }),
+        ).toBe('/projects/p1/ai-agents/agent-1/threads');
+    });
+
+    it('targets the auto-routing page for the auto agent', () => {
+        expect(
+            buildNewThreadUrl({
+                projectUuid: 'p1',
+                agent: LAUNCHER_AUTO_AGENT,
+                pendingContext: { dataAppUuid: 'app-1' },
+            }),
+        ).toBe('/projects/p1/ai-agents?dataAppUuid=app-1&routing=auto');
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/newThreadUrl.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/newThreadUrl.ts
@@ -1,0 +1,43 @@
+import { type AiAgentSummary } from '@lightdash/common';
+import { type LauncherPendingContext } from '../../store/aiAgentLauncherSlice';
+import {
+    AI_ROUTING_AUTO_VALUE,
+    AI_ROUTING_SEARCH_PARAM,
+} from '../AgentSelector/AgentSelectorUtils';
+import {
+    isLauncherAutoAgent,
+    type LAUNCHER_AUTO_AGENT,
+} from './launcherAgentSelection';
+
+type Args = {
+    projectUuid: string;
+    agent: AiAgentSummary | typeof LAUNCHER_AUTO_AGENT;
+    pendingContext: LauncherPendingContext | null;
+};
+
+/** Full-page new-thread URL carrying the pending context as query params. */
+export const buildNewThreadUrl = ({
+    projectUuid,
+    agent,
+    pendingContext,
+}: Args) => {
+    const params = new URLSearchParams();
+    if (pendingContext?.chartUuid) {
+        params.set('chartUuid', pendingContext.chartUuid);
+    }
+    if (pendingContext?.dashboardUuid) {
+        params.set('dashboardUuid', pendingContext.dashboardUuid);
+    }
+    if (pendingContext?.dataAppUuid) {
+        params.set('dataAppUuid', pendingContext.dataAppUuid);
+    }
+    const isAuto = isLauncherAutoAgent(agent);
+    if (isAuto) {
+        params.set(AI_ROUTING_SEARCH_PARAM, AI_ROUTING_AUTO_VALUE);
+    }
+    const search = params.toString();
+    const base = isAuto
+        ? `/projects/${projectUuid}/ai-agents`
+        : `/projects/${projectUuid}/ai-agents/${agent.uuid}/threads`;
+    return search ? `${base}?${search}` : base;
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/useIsLauncherMounted.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/useIsLauncherMounted.ts
@@ -13,9 +13,13 @@ export const useIsLauncherMounted = (
     const currentDashboard = useAiAgentStoreSelector(
         (state) => state.aiAgentLauncher.currentDashboard,
     );
+    const currentDataApp = useAiAgentStoreSelector(
+        (state) => state.aiAgentLauncher.currentDataApp,
+    );
+    const isContentPage =
+        currentDashboard?.projectUuid === projectUuid ||
+        currentDataApp?.projectUuid === projectUuid;
     return (
-        isPanelOpen ||
-        dock.length > 0 ||
-        (currentDashboard?.projectUuid === projectUuid && isAiAgentEnabled)
+        isPanelOpen || dock.length > 0 || (isContentPage && isAiAgentEnabled)
     );
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/PinnedContextCard/PinnedContextCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/PinnedContextCard/PinnedContextCard.tsx
@@ -1,14 +1,10 @@
 import { assertUnreachable, type AiPromptContextItem } from '@lightdash/common';
-import { type FC, type MouseEvent } from 'react';
+import { type FC } from 'react';
 import { dataAppHref } from '../../../../../features/apps/utils/appUrls';
 import { elementRefChipLabel } from '../../../../../features/apps/utils/elementRefs';
-import { selectDataAppPreview, setPreview } from '../../store/aiArtifactSlice';
-import {
-    useAiAgentStoreDispatch,
-    useAiAgentStoreSelector,
-} from '../../store/hooks';
 import { ContentReferenceLink } from '../ChatElements/ContentReferenceLink';
 import { getDataAppContextItemLabel } from '../ChatElements/contentReferenceUtils';
+import { useDataAppPreviewLink } from '../ChatElements/useDataAppPreviewLink';
 import { PinnedReviewEntityCard } from './PinnedReviewEntityCard';
 
 // The sent thread message the chip belongs to; lets a data app chip open the
@@ -97,40 +93,15 @@ const getItemMeta = (
     }
 };
 
-const isPlainLeftClick = (e: MouseEvent<HTMLAnchorElement>) =>
-    !e.defaultPrevented &&
-    e.button === 0 &&
-    !e.metaKey &&
-    !e.altKey &&
-    !e.ctrlKey &&
-    !e.shiftKey;
-
 const PinnedDataAppCard: FC<{
     item: Extract<AiPromptContextItem, { type: 'data_app' }>;
     projectUuid: string;
     previewScope: PinnedContextPreviewScope | null;
 }> = ({ item, projectUuid, previewScope }) => {
-    const dispatch = useAiAgentStoreDispatch();
-    const currentPreview = useAiAgentStoreSelector(selectDataAppPreview);
-    const isActive =
-        currentPreview !== null && currentPreview.appUuid === item.appUuid;
-
-    // Plain click opens the in-thread preview; modified clicks fall through
-    // to the anchor and open the full page in a new tab.
-    const handleClick = (e: MouseEvent<HTMLAnchorElement>) => {
-        if (!previewScope || !isPlainLeftClick(e)) return;
-        e.preventDefault();
-        dispatch(
-            setPreview({
-                type: 'dataApp',
-                appUuid: item.appUuid,
-                messageUuid: previewScope.messageUuid,
-                threadUuid: previewScope.threadUuid,
-                projectUuid,
-                agentUuid: previewScope.agentUuid,
-            }),
-        );
-    };
+    const { isActive, onClick } = useDataAppPreviewLink(
+        item.appUuid,
+        previewScope ? { ...previewScope, projectUuid } : null,
+    );
 
     return (
         <ContentReferenceLink
@@ -138,7 +109,7 @@ const PinnedDataAppCard: FC<{
             rel="noreferrer"
             to={dataAppHref(projectUuid, item.appUuid)}
             target="_blank"
-            onClick={handleClick}
+            onClick={onClick}
             data-app-active={isActive || undefined}
             showArrow
         >

--- a/packages/frontend/src/ee/features/aiCopilot/components/PinnedContextCard/PinnedContextCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/PinnedContextCard/PinnedContextCard.tsx
@@ -1,5 +1,6 @@
 import { assertUnreachable, type AiPromptContextItem } from '@lightdash/common';
 import { type FC, type MouseEvent } from 'react';
+import { dataAppHref } from '../../../../../features/apps/utils/appUrls';
 import { elementRefChipLabel } from '../../../../../features/apps/utils/elementRefs';
 import { selectDataAppPreview, setPreview } from '../../store/aiArtifactSlice';
 import {
@@ -7,10 +8,7 @@ import {
     useAiAgentStoreSelector,
 } from '../../store/hooks';
 import { ContentReferenceLink } from '../ChatElements/ContentReferenceLink';
-import {
-    getDataAppContextItemLabel,
-    getDataAppHref,
-} from '../ChatElements/contentReferenceUtils';
+import { getDataAppContextItemLabel } from '../ChatElements/contentReferenceUtils';
 import { PinnedReviewEntityCard } from './PinnedReviewEntityCard';
 
 // The sent thread message the chip belongs to; lets a data app chip open the
@@ -138,7 +136,7 @@ const PinnedDataAppCard: FC<{
         <ContentReferenceLink
             kind="data_app"
             rel="noreferrer"
-            to={getDataAppHref(projectUuid, item.appUuid)}
+            to={dataAppHref(projectUuid, item.appUuid)}
             target="_blank"
             onClick={handleClick}
             data-app-active={isActive || undefined}

--- a/packages/frontend/src/ee/features/aiCopilot/components/PinnedContextCard/PinnedContextCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/PinnedContextCard/PinnedContextCard.tsx
@@ -1,12 +1,30 @@
 import { assertUnreachable, type AiPromptContextItem } from '@lightdash/common';
-import { type FC } from 'react';
+import { type FC, type MouseEvent } from 'react';
 import { elementRefChipLabel } from '../../../../../features/apps/utils/elementRefs';
+import { selectDataAppPreview, setPreview } from '../../store/aiArtifactSlice';
+import {
+    useAiAgentStoreDispatch,
+    useAiAgentStoreSelector,
+} from '../../store/hooks';
 import { ContentReferenceLink } from '../ChatElements/ContentReferenceLink';
+import {
+    getDataAppContextItemLabel,
+    getDataAppHref,
+} from '../ChatElements/contentReferenceUtils';
 import { PinnedReviewEntityCard } from './PinnedReviewEntityCard';
+
+// The thread message the chip belongs to; lets a data app chip open the
+// in-thread preview panel. Absent on pre-send surfaces (no message yet).
+export type PinnedContextPreviewScope = {
+    messageUuid: string;
+    threadUuid: string;
+    agentUuid: string;
+};
 
 type Props = {
     item: AiPromptContextItem;
     projectUuid: string;
+    previewScope?: PinnedContextPreviewScope;
 };
 
 type ItemMeta = {
@@ -81,7 +99,61 @@ const getItemMeta = (
     }
 };
 
-export const PinnedContextCard: FC<Props> = ({ item, projectUuid }) => {
+const isPlainLeftClick = (e: MouseEvent<HTMLAnchorElement>) =>
+    !e.defaultPrevented &&
+    e.button === 0 &&
+    !e.metaKey &&
+    !e.altKey &&
+    !e.ctrlKey &&
+    !e.shiftKey;
+
+const PinnedDataAppCard: FC<{
+    item: Extract<AiPromptContextItem, { type: 'data_app' }>;
+    projectUuid: string;
+    previewScope: PinnedContextPreviewScope | undefined;
+}> = ({ item, projectUuid, previewScope }) => {
+    const dispatch = useAiAgentStoreDispatch();
+    const currentPreview = useAiAgentStoreSelector(selectDataAppPreview);
+    const isActive =
+        currentPreview !== null && currentPreview.appUuid === item.appUuid;
+
+    // Plain click opens the in-thread preview; modified clicks fall through
+    // to the anchor and open the full page in a new tab.
+    const handleClick = (e: MouseEvent<HTMLAnchorElement>) => {
+        if (!previewScope || !isPlainLeftClick(e)) return;
+        e.preventDefault();
+        dispatch(
+            setPreview({
+                type: 'dataApp',
+                appUuid: item.appUuid,
+                messageUuid: previewScope.messageUuid,
+                threadUuid: previewScope.threadUuid,
+                projectUuid,
+                agentUuid: previewScope.agentUuid,
+            }),
+        );
+    };
+
+    return (
+        <ContentReferenceLink
+            kind="data_app"
+            rel="noreferrer"
+            to={getDataAppHref(projectUuid, item.appUuid)}
+            target="_blank"
+            onClick={handleClick}
+            data-app-active={isActive || undefined}
+            showArrow
+        >
+            {getDataAppContextItemLabel(item)}
+        </ContentReferenceLink>
+    );
+};
+
+export const PinnedContextCard: FC<Props> = ({
+    item,
+    projectUuid,
+    previewScope,
+}) => {
     switch (item.type) {
         case 'chart':
         case 'dashboard':
@@ -103,6 +175,14 @@ export const PinnedContextCard: FC<Props> = ({ item, projectUuid }) => {
                 </ContentReferenceLink>
             );
         }
+        case 'data_app':
+            return (
+                <PinnedDataAppCard
+                    item={item}
+                    projectUuid={projectUuid}
+                    previewScope={previewScope}
+                />
+            );
         case 'pull_request':
         case 'proposed_change':
         case 'review_finding':

--- a/packages/frontend/src/ee/features/aiCopilot/components/PinnedContextCard/PinnedContextCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/PinnedContextCard/PinnedContextCard.tsx
@@ -13,8 +13,8 @@ import {
 } from '../ChatElements/contentReferenceUtils';
 import { PinnedReviewEntityCard } from './PinnedReviewEntityCard';
 
-// The thread message the chip belongs to; lets a data app chip open the
-// in-thread preview panel. Absent on pre-send surfaces (no message yet).
+// The sent thread message the chip belongs to; lets a data app chip open the
+// in-thread preview panel. Null on pre-send surfaces (no message yet).
 export type PinnedContextPreviewScope = {
     messageUuid: string;
     threadUuid: string;
@@ -24,7 +24,7 @@ export type PinnedContextPreviewScope = {
 type Props = {
     item: AiPromptContextItem;
     projectUuid: string;
-    previewScope?: PinnedContextPreviewScope;
+    previewScope: PinnedContextPreviewScope | null;
 };
 
 type ItemMeta = {
@@ -110,7 +110,7 @@ const isPlainLeftClick = (e: MouseEvent<HTMLAnchorElement>) =>
 const PinnedDataAppCard: FC<{
     item: Extract<AiPromptContextItem, { type: 'data_app' }>;
     projectUuid: string;
-    previewScope: PinnedContextPreviewScope | undefined;
+    previewScope: PinnedContextPreviewScope | null;
 }> = ({ item, projectUuid, previewScope }) => {
     const dispatch = useAiAgentStoreDispatch();
     const currentPreview = useAiAgentStoreSelector(selectDataAppPreview);

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/usePinnedContext.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/usePinnedContext.test.tsx
@@ -27,6 +27,7 @@ const app = {
     name: 'Sales explorer',
     slug: 'sales-explorer',
     latestReadyVersion: 3,
+    spaceUuid: 'space-1',
 };
 
 const dashboard = {
@@ -74,6 +75,7 @@ describe('usePinnedContext', () => {
                     appSlug: 'sales-explorer',
                     displayName: 'Sales explorer',
                     pinnedVersion: 3,
+                    isPersonal: false,
                 },
             ]);
             expect(result.current.contentMentionItems).toEqual([
@@ -82,6 +84,7 @@ describe('usePinnedContext', () => {
                     uuid: 'app-1',
                     slug: 'sales-explorer',
                     label: 'Sales explorer',
+                    isPersonalDataApp: false,
                     group: 'current',
                 }),
             ]);

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/usePinnedContext.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/usePinnedContext.test.tsx
@@ -1,0 +1,123 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { usePinnedContext } from './usePinnedContext';
+
+const { useGetAppMock, useSavedQueryMock, useDashboardQueryMock } = vi.hoisted(
+    () => ({
+        useGetAppMock: vi.fn(),
+        useSavedQueryMock: vi.fn(),
+        useDashboardQueryMock: vi.fn(),
+    }),
+);
+
+vi.mock('../../../../features/apps/hooks/useGetApp', () => ({
+    useGetApp: useGetAppMock,
+}));
+vi.mock('../../../../hooks/useSavedQuery', () => ({
+    useSavedQuery: useSavedQueryMock,
+}));
+vi.mock('../../../../hooks/dashboard/useDashboard', () => ({
+    useDashboardQuery: useDashboardQueryMock,
+}));
+
+const projectUuid = 'project-1';
+
+const app = {
+    appUuid: 'app-1',
+    name: 'Sales explorer',
+    slug: 'sales-explorer',
+    latestReadyVersion: 3,
+};
+
+const dashboard = {
+    uuid: 'dashboard-1',
+    slug: 'orders',
+    name: 'Orders',
+    spaceName: 'Space',
+    tiles: [],
+};
+
+describe('usePinnedContext', () => {
+    beforeEach(() => {
+        useGetAppMock.mockReset();
+        useSavedQueryMock.mockReset().mockReturnValue({ data: undefined });
+        useDashboardQueryMock.mockReset().mockReturnValue({ data: undefined });
+        useGetAppMock.mockReturnValue({ data: { pages: [app] } });
+    });
+
+    it.each([
+        ['uuid', 'app-1'],
+        ['slug', 'sales-explorer'],
+    ])(
+        'resolves a data app %s into context input and preview chip',
+        (_label, dataAppUuidOrSlug) => {
+            const { result } = renderHook(() =>
+                usePinnedContext({ projectUuid, dataAppUuidOrSlug }),
+            );
+
+            expect(useGetAppMock).toHaveBeenCalledWith(
+                projectUuid,
+                dataAppUuidOrSlug,
+            );
+            expect(result.current.isReady).toBe(true);
+            expect(result.current.contextInput).toEqual([
+                {
+                    type: 'data_app',
+                    appUuid: 'app-1',
+                    appSlug: 'sales-explorer',
+                },
+            ]);
+            expect(result.current.previewItems).toEqual([
+                {
+                    type: 'data_app',
+                    appUuid: 'app-1',
+                    appSlug: 'sales-explorer',
+                    displayName: 'Sales explorer',
+                    pinnedVersion: 3,
+                },
+            ]);
+            expect(result.current.contentMentionItems).toEqual([
+                expect.objectContaining({
+                    contentType: 'data_app',
+                    uuid: 'app-1',
+                    slug: 'sales-explorer',
+                    label: 'Sales explorer',
+                    group: 'current',
+                }),
+            ]);
+        },
+    );
+
+    it('is not ready until the data app resolves', () => {
+        useGetAppMock.mockReturnValue({ data: undefined });
+
+        const { result } = renderHook(() =>
+            usePinnedContext({ projectUuid, dataAppUuidOrSlug: 'app-1' }),
+        );
+
+        expect(result.current.isReady).toBe(false);
+        expect(result.current.contextInput).toEqual([]);
+        expect(result.current.previewItems).toEqual([]);
+    });
+
+    it('sorts a pinned dashboard before the data app', () => {
+        useDashboardQueryMock.mockReturnValue({ data: dashboard });
+
+        const { result } = renderHook(() =>
+            usePinnedContext({
+                projectUuid,
+                dataAppUuidOrSlug: 'app-1',
+                dashboardUuidOrSlug: 'dashboard-1',
+            }),
+        );
+
+        expect(result.current.contextInput.map((item) => item.type)).toEqual([
+            'dashboard',
+            'data_app',
+        ]);
+        expect(result.current.previewItems.map((item) => item.type)).toEqual([
+            'dashboard',
+            'data_app',
+        ]);
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/usePinnedContext.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/usePinnedContext.ts
@@ -137,6 +137,7 @@ export const usePinnedContext = ({
                 appSlug: dataApp.slug,
                 displayName: getAppDisplayName(dataApp.name, dataApp.appUuid),
                 pinnedVersion: dataApp.latestReadyVersion,
+                isPersonal: dataApp.spaceUuid === null,
             });
         }
         return sortPinnedContext(items);
@@ -152,6 +153,7 @@ export const usePinnedContext = ({
         dataApp?.slug,
         dataApp?.name,
         dataApp?.latestReadyVersion,
+        dataApp?.spaceUuid,
     ]);
 
     const contentMentionItems = useMemo<ContentMentionSuggestionItem[]>(() => {
@@ -169,6 +171,7 @@ export const usePinnedContext = ({
                     uuid: tile.properties.savedChartUuid!,
                     slug: tile.properties.chartSlug ?? null,
                     chartKind: tile.properties.lastVersionChartKind ?? null,
+                    isPersonalDataApp: false,
                     group: 'dashboardTile',
                     dashboardUuid: dashboard.uuid,
                     dashboardSlug: dashboard.slug,

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/usePinnedContext.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/usePinnedContext.ts
@@ -1,11 +1,13 @@
 import {
     ContentType,
+    getAppDisplayName,
     getChartKind,
     isDashboardChartTileType,
     type AiPromptContextInput,
     type AiPromptContextItem,
 } from '@lightdash/common';
 import { useMemo } from 'react';
+import { useGetApp } from '../../../../features/apps/hooks/useGetApp';
 import { useDashboardQuery } from '../../../../hooks/dashboard/useDashboard';
 import { useSavedQuery } from '../../../../hooks/useSavedQuery';
 import {
@@ -17,6 +19,7 @@ type Args = {
     projectUuid: string | undefined;
     chartUuidOrSlug?: string | null;
     dashboardUuidOrSlug?: string | null;
+    dataAppUuidOrSlug?: string | null;
 };
 
 const sortPinnedContext = <
@@ -30,8 +33,8 @@ const sortPinnedContext = <
     });
 
 /**
- * Resolves a chart and/or dashboard into the two shapes the AI agent
- * thread-creation flow needs:
+ * Resolves a chart, dashboard and/or data app into the two shapes the AI
+ * agent thread-creation flow needs:
  *  - `contextInput`: the minimal payload sent to the API.
  *  - `previewItems`: the optimistic, hydrated items rendered in the UI
  *    while the chart/dashboard queries are still resolving.
@@ -40,6 +43,7 @@ export const usePinnedContext = ({
     projectUuid,
     chartUuidOrSlug,
     dashboardUuidOrSlug,
+    dataAppUuidOrSlug,
 }: Args) => {
     const { data: chart } = useSavedQuery({
         uuidOrSlug: chartUuidOrSlug ?? undefined,
@@ -49,9 +53,15 @@ export const usePinnedContext = ({
         uuidOrSlug: dashboardUuidOrSlug ?? undefined,
         projectUuid,
     });
+    const { data: appData } = useGetApp(
+        projectUuid,
+        dataAppUuidOrSlug ?? undefined,
+    );
+    const dataApp = appData?.pages[0];
     const isReady =
         (!chartUuidOrSlug || !!chart?.uuid) &&
-        (!dashboardUuidOrSlug || !!dashboard?.uuid);
+        (!dashboardUuidOrSlug || !!dashboard?.uuid) &&
+        (!dataAppUuidOrSlug || !!dataApp?.appUuid);
 
     const contextInput: AiPromptContextInput = useMemo(() => {
         const items: AiPromptContextInput = [];
@@ -69,8 +79,22 @@ export const usePinnedContext = ({
                 dashboardSlug: dashboard?.slug ?? null,
             });
         }
+        if (dataApp?.appUuid) {
+            items.push({
+                type: 'data_app',
+                appUuid: dataApp.appUuid,
+                appSlug: dataApp.slug,
+            });
+        }
         return sortPinnedContext(items);
-    }, [chart?.uuid, dashboard?.uuid, chart?.slug, dashboard?.slug]);
+    }, [
+        chart?.uuid,
+        dashboard?.uuid,
+        chart?.slug,
+        dashboard?.slug,
+        dataApp?.appUuid,
+        dataApp?.slug,
+    ]);
 
     const chartKind = useMemo(
         () =>
@@ -106,6 +130,15 @@ export const usePinnedContext = ({
                 runtimeOverrides: null,
             });
         }
+        if (dataApp?.appUuid) {
+            items.push({
+                type: 'data_app',
+                appUuid: dataApp.appUuid,
+                appSlug: dataApp.slug,
+                displayName: getAppDisplayName(dataApp.name, dataApp.appUuid),
+                pinnedVersion: dataApp.latestReadyVersion,
+            });
+        }
         return sortPinnedContext(items);
     }, [
         chart?.uuid,
@@ -115,6 +148,10 @@ export const usePinnedContext = ({
         dashboard?.uuid,
         dashboard?.name,
         dashboard?.slug,
+        dataApp?.appUuid,
+        dataApp?.slug,
+        dataApp?.name,
+        dataApp?.latestReadyVersion,
     ]);
 
     const contentMentionItems = useMemo<ContentMentionSuggestionItem[]>(() => {

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
@@ -791,6 +791,7 @@ const toOptimisticContextItem = (
                 appSlug: item.appSlug ?? null,
                 displayName: null,
                 pinnedVersion: null,
+                isPersonal: false,
             };
         // System-only pins are seeded by the remediation flow, never optimistically
         // attached from the UI, so they have no client-resolvable shape.

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
@@ -784,6 +784,14 @@ const toOptimisticContextItem = (
                 appSlug: null,
                 displayName: null,
             };
+        case 'data_app':
+            return {
+                type: 'data_app',
+                appUuid: item.appUuid,
+                appSlug: item.appSlug ?? null,
+                displayName: null,
+                pinnedVersion: null,
+            };
         // System-only pins are seeded by the remediation flow, never optimistically
         // attached from the UI, so they have no client-resolvable shape.
         case 'proposed_change':

--- a/packages/frontend/src/ee/features/aiCopilot/store/aiAgentLauncherSlice.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/store/aiAgentLauncherSlice.ts
@@ -13,6 +13,7 @@ export type LauncherDockItem = {
 export type LauncherPendingContext = {
     chartUuid?: string;
     dashboardUuid?: string;
+    dataAppUuid?: string;
 };
 
 export type LauncherCurrentDashboard = {

--- a/packages/frontend/src/ee/features/aiCopilot/store/aiAgentLauncherSlice.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/store/aiAgentLauncherSlice.ts
@@ -24,6 +24,12 @@ export type LauncherCurrentDashboard = {
     runtimeOverrides: AiDashboardRuntimeOverrides | null;
 };
 
+// The data app page the user is on; no runtime overrides are captured.
+export type LauncherCurrentDataApp = {
+    projectUuid: string;
+    uuid: string;
+};
+
 export type DashboardRefreshRequest = {
     dashboardUuid: string;
     focusChartSlug: string | null;
@@ -38,6 +44,7 @@ export interface AiAgentLauncherState {
     activeAgentUuid: LauncherActiveAgentUuid | null;
     pendingContext: LauncherPendingContext | null;
     currentDashboard: LauncherCurrentDashboard | null;
+    currentDataApp: LauncherCurrentDataApp | null;
     dashboardRefreshRequest: DashboardRefreshRequest | null;
 }
 
@@ -47,6 +54,7 @@ const initialState: AiAgentLauncherState = {
     activeAgentUuid: null,
     pendingContext: null,
     currentDashboard: null,
+    currentDataApp: null,
     dashboardRefreshRequest: null,
 };
 
@@ -112,6 +120,12 @@ export const aiAgentLauncherSlice = createSlice({
         ) => {
             state.currentDashboard = action.payload;
         },
+        setCurrentDataApp: (
+            state,
+            action: PayloadAction<LauncherCurrentDataApp | null>,
+        ) => {
+            state.currentDataApp = action.payload;
+        },
         requestDashboardRefresh: (
             state,
             action: PayloadAction<{
@@ -136,5 +150,6 @@ export const {
     resetActivePanel,
     dockItemRemoved,
     setCurrentDashboard,
+    setCurrentDataApp,
     requestDashboardRefresh,
 } = aiAgentLauncherSlice.actions;

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/DataAppPickerModal.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/DataAppPickerModal.tsx
@@ -20,9 +20,9 @@ import { useMemo, useRef, useState, type FC } from 'react';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import MantineModal from '../../../../components/common/MantineModal';
 import { ResourceIcon } from '../../../../components/common/ResourceIcon';
+import { dataAppHref } from '../../../../features/apps/utils/appUrls';
 import { useInfiniteContent } from '../../../../hooks/useContent';
 import classes from './blockStyles.module.css';
-import { dataAppHref } from './resourceUrls';
 
 const PAGE_SIZE = 50;
 

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.tsx
@@ -35,13 +35,13 @@ import {
 } from 'react';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import { useAppThumbnailUrl } from '../../../../features/apps/hooks/useAppThumbnail';
+import { dataAppHref } from '../../../../features/apps/utils/appUrls';
 import { BlockHeader, IconSquare, MiniPill } from './BlockShell';
 import classes from './blockStyles.module.css';
 import { ContentLayoutControl } from './ContentLayoutControl';
 import { DataAppPickerModal } from './DataAppPickerModal';
 import { PageGrid, PageGridItem } from './PageGrid';
 import {
-    dataAppHref,
     faviconUrl,
     hostnameOf,
     looksLikeUrl,

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/resourceUrls.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/resourceUrls.ts
@@ -1,9 +1,6 @@
 import { type HomepageResourceItem } from '@lightdash/common';
 import { fetchHomepageLinkMetadata } from '../hooks/useHomepageLinkMetadata';
 
-export const dataAppHref = (projectUuid: string, appUuid: string): string =>
-    `/projects/${projectUuid}/apps/${appUuid}/view`;
-
 export const hostnameOf = (url: string): string => {
     try {
         return new URL(url).hostname.replace(/^www\./, '');

--- a/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
@@ -134,11 +134,13 @@ const AgentPage = () => {
             } else {
                 const chartUuid = searchParams.get('chartUuid');
                 const dashboardUuid = searchParams.get('dashboardUuid');
+                const dataAppUuid = searchParams.get('dataAppUuid');
                 const pendingContext =
-                    chartUuid || dashboardUuid
+                    chartUuid || dashboardUuid || dataAppUuid
                         ? {
                               chartUuid: chartUuid ?? undefined,
                               dashboardUuid: dashboardUuid ?? undefined,
+                              dataAppUuid: dataAppUuid ?? undefined,
                           }
                         : null;
                 aiAgentStore.dispatch(

--- a/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
@@ -258,6 +258,7 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
         dashboardUuidOrSlug: pinnedDashboardUuid,
     });
     const dashboardUuid = searchParams.get('dashboardUuid');
+    const dataAppUuid = searchParams.get('dataAppUuid');
     const {
         contextInput: pageContextInput,
         previewItems: pagePreviewItems,
@@ -265,6 +266,7 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
     } = usePinnedContext({
         projectUuid,
         dashboardUuidOrSlug: dashboardUuid,
+        dataAppUuidOrSlug: dataAppUuid,
     });
 
     const contentMentionItems = useMemo(

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
@@ -85,6 +85,7 @@ const AgentsRouterPage = () => {
     const canStartDeepResearch = useDeepResearchAccess(projectUuid);
     const chartUuid = searchParams.get('chartUuid');
     const dashboardUuid = searchParams.get('dashboardUuid');
+    const dataAppUuid = searchParams.get('dataAppUuid');
 
     const {
         contextInput,
@@ -95,6 +96,7 @@ const AgentsRouterPage = () => {
         projectUuid,
         chartUuidOrSlug: chartUuid,
         dashboardUuidOrSlug: dashboardUuid,
+        dataAppUuidOrSlug: dataAppUuid,
     });
 
     const {

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
@@ -410,6 +410,7 @@ const AgentsRouterPage = () => {
                                             key={getPromptContextItemKey(item)}
                                             item={item}
                                             projectUuid={projectUuid!}
+                                            previewScope={null}
                                         />
                                     ))}
                                 </Group>

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
@@ -55,6 +55,7 @@ const AiAgentNewThreadPage: FC = () => {
     const [searchParams] = useSearchParams();
     const chartUuid = searchParams.get('chartUuid');
     const dashboardUuid = searchParams.get('dashboardUuid');
+    const dataAppUuid = searchParams.get('dataAppUuid');
 
     const {
         contextInput,
@@ -65,6 +66,7 @@ const AiAgentNewThreadPage: FC = () => {
         projectUuid,
         chartUuidOrSlug: chartUuid,
         dashboardUuidOrSlug: dashboardUuid,
+        dataAppUuidOrSlug: dataAppUuid,
     });
 
     const { agent, agents, navigateFromAgentChat } =

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
@@ -352,6 +352,7 @@ const AiAgentNewThreadPage: FC = () => {
                                         key={getPromptContextItemKey(item)}
                                         item={item}
                                         projectUuid={projectUuid}
+                                        previewScope={null}
                                     />
                                 ))}
                             </Group>

--- a/packages/frontend/src/features/apps/components/AppHeaderActions.test.tsx
+++ b/packages/frontend/src/features/apps/components/AppHeaderActions.test.tsx
@@ -111,6 +111,7 @@ const baseProps = {
     onEdit: null,
     shareUrl: null,
     navItem: null,
+    askAiItem: null,
     fullscreenToggle: null,
     captureThumbnail: null,
     capturePreviewScreenshot: null,

--- a/packages/frontend/src/features/apps/components/AppHeaderActions.tsx
+++ b/packages/frontend/src/features/apps/components/AppHeaderActions.tsx
@@ -88,6 +88,9 @@ type Props = {
      *  latest" in the builder). Rendered at the top of the menu; pass null
      *  to omit it. */
     navItem: ReactNode;
+    /** "Ask AI Agent" menu item, rendered right after `navItem`. Pass null
+     *  on surfaces that don't offer it. */
+    askAiItem: ReactNode;
     /** Fullscreen/presentation toggle, rendered between the refresh button
      *  and the overflow menu to match the dashboard header's ordering. Pass
      *  null on surfaces without it (the builder). */
@@ -140,6 +143,7 @@ const AppHeaderActions: FC<Props> = ({
     onEdit,
     shareUrl,
     navItem,
+    askAiItem,
     fullscreenToggle,
     captureThumbnail,
     capturePreviewScreenshot,
@@ -334,6 +338,7 @@ const AppHeaderActions: FC<Props> = ({
                 </Menu.Target>
                 <Menu.Dropdown>
                     {navItem}
+                    {askAiItem}
                     <Menu.Item
                         leftSection={
                             <MantineIcon icon={IconArrowsUpDown} size={14} />

--- a/packages/frontend/src/features/apps/components/DataAppAiAgentContextBridge.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppAiAgentContextBridge.tsx
@@ -1,0 +1,24 @@
+import { useEffect, type FC } from 'react';
+import { setCurrentDataApp } from '../../../ee/features/aiCopilot/store/aiAgentLauncherSlice';
+import { useAiAgentStoreDispatch } from '../../../ee/features/aiCopilot/store/hooks';
+
+type Props = {
+    projectUuid: string;
+    appUuid: string;
+};
+
+// Tells the AI launcher which data app page is open so new threads pin it.
+const DataAppAiAgentContextBridge: FC<Props> = ({ projectUuid, appUuid }) => {
+    const dispatch = useAiAgentStoreDispatch();
+
+    useEffect(() => {
+        dispatch(setCurrentDataApp({ projectUuid, uuid: appUuid }));
+        return () => {
+            dispatch(setCurrentDataApp(null));
+        };
+    }, [dispatch, projectUuid, appUuid]);
+
+    return null;
+};
+
+export default DataAppAiAgentContextBridge;

--- a/packages/frontend/src/features/apps/hooks/useGetApp.ts
+++ b/packages/frontend/src/features/apps/hooks/useGetApp.ts
@@ -8,7 +8,7 @@ const PAGE_SIZE = 5;
 
 const fetchAppVersions = async (
     projectUuid: string,
-    appUuid: string,
+    appUuidOrSlug: string,
     beforeVersion?: number,
 ): Promise<GetAppResult> => {
     const params = new URLSearchParams();
@@ -19,7 +19,7 @@ const fetchAppVersions = async (
     const qs = params.toString();
     const data = await lightdashApi<GetAppResult>({
         method: 'GET',
-        url: `/ee/projects/${projectUuid}/apps/${appUuid}?${qs}`,
+        url: `/ee/projects/${projectUuid}/apps/${appUuidOrSlug}?${qs}`,
         body: undefined,
     });
     return data;
@@ -27,14 +27,14 @@ const fetchAppVersions = async (
 
 export const useGetApp = (
     projectUuid: string | undefined,
-    appUuid: string | undefined,
+    appUuidOrSlug: string | undefined,
 ) => {
     const query = useInfiniteQuery<GetAppResult, ApiError>({
-        queryKey: ['app', projectUuid, appUuid],
+        queryKey: ['app', projectUuid, appUuidOrSlug],
         queryFn: ({ pageParam }) =>
             fetchAppVersions(
                 projectUuid!,
-                appUuid!,
+                appUuidOrSlug!,
                 pageParam as number | undefined,
             ),
         getNextPageParam: (lastPage) => {
@@ -42,7 +42,7 @@ export const useGetApp = (
                 return undefined;
             return lastPage.versions[lastPage.versions.length - 1].version;
         },
-        enabled: !!projectUuid && !!appUuid,
+        enabled: !!projectUuid && !!appUuidOrSlug,
     });
     return query;
 };

--- a/packages/frontend/src/features/apps/utils/appUrls.ts
+++ b/packages/frontend/src/features/apps/utils/appUrls.ts
@@ -1,0 +1,2 @@
+export const dataAppHref = (projectUuid: string, appUuid: string): string =>
+    `/projects/${projectUuid}/apps/${appUuid}/view`;

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -2963,6 +2963,7 @@ const AppGenerate: FC = () => {
                                                     </Menu.Item>
                                                 ) : null
                                             }
+                                            askAiItem={null}
                                         />
                                     }
                                 />

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -73,7 +73,6 @@ import {
 } from '../components/common/PromptComposer';
 import { getChartIcon } from '../components/common/ResourceIcon/utils';
 import SuboptimalState from '../components/common/SuboptimalState/SuboptimalState';
-import { AskAiAgentMenuItem } from '../ee/features/aiCopilot/components/AskAiAgentMenuItem/AskAiAgentMenuItem';
 import { type AppIframePreviewHandle } from '../features/apps/AppIframePreview';
 import AppInspectorPanel from '../features/apps/AppInspectorPanel';
 import {
@@ -2964,20 +2963,7 @@ const AppGenerate: FC = () => {
                                                     </Menu.Item>
                                                 ) : null
                                             }
-                                            askAiItem={
-                                                activeAppUuid ? (
-                                                    <AskAiAgentMenuItem
-                                                        projectUuid={
-                                                            projectUuid
-                                                        }
-                                                        dataAppUuid={
-                                                            activeAppUuid
-                                                        }
-                                                        clickedFrom="data_app_builder_menu"
-                                                        mode="navigate"
-                                                    />
-                                                ) : null
-                                            }
+                                            askAiItem={null}
                                         />
                                     }
                                 />

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -73,6 +73,7 @@ import {
 } from '../components/common/PromptComposer';
 import { getChartIcon } from '../components/common/ResourceIcon/utils';
 import SuboptimalState from '../components/common/SuboptimalState/SuboptimalState';
+import { AskAiAgentMenuItem } from '../ee/features/aiCopilot/components/AskAiAgentMenuItem/AskAiAgentMenuItem';
 import { type AppIframePreviewHandle } from '../features/apps/AppIframePreview';
 import AppInspectorPanel from '../features/apps/AppInspectorPanel';
 import {
@@ -2963,7 +2964,20 @@ const AppGenerate: FC = () => {
                                                     </Menu.Item>
                                                 ) : null
                                             }
-                                            askAiItem={null}
+                                            askAiItem={
+                                                activeAppUuid ? (
+                                                    <AskAiAgentMenuItem
+                                                        projectUuid={
+                                                            projectUuid
+                                                        }
+                                                        dataAppUuid={
+                                                            activeAppUuid
+                                                        }
+                                                        clickedFrom="data_app_builder_menu"
+                                                        mode="navigate"
+                                                    />
+                                                ) : null
+                                            }
                                         />
                                     }
                                 />

--- a/packages/frontend/src/pages/AppPreviewTest.tsx
+++ b/packages/frontend/src/pages/AppPreviewTest.tsx
@@ -6,6 +6,7 @@ import { Navigate, useNavigate, useParams } from 'react-router';
 import MantineIcon from '../components/common/MantineIcon';
 import SuboptimalState from '../components/common/SuboptimalState/SuboptimalState';
 import ForbiddenPanel from '../components/ForbiddenPanel';
+import { AskAiAgentMenuItem } from '../ee/features/aiCopilot/components/AskAiAgentMenuItem/AskAiAgentMenuItem';
 import AppIframePreview, {
     type AppIframePreviewHandle,
 } from '../features/apps/AppIframePreview';
@@ -330,6 +331,17 @@ export default function AppPreviewTest() {
                             }
                             shareUrl={window.location.href}
                             navItem={null}
+                            askAiItem={
+                                <AskAiAgentMenuItem
+                                    projectUuid={projectUuid}
+                                    dataAppUuid={appUuid}
+                                    clickedFrom={
+                                        explicitVersion === undefined
+                                            ? 'data_app_header'
+                                            : 'data_app_version_header'
+                                    }
+                                />
+                            }
                         />
                     }
                 />

--- a/packages/frontend/src/pages/AppPreviewTest.tsx
+++ b/packages/frontend/src/pages/AppPreviewTest.tsx
@@ -13,6 +13,7 @@ import AppIframePreview, {
 import AppInspectorPanel from '../features/apps/AppInspectorPanel';
 import AppHeader from '../features/apps/components/AppHeader';
 import AppHeaderActions from '../features/apps/components/AppHeaderActions';
+import DataAppAiAgentContextBridge from '../features/apps/components/DataAppAiAgentContextBridge';
 import { getVisiblePreviewTokenError } from '../features/apps/hooks/previewTokenQueryOptions';
 import { useAppBuildPoller } from '../features/apps/hooks/useAppBuildPoller';
 import { useAppInspector } from '../features/apps/hooks/useAppInspector';
@@ -251,6 +252,12 @@ export default function AppPreviewTest() {
                     : classes.previewContainer
             }
         >
+            {firstPage && (
+                <DataAppAiAgentContextBridge
+                    projectUuid={projectUuid}
+                    appUuid={firstPage.appUuid}
+                />
+            )}
             {!isFullscreen && (
                 <AppHeader
                     projectUuid={projectUuid}

--- a/packages/frontend/src/providers/Tracking/types.ts
+++ b/packages/frontend/src/providers/Tracking/types.ts
@@ -551,6 +551,7 @@ export type AiAgentAskClickedSource =
     | 'data_app_version_header'
     | 'data_app_resource_action_menu'
     | 'data_app_builder_menu'
+    | 'data_app_my_apps_menu'
     | 'dashboard_data_app_tile';
 
 type AiAgentAskClickedEvent = {

--- a/packages/frontend/src/providers/Tracking/types.ts
+++ b/packages/frontend/src/providers/Tracking/types.ts
@@ -546,7 +546,10 @@ export type AiAgentAskClickedSource =
     | 'dashboard_header'
     | 'dashboard_chart_tile'
     | 'saved_chart_header'
-    | 'resource_action_menu';
+    | 'resource_action_menu'
+    | 'data_app_header'
+    | 'data_app_version_header'
+    | 'data_app_resource_action_menu';
 
 type AiAgentAskClickedEvent = {
     name: EventName.AI_AGENT_ASK_CLICKED;

--- a/packages/frontend/src/providers/Tracking/types.ts
+++ b/packages/frontend/src/providers/Tracking/types.ts
@@ -551,7 +551,6 @@ export type AiAgentAskClickedSource =
     | 'data_app_version_header'
     | 'data_app_resource_action_menu'
     | 'data_app_builder_menu'
-    | 'data_app_my_apps_menu'
     | 'dashboard_data_app_tile';
 
 type AiAgentAskClickedEvent = {

--- a/packages/frontend/src/providers/Tracking/types.ts
+++ b/packages/frontend/src/providers/Tracking/types.ts
@@ -549,7 +549,9 @@ export type AiAgentAskClickedSource =
     | 'resource_action_menu'
     | 'data_app_header'
     | 'data_app_version_header'
-    | 'data_app_resource_action_menu';
+    | 'data_app_resource_action_menu'
+    | 'data_app_builder_menu'
+    | 'dashboard_data_app_tile';
 
 type AiAgentAskClickedEvent = {
     name: EventName.AI_AGENT_ASK_CLICKED;

--- a/packages/frontend/src/providers/Tracking/types.ts
+++ b/packages/frontend/src/providers/Tracking/types.ts
@@ -550,7 +550,6 @@ export type AiAgentAskClickedSource =
     | 'data_app_header'
     | 'data_app_version_header'
     | 'data_app_resource_action_menu'
-    | 'data_app_builder_menu'
     | 'data_app_my_apps_menu'
     | 'dashboard_data_app_tile';
 

--- a/packages/frontend/src/stories/AiAgentChatWorkbench.stories.tsx
+++ b/packages/frontend/src/stories/AiAgentChatWorkbench.stories.tsx
@@ -999,6 +999,7 @@ const ComponentInventory = () => (
                         key={`${item.type}-${JSON.stringify(item)}`}
                         item={item}
                         projectUuid={projectUuid}
+                        previewScope={null}
                     />
                 ))}
             </Group>
@@ -1119,6 +1120,7 @@ const PinnedContextScenario = () => (
                         key={`${item.type}-${JSON.stringify(item)}`}
                         item={item}
                         projectUuid={projectUuid}
+                        previewScope={null}
                     />
                 ))}
             </Group>


### PR DESCRIPTION
## Summary

Data apps become AI agent **pinned context**, exactly like charts and dashboards. Every surface that offers Ask AI for a chart or dashboard now offers it for a data app, `@` in the prompt finds data apps, and the pinned chip opens the app in the in-thread preview panel.

```diff
 AiPromptContextItemInput / AiPromptContextItem
   chart | dashboard | data_app_element | …
+  data_app { appUuid, appSlug }            # row snapshots display name + latest ready version

 Pinned-context message
   - Chart "…" (chartSlug: …)
+  - Data app "name" (dataAppSlug: slug)     # read via readContent, iterate via existing tool

 Ask AI surfaces
   <DashboardChartTile>       Ask AI
+  <DashboardDataAppTile>     Ask AI          # pins dashboard + app, dashboard first
   <ResourceActionMenu>       chart/dashboard rows
+                             data app rows   # spaces, home pinned content
+  <MyAppsPanel> row menu                     # → full-page new thread
+  <AppHeaderActions askAiItem>               # viewer + version view → docked launcher
+                                             # builder: none (coding-agent chat owns that screen)

 Launcher
   pendingContext { chartUuid, dashboardUuid }
+                 { …, dataAppUuid }          # survives expand ⇄ collapse, ?dataAppUuid on thread pages
+  <DataAppAiAgentContextBridge>              # app pages seed "Current page" like dashboards

 @ mentions
   content search: chart, dashboard
+  + data_app (personal apps included, project chart types dropped,
+              personal hidden for space-restricted agents)
```

- **Backend**: `data_app` context type; attach validation mirrors charts (`canViewApp`; another user's personal app → 403; project chart type → 400; duplicates collapse). No migration: version snapshot lives in the existing `runtime_overrides` jsonb, hydration re-resolves slug/name from the app.
- **Chip**: label `Name v3`; plain click → in-thread preview (works in docked launcher and full page), modified click → app page in a new tab. Click handling shared with data app links in agent replies (`useDataAppPreviewLink`).
- **Tracking**: new `AiAgentAskClickedSource` values `data_app_header`, `data_app_version_header`, `data_app_resource_action_menu`, `data_app_my_apps_menu`, `dashboard_data_app_tile`. The app builder deliberately has no Ask AI.
- **Glossary**: new `docs/ai-agent/CONTEXT.md` (pinned context, mention, launcher, preview panel); data-app **Context** cross-links to it.

Out of scope (per spec): runtime overrides for apps, versioned reads, source code exposure, list-content tool, MCP, Slack.

## Test plan

- [x] `pinnedContextMessage.test.ts`: data app line, mixed order
- [x] `promptContextAccess.test.ts`: accept / other user's personal app / project chart type / other project / dedupe
- [x] `compaction.test.ts`: data app item serialised
- [x] `contentMentions.test.ts`: extraction, search request, viz results dropped, dedupe, priority groups, space-restricted filter
- [x] `contentReferenceUtils.test.ts`, `usePinnedContext.test.tsx` (uuid, slug, tile ordering), `newThreadUrl.test.ts`
- [x] common/backend/frontend typecheck + lint; MCP tool snapshot unchanged
- [ ] Manual: Ask AI from viewer, version view, space row, My apps, home, dashboard tile; `@` a data app; chip preview; ask "what data does this app use" / "change the chart to a bar chart"

Closes: ZAP-988
Closes: ZAP-990
Closes: ZAP-991
Closes: ZAP-992

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TwHfhTktNpT2Wq6bGAVVJN
