### PR TITLE
feat(dashboard): edit a tile's chart in the dashboard modal

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartEditorModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartEditorModal.tsx
@@ -99,7 +99,7 @@ const DashboardChartEditorContent: FC<ContentProps> = ({
                 withFullHeight
                 withPaddedContent
             >
-                <MergeProvider>
+                <MergeProvider savedMerge={editChart?.merge ?? null}>
                     <Explorer />
                 </MergeProvider>
             </Page>

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -1550,6 +1550,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
                                                 <EditChartMenuItem
                                                     tile={props.tile}
                                                     chartSlug={chart.slug}
+                                                    chart={chart}
                                                     disabled={
                                                         isEditMode ||
                                                         !userCanManageChart

--- a/packages/frontend/src/components/DashboardTiles/EditChartMenuItem.tsx
+++ b/packages/frontend/src/components/DashboardTiles/EditChartMenuItem.tsx
@@ -1,9 +1,15 @@
-import { type DashboardChartTile } from '@lightdash/common';
+import {
+    canMutateVerifiedContent,
+    type DashboardChartTile,
+    type SavedChart,
+} from '@lightdash/common';
+import { Menu } from '@mantine/core';
 import { IconFilePencil } from '@tabler/icons-react';
 import { type FC } from 'react';
 import useDashboardStorage from '../../hooks/dashboard/useDashboardStorage';
 import { useProjectUrlIdentifier } from '../../hooks/useProjectRoute';
 import useApp from '../../providers/App/useApp';
+import { useDashboardChartEdit } from '../../providers/Dashboard/useDashboardChartEdit';
 import useDashboardContext from '../../providers/Dashboard/useDashboardContext';
 import LinkMenuItem, { type LinkMenuItemProps } from '../common/LinkMenuItem';
 import MantineIcon from '../common/MantineIcon';
@@ -11,9 +17,14 @@ import MantineIcon from '../common/MantineIcon';
 type Props = LinkMenuItemProps & {
     tile: DashboardChartTile;
     chartSlug?: string;
+    /**
+     * The loaded chart. Only supplied where the tile has one, which is what
+     * makes editing in place possible instead of navigating.
+     */
+    chart?: SavedChart;
 };
 
-const EditChartMenuItem: FC<Props> = ({ tile, chartSlug, ...props }) => {
+const EditChartMenuItem: FC<Props> = ({ tile, chartSlug, chart, ...props }) => {
     const { user } = useApp();
     const dashboardTiles = useDashboardContext((c) => c.dashboardTiles);
     const filtersFromContext = useDashboardContext((c) => c.dashboardFilters);
@@ -24,12 +35,40 @@ const EditChartMenuItem: FC<Props> = ({ tile, chartSlug, ...props }) => {
     const dashboardTabs = useDashboardContext((c) => c.dashboardTabs);
 
     const { storeDashboard } = useDashboardStorage();
+    const onEditChart = useDashboardChartEdit();
 
     const projectUrlIdentifier = useProjectUrlIdentifier();
 
     const userCanManageExplore = user.data?.ability?.can('manage', 'Explore');
 
+    // Otherwise the menu opens an editor that only fails on save.
+    const userCanMutateThisChart =
+        !chart ||
+        !user.data ||
+        canMutateVerifiedContent(
+            user.data.ability,
+            {
+                organizationUuid: chart.organizationUuid,
+                projectUuid: chart.projectUuid,
+            },
+            chart.verification,
+            user.data.userUuid,
+        );
+
     if (!tile.properties.savedChartUuid || !userCanManageExplore) return null;
+
+    // Edit over the dashboard when the host offers it and the chart is loaded.
+    if (onEditChart && chart && userCanMutateThisChart) {
+        return (
+            <Menu.Item
+                leftSection={<MantineIcon icon={IconFilePencil} />}
+                onClick={() => onEditChart(chart)}
+                disabled={props.disabled}
+            >
+                Edit chart
+            </Menu.Item>
+        );
+    }
 
     return (
         <LinkMenuItem

--- a/packages/frontend/src/components/Explorer/ExplorerHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorerHeader/index.tsx
@@ -16,9 +16,11 @@ import { useExplorerQuery } from '../../../hooks/useExplorerQuery';
 import { getExplorerUrlFromCreateSavedChartVersion } from '../../../hooks/useExplorerRoute';
 import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import useCreateInAnySpaceAccess from '../../../hooks/user/useCreateInAnySpaceAccess';
+import { useVerificationSavePrompt } from '../../../hooks/useVerificationSavePrompt';
 import { Can } from '../../../providers/Ability';
 import { useAbilityContext } from '../../../providers/Ability/useAbilityContext';
 import useApp from '../../../providers/App/useApp';
+import { useIsModalHosted } from '../../../providers/Explorer/useIsModalHosted';
 import MantineIcon from '../../common/MantineIcon';
 import ShareShortLinkButton from '../../common/ShareShortLinkButton';
 import { RefreshButton } from '../../RefreshButton';
@@ -68,6 +70,8 @@ const ExplorerHeader: FC = memo(() => {
     );
     const embed = useEmbed();
     const isEmbedded = embed.embedToken !== undefined;
+    const isModalHosted = useIsModalHosted();
+    const verificationSavePrompt = useVerificationSavePrompt(savedChart);
     const hasEmbedWriteActions =
         !!embed.writeActions?.spaceUuid &&
         (!!embed.writeActions.userUuid ||
@@ -185,9 +189,10 @@ const ExplorerHeader: FC = memo(() => {
 
                 <RefreshButton size="xs" />
 
-                {/* For saved charts the main app saves from SavedChartsHeader;
-                    embeds edit saved charts here, so keep the button ("Save changes") */}
-                {(!savedChart || isEmbedded) &&
+                {/* For saved charts the main app saves from SavedChartsHeader.
+                    Embeds and modal hosts have no such header, so they edit
+                    saved charts here and keep the button ("Save changes") */}
+                {(!savedChart || isEmbedded || isModalHosted) &&
                     (!isEmbedded || canCreateEmbedSavedChart) && (
                         <Tooltip
                             disabled={buttonDisabledMessage === null}
@@ -197,6 +202,9 @@ const ExplorerHeader: FC = memo(() => {
                             <div>
                                 <SaveChartButton
                                     disabled={buttonDisabledMessage !== null}
+                                    verificationSavePrompt={
+                                        verificationSavePrompt
+                                    }
                                 />
                             </div>
                         </Tooltip>

--- a/packages/frontend/src/components/Explorer/SaveChartButton/index.tsx
+++ b/packages/frontend/src/components/Explorer/SaveChartButton/index.tsx
@@ -133,6 +133,7 @@ const SaveChartButton: FC<{
                     onSuccess: (data) => {
                         if (!hasVersionChanges && !hasMergeChanges) {
                             embed.onChartSaved?.(data, 'updated');
+                            onModalHostChartSaved?.(data);
                         }
                     },
                 },
@@ -149,9 +150,12 @@ const SaveChartButton: FC<{
                     },
                 },
                 {
-                    // Lets the embed dashboard builder react to the update
+                    // Lets a dashboard builder react to the update
                     // (e.g. close its chart editor modal)
-                    onSuccess: (data) => embed.onChartSaved?.(data, 'updated'),
+                    onSuccess: (data) => {
+                        embed.onChartSaved?.(data, 'updated');
+                        onModalHostChartSaved?.(data);
+                    },
                 },
             );
         }

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -118,6 +118,7 @@ import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { useUpdateMutation } from '../../../hooks/useSavedQuery';
 import useSearchParams from '../../../hooks/useSearchParams';
 import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
+import { getVerificationSavePrompt } from '../../../hooks/useVerificationSavePrompt';
 import { Can } from '../../../providers/Ability';
 import useApp from '../../../providers/App/useApp';
 import {
@@ -145,9 +146,7 @@ import ShareShortLinkButton from '../../common/ShareShortLinkButton';
 import TransferItemsModal from '../../common/TransferItemsModal/TransferItemsModal';
 import ExploreFromHereButton from '../../ExploreFromHereButton';
 import AddTilesToDashboardModal from '../../SavedDashboards/AddTilesToDashboardModal';
-import SaveChartButton, {
-    type VerificationSavePrompt,
-} from '../SaveChartButton';
+import SaveChartButton from '../SaveChartButton';
 import ChartSlugRenameModal from './ChartSlugRenameModal';
 import { TitleBreadCrumbs } from './TitleBreadcrumbs';
 
@@ -499,16 +498,11 @@ const SavedChartsHeader: FC = () => {
         savedChart?.verification !== null &&
         savedChart?.verification !== undefined;
 
-    const isOwnVerification =
-        savedChart?.verification?.verifiedBy.userUuid === user.data?.userUuid;
-
-    let verificationSavePrompt: VerificationSavePrompt | undefined;
-    if (isChartVerified) {
-        verificationSavePrompt =
-            canManageContentVerification || isOwnVerification
-                ? 'confirm-keep'
-                : 'warn-removal';
-    }
+    const verificationSavePrompt = getVerificationSavePrompt({
+        verification: savedChart?.verification,
+        canManageContentVerification,
+        userUuid: user.data?.userUuid,
+    });
 
     const userCanPinChart = user.data?.ability.can(
         'manage',

--- a/packages/frontend/src/hooks/useVerificationSavePrompt.test.ts
+++ b/packages/frontend/src/hooks/useVerificationSavePrompt.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { getVerificationSavePrompt } from './useVerificationSavePrompt';
+
+const VERIFIER = 'verifier-uuid';
+const verification = {
+    verifiedBy: { userUuid: VERIFIER },
+} as Parameters<typeof getVerificationSavePrompt>[0]['verification'];
+
+describe('getVerificationSavePrompt', () => {
+    it('is undefined for an unverified chart', () => {
+        expect(
+            getVerificationSavePrompt({
+                verification: null,
+                canManageContentVerification: false,
+                userUuid: 'someone',
+            }),
+        ).toBeUndefined();
+    });
+
+    it('is undefined when verification is absent', () => {
+        expect(
+            getVerificationSavePrompt({
+                verification: undefined,
+                canManageContentVerification: true,
+                userUuid: 'someone',
+            }),
+        ).toBeUndefined();
+    });
+
+    it('confirms keeping the badge for someone who can manage verification', () => {
+        expect(
+            getVerificationSavePrompt({
+                verification,
+                canManageContentVerification: true,
+                userUuid: 'someone-else',
+            }),
+        ).toBe('confirm-keep');
+    });
+
+    it('confirms keeping the badge for the verifier without the scope', () => {
+        expect(
+            getVerificationSavePrompt({
+                verification,
+                canManageContentVerification: false,
+                userUuid: VERIFIER,
+            }),
+        ).toBe('confirm-keep');
+    });
+
+    it('warns about removal for anyone else', () => {
+        expect(
+            getVerificationSavePrompt({
+                verification,
+                canManageContentVerification: false,
+                userUuid: 'someone-else',
+            }),
+        ).toBe('warn-removal');
+    });
+
+    it('warns about removal for an anonymous actor', () => {
+        expect(
+            getVerificationSavePrompt({
+                verification,
+                canManageContentVerification: false,
+                userUuid: undefined,
+            }),
+        ).toBe('warn-removal');
+    });
+});

--- a/packages/frontend/src/hooks/useVerificationSavePrompt.ts
+++ b/packages/frontend/src/hooks/useVerificationSavePrompt.ts
@@ -1,0 +1,51 @@
+import { subject } from '@casl/ability';
+import {
+    type ContentVerificationInfo,
+    type SavedChart,
+} from '@lightdash/common';
+import { type VerificationSavePrompt } from '../components/Explorer/SaveChartButton';
+import useApp from '../providers/App/useApp';
+
+/**
+ * How a save treats the verification badge, or undefined when unverified.
+ * The verifier keeps their own badge without the scope, as elsewhere.
+ */
+export const getVerificationSavePrompt = ({
+    verification,
+    canManageContentVerification,
+    userUuid,
+}: {
+    verification: ContentVerificationInfo | null | undefined;
+    canManageContentVerification: boolean;
+    userUuid: string | undefined;
+}): VerificationSavePrompt | undefined => {
+    if (!verification) return undefined;
+
+    const isOwnVerification = verification.verifiedBy.userUuid === userUuid;
+
+    return canManageContentVerification || isOwnVerification
+        ? 'confirm-keep'
+        : 'warn-removal';
+};
+
+/** Shared by SavedChartsHeader and, where it is absent, ExplorerHeader. */
+export const useVerificationSavePrompt = (
+    savedChart: Pick<SavedChart, 'verification' | 'projectUuid'> | undefined,
+): VerificationSavePrompt | undefined => {
+    const { user } = useApp();
+
+    const canManageContentVerification =
+        user.data?.ability?.can(
+            'manage',
+            subject('ContentVerification', {
+                organizationUuid: user.data?.organizationUuid,
+                projectUuid: savedChart?.projectUuid,
+            }),
+        ) === true;
+
+    return getVerificationSavePrompt({
+        verification: savedChart?.verification,
+        canManageContentVerification,
+        userUuid: user.data?.userUuid,
+    });
+};

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -65,6 +65,7 @@ import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
 import useApp from '../providers/App/useApp';
 import DashboardAiAgentContextBridge from '../providers/Dashboard/DashboardAiAgentContextBridge';
 import DashboardProvider from '../providers/Dashboard/DashboardProvider';
+import { DashboardChartEditContext } from '../providers/Dashboard/useDashboardChartEdit';
 import useDashboardContext from '../providers/Dashboard/useDashboardContext';
 import useDashboardTileStatusContext from '../providers/Dashboard/useDashboardTileStatusContext';
 import useNativeFullscreenToggle from '../providers/Fullscreen/useNativeFullscreenToggle';
@@ -1130,38 +1131,46 @@ const Dashboard: FC = () => {
                     ) : null}
 
                     {/* Coordinates filter chip / rules popovers across the dashboard */}
-                    <FilterBarPopoversProvider>
-                        <DashboardTabs
-                            isEditMode={isEditMode}
-                            hasTilesThatSupportFilters={
-                                hasTilesThatSupportFilters
-                            }
-                            // parameters
-                            shadowedReservedNames={shadowedReservedNames}
-                            parameterValues={parameterValues}
-                            onParameterChange={handleParameterChange}
-                            onParameterClearAll={clearAllParameters}
-                            isParameterLoading={!areAllChartsLoaded}
-                            missingRequiredParameters={
-                                missingRequiredParameters
-                            }
-                            pinnedParameters={pinnedParameters}
-                            onParameterPin={toggleParameterPin}
-                            parameterOrder={parameterOrder}
-                            onParameterReorder={setParameterOrder}
-                            // tabs
-                            activeTab={activeTab}
-                            addingTab={addingTab}
-                            dashboardTiles={dashboardTiles}
-                            handleAddTiles={handleAddTiles}
-                            handleUpdateTiles={handleUpdateTiles}
-                            handleDeleteTile={handleDeleteTile}
-                            handleBatchDeleteTiles={handleBatchDeleteTiles}
-                            handleEditTile={handleEditTiles}
-                            setGridWidth={setGridWidth}
-                            setAddingTab={setAddingTab}
-                        />
-                    </FilterBarPopoversProvider>
+                    <DashboardChartEditContext.Provider
+                        value={
+                            isDashboardCustomMetricsEnabled
+                                ? setChartToEdit
+                                : undefined
+                        }
+                    >
+                        <FilterBarPopoversProvider>
+                            <DashboardTabs
+                                isEditMode={isEditMode}
+                                hasTilesThatSupportFilters={
+                                    hasTilesThatSupportFilters
+                                }
+                                // parameters
+                                shadowedReservedNames={shadowedReservedNames}
+                                parameterValues={parameterValues}
+                                onParameterChange={handleParameterChange}
+                                onParameterClearAll={clearAllParameters}
+                                isParameterLoading={!areAllChartsLoaded}
+                                missingRequiredParameters={
+                                    missingRequiredParameters
+                                }
+                                pinnedParameters={pinnedParameters}
+                                onParameterPin={toggleParameterPin}
+                                parameterOrder={parameterOrder}
+                                onParameterReorder={setParameterOrder}
+                                // tabs
+                                activeTab={activeTab}
+                                addingTab={addingTab}
+                                dashboardTiles={dashboardTiles}
+                                handleAddTiles={handleAddTiles}
+                                handleUpdateTiles={handleUpdateTiles}
+                                handleDeleteTile={handleDeleteTile}
+                                handleBatchDeleteTiles={handleBatchDeleteTiles}
+                                handleEditTile={handleEditTiles}
+                                setGridWidth={setGridWidth}
+                                setAddingTab={setAddingTab}
+                            />
+                        </FilterBarPopoversProvider>
+                    </DashboardChartEditContext.Provider>
                 </div>
                 {isDeleteModalOpen && (
                     <DashboardDeleteModal

--- a/packages/frontend/src/providers/Dashboard/useDashboardChartEdit.ts
+++ b/packages/frontend/src/providers/Dashboard/useDashboardChartEdit.ts
@@ -1,0 +1,11 @@
+import { type SavedChart } from '@lightdash/common';
+import { createContext, useContext } from 'react';
+
+/** Set when tiles can edit in place; absent falls back to navigation. */
+export const DashboardChartEditContext = createContext<
+    ((chart: SavedChart) => void) | undefined
+>(undefined);
+
+export const useDashboardChartEdit = ():
+    | ((chart: SavedChart) => void)
+    | undefined => useContext(DashboardChartEditContext);


### PR DESCRIPTION
Closes: GLITCH-744

### Description:

A tile's **Edit chart** now opens the in-dashboard editor instead of navigating to the Explorer, completing the loop started in the previous PR: create *and* edit both happen over the dashboard.

Behind the `dashboard-custom-metrics` flag. With the flag off the menu item stays a plain link to the chart edit route, unchanged.

### Scope

`DashboardChartTile` renders `EditChartMenuItem` in three places — loaded, error, and loading. Only the **loaded** site opts in, because it's the only one holding a chart to open. The other two keep the link, which is the right behaviour when there's nothing to edit yet.

The callback reaches the menu item through a small `DashboardChartEditContext` rather than a prop threaded through the grid, since `EditChartMenuItem` already consumes dashboard context.

### Two fixes the update path needed

Editing goes through `useAddVersionMutation`, a different path from the create flow, and both problems mirror how embeds already solve them:

- **No save button appeared.** `ExplorerHeader` renders it only when `(!savedChart || isEmbedded)` — for saved charts the app saves from `SavedChartsHeader`, which a modal doesn't render. Extended to cover modal hosts.
- **The modal stayed open after "Save changes".** The update mutation never told the host it had saved; only the create flow's `onConfirm` did. Both update call sites already had `onSuccess` hooks notifying embeds for exactly this reason, so the modal host was added alongside. The uuid comparison in the host's handler means an update closes the modal without spawning a duplicate tile.

### Verified in the app

- Edit chart renders as a menu item, not a link
- Modal opens titled "Edit chart" with the chart's explore, fields and viz loaded
- Save changes updates the chart, does not navigate, and closes the modal
- The tile behind refreshes with the change
- With the flag off, Edit chart navigates to the chart edit route as before

### Risk assessment:

- [ ] This is a high-risk change
