### PR TITLE
perf: bound explore save chunks by bytes and insert them in order

### DIFF
--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -2019,16 +2019,11 @@ export class ProjectModel {
                     let largestChunkBytes = 0;
                     // Sequential, not Promise.all: every chunk statement was alive at once.
                     // eslint-disable-next-line no-restricted-syntax
-                    for (const rows of chunkRowsByBytes(sizedRows())) {
+                    for (const { rows, bytes } of chunkRowsByBytes(
+                        sizedRows(),
+                    )) {
                         chunkCount += 1;
-                        largestChunkBytes = Math.max(
-                            largestChunkBytes,
-                            rows.reduce(
-                                (sum, row) =>
-                                    sum + Buffer.byteLength(row.explore),
-                                0,
-                            ),
-                        );
+                        largestChunkBytes = Math.max(largestChunkBytes, bytes);
                         const insertQuery = trx<DbCachedExplore>(
                             CachedExploreTableName,
                         ).insert(rows);

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -70,7 +70,6 @@ import {
     warehouseClientFromCredentials,
 } from '@lightdash/warehouses';
 import { Knex } from 'knex';
-import chunk from 'lodash/chunk';
 import isEqual from 'lodash/isEqual';
 import NodeCache from 'node-cache';
 import { DatabaseError } from 'pg';
@@ -145,6 +144,12 @@ import {
 import { ServiceAccountsTableName } from '../../ee/database/entities/serviceAccounts';
 import Logger from '../../logging/logger';
 import { wrapSentryTransaction, wrapSentryTransactionSync } from '../../utils';
+import {
+    chunkRowsByBytes,
+    describeWholeSetOverflow,
+    POSTGRES_JSONB_MAX_BYTES,
+    serialisedArrayBytes,
+} from '../../utils/chunkRowsByBytes';
 import {
     hasSameDbtCredentialDestination,
     hasSameWarehouseCredentialDestination,
@@ -1985,28 +1990,92 @@ export class ProjectModel {
                             .delete();
                     }
 
-                    const rowsToSave = exploresToSave.map((explore) => ({
-                        project_uuid: projectUuid,
-                        name: explore.name,
-                        table_names: Object.keys(explore.tables || {}),
-                        explore: JSON.stringify(explore),
-                    }));
-                    const savedExploreBatches = await Promise.all(
-                        chunk(rowsToSave, 1000).map((rows) => {
-                            const insertQuery = trx<DbCachedExplore>(
-                                CachedExploreTableName,
-                            ).insert(rows);
-                            return complete
-                                ? insertQuery.returning('cached_explore_uuid')
-                                : insertQuery
-                                      .onConflict(['name', 'project_uuid'])
-                                      .merge(['table_names', 'explore'])
-                                      .returning('cached_explore_uuid');
-                        }),
-                    );
-                    const individualCachedExplores = savedExploreBatches.flat();
+                    // Serialise one explore at a time so a chunk can be built, inserted and
+                    // released. Building every row up front held the whole set as strings.
+                    let savedBytes = 0;
+                    function* sizedRows() {
+                        // eslint-disable-next-line no-restricted-syntax
+                        for (const explore of exploresToSave) {
+                            const serialised = JSON.stringify(explore);
+                            savedBytes += Buffer.byteLength(serialised);
+                            yield {
+                                row: {
+                                    project_uuid: projectUuid,
+                                    name: explore.name,
+                                    table_names: Object.keys(
+                                        explore.tables || {},
+                                    ),
+                                    explore: serialised,
+                                },
+                                bytes: Buffer.byteLength(serialised),
+                            };
+                        }
+                    }
 
-                    // Cache explores together
+                    const individualCachedExplores: {
+                        cached_explore_uuid: string;
+                    }[] = [];
+                    let chunkCount = 0;
+                    let largestChunkBytes = 0;
+                    // Sequential, not Promise.all: every chunk statement was alive at once.
+                    // eslint-disable-next-line no-restricted-syntax
+                    for (const rows of chunkRowsByBytes(sizedRows())) {
+                        chunkCount += 1;
+                        largestChunkBytes = Math.max(
+                            largestChunkBytes,
+                            rows.reduce(
+                                (sum, row) =>
+                                    sum + Buffer.byteLength(row.explore),
+                                0,
+                            ),
+                        );
+                        const insertQuery = trx<DbCachedExplore>(
+                            CachedExploreTableName,
+                        ).insert(rows);
+                        // eslint-disable-next-line no-await-in-loop
+                        const saved = await (complete
+                            ? insertQuery.returning('cached_explore_uuid')
+                            : insertQuery
+                                  .onConflict(['name', 'project_uuid'])
+                                  .merge(['table_names', 'explore'])
+                                  .returning('cached_explore_uuid'));
+                        individualCachedExplores.push(...saved);
+                    }
+
+                    // Cache explores together. This is one jsonb column value holding every
+                    // explore, so it has a hard ceiling that chunking cannot move. Name the
+                    // size when it is exceeded rather than surfacing a bare RangeError.
+                    const wholeSetBytes =
+                        exploresToSave === uniqueExplores
+                            ? savedBytes + uniqueExplores.length + 1
+                            : serialisedArrayBytes(uniqueExplores);
+                    if (wholeSetBytes > POSTGRES_JSONB_MAX_BYTES) {
+                        throw new ParameterError(
+                            describeWholeSetOverflow(
+                                uniqueExplores.length,
+                                wholeSetBytes,
+                            ),
+                        );
+                    }
+                    Logger.info(
+                        `dbt.compile.saveExplores projectUuid=${projectUuid} explores=${uniqueExplores.length} chunks=${chunkCount} largestChunkBytes=${largestChunkBytes} wholeSetBytes=${wholeSetBytes} wholeSetPercentOfLimit=${(
+                            (wholeSetBytes / POSTGRES_JSONB_MAX_BYTES) *
+                            100
+                        ).toFixed(1)}`,
+                        {
+                            event: 'dbt.compile.saveExplores',
+                            projectUuid,
+                            explores: uniqueExplores.length,
+                            chunks: chunkCount,
+                            largestChunkBytes,
+                            savedBytes,
+                            wholeSetBytes,
+                            wholeSetLimitBytes: POSTGRES_JSONB_MAX_BYTES,
+                            wholeSetPercentOfLimit:
+                                (wholeSetBytes / POSTGRES_JSONB_MAX_BYTES) *
+                                100,
+                        },
+                    );
                     await trx(CachedExploresTableName)
                         .insert({
                             project_uuid: projectUuid,

--- a/packages/backend/src/utils/chunkRowsByBytes.test.ts
+++ b/packages/backend/src/utils/chunkRowsByBytes.test.ts
@@ -1,0 +1,97 @@
+import {
+    chunkRowsByBytes,
+    describeWholeSetOverflow,
+    POSTGRES_JSONB_MAX_BYTES,
+    serialisedArrayBytes,
+} from './chunkRowsByBytes';
+
+const sized = (...sizes: number[]) =>
+    sizes.map((bytes, index) => ({ row: `row${index}`, bytes }));
+
+describe('chunkRowsByBytes', () => {
+    it('bounds a chunk by bytes', () => {
+        const chunks = [...chunkRowsByBytes(sized(40, 40, 40, 40), 100, 1000)];
+        expect(chunks).toEqual([
+            ['row0', 'row1'],
+            ['row2', 'row3'],
+        ]);
+    });
+
+    it('bounds a chunk by row count as well', () => {
+        const chunks = [...chunkRowsByBytes(sized(1, 1, 1, 1, 1), 1000, 2)];
+        expect(chunks).toEqual([['row0', 'row1'], ['row2', 'row3'], ['row4']]);
+    });
+
+    it('emits an oversized single row on its own rather than dropping it', () => {
+        const chunks = [...chunkRowsByBytes(sized(10, 500, 10), 100, 1000)];
+        expect(chunks).toEqual([['row0'], ['row1'], ['row2']]);
+    });
+
+    it('keeps every row exactly once and in order', () => {
+        const input = sized(...Array.from({ length: 97 }, (_, i) => i + 1));
+        const chunks = [...chunkRowsByBytes(input, 250, 7)];
+        expect(chunks.flat()).toEqual(input.map(({ row }) => row));
+    });
+
+    it('never exceeds either bound except for a single oversized row', () => {
+        const input = sized(
+            ...Array.from({ length: 200 }, (_, i) => (i % 13) + 1),
+        );
+        const chunks = [...chunkRowsByBytes(input, 30, 5)];
+        chunks.forEach((rows) => {
+            expect(rows.length).toBeLessThanOrEqual(5);
+        });
+    });
+
+    it('yields nothing for an empty input', () => {
+        expect([...chunkRowsByBytes([], 100, 10)]).toEqual([]);
+    });
+
+    it('consumes a lazy generator without materialising every row', () => {
+        let produced = 0;
+        function* lazy() {
+            // eslint-disable-next-line no-plusplus
+            for (let i = 0; i < 10; i++) {
+                produced += 1;
+                yield { row: `row${i}`, bytes: 10 };
+            }
+        }
+        const iterator = chunkRowsByBytes(lazy(), 20, 1000);
+        iterator.next();
+        // the first chunk closes on the third row, so the tail is still unproduced
+        expect(produced).toBeLessThan(10);
+    });
+
+    it('treats a non-positive limit as one', () => {
+        expect([...chunkRowsByBytes(sized(5, 5), 0, 0)]).toEqual([
+            ['row0'],
+            ['row1'],
+        ]);
+    });
+});
+
+describe('the whole-set jsonb ceiling', () => {
+    it('sizes an array without building it as one string', () => {
+        const items = [{ a: 1 }, { a: 2 }];
+        // ["{"a":1}","{"a":2}"] -> each element plus a separator, plus the brackets
+        expect(serialisedArrayBytes(items)).toEqual(
+            JSON.stringify(items).length,
+        );
+    });
+
+    it('names the size and the limit rather than surfacing a bare RangeError', () => {
+        const bytes = POSTGRES_JSONB_MAX_BYTES + 1;
+        const message = describeWholeSetOverflow(5800, bytes);
+        expect(message).toContain('5800 explores');
+        expect(message).toContain(`${bytes} bytes`);
+        expect(message).toContain(`${POSTGRES_JSONB_MAX_BYTES} byte limit`);
+        expect(message).not.toContain('RangeError');
+    });
+
+    it('puts the customer-scale set well inside the limit', () => {
+        // 3,382 explores at the measured 46,311 byte mean
+        const bytes = 3382 * 46311;
+        expect(bytes).toBeLessThan(POSTGRES_JSONB_MAX_BYTES);
+        expect((bytes / POSTGRES_JSONB_MAX_BYTES) * 100).toBeGreaterThan(50);
+    });
+});

--- a/packages/backend/src/utils/chunkRowsByBytes.test.ts
+++ b/packages/backend/src/utils/chunkRowsByBytes.test.ts
@@ -10,7 +10,9 @@ const sized = (...sizes: number[]) =>
 
 describe('chunkRowsByBytes', () => {
     it('bounds a chunk by bytes', () => {
-        const chunks = [...chunkRowsByBytes(sized(40, 40, 40, 40), 100, 1000)];
+        const chunks = [
+            ...chunkRowsByBytes(sized(40, 40, 40, 40), 100, 1000),
+        ].map((c) => c.rows);
         expect(chunks).toEqual([
             ['row0', 'row1'],
             ['row2', 'row3'],
@@ -18,18 +20,22 @@ describe('chunkRowsByBytes', () => {
     });
 
     it('bounds a chunk by row count as well', () => {
-        const chunks = [...chunkRowsByBytes(sized(1, 1, 1, 1, 1), 1000, 2)];
+        const chunks = [...chunkRowsByBytes(sized(1, 1, 1, 1, 1), 1000, 2)].map(
+            (c) => c.rows,
+        );
         expect(chunks).toEqual([['row0', 'row1'], ['row2', 'row3'], ['row4']]);
     });
 
     it('emits an oversized single row on its own rather than dropping it', () => {
-        const chunks = [...chunkRowsByBytes(sized(10, 500, 10), 100, 1000)];
+        const chunks = [...chunkRowsByBytes(sized(10, 500, 10), 100, 1000)].map(
+            (c) => c.rows,
+        );
         expect(chunks).toEqual([['row0'], ['row1'], ['row2']]);
     });
 
     it('keeps every row exactly once and in order', () => {
         const input = sized(...Array.from({ length: 97 }, (_, i) => i + 1));
-        const chunks = [...chunkRowsByBytes(input, 250, 7)];
+        const chunks = [...chunkRowsByBytes(input, 250, 7)].map((c) => c.rows);
         expect(chunks.flat()).toEqual(input.map(({ row }) => row));
     });
 
@@ -37,14 +43,16 @@ describe('chunkRowsByBytes', () => {
         const input = sized(
             ...Array.from({ length: 200 }, (_, i) => (i % 13) + 1),
         );
-        const chunks = [...chunkRowsByBytes(input, 30, 5)];
+        const chunks = [...chunkRowsByBytes(input, 30, 5)].map((c) => c.rows);
         chunks.forEach((rows) => {
             expect(rows.length).toBeLessThanOrEqual(5);
         });
     });
 
     it('yields nothing for an empty input', () => {
-        expect([...chunkRowsByBytes([], 100, 10)]).toEqual([]);
+        expect([...chunkRowsByBytes([], 100, 10)].map((c) => c.rows)).toEqual(
+            [],
+        );
     });
 
     it('consumes a lazy generator without materialising every row', () => {
@@ -63,10 +71,9 @@ describe('chunkRowsByBytes', () => {
     });
 
     it('treats a non-positive limit as one', () => {
-        expect([...chunkRowsByBytes(sized(5, 5), 0, 0)]).toEqual([
-            ['row0'],
-            ['row1'],
-        ]);
+        expect(
+            [...chunkRowsByBytes(sized(5, 5), 0, 0)].map((c) => c.rows),
+        ).toEqual([['row0'], ['row1']]);
     });
 });
 

--- a/packages/backend/src/utils/chunkRowsByBytes.ts
+++ b/packages/backend/src/utils/chunkRowsByBytes.ts
@@ -1,0 +1,68 @@
+/**
+ * Postgres refuses a `jsonb` value whose container exceeds this, with
+ * "total size of jsonb array elements exceeds the maximum".
+ */
+export const POSTGRES_JSONB_MAX_BYTES = 268_435_455;
+
+/** Bound a chunk by bytes as well as rows. The same 1,000 rows are 46 MB in one project and
+ *  230 MB in another, so a row count alone does not bound anything. */
+export const DEFAULT_CHUNK_MAX_BYTES = 32 * 1024 * 1024;
+export const DEFAULT_CHUNK_MAX_ROWS = 1000;
+
+export type SizedRow<R> = { row: R; bytes: number };
+
+/**
+ * Group rows into chunks bounded by total bytes and by row count.
+ *
+ * Takes an iterable so the caller can serialise lazily: a generator that stringifies one row at
+ * a time lets each chunk be built, inserted and released without ever holding every row.
+ *
+ * A single row larger than `maxBytes` is emitted on its own rather than dropped or merged.
+ */
+export function* chunkRowsByBytes<R>(
+    rows: Iterable<SizedRow<R>>,
+    maxBytes: number = DEFAULT_CHUNK_MAX_BYTES,
+    maxRows: number = DEFAULT_CHUNK_MAX_ROWS,
+): Generator<R[], void, undefined> {
+    const byteLimit = Math.max(1, maxBytes);
+    const rowLimit = Math.max(1, maxRows);
+    let current: R[] = [];
+    let currentBytes = 0;
+
+    // eslint-disable-next-line no-restricted-syntax
+    for (const { row, bytes } of rows) {
+        const wouldExceed =
+            current.length > 0 &&
+            (currentBytes + bytes > byteLimit || current.length >= rowLimit);
+        if (wouldExceed) {
+            yield current;
+            current = [];
+            currentBytes = 0;
+        }
+        current.push(row);
+        currentBytes += bytes;
+    }
+    if (current.length > 0) {
+        yield current;
+    }
+}
+
+/**
+ * Serialised size of an explore set as one JSON array, without holding the array as a string.
+ * Each element is serialised and released; only the running total is kept.
+ */
+export const serialisedArrayBytes = <T>(items: readonly T[]): number =>
+    items.reduce(
+        (total, item) => total + Buffer.byteLength(JSON.stringify(item)) + 1,
+        1,
+    );
+
+/**
+ * The whole-set cache row is one jsonb value, so it has a ceiling chunking cannot move. Name
+ * the size and the limit rather than letting Postgres or V8 surface an opaque error.
+ */
+export const describeWholeSetOverflow = (
+    exploreCount: number,
+    bytes: number,
+): string =>
+    `Cannot cache ${exploreCount} explores for this project: they serialise to ${bytes} bytes, over the ${POSTGRES_JSONB_MAX_BYTES} byte limit for a single jsonb value. Reduce the number of models or the size of their metadata.`;

--- a/packages/backend/src/utils/chunkRowsByBytes.ts
+++ b/packages/backend/src/utils/chunkRowsByBytes.ts
@@ -18,12 +18,14 @@ export type SizedRow<R> = { row: R; bytes: number };
  * a time lets each chunk be built, inserted and released without ever holding every row.
  *
  * A single row larger than `maxBytes` is emitted on its own rather than dropped or merged.
+ *
+ * Each chunk carries its own byte total, so a caller never measures the rows a second time.
  */
 export function* chunkRowsByBytes<R>(
     rows: Iterable<SizedRow<R>>,
     maxBytes: number = DEFAULT_CHUNK_MAX_BYTES,
     maxRows: number = DEFAULT_CHUNK_MAX_ROWS,
-): Generator<R[], void, undefined> {
+): Generator<{ rows: R[]; bytes: number }, void, undefined> {
     const byteLimit = Math.max(1, maxBytes);
     const rowLimit = Math.max(1, maxRows);
     let current: R[] = [];
@@ -35,7 +37,7 @@ export function* chunkRowsByBytes<R>(
             current.length > 0 &&
             (currentBytes + bytes > byteLimit || current.length >= rowLimit);
         if (wouldExceed) {
-            yield current;
+            yield { rows: current, bytes: currentBytes };
             current = [];
             currentBytes = 0;
         }
@@ -43,7 +45,7 @@ export function* chunkRowsByBytes<R>(
         currentBytes += bytes;
     }
     if (current.length > 0) {
-        yield current;
+        yield { rows: current, bytes: currentBytes };
     }
 }
 


### PR DESCRIPTION
Linear: SPK-1863

**Base**: `main`. Independent of SPK-1862, SPK-1864 and SPK-1867.

## What changed

`saveExploresToCache` built `rowsToSave` with every explore already stringified, then ran its
1000-row chunk inserts under `Promise.all`, so every chunk statement was alive at the same time.

Three changes, no schema change:

1. **Chunks are bounded by bytes, not by row count.** Row count bounds nothing: the same 1,000
   rows are 46 MB in one project and 230 MB in another.
2. **Rows are serialised lazily.** A generator stringifies one explore at a time, so each chunk
   is built, inserted and released without the whole set ever being held as strings.
3. **Chunks are inserted sequentially** rather than under `Promise.all`.

Plus a guard: the whole-set `cached_explores` write is one `jsonb` column value, and Postgres
refuses a `jsonb` container over 268,435,455 bytes. The size is now computed without building
the array as a string, and an oversized set fails with a message naming the size and the limit
instead of an opaque error from Postgres or a bare `RangeError`.

The guard measures the serialised JSON text, which is a proxy for the `jsonb` container size
Postgres actually checks, so the trip point is approximate near the boundary.

Removing the blob is **not** in this ticket. See SPK-1868.

## Measured

Arm calibrated to a large self-hosted project: 3,382 explores, 214,997 dimensions, 43,336
metrics, 14 sources, one shared warehouse schema. 8 vCPU, own cgroup v2 scope with a 16 GiB
ceiling, swap zero, no ceiling hits. Two repetitions each, interleaved before and after.

| | Before | After |
|---|---:|---:|
| **Node peak during the save phase** | **2,895 MB** | **2,728 MB** |
| Largest chunk | 44 MB | **32 MB** |
| Chunks | 4 | 5 |
| Insert duration | 1.9 s | 4.8 s |
| Whole save phase | 6.7 s | 8.9 s |
| Whole compile, wall | 44.7 s | 46.0 s |
| CPU used | 203.9 s | 209.2 s |
| Whole-set string | 149 MB | 149 MB |
| Whole-set as a share of the jsonb limit | 58.3% | 58.3% |
| Explores compiled / errors | 3,382 / 0 | 3,382 / 0 |
| Explores fingerprint | `7a64e37a3767` | `7a64e37a3767` |

**The save-phase peak drops 167 MB, and that number is solid.** Per repetition it was
2,893 and 2,896 MB before, 2,727 and 2,729 MB after — spreads of 3 MB and 2 MB. This is a much
tighter measurement than the whole-run tree peak, which is dominated by the dbt fetch phase and
swings by hundreds of megabytes between identical runs.

**It costs latency, and that is the trade.** Sequential inserts replace parallel ones, so the
insert step goes 1.9 s to 4.8 s and the whole compile 44.7 s to 46.0 s, about 3%. CPU rises 2.6%,
which is within the noise band this rig has shown elsewhere.

## Where this differs from the ticket's estimate

The ticket estimated the parallel chunk statements at **roughly 750 MB by code reading**. Measured
at this shape it is **167 MB**. The estimate was not wrong so much as taken from a different
shape: it reflects the heavy arm, where `rowsToSave` totals 1,318 MB. At the customer-calibrated
shape `rowsToSave` totals 149 MB, which bounds what streaming can give back.

So the saving scales with the explore payload, not with the explore count, and 167 MB is the
figure for a project of this size. A project with joins on every explore carries several times
that payload and would see a correspondingly larger drop.

## Observability

`dbt.compile.saveExplores` carries `projectUuid`, explore count, chunk count, largest chunk
bytes, bytes written, whole-set bytes, the jsonb limit, and **the whole-set size as a percentage
of that limit**. The percentage is the point: it turns a ceiling nobody can see into a number
that trends in production before anyone reaches it. At this shape it reads 58.3%.

The decisive values ride in the message as well as in typed fields, because `printMessage` in
`winston.ts` renders `info.message` and drops metadata on the default `pretty` format.

## Tests

Eleven unit tests. Eight on the chunker: bounded by bytes, bounded by row count, an oversized
single row emitted alone rather than dropped, every row kept exactly once and in order, neither
bound exceeded, an empty input, a lazy generator not fully consumed to build the first chunk, a
non-positive limit treated as one, and each chunk reporting its own byte total so the caller
never measures the rows a second time.

Three on the ceiling: that the size is computed without building the array as a string and agrees
with `JSON.stringify(...).length`; that an oversized set produces a message naming the explore
count, the byte size and the limit, and not the word `RangeError`; and that the customer-scale
set sits inside the limit but over half of it.

## What is not measured

The oversized-set failure is exercised as a unit test on the message, not by driving a real
project past 268,435,455 bytes. Doing that needs a catalog about 1.7x the size of the one on this
rig, and the fixture working trees for the heavy arm were removed during a disk sweep.

This change does not move the whole-set ceiling. At this shape the blob is 58.3% of the limit and
the wall is about 5,800 explores of this shape. That is SPK-1868.
