### PR TITLE
feat(ai): restore an older data app version from the thread preview pill

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDataAppPreviewPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDataAppPreviewPanel.tsx
@@ -76,7 +76,12 @@ export const AiDataAppPreviewPanel: FC<Props> = ({
         latestReadyVersionAtOpen,
         latestReadyVersion,
     });
-    const isViewingLatest = effectiveVersion === latestReadyVersion;
+    // An explicit version newer than the cached latest (just restored) is
+    // latest by definition, so compare rather than test equality.
+    const isViewingOlderVersion =
+        effectiveVersion !== null &&
+        latestReadyVersion !== null &&
+        effectiveVersion < latestReadyVersion;
     const identityKey = `${appUuid}:${effectiveVersion}`;
     // Lives here, not next to the iframe, so logs and dismissal survive the
     // token reload between versions. Only wired in when `showInspector`.
@@ -166,10 +171,6 @@ export const AiDataAppPreviewPanel: FC<Props> = ({
             ? `${previewOrigin}/api/apps/${appUuid}/versions/${effectiveVersion}/t/${token}/#transport=postMessage&projectUuid=${projectUuid}`
             : undefined;
 
-    const isViewingOlderVersion =
-        effectiveVersion !== null &&
-        latestReadyVersion !== null &&
-        effectiveVersion < latestReadyVersion;
     const returnToLatest = () =>
         dispatch(
             setDataAppPreviewVersion({
@@ -219,7 +220,6 @@ export const AiDataAppPreviewPanel: FC<Props> = ({
         canManageApp && effectiveVersion !== null
             ? {
                   onClick: () => setRestoreTargetVersion(effectiveVersion),
-                  disabled: isBuildInProgress,
                   disabledReason: isBuildInProgress
                       ? 'A version is building; restore once it finishes.'
                       : null,
@@ -319,9 +319,9 @@ export const AiDataAppPreviewPanel: FC<Props> = ({
         );
     }
 
-    const appUrl = isViewingLatest
-        ? `/projects/${projectUuid}/apps/${appUuid}/view`
-        : `/projects/${projectUuid}/apps/${appUuid}/versions/${effectiveVersion}/view`;
+    const appUrl = isViewingOlderVersion
+        ? `/projects/${projectUuid}/apps/${appUuid}/versions/${effectiveVersion}/view`
+        : `/projects/${projectUuid}/apps/${appUuid}/view`;
 
     return (
         <Box className={artifactStyles.floatingPanel}>
@@ -384,7 +384,7 @@ export const AiDataAppPreviewPanel: FC<Props> = ({
                         </Menu>
                         {showInspector &&
                             picker.available &&
-                            isViewingLatest && (
+                            !isViewingOlderVersion && (
                                 <ElementPickerButton
                                     enabled={picker.enabled}
                                     onToggle={picker.toggle}
@@ -407,15 +407,9 @@ export const AiDataAppPreviewPanel: FC<Props> = ({
             </Box>
             {restoreTargetVersion !== null && (
                 <RestoreAppVersionModal
-                    opened
                     version={restoreTargetVersion}
                     isLoading={restoreMutation.isLoading}
-                    errorMessage={
-                        restoreMutation.error
-                            ? (restoreMutation.error.error?.message ??
-                              'Failed to restore version.')
-                            : null
-                    }
+                    error={restoreMutation.error}
                     onClose={closeRestoreModal}
                     onConfirm={() => confirmRestore(restoreTargetVersion)}
                 />

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDataAppPreviewPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDataAppPreviewPanel.tsx
@@ -1,4 +1,4 @@
-import { getAppDisplayName } from '@lightdash/common';
+import { getAppDisplayName, isAppVersionInProgress } from '@lightdash/common';
 import {
     ActionIcon,
     Box,
@@ -22,13 +22,16 @@ import TruncatedText from '../../../../../components/common/TruncatedText';
 import AppIframePreview from '../../../../../features/apps/AppIframePreview';
 import AppInspectorPanel from '../../../../../features/apps/AppInspectorPanel';
 import { ElementPickerButton } from '../../../../../features/apps/components/ElementPickerButton';
+import { RestoreAppVersionModal } from '../../../../../features/apps/components/RestoreAppVersionModal';
 import { getVisiblePreviewTokenError } from '../../../../../features/apps/hooks/previewTokenQueryOptions';
 import { useAppInspector } from '../../../../../features/apps/hooks/useAppInspector';
 import { useAppPreviewToken } from '../../../../../features/apps/hooks/useAppPreviewToken';
+import { useCanEditDataApp } from '../../../../../features/apps/hooks/useCanEditDataApp';
 import { useElementPicker } from '../../../../../features/apps/hooks/useElementPicker';
 import { useGetApp } from '../../../../../features/apps/hooks/useGetApp';
 import { usePreviewOrigin } from '../../../../../features/apps/previewOrigin';
 import { type ElementRef } from '../../../../../features/apps/utils/elementRefs';
+import { useRestoreAiAgentThreadDataAppVersionMutation } from '../../hooks/useProjectAiAgents';
 import { addThreadElementReference } from '../../store/aiAgentThreadElementRefsSlice';
 import {
     clearPreview,
@@ -55,6 +58,7 @@ export const AiDataAppPreviewPanel: FC<Props> = ({
     const {
         appUuid,
         projectUuid,
+        agentUuid,
         threadUuid,
         version,
         latestReadyVersionAtOpen,
@@ -173,6 +177,54 @@ export const AiDataAppPreviewPanel: FC<Props> = ({
                 latestReadyVersionAtOpen: latestReadyVersion,
             }),
         );
+
+    // Same gate as Edit on the standalone view page.
+    const canManageApp = useCanEditDataApp(projectUuid, {
+        spaceUuid: app?.spaceUuid ?? null,
+        createdByUserUuid: app?.createdByUserUuid ?? null,
+    });
+    // Versions come newest first; the backend refuses restores mid-build.
+    const latestVersionStatus = app?.versions[0]?.status;
+    const isBuildInProgress =
+        latestVersionStatus !== undefined &&
+        isAppVersionInProgress(latestVersionStatus);
+    const [restoreTargetVersion, setRestoreTargetVersion] = useState<
+        number | null
+    >(null);
+    const restoreMutation = useRestoreAiAgentThreadDataAppVersionMutation(
+        projectUuid,
+        agentUuid,
+        threadUuid,
+    );
+    const closeRestoreModal = () => {
+        setRestoreTargetVersion(null);
+        restoreMutation.reset();
+    };
+    const confirmRestore = (targetVersion: number) =>
+        restoreMutation.mutate(
+            { appUuid, version: targetVersion },
+            {
+                onSuccess: (result) => {
+                    dispatch(
+                        setDataAppPreviewVersion({
+                            version: result.version,
+                            latestReadyVersionAtOpen: result.version,
+                        }),
+                    );
+                    closeRestoreModal();
+                },
+            },
+        );
+    const restore =
+        canManageApp && effectiveVersion !== null
+            ? {
+                  onClick: () => setRestoreTargetVersion(effectiveVersion),
+                  disabled: isBuildInProgress,
+                  disabledReason: isBuildInProgress
+                      ? 'A version is building; restore once it finishes.'
+                      : null,
+              }
+            : null;
 
     const closeButton = (
         <ActionIcon
@@ -348,11 +400,26 @@ export const AiDataAppPreviewPanel: FC<Props> = ({
                         <DataAppVersionPill
                             version={effectiveVersion}
                             onReturnToLatest={returnToLatest}
-                            restore={null}
+                            restore={restore}
                         />
                     )}
                 </Box>
             </Box>
+            {restoreTargetVersion !== null && (
+                <RestoreAppVersionModal
+                    opened
+                    version={restoreTargetVersion}
+                    isLoading={restoreMutation.isLoading}
+                    errorMessage={
+                        restoreMutation.error
+                            ? (restoreMutation.error.error?.message ??
+                              'Failed to restore version.')
+                            : null
+                    }
+                    onClose={closeRestoreModal}
+                    onConfirm={() => confirmRestore(restoreTargetVersion)}
+                />
+            )}
         </Box>
     );
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDataAppPreviewPanel.version.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDataAppPreviewPanel.version.test.tsx
@@ -10,11 +10,19 @@ import {
 
 type IframePreviewProps = {
     src: string;
+    identityKey: string;
     onInspectorAvailabilityChange?: (available: boolean) => void;
 };
 
 const mocks = vi.hoisted(() => ({
     iframePreview: vi.fn((_props: IframePreviewProps) => null),
+    previewToken: vi.fn(
+        (_projectUuid: string, _appUuid: string, _version?: number) => ({
+            data: mocks.tokenLoading ? undefined : 'preview-token',
+            isLoading: mocks.tokenLoading,
+            error: undefined,
+        }),
+    ),
     latestReadyVersion: 3,
     latestVersionStatus: 'ready' as AppVersionStatus,
     tokenLoading: false,
@@ -35,11 +43,7 @@ vi.mock('../../../../../features/apps/AppIframePreview', () => ({
 }));
 
 vi.mock('../../../../../features/apps/hooks/useAppPreviewToken', () => ({
-    useAppPreviewToken: () => ({
-        data: mocks.tokenLoading ? undefined : 'preview-token',
-        isLoading: mocks.tokenLoading,
-        error: undefined,
-    }),
+    useAppPreviewToken: mocks.previewToken,
 }));
 
 vi.mock('../../../../../features/apps/hooks/useGetApp', () => ({
@@ -139,6 +143,7 @@ describe('AiDataAppPreviewPanel versions', () => {
         mocks.canManageApp = true;
         mocks.dispatch.mockReset();
         mocks.lightdashApi.mockReset();
+        mocks.previewToken.mockClear();
         window.localStorage.clear();
     });
 
@@ -161,6 +166,12 @@ describe('AiDataAppPreviewPanel versions', () => {
         announcePicker();
 
         expect(iframeVersion()).toBe('1');
+        expect(mocks.previewToken).toHaveBeenLastCalledWith(
+            'project-uuid',
+            'app-uuid',
+            1,
+        );
+        expect(latestIframeProps().identityKey).toBe('app-uuid:1');
         expect(screen.getByText('Viewing v1')).toBeInTheDocument();
         expect(pickerToggle()).not.toBeInTheDocument();
         expect(await openInNewTabHref(user)).toBe(
@@ -201,6 +212,22 @@ describe('AiDataAppPreviewPanel versions', () => {
 
         expect(iframeVersion()).toBe('3');
         expect(pill()).not.toBeInTheDocument();
+    });
+
+    it('treats a just-restored version as latest before the app refetch lands', async () => {
+        const user = userEvent.setup();
+        // The cached app still says v3 is latest; the restore produced v4.
+        renderWithProviders(
+            panel(preview({ version: 4, latestReadyVersionAtOpen: 4 })),
+        );
+        announcePicker();
+
+        expect(iframeVersion()).toBe('4');
+        expect(pill()).not.toBeInTheDocument();
+        expect(pickerToggle()).toBeInTheDocument();
+        expect(await openInNewTabHref(user)).toBe(
+            '/projects/project-uuid/apps/app-uuid/view',
+        );
     });
 
     describe('restore', () => {

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDataAppPreviewPanel.version.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDataAppPreviewPanel.version.test.tsx
@@ -1,4 +1,5 @@
-import { act, screen } from '@testing-library/react';
+import { type AppVersionStatus } from '@lightdash/common';
+import { act, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '../../../../../testing/testUtils';
@@ -15,8 +16,18 @@ type IframePreviewProps = {
 const mocks = vi.hoisted(() => ({
     iframePreview: vi.fn((_props: IframePreviewProps) => null),
     latestReadyVersion: 3,
+    latestVersionStatus: 'ready' as AppVersionStatus,
     tokenLoading: false,
     dispatch: vi.fn(),
+    canManageApp: true,
+    lightdashApi: vi.fn(),
+}));
+
+vi.mock('../../../../../api', () => ({ lightdashApi: mocks.lightdashApi }));
+
+vi.mock('../../../../../features/apps/hooks/useCanEditDataApp', () => ({
+    useCanEditDataApp: () => mocks.canManageApp,
+    useCanEditDataAppChecker: () => () => mocks.canManageApp,
 }));
 
 vi.mock('../../../../../features/apps/AppIframePreview', () => ({
@@ -41,7 +52,7 @@ vi.mock('../../../../../features/apps/hooks/useGetApp', () => ({
                     slug: 'sales-app',
                     description: null,
                     latestReadyVersion: mocks.latestReadyVersion,
-                    versions: [{ status: 'ready' }],
+                    versions: [{ status: mocks.latestVersionStatus }],
                 },
             ],
         },
@@ -94,6 +105,10 @@ const pickerToggle = () => screen.queryByLabelText('Toggle element picker');
 
 const pill = () => screen.queryByText(/Viewing v/);
 
+const restoreButton = () => screen.queryByRole('button', { name: 'Restore' });
+
+const BUILDING_REASON = 'A version is building; restore once it finishes.';
+
 const openInNewTabHref = async (user: ReturnType<typeof userEvent.setup>) => {
     await user.click(screen.getByLabelText('More options'));
     const item = await screen.findByRole('menuitem', {
@@ -119,8 +134,11 @@ const landNewVersion = (
 describe('AiDataAppPreviewPanel versions', () => {
     beforeEach(() => {
         mocks.latestReadyVersion = 3;
+        mocks.latestVersionStatus = 'ready';
         mocks.tokenLoading = false;
+        mocks.canManageApp = true;
         mocks.dispatch.mockReset();
+        mocks.lightdashApi.mockReset();
         window.localStorage.clear();
     });
 
@@ -183,5 +201,89 @@ describe('AiDataAppPreviewPanel versions', () => {
 
         expect(iframeVersion()).toBe('3');
         expect(pill()).not.toBeInTheDocument();
+    });
+
+    describe('restore', () => {
+        it('hides Restore when the user cannot manage the app', () => {
+            mocks.canManageApp = false;
+            renderWithProviders(panel(olderVersion));
+
+            expect(pill()).toBeInTheDocument();
+            expect(restoreButton()).not.toBeInTheDocument();
+        });
+
+        it('disables Restore with a reason while a version is building', async () => {
+            mocks.latestVersionStatus = 'generating';
+            const user = userEvent.setup();
+            renderWithProviders(panel(olderVersion));
+
+            const button = restoreButton();
+            expect(button).toBeDisabled();
+            await user.hover(button!);
+            expect(
+                await screen.findByText(BUILDING_REASON),
+            ).toBeInTheDocument();
+        });
+
+        it('restores through the thread and moves the preview to the new version', async () => {
+            mocks.lightdashApi.mockResolvedValue({
+                appUuid: 'app-uuid',
+                version: 4,
+                restoredFromVersion: 1,
+                promptUuid: 'prompt-uuid',
+            });
+            const user = userEvent.setup();
+            renderWithProviders(panel(olderVersion));
+
+            await user.click(restoreButton()!);
+            expect(
+                await screen.findByText('Restore version 1?'),
+            ).toBeInTheDocument();
+            await user.click(
+                screen.getByRole('button', { name: 'Restore version' }),
+            );
+
+            await waitFor(() =>
+                expect(mocks.dispatch).toHaveBeenCalledWith(
+                    setDataAppPreviewVersion({
+                        version: 4,
+                        latestReadyVersionAtOpen: 4,
+                    }),
+                ),
+            );
+            expect(mocks.lightdashApi).toHaveBeenCalledWith({
+                url: '/projects/project-uuid/aiAgents/agent-uuid/threads/thread-uuid/data-app-restores',
+                method: 'POST',
+                body: JSON.stringify({ appUuid: 'app-uuid', version: 1 }),
+            });
+            await waitFor(() =>
+                expect(
+                    screen.queryByText('Restore version 1?'),
+                ).not.toBeInTheDocument(),
+            );
+        });
+
+        it('keeps the modal open and shows the error when the restore is refused', async () => {
+            mocks.lightdashApi.mockRejectedValue({
+                error: {
+                    message: 'A version is already building for this app',
+                },
+            });
+            const user = userEvent.setup();
+            renderWithProviders(panel(olderVersion));
+
+            await user.click(restoreButton()!);
+            await user.click(
+                await screen.findByRole('button', { name: 'Restore version' }),
+            );
+
+            expect(
+                await screen.findByText(
+                    'A version is already building for this app',
+                ),
+            ).toBeInTheDocument();
+            expect(screen.getByText('Restore version 1?')).toBeInTheDocument();
+            expect(mocks.dispatch).not.toHaveBeenCalled();
+        });
     });
 });

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/AiDataAppRestoreCard.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/AiDataAppRestoreCard.test.tsx
@@ -112,6 +112,18 @@ describe('AiDataAppRestoreCard', () => {
         expect(cardPaper()?.className).toMatch(/cardActive/);
     });
 
+    it('records its own version as the floor when View beats the app fetch', () => {
+        mockedLightdashApi.mockReturnValue(new Promise(() => {}));
+        renderCard();
+
+        fireEvent.click(screen.getByRole('button', { name: 'View' }));
+
+        expect(store.getState().aiArtifact.preview).toMatchObject({
+            version: 3,
+            latestReadyVersionAtOpen: 3,
+        });
+    });
+
     it('is only active when the preview shows its version', async () => {
         store.dispatch(
             setPreview({

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/dataAppBuildCardState.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/dataAppBuildCardState.ts
@@ -145,11 +145,8 @@ export const getDataAppRestoreItem = (
             item.type === 'data_app_restore',
     ) ?? null;
 
-/**
- * Card state for a restore made from the thread. The restore already
- * succeeded when the turn was written, so the card is ready unless the app
- * has gone since; the assistant's response is the completion message.
- */
+/** A thread restore already succeeded when its turn was written, so the card
+ *  is ready unless the app has gone since. */
 export const getDataAppRestoreCardState = (
     item: DataAppRestoreContextItem,
     response: string | null,

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/dataAppPreviewVersion.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/dataAppPreviewVersion.test.ts
@@ -69,7 +69,7 @@ describe('getEffectiveDataAppVersion', () => {
         ).toBe(2);
     });
 
-    it('never jumps when no latest version was recorded at open', () => {
+    it('keeps an explicit version when nothing was recorded at open', () => {
         expect(
             getEffectiveDataAppVersion({
                 version: 1,

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/dataAppPreviewVersion.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/dataAppPreviewVersion.ts
@@ -6,13 +6,8 @@ type EffectiveVersionArgs = {
     latestReadyVersion: number | null;
 };
 
-/**
- * The version the thread preview shows. A null version means latest ready.
- * An explicit version is kept until a ready version newer than the one
- * recorded at open time lands, which moves the panel to latest. With no
- * version recorded at open there is nothing to compare against, so the
- * explicit version stays.
- */
+/** The version the preview shows: null means latest ready; an explicit one
+ *  holds until a ready version newer than the one recorded at open lands. */
 export const getEffectiveDataAppVersion = ({
     version,
     latestReadyVersionAtOpen,

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/useDataAppCardPreview.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/useDataAppCardPreview.ts
@@ -71,7 +71,8 @@ export const useDataAppCardPreview = ({
                 projectUuid,
                 agentUuid,
                 version,
-                latestReadyVersionAtOpen: latestReadyVersion,
+                // The card's own version is the floor until the app resolves.
+                latestReadyVersionAtOpen: latestReadyVersion ?? version,
             }),
         );
     }, [

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppVersionPill.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppVersionPill.tsx
@@ -7,10 +7,9 @@ import classes from './DataAppVersionPill.module.css';
 type Props = {
     version: number;
     onReturnToLatest: () => void;
-    /** Restore is offered only where the user can manage the app. */
+    /** Offered only where the user can manage the app; disabled iff a reason. */
     restore: null | {
         onClick: () => void;
-        disabled: boolean;
         disabledReason: string | null;
     };
 };
@@ -44,7 +43,7 @@ export const DataAppVersionPill: FC<Props> = ({
                         leftSection={
                             <MantineIcon icon={IconRestore} size="sm" />
                         }
-                        disabled={restore.disabled}
+                        disabled={restore.disabledReason !== null}
                         onClick={restore.onClick}
                     >
                         Restore

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.tsx
@@ -3,6 +3,7 @@ import {
     ChartSourceType,
     ContentType,
     dataAppElementContextKey,
+    dataAppRestoreContextKey,
     type AiPromptContextInput,
     type AiPromptContextItem,
     type ApiContentResponse,
@@ -323,7 +324,7 @@ const getContextKey = (item: AiPromptContextInput[number]) => {
         case 'data_app_element':
             return dataAppElementContextKey(item);
         case 'data_app_restore':
-            return `data_app_restore:${item.appUuid}:${item.version}`;
+            return dataAppRestoreContextKey(item);
         default:
             return assertUnreachable(
                 item,

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentReferenceUtils.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentReferenceUtils.ts
@@ -1,6 +1,7 @@
 import {
     assertUnreachable,
     dataAppElementContextKey,
+    dataAppRestoreContextKey,
     type AiPromptContextItem,
 } from '@lightdash/common';
 
@@ -53,7 +54,7 @@ export const getPromptContextItemKey = (item: AiPromptContextItem) => {
         case 'data_app_element':
             return dataAppElementContextKey(item);
         case 'data_app_restore':
-            return `data_app_restore:${item.appUuid}:${item.version}`;
+            return dataAppRestoreContextKey(item);
         default:
             return assertUnreachable(item, 'Unknown AiPromptContextItem type');
     }

--- a/packages/frontend/src/ee/features/aiCopilot/components/PinnedContextCard/PinnedContextCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/PinnedContextCard/PinnedContextCard.tsx
@@ -17,8 +17,7 @@ type ItemMeta = {
         | 'file'
         | 'repository'
         | 'external_source'
-        | 'data_app_element'
-        | 'data_app';
+        | 'data_app_element';
     label: string;
     href: string | null;
 };
@@ -34,8 +33,7 @@ const getItemMeta = (
                 | 'file'
                 | 'repository'
                 | 'external_source'
-                | 'data_app_element'
-                | 'data_app_restore';
+                | 'data_app_element';
         }
     >,
     projectUuid: string,
@@ -78,12 +76,6 @@ const getItemMeta = (
                 label: elementRefChipLabel(item),
                 href: null,
             };
-        case 'data_app_restore':
-            return {
-                kind: 'data_app',
-                label: `Restored v${item.version} of ${item.displayName ?? 'data app'}`,
-                href: null,
-            };
         default:
             return assertUnreachable(item, 'Unknown AiPromptContextItem type');
     }
@@ -97,8 +89,7 @@ export const PinnedContextCard: FC<Props> = ({ item, projectUuid }) => {
         case 'file':
         case 'repository':
         case 'external_source':
-        case 'data_app_element':
-        case 'data_app_restore': {
+        case 'data_app_element': {
             const meta = getItemMeta(item, projectUuid);
             return (
                 <ContentReferenceLink
@@ -117,6 +108,9 @@ export const PinnedContextCard: FC<Props> = ({ item, projectUuid }) => {
         case 'review_finding':
         case 'preview_environment':
             return <PinnedReviewEntityCard item={item} />;
+        // System-only: written by the thread restore, rendered as a build card.
+        case 'data_app_restore':
+            return null;
         default:
             return assertUnreachable(item, 'Unknown AiPromptContextItem type');
     }

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
@@ -44,6 +44,7 @@ import {
 } from '@tanstack/react-query';
 import { useNavigate, useParams } from 'react-router';
 import { lightdashApi } from '../../../../api';
+import { invalidateAppAfterRestore } from '../../../../features/apps/hooks/useRestoreAppVersion';
 import useHealth from '../../../../hooks/health/useHealth';
 import { useOrganization } from '../../../../hooks/organization/useOrganization';
 import useToaster from '../../../../hooks/toaster/useToaster';
@@ -1492,22 +1493,19 @@ export const useRestoreAiAgentThreadDataAppVersionMutation = (
                 method: 'POST',
                 body: JSON.stringify(body),
             }),
-        onSuccess: (_result, { appUuid }) => {
-            // The thread gained a hidden restore turn; the app gained a version.
-            void queryClient.invalidateQueries({
-                queryKey: getAiAgentThreadQueryKey(
-                    projectUuid,
-                    agentUuid,
-                    threadUuid,
-                ),
-            });
-            void queryClient.invalidateQueries({
-                queryKey: ['app', projectUuid, appUuid],
-            });
-            void queryClient.invalidateQueries({
-                queryKey: ['data-app-viz', projectUuid, appUuid],
-            });
-        },
+        // The thread gained a hidden restore turn; the app gained a version.
+        // Awaited so per-call onSuccess runs once the app refetch has landed.
+        onSuccess: (_result, { appUuid }) =>
+            Promise.all([
+                queryClient.invalidateQueries({
+                    queryKey: getAiAgentThreadQueryKey(
+                        projectUuid,
+                        agentUuid,
+                        threadUuid,
+                    ),
+                }),
+                invalidateAppAfterRestore(queryClient, projectUuid, appUuid),
+            ]),
     });
 };
 

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
@@ -8,6 +8,8 @@ import type {
     ApiAiAgentSummaryResponse,
     ApiAiAgentThreadCreateRequest,
     ApiAiAgentThreadCreateResponse,
+    ApiAiAgentThreadDataAppRestoreRequest,
+    ApiAiAgentThreadDataAppRestoreResponse,
     ApiAiAgentThreadGenerateTitleResponse,
     ApiAiAgentThreadMessageCreateRequest,
     ApiAiAgentThreadMessageCreateResponse,
@@ -1466,6 +1468,45 @@ export const useCreateAiAgentThreadMessageSteerMutation = () => {
                     };
                 },
             );
+        },
+    });
+};
+
+export const useRestoreAiAgentThreadDataAppVersionMutation = (
+    projectUuid: string,
+    agentUuid: string,
+    threadUuid: string,
+) => {
+    const queryClient = useQueryClient();
+
+    return useMutation<
+        ApiAiAgentThreadDataAppRestoreResponse['results'],
+        ApiError,
+        ApiAiAgentThreadDataAppRestoreRequest
+    >({
+        mutationFn: (body) =>
+            lightdashApi<ApiAiAgentThreadDataAppRestoreResponse['results']>({
+                url: `${getAiAgentApiBase(
+                    projectUuid,
+                )}/${agentUuid}/threads/${threadUuid}/data-app-restores`,
+                method: 'POST',
+                body: JSON.stringify(body),
+            }),
+        onSuccess: (_result, { appUuid }) => {
+            // The thread gained a hidden restore turn; the app gained a version.
+            void queryClient.invalidateQueries({
+                queryKey: getAiAgentThreadQueryKey(
+                    projectUuid,
+                    agentUuid,
+                    threadUuid,
+                ),
+            });
+            void queryClient.invalidateQueries({
+                queryKey: ['app', projectUuid, appUuid],
+            });
+            void queryClient.invalidateQueries({
+                queryKey: ['data-app-viz', projectUuid, appUuid],
+            });
         },
     });
 };

--- a/packages/frontend/src/ee/features/aiCopilot/store/aiArtifactSlice.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/store/aiArtifactSlice.ts
@@ -25,8 +25,7 @@ export interface DataAppPreviewData {
     agentUuid: string;
     /** null means the app's latest ready version. */
     version: number | null;
-    /** Latest ready version when the preview was opened; a newer one landing
-     *  moves the panel to latest. See `getEffectiveDataAppVersion`. */
+    /** Latest ready version at open; a newer one landing moves to latest. */
     latestReadyVersionAtOpen: number | null;
 }
 

--- a/packages/frontend/src/features/apps/components/RestoreAppVersionModal.tsx
+++ b/packages/frontend/src/features/apps/components/RestoreAppVersionModal.tsx
@@ -1,3 +1,4 @@
+import { type ApiError } from '@lightdash/common';
 import { Stack, Text } from '@mantine/core';
 import { IconRestore } from '@tabler/icons-react';
 import { type FC } from 'react';
@@ -6,25 +7,23 @@ import MantineModal from '../../../components/common/MantineModal';
 
 type Props = {
     version: number;
-    opened: boolean;
     onClose: () => void;
     onConfirm: () => void;
     isLoading: boolean;
-    errorMessage: string | null;
+    error: ApiError | null;
 };
 
 /** Confirms a restore; the caller owns the mutation so the builder and the
  *  thread preview can restore through different endpoints. */
 export const RestoreAppVersionModal: FC<Props> = ({
     version,
-    opened,
     onClose,
     onConfirm,
     isLoading,
-    errorMessage,
+    error,
 }) => (
     <MantineModal
-        opened={opened}
+        opened
         onClose={() => {
             if (isLoading) return;
             onClose();
@@ -42,8 +41,10 @@ export const RestoreAppVersionModal: FC<Props> = ({
                 duplicates the contents of version {version}. Your next prompt
                 will iterate from there.
             </Text>
-            {errorMessage !== null && (
-                <Callout variant="danger">{errorMessage}</Callout>
+            {error !== null && (
+                <Callout variant="danger">
+                    {error.error?.message ?? 'Failed to restore version.'}
+                </Callout>
             )}
         </Stack>
     </MantineModal>

--- a/packages/frontend/src/features/apps/components/RestoreAppVersionModal.tsx
+++ b/packages/frontend/src/features/apps/components/RestoreAppVersionModal.tsx
@@ -1,0 +1,50 @@
+import { Stack, Text } from '@mantine/core';
+import { IconRestore } from '@tabler/icons-react';
+import { type FC } from 'react';
+import Callout from '../../../components/common/Callout';
+import MantineModal from '../../../components/common/MantineModal';
+
+type Props = {
+    version: number;
+    opened: boolean;
+    onClose: () => void;
+    onConfirm: () => void;
+    isLoading: boolean;
+    errorMessage: string | null;
+};
+
+/** Confirms a restore; the caller owns the mutation so the builder and the
+ *  thread preview can restore through different endpoints. */
+export const RestoreAppVersionModal: FC<Props> = ({
+    version,
+    opened,
+    onClose,
+    onConfirm,
+    isLoading,
+    errorMessage,
+}) => (
+    <MantineModal
+        opened={opened}
+        onClose={() => {
+            if (isLoading) return;
+            onClose();
+        }}
+        title={`Restore version ${version}?`}
+        icon={IconRestore}
+        confirmLabel="Restore version"
+        cancelDisabled={isLoading}
+        confirmLoading={isLoading}
+        onConfirm={onConfirm}
+    >
+        <Stack gap="sm">
+            <Text fz="sm">
+                This will create a new version on top of the timeline that
+                duplicates the contents of version {version}. Your next prompt
+                will iterate from there.
+            </Text>
+            {errorMessage !== null && (
+                <Callout variant="danger">{errorMessage}</Callout>
+            )}
+        </Stack>
+    </MantineModal>
+);

--- a/packages/frontend/src/features/apps/hooks/useRestoreAppVersion.ts
+++ b/packages/frontend/src/features/apps/hooks/useRestoreAppVersion.ts
@@ -2,7 +2,11 @@ import {
     type ApiError,
     type ApiRestoreAppVersionResponse,
 } from '@lightdash/common';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+    useMutation,
+    useQueryClient,
+    type QueryClient,
+} from '@tanstack/react-query';
 import { lightdashApi } from '../../../api';
 
 type RestoreAppVersionParams = {
@@ -24,6 +28,21 @@ const restoreAppVersion = ({
         body: undefined,
     });
 
+/** The app gained a ready version; its viz contract may have changed too. */
+export const invalidateAppAfterRestore = (
+    queryClient: QueryClient,
+    projectUuid: string,
+    appUuid: string,
+) =>
+    Promise.all([
+        queryClient.invalidateQueries({
+            queryKey: ['app', projectUuid, appUuid],
+        }),
+        queryClient.invalidateQueries({
+            queryKey: ['data-app-viz', projectUuid, appUuid],
+        }),
+    ]);
+
 export const useRestoreAppVersion = () => {
     const queryClient = useQueryClient();
     return useMutation<
@@ -32,22 +51,8 @@ export const useRestoreAppVersion = () => {
         RestoreAppVersionParams
     >({
         mutationFn: restoreAppVersion,
-        onSuccess: (_data, variables) => {
-            // Pull the new ready version into the timeline so AppGenerate
-            // auto-pins onto it.
-            void queryClient.invalidateQueries({
-                queryKey: ['app', variables.projectUuid, variables.appUuid],
-            });
-            // The restored version carries its own field schema, so any panel
-            // open over this visualization is now reconciling against a
-            // contract that is no longer the one being rendered.
-            void queryClient.invalidateQueries({
-                queryKey: [
-                    'data-app-viz',
-                    variables.projectUuid,
-                    variables.appUuid,
-                ],
-            });
+        onSuccess: (_data, { projectUuid, appUuid }) => {
+            void invalidateAppAfterRestore(queryClient, projectUuid, appUuid);
         },
     });
 };

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -2969,16 +2969,9 @@ const AppGenerate: FC = () => {
                             )}
                             {restoreTargetVersion !== null && activeAppUuid && (
                                 <RestoreAppVersionModal
-                                    opened
                                     version={restoreTargetVersion}
                                     isLoading={isRestoringVersion}
-                                    errorMessage={
-                                        restoreVersionError
-                                            ? (restoreVersionError.error
-                                                  ?.message ??
-                                              'Failed to restore version.')
-                                            : null
-                                    }
+                                    error={restoreVersionError}
                                     onClose={() => {
                                         setRestoreTargetVersion(null);
                                         resetRestoreVersion();

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -65,7 +65,6 @@ import { validate as isUuidString, v4 as uuid4 } from 'uuid';
 import { AiMarkdown } from '../components/common/AiMarkdown';
 import Callout from '../components/common/Callout';
 import MantineIcon from '../components/common/MantineIcon';
-import MantineModal from '../components/common/MantineModal';
 import {
     ComposerSubmitButton,
     PromptComposer,
@@ -100,6 +99,7 @@ import { ElementPickerButton } from '../features/apps/components/ElementPickerBu
 import { ElementRefPill } from '../features/apps/components/ElementRefPill';
 import LoadingDots from '../features/apps/components/LoadingDots';
 import RecentAppSuggestions from '../features/apps/components/RecentAppSuggestions';
+import { RestoreAppVersionModal } from '../features/apps/components/RestoreAppVersionModal';
 import { useAppBuildPoller } from '../features/apps/hooks/useAppBuildPoller';
 import { useAppFileUpload } from '../features/apps/hooks/useAppFileUpload';
 import { useAppImageUrl } from '../features/apps/hooks/useAppImageUrl';
@@ -2968,18 +2968,21 @@ const AppGenerate: FC = () => {
                                 />
                             )}
                             {restoreTargetVersion !== null && activeAppUuid && (
-                                <MantineModal
+                                <RestoreAppVersionModal
                                     opened
+                                    version={restoreTargetVersion}
+                                    isLoading={isRestoringVersion}
+                                    errorMessage={
+                                        restoreVersionError
+                                            ? (restoreVersionError.error
+                                                  ?.message ??
+                                              'Failed to restore version.')
+                                            : null
+                                    }
                                     onClose={() => {
-                                        if (isRestoringVersion) return;
                                         setRestoreTargetVersion(null);
                                         resetRestoreVersion();
                                     }}
-                                    title={`Restore version ${restoreTargetVersion}?`}
-                                    icon={IconRestore}
-                                    confirmLabel="Restore version"
-                                    cancelDisabled={isRestoringVersion}
-                                    confirmLoading={isRestoringVersion}
                                     onConfirm={() =>
                                         restoreVersionMutate(
                                             {
@@ -2996,24 +2999,7 @@ const AppGenerate: FC = () => {
                                             },
                                         )
                                     }
-                                >
-                                    <Stack gap="sm">
-                                        <Text fz="sm">
-                                            This will create a new version on
-                                            top of the timeline that duplicates
-                                            the contents of version{' '}
-                                            {restoreTargetVersion}. Your next
-                                            prompt will iterate from there.
-                                        </Text>
-                                        {restoreVersionError && (
-                                            <Callout variant="danger">
-                                                {restoreVersionError.error
-                                                    ?.message ??
-                                                    'Failed to restore version.'}
-                                            </Callout>
-                                        )}
-                                    </Stack>
-                                </MantineModal>
+                                />
                             )}
 
                             <Box className={classes.previewContent}>


### PR DESCRIPTION
Top of a 4-PR stack for ZAP-989. Stacked on the ZAP-994 frontend PR.

While viewing an older version in the thread preview, the pill offers Restore next to Return to latest.

- Restore is shown only when the user can manage the app (same check as Edit on the standalone view page) and disabled with a tooltip while a build is in progress.
- Confirms through `RestoreAppVersionModal`, extracted from the builder and shared; builder behaviour unchanged.
- Calls the thread-scoped restore endpoint; on success the preview moves to the returned version, so the pill disappears and the new restore card is the active one. The app invalidation is shared with the builder's restore hook and awaited so the panel never sees a stale latest version.
- Includes the review fix-up commit for the stack (post-restore "viewing latest" gate, fast-View jump-to-latest floor, modal owning its error fallback, system-only pinned item not rendered as a chip).

Tests: preview panel version tests cover the permission gate, the in-progress gate, confirm → API call → preview moved to the restored version, a refused restore keeping the modal open, and the restored version treated as latest before the app refetch lands.

Known limits: the content-link chip in an agent reply stays active for any version of its app; restore and the thread row are not one transaction.

Closes: ZAP-995
Closes: ZAP-989

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYqCC1cLQv5apggPng7HgQ
