### PR TITLE
fix(query): stop rebasing Snowflake MIN/MAX metrics that inherit wrapped dimension SQL

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -7536,6 +7536,44 @@ describe('Naive timestamp domain — explicit, session-independent conversion', 
         ],
     };
 
+    const snowflakeWrappedDimensionSql = `TO_TIMESTAMP_NTZ(CONVERT_TIMEZONE('UTC', \${TABLE}.occurred_at))`;
+    const snowflakeWrappedSql = `TO_TIMESTAMP_NTZ(CONVERT_TIMEZONE('UTC', "events".occurred_at))`;
+    const snowflakeClientMock = {
+        ...warehouseClientMock,
+        getAdapterType: () => SupportedDbtAdapter.SNOWFLAKE,
+    };
+    // Mirrors the compile-time wrap the translator applies to every Snowflake
+    // TIMESTAMP dimension when the connection's timestamp conversion is on.
+    const buildSnowflakeWrappedExplore = () => {
+        const explore = buildNaiveExplore(
+            SupportedDbtAdapter.SNOWFLAKE,
+            'naive',
+        );
+        ['occurred_at', 'occurred_at_raw'].forEach((dimensionName) => {
+            const dimension = explore.tables.events.dimensions[dimensionName];
+            dimension.sql = snowflakeWrappedDimensionSql;
+            dimension.compiledSql = snowflakeWrappedSql;
+        });
+        return explore;
+    };
+    const buildSnowflakeWrappedQuery = ({
+        explore,
+        compiledMetricQuery,
+    }: {
+        explore: Explore;
+        compiledMetricQuery: CompiledMetricQuery;
+    }) =>
+        buildQuery({
+            explore,
+            compiledMetricQuery,
+            warehouseSqlBuilder: snowflakeClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: 'Asia/Tokyo',
+            useTimezoneAwareDateTrunc: true,
+            columnTimezone: 'UTC',
+            dataTimezone: 'Asia/Tokyo',
+        }).query;
+
     test('MIN/MAX over a known-naive TIMESTAMP base converts the aggregate operand (Postgres)', () => {
         const { query } = buildQuery({
             explore: buildNaiveExplore(SupportedDbtAdapter.POSTGRES, 'naive'),
@@ -7609,33 +7647,102 @@ describe('Naive timestamp domain — explicit, session-independent conversion', 
     });
 
     test('MIN/MAX over a known-naive base rebases the aggregate from the DATA timezone (Snowflake, wrap enabled)', () => {
-        const snowflakeClientMock = {
-            ...warehouseClientMock,
-            getAdapterType: () => SupportedDbtAdapter.SNOWFLAKE,
-        };
         // Production wiring for wrap-enabled Snowflake: dimension SQL is
-        // compile-time normalized to UTC (columnTimezone) while the bare
-        // column the aggregate reads stays in the data timezone.
-        const { query } = buildQuery({
-            explore: buildNaiveExplore(SupportedDbtAdapter.SNOWFLAKE, 'naive'),
+        // compile-time normalized to UTC (columnTimezone) while a metric
+        // written against the bare column reads the data timezone.
+        const query = buildSnowflakeWrappedQuery({
+            explore: buildSnowflakeWrappedExplore(),
             compiledMetricQuery: maxNaiveQuery,
-            warehouseSqlBuilder: snowflakeClientMock,
-            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
-            timezone: 'Asia/Tokyo',
-            useTimezoneAwareDateTrunc: true,
-            columnTimezone: 'UTC',
-            dataTimezone: 'Asia/Tokyo',
         });
         expect(query).toContain(
             `MAX(CONVERT_TIMEZONE('Asia/Tokyo', 'UTC', "events".occurred_at)) AS "events_max_ts"`,
         );
     });
 
-    test('MIN/MAX over an unknown TIMESTAMP base stays byte-identical on Snowflake (identity cast)', () => {
-        const snowflakeClientMock = {
-            ...warehouseClientMock,
-            getAdapterType: () => SupportedDbtAdapter.SNOWFLAKE,
+    test('MIN/MAX inherited from a wrapped Snowflake timestamp dimension is not rebased a second time', () => {
+        const query = buildSnowflakeWrappedQuery({
+            explore: buildSnowflakeWrappedExplore(),
+            compiledMetricQuery: {
+                ...maxNaiveQuery,
+                dimensions: ['events_occurred_at_raw'],
+                additionalMetrics: maxNaiveQuery.additionalMetrics?.map(
+                    (metric) => ({
+                        ...metric,
+                        sql: snowflakeWrappedDimensionSql,
+                    }),
+                ),
+                compiledAdditionalMetrics:
+                    maxNaiveQuery.compiledAdditionalMetrics?.map((metric) => ({
+                        ...metric,
+                        sql: snowflakeWrappedDimensionSql,
+                        compiledSql: `MAX(${snowflakeWrappedSql})`,
+                    })),
+            },
+        });
+
+        expect(query).toContain(
+            `${snowflakeWrappedSql} AS "events_occurred_at_raw"`,
+        );
+        expect(query).toContain(
+            `MAX(${snowflakeWrappedSql}) AS "events_max_ts"`,
+        );
+        expect(query).not.toContain(`CONVERT_TIMEZONE('Asia/Tokyo'`);
+    });
+
+    test('Snowflake filtered MIN/MAX rebases a bare column but not the inherited wrapped dimension SQL', () => {
+        const filters = [
+            {
+                id: 'f1',
+                target: { fieldRef: 'events.occurred_at' },
+                operator: FilterOperator.NOT_NULL,
+                values: [],
+            },
+        ];
+        const inheritedFilteredSql = `MAX(CASE WHEN "events".occurred_at IS NOT NULL THEN ${snowflakeWrappedSql} ELSE NULL END)`;
+        const explicitFilteredSql = `MAX(CASE WHEN "events".occurred_at IS NOT NULL THEN "events".occurred_at ELSE NULL END)`;
+        const inheritedQuery: CompiledMetricQuery = {
+            ...maxNaiveQuery,
+            additionalMetrics: maxNaiveQuery.additionalMetrics?.map(
+                (metric) => ({
+                    ...metric,
+                    sql: snowflakeWrappedDimensionSql,
+                }),
+            ),
+            compiledAdditionalMetrics:
+                maxNaiveQuery.compiledAdditionalMetrics?.map((metric) => ({
+                    ...metric,
+                    sql: snowflakeWrappedDimensionSql,
+                    filters,
+                    compiledSql: inheritedFilteredSql,
+                })),
         };
+        const explicitQuery: CompiledMetricQuery = {
+            ...maxNaiveQuery,
+            compiledAdditionalMetrics:
+                maxNaiveQuery.compiledAdditionalMetrics?.map((metric) => ({
+                    ...metric,
+                    filters,
+                    compiledSql: explicitFilteredSql,
+                })),
+        };
+
+        expect(
+            buildSnowflakeWrappedQuery({
+                explore: buildSnowflakeWrappedExplore(),
+                compiledMetricQuery: inheritedQuery,
+            }),
+        ).toContain(`${inheritedFilteredSql} AS "events_max_ts"`);
+        expect(
+            buildSnowflakeWrappedQuery({
+                explore: buildSnowflakeWrappedExplore(),
+                compiledMetricQuery: explicitQuery,
+            }),
+        ).toContain(
+            `CONVERT_TIMEZONE('Asia/Tokyo', 'UTC', ${explicitFilteredSql}) AS "events_max_ts"`,
+        );
+    });
+
+    test('MIN/MAX over an unknown TIMESTAMP base stays byte-identical on Snowflake (identity cast)', () => {
         const { query } = buildQuery({
             explore: buildNaiveExplore(SupportedDbtAdapter.SNOWFLAKE),
             compiledMetricQuery: maxNaiveQuery,

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -169,9 +169,10 @@ export type BuildQueryProps = {
      *  Derived from warehouse credentials via `getColumnTimezone`. */
     columnTimezone?: string;
     /** Raw project data timezone from the warehouse credentials. Differs from
-     *  `columnTimezone` only on Snowflake, whose compile-time wrap normalizes
-     *  dimension columns to UTC while bare columns (aggregate inputs) remain
-     *  in the data timezone. */
+     *  `columnTimezone` only when the compiler wraps timestamp dimensions
+     *  into UTC at compile time: the wrapped dimension SQL is then in UTC
+     *  while raw column references (aggregate inputs) remain in the data
+     *  timezone. */
     dataTimezone?: string;
     queryExecutionContext?: QueryExecutionContext;
     /**
@@ -436,8 +437,8 @@ export class MetricQueryBuilder {
         return !this.args.skipModelRequiredFilters;
     }
 
-    /** Falls back to `columnTimezone`, which is equal on every warehouse
-     *  except Snowflake (see BuildQueryProps.dataTimezone). */
+    /** Falls back to `columnTimezone`, which is equal unless the compiler
+     *  wraps timestamp dimensions (see BuildQueryProps.dataTimezone). */
     private get dataTimezone(): string {
         return this.args.dataTimezone ?? this.columnTimezone;
     }
@@ -1170,10 +1171,9 @@ export class MetricQueryBuilder {
         }
         // A MIN/MAX over a naive TIMESTAMP column aggregates the bare wall
         // clock, which the wire stamps as UTC — rebase to a true instant:
-        // explicitly from the data timezone when the base is known-naive (on
-        // Snowflake that differs from columnTimezone, which only describes the
-        // compile-time-wrapped dimension SQL), via the session cast (identity
-        // in value for aware columns) as the unknown-domain fallback.
+        // explicitly from the timezone the operand carries when the base is
+        // known-naive, via the session cast (identity in value for aware
+        // columns) as the unknown-domain fallback.
         if (metric.baseDimensionType === DimensionType.TIMESTAMP) {
             const baseDimension = this.resolveMinMaxBaseDimension(
                 metricId,
@@ -1185,10 +1185,23 @@ export class MetricQueryBuilder {
                 castNaiveAggregateToInstant,
                 castAwareToInstant,
             } = dateTruncTimezoneConversions[adapterType];
+            const operand = this.resolveMinMaxOperand(
+                metric,
+                baseDimension,
+                baseSql,
+            );
+            // The operand form decides which timezone the aggregate reads: the
+            // dimension's compiled SQL is in columnTimezone, a raw column in
+            // dataTimezone. When the compiler wrapped the dimension, a metric
+            // that inherited its SQL already aggregates the UTC expression.
+            const operandTimezone =
+                operand !== undefined && operand === baseDimension?.compiledSql
+                    ? this.columnTimezone
+                    : this.dataTimezone;
             const explicitNaive =
                 baseDimension?.timestampDomain === 'naive' &&
                 castNaiveAggregateToInstant !== null &&
-                this.dataTimezone !== 'UTC';
+                operandTimezone !== 'UTC';
             const explicitAware =
                 baseDimension?.timestampDomain === 'aware' &&
                 castAwareToInstant !== null &&
@@ -1203,7 +1216,7 @@ export class MetricQueryBuilder {
             let convert: (sql: string) => string;
             if (explicitNaive) {
                 convert = (sql: string) =>
-                    castNaiveAggregateToInstant!(sql, this.dataTimezone);
+                    castNaiveAggregateToInstant!(sql, operandTimezone);
             } else if (explicitAware) {
                 convert = castAwareToInstant!;
             } else {
@@ -1214,11 +1227,6 @@ export class MetricQueryBuilder {
             // can disagree. Falls back to the output wrap when the operand
             // isn't found, or when metric filters may repeat the column
             // reference inside compiled predicates.
-            const operand = this.resolveMinMaxOperand(
-                metric,
-                baseDimension,
-                baseSql,
-            );
             if (operand && !metric.filters?.length) {
                 return baseSql.replace(
                     MetricQueryBuilder.sqlReferenceBoundary(operand),
@@ -1283,10 +1291,11 @@ export class MetricQueryBuilder {
 
     /**
      * The column expression a MIN/MAX metric aggregates, as it appears inside
-     * the compiled metric SQL. The dimension's compiledSql matches everywhere
-     * except wrap-enabled Snowflake, where the metric aggregates the bare
-     * column while the dimension SQL is compile-time wrapped — the bare
-     * reference is reconstructed from the table and dimension name.
+     * the compiled metric SQL. The dimension's compiledSql matches unless the
+     * compiler wrapped the dimension: then only a metric that inherited the
+     * dimension SQL aggregates the wrapped expression, while one written
+     * against the source column aggregates the raw column, which is
+     * reconstructed from the table and dimension name.
      */
     private resolveMinMaxOperand(
         metric: CompiledMetric,


### PR DESCRIPTION
Min/Max metrics created from a TIMESTAMP_NTZ dimension on Snowflake returned a value shifted by the data timezone offset when a non-UTC data timezone was set. The compile-time wrap already normalizes the dimension SQL to UTC, and both the UI and YAML column metrics copy that SQL into the aggregate, but the query builder assumed the aggregate read the bare column and rebased it from the data timezone a second time. Affects every Snowflake project with timestamp conversion on and a non-UTC data timezone.

Supersedes #28528, which fixed the same symptom with a new persisted dimension flag.

Closes PROD-10850
