### PR TITLE
perf: serve explores from per-explore rows, not the whole-set blob

### DIFF
--- a/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
@@ -702,15 +702,19 @@ describe('ProjectModel', () => {
                     }),
                     expect.objectContaining({
                         bindings: expect.arrayContaining([
-                            JSON.stringify([
-                                cachedExplore,
-                                virtualView,
-                                incomingExplore,
-                            ]),
+                            JSON.stringify(incomingExplore),
                         ]),
                     }),
                 ]),
             );
+            // The cached explores are preserved by upserting the incoming row and deleting
+            // nothing, rather than by rewriting a whole-set value. The only write to
+            // cached_explores is the lock row, which carries an empty array.
+            tracker.history.insert
+                .filter(({ sql }) => sql.includes('"cached_explores"'))
+                .forEach(({ bindings }) => {
+                    expect(bindings).toEqual([[], projectUuid]);
+                });
         });
 
         test('accepts an empty additive payload when cached explores exist', async () => {
@@ -800,11 +804,16 @@ describe('ProjectModel', () => {
                 expect.arrayContaining([
                     expect.objectContaining({
                         bindings: expect.arrayContaining([
-                            JSON.stringify([virtualView]),
+                            JSON.stringify(virtualView),
                         ]),
                     }),
                 ]),
             );
+            tracker.history.insert
+                .filter(({ sql }) => sql.includes('"cached_explores"'))
+                .forEach(({ bindings }) => {
+                    expect(bindings).toEqual([[], projectUuid]);
+                });
         });
 
         // TODO: this test is skipped because there is an issue in our version of knex-mock-client

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -146,9 +146,6 @@ import Logger from '../../logging/logger';
 import { wrapSentryTransaction, wrapSentryTransactionSync } from '../../utils';
 import {
     chunkRowsByBytes,
-    describeWholeSetOverflow,
-    POSTGRES_JSONB_MAX_BYTES,
-    serialisedArrayBytes,
 } from '../../utils/chunkRowsByBytes';
 import {
     hasSameDbtCredentialDestination,
@@ -2037,26 +2034,8 @@ export class ProjectModel {
                         individualCachedExplores.push(...saved);
                     }
 
-                    // Cache explores together. This is one jsonb column value holding every
-                    // explore, so it has a hard ceiling that chunking cannot move. Name the
-                    // size when it is exceeded rather than surfacing a bare RangeError.
-                    const wholeSetBytes =
-                        exploresToSave === uniqueExplores
-                            ? savedBytes + uniqueExplores.length + 1
-                            : serialisedArrayBytes(uniqueExplores);
-                    if (wholeSetBytes > POSTGRES_JSONB_MAX_BYTES) {
-                        throw new ParameterError(
-                            describeWholeSetOverflow(
-                                uniqueExplores.length,
-                                wholeSetBytes,
-                            ),
-                        );
-                    }
                     Logger.info(
-                        `dbt.compile.saveExplores projectUuid=${projectUuid} explores=${uniqueExplores.length} chunks=${chunkCount} largestChunkBytes=${largestChunkBytes} wholeSetBytes=${wholeSetBytes} wholeSetPercentOfLimit=${(
-                            (wholeSetBytes / POSTGRES_JSONB_MAX_BYTES) *
-                            100
-                        ).toFixed(1)}`,
+                        `dbt.compile.saveExplores projectUuid=${projectUuid} explores=${uniqueExplores.length} chunks=${chunkCount} largestChunkBytes=${largestChunkBytes}`,
                         {
                             event: 'dbt.compile.saveExplores',
                             projectUuid,
@@ -2064,21 +2043,8 @@ export class ProjectModel {
                             chunks: chunkCount,
                             largestChunkBytes,
                             savedBytes,
-                            wholeSetBytes,
-                            wholeSetLimitBytes: POSTGRES_JSONB_MAX_BYTES,
-                            wholeSetPercentOfLimit:
-                                (wholeSetBytes / POSTGRES_JSONB_MAX_BYTES) *
-                                100,
                         },
                     );
-                    await trx(CachedExploresTableName)
-                        .insert({
-                            project_uuid: projectUuid,
-                            explores: JSON.stringify(uniqueExplores),
-                        })
-                        .onConflict('project_uuid')
-                        .merge()
-                        .returning('*');
 
                     return {
                         cachedExploreUuids: individualCachedExplores.map(
@@ -4590,7 +4556,6 @@ export class ProjectModel {
                 table_names: Object.keys(virtualView.tables || {}),
                 explore: virtualView,
             });
-            await ProjectModel.rebuildCachedExplores(trx, projectUuid);
         });
 
         return virtualView;
@@ -4639,7 +4604,6 @@ export class ProjectModel {
                 })
                 .where('project_uuid', projectUuid)
                 .andWhere('name', exploreName);
-            await ProjectModel.rebuildCachedExplores(trx, projectUuid);
         });
 
         return translatedToExplore;
@@ -4653,7 +4617,6 @@ export class ProjectModel {
                 .whereRaw("explore->>'type' = ?", [ExploreType.VIRTUAL])
                 .andWhere('name', name)
                 .delete();
-            await ProjectModel.rebuildCachedExplores(trx, projectUuid);
         });
     }
 
@@ -4699,7 +4662,6 @@ export class ProjectModel {
                     explore,
                 });
             }
-            await ProjectModel.rebuildCachedExplores(trx, projectUuid);
         });
     }
 
@@ -4715,7 +4677,6 @@ export class ProjectModel {
                 .whereRaw("explore->>'type' = ?", [ExploreType.EXTERNAL_SOURCE])
                 .whereIn('name', names)
                 .delete();
-            await ProjectModel.rebuildCachedExplores(trx, projectUuid);
         });
     }
 
@@ -4731,23 +4692,6 @@ export class ProjectModel {
             .where('project_uuid', projectUuid)
             .forUpdate()
             .first();
-    }
-
-    private static async rebuildCachedExplores(
-        trx: Transaction,
-        projectUuid: string,
-    ): Promise<void> {
-        const cachedExplores = await trx(CachedExploreTableName)
-            .select<{ explore: Explore | ExploreError }[]>('explore')
-            .where('project_uuid', projectUuid)
-            .orderBy('name');
-        await trx(CachedExploresTableName)
-            .where('project_uuid', projectUuid)
-            .update({
-                explores: JSON.stringify(
-                    cachedExplores.map(({ explore }) => explore),
-                ),
-            });
     }
 
     async updateSchedulerSettings(

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -144,9 +144,7 @@ import {
 import { ServiceAccountsTableName } from '../../ee/database/entities/serviceAccounts';
 import Logger from '../../logging/logger';
 import { wrapSentryTransaction, wrapSentryTransactionSync } from '../../utils';
-import {
-    chunkRowsByBytes,
-} from '../../utils/chunkRowsByBytes';
+import { chunkRowsByBytes } from '../../utils/chunkRowsByBytes';
 import {
     hasSameDbtCredentialDestination,
     hasSameWarehouseCredentialDestination,

--- a/packages/backend/src/models/SearchModel/index.ts
+++ b/packages/backend/src/models/SearchModel/index.ts
@@ -37,7 +37,7 @@ import {
     DashboardVersionsTableName,
 } from '../../database/entities/dashboards';
 import {
-    CachedExploresTableName,
+    CachedExploreTableName,
     ProjectTableName,
 } from '../../database/entities/projects';
 import { SavedChartsTableName } from '../../database/entities/savedCharts';
@@ -1573,37 +1573,38 @@ export class SearchModel {
             value: projects[0].table_selection_value,
         };
 
-        const explores = await this.database(CachedExploresTableName)
-            .select(['explores'])
+        // One row per explore, not the whole-set blob. That blob was a single jsonb value
+        // holding every explore, so a global search parsed the entire catalog on every
+        // request. The pre-aggregate exclusion is pushed into SQL so those rows never leave
+        // Postgres. Explores with no type predate the column and must be kept, hence
+        // IS DISTINCT FROM rather than <>.
+        const rows = await this.database(CachedExploreTableName)
+            .select<{ explore: Explore | ExploreError }[]>('explore')
             .where('project_uuid', projectUuid)
-            .limit(1);
+            .whereRaw("explore->>'type' IS DISTINCT FROM ?", [
+                ExploreType.PRE_AGGREGATE,
+            ])
+            .orderBy('name');
 
-        if (explores.length > 0 && explores[0].explores) {
-            return explores[0].explores.filter(
-                (explore: Explore | ExploreError) => {
-                    if (explore.type === ExploreType.PRE_AGGREGATE) {
-                        return false;
-                    }
-                    if (tableSelection.type === TableSelectionType.WITH_TAGS) {
-                        return (
-                            hasIntersection(
-                                explore.tags || [],
-                                tableSelection.value || [],
-                            ) || isUserManagedExplore(explore)
-                        );
-                    }
-                    if (tableSelection.type === TableSelectionType.WITH_NAMES) {
-                        return (
-                            (tableSelection.value || []).includes(
-                                explore.name,
-                            ) || isUserManagedExplore(explore)
-                        );
-                    }
-                    return true;
-                },
-            );
-        }
-        return [];
+        return rows
+            .map(({ explore }) => explore)
+            .filter((explore: Explore | ExploreError) => {
+                if (tableSelection.type === TableSelectionType.WITH_TAGS) {
+                    return (
+                        hasIntersection(
+                            explore.tags || [],
+                            tableSelection.value || [],
+                        ) || isUserManagedExplore(explore)
+                    );
+                }
+                if (tableSelection.type === TableSelectionType.WITH_NAMES) {
+                    return (
+                        (tableSelection.value || []).includes(explore.name) ||
+                        isUserManagedExplore(explore)
+                    );
+                }
+                return true;
+            }) as Explore[];
     }
 
     static searchTablesAndFields(


### PR DESCRIPTION
Linear: SPK-1868

**Base**: `main`. Step one of two. This stops writing the whole-set value and moves every reader
off it. The column and its row stay for the project advisory lock. Dropping the column is step
two, in a later release.

## What breaks today

`cached_explores.explores` holds a project's entire explore set as one `jsonb` value in one row.
Postgres caps a `jsonb` container at 268,435,455 bytes. At the shape of a large self-hosted
project we have measured — 3,382 explores at about 45 KB each — the value is 149 MB, **58% of
that ceiling**, and the wall is around 5,800 explores of that shape.

Two things make it worse than a distant limit.

**It fails after everything succeeded.** The compile completes, the explores are correct, then
the write throws. The write shares a transaction with the per-explore inserts, so the whole
result rolls back and a project over the line cannot deploy at all.

**Every global search parses it.** `SearchModel.getProjectExplores` read the blob and parsed all
149 MB on every search request.

## What changed

The rows already exist. `cached_explore` holds one row per explore, written in the same
transaction, so it needs no separate invalidation.

- **`SearchModel.getProjectExplores`** now selects one row per explore, with the pre-aggregate
  exclusion pushed into SQL so those rows never leave Postgres. Explores written before the
  `type` column existed have no type and must still be returned, so the predicate is
  `IS DISTINCT FROM` rather than `<>`.
- **`saveExploresToCache`** no longer writes the whole-set value.
- **`rebuildCachedExplores` is deleted**, with its five call sites: `createVirtualView`,
  `updateVirtualView`, `deleteVirtualView`, `saveExternalSourceExplore` and
  `deleteExternalSourceExplores`. It existed only to re-stringify the whole set from the
  per-explore rows after a mutation. With nothing reading the blob it has no work to do.
- **`lockAndEnsureCachedExplores` is unchanged.** It still inserts and locks the row, which now
  carries an empty array. The lock semantics are untouched in this step.

Rejected, as the ticket sets out: gzip does nothing while the column is `jsonb`, still builds the
whole string first, and adds a decompress plus full parse to every search. A streamed write
cannot pass the container limit, because the limit is on the stored value rather than on how it
arrives.

## Every reader changed, and how it was proved

| Reader or writer | Change | How it was proved |
|---|---|---|
| `SearchModel.getProjectExplores` | blob read to per-row select | Both queries run against the same database holding 3,382 explores; results sorted by name and hashed. **Identical sha256 `09fca7715f43dc45`, 3,382 explores each.** |
| `saveExploresToCache` | stops writing the whole set | The two `ProjectModel` tests that asserted the union through the blob binding now assert it through the per-explore upsert and the absence of a delete, and additionally assert that the only write to `cached_explores` is the lock row carrying an empty array. |
| `rebuildCachedExplores` and its five callers | deleted | Its only effect was the `cached_explores.explores` update; it read from `cached_explore`, which is untouched. All 56 `ProjectModel` tests pass. |
| `lockAndEnsureCachedExplores` | unchanged | Asserted directly: the remaining `cached_explores` inserts bind `[[], projectUuid]`. |

`CatalogModel` does not read the blob; the similarly named `getCachedExploresTableNameMap` is a
callback parameter over `cached_explore`.

## Downstream readers

After this change the whole-set column carries an empty array after every deploy, so anything
outside this repository that read it would see a project with no explores.

A code search across the `lightdash` organisation finds no such reader. Within this repository
the only remaining references are the delete on project removal, the lock row, and the
`SearchModel` read this change moves. Two further hits are comments rather than reads: the AI
agent memory consolidation path mentions the blob in a comment but calls
`ProjectModel.findExploresFromCache`, which selects from `cached_explore`, and the AI review
classifier reference is prose in a type file.

The column is dropped in step two, which is when a reader outside this repository would break
loudly rather than quietly. Anyone holding one has until then.

## Measured: the search path

Both paths against the same database, 3,382 explores, two runs each, fresh process per run.

| | Before | After |
|---|---:|---:|
| **Peak RSS per search** | **667 MB** | **373 MB** |
| Peak RSS growth during the read | 606 MB | 313 MB |
| Latency | 2,028 ms | 1,349 ms |
| Explores returned | 3,382 | 3,382 |
| Result fingerprint | `09fca7715f43dc45` | `09fca7715f43dc45` |

Per run: before 658 and 676 MB at 2,093 and 1,963 ms; after 366 and 380 MB at 1,396 and 1,302 ms.

**A global search on a project this size allocated about 600 MB and took two seconds. It now
allocates about 310 MB and takes 1.35 seconds, and returns byte-identical results.** That is the
149 MB column read, and the parse of it, removed from every search request.

## Measured: the save path

Same arm, 8 vCPU, own cgroup scope, two repetitions each, interleaved. Chunking is held constant
across both arms so this isolates the blob write alone.

| | Blob written | Blob removed |
|---|---:|---:|
| **Save phase duration** | **6.4 s** | **2.1 s** |
| Chunked insert | 1.9 s | 1.6 s |
| Whole compile, wall | 43.3 s | 39.3 s |
| CPU used | 203.0 s | 201.8 s |
| Chunks / largest chunk | 4 / 44 MB | 4 / 44 MB |
| Whole-set value written | 149 MB | none |
| Node peak in the save window | 2,914 and 2,265 MB | 2,826 and 2,829 MB |
| Explores / fingerprint | 3,382 / `7a64e37a3767` | 3,382 / `7a64e37a3767` |

**The save phase gets 67% shorter and the whole compile about 9% shorter.** Chunk count and
largest chunk are identical across the arms, which is the check that the comparison isolates the
blob write rather than picking up the chunking change in SPK-1863.

**There is no measurable save-phase memory win at this shape, and the honest reason is noise.**
The blob arm's two repetitions came in at 2,914 MB and 2,265 MB, a 649 MB spread, while the
no-blob arm sat at 2,826 and 2,829 MB. The arms overlap, so the medians say nothing. The 149 MB
string is transient: V8 reclaims it quickly and it never lifts the peak above the explore objects
and chunk statements that are already resident.

An earlier run of this comparison reported a 478 MB reduction. That run was wrong: the no-blob
arm had silently taken the byte-bounded chunking path as well, so it measured SPK-1863 and this
change together. The chunk counts gave it away. The table above is the corrected run.

So the memory case for this change is the **search path**, not the save path, and the correctness
case is the ceiling.

## What is not measured

The ceiling itself is not exercised. Demonstrating the old failure needs a catalog about 1.7x
this rig's, and the heavy-arm fixture working trees were removed during a disk sweep. The
ceiling is established from the ticket's Postgres 18 measurement — 3,000 elements of 45 KB cast
fine, 6,200 fail with `total size of jsonb array elements exceeds the maximum of 268435455
bytes` — and from this rig's 149 MB at 3,382 explores.

Step two, dropping the column and moving the lock, is not in this change.
