### PR TITLE
fix(users): show impersonate action for roles granted only the impersonation scope

### DIFF
--- a/packages/backend/src/services/OrganizationService/OrganizationService.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.ts
@@ -1201,12 +1201,16 @@ export class OrganizationService extends BaseService {
             throw new NotFoundError('Organization not found');
         }
         const auditedAbility = this.createAuditedAbility(user);
-        if (
-            auditedAbility.cannot(
+        const canReadSetting =
+            auditedAbility.can(
                 'update',
                 subject('Organization', { organizationUuid }),
-            )
-        ) {
+            ) ||
+            auditedAbility.can(
+                'impersonate',
+                subject('User', { organizationUuid, isActive: true }),
+            );
+        if (!canReadSetting) {
             throw new ForbiddenError();
         }
         const flag = await this.featureFlagModel.get({

--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersActionMenu.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersActionMenu.tsx
@@ -52,6 +52,7 @@ interface UsersActionMenuProps {
     user: OrganizationMemberProfile | OrganizationMemberProfileWithGroups;
     disabled: boolean;
     canInvite: boolean;
+    canDelete: boolean;
     inviteLink: ReturnType<typeof useCreateInviteLinkMutation>;
     onInviteSent: (userUuid: string) => void;
 }
@@ -89,6 +90,7 @@ const UsersActionMenu: FC<UsersActionMenuProps> = ({
     user,
     disabled,
     canInvite,
+    canDelete,
     inviteLink,
     onInviteSent,
 }) => {
@@ -252,6 +254,10 @@ const UsersActionMenu: FC<UsersActionMenuProps> = ({
         setDashboardOwnerAction(value);
     }, []);
 
+    if (!showResendInvite && !canImpersonate && !canDelete) {
+        return null;
+    }
+
     return (
         <>
             <Menu
@@ -300,16 +306,18 @@ const UsersActionMenu: FC<UsersActionMenuProps> = ({
                             <Menu.Divider />
                         </>
                     )}
-                    <Menu.Item
-                        component="button"
-                        role="menuitem"
-                        color="red"
-                        leftSection={<MantineIcon icon={IconTrash} />}
-                        onClick={() => setIsDeleteDialogOpen(true)}
-                        disabled={disabled}
-                    >
-                        Delete user
-                    </Menu.Item>
+                    {canDelete && (
+                        <Menu.Item
+                            component="button"
+                            role="menuitem"
+                            color="red"
+                            leftSection={<MantineIcon icon={IconTrash} />}
+                            onClick={() => setIsDeleteDialogOpen(true)}
+                            disabled={disabled}
+                        >
+                            Delete user
+                        </Menu.Item>
+                    )}
                 </Menu.Dropdown>
             </Menu>
 

--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersTable.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersTable.tsx
@@ -224,6 +224,9 @@ const UsersTable: FC = () => {
         false;
     const canInvite =
         activeUser.data?.ability?.can('create', 'InviteLink') ?? false;
+    const canImpersonate =
+        activeUser.data?.ability?.can('impersonate', 'User') ?? false;
+    const showActions = canManageUsers || canInvite || canImpersonate;
 
     const columns: ContentTableColumnDef<
         OrganizationMemberProfile | OrganizationMemberProfileWithGroups
@@ -385,7 +388,9 @@ const UsersTable: FC = () => {
                     },
                 });
             }
+        }
 
+        if (showActions) {
             cols.push({
                 id: 'actions',
                 header: '',
@@ -409,6 +414,7 @@ const UsersTable: FC = () => {
                                 user={user}
                                 disabled={disabled}
                                 canInvite={canInvite}
+                                canDelete={canManageUsers}
                                 inviteLink={inviteLink}
                                 onInviteSent={handleInviteSent}
                             />
@@ -421,6 +427,7 @@ const UsersTable: FC = () => {
         return cols;
     }, [
         canManageUsers,
+        showActions,
         inviteLink,
         inviteSuccessFor,
         isGroupManagementEnabled,


### PR DESCRIPTION
A custom role granted only the impersonate-users scope never saw the "Impersonate user" action in Users & Groups, so admins had to also grant broader organization-management access to delegate impersonation. Two gates caused it: the row actions column only rendered for members who can manage organization member profiles, and the impersonation settings read on the backend required the update-organization ability, so the toggle value never reached the menu even when the column did render. The start-impersonation endpoint was already correctly authorized.

Closes: #28555

