### PR TITLE
fix(merge): refuse a compose merge whose leg reached the row cap

### DIFF
--- a/docs/merge-queries/CONTEXT.md
+++ b/docs/merge-queries/CONTEXT.md
@@ -63,9 +63,11 @@ error: it is the feature working.
 _Avoid_: validation error, failure
 
 **Row cap**:
-The maximum rows one source may contribute. Reaching it is reported, never
-silently trimmed, because a join over a trimmed side returns numbers that look
-complete and are not.
+The maximum rows one source may contribute. A leg that reaches it is refused
+before the join, naming the source, never silently trimmed, because a join over
+a trimmed side returns numbers that look complete and are not. It is known only
+once the leg has run, so unlike other refusals it arrives as the merged query's
+error.
 _Avoid_: limit (collides with the merged result's own limit), truncation
 
 **Compose engine**:

--- a/docs/merge-queries/architecture.md
+++ b/docs/merge-queries/architecture.md
@@ -127,7 +127,9 @@ These exist because getting them wrong produces confident wrong numbers.
   null-ness equality that keeps the sentinel collision-safe. On DuckDB this
   reduces to the null-safe operator.
 - **Fan-out is refused before execution**, naming the source and the dimension.
-- **Reaching the row cap is reported, never trimmed.**
+- **A leg that reaches the row cap is refused before the join**, from the leg's
+  own `query_history` row count. On the compose path the legs run at the cap,
+  so no guard inside the join SQL could ever see past it.
 - **Table calculations that depend on a source's own row set are refused**,
   because merging changes those rows.
 
@@ -143,7 +145,8 @@ These exist because getting them wrong produces confident wrong numbers.
 Known gaps in that coverage, so you do not assume it is proving more than it is:
 the parity suite compares values numerically, so it cannot catch a formatting
 regression; there is no end-to-end test of merging at all; and a live row-cap
-trip needs more rows than the seed carries.
+trip needs more rows than the seed carries (the refusal itself is proven in
+`AsyncQueryService.test.ts` with the cap lowered through config).
 
 ## Current work
 

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -5415,3 +5415,113 @@ describe('getQueryHistoryList', () => {
         expect(counts.total).toBe(347);
     });
 });
+
+describe('runComposeMergeQuery row cap refusal', () => {
+    const SOURCE_ROW_CAP = 3;
+
+    // Lowered through config rather than by seeding cap-many rows: the run
+    // path reads the cap from the same config the legs were submitted with.
+    const cappedConfig = {
+        ...lightdashConfigMock,
+        query: { ...lightdashConfigMock.query, maxLimit: SOURCE_ROW_CAP },
+    };
+
+    const legHistory = (totalRowCount: number | null) =>
+        ({
+            queryUuid: 'leg-uuid',
+            projectUuid,
+            status: QueryHistoryStatus.READY,
+            totalRowCount,
+            resultsFileName: 'leg-results.jsonl',
+            resultsExpiresAt: null,
+            columns: {},
+            context: QueryExecutionContext.EXPLORE,
+        }) as unknown as QueryHistory;
+
+    const runRefusalCase = async (totalRowCount: number | null) => {
+        const service = getMockedAsyncQueryService(cappedConfig);
+        const storageClient = service.resultsStorageClient as unknown as {
+            configuration: { bucket: string };
+        };
+        storageClient.configuration = { bucket: 'results-bucket' };
+
+        (
+            service.queryHistoryModel as unknown as {
+                pollForQueryCompletion: import('vitest').Mock;
+            }
+        ).pollForQueryCompletion = vi.fn(async () => legHistory(totalRowCount));
+
+        const runWarehouseQuery = vi
+            .spyOn(
+                service as unknown as {
+                    runAsyncWarehouseQuery: (
+                        ...args: unknown[]
+                    ) => Promise<void>;
+                },
+                'runAsyncWarehouseQuery',
+            )
+            .mockResolvedValue(undefined);
+
+        await (
+            service as unknown as {
+                runComposeMergeQuery: (
+                    args: Record<string, unknown>,
+                ) => Promise<void>;
+            }
+        ).runComposeMergeQuery({
+            account: buildAccount(),
+            projectUuid,
+            organizationUuid: projectSummary.organizationUuid,
+            isPreviewProject: false,
+            onboardingFlow: 'default' as AnyType,
+            queryUuid: 'merge-query-uuid',
+            sql: 'SELECT 1',
+            references: { merge_source_0: 'leg-uuid' },
+            legLabelByReferenceTable: { merge_source_0: 'Orders' },
+            warehouseClient: warehouseClientMock,
+            queryTags: {} as AnyType,
+            queryCreatedAt: new Date(),
+            cacheKey: 'cache-key',
+            context: QueryExecutionContext.EXPLORE,
+            fieldsMap: {} as ItemsMap,
+            usedParameters: {},
+            pivotConfiguration: undefined,
+            originalColumns: {} as ResultColumns,
+        });
+
+        return {
+            runWarehouseQuery,
+            update: service.queryHistoryModel.update as import('vitest').Mock,
+        };
+    };
+
+    it('refuses before the join when a leg reached the row cap, naming the source', async () => {
+        const { runWarehouseQuery, update } =
+            await runRefusalCase(SOURCE_ROW_CAP);
+
+        expect(runWarehouseQuery).not.toHaveBeenCalled();
+        expect(update).toHaveBeenCalledWith(
+            'merge-query-uuid',
+            projectUuid,
+            expect.objectContaining({
+                status: QueryHistoryStatus.ERROR,
+                error: `Orders returned the maximum of ${SOURCE_ROW_CAP} rows, so the merged results would be missing data. Add a filter to Orders, then merge again.`,
+            }),
+            expect.anything(),
+        );
+    });
+
+    it('runs the join when every leg is under the row cap', async () => {
+        const { runWarehouseQuery, update } = await runRefusalCase(
+            SOURCE_ROW_CAP - 1,
+        );
+
+        expect(runWarehouseQuery).toHaveBeenCalledTimes(1);
+        expect(update).not.toHaveBeenCalledWith(
+            expect.anything(),
+            expect.anything(),
+            expect.objectContaining({ status: QueryHistoryStatus.ERROR }),
+            expect.anything(),
+        );
+    });
+});

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -67,6 +67,7 @@ import {
     isExploreError,
     isField,
     isJwtUser,
+    isMergeMetricSource,
     isMergeResultSource,
     isMetric,
     isMetricSourcedMergeQuery,
@@ -252,6 +253,8 @@ import { getUnpivotedColumns } from './getUnpivotedColumns';
 import {
     applyMergeExportLimit,
     buildComposeMergeOriginalColumns,
+    getMergeRowCapError,
+    getMergeSourceLabels,
 } from './mergeQueryExecution';
 import {
     NoOpPreAggregateStrategy,
@@ -6920,7 +6923,7 @@ export class AsyncQueryService extends ProjectService {
      * uuid (the creator-scoped QueryHistoryModel.get lookup plus
      * throwIfCannotReadQueryHistory). The referenced query does NOT need to
      * be finished — waiting for results happens in the background execution
-     * phase (buildQueryReferenceCtes).
+     * phase (waitForQueryReferences).
      */
     private async authorizeQueryReferences({
         account,
@@ -6975,15 +6978,14 @@ export class AsyncQueryService extends ProjectService {
     }
 
     /**
-     * Builds one CTE per referenced query so the user SQL can select from
-     * semantically-named tables: {"orders": "<queryUuid>"} exposes that
-     * query's results as `orders`. References to queries that are still
-     * running are waited on — this is the whole of pipeline orchestration:
-     * a query that reads another query's results starts once those results
-     * exist, and fails if the referenced query fails. References must
-     * already be authorized (authorizeQueryReferences).
+     * Waits for every referenced query to complete and returns what each one
+     * produced, keyed by the table name it is exposed under. This is the
+     * whole of pipeline orchestration: a query that reads another query's
+     * results starts once those results exist, and fails if the referenced
+     * query fails. References must already be authorized
+     * (authorizeQueryReferences).
      */
-    private async buildQueryReferenceCtes({
+    private async waitForQueryReferences({
         account,
         projectUuid,
         references,
@@ -6991,12 +6993,11 @@ export class AsyncQueryService extends ProjectService {
         account: Account;
         projectUuid: string;
         references: Record<string, string>;
-    }): Promise<string[]> {
-        return Promise.all(
+    }): Promise<Record<string, QueryHistory>> {
+        const completed = await Promise.all(
             Object.entries(references).map(async ([tableName, queryUuid]) => {
-                let queryHistory: QueryHistory;
                 try {
-                    queryHistory =
+                    const queryHistory =
                         await this.queryHistoryModel.pollForQueryCompletion({
                             queryUuid,
                             account,
@@ -7004,6 +7005,7 @@ export class AsyncQueryService extends ProjectService {
                             timeoutMs:
                                 AsyncQueryService.REFERENCE_WAIT_TIMEOUT_MS,
                         });
+                    return [tableName, queryHistory] as const;
                 } catch (e) {
                     throw new ParameterError(
                         `Referenced query "${tableName}" (${queryUuid}) did not complete: ${getErrorMessage(
@@ -7011,7 +7013,21 @@ export class AsyncQueryService extends ProjectService {
                         )}`,
                     );
                 }
+            }),
+        );
+        return Object.fromEntries(completed);
+    }
 
+    /**
+     * Builds one CTE per completed reference so the user SQL can select from
+     * semantically-named tables: {"orders": "<queryUuid>"} exposes that
+     * query's results as `orders`.
+     */
+    private buildQueryReferenceCtes(
+        queryHistoryByTableName: Record<string, QueryHistory>,
+    ): string[] {
+        return Object.entries(queryHistoryByTableName).map(
+            ([tableName, queryHistory]) => {
                 if (
                     queryHistory.resultsExpiresAt &&
                     queryHistory.resultsExpiresAt < new Date()
@@ -7021,7 +7037,7 @@ export class AsyncQueryService extends ProjectService {
 
                 if (!queryHistory.resultsFileName) {
                     throw new NotFoundError(
-                        `Result file not found for query ${queryUuid}`,
+                        `Result file not found for query ${queryHistory.queryUuid}`,
                     );
                 }
 
@@ -7044,7 +7060,7 @@ export class AsyncQueryService extends ProjectService {
                 return `${quoteDuckdbIdentifier(
                     tableName,
                 )} AS (SELECT * FROM ${table})`;
-            }),
+            },
         );
     }
 
@@ -7510,11 +7526,13 @@ export class AsyncQueryService extends ProjectService {
     }): Promise<void> {
         try {
             const referenceCtes = references
-                ? await this.buildQueryReferenceCtes({
-                      account,
-                      projectUuid,
-                      references,
-                  })
+                ? this.buildQueryReferenceCtes(
+                      await this.waitForQueryReferences({
+                          account,
+                          projectUuid,
+                          references,
+                      }),
+                  )
                 : [];
 
             await this.runDuckdbSqlQuery({
@@ -8138,7 +8156,6 @@ export class AsyncQueryService extends ProjectService {
                 fieldTypes,
                 outputAliasByColumn: compiledMerge.fieldIdByColumn,
                 limit: Math.min(mergeQuery.limit, sourceRowCap),
-                sourceRowCap,
             });
 
         // The same composer as the warehouse merge, with the compose engine
@@ -8176,6 +8193,21 @@ export class AsyncQueryService extends ProjectService {
                     legQueryUuidBySourceId[sourceId],
                 ],
             ),
+        );
+        const labelBySourceId = getMergeSourceLabels({
+            sources: mergeQuery.sources,
+            typedColumns: compiledMerge.typedColumns,
+            itemsMap: compiledMerge.itemsMap,
+        });
+        // Only the legs this merge ran are checked against the cap; a
+        // referenced result's row count is its own query's concern
+        const legLabelByReferenceTable = Object.fromEntries(
+            mergeQuery.sources
+                .filter(isMergeMetricSource)
+                .map((source) => [
+                    referenceTableBySourceId[source.id],
+                    labelBySourceId[source.id],
+                ]),
         );
         await this.authorizeQueryReferences({
             account,
@@ -8252,6 +8284,7 @@ export class AsyncQueryService extends ProjectService {
             queryUuid,
             sql,
             references,
+            legLabelByReferenceTable,
             warehouseClient,
             queryTags,
             queryCreatedAt,
@@ -8337,6 +8370,7 @@ export class AsyncQueryService extends ProjectService {
         queryUuid,
         sql,
         references,
+        legLabelByReferenceTable,
         warehouseClient,
         queryTags,
         queryCreatedAt,
@@ -8355,6 +8389,8 @@ export class AsyncQueryService extends ProjectService {
         queryUuid: string;
         sql: string;
         references: Record<string, string>;
+        /** The user-facing label of the source each reference table holds. */
+        legLabelByReferenceTable: Record<string, string>;
         warehouseClient: WarehouseClient;
         queryTags: RunQueryTags;
         queryCreatedAt: Date;
@@ -8366,14 +8402,28 @@ export class AsyncQueryService extends ProjectService {
         originalColumns: ResultColumns;
     }): Promise<void> {
         try {
-            const referenceCtes = await this.buildQueryReferenceCtes({
+            const queryHistoryByTableName = await this.waitForQueryReferences({
                 account,
                 projectUuid,
                 references,
             });
+
+            const rowCapError = getMergeRowCapError({
+                legs: Object.entries(legLabelByReferenceTable).map(
+                    ([tableName, label]) => ({
+                        label,
+                        rowCount:
+                            queryHistoryByTableName[tableName]?.totalRowCount ??
+                            null,
+                    }),
+                ),
+                sourceRowCap: this.lightdashConfig.query.maxLimit,
+            });
+            if (rowCapError !== null) throw new ParameterError(rowCapError);
+
             const query = AsyncQueryService.wrapSqlWithReferenceCtes(
                 sql,
-                referenceCtes,
+                this.buildQueryReferenceCtes(queryHistoryByTableName),
             );
             await this.queryHistoryModel.update(
                 queryUuid,

--- a/packages/backend/src/services/AsyncQueryService/mergeQueryExecution.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/mergeQueryExecution.test.ts
@@ -13,6 +13,8 @@ import {
     applyMergeExportLimit,
     buildComposeMergeOriginalColumns,
     getMergeOutputColumnCount,
+    getMergeRowCapError,
+    getMergeSourceLabels,
 } from './mergeQueryExecution';
 
 const sourceQuery = (metrics: string[], calculations: string[] = []) =>
@@ -98,64 +100,64 @@ describe('merge query execution', () => {
     });
 });
 
-describe('buildComposeMergeOriginalColumns', () => {
-    const itemsMap: ItemsMap = {
-        orders_month: {
-            fieldType: FieldType.DIMENSION,
-            type: DimensionType.DATE,
-            name: 'month',
-            label: 'Month',
-            table: 'orders',
-            tableLabel: 'Orders',
-            sql: '${TABLE}.month',
-            hidden: false,
-            groups: [],
-        },
-        orders_count: {
-            fieldType: FieldType.METRIC,
-            type: MetricType.COUNT,
-            name: 'count',
-            label: 'Count',
-            table: 'orders',
-            tableLabel: 'Orders',
-            sql: '${TABLE}.count',
-            hidden: false,
-            groups: [],
-        },
-        merged_calc: {
-            name: 'merged_calc',
-            displayName: 'Merged calc',
-            sql: '1',
-        },
-    };
-    const typedColumns: MergeTypedColumn[] = [
-        {
-            reference: 'orders_month',
-            type: DimensionType.DATE,
-            origin: {
-                kind: 'joinKey',
-                fieldIdBySourceId: {
-                    orders: 'orders_month',
-                    payments: 'payments_month',
-                },
+const itemsMap: ItemsMap = {
+    orders_month: {
+        fieldType: FieldType.DIMENSION,
+        type: DimensionType.DATE,
+        name: 'month',
+        label: 'Month',
+        table: 'orders',
+        tableLabel: 'Orders',
+        sql: '${TABLE}.month',
+        hidden: false,
+        groups: [],
+    },
+    orders_count: {
+        fieldType: FieldType.METRIC,
+        type: MetricType.COUNT,
+        name: 'count',
+        label: 'Count',
+        table: 'orders',
+        tableLabel: 'Orders',
+        sql: '${TABLE}.count',
+        hidden: false,
+        groups: [],
+    },
+    merged_calc: {
+        name: 'merged_calc',
+        displayName: 'Merged calc',
+        sql: '1',
+    },
+};
+const typedColumns: MergeTypedColumn[] = [
+    {
+        reference: 'orders_month',
+        type: DimensionType.DATE,
+        origin: {
+            kind: 'joinKey',
+            fieldIdBySourceId: {
+                orders: 'orders_month',
+                payments: 'payments_month',
             },
         },
-        {
-            reference: 'orders_count',
-            type: DimensionType.NUMBER,
-            origin: {
-                kind: 'source',
-                sourceId: 'orders',
-                sourceFieldId: 'orders_count',
-            },
+    },
+    {
+        reference: 'orders_count',
+        type: DimensionType.NUMBER,
+        origin: {
+            kind: 'source',
+            sourceId: 'orders',
+            sourceFieldId: 'orders_count',
         },
-        {
-            reference: 'merged_calc',
-            type: DimensionType.NUMBER,
-            origin: { kind: 'tableCalculation' },
-        },
-    ];
+    },
+    {
+        reference: 'merged_calc',
+        type: DimensionType.NUMBER,
+        origin: { kind: 'tableCalculation' },
+    },
+];
 
+describe('buildComposeMergeOriginalColumns', () => {
     const columns = buildComposeMergeOriginalColumns({
         typedColumns,
         itemsMap,
@@ -203,5 +205,78 @@ describe('buildComposeMergeOriginalColumns', () => {
         expect(withoutLeg.orders_count.provenance).toEqual({
             fieldId: 'orders_count',
         });
+    });
+});
+
+describe('getMergeSourceLabels', () => {
+    test('labels a source by the explore label its columns carry', () => {
+        expect(
+            getMergeSourceLabels({
+                sources: [{ id: 'orders' }],
+                typedColumns,
+                itemsMap,
+            }),
+        ).toEqual({ orders: 'Orders' });
+    });
+
+    test('falls back to the slot label for a source with no value column', () => {
+        expect(
+            getMergeSourceLabels({
+                sources: [{ id: 'orders' }, { id: 'empty' }],
+                typedColumns,
+                itemsMap,
+            }),
+        ).toEqual({ orders: 'Orders', empty: 'Query B' });
+    });
+});
+
+describe('getMergeRowCapError', () => {
+    test('refuses and names the source that reached the cap', () => {
+        expect(
+            getMergeRowCapError({
+                legs: [
+                    { label: 'Orders', rowCount: 500 },
+                    { label: 'Payments', rowCount: 12 },
+                ],
+                sourceRowCap: 500,
+            }),
+        ).toBe(
+            'Orders returned the maximum of 500 rows, so the merged results would be missing data. Add a filter to Orders, then merge again.',
+        );
+    });
+
+    test('names every source that reached the cap', () => {
+        expect(
+            getMergeRowCapError({
+                legs: [
+                    { label: 'Orders', rowCount: 500 },
+                    { label: 'Payments', rowCount: 501 },
+                ],
+                sourceRowCap: 500,
+            }),
+        ).toBe(
+            'Orders and Payments each returned the maximum of 500 rows, so the merged results would be missing data. Add a filter to each, then merge again.',
+        );
+    });
+
+    test('allows a merge whose sources are all under the cap', () => {
+        expect(
+            getMergeRowCapError({
+                legs: [
+                    { label: 'Orders', rowCount: 499 },
+                    { label: 'Payments', rowCount: 0 },
+                ],
+                sourceRowCap: 500,
+            }),
+        ).toBeNull();
+    });
+
+    test('allows a source whose row count is unknown', () => {
+        expect(
+            getMergeRowCapError({
+                legs: [{ label: 'Orders', rowCount: null }],
+                sourceRowCap: 500,
+            }),
+        ).toBeNull();
     });
 });

--- a/packages/backend/src/services/AsyncQueryService/mergeQueryExecution.ts
+++ b/packages/backend/src/services/AsyncQueryService/mergeQueryExecution.ts
@@ -1,5 +1,7 @@
 import {
+    getMergeSourceTableLabel,
     getResultColumnMetadataFromItem,
+    isField,
     isMergeMetricSource,
     type ItemsMap,
     type MergeQuery,
@@ -93,4 +95,59 @@ export const applyMergeExportLimit = ({
                 ? cellLimitedRows
                 : Math.min(requestedRows, cellLimitedRows),
     };
+};
+
+/**
+ * What each source is called where the user can see it: the explore label the
+ * compile already gave that source's columns, or the slot label when a source
+ * contributes no value column. Source ids are internal and never shown.
+ */
+export const getMergeSourceLabels = ({
+    sources,
+    typedColumns,
+    itemsMap,
+}: {
+    sources: Array<{ id: string }>;
+    typedColumns: MergeTypedColumn[];
+    itemsMap: ItemsMap;
+}): Record<string, string> =>
+    Object.fromEntries(
+        sources.map((source, index) => {
+            const column = typedColumns.find(
+                ({ origin }) =>
+                    origin.kind === 'source' && origin.sourceId === source.id,
+            );
+            const item = column ? itemsMap[column.reference] : undefined;
+            return [
+                source.id,
+                item && isField(item)
+                    ? item.tableLabel
+                    : getMergeSourceTableLabel(index),
+            ];
+        }),
+    );
+
+/**
+ * A leg that came back at the row cap may have had more rows behind it, and
+ * the join cannot tell because the leg ran with its limit already at that
+ * cap. Refuse on the leg's own row count instead, naming the source to
+ * narrow. Known only once the leg has run, so it lands as the merged
+ * query's error rather than a pre-execution refusal. An unknown row count
+ * is not evidence, so it never refuses.
+ */
+export const getMergeRowCapError = ({
+    legs,
+    sourceRowCap,
+}: {
+    legs: Array<{ label: string; rowCount: number | null }>;
+    sourceRowCap: number;
+}): string | null => {
+    const capped = legs
+        .filter(({ rowCount }) => rowCount !== null && rowCount >= sourceRowCap)
+        .map(({ label }) => label);
+    if (capped.length === 0) return null;
+    const consequence = `returned the maximum of ${sourceRowCap} rows, so the merged results would be missing data.`;
+    return capped.length === 1
+        ? `${capped[0]} ${consequence} Add a filter to ${capped[0]}, then merge again.`
+        : `${capped.join(' and ')} each ${consequence} Add a filter to each, then merge again.`;
 };

--- a/packages/backend/src/utils/QueryBuilder/composeMergeSql.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/composeMergeSql.test.ts
@@ -2,6 +2,7 @@ import { DuckDBInstance } from '@duckdb/node-api';
 import {
     DimensionType,
     FieldType,
+    MERGE_ROW_PRESENT_COLUMN,
     MERGE_TRUNCATED_COLUMN,
     MergeJoinType,
     MetricType,
@@ -125,7 +126,6 @@ const build = (
         fieldTypes,
         outputAliasByColumn,
         limit: 500,
-        sourceRowCap: 100,
         ...overrides,
     });
 
@@ -137,8 +137,8 @@ const toSql = (result: ReturnType<typeof buildComposeMergeSql>) =>
  * Executes the generated statement on a real in-memory DuckDB with the
  * reference tables predefined — exactly how the compose engine sees it,
  * minus the S3 read_json binding. This is the dialect-validity proof: the
- * FULL OUTER JOIN, typed null placeholders and truncation guard must run on
- * the actual engine, not just look plausible.
+ * FULL OUTER JOIN and typed null placeholders must run on the actual engine,
+ * not just look plausible.
  */
 const runOnDuckdb = async (
     sql: string,
@@ -201,11 +201,14 @@ describe('buildComposeMergeSql', () => {
         expect(sql).toContain('1970-01-01');
     });
 
-    test('guards truncation by counting the capped reference tables', () => {
-        const sql = toSql(build({ sourceRowCap: 100 }));
-        expect(sql).toContain(MERGE_TRUNCATED_COLUMN);
-        expect(sql).toMatch(/SELECT COUNT\(\*\) FROM \(\s*SELECT \* FROM \(/);
-        expect(sql).toContain('> 100');
+    // The sources are legs that already ran at the row cap, so a guard here
+    // could never see past it. The run path reads the legs' own row counts
+    // instead (getMergeRowCapError).
+    test('carries no in-SQL row cap guard', () => {
+        const sql = toSql(build());
+        expect(sql).not.toContain(MERGE_TRUNCATED_COLUMN);
+        expect(sql).not.toContain(MERGE_ROW_PRESENT_COLUMN);
+        expect(sql).not.toContain('COUNT(*)');
     });
 
     test('full outer join merges on the key, keeps unmatched sides and matches null keys', async () => {
@@ -223,19 +226,6 @@ describe('buildComposeMergeSql', () => {
             // Null keys match each other via the typed placeholder
             [null, '2', '4'],
         ]);
-        expect(
-            rows.every((row) => row[MERGE_TRUNCATED_COLUMN] === 'false'),
-        ).toBe(true);
-    });
-
-    test('reports truncation when a source reaches the row cap', async () => {
-        const rows = await runOnDuckdb(
-            toSql(build({ sourceRowCap: 2 })),
-            SETUP,
-        );
-        expect(
-            rows.every((row) => row[MERGE_TRUNCATED_COLUMN] === 'true'),
-        ).toBe(true);
     });
 
     test('left join keeps only the first source keys', async () => {

--- a/packages/backend/src/utils/QueryBuilder/composeMergeSql.ts
+++ b/packages/backend/src/utils/QueryBuilder/composeMergeSql.ts
@@ -15,7 +15,7 @@ import {
 export type ComposeMergeSql = {
     /** The composable DuckDB join core — no ORDER BY, LIMIT or guard column. */
     coreSql: string;
-    /** Terminal stage (sort, limit, truncation guard) for the run path to attach. */
+    /** Terminal stage (sort, limit) for the run path to attach. */
     terminalWrapper: MergeTerminalWrapper;
     /** Reference table name per source id, for binding to result queryUuids. */
     referenceTableBySourceId: Record<string, string>;
@@ -32,9 +32,13 @@ export const composeMergeReferenceTable = (sourceIndex: number): string =>
  * that source's already-materialized results (a freshly-run leg or an
  * existing result referenced by queryUuid; the builder cannot tell and does
  * not care). The join semantics (coalesced keys, typed null placeholders,
- * string casts, per-source row caps with truncation detection) are identical
- * by construction because the builder and the key-option derivation are
- * shared; only the dialect and where the source rows come from differ.
+ * string casts) are identical by construction because the builder and the
+ * key-option derivation are shared; only the dialect and where the source
+ * rows come from differ.
+ *
+ * No source row cap here: the sources are legs that already ran at the cap,
+ * so a cap in this statement could never see past it. The run path reads
+ * the legs' own row counts instead (getMergeRowCapError).
  */
 export const buildComposeMergeSql = (args: {
     /** Sources in merge order; value columns in the compile's column order. */
@@ -47,8 +51,6 @@ export const buildComposeMergeSql = (args: {
     outputAliasByColumn: Record<string, string>;
     /** Row cap for the merged result, already clamped to the instance limit. */
     limit: number;
-    /** Most rows one source may contribute; reaching it is reported, not trimmed. */
-    sourceRowCap: number;
 }): ComposeMergeSql => {
     const {
         sources,
@@ -58,7 +60,6 @@ export const buildComposeMergeSql = (args: {
         fieldTypes,
         outputAliasByColumn,
         limit,
-        sourceRowCap,
     } = args;
     const warehouseSqlBuilder = warehouseSqlBuilderFromType(
         SupportedDbtAdapter.DUCKDB,
@@ -98,7 +99,6 @@ export const buildComposeMergeSql = (args: {
         tableCalculations,
         nullPlaceholderByKeyName,
         stringJoinKeyNames,
-        sourceRowCap,
     });
 
     return {

--- a/packages/backend/src/utils/QueryBuilder/mergeQueryResults.ts
+++ b/packages/backend/src/utils/QueryBuilder/mergeQueryResults.ts
@@ -8,6 +8,13 @@ import {
 const isTrue = (value: unknown) =>
     value === true || value === 1 || value === 'true';
 
+/**
+ * Strips the row-cap guard the warehouse merge statement carries and refuses
+ * when it tripped. Only the warehouse path emits the guard: its sources
+ * compile without a limit, so counting past the cap is possible there. The
+ * compose path runs its legs at the cap and refuses on their own row counts
+ * instead (getMergeRowCapError), so this is a no-op for it.
+ */
 export const consumeMergeResultMetadata = (
     rows: WarehouseResults['rows'],
     fields: WarehouseResults['fields'],


### PR DESCRIPTION
## What

A merge on the compose (DuckDB) path whose leg reached the source row cap now refuses before the join, naming the source and the remedy, instead of returning totals that look complete.

Example error: `Orders returned the maximum of 500 rows, so the merged results would be missing data. Add a filter to Orders, then merge again.`

## Why

The in-SQL truncation guard was structurally dead on the compose path. Each leg executes with its limit already set to the row cap, and the guard then asks whether any leg exceeded that same cap. It never can, so a merge over a capped source silently under-reported. The warehouse path was never affected: its sources compile without a limit, so its guard is live.

## How

- `runComposeMergeQuery` waits for the legs, reads each leg's own `query_history.total_row_count`, and throws before the join SQL is assembled. The reference wait was split from CTE building (`waitForQueryReferences` / `buildQueryReferenceCtes`) so the check sits between "legs complete" and "join runs".
- The cap is read from `lightdashConfig.query.maxLimit`, the same config the legs were submitted with.
- Only the legs this merge ran (metric sources) are checked. A referenced result source is not re-run and is not limited to the cap, so its row count is its own query's concern (see follow-up).
- The message names the source by the explore label the compile already gives its columns. Source ids are internal and never reach the user, per the merge-queries glossary.
- `buildComposeMergeSql` no longer takes `sourceRowCap`, so the compose statement carries no guard column or guard row. `consumeMergeResultMetadata` stays for the warehouse path and is now a documented no-op for compose.
- `docs/merge-queries/CONTEXT.md` and `architecture.md` updated from "reported" to "refused before the join".

## Regression analysis

- **Warehouse merge path**: untouched. `ProjectService.compileMergeQuery` still passes `sourceRowCap` to `MergeQueryBuilder`, so its guard column, guard row and `consumeMergeResultMetadata` behave exactly as before.
- **Compose merge, legs under the cap**: unchanged result. The only difference in the generated SQL is the absence of the (previously inert) guard wrapper; `composeMergeSql.test.ts` executes the join on a real in-memory DuckDB and asserts the rows are identical.
- **Compose merge, a leg at the cap**: previously returned silently short totals; now refuses with `status: ERROR` on the merged query. This is the intended behaviour change.
- **Raw compose SQL (`executeAsyncComposeSqlQuery`)**: same reference wait and CTE strings, now via the two split functions. No behaviour change.
- **Unknown row count** (`total_row_count` null): treated as no evidence, never refuses. Both the fresh-run and cache-hit paths populate it, so this is a defensive default rather than a reachable case.

## Tests

- `getMergeRowCapError` / `getMergeSourceLabels` unit tests.
- Service-level test with `query.maxLimit` lowered to 3 through config: asserts the refusal fires with the source label, and that `runAsyncWarehouseQuery` is never called. Mutation-checked.
- Under-cap test asserts the join runs and no error is recorded.
- Full backend unit suite green.

## Follow-up

A result source that was truncated at its own, smaller limit can still under-report a merge. Pre-existing, reachable through the AI agent path only, and explicitly out of this check's scope. Tracked in PROD-10909.

Closes: PROD-10890
Relates: PROD-10909

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LyhpDxbUsZ9YXhk8GJVPjM
