### PR TITLE
feat(ai): build cards open their own data app version in the thread preview

### DIFF
--- a/docs/data-apps/CONTEXT.md
+++ b/docs/data-apps/CONTEXT.md
@@ -207,11 +207,14 @@ _Avoid_: AI analyst, copilot (in code and docs), assistant, the agent
 (where more than one agent is in scope)
 
 **Build card**:
-The card under an AI agent reply that follows a build the agent started:
-queued, building (status message and narration), ready, failed, cancelled,
-or unavailable. It reads the version while the tool result is pending and
-the tool result once it is terminal; when a build watched in the thread
-lands, the app opens in the thread's preview panel.
+The card under an AI agent reply that follows a build the agent started,
+or a restore made from the thread: queued, building (status message and
+narration), ready, failed, cancelled, or unavailable. Each card names one
+version; View opens that version in the thread's preview panel, and only
+the card for the version on show is active. It reads the version while the
+tool result is pending and the tool result once it is terminal; when a
+build watched in the thread lands, the app opens in the thread's preview
+panel.
 _Avoid_: job card, progress card, status widget
 
 **External agent**:

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDataAppPreviewPanel.inspector.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDataAppPreviewPanel.inspector.test.tsx
@@ -60,6 +60,8 @@ const dataAppPreview = {
     threadUuid: 'thread-uuid',
     projectUuid: 'project-uuid',
     agentUuid: 'agent-uuid',
+    version: null,
+    latestReadyVersionAtOpen: null,
 };
 
 const latestIframeProps = (): IframePreviewProps => {

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDataAppPreviewPanel.picker.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDataAppPreviewPanel.picker.test.tsx
@@ -78,6 +78,8 @@ const dataAppPreview = {
     threadUuid: THREAD_UUID,
     projectUuid: 'project-uuid',
     agentUuid: 'agent-uuid',
+    version: null,
+    latestReadyVersionAtOpen: null,
 };
 
 const latestIframeProps = (): IframePreviewProps => {

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDataAppPreviewPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDataAppPreviewPanel.tsx
@@ -32,10 +32,13 @@ import { type ElementRef } from '../../../../../features/apps/utils/elementRefs'
 import { addThreadElementReference } from '../../store/aiAgentThreadElementRefsSlice';
 import {
     clearPreview,
+    setDataAppPreviewVersion,
     type DataAppPreviewData,
 } from '../../store/aiArtifactSlice';
 import { useAiAgentStoreDispatch } from '../../store/hooks';
 import artifactStyles from './AiArtifactPanel.module.css';
+import { getEffectiveDataAppVersion } from './DataAppBuildCard/dataAppPreviewVersion';
+import { DataAppVersionPill } from './DataAppVersionPill';
 
 type Props = {
     dataAppPreview: DataAppPreviewData;
@@ -49,7 +52,13 @@ export const AiDataAppPreviewPanel: FC<Props> = ({
     showInspector,
 }) => {
     const dispatch = useAiAgentStoreDispatch();
-    const { appUuid, projectUuid, threadUuid } = dataAppPreview;
+    const {
+        appUuid,
+        projectUuid,
+        threadUuid,
+        version,
+        latestReadyVersionAtOpen,
+    } = dataAppPreview;
 
     const previewOrigin = usePreviewOrigin();
     const appQuery = useGetApp(projectUuid, appUuid);
@@ -57,8 +66,14 @@ export const AiDataAppPreviewPanel: FC<Props> = ({
 
     // Authoritative across ALL versions — the ready version may be older than
     // the fetched page of versions, so never scan `versions` for it.
-    const latestReadyVersion = app?.latestReadyVersion ?? undefined;
-    const identityKey = `${appUuid}:${latestReadyVersion}`;
+    const latestReadyVersion = app?.latestReadyVersion ?? null;
+    const effectiveVersion = getEffectiveDataAppVersion({
+        version,
+        latestReadyVersionAtOpen,
+        latestReadyVersion,
+    });
+    const isViewingLatest = effectiveVersion === latestReadyVersion;
+    const identityKey = `${appUuid}:${effectiveVersion}`;
     // Lives here, not next to the iframe, so logs and dismissal survive the
     // token reload between versions. Only wired in when `showInspector`.
     const inspector = useAppInspector({ identityKey, defaultHidden: false });
@@ -83,7 +98,9 @@ export const AiDataAppPreviewPanel: FC<Props> = ({
     const { onLineageCancelled } = inspector.iframeProps;
 
     // Picked references go to the thread's composer state, not the hook's own
-    // list, so they outlive closing the panel and the next version.
+    // list, so they outlive closing the panel and the next version. They
+    // always name the latest ready version, which is what the coding agent
+    // iterates from.
     const appSlug = app?.slug;
     const appName = app?.name;
     const handlePick = useCallback(
@@ -91,7 +108,7 @@ export const AiDataAppPreviewPanel: FC<Props> = ({
             if (
                 appSlug === undefined ||
                 appName === undefined ||
-                latestReadyVersion === undefined
+                latestReadyVersion === null
             ) {
                 return;
             }
@@ -126,7 +143,7 @@ export const AiDataAppPreviewPanel: FC<Props> = ({
         data: token,
         isLoading: isTokenLoading,
         error: tokenError,
-    } = useAppPreviewToken(projectUuid, appUuid, latestReadyVersion);
+    } = useAppPreviewToken(projectUuid, appUuid, effectiveVersion ?? undefined);
     const visibleTokenError = getVisiblePreviewTokenError(tokenError, !!token);
 
     const isForbidden =
@@ -136,14 +153,26 @@ export const AiDataAppPreviewPanel: FC<Props> = ({
         appQuery.error?.error?.statusCode === 404 ||
         visibleTokenError?.error?.statusCode === 404;
     const hasNoReadyVersion =
-        !appQuery.isLoading && !appQuery.error && !latestReadyVersion;
+        !appQuery.isLoading && !appQuery.error && effectiveVersion === null;
     const otherError =
         !isForbidden && !isNotFound && (appQuery.error || visibleTokenError);
 
     const previewUrl =
-        token && latestReadyVersion
-            ? `${previewOrigin}/api/apps/${appUuid}/versions/${latestReadyVersion}/t/${token}/#transport=postMessage&projectUuid=${projectUuid}`
+        token && effectiveVersion !== null
+            ? `${previewOrigin}/api/apps/${appUuid}/versions/${effectiveVersion}/t/${token}/#transport=postMessage&projectUuid=${projectUuid}`
             : undefined;
+
+    const isViewingOlderVersion =
+        effectiveVersion !== null &&
+        latestReadyVersion !== null &&
+        effectiveVersion < latestReadyVersion;
+    const returnToLatest = () =>
+        dispatch(
+            setDataAppPreviewVersion({
+                version: null,
+                latestReadyVersionAtOpen: latestReadyVersion,
+            }),
+        );
 
     const closeButton = (
         <ActionIcon
@@ -238,7 +267,9 @@ export const AiDataAppPreviewPanel: FC<Props> = ({
         );
     }
 
-    const appUrl = `/projects/${projectUuid}/apps/${appUuid}/view`;
+    const appUrl = isViewingLatest
+        ? `/projects/${projectUuid}/apps/${appUuid}/view`
+        : `/projects/${projectUuid}/apps/${appUuid}/versions/${effectiveVersion}/view`;
 
     return (
         <Box className={artifactStyles.floatingPanel}>
@@ -299,17 +330,28 @@ export const AiDataAppPreviewPanel: FC<Props> = ({
                                 )}
                             </Menu.Dropdown>
                         </Menu>
-                        {showInspector && picker.available && (
-                            <ElementPickerButton
-                                enabled={picker.enabled}
-                                onToggle={picker.toggle}
-                            />
-                        )}
+                        {showInspector &&
+                            picker.available &&
+                            isViewingLatest && (
+                                <ElementPickerButton
+                                    enabled={picker.enabled}
+                                    onToggle={picker.toggle}
+                                />
+                            )}
                         {closeButton}
                     </Group>
                 </Box>
 
-                <Box className={artifactStyles.previewBody}>{body}</Box>
+                <Box className={artifactStyles.previewBody}>
+                    {body}
+                    {isViewingOlderVersion && (
+                        <DataAppVersionPill
+                            version={effectiveVersion}
+                            onReturnToLatest={returnToLatest}
+                            restore={null}
+                        />
+                    )}
+                </Box>
             </Box>
         </Box>
     );

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDataAppPreviewPanel.version.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDataAppPreviewPanel.version.test.tsx
@@ -1,0 +1,187 @@
+import { act, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../../../testing/testUtils';
+import {
+    setDataAppPreviewVersion,
+    type DataAppPreviewData,
+} from '../../store/aiArtifactSlice';
+
+type IframePreviewProps = {
+    src: string;
+    onInspectorAvailabilityChange?: (available: boolean) => void;
+};
+
+const mocks = vi.hoisted(() => ({
+    iframePreview: vi.fn((_props: IframePreviewProps) => null),
+    latestReadyVersion: 3,
+    tokenLoading: false,
+    dispatch: vi.fn(),
+}));
+
+vi.mock('../../../../../features/apps/AppIframePreview', () => ({
+    default: mocks.iframePreview,
+}));
+
+vi.mock('../../../../../features/apps/hooks/useAppPreviewToken', () => ({
+    useAppPreviewToken: () => ({
+        data: mocks.tokenLoading ? undefined : 'preview-token',
+        isLoading: mocks.tokenLoading,
+        error: undefined,
+    }),
+}));
+
+vi.mock('../../../../../features/apps/hooks/useGetApp', () => ({
+    useGetApp: () => ({
+        data: {
+            pages: [
+                {
+                    appUuid: 'app-uuid',
+                    name: 'Sales app',
+                    slug: 'sales-app',
+                    description: null,
+                    latestReadyVersion: mocks.latestReadyVersion,
+                    versions: [{ status: 'ready' }],
+                },
+            ],
+        },
+        isLoading: false,
+        error: undefined,
+    }),
+}));
+
+vi.mock('../../../../../features/apps/previewOrigin', () => ({
+    usePreviewOrigin: () => 'https://preview.example.com',
+}));
+
+vi.mock('../../store/hooks', () => ({
+    useAiAgentStoreDispatch: () => mocks.dispatch,
+}));
+
+// eslint-disable-next-line import/first
+import { AiDataAppPreviewPanel } from './AiDataAppPreviewPanel';
+
+const preview = (
+    version: Pick<DataAppPreviewData, 'version' | 'latestReadyVersionAtOpen'>,
+): DataAppPreviewData => ({
+    appUuid: 'app-uuid',
+    messageUuid: 'message-uuid',
+    threadUuid: 'thread-uuid',
+    projectUuid: 'project-uuid',
+    agentUuid: 'agent-uuid',
+    ...version,
+});
+
+const latest = preview({ version: null, latestReadyVersionAtOpen: null });
+const olderVersion = preview({ version: 1, latestReadyVersionAtOpen: 3 });
+
+const panel = (dataAppPreview: DataAppPreviewData) => (
+    <AiDataAppPreviewPanel dataAppPreview={dataAppPreview} showInspector />
+);
+
+const latestIframeProps = (): IframePreviewProps => {
+    const { calls } = mocks.iframePreview.mock;
+    return calls[calls.length - 1][0];
+};
+
+const iframeVersion = () =>
+    latestIframeProps().src.match(/\/versions\/(\d+)\//)?.[1];
+
+const announcePicker = () =>
+    act(() => latestIframeProps().onInspectorAvailabilityChange?.(true));
+
+const pickerToggle = () => screen.queryByLabelText('Toggle element picker');
+
+const pill = () => screen.queryByText(/Viewing v/);
+
+const openInNewTabHref = async (user: ReturnType<typeof userEvent.setup>) => {
+    await user.click(screen.getByLabelText('More options'));
+    const item = await screen.findByRole('menuitem', {
+        name: 'Open in new tab',
+    });
+    return item.getAttribute('href');
+};
+
+// A new ready version refetches the preview token, so the iframe briefly
+// gives way to a loader before the new bundle mounts.
+const landNewVersion = (
+    rerender: (ui: React.ReactElement) => void,
+    dataAppPreview: DataAppPreviewData,
+    version: number,
+) => {
+    mocks.latestReadyVersion = version;
+    mocks.tokenLoading = true;
+    rerender(panel(dataAppPreview));
+    mocks.tokenLoading = false;
+    rerender(panel(dataAppPreview));
+};
+
+describe('AiDataAppPreviewPanel versions', () => {
+    beforeEach(() => {
+        mocks.latestReadyVersion = 3;
+        mocks.tokenLoading = false;
+        mocks.dispatch.mockReset();
+        window.localStorage.clear();
+    });
+
+    it('shows the latest ready version with the picker and no pill', async () => {
+        const user = userEvent.setup();
+        renderWithProviders(panel(latest));
+        announcePicker();
+
+        expect(iframeVersion()).toBe('3');
+        expect(pill()).not.toBeInTheDocument();
+        expect(pickerToggle()).toBeInTheDocument();
+        expect(await openInNewTabHref(user)).toBe(
+            '/projects/project-uuid/apps/app-uuid/view',
+        );
+    });
+
+    it('shows the pill and hides the picker on an older version', async () => {
+        const user = userEvent.setup();
+        renderWithProviders(panel(olderVersion));
+        announcePicker();
+
+        expect(iframeVersion()).toBe('1');
+        expect(screen.getByText('Viewing v1')).toBeInTheDocument();
+        expect(pickerToggle()).not.toBeInTheDocument();
+        expect(await openInNewTabHref(user)).toBe(
+            '/projects/project-uuid/apps/app-uuid/versions/1/view',
+        );
+    });
+
+    it('returns to the latest ready version from the pill', async () => {
+        const user = userEvent.setup();
+        renderWithProviders(panel(olderVersion));
+
+        await user.click(
+            screen.getByRole('button', { name: 'Return to latest' }),
+        );
+
+        expect(mocks.dispatch).toHaveBeenCalledWith(
+            setDataAppPreviewVersion({
+                version: null,
+                latestReadyVersionAtOpen: 3,
+            }),
+        );
+    });
+
+    it('jumps to latest when a newer ready version lands', () => {
+        const { rerender } = renderWithProviders(panel(olderVersion));
+        expect(iframeVersion()).toBe('1');
+
+        landNewVersion(rerender, olderVersion, 4);
+
+        expect(iframeVersion()).toBe('4');
+        expect(pill()).not.toBeInTheDocument();
+    });
+
+    it('shows no pill for a card whose version is the latest', () => {
+        renderWithProviders(
+            panel(preview({ version: 3, latestReadyVersionAtOpen: 3 })),
+        );
+
+        expect(iframeVersion()).toBe('3');
+        expect(pill()).not.toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentLink.dataApp.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentLink.dataApp.test.tsx
@@ -68,6 +68,8 @@ describe('ContentLink data-app chip', () => {
             threadUuid: 'thread-1',
             projectUuid: 'project-1',
             agentUuid: 'agent-1',
+            version: null,
+            latestReadyVersionAtOpen: null,
         });
     });
 
@@ -84,6 +86,31 @@ describe('ContentLink data-app chip', () => {
 
         expect(defaultNotPrevented).toBe(true);
         expect(store.getState().aiArtifact.preview).toBeNull();
+    });
+
+    it('opens the latest ready version even after a card pinned an older one', () => {
+        renderDataAppChip();
+        act(() => {
+            store.dispatch(
+                setPreview({
+                    type: 'dataApp',
+                    appUuid: APP_UUID,
+                    messageUuid: 'message-1',
+                    threadUuid: 'thread-1',
+                    projectUuid: 'project-1',
+                    agentUuid: 'agent-1',
+                    version: 1,
+                    latestReadyVersionAtOpen: 3,
+                }),
+            );
+        });
+
+        fireEvent.click(screen.getByRole('link', { name: /Revenue explorer/ }));
+
+        expect(store.getState().aiArtifact.preview).toMatchObject({
+            version: null,
+            latestReadyVersionAtOpen: null,
+        });
     });
 
     it('shows the active indicator only while its app is previewed', () => {

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentLink.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentLink.tsx
@@ -118,13 +118,15 @@ export const ContentLink: FC<ContentLinkProps> = ({
                 typeof props['data-app-uuid'] === 'string'
                     ? props['data-app-uuid']
                     : undefined;
+            // App-level match: the link has no app data to tell which
+            // version the panel is on, so it lights up for any version.
             const isActive =
                 !!appUuid &&
                 currentPreview?.type === 'dataApp' &&
                 currentPreview.appUuid === appUuid;
 
             // Modified clicks fall through to the anchor and open the full
-            // page in a new tab.
+            // page in a new tab. A link always opens the latest ready version.
             const handleDataAppClick = (e: MouseEvent<HTMLAnchorElement>) => {
                 if (!appUuid || !isPlainLeftClick(e)) {
                     return;
@@ -139,6 +141,8 @@ export const ContentLink: FC<ContentLinkProps> = ({
                         threadUuid: message.threadUuid,
                         projectUuid,
                         agentUuid,
+                        version: null,
+                        latestReadyVersionAtOpen: null,
                     }),
                 );
             };

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/AiDataAppBuildCard.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/AiDataAppBuildCard.test.tsx
@@ -59,7 +59,13 @@ const IDS = {
     messageUuid: 'message-1',
 };
 
-const expectedPreview = { type: 'dataApp', appUuid: APP_UUID, ...IDS };
+const expectedPreview = {
+    type: 'dataApp',
+    appUuid: APP_UUID,
+    ...IDS,
+    version: 1,
+    latestReadyVersionAtOpen: 1,
+};
 
 const version = (
     overrides: Partial<ApiAppVersionSummary>,
@@ -94,7 +100,8 @@ const app = (
     views: 0,
     versions,
     hasMore: false,
-    latestReadyVersion: null,
+    latestReadyVersion:
+        versions.find((v) => v.status === 'ready')?.version ?? null,
 });
 
 const pending: ToolGenerateDataAppOutput['metadata'] = {
@@ -174,6 +181,62 @@ describe('AiDataAppBuildCard', () => {
 
         fireEvent.click(screen.getByRole('button', { name: 'View' }));
         expect(store.getState().aiArtifact.preview).toEqual(expectedPreview);
+    });
+
+    it('opens its own version and is the only active card for it', async () => {
+        const builtAt = new Date('2026-08-28T10:00:30.000Z');
+        const readyApp = app([
+            version({ version: 2, status: 'ready', statusUpdatedAt: builtAt }),
+            version({ version: 1, status: 'ready', statusUpdatedAt: builtAt }),
+        ]);
+        mockedLightdashApi.mockResolvedValue(readyApp);
+        const success = (v: number): ToolGenerateDataAppOutput['metadata'] => ({
+            status: 'success',
+            appUuid: APP_UUID,
+            version: v,
+            name: 'Revenue app',
+            href: '/projects/project-1/apps/app-1',
+        });
+        renderWithProviders(
+            <Provider store={store}>
+                <MemoryRouter>
+                    <div data-testid="card-1">
+                        <AiDataAppBuildCard
+                            metadata={success(1)}
+                            compact={false}
+                            {...IDS}
+                        />
+                    </div>
+                    <div data-testid="card-2">
+                        <AiDataAppBuildCard
+                            metadata={success(2)}
+                            compact={false}
+                            {...IDS}
+                        />
+                    </div>
+                </MemoryRouter>
+            </Provider>,
+        );
+        // Both cards read the same app; wait for it to fill in the subtitles.
+        expect(await screen.findByText('v1 · built in 30s')).toBeVisible();
+        expect(await screen.findByText('v2 · built in 30s')).toBeVisible();
+        const cardPaper = (id: string) =>
+            screen.getByTestId(id).firstElementChild;
+
+        fireEvent.click(screen.getAllByRole('button', { name: 'View' })[0]);
+
+        expect(store.getState().aiArtifact.preview).toEqual({
+            ...expectedPreview,
+            version: 1,
+            latestReadyVersionAtOpen: 2,
+        });
+        expect(cardPaper('card-1')?.className).toMatch(/cardActive/);
+        expect(cardPaper('card-2')?.className).not.toMatch(/cardActive/);
+
+        fireEvent.click(screen.getAllByRole('button', { name: 'View' })[1]);
+
+        expect(cardPaper('card-1')?.className).not.toMatch(/cardActive/);
+        expect(cardPaper('card-2')?.className).toMatch(/cardActive/);
     });
 
     it('does not open the preview for a build that finished before this session', async () => {

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/AiDataAppBuildCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/AiDataAppBuildCard.tsx
@@ -22,6 +22,7 @@ import {
     isDataAppBuildInProgress,
     type DataAppBuildCardAppSource,
 } from './dataAppBuildCardState';
+import { isDataAppCardActive } from './dataAppPreviewVersion';
 
 type Props = {
     metadata: ToolGenerateDataAppOutput['metadata'];
@@ -63,11 +64,20 @@ export const AiDataAppBuildCard: FC<Props> = ({
     const navigate = useNavigate();
     const queryClient = useQueryClient();
     const { appUuid } = metadata;
+    // A failed build names no version and can never be on show.
+    const cardVersion = metadata.status === 'error' ? null : metadata.version;
     const preview = useAiAgentStoreSelector(selectDataAppPreview);
-    const isActive = appUuid !== null && preview?.appUuid === appUuid;
 
     const appQuery = useGetApp(projectUuid, appUuid ?? undefined);
     const source = toAppSource(appQuery);
+    const latestReadyVersion =
+        source.kind === 'loaded' ? source.app.latestReadyVersion : null;
+    const isActive = isDataAppCardActive({
+        preview,
+        appUuid,
+        version: cardVersion,
+        latestReadyVersion,
+    });
     const state = getDataAppBuildCardState(metadata, source);
     const inProgress = state !== null && isDataAppBuildInProgress(state);
     const isPolling = metadata.status === 'pending' && inProgress;
@@ -100,9 +110,20 @@ export const AiDataAppBuildCard: FC<Props> = ({
                 threadUuid,
                 projectUuid,
                 agentUuid,
+                version: cardVersion,
+                latestReadyVersionAtOpen: latestReadyVersion,
             }),
         );
-    }, [dispatch, appUuid, messageUuid, threadUuid, projectUuid, agentUuid]);
+    }, [
+        dispatch,
+        appUuid,
+        messageUuid,
+        threadUuid,
+        projectUuid,
+        agentUuid,
+        cardVersion,
+        latestReadyVersion,
+    ]);
 
     // Open the preview once when a build watched in this session lands.
     // Never on reload, and never again after the user closes it.

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/dataAppPreviewVersion.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/dataAppPreviewVersion.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from 'vitest';
+import { type DataAppPreviewData } from '../../../store/aiArtifactSlice';
+import {
+    getEffectiveDataAppVersion,
+    isDataAppCardActive,
+} from './dataAppPreviewVersion';
+
+const preview = (
+    overrides: Partial<DataAppPreviewData>,
+): DataAppPreviewData => ({
+    appUuid: 'app-1',
+    messageUuid: 'message-1',
+    threadUuid: 'thread-1',
+    projectUuid: 'project-1',
+    agentUuid: 'agent-1',
+    version: null,
+    latestReadyVersionAtOpen: null,
+    ...overrides,
+});
+
+describe('getEffectiveDataAppVersion', () => {
+    it('resolves a null version to the latest ready version', () => {
+        expect(
+            getEffectiveDataAppVersion({
+                version: null,
+                latestReadyVersionAtOpen: null,
+                latestReadyVersion: 3,
+            }),
+        ).toBe(3);
+    });
+
+    it('is null while the app has no ready version', () => {
+        expect(
+            getEffectiveDataAppVersion({
+                version: null,
+                latestReadyVersionAtOpen: null,
+                latestReadyVersion: null,
+            }),
+        ).toBeNull();
+    });
+
+    it('keeps an explicit older version while latest is unchanged', () => {
+        expect(
+            getEffectiveDataAppVersion({
+                version: 1,
+                latestReadyVersionAtOpen: 3,
+                latestReadyVersion: 3,
+            }),
+        ).toBe(1);
+    });
+
+    it('jumps to latest once a newer ready version lands', () => {
+        expect(
+            getEffectiveDataAppVersion({
+                version: 1,
+                latestReadyVersionAtOpen: 3,
+                latestReadyVersion: 4,
+            }),
+        ).toBe(4);
+    });
+
+    it('keeps an explicit version while the app is still loading', () => {
+        expect(
+            getEffectiveDataAppVersion({
+                version: 2,
+                latestReadyVersionAtOpen: 3,
+                latestReadyVersion: null,
+            }),
+        ).toBe(2);
+    });
+
+    it('never jumps when no latest version was recorded at open', () => {
+        expect(
+            getEffectiveDataAppVersion({
+                version: 1,
+                latestReadyVersionAtOpen: null,
+                latestReadyVersion: 4,
+            }),
+        ).toBe(1);
+    });
+});
+
+describe('isDataAppCardActive', () => {
+    it('is inactive with no preview open', () => {
+        expect(
+            isDataAppCardActive({
+                preview: null,
+                appUuid: 'app-1',
+                version: 1,
+                latestReadyVersion: 1,
+            }),
+        ).toBe(false);
+    });
+
+    it('is inactive for a card without an app or version', () => {
+        const open = preview({ version: 1 });
+        expect(
+            isDataAppCardActive({
+                preview: open,
+                appUuid: null,
+                version: 1,
+                latestReadyVersion: 1,
+            }),
+        ).toBe(false);
+        expect(
+            isDataAppCardActive({
+                preview: open,
+                appUuid: 'app-1',
+                version: null,
+                latestReadyVersion: 1,
+            }),
+        ).toBe(false);
+    });
+
+    it('is inactive for another app', () => {
+        expect(
+            isDataAppCardActive({
+                preview: preview({ appUuid: 'app-2', version: 1 }),
+                appUuid: 'app-1',
+                version: 1,
+                latestReadyVersion: 1,
+            }),
+        ).toBe(false);
+    });
+
+    it('activates only the card for the version on show', () => {
+        const open = preview({ version: 1, latestReadyVersionAtOpen: 3 });
+        const active = (version: number) =>
+            isDataAppCardActive({
+                preview: open,
+                appUuid: 'app-1',
+                version,
+                latestReadyVersion: 3,
+            });
+        expect(active(1)).toBe(true);
+        expect(active(3)).toBe(false);
+    });
+
+    it('activates the latest card for a content link preview', () => {
+        const open = preview({ version: null });
+        const active = (version: number) =>
+            isDataAppCardActive({
+                preview: open,
+                appUuid: 'app-1',
+                version,
+                latestReadyVersion: 3,
+            });
+        expect(active(3)).toBe(true);
+        expect(active(1)).toBe(false);
+    });
+
+    it('moves the highlight to the card that just landed', () => {
+        const open = preview({ version: 1, latestReadyVersionAtOpen: 3 });
+        const active = (version: number) =>
+            isDataAppCardActive({
+                preview: open,
+                appUuid: 'app-1',
+                version,
+                latestReadyVersion: 4,
+            });
+        expect(active(4)).toBe(true);
+        expect(active(1)).toBe(false);
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/dataAppPreviewVersion.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/dataAppPreviewVersion.ts
@@ -1,0 +1,53 @@
+import { type DataAppPreviewData } from '../../../store/aiArtifactSlice';
+
+type EffectiveVersionArgs = {
+    version: number | null;
+    latestReadyVersionAtOpen: number | null;
+    latestReadyVersion: number | null;
+};
+
+/**
+ * The version the thread preview shows. A null version means latest ready.
+ * An explicit version is kept until a ready version newer than the one
+ * recorded at open time lands, which moves the panel to latest. With no
+ * version recorded at open there is nothing to compare against, so the
+ * explicit version stays.
+ */
+export const getEffectiveDataAppVersion = ({
+    version,
+    latestReadyVersionAtOpen,
+    latestReadyVersion,
+}: EffectiveVersionArgs): number | null => {
+    if (version === null) return latestReadyVersion;
+    const newerVersionLanded =
+        latestReadyVersion !== null &&
+        latestReadyVersionAtOpen !== null &&
+        latestReadyVersion > latestReadyVersionAtOpen;
+    return newerVersionLanded ? latestReadyVersion : version;
+};
+
+type CardActiveArgs = {
+    preview: DataAppPreviewData | null;
+    appUuid: string | null;
+    version: number | null;
+    latestReadyVersion: number | null;
+};
+
+/** A build card is active when its app and version are the ones on show. */
+export const isDataAppCardActive = ({
+    preview,
+    appUuid,
+    version,
+    latestReadyVersion,
+}: CardActiveArgs): boolean => {
+    if (!preview || appUuid === null || version === null) return false;
+    if (preview.appUuid !== appUuid) return false;
+    return (
+        version ===
+        getEffectiveDataAppVersion({
+            version: preview.version,
+            latestReadyVersionAtOpen: preview.latestReadyVersionAtOpen,
+            latestReadyVersion,
+        })
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppVersionPill.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppVersionPill.module.css
@@ -1,0 +1,13 @@
+/* Same shell and vertical rhythm as the collapsed network inspector bar
+ * (bottom-left) so both overlays share one height; this one sits bottom-right. */
+.pill {
+    position: absolute;
+    bottom: var(--mantine-spacing-sm);
+    right: var(--mantine-spacing-sm);
+    z-index: 10;
+    padding: var(--mantine-spacing-xs) var(--mantine-spacing-sm);
+    border-radius: var(--mantine-radius-md);
+    background-color: var(--mantine-color-body);
+    border: 1px solid var(--mantine-color-default-border);
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.15);
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppVersionPill.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppVersionPill.tsx
@@ -1,0 +1,56 @@
+import { Box, Button, Group, Text, Tooltip } from '@mantine/core';
+import { IconArrowBackUp, IconRestore } from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import classes from './DataAppVersionPill.module.css';
+
+type Props = {
+    version: number;
+    onReturnToLatest: () => void;
+    /** Restore is offered only where the user can manage the app. */
+    restore: null | {
+        onClick: () => void;
+        disabled: boolean;
+        disabledReason: string | null;
+    };
+};
+
+/** Floats over the preview while it shows a version older than latest ready. */
+export const DataAppVersionPill: FC<Props> = ({
+    version,
+    onReturnToLatest,
+    restore,
+}) => (
+    <Group gap="xs" wrap="nowrap" className={classes.pill}>
+        <Text size="xs" fw={500} className="ld-nowrap">
+            Viewing v{version}
+        </Text>
+        <Button
+            size="compact-sm"
+            leftSection={<MantineIcon icon={IconArrowBackUp} size="sm" />}
+            onClick={onReturnToLatest}
+        >
+            Return to latest
+        </Button>
+        {restore && (
+            <Tooltip
+                label={restore.disabledReason}
+                disabled={restore.disabledReason === null}
+            >
+                <Box>
+                    <Button
+                        size="compact-sm"
+                        variant="default"
+                        leftSection={
+                            <MantineIcon icon={IconRestore} size="sm" />
+                        }
+                        disabled={restore.disabled}
+                        onClick={restore.onClick}
+                    >
+                        Restore
+                    </Button>
+                </Box>
+            </Tooltip>
+        )}
+    </Group>
+);

--- a/packages/frontend/src/ee/features/aiCopilot/store/aiArtifactSlice.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/store/aiArtifactSlice.ts
@@ -23,7 +23,17 @@ export interface DataAppPreviewData {
     threadUuid: string;
     projectUuid: string;
     agentUuid: string;
+    /** null means the app's latest ready version. */
+    version: number | null;
+    /** Latest ready version when the preview was opened; a newer one landing
+     *  moves the panel to latest. See `getEffectiveDataAppVersion`. */
+    latestReadyVersionAtOpen: number | null;
 }
+
+export type DataAppPreviewVersion = Pick<
+    DataAppPreviewData,
+    'version' | 'latestReadyVersionAtOpen'
+>;
 
 export type AiPreview =
     | ({ type: 'artifact' } & ArtifactData)
@@ -48,10 +58,20 @@ export const aiArtifactSlice = createSlice({
         clearPreview: (state) => {
             state.preview = null;
         },
+        setDataAppPreviewVersion: (
+            state,
+            action: PayloadAction<DataAppPreviewVersion>,
+        ) => {
+            if (state.preview?.type !== 'dataApp') return;
+            state.preview.version = action.payload.version;
+            state.preview.latestReadyVersionAtOpen =
+                action.payload.latestReadyVersionAtOpen;
+        },
     },
 });
 
-export const { setPreview, clearPreview } = aiArtifactSlice.actions;
+export const { setPreview, clearPreview, setDataAppPreviewVersion } =
+    aiArtifactSlice.actions;
 
 type StateWithAiArtifact = { aiArtifact: AiArtifactState };
 


### PR DESCRIPTION
First of a 4-PR stack for ZAP-989 (view and restore previous data app versions from the AI agent thread).

In a thread, every build card for an app lit up once the app was open in the preview, and **View** on any card opened the latest version. This makes the thread preview show one version at a time.

```diff
 DataAppPreviewData
   appUuid, messageUuid, threadUuid, projectUuid, agentUuid
+  version: number | null              // null = latest ready
+  latestReadyVersionAtOpen: number | null
```

The effective version is derived, never stored:

```text
effectiveVersion(preview, latestReady)
  if preview.version is null                → latestReady
  if latestReady > latestReadyVersionAtOpen → latestReady   // a newer build landed: jump
  else                                      → preview.version
```

```diff
 <AiDataAppPreviewPanel>
-  identityKey / preview token / iframe URL / Open in new tab  ← latestReadyVersion
+  identityKey / preview token / iframe URL / Open in new tab  ← effectiveVersion
+  <DataAppVersionPill>            // bottom-right, only when effectiveVersion < latestReady
+    "Viewing v1"  [Return to latest]  [Restore]   // Restore is wired in ZAP-995
   <ElementPickerButton>           // hidden on older versions; refs still stamp latest ready
```

- Build cards dispatch their own version; content links dispatch `null`. A card is active when app **and** effective version match.
- The floating launcher shares the panel, so it gets the same behaviour.
- Glossary: the Build card entry states each card names one version and only the one on show is active.

Tests: `dataAppPreviewVersion.test.ts` (null-means-latest, jump-to-latest, active state) and preview panel version tests (pill, Return to latest, picker hidden, versioned Open URL).

Closes: ZAP-993
Relates: ZAP-989

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYqCC1cLQv5apggPng7HgQ
