### PR TITLE
feat(ai): thread-scoped data app restore endpoint records a hidden turn

### DIFF
--- a/packages/backend/src/ee/controllers/aiAgentController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentController.ts
@@ -27,6 +27,8 @@ import {
     ApiAiAgentSummaryResponse,
     ApiAiAgentThreadCreateRequest,
     ApiAiAgentThreadCreateResponse,
+    ApiAiAgentThreadDataAppRestoreRequest,
+    ApiAiAgentThreadDataAppRestoreResponse,
     ApiAiAgentThreadGenerateResponse,
     ApiAiAgentThreadGenerateTitleResponse,
     ApiAiAgentThreadLiveStatusesResponse,
@@ -1188,6 +1190,36 @@ export class AiAgentController extends BaseController {
                 threadUuid,
                 body,
             ),
+        };
+    }
+
+    /**
+     * Restores a ready data app version as a new latest version on behalf of
+     * the thread and records the restore as a hidden thread turn
+     * @summary Restore data app version
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('/{agentUuid}/threads/{threadUuid}/data-app-restores')
+    @OperationId('restoreAgentThreadDataAppVersion')
+    async restoreAgentThreadDataAppVersion(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() agentUuid: string,
+        @Path() threadUuid: string,
+        @Body() body: ApiAiAgentThreadDataAppRestoreRequest,
+    ): Promise<ApiAiAgentThreadDataAppRestoreResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results:
+                await this.getAiAgentService().restoreDataAppVersionForThread(
+                    toSessionUser(req.account),
+                    agentUuid,
+                    threadUuid,
+                    body,
+                ),
         };
     }
 

--- a/packages/backend/src/ee/controllers/aiAgentController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentController.ts
@@ -1204,9 +1204,9 @@ export class AiAgentController extends BaseController {
     @OperationId('restoreAgentThreadDataAppVersion')
     async restoreAgentThreadDataAppVersion(
         @Request() req: express.Request,
-        @Path() projectUuid: string,
-        @Path() agentUuid: string,
-        @Path() threadUuid: string,
+        @Path() projectUuid: UUID,
+        @Path() agentUuid: UUID,
+        @Path() threadUuid: UUID,
         @Body() body: ApiAiAgentThreadDataAppRestoreRequest,
     ): Promise<ApiAiAgentThreadDataAppRestoreResponse> {
         assertRegisteredAccount(req.account);

--- a/packages/backend/src/ee/database/entities/ai.ts
+++ b/packages/backend/src/ee/database/entities/ai.ts
@@ -467,7 +467,8 @@ export type AiPromptContextEntityType =
     | 'proposed_change'
     | 'review_finding'
     | 'preview_environment'
-    | 'data_app_element';
+    | 'data_app_element'
+    | 'data_app_restore';
 
 // Element reference snapshot stored in runtime_overrides; entity_ref holds the
 // natural key so one prompt can reference several elements of the same app.
@@ -477,6 +478,12 @@ export type AiPromptDataAppElementSnapshot = {
     tag: string;
     text: string;
     loc: string;
+};
+
+// Restore snapshot stored in runtime_overrides; entity_uuid holds the app uuid.
+export type AiPromptDataAppRestoreSnapshot = {
+    version: number;
+    restoredFromVersion: number;
 };
 
 export type DbAiPromptContext = {
@@ -496,6 +503,7 @@ export type DbAiPromptContext = {
         | AiDashboardRuntimeOverrides
         | AiPromptExternalSourceSnapshot
         | AiPromptDataAppElementSnapshot
+        | AiPromptDataAppRestoreSnapshot
         | null;
     created_at: Date;
 };

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -146,6 +146,7 @@ import {
     AiPromptContextEntityType,
     AiPromptContextTableName,
     AiPromptDataAppElementSnapshot,
+    AiPromptDataAppRestoreSnapshot,
     AiPromptInterruptTableName,
     AiPromptSteerTableName,
     AiPromptTableName,
@@ -6506,7 +6507,9 @@ export class AiAgentModel {
             c.type === 'dashboard' ? [c.dashboardUuid] : [],
         );
         const appUuids = context.flatMap((c) =>
-            c.type === 'data_app_element' ? [c.appUuid] : [],
+            c.type === 'data_app_element' || c.type === 'data_app_restore'
+                ? [c.appUuid]
+                : [],
         );
 
         const appNameByUuid = new Map(
@@ -6803,6 +6806,24 @@ export class AiAgentModel {
                         } satisfies AiPromptDataAppElementSnapshot,
                     };
                 }
+                case 'data_app_restore': {
+                    const appName = appNameByUuid.get(ctx.appUuid);
+                    return {
+                        ai_prompt_uuid: promptUuid,
+                        entity_type:
+                            'data_app_restore' as AiPromptContextEntityType,
+                        entity_uuid: ctx.appUuid,
+                        entity_ref: null,
+                        display_name:
+                            appName === undefined
+                                ? null
+                                : getAppDisplayName(appName, ctx.appUuid),
+                        runtime_overrides: {
+                            version: ctx.version,
+                            restoredFromVersion: ctx.restoredFromVersion,
+                        } satisfies AiPromptDataAppRestoreSnapshot,
+                    };
+                }
                 default:
                     return assertUnreachable(
                         ctx,
@@ -6939,14 +6960,18 @@ export class AiAgentModel {
             }),
         );
 
-        const appUuids = rows.flatMap((r) =>
-            r.entity_type === 'data_app_element'
-                ? [
-                      (r.runtime_overrides as AiPromptDataAppElementSnapshot)
-                          .appUuid,
-                  ]
-                : [],
-        );
+        const appUuids = rows.flatMap((r) => {
+            if (r.entity_type === 'data_app_element') {
+                return [
+                    (r.runtime_overrides as AiPromptDataAppElementSnapshot)
+                        .appUuid,
+                ];
+            }
+            if (r.entity_type === 'data_app_restore' && r.entity_uuid) {
+                return [r.entity_uuid];
+            }
+            return [];
+        });
         const appDataByUuid = new Map(
             (
                 await this.database(AppsTableName)
@@ -7158,6 +7183,27 @@ export class AiAgentModel {
                     appSlug: app?.slug ?? null,
                     displayName: app
                         ? getAppDisplayName(app.name, snapshot.appUuid)
+                        : row.display_name,
+                };
+            }
+            case 'data_app_restore': {
+                const appUuid = requireEntityUuid();
+                if (row.runtime_overrides === null) {
+                    throw new Error(
+                        `ai_prompt_context row ${row.ai_prompt_context_uuid} of type 'data_app_restore' is missing runtime_overrides`,
+                    );
+                }
+                const snapshot =
+                    row.runtime_overrides as AiPromptDataAppRestoreSnapshot;
+                const app = appDataByUuid.get(appUuid);
+                return {
+                    type: 'data_app_restore',
+                    appUuid,
+                    version: snapshot.version,
+                    restoredFromVersion: snapshot.restoredFromVersion,
+                    appSlug: app?.slug ?? null,
+                    displayName: app
+                        ? getAppDisplayName(app.name, appUuid)
                         : row.display_name,
                 };
             }

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.integration.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.integration.test.ts
@@ -1,6 +1,8 @@
 import {
     defineUserAbility,
     OrganizationMemberRole,
+    ParameterError,
+    SEED_ORG_1,
     SEED_ORG_1_EDITOR,
     SEED_ORG_1_EDITOR_EMAIL,
     SEED_ORG_1_VIEWER,
@@ -15,12 +17,15 @@ import type { Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
+import { AppsTableName } from '../../../database/entities/apps';
 import {
     getModels,
     getServices,
     getTestContext,
     type IntegrationTestContext,
 } from '../../../vitest.setup.integration';
+import { AiThreadTableName } from '../../database/entities/ai';
+import { AiAgentTableName } from '../../database/entities/aiAgent';
 
 type RuntimeClientSpies = {
     startOAuthConnection: (...args: unknown[]) => Promise<string>;
@@ -1070,5 +1075,171 @@ describe('AiAgentService MCP support', () => {
         completeOAuthConnectionSpy.mockRestore();
         discoverMcpServerToolsSpy.mockRestore();
         getOauthCredentialByStateSpy.mockRestore();
+    });
+});
+
+describe('AiAgentService thread data app restore', () => {
+    let context: IntegrationTestContext;
+    let agentUuid: string;
+    const threadUuids = new Set<string>();
+    const appUuids = new Set<string>();
+
+    beforeAll(async () => {
+        context = getTestContext();
+        const agent = await getServices(context.app).aiAgentService.createAgent(
+            context.testUser,
+            {
+                name: `Restore Agent ${crypto.randomUUID().slice(0, 8)}`,
+                description: null,
+                projectUuid: SEED_PROJECT.project_uuid,
+                tags: null,
+                integrations: [],
+                instruction: '',
+                groupAccess: [],
+                userAccess: [],
+                spaceAccess: [],
+                mcpServerUuids: [],
+                imageUrl: null,
+                enableDataAccess: true,
+                enableSelfImprovement: false,
+                version: 2,
+            },
+        );
+        agentUuid = agent.uuid;
+    });
+
+    afterAll(async () => {
+        await context
+            .db(AiThreadTableName)
+            .whereIn('ai_thread_uuid', [...threadUuids])
+            .delete();
+        await context
+            .db(AppsTableName)
+            .whereIn('app_id', [...appUuids])
+            .delete();
+        await context
+            .db(AiAgentTableName)
+            .where('ai_agent_uuid', agentUuid)
+            .delete();
+    });
+
+    const createAppWithVersions = async (latestStatus: 'ready' | 'pending') => {
+        const appModel = context.app.getModels().getAppModel();
+        const { app } = await appModel.createWithVersion(
+            {
+                project_uuid: SEED_PROJECT.project_uuid,
+                created_by_user_uuid: context.testUser.userUuid,
+                name: 'Revenue app',
+            },
+            { version: 1, prompt: 'Build a revenue app' },
+            'ready',
+        );
+        appUuids.add(app.app_id);
+        await appModel.createVersion(
+            app.app_id,
+            { version: 2, prompt: 'Add a chart' },
+            latestStatus,
+            context.testUser.userUuid,
+        );
+        // Threads are only listed once they hold a first prompt.
+        const { aiAgentModel } = getModels(context.app);
+        const threadUuid = await aiAgentModel.createWebAppThread({
+            organizationUuid: SEED_ORG_1.organization_uuid,
+            projectUuid: SEED_PROJECT.project_uuid,
+            userUuid: context.testUser.userUuid,
+            createdFrom: 'web_app',
+            agentUuid,
+        });
+        threadUuids.add(threadUuid);
+        const firstPromptUuid = await aiAgentModel.createWebAppPrompt({
+            threadUuid,
+            createdByUserUuid: context.testUser.userUuid,
+            prompt: 'Build me a revenue app',
+        });
+        await aiAgentModel.updateModelResponse({
+            promptUuid: firstPromptUuid,
+            response: 'Started the data app build.',
+        });
+        return { app, threadUuid };
+    };
+
+    it('restores the version and records a hidden, answered turn in the thread', async () => {
+        const { app, threadUuid } = await createAppWithVersions('ready');
+        const { aiAgentService } = getServices(context.app);
+        const { aiAgentModel } = getModels(context.app);
+
+        const result = await aiAgentService.restoreDataAppVersionForThread(
+            context.testUser,
+            agentUuid,
+            threadUuid,
+            { appUuid: app.app_id, version: 1 },
+        );
+
+        expect(result).toEqual({
+            appUuid: app.app_id,
+            version: 3,
+            restoredFromVersion: 1,
+            promptUuid: expect.any(String),
+        });
+        const latest = await context.app
+            .getModels()
+            .getAppModel()
+            .getLatestVersion(app.app_id);
+        expect(latest).toMatchObject({ version: 3, status: 'ready' });
+
+        const messages = await aiAgentModel.findThreadMessages({
+            organizationUuid: SEED_ORG_1.organization_uuid,
+            threadUuid,
+        });
+        expect(messages).toHaveLength(4);
+        expect(messages[2]).toMatchObject({
+            role: 'user',
+            uuid: result.promptUuid,
+            hidden: true,
+            message: 'Restore version 1 of Revenue app',
+            context: [
+                {
+                    type: 'data_app_restore',
+                    appUuid: app.app_id,
+                    version: 3,
+                    restoredFromVersion: 1,
+                    appSlug: app.slug,
+                    displayName: 'Revenue app',
+                },
+            ],
+        });
+        expect(messages[3]).toMatchObject({
+            role: 'assistant',
+            uuid: result.promptUuid,
+            status: 'idle',
+            message: 'Restored version 1 as version 3.',
+        });
+    });
+
+    it('writes nothing to the thread when the restore is refused', async () => {
+        const { app, threadUuid } = await createAppWithVersions('pending');
+        const { aiAgentService } = getServices(context.app);
+        const { aiAgentModel } = getModels(context.app);
+
+        await expect(
+            aiAgentService.restoreDataAppVersionForThread(
+                context.testUser,
+                agentUuid,
+                threadUuid,
+                { appUuid: app.app_id, version: 1 },
+            ),
+        ).rejects.toThrow(ParameterError);
+
+        const latest = await context.app
+            .getModels()
+            .getAppModel()
+            .getLatestVersion(app.app_id);
+        expect(latest).toMatchObject({ version: 2, status: 'pending' });
+        const messages = await aiAgentModel.findThreadMessages({
+            organizationUuid: SEED_ORG_1.organization_uuid,
+            threadUuid,
+        });
+        expect(messages).toHaveLength(2);
+        expect(messages.some((m) => m.role === 'user' && m.hidden)).toBe(false);
     });
 });

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -42,6 +42,8 @@ import {
     AnyType,
     ApiAiAgentArtifactVizQuery,
     ApiAiAgentThreadCreateRequest,
+    ApiAiAgentThreadDataAppRestoreRequest,
+    ApiAiAgentThreadDataAppRestoreResponse,
     ApiAiAgentThreadMessageCreateRequest,
     ApiAiAgentThreadMessageCreateResponse,
     ApiAiAgentThreadMessageVizQuery,
@@ -571,7 +573,10 @@ type AiAgentServiceDependencies = {
         AppModel,
         'findVisualizationApp' | 'findAppByUuid' | 'getVersion'
     >;
-    appGenerateService: Pick<AppGenerateService, 'canViewApp'>;
+    appGenerateService: Pick<
+        AppGenerateService,
+        'canViewApp' | 'restoreVersion'
+    >;
     aiAgentMemoryModel: AiAgentMemoryModel;
     aiAgentDocumentModel: AiAgentDocumentModel;
     externalSourceModel: Pick<ExternalSourceModel, 'getSource'>;
@@ -851,7 +856,10 @@ export class AiAgentService extends BaseService {
         'findVisualizationApp' | 'findAppByUuid' | 'getVersion'
     >;
 
-    private readonly appGenerateService: Pick<AppGenerateService, 'canViewApp'>;
+    private readonly appGenerateService: Pick<
+        AppGenerateService,
+        'canViewApp' | 'restoreVersion'
+    >;
 
     private readonly inFlightStreamPrompts = new Map<
         string,
@@ -1066,6 +1074,9 @@ export class AiAgentService extends BaseService {
                 case 'data_app_element':
                     key = dataAppElementContextKey(item);
                     break;
+                case 'data_app_restore':
+                    key = `data_app_restore:${item.appUuid}:${item.version}`;
+                    break;
                 default:
                     return assertUnreachable(
                         item,
@@ -1222,6 +1233,12 @@ export class AiAgentService extends BaseService {
                 ) {
                     throw new ForbiddenError(
                         'This context item can only be attached by the review remediation flow',
+                    );
+                }
+                // data_app_restore is written by the thread restore endpoint only.
+                if (item.type === 'data_app_restore') {
+                    throw new ForbiddenError(
+                        'This context item can only be attached by restoring a data app version from the thread',
                     );
                 }
 
@@ -3741,6 +3758,91 @@ export class AiAgentService extends BaseService {
             threadUuid,
             messageUuid,
         });
+    }
+
+    // Restores a data app version on behalf of a thread and records it as a
+    // hidden, already-answered turn so the agent's next prompt sees it.
+    async restoreDataAppVersionForThread(
+        user: SessionUser,
+        agentUuid: string,
+        threadUuid: string,
+        body: ApiAiAgentThreadDataAppRestoreRequest,
+    ): Promise<ApiAiAgentThreadDataAppRestoreResponse['results']> {
+        const { organizationUuid } = user;
+        if (!organizationUuid) {
+            throw new ForbiddenError('Organization not found');
+        }
+
+        const isCopilotEnabled = await this.getIsCopilotEnabled(user);
+        if (!isCopilotEnabled) {
+            throw new ForbiddenError('Copilot is not enabled');
+        }
+
+        const agent = await this.aiAgentModel.getAgent({
+            organizationUuid,
+            agentUuid,
+        });
+        if (!agent) {
+            throw new NotFoundError(`Agent not found: ${agentUuid}`);
+        }
+
+        const thread = await this.aiAgentModel.getThread({
+            organizationUuid,
+            agentUuid,
+            threadUuid,
+        });
+        if (!thread) {
+            throw new NotFoundError(`Thread not found: ${threadUuid}`);
+        }
+
+        const hasAccess = await this.checkAgentThreadAccess(
+            user,
+            agent,
+            thread.user.uuid,
+        );
+        if (!hasAccess) {
+            throw new ForbiddenError(
+                'Insufficient permissions to create messages for this thread',
+            );
+        }
+
+        const app = await this.appModel.findAppByUuid(body.appUuid);
+        if (!app || app.project_uuid !== agent.projectUuid) {
+            throw new NotFoundError('Data app not found');
+        }
+
+        const restored = await this.appGenerateService.restoreVersion(
+            user,
+            agent.projectUuid,
+            body.appUuid,
+            body.version,
+        );
+
+        const promptUuid = await this.aiAgentModel.createWebAppPrompt({
+            threadUuid,
+            createdByUserUuid: user.userUuid,
+            prompt: `Restore version ${body.version} of ${app.name}`,
+            context: [
+                {
+                    type: 'data_app_restore',
+                    appUuid: body.appUuid,
+                    version: restored.version,
+                    restoredFromVersion: body.version,
+                },
+            ],
+            hidden: true,
+        });
+        await this.aiAgentModel.updateModelResponse({
+            promptUuid,
+            response: `Restored version ${body.version} as version ${restored.version}.`,
+        });
+
+        return {
+            appUuid: body.appUuid,
+            version: restored.version,
+            restoredFromVersion: body.version,
+            promptUuid,
+        };
     }
 
     async cleanExpiredThreads(batchSize: number): Promise<{
@@ -8731,6 +8833,11 @@ Use them as a reference, but do all the due dilligence and follow the instructio
                     const name = item.displayName ?? '(name unavailable)';
                     const slugText = item.appSlug ?? '(slug unavailable)';
                     return `- Element reference ${elementReferenceToWireString(item)} in data app "${name}" (appSlug: ${slugText}, version ${item.version}) — the app's source is not readable in this thread; copy the bracketed reference verbatim into the iterateDataApp brief so the coding agent can locate the element.`;
+                }
+                case 'data_app_restore': {
+                    const name = item.displayName ?? '(name unavailable)';
+                    const slugText = item.appSlug ?? '(slug unavailable)';
+                    return `- Data app restore: version ${item.restoredFromVersion} of "${name}" (appSlug: ${slugText}) was restored as version ${item.version} — the app now matches version ${item.restoredFromVersion}; iterate from version ${item.version}.`;
                 }
                 default:
                     return assertUnreachable(

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -63,6 +63,7 @@ import {
     ConflictError,
     ContentType,
     dataAppElementContextKey,
+    dataAppRestoreContextKey,
     dataAppVizSchema,
     DbtProjectType,
     deriveDataAppVizPivotConfig,
@@ -79,6 +80,7 @@ import {
     ForbiddenError,
     formatMergeQueryRefusal,
     GenerateArtifactQuestionJobPayload,
+    getAppDisplayName,
     getDataAppVizChartFromArtifact,
     getErrorMessage,
     getGenerateDataAppBuildOutcome,
@@ -1075,7 +1077,7 @@ export class AiAgentService extends BaseService {
                     key = dataAppElementContextKey(item);
                     break;
                 case 'data_app_restore':
-                    key = `data_app_restore:${item.appUuid}:${item.version}`;
+                    key = dataAppRestoreContextKey(item);
                     break;
                 default:
                     return assertUnreachable(
@@ -3821,7 +3823,10 @@ export class AiAgentService extends BaseService {
         const promptUuid = await this.aiAgentModel.createWebAppPrompt({
             threadUuid,
             createdByUserUuid: user.userUuid,
-            prompt: `Restore version ${body.version} of ${app.name}`,
+            prompt: `Restore version ${body.version} of ${getAppDisplayName(
+                app.name,
+                body.appUuid,
+            )}`,
             context: [
                 {
                     type: 'data_app_restore',

--- a/packages/backend/src/ee/services/AiAgentService/pinnedContextMessage.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/pinnedContextMessage.test.ts
@@ -328,4 +328,21 @@ describe('AiAgentService.createPinnedContextMessage review pins', () => {
             'copy the bracketed reference verbatim into the iterateDataApp brief',
         );
     });
+
+    it('renders a data app restore as one line naming both versions', () => {
+        const content = buildMessage([
+            {
+                type: 'data_app_restore',
+                appUuid: 'app-1',
+                version: 5,
+                restoredFromVersion: 2,
+                appSlug: 'f1-standings',
+                displayName: 'F1 standings',
+            },
+        ]);
+
+        expect(content).toContain(
+            '- Data app restore: version 2 of "F1 standings" (appSlug: f1-standings) was restored as version 5 — the app now matches version 2; iterate from version 5.',
+        );
+    });
 });

--- a/packages/backend/src/ee/services/ai/compaction.ts
+++ b/packages/backend/src/ee/services/ai/compaction.ts
@@ -236,6 +236,8 @@ export class Compaction {
                 }${item.status ? ` — ${item.status}` : ''}`;
             case 'data_app_element':
                 return `element reference ${elementReferenceToWireString(item)} in data app ${item.displayName ?? item.appUuid} (${item.appUuid}, version ${item.version}; copy it verbatim into the iterateDataApp brief)`;
+            case 'data_app_restore':
+                return `data app ${item.displayName ?? item.appUuid} (${item.appUuid}) restored version ${item.restoredFromVersion} as version ${item.version}`;
             default:
                 return assertUnreachable(
                     item,

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -860,6 +860,18 @@ export type ApiAiAgentThreadMessageCreateResponse = ApiSuccess<
     AiAgentMessageUser<AiAgentUser>
 >;
 
+export type ApiAiAgentThreadDataAppRestoreRequest = {
+    appUuid: string;
+    version: number;
+};
+
+export type ApiAiAgentThreadDataAppRestoreResponse = ApiSuccess<{
+    appUuid: string;
+    version: number;
+    restoredFromVersion: number;
+    promptUuid: string;
+}>;
+
 export type ApiAiAgentStartThreadResponse = {
     status: 'ok';
     results: {

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -13,6 +13,7 @@ import type {
     ToolName,
     ToolRunQueryArgs,
 } from '../..';
+import { type UUID } from '../../types/api/uuid';
 import {
     MAX_RETENTION_WINDOW_HOURS,
     MIN_RETENTION_WINDOW_HOURS,
@@ -861,7 +862,7 @@ export type ApiAiAgentThreadMessageCreateResponse = ApiSuccess<
 >;
 
 export type ApiAiAgentThreadDataAppRestoreRequest = {
-    appUuid: string;
+    appUuid: UUID;
     version: number;
 };
 

--- a/packages/common/src/ee/AiAgent/requestTypes.ts
+++ b/packages/common/src/ee/AiAgent/requestTypes.ts
@@ -245,6 +245,15 @@ export type AiPromptContextItemInput =
           tag: string;
           text: string;
           loc: string;
+      }
+    | {
+          // A data app version restored from the thread: the new version and
+          // the ready version it copies. System-only: written by the thread
+          // restore endpoint, never user-attached.
+          type: 'data_app_restore';
+          appUuid: string;
+          version: number;
+          restoredFromVersion: number;
       };
 
 export type AiPromptContextInput = AiPromptContextItemInput[];
@@ -342,6 +351,14 @@ export type AiPromptContextItem =
           tag: string;
           text: string;
           loc: string;
+          appSlug: string | null;
+          displayName: string | null;
+      }
+    | {
+          type: 'data_app_restore';
+          appUuid: string;
+          version: number;
+          restoredFromVersion: number;
           appSlug: string | null;
           displayName: string | null;
       };

--- a/packages/common/src/ee/AiAgent/requestTypes.ts
+++ b/packages/common/src/ee/AiAgent/requestTypes.ts
@@ -247,9 +247,8 @@ export type AiPromptContextItemInput =
           loc: string;
       }
     | {
-          // A data app version restored from the thread: the new version and
-          // the ready version it copies. System-only: written by the thread
-          // restore endpoint, never user-attached.
+          // A thread restore: the new version and the ready one it copies.
+          // System-only, never user-attached.
           type: 'data_app_restore';
           appUuid: string;
           version: number;

--- a/packages/common/src/ee/apps/elementReference.ts
+++ b/packages/common/src/ee/apps/elementReference.ts
@@ -31,3 +31,12 @@ export const dataAppElementContextKey = ({
     loc,
 }: DataAppElementReference & { appUuid: string; version: number }): string =>
     `data_app_element:${appUuid}:${version}:${elementReferenceToWireString({ tag, text, loc })}`;
+
+/** Identity of a thread restore as prompt context: app and the new version. */
+export const dataAppRestoreContextKey = ({
+    appUuid,
+    version,
+}: {
+    appUuid: string;
+    version: number;
+}): string => `data_app_restore:${appUuid}:${version}`;

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.tsx
@@ -322,6 +322,8 @@ const getContextKey = (item: AiPromptContextInput[number]) => {
             return `preview_environment:${item.previewProjectUuid}`;
         case 'data_app_element':
             return dataAppElementContextKey(item);
+        case 'data_app_restore':
+            return `data_app_restore:${item.appUuid}:${item.version}`;
         default:
             return assertUnreachable(
                 item,

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentReferenceUtils.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentReferenceUtils.ts
@@ -5,14 +5,16 @@ import {
 } from '@lightdash/common';
 
 // Element references never render inline; they always show as pills.
+// Restore items live on hidden turns and are rendered as build cards.
 type InlineReferenceItem = Exclude<
     AiPromptContextItem,
-    { type: 'data_app_element' }
+    { type: 'data_app_element' | 'data_app_restore' }
 >;
 
 const isInlineReferenceItem = (
     item: AiPromptContextItem,
-): item is InlineReferenceItem => item.type !== 'data_app_element';
+): item is InlineReferenceItem =>
+    item.type !== 'data_app_element' && item.type !== 'data_app_restore';
 
 export type ContentReferenceSegment =
     | {
@@ -50,6 +52,8 @@ export const getPromptContextItemKey = (item: AiPromptContextItem) => {
             return `preview_environment:${item.previewProjectUuid}`;
         case 'data_app_element':
             return dataAppElementContextKey(item);
+        case 'data_app_restore':
+            return `data_app_restore:${item.appUuid}:${item.version}`;
         default:
             return assertUnreachable(item, 'Unknown AiPromptContextItem type');
     }
@@ -118,8 +122,10 @@ export const getPromptContextItemHref = (
         case 'review_finding':
         case 'proposed_change':
             return null;
-        // An element reference points inside a running app, not at a route.
+        // An element reference points inside a running app, not at a route;
+        // a restore is surfaced by its build card instead.
         case 'data_app_element':
+        case 'data_app_restore':
             return null;
         default:
             return assertUnreachable(item, 'Unknown AiPromptContextItem type');

--- a/packages/frontend/src/ee/features/aiCopilot/components/PinnedContextCard/PinnedContextCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/PinnedContextCard/PinnedContextCard.tsx
@@ -17,7 +17,8 @@ type ItemMeta = {
         | 'file'
         | 'repository'
         | 'external_source'
-        | 'data_app_element';
+        | 'data_app_element'
+        | 'data_app';
     label: string;
     href: string | null;
 };
@@ -33,7 +34,8 @@ const getItemMeta = (
                 | 'file'
                 | 'repository'
                 | 'external_source'
-                | 'data_app_element';
+                | 'data_app_element'
+                | 'data_app_restore';
         }
     >,
     projectUuid: string,
@@ -76,6 +78,12 @@ const getItemMeta = (
                 label: elementRefChipLabel(item),
                 href: null,
             };
+        case 'data_app_restore':
+            return {
+                kind: 'data_app',
+                label: `Restored v${item.version} of ${item.displayName ?? 'data app'}`,
+                href: null,
+            };
         default:
             return assertUnreachable(item, 'Unknown AiPromptContextItem type');
     }
@@ -89,7 +97,8 @@ export const PinnedContextCard: FC<Props> = ({ item, projectUuid }) => {
         case 'file':
         case 'repository':
         case 'external_source':
-        case 'data_app_element': {
+        case 'data_app_element':
+        case 'data_app_restore': {
             const meta = getItemMeta(item, projectUuid);
             return (
                 <ContentReferenceLink

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
@@ -784,10 +784,11 @@ const toOptimisticContextItem = (
                 appSlug: null,
                 displayName: null,
             };
-        // System-only pins are seeded by the remediation flow, never optimistically
-        // attached from the UI, so they have no client-resolvable shape.
+        // System-only pins are seeded by the remediation flow or the thread
+        // restore endpoint, never optimistically attached from the UI.
         case 'proposed_change':
         case 'review_finding':
+        case 'data_app_restore':
             throw new Error(
                 `Cannot optimistically resolve system-only context item: ${item.type}`,
             );


### PR DESCRIPTION
Second of a 4-PR stack for ZAP-989. Stacked on ZAP-993.

A thread-scoped endpoint restores a data app version on behalf of a thread and records the restore in the thread through the existing prompt and context mechanisms. No LLM call, no tool, no new message type.

```mermaid
sequenceDiagram
    participant UI
    participant API as POST …/threads/{thread}/data-app-restores
    participant App as AppGenerateService.restoreVersion
    participant Thread as ai_prompt (hidden)
    UI->>API: { appUuid, version: 1 }
    API->>App: restore v1 → v3 (S3 copy, ready row)
    App-->>API: { version: 3 }
    API->>Thread: prompt "Restore version 1 of <app>" + context data_app_restore {appUuid, 3, from 1}
    API->>Thread: response "Restored version 1 as version 3." (responded immediately)
    API-->>UI: { appUuid, version: 3, restoredFromVersion: 1, promptUuid }
```

- `data_app_restore` joins the prompt context vocabulary as a system-only item (rejected if a user attaches it, like the review remediation items). The pinned-context builder renders it as one line so the agent's next turn sees user turn, context line, assistant response.
- The hidden row is written only after the restore succeeds; a refused restore (build in progress, already latest) writes nothing.
- Frontend context switches get minimal `data_app_restore` cases; the card UI lands in the next PR.
- Path params typed `UUID`; shared `dataAppRestoreContextKey` helper.

Tests: pinned-context line pinned in `pinnedContextMessage.test.ts`; `AiAgentService.integration.test.ts` drives the thread restore end to end against MinIO and asserts the new ready version, the hidden turn with its context item, the assistant turn, and that a refused restore writes nothing.

Relates: ZAP-994
Relates: ZAP-989

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYqCC1cLQv5apggPng7HgQ
