### PR TITLE
feat(ai): thread renders a data app restore as a build card

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
@@ -1,5 +1,6 @@
 import {
     type AiAgentMessageAssistant,
+    type AiAgentMessageUser,
     type AiAgentToolCall,
     type AiMcpServer,
     isToolEditDbtProjectResult,
@@ -67,6 +68,8 @@ import { AiArtifactInline } from './AiArtifactInline';
 import { AiArtifactButton } from './ArtifactButton/AiArtifactButton';
 import { ContentLink, type SqlRunnerLinkState } from './ContentLink';
 import { AiDataAppBuildCard } from './DataAppBuildCard/AiDataAppBuildCard';
+import { AiDataAppRestoreCard } from './DataAppBuildCard/AiDataAppRestoreCard';
+import { getDataAppRestoreItem } from './DataAppBuildCard/dataAppBuildCardState';
 import { isHiddenToolName } from './hiddenToolNames';
 import {
     MEMORY_CITATION_ALLOWED_TAGS,
@@ -958,6 +961,8 @@ const AssistantBubbleContent: FC<{
 
 type Props = {
     message: AiAgentMessageAssistant;
+    /** The hidden user turn this reply answers, if any (same prompt uuid). */
+    hiddenSibling: AiAgentMessageUser | null;
     isLastMessage: boolean;
     isActive?: boolean;
     debug?: boolean;
@@ -973,6 +978,7 @@ type Props = {
 export const AssistantBubble: FC<Props> = memo(
     ({
         message,
+        hiddenSibling,
         isLastMessage,
         isActive = false,
         debug = false,
@@ -1061,6 +1067,23 @@ export const AssistantBubble: FC<Props> = memo(
         const isArtifactAvailable = !!(
             message.artifacts && message.artifacts.length > 0
         );
+
+        // A restore turn is deterministic (no LLM): the card is the whole
+        // reply, its message included, so nothing else renders for it.
+        const restoreItem = getDataAppRestoreItem(hiddenSibling);
+        if (restoreItem) {
+            return (
+                <AiDataAppRestoreCard
+                    item={restoreItem}
+                    completionMessage={message.message}
+                    projectUuid={projectUuid}
+                    agentUuid={agentUuid}
+                    threadUuid={message.threadUuid}
+                    messageUuid={message.uuid}
+                    compact={!isLastMessage}
+                />
+            );
+        }
 
         return (
             <Stack

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.restore.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.restore.test.tsx
@@ -1,0 +1,164 @@
+import {
+    type AiAgentMessageAssistant,
+    type AiAgentMessageUser,
+    type AiAgentThread,
+    type ApiGetAppResponse,
+} from '@lightdash/common';
+import { fireEvent, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { lightdashApi } from '../../../../../api';
+import { renderWithProviders } from '../../../../../testing/testUtils';
+import { store } from '../../store';
+import { clearPreview } from '../../store/aiArtifactSlice';
+import { AiAgentThreadStreamAbortControllerContextProvider } from '../../streaming/AiAgentThreadStreamAbortControllerContextProvider';
+import { AgentChatDisplay } from './AgentChatDisplay';
+
+vi.mock('../../../../../api', () => ({ lightdashApi: vi.fn() }));
+const mockedLightdashApi = vi.mocked(lightdashApi);
+
+vi.mock('../../hooks/useProjectAiMcpServers', () => ({
+    useAgentAiMcpServers: () => ({ data: [] }),
+}));
+
+vi.mock('../../hooks/useDeepResearch', () => ({
+    useDeepResearchThreadRunRegistrations: () => [],
+}));
+
+const app: ApiGetAppResponse['results'] = {
+    appUuid: 'app-1',
+    name: 'Revenue app',
+    description: '',
+    createdByUserUuid: 'user-1',
+    spaceUuid: null,
+    spaceName: null,
+    registrySlug: null,
+    template: null,
+    pinnedListUuid: null,
+    pinnedListOrder: null,
+    slug: 'revenue-app',
+    views: 0,
+    versions: [],
+    hasMore: false,
+    latestReadyVersion: 3,
+};
+
+const userMessage = (
+    overrides: Partial<AiAgentMessageUser>,
+): AiAgentMessageUser => ({
+    role: 'user',
+    uuid: 'prompt-1',
+    threadUuid: 'thread-1',
+    message: 'Build me a revenue app',
+    createdAt: '2026-07-29T09:00:00.000Z',
+    user: { uuid: 'user-1', name: 'Demo User' },
+    context: [],
+    steers: [],
+    hidden: false,
+    ...overrides,
+});
+
+const assistantMessage = (
+    overrides: Partial<AiAgentMessageAssistant>,
+): AiAgentMessageAssistant => ({
+    role: 'assistant',
+    status: 'idle',
+    uuid: 'prompt-1',
+    threadUuid: 'thread-1',
+    message: 'Here is your app.',
+    errorMessage: null,
+    interrupted: false,
+    createdAt: '2026-07-29T09:00:01.000Z',
+    humanScore: null,
+    humanFeedback: null,
+    toolCalls: [],
+    toolResults: [],
+    reasoning: [],
+    savedQueryUuid: null,
+    artifacts: null,
+    referencedArtifacts: null,
+    modelConfig: null,
+    tokenUsage: null,
+    ...overrides,
+});
+
+const thread: AiAgentThread = {
+    uuid: 'thread-1',
+    agentUuid: 'agent-1',
+    createdAt: '2026-07-29T09:00:00.000Z',
+    createdFrom: 'web_app',
+    title: 'Revenue app',
+    titleGeneratedAt: null,
+    liveStatus: null,
+    firstMessage: { uuid: 'prompt-1', message: 'Build me a revenue app' },
+    user: { uuid: 'user-1', name: 'Demo User' },
+    compactions: [],
+    messages: [
+        userMessage({}),
+        assistantMessage({}),
+        userMessage({
+            uuid: 'restore-prompt',
+            message: 'Restore version 1 of Revenue app',
+            createdAt: '2026-07-29T09:02:00.000Z',
+            hidden: true,
+            context: [
+                {
+                    type: 'data_app_restore',
+                    appUuid: 'app-1',
+                    version: 3,
+                    restoredFromVersion: 1,
+                    appSlug: 'revenue-app',
+                    displayName: 'Revenue app',
+                },
+            ],
+        }),
+        assistantMessage({
+            uuid: 'restore-prompt',
+            message: 'Restored version 1 as version 3.',
+            createdAt: '2026-07-29T09:02:01.000Z',
+        }),
+    ],
+};
+
+describe('AgentChatDisplay with a restore turn', () => {
+    beforeEach(() => {
+        store.dispatch(clearPreview());
+        mockedLightdashApi.mockReset();
+        mockedLightdashApi.mockResolvedValue(app);
+    });
+
+    it('renders one restore card in place of the hidden turn, and View opens the restored version', async () => {
+        renderWithProviders(
+            <Provider store={store}>
+                <MemoryRouter>
+                    <AiAgentThreadStreamAbortControllerContextProvider>
+                        <AgentChatDisplay
+                            thread={thread}
+                            projectUuid="project-1"
+                            agentUuid="agent-1"
+                        />
+                    </AiAgentThreadStreamAbortControllerContextProvider>
+                </MemoryRouter>
+            </Provider>,
+        );
+
+        expect(screen.getByText('Build me a revenue app')).toBeVisible();
+        expect(screen.getByText('Here is your app.')).toBeVisible();
+        expect(
+            screen.queryByText('Restore version 1 of Revenue app'),
+        ).not.toBeInTheDocument();
+        expect(screen.getByText('v3 · restored from v1')).toBeVisible();
+        expect(
+            screen.getAllByText('Restored version 1 as version 3.'),
+        ).toHaveLength(1);
+
+        fireEvent.click(screen.getByRole('button', { name: 'View' }));
+        expect(store.getState().aiArtifact.preview).toMatchObject({
+            type: 'dataApp',
+            appUuid: 'app-1',
+            messageUuid: 'restore-prompt',
+            version: 3,
+        });
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.test.tsx
@@ -38,8 +38,19 @@ vi.mock('./AgentChatUserBubble', () => ({
 }));
 
 vi.mock('./AgentChatAssistantBubble', () => ({
-    AssistantBubble: ({ message }: { message: { message: string } }) => (
-        <div data-testid="conversation-item">{message.message}</div>
+    AssistantBubble: ({
+        message,
+        hiddenSibling,
+    }: {
+        message: { message: string };
+        hiddenSibling: { message: string } | null;
+    }) => (
+        <div
+            data-testid="conversation-item"
+            data-hidden-sibling={hiddenSibling?.message}
+        >
+            {message.message}
+        </div>
     ),
 }));
 
@@ -179,6 +190,63 @@ describe('AgentChatDisplay', () => {
             'What is inside the report?',
             'The report covers anomalies.',
             'Deep research card',
+        ]);
+    });
+
+    it('hands a hidden restore turn to its assistant reply and shows no user bubble', () => {
+        deepResearchRegistrationsMock.mockReturnValue([]);
+        const restoreUserMessage: AiAgentMessageUser = {
+            ...followUpUserMessage,
+            uuid: 'restore-prompt',
+            message: 'Restore version 1 of Revenue app',
+            createdAt: '2026-07-29T09:02:00.000Z',
+            hidden: true,
+            context: [
+                {
+                    type: 'data_app_restore',
+                    appUuid: 'app-1',
+                    version: 3,
+                    restoredFromVersion: 1,
+                    appSlug: 'revenue-app',
+                    displayName: 'Revenue app',
+                },
+            ],
+        };
+
+        renderWithProviders(
+            <AgentChatDisplay
+                thread={{
+                    ...thread,
+                    messages: [
+                        followUpUserMessage,
+                        getAssistantMessage(
+                            'follow-up-prompt',
+                            'The report covers anomalies.',
+                            '2026-07-29T09:01:01.000Z',
+                        ),
+                        restoreUserMessage,
+                        getAssistantMessage(
+                            'restore-prompt',
+                            'Restored version 1 as version 3.',
+                            '2026-07-29T09:02:01.000Z',
+                        ),
+                    ],
+                }}
+                projectUuid="project-1"
+                agentUuid="agent-1"
+            />,
+        );
+
+        const items = screen.getAllByTestId('conversation-item');
+        expect(items.map((element) => element.textContent)).toEqual([
+            'What is inside the report?',
+            'The report covers anomalies.',
+            'Restored version 1 as version 3.',
+        ]);
+        expect(items.map((element) => element.dataset.hiddenSibling)).toEqual([
+            undefined,
+            undefined,
+            'Restore version 1 of Revenue app',
         ]);
     });
 });

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.tsx
@@ -151,6 +151,15 @@ export const AgentChatDisplay: FC<PropsWithChildren<Props>> = ({
     );
     // Hidden turns are answered by the agent but are not part of the visible
     // conversation. Deep research assistant rows are replaced by run cards.
+    // A hidden user turn shares its uuid with the assistant reply, which may
+    // render it (e.g. a data app restore card).
+    const hiddenUserMessagesByUuid = new Map(
+        thread.messages.flatMap((message) =>
+            message.role === 'user' && message.hidden
+                ? [[message.uuid, message] as const]
+                : [],
+        ),
+    );
     const visibleMessages = thread.messages.filter(
         (message) =>
             !(
@@ -224,6 +233,11 @@ export const AgentChatDisplay: FC<PropsWithChildren<Props>> = ({
                                         {projectUuid && agentUuid && (
                                             <AssistantBubble
                                                 message={message}
+                                                hiddenSibling={
+                                                    hiddenUserMessagesByUuid.get(
+                                                        message.uuid,
+                                                    ) ?? null
+                                                }
                                                 isLastMessage={
                                                     i === xs.length - 1
                                                 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/AiDataAppBuildCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/AiDataAppBuildCard.tsx
@@ -6,23 +6,13 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useRef, type FC } from 'react';
 import { useNavigate } from 'react-router';
 import { useAppBuildPoller } from '../../../../../../features/apps/hooks/useAppBuildPoller';
-import { useGetApp } from '../../../../../../features/apps/hooks/useGetApp';
 import { getAiAgentThreadQueryKey } from '../../../hooks/useProjectAiAgents';
-import {
-    selectDataAppPreview,
-    setPreview,
-} from '../../../store/aiArtifactSlice';
-import {
-    useAiAgentStoreDispatch,
-    useAiAgentStoreSelector,
-} from '../../../store/hooks';
 import { DataAppBuildCard } from './DataAppBuildCard';
 import {
     getDataAppBuildCardState,
     isDataAppBuildInProgress,
-    type DataAppBuildCardAppSource,
 } from './dataAppBuildCardState';
-import { isDataAppCardActive } from './dataAppPreviewVersion';
+import { useDataAppCardPreview } from './useDataAppCardPreview';
 
 type Props = {
     metadata: ToolGenerateDataAppOutput['metadata'];
@@ -31,20 +21,6 @@ type Props = {
     threadUuid: string;
     messageUuid: string;
     compact: boolean;
-};
-
-const toAppSource = (
-    query: ReturnType<typeof useGetApp>,
-): DataAppBuildCardAppSource => {
-    const app = query.data?.pages[0];
-    if (app) return { kind: 'loaded', app };
-    if (query.error) {
-        const statusCode = query.error.error?.statusCode;
-        return statusCode === 403 || statusCode === 404
-            ? { kind: 'unavailable' }
-            : { kind: 'error' };
-    }
-    return { kind: 'loading' };
 };
 
 /**
@@ -60,23 +36,17 @@ export const AiDataAppBuildCard: FC<Props> = ({
     messageUuid,
     compact,
 }) => {
-    const dispatch = useAiAgentStoreDispatch();
     const navigate = useNavigate();
     const queryClient = useQueryClient();
     const { appUuid } = metadata;
-    // A failed build names no version and can never be on show.
-    const cardVersion = metadata.status === 'error' ? null : metadata.version;
-    const preview = useAiAgentStoreSelector(selectDataAppPreview);
-
-    const appQuery = useGetApp(projectUuid, appUuid ?? undefined);
-    const source = toAppSource(appQuery);
-    const latestReadyVersion =
-        source.kind === 'loaded' ? source.app.latestReadyVersion : null;
-    const isActive = isDataAppCardActive({
-        preview,
+    const { source, isActive, openPreview } = useDataAppCardPreview({
+        projectUuid,
+        agentUuid,
+        threadUuid,
+        messageUuid,
         appUuid,
-        version: cardVersion,
-        latestReadyVersion,
+        // A failed build names no version and can never be on show.
+        version: metadata.status === 'error' ? null : metadata.version,
     });
     const state = getDataAppBuildCardState(metadata, source);
     const inProgress = state !== null && isDataAppBuildInProgress(state);
@@ -99,31 +69,6 @@ export const AiDataAppBuildCard: FC<Props> = ({
         isPolling,
         refetchThread,
     );
-
-    const openPreview = useCallback(() => {
-        if (!appUuid) return;
-        dispatch(
-            setPreview({
-                type: 'dataApp',
-                appUuid,
-                messageUuid,
-                threadUuid,
-                projectUuid,
-                agentUuid,
-                version: cardVersion,
-                latestReadyVersionAtOpen: latestReadyVersion,
-            }),
-        );
-    }, [
-        dispatch,
-        appUuid,
-        messageUuid,
-        threadUuid,
-        projectUuid,
-        agentUuid,
-        cardVersion,
-        latestReadyVersion,
-    ]);
 
     // Open the preview once when a build watched in this session lands.
     // Never on reload, and never again after the user closes it.

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/AiDataAppRestoreCard.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/AiDataAppRestoreCard.test.tsx
@@ -1,0 +1,142 @@
+import {
+    type ApiAppVersionSummary,
+    type ApiGetAppResponse,
+} from '@lightdash/common';
+import { fireEvent, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { lightdashApi } from '../../../../../../api';
+import { renderWithProviders } from '../../../../../../testing/testUtils';
+import { store } from '../../../store';
+import { clearPreview, setPreview } from '../../../store/aiArtifactSlice';
+import { AiDataAppRestoreCard } from './AiDataAppRestoreCard';
+import { type DataAppRestoreContextItem } from './dataAppBuildCardState';
+
+vi.mock('../../../../../../api', () => ({ lightdashApi: vi.fn() }));
+const mockedLightdashApi = vi.mocked(lightdashApi);
+
+const APP_UUID = 'app-1';
+const IDS = {
+    projectUuid: 'project-1',
+    agentUuid: 'agent-1',
+    threadUuid: 'thread-1',
+    messageUuid: 'message-1',
+};
+
+const readyVersion = (v: number): ApiAppVersionSummary => ({
+    version: v,
+    prompt: 'Build me a revenue app',
+    status: 'ready',
+    statusMessage: null,
+    statusHistory: [],
+    error: null,
+    createdAt: new Date('2026-08-28T10:00:00.000Z'),
+    statusUpdatedAt: new Date('2026-08-28T10:00:30.000Z'),
+    createdByUser: null,
+    resources: null,
+});
+
+const app: ApiGetAppResponse['results'] = {
+    appUuid: APP_UUID,
+    name: 'Revenue app',
+    description: '',
+    createdByUserUuid: 'user-1',
+    spaceUuid: null,
+    spaceName: null,
+    registrySlug: null,
+    template: null,
+    pinnedListUuid: null,
+    pinnedListOrder: null,
+    slug: 'revenue-app',
+    views: 0,
+    versions: [readyVersion(3), readyVersion(2), readyVersion(1)],
+    hasMore: false,
+    latestReadyVersion: 3,
+};
+
+const item: DataAppRestoreContextItem = {
+    type: 'data_app_restore',
+    appUuid: APP_UUID,
+    version: 3,
+    restoredFromVersion: 1,
+    appSlug: 'revenue-app',
+    displayName: 'Revenue app',
+};
+
+const renderCard = (compact = false, restore = item) =>
+    renderWithProviders(
+        <Provider store={store}>
+            <MemoryRouter>
+                <div data-testid="host">
+                    <AiDataAppRestoreCard
+                        item={restore}
+                        completionMessage="Restored version 1 as version 3."
+                        compact={compact}
+                        {...IDS}
+                    />
+                </div>
+            </MemoryRouter>
+        </Provider>,
+    );
+
+const cardPaper = () => screen.getByTestId('host').firstElementChild;
+
+describe('AiDataAppRestoreCard', () => {
+    beforeEach(() => {
+        store.dispatch(clearPreview());
+        mockedLightdashApi.mockReset();
+        mockedLightdashApi.mockResolvedValue(app);
+    });
+
+    it('is a ready card naming the restored version and View opens it', async () => {
+        renderCard(false, { ...item, displayName: null });
+
+        expect(screen.getByText('v3 · restored from v1')).toBeVisible();
+        expect(
+            screen.getByText('Restored version 1 as version 3.'),
+        ).toBeVisible();
+        expect(cardPaper()?.className).not.toMatch(/cardActive/);
+
+        // The name lands with the app; the open then records latest ready.
+        expect(await screen.findByText('Revenue app')).toBeVisible();
+        fireEvent.click(screen.getByRole('button', { name: 'View' }));
+
+        expect(store.getState().aiArtifact.preview).toEqual({
+            type: 'dataApp',
+            appUuid: APP_UUID,
+            ...IDS,
+            version: 3,
+            latestReadyVersionAtOpen: 3,
+        });
+        expect(cardPaper()?.className).toMatch(/cardActive/);
+    });
+
+    it('is only active when the preview shows its version', async () => {
+        store.dispatch(
+            setPreview({
+                type: 'dataApp',
+                appUuid: APP_UUID,
+                ...IDS,
+                version: 1,
+                latestReadyVersionAtOpen: 3,
+            }),
+        );
+        renderCard(true);
+
+        expect(await screen.findByText('v3 · restored from v1')).toBeVisible();
+        expect(cardPaper()?.className).not.toMatch(/cardActive/);
+    });
+
+    it('is unavailable when the app is gone', async () => {
+        mockedLightdashApi.mockRejectedValue({
+            status: 'error',
+            error: { statusCode: 404, name: 'NotFoundError', message: '' },
+        });
+        renderCard();
+
+        expect(
+            await screen.findByText('This app is no longer available.'),
+        ).toBeVisible();
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/AiDataAppRestoreCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/AiDataAppRestoreCard.tsx
@@ -1,0 +1,53 @@
+import { getDataAppBuilderPath } from '@lightdash/common';
+import { type FC } from 'react';
+import { useNavigate } from 'react-router';
+import { DataAppBuildCard } from './DataAppBuildCard';
+import {
+    getDataAppRestoreCardState,
+    type DataAppRestoreContextItem,
+} from './dataAppBuildCardState';
+import { useDataAppCardPreview } from './useDataAppCardPreview';
+
+type Props = {
+    item: DataAppRestoreContextItem;
+    /** The assistant's response to the restore turn. */
+    completionMessage: string;
+    projectUuid: string;
+    agentUuid: string;
+    threadUuid: string;
+    messageUuid: string;
+    compact: boolean;
+};
+
+/** The build card for a restore made from the thread; View opens the new version. */
+export const AiDataAppRestoreCard: FC<Props> = ({
+    item,
+    completionMessage,
+    projectUuid,
+    agentUuid,
+    threadUuid,
+    messageUuid,
+    compact,
+}) => {
+    const navigate = useNavigate();
+    const { source, isActive, openPreview } = useDataAppCardPreview({
+        projectUuid,
+        agentUuid,
+        threadUuid,
+        messageUuid,
+        appUuid: item.appUuid,
+        version: item.version,
+    });
+
+    return (
+        <DataAppBuildCard
+            state={getDataAppRestoreCardState(item, completionMessage, source)}
+            compact={compact}
+            isActive={isActive}
+            onOpenBuilder={() =>
+                void navigate(getDataAppBuilderPath(projectUuid, item.appUuid))
+            }
+            onView={openPreview}
+        />
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/AiDataAppRestoreCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/AiDataAppRestoreCard.tsx
@@ -11,7 +11,7 @@ import { useDataAppCardPreview } from './useDataAppCardPreview';
 type Props = {
     item: DataAppRestoreContextItem;
     /** The assistant's response to the restore turn. */
-    completionMessage: string;
+    completionMessage: string | null;
     projectUuid: string;
     agentUuid: string;
     threadUuid: string;

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/DataAppBuildCard.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/DataAppBuildCard.test.tsx
@@ -81,6 +81,7 @@ describe('DataAppBuildCard', () => {
                     name: 'Weekly revenue by region',
                     version: 1,
                     durationMs: 372_000,
+                    restoredFromVersion: null,
                     completionMessage: 'Your app is ready.',
                 }}
                 compact={false}
@@ -116,6 +117,7 @@ describe('DataAppBuildCard', () => {
                     name: 'Weekly revenue by region',
                     version: 3,
                     durationMs: null,
+                    restoredFromVersion: null,
                     completionMessage: 'Done.',
                 }}
                 compact={false}
@@ -127,6 +129,30 @@ describe('DataAppBuildCard', () => {
         expect(screen.getByText('v3')).toBeVisible();
     });
 
+    it('ready: a restored version says where it came from instead of a duration', () => {
+        renderWithProviders(
+            <DataAppBuildCard
+                state={{
+                    kind: 'ready',
+                    name: 'Weekly revenue by region',
+                    version: 3,
+                    durationMs: null,
+                    restoredFromVersion: 1,
+                    completionMessage: 'Restored version 1 as version 3.',
+                }}
+                compact={false}
+                isActive={false}
+                onOpenBuilder={noop}
+                onView={noop}
+            />,
+        );
+        expect(screen.getByText('v3 · restored from v1')).toBeVisible();
+        expect(
+            screen.getByText('Restored version 1 as version 3.'),
+        ).toBeVisible();
+        expect(screen.getByRole('button', { name: 'View' })).toBeVisible();
+    });
+
     it('ready: renders the summary as markdown', () => {
         renderWithProviders(
             <DataAppBuildCard
@@ -135,6 +161,7 @@ describe('DataAppBuildCard', () => {
                     name: 'Weekly revenue by region',
                     version: 1,
                     durationMs: 372_000,
+                    restoredFromVersion: null,
                     completionMessage:
                         'Built **five pages** from `src/App.jsx`.',
                 }}
@@ -163,6 +190,7 @@ describe('DataAppBuildCard', () => {
                     name: 'Weekly revenue by region',
                     version: 1,
                     durationMs: 372_000,
+                    restoredFromVersion: null,
                     completionMessage: 'A very long summary. '.repeat(50),
                 }}
                 compact={false}
@@ -185,6 +213,7 @@ describe('DataAppBuildCard', () => {
                     name: 'Weekly revenue by region',
                     version: 1,
                     durationMs: 372_000,
+                    restoredFromVersion: null,
                     completionMessage: 'Your app is ready.',
                 }}
                 compact={false}
@@ -262,6 +291,7 @@ describe('DataAppBuildCard', () => {
                     name: 'Weekly revenue by region',
                     version: 1,
                     durationMs: 372_000,
+                    restoredFromVersion: null,
                     completionMessage: 'Your app is ready.',
                 }}
                 compact

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/DataAppBuildCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/DataAppBuildCard.tsx
@@ -39,6 +39,8 @@ export type DataAppBuildCardState =
           name: string;
           version: number;
           durationMs: number | null;
+          /** Set when this version was restored from an earlier one. */
+          restoredFromVersion: number | null;
           completionMessage: string;
       }
     | { kind: 'failed'; message: string }
@@ -59,10 +61,14 @@ const FAILED_TITLE = "The app couldn't be built";
 
 const readySubtitle = (
     state: Extract<DataAppBuildCardState, { kind: 'ready' }>,
-) =>
-    state.durationMs === null
+) => {
+    if (state.restoredFromVersion !== null) {
+        return `v${state.version} · restored from v${state.restoredFromVersion}`;
+    }
+    return state.durationMs === null
         ? `v${state.version}`
         : `v${state.version} · built in ${formatBuildDuration(state.durationMs)}`;
+};
 
 const BuilderButton: FC<{
     label: 'Continue in builder' | 'Open in builder';

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/dataAppBuildCardState.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/dataAppBuildCardState.test.ts
@@ -392,6 +392,12 @@ describe('getDataAppRestoreCardState', () => {
         ).toMatchObject({ name: 'Data app' });
     });
 
+    it('writes its own completion message when the turn has none', () => {
+        expect(
+            getDataAppRestoreCardState(restoreItem, null, { kind: 'loading' }),
+        ).toMatchObject({ completionMessage: message });
+    });
+
     it('is unavailable when the app was deleted since', () => {
         expect(
             getDataAppRestoreCardState(restoreItem, message, {

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/dataAppBuildCardState.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/dataAppBuildCardState.test.ts
@@ -5,7 +5,12 @@ import {
     type ToolGenerateDataAppOutput,
 } from '@lightdash/common';
 import { describe, expect, it } from 'vitest';
-import { getDataAppBuildCardState } from './dataAppBuildCardState';
+import {
+    getDataAppBuildCardState,
+    getDataAppRestoreCardState,
+    getDataAppRestoreItem,
+    type DataAppRestoreContextItem,
+} from './dataAppBuildCardState';
 
 type Metadata = ToolGenerateDataAppOutput['metadata'];
 
@@ -144,6 +149,7 @@ describe('getDataAppBuildCardState', () => {
                 name: 'Revenue app',
                 version: 1,
                 durationMs: 372_000,
+                restoredFromVersion: null,
                 completionMessage: 'Your revenue app is ready.',
             });
         });
@@ -159,6 +165,7 @@ describe('getDataAppBuildCardState', () => {
                 name: 'Untitled app app-1',
                 completionMessage: 'Your app is ready!',
                 durationMs: null,
+                restoredFromVersion: null,
             });
         });
 
@@ -231,6 +238,7 @@ describe('getDataAppBuildCardState', () => {
                 name: 'Revenue app',
                 version: 1,
                 durationMs: null,
+                restoredFromVersion: null,
                 completionMessage: 'Your app is ready!',
             });
         });
@@ -254,6 +262,7 @@ describe('getDataAppBuildCardState', () => {
                 name: 'Revenue app',
                 version: 1,
                 durationMs: 30_000,
+                restoredFromVersion: null,
                 completionMessage: 'Done.',
             });
         });
@@ -321,5 +330,73 @@ describe('getDataAppBuildCardState', () => {
                 ),
             ).toBeNull();
         });
+    });
+});
+
+const restoreItem: DataAppRestoreContextItem = {
+    type: 'data_app_restore',
+    appUuid: 'app-1',
+    version: 3,
+    restoredFromVersion: 1,
+    appSlug: 'revenue-app',
+    displayName: 'Revenue app',
+};
+
+describe('getDataAppRestoreItem', () => {
+    it('finds the restore item on a hidden turn', () => {
+        expect(
+            getDataAppRestoreItem({
+                role: 'user',
+                uuid: 'prompt-1',
+                threadUuid: 'thread-1',
+                message: 'Restore version 1 of Revenue app',
+                createdAt: '2026-08-28T10:00:00.000Z',
+                user: { uuid: 'user-1', name: 'Demo' },
+                context: [restoreItem],
+                steers: [],
+                hidden: true,
+            }),
+        ).toBe(restoreItem);
+    });
+
+    it('is null without a sibling or a restore item', () => {
+        expect(getDataAppRestoreItem(null)).toBeNull();
+    });
+});
+
+describe('getDataAppRestoreCardState', () => {
+    const message = 'Restored version 1 as version 3.';
+
+    it('is ready with the restored-from version and the assistant response', () => {
+        expect(
+            getDataAppRestoreCardState(restoreItem, message, {
+                kind: 'loading',
+            }),
+        ).toEqual({
+            kind: 'ready',
+            name: 'Revenue app',
+            version: 3,
+            durationMs: null,
+            restoredFromVersion: 1,
+            completionMessage: message,
+        });
+    });
+
+    it('falls back to the fetched app name, then a generic one', () => {
+        const unnamed = { ...restoreItem, displayName: null };
+        expect(
+            getDataAppRestoreCardState(unnamed, message, loaded([], 'Renamed')),
+        ).toMatchObject({ name: 'Renamed' });
+        expect(
+            getDataAppRestoreCardState(unnamed, message, { kind: 'loading' }),
+        ).toMatchObject({ name: 'Data app' });
+    });
+
+    it('is unavailable when the app was deleted since', () => {
+        expect(
+            getDataAppRestoreCardState(restoreItem, message, {
+                kind: 'unavailable',
+            }),
+        ).toEqual({ kind: 'unavailable' });
     });
 });

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/dataAppBuildCardState.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/dataAppBuildCardState.ts
@@ -3,6 +3,8 @@ import {
     assertUnreachable,
     getAppDisplayName,
     isAppVersionInProgress,
+    type AiAgentMessageUser,
+    type AiPromptContextItem,
     type ApiAppVersionSummary,
     type ApiGetAppResponse,
     type ToolGenerateDataAppOutput,
@@ -43,6 +45,7 @@ const getReadyState = ({
     name: getAppDisplayName(name, appUuid),
     version,
     durationMs: row ? getBuildDurationMs(row) : null,
+    restoredFromVersion: null,
     completionMessage:
         row?.statusMessage ??
         (version === 1 ? 'Your app is ready!' : `Version ${version} is ready!`),
@@ -126,6 +129,46 @@ export const getDataAppBuildCardState = (
         default:
             return assertUnreachable(metadata, 'Unknown build result');
     }
+};
+
+export type DataAppRestoreContextItem = Extract<
+    AiPromptContextItem,
+    { type: 'data_app_restore' }
+>;
+
+/** The restore a hidden user turn records, if that is what the turn is. */
+export const getDataAppRestoreItem = (
+    hiddenSibling: AiAgentMessageUser | null,
+): DataAppRestoreContextItem | null =>
+    hiddenSibling?.context.find(
+        (item): item is DataAppRestoreContextItem =>
+            item.type === 'data_app_restore',
+    ) ?? null;
+
+/**
+ * Card state for a restore made from the thread. The restore already
+ * succeeded when the turn was written, so the card is ready unless the app
+ * has gone since; the assistant's response is the completion message.
+ */
+export const getDataAppRestoreCardState = (
+    item: DataAppRestoreContextItem,
+    completionMessage: string,
+    source: DataAppBuildCardAppSource,
+): DataAppBuildCardState => {
+    if (source.kind === 'unavailable') return { kind: 'unavailable' };
+    const name =
+        item.displayName ??
+        (source.kind === 'loaded'
+            ? getAppDisplayName(source.app.name, item.appUuid)
+            : 'Data app');
+    return {
+        kind: 'ready',
+        name,
+        version: item.version,
+        durationMs: null,
+        restoredFromVersion: item.restoredFromVersion,
+        completionMessage,
+    };
 };
 
 export const isDataAppBuildInProgress = (

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/dataAppBuildCardState.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/dataAppBuildCardState.ts
@@ -152,7 +152,7 @@ export const getDataAppRestoreItem = (
  */
 export const getDataAppRestoreCardState = (
     item: DataAppRestoreContextItem,
-    completionMessage: string,
+    response: string | null,
     source: DataAppBuildCardAppSource,
 ): DataAppBuildCardState => {
     if (source.kind === 'unavailable') return { kind: 'unavailable' };
@@ -167,7 +167,9 @@ export const getDataAppRestoreCardState = (
         version: item.version,
         durationMs: null,
         restoredFromVersion: item.restoredFromVersion,
-        completionMessage,
+        completionMessage:
+            response ??
+            `Restored version ${item.restoredFromVersion} as version ${item.version}.`,
     };
 };
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/useDataAppCardPreview.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/useDataAppCardPreview.ts
@@ -1,0 +1,89 @@
+import { useCallback } from 'react';
+import { useGetApp } from '../../../../../../features/apps/hooks/useGetApp';
+import {
+    selectDataAppPreview,
+    setPreview,
+} from '../../../store/aiArtifactSlice';
+import {
+    useAiAgentStoreDispatch,
+    useAiAgentStoreSelector,
+} from '../../../store/hooks';
+import { type DataAppBuildCardAppSource } from './dataAppBuildCardState';
+import { isDataAppCardActive } from './dataAppPreviewVersion';
+
+type Args = {
+    projectUuid: string;
+    agentUuid: string;
+    threadUuid: string;
+    messageUuid: string;
+    appUuid: string | null;
+    /** The version this card names; null when it names none. */
+    version: number | null;
+};
+
+const toAppSource = (
+    query: ReturnType<typeof useGetApp>,
+): DataAppBuildCardAppSource => {
+    const app = query.data?.pages[0];
+    if (app) return { kind: 'loaded', app };
+    if (query.error) {
+        const statusCode = query.error.error?.statusCode;
+        return statusCode === 403 || statusCode === 404
+            ? { kind: 'unavailable' }
+            : { kind: 'error' };
+    }
+    return { kind: 'loading' };
+};
+
+/**
+ * What a data app card in the thread shares: the app it reads, whether its
+ * version is the one on show, and opening that version in the preview.
+ */
+export const useDataAppCardPreview = ({
+    projectUuid,
+    agentUuid,
+    threadUuid,
+    messageUuid,
+    appUuid,
+    version,
+}: Args) => {
+    const dispatch = useAiAgentStoreDispatch();
+    const preview = useAiAgentStoreSelector(selectDataAppPreview);
+    const appQuery = useGetApp(projectUuid, appUuid ?? undefined);
+    const source = toAppSource(appQuery);
+    const latestReadyVersion =
+        source.kind === 'loaded' ? source.app.latestReadyVersion : null;
+    const isActive = isDataAppCardActive({
+        preview,
+        appUuid,
+        version,
+        latestReadyVersion,
+    });
+
+    const openPreview = useCallback(() => {
+        if (!appUuid) return;
+        dispatch(
+            setPreview({
+                type: 'dataApp',
+                appUuid,
+                messageUuid,
+                threadUuid,
+                projectUuid,
+                agentUuid,
+                version,
+                latestReadyVersionAtOpen: latestReadyVersion,
+            }),
+        );
+    }, [
+        dispatch,
+        appUuid,
+        messageUuid,
+        threadUuid,
+        projectUuid,
+        agentUuid,
+        version,
+        latestReadyVersion,
+    ]);
+
+    return { source, isActive, openPreview };
+};

--- a/packages/frontend/src/stories/AiAgentChatWorkbench.stories.tsx
+++ b/packages/frontend/src/stories/AiAgentChatWorkbench.stories.tsx
@@ -801,6 +801,7 @@ const buildCardStates: DataAppBuildCardState[] = [
         name: 'Weekly revenue by region',
         version: 1,
         durationMs: 372_000,
+        restoredFromVersion: null,
         completionMessage:
             'Your app is ready. Five regional pages, weekly revenue over the last 26 weeks.',
     },

--- a/packages/frontend/src/stories/DataAppBuildCard.stories.tsx
+++ b/packages/frontend/src/stories/DataAppBuildCard.stories.tsx
@@ -27,6 +27,7 @@ const states = {
         name: APP_NAME,
         version: 1,
         durationMs: 372_000,
+        restoredFromVersion: null,
         completionMessage:
             'Your app is ready. Five regional pages, weekly revenue over the last 26 weeks.',
     },
@@ -71,6 +72,19 @@ export const Ready: Story = { args: { state: states.ready } };
 
 export const ReadyWithoutDuration: Story = {
     args: { state: { ...states.ready, version: 3, durationMs: null } },
+};
+
+/** A restore made from the thread: no build duration, names the origin. */
+export const ReadyRestored: Story = {
+    args: {
+        state: {
+            ...states.ready,
+            version: 3,
+            durationMs: null,
+            restoredFromVersion: 1,
+            completionMessage: 'Restored version 1 as version 3.',
+        },
+    },
 };
 
 export const ReadyWithLongSummary: Story = {


### PR DESCRIPTION
Third of a 4-PR stack for ZAP-989. Stacked on the ZAP-994 backend PR.

The thread renders a restore recorded by the endpoint as a build card, so the timeline stays honest for the user and the agent.

```diff
 <AgentChatDisplay>
   visibleMessages = thread.messages without hidden user turns
   <AssistantBubble message hiddenSibling={hidden user turn with the same prompt uuid}>
+    if hiddenSibling carries data_app_restore
+      <AiDataAppRestoreCard>            // only this, no text bubble
+        <DataAppBuildCard state=ready subtitle="v3 · restored from v1">
+          [View] [Continue in builder]
```

- `DataAppBuildCardState` ready variant gains `restoredFromVersion`.
- `useDataAppCardPreview` is shared by the build card and the restore card: same app source mapping, same active-state rule, same preview dispatch (the card's version, latest ready at open).
- Compact form in earlier turns like any other card; unavailable when the app is gone.

Tests: `AgentChatDisplay.restore.test.tsx` renders a thread with a restore turn through the real assistant bubble and asserts a single card with the restored subtitle, no user bubble, and View opening the restored version; restore card and state tests.

Closes: ZAP-994
Relates: ZAP-989

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYqCC1cLQv5apggPng7HgQ
