### PR TITLE
feat(compose): run the DuckDB execution engine in OSS

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -410,6 +410,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     fontconfig \
     # Required so headless chart screenshots can render CJK glyphs
     fonts-noto-cjk \
+    # Required so DuckDB httpfs can verify HTTPS object storage (Node carries its own trust store)
+    ca-certificates \
     dumb-init \
     # Optional: jemalloc allocator reduces native memory fragmentation vs glibc malloc.
     # Dormant unless activated via LD_PRELOAD env var per customer.

--- a/dockerfile-prs
+++ b/dockerfile-prs
@@ -212,6 +212,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     # Required by node-canvas prebuilt binaries for font rendering in chart images
     fontconfig \
     # Required so headless chart screenshots can render CJK glyphs
+    # Required so DuckDB httpfs can verify HTTPS object storage (Node carries its own trust store)
+    ca-certificates \
     fonts-noto-cjk \
     dumb-init \
     && apt-get clean \

--- a/docs/external-sources/CONTEXT.md
+++ b/docs/external-sources/CONTEXT.md
@@ -59,8 +59,10 @@ _Avoid_: path, URL, link
 ## Notes
 
 - Storage lives in the pre-aggregates S3 bucket under
-  `external-sources/{projectUuid}/{sourceUuid}/…` because the shared DuckDB
-  engine's S3 session is configured exclusively from that bucket's config.
+  `external-sources/{projectUuid}/{sourceUuid}/…`. The compose engine that
+  queries it configures its S3 session from the results storage config, so
+  those credentials must be able to read this bucket too (the default, since
+  pre-aggregate credentials fall back to the base S3 credentials).
 - Every raw/parquet object is registered before upload. Replaced, deleted,
   failed, and abandoned-stage objects become `pending_delete`; a five-minute
   maintenance task retries exact-key deletion. Manifests intentionally survive

--- a/docs/external-sources/CONTEXT.md
+++ b/docs/external-sources/CONTEXT.md
@@ -59,10 +59,10 @@ _Avoid_: path, URL, link
 ## Notes
 
 - Storage lives in the pre-aggregates S3 bucket under
-  `external-sources/{projectUuid}/{sourceUuid}/…`. The compose engine that
-  queries it configures its S3 session from the results storage config, so
-  those credentials must be able to read this bucket too (the default, since
-  pre-aggregate credentials fall back to the base S3 credentials).
+  `external-sources/{projectUuid}/{sourceUuid}/…`. The compose engine reads
+  it with a session built from that bucket's config (its endpoint, region and
+  credentials, falling back to the base S3 values), because a DuckDB S3
+  secret pins one endpoint and region; result files use the results session.
 - Every raw/parquet object is registered before upload. Replaced, deleted,
   failed, and abandoned-stage objects become `pending_delete`; a five-minute
   maintenance task retries exact-key deletion. Manifests intentionally survive

--- a/docs/merge-queries/architecture.md
+++ b/docs/merge-queries/architecture.md
@@ -111,6 +111,10 @@ through its own pre-aggregate-bucket session. Do not route a composed query
 through the strategy. An instance without results storage is refused with a
 `MissingConfigError` naming the variables; the engine is never a silent
 fallback.
+An HTTPS session with no CA bundle is refused the same way: httpfs verifies
+object storage with the system bundle (`SSL_CERT_FILE` overrides it), which the
+runtime image installs as `ca-certificates`; Node's own trust store does not
+help it.
 
 **The compose path has no resource governance.** No query timeout (the deadline
 that exists applies only to the playground path), memory limit unset by default,

--- a/docs/merge-queries/architecture.md
+++ b/docs/merge-queries/architecture.md
@@ -100,14 +100,17 @@ optional: the failure mode is a user seeing another tenant's rows, and no test
 currently catches it.
 
 **The engine is OSS; managed pre-aggregates are not.** `ComposeEngineClient`
-(`services/AsyncQueryService/`) owns the compose engine in every edition, and
-its session is configured from the results S3 config, which every instance
-that can run a query already has. `PreAggregateStrategy` is only about managed
+(`services/AsyncQueryService/`) owns the compose engine in every edition. A
+session is built from the S3 config that owns the bucket it reads, because a
+DuckDB S3 secret pins one endpoint and region: compose SQL and merges read
+result files on the results session, which every instance that can run a
+query already has; external SQL reads external-source files on the
+pre-aggregates bucket's session. `PreAggregateStrategy` is only about managed
 pre-aggregates (routing, resolution, stats, audit) and reads materializations
 through its own pre-aggregate-bucket session. Do not route a composed query
-through the strategy, and do not read pre-aggregate config from the engine.
-An instance without results storage is refused with a `MissingConfigError`
-naming the variables; the engine is never a silent fallback.
+through the strategy. An instance without results storage is refused with a
+`MissingConfigError` naming the variables; the engine is never a silent
+fallback.
 
 **The compose path has no resource governance.** No query timeout (the deadline
 that exists applies only to the playground path), memory limit unset by default,

--- a/docs/merge-queries/architecture.md
+++ b/docs/merge-queries/architecture.md
@@ -99,16 +99,15 @@ execution context through query sources, make them a required field rather than
 optional: the failure mode is a user seeing another tenant's rows, and no test
 currently catches it.
 
-**The engine is EE-only today, and that is a defect, not a design.** The
-execution client lives under `ee/` and OSS resolves to a strategy that throws,
-so composed queries do not run in OSS at all. The failure is caught and logged
-at debug, which is why it looks like nothing is wrong. Merges are meant to be
-available to everyone; the strategy is being split so the execution half is OSS
-while managed pre-aggregates stay licensed.
-
-**The engine's session is configured from the pre-aggregate S3 config**, which
-an OSS instance does not have. It should come from the results config, which
-every instance that can run a query already has.
+**The engine is OSS; managed pre-aggregates are not.** `ComposeEngineClient`
+(`services/AsyncQueryService/`) owns the compose engine in every edition, and
+its session is configured from the results S3 config, which every instance
+that can run a query already has. `PreAggregateStrategy` is only about managed
+pre-aggregates (routing, resolution, stats, audit) and reads materializations
+through its own pre-aggregate-bucket session. Do not route a composed query
+through the strategy, and do not read pre-aggregate config from the engine.
+An instance without results storage is refused with a `MissingConfigError`
+naming the variables; the engine is never a silent fallback.
 
 **The compose path has no resource governance.** No query timeout (the deadline
 that exists applies only to the playground path), memory limit unset by default,

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -16,6 +16,7 @@ import Logger from '../logging/logger';
 import { McpContextModel } from '../models/McpContextModel';
 import { registerPreAggregateStream } from '../nats/natsConfig';
 import { AsyncQueryService } from '../services/AsyncQueryService/AsyncQueryService';
+import { ComposeEngineClient } from '../services/AsyncQueryService/ComposeEngineClient';
 import { DeployService } from '../services/DeployService';
 import { InstanceConfigurationService } from '../services/InstanceConfigurationService/InstanceConfigurationService';
 import { JiraAppService } from '../services/JiraAppService/JiraAppService';
@@ -1166,6 +1167,10 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     cacheService: repository.getCacheService(),
                     savedSqlModel: models.getSavedSqlModel(),
                     resultsStorageClient: clients.getResultsFileStorageClient(),
+                    composeEngineClient: new ComposeEngineClient({
+                        lightdashConfig: context.lightdashConfig,
+                        prometheusMetrics,
+                    }),
                     featureFlagModel: models.getFeatureFlagModel(),
                     projectParametersModel: models.getProjectParametersModel(),
                     organizationWarehouseCredentialsModel:

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -16,7 +16,6 @@ import Logger from '../logging/logger';
 import { McpContextModel } from '../models/McpContextModel';
 import { registerPreAggregateStream } from '../nats/natsConfig';
 import { AsyncQueryService } from '../services/AsyncQueryService/AsyncQueryService';
-import { ComposeEngineClient } from '../services/AsyncQueryService/ComposeEngineClient';
 import { DeployService } from '../services/DeployService';
 import { InstanceConfigurationService } from '../services/InstanceConfigurationService/InstanceConfigurationService';
 import { JiraAppService } from '../services/JiraAppService/JiraAppService';
@@ -1167,10 +1166,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     cacheService: repository.getCacheService(),
                     savedSqlModel: models.getSavedSqlModel(),
                     resultsStorageClient: clients.getResultsFileStorageClient(),
-                    composeEngineClient: new ComposeEngineClient({
-                        lightdashConfig: context.lightdashConfig,
-                        prometheusMetrics,
-                    }),
+                    composeEngineClient: repository.getComposeEngineClient(),
                     featureFlagModel: models.getFeatureFlagModel(),
                     projectParametersModel: models.getProjectParametersModel(),
                     organizationWarehouseCredentialsModel:

--- a/packages/backend/src/ee/services/AsyncQueryService/PreAggregateStrategy.ts
+++ b/packages/backend/src/ee/services/AsyncQueryService/PreAggregateStrategy.ts
@@ -238,8 +238,8 @@ export class PreAggregateStrategy implements IPreAggregateStrategy {
         };
     }
 
-    createExecutionWarehouseClient(scope?: string): WarehouseClient {
-        return this.duckDbClient.createExecutionWarehouseClient(scope);
+    createPreAggregateWarehouseClient(): WarehouseClient {
+        return this.duckDbClient.createPreAggregateWarehouseClient();
     }
 
     recordStats(params: {

--- a/packages/backend/src/ee/services/AsyncQueryService/PreAggregationDuckDbClient.test.ts
+++ b/packages/backend/src/ee/services/AsyncQueryService/PreAggregationDuckDbClient.test.ts
@@ -166,7 +166,7 @@ describe('PreAggregationDuckDbClient', () => {
         ).not.toHaveBeenCalled();
     });
 
-    test('creates the explicitly scoped pre-aggregate DuckDB client', () => {
+    test('creates the pre-aggregate DuckDB client from the pre-aggregate S3 config', () => {
         const createForPreAggregateSpy = vi.spyOn(
             DuckdbWarehouseClient,
             'createForPreAggregate',
@@ -187,7 +187,7 @@ describe('PreAggregationDuckDbClient', () => {
             },
         });
 
-        const warehouseClient = client.createExecutionWarehouseClient();
+        const warehouseClient = client.createPreAggregateWarehouseClient();
 
         expect(warehouseClient).toBeInstanceOf(DuckdbWarehouseClient);
         expect(createForPreAggregateSpy).toHaveBeenCalledWith(

--- a/packages/backend/src/ee/services/AsyncQueryService/PreAggregationDuckDbClient.ts
+++ b/packages/backend/src/ee/services/AsyncQueryService/PreAggregationDuckDbClient.ts
@@ -27,6 +27,7 @@ import { type LightdashConfig } from '../../../config/parseConfig';
 import Logger from '../../../logging/logger';
 import { type ProjectModel } from '../../../models/ProjectModel/ProjectModel';
 import type PrometheusMetrics from '../../../prometheus/PrometheusMetrics';
+import { PRE_AGGREGATE_QUERY_INSTANCE_CACHE_KEY } from '../../../services/AsyncQueryService/ComposeEngineClient';
 import { type PreAggregationRoute } from '../../../services/AsyncQueryService/types';
 import { traceSpan } from '../../../tracing/tracing';
 import { wrapSentryTransaction } from '../../../utils';
@@ -37,8 +38,6 @@ import {
 import { getDuckdbRuntimeConfig } from '../../../utils/duckdb/getDuckdbRuntimeConfig';
 import { QueryComposer } from '../../../utils/QueryBuilder/QueryComposer';
 import { type PreAggregateModel } from '../../models/PreAggregateModel';
-
-const PRE_AGGREGATE_QUERY_INSTANCE_CACHE_KEY = 'pre-aggregate-query-instance';
 
 type PreAggregationDuckDbClientArgs = {
     lightdashConfig: LightdashConfig;

--- a/packages/backend/src/ee/services/AsyncQueryService/PreAggregationDuckDbClient.ts
+++ b/packages/backend/src/ee/services/AsyncQueryService/PreAggregationDuckDbClient.ts
@@ -134,7 +134,9 @@ export class PreAggregationDuckDbClient {
                 ));
     }
 
-    private getOrCreateWarehouseClient(): WarehouseClient {
+    // Reads managed materializations, so its session is the pre-aggregate
+    // bucket's; composed queries run on the OSS compose engine instead
+    createPreAggregateWarehouseClient(): WarehouseClient {
         if (!this.cachedWarehouseClient) {
             const duckdbRuntimeConfig = getDuckdbRuntimeConfig(
                 this.lightdashConfig.preAggregates.s3,
@@ -186,32 +188,6 @@ export class PreAggregationDuckDbClient {
                     'Unknown pre-aggregate resolution reason',
                 );
         }
-    }
-
-    createExecutionWarehouseClient(scope?: string): WarehouseClient {
-        if (scope) {
-            const s3Config = getDuckdbRuntimeConfig(
-                this.lightdashConfig.preAggregates.s3,
-            );
-            if (!s3Config) {
-                throw new MissingConfigError(
-                    'External source DuckDB execution is unavailable',
-                );
-            }
-            // External-source credentials are isolated and URI-scoped. Never
-            // place this client in the bucket-wide pre-aggregate cache.
-            return this.createDuckdbWarehouseClient({
-                s3Config: { ...s3Config, scope },
-                resourceLimits: this.sharedResourceLimits ?? {
-                    memoryLimit: '512MB',
-                    threads: 2,
-                },
-                organizationConcurrencyLimit:
-                    this.lightdashConfig.externalSources
-                        .maxConcurrentDuckdbQueriesPerOrganization,
-            });
-        }
-        return this.getOrCreateWarehouseClient();
     }
 
     async resolve(
@@ -418,7 +394,7 @@ export class PreAggregationDuckDbClient {
                 }),
         );
 
-        const warehouseClient = this.getOrCreateWarehouseClient();
+        const warehouseClient = this.createPreAggregateWarehouseClient();
 
         return {
             resolved: true,

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -389,6 +389,7 @@ const getMockedAsyncQueryService = (
         } as unknown as OrganizationAccessService,
         preAggregateStrategy: new NoOpPreAggregateStrategy(),
         composeEngineClient: new ComposeEngineClient({
+            resolveCaCertFile: () => '/etc/ssl/certs/ca-certificates.crt',
             lightdashConfig,
             createDuckdbWarehouseClient: () => warehouseClientMock,
         }),
@@ -626,6 +627,8 @@ describe('AsyncQueryService', () => {
             const service = getMockedAsyncQueryService(lightdashConfigMock, {
                 featureFlagModel: composeFlags,
                 composeEngineClient: new ComposeEngineClient({
+                    resolveCaCertFile: () =>
+                        '/etc/ssl/certs/ca-certificates.crt',
                     lightdashConfig: lightdashConfigMock,
                     createDuckdbWarehouseClient,
                 }),
@@ -665,6 +668,7 @@ describe('AsyncQueryService', () => {
                 s3Config: {
                     endpoint: 'mock_endpoint',
                     region: 'mock_region',
+                    caCertFile: '/etc/ssl/certs/ca-certificates.crt',
                     accessKey: undefined,
                     secretKey: undefined,
                     forcePathStyle: false,

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -14,6 +14,7 @@ import {
     FilterOperator,
     ForbiddenError,
     MetricType,
+    MissingConfigError,
     NotFoundError,
     OrganizationAccessStatus,
     PersistentDownloadFileAccessMode,
@@ -112,6 +113,10 @@ import {
     QUEUED_QUERY_EXPIRED_MESSAGE,
 } from './AsyncQueryService';
 import {
+    COMPOSE_ENGINE_INSTANCE_CACHE_KEY,
+    ComposeEngineClient,
+} from './ComposeEngineClient';
+import {
     NoOpPreAggregateStrategy,
     type PreAggregateExecutionResolution,
     type PreAggregateStrategy,
@@ -129,7 +134,7 @@ const makeMockStrategy = (
 ): PreAggregateStrategy => ({
     getRoutingDecision: noOpStrategy.getRoutingDecision.bind(noOpStrategy),
     resolveExecution: vi.fn(async () => resolveResult),
-    createExecutionWarehouseClient: vi.fn(
+    createPreAggregateWarehouseClient: vi.fn(
         () => warehouseClientMock as unknown as WarehouseClient,
     ),
     recordStats: vi.fn(),
@@ -383,6 +388,10 @@ const getMockedAsyncQueryService = (
             })),
         } as unknown as OrganizationAccessService,
         preAggregateStrategy: new NoOpPreAggregateStrategy(),
+        composeEngineClient: new ComposeEngineClient({
+            lightdashConfig,
+            createDuckdbWarehouseClient: () => warehouseClientMock,
+        }),
         projectCompileLogModel: {} as ProjectCompileLogModel,
         adminNotificationService: {} as AdminNotificationService,
         spacePermissionService: {
@@ -577,6 +586,155 @@ describe('AsyncQueryService', () => {
                     tables: { attachment: 'table-uuid' },
                 }),
             ).rejects.toThrow('This attachment belongs to another user');
+        });
+    });
+
+    describe('compose engine in every edition', () => {
+        const composeFlags = {
+            get: vi.fn(
+                async ({ featureFlagId }: { featureFlagId: string }) => ({
+                    id: featureFlagId,
+                    enabled:
+                        featureFlagId === FeatureFlags.ComposeSqlRunner ||
+                        featureFlagId === FeatureFlags.MergeOnCompose,
+                }),
+            ),
+        } as unknown as FeatureFlagModel;
+
+        const withoutResultsStorage: LightdashConfig = {
+            ...lightdashConfigMock,
+            results: { ...lightdashConfigMock.results, s3: undefined },
+        };
+
+        const referencedQueryHistory = {
+            queryUuid: '0b7c9c62-4b6e-4b1a-9c3e-4f6a0c8d2e11',
+            projectUuid,
+            organizationUuid: projectSummary.organizationUuid,
+            createdByUserUuid: sessionAccount.user.id,
+            context: QueryExecutionContext.EXPLORE,
+            status: QueryHistoryStatus.READY,
+            resultsFileName: 'referenced-results.jsonl',
+            resultsExpiresAt: null,
+            columns: { one: { reference: 'one', type: DimensionType.NUMBER } },
+            metricQuery: { exploreName: 'orders' },
+        } as unknown as QueryHistory;
+
+        test('runs a compose SQL query over referenced results without a license', async () => {
+            const createDuckdbWarehouseClient = vi.fn(
+                () => warehouseClientMock,
+            );
+            const service = getMockedAsyncQueryService(lightdashConfigMock, {
+                featureFlagModel: composeFlags,
+                composeEngineClient: new ComposeEngineClient({
+                    lightdashConfig: lightdashConfigMock,
+                    createDuckdbWarehouseClient,
+                }),
+                queryHistoryModel: {
+                    create: vi.fn(async () => ({ queryUuid: 'queryUuid' })),
+                    get: vi.fn(async () => referencedQueryHistory),
+                    pollForQueryCompletion: vi.fn(
+                        async () => referencedQueryHistory,
+                    ),
+                    update: vi.fn(),
+                } as unknown as QueryHistoryModel,
+                resultsStorageClient: {
+                    isEnabled: true,
+                    configuration: { bucket: 'mock_bucket' },
+                } as unknown as S3ResultsFileStorageClient,
+            } as never);
+            expect((service as AnyType).preAggregateStrategy).toBeInstanceOf(
+                NoOpPreAggregateStrategy,
+            );
+            const runAsyncWarehouseSpy = vi
+                .spyOn(service, 'runAsyncWarehouseQuery')
+                .mockResolvedValue(undefined);
+
+            const result = await service.executeAsyncComposeSqlQuery({
+                account: sessionAccount,
+                projectUuid,
+                context: QueryExecutionContext.SQL_RUNNER,
+                sql: 'SELECT one FROM orders',
+                references: { orders: '0b7c9c62-4b6e-4b1a-9c3e-4f6a0c8d2e11' },
+            });
+
+            expect(result.queryUuid).toBe('queryUuid');
+            await vi.waitFor(() =>
+                expect(runAsyncWarehouseSpy).toHaveBeenCalledTimes(1),
+            );
+            expect(createDuckdbWarehouseClient).toHaveBeenCalledWith({
+                s3Config: {
+                    endpoint: 'mock_endpoint',
+                    region: 'mock_region',
+                    accessKey: undefined,
+                    secretKey: undefined,
+                    forcePathStyle: false,
+                    useSsl: true,
+                },
+                sharedResourceLimits: undefined,
+                instanceCacheKey: COMPOSE_ENGINE_INSTANCE_CACHE_KEY,
+            });
+            expect(runAsyncWarehouseSpy.mock.calls[0][0]).toMatchObject({
+                warehouseClientOverride: warehouseClientMock,
+                query: expect.stringContaining(
+                    "read_json('s3://mock_bucket/referenced-results.jsonl'",
+                ),
+            });
+        });
+
+        test('refuses a compose SQL query naming the missing results storage', async () => {
+            const service = getMockedAsyncQueryService(withoutResultsStorage, {
+                featureFlagModel: composeFlags,
+            } as never);
+
+            await expect(
+                service.executeAsyncComposeSqlQuery({
+                    account: sessionAccount,
+                    projectUuid,
+                    context: QueryExecutionContext.SQL_RUNNER,
+                    sql: 'SELECT 1 AS one',
+                }),
+            ).rejects.toThrow(
+                new MissingConfigError(
+                    'The compose engine needs results storage to read referenced query results. Set S3_ENDPOINT, S3_BUCKET and S3_REGION, or the RESULTS_S3_* overrides.',
+                ),
+            );
+            expect(service.queryHistoryModel.create).not.toHaveBeenCalled();
+        });
+
+        test('refuses a merge naming the missing results storage instead of downgrading it', async () => {
+            const service = getMockedAsyncQueryService(withoutResultsStorage, {
+                featureFlagModel: composeFlags,
+            } as never);
+            vi.spyOn(service, 'compileMergeQuery').mockResolvedValue({
+                coreSql: 'SELECT 1',
+                typedColumns: [],
+                terminalWrapper: null,
+                errors: [],
+                parameterReferences: [],
+                fieldOrigins: {},
+                columns: { valueColumnBySourceColumn: {} },
+                fieldIdByColumn: {},
+                itemsMap: {},
+                usedParametersValues: {},
+                requiresCompose: false,
+            } as never);
+
+            await expect(
+                service.executeAsyncMergeQuery({
+                    account: sessionAccount,
+                    projectUuid,
+                    mergeQuery: {
+                        sources: [],
+                        joinKey: [],
+                        joinType: 'full',
+                        tableCalculations: [],
+                        limit: 500,
+                    } as never,
+                    context: QueryExecutionContext.EXPLORE,
+                    mode: { type: 'interactive' },
+                }),
+            ).rejects.toThrow(MissingConfigError);
+            expect(service.queryHistoryModel.create).not.toHaveBeenCalled();
         });
     });
 

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -701,6 +701,53 @@ describe('AsyncQueryService', () => {
             expect(service.queryHistoryModel.create).not.toHaveBeenCalled();
         });
 
+        test('reads external-source files on the pre-aggregate bucket session', async () => {
+            const createExecutionWarehouseClient = vi.fn(
+                () => warehouseClientMock,
+            );
+            const service = getMockedAsyncQueryService(lightdashConfigMock, {
+                featureFlagModel: {
+                    get: vi.fn(async ({ featureFlagId }) => ({
+                        id: featureFlagId,
+                        enabled: true,
+                    })),
+                } as unknown as FeatureFlagModel,
+                composeEngineClient: {
+                    createExecutionWarehouseClient,
+                } as unknown as ComposeEngineClient,
+                externalSourceTableResolver: vi.fn(async () => ({
+                    external_source_table_uuid: 'table-uuid',
+                    external_source_scope: null,
+                    external_source_created_by_user_uuid: null,
+                    version: 3,
+                    locator: {
+                        storage: 's3',
+                        format: 'parquet',
+                        uri: 's3://mock_preagg_bucket/external-sources/file.parquet',
+                    },
+                    columns: {
+                        one: { reference: 'one', type: DimensionType.NUMBER },
+                    },
+                })),
+            } as never);
+            vi.spyOn(service, 'runAsyncWarehouseQuery').mockResolvedValue(
+                undefined,
+            );
+
+            await service.executeAsyncExternalSqlQuery({
+                account: sessionAccount,
+                projectUuid,
+                context: QueryExecutionContext.AI,
+                sql: 'SELECT one FROM attachment',
+                tables: { attachment: 'table-uuid' },
+            });
+
+            expect(createExecutionWarehouseClient).toHaveBeenCalledWith({
+                storage: 'externalSources',
+                scope: null,
+            });
+        });
+
         test('refuses a merge naming the missing results storage instead of downgrading it', async () => {
             const service = getMockedAsyncQueryService(withoutResultsStorage, {
                 featureFlagModel: composeFlags,

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -246,6 +246,7 @@ import {
     exploreHasFilteredAttribute,
     getFilteredExplore,
 } from '../UserAttributesService/UserAttributeUtils';
+import { type ComposeEngineClient } from './ComposeEngineClient';
 import { getValidatedDashboardSorts } from './dashboardSorts';
 import { getPivotedColumns } from './getPivotedColumns';
 import { getUnpivotedColumns } from './getUnpivotedColumns';
@@ -398,6 +399,7 @@ type AsyncQueryServiceArguments = ProjectServiceArguments & {
     natsClient: INatsClient;
     persistentDownloadFileService: PersistentDownloadFileService;
     organizationAccessService: OrganizationAccessService;
+    composeEngineClient: ComposeEngineClient;
     preAggregateStrategy?: PreAggregateStrategy;
     /** EE resolver for external tables; absent in OSS. */
     externalSourceTableResolver?: (
@@ -531,6 +533,8 @@ export class AsyncQueryService extends ProjectService {
 
     private readonly organizationAccessService: OrganizationAccessService;
 
+    private readonly composeEngineClient: ComposeEngineClient;
+
     protected readonly preAggregateStrategy: PreAggregateStrategy;
 
     private readonly externalSourceTableResolver: AsyncQueryServiceArguments['externalSourceTableResolver'];
@@ -550,6 +554,7 @@ export class AsyncQueryService extends ProjectService {
         this.natsClient = args.natsClient;
         this.persistentDownloadFileService = args.persistentDownloadFileService;
         this.organizationAccessService = args.organizationAccessService;
+        this.composeEngineClient = args.composeEngineClient;
         this.preAggregateStrategy =
             args.preAggregateStrategy ?? new NoOpPreAggregateStrategy();
         this.externalSourceTableResolver = args.externalSourceTableResolver;
@@ -658,7 +663,7 @@ export class AsyncQueryService extends ProjectService {
     ): Promise<void> {
         try {
             const warehouseClient =
-                this.preAggregateStrategy.createExecutionWarehouseClient(
+                this.composeEngineClient.createExecutionWarehouseClient(
                     objectScope,
                 );
             await this.runAsyncWarehouseQuery({
@@ -2849,7 +2854,7 @@ export class AsyncQueryService extends ProjectService {
             // external ones run on the normal project warehouse client.
             const duckDbWarehouseClient =
                 preAggregateExecution === 'duckdb'
-                    ? this.preAggregateStrategy.createExecutionWarehouseClient()
+                    ? this.preAggregateStrategy.createPreAggregateWarehouseClient()
                     : undefined;
 
             await this.runAsyncWarehouseQuery({
@@ -7049,9 +7054,8 @@ export class AsyncQueryService extends ProjectService {
     }
 
     /**
-     * Runs raw SQL directly on the shared pre-aggregate DuckDB engine (the
-     * one that serves managed materializations) and streams results through
-     * the standard async query pipeline, so results are polled with
+     * Runs raw SQL directly on the compose engine and streams results
+     * through the standard async query pipeline, so results are polled with
      * getAsyncQueryResults like any other async query.
      *
      * The references map ({"orders": "<queryUuid>"}) exposes previous
@@ -7132,9 +7136,9 @@ export class AsyncQueryService extends ProjectService {
             });
         }
 
-        // Throws NotImplementedError when pre-aggregate execution is unavailable
+        // Throws MissingConfigError when results storage is not configured
         const warehouseClient =
-            this.preAggregateStrategy.createExecutionWarehouseClient();
+            this.composeEngineClient.createExecutionWarehouseClient();
 
         const queryTags: RunQueryTags = {
             ...this.getUserQueryTags(account),
@@ -7361,9 +7365,9 @@ export class AsyncQueryService extends ProjectService {
             externalSourceSalt,
         });
 
-        // Throws NotImplementedError when the engine is unavailable
+        // Throws MissingConfigError when results storage is not configured
         const warehouseClient =
-            this.preAggregateStrategy.createExecutionWarehouseClient();
+            this.composeEngineClient.createExecutionWarehouseClient();
 
         const queryTags: RunQueryTags = {
             ...this.getUserQueryTags(account),
@@ -8073,18 +8077,10 @@ export class AsyncQueryService extends ProjectService {
         });
         if (!enabled) return null;
 
-        let warehouseClient: WarehouseClient;
-        try {
-            warehouseClient =
-                this.preAggregateStrategy.createExecutionWarehouseClient();
-        } catch (e) {
-            this.logger.debug(
-                `Merge-on-compose unavailable, using the warehouse merge: ${getErrorMessage(
-                    e,
-                )}`,
-            );
-            return null;
-        }
+        // Throws MissingConfigError when results storage is not configured:
+        // a merge without an engine is refused, never silently downgraded
+        const warehouseClient =
+            this.composeEngineClient.createExecutionWarehouseClient();
 
         const projectSummary = await this.projectModel.getSummary(projectUuid);
         const sourceRowCap = this.lightdashConfig.query.maxLimit;

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -663,9 +663,10 @@ export class AsyncQueryService extends ProjectService {
     ): Promise<void> {
         try {
             const warehouseClient =
-                this.composeEngineClient.createExecutionWarehouseClient(
-                    objectScope,
-                );
+                this.composeEngineClient.createExecutionWarehouseClient({
+                    storage: 'externalSources',
+                    scope: objectScope,
+                });
             await this.runAsyncWarehouseQuery({
                 ...warehouseArgs,
                 warehouseClientOverride: warehouseClient,
@@ -7138,7 +7139,9 @@ export class AsyncQueryService extends ProjectService {
 
         // Throws MissingConfigError when results storage is not configured
         const warehouseClient =
-            this.composeEngineClient.createExecutionWarehouseClient();
+            this.composeEngineClient.createExecutionWarehouseClient({
+                storage: 'results',
+            });
 
         const queryTags: RunQueryTags = {
             ...this.getUserQueryTags(account),
@@ -7365,9 +7368,13 @@ export class AsyncQueryService extends ProjectService {
             externalSourceSalt,
         });
 
-        // Throws MissingConfigError when results storage is not configured
+        // External-source files live in the pre-aggregates bucket, so the
+        // session is that bucket's. Throws MissingConfigError without it
         const warehouseClient =
-            this.composeEngineClient.createExecutionWarehouseClient();
+            this.composeEngineClient.createExecutionWarehouseClient({
+                storage: 'externalSources',
+                scope: null,
+            });
 
         const queryTags: RunQueryTags = {
             ...this.getUserQueryTags(account),
@@ -8080,7 +8087,9 @@ export class AsyncQueryService extends ProjectService {
         // Throws MissingConfigError when results storage is not configured:
         // a merge without an engine is refused, never silently downgraded
         const warehouseClient =
-            this.composeEngineClient.createExecutionWarehouseClient();
+            this.composeEngineClient.createExecutionWarehouseClient({
+                storage: 'results',
+            });
 
         const projectSummary = await this.projectModel.getSummary(projectUuid);
         const sourceRowCap = this.lightdashConfig.query.maxLimit;

--- a/packages/backend/src/services/AsyncQueryService/ComposeEngineClient.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/ComposeEngineClient.test.ts
@@ -5,6 +5,7 @@ import { type LightdashConfig } from '../../config/parseConfig';
 import { warehouseClientMock } from '../../utils/QueryBuilder/MetricQueryBuilder.mock';
 import {
     COMPOSE_ENGINE_INSTANCE_CACHE_KEY,
+    COMPOSE_ENGINE_MISSING_CA_BUNDLE_MESSAGE,
     COMPOSE_ENGINE_MISSING_EXTERNAL_SOURCES_STORAGE_MESSAGE,
     COMPOSE_ENGINE_MISSING_RESULTS_STORAGE_MESSAGE,
     ComposeEngineClient,
@@ -46,6 +47,9 @@ const withPreAggregateBucket: LightdashConfig = {
     },
 };
 
+const CA_BUNDLE = '/etc/ssl/certs/ca-certificates.crt';
+const resolveCaCertFile = () => CA_BUNDLE;
+
 const resultsSession = {
     endpoint: 'results.example.com',
     region: 'results-region',
@@ -53,6 +57,7 @@ const resultsSession = {
     secretKey: 'results-secret-key',
     forcePathStyle: false,
     useSsl: true,
+    caCertFile: CA_BUNDLE,
 };
 
 const preAggregateSession = {
@@ -72,6 +77,7 @@ describe('ComposeEngineClient', () => {
     test('configures the shared results session from the results S3 config', () => {
         const createDuckdbWarehouseClient = vi.fn(() => warehouseClientMock);
         const client = new ComposeEngineClient({
+            resolveCaCertFile,
             lightdashConfig: ossConfig,
             createDuckdbWarehouseClient,
         });
@@ -96,6 +102,7 @@ describe('ComposeEngineClient', () => {
     test('a results locator gets the results session even with a pre-aggregate bucket configured', () => {
         const createDuckdbWarehouseClient = vi.fn(() => warehouseClientMock);
         const client = new ComposeEngineClient({
+            resolveCaCertFile,
             lightdashConfig: withPreAggregateBucket,
             createDuckdbWarehouseClient,
         });
@@ -113,6 +120,7 @@ describe('ComposeEngineClient', () => {
     test('an external-source locator gets the pre-aggregate bucket session, shared with managed pre-aggregates', () => {
         const createDuckdbWarehouseClient = vi.fn(() => warehouseClientMock);
         const client = new ComposeEngineClient({
+            resolveCaCertFile,
             lightdashConfig: withPreAggregateBucket,
             createDuckdbWarehouseClient,
         });
@@ -146,6 +154,7 @@ describe('ComposeEngineClient', () => {
     test('a scoped external-source session uses the pre-aggregate bucket session and is never cached', () => {
         const createDuckdbWarehouseClient = vi.fn(() => warehouseClientMock);
         const client = new ComposeEngineClient({
+            resolveCaCertFile,
             lightdashConfig: withPreAggregateBucket,
             createDuckdbWarehouseClient,
         });
@@ -175,7 +184,10 @@ describe('ComposeEngineClient', () => {
             DuckdbWarehouseClient,
             'createForPreAggregate',
         );
-        const client = new ComposeEngineClient({ lightdashConfig: ossConfig });
+        const client = new ComposeEngineClient({
+            resolveCaCertFile,
+            lightdashConfig: ossConfig,
+        });
 
         const warehouseClient = client.createExecutionWarehouseClient({
             storage: 'results',
@@ -194,6 +206,7 @@ describe('ComposeEngineClient', () => {
     test('applies the shared memory budget to the engine instance', () => {
         const createDuckdbWarehouseClient = vi.fn(() => warehouseClientMock);
         const client = new ComposeEngineClient({
+            resolveCaCertFile,
             lightdashConfig: {
                 ...ossConfig,
                 preAggregates: {
@@ -216,6 +229,7 @@ describe('ComposeEngineClient', () => {
     test('refuses a results session with the missing results storage configuration', () => {
         const createDuckdbWarehouseClient = vi.fn(() => warehouseClientMock);
         const client = new ComposeEngineClient({
+            resolveCaCertFile,
             lightdashConfig: {
                 ...ossConfig,
                 results: { ...ossConfig.results, s3: undefined },
@@ -236,6 +250,7 @@ describe('ComposeEngineClient', () => {
     test('refuses an external-source session without the pre-aggregates configuration', () => {
         const createDuckdbWarehouseClient = vi.fn(() => warehouseClientMock);
         const client = new ComposeEngineClient({
+            resolveCaCertFile,
             lightdashConfig: ossConfig,
             createDuckdbWarehouseClient,
         });
@@ -257,5 +272,39 @@ describe('ComposeEngineClient', () => {
             }),
         ).toThrow(MissingConfigError);
         expect(createDuckdbWarehouseClient).not.toHaveBeenCalled();
+    });
+
+    test('refuses an HTTPS session when no CA bundle can be found', () => {
+        const createDuckdbWarehouseClient = vi.fn(() => warehouseClientMock);
+        const client = new ComposeEngineClient({
+            resolveCaCertFile: () => null,
+            lightdashConfig: withPreAggregateBucket,
+            createDuckdbWarehouseClient,
+        });
+
+        expect(() =>
+            client.createExecutionWarehouseClient({ storage: 'results' }),
+        ).toThrow(
+            new MissingConfigError(COMPOSE_ENGINE_MISSING_CA_BUNDLE_MESSAGE),
+        );
+        expect(createDuckdbWarehouseClient).not.toHaveBeenCalled();
+    });
+
+    test('a plain HTTP session needs no CA bundle', () => {
+        const createDuckdbWarehouseClient = vi.fn(() => warehouseClientMock);
+        const client = new ComposeEngineClient({
+            resolveCaCertFile: () => null,
+            lightdashConfig: withPreAggregateBucket,
+            createDuckdbWarehouseClient,
+        });
+
+        client.createExecutionWarehouseClient({
+            storage: 'externalSources',
+            scope: null,
+        });
+
+        expect(createDuckdbWarehouseClient).toHaveBeenCalledWith(
+            expect.objectContaining({ s3Config: preAggregateSession }),
+        );
     });
 });

--- a/packages/backend/src/services/AsyncQueryService/ComposeEngineClient.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/ComposeEngineClient.test.ts
@@ -1,0 +1,179 @@
+import { MissingConfigError } from '@lightdash/common';
+import { DuckdbWarehouseClient } from '@lightdash/warehouses';
+import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
+import { type LightdashConfig } from '../../config/parseConfig';
+import { warehouseClientMock } from '../../utils/QueryBuilder/MetricQueryBuilder.mock';
+import {
+    COMPOSE_ENGINE_INSTANCE_CACHE_KEY,
+    COMPOSE_ENGINE_MISSING_RESULTS_STORAGE_MESSAGE,
+    ComposeEngineClient,
+} from './ComposeEngineClient';
+
+// An OSS instance: results storage only, no pre-aggregate bucket
+const ossConfig: LightdashConfig = {
+    ...lightdashConfigMock,
+    results: {
+        ...lightdashConfigMock.results,
+        s3: {
+            endpoint: 'https://results.example.com',
+            bucket: 'results-bucket',
+            region: 'results-region',
+            accessKey: 'results-access-key',
+            secretKey: 'results-secret-key',
+        },
+    },
+    preAggregates: {
+        ...lightdashConfigMock.preAggregates,
+        s3: undefined,
+    },
+};
+
+const resultsSession = {
+    endpoint: 'results.example.com',
+    region: 'results-region',
+    accessKey: 'results-access-key',
+    secretKey: 'results-secret-key',
+    forcePathStyle: false,
+    useSsl: true,
+};
+
+describe('ComposeEngineClient', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    test('configures the shared engine session from the results S3 config', () => {
+        const createDuckdbWarehouseClient = vi.fn(() => warehouseClientMock);
+        const client = new ComposeEngineClient({
+            lightdashConfig: ossConfig,
+            createDuckdbWarehouseClient,
+        });
+
+        const first = client.createExecutionWarehouseClient();
+        const second = client.createExecutionWarehouseClient();
+
+        expect(first).toBe(warehouseClientMock);
+        expect(second).toBe(first);
+        expect(createDuckdbWarehouseClient).toHaveBeenCalledTimes(1);
+        expect(createDuckdbWarehouseClient).toHaveBeenCalledWith({
+            s3Config: resultsSession,
+            sharedResourceLimits: undefined,
+            instanceCacheKey: COMPOSE_ENGINE_INSTANCE_CACHE_KEY,
+        });
+    });
+
+    test('prefers the results config over a configured pre-aggregate bucket', () => {
+        const createDuckdbWarehouseClient = vi.fn(() => warehouseClientMock);
+        const client = new ComposeEngineClient({
+            lightdashConfig: {
+                ...ossConfig,
+                preAggregates: {
+                    ...ossConfig.preAggregates,
+                    s3: {
+                        endpoint: 'https://preagg.example.com',
+                        bucket: 'preagg-bucket',
+                        region: 'preagg-region',
+                        accessKey: 'preagg-access-key',
+                        secretKey: 'preagg-secret-key',
+                    },
+                },
+            },
+            createDuckdbWarehouseClient,
+        });
+
+        client.createExecutionWarehouseClient();
+
+        expect(createDuckdbWarehouseClient).toHaveBeenCalledWith(
+            expect.objectContaining({ s3Config: resultsSession }),
+        );
+    });
+
+    test('creates a real DuckDB client that may read result files', () => {
+        const createForPreAggregateSpy = vi.spyOn(
+            DuckdbWarehouseClient,
+            'createForPreAggregate',
+        );
+        const client = new ComposeEngineClient({ lightdashConfig: ossConfig });
+
+        const warehouseClient = client.createExecutionWarehouseClient();
+
+        expect(warehouseClient).toBeInstanceOf(DuckdbWarehouseClient);
+        expect(createForPreAggregateSpy).toHaveBeenCalledWith(
+            { type: 'duckdb_s3', s3Config: resultsSession },
+            expect.objectContaining({
+                instanceCacheKey: COMPOSE_ENGINE_INSTANCE_CACHE_KEY,
+                enableQueryProfiling: true,
+            }),
+        );
+    });
+
+    test('applies the shared memory budget to the engine instance', () => {
+        const createDuckdbWarehouseClient = vi.fn(() => warehouseClientMock);
+        const client = new ComposeEngineClient({
+            lightdashConfig: {
+                ...ossConfig,
+                preAggregates: {
+                    ...ossConfig.preAggregates,
+                    duckdbQueryMemoryLimit: '2GB',
+                },
+            },
+            createDuckdbWarehouseClient,
+        });
+
+        client.createExecutionWarehouseClient();
+
+        expect(createDuckdbWarehouseClient).toHaveBeenCalledWith(
+            expect.objectContaining({
+                sharedResourceLimits: { memoryLimit: '2GB' },
+            }),
+        );
+    });
+
+    test('a scoped session is isolated, URI-scoped and never cached', () => {
+        const createDuckdbWarehouseClient = vi.fn(() => warehouseClientMock);
+        const client = new ComposeEngineClient({
+            lightdashConfig: ossConfig,
+            createDuckdbWarehouseClient,
+        });
+
+        client.createExecutionWarehouseClient(
+            's3://results-bucket/file.parquet',
+        );
+        client.createExecutionWarehouseClient(
+            's3://results-bucket/file.parquet',
+        );
+
+        expect(createDuckdbWarehouseClient).toHaveBeenCalledTimes(2);
+        expect(createDuckdbWarehouseClient).toHaveBeenCalledWith({
+            s3Config: {
+                ...resultsSession,
+                scope: 's3://results-bucket/file.parquet',
+            },
+            resourceLimits: { memoryLimit: '512MB', threads: 2 },
+            organizationConcurrencyLimit:
+                ossConfig.externalSources
+                    .maxConcurrentDuckdbQueriesPerOrganization,
+        });
+    });
+
+    test('refuses with the missing results storage configuration', () => {
+        const createDuckdbWarehouseClient = vi.fn(() => warehouseClientMock);
+        const client = new ComposeEngineClient({
+            lightdashConfig: {
+                ...ossConfig,
+                results: { ...ossConfig.results, s3: undefined },
+            },
+            createDuckdbWarehouseClient,
+        });
+
+        expect(() => client.createExecutionWarehouseClient()).toThrow(
+            new MissingConfigError(
+                COMPOSE_ENGINE_MISSING_RESULTS_STORAGE_MESSAGE,
+            ),
+        );
+        expect(() =>
+            client.createExecutionWarehouseClient('s3://bucket/file.parquet'),
+        ).toThrow(MissingConfigError);
+        expect(createDuckdbWarehouseClient).not.toHaveBeenCalled();
+    });
+});

--- a/packages/backend/src/services/AsyncQueryService/ComposeEngineClient.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/ComposeEngineClient.test.ts
@@ -5,8 +5,10 @@ import { type LightdashConfig } from '../../config/parseConfig';
 import { warehouseClientMock } from '../../utils/QueryBuilder/MetricQueryBuilder.mock';
 import {
     COMPOSE_ENGINE_INSTANCE_CACHE_KEY,
+    COMPOSE_ENGINE_MISSING_EXTERNAL_SOURCES_STORAGE_MESSAGE,
     COMPOSE_ENGINE_MISSING_RESULTS_STORAGE_MESSAGE,
     ComposeEngineClient,
+    PRE_AGGREGATE_QUERY_INSTANCE_CACHE_KEY,
 } from './ComposeEngineClient';
 
 // An OSS instance: results storage only, no pre-aggregate bucket
@@ -28,6 +30,22 @@ const ossConfig: LightdashConfig = {
     },
 };
 
+// The same instance with a pre-aggregates bucket in another region
+const withPreAggregateBucket: LightdashConfig = {
+    ...ossConfig,
+    preAggregates: {
+        ...ossConfig.preAggregates,
+        s3: {
+            endpoint: 'http://preagg.example.com:9000',
+            bucket: 'preagg-bucket',
+            region: 'preagg-region',
+            accessKey: 'preagg-access-key',
+            secretKey: 'preagg-secret-key',
+            forcePathStyle: true,
+        },
+    },
+};
+
 const resultsSession = {
     endpoint: 'results.example.com',
     region: 'results-region',
@@ -37,20 +55,33 @@ const resultsSession = {
     useSsl: true,
 };
 
+const preAggregateSession = {
+    endpoint: 'preagg.example.com:9000',
+    region: 'preagg-region',
+    accessKey: 'preagg-access-key',
+    secretKey: 'preagg-secret-key',
+    forcePathStyle: true,
+    useSsl: false,
+};
+
 describe('ComposeEngineClient', () => {
     afterEach(() => {
         vi.restoreAllMocks();
     });
 
-    test('configures the shared engine session from the results S3 config', () => {
+    test('configures the shared results session from the results S3 config', () => {
         const createDuckdbWarehouseClient = vi.fn(() => warehouseClientMock);
         const client = new ComposeEngineClient({
             lightdashConfig: ossConfig,
             createDuckdbWarehouseClient,
         });
 
-        const first = client.createExecutionWarehouseClient();
-        const second = client.createExecutionWarehouseClient();
+        const first = client.createExecutionWarehouseClient({
+            storage: 'results',
+        });
+        const second = client.createExecutionWarehouseClient({
+            storage: 'results',
+        });
 
         expect(first).toBe(warehouseClientMock);
         expect(second).toBe(first);
@@ -62,30 +93,81 @@ describe('ComposeEngineClient', () => {
         });
     });
 
-    test('prefers the results config over a configured pre-aggregate bucket', () => {
+    test('a results locator gets the results session even with a pre-aggregate bucket configured', () => {
         const createDuckdbWarehouseClient = vi.fn(() => warehouseClientMock);
         const client = new ComposeEngineClient({
-            lightdashConfig: {
-                ...ossConfig,
-                preAggregates: {
-                    ...ossConfig.preAggregates,
-                    s3: {
-                        endpoint: 'https://preagg.example.com',
-                        bucket: 'preagg-bucket',
-                        region: 'preagg-region',
-                        accessKey: 'preagg-access-key',
-                        secretKey: 'preagg-secret-key',
-                    },
-                },
-            },
+            lightdashConfig: withPreAggregateBucket,
             createDuckdbWarehouseClient,
         });
 
-        client.createExecutionWarehouseClient();
+        client.createExecutionWarehouseClient({ storage: 'results' });
 
         expect(createDuckdbWarehouseClient).toHaveBeenCalledWith(
+            expect.objectContaining({
+                s3Config: resultsSession,
+                instanceCacheKey: COMPOSE_ENGINE_INSTANCE_CACHE_KEY,
+            }),
+        );
+    });
+
+    test('an external-source locator gets the pre-aggregate bucket session, shared with managed pre-aggregates', () => {
+        const createDuckdbWarehouseClient = vi.fn(() => warehouseClientMock);
+        const client = new ComposeEngineClient({
+            lightdashConfig: withPreAggregateBucket,
+            createDuckdbWarehouseClient,
+        });
+
+        const first = client.createExecutionWarehouseClient({
+            storage: 'externalSources',
+            scope: null,
+        });
+        const second = client.createExecutionWarehouseClient({
+            storage: 'externalSources',
+            scope: null,
+        });
+        const results = client.createExecutionWarehouseClient({
+            storage: 'results',
+        });
+
+        expect(second).toBe(first);
+        expect(createDuckdbWarehouseClient).toHaveBeenCalledTimes(2);
+        expect(createDuckdbWarehouseClient).toHaveBeenNthCalledWith(1, {
+            s3Config: preAggregateSession,
+            sharedResourceLimits: undefined,
+            instanceCacheKey: PRE_AGGREGATE_QUERY_INSTANCE_CACHE_KEY,
+        });
+        expect(createDuckdbWarehouseClient).toHaveBeenNthCalledWith(
+            2,
             expect.objectContaining({ s3Config: resultsSession }),
         );
+        expect(results).toBe(warehouseClientMock);
+    });
+
+    test('a scoped external-source session uses the pre-aggregate bucket session and is never cached', () => {
+        const createDuckdbWarehouseClient = vi.fn(() => warehouseClientMock);
+        const client = new ComposeEngineClient({
+            lightdashConfig: withPreAggregateBucket,
+            createDuckdbWarehouseClient,
+        });
+        const scope = 's3://preagg-bucket/external-sources/file.parquet';
+
+        client.createExecutionWarehouseClient({
+            storage: 'externalSources',
+            scope,
+        });
+        client.createExecutionWarehouseClient({
+            storage: 'externalSources',
+            scope,
+        });
+
+        expect(createDuckdbWarehouseClient).toHaveBeenCalledTimes(2);
+        expect(createDuckdbWarehouseClient).toHaveBeenCalledWith({
+            s3Config: { ...preAggregateSession, scope },
+            resourceLimits: { memoryLimit: '512MB', threads: 2 },
+            organizationConcurrencyLimit:
+                withPreAggregateBucket.externalSources
+                    .maxConcurrentDuckdbQueriesPerOrganization,
+        });
     });
 
     test('creates a real DuckDB client that may read result files', () => {
@@ -95,7 +177,9 @@ describe('ComposeEngineClient', () => {
         );
         const client = new ComposeEngineClient({ lightdashConfig: ossConfig });
 
-        const warehouseClient = client.createExecutionWarehouseClient();
+        const warehouseClient = client.createExecutionWarehouseClient({
+            storage: 'results',
+        });
 
         expect(warehouseClient).toBeInstanceOf(DuckdbWarehouseClient);
         expect(createForPreAggregateSpy).toHaveBeenCalledWith(
@@ -120,7 +204,7 @@ describe('ComposeEngineClient', () => {
             createDuckdbWarehouseClient,
         });
 
-        client.createExecutionWarehouseClient();
+        client.createExecutionWarehouseClient({ storage: 'results' });
 
         expect(createDuckdbWarehouseClient).toHaveBeenCalledWith(
             expect.objectContaining({
@@ -129,34 +213,7 @@ describe('ComposeEngineClient', () => {
         );
     });
 
-    test('a scoped session is isolated, URI-scoped and never cached', () => {
-        const createDuckdbWarehouseClient = vi.fn(() => warehouseClientMock);
-        const client = new ComposeEngineClient({
-            lightdashConfig: ossConfig,
-            createDuckdbWarehouseClient,
-        });
-
-        client.createExecutionWarehouseClient(
-            's3://results-bucket/file.parquet',
-        );
-        client.createExecutionWarehouseClient(
-            's3://results-bucket/file.parquet',
-        );
-
-        expect(createDuckdbWarehouseClient).toHaveBeenCalledTimes(2);
-        expect(createDuckdbWarehouseClient).toHaveBeenCalledWith({
-            s3Config: {
-                ...resultsSession,
-                scope: 's3://results-bucket/file.parquet',
-            },
-            resourceLimits: { memoryLimit: '512MB', threads: 2 },
-            organizationConcurrencyLimit:
-                ossConfig.externalSources
-                    .maxConcurrentDuckdbQueriesPerOrganization,
-        });
-    });
-
-    test('refuses with the missing results storage configuration', () => {
+    test('refuses a results session with the missing results storage configuration', () => {
         const createDuckdbWarehouseClient = vi.fn(() => warehouseClientMock);
         const client = new ComposeEngineClient({
             lightdashConfig: {
@@ -166,13 +223,38 @@ describe('ComposeEngineClient', () => {
             createDuckdbWarehouseClient,
         });
 
-        expect(() => client.createExecutionWarehouseClient()).toThrow(
+        expect(() =>
+            client.createExecutionWarehouseClient({ storage: 'results' }),
+        ).toThrow(
             new MissingConfigError(
                 COMPOSE_ENGINE_MISSING_RESULTS_STORAGE_MESSAGE,
             ),
         );
+        expect(createDuckdbWarehouseClient).not.toHaveBeenCalled();
+    });
+
+    test('refuses an external-source session without the pre-aggregates configuration', () => {
+        const createDuckdbWarehouseClient = vi.fn(() => warehouseClientMock);
+        const client = new ComposeEngineClient({
+            lightdashConfig: ossConfig,
+            createDuckdbWarehouseClient,
+        });
+
         expect(() =>
-            client.createExecutionWarehouseClient('s3://bucket/file.parquet'),
+            client.createExecutionWarehouseClient({
+                storage: 'externalSources',
+                scope: null,
+            }),
+        ).toThrow(
+            new MissingConfigError(
+                COMPOSE_ENGINE_MISSING_EXTERNAL_SOURCES_STORAGE_MESSAGE,
+            ),
+        );
+        expect(() =>
+            client.createExecutionWarehouseClient({
+                storage: 'externalSources',
+                scope: 's3://bucket/file.parquet',
+            }),
         ).toThrow(MissingConfigError);
         expect(createDuckdbWarehouseClient).not.toHaveBeenCalled();
     });

--- a/packages/backend/src/services/AsyncQueryService/ComposeEngineClient.ts
+++ b/packages/backend/src/services/AsyncQueryService/ComposeEngineClient.ts
@@ -12,6 +12,7 @@ import { type LightdashConfig } from '../../config/parseConfig';
 import Logger from '../../logging/logger';
 import type PrometheusMetrics from '../../prometheus/PrometheusMetrics';
 import { getDuckdbRuntimeConfig } from '../../utils/duckdb/getDuckdbRuntimeConfig';
+import { resolveCaCertFile } from '../../utils/duckdb/resolveCaCertFile';
 
 export const COMPOSE_ENGINE_INSTANCE_CACHE_KEY = 'compose-engine-instance';
 
@@ -25,6 +26,9 @@ export const COMPOSE_ENGINE_MISSING_RESULTS_STORAGE_MESSAGE =
 
 export const COMPOSE_ENGINE_MISSING_EXTERNAL_SOURCES_STORAGE_MESSAGE =
     'External sources need the pre-aggregates S3 configuration (PRE_AGGREGATE_RESULTS_S3_*) to read their ingested files.';
+
+export const COMPOSE_ENGINE_MISSING_CA_BUNDLE_MESSAGE =
+    'The compose engine reads object storage over HTTPS but found no CA certificate bundle to verify it with. Install ca-certificates in the image, or set SSL_CERT_FILE to a PEM bundle.';
 
 const SCOPED_SESSION_RESOURCE_LIMITS: DuckdbResourceLimits = {
     memoryLimit: '512MB',
@@ -59,6 +63,7 @@ type ComposeEngineClientArgs = {
     lightdashConfig: LightdashConfig;
     prometheusMetrics?: PrometheusMetrics;
     createDuckdbWarehouseClient?: CreateComposeEngineWarehouseClient;
+    resolveCaCertFile?: () => string | null;
 };
 
 /**
@@ -74,6 +79,8 @@ export class ComposeEngineClient {
 
     private readonly createDuckdbWarehouseClient: CreateComposeEngineWarehouseClient;
 
+    private readonly resolveCaCertFile: () => string | null;
+
     private readonly sharedWarehouseClients = new Map<
         ComposeEngineStorage,
         WarehouseClient
@@ -86,6 +93,8 @@ export class ComposeEngineClient {
             args.lightdashConfig.preAggregates.duckdbQueryMemoryLimit;
         this.sharedResourceLimits = memoryLimit ? { memoryLimit } : null;
         const { prometheusMetrics } = args;
+        this.resolveCaCertFile =
+            args.resolveCaCertFile ?? (() => resolveCaCertFile());
         this.createDuckdbWarehouseClient =
             args.createDuckdbWarehouseClient ??
             ((warehouseArgs) =>
@@ -106,6 +115,24 @@ export class ComposeEngineClient {
                 ));
     }
 
+    /**
+     * httpfs must load a CA bundle to speak HTTPS at all, and the runtime
+     * image only has one if it was installed. Refuse up front with the fix
+     * named rather than let every read fail with an opaque IO error.
+     */
+    private withCaCertFile(
+        sessionConfig: DuckdbS3SessionConfig,
+    ): DuckdbS3SessionConfig {
+        if (!sessionConfig.useSsl) return sessionConfig;
+        const caCertFile = this.resolveCaCertFile();
+        if (caCertFile === null) {
+            throw new MissingConfigError(
+                COMPOSE_ENGINE_MISSING_CA_BUNDLE_MESSAGE,
+            );
+        }
+        return { ...sessionConfig, caCertFile };
+    }
+
     private getSessionConfig(
         storage: ComposeEngineStorage,
     ): DuckdbS3SessionConfig {
@@ -119,7 +146,7 @@ export class ComposeEngineClient {
                         COMPOSE_ENGINE_MISSING_RESULTS_STORAGE_MESSAGE,
                     );
                 }
-                return sessionConfig;
+                return this.withCaCertFile(sessionConfig);
             }
             case 'externalSources': {
                 const sessionConfig = getDuckdbRuntimeConfig(
@@ -130,7 +157,7 @@ export class ComposeEngineClient {
                         COMPOSE_ENGINE_MISSING_EXTERNAL_SOURCES_STORAGE_MESSAGE,
                     );
                 }
-                return sessionConfig;
+                return this.withCaCertFile(sessionConfig);
             }
             default:
                 return assertUnreachable(

--- a/packages/backend/src/services/AsyncQueryService/ComposeEngineClient.ts
+++ b/packages/backend/src/services/AsyncQueryService/ComposeEngineClient.ts
@@ -1,0 +1,123 @@
+import { MissingConfigError, type WarehouseClient } from '@lightdash/common';
+import {
+    DuckdbWarehouseClient,
+    type DuckdbResourceLimits,
+    type DuckdbS3SessionConfig,
+} from '@lightdash/warehouses';
+import { type LightdashConfig } from '../../config/parseConfig';
+import Logger from '../../logging/logger';
+import type PrometheusMetrics from '../../prometheus/PrometheusMetrics';
+import { getDuckdbRuntimeConfig } from '../../utils/duckdb/getDuckdbRuntimeConfig';
+
+export const COMPOSE_ENGINE_INSTANCE_CACHE_KEY = 'compose-engine-instance';
+
+export const COMPOSE_ENGINE_MISSING_RESULTS_STORAGE_MESSAGE =
+    'The compose engine needs results storage to read referenced query results. Set S3_ENDPOINT, S3_BUCKET and S3_REGION, or the RESULTS_S3_* overrides.';
+
+const SCOPED_SESSION_RESOURCE_LIMITS: DuckdbResourceLimits = {
+    memoryLimit: '512MB',
+    threads: 2,
+};
+
+type CreateComposeEngineWarehouseClientArgs = {
+    s3Config: DuckdbS3SessionConfig;
+    sharedResourceLimits?: DuckdbResourceLimits;
+    resourceLimits?: DuckdbResourceLimits;
+    instanceCacheKey?: string;
+    organizationConcurrencyLimit?: number;
+};
+
+type CreateComposeEngineWarehouseClient = (
+    args: CreateComposeEngineWarehouseClientArgs,
+) => WarehouseClient;
+
+type ComposeEngineClientArgs = {
+    lightdashConfig: LightdashConfig;
+    prometheusMetrics?: PrometheusMetrics;
+    createDuckdbWarehouseClient?: CreateComposeEngineWarehouseClient;
+};
+
+/**
+ * The DuckDB engine that executes composed queries (compose SQL, merges and
+ * external SQL) over materialized results. Available in every edition: its
+ * session is configured from results storage, which every instance that can
+ * run an async query already has.
+ */
+export class ComposeEngineClient {
+    private readonly lightdashConfig: LightdashConfig;
+
+    private readonly sharedResourceLimits: DuckdbResourceLimits | null;
+
+    private readonly createDuckdbWarehouseClient: CreateComposeEngineWarehouseClient;
+
+    private sharedWarehouseClient: WarehouseClient | null = null;
+
+    constructor(args: ComposeEngineClientArgs) {
+        this.lightdashConfig = args.lightdashConfig;
+        // Shares the pre-aggregate memory budget until the engine has its own
+        const memoryLimit =
+            args.lightdashConfig.preAggregates.duckdbQueryMemoryLimit;
+        this.sharedResourceLimits = memoryLimit ? { memoryLimit } : null;
+        const { prometheusMetrics } = args;
+        this.createDuckdbWarehouseClient =
+            args.createDuckdbWarehouseClient ??
+            ((warehouseArgs) =>
+                DuckdbWarehouseClient.createForPreAggregate(
+                    { type: 'duckdb_s3', s3Config: warehouseArgs.s3Config },
+                    {
+                        sharedResourceLimits:
+                            warehouseArgs.sharedResourceLimits,
+                        resourceLimits: warehouseArgs.resourceLimits,
+                        instanceCacheKey: warehouseArgs.instanceCacheKey,
+                        organizationConcurrencyLimit:
+                            warehouseArgs.organizationConcurrencyLimit,
+                        logger: Logger,
+                        enableQueryProfiling: true,
+                        onQueryProfile:
+                            prometheusMetrics?.observeDuckdbQueryProfile,
+                    },
+                ));
+    }
+
+    private getSessionConfig(): DuckdbS3SessionConfig {
+        const sessionConfig = getDuckdbRuntimeConfig(
+            this.lightdashConfig.results.s3,
+        );
+        if (!sessionConfig) {
+            throw new MissingConfigError(
+                COMPOSE_ENGINE_MISSING_RESULTS_STORAGE_MESSAGE,
+            );
+        }
+        return sessionConfig;
+    }
+
+    /**
+     * A warehouse client on the compose engine. Without a scope this is the
+     * shared warm instance; with one it is an isolated, resource-limited
+     * session whose S3 secret only reaches that URI, and it is never cached.
+     */
+    createExecutionWarehouseClient(scope?: string): WarehouseClient {
+        const s3Config = this.getSessionConfig();
+
+        if (scope !== undefined) {
+            return this.createDuckdbWarehouseClient({
+                s3Config: { ...s3Config, scope },
+                resourceLimits:
+                    this.sharedResourceLimits ?? SCOPED_SESSION_RESOURCE_LIMITS,
+                organizationConcurrencyLimit:
+                    this.lightdashConfig.externalSources
+                        .maxConcurrentDuckdbQueriesPerOrganization,
+            });
+        }
+
+        if (!this.sharedWarehouseClient) {
+            this.sharedWarehouseClient = this.createDuckdbWarehouseClient({
+                s3Config,
+                sharedResourceLimits: this.sharedResourceLimits ?? undefined,
+                instanceCacheKey: COMPOSE_ENGINE_INSTANCE_CACHE_KEY,
+            });
+            Logger.info('Compose engine warehouse client created and cached');
+        }
+        return this.sharedWarehouseClient;
+    }
+}

--- a/packages/backend/src/services/AsyncQueryService/ComposeEngineClient.ts
+++ b/packages/backend/src/services/AsyncQueryService/ComposeEngineClient.ts
@@ -1,4 +1,8 @@
-import { MissingConfigError, type WarehouseClient } from '@lightdash/common';
+import {
+    assertUnreachable,
+    MissingConfigError,
+    type WarehouseClient,
+} from '@lightdash/common';
 import {
     DuckdbWarehouseClient,
     type DuckdbResourceLimits,
@@ -11,13 +15,33 @@ import { getDuckdbRuntimeConfig } from '../../utils/duckdb/getDuckdbRuntimeConfi
 
 export const COMPOSE_ENGINE_INSTANCE_CACHE_KEY = 'compose-engine-instance';
 
+// External-source files share the pre-aggregates bucket, so they share its
+// warm instance with managed pre-aggregates too
+export const PRE_AGGREGATE_QUERY_INSTANCE_CACHE_KEY =
+    'pre-aggregate-query-instance';
+
 export const COMPOSE_ENGINE_MISSING_RESULTS_STORAGE_MESSAGE =
     'The compose engine needs results storage to read referenced query results. Set S3_ENDPOINT, S3_BUCKET and S3_REGION, or the RESULTS_S3_* overrides.';
+
+export const COMPOSE_ENGINE_MISSING_EXTERNAL_SOURCES_STORAGE_MESSAGE =
+    'External sources need the pre-aggregates S3 configuration (PRE_AGGREGATE_RESULTS_S3_*) to read their ingested files.';
 
 const SCOPED_SESSION_RESOURCE_LIMITS: DuckdbResourceLimits = {
     memoryLimit: '512MB',
     threads: 2,
 };
+
+/**
+ * Which S3 config owns the files a session reads. The DuckDB secret pins one
+ * endpoint and region, so a session must be built from the config of the
+ * bucket it reads: results storage for result files, the pre-aggregates
+ * bucket for external-source files.
+ */
+export type ComposeEngineSession =
+    | { storage: 'results' }
+    | { storage: 'externalSources'; scope: string | null };
+
+type ComposeEngineStorage = ComposeEngineSession['storage'];
 
 type CreateComposeEngineWarehouseClientArgs = {
     s3Config: DuckdbS3SessionConfig;
@@ -39,8 +63,8 @@ type ComposeEngineClientArgs = {
 
 /**
  * The DuckDB engine that executes composed queries (compose SQL, merges and
- * external SQL) over materialized results. Available in every edition: its
- * session is configured from results storage, which every instance that can
+ * external SQL) over materialized results. Available in every edition: the
+ * results session only needs results storage, which every instance that can
  * run an async query already has.
  */
 export class ComposeEngineClient {
@@ -50,7 +74,10 @@ export class ComposeEngineClient {
 
     private readonly createDuckdbWarehouseClient: CreateComposeEngineWarehouseClient;
 
-    private sharedWarehouseClient: WarehouseClient | null = null;
+    private readonly sharedWarehouseClients = new Map<
+        ComposeEngineStorage,
+        WarehouseClient
+    >();
 
     constructor(args: ComposeEngineClientArgs) {
         this.lightdashConfig = args.lightdashConfig;
@@ -79,29 +106,68 @@ export class ComposeEngineClient {
                 ));
     }
 
-    private getSessionConfig(): DuckdbS3SessionConfig {
-        const sessionConfig = getDuckdbRuntimeConfig(
-            this.lightdashConfig.results.s3,
-        );
-        if (!sessionConfig) {
-            throw new MissingConfigError(
-                COMPOSE_ENGINE_MISSING_RESULTS_STORAGE_MESSAGE,
-            );
+    private getSessionConfig(
+        storage: ComposeEngineStorage,
+    ): DuckdbS3SessionConfig {
+        switch (storage) {
+            case 'results': {
+                const sessionConfig = getDuckdbRuntimeConfig(
+                    this.lightdashConfig.results.s3,
+                );
+                if (!sessionConfig) {
+                    throw new MissingConfigError(
+                        COMPOSE_ENGINE_MISSING_RESULTS_STORAGE_MESSAGE,
+                    );
+                }
+                return sessionConfig;
+            }
+            case 'externalSources': {
+                const sessionConfig = getDuckdbRuntimeConfig(
+                    this.lightdashConfig.preAggregates.s3,
+                );
+                if (!sessionConfig) {
+                    throw new MissingConfigError(
+                        COMPOSE_ENGINE_MISSING_EXTERNAL_SOURCES_STORAGE_MESSAGE,
+                    );
+                }
+                return sessionConfig;
+            }
+            default:
+                return assertUnreachable(
+                    storage,
+                    'Unknown compose engine storage',
+                );
         }
-        return sessionConfig;
+    }
+
+    private static getInstanceCacheKey(storage: ComposeEngineStorage): string {
+        switch (storage) {
+            case 'results':
+                return COMPOSE_ENGINE_INSTANCE_CACHE_KEY;
+            case 'externalSources':
+                return PRE_AGGREGATE_QUERY_INSTANCE_CACHE_KEY;
+            default:
+                return assertUnreachable(
+                    storage,
+                    'Unknown compose engine storage',
+                );
+        }
     }
 
     /**
-     * A warehouse client on the compose engine. Without a scope this is the
-     * shared warm instance; with one it is an isolated, resource-limited
-     * session whose S3 secret only reaches that URI, and it is never cached.
+     * A warehouse client on the compose engine for the given session. A
+     * session without a scope is the shared warm instance of its storage; a
+     * scoped one is an isolated, resource-limited session whose S3 secret
+     * only reaches that URI, and it is never cached.
      */
-    createExecutionWarehouseClient(scope?: string): WarehouseClient {
-        const s3Config = this.getSessionConfig();
+    createExecutionWarehouseClient(
+        session: ComposeEngineSession,
+    ): WarehouseClient {
+        const s3Config = this.getSessionConfig(session.storage);
 
-        if (scope !== undefined) {
+        if (session.storage === 'externalSources' && session.scope !== null) {
             return this.createDuckdbWarehouseClient({
-                s3Config: { ...s3Config, scope },
+                s3Config: { ...s3Config, scope: session.scope },
                 resourceLimits:
                     this.sharedResourceLimits ?? SCOPED_SESSION_RESOURCE_LIMITS,
                 organizationConcurrencyLimit:
@@ -110,14 +176,21 @@ export class ComposeEngineClient {
             });
         }
 
-        if (!this.sharedWarehouseClient) {
-            this.sharedWarehouseClient = this.createDuckdbWarehouseClient({
-                s3Config,
-                sharedResourceLimits: this.sharedResourceLimits ?? undefined,
-                instanceCacheKey: COMPOSE_ENGINE_INSTANCE_CACHE_KEY,
-            });
-            Logger.info('Compose engine warehouse client created and cached');
+        const cached = this.sharedWarehouseClients.get(session.storage);
+        if (cached) {
+            return cached;
         }
-        return this.sharedWarehouseClient;
+        const warehouseClient = this.createDuckdbWarehouseClient({
+            s3Config,
+            sharedResourceLimits: this.sharedResourceLimits ?? undefined,
+            instanceCacheKey: ComposeEngineClient.getInstanceCacheKey(
+                session.storage,
+            ),
+        });
+        this.sharedWarehouseClients.set(session.storage, warehouseClient);
+        Logger.info(
+            `Compose engine warehouse client created and cached for ${session.storage}`,
+        );
+        return warehouseClient;
     }
 }

--- a/packages/backend/src/services/AsyncQueryService/PreAggregateStrategy.ts
+++ b/packages/backend/src/services/AsyncQueryService/PreAggregateStrategy.ts
@@ -70,7 +70,8 @@ export interface PreAggregateStrategy {
         resolveArgs: ResolveExecutionArgs;
     }): Promise<PreAggregateExecutionResolution>;
 
-    createExecutionWarehouseClient(scope?: string): WarehouseClient;
+    // The DuckDB client that reads managed materializations
+    createPreAggregateWarehouseClient(): WarehouseClient;
 
     recordStats(params: {
         projectUuid: string;
@@ -131,9 +132,9 @@ export class NoOpPreAggregateStrategy implements PreAggregateStrategy {
         return { resolved: false, reason: 'not_available', isFatal: false };
     }
 
-    createExecutionWarehouseClient(): never {
+    createPreAggregateWarehouseClient(): never {
         throw new NotImplementedError(
-            'Pre-aggregate execution is not available in this edition',
+            'Managed pre-aggregate execution is not available in this edition',
         );
     }
 

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -20,6 +20,7 @@ import type { UtilRepository } from '../utils/UtilRepository';
 import { AdminNotificationService } from './AdminNotificationService/AdminNotificationService';
 import { AnalyticsService } from './AnalyticsService/AnalyticsService';
 import { AsyncQueryService } from './AsyncQueryService/AsyncQueryService';
+import { ComposeEngineClient } from './AsyncQueryService/ComposeEngineClient';
 import { BaseService } from './BaseService';
 import { CatalogService } from './CatalogService/CatalogService';
 import { CiService } from './CiService/CiService';
@@ -1002,6 +1003,10 @@ export class ServiceRepository
                     savedSqlModel: this.models.getSavedSqlModel(),
                     resultsStorageClient:
                         this.clients.getResultsFileStorageClient(),
+                    composeEngineClient: new ComposeEngineClient({
+                        lightdashConfig: this.context.lightdashConfig,
+                        prometheusMetrics: this.prometheusMetrics,
+                    }),
                     featureFlagModel: this.models.getFeatureFlagModel(),
                     projectParametersModel:
                         this.models.getProjectParametersModel(),

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -960,6 +960,19 @@ export class ServiceRepository
         );
     }
 
+    private composeEngineClient: ComposeEngineClient | null = null;
+
+    // One engine per process; enterprise wiring injects this same instance
+    public getComposeEngineClient(): ComposeEngineClient {
+        if (!this.composeEngineClient) {
+            this.composeEngineClient = new ComposeEngineClient({
+                lightdashConfig: this.context.lightdashConfig,
+                prometheusMetrics: this.prometheusMetrics,
+            });
+        }
+        return this.composeEngineClient;
+    }
+
     public getAsyncQueryService(): AsyncQueryService {
         return this.getService(
             'asyncQueryService',
@@ -1003,10 +1016,7 @@ export class ServiceRepository
                     savedSqlModel: this.models.getSavedSqlModel(),
                     resultsStorageClient:
                         this.clients.getResultsFileStorageClient(),
-                    composeEngineClient: new ComposeEngineClient({
-                        lightdashConfig: this.context.lightdashConfig,
-                        prometheusMetrics: this.prometheusMetrics,
-                    }),
+                    composeEngineClient: this.getComposeEngineClient(),
                     featureFlagModel: this.models.getFeatureFlagModel(),
                     projectParametersModel:
                         this.models.getProjectParametersModel(),

--- a/packages/backend/src/utils/duckdb/getDuckdbRuntimeConfig.ts
+++ b/packages/backend/src/utils/duckdb/getDuckdbRuntimeConfig.ts
@@ -1,4 +1,4 @@
-import { type LightdashConfig } from '../../config/parseConfig';
+import { type S3Config } from '../../config/parseConfig';
 
 export type DuckdbRuntimeConfig = {
     endpoint: string;
@@ -36,7 +36,7 @@ const parseDuckdbS3Endpoint = (
 };
 
 export const getDuckdbRuntimeConfig = (
-    s3Config: LightdashConfig['preAggregates']['s3'],
+    s3Config: Omit<S3Config, 'expirationTime'> | undefined,
 ): DuckdbRuntimeConfig | undefined => {
     if (!s3Config) {
         return undefined;

--- a/packages/backend/src/utils/duckdb/resolveCaCertFile.test.ts
+++ b/packages/backend/src/utils/duckdb/resolveCaCertFile.test.ts
@@ -1,0 +1,45 @@
+import {
+    resolveCaCertFile,
+    WELL_KNOWN_CA_BUNDLE_PATHS,
+} from './resolveCaCertFile';
+
+const existsOnly =
+    (...present: string[]) =>
+    (path: string) =>
+        present.includes(path);
+
+describe('resolveCaCertFile', () => {
+    test('prefers an existing SSL_CERT_FILE', () => {
+        expect(
+            resolveCaCertFile({
+                env: { SSL_CERT_FILE: '/custom/bundle.pem' },
+                exists: existsOnly(
+                    '/custom/bundle.pem',
+                    WELL_KNOWN_CA_BUNDLE_PATHS[0],
+                ),
+            }),
+        ).toBe('/custom/bundle.pem');
+    });
+
+    test('reports a missing SSL_CERT_FILE instead of falling back', () => {
+        expect(
+            resolveCaCertFile({
+                env: { SSL_CERT_FILE: '/custom/missing.pem' },
+                exists: existsOnly(WELL_KNOWN_CA_BUNDLE_PATHS[0]),
+            }),
+        ).toBeNull();
+    });
+
+    test('finds the first well-known bundle that exists', () => {
+        expect(
+            resolveCaCertFile({
+                env: {},
+                exists: existsOnly(WELL_KNOWN_CA_BUNDLE_PATHS[2]),
+            }),
+        ).toBe(WELL_KNOWN_CA_BUNDLE_PATHS[2]);
+    });
+
+    test('is null when no bundle exists', () => {
+        expect(resolveCaCertFile({ env: {}, exists: () => false })).toBeNull();
+    });
+});

--- a/packages/backend/src/utils/duckdb/resolveCaCertFile.ts
+++ b/packages/backend/src/utils/duckdb/resolveCaCertFile.ts
@@ -1,0 +1,30 @@
+import { existsSync } from 'fs';
+
+/** Where Debian, RHEL, SUSE and macOS keep the system CA bundle. */
+export const WELL_KNOWN_CA_BUNDLE_PATHS = [
+    '/etc/ssl/certs/ca-certificates.crt',
+    '/etc/pki/tls/certs/ca-bundle.crt',
+    '/etc/ssl/ca-bundle.pem',
+    '/etc/ssl/cert.pem',
+];
+
+/**
+ * The PEM bundle DuckDB's httpfs verifies HTTPS object storage with. Node
+ * carries its own trust store, so a container can write results over HTTPS
+ * and still have no bundle for httpfs to load; that surfaces as an opaque
+ * "SSL CA cert" IO error. An explicit SSL_CERT_FILE that does not exist is
+ * reported as missing rather than silently replaced by a well-known path.
+ */
+export const resolveCaCertFile = ({
+    env = process.env,
+    exists = existsSync,
+}: {
+    env?: NodeJS.ProcessEnv;
+    exists?: (path: string) => boolean;
+} = {}): string | null => {
+    const fromEnv = env.SSL_CERT_FILE?.trim();
+    if (fromEnv) {
+        return exists(fromEnv) ? fromEnv : null;
+    }
+    return WELL_KNOWN_CA_BUNDLE_PATHS.find((path) => exists(path)) ?? null;
+};

--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
@@ -1197,6 +1197,54 @@ describe('DuckdbWarehouseClient', () => {
         ]);
     });
 
+    it('points httpfs at the CA bundle the session config names', async () => {
+        const bootstrapRunMock = vi.fn();
+        const queryRunMock = vi.fn();
+        const streamMock = vi.fn(async () =>
+            getMockStreamResult([[{ val: 1 }]], [DUCKDB_TYPE_IDS.INTEGER]),
+        );
+        const connectMock = vi
+            .fn()
+            .mockResolvedValueOnce({
+                run: bootstrapRunMock,
+                closeSync: vi.fn(),
+                disconnectSync: vi.fn(),
+            })
+            .mockResolvedValueOnce({
+                run: queryRunMock,
+                stream: streamMock,
+                extractStatements: createMockExtractStatements(),
+                closeSync: vi.fn(),
+                disconnectSync: vi.fn(),
+            });
+        createInstanceMock.mockResolvedValue({
+            connect: connectMock,
+            closeSync: vi.fn(),
+        });
+
+        const client = new DuckdbWarehouseClient(
+            {
+                type: 'duckdb_s3',
+                s3Config: {
+                    endpoint: 'results.example.com',
+                    region: 'eu-west-1',
+                    accessKey: 'key',
+                    secretKey: 'secret',
+                    forcePathStyle: false,
+                    useSsl: true,
+                    caCertFile: '/etc/ssl/certs/ca-certificates.crt',
+                },
+            },
+            { instanceCacheKey: 'ca-bundle-session' },
+        );
+
+        await client.runQuery('SELECT 1 AS val');
+
+        expect(bootstrapRunMock).toHaveBeenCalledWith(
+            "SET ca_cert_file = '/etc/ssl/certs/ca-certificates.crt';",
+        );
+    });
+
     it('confines embedded user queries without writing profiles to local files', async () => {
         const runMock = vi.fn();
         const streamMock = vi.fn(async () =>

--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
@@ -106,6 +106,8 @@ export type DuckdbS3SessionConfig = {
     useSsl: boolean;
     /** Limit this DuckDB secret to one trusted S3 URI or prefix. */
     scope?: string;
+    /** PEM bundle httpfs verifies HTTPS object storage with. */
+    caCertFile?: string;
 };
 
 export type DuckdbResourceLimits = {
@@ -895,6 +897,13 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
             // For DuckLake mode, httpfs and the ducklake/postgres/mysql/azure
             // extensions are autoloaded by ATTACH — no explicit INSTALL/LOAD.
             await client.loadExtension(db, 'httpfs');
+            if (client.s3Config?.caCertFile) {
+                await db.run(
+                    `SET ca_cert_file = '${DuckdbWarehouseClient.escapeDuckdbString(
+                        client.s3Config.caCertFile,
+                    )}';`,
+                );
+            }
             await client.loadAwsExtensionForCredentialChain(db);
         }
         const httpfsMs = performance.now() - httpfsStart;


### PR DESCRIPTION
## What

Every deployment, licensed or not, can execute a DuckDB query over cached result files. Composer queries and merges now run in OSS; a missing results-storage configuration is a clear refusal instead of a debug-logged exception.

## Why

The compose engine lived under `ee/`, and OSS resolved to a no-op strategy whose execution client threw. The throw was caught and logged at debug, so on an OSS instance composer queries and merges did not run and nobody saw why. PROD-9389 stated the constraint ("OSS for everyone… the file-locator and DuckDB execution pieces need OSS homes") but closed without meeting it.

## How

- **Constructed once**: `ServiceRepository.getComposeEngineClient()` is the single construction site; EE injects it (resolves the Graphite thread on `ee/index.ts`).
- **New OSS `ComposeEngineClient`** (`services/AsyncQueryService/ComposeEngineClient.ts`): the shared warm DuckDB instance (own cache key) and the isolated URI-scoped session. The session is built from the **results** S3 config, which every instance that can run an async query already has. Missing config throws `MissingConfigError` naming the exact `S3_*` / `RESULTS_S3_*` keys.
- **`AsyncQueryService`** takes a required `composeEngineClient`; compose SQL, external SQL, external-source and merge-on-compose paths use it. The debug-level catch in `tryExecuteComposeMergeQuery` is removed.
- **EE keeps only pre-aggregates**: `createExecutionWarehouseClient(scope?)` becomes `createPreAggregateWarehouseClient()`, used solely to read managed materializations on the pre-aggregate bucket session. Routing, execution resolution, stats, fallback recording, cleanup and dashboard audit stay EE and delegate to the OSS provider.
- `getDuckdbRuntimeConfig` accepts any S3 config. No migration.
- **CA bundle for httpfs** (`76ad0b6bcb`, found by the E2E run on preview): the runtime image `node:24-bookworm-slim` ships no CA bundle at all. Node carries its own trust store, so the results *writer* works, but DuckDB httpfs verifies with OpenSSL and needs a bundle file to load before it can speak HTTPS — every merge on preview failed reading legs' result files from GCS with the opaque `IO Error: Problem with the SSL CA cert`. This was masked until now because the engine was "unavailable" there and merges silently fell back to the warehouse path. Fix: `ca-certificates` installed in both runtime images (`dockerfile`, `dockerfile-prs`); `resolveCaCertFile` (`SSL_CERT_FILE`, then the well-known paths) feeds `DuckdbS3SessionConfig.caCertFile`, applied as `SET ca_cert_file` after `LOAD httpfs`; the compose engine refuses an HTTPS session with no bundle, naming the fix.
- Docs: `docs/merge-queries/architecture.md`, `docs/external-sources/CONTEXT.md`.

## Regression analysis

- **OSS compose SQL / merges**: previously failed silently; now execute. Intended change.
- **EE managed pre-aggregates**: unchanged. Same client, same bucket session, existing EE tests pass (`PreAggregationDuckDbClient.test.ts`, `PreAggregateStrategy.*.test.ts`).
- **EE compose paths**: now run on a second shared DuckDB instance (results session) alongside the pre-aggregate one. Behaviour identical; resource footprint is two instances rather than one.
- **External-source Parquet in the pre-aggregates bucket** is read with a session built from the config that owns that bucket (`preAggregates.s3`: endpoint, region and credentials, base fallback as before), not the results session. Review found the first cut used the results session's region/endpoint too, which would have broken external-source reads on a cross-region pre-aggregate bucket (DuckDB pins `ENDPOINT`/`REGION` in its S3 secret and httpfs does not follow region redirects); fixed in `e32740d100`, with tests for both locator kinds. Unscoped external sessions share the managed pre-aggregate warm instance; scoped ones stay isolated and uncached.
- **Compose memory budget** still reads `PRE_AGGREGATE_DUCKDB_QUERY_MEMORY_LIMIT`, for parity with today.
- **Image change**: `ca-certificates` is added to the runtime stages. Any other HTTPS read DuckDB does from this image (managed pre-aggregates, external sources) was equally unable to load a bundle before; they now get one. `enable_server_cert_verification` stays at DuckDB's default (off) — turning it on is a separate, deliberate change.

## Tests

- `ComposeEngineClient.test.ts`: session from results config; results config preferred over a configured pre-aggregate bucket; real DuckDB client can read result files; refuses naming the missing results storage.
- `AsyncQueryService.test.ts`: compose SQL over referenced results without a license (NoOp strategy asserted); compose SQL and merge each refuse naming the missing results storage instead of downgrading.
- `resolveCaCertFile.test.ts`; `ComposeEngineClient.test.ts` refuses an HTTPS session with no bundle, plain HTTP needs none; `DuckdbWarehouseClient.test.ts` points httpfs at the configured bundle.
- Full backend suite green after each fix; the merge parity suite (`tests/mergeQuery.test.ts`) on preview is the proof for the CA change. Typecheck and lint clean. Not run: live app, api-tests, real S3-bootstrapped DuckDB (needs network for httpfs).

## Stack

Base of #28578 (one DuckDB execution tail). Part of the Query & Explore V2 milestone "One execution path: merge as composition".

Closes: PROD-10893

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LyhpDxbUsZ9YXhk8GJVPjM
