### PR TITLE
feat(query-sources): carry parameters, user attributes, cache control and pivot

### DIFF
--- a/docs/merge-queries/architecture.md
+++ b/docs/merge-queries/architecture.md
@@ -99,10 +99,11 @@ behind three feature flags and a permission it should not need. The join node
 calls the shared execution tail directly, below the flag gate.
 
 **User attribute overrides are load-bearing.** They were silently dropped on the
-merge path once and fixed as an embed row-level-security risk. When threading
-execution context through query sources, make them a required field rather than
-optional: the failure mode is a user seeing another tenant's rows, and no test
-currently catches it.
+merge path once and fixed as an embed row-level-security risk. The query source
+submit contract therefore requires them (`SourceQueryExecutionContext` in
+`QuerySourceService/types.ts`): a caller without overrides passes an empty map,
+never leaves the field out. Keep it that way when adding callers or sources; the
+failure mode is a user seeing another tenant's rows.
 
 **The engine is OSS; managed pre-aggregates are not.** `ComposeEngineClient`
 (`services/AsyncQueryService/`) owns the compose engine in every edition. A

--- a/docs/multi-source-queries.md
+++ b/docs/multi-source-queries.md
@@ -30,6 +30,14 @@ results are fetched with the standard results endpoint and carry the universal
   and reaches results of previous submissions. A referenced result keeps the
   column names of the query that produced it: field ids for `semanticLayer`
   queries, SELECT output names for `sql` queries.
+- **Execution context** (`SourceQueryExecutionContext` on the backend): what a
+  submission carries besides its queries — parameter values, user attribute
+  overrides and cache invalidation, shared by every node — plus each node's
+  own `pivotConfiguration`. All of it is required on the submit contract, so a
+  new source or caller decides each value explicitly. User attribute overrides
+  in particular are never optional: they come from the caller's runtime
+  (embed, MCP, the AI agent) and a dropped override shows a user another
+  tenant's rows. The HTTP API has none and passes an empty map.
 
 ## No orchestrator
 
@@ -62,7 +70,12 @@ than referencing expired results.
 - `types.ts` — `QuerySourceClient`: `scanSchema` (standard tables/columns
   shape), `getQueryReferences` (declares which results a query reads),
   `submitQuery` (returns a `queryUuid`). Each source owns its authorization,
-  applying the same checks as the execution path it wraps.
+  applying the same checks as the execution path it wraps, and honours the
+  execution context it is handed: `semanticLayer` and `sql` nodes apply all
+  of it; `duckdb` and `external` nodes resolve parameters, never serve from a
+  cache (so invalidation is trivially honoured), have no attribute-scoped SQL
+  to apply overrides to, and refuse a pivot until the join node owns the
+  pivot stage.
 - `QuerySourceRegistry.ts` — sources register by `sourceType`; the service
   resolves and lists them. Commercial/self-hosted extensions register
   additional sources at construction time (`ServiceRepository`).
@@ -91,7 +104,7 @@ preview environments) and live under
 | --- | --- |
 | `GET /` | List registered sources |
 | `GET /{sourceType}/schema` | Scan one source's schema into the standard `{tables: [{reference, columns: [{reference, type}]}]}` shape |
-| `POST /queries` | Submit 1..n source queries → immediate `{nodeId, queryUuid}` per query |
+| `POST /queries` | Submit 1..n source queries → immediate `{nodeId, queryUuid}` per query. Optional `parameters` and `invalidateCache` apply to every query; a query may carry its own `pivotConfiguration` |
 | `GET /queries/status?queryUuids=...` | Batch status poll (standard async query lifecycle) |
 
 Individual results are fetched with the existing

--- a/packages/backend/src/controllers/v2/QuerySourceController.ts
+++ b/packages/backend/src/controllers/v2/QuerySourceController.ts
@@ -122,6 +122,11 @@ export class QuerySourceController extends BaseController {
                 projectUuid,
                 queries: body.queries,
                 context: context ?? QueryExecutionContext.MULTI_SOURCE_QUERY,
+                parameters: body.parameters ?? {},
+                // Overrides are a runtime concern (embed, MCP, AI agent); the
+                // HTTP API resolves attributes from the account alone
+                userAttributeOverrides: {},
+                invalidateCache: body.invalidateCache ?? false,
             });
         return { status: 'ok', results };
     }

--- a/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.test.ts
@@ -2121,6 +2121,9 @@ describe('AiAgentToolsService runComposerQueries', () => {
             projectUuid,
             queries: composerQueries,
             context: QueryExecutionContext.AI,
+            parameters: {},
+            userAttributeOverrides: {},
+            invalidateCache: false,
         });
         expect(getAsyncQueryResults).toHaveBeenCalledWith(
             expect.objectContaining({ queryUuid: 'query-2', page: 1 }),
@@ -2132,6 +2135,34 @@ describe('AiAgentToolsService runComposerQueries', () => {
             rows: [{ orders_total: 42 }],
             rowCount: 1,
         });
+    });
+
+    it('carries the runtime user attribute overrides into the pipeline', async () => {
+        const executeSourceQueries = vi
+            .fn()
+            .mockResolvedValue({ queries: submissions });
+        const getAsyncQueryResults = vi.fn().mockResolvedValue(readyResults);
+        const service = makeService({
+            querySourceService: { executeSourceQueries },
+            asyncQueryService: { getAsyncQueryResults },
+        });
+
+        await service
+            .createRuntime(
+                makeRuntimeContext({
+                    userAttributeOverrides: { tenant: ['acme'] },
+                }),
+            )
+            .runComposerQueries({
+                queries: composerQueries,
+                terminalNodeId: 'joined',
+            });
+
+        expect(executeSourceQueries).toHaveBeenCalledWith(
+            expect.objectContaining({
+                userAttributeOverrides: { tenant: ['acme'] },
+            }),
+        );
     });
 
     it('emits per-node status transitions while the pipeline executes', async () => {

--- a/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts
+++ b/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts
@@ -2868,6 +2868,10 @@ export class AiAgentToolsService extends BaseService {
                         projectUuid: context.projectUuid,
                         queries,
                         context: context.defaultQueryExecutionContext,
+                        parameters: {},
+                        userAttributeOverrides:
+                            context.userAttributeOverrides ?? {},
+                        invalidateCache: false,
                     });
 
                 // Per-node status emission is best-effort UI telemetry: only

--- a/packages/backend/src/ee/services/ExternalSourceService/ExternalQuerySource.test.ts
+++ b/packages/backend/src/ee/services/ExternalSourceService/ExternalQuerySource.test.ts
@@ -18,6 +18,10 @@ const submitArgs = {
     projectUuid: 'project-1',
     context: QueryExecutionContext.API,
     resolvedReferences: {},
+    parameters: {},
+    userAttributeOverrides: {},
+    invalidateCache: false,
+    pivotConfiguration: null,
 };
 
 describe('ExternalQuerySource', () => {
@@ -86,7 +90,49 @@ describe('ExternalQuerySource', () => {
                 monthly_targets: 'monthly_targets',
                 other_table: 'other_table',
             },
+            parameters: {},
+            invalidateCache: false,
         });
+    });
+
+    it('hands parameters and cache control to the external SQL execution', async () => {
+        await source.submitQuery({
+            ...submitArgs,
+            parameters: { region: 'EU' },
+            invalidateCache: true,
+            query: {
+                sourceType: QuerySourceType.EXTERNAL,
+                sql: 'SELECT * FROM t WHERE region = ${ld.parameters.region}',
+                tables: ['t'],
+            },
+        });
+
+        expect(executeAsyncExternalSqlQuery).toHaveBeenCalledWith(
+            expect.objectContaining({
+                parameters: { region: 'EU' },
+                invalidateCache: true,
+            }),
+        );
+    });
+
+    it('refuses a pivot until the join node owns the pivot stage', async () => {
+        await expect(
+            source.submitQuery({
+                ...submitArgs,
+                pivotConfiguration: {
+                    indexColumn: undefined,
+                    valuesColumns: [],
+                    groupByColumns: undefined,
+                    sortBy: undefined,
+                },
+                query: {
+                    sourceType: QuerySourceType.EXTERNAL,
+                    sql: 'SELECT * FROM t',
+                    tables: ['t'],
+                },
+            }),
+        ).rejects.toThrow(ParameterError);
+        expect(executeAsyncExternalSqlQuery).not.toHaveBeenCalled();
     });
 
     it('passes the map form through unchanged', async () => {

--- a/packages/backend/src/ee/services/ExternalSourceService/ExternalQuerySource.ts
+++ b/packages/backend/src/ee/services/ExternalSourceService/ExternalQuerySource.ts
@@ -120,13 +120,26 @@ export class ExternalQuerySource implements QuerySourceClient {
         return [];
     }
 
+    /**
+     * User attribute overrides have nothing to apply to: external tables are
+     * ingested files, not attribute-scoped SQL. A pivot refuses until the
+     * join node owns the pivot stage.
+     */
     async submitQuery({
         account,
         projectUuid,
         context,
         query,
+        parameters,
+        invalidateCache,
+        pivotConfiguration,
     }: SubmitSourceQueryArgs): Promise<{ queryUuid: string }> {
         const sourceQuery = ExternalQuerySource.assertSourceQuery(query);
+        if (pivotConfiguration !== null) {
+            throw new ParameterError(
+                `${QuerySourceType.EXTERNAL} queries do not support pivotConfiguration yet`,
+            );
+        }
 
         const results =
             await this.asyncQueryService.executeAsyncExternalSqlQuery({
@@ -136,6 +149,8 @@ export class ExternalQuerySource implements QuerySourceClient {
                 limit: sourceQuery.limit,
                 tables: ExternalQuerySource.normalizeTables(sourceQuery.tables),
                 context,
+                parameters,
+                invalidateCache,
             });
 
         return { queryUuid: results.queryUuid };

--- a/packages/backend/src/ee/services/ExternalSourceService/ExternalQuerySource.ts
+++ b/packages/backend/src/ee/services/ExternalSourceService/ExternalQuerySource.ts
@@ -34,6 +34,8 @@ export class ExternalQuerySource implements QuerySourceClient {
             'DuckDB SQL over external source tables (uploaded CSVs, connected Google Sheets). Tables expose ingested files as named tables: an array of table names, or a {tableName: tableNameOrUuid} map for aliasing. Column names are the ingested columns from scanSchema, not explore field ids. Join the result with warehouse data in a referencing duckdb query.',
     };
 
+    readonly supportsPivot = false;
+
     private readonly asyncQueryService: AsyncQueryService;
 
     private readonly projectService: ProjectService;

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -18,12 +18,14 @@ import {
     MissingConfigError,
     NotFoundError,
     OrganizationAccessStatus,
+    ParameterError,
     PersistentDownloadFileAccessMode,
     PossibleAbilities,
     QueryExecutionContext,
     QueryHistory,
     QueryHistoryStatus,
     QueryHistoryWindow,
+    QuerySourceType,
     QueryTrigger,
     ResultColumns,
     VizAggregationOptions,
@@ -95,6 +97,7 @@ import { OrganizationAccessService } from '../OrganizationAccessService/Organiza
 import { PermissionsService } from '../PermissionsService/PermissionsService';
 import { PersistentDownloadFileService } from '../PersistentDownloadFileService/PersistentDownloadFileService';
 import { PivotTableService } from '../PivotTableService/PivotTableService';
+import type { ProjectService } from '../ProjectService/ProjectService';
 import {
     allExplores,
     buildAccount,
@@ -112,6 +115,9 @@ import {
     tablesConfiguration,
     validExplore,
 } from '../ProjectService/ProjectService.mock';
+import { SemanticLayerQuerySource } from '../QuerySourceService/sources/SemanticLayerQuerySource';
+import { SqlQuerySource } from '../QuerySourceService/sources/SqlQuerySource';
+import type { SubmitSourceQueryArgs } from '../QuerySourceService/types';
 import { SpacePermissionService } from '../SpaceService/SpacePermissionService';
 import {
     AsyncQueryService,
@@ -5705,7 +5711,7 @@ describe('runDuckdbQuery', () => {
         queryUuid: 'duckdb-query-uuid',
         sql: 'SELECT 1 AS one',
         references: { kind: 'bound', referenceCtes: [] },
-        columns: { mode: 'discover', limit: undefined },
+        columns: { mode: 'discover', limit: undefined, parameters: {} },
         storedCompiledSql: null,
         warehouseClient: warehouseClientMock,
         queryTags: {} as AnyType,
@@ -6204,5 +6210,219 @@ describe('executeAsyncMergeQuery on the compose engine', () => {
             expect.objectContaining({ status: QueryHistoryStatus.ERROR }),
             expect.anything(),
         );
+    });
+});
+
+/**
+ * Query sources hand the submission's execution context to the execution
+ * path they wrap. Proven on the compiled query rather than on call shapes:
+ * a different attribute value is a different WHERE clause, a parameter
+ * value lands in the SQL, and a missing one refuses.
+ */
+describe('query sources carry the execution context', () => {
+    const attributeScopedExplore: Explore = {
+        ...validExplore,
+        tables: {
+            ...validExplore.tables,
+            a: {
+                ...validExplore.tables.a,
+                sqlWhere: 'region = ${lightdash.attribute.region}',
+                dimensions: {
+                    ...validExplore.tables.a.dimensions,
+                    region_param: {
+                        ...validExplore.tables.a.dimensions.dim1,
+                        name: 'region_param',
+                        label: 'region_param',
+                        sql: '${ld.parameters.region}',
+                        compiledSql: '${ld.parameters.region}',
+                    },
+                },
+            },
+        },
+    };
+
+    const submissionDefaults: Omit<SubmitSourceQueryArgs, 'query'> = {
+        account: sessionAccount,
+        projectUuid,
+        context: QueryExecutionContext.MULTI_SOURCE_QUERY,
+        resolvedReferences: {},
+        parameters: {},
+        userAttributeOverrides: {},
+        invalidateCache: false,
+        pivotConfiguration: null,
+    };
+
+    const createSemanticLayerHarness = () => {
+        const service = getMockedAsyncQueryService(lightdashConfigMock);
+        vi.spyOn(
+            service as AnyType,
+            'assertCustomSqlAuthorizedForQuery',
+        ).mockResolvedValue(undefined);
+        // The account's own attributes; overrides layer on top of these
+        service.getExploreWithUserAccessControls = vi.fn().mockResolvedValue({
+            explore: attributeScopedExplore,
+            userAccessControls: {
+                userAttributes: { region: ['base'] },
+                intrinsicUserAttributes: {},
+            },
+        });
+        (service as AnyType).getWarehouseCredentials = vi
+            .fn()
+            .mockResolvedValue(warehouseClientMock.credentials);
+        const executeAsyncQuery = vi.fn().mockResolvedValue({
+            queryUuid: 'queryUuid',
+            cacheMetadata: { cacheHit: false },
+        });
+        service['executeAsyncQuery'] = executeAsyncQuery;
+
+        const source = new SemanticLayerQuerySource({
+            asyncQueryService: service,
+            projectService: {} as ProjectService,
+        });
+        const submit = (
+            overrides: Partial<SubmitSourceQueryArgs> & {
+                dimensions?: string[];
+            },
+        ) =>
+            source.submitQuery({
+                ...submissionDefaults,
+                ...overrides,
+                query: {
+                    sourceType: QuerySourceType.SEMANTIC_LAYER,
+                    exploreName: attributeScopedExplore.name,
+                    dimensions: overrides.dimensions ?? ['a_dim1'],
+                    metrics: [],
+                },
+            });
+        const composerOf = (call: number): QueryComposer =>
+            executeAsyncQuery.mock.calls[call][0].queryComposer;
+        const sqlOf = (call: number) =>
+            composerOf(call).getSql({ columnLimit: 100 });
+        return { submit, composerOf, sqlOf, executeAsyncQuery };
+    };
+
+    test('a semantic-layer node compiles a different query per user attribute override', async () => {
+        const { submit, sqlOf } = createSemanticLayerHarness();
+
+        await submit({ userAttributeOverrides: { region: ['EU'] } });
+        await submit({ userAttributeOverrides: { region: ['US'] } });
+
+        const [euSql, usSql] = [sqlOf(0), sqlOf(1)];
+        expect(euSql).toContain("region = 'EU'");
+        expect(usSql).toContain("region = 'US'");
+        expect(euSql).not.toEqual(usSql);
+        // The override replaces the account's own value rather than adding to it
+        expect(euSql).not.toContain('base');
+        expect(usSql).not.toContain('base');
+    });
+
+    test('a semantic-layer node resolves parameter values and reports a missing one for refusal', async () => {
+        const { submit, sqlOf, composerOf } = createSemanticLayerHarness();
+        const dimensions = ['a_region_param'];
+
+        await submit({ dimensions, parameters: { region: 'EU' } });
+        expect(sqlOf(0)).toContain("'EU'");
+        expect(sqlOf(0)).not.toContain('ld.parameters');
+
+        // executeAsyncQuery turns a missing reference into an error row
+        // before anything runs; the composer is where it is detected
+        await submit({ dimensions, parameters: {} });
+        expect(composerOf(1).getMissingParameterReferences()).toEqual([
+            'region',
+        ]);
+    });
+
+    test('cache invalidation and pivot configuration reach the metric execution unchanged', async () => {
+        const { submit, composerOf, executeAsyncQuery } =
+            createSemanticLayerHarness();
+        const pivotConfiguration: PivotConfiguration = {
+            indexColumn: { reference: 'a_dim1', type: VizIndexType.CATEGORY },
+            valuesColumns: [
+                {
+                    reference: 'a_dim1',
+                    aggregation: VizAggregationOptions.COUNT,
+                },
+            ],
+            groupByColumns: undefined,
+            sortBy: undefined,
+        };
+
+        await submit({
+            userAttributeOverrides: { region: ['EU'] },
+            invalidateCache: true,
+            pivotConfiguration,
+        });
+
+        expect(executeAsyncQuery).toHaveBeenCalledWith(
+            expect.objectContaining({ invalidateCache: true }),
+            expect.any(Object),
+        );
+        expect(composerOf(0).getPivotConfiguration()).toEqual(
+            pivotConfiguration,
+        );
+    });
+
+    test('a sql node applies overrides and parameters to the executed SQL, bypasses the cache, and refuses a missing parameter', async () => {
+        const service = getMockedAsyncQueryService(lightdashConfigMock);
+        service.getUserAttributes = vi.fn(async () => ({
+            userAttributes: { region: ['base'] },
+            intrinsicUserAttributes: { email: 'test@example.com' },
+        }));
+        let capturedSql = '';
+        service._getWarehouseClient = vi.fn(async () => ({
+            warehouseClient: {
+                ...warehouseClientMock,
+                streamQuery: vi.fn(async (sql, callback) => {
+                    capturedSql = sql;
+                    await callback({
+                        fields: { test_col: { type: DimensionType.STRING } },
+                        rows: [],
+                    });
+                }),
+            },
+            sshTunnel: mockSshTunnel,
+            tunnelConnectMs: null,
+        }));
+        service.findResultsCache = vi.fn().mockResolvedValue({
+            cacheHit: false,
+            updatedAt: undefined,
+            expiresAt: undefined,
+        } satisfies MissCacheResult);
+        vi.spyOn(service, 'runAsyncWarehouseQuery').mockResolvedValue(
+            undefined,
+        );
+        const source = new SqlQuerySource({
+            asyncQueryService: service,
+            projectService: {} as ProjectService,
+        });
+        const query = {
+            sourceType: QuerySourceType.SQL,
+            sql: 'SELECT * FROM t WHERE region = ${lightdash.attribute.region} AND plan = ${ld.parameters.plan}',
+        } as const;
+
+        await source.submitQuery({
+            ...submissionDefaults,
+            query,
+            parameters: { plan: 'pro' },
+            userAttributeOverrides: { region: ['EU'] },
+            invalidateCache: true,
+        });
+
+        expect(capturedSql).toContain("region = 'EU'");
+        expect(capturedSql).toContain("plan = 'pro'");
+        expect(service.findResultsCache).toHaveBeenCalledWith(
+            projectUuid,
+            expect.any(String),
+            sessionAccount,
+            true,
+        );
+
+        await expect(
+            source.submitQuery({
+                ...submissionDefaults,
+                query,
+                userAttributeOverrides: { region: ['EU'] },
+            }),
+        ).rejects.toThrow(ParameterError);
     });
 });

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -6362,6 +6362,67 @@ describe('query sources carry the execution context', () => {
         );
     });
 
+    const createComposeEngineService = () =>
+        getMockedAsyncQueryService(lightdashConfigMock, {
+            featureFlagModel: {
+                get: vi.fn(
+                    async ({ featureFlagId }: { featureFlagId: string }) => ({
+                        id: featureFlagId,
+                        enabled: true,
+                    }),
+                ),
+            } as unknown as FeatureFlagModel,
+            preAggregateStrategy: makeMockStrategy({
+                resolved: false,
+                reason: 'not routed',
+                isFatal: false,
+            }),
+            externalSourceTableResolver: vi.fn(async () => ({
+                external_source_table_uuid: 'table-uuid',
+                external_source_scope: ExternalSourceScope.CATALOG,
+                external_source_created_by_user_uuid: sessionAccount.user.id,
+                version: 1,
+                locator: {
+                    format: 'parquet',
+                    uri: 's3://bucket/table.parquet',
+                },
+                columns: {
+                    region: { reference: 'region', type: DimensionType.STRING },
+                },
+            })),
+        } as never);
+
+    test('a compose SQL submit with a missing parameter refuses synchronously and creates no query history row', async () => {
+        const service = createComposeEngineService();
+
+        await expect(
+            service.executeAsyncComposeSqlQuery({
+                account: sessionAccount,
+                projectUuid,
+                context: QueryExecutionContext.MULTI_SOURCE_QUERY,
+                sql: 'SELECT * FROM t WHERE region = ${ld.parameters.region}',
+                parameters: {},
+            }),
+        ).rejects.toThrow(ParameterError);
+        expect(service.queryHistoryModel.create).not.toHaveBeenCalled();
+    });
+
+    test('an external SQL submit with a missing parameter refuses synchronously and creates no query history row', async () => {
+        const service = createComposeEngineService();
+
+        await expect(
+            service.executeAsyncExternalSqlQuery({
+                account: sessionAccount,
+                projectUuid,
+                context: QueryExecutionContext.MULTI_SOURCE_QUERY,
+                sql: 'SELECT * FROM t WHERE region = ${ld.parameters.region}',
+                tables: { t: 'table-uuid' },
+                parameters: {},
+            }),
+        ).rejects.toThrow(ParameterError);
+        expect(service.queryHistoryModel.create).not.toHaveBeenCalled();
+    });
+
     test('a sql node applies overrides and parameters to the executed SQL, bypasses the cache, and refuses a missing parameter', async () => {
         const service = getMockedAsyncQueryService(lightdashConfigMock);
         service.getUserAttributes = vi.fn(async () => ({

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -7204,6 +7204,8 @@ export class AsyncQueryService extends ProjectService {
             dashboardSorts: undefined,
         });
 
+        AsyncQueryService.throwIfMissingParameterValues(placeholderComposer);
+
         // Parameter values change the executed SQL without changing its text
         const cacheKey = QueryHistoryModel.getCacheKey(projectUuid, {
             sql: JSON.stringify({
@@ -7453,6 +7455,8 @@ export class AsyncQueryService extends ProjectService {
             dashboardSorts: undefined,
         });
 
+        AsyncQueryService.throwIfMissingParameterValues(placeholderComposer);
+
         const requestParameters: ExecuteAsyncExternalSqlQueryRequestParams = {
             sql,
             limit,
@@ -7539,6 +7543,19 @@ export class AsyncQueryService extends ProjectService {
                   ',\n',
               )}\nSELECT * FROM (\n${sql}\n) AS lightdash_user_query`
             : sql;
+    }
+
+    /** Refuses at submit time, before a query history row exists. */
+    private static throwIfMissingParameterValues(
+        composer: SqlQueryComposer,
+    ): void {
+        const missing = composer.getMissingParameterReferences();
+        if (missing.length > 0) {
+            throw new ParameterError(
+                `Missing values for SQL parameter(s): ${missing.join(', ')}`,
+                { missingReferences: missing },
+            );
+        }
     }
 
     /**

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -6838,6 +6838,7 @@ export class AsyncQueryService extends ProjectService {
         pivotConfiguration,
         limit,
         parameters,
+        userAttributeOverrides,
     }: ExecuteAsyncSqlQueryArgs): Promise<ApiExecuteAsyncSqlQueryResults> {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
@@ -6899,6 +6900,7 @@ export class AsyncQueryService extends ProjectService {
             limit,
             parameters: combinedParameters,
             pivotConfiguration,
+            userAttributeOverrides,
         });
 
         // Disconnect the ssh tunnel to avoid leaking connections, another client is created in the scheduler task
@@ -7111,6 +7113,7 @@ export class AsyncQueryService extends ProjectService {
         context,
         limit,
         references,
+        parameters,
     }: ExecuteAsyncComposeSqlQueryArgs): Promise<ApiExecuteAsyncSqlQueryResults> {
         assertIsAccountWithOrg(account);
 
@@ -7171,6 +7174,12 @@ export class AsyncQueryService extends ProjectService {
                 storage: 'results',
             });
 
+        const combinedParameters = await this.combineParameters(
+            projectUuid,
+            undefined,
+            parameters,
+        );
+
         const queryTags: RunQueryTags = {
             ...this.getUserQueryTags(account),
             ...AsyncQueryService.getSchedulerQueryTags(),
@@ -7189,16 +7198,18 @@ export class AsyncQueryService extends ProjectService {
             warehouseClient,
             pivotConfiguration: undefined,
             limit,
-            parameters: undefined,
+            parameters: combinedParameters,
             dashboardFilters: undefined,
             tileUuid: undefined,
             dashboardSorts: undefined,
         });
 
+        // Parameter values change the executed SQL without changing its text
         const cacheKey = QueryHistoryModel.getCacheKey(projectUuid, {
             sql: JSON.stringify({
                 sql,
                 references: normalizedReferences ?? null,
+                parameters: combinedParameters,
             }),
             userUuid: null,
         });
@@ -7208,6 +7219,7 @@ export class AsyncQueryService extends ProjectService {
             limit,
             context,
             references,
+            parameters: combinedParameters,
         };
 
         const queryCreatedAt = new Date();
@@ -7250,7 +7262,11 @@ export class AsyncQueryService extends ProjectService {
                 references: normalizedReferences ?? {},
                 guard: null,
             },
-            columns: { mode: 'discover', limit },
+            columns: {
+                mode: 'discover',
+                limit,
+                parameters: combinedParameters,
+            },
             storedCompiledSql: null,
             warehouseClient,
             queryTags,
@@ -7282,6 +7298,7 @@ export class AsyncQueryService extends ProjectService {
         context,
         limit,
         tables,
+        parameters,
     }: ExecuteAsyncExternalSqlQueryArgs): Promise<ApiExecuteAsyncSqlQueryResults> {
         assertIsAccountWithOrg(account);
 
@@ -7385,6 +7402,12 @@ export class AsyncQueryService extends ProjectService {
                 )})`,
         );
 
+        const combinedParameters = await this.combineParameters(
+            projectUuid,
+            undefined,
+            parameters,
+        );
+
         // Table versions invalidate cached SQL results after refresh.
         const externalSourceSalt = resolvedTables
             .map(({ tableUuid, version }) => `esv:${tableUuid}:${version}`)
@@ -7396,6 +7419,7 @@ export class AsyncQueryService extends ProjectService {
                 tables: [...tableEntries].sort(([a], [b]) =>
                     a.localeCompare(b),
                 ),
+                parameters: combinedParameters,
             }),
             userUuid: null,
             externalSourceSalt,
@@ -7423,7 +7447,7 @@ export class AsyncQueryService extends ProjectService {
             warehouseClient,
             pivotConfiguration: undefined,
             limit,
-            parameters: undefined,
+            parameters: combinedParameters,
             dashboardFilters: undefined,
             tileUuid: undefined,
             dashboardSorts: undefined,
@@ -7434,6 +7458,7 @@ export class AsyncQueryService extends ProjectService {
             limit,
             context,
             tables,
+            parameters: combinedParameters,
         };
 
         const queryCreatedAt = new Date();
@@ -7472,7 +7497,11 @@ export class AsyncQueryService extends ProjectService {
             queryUuid,
             sql,
             references: { kind: 'bound', referenceCtes },
-            columns: { mode: 'discover', limit },
+            columns: {
+                mode: 'discover',
+                limit,
+                parameters: combinedParameters,
+            },
             // Only persist the user SQL; resolved SQL contains private URIs.
             storedCompiledSql: sql,
             warehouseClient,
@@ -7675,6 +7704,7 @@ export class AsyncQueryService extends ProjectService {
                 return this.discoverDuckdbQueryColumns({
                     resolvedSql,
                     limit: columns.limit,
+                    parameters: columns.parameters,
                     warehouseClient,
                     queryTags,
                 });
@@ -7689,18 +7719,34 @@ export class AsyncQueryService extends ProjectService {
     private async discoverDuckdbQueryColumns({
         resolvedSql,
         limit,
+        parameters,
         warehouseClient,
         queryTags,
     }: {
         resolvedSql: string;
         limit: number | undefined;
+        parameters: ParametersValuesMap;
         warehouseClient: WarehouseClient;
         queryTags: RunQueryTags;
     }): Promise<DuckdbQueryExecution> {
-        // Column discovery (LIMIT 1) also validates the SQL
+        // Column discovery (LIMIT 1) also validates the SQL, so
+        // parameters resolve first and a missing value refuses here
+        const { replacedSql: sqlWithParameters, missingReferences } =
+            safeReplaceParametersWithSqlBuilder(
+                resolvedSql,
+                parameters,
+                warehouseClient,
+            );
+        if (missingReferences.size > 0) {
+            const missing = Array.from(missingReferences);
+            throw new ParameterError(
+                `Missing values for SQL parameter(s): ${missing.join(', ')}`,
+                { missingReferences: missing },
+            );
+        }
         const columns: { name: string; type: DimensionType }[] = [];
         const columnDiscoverySql = applyLimitToSqlQuery({
-            sqlQuery: resolvedSql,
+            sqlQuery: sqlWithParameters,
             limit: 1,
         });
         try {
@@ -7730,19 +7776,11 @@ export class AsyncQueryService extends ProjectService {
             warehouseClient,
             pivotConfiguration: undefined,
             limit,
-            parameters: undefined,
+            parameters,
             dashboardFilters: undefined,
             tileUuid: undefined,
             dashboardSorts: undefined,
         });
-        const compiled = composer.compile();
-        if (compiled.missingParameterReferences.size > 0) {
-            const missing = Array.from(compiled.missingParameterReferences);
-            throw new ParameterError(
-                `Missing values for SQL parameter(s): ${missing.join(', ')}`,
-                { missingReferences: missing },
-            );
-        }
 
         // Compose columns carry only the reference, the probed type, and
         // a label derived from the reference. Metadata is never inferred
@@ -8414,6 +8452,7 @@ export class AsyncQueryService extends ProjectService {
         pivotConfiguration,
         chartUuid,
         dashboardUuid,
+        userAttributeOverrides,
     }: {
         account: Account;
         projectUuid: string;
@@ -8429,6 +8468,7 @@ export class AsyncQueryService extends ProjectService {
         pivotConfiguration?: PivotConfiguration;
         chartUuid?: string;
         dashboardUuid?: string;
+        userAttributeOverrides?: UserAttributeValueMap;
     }) {
         const startTime = performance.now();
 
@@ -8437,7 +8477,7 @@ export class AsyncQueryService extends ProjectService {
         const sectionStartWarehouse = performance.now();
         const [
             warehouseCredentials,
-            { userAttributes, intrinsicUserAttributes },
+            { userAttributes: baseUserAttributes, intrinsicUserAttributes },
         ] = await Promise.all([
             this.getWarehouseCredentials({
                 projectUuid,
@@ -8447,6 +8487,9 @@ export class AsyncQueryService extends ProjectService {
             }),
             this.getUserAttributes({ account }),
         ]);
+        const userAttributes = userAttributeOverrides
+            ? { ...baseUserAttributes, ...userAttributeOverrides }
+            : baseUserAttributes;
         const warehouseConnection = await this._getWarehouseClient(
             projectUuid,
             warehouseCredentials,

--- a/packages/backend/src/services/AsyncQueryService/types.ts
+++ b/packages/backend/src/services/AsyncQueryService/types.ts
@@ -301,6 +301,7 @@ export type DuckdbQueryColumns =
           /** Probe the SQL with a one-row query: raw SQL has no known shape. */
           mode: 'discover';
           limit: number | undefined;
+          parameters: ParametersValuesMap;
       }
     | {
           /** Known at compile time, so nothing is probed and nothing overwritten. */

--- a/packages/backend/src/services/QuerySourceService/QuerySourceService.test.ts
+++ b/packages/backend/src/services/QuerySourceService/QuerySourceService.test.ts
@@ -44,6 +44,7 @@ const createFakeSource = (
         })),
 ): QuerySourceClient & { submitQuery: Mock } => ({
     definition: { sourceType, label: sourceType, description: 'fake source' },
+    supportsPivot: sourceType !== QuerySourceType.DUCKDB,
     scanSchema: vi.fn().mockResolvedValue({ sourceType, tables: [] }),
     getQueryReferences: (query: SourceQuery) => {
         if (query.sourceType !== QuerySourceType.DUCKDB) return [];
@@ -377,6 +378,59 @@ describe('QuerySourceService', () => {
                     pivotConfiguration: null,
                 }),
             );
+        });
+
+        it('refuses a pivot on a node that cannot pivot before submitting any node', async () => {
+            const fakes = createRegistryWithFakes();
+            const { service } = createService(fakes.registry);
+
+            await expect(
+                service.executeSourceQueries({
+                    ...executionContext,
+                    account,
+                    projectUuid,
+                    context: QueryExecutionContext.MULTI_SOURCE_QUERY,
+                    queries: [
+                        {
+                            nodeId: 'orders',
+                            sourceType: QuerySourceType.SEMANTIC_LAYER,
+                            exploreName: 'orders',
+                            dimensions: ['orders_status'],
+                            metrics: ['orders_total'],
+                        },
+                        {
+                            nodeId: 'payments',
+                            sourceType: QuerySourceType.SEMANTIC_LAYER,
+                            exploreName: 'payments',
+                            dimensions: ['payments_status'],
+                            metrics: ['payments_total'],
+                        },
+                        {
+                            nodeId: 'joined',
+                            sourceType: QuerySourceType.DUCKDB,
+                            sql: 'SELECT * FROM orders JOIN payments USING (status)',
+                            references: ['orders', 'payments'],
+                            pivotConfiguration: {
+                                indexColumn: undefined,
+                                valuesColumns: [],
+                                groupByColumns: undefined,
+                                sortBy: undefined,
+                            },
+                        },
+                    ],
+                }),
+            ).rejects.toThrow(
+                expect.objectContaining({
+                    name: ParameterError.name,
+                    message: expect.stringContaining('"joined"'),
+                }),
+            );
+
+            // Nothing ran: the legs never reached the warehouse
+            expect(
+                fakes.semanticLayerSource.submitQuery,
+            ).not.toHaveBeenCalled();
+            expect(fakes.duckdbSource.submitQuery).not.toHaveBeenCalled();
         });
 
         it('requires user attribute overrides on the submit contract', () => {

--- a/packages/backend/src/services/QuerySourceService/QuerySourceService.test.ts
+++ b/packages/backend/src/services/QuerySourceService/QuerySourceService.test.ts
@@ -4,6 +4,9 @@ import {
     QueryExecutionContext,
     QueryHistoryStatus,
     QuerySourceType,
+    VizAggregationOptions,
+    VizIndexType,
+    type PivotConfiguration,
     type SourceQuery,
 } from '@lightdash/common';
 import type { Mock } from 'vitest';
@@ -17,11 +20,20 @@ import { QuerySourceRegistry } from './QuerySourceRegistry';
 import { QuerySourceService } from './QuerySourceService';
 import { DuckdbQuerySource } from './sources/DuckdbQuerySource';
 import { SemanticLayerQuerySource } from './sources/SemanticLayerQuerySource';
-import type { QuerySourceClient } from './types';
+import type {
+    QuerySourceClient,
+    SourceQueryExecutionContext,
+    SubmitSourceQueryArgs,
+} from './types';
 
 const account = buildAccount();
 const projectUuid = 'test-project-uuid';
 const organizationUuid = 'test-org-uuid';
+const executionContext: SourceQueryExecutionContext = {
+    parameters: {},
+    userAttributeOverrides: {},
+    invalidateCache: false,
+};
 
 const createFakeSource = (
     sourceType: QuerySourceType,
@@ -117,6 +129,7 @@ describe('QuerySourceService', () => {
             const fakes = createRegistryWithFakes();
             const { service } = createService(fakes.registry);
             return service.executeSourceQueries({
+                ...executionContext,
                 account,
                 projectUuid,
                 queries,
@@ -214,6 +227,7 @@ describe('QuerySourceService', () => {
 
             await expect(
                 service.executeSourceQueries({
+                    ...executionContext,
                     account,
                     projectUuid,
                     queries: [
@@ -231,6 +245,7 @@ describe('QuerySourceService', () => {
             const { service } = createService(fakes.registry);
 
             const results = await service.executeSourceQueries({
+                ...executionContext,
                 account,
                 projectUuid,
                 queries: [{ sourceType: QuerySourceType.SQL, sql: 'SELECT 1' }],
@@ -255,6 +270,7 @@ describe('QuerySourceService', () => {
             // The merge query comes first in the payload; submission order
             // must still be dependencies-first
             const results = await service.executeSourceQueries({
+                ...executionContext,
                 account,
                 projectUuid,
                 queries: [
@@ -299,6 +315,89 @@ describe('QuerySourceService', () => {
             expect(mergeSubmission?.queryUuid).toEqual('merged-query-uuid');
         });
 
+        it('hands every source the submission execution context and its own pivot', async () => {
+            const fakes = createRegistryWithFakes();
+            const { service } = createService(fakes.registry);
+            const pivotConfiguration: PivotConfiguration = {
+                indexColumn: {
+                    reference: 'orders_status',
+                    type: VizIndexType.CATEGORY,
+                },
+                valuesColumns: [
+                    {
+                        reference: 'orders_total',
+                        aggregation: VizAggregationOptions.SUM,
+                    },
+                ],
+                groupByColumns: undefined,
+                sortBy: undefined,
+            };
+
+            await service.executeSourceQueries({
+                account,
+                projectUuid,
+                context: QueryExecutionContext.MULTI_SOURCE_QUERY,
+                parameters: { region: 'EU' },
+                userAttributeOverrides: { tenant: ['acme'] },
+                invalidateCache: true,
+                queries: [
+                    {
+                        nodeId: 'orders',
+                        sourceType: QuerySourceType.SEMANTIC_LAYER,
+                        exploreName: 'orders',
+                        dimensions: ['orders_status'],
+                        metrics: ['orders_total'],
+                        pivotConfiguration,
+                    },
+                    {
+                        nodeId: 'summary',
+                        sourceType: QuerySourceType.DUCKDB,
+                        sql: 'SELECT * FROM orders',
+                        references: ['orders'],
+                    },
+                ],
+            });
+
+            const sharedContext = {
+                parameters: { region: 'EU' },
+                userAttributeOverrides: { tenant: ['acme'] },
+                invalidateCache: true,
+            };
+            expect(fakes.semanticLayerSource.submitQuery).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    ...sharedContext,
+                    pivotConfiguration,
+                }),
+            );
+            // The pivot belongs to the node that declared it; nodes without
+            // one get an explicit null, never the neighbour's pivot
+            expect(fakes.duckdbSource.submitQuery).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    ...sharedContext,
+                    pivotConfiguration: null,
+                }),
+            );
+        });
+
+        it('requires user attribute overrides on the submit contract', () => {
+            const args: SubmitSourceQueryArgs = {
+                account,
+                projectUuid,
+                context: QueryExecutionContext.MULTI_SOURCE_QUERY,
+                query: { sourceType: QuerySourceType.SQL, sql: 'SELECT 1' },
+                resolvedReferences: {},
+                parameters: {},
+                userAttributeOverrides: {},
+                invalidateCache: false,
+                pivotConfiguration: null,
+            };
+            const { userAttributeOverrides, ...withoutOverrides } = args;
+            // @ts-expect-error omitting the overrides is a compile error, not a silent default
+            const rejected: SubmitSourceQueryArgs = withoutOverrides;
+            expect(rejected).not.toHaveProperty('userAttributeOverrides');
+            expect(userAttributeOverrides).toEqual({});
+        });
+
         it('propagates submit failures as-is', async () => {
             const fakes = createRegistryWithFakes();
             fakes.sqlSource.submitQuery.mockRejectedValue(
@@ -308,6 +407,7 @@ describe('QuerySourceService', () => {
 
             await expect(
                 service.executeSourceQueries({
+                    ...executionContext,
                     account,
                     projectUuid,
                     queries: [
@@ -404,6 +504,7 @@ describe('composer pipelines return the standard results interface', () => {
         const { service } = createService(registry);
 
         const result = await service.executeSourceQueries({
+            ...executionContext,
             account,
             projectUuid,
             context: QueryExecutionContext.MULTI_SOURCE_QUERY,
@@ -446,6 +547,7 @@ describe('composer pipelines return the standard results interface', () => {
         const { service } = createService(registry);
 
         const result = await service.executeSourceQueries({
+            ...executionContext,
             account,
             projectUuid,
             context: QueryExecutionContext.MULTI_SOURCE_QUERY,
@@ -488,5 +590,54 @@ describe('composer pipelines return the standard results interface', () => {
                 references: { orders: 'metric-query-uuid' },
             }),
         );
+    });
+
+    it('hands a DuckDB node its parameters and cache control, and refuses a pivot on it', async () => {
+        const { registry, asyncQueryService } = createRealSources();
+        const { service } = createService(registry);
+        const duckdbNode: SourceQuery = {
+            sourceType: QuerySourceType.DUCKDB,
+            nodeId: 'summary',
+            sql: 'SELECT * FROM t WHERE region = ${ld.parameters.region}',
+            references: { t: '123e4567-e89b-12d3-a456-426614174000' },
+        };
+
+        await service.executeSourceQueries({
+            account,
+            projectUuid,
+            context: QueryExecutionContext.MULTI_SOURCE_QUERY,
+            parameters: { region: 'EU' },
+            userAttributeOverrides: {},
+            invalidateCache: true,
+            queries: [duckdbNode],
+        });
+        expect(
+            asyncQueryService.executeAsyncComposeSqlQuery,
+        ).toHaveBeenCalledWith(
+            expect.objectContaining({
+                parameters: { region: 'EU' },
+                invalidateCache: true,
+            }),
+        );
+
+        await expect(
+            service.executeSourceQueries({
+                ...executionContext,
+                account,
+                projectUuid,
+                context: QueryExecutionContext.MULTI_SOURCE_QUERY,
+                queries: [
+                    {
+                        ...duckdbNode,
+                        pivotConfiguration: {
+                            indexColumn: undefined,
+                            valuesColumns: [],
+                            groupByColumns: undefined,
+                            sortBy: undefined,
+                        },
+                    },
+                ],
+            }),
+        ).rejects.toThrow(ParameterError);
     });
 });

--- a/packages/backend/src/services/QuerySourceService/QuerySourceService.ts
+++ b/packages/backend/src/services/QuerySourceService/QuerySourceService.ts
@@ -187,6 +187,17 @@ export class QuerySourceService extends BaseService {
         const validated = queries.map((query): ValidatedQuery => {
             const nodeId = query.nodeId ?? generateNodeId();
             const source = this.registry.get(query.sourceType);
+            // Refused here, before any node is submitted: a refusal inside
+            // the submit loop would leave upstream nodes running with no
+            // queryUuid handed back to poll or cancel
+            if (
+                query.pivotConfiguration !== undefined &&
+                !source.supportsPivot
+            ) {
+                throw new ParameterError(
+                    `Query "${nodeId}" carries a pivotConfiguration, which ${query.sourceType} queries do not support yet`,
+                );
+            }
             const references = source.getQueryReferences(query);
             const dependsOn = [
                 ...new Set(

--- a/packages/backend/src/services/QuerySourceService/QuerySourceService.ts
+++ b/packages/backend/src/services/QuerySourceService/QuerySourceService.ts
@@ -19,7 +19,7 @@ import type { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import type { QueryHistoryModel } from '../../models/QueryHistoryModel/QueryHistoryModel';
 import { BaseService } from '../BaseService';
 import type { QuerySourceRegistry } from './QuerySourceRegistry';
-import type { QuerySourceClient } from './types';
+import type { QuerySourceClient, SourceQueryExecutionContext } from './types';
 
 type QuerySourceServiceArguments = {
     projectModel: ProjectModel;
@@ -263,7 +263,10 @@ export class QuerySourceService extends BaseService {
         projectUuid,
         queries,
         context,
-    }: {
+        parameters,
+        userAttributeOverrides,
+        invalidateCache,
+    }: SourceQueryExecutionContext & {
         account: Account;
         projectUuid: string;
         queries: SourceQuery[];
@@ -286,6 +289,10 @@ export class QuerySourceService extends BaseService {
                 context,
                 query: entry.query,
                 resolvedReferences: { ...resolvedReferences },
+                parameters,
+                userAttributeOverrides,
+                invalidateCache,
+                pivotConfiguration: entry.query.pivotConfiguration ?? null,
             });
             resolvedReferences[entry.nodeId] = queryUuid;
             submissions.push({

--- a/packages/backend/src/services/QuerySourceService/sources/DuckdbQuerySource.ts
+++ b/packages/backend/src/services/QuerySourceService/sources/DuckdbQuerySource.ts
@@ -74,14 +74,27 @@ export class DuckdbQuerySource implements QuerySourceClient {
         );
     }
 
+    /**
+     * User attribute overrides have nothing to apply to here: referenced
+     * results were produced under them and compose SQL carries no attribute
+     * references. A pivot refuses until the join node owns the pivot stage.
+     */
     async submitQuery({
         account,
         projectUuid,
         context,
         query,
         resolvedReferences,
+        parameters,
+        invalidateCache,
+        pivotConfiguration,
     }: SubmitSourceQueryArgs): Promise<{ queryUuid: string }> {
         const sourceQuery = DuckdbQuerySource.assertSourceQuery(query);
+        if (pivotConfiguration !== null) {
+            throw new ParameterError(
+                `${QuerySourceType.DUCKDB} queries do not support pivotConfiguration yet`,
+            );
+        }
 
         const normalized = DuckdbQuerySource.normalizeReferences(
             sourceQuery.references,
@@ -103,6 +116,8 @@ export class DuckdbQuerySource implements QuerySourceClient {
                 limit: sourceQuery.limit,
                 references,
                 context,
+                parameters,
+                invalidateCache,
             });
 
         return { queryUuid: results.queryUuid };

--- a/packages/backend/src/services/QuerySourceService/sources/DuckdbQuerySource.ts
+++ b/packages/backend/src/services/QuerySourceService/sources/DuckdbQuerySource.ts
@@ -31,6 +31,8 @@ export class DuckdbQuerySource implements QuerySourceClient {
             'DuckDB SQL over other query results. References expose results as named tables: an array of node ids (each a table named by its node id) or a {tableName: nodeIdOrQueryUuid} map. A referenced result keeps the column names of the query that produced it — field ids for semanticLayer queries, SELECT output names for sql queries. References to still-running queries are waited on.',
     };
 
+    readonly supportsPivot = false;
+
     private readonly asyncQueryService: AsyncQueryService;
 
     constructor(args: DuckdbQuerySourceArguments) {

--- a/packages/backend/src/services/QuerySourceService/sources/SemanticLayerQuerySource.ts
+++ b/packages/backend/src/services/QuerySourceService/sources/SemanticLayerQuerySource.ts
@@ -132,6 +132,10 @@ export class SemanticLayerQuerySource implements QuerySourceClient {
         projectUuid,
         context,
         query,
+        parameters,
+        userAttributeOverrides,
+        invalidateCache,
+        pivotConfiguration,
     }: SubmitSourceQueryArgs): Promise<{ queryUuid: string }> {
         const sourceQuery = SemanticLayerQuerySource.assertSourceQuery(query);
 
@@ -155,6 +159,10 @@ export class SemanticLayerQuerySource implements QuerySourceClient {
             projectUuid,
             metricQuery,
             context,
+            parameters,
+            userAttributeOverrides,
+            invalidateCache,
+            pivotConfiguration: pivotConfiguration ?? undefined,
         });
 
         return { queryUuid: results.queryUuid };

--- a/packages/backend/src/services/QuerySourceService/sources/SemanticLayerQuerySource.ts
+++ b/packages/backend/src/services/QuerySourceService/sources/SemanticLayerQuerySource.ts
@@ -41,6 +41,8 @@ export class SemanticLayerQuerySource implements QuerySourceClient {
             'Metric queries against the explores of this project. Tables are explores; columns are their dimensions and metrics, referenced by field id. Result columns are named by field id — exactly the dimensions and metrics requested.',
     };
 
+    readonly supportsPivot = true;
+
     private readonly asyncQueryService: AsyncQueryService;
 
     private readonly projectService: ProjectService;

--- a/packages/backend/src/services/QuerySourceService/sources/SqlQuerySource.ts
+++ b/packages/backend/src/services/QuerySourceService/sources/SqlQuerySource.ts
@@ -97,6 +97,10 @@ export class SqlQuerySource implements QuerySourceClient {
         projectUuid,
         context,
         query,
+        parameters,
+        userAttributeOverrides,
+        invalidateCache,
+        pivotConfiguration,
     }: SubmitSourceQueryArgs): Promise<{ queryUuid: string }> {
         const sourceQuery = SqlQuerySource.assertSourceQuery(query);
 
@@ -105,8 +109,11 @@ export class SqlQuerySource implements QuerySourceClient {
             projectUuid,
             sql: sourceQuery.sql,
             limit: sourceQuery.limit,
-            invalidateCache: false,
             context,
+            parameters,
+            userAttributeOverrides,
+            invalidateCache,
+            pivotConfiguration: pivotConfiguration ?? undefined,
         });
 
         return { queryUuid: results.queryUuid };

--- a/packages/backend/src/services/QuerySourceService/sources/SqlQuerySource.ts
+++ b/packages/backend/src/services/QuerySourceService/sources/SqlQuerySource.ts
@@ -36,6 +36,8 @@ export class SqlQuerySource implements QuerySourceClient {
             'Raw SQL against the project data warehouse. Tables are referenced as database.schema.table in the SQL dialect of the warehouse. Result columns are named by the SELECT output names.',
     };
 
+    readonly supportsPivot = true;
+
     private readonly asyncQueryService: AsyncQueryService;
 
     private readonly projectService: ProjectService;

--- a/packages/backend/src/services/QuerySourceService/types.ts
+++ b/packages/backend/src/services/QuerySourceService/types.ts
@@ -1,9 +1,12 @@
 import type {
     Account,
+    ParametersValuesMap,
+    PivotConfiguration,
     QueryExecutionContext,
     QuerySourceDefinition,
     QuerySourceSchema,
     SourceQuery,
+    UserAttributeValueMap,
 } from '@lightdash/common';
 
 export type ScanSchemaArgs = {
@@ -11,7 +14,23 @@ export type ScanSchemaArgs = {
     projectUuid: string;
 };
 
-export type SubmitSourceQueryArgs = {
+/**
+ * Execution context shared by every query of one submission. Each field is
+ * required so a caller decides it explicitly; none of them defaults.
+ */
+export type SourceQueryExecutionContext = {
+    /** Parameter values every node resolves its references against. */
+    parameters: ParametersValuesMap;
+    /**
+     * Never optional: overrides come from the caller's runtime (embed, MCP,
+     * AI agent) and a dropped override shows a user another tenant's rows.
+     * Callers without overrides pass an empty map.
+     */
+    userAttributeOverrides: UserAttributeValueMap;
+    invalidateCache: boolean;
+};
+
+export type SubmitSourceQueryArgs = SourceQueryExecutionContext & {
     account: Account;
     projectUuid: string;
     context: QueryExecutionContext;
@@ -22,6 +41,8 @@ export type SubmitSourceQueryArgs = {
      * existing results and pass through unchanged.
      */
     resolvedReferences: Record<string, string>;
+    /** The node's own pivot, lifted off the query so every source reads one place. */
+    pivotConfiguration: PivotConfiguration | null;
 };
 
 /**

--- a/packages/backend/src/services/QuerySourceService/types.ts
+++ b/packages/backend/src/services/QuerySourceService/types.ts
@@ -59,6 +59,8 @@ export type SubmitSourceQueryArgs = SourceQueryExecutionContext & {
  */
 export interface QuerySourceClient {
     definition: QuerySourceDefinition;
+    /** Whether a query of this source may carry a pivotConfiguration. */
+    supportsPivot: boolean;
     scanSchema(args: ScanSchemaArgs): Promise<QuerySourceSchema>;
     getQueryReferences(query: SourceQuery): string[];
     submitQuery(args: SubmitSourceQueryArgs): Promise<{ queryUuid: string }>;

--- a/packages/common/src/types/querySources.ts
+++ b/packages/common/src/types/querySources.ts
@@ -11,6 +11,8 @@ import {
     type MetricQueryRequest,
     type SortField,
 } from './metricQuery';
+import { type ParametersValuesMap } from './parameters';
+import { type PivotConfiguration } from './pivot';
 import { type QueryHistoryStatus } from './queryHistory';
 
 /**
@@ -100,6 +102,12 @@ export type SemanticLayerSourceQuery = {
     customDimensions?: CustomDimension[];
     /** IANA timezone for time dimension bucketing, e.g. "America/New_York". */
     timezone?: string;
+    /**
+     * Pivots this node's result the way a pivoted chart does. Honoured by
+     * semanticLayer and sql nodes; duckdb and external nodes refuse it until
+     * the join node owns the pivot stage.
+     */
+    pivotConfiguration?: PivotConfiguration;
 };
 
 /** A raw warehouse SQL query as a source query. */
@@ -109,6 +117,12 @@ export type SqlSourceQuery = {
     nodeId?: QueryNodeId;
     sql: string;
     limit?: number;
+    /**
+     * Pivots this node's result the way a pivoted chart does. Honoured by
+     * semanticLayer and sql nodes; duckdb and external nodes refuse it until
+     * the join node owns the pivot stage.
+     */
+    pivotConfiguration?: PivotConfiguration;
 };
 
 /**
@@ -138,6 +152,12 @@ export type DuckdbSourceQuery = {
     references?:
         | QueryNodeId[]
         | Record<QuerySourceTableName, QueryResultReference>;
+    /**
+     * Pivots this node's result the way a pivoted chart does. Honoured by
+     * semanticLayer and sql nodes; duckdb and external nodes refuse it until
+     * the join node owns the pivot stage.
+     */
+    pivotConfiguration?: PivotConfiguration;
 };
 
 /**
@@ -156,6 +176,12 @@ export type ExternalSourceQuery = {
     tables:
         | ExternalSourceTableReference[]
         | Record<QuerySourceTableName, ExternalSourceTableReference>;
+    /**
+     * Pivots this node's result the way a pivoted chart does. Honoured by
+     * semanticLayer and sql nodes; duckdb and external nodes refuse it until
+     * the join node owns the pivot stage.
+     */
+    pivotConfiguration?: PivotConfiguration;
 };
 
 /**
@@ -210,6 +236,14 @@ export type ExecuteSourceQueriesRequestParams = {
      */
     queries: SourceQuery[];
     context?: QueryExecutionContext;
+    /**
+     * Parameter values shared by every query in the submission, layered over
+     * project and explore defaults. A query referencing a parameter with no
+     * value refuses rather than running with a placeholder.
+     */
+    parameters?: ParametersValuesMap;
+    /** Bypass cached results for every query in the submission. */
+    invalidateCache?: boolean;
 };
 
 /** One submitted query: its (possibly generated) node id and the queryUuid to poll. */


### PR DESCRIPTION
## What

A query source node can be submitted with the full execution context a real query needs: parameter values, user attribute overrides, cache invalidation and pivot configuration. User attribute overrides are required on the type.

## Why

The submit contract shared by every query source carried only the account, project, execution context, the query and its resolved references. A merge depends on all four missing fields, so no merge could execute as a DAG without losing behaviour. Overrides in particular were already silently dropped on the merge path once and fixed as an embed row-level-security risk; an optional field invites that regression back, and the failure mode is a user seeing another tenant's rows.

## How

- **`SourceQueryExecutionContext`** (`services/QuerySourceService/types.ts`): `parameters`, `userAttributeOverrides`, `invalidateCache`, all required, folded into `SubmitSourceQueryArgs` with `pivotConfiguration: PivotConfiguration | null`. Omitting overrides is a compile error (pinned with `@ts-expect-error`).
- **Wire shape, expand-only** (`common/types/querySources.ts`): request params gain optional `parameters` and `invalidateCache`; each node type gains optional `pivotConfiguration`. Nothing removed or renamed.
- **All four sources honour it**: semantic layer and SQL apply overrides and parameters; DuckDB and external sources take parameters and cache control. A pivot on a node that cannot pivot (DuckDB/external, until the join node owns pivoting in PROD-10902) is *refused before any node is submitted*: `QuerySourceClient.supportsPivot` is checked in `validateQueries`, so sibling legs are never started (review found the first cut refused mid-DAG with legs already running; fixed in `83190e91f3`). The per-source refusal stays as defence in depth.
- **`AsyncQueryService`**: `executeAsyncSqlQuery` now honours `userAttributeOverrides`; the compose/external tails resolve parameters (project defaults combined, cache key salted). A missing parameter value now refuses *synchronously at submit* (`throwIfMissingParameterValues` at the head of `executeAsyncComposeSqlQuery` / `executeAsyncExternalSqlQuery`), before a query-history row is created; the background check on the resolved SQL remains.
- **Controller and AI tool** pass the context; `runComposerQueries` now forwards the runtime user attribute overrides into the pipeline.
- Docs: `docs/multi-source-queries.md`, `docs/merge-queries/architecture.md`.

## Regression analysis

- **Existing composer callers** (controller, AI tool): request bodies unchanged in shape; new fields optional. Callers that passed no overrides now pass the resolved map explicitly.
- **Raw compose SQL path**: two real behaviour changes. `executeAsyncSqlQuery` applies user attribute overrides where it previously did not; parameter substitution moved ahead of the column-discovery probe, so the probe sees resolved SQL and a missing parameter refuses before any query runs. Both are the intended direction.
- **Cache keys**: salted with parameter values on the compose/external tails, so a different parameter value no longer hits a stale entry.
- **Pivot on DuckDB/external nodes**: previously not expressible; now refused explicitly and pre-submission. No caller sends it today.
- **Missing parameter on compose/external SQL**: previously surfaced as a query-history ERROR after the caller already held a queryUuid; now a 4xx at submit with no row created.
- **API generation**: `pnpm generate-api` succeeded; MCP tool snapshot unchanged (tool schema untouched); generated files not committed.

## Tests

- `QuerySourceService.test.ts`: every source receives the context and its own pivot; overrides required at compile time; DuckDB refuses a pivot. `ExternalQuerySource.test.ts`: parameters/cache control; pivot refused.
- `AsyncQueryService.test.ts`: a semantic-layer node compiles a different query per override (`region = 'EU'` vs `'US'`); parameters resolve and a missing one refuses; SQL node applies overrides and parameters, bypasses cache, refuses a missing parameter; cache invalidation and pivot reach `executeAsyncMetricQuery` unchanged.
- `AiAgentToolsService.test.ts`: runtime overrides carried into the pipeline.
- `QuerySourceService.test.ts`: refuses a pivot on a node that cannot pivot before submitting any node. `AsyncQueryService.test.ts`: compose SQL and external SQL submits with a missing parameter refuse synchronously and create no query-history row.
- Backend `571 files / 9330 passed` after the review fix; common `174 files / 4085 passed`; typecheck (common, backend, frontend) and lint clean.

Part of the Query & Explore V2 milestone "One execution path: merge as composition". Independent of #28576.

Closes: PROD-10897

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LyhpDxbUsZ9YXhk8GJVPjM
