### PR TITLE
refactor(compose): one DuckDB execution tail for compose SQL, external SQL and merges

### DIFF
--- a/docs/merge-queries/architecture.md
+++ b/docs/merge-queries/architecture.md
@@ -66,16 +66,21 @@ any of it.
 | --- | --- | --- | --- |
 | `runAsyncPreAggregateQuery` | Managed pre-aggregates | its own | materialized table |
 | `runExternalSourceQuery` | External-source explores | its own, scoped client | `read_parquet` |
-| `executeAsyncComposeSqlQuery` | Compose SQL runner | `runDuckdbSqlQuery` | `read_json` |
-| `executeAsyncExternalSqlQuery` | External SQL as a DAG node | `runDuckdbSqlQuery` | `read_parquet` |
-| `tryExecuteComposeMergeQuery` | Merge | its own, private | `read_json` |
+| `executeAsyncComposeSqlQuery` | Compose SQL runner | `runDuckdbQuery`, discover | `read_json` |
+| `executeAsyncExternalSqlQuery` | External SQL as a DAG node | `runDuckdbQuery`, discover | `read_parquet` |
+| `tryExecuteComposeMergeQuery` | Merge | `runDuckdbQuery`, supplied | `read_json` |
 
 Two things follow from that table.
 
-**Merge is the only caller with a private tail** and the only one absent from
-`QuerySourceRegistry`. Unifying the tail is prefactoring for the DAG work: one
-function with two modes, discovering columns by probe for raw SQL, or accepting
-a supplied fields map for a merge whose columns are known at compile time.
+**Compose SQL, external SQL and merges share one tail**, `runDuckdbQuery`,
+with two column modes: *discover* probes raw SQL with a one-row query because
+nobody knows its shape ahead of time; *supplied* takes the fields map, columns
+and pivot a merge already produced at compile time, so no probe runs and the
+labels, formats and provenance survive. References are either *bound* (CTEs
+built at submit time, as external SQL does) or *queries* waited on until they
+complete, with a guard between "references complete" and "query builds" that
+carries the merge row-cap refusal. Merge is still the only caller absent from
+`QuerySourceRegistry`; the shared tail is what the DAG work plugs into.
 
 **Parquet versus JSONL is the entire fidelity story.** Ingested data is written
 as parquet and carries its own schema. Referenced query results are written as

--- a/docs/multi-source-queries.md
+++ b/docs/multi-source-queries.md
@@ -72,7 +72,7 @@ than referencing expired results.
 - `QuerySourceService.ts` — endpoint logic: validation, dependency-ordered
   submission, batch status.
 
-The reference wait lives in `AsyncQueryService.runComposeSqlQuery` (the
+The reference wait lives in `AsyncQueryService.runDuckdbQuery` (the
 background phase of `executeAsyncComposeSqlQuery`): references are validated
 and authorized at submit time with the exact access checks of fetching results
 by uuid, then resolved to S3-backed CTEs once the referenced queries complete.

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -13,6 +13,7 @@ import {
     FieldType,
     FilterOperator,
     ForbiddenError,
+    MergeJoinType,
     MetricType,
     MissingConfigError,
     NotFoundError,
@@ -31,8 +32,12 @@ import {
     WarehouseTypes,
     type Explore,
     type ItemsMap,
+    type MergeFieldTypes,
+    type MergeQuery,
+    type MergeTypedColumn,
     type MetricQuery,
     type ParameterDefinitions,
+    type PivotConfiguration,
     type ProjectDefaults,
     type UserAccessControls,
 } from '@lightdash/common';
@@ -116,6 +121,7 @@ import {
     COMPOSE_ENGINE_INSTANCE_CACHE_KEY,
     ComposeEngineClient,
 } from './ComposeEngineClient';
+import { buildComposeMergeOriginalColumns } from './mergeQueryExecution';
 import {
     NoOpPreAggregateStrategy,
     type PreAggregateExecutionResolution,
@@ -125,6 +131,7 @@ import type {
     DownloadAsyncQueryResultsArgs,
     ExecuteAsyncQueryReturn,
     RunAsyncWarehouseQueryArgs,
+    RunDuckdbQueryArgs,
 } from './types';
 
 const noOpStrategy = new NoOpPreAggregateStrategy();
@@ -5625,16 +5632,7 @@ describe('getQueryHistoryList', () => {
     });
 });
 
-describe('runComposeMergeQuery row cap refusal', () => {
-    const SOURCE_ROW_CAP = 3;
-
-    // Lowered through config rather than by seeding cap-many rows: the run
-    // path reads the cap from the same config the legs were submitted with.
-    const cappedConfig = {
-        ...lightdashConfigMock,
-        query: { ...lightdashConfigMock.query, maxLimit: SOURCE_ROW_CAP },
-    };
-
+describe('runDuckdbQuery', () => {
     const legHistory = (totalRowCount: number | null) =>
         ({
             queryUuid: 'leg-uuid',
@@ -5643,89 +5641,563 @@ describe('runComposeMergeQuery row cap refusal', () => {
             totalRowCount,
             resultsFileName: 'leg-results.jsonl',
             resultsExpiresAt: null,
-            columns: {},
+            columns: { one: { reference: 'one', type: DimensionType.NUMBER } },
             context: QueryExecutionContext.EXPLORE,
         }) as unknown as QueryHistory;
 
-    const runRefusalCase = async (totalRowCount: number | null) => {
-        const service = getMockedAsyncQueryService(cappedConfig);
-        const storageClient = service.resultsStorageClient as unknown as {
-            configuration: { bucket: string };
-        };
-        storageClient.configuration = { bucket: 'results-bucket' };
+    type DuckdbQueryRunner = {
+        runDuckdbQuery: (args: RunDuckdbQueryArgs) => Promise<void>;
+    };
 
-        (
-            service.queryHistoryModel as unknown as {
-                pollForQueryCompletion: import('vitest').Mock;
-            }
-        ).pollForQueryCompletion = vi.fn(async () => legHistory(totalRowCount));
-
+    const buildService = () => {
+        const pollForQueryCompletion = vi.fn(async () => legHistory(1));
+        const service = getMockedAsyncQueryService(lightdashConfigMock, {
+            resultsStorageClient: {
+                isEnabled: true,
+                configuration: { bucket: 'results-bucket' },
+            } as unknown as S3ResultsFileStorageClient,
+            queryHistoryModel: {
+                update: vi.fn(),
+                pollForQueryCompletion,
+            } as unknown as QueryHistoryModel,
+        } as never);
         const runWarehouseQuery = vi
-            .spyOn(
-                service as unknown as {
-                    runAsyncWarehouseQuery: (
-                        ...args: unknown[]
-                    ) => Promise<void>;
-                },
-                'runAsyncWarehouseQuery',
-            )
+            .spyOn(service, 'runAsyncWarehouseQuery')
             .mockResolvedValue(undefined);
-
-        await (
-            service as unknown as {
-                runComposeMergeQuery: (
-                    args: Record<string, unknown>,
-                ) => Promise<void>;
-            }
-        ).runComposeMergeQuery({
-            account: buildAccount(),
-            projectUuid,
-            organizationUuid: projectSummary.organizationUuid,
-            isPreviewProject: false,
-            onboardingFlow: 'default' as AnyType,
-            queryUuid: 'merge-query-uuid',
-            sql: 'SELECT 1',
-            references: { merge_source_0: 'leg-uuid' },
-            legLabelByReferenceTable: { merge_source_0: 'Orders' },
-            warehouseClient: warehouseClientMock,
-            queryTags: {} as AnyType,
-            queryCreatedAt: new Date(),
-            cacheKey: 'cache-key',
-            context: QueryExecutionContext.EXPLORE,
-            fieldsMap: {} as ItemsMap,
-            usedParameters: {},
-            pivotConfiguration: undefined,
-            originalColumns: {} as ResultColumns,
-        });
-
         return {
+            run: (args: RunDuckdbQueryArgs) =>
+                (service as unknown as DuckdbQueryRunner).runDuckdbQuery(args),
             runWarehouseQuery,
+            pollForQueryCompletion,
             update: service.queryHistoryModel.update as import('vitest').Mock,
         };
     };
 
-    it('refuses before the join when a leg reached the row cap, naming the source', async () => {
-        const { runWarehouseQuery, update } =
-            await runRefusalCase(SOURCE_ROW_CAP);
+    const probingClient = (fields: Record<string, { type: DimensionType }>) => {
+        const streamQuery = vi.fn(
+            async (
+                _sql: string,
+                callback: (chunk: {
+                    fields: Record<string, { type: DimensionType }>;
+                    rows: Record<string, unknown>[];
+                }) => void,
+            ) => {
+                callback({ fields, rows: [] });
+            },
+        );
+        return {
+            streamQuery,
+            warehouseClient: {
+                ...warehouseClientMock,
+                streamQuery,
+            } as unknown as WarehouseClient,
+        };
+    };
 
-        expect(runWarehouseQuery).not.toHaveBeenCalled();
+    const baseArgs = (
+        overrides: Partial<RunDuckdbQueryArgs>,
+    ): RunDuckdbQueryArgs => ({
+        account: buildAccount(),
+        projectUuid,
+        organizationUuid: projectSummary.organizationUuid,
+        isPreviewProject: false,
+        onboardingFlow: 'default' as AnyType,
+        queryUuid: 'duckdb-query-uuid',
+        sql: 'SELECT 1 AS one',
+        references: { kind: 'bound', referenceCtes: [] },
+        columns: { mode: 'discover', limit: undefined },
+        storedCompiledSql: null,
+        warehouseClient: warehouseClientMock,
+        queryTags: {} as AnyType,
+        queryCreatedAt: new Date(),
+        cacheKey: 'cache-key',
+        context: QueryExecutionContext.EXPLORE,
+        ...overrides,
+    });
+
+    it('discover mode probes the SQL with one row and executes with the columns it found', async () => {
+        const { streamQuery, warehouseClient } = probingClient({
+            one: { type: DimensionType.NUMBER },
+        });
+        const { run, runWarehouseQuery, update } = buildService();
+
+        await run(baseArgs({ warehouseClient }));
+
+        expect(streamQuery).toHaveBeenCalledTimes(1);
+        expect(streamQuery.mock.calls[0][0]).toMatch(/LIMIT 1$/);
+        expect(runWarehouseQuery).toHaveBeenCalledTimes(1);
+        expect(streamQuery.mock.invocationCallOrder[0]).toBeLessThan(
+            runWarehouseQuery.mock.invocationCallOrder[0],
+        );
+        const executed = runWarehouseQuery.mock.calls[0][0];
+        expect(executed.originalColumns).toEqual({
+            one: { reference: 'one', type: DimensionType.NUMBER, label: 'One' },
+        });
+        expect(Object.keys(executed.fieldsMap)).toEqual([
+            'sql_query_explorer_one',
+        ]);
+        expect(executed.pivotConfiguration).toBeUndefined();
+        expect(executed.warehouseClientOverride).toBe(warehouseClient);
         expect(update).toHaveBeenCalledWith(
-            'merge-query-uuid',
+            'duckdb-query-uuid',
+            projectUuid,
+            {
+                compiled_sql: executed.query,
+                fields: executed.fieldsMap,
+                original_columns: executed.originalColumns,
+            },
+            expect.anything(),
+        );
+    });
+
+    it('supplied mode executes with the caller fields, columns and pivot and never probes', async () => {
+        const { streamQuery, warehouseClient } = probingClient({});
+        const { run, runWarehouseQuery, update } = buildService();
+        const fieldsMap = {
+            a_orders_count: {
+                fieldType: FieldType.METRIC,
+                type: MetricType.COUNT,
+                name: 'orders_count',
+                label: 'Orders',
+                table: 'a',
+                tableLabel: 'Query A',
+                sql: '',
+                hidden: false,
+            },
+        } as ItemsMap;
+        const originalColumns: ResultColumns = {
+            a_orders_count: {
+                reference: 'a_orders_count',
+                type: DimensionType.NUMBER,
+                label: 'Orders',
+                provenance: {
+                    fieldId: 'orders_count',
+                    sourceQueryUuid: 'leg-uuid',
+                },
+            },
+        };
+        const pivotConfiguration: PivotConfiguration = {
+            indexColumn: [
+                { reference: 'a_orders_count', type: VizIndexType.CATEGORY },
+            ],
+            valuesColumns: [
+                {
+                    reference: 'a_orders_count',
+                    aggregation: VizAggregationOptions.SUM,
+                },
+            ],
+            groupByColumns: undefined,
+            sortBy: undefined,
+        };
+
+        await run(
+            baseArgs({
+                warehouseClient,
+                sql: 'SELECT * FROM merge_source_0',
+                references: {
+                    kind: 'queries',
+                    references: { merge_source_0: 'leg-uuid' },
+                    guard: null,
+                },
+                columns: {
+                    mode: 'supplied',
+                    fieldsMap,
+                    usedParameters: { region: 'EU' },
+                    originalColumns,
+                    pivotConfiguration,
+                },
+            }),
+        );
+
+        expect(streamQuery).not.toHaveBeenCalled();
+        expect(runWarehouseQuery).toHaveBeenCalledTimes(1);
+        const executed = runWarehouseQuery.mock.calls[0][0];
+        expect(executed.fieldsMap).toBe(fieldsMap);
+        expect(executed.originalColumns).toBe(originalColumns);
+        expect(executed.pivotConfiguration).toBe(pivotConfiguration);
+        expect(executed.usedParameters).toEqual({ region: 'EU' });
+        expect(executed.query).toContain(
+            "read_json('s3://results-bucket/leg-results.jsonl'",
+        );
+        expect(executed.query).toContain('SELECT * FROM merge_source_0');
+        expect(update).toHaveBeenCalledWith(
+            'duckdb-query-uuid',
+            projectUuid,
+            {
+                compiled_sql: executed.query,
+                fields: fieldsMap,
+                original_columns: originalColumns,
+            },
+            expect.anything(),
+        );
+    });
+
+    it('bound references attach without waiting on any query and persist the stored SQL', async () => {
+        const { run, runWarehouseQuery, pollForQueryCompletion, update } =
+            buildService();
+
+        await run(
+            baseArgs({
+                sql: 'SELECT * FROM attachment',
+                references: {
+                    kind: 'bound',
+                    referenceCtes: [
+                        `"attachment" AS (SELECT * FROM read_parquet('s3://private/file.parquet'))`,
+                    ],
+                },
+                storedCompiledSql: 'SELECT * FROM attachment',
+            }),
+        );
+
+        expect(pollForQueryCompletion).not.toHaveBeenCalled();
+        expect(runWarehouseQuery).toHaveBeenCalledTimes(1);
+        expect(runWarehouseQuery.mock.calls[0][0].query).toContain(
+            "read_parquet('s3://private/file.parquet')",
+        );
+        expect(update).toHaveBeenCalledWith(
+            'duckdb-query-uuid',
             projectUuid,
             expect.objectContaining({
-                status: QueryHistoryStatus.ERROR,
-                error: `Orders returned the maximum of ${SOURCE_ROW_CAP} rows, so the merged results would be missing data. Add a filter to Orders, then merge again.`,
+                compiled_sql: 'SELECT * FROM attachment',
             }),
             expect.anything(),
         );
     });
 
-    it('runs the join when every leg is under the row cap', async () => {
-        const { runWarehouseQuery, update } = await runRefusalCase(
-            SOURCE_ROW_CAP - 1,
+    it('a guard refusal lands as the query error before anything runs', async () => {
+        const { streamQuery, warehouseClient } = probingClient({});
+        const { run, runWarehouseQuery, update } = buildService();
+        const guard = vi.fn(() => 'Orders returned too many rows');
+
+        await run(
+            baseArgs({
+                warehouseClient,
+                references: {
+                    kind: 'queries',
+                    references: { orders: 'leg-uuid' },
+                    guard,
+                },
+            }),
         );
 
-        expect(runWarehouseQuery).toHaveBeenCalledTimes(1);
+        expect(guard).toHaveBeenCalledWith({ orders: legHistory(1) });
+        expect(streamQuery).not.toHaveBeenCalled();
+        expect(runWarehouseQuery).not.toHaveBeenCalled();
+        expect(update).toHaveBeenCalledWith(
+            'duckdb-query-uuid',
+            projectUuid,
+            expect.objectContaining({
+                status: QueryHistoryStatus.ERROR,
+                error: 'Orders returned too many rows',
+            }),
+            expect.anything(),
+        );
+    });
+});
+
+describe('executeAsyncMergeQuery on the compose engine', () => {
+    const SOURCE_ROW_CAP = 3;
+    // Lowered through config rather than by seeding cap-many rows: the run
+    // path reads the cap from the same config the legs were submitted with.
+    const cappedConfig: LightdashConfig = {
+        ...lightdashConfigMock,
+        query: { ...lightdashConfigMock.query, maxLimit: SOURCE_ROW_CAP },
+    };
+    const legQueryUuidBySourceId = {
+        a: '1a6f0f8c-2d3e-4f5a-8b9c-0d1e2f3a4b5c',
+        b: '2b7a1a9d-3e4f-4a6b-9c0d-1e2f3a4b5c6d',
+    };
+    const composeFlags = {
+        get: vi.fn(async ({ featureFlagId }: { featureFlagId: string }) => ({
+            id: featureFlagId,
+            enabled: featureFlagId === FeatureFlags.MergeOnCompose,
+        })),
+    } as unknown as FeatureFlagModel;
+
+    const itemsMap = {
+        merge_month: {
+            fieldType: FieldType.DIMENSION,
+            type: DimensionType.DATE,
+            name: 'month',
+            label: 'Month',
+            table: 'merge',
+            tableLabel: 'Merged',
+            sql: '',
+            hidden: false,
+        },
+        a_orders_count: {
+            fieldType: FieldType.METRIC,
+            type: MetricType.COUNT_DISTINCT,
+            name: 'orders_count',
+            label: 'Orders',
+            table: 'a',
+            tableLabel: 'Query A',
+            sql: '',
+            hidden: false,
+            format: '#,##0',
+        },
+        b_payments_sum: {
+            fieldType: FieldType.METRIC,
+            type: MetricType.SUM,
+            name: 'payments_sum',
+            label: 'Payments',
+            table: 'b',
+            tableLabel: 'Query B',
+            sql: '',
+            hidden: false,
+        },
+    } as ItemsMap;
+    const typedColumns: MergeTypedColumn[] = [
+        {
+            reference: 'merge_month',
+            type: DimensionType.DATE,
+            origin: {
+                kind: 'joinKey',
+                fieldIdBySourceId: { a: 'orders_month', b: 'payments_month' },
+            },
+        },
+        {
+            reference: 'a_orders_count',
+            type: DimensionType.NUMBER,
+            origin: {
+                kind: 'source',
+                sourceId: 'a',
+                sourceFieldId: 'orders_count',
+            },
+        },
+        {
+            reference: 'b_payments_sum',
+            type: DimensionType.NUMBER,
+            origin: {
+                kind: 'source',
+                sourceId: 'b',
+                sourceFieldId: 'payments_sum',
+            },
+        },
+    ];
+    const fieldTypes: MergeFieldTypes = {
+        a: { orders_month: { type: DimensionType.DATE, timeInterval: null } },
+        b: { payments_month: { type: DimensionType.DATE, timeInterval: null } },
+    };
+    const compiledMerge = {
+        sql: null,
+        coreSql: null,
+        typedColumns,
+        terminalWrapper: null,
+        columns: {
+            joinKeyColumns: ['month'],
+            valueColumnBySourceColumn: {
+                a: { orders_count: 'c0_0' },
+                b: { payments_sum: 'c1_0' },
+            },
+        },
+        fields: [],
+        itemsMap,
+        fieldOrigins: {},
+        parameterReferences: [],
+        usedParametersValues: {},
+        fieldIdByColumn: {
+            month: 'merge_month',
+            c0_0: 'a_orders_count',
+            c1_0: 'b_payments_sum',
+        },
+        requiresCompose: false,
+        errors: [],
+    };
+    const mergeQuery: MergeQuery = {
+        sources: [
+            {
+                id: 'a',
+                metricQuery: {
+                    ...metricQueryMock,
+                    exploreName: 'orders',
+                    dimensions: ['orders_month'],
+                    metrics: ['orders_count'],
+                    tableCalculations: [],
+                },
+            },
+            {
+                id: 'b',
+                metricQuery: {
+                    ...metricQueryMock,
+                    exploreName: 'payments',
+                    dimensions: ['payments_month'],
+                    metrics: ['payments_sum'],
+                    tableCalculations: [],
+                },
+            },
+        ],
+        joinKey: [
+            {
+                name: 'month',
+                fieldIdBySourceId: { a: 'orders_month', b: 'payments_month' },
+            },
+        ],
+        joinType: MergeJoinType.FULL,
+        tableCalculations: [],
+        limit: 500,
+    };
+
+    const legHistory = (queryUuid: string, totalRowCount: number) =>
+        ({
+            queryUuid,
+            projectUuid,
+            organizationUuid: projectSummary.organizationUuid,
+            createdByUserUuid: sessionAccount.user.id,
+            context: QueryExecutionContext.EXPLORE,
+            status: QueryHistoryStatus.READY,
+            totalRowCount,
+            resultsFileName: `${queryUuid}.jsonl`,
+            resultsExpiresAt: null,
+            columns: {},
+            metricQuery: metricQueryMock,
+        }) as unknown as QueryHistory;
+
+    const buildService = ({
+        config,
+        legRowCount,
+    }: {
+        config: LightdashConfig;
+        legRowCount: number;
+    }) => {
+        const streamQuery = vi.fn();
+        const warehouseClient = {
+            ...warehouseClientMock,
+            streamQuery,
+        } as unknown as WarehouseClient;
+        const legByUuid = (queryUuid: string) =>
+            legHistory(queryUuid, legRowCount);
+        const service = getMockedAsyncQueryService(config, {
+            featureFlagModel: composeFlags,
+            composeEngineClient: new ComposeEngineClient({
+                lightdashConfig: config,
+                createDuckdbWarehouseClient: () => warehouseClient,
+            }),
+            queryHistoryModel: {
+                create: vi.fn(async () => ({ queryUuid: 'merge-query-uuid' })),
+                get: vi.fn(async (queryUuid: string) => legByUuid(queryUuid)),
+                pollForQueryCompletion: vi.fn(
+                    async ({ queryUuid }: { queryUuid: string }) =>
+                        legByUuid(queryUuid),
+                ),
+                update: vi.fn(),
+            } as unknown as QueryHistoryModel,
+            resultsStorageClient: {
+                isEnabled: true,
+                configuration: { bucket: 'results-bucket' },
+            } as unknown as S3ResultsFileStorageClient,
+        } as never);
+        vi.spyOn(service, 'compileMergeQuery').mockResolvedValue(
+            compiledMerge as never,
+        );
+        vi.spyOn(
+            service as AnyType,
+            'getMergeFieldTypesForQuery',
+        ).mockResolvedValue(fieldTypes);
+        vi.spyOn(service, 'executeAsyncMetricQuery').mockImplementation(
+            async ({ metricQuery }) =>
+                ({
+                    queryUuid:
+                        metricQuery.exploreName === 'orders'
+                            ? legQueryUuidBySourceId.a
+                            : legQueryUuidBySourceId.b,
+                }) as never,
+        );
+        const runWarehouseQuery = vi
+            .spyOn(service, 'runAsyncWarehouseQuery')
+            .mockResolvedValue(undefined);
+        return {
+            service,
+            streamQuery,
+            runWarehouseQuery,
+            create: service.queryHistoryModel.create as import('vitest').Mock,
+            update: service.queryHistoryModel.update as import('vitest').Mock,
+        };
+    };
+
+    const execute = (service: AsyncQueryService) =>
+        service.executeAsyncMergeQuery({
+            account: sessionAccount,
+            projectUuid,
+            mergeQuery,
+            context: QueryExecutionContext.EXPLORE,
+            mode: { type: 'interactive' },
+        });
+
+    it('runs the join in supplied mode: no column probe, and the compile-time columns reach execution unchanged', async () => {
+        const { service, streamQuery, runWarehouseQuery, create } =
+            buildService({ config: lightdashConfigMock, legRowCount: 2 });
+
+        const outcome = await execute(service);
+        if (outcome.outcome !== 'started') {
+            throw new Error(`Expected the merge to start: ${outcome.outcome}`);
+        }
+        await vi.waitFor(() =>
+            expect(runWarehouseQuery).toHaveBeenCalledTimes(1),
+        );
+
+        expect(streamQuery).not.toHaveBeenCalled();
+        const executed = runWarehouseQuery.mock.calls[0][0];
+        expect(executed.originalColumns).toEqual(
+            buildComposeMergeOriginalColumns({
+                typedColumns,
+                itemsMap,
+                usedParametersValues: {},
+                legQueryUuidBySourceId,
+            }),
+        );
+        expect(executed.originalColumns?.a_orders_count).toMatchObject({
+            label: 'Query A Orders',
+            format: '#,##0',
+            provenance: {
+                fieldId: 'orders_count',
+                sourceQueryUuid: legQueryUuidBySourceId.a,
+            },
+        });
+        expect(executed.originalColumns).toBe(
+            create.mock.calls[0][1].originalColumns,
+        );
+        expect(executed.fieldsMap).toBe(outcome.query.fields);
+        expect(executed.query).toContain(
+            `read_json_auto('s3://results-bucket/${legQueryUuidBySourceId.a}.jsonl')`,
+        );
+        expect(executed.query).toContain(
+            `read_json_auto('s3://results-bucket/${legQueryUuidBySourceId.b}.jsonl')`,
+        );
+    });
+
+    it('refuses before the join when a leg reached the row cap, naming the source', async () => {
+        const { service, streamQuery, runWarehouseQuery, update } =
+            buildService({ config: cappedConfig, legRowCount: SOURCE_ROW_CAP });
+
+        await execute(service);
+
+        await vi.waitFor(() =>
+            expect(update).toHaveBeenCalledWith(
+                'merge-query-uuid',
+                projectUuid,
+                expect.objectContaining({
+                    status: QueryHistoryStatus.ERROR,
+                    error: `Query A and Query B each returned the maximum of ${SOURCE_ROW_CAP} rows, so the merged results would be missing data. Add a filter to each, then merge again.`,
+                }),
+                expect.anything(),
+            ),
+        );
+        expect(streamQuery).not.toHaveBeenCalled();
+        expect(runWarehouseQuery).not.toHaveBeenCalled();
+    });
+
+    it('runs the join when every leg is under the row cap', async () => {
+        const { service, runWarehouseQuery, update } = buildService({
+            config: cappedConfig,
+            legRowCount: SOURCE_ROW_CAP - 1,
+        });
+
+        await execute(service);
+
+        await vi.waitFor(() =>
+            expect(runWarehouseQuery).toHaveBeenCalledTimes(1),
+        );
         expect(update).not.toHaveBeenCalledWith(
             expect.anything(),
             expect.anything(),

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -254,7 +254,7 @@ import { getUnpivotedColumns } from './getUnpivotedColumns';
 import {
     applyMergeExportLimit,
     buildComposeMergeOriginalColumns,
-    getMergeRowCapError,
+    buildMergeRowCapGuard,
     getMergeSourceLabels,
 } from './mergeQueryExecution';
 import {
@@ -269,6 +269,8 @@ import {
     isExecuteAsyncSqlChartByUuid,
     type CommonAsyncQueryArgs,
     type DownloadAsyncQueryResultsArgs,
+    type DuckdbQueryColumns,
+    type DuckdbQueryReferences,
     type ExecuteAsyncComposeSqlQueryArgs,
     type ExecuteAsyncDashboardChartQueryArgs,
     type ExecuteAsyncDashboardSqlChartArgs,
@@ -286,6 +288,7 @@ import {
     type PreAggregationRoute,
     type RunAsyncPreAggregateQueryArgs,
     type RunAsyncWarehouseQueryArgs,
+    type RunDuckdbQueryArgs,
     type ScheduleDownloadAsyncQueryResultsArgs,
     type UnboundedRerunFromQueryHistoryResult,
 } from './types';
@@ -322,6 +325,15 @@ const isComposableCompiledMergeQuery = (
     compiled.errors.length === 0 &&
     compiled.typedColumns !== null &&
     compiled.columns !== null;
+
+/** What a DuckDB query executes with once its columns are resolved. */
+type DuckdbQueryExecution = {
+    query: string;
+    fieldsMap: ItemsMap;
+    usedParameters: ParametersValuesMap | null;
+    originalColumns: ResultColumns;
+    pivotConfiguration: PivotConfiguration | undefined;
+};
 
 type ExecuteCompiledAsyncMergeQueryArgs = Omit<
     ExecuteAsyncMergeQueryArgs,
@@ -7223,7 +7235,7 @@ export class AsyncQueryService extends ProjectService {
             organizationUuid,
         });
 
-        void this.runComposeSqlQuery({
+        void this.runDuckdbQuery({
             account,
             projectUuid,
             organizationUuid,
@@ -7233,8 +7245,13 @@ export class AsyncQueryService extends ProjectService {
             onboardingFlow,
             queryUuid,
             sql,
-            limit,
-            references: normalizedReferences,
+            references: {
+                kind: 'queries',
+                references: normalizedReferences ?? {},
+                guard: null,
+            },
+            columns: { mode: 'discover', limit },
+            storedCompiledSql: null,
             warehouseClient,
             queryTags,
             queryCreatedAt,
@@ -7444,7 +7461,7 @@ export class AsyncQueryService extends ProjectService {
             organizationUuid,
         });
 
-        void this.runDuckdbSqlQuery({
+        void this.runDuckdbQuery({
             account,
             projectUuid,
             organizationUuid,
@@ -7453,13 +7470,11 @@ export class AsyncQueryService extends ProjectService {
                 projectSummary.provisioningSource === 'playground',
             onboardingFlow,
             queryUuid,
-            resolvedSql: AsyncQueryService.wrapSqlWithReferenceCtes(
-                sql,
-                referenceCtes,
-            ),
+            sql,
+            references: { kind: 'bound', referenceCtes },
+            columns: { mode: 'discover', limit },
             // Only persist the user SQL; resolved SQL contains private URIs.
             storedCompiledSql: sql,
-            limit,
             warehouseClient,
             queryTags,
             queryCreatedAt,
@@ -7498,13 +7513,13 @@ export class AsyncQueryService extends ProjectService {
     }
 
     /**
-     * Background phase of a compose query: wait for referenced results (the
-     * whole of pipeline orchestration), build the reference CTEs, discover
-     * columns, compile, then execute through the standard async pipeline.
-     * Failures before execution mark the query history row errored so
-     * pollers see them through the standard status lifecycle.
+     * The one execution tail for DuckDB queries over referenced results,
+     * whatever submitted them: bind the references, resolve the output
+     * columns, then execute through the standard async pipeline. Failures
+     * before execution mark the query history row errored so pollers see
+     * them through the standard status lifecycle.
      */
-    private async runComposeSqlQuery({
+    private async runDuckdbQuery({
         account,
         projectUuid,
         organizationUuid,
@@ -7512,181 +7527,39 @@ export class AsyncQueryService extends ProjectService {
         onboardingFlow,
         queryUuid,
         sql,
-        limit,
         references,
-        warehouseClient,
-        queryTags,
-        queryCreatedAt,
-        cacheKey,
-        context,
-    }: {
-        account: Account;
-        projectUuid: string;
-        organizationUuid: string;
-        isPreviewProject: boolean;
-        onboardingFlow: OnboardingFlow;
-        queryUuid: string;
-        sql: string;
-        limit: number | undefined;
-        references: Record<string, string> | undefined;
-        warehouseClient: WarehouseClient;
-        queryTags: RunQueryTags;
-        queryCreatedAt: Date;
-        cacheKey: string;
-        context: QueryExecutionContext;
-    }): Promise<void> {
-        try {
-            const referenceCtes = references
-                ? this.buildQueryReferenceCtes(
-                      await this.waitForQueryReferences({
-                          account,
-                          projectUuid,
-                          references,
-                      }),
-                  )
-                : [];
-
-            await this.runDuckdbSqlQuery({
-                account,
-                projectUuid,
-                organizationUuid,
-                isPreviewProject,
-                onboardingFlow,
-                queryUuid,
-                resolvedSql: AsyncQueryService.wrapSqlWithReferenceCtes(
-                    sql,
-                    referenceCtes,
-                ),
-                limit,
-                warehouseClient,
-                queryTags,
-                queryCreatedAt,
-                cacheKey,
-                context,
-            });
-        } catch (e) {
-            await this.queryHistoryModel.update(
-                queryUuid,
-                projectUuid,
-                {
-                    status: QueryHistoryStatus.ERROR,
-                    error: getErrorMessage(e),
-                    errored_at: new Date(),
-                },
-                account,
-            );
-        }
-    }
-
-    /** Executes resolved DuckDB SQL through the standard query lifecycle. */
-    private async runDuckdbSqlQuery({
-        account,
-        projectUuid,
-        organizationUuid,
-        isPreviewProject,
-        onboardingFlow,
-        queryUuid,
-        resolvedSql,
+        columns,
         storedCompiledSql,
-        limit,
         warehouseClient,
         queryTags,
         queryCreatedAt,
         cacheKey,
         context,
-    }: {
-        account: Account;
-        projectUuid: string;
-        organizationUuid: string;
-        isPreviewProject: boolean;
-        onboardingFlow: OnboardingFlow;
-        queryUuid: string;
-        resolvedSql: string;
-        /** Safe SQL persisted instead of resolved SQL containing private URIs. */
-        storedCompiledSql?: string;
-        limit: number | undefined;
-        warehouseClient: WarehouseClient;
-        queryTags: RunQueryTags;
-        queryCreatedAt: Date;
-        cacheKey: string;
-        context: QueryExecutionContext;
-    }): Promise<void> {
+    }: RunDuckdbQueryArgs): Promise<void> {
         try {
-            // Column discovery (LIMIT 1) also validates the SQL
-            const columns: { name: string; type: DimensionType }[] = [];
-            const columnDiscoverySql = applyLimitToSqlQuery({
-                sqlQuery: resolvedSql,
-                limit: 1,
+            const referenceCtes = await this.bindDuckdbQueryReferences({
+                account,
+                projectUuid,
+                references,
             });
-            try {
-                await warehouseClient.streamQuery(
-                    columnDiscoverySql,
-                    (chunk) => {
-                        if (columns.length === 0 && chunk.fields) {
-                            Object.keys(chunk.fields).forEach((key) => {
-                                columns.push({
-                                    name: key,
-                                    type: chunk.fields[key].type,
-                                });
-                            });
-                        }
-                    },
-                    { tags: queryTags },
-                );
-            } catch (e) {
-                // The DuckDB client throws raw errors (validation + engine)
-                if (e instanceof LightdashError) throw e;
-                throw new WarehouseQueryError(getErrorMessage(e));
-            }
-
-            const composer = new SqlQueryComposer({
-                userSql: resolvedSql,
+            const resolvedSql = AsyncQueryService.wrapSqlWithReferenceCtes(
+                sql,
+                referenceCtes,
+            );
+            const execution = await this.resolveDuckdbQueryColumns({
+                resolvedSql,
                 columns,
                 warehouseClient,
-                pivotConfiguration: undefined,
-                limit,
-                parameters: undefined,
-                dashboardFilters: undefined,
-                tileUuid: undefined,
-                dashboardSorts: undefined,
+                queryTags,
             });
-            const compiled = composer.compile();
-            if (compiled.missingParameterReferences.size > 0) {
-                const missing = Array.from(compiled.missingParameterReferences);
-                throw new ParameterError(
-                    `Missing values for SQL parameter(s): ${missing.join(
-                        ', ',
-                    )}`,
-                    { missingReferences: missing },
-                );
-            }
-            const query = composer.getSql({
-                columnLimit: this.lightdashConfig.pivotTable.maxColumnLimit,
-            });
-            const fieldsMap = composer.getFields();
-
-            // Compose columns carry only the reference, the probed type, and
-            // a label derived from the reference. Metadata is never inferred
-            // from the referenced queries' columns.
-            const originalColumns: ResultColumns = columns.reduce(
-                (acc, col) => {
-                    acc[col.name] = {
-                        reference: col.name,
-                        type: col.type,
-                        label: friendlyName(col.name),
-                    };
-                    return acc;
-                },
-                {} as ResultColumns,
-            );
 
             await this.queryHistoryModel.update(
                 queryUuid,
                 projectUuid,
                 {
-                    compiled_sql: storedCompiledSql ?? query,
-                    fields: fieldsMap,
-                    original_columns: originalColumns,
+                    compiled_sql: storedCompiledSql ?? execution.query,
+                    fields: execution.fieldsMap,
+                    original_columns: execution.originalColumns,
                 },
                 account,
             );
@@ -7712,11 +7585,12 @@ export class AsyncQueryService extends ProjectService {
                 projectUuid,
                 queryUuid,
                 queryTags,
-                query,
-                fieldsMap,
-                usedParameters: composer.getUsedParameters(),
+                query: execution.query,
+                fieldsMap: execution.fieldsMap,
+                usedParameters: execution.usedParameters,
                 cacheKey,
-                originalColumns,
+                pivotConfiguration: execution.pivotConfiguration,
+                originalColumns: execution.originalColumns,
                 queryCreatedAt,
                 displayTimezone: null,
                 warehouseClientOverride: warehouseClient,
@@ -7735,6 +7609,162 @@ export class AsyncQueryService extends ProjectService {
                 account,
             );
         }
+    }
+
+    /**
+     * Resolves a query's references to the CTEs that expose them. Referenced
+     * queries are waited on, then the guard runs before anything is built,
+     * so a refusal never costs an execution.
+     */
+    private async bindDuckdbQueryReferences({
+        account,
+        projectUuid,
+        references,
+    }: {
+        account: Account;
+        projectUuid: string;
+        references: DuckdbQueryReferences;
+    }): Promise<string[]> {
+        switch (references.kind) {
+            case 'bound':
+                return references.referenceCtes;
+            case 'queries': {
+                const completed = await this.waitForQueryReferences({
+                    account,
+                    projectUuid,
+                    references: references.references,
+                });
+                const refusal = references.guard?.(completed) ?? null;
+                if (refusal !== null) throw new ParameterError(refusal);
+                return this.buildQueryReferenceCtes(completed);
+            }
+            default:
+                return assertUnreachable(
+                    references,
+                    'Unknown DuckDB query reference kind',
+                );
+        }
+    }
+
+    /**
+     * Discover mode probes the SQL and compiles it around the columns found;
+     * supplied mode executes with the caller's compile-time fields, columns
+     * and pivot as they are.
+     */
+    private async resolveDuckdbQueryColumns({
+        resolvedSql,
+        columns,
+        warehouseClient,
+        queryTags,
+    }: {
+        resolvedSql: string;
+        columns: DuckdbQueryColumns;
+        warehouseClient: WarehouseClient;
+        queryTags: RunQueryTags;
+    }): Promise<DuckdbQueryExecution> {
+        switch (columns.mode) {
+            case 'supplied':
+                return {
+                    query: resolvedSql,
+                    fieldsMap: columns.fieldsMap,
+                    usedParameters: columns.usedParameters,
+                    originalColumns: columns.originalColumns,
+                    pivotConfiguration: columns.pivotConfiguration,
+                };
+            case 'discover':
+                return this.discoverDuckdbQueryColumns({
+                    resolvedSql,
+                    limit: columns.limit,
+                    warehouseClient,
+                    queryTags,
+                });
+            default:
+                return assertUnreachable(
+                    columns,
+                    'Unknown DuckDB query columns mode',
+                );
+        }
+    }
+
+    private async discoverDuckdbQueryColumns({
+        resolvedSql,
+        limit,
+        warehouseClient,
+        queryTags,
+    }: {
+        resolvedSql: string;
+        limit: number | undefined;
+        warehouseClient: WarehouseClient;
+        queryTags: RunQueryTags;
+    }): Promise<DuckdbQueryExecution> {
+        // Column discovery (LIMIT 1) also validates the SQL
+        const columns: { name: string; type: DimensionType }[] = [];
+        const columnDiscoverySql = applyLimitToSqlQuery({
+            sqlQuery: resolvedSql,
+            limit: 1,
+        });
+        try {
+            await warehouseClient.streamQuery(
+                columnDiscoverySql,
+                (chunk) => {
+                    if (columns.length === 0 && chunk.fields) {
+                        Object.keys(chunk.fields).forEach((key) => {
+                            columns.push({
+                                name: key,
+                                type: chunk.fields[key].type,
+                            });
+                        });
+                    }
+                },
+                { tags: queryTags },
+            );
+        } catch (e) {
+            // The DuckDB client throws raw errors (validation + engine)
+            if (e instanceof LightdashError) throw e;
+            throw new WarehouseQueryError(getErrorMessage(e));
+        }
+
+        const composer = new SqlQueryComposer({
+            userSql: resolvedSql,
+            columns,
+            warehouseClient,
+            pivotConfiguration: undefined,
+            limit,
+            parameters: undefined,
+            dashboardFilters: undefined,
+            tileUuid: undefined,
+            dashboardSorts: undefined,
+        });
+        const compiled = composer.compile();
+        if (compiled.missingParameterReferences.size > 0) {
+            const missing = Array.from(compiled.missingParameterReferences);
+            throw new ParameterError(
+                `Missing values for SQL parameter(s): ${missing.join(', ')}`,
+                { missingReferences: missing },
+            );
+        }
+
+        // Compose columns carry only the reference, the probed type, and
+        // a label derived from the reference. Metadata is never inferred
+        // from the referenced queries' columns.
+        const originalColumns: ResultColumns = columns.reduce((acc, col) => {
+            acc[col.name] = {
+                reference: col.name,
+                type: col.type,
+                label: friendlyName(col.name),
+            };
+            return acc;
+        }, {} as ResultColumns);
+
+        return {
+            query: composer.getSql({
+                columnLimit: this.lightdashConfig.pivotTable.maxColumnLimit,
+            }),
+            fieldsMap: composer.getFields(),
+            usedParameters: composer.getUsedParameters(),
+            originalColumns,
+            pivotConfiguration: undefined,
+        };
     }
 
     /**
@@ -8278,7 +8308,7 @@ export class AsyncQueryService extends ProjectService {
             organizationUuid,
         });
 
-        void this.runComposeMergeQuery({
+        void this.runDuckdbQuery({
             account,
             projectUuid,
             organizationUuid,
@@ -8288,17 +8318,27 @@ export class AsyncQueryService extends ProjectService {
             onboardingFlow,
             queryUuid,
             sql,
-            references,
-            legLabelByReferenceTable,
+            references: {
+                kind: 'queries',
+                references,
+                guard: buildMergeRowCapGuard({
+                    legLabelByReferenceTable,
+                    sourceRowCap,
+                }),
+            },
+            columns: {
+                mode: 'supplied',
+                fieldsMap,
+                usedParameters: composer.getUsedParameters(),
+                originalColumns,
+                pivotConfiguration,
+            },
+            storedCompiledSql: null,
             warehouseClient,
             queryTags,
             queryCreatedAt,
             cacheKey,
             context,
-            fieldsMap,
-            usedParameters: composer.getUsedParameters(),
-            pivotConfiguration,
-            originalColumns,
         }).catch((e) => {
             this.logger.error(
                 `Async compose merge query ${queryUuid} failed: ${getErrorMessage(
@@ -8357,127 +8397,6 @@ export class AsyncQueryService extends ProjectService {
             metricQuery: queryHistory.metricQuery,
             fields: queryHistory.fields,
         };
-    }
-
-    /**
-     * Background phase of a compose-mode merge: wait for the legs' results
-     * (the standard reference wait), bind them as reference CTEs, then run
-     * the join on the compose engine through the standard async pipeline.
-     * The merge fields and columns are known at submit time, so unlike raw
-     * compose SQL there is no column discovery and no metadata overwrite.
-     */
-    private async runComposeMergeQuery({
-        account,
-        projectUuid,
-        organizationUuid,
-        isPreviewProject,
-        onboardingFlow,
-        queryUuid,
-        sql,
-        references,
-        legLabelByReferenceTable,
-        warehouseClient,
-        queryTags,
-        queryCreatedAt,
-        cacheKey,
-        context,
-        fieldsMap,
-        usedParameters,
-        pivotConfiguration,
-        originalColumns,
-    }: {
-        account: Account;
-        projectUuid: string;
-        organizationUuid: string;
-        isPreviewProject: boolean;
-        onboardingFlow: OnboardingFlow;
-        queryUuid: string;
-        sql: string;
-        references: Record<string, string>;
-        /** The user-facing label of the source each reference table holds. */
-        legLabelByReferenceTable: Record<string, string>;
-        warehouseClient: WarehouseClient;
-        queryTags: RunQueryTags;
-        queryCreatedAt: Date;
-        cacheKey: string;
-        context: QueryExecutionContext;
-        fieldsMap: ItemsMap;
-        usedParameters: ParametersValuesMap | null;
-        pivotConfiguration: PivotConfiguration | undefined;
-        originalColumns: ResultColumns;
-    }): Promise<void> {
-        try {
-            const queryHistoryByTableName = await this.waitForQueryReferences({
-                account,
-                projectUuid,
-                references,
-            });
-
-            const rowCapError = getMergeRowCapError({
-                legs: Object.entries(legLabelByReferenceTable).map(
-                    ([tableName, label]) => ({
-                        label,
-                        rowCount:
-                            queryHistoryByTableName[tableName]?.totalRowCount ??
-                            null,
-                    }),
-                ),
-                sourceRowCap: this.lightdashConfig.query.maxLimit,
-            });
-            if (rowCapError !== null) throw new ParameterError(rowCapError);
-
-            const query = AsyncQueryService.wrapSqlWithReferenceCtes(
-                sql,
-                this.buildQueryReferenceCtes(queryHistoryByTableName),
-            );
-            await this.queryHistoryModel.update(
-                queryUuid,
-                projectUuid,
-                { compiled_sql: query },
-                account,
-            );
-
-            this.prometheusMetrics?.trackQueryStateTransition(
-                QueryHistoryStatus.PENDING,
-                QueryHistoryStatus.EXECUTING,
-                context,
-            );
-            this.prometheusMetrics?.observeQueueWaitDuration(0, context);
-
-            await this.runAsyncWarehouseQuery({
-                userUuid: account.user.id,
-                organizationUuid,
-                isPreviewProject,
-                isRegisteredUser: account.isRegisteredUser(),
-                isServiceAccount: account.isServiceAccount(),
-                onboardingFlow,
-                projectUuid,
-                queryUuid,
-                queryTags,
-                query,
-                fieldsMap,
-                usedParameters,
-                cacheKey,
-                pivotConfiguration,
-                originalColumns,
-                queryCreatedAt,
-                displayTimezone: null,
-                warehouseClientOverride: warehouseClient,
-                warehouseCredentialsTypeOverride:
-                    warehouseClient.credentials.type,
-            });
-        } catch (e) {
-            await this.queryHistoryModel.update(
-                queryUuid,
-                projectUuid,
-                {
-                    status: QueryHistoryStatus.ERROR,
-                    error: getErrorMessage(e),
-                    errored_at: new Date(),
-                },
-                account,
-            );
-        }
     }
 
     private async prepareSqlChartAsyncQueryArgs({

--- a/packages/backend/src/services/AsyncQueryService/mergeQueryExecution.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/mergeQueryExecution.test.ts
@@ -8,10 +8,12 @@ import {
     type MergeQuery,
     type MergeTypedColumn,
     type MetricQuery,
+    type QueryHistory,
 } from '@lightdash/common';
 import {
     applyMergeExportLimit,
     buildComposeMergeOriginalColumns,
+    buildMergeRowCapGuard,
     getMergeOutputColumnCount,
     getMergeRowCapError,
     getMergeSourceLabels,
@@ -277,6 +279,46 @@ describe('getMergeRowCapError', () => {
                 legs: [{ label: 'Orders', rowCount: null }],
                 sourceRowCap: 500,
             }),
+        ).toBeNull();
+    });
+});
+
+describe('buildMergeRowCapGuard', () => {
+    const completed = (rowCountByTable: Record<string, number | null>) =>
+        Object.fromEntries(
+            Object.entries(rowCountByTable).map(([table, totalRowCount]) => [
+                table,
+                { totalRowCount } as QueryHistory,
+            ]),
+        );
+    const guard = buildMergeRowCapGuard({
+        legLabelByReferenceTable: {
+            merge_source_0: 'Orders',
+            merge_source_1: 'Payments',
+        },
+        sourceRowCap: 500,
+    });
+
+    test('reads each leg row count from its completed query history', () => {
+        expect(
+            guard(completed({ merge_source_0: 500, merge_source_1: 12 })),
+        ).toBe(
+            'Orders returned the maximum of 500 rows, so the merged results would be missing data. Add a filter to Orders, then merge again.',
+        );
+        expect(
+            guard(completed({ merge_source_0: 499, merge_source_1: 12 })),
+        ).toBeNull();
+    });
+
+    test('checks only the legs it was given, never a referenced result', () => {
+        expect(
+            guard(
+                completed({
+                    merge_source_0: 1,
+                    merge_source_1: 1,
+                    merge_source_2: 500,
+                }),
+            ),
         ).toBeNull();
     });
 });

--- a/packages/backend/src/services/AsyncQueryService/mergeQueryExecution.ts
+++ b/packages/backend/src/services/AsyncQueryService/mergeQueryExecution.ts
@@ -9,6 +9,7 @@ import {
     type ParametersValuesMap,
     type ResultColumns,
 } from '@lightdash/common';
+import type { DuckdbQueryReferenceGuard } from './types';
 
 /**
  * Builds the pre-pivot original columns of a compose-mode merge: display
@@ -151,3 +152,26 @@ export const getMergeRowCapError = ({
         ? `${capped[0]} ${consequence} Add a filter to ${capped[0]}, then merge again.`
         : `${capped.join(' and ')} each ${consequence} Add a filter to each, then merge again.`;
 };
+
+/**
+ * The guard a merge hands the execution tail: once the legs complete, refuse
+ * before the join when one of them reached the row cap.
+ */
+export const buildMergeRowCapGuard =
+    ({
+        legLabelByReferenceTable,
+        sourceRowCap,
+    }: {
+        legLabelByReferenceTable: Record<string, string>;
+        sourceRowCap: number;
+    }): DuckdbQueryReferenceGuard =>
+    (completed) =>
+        getMergeRowCapError({
+            legs: Object.entries(legLabelByReferenceTable).map(
+                ([tableName, label]) => ({
+                    label,
+                    rowCount: completed[tableName]?.totalRowCount ?? null,
+                }),
+            ),
+            sourceRowCap,
+        });

--- a/packages/backend/src/services/AsyncQueryService/types.ts
+++ b/packages/backend/src/services/AsyncQueryService/types.ts
@@ -21,6 +21,7 @@ import {
     type ParametersValuesMap,
     type PreAggregateExecutionEngine,
     type QueryExecutionContext,
+    type QueryHistory,
     type QuerySourceTableName,
     type ResultColumns,
     type ResultsPaginationArgs,
@@ -30,6 +31,7 @@ import {
     type UserAccessControls,
     type UserAttributeValueMap,
     type UUID,
+    type WarehouseClient,
 } from '@lightdash/common';
 import type { OnboardingFlow } from '../../analytics/LightdashAnalytics';
 import type { DbProjectParameter } from '../../database/entities/projectParameters';
@@ -291,4 +293,62 @@ export type RunAsyncPreAggregateQueryArgs = Omit<
     preAggregateQuery: string;
     warehouseQuery: string;
     preAggregateExecution: PreAggregateExecutionEngine;
+};
+
+/** Where a DuckDB query's output columns come from. */
+export type DuckdbQueryColumns =
+    | {
+          /** Probe the SQL with a one-row query: raw SQL has no known shape. */
+          mode: 'discover';
+          limit: number | undefined;
+      }
+    | {
+          /** Known at compile time, so nothing is probed and nothing overwritten. */
+          mode: 'supplied';
+          fieldsMap: ItemsMap;
+          usedParameters: ParametersValuesMap | null;
+          originalColumns: ResultColumns;
+          pivotConfiguration: PivotConfiguration | undefined;
+      };
+
+/**
+ * Runs once every referenced query has completed and before anything
+ * executes. Returns the refusal message, or null to proceed.
+ */
+export type DuckdbQueryReferenceGuard = (
+    completed: Record<string, QueryHistory>,
+) => string | null;
+
+/** How a DuckDB query binds the results it reads. */
+export type DuckdbQueryReferences =
+    | {
+          /** CTEs built at submit time, such as over ingested external tables. */
+          kind: 'bound';
+          referenceCtes: string[];
+      }
+    | {
+          /** Other queries' results, waited on and bound once they complete. */
+          kind: 'queries';
+          references: Record<string, string>;
+          guard: DuckdbQueryReferenceGuard | null;
+      };
+
+export type RunDuckdbQueryArgs = {
+    account: Account;
+    projectUuid: string;
+    organizationUuid: string;
+    isPreviewProject: boolean;
+    onboardingFlow: OnboardingFlow;
+    queryUuid: string;
+    /** The statement before its reference CTEs are attached. */
+    sql: string;
+    references: DuckdbQueryReferences;
+    columns: DuckdbQueryColumns;
+    /** Persisted instead of the executed SQL when that carries private URIs. */
+    storedCompiledSql: string | null;
+    warehouseClient: WarehouseClient;
+    queryTags: RunQueryTags;
+    queryCreatedAt: Date;
+    cacheKey: string;
+    context: QueryExecutionContext;
 };


### PR DESCRIPTION
## What

One function runs a DuckDB query over referenced results, whatever submitted it. The private merge tail is deleted.

## Why

There were two tails doing the same job in the same order: build reference CTEs, wrap the SQL, run through the async warehouse path with the DuckDB client override, persist errors to query history. The only real difference was where the output columns come from. This is prefactoring for PROD-10901 (merge executes as a query source DAG): no behaviour change, one place to plug into.

## How

- **`runDuckdbQuery`** (private, `AsyncQueryService.ts`) replaces `runComposeSqlQuery`, `runDuckdbSqlQuery` and `runComposeMergeQuery`. Three callers rewired: compose SQL, external SQL, merge.
- **Two column modes**, exhaustive via `assertUnreachable`: `{ mode: 'discover'; limit }` probes the SQL with a one-row query (raw compose SQL, whose shape nobody knows ahead of time); `{ mode: 'supplied'; fieldsMap; usedParameters; originalColumns; pivotConfiguration }` skips the probe (merges, whose columns the compile already produced with labels, formats and provenance).
- **Two reference kinds**: `{ kind: 'bound'; referenceCtes }` and `{ kind: 'queries'; references; guard }`. The `guard: (completed) => string | null` runs after `waitForQueryReferences` and before `buildQueryReferenceCtes`, so a refusal never costs an execution and the tail stays merge-agnostic. The merge's row-cap check becomes `buildMergeRowCapGuard` (wrapping `getMergeRowCapError`, unchanged).
- Types in `services/AsyncQueryService/types.ts`: `RunDuckdbQueryArgs`, `DuckdbQueryColumns`, `DuckdbQueryReferences`, `DuckdbQueryReferenceGuard`.
- Docs: `docs/merge-queries/architecture.md`, `docs/multi-source-queries.md`.

## Regression analysis

- **Compose SQL**: same discover probe, same CTE strings, same execution. Existing compose-SQL tests unchanged and passing.
- **External SQL**: same path as compose SQL; no change.
- **Merge**: supplied mode issues no discovery query (previously none either — the merge tail never probed). `originalColumns` reaching `runAsyncWarehouseQuery` is the same reference `create` received; label, format and provenance asserted intact. Row-cap refusal still fires before the join; under-cap merges still run.
- **One write-shape change**: supplied mode also rewrites `fields` / `original_columns` on the query-history row with the values the merge persisted at create. Same references, proven by test; visible only if a reader compared the two writes.
- No public contract touched; no generated files; no migration.

## Tests

- `runDuckdbQuery`: supplied mode executes with the caller's fields/columns/pivot and never probes; discover mode probes with one row; a guard refusal lands as the query error before anything runs.
- `executeAsyncMergeQuery on the compose engine`: runs the join in supplied mode (stream never called; `originalColumns` identity; `Query A Orders`, `#,##0`, provenance); refuses before the join when a leg reached the row cap, naming the source; runs when every leg is under the cap.
- `mergeQueryExecution.test.ts`: `buildMergeRowCapGuard`.
- `AsyncQueryService.test.ts` 92 passed; full backend `572 files / 9340 passed`; typecheck and lint clean.

## Stack

Based on #28576 (DuckDB engine in OSS). This branch also carries a cherry-pick of #28572's single commit (the row-cap seam this tail preserves), unchanged and as its own commit; it drops out by patch-id once #28572 merges. Review this PR's own change as its last commit.

Part of the Query & Explore V2 milestone "One execution path: merge as composition".

Closes: PROD-10900
Relates: PROD-10893
Relates: PROD-10890

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LyhpDxbUsZ9YXhk8GJVPjM
