### PR TITLE
feat(ai): data app as pinned context via @ mention

### DIFF
--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -12,6 +12,7 @@ collisions with other contexts' or repo-wide meanings.
 
 - [Data apps](./docs/data-apps/CONTEXT.md) — AI-generated interactive apps built on the semantic layer by a coding agent in a sandbox, versioned per prompt, found and read by the AI agent
 - [Pre-aggregates](./docs/pre-aggregates/CONTEXT.md) — user-defined, pre-computed summaries of explores that serve matching queries from materialized files instead of the warehouse
+- [AI agent](./docs/ai-agent/CONTEXT.md) — the in-app conversational agent (Ask AI), what users pin to its prompts, and where it opens from
 - [AI agent memory](./docs/ai-agent-memory/CONTEXT.md) — per-user, per-project knowledge the AI agent distills from a user's threads and recalls on their future threads
 - [External sources](./docs/external-sources/CONTEXT.md) — uploaded CSVs and connected Google Sheets ingested to typed parquet and queried as explores on the DuckDB engine
 - [Merge queries](./docs/merge-queries/CONTEXT.md) — joining the results of two explore queries on a shared key, executed as a composed query with the join running in DuckDB

--- a/docs/ai-agent/CONTEXT.md
+++ b/docs/ai-agent/CONTEXT.md
@@ -1,0 +1,47 @@
+# AI agent
+
+Lightdash's in-app conversational agent, surfaced as Ask AI. A user asks
+questions in a thread; the agent answers with tools that read and query the
+project. Users can attach project content to a prompt so the agent knows what
+they are looking at. Not the coding agent that writes data apps, and not an
+external agent reaching Lightdash through MCP.
+
+## Language
+
+**Ask AI**:
+The entry point that opens the AI agent from a piece of content — a chart,
+dashboard, dashboard tile, data app, or listing row — with that content
+already pinned to the new prompt.
+_Avoid_: ask agent, open copilot, AI button
+
+**Pinned context**:
+The set of content a user attaches to one AI agent prompt: charts,
+dashboards, data apps, previous conversations, dbt files, repositories,
+external sources. Stored with the prompt and shown to the agent as names and
+slugs; the agent reads the content itself with its tools. Outside this
+context, qualify as "AI agent pinned context"; it is not data-app **Context**,
+which is what the coding agent receives.
+_Avoid_: context (unqualified), attachments, references, mentions (for the
+set)
+
+**Mention**:
+Attaching content to a prompt by typing `@` and picking it from search, the
+current page, or the tiles of a pinned dashboard. A mention is one way to
+add pinned context; Ask AI is the other.
+_Avoid_: tag, link, reference
+
+**Runtime overrides**:
+The live state a chart or dashboard had when it was pinned — dashboard
+filters, parameter values, date zoom, active tab — recorded so the agent
+queries what the user saw rather than the saved state.
+_Avoid_: filters (unqualified), page state, snapshot
+
+**Launcher**:
+The docked panel that hosts the AI agent on content pages. Ask AI opens it;
+a thread can expand from it to the full page and collapse back.
+_Avoid_: sidebar, widget, chat panel
+
+**Preview panel**:
+The in-thread panel that renders a data app the agent built or the user
+pinned, so it can be inspected without leaving the thread.
+_Avoid_: iframe, side panel, viewer

--- a/docs/data-apps/CONTEXT.md
+++ b/docs/data-apps/CONTEXT.md
@@ -101,8 +101,9 @@ _Avoid_: follow-ups, Q&A, refinements
 **Context**:
 Everything a user attaches to a prompt for the coding agent: saved charts,
 dashboards, images, screenshots of the running app, files, sample data, and
-external connections. Kept with the version.
-_Avoid_: attachments, resources (unqualified)
+external connections. Kept with the version. Not the AI agent's **pinned
+context**, which is what a user attaches to an Ask AI prompt.
+_Avoid_: attachments, resources (unqualified), pinned context
 
 **Generate from**:
 To create a new data app with existing charts or dashboards attached as

--- a/packages/backend/src/ee/database/entities/ai.ts
+++ b/packages/backend/src/ee/database/entities/ai.ts
@@ -468,7 +468,8 @@ export type AiPromptContextEntityType =
     | 'review_finding'
     | 'preview_environment'
     | 'data_app_element'
-    | 'data_app_restore';
+    | 'data_app_restore'
+    | 'data_app';
 
 // Element reference snapshot stored in runtime_overrides; entity_ref holds the
 // natural key so one prompt can reference several elements of the same app.
@@ -484,6 +485,12 @@ export type AiPromptDataAppElementSnapshot = {
 export type AiPromptDataAppRestoreSnapshot = {
     version: number;
     restoredFromVersion: number;
+};
+
+// Latest ready version number at attach time; app versions are integers, so
+// pinned_version_uuid stays null.
+export type AiPromptDataAppSnapshot = {
+    version: number | null;
 };
 
 export type DbAiPromptContext = {
@@ -504,6 +511,7 @@ export type DbAiPromptContext = {
         | AiPromptExternalSourceSnapshot
         | AiPromptDataAppElementSnapshot
         | AiPromptDataAppRestoreSnapshot
+        | AiPromptDataAppSnapshot
         | null;
     created_at: Date;
 };

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -147,6 +147,7 @@ import {
     AiPromptContextTableName,
     AiPromptDataAppElementSnapshot,
     AiPromptDataAppRestoreSnapshot,
+    AiPromptDataAppSnapshot,
     AiPromptInterruptTableName,
     AiPromptSteerTableName,
     AiPromptTableName,
@@ -6507,7 +6508,9 @@ export class AiAgentModel {
             c.type === 'dashboard' ? [c.dashboardUuid] : [],
         );
         const appUuids = context.flatMap((c) =>
-            c.type === 'data_app_element' || c.type === 'data_app_restore'
+            c.type === 'data_app_element' ||
+            c.type === 'data_app_restore' ||
+            c.type === 'data_app'
                 ? [c.appUuid]
                 : [],
         );
@@ -6522,6 +6525,22 @@ export class AiAgentModel {
                         'name',
                     )
             ).map((r) => [r.app_id, r.name] as const),
+        );
+
+        const pinnedAppUuids = context.flatMap((c) =>
+            c.type === 'data_app' ? [c.appUuid] : [],
+        );
+        const latestReadyVersionByAppUuid = new Map(
+            (
+                await trx(AppVersionsTableName)
+                    .whereIn('app_id', pinnedAppUuids)
+                    .where('status', 'ready')
+                    .groupBy('app_id')
+                    .select<{ app_id: string; version: number }[]>(
+                        'app_id',
+                        trx.raw('max(version) as version'),
+                    )
+            ).map((r) => [r.app_id, r.version] as const),
         );
 
         const chartLookup = new Map(
@@ -6824,6 +6843,23 @@ export class AiAgentModel {
                         } satisfies AiPromptDataAppRestoreSnapshot,
                     };
                 }
+                case 'data_app': {
+                    const appName = appNameByUuid.get(ctx.appUuid);
+                    return {
+                        ai_prompt_uuid: promptUuid,
+                        entity_type: 'data_app' as AiPromptContextEntityType,
+                        entity_uuid: ctx.appUuid,
+                        display_name:
+                            appName === undefined
+                                ? null
+                                : getAppDisplayName(appName, ctx.appUuid),
+                        runtime_overrides: {
+                            version:
+                                latestReadyVersionByAppUuid.get(ctx.appUuid) ??
+                                null,
+                        } satisfies AiPromptDataAppSnapshot,
+                    };
+                }
                 default:
                     return assertUnreachable(
                         ctx,
@@ -6967,7 +7003,11 @@ export class AiAgentModel {
                         .appUuid,
                 ];
             }
-            if (r.entity_type === 'data_app_restore' && r.entity_uuid) {
+            if (
+                (r.entity_type === 'data_app_restore' ||
+                    r.entity_type === 'data_app') &&
+                r.entity_uuid !== null
+            ) {
                 return [r.entity_uuid];
             }
             return [];
@@ -6977,12 +7017,25 @@ export class AiAgentModel {
                 await this.database(AppsTableName)
                     .whereIn('app_id', appUuids)
                     .whereNull('deleted_at')
-                    .select<{ app_id: string; slug: string; name: string }[]>(
-                        'app_id',
-                        'slug',
-                        'name',
-                    )
-            ).map((r) => [r.app_id, { slug: r.slug, name: r.name }] as const),
+                    .select<
+                        {
+                            app_id: string;
+                            slug: string;
+                            name: string;
+                            space_uuid: string | null;
+                        }[]
+                    >('app_id', 'slug', 'name', 'space_uuid')
+            ).map(
+                (r) =>
+                    [
+                        r.app_id,
+                        {
+                            slug: r.slug,
+                            name: r.name,
+                            spaceUuid: r.space_uuid,
+                        },
+                    ] as const,
+            ),
         );
 
         const previewProjectUuids = rows
@@ -7062,7 +7115,10 @@ export class AiAgentModel {
         dashboardSlugByUuid: Map<string, string>,
         reviewItem: AiAgentReviewItemSummary | null,
         projectNameByUuid: Map<string, string>,
-        appDataByUuid: Map<string, { slug: string; name: string }>,
+        appDataByUuid: Map<
+            string,
+            { slug: string; name: string; spaceUuid: string | null }
+        >,
     ): AiPromptContextItem {
         // chart/dashboard/thread are uuid-keyed: entity_uuid is a non-null
         // invariant (only file/repository leave it null, using entity_ref).
@@ -7205,6 +7261,22 @@ export class AiAgentModel {
                     displayName: app
                         ? getAppDisplayName(app.name, appUuid)
                         : row.display_name,
+                };
+            }
+            case 'data_app': {
+                const appUuid = requireEntityUuid();
+                const app = appDataByUuid.get(appUuid);
+                const snapshot =
+                    row.runtime_overrides as AiPromptDataAppSnapshot | null;
+                return {
+                    type: 'data_app',
+                    appUuid,
+                    appSlug: app?.slug ?? null,
+                    displayName: app
+                        ? getAppDisplayName(app.name, appUuid)
+                        : row.display_name,
+                    pinnedVersion: snapshot?.version ?? null,
+                    isPersonal: app !== undefined && app.spaceUuid === null,
                 };
             }
             default:

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -62,6 +62,8 @@ import {
     CommercialFeatureFlags,
     ConflictError,
     ContentType,
+    DATA_APP_VIZ_TEMPLATE,
+    dataAppContextKey,
     dataAppElementContextKey,
     dataAppRestoreContextKey,
     dataAppVizSchema,
@@ -1079,6 +1081,9 @@ export class AiAgentService extends BaseService {
                 case 'data_app_restore':
                     key = dataAppRestoreContextKey(item);
                     break;
+                case 'data_app':
+                    key = dataAppContextKey(item.appUuid);
+                    break;
                 default:
                     return assertUnreachable(
                         item,
@@ -1160,10 +1165,21 @@ export class AiAgentService extends BaseService {
                     return;
                 }
 
-                if (item.type === 'data_app_element') {
+                if (
+                    item.type === 'data_app_element' ||
+                    item.type === 'data_app'
+                ) {
                     const app = await this.appModel.findAppByUuid(item.appUuid);
                     if (!app || app.project_uuid !== agent.projectUuid) {
                         throw new NotFoundError('Data app not found');
+                    }
+                    if (
+                        item.type === 'data_app' &&
+                        app.template === DATA_APP_VIZ_TEMPLATE
+                    ) {
+                        throw new ParameterError(
+                            'Project chart types cannot be pinned context',
+                        );
                     }
                     if (
                         !(await this.appGenerateService.canViewApp(user, app))
@@ -8834,6 +8850,11 @@ Use them as a reference, but do all the due dilligence and follow the instructio
                     const status = item.status ? ` — ${item.status}` : '';
                     return `- Preview environment${name}${status} — test the fix in this preview project.`;
                 }
+                case 'data_app': {
+                    const name = item.displayName ?? '(name unavailable)';
+                    const slugText = item.appSlug ?? '(slug unavailable)';
+                    return `- Data app "${name}" (dataAppSlug: ${slugText})`;
+                }
                 case 'data_app_element': {
                     const name = item.displayName ?? '(name unavailable)';
                     const slugText = item.appSlug ?? '(slug unavailable)';
@@ -8858,7 +8879,7 @@ Use them as a reference, but do all the due dilligence and follow the instructio
 The user attached the following to this message as context:
 ${lines.join('\n')}
 
-Use your existing tools to inspect them when relevant to the user's question. When runtime overrides are listed, apply them on top of the chart's saved state when querying.`,
+Use your existing tools to inspect them when relevant to the user's question (readContent for charts, dashboards, and data apps). When runtime overrides are listed, apply them on top of the chart's saved state when querying.`,
         } satisfies UserModelMessage;
     }
 

--- a/packages/backend/src/ee/services/AiAgentService/pinnedContextMessage.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/pinnedContextMessage.test.ts
@@ -346,3 +346,63 @@ describe('AiAgentService.createPinnedContextMessage review pins', () => {
         );
     });
 });
+
+describe('AiAgentService.createPinnedContextMessage data app pins', () => {
+    it('renders a data app by name and slug only', () => {
+        const content = buildMessage([
+            {
+                type: 'data_app',
+                appUuid: 'app-1',
+                appSlug: 'f1-standings',
+                displayName: 'F1 standings',
+                pinnedVersion: 3,
+                isPersonal: false,
+            },
+        ]);
+
+        expect(content).toContain(
+            '- Data app "F1 standings" (dataAppSlug: f1-standings)',
+        );
+        expect(content).not.toContain('version 3');
+        expect(content).toContain('readContent');
+    });
+
+    it('keeps mixed items in their pinned order', () => {
+        const content = buildMessage([
+            {
+                type: 'dashboard',
+                dashboardUuid: 'dashboard-1',
+                dashboardSlug: 'exec-dashboard',
+                displayName: 'Executive dashboard',
+                pinnedVersionUuid: null,
+                runtimeOverrides: null,
+            },
+            {
+                type: 'data_app',
+                appUuid: 'app-1',
+                appSlug: 'f1-standings',
+                displayName: 'F1 standings',
+                pinnedVersion: null,
+                isPersonal: false,
+            },
+            {
+                type: 'chart',
+                chartUuid: 'chart-1',
+                chartSlug: 'revenue',
+                displayName: 'Revenue',
+                pinnedVersionUuid: null,
+                runtimeOverrides: null,
+                chartKind: null,
+            },
+        ]);
+
+        const dashboardAt = content.indexOf(
+            '- Dashboard "Executive dashboard"',
+        );
+        const appAt = content.indexOf('- Data app "F1 standings"');
+        const chartAt = content.indexOf('- Chart "Revenue"');
+        expect(dashboardAt).toBeGreaterThan(-1);
+        expect(appAt).toBeGreaterThan(dashboardAt);
+        expect(chartAt).toBeGreaterThan(appAt);
+    });
+});

--- a/packages/backend/src/ee/services/AiAgentService/promptContextAccess.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/promptContextAccess.test.ts
@@ -1,0 +1,150 @@
+import {
+    ForbiddenError,
+    NotFoundError,
+    ParameterError,
+    type AiAgent,
+    type AiPromptContextInput,
+    type SessionUser,
+} from '@lightdash/common';
+import { AiAgentService } from './AiAgentService';
+
+vi.mock('../ai/AiAgentMcpRuntimeClient', () => ({
+    AiAgentMcpRuntimeClient: vi
+        .fn()
+        // eslint-disable-next-line prefer-arrow-callback
+        .mockImplementation(function MockAiAgentMcpRuntimeClient() {
+            return {};
+        }),
+}));
+
+const PROJECT_UUID = 'project-uuid';
+const USER_UUID = 'user-uuid';
+
+const user = { userUuid: USER_UUID } as SessionUser;
+const agent = {
+    uuid: 'agent-uuid',
+    organizationUuid: 'org-uuid',
+    projectUuid: PROJECT_UUID,
+} as AiAgent;
+
+type App = {
+    app_id: string;
+    project_uuid: string;
+    space_uuid: string | null;
+    created_by_user_uuid: string;
+    template: string | null;
+    organization_uuid: string;
+};
+
+const sharedApp: App = {
+    app_id: 'app-shared',
+    project_uuid: PROJECT_UUID,
+    space_uuid: 'space-1',
+    created_by_user_uuid: 'someone-else',
+    template: 'dashboard',
+    organization_uuid: 'org-uuid',
+};
+
+const otherUsersPersonalApp: App = {
+    ...sharedApp,
+    app_id: 'app-personal',
+    space_uuid: null,
+};
+
+const chartTypeApp: App = {
+    ...sharedApp,
+    app_id: 'app-viz',
+    template: 'data_app_viz',
+};
+
+const buildService = (apps: App[]) => {
+    const appModel = {
+        findAppByUuid: vi
+            .fn()
+            .mockImplementation(async (appUuid: string) =>
+                apps.find((a) => a.app_id === appUuid),
+            ),
+    };
+    // Personal apps (no space) are viewable only by their creator.
+    const appGenerateService = {
+        canViewApp: vi
+            .fn()
+            .mockImplementation(
+                async (u: SessionUser, app: App) =>
+                    app.space_uuid !== null ||
+                    app.created_by_user_uuid === u.userUuid,
+            ),
+    };
+    const service = new AiAgentService({
+        appModel,
+        appGenerateService,
+        analytics: { track: vi.fn() },
+        lightdashConfig: { ai: { copilot: {} } },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    const validate = (context: AiPromptContextInput) =>
+        (
+            service as unknown as {
+                validatePromptContextAccess: (
+                    u: SessionUser,
+                    a: AiAgent,
+                    c: AiPromptContextInput,
+                ) => Promise<AiPromptContextInput | undefined>;
+            }
+        ).validatePromptContextAccess(user, agent, context);
+    return { validate, appModel, appGenerateService };
+};
+
+describe('validatePromptContextAccess for data apps', () => {
+    it('accepts a data app the user can view', async () => {
+        const { validate } = buildService([sharedApp]);
+        const context: AiPromptContextInput = [
+            { type: 'data_app', appUuid: 'app-shared', appSlug: 'shared' },
+        ];
+
+        await expect(validate(context)).resolves.toEqual(context);
+    });
+
+    it("rejects another user's personal app", async () => {
+        const { validate } = buildService([otherUsersPersonalApp]);
+
+        await expect(
+            validate([{ type: 'data_app', appUuid: 'app-personal' }]),
+        ).rejects.toThrow(ForbiddenError);
+    });
+
+    it('rejects a project chart type', async () => {
+        const { validate, appGenerateService } = buildService([chartTypeApp]);
+
+        const result = validate([{ type: 'data_app', appUuid: 'app-viz' }]);
+        await expect(result).rejects.toThrow(ParameterError);
+        await expect(result).rejects.toThrow(
+            'Project chart types cannot be pinned context',
+        );
+        expect(appGenerateService.canViewApp).not.toHaveBeenCalled();
+    });
+
+    it('rejects an app from another project as not found', async () => {
+        const { validate } = buildService([
+            { ...sharedApp, project_uuid: 'other-project' },
+        ]);
+
+        await expect(
+            validate([{ type: 'data_app', appUuid: 'app-shared' }]),
+        ).rejects.toThrow(NotFoundError);
+    });
+
+    it('collapses the same app pinned twice into one item', async () => {
+        const { validate, appModel } = buildService([sharedApp]);
+
+        await expect(
+            validate([
+                { type: 'data_app', appUuid: 'app-shared', appSlug: 'shared' },
+                { type: 'data_app', appUuid: 'app-shared' },
+            ]),
+        ).resolves.toEqual([
+            { type: 'data_app', appUuid: 'app-shared', appSlug: 'shared' },
+        ]);
+        expect(appModel.findAppByUuid).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/backend/src/ee/services/ai/compaction.test.ts
+++ b/packages/backend/src/ee/services/ai/compaction.test.ts
@@ -303,6 +303,34 @@ describe('AI context compaction helpers', () => {
             'element reference [button "Send"] in data app F1 standings (app-1, version 3',
         );
     });
+
+    it('serializes a pinned data app by name and slug', () => {
+        const serialized = Compaction.serializeConversation([
+            {
+                role: 'user',
+                uuid: 'prompt-1',
+                threadUuid: 'thread-1',
+                message: 'What data does this app use?',
+                createdAt: new Date().toISOString(),
+                user: { uuid: 'user-1', name: 'Test User' },
+                context: [
+                    {
+                        type: 'data_app',
+                        appUuid: 'app-1',
+                        appSlug: 'f1-standings',
+                        displayName: 'F1 standings',
+                        pinnedVersion: 3,
+                        isPersonal: false,
+                    },
+                ],
+                steers: [],
+                hidden: false,
+            },
+        ]);
+
+        expect(serialized).toContain('data app F1 standings (f1-standings)');
+    });
+
     it('filters raw prompt rows after the latest compaction boundary', () => {
         const filtered = Compaction.filterThreadMessagesAfterCompaction(
             [

--- a/packages/backend/src/ee/services/ai/compaction.ts
+++ b/packages/backend/src/ee/services/ai/compaction.ts
@@ -234,6 +234,8 @@ export class Compaction {
                 return `preview environment${
                     item.projectName ? ` (${item.projectName})` : ''
                 }${item.status ? ` — ${item.status}` : ''}`;
+            case 'data_app':
+                return `data app ${item.displayName ?? item.appUuid} (${item.appSlug ?? item.appUuid})`;
             case 'data_app_element':
                 return `element reference ${elementReferenceToWireString(item)} in data app ${item.displayName ?? item.appUuid} (${item.appUuid}, version ${item.version}; copy it verbatim into the iterateDataApp brief)`;
             case 'data_app_restore':

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -230,11 +230,15 @@ export type AiAgentSummary = Pick<
 >;
 
 // An empty spaceAccess list means the agent is unrestricted (all spaces).
+export const isSpaceRestrictedAgent = (
+    agent: Pick<AiAgent, 'spaceAccess'>,
+): boolean => agent.spaceAccess.length > 0;
+
 export const hasAiAgentAccessToSpace = (
     agent: Pick<AiAgent, 'spaceAccess'>,
     spaceUuid: string,
 ): boolean =>
-    agent.spaceAccess.length === 0 || agent.spaceAccess.includes(spaceUuid);
+    !isSpaceRestrictedAgent(agent) || agent.spaceAccess.includes(spaceUuid);
 
 export type AiAgentUser = {
     uuid: string;

--- a/packages/common/src/ee/AiAgent/requestTypes.ts
+++ b/packages/common/src/ee/AiAgent/requestTypes.ts
@@ -253,6 +253,13 @@ export type AiPromptContextItemInput =
           appUuid: string;
           version: number;
           restoredFromVersion: number;
+      }
+    | {
+          // A data app the user pinned; the server snapshots its name and
+          // latest ready version number at attach time.
+          type: 'data_app';
+          appUuid: string;
+          appSlug?: string | null;
       };
 
 export type AiPromptContextInput = AiPromptContextItemInput[];
@@ -360,6 +367,15 @@ export type AiPromptContextItem =
           restoredFromVersion: number;
           appSlug: string | null;
           displayName: string | null;
+      }
+    | {
+          type: 'data_app';
+          appUuid: string;
+          appSlug: string | null;
+          displayName: string | null;
+          pinnedVersion: number | null;
+          // Personal apps have no space; space-restricted agents cannot read them.
+          isPersonal: boolean;
       };
 
 export type AiPromptContext = AiPromptContextItem[];

--- a/packages/common/src/ee/apps/elementReference.ts
+++ b/packages/common/src/ee/apps/elementReference.ts
@@ -40,3 +40,6 @@ export const dataAppRestoreContextKey = ({
     appUuid: string;
     version: number;
 }): string => `data_app_restore:${appUuid}:${version}`;
+/** Identity of a pinned data app as prompt context. */
+export const dataAppContextKey = (appUuid: string): string =>
+    `data_app:${appUuid}`;

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.tsx
@@ -227,6 +227,7 @@ export const AgentChatDisplay: FC<PropsWithChildren<Props>> = ({
                                     <UserBubble
                                         message={message}
                                         projectUuid={projectUuid}
+                                        agentUuid={agentUuid}
                                     />
                                 ) : (
                                     <ErrorBoundary>

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.module.css
@@ -288,6 +288,13 @@
         linear-gradient(currentColor 0 0) 7px 6px / 4px 5px no-repeat;
 }
 
+.contentMentionIcon[data-icon-type='data_app']::before {
+    background:
+        linear-gradient(currentColor 0 0) 1px 1px / 10px 10px no-repeat,
+        linear-gradient(var(--mantine-color-body) 0 0) 2px 4px / 8px 6px
+            no-repeat;
+}
+
 .contentMentionIcon[data-rendered-icon='true']::before {
     content: none;
 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -2,6 +2,7 @@ import { subject } from '@casl/ability';
 import {
     FeatureFlags,
     getExternalSourceDisplayName,
+    isSpaceRestrictedAgent,
     type AgentSuggestion,
     type AiPromptContextInput,
     type AiPromptContextItem,
@@ -65,6 +66,7 @@ import { useDeepResearchComposer } from '../../hooks/useDeepResearchComposer';
 import {
     useCreateAiAgentThreadMessageSteerMutation,
     useInterruptAiAgentThreadMessageMutation,
+    useProjectAiAgent,
 } from '../../hooks/useProjectAiAgents';
 import {
     clearThreadElementReferences,
@@ -352,6 +354,11 @@ export const AgentChatInput = ({
     projectUuidRef.current = projectUuid;
     const contentMentionPriorityItemsRef = useRef(contentMentionPriorityItems);
     contentMentionPriorityItemsRef.current = contentMentionPriorityItems;
+    // A space-restricted agent cannot read personal data apps, so @ hides them.
+    const { data: agent } = useProjectAiAgent(projectUuid, agentUuid);
+    const hidePersonalDataAppsRef = useRef(false);
+    hidePersonalDataAppsRef.current =
+        agent !== undefined && isSpaceRestrictedAgent(agent);
     // What the @-mention dropdown is doing, sourced from the suggestion render
     // lifecycle — the plugin's own `active` flag alone can't tell an open
     // menu from a dismissed or empty one.
@@ -463,6 +470,7 @@ export const AgentChatInput = ({
             createContentMentionExtension({
                 getProjectUuid: () => projectUuidRef.current,
                 getPriorityItems: () => contentMentionPriorityItemsRef.current,
+                getHidePersonalDataApps: () => hidePersonalDataAppsRef.current,
                 onMenuStateChange: (state) => {
                     contentMentionMenuRef.current = state;
                 },

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatUserBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatUserBubble.tsx
@@ -24,6 +24,8 @@ type Props = {
     // Explicit for routes where projectUuid isn't a URL param (the review
     // remediation workspace); falls back to params for the normal agent chat.
     projectUuid?: string;
+    // Explicit for the docked launcher, where the route is the host page.
+    agentUuid?: string;
 };
 
 const getVisibleUserName = (name: string) => {
@@ -39,10 +41,12 @@ export const UserBubble: FC<Props> = ({
     message,
     isActive = false,
     projectUuid: projectUuidProp,
+    agentUuid: agentUuidProp,
 }) => {
-    const { agentUuid } = useParams();
+    const { agentUuid: paramsAgentUuid } = useParams();
     const paramsProjectUuid = useProjectUuid();
     const projectUuid = projectUuidProp ?? paramsProjectUuid;
+    const agentUuid = agentUuidProp ?? paramsAgentUuid;
     const timeAgo = useTimeAgo(message.createdAt);
     const name = getVisibleUserName(message.user.name);
     const app = useApp();
@@ -103,6 +107,16 @@ export const UserBubble: FC<Props> = ({
                                     key={`${getPromptContextItemKey(item)}-${idx}`}
                                     item={item}
                                     projectUuid={projectUuid}
+                                    previewScope={
+                                        agentUuid
+                                            ? {
+                                                  messageUuid: message.uuid,
+                                                  threadUuid:
+                                                      message.threadUuid,
+                                                  agentUuid,
+                                              }
+                                            : null
+                                    }
                                 />
                             ))}
                         </Group>

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentLink.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentLink.tsx
@@ -20,19 +20,15 @@ import {
 import styles from './ContentLink.module.css';
 import { ContentReferenceLink } from './ContentReferenceLink';
 import { type ContentType } from './rehypeContentLinks';
+import {
+    isPlainLeftClick,
+    useDataAppPreviewLink,
+} from './useDataAppPreviewLink';
 
 export type SqlRunnerLinkState = {
     sql: string;
     limit?: number;
 };
-
-const isPlainLeftClick = (e: MouseEvent<HTMLAnchorElement>) =>
-    !e.defaultPrevented &&
-    e.button === 0 &&
-    !e.metaKey &&
-    !e.altKey &&
-    !e.ctrlKey &&
-    !e.shiftKey;
 
 const REFERENCE_LINK_KINDS = {
     'dashboard-link': 'dashboard',
@@ -63,10 +59,20 @@ export const ContentLink: FC<ContentLinkProps> = ({
 }) => {
     const navigate = useNavigate();
     const location = useLocation();
-    const resourceHref = typeof props.href === 'string' ? props.href : '';
-    const title = typeof props.title === 'string' ? props.title : undefined;
     const dispatch = useAiAgentStoreDispatch();
     const currentPreview = useAiAgentStoreSelector(selectPreview);
+    const resourceHref = typeof props.href === 'string' ? props.href : '';
+    const title = typeof props.title === 'string' ? props.title : undefined;
+    const dataAppUuid =
+        'data-app-uuid' in props && typeof props['data-app-uuid'] === 'string'
+            ? props['data-app-uuid']
+            : null;
+    const dataAppPreviewLink = useDataAppPreviewLink(dataAppUuid, {
+        messageUuid: message.uuid,
+        threadUuid: message.threadUuid,
+        projectUuid,
+        agentUuid,
+    });
 
     const handleResourceClick = (e: MouseEvent<HTMLAnchorElement>) => {
         if (!resourceHref || !isPlainLeftClick(e)) {
@@ -112,47 +118,13 @@ export const ContentLink: FC<ContentLinkProps> = ({
                 </ContentReferenceLink>
             );
 
-        case 'data-app-link': {
-            const appUuid =
-                'data-app-uuid' in props &&
-                typeof props['data-app-uuid'] === 'string'
-                    ? props['data-app-uuid']
-                    : undefined;
-            // App-level match: the link has no app data to tell which
-            // version the panel is on, so it lights up for any version.
-            const isActive =
-                !!appUuid &&
-                currentPreview?.type === 'dataApp' &&
-                currentPreview.appUuid === appUuid;
-
-            // Modified clicks fall through to the anchor and open the full
-            // page in a new tab. A link always opens the latest ready version.
-            const handleDataAppClick = (e: MouseEvent<HTMLAnchorElement>) => {
-                if (!appUuid || !isPlainLeftClick(e)) {
-                    return;
-                }
-
-                e.preventDefault();
-                dispatch(
-                    setPreview({
-                        type: 'dataApp',
-                        appUuid,
-                        messageUuid: message.uuid,
-                        threadUuid: message.threadUuid,
-                        projectUuid,
-                        agentUuid,
-                        version: null,
-                        latestReadyVersionAtOpen: null,
-                    }),
-                );
-            };
-
+        case 'data-app-link':
             return (
                 <ContentReferenceLink
                     to={resourceHref || undefined}
                     kind={REFERENCE_LINK_KINDS[contentType]}
-                    data-app-active={isActive || undefined}
-                    onClick={handleDataAppClick}
+                    data-app-active={dataAppPreviewLink.isActive || undefined}
+                    onClick={dataAppPreviewLink.onClick}
                     target="_blank"
                     rel="noreferrer"
                     title={title}
@@ -160,7 +132,6 @@ export const ContentLink: FC<ContentLinkProps> = ({
                     {children}
                 </ContentReferenceLink>
             );
-        }
 
         case 'chart-link': {
             const chartUuid =

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentMentionNodeView.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentMentionNodeView.tsx
@@ -1,48 +1,27 @@
-import { ContentType, type ChartKind } from '@lightdash/common';
-import {
-    IconBrandGithub,
-    IconFile,
-    IconLayoutDashboard,
-} from '@tabler/icons-react';
+import { type ChartKind } from '@lightdash/common';
+import { IconBrandGithub, IconFile } from '@tabler/icons-react';
 import { NodeViewWrapper, type NodeViewProps } from '@tiptap/react';
 import MantineIcon from '../../../../../components/common/MantineIcon';
-import { getChartIcon } from '../../../../../components/common/ResourceIcon/utils';
 import TruncatedText from '../../../../../components/common/TruncatedText';
 import styles from './AgentChatInput.module.css';
-
-// File and repository mentions reuse this node so they get the same pill chrome;
-// they're distinguished by their contentType and carry the path / `owner/repo`
-// in `label`.
-const FILE_CONTENT_TYPE = 'file';
-const REPOSITORY_CONTENT_TYPE = 'repository';
-
-const getContentMentionContentType = (value: unknown) => {
-    if (value === FILE_CONTENT_TYPE) return FILE_CONTENT_TYPE;
-    if (value === REPOSITORY_CONTENT_TYPE) return REPOSITORY_CONTENT_TYPE;
-    return value === ContentType.DASHBOARD
-        ? ContentType.DASHBOARD
-        : ContentType.CHART;
-};
+import {
+    FILE_MENTION_CONTENT_TYPE,
+    getContentMentionContentType,
+    REPOSITORY_MENTION_CONTENT_TYPE,
+} from './contentMentionContentType';
+import { getContentMentionIcon } from './contentMentionIcon';
 
 export const ContentMentionNodeView = ({ node }: NodeViewProps) => {
     const contentType = getContentMentionContentType(node.attrs.contentType);
-    const isFile = contentType === FILE_CONTENT_TYPE;
-    const isRepository = contentType === REPOSITORY_CONTENT_TYPE;
-    const Icon = isFile
-        ? IconFile
-        : isRepository
-          ? IconBrandGithub
-          : contentType === ContentType.DASHBOARD
-            ? IconLayoutDashboard
-            : getChartIcon(
-                  (node.attrs.chartKind as ChartKind | null) ?? undefined,
-              );
-    const iconColor =
+    const isFile = contentType === FILE_MENTION_CONTENT_TYPE;
+    const isRepository = contentType === REPOSITORY_MENTION_CONTENT_TYPE;
+    const { icon: Icon, color: iconColor } =
         isFile || isRepository
-            ? 'ldGray.6'
-            : contentType === ContentType.DASHBOARD
-              ? 'green.7'
-              : 'blue.7';
+            ? { icon: isFile ? IconFile : IconBrandGithub, color: 'ldGray.6' }
+            : getContentMentionIcon(
+                  contentType,
+                  (node.attrs.chartKind as ChartKind | null) ?? null,
+              );
     const label = typeof node.attrs.label === 'string' ? node.attrs.label : '';
 
     return (

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentionContentType.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentionContentType.ts
@@ -1,0 +1,16 @@
+import { ContentType } from '@lightdash/common';
+
+// `contentType` values marking a content-mention node as a file or repository
+// (vs chart / dashboard / data app). Those nodes carry the path / `owner/repo`
+// in `label` and no context payload.
+export const FILE_MENTION_CONTENT_TYPE = 'file';
+export const REPOSITORY_MENTION_CONTENT_TYPE = 'repository';
+
+export const getContentMentionContentType = (value: unknown) => {
+    if (value === FILE_MENTION_CONTENT_TYPE) return FILE_MENTION_CONTENT_TYPE;
+    if (value === REPOSITORY_MENTION_CONTENT_TYPE)
+        return REPOSITORY_MENTION_CONTENT_TYPE;
+    if (value === ContentType.DASHBOARD) return ContentType.DASHBOARD;
+    if (value === ContentType.DATA_APP) return ContentType.DATA_APP;
+    return ContentType.CHART;
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentionIcon.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentionIcon.ts
@@ -1,0 +1,36 @@
+import {
+    assertUnreachable,
+    ContentType,
+    type ChartKind,
+} from '@lightdash/common';
+import {
+    IconAppWindow,
+    IconLayoutDashboard,
+    type Icon,
+} from '@tabler/icons-react';
+import { getChartIcon } from '../../../../../components/common/ResourceIcon/utils';
+
+export const getContentMentionIcon = (
+    contentType:
+        | ContentType.CHART
+        | ContentType.DASHBOARD
+        | ContentType.DATA_APP,
+    chartKind: ChartKind | null,
+): { icon: Icon; color: string } => {
+    switch (contentType) {
+        case ContentType.DASHBOARD:
+            return { icon: IconLayoutDashboard, color: 'green.7' };
+        case ContentType.DATA_APP:
+            return { icon: IconAppWindow, color: 'orange.6' };
+        case ContentType.CHART:
+            return {
+                icon: getChartIcon(chartKind ?? undefined),
+                color: 'blue.7',
+            };
+        default:
+            return assertUnreachable(
+                contentType,
+                'Unknown content mention type',
+            );
+    }
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.test.ts
@@ -1,10 +1,21 @@
-import { ChartKind, ContentType } from '@lightdash/common';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+    ChartKind,
+    ContentType,
+    type ApiContentResponse,
+    type DataAppContent,
+} from '@lightdash/common';
+import { Editor } from '@tiptap/core';
+import Document from '@tiptap/extension-document';
+import Paragraph from '@tiptap/extension-paragraph';
+import Text from '@tiptap/extension-text';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { lightdashApi } from '../../../../../api';
 import {
     buildContentMentionSuggestionItems,
     contentMentionMenuOwnsEnter,
     contextItemsToContentMentionSuggestions,
+    createContentMentionExtension,
+    extractContentMentionContext,
     fuzzyContentMentionLabelMatch,
     getContentMentionEmptyMessage,
     mergeAiPromptContextInput,
@@ -18,9 +29,253 @@ vi.mock('../../../../../api', () => ({
 
 const mockedLightdashApi = vi.mocked(lightdashApi);
 
+const dataAppResult = (
+    overrides: Partial<DataAppContent> & Pick<DataAppContent, 'uuid'>,
+): DataAppContent =>
+    ({
+        contentType: ContentType.DATA_APP,
+        name: `App ${overrides.uuid}`,
+        slug: overrides.uuid,
+        space: { uuid: 'space-1', name: 'Shared' },
+        template: 'dashboard',
+        ...overrides,
+    }) as DataAppContent;
+
+const mockContentSearch = (data: DataAppContent[]) => {
+    mockedLightdashApi.mockResolvedValue({
+        data,
+    } as unknown as ApiContentResponse['results']);
+};
+
+// Undestroyed editors leave DOMObserver timers behind that fire after jsdom
+// teardown.
+const editors: Editor[] = [];
+
+afterEach(() => {
+    editors.splice(0).forEach((editor) => editor.destroy());
+});
+
+const buildMentionEditor = (mentions: Record<string, unknown>[]) => {
+    const editor = new Editor({
+        extensions: [
+            Document,
+            Paragraph,
+            Text,
+            createContentMentionExtension({
+                getProjectUuid: () => 'project-uuid',
+                getPriorityItems: () => [],
+            }),
+        ],
+        content: {
+            type: 'doc',
+            content: [
+                {
+                    type: 'paragraph',
+                    content: mentions.map((attrs) => ({
+                        type: 'contentMention',
+                        attrs,
+                    })),
+                },
+            ],
+        },
+    });
+    editors.push(editor);
+    return editor;
+};
+
 describe('contentMentions', () => {
     beforeEach(() => {
         mockedLightdashApi.mockReset();
+    });
+
+    describe('data app mentions', () => {
+        it('requests data apps, including personal ones, without chart types', async () => {
+            mockContentSearch([]);
+
+            await buildContentMentionSuggestionItems({
+                projectUuid: 'project-uuid',
+                query: 'f1',
+                priorityItems: [],
+            });
+
+            const url = new URL(
+                mockedLightdashApi.mock.calls[0][0].url,
+                'http://localhost',
+            );
+            expect(url.searchParams.getAll('contentTypes')).toEqual([
+                ContentType.CHART,
+                ContentType.DASHBOARD,
+                ContentType.DATA_APP,
+            ]);
+            expect(url.searchParams.get('includePersonalDataApps')).toBe(
+                'true',
+            );
+            expect(url.searchParams.get('dataAppVizsFilter')).toBe('exclude');
+        });
+
+        it('drops project chart type results and labels personal apps', async () => {
+            mockContentSearch([
+                dataAppResult({ uuid: 'app-1', name: 'F1 standings' }),
+                dataAppResult({ uuid: 'viz-1', template: 'data_app_viz' }),
+                dataAppResult({
+                    uuid: 'app-personal',
+                    name: 'My scratch app',
+                    space: null,
+                }),
+            ]);
+
+            const items = await buildContentMentionSuggestionItems({
+                projectUuid: 'project-uuid',
+                query: 'app',
+                priorityItems: [],
+            });
+
+            expect(items.map((item) => item.uuid)).toEqual([
+                'app-1',
+                'app-personal',
+            ]);
+            expect(items[0]).toMatchObject({
+                contentType: ContentType.DATA_APP,
+                label: 'F1 standings',
+                slug: 'app-1',
+                spaceName: 'Shared',
+                isPersonalDataApp: false,
+                group: 'search',
+            });
+            expect(items[1]).toMatchObject({
+                spaceName: null,
+                isPersonalDataApp: true,
+            });
+        });
+
+        it('hides personal apps when the agent is space-restricted', async () => {
+            mockContentSearch([
+                dataAppResult({ uuid: 'app-1' }),
+                dataAppResult({ uuid: 'app-personal', space: null }),
+            ]);
+
+            const items = await buildContentMentionSuggestionItems({
+                projectUuid: 'project-uuid',
+                query: 'app',
+                priorityItems: [],
+                hidePersonalDataApps: true,
+            });
+
+            expect(items.map((item) => item.uuid)).toEqual(['app-1']);
+        });
+
+        it('hides personal apps offered by priority groups when the agent is space-restricted', async () => {
+            mockContentSearch([dataAppResult({ uuid: 'app-1' })]);
+
+            const items = await buildContentMentionSuggestionItems({
+                projectUuid: 'project-uuid',
+                query: 'app',
+                priorityItems: [
+                    {
+                        id: 'current:data_app:app-personal',
+                        label: 'App scratch',
+                        contentType: ContentType.DATA_APP,
+                        uuid: 'app-personal',
+                        slug: 'scratch',
+                        isPersonalDataApp: true,
+                        group: 'current',
+                    },
+                ],
+                hidePersonalDataApps: true,
+            });
+
+            expect(items.map((item) => item.uuid)).toEqual(['app-1']);
+        });
+
+        it('dedupes an already mentioned app against search results by uuid', async () => {
+            mockContentSearch([
+                dataAppResult({ uuid: 'app-1', name: 'F1 standings' }),
+            ]);
+
+            const items = await buildContentMentionSuggestionItems({
+                projectUuid: 'project-uuid',
+                query: 'f1',
+                priorityItems: [
+                    {
+                        id: 'thread:data_app:app-1',
+                        label: 'F1 standings',
+                        contentType: ContentType.DATA_APP,
+                        uuid: 'app-1',
+                        slug: 'f1-standings',
+                        isPersonalDataApp: false,
+                        group: 'thread',
+                    },
+                ],
+            });
+
+            expect(items).toHaveLength(1);
+            expect(items[0].group).toBe('thread');
+        });
+
+        it('maps pinned data apps into "Already mentioned" suggestions', () => {
+            expect(
+                contextItemsToContentMentionSuggestions(
+                    [
+                        {
+                            type: 'data_app',
+                            appUuid: 'app-1',
+                            appSlug: 'f1-standings',
+                            displayName: 'F1 standings',
+                            pinnedVersion: 3,
+                            isPersonal: false,
+                        },
+                    ],
+                    'thread',
+                ),
+            ).toEqual([
+                {
+                    id: 'thread:data_app:app-1',
+                    label: 'F1 standings',
+                    contentType: ContentType.DATA_APP,
+                    uuid: 'app-1',
+                    slug: 'f1-standings',
+                    isPersonalDataApp: false,
+                    group: 'thread',
+                },
+            ]);
+        });
+
+        it('extracts a data app mention as a data_app context item, deduped by uuid', () => {
+            const editor = buildMentionEditor([
+                {
+                    contentType: ContentType.DATA_APP,
+                    uuid: 'app-1',
+                    slug: 'f1-standings',
+                    label: 'F1 standings',
+                },
+                {
+                    contentType: ContentType.DATA_APP,
+                    uuid: 'app-1',
+                    slug: 'f1-standings',
+                    label: 'F1 standings',
+                },
+            ]);
+
+            expect(extractContentMentionContext(editor)).toEqual({
+                context: [
+                    {
+                        type: 'data_app',
+                        appUuid: 'app-1',
+                        appSlug: 'f1-standings',
+                    },
+                ],
+                optimisticContext: [
+                    {
+                        type: 'data_app',
+                        appUuid: 'app-1',
+                        appSlug: 'f1-standings',
+                        displayName: 'F1 standings',
+                        pinnedVersion: null,
+                        isPersonal: false,
+                    },
+                ],
+            });
+        });
     });
 
     it('dedupes prompt context preserving first occurrence', () => {
@@ -149,6 +404,7 @@ describe('contentMentions', () => {
             contentType: ContentType.CHART,
             uuid: 'chart-1',
             slug: 'revenue-chart',
+            isPersonalDataApp: false,
             group: 'thread',
         };
         const tileChart: ContentMentionSuggestionItem = {
@@ -157,6 +413,7 @@ describe('contentMentions', () => {
             contentType: ContentType.CHART,
             uuid: 'chart-1',
             slug: 'revenue-chart',
+            isPersonalDataApp: false,
             group: 'dashboardTile',
         };
         const tileChart2: ContentMentionSuggestionItem = {
@@ -165,6 +422,7 @@ describe('contentMentions', () => {
             contentType: ContentType.CHART,
             uuid: 'chart-2',
             slug: 'active-users',
+            isPersonalDataApp: false,
             group: 'dashboardTile',
         };
 
@@ -200,6 +458,7 @@ describe('contentMentions', () => {
                 uuid: 'chart-1',
                 slug: 'revenue-chart',
                 chartKind: ChartKind.VERTICAL_BAR,
+                isPersonalDataApp: false,
                 group: 'thread',
             },
         ]);
@@ -217,6 +476,7 @@ describe('contentMentions', () => {
                         contentType: ContentType.DASHBOARD,
                         uuid: 'dashboard-1',
                         slug: 'exec-dashboard',
+                        isPersonalDataApp: false,
                         group: 'current',
                     },
                     {
@@ -225,6 +485,7 @@ describe('contentMentions', () => {
                         contentType: ContentType.CHART,
                         uuid: 'chart-1',
                         slug: 'revenue-by-month',
+                        isPersonalDataApp: false,
                         group: 'dashboardTile',
                     },
                 ],
@@ -236,6 +497,7 @@ describe('contentMentions', () => {
                 contentType: ContentType.CHART,
                 uuid: 'chart-1',
                 slug: 'revenue-by-month',
+                isPersonalDataApp: false,
                 group: 'dashboardTile',
             },
         ]);

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.tsx
@@ -2,8 +2,7 @@ import {
     assertUnreachable,
     ChartSourceType,
     ContentType,
-    dataAppElementContextKey,
-    dataAppRestoreContextKey,
+    DATA_APP_VIZ_TEMPLATE,
     type AiPromptContextInput,
     type AiPromptContextItem,
     type ApiContentResponse,
@@ -19,7 +18,6 @@ import {
     IconBrandGitlab,
     IconCircleCheck,
     IconFile,
-    IconLayoutDashboard,
 } from '@tabler/icons-react';
 import Mention, { type MentionOptions } from '@tiptap/extension-mention';
 import { type DOMOutputSpec } from '@tiptap/pm/model';
@@ -33,7 +31,6 @@ import tippy, { type Instance as TippyInstance } from 'tippy.js';
 import { lightdashApi } from '../../../../../api';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import { PolymorphicGroupButton } from '../../../../../components/common/PolymorphicGroupButton';
-import { getChartIcon } from '../../../../../components/common/ResourceIcon/utils';
 import {
     SuggestionList,
     type SuggestionItem,
@@ -42,8 +39,17 @@ import {
 import suggestionStyles from '../../../../../components/common/SuggestionList/SuggestionList.module.css';
 import TruncatedText from '../../../../../components/common/TruncatedText';
 import styles from './AgentChatInput.module.css';
+import {
+    FILE_MENTION_CONTENT_TYPE,
+    getContentMentionContentType,
+    REPOSITORY_MENTION_CONTENT_TYPE,
+} from './contentMentionContentType';
+import { getContentMentionIcon } from './contentMentionIcon';
 import { ContentMentionNodeView } from './ContentMentionNodeView';
-import { getPromptContextItemKey } from './contentReferenceUtils';
+import {
+    getDataAppContextItemName,
+    getPromptContextItemKey,
+} from './contentReferenceUtils';
 
 const CONTENT_MENTION_NAME = 'contentMention';
 const MIN_CONTENT_SEARCH_QUERY_LENGTH = 2;
@@ -67,11 +73,16 @@ const DOM_RECT_FALLBACK: DOMRect = {
 type ContentMentionGroup = 'thread' | 'current' | 'dashboardTile' | 'search';
 
 export type ContentMentionSuggestionItem = SuggestionItem & {
-    contentType: ContentType.CHART | ContentType.DASHBOARD;
+    contentType:
+        | ContentType.CHART
+        | ContentType.DASHBOARD
+        | ContentType.DATA_APP;
     uuid: string;
     slug: string | null;
     chartKind?: ChartKind | null;
     spaceName?: string | null;
+    // Personal data apps have no space; agents restricted to spaces hide them.
+    isPersonalDataApp: boolean;
     group: ContentMentionGroup;
     dashboardUuid?: string | null;
     dashboardSlug?: string | null;
@@ -80,9 +91,6 @@ export type ContentMentionSuggestionItem = SuggestionItem & {
 };
 
 const FILE_MENTION_GROUP = 'file';
-// `contentType` value marking a content-mention node as a file (vs chart /
-// dashboard). The node carries the path in `label`; no context payload.
-const FILE_MENTION_CONTENT_TYPE = 'file';
 const MAX_FILE_SUGGESTIONS = 8;
 
 // A dbt source file the user can `@`-mention. Unlike content mentions it carries
@@ -95,10 +103,6 @@ export type FileMentionSuggestionItem = SuggestionItem & {
 };
 
 const REPOSITORY_MENTION_GROUP = 'repository';
-// `contentType` value marking a content-mention node as a repository (vs chart /
-// dashboard / file). The node carries `owner/repo` in `label`; no context
-// payload — the agent reads the repo via its exploreRepo tool.
-const REPOSITORY_MENTION_CONTENT_TYPE = 'repository';
 const MAX_REPOSITORY_SUGGESTIONS = 8;
 
 // A GitHub or GitLab repository the org's installation can access. Like file
@@ -281,15 +285,6 @@ export const contentMentionMenuOwnsEnter = (
     }
 };
 
-const getContentMentionContentType = (value: unknown) => {
-    if (value === FILE_MENTION_CONTENT_TYPE) return FILE_MENTION_CONTENT_TYPE;
-    if (value === REPOSITORY_MENTION_CONTENT_TYPE)
-        return REPOSITORY_MENTION_CONTENT_TYPE;
-    return value === ContentType.DASHBOARD
-        ? ContentType.DASHBOARD
-        : ContentType.CHART;
-};
-
 const getContentMentionIconSpec = (contentType: string): DOMOutputSpec => [
     'span',
     {
@@ -298,40 +293,6 @@ const getContentMentionIconSpec = (contentType: string): DOMOutputSpec => [
         'data-icon-type': contentType,
     },
 ];
-
-const getContextKey = (item: AiPromptContextInput[number]) => {
-    switch (item.type) {
-        case 'chart':
-            return `chart:${item.chartUuid}`;
-        case 'dashboard':
-            return `dashboard:${item.dashboardUuid}`;
-        case 'thread':
-            return `thread:${item.threadUuid}`;
-        case 'file':
-            return `file:${item.path}`;
-        case 'repository':
-            return `repository:${item.fullName}`;
-        case 'external_source':
-            return `external_source:${item.sourceUuid}`;
-        case 'pull_request':
-            return `pull_request:${item.prUrl}`;
-        case 'proposed_change':
-            return `proposed_change:${item.fingerprint}`;
-        case 'review_finding':
-            return `review_finding:${item.fingerprint}`;
-        case 'preview_environment':
-            return `preview_environment:${item.previewProjectUuid}`;
-        case 'data_app_element':
-            return dataAppElementContextKey(item);
-        case 'data_app_restore':
-            return dataAppRestoreContextKey(item);
-        default:
-            return assertUnreachable(
-                item,
-                'Unknown AiPromptContextItemInput type',
-            );
-    }
-};
 
 const normalizeSearchText = (value: string) =>
     value
@@ -371,7 +332,7 @@ export const mergeAiPromptContextInput = (
     contextGroups
         .flatMap((context) => context ?? [])
         .forEach((item) => {
-            const key = getContextKey(item);
+            const key = getPromptContextItemKey(item);
             if (seen.has(key)) {
                 return;
             }
@@ -426,6 +387,7 @@ export const contextItemsToContentMentionSuggestions = (
                 uuid: item.chartUuid,
                 slug: item.chartSlug,
                 chartKind: item.chartKind,
+                isPersonalDataApp: false,
                 group,
             };
         }
@@ -436,6 +398,18 @@ export const contextItemsToContentMentionSuggestions = (
                 contentType: ContentType.DASHBOARD,
                 uuid: item.dashboardUuid,
                 slug: item.dashboardSlug,
+                isPersonalDataApp: false,
+                group,
+            };
+        }
+        if (item.type === 'data_app') {
+            return {
+                id: `${group}:data_app:${item.appUuid}`,
+                label: getDataAppContextItemName(item),
+                contentType: ContentType.DATA_APP,
+                uuid: item.appUuid,
+                slug: item.appSlug,
+                isPersonalDataApp: item.isPersonal,
                 group,
             };
         }
@@ -456,6 +430,7 @@ const summaryContentToSuggestion = (
             slug: item.slug,
             chartKind: item.chartKind,
             spaceName: item.space.name,
+            isPersonalDataApp: false,
             group: 'search',
             verified: item.verification !== null,
         };
@@ -469,8 +444,25 @@ const summaryContentToSuggestion = (
             uuid: item.uuid,
             slug: item.slug,
             spaceName: item.space.name,
+            isPersonalDataApp: false,
             group: 'search',
             verified: item.verification !== null,
+        };
+    }
+
+    // Project chart types are data apps under the hood but not content the
+    // agent reads, so they never show up as mentions.
+    if (item.contentType === ContentType.DATA_APP) {
+        if (item.template === DATA_APP_VIZ_TEMPLATE) return null;
+        return {
+            id: `search:data_app:${item.uuid}`,
+            label: item.name,
+            contentType: ContentType.DATA_APP,
+            uuid: item.uuid,
+            slug: item.slug,
+            spaceName: item.space?.name ?? null,
+            isPersonalDataApp: item.space === null,
+            group: 'search',
         };
     }
 
@@ -488,6 +480,9 @@ const getSearchSuggestions = async (
     params.append('projectUuids', projectUuid);
     params.append('contentTypes', ContentType.CHART);
     params.append('contentTypes', ContentType.DASHBOARD);
+    params.append('contentTypes', ContentType.DATA_APP);
+    params.set('includePersonalDataApps', 'true');
+    params.set('dataAppVizsFilter', 'exclude');
     params.set('pageSize', '20');
     params.set('page', '1');
     params.set('search', trimmedQuery);
@@ -508,10 +503,13 @@ export const buildContentMentionSuggestionItems = async ({
     projectUuid,
     query,
     priorityItems,
+    hidePersonalDataApps = false,
 }: {
     projectUuid: string | undefined;
     query: string;
     priorityItems: ContentMentionSuggestionItem[];
+    // A space-restricted agent cannot read personal apps, so don't offer them.
+    hidePersonalDataApps?: boolean;
 }) => {
     const matchingPriorityItems = priorityItems.filter((item) =>
         fuzzyContentMentionLabelMatch(item.label, query),
@@ -522,6 +520,7 @@ export const buildContentMentionSuggestionItems = async ({
 
     const seen = new Set<string>();
     return [...matchingPriorityItems, ...searchItems].filter((item) => {
+        if (hidePersonalDataApps && item.isPersonalDataApp) return false;
         const key = `${item.contentType}:${item.uuid}`;
         if (seen.has(key)) return false;
         seen.add(key);
@@ -631,12 +630,10 @@ const renderContentMentionItem = (
     if (isRepositoryMentionItem(item)) {
         return renderRepositoryMentionItem(item, isSelected, onClick);
     }
-    const Icon =
-        item.contentType === ContentType.DASHBOARD
-            ? IconLayoutDashboard
-            : getChartIcon(item.chartKind ?? undefined);
-    const iconColor =
-        item.contentType === ContentType.DASHBOARD ? 'green.7' : 'blue.7';
+    const { icon: Icon, color: iconColor } = getContentMentionIcon(
+        item.contentType,
+        item.chartKind ?? null,
+    );
     const detail = item.spaceName ?? groupLabels[item.group];
 
     return (
@@ -682,11 +679,13 @@ const renderContentMentionItem = (
 const generateContentMentionSuggestion = ({
     getProjectUuid,
     getPriorityItems,
+    getHidePersonalDataApps,
     onMenuStateChange,
     includeFilesAndRepositories,
 }: {
     getProjectUuid: () => string | undefined;
     getPriorityItems: () => ContentMentionSuggestionItem[];
+    getHidePersonalDataApps: () => boolean;
     onMenuStateChange?: (state: ContentMentionMenuState) => void;
     includeFilesAndRepositories: boolean;
 }): MentionOptions['suggestion'] => ({
@@ -702,6 +701,7 @@ const generateContentMentionSuggestion = ({
                 projectUuid,
                 query,
                 priorityItems: getPriorityItems(),
+                hidePersonalDataApps: getHidePersonalDataApps(),
             });
         }
         // Fetch all three in parallel so files/repos don't wait on content.
@@ -710,6 +710,7 @@ const generateContentMentionSuggestion = ({
                 projectUuid,
                 query,
                 priorityItems: getPriorityItems(),
+                hidePersonalDataApps: getHidePersonalDataApps(),
             }),
             getProjectFileSuggestions(projectUuid, query),
             getRepositorySuggestions(projectUuid, query),
@@ -727,6 +728,7 @@ const generateContentMentionSuggestion = ({
             uuid: null,
             slug: null,
             chartKind: null,
+            isPersonalDataApp: false,
             dashboardUuid: null,
             dashboardSlug: null,
             dashboardName: null,
@@ -756,6 +758,7 @@ const generateContentMentionSuggestion = ({
                 slug: item.slug,
                 label: item.label,
                 chartKind: item.chartKind ?? null,
+                isPersonalDataApp: item.isPersonalDataApp,
                 dashboardUuid: item.dashboardUuid ?? null,
                 dashboardSlug: item.dashboardSlug ?? null,
                 dashboardName: item.dashboardName ?? null,
@@ -855,11 +858,13 @@ const generateContentMentionSuggestion = ({
 export const createContentMentionExtension = ({
     getProjectUuid,
     getPriorityItems,
+    getHidePersonalDataApps = () => false,
     onMenuStateChange,
     includeFilesAndRepositories = true,
 }: {
     getProjectUuid: () => string | undefined;
     getPriorityItems: () => ContentMentionSuggestionItem[];
+    getHidePersonalDataApps?: () => boolean;
     onMenuStateChange?: (state: ContentMentionMenuState) => void;
     includeFilesAndRepositories?: boolean;
 }) =>
@@ -873,6 +878,7 @@ export const createContentMentionExtension = ({
                 slug: { default: null },
                 label: { default: null },
                 chartKind: { default: null },
+                isPersonalDataApp: { default: false },
                 dashboardUuid: { default: null },
                 dashboardSlug: { default: null },
                 dashboardName: { default: null },
@@ -908,6 +914,7 @@ export const createContentMentionExtension = ({
         suggestion: generateContentMentionSuggestion({
             getProjectUuid,
             getPriorityItems,
+            getHidePersonalDataApps,
             onMenuStateChange,
             includeFilesAndRepositories,
         }),
@@ -958,6 +965,7 @@ export const extractContentMentionContext = (
             slug?: string | null;
             label?: string | null;
             chartKind?: ChartKind | null;
+            isPersonalDataApp?: boolean;
             dashboardUuid?: string | null;
             dashboardSlug?: string | null;
             dashboardName?: string | null;
@@ -1010,6 +1018,23 @@ export const extractContentMentionContext = (
                 displayName: attrs.label ?? null,
                 pinnedVersionUuid: null,
                 runtimeOverrides: null,
+            });
+            return;
+        }
+
+        if (attrs.contentType === ContentType.DATA_APP && attrs.uuid) {
+            context.push({
+                type: 'data_app',
+                appUuid: attrs.uuid,
+                appSlug: attrs.slug ?? null,
+            });
+            optimisticContext.push({
+                type: 'data_app',
+                appUuid: attrs.uuid,
+                appSlug: attrs.slug ?? null,
+                displayName: attrs.label ?? null,
+                pinnedVersion: null,
+                isPersonal: attrs.isPersonalDataApp === true,
             });
             return;
         }

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentReferenceUtils.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentReferenceUtils.test.ts
@@ -2,6 +2,8 @@ import { ChartKind } from '@lightdash/common';
 import { describe, expect, it } from 'vitest';
 import {
     buildContentReferenceSegments,
+    getDataAppContextItemLabel,
+    getPromptContextItemHref,
     getPromptContextItemKey,
 } from './contentReferenceUtils';
 
@@ -206,6 +208,26 @@ describe('contentReferenceUtils', () => {
         expect(result.matchedKeys.size).toBe(0);
         expect(getPromptContextItemKey(item)).toBe(
             'data_app_element:app-1:3:[h1 "FORMULA 1" @src/App.jsx:14]',
+        );
+    });
+
+    it('resolves key, chip label with pinned version, and href for a data app', () => {
+        const item = {
+            type: 'data_app' as const,
+            appUuid: 'app-1',
+            appSlug: 'f1-standings',
+            displayName: 'F1 standings',
+            pinnedVersion: 3,
+            isPersonal: false,
+        };
+
+        expect(getPromptContextItemKey(item)).toBe('data_app:app-1');
+        expect(getDataAppContextItemLabel(item)).toBe('F1 standings v3');
+        expect(
+            getDataAppContextItemLabel({ ...item, pinnedVersion: null }),
+        ).toBe('F1 standings');
+        expect(getPromptContextItemHref(item, 'project-1')).toBe(
+            '/projects/project-1/apps/app-1/view',
         );
     });
 });

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentReferenceUtils.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentReferenceUtils.ts
@@ -1,9 +1,12 @@
 import {
     assertUnreachable,
+    dataAppContextKey,
     dataAppElementContextKey,
     dataAppRestoreContextKey,
+    type AiPromptContextInput,
     type AiPromptContextItem,
 } from '@lightdash/common';
+import { dataAppHref } from '../../../../../features/apps/utils/appUrls';
 
 // Element references never render inline; they always show as pills.
 // Restore items live on hidden turns and are rendered as build cards.
@@ -29,7 +32,9 @@ export type ContentReferenceSegment =
           label: string;
       };
 
-export const getPromptContextItemKey = (item: AiPromptContextItem) => {
+export const getPromptContextItemKey = (
+    item: AiPromptContextItem | AiPromptContextInput[number],
+) => {
     switch (item.type) {
         case 'chart':
             return `chart:${item.chartUuid}`;
@@ -55,9 +60,27 @@ export const getPromptContextItemKey = (item: AiPromptContextItem) => {
             return dataAppElementContextKey(item);
         case 'data_app_restore':
             return dataAppRestoreContextKey(item);
+        case 'data_app':
+            return dataAppContextKey(item.appUuid);
         default:
             return assertUnreachable(item, 'Unknown AiPromptContextItem type');
     }
+};
+
+export const getDataAppContextItemName = (
+    item: Pick<
+        Extract<AiPromptContextItem, { type: 'data_app' }>,
+        'displayName' | 'appSlug'
+    >,
+): string => item.displayName ?? item.appSlug ?? 'Data app';
+
+export const getDataAppContextItemLabel = (
+    item: Extract<AiPromptContextItem, { type: 'data_app' }>,
+): string => {
+    const name = getDataAppContextItemName(item);
+    return item.pinnedVersion === null
+        ? name
+        : `${name} v${item.pinnedVersion}`;
 };
 
 const getProposedChangeLabel = (
@@ -89,6 +112,8 @@ const getPromptContextItemLabel = (item: InlineReferenceItem) => {
             return item.title;
         case 'preview_environment':
             return item.projectName ?? 'Preview environment';
+        case 'data_app':
+            return getDataAppContextItemName(item);
         default:
             return assertUnreachable(item, 'Unknown AiPromptContextItem type');
     }
@@ -128,6 +153,8 @@ export const getPromptContextItemHref = (
         case 'data_app_element':
         case 'data_app_restore':
             return null;
+        case 'data_app':
+            return dataAppHref(projectUuid, item.appUuid);
         default:
             return assertUnreachable(item, 'Unknown AiPromptContextItem type');
     }

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/useDataAppPreviewLink.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/useDataAppPreviewLink.ts
@@ -1,0 +1,51 @@
+import { type MouseEvent } from 'react';
+import { selectDataAppPreview, setPreview } from '../../store/aiArtifactSlice';
+import {
+    useAiAgentStoreDispatch,
+    useAiAgentStoreSelector,
+} from '../../store/hooks';
+
+export const isPlainLeftClick = (e: MouseEvent<HTMLAnchorElement>) =>
+    !e.defaultPrevented &&
+    e.button === 0 &&
+    !e.metaKey &&
+    !e.altKey &&
+    !e.ctrlKey &&
+    !e.shiftKey;
+
+export type DataAppPreviewScope = {
+    messageUuid: string;
+    threadUuid: string;
+    projectUuid: string;
+    agentUuid: string;
+};
+
+// Plain click opens the app's latest ready version in the in-thread preview
+// panel; modified clicks fall through to the anchor and open the full page.
+export const useDataAppPreviewLink = (
+    appUuid: string | null,
+    scope: DataAppPreviewScope | null,
+) => {
+    const dispatch = useAiAgentStoreDispatch();
+    const currentPreview = useAiAgentStoreSelector(selectDataAppPreview);
+    const isActive =
+        appUuid !== null &&
+        currentPreview !== null &&
+        currentPreview.appUuid === appUuid;
+
+    const onClick = (e: MouseEvent<HTMLAnchorElement>) => {
+        if (!appUuid || !scope || !isPlainLeftClick(e)) return;
+        e.preventDefault();
+        dispatch(
+            setPreview({
+                type: 'dataApp',
+                appUuid,
+                ...scope,
+                version: null,
+                latestReadyVersionAtOpen: null,
+            }),
+        );
+    };
+
+    return { isActive, onClick };
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
@@ -377,6 +377,7 @@ const NewThreadPanel: FC<{
                                     key={getPromptContextItemKey(item)}
                                     item={item}
                                     projectUuid={projectUuid}
+                                    previewScope={null}
                                 />
                             ))}
                         </Group>

--- a/packages/frontend/src/ee/features/aiCopilot/components/PinnedContextCard/PinnedContextCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/PinnedContextCard/PinnedContextCard.tsx
@@ -1,12 +1,24 @@
 import { assertUnreachable, type AiPromptContextItem } from '@lightdash/common';
 import { type FC } from 'react';
+import { dataAppHref } from '../../../../../features/apps/utils/appUrls';
 import { elementRefChipLabel } from '../../../../../features/apps/utils/elementRefs';
 import { ContentReferenceLink } from '../ChatElements/ContentReferenceLink';
+import { getDataAppContextItemLabel } from '../ChatElements/contentReferenceUtils';
+import { useDataAppPreviewLink } from '../ChatElements/useDataAppPreviewLink';
 import { PinnedReviewEntityCard } from './PinnedReviewEntityCard';
+
+// The sent thread message the chip belongs to; lets a data app chip open the
+// in-thread preview panel. Null on pre-send surfaces (no message yet).
+export type PinnedContextPreviewScope = {
+    messageUuid: string;
+    threadUuid: string;
+    agentUuid: string;
+};
 
 type Props = {
     item: AiPromptContextItem;
     projectUuid: string;
+    previewScope: PinnedContextPreviewScope | null;
 };
 
 type ItemMeta = {
@@ -81,7 +93,36 @@ const getItemMeta = (
     }
 };
 
-export const PinnedContextCard: FC<Props> = ({ item, projectUuid }) => {
+const PinnedDataAppCard: FC<{
+    item: Extract<AiPromptContextItem, { type: 'data_app' }>;
+    projectUuid: string;
+    previewScope: PinnedContextPreviewScope | null;
+}> = ({ item, projectUuid, previewScope }) => {
+    const { isActive, onClick } = useDataAppPreviewLink(
+        item.appUuid,
+        previewScope ? { ...previewScope, projectUuid } : null,
+    );
+
+    return (
+        <ContentReferenceLink
+            kind="data_app"
+            rel="noreferrer"
+            to={dataAppHref(projectUuid, item.appUuid)}
+            target="_blank"
+            onClick={onClick}
+            data-app-active={isActive || undefined}
+            showArrow
+        >
+            {getDataAppContextItemLabel(item)}
+        </ContentReferenceLink>
+    );
+};
+
+export const PinnedContextCard: FC<Props> = ({
+    item,
+    projectUuid,
+    previewScope,
+}) => {
     switch (item.type) {
         case 'chart':
         case 'dashboard':
@@ -103,6 +144,14 @@ export const PinnedContextCard: FC<Props> = ({ item, projectUuid }) => {
                 </ContentReferenceLink>
             );
         }
+        case 'data_app':
+            return (
+                <PinnedDataAppCard
+                    item={item}
+                    projectUuid={projectUuid}
+                    previewScope={previewScope}
+                />
+            );
         case 'pull_request':
         case 'proposed_change':
         case 'review_finding':

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/usePinnedContext.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/usePinnedContext.ts
@@ -132,6 +132,7 @@ export const usePinnedContext = ({
                     uuid: tile.properties.savedChartUuid!,
                     slug: tile.properties.chartSlug ?? null,
                     chartKind: tile.properties.lastVersionChartKind ?? null,
+                    isPersonalDataApp: false,
                     group: 'dashboardTile',
                     dashboardUuid: dashboard.uuid,
                     dashboardSlug: dashboard.slug,

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
@@ -787,6 +787,15 @@ const toOptimisticContextItem = (
                 appSlug: null,
                 displayName: null,
             };
+        case 'data_app':
+            return {
+                type: 'data_app',
+                appUuid: item.appUuid,
+                appSlug: item.appSlug ?? null,
+                displayName: null,
+                pinnedVersion: null,
+                isPersonal: false,
+            };
         // System-only pins are seeded by the remediation flow or the thread
         // restore endpoint, never optimistically attached from the UI.
         case 'proposed_change':

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/DataAppPickerModal.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/DataAppPickerModal.tsx
@@ -20,9 +20,9 @@ import { useMemo, useRef, useState, type FC } from 'react';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import MantineModal from '../../../../components/common/MantineModal';
 import { ResourceIcon } from '../../../../components/common/ResourceIcon';
+import { dataAppHref } from '../../../../features/apps/utils/appUrls';
 import { useInfiniteContent } from '../../../../hooks/useContent';
 import classes from './blockStyles.module.css';
-import { dataAppHref } from './resourceUrls';
 
 const PAGE_SIZE = 50;
 

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.tsx
@@ -35,13 +35,13 @@ import {
 } from 'react';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import { useAppThumbnailUrl } from '../../../../features/apps/hooks/useAppThumbnail';
+import { dataAppHref } from '../../../../features/apps/utils/appUrls';
 import { BlockHeader, IconSquare, MiniPill } from './BlockShell';
 import classes from './blockStyles.module.css';
 import { ContentLayoutControl } from './ContentLayoutControl';
 import { DataAppPickerModal } from './DataAppPickerModal';
 import { PageGrid, PageGridItem } from './PageGrid';
 import {
-    dataAppHref,
     faviconUrl,
     hostnameOf,
     looksLikeUrl,

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/resourceUrls.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/resourceUrls.ts
@@ -1,9 +1,6 @@
 import { type HomepageResourceItem } from '@lightdash/common';
 import { fetchHomepageLinkMetadata } from '../hooks/useHomepageLinkMetadata';
 
-export const dataAppHref = (projectUuid: string, appUuid: string): string =>
-    `/projects/${projectUuid}/apps/${appUuid}/view`;
-
 export const hostnameOf = (url: string): string => {
     try {
         return new URL(url).hostname.replace(/^www\./, '');

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
@@ -408,6 +408,7 @@ const AgentsRouterPage = () => {
                                             key={getPromptContextItemKey(item)}
                                             item={item}
                                             projectUuid={projectUuid!}
+                                            previewScope={null}
                                         />
                                     ))}
                                 </Group>

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
@@ -350,6 +350,7 @@ const AiAgentNewThreadPage: FC = () => {
                                         key={getPromptContextItemKey(item)}
                                         item={item}
                                         projectUuid={projectUuid}
+                                        previewScope={null}
                                     />
                                 ))}
                             </Group>

--- a/packages/frontend/src/features/apps/utils/appUrls.ts
+++ b/packages/frontend/src/features/apps/utils/appUrls.ts
@@ -1,0 +1,2 @@
+export const dataAppHref = (projectUuid: string, appUuid: string): string =>
+    `/projects/${projectUuid}/apps/${appUuid}/view`;

--- a/packages/frontend/src/stories/AiAgentChatWorkbench.stories.tsx
+++ b/packages/frontend/src/stories/AiAgentChatWorkbench.stories.tsx
@@ -1000,6 +1000,7 @@ const ComponentInventory = () => (
                         key={`${item.type}-${JSON.stringify(item)}`}
                         item={item}
                         projectUuid={projectUuid}
+                        previewScope={null}
                     />
                 ))}
             </Group>
@@ -1120,6 +1121,7 @@ const PinnedContextScenario = () => (
                         key={`${item.type}-${JSON.stringify(item)}`}
                         item={item}
                         projectUuid={projectUuid}
+                        previewScope={null}
                     />
                 ))}
             </Group>


### PR DESCRIPTION
## Summary

Stack 1/3 for ZAP-988 (Ask AI for data apps). Data apps become AI agent **pinned context**: `@` in the prompt finds them, the agent sees them by name and slug, and the pinned chip opens the app in the in-thread preview.

```diff
 AiPromptContextItemInput / AiPromptContextItem
   chart | dashboard | data_app_element | data_app_restore | …
+  data_app { appUuid, appSlug }            # row snapshots display name + latest ready version

 Pinned-context message
   - Chart "…" (chartSlug: …)
+  - Data app "name" (dataAppSlug: slug)     # read via readContent, iterate via existing tool

 @ mentions
   content search: chart, dashboard
+  + data_app (personal apps included, project chart types dropped,
+              personal hidden for space-restricted agents)

 <PinnedContextCard>
+  <PinnedDataAppCard>                       # "Name v3"; click → preview panel, ⌘-click → app page
```

- **Backend**: `data_app` context type; attach validation mirrors charts (`canViewApp`, project chart type → 400, duplicates collapse). No migration: version snapshot lives in the existing `runtime_overrides` jsonb, hydration re-resolves slug, name, and `isPersonal` from the app.
- **Mentions**: search requests `data_app`, `@` results carry `isPersonalDataApp`, space-restricted agents hide personal apps in both search and priority groups (`isSpaceRestrictedAgent` helper in common).
- **Chip**: click handling shared with data app links in agent replies via `useDataAppPreviewLink`; `previewScope` is threaded from the message bubble so it works in the docked launcher too.
- **Glossary**: new `docs/ai-agent/CONTEXT.md` (pinned context, mention, launcher, preview panel); data-app **Context** cross-links to it.

## Test plan

- [x] `pinnedContextMessage.test.ts`: data app line, mixed order
- [x] `promptContextAccess.test.ts`: accept / other user's personal app (creator-only via `canViewApp`) / project chart type / other project / dedupe
- [x] `compaction.test.ts`: data app item serialised
- [x] `contentMentions.test.ts`: extraction, search request, viz results dropped, dedupe, priority groups, space-restricted filter
- [x] `contentReferenceUtils.test.ts`
- [x] common/backend/frontend typecheck + lint; MCP tool snapshot unchanged

Closes: ZAP-990
Part of: ZAP-988

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TwHfhTktNpT2Wq6bGAVVJN
