### PR TITLE
feat(ai): ask AI from data app pages and listing rows

### DIFF
--- a/packages/frontend/src/Routes.tsx
+++ b/packages/frontend/src/Routes.tsx
@@ -750,7 +750,6 @@ const PROJECT_LAYOUT_ROUTES: RouteObject[] = [
     },
     {
         path: 'apps/:appUuid/versions/:version/view',
-        handle: { hideAILauncher: true },
         lazy: async () => {
             const AppPreviewTest = await loadLazyRouteDefault(
                 './pages/AppPreviewTest',
@@ -761,7 +760,6 @@ const PROJECT_LAYOUT_ROUTES: RouteObject[] = [
     },
     {
         path: 'apps/:appUuid/view',
-        handle: { hideAILauncher: true },
         lazy: async () => {
             const AppPreviewTest = await loadLazyRouteDefault(
                 './pages/AppPreviewTest',

--- a/packages/frontend/src/components/UserSettings/MyAppsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/MyAppsPanel/index.tsx
@@ -22,6 +22,7 @@ import {
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useMemo, useState, type FC } from 'react';
 import { Link } from 'react-router';
+import { AskAiAgentMenuItem } from '../../../ee/features/aiCopilot/components/AskAiAgentMenuItem/AskAiAgentMenuItem';
 import AppThumbnailHoverCard from '../../../features/apps/components/AppThumbnailHoverCard';
 import { MoveAppToSpaceModal as SharedMoveAppToSpaceModal } from '../../../features/apps/components/MoveAppToSpaceModal';
 import { useMyApps } from '../../../features/apps/hooks/useMyApps';
@@ -276,6 +277,13 @@ const MyAppsPanel: FC<MyAppsPanelProps> = ({
                                 </ActionIcon>
                             </Menu.Target>
                             <Menu.Dropdown>
+                                <AskAiAgentMenuItem
+                                    projectUuid={app.projectUuid}
+                                    dataAppUuid={app.appUuid}
+                                    clickedFrom="data_app_my_apps_menu"
+                                    mode="navigate"
+                                    withDivider
+                                />
                                 {hasReadyVersion(app) && (
                                     <Menu.Item
                                         component={Link}

--- a/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
@@ -4,6 +4,7 @@ import {
     ChartSourceType,
     ContentReviewContentType,
     DirectAccessResourceType,
+    isResourceViewDataAppItem,
     isResourceViewItemChart,
     isResourceViewItemDashboard,
     ResourceViewItemType,
@@ -457,6 +458,14 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
                             />
                             {/* TODO: add a create-issue entry point once the issues flow is finalized */}
                         </>
+                    )}
+
+                    {isResourceViewDataAppItem(item) && (
+                        <AskAiAgentMenuItem
+                            projectUuid={projectUuid}
+                            dataAppUuid={item.data.uuid}
+                            clickedFrom="data_app_resource_action_menu"
+                        />
                     )}
 
                     {(userCanManage || canDuplicateDataApp) &&

--- a/packages/frontend/src/ee/features/aiCopilot/components/AskAiAgentMenuItem/AskAiAgentButton.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AskAiAgentMenuItem/AskAiAgentButton.tsx
@@ -8,6 +8,7 @@ type Props = {
     projectUuid: string | undefined;
     chartUuid?: string;
     dashboardUuid?: string;
+    dataAppUuid?: string;
     clickedFrom: AiAgentAskClickedSource;
     variant?: ActionIconProps['variant'];
     size?: ActionIconProps['size'];
@@ -24,6 +25,7 @@ export const AskAiAgentButton: FC<Props> = ({
     projectUuid,
     chartUuid,
     dashboardUuid,
+    dataAppUuid,
     clickedFrom,
     variant = 'subtle',
     size = 'sm',
@@ -34,6 +36,7 @@ export const AskAiAgentButton: FC<Props> = ({
         projectUuid,
         chartUuid,
         dashboardUuid,
+        dataAppUuid,
         clickedFrom,
     });
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/AskAiAgentMenuItem/AskAiAgentMenuItem.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AskAiAgentMenuItem/AskAiAgentMenuItem.tsx
@@ -2,13 +2,18 @@ import { Menu } from '@mantine/core';
 import { type FC } from 'react';
 import { type AiAgentAskClickedSource } from '../../../../../providers/Tracking/types';
 import { AiAgentIcon } from '../AiAgentIcon';
-import { useAskAiAgentAction } from './useAskAiAgentAction';
+import {
+    useAskAiAgentAction,
+    type AskAiAgentMode,
+} from './useAskAiAgentAction';
 
 type Props = {
     projectUuid: string | undefined;
     chartUuid?: string;
     dashboardUuid?: string;
+    dataAppUuid?: string;
     clickedFrom: AiAgentAskClickedSource;
+    mode?: AskAiAgentMode;
     /**
      * Render a `<Menu.Divider />` after the item. The divider is only rendered
      * when the item itself is visible, so callers don't need to gate it.
@@ -17,7 +22,7 @@ type Props = {
 };
 
 /**
- * Menu item that opens the AI agent launcher panel for a new conversation.
+ * Menu item that starts a new AI agent conversation (panel or full page).
  * Renders nothing when AI agents are not enabled, the user lacks permission,
  * or no default agent can be resolved.
  */
@@ -25,14 +30,18 @@ export const AskAiAgentMenuItem: FC<Props> = ({
     projectUuid,
     chartUuid,
     dashboardUuid,
+    dataAppUuid,
     clickedFrom,
+    mode,
     withDivider = false,
 }) => {
     const { canAsk, handleClick } = useAskAiAgentAction({
         projectUuid,
         chartUuid,
         dashboardUuid,
+        dataAppUuid,
         clickedFrom,
+        mode,
     });
 
     if (!canAsk) return null;

--- a/packages/frontend/src/ee/features/aiCopilot/components/AskAiAgentMenuItem/useAskAiAgentAction.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AskAiAgentMenuItem/useAskAiAgentAction.ts
@@ -1,3 +1,6 @@
+import { assertUnreachable, FeatureFlags } from '@lightdash/common';
+import { useNavigate } from 'react-router';
+import { useServerFeatureFlag } from '../../../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../../../providers/App/useApp';
 import { type AiAgentAskClickedSource } from '../../../../../providers/Tracking/types';
 import useTracking from '../../../../../providers/Tracking/useTracking';
@@ -5,36 +8,57 @@ import { EventName } from '../../../../../types/Events';
 import { useAiAgentButtonVisibility } from '../../hooks/useAiAgentsButtonVisibility';
 import { store as aiAgentStore } from '../../store';
 import { openDefaultAgentPanel } from '../../store/aiAgentLauncherSlice';
+import { buildNewThreadUrl } from '../Launcher/newThreadUrl';
 import { useDefaultAiAgent } from '../Launcher/useDefaultAiAgent';
+
+/**
+ * `panel` opens the docked launcher; `navigate` goes to the full-page
+ * new-thread route for surfaces where the launcher is hidden (My apps).
+ */
+export type AskAiAgentMode = 'panel' | 'navigate';
 
 type Args = {
     projectUuid: string | undefined;
     chartUuid?: string;
     dashboardUuid?: string;
+    dataAppUuid?: string;
     clickedFrom: AiAgentAskClickedSource;
+    mode?: AskAiAgentMode;
 };
 
 /**
  * Shared logic for the "Ask AI Agent" entry points: resolves whether the action
- * should be shown and opens the launcher panel for a new conversation on click.
+ * should be shown and starts a new conversation on click.
  * `canAsk` is false when AI agents are disabled, the user lacks permission, or
- * no default agent can be resolved.
+ * no default agent can be resolved. Data app context additionally requires
+ * data apps to be enabled.
  */
 export const useAskAiAgentAction = ({
     projectUuid,
     chartUuid,
     dashboardUuid,
+    dataAppUuid,
     clickedFrom,
+    mode = 'panel',
 }: Args) => {
     const isVisible = useAiAgentButtonVisibility();
-    const { agents } = useDefaultAiAgent(projectUuid);
+    const { agents, selectedAgent } = useDefaultAiAgent(projectUuid);
     const { user } = useApp();
     const { track } = useTracking();
+    const navigate = useNavigate();
+    const dataAppsFlag = useServerFeatureFlag(FeatureFlags.EnableDataApps);
+    const dataAppsEnabled = dataAppsFlag.data?.enabled === true;
 
-    const canAsk = isVisible && agents.length > 0;
+    // Navigate mode needs the resolved agent for the URL before it can act.
+    const canNavigate = !!projectUuid && !!selectedAgent;
+    const canAsk =
+        isVisible &&
+        agents.length > 0 &&
+        (!dataAppUuid || dataAppsEnabled) &&
+        (mode !== 'navigate' || canNavigate);
 
     const handleClick = () => {
-        if (agents.length === 0) return;
+        if (!canAsk) return;
         track({
             name: EventName.AI_AGENT_ASK_CLICKED,
             properties: {
@@ -45,8 +69,28 @@ export const useAskAiAgentAction = ({
             },
         });
         const pendingContext =
-            chartUuid || dashboardUuid ? { chartUuid, dashboardUuid } : null;
-        aiAgentStore.dispatch(openDefaultAgentPanel({ pendingContext }));
+            chartUuid || dashboardUuid || dataAppUuid
+                ? { chartUuid, dashboardUuid, dataAppUuid }
+                : null;
+        switch (mode) {
+            case 'panel':
+                aiAgentStore.dispatch(
+                    openDefaultAgentPanel({ pendingContext }),
+                );
+                return;
+            case 'navigate':
+                if (!projectUuid || !selectedAgent) return;
+                void navigate(
+                    buildNewThreadUrl({
+                        projectUuid,
+                        agent: selectedAgent,
+                        pendingContext,
+                    }),
+                );
+                return;
+            default:
+                return assertUnreachable(mode, 'Unknown ask AI mode');
+        }
     };
 
     return { canAsk, handleClick };

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/AiAgentsLauncher.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/AiAgentsLauncher.tsx
@@ -69,6 +69,9 @@ const AiAgentsLauncherInner: FC = () => {
     const currentDashboard = useAiAgentStoreSelector(
         (state) => state.aiAgentLauncher.currentDashboard,
     );
+    const currentDataApp = useAiAgentStoreSelector(
+        (state) => state.aiAgentLauncher.currentDataApp,
+    );
     const { dock } = useLauncherDock(activeProjectUuid);
 
     const prevProjectUuidRef = useRef(activeProjectUuid);
@@ -165,13 +168,15 @@ const AiAgentsLauncherInner: FC = () => {
     }
     const transitionDataAppPreview =
         activeDataAppPreview ?? lastDataAppPreviewRef.current;
-    const isDashboardPage = currentDashboard?.projectUuid === activeProjectUuid;
+    const isContentPage =
+        currentDashboard?.projectUuid === activeProjectUuid ||
+        currentDataApp?.projectUuid === activeProjectUuid;
 
     if (!isAllowed || !activeProjectUuid) return null;
     if (
         !isPanelOpenSafe &&
         dock.length === 0 &&
-        (!selectedAgent || !isDashboardPage)
+        (!selectedAgent || !isContentPage)
     ) {
         return null;
     }

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherDock.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherDock.tsx
@@ -44,6 +44,9 @@ export const LauncherDock: FC<Props> = ({
     const currentDashboard = useAiAgentStoreSelector(
         (state) => state.aiAgentLauncher.currentDashboard,
     );
+    const currentDataApp = useAiAgentStoreSelector(
+        (state) => state.aiAgentLauncher.currentDataApp,
+    );
 
     const agentsByUuid = useMemo(
         () => new Map(agents.map((a) => [a.uuid, a])),
@@ -86,10 +89,10 @@ export const LauncherDock: FC<Props> = ({
         if (!agentUuid) return;
         const pendingContext =
             currentDashboard?.projectUuid === projectUuid
-                ? {
-                      dashboardUuid: currentDashboard.uuid,
-                  }
-                : null;
+                ? { dashboardUuid: currentDashboard.uuid }
+                : currentDataApp?.projectUuid === projectUuid
+                  ? { dataAppUuid: currentDataApp.uuid }
+                  : null;
         dispatch(
             openPanel({
                 threadId: null,

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
@@ -140,6 +140,7 @@ const NewThreadPanel: FC<{
 
     const chartUuid = pendingContext?.chartUuid;
     const dashboardUuid = pendingContext?.dashboardUuid;
+    const dataAppUuid = pendingContext?.dataAppUuid;
 
     const { addItem: addDockItem } = useLauncherDock(projectUuid);
     const isAuto = isLauncherAutoAgent(agent);
@@ -155,6 +156,7 @@ const NewThreadPanel: FC<{
         projectUuid,
         chartUuidOrSlug: chartUuid,
         dashboardUuidOrSlug: dashboardUuid,
+        dataAppUuidOrSlug: dataAppUuid,
     });
     const { curateContext } = useDashboardPageContextCuration({
         previousContext: contextInput,

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/PanelHeader.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/PanelHeader.tsx
@@ -23,10 +23,6 @@ import {
     useAiAgentStoreDispatch,
     useAiAgentStoreSelector,
 } from '../../store/hooks';
-import {
-    AI_ROUTING_AUTO_VALUE,
-    AI_ROUTING_SEARCH_PARAM,
-} from '../AgentSelector/AgentSelectorUtils';
 import styles from './AiAgentsLauncher.module.css';
 import {
     getConcreteLauncherAgent,
@@ -34,6 +30,7 @@ import {
     LAUNCHER_AUTO_AGENT,
 } from './launcherAgentSelection';
 import { launcherSession } from './launcherSession';
+import { buildNewThreadUrl } from './newThreadUrl';
 
 type Props = {
     projectUuid: string;
@@ -88,22 +85,7 @@ export const PanelHeader: FC<Props> = ({
             if (isAuto) return;
             target = `/projects/${projectUuid}/ai-agents/${agent.uuid}/threads/${threadId}`;
         } else {
-            const params = new URLSearchParams();
-            if (pendingContext?.chartUuid) {
-                params.set('chartUuid', pendingContext.chartUuid);
-            }
-            if (pendingContext?.dashboardUuid) {
-                params.set('dashboardUuid', pendingContext.dashboardUuid);
-            }
-            if (isAuto) {
-                params.set(AI_ROUTING_SEARCH_PARAM, AI_ROUTING_AUTO_VALUE);
-            }
-            const search = params.toString();
-            target = isAuto
-                ? `/projects/${projectUuid}/ai-agents${search ? `?${search}` : ''}`
-                : `/projects/${projectUuid}/ai-agents/${agent.uuid}/threads${
-                      search ? `?${search}` : ''
-                  }`;
+            target = buildNewThreadUrl({ projectUuid, agent, pendingContext });
         }
         dispatch(closePanel());
         void navigate(target);

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/newThreadUrl.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/newThreadUrl.test.ts
@@ -1,0 +1,50 @@
+import { type AiAgentSummary } from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import { LAUNCHER_AUTO_AGENT } from './launcherAgentSelection';
+import { buildNewThreadUrl } from './newThreadUrl';
+
+const agent = { uuid: 'agent-1' } as AiAgentSummary;
+
+describe('buildNewThreadUrl', () => {
+    it('targets the agent thread route with the data app query param', () => {
+        expect(
+            buildNewThreadUrl({
+                projectUuid: 'p1',
+                agent,
+                pendingContext: { dataAppUuid: 'app-1' },
+            }),
+        ).toBe('/projects/p1/ai-agents/agent-1/threads?dataAppUuid=app-1');
+    });
+
+    it('carries chart and dashboard params', () => {
+        expect(
+            buildNewThreadUrl({
+                projectUuid: 'p1',
+                agent,
+                pendingContext: { chartUuid: 'c1', dashboardUuid: 'd1' },
+            }),
+        ).toBe(
+            '/projects/p1/ai-agents/agent-1/threads?chartUuid=c1&dashboardUuid=d1',
+        );
+    });
+
+    it('omits the query string without context', () => {
+        expect(
+            buildNewThreadUrl({
+                projectUuid: 'p1',
+                agent,
+                pendingContext: null,
+            }),
+        ).toBe('/projects/p1/ai-agents/agent-1/threads');
+    });
+
+    it('targets the auto-routing page for the auto agent', () => {
+        expect(
+            buildNewThreadUrl({
+                projectUuid: 'p1',
+                agent: LAUNCHER_AUTO_AGENT,
+                pendingContext: { dataAppUuid: 'app-1' },
+            }),
+        ).toBe('/projects/p1/ai-agents?dataAppUuid=app-1&routing=auto');
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/newThreadUrl.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/newThreadUrl.ts
@@ -1,0 +1,43 @@
+import { type AiAgentSummary } from '@lightdash/common';
+import { type LauncherPendingContext } from '../../store/aiAgentLauncherSlice';
+import {
+    AI_ROUTING_AUTO_VALUE,
+    AI_ROUTING_SEARCH_PARAM,
+} from '../AgentSelector/AgentSelectorUtils';
+import {
+    isLauncherAutoAgent,
+    type LAUNCHER_AUTO_AGENT,
+} from './launcherAgentSelection';
+
+type Args = {
+    projectUuid: string;
+    agent: AiAgentSummary | typeof LAUNCHER_AUTO_AGENT;
+    pendingContext: LauncherPendingContext | null;
+};
+
+/** Full-page new-thread URL carrying the pending context as query params. */
+export const buildNewThreadUrl = ({
+    projectUuid,
+    agent,
+    pendingContext,
+}: Args) => {
+    const params = new URLSearchParams();
+    if (pendingContext?.chartUuid) {
+        params.set('chartUuid', pendingContext.chartUuid);
+    }
+    if (pendingContext?.dashboardUuid) {
+        params.set('dashboardUuid', pendingContext.dashboardUuid);
+    }
+    if (pendingContext?.dataAppUuid) {
+        params.set('dataAppUuid', pendingContext.dataAppUuid);
+    }
+    const isAuto = isLauncherAutoAgent(agent);
+    if (isAuto) {
+        params.set(AI_ROUTING_SEARCH_PARAM, AI_ROUTING_AUTO_VALUE);
+    }
+    const search = params.toString();
+    const base = isAuto
+        ? `/projects/${projectUuid}/ai-agents`
+        : `/projects/${projectUuid}/ai-agents/${agent.uuid}/threads`;
+    return search ? `${base}?${search}` : base;
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/useIsLauncherMounted.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/useIsLauncherMounted.ts
@@ -13,9 +13,13 @@ export const useIsLauncherMounted = (
     const currentDashboard = useAiAgentStoreSelector(
         (state) => state.aiAgentLauncher.currentDashboard,
     );
+    const currentDataApp = useAiAgentStoreSelector(
+        (state) => state.aiAgentLauncher.currentDataApp,
+    );
+    const isContentPage =
+        currentDashboard?.projectUuid === projectUuid ||
+        currentDataApp?.projectUuid === projectUuid;
     return (
-        isPanelOpen ||
-        dock.length > 0 ||
-        (currentDashboard?.projectUuid === projectUuid && isAiAgentEnabled)
+        isPanelOpen || dock.length > 0 || (isContentPage && isAiAgentEnabled)
     );
 };

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/usePinnedContext.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/usePinnedContext.test.tsx
@@ -1,0 +1,126 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { usePinnedContext } from './usePinnedContext';
+
+const { useGetAppMock, useSavedQueryMock, useDashboardQueryMock } = vi.hoisted(
+    () => ({
+        useGetAppMock: vi.fn(),
+        useSavedQueryMock: vi.fn(),
+        useDashboardQueryMock: vi.fn(),
+    }),
+);
+
+vi.mock('../../../../features/apps/hooks/useGetApp', () => ({
+    useGetApp: useGetAppMock,
+}));
+vi.mock('../../../../hooks/useSavedQuery', () => ({
+    useSavedQuery: useSavedQueryMock,
+}));
+vi.mock('../../../../hooks/dashboard/useDashboard', () => ({
+    useDashboardQuery: useDashboardQueryMock,
+}));
+
+const projectUuid = 'project-1';
+
+const app = {
+    appUuid: 'app-1',
+    name: 'Sales explorer',
+    slug: 'sales-explorer',
+    latestReadyVersion: 3,
+    spaceUuid: 'space-1',
+};
+
+const dashboard = {
+    uuid: 'dashboard-1',
+    slug: 'orders',
+    name: 'Orders',
+    spaceName: 'Space',
+    tiles: [],
+};
+
+describe('usePinnedContext', () => {
+    beforeEach(() => {
+        useGetAppMock.mockReset();
+        useSavedQueryMock.mockReset().mockReturnValue({ data: undefined });
+        useDashboardQueryMock.mockReset().mockReturnValue({ data: undefined });
+        useGetAppMock.mockReturnValue({ data: { pages: [app] } });
+    });
+
+    it.each([
+        ['uuid', 'app-1'],
+        ['slug', 'sales-explorer'],
+    ])(
+        'resolves a data app %s into context input and preview chip',
+        (_label, dataAppUuidOrSlug) => {
+            const { result } = renderHook(() =>
+                usePinnedContext({ projectUuid, dataAppUuidOrSlug }),
+            );
+
+            expect(useGetAppMock).toHaveBeenCalledWith(
+                projectUuid,
+                dataAppUuidOrSlug,
+            );
+            expect(result.current.isReady).toBe(true);
+            expect(result.current.contextInput).toEqual([
+                {
+                    type: 'data_app',
+                    appUuid: 'app-1',
+                    appSlug: 'sales-explorer',
+                },
+            ]);
+            expect(result.current.previewItems).toEqual([
+                {
+                    type: 'data_app',
+                    appUuid: 'app-1',
+                    appSlug: 'sales-explorer',
+                    displayName: 'Sales explorer',
+                    pinnedVersion: 3,
+                    isPersonal: false,
+                },
+            ]);
+            expect(result.current.contentMentionItems).toEqual([
+                expect.objectContaining({
+                    contentType: 'data_app',
+                    uuid: 'app-1',
+                    slug: 'sales-explorer',
+                    label: 'Sales explorer',
+                    isPersonalDataApp: false,
+                    group: 'current',
+                }),
+            ]);
+        },
+    );
+
+    it('is not ready until the data app resolves', () => {
+        useGetAppMock.mockReturnValue({ data: undefined });
+
+        const { result } = renderHook(() =>
+            usePinnedContext({ projectUuid, dataAppUuidOrSlug: 'app-1' }),
+        );
+
+        expect(result.current.isReady).toBe(false);
+        expect(result.current.contextInput).toEqual([]);
+        expect(result.current.previewItems).toEqual([]);
+    });
+
+    it('sorts a pinned dashboard before the data app', () => {
+        useDashboardQueryMock.mockReturnValue({ data: dashboard });
+
+        const { result } = renderHook(() =>
+            usePinnedContext({
+                projectUuid,
+                dataAppUuidOrSlug: 'app-1',
+                dashboardUuidOrSlug: 'dashboard-1',
+            }),
+        );
+
+        expect(result.current.contextInput.map((item) => item.type)).toEqual([
+            'dashboard',
+            'data_app',
+        ]);
+        expect(result.current.previewItems.map((item) => item.type)).toEqual([
+            'dashboard',
+            'data_app',
+        ]);
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/usePinnedContext.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/usePinnedContext.ts
@@ -1,11 +1,13 @@
 import {
     ContentType,
+    getAppDisplayName,
     getChartKind,
     isDashboardChartTileType,
     type AiPromptContextInput,
     type AiPromptContextItem,
 } from '@lightdash/common';
 import { useMemo } from 'react';
+import { useGetApp } from '../../../../features/apps/hooks/useGetApp';
 import { useDashboardQuery } from '../../../../hooks/dashboard/useDashboard';
 import { useSavedQuery } from '../../../../hooks/useSavedQuery';
 import {
@@ -17,6 +19,7 @@ type Args = {
     projectUuid: string | undefined;
     chartUuidOrSlug?: string | null;
     dashboardUuidOrSlug?: string | null;
+    dataAppUuidOrSlug?: string | null;
 };
 
 const sortPinnedContext = <
@@ -30,8 +33,8 @@ const sortPinnedContext = <
     });
 
 /**
- * Resolves a chart and/or dashboard into the two shapes the AI agent
- * thread-creation flow needs:
+ * Resolves a chart, dashboard and/or data app into the two shapes the AI
+ * agent thread-creation flow needs:
  *  - `contextInput`: the minimal payload sent to the API.
  *  - `previewItems`: the optimistic, hydrated items rendered in the UI
  *    while the chart/dashboard queries are still resolving.
@@ -40,6 +43,7 @@ export const usePinnedContext = ({
     projectUuid,
     chartUuidOrSlug,
     dashboardUuidOrSlug,
+    dataAppUuidOrSlug,
 }: Args) => {
     const { data: chart } = useSavedQuery({
         uuidOrSlug: chartUuidOrSlug ?? undefined,
@@ -49,9 +53,15 @@ export const usePinnedContext = ({
         uuidOrSlug: dashboardUuidOrSlug ?? undefined,
         projectUuid,
     });
+    const { data: appData } = useGetApp(
+        projectUuid,
+        dataAppUuidOrSlug ?? undefined,
+    );
+    const dataApp = appData?.pages[0];
     const isReady =
         (!chartUuidOrSlug || !!chart?.uuid) &&
-        (!dashboardUuidOrSlug || !!dashboard?.uuid);
+        (!dashboardUuidOrSlug || !!dashboard?.uuid) &&
+        (!dataAppUuidOrSlug || !!dataApp?.appUuid);
 
     const contextInput: AiPromptContextInput = useMemo(() => {
         const items: AiPromptContextInput = [];
@@ -69,8 +79,22 @@ export const usePinnedContext = ({
                 dashboardSlug: dashboard?.slug ?? null,
             });
         }
+        if (dataApp?.appUuid) {
+            items.push({
+                type: 'data_app',
+                appUuid: dataApp.appUuid,
+                appSlug: dataApp.slug,
+            });
+        }
         return sortPinnedContext(items);
-    }, [chart?.uuid, dashboard?.uuid, chart?.slug, dashboard?.slug]);
+    }, [
+        chart?.uuid,
+        dashboard?.uuid,
+        chart?.slug,
+        dashboard?.slug,
+        dataApp?.appUuid,
+        dataApp?.slug,
+    ]);
 
     const chartKind = useMemo(
         () =>
@@ -106,6 +130,16 @@ export const usePinnedContext = ({
                 runtimeOverrides: null,
             });
         }
+        if (dataApp?.appUuid) {
+            items.push({
+                type: 'data_app',
+                appUuid: dataApp.appUuid,
+                appSlug: dataApp.slug,
+                displayName: getAppDisplayName(dataApp.name, dataApp.appUuid),
+                pinnedVersion: dataApp.latestReadyVersion,
+                isPersonal: dataApp.spaceUuid === null,
+            });
+        }
         return sortPinnedContext(items);
     }, [
         chart?.uuid,
@@ -115,6 +149,11 @@ export const usePinnedContext = ({
         dashboard?.uuid,
         dashboard?.name,
         dashboard?.slug,
+        dataApp?.appUuid,
+        dataApp?.slug,
+        dataApp?.name,
+        dataApp?.latestReadyVersion,
+        dataApp?.spaceUuid,
     ]);
 
     const contentMentionItems = useMemo<ContentMentionSuggestionItem[]>(() => {

--- a/packages/frontend/src/ee/features/aiCopilot/store/aiAgentLauncherSlice.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/store/aiAgentLauncherSlice.ts
@@ -13,6 +13,7 @@ export type LauncherDockItem = {
 export type LauncherPendingContext = {
     chartUuid?: string;
     dashboardUuid?: string;
+    dataAppUuid?: string;
 };
 
 export type LauncherCurrentDashboard = {
@@ -21,6 +22,12 @@ export type LauncherCurrentDashboard = {
     name: string;
     activeTabUuid: string | null;
     runtimeOverrides: AiDashboardRuntimeOverrides | null;
+};
+
+// The data app page the user is on; no runtime overrides are captured.
+export type LauncherCurrentDataApp = {
+    projectUuid: string;
+    uuid: string;
 };
 
 export type DashboardRefreshRequest = {
@@ -37,6 +44,7 @@ export interface AiAgentLauncherState {
     activeAgentUuid: LauncherActiveAgentUuid | null;
     pendingContext: LauncherPendingContext | null;
     currentDashboard: LauncherCurrentDashboard | null;
+    currentDataApp: LauncherCurrentDataApp | null;
     dashboardRefreshRequest: DashboardRefreshRequest | null;
 }
 
@@ -46,6 +54,7 @@ const initialState: AiAgentLauncherState = {
     activeAgentUuid: null,
     pendingContext: null,
     currentDashboard: null,
+    currentDataApp: null,
     dashboardRefreshRequest: null,
 };
 
@@ -111,6 +120,12 @@ export const aiAgentLauncherSlice = createSlice({
         ) => {
             state.currentDashboard = action.payload;
         },
+        setCurrentDataApp: (
+            state,
+            action: PayloadAction<LauncherCurrentDataApp | null>,
+        ) => {
+            state.currentDataApp = action.payload;
+        },
         requestDashboardRefresh: (
             state,
             action: PayloadAction<{
@@ -135,5 +150,6 @@ export const {
     resetActivePanel,
     dockItemRemoved,
     setCurrentDashboard,
+    setCurrentDataApp,
     requestDashboardRefresh,
 } = aiAgentLauncherSlice.actions;

--- a/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
@@ -134,11 +134,13 @@ const AgentPage = () => {
             } else {
                 const chartUuid = searchParams.get('chartUuid');
                 const dashboardUuid = searchParams.get('dashboardUuid');
+                const dataAppUuid = searchParams.get('dataAppUuid');
                 const pendingContext =
-                    chartUuid || dashboardUuid
+                    chartUuid || dashboardUuid || dataAppUuid
                         ? {
                               chartUuid: chartUuid ?? undefined,
                               dashboardUuid: dashboardUuid ?? undefined,
+                              dataAppUuid: dataAppUuid ?? undefined,
                           }
                         : null;
                 aiAgentStore.dispatch(

--- a/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
@@ -258,6 +258,7 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
         dashboardUuidOrSlug: pinnedDashboardUuid,
     });
     const dashboardUuid = searchParams.get('dashboardUuid');
+    const dataAppUuid = searchParams.get('dataAppUuid');
     const {
         contextInput: pageContextInput,
         previewItems: pagePreviewItems,
@@ -265,6 +266,7 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
     } = usePinnedContext({
         projectUuid,
         dashboardUuidOrSlug: dashboardUuid,
+        dataAppUuidOrSlug: dataAppUuid,
     });
 
     const contentMentionItems = useMemo(

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
@@ -85,6 +85,7 @@ const AgentsRouterPage = () => {
     const canStartDeepResearch = useDeepResearchAccess(projectUuid);
     const chartUuid = searchParams.get('chartUuid');
     const dashboardUuid = searchParams.get('dashboardUuid');
+    const dataAppUuid = searchParams.get('dataAppUuid');
 
     const {
         contextInput,
@@ -95,6 +96,7 @@ const AgentsRouterPage = () => {
         projectUuid,
         chartUuidOrSlug: chartUuid,
         dashboardUuidOrSlug: dashboardUuid,
+        dataAppUuidOrSlug: dataAppUuid,
     });
 
     const {

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
@@ -55,6 +55,7 @@ const AiAgentNewThreadPage: FC = () => {
     const [searchParams] = useSearchParams();
     const chartUuid = searchParams.get('chartUuid');
     const dashboardUuid = searchParams.get('dashboardUuid');
+    const dataAppUuid = searchParams.get('dataAppUuid');
 
     const {
         contextInput,
@@ -65,6 +66,7 @@ const AiAgentNewThreadPage: FC = () => {
         projectUuid,
         chartUuidOrSlug: chartUuid,
         dashboardUuidOrSlug: dashboardUuid,
+        dataAppUuidOrSlug: dataAppUuid,
     });
 
     const { agent, agents, navigateFromAgentChat } =

--- a/packages/frontend/src/features/apps/components/AppHeaderActions.test.tsx
+++ b/packages/frontend/src/features/apps/components/AppHeaderActions.test.tsx
@@ -111,6 +111,7 @@ const baseProps = {
     onEdit: null,
     shareUrl: null,
     navItem: null,
+    askAiItem: null,
     fullscreenToggle: null,
     captureThumbnail: null,
     capturePreviewScreenshot: null,

--- a/packages/frontend/src/features/apps/components/AppHeaderActions.tsx
+++ b/packages/frontend/src/features/apps/components/AppHeaderActions.tsx
@@ -88,6 +88,9 @@ type Props = {
      *  latest" in the builder). Rendered at the top of the menu; pass null
      *  to omit it. */
     navItem: ReactNode;
+    /** "Ask AI Agent" menu item, rendered right after `navItem`. Pass null
+     *  on surfaces that don't offer it. */
+    askAiItem: ReactNode;
     /** Fullscreen/presentation toggle, rendered between the refresh button
      *  and the overflow menu to match the dashboard header's ordering. Pass
      *  null on surfaces without it (the builder). */
@@ -140,6 +143,7 @@ const AppHeaderActions: FC<Props> = ({
     onEdit,
     shareUrl,
     navItem,
+    askAiItem,
     fullscreenToggle,
     captureThumbnail,
     capturePreviewScreenshot,
@@ -334,6 +338,7 @@ const AppHeaderActions: FC<Props> = ({
                 </Menu.Target>
                 <Menu.Dropdown>
                     {navItem}
+                    {askAiItem}
                     <Menu.Item
                         leftSection={
                             <MantineIcon icon={IconArrowsUpDown} size={14} />

--- a/packages/frontend/src/features/apps/components/DataAppAiAgentContextBridge.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppAiAgentContextBridge.tsx
@@ -1,0 +1,24 @@
+import { useEffect, type FC } from 'react';
+import { setCurrentDataApp } from '../../../ee/features/aiCopilot/store/aiAgentLauncherSlice';
+import { useAiAgentStoreDispatch } from '../../../ee/features/aiCopilot/store/hooks';
+
+type Props = {
+    projectUuid: string;
+    appUuid: string;
+};
+
+// Tells the AI launcher which data app page is open so new threads pin it.
+const DataAppAiAgentContextBridge: FC<Props> = ({ projectUuid, appUuid }) => {
+    const dispatch = useAiAgentStoreDispatch();
+
+    useEffect(() => {
+        dispatch(setCurrentDataApp({ projectUuid, uuid: appUuid }));
+        return () => {
+            dispatch(setCurrentDataApp(null));
+        };
+    }, [dispatch, projectUuid, appUuid]);
+
+    return null;
+};
+
+export default DataAppAiAgentContextBridge;

--- a/packages/frontend/src/features/apps/hooks/useGetApp.ts
+++ b/packages/frontend/src/features/apps/hooks/useGetApp.ts
@@ -8,7 +8,7 @@ const PAGE_SIZE = 5;
 
 const fetchAppVersions = async (
     projectUuid: string,
-    appUuid: string,
+    appUuidOrSlug: string,
     beforeVersion?: number,
 ): Promise<GetAppResult> => {
     const params = new URLSearchParams();
@@ -19,7 +19,7 @@ const fetchAppVersions = async (
     const qs = params.toString();
     const data = await lightdashApi<GetAppResult>({
         method: 'GET',
-        url: `/ee/projects/${projectUuid}/apps/${appUuid}?${qs}`,
+        url: `/ee/projects/${projectUuid}/apps/${appUuidOrSlug}?${qs}`,
         body: undefined,
     });
     return data;
@@ -27,14 +27,14 @@ const fetchAppVersions = async (
 
 export const useGetApp = (
     projectUuid: string | undefined,
-    appUuid: string | undefined,
+    appUuidOrSlug: string | undefined,
 ) => {
     const query = useInfiniteQuery<GetAppResult, ApiError>({
-        queryKey: ['app', projectUuid, appUuid],
+        queryKey: ['app', projectUuid, appUuidOrSlug],
         queryFn: ({ pageParam }) =>
             fetchAppVersions(
                 projectUuid!,
-                appUuid!,
+                appUuidOrSlug!,
                 pageParam as number | undefined,
             ),
         getNextPageParam: (lastPage) => {
@@ -42,7 +42,7 @@ export const useGetApp = (
                 return undefined;
             return lastPage.versions[lastPage.versions.length - 1].version;
         },
-        enabled: !!projectUuid && !!appUuid,
+        enabled: !!projectUuid && !!appUuidOrSlug,
     });
     return query;
 };

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -2963,6 +2963,7 @@ const AppGenerate: FC = () => {
                                                     </Menu.Item>
                                                 ) : null
                                             }
+                                            askAiItem={null}
                                         />
                                     }
                                 />

--- a/packages/frontend/src/pages/AppPreviewTest.capturedQueryCount.test.tsx
+++ b/packages/frontend/src/pages/AppPreviewTest.capturedQueryCount.test.tsx
@@ -36,6 +36,10 @@ vi.mock('../features/apps/components/AppHeaderActions', () => ({
     default: mocks.headerActions,
 }));
 
+vi.mock('../features/apps/components/DataAppAiAgentContextBridge', () => ({
+    default: () => null,
+}));
+
 vi.mock('../features/apps/hooks/useAppPreviewToken', () => ({
     useAppPreviewToken: () => ({
         data: 'preview-token',

--- a/packages/frontend/src/pages/AppPreviewTest.tsx
+++ b/packages/frontend/src/pages/AppPreviewTest.tsx
@@ -6,12 +6,14 @@ import { Navigate, useNavigate, useParams } from 'react-router';
 import MantineIcon from '../components/common/MantineIcon';
 import SuboptimalState from '../components/common/SuboptimalState/SuboptimalState';
 import ForbiddenPanel from '../components/ForbiddenPanel';
+import { AskAiAgentMenuItem } from '../ee/features/aiCopilot/components/AskAiAgentMenuItem/AskAiAgentMenuItem';
 import AppIframePreview, {
     type AppIframePreviewHandle,
 } from '../features/apps/AppIframePreview';
 import AppInspectorPanel from '../features/apps/AppInspectorPanel';
 import AppHeader from '../features/apps/components/AppHeader';
 import AppHeaderActions from '../features/apps/components/AppHeaderActions';
+import DataAppAiAgentContextBridge from '../features/apps/components/DataAppAiAgentContextBridge';
 import { getVisiblePreviewTokenError } from '../features/apps/hooks/previewTokenQueryOptions';
 import { useAppBuildPoller } from '../features/apps/hooks/useAppBuildPoller';
 import { useAppInspector } from '../features/apps/hooks/useAppInspector';
@@ -250,6 +252,12 @@ export default function AppPreviewTest() {
                     : classes.previewContainer
             }
         >
+            {firstPage && (
+                <DataAppAiAgentContextBridge
+                    projectUuid={projectUuid}
+                    appUuid={firstPage.appUuid}
+                />
+            )}
             {!isFullscreen && (
                 <AppHeader
                     projectUuid={projectUuid}
@@ -330,6 +338,17 @@ export default function AppPreviewTest() {
                             }
                             shareUrl={window.location.href}
                             navItem={null}
+                            askAiItem={
+                                <AskAiAgentMenuItem
+                                    projectUuid={projectUuid}
+                                    dataAppUuid={appUuid}
+                                    clickedFrom={
+                                        explicitVersion === undefined
+                                            ? 'data_app_header'
+                                            : 'data_app_version_header'
+                                    }
+                                />
+                            }
                         />
                     }
                 />

--- a/packages/frontend/src/providers/Tracking/types.ts
+++ b/packages/frontend/src/providers/Tracking/types.ts
@@ -546,7 +546,11 @@ export type AiAgentAskClickedSource =
     | 'dashboard_header'
     | 'dashboard_chart_tile'
     | 'saved_chart_header'
-    | 'resource_action_menu';
+    | 'resource_action_menu'
+    | 'data_app_header'
+    | 'data_app_version_header'
+    | 'data_app_resource_action_menu'
+    | 'data_app_my_apps_menu';
 
 type AiAgentAskClickedEvent = {
     name: EventName.AI_AGENT_ASK_CLICKED;


### PR DESCRIPTION
## Summary

Stack 2/3 for ZAP-988 (Ask AI for data apps), on top of the ZAP-990 PR. Every data app surface except the builder gets Ask AI, and the launcher carries the pinned app across pages.

```diff
 Ask AI surfaces
   <ResourceActionMenu>       chart/dashboard rows
+                             data app rows   # spaces, home pinned content
+  <MyAppsPanel> row menu                     # → full-page new thread
+  <AppHeaderActions askAiItem>               # viewer + version view → docked launcher
+                                             # builder: none (coding-agent chat owns that screen)

 Launcher
   pendingContext { chartUuid, dashboardUuid }
+                 { …, dataAppUuid }          # survives expand ⇄ collapse, ?dataAppUuid on thread pages
+  <DataAppAiAgentContextBridge>              # app view pages seed "Current page" like dashboards
   hideAILauncher: apps/*                     # builder + generate only
-                  apps/:appUuid/view, apps/:appUuid/versions/:v/view
```

- `useAskAiAgentAction({ …, dataAppUuid, mode: 'panel' | 'navigate' })`: data apps additionally require the data apps feature flag; `navigate` mode builds the full-page new-thread URL (shared `buildNewThreadUrl`, also used by panel expand) for surfaces where the launcher is hidden.
- `usePinnedContext` accepts a data app uuid or slug (`useGetApp` param renamed to `appUuidOrSlug`), keeps dashboard-first ordering.
- New tracking click sources: `data_app_header`, `data_app_version_header`, `data_app_resource_action_menu`, `data_app_my_apps_menu`.

## Test plan

- [x] `usePinnedContext.test.tsx`: uuid, slug, not-ready, dashboard-before-data-app ordering
- [x] `newThreadUrl.test.ts`
- [x] `AppHeaderActions.test.tsx`
- [x] frontend typecheck + lint
- [x] proof of work on a local instance (`.local/proofs/ZAP-988/proof.md`, untracked): viewer, version view, space row, home pinned, My apps, expand/collapse, current-page mention

Closes: ZAP-991
Part of: ZAP-988

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TwHfhTktNpT2Wq6bGAVVJN
