### PR TITLE
feat(dashboard): ask AI on data app tile pins dashboard and app

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardDataAppTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardDataAppTile.tsx
@@ -21,6 +21,7 @@ import {
 } from '@mantine/core';
 import { IconAppsOff, IconCode, IconFilter } from '@tabler/icons-react';
 import React, { useMemo, useState, type FC } from 'react';
+import { AskAiAgentButton } from '../../ee/features/aiCopilot/components/AskAiAgentMenuItem/AskAiAgentButton';
 import AppIframePreview from '../../features/apps/AppIframePreview';
 import { getVisiblePreviewTokenError } from '../../features/apps/hooks/previewTokenQueryOptions';
 import { useAppPreviewToken } from '../../features/apps/hooks/useAppPreviewToken';
@@ -125,6 +126,7 @@ const DataAppTile: FC<Props> = (props) => {
         },
     } = props;
     const projectUuid = useProjectUuid();
+    const dashboardUuid = useDashboardContext((c) => c.dashboard?.uuid);
 
     const [isCommentsMenuOpen, setIsCommentsMenuOpen] = useState(false);
     const showComments = useDashboardContext(
@@ -281,6 +283,14 @@ const DataAppTile: FC<Props> = (props) => {
     return (
         <TileBase
             title={title}
+            titleLeftIcon={
+                <AskAiAgentButton
+                    projectUuid={projectUuid}
+                    dataAppUuid={appUuid}
+                    dashboardUuid={dashboardUuid}
+                    clickedFrom="dashboard_data_app_tile"
+                />
+            }
             lockHeaderVisibility={isCommentsMenuOpen}
             visibleHeaderElement={
                 tileHasComments ? dashboardComments : undefined

--- a/packages/frontend/src/providers/Tracking/types.ts
+++ b/packages/frontend/src/providers/Tracking/types.ts
@@ -550,7 +550,8 @@ export type AiAgentAskClickedSource =
     | 'data_app_header'
     | 'data_app_version_header'
     | 'data_app_resource_action_menu'
-    | 'data_app_my_apps_menu';
+    | 'data_app_my_apps_menu'
+    | 'dashboard_data_app_tile';
 
 type AiAgentAskClickedEvent = {
     name: EventName.AI_AGENT_ASK_CLICKED;


### PR DESCRIPTION
## Summary

Stack 3/3 for ZAP-988 (Ask AI for data apps), on top of the ZAP-991 PR. The dashboard data app tile gets Ask AI, pinning the dashboard and the app.

```diff
 <DashboardDataAppTile>
   <TileBase
+    titleLeftIcon={<AskAiAgentButton dashboardUuid dataAppUuid clickedFrom="dashboard_data_app_tile" />}
```

`usePinnedContext` (previous PR) sorts the dashboard first, so the new prompt shows the dashboard chip then the app chip, the same as chart tiles. No runtime overrides on the app item.

Per product decision the builder overflow menu does **not** get Ask AI (ZAP-992's original ask), so the builder's coding-agent chat stays the only prompt on that screen.

## Test plan

- [x] `usePinnedContext.test.tsx` "sorts a pinned dashboard before the data app" (previous PR)
- [x] frontend typecheck + lint
- [x] proof of work on a local instance (`.local/proofs/ZAP-988/proof.md`, untracked): tile action pins dashboard first, app second

Closes: ZAP-992
Closes: ZAP-988

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TwHfhTktNpT2Wq6bGAVVJN
