### PR TITLE
fix(frontend): drop the deleted dark Button variant and fix dark-mode contrast in the metrics catalog

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/ToolCallIcon.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/ToolCallIcon.module.css
@@ -8,7 +8,7 @@
     box-sizing: border-box;
     border-radius: 4px;
     background-color: var(--mcp-icon-bg, var(--mantine-color-ldGray-7));
-    color: var(--mcp-icon-color, var(--mantine-color-white));
+    color: var(--mcp-icon-color, var(--mantine-color-ldGray-0));
     border: 1px solid var(--mcp-icon-border, transparent);
     box-shadow: 0 1px 2px rgba(15, 23, 42, 0.12);
     font-size: 7px;

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsWelcome.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsWelcome.tsx
@@ -239,7 +239,6 @@ const AgentsWelcome = () => {
                         <Box mt="lg">
                             {canCreateAgent ? (
                                 <Button
-                                    variant="dark"
                                     leftSection={
                                         <MantineIcon icon={IconPlus} />
                                     }

--- a/packages/frontend/src/features/metricsCatalog/components/ExploreMetricButton.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/ExploreMetricButton.tsx
@@ -62,7 +62,6 @@ export const ExploreMetricButton = ({ row }: Props) => {
         >
             <Button
                 size="compact-sm"
-                variant="dark"
                 onClick={handleExploreClick}
                 py="xxs"
                 px={10}

--- a/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.tsx
@@ -160,11 +160,7 @@ const EditPopover: FC<EditPopoverProps> = ({
                             </ActionIcon>
                         </Tooltip>
 
-                        <Button
-                            variant="dark"
-                            size="compact-xs"
-                            onClick={handleSave}
-                        >
+                        <Button size="compact-xs" onClick={handleSave}>
                             Save
                         </Button>
                     </Group>

--- a/packages/frontend/src/features/metricsCatalog/components/MetricCatalogColumnHeaderCell.module.css
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricCatalogColumnHeaderCell.module.css
@@ -8,11 +8,15 @@
     width: max-content;
     max-width: 250px;
     padding: 4px 8px;
-    color: var(--mantine-color-white);
+    /* Inverted like the themed Tooltip: ink on light, paper on dark. */
+    color: light-dark(var(--mantine-color-white), var(--mantine-color-gray-9));
     font-size: var(--mantine-font-size-xs);
     font-weight: 500;
     line-height: 1.3;
-    background-color: var(--mantine-color-dark-7);
+    background-color: light-dark(
+        var(--mantine-color-gray-9),
+        var(--mantine-color-gray-1)
+    );
     border-radius: var(--mantine-radius-sm);
     box-shadow: var(--mantine-shadow-sm);
     pointer-events: none;

--- a/packages/frontend/src/features/metricsCatalog/components/MetricDetailPopover.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricDetailPopover.tsx
@@ -224,7 +224,6 @@ const MetricDetailContent: FC<MetricDetailContentProps> = ({
 
             {showExploreButton && (
                 <Button
-                    variant="dark"
                     size="xs"
                     fullWidth
                     onClick={() => {

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
@@ -99,8 +99,8 @@ const LearnMorePopover: FC<{ buttonStyles?: ButtonProps['style'] }> = ({
                 </Button>
             </Popover.Target>
             <Popover.Dropdown
-                bg="ldDark.6"
-                c="white"
+                bg="ldDark.9"
+                c="ldGray.0"
                 p={16}
                 className={classes.spotlightDropdown}
             >
@@ -146,6 +146,7 @@ const LearnMorePopover: FC<{ buttonStyles?: ButtonProps['style'] }> = ({
                         </Button>
                         <Button
                             component="a"
+                            variant="default"
                             href="https://docs.lightdash.com/guides/metrics-catalog/"
                             target="_blank"
                             style={{ border: 'none', flexGrow: 1 }}

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
@@ -528,7 +528,6 @@ export const MetricsTableTopToolbar: FC<MetricsTableTopToolbarProps> = memo(
                                             <Button
                                                 size="xs"
                                                 h={28}
-                                                variant="dark"
                                                 onClick={handleSave}
                                                 loading={
                                                     isCreatingSpotlightConfig

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreDatePicker.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreDatePicker.tsx
@@ -242,21 +242,18 @@ export const MetricExploreDatePicker: FC<Props> = ({
                                     {...calendarConfig.props}
                                     mih={180}
                                     w="100%"
-                                    color="dark"
                                     size="xs"
                                 />
                             ) : calendarConfig?.type === TimeFrames.MONTH ? (
                                 <MonthRangePicker
                                     {...calendarConfig.props}
                                     mih={180}
-                                    color="dark"
                                     size="xs"
                                 />
                             ) : calendarConfig ? (
                                 <CalendarRangePicker
                                     {...calendarConfig.props}
                                     mih={225}
-                                    color="dark"
                                     size="xs"
                                     withCellSpacing={false}
                                 />

--- a/packages/frontend/src/stories/Button.stories.tsx
+++ b/packages/frontend/src/stories/Button.stories.tsx
@@ -7,8 +7,8 @@ const meta: Meta<typeof Button> = {
     argTypes: {
         variant: {
             control: 'select',
-            options: ['dark', 'default'],
-            defaultValue: 'dark',
+            options: ['filled', 'default'],
+            defaultValue: 'filled',
         },
         loading: {
             control: 'boolean',
@@ -32,7 +32,7 @@ type Story = StoryObj<typeof Button>;
 export const PrimaryButton: Story = {
     args: {
         children: 'Primary Button',
-        variant: 'dark',
+        variant: 'filled',
         radius: 'md',
         loading: false,
         disabled: false,

--- a/packages/frontend/src/stories/FormCard.stories.tsx
+++ b/packages/frontend/src/stories/FormCard.stories.tsx
@@ -59,7 +59,6 @@ export function FormCard({ hasError = false }: FormCardProps) {
                     <Button
                         type="submit"
                         radius="md"
-                        variant="dark"
                         style={{
                             alignSelf: 'flex-end',
                         }}


### PR DESCRIPTION
## Problem

The Explore button that appears when hovering a metric row in the Metrics Catalog rendered white text on a near-white fill in dark mode.

## Root cause

The theme revamp (#28442) deleted the custom `dark` Button variant, but six call sites still passed `variant="dark"`. Mantine's variant resolver returns nothing for an unknown variant, so those buttons fell back to Mantine's CSS defaults: the primary fill with hardcoded white text. In light mode that happens to look like the old ink button. In dark mode the primary fill is near-white, so the text disappears.

## Fix

- Drop `variant="dark"` everywhere (metrics table Explore, metric detail popover Explore, category Save, "Save for everyone", AI Agents welcome CTA, two stories). Buttons now use the theme's filled primary, which is the one primary action per surface in the style guide and picks its text colour from the fill.
- Sweep for the same failure class (a fill that inverts in dark mode paired with text that does not) and fix the hits:
  - Metrics Catalog spotlight "Learn more" popover: mid-grey surface with white text in dark. Now the inverted `ldDark.9` surface with `ldGray.0` text, and the docs button is `default` so it stays visible on the inverted surface in both schemes.
  - Metrics Catalog column header floating tooltip: hand-rolled `dark-7` with white text. Now mirrors the themed Tooltip's inverted light/dark pair.
  - Metric Explorer month, year and day range pickers had `color="dark"`, which painted the selected range near-black on a near-black popover in dark mode. Removed so they use the ink primary.
  - AI chat MCP tool-call icon: `ldGray-7` fill with white text was white on light grey in dark. Text is now `ldGray-0`.

## Regression analysis

- Light mode: the filled primary is near-black with white text, visually the same as the old `dark` variant. The spotlight popover goes from `ldDark.6` to `ldDark.9` (slightly darker) and its docs button becomes a white bordered button instead of a black one on a dark surface, which was barely visible before.
- Dark mode: every touched control now renders with readable contrast. Nothing else consumes the `dark` variant (`grep variant="dark"` is empty), and no other dropped variant (`compact-outline`) is referenced.
- Left alone on purpose: the homepage editor toolbar's hardcoded `#141414` / `#fff` button and the homepage promo "New" badge are legible in both schemes; a deep-research card button coloured `ldDark` renders correctly but breaks the style-guide rule and is a separate cleanup.

## Verification

- `pnpm -F frontend typecheck`, oxlint and oxfmt pass.
- Worktree frontend run against the local backend for manual dark/light review of the Metrics Catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K8LYkwDSoiwLAL71T4YxPW
