### PR TITLE
feat(dashboard): preserve customMetrics through dashboard save

### DIFF
--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -4,9 +4,7 @@ import {
     excludeTilesFromTabScopedFilters,
     getDefaultChartTileSize,
     getShadowedReservedNames,
-    isEmptyDateZoomConfig,
     normalizeDateZoomConfig,
-    pruneDateZoomConfig,
     removeDateZoomTileTargets,
     ChartType,
     ContentType,
@@ -69,6 +67,7 @@ import { DashboardChartEditContext } from '../providers/Dashboard/useDashboardCh
 import useDashboardContext from '../providers/Dashboard/useDashboardContext';
 import useDashboardTileStatusContext from '../providers/Dashboard/useDashboardTileStatusContext';
 import useNativeFullscreenToggle from '../providers/Fullscreen/useNativeFullscreenToggle';
+import { buildDashboardConfig } from '../utils/dashboardConfig';
 import { isSameDashboardRoute } from '../utils/dashboardRoutes';
 import '../styles/react-grid.css';
 
@@ -880,15 +879,6 @@ const Dashboard: FC = () => {
             return filter;
         });
 
-        // Prune empty controls + dangling targets on save; omit the field
-        // entirely when no controls remain so untouched dashboards don't churn.
-        const prunedDateZoomConfig = pruneDateZoomConfig(dateZoomConfig);
-        const savedDateZoomConfig = hasDateZoomConfigChanged
-            ? isEmptyDateZoomConfig(prunedDateZoomConfig)
-                ? undefined
-                : prunedDateZoomConfig
-            : dashboard.config?.dateZoomConfig;
-
         const dashboardUpdate: UpdateDashboard = {
             tiles: dashboardTiles,
             filters: {
@@ -904,22 +894,21 @@ const Dashboard: FC = () => {
             },
             name: dashboard.name,
             tabs: dashboardTabs,
-            config: {
+            config: buildDashboardConfig({
+                existingConfig: dashboard.config,
                 isDateZoomDisabled,
                 isAddFilterDisabled,
                 pinnedParameters,
-                parameterOrder: hasParameterOrderChanged
-                    ? parameterOrder
-                    : dashboard.config?.parameterOrder,
-                dateZoomGranularities: haveDateZoomGranularitiesChanged
-                    ? dateZoomGranularities
-                    : dashboard.config?.dateZoomGranularities,
-                defaultDateZoomGranularity: hasDefaultDateZoomGranularityChanged
-                    ? defaultDateZoomGranularity
-                    : dashboard.config?.defaultDateZoomGranularity,
-                dateZoomConfig: savedDateZoomConfig,
-                requiredFiltersNote: requiredFiltersNote || undefined,
-            },
+                parameterOrder,
+                hasParameterOrderChanged,
+                dateZoomGranularities,
+                haveDateZoomGranularitiesChanged,
+                defaultDateZoomGranularity,
+                hasDefaultDateZoomGranularityChanged,
+                dateZoomConfig,
+                hasDateZoomConfigChanged,
+                requiredFiltersNote,
+            }),
             parameters: dashboardParameters,
             ...(preserveVerification !== undefined
                 ? { preserveVerification }

--- a/packages/frontend/src/utils/dashboardConfig.test.ts
+++ b/packages/frontend/src/utils/dashboardConfig.test.ts
@@ -1,0 +1,132 @@
+import {
+    MetricType,
+    type AdditionalMetric,
+    type DashboardConfig,
+} from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import { buildDashboardConfig } from './dashboardConfig';
+
+const customMetric = (name: string): AdditionalMetric => ({
+    name,
+    label: name,
+    table: 'orders',
+    sql: '${TABLE}.amount',
+    type: MetricType.SUM,
+});
+
+const baseArgs = {
+    existingConfig: undefined as DashboardConfig | undefined,
+    isDateZoomDisabled: false,
+    isAddFilterDisabled: false,
+    pinnedParameters: [],
+    parameterOrder: [],
+    hasParameterOrderChanged: false,
+    dateZoomGranularities: [],
+    haveDateZoomGranularitiesChanged: false,
+    defaultDateZoomGranularity: undefined,
+    hasDefaultDateZoomGranularityChanged: false,
+    dateZoomConfig: { controls: [], tileTargets: {} },
+    hasDateZoomConfigChanged: false,
+    requiredFiltersNote: undefined,
+};
+
+describe('buildDashboardConfig', () => {
+    it('carries the persisted customMetrics registry through an unrelated save', () => {
+        const registry = [customMetric('total_revenue')];
+        const result = buildDashboardConfig({
+            ...baseArgs,
+            existingConfig: {
+                isDateZoomDisabled: false,
+                customMetrics: registry,
+            },
+            // Unrelated change being saved
+            isDateZoomDisabled: true,
+        });
+
+        expect(result.customMetrics).toEqual(registry);
+        expect(result.isDateZoomDisabled).toBe(true);
+    });
+
+    it('staged customMetrics overwrite the persisted registry', () => {
+        const staged = [customMetric('avg_basket')];
+        const result = buildDashboardConfig({
+            ...baseArgs,
+            existingConfig: {
+                isDateZoomDisabled: false,
+                customMetrics: [customMetric('total_revenue')],
+            },
+            stagedCustomMetrics: staged,
+        });
+
+        expect(result.customMetrics).toEqual(staged);
+    });
+
+    it('staged empty array clears the registry (deleting the last metric)', () => {
+        const result = buildDashboardConfig({
+            ...baseArgs,
+            existingConfig: {
+                isDateZoomDisabled: false,
+                customMetrics: [customMetric('total_revenue')],
+            },
+            stagedCustomMetrics: [],
+        });
+
+        expect(result.customMetrics).toEqual([]);
+    });
+
+    it('carries unchanged parameterOrder and date zoom settings forward', () => {
+        const existingConfig: DashboardConfig = {
+            isDateZoomDisabled: false,
+            parameterOrder: ['p1', 'p2'],
+            dateZoomGranularities: ['month'],
+            defaultDateZoomGranularity: 'month',
+            dateZoomConfig: {
+                controls: [{ uuid: 'c1', name: 'Grain', granularity: 'month' }],
+                tileTargets: {},
+            },
+        };
+        const result = buildDashboardConfig({
+            ...baseArgs,
+            existingConfig,
+        });
+
+        expect(result.parameterOrder).toEqual(['p1', 'p2']);
+        expect(result.dateZoomGranularities).toEqual(['month']);
+        expect(result.defaultDateZoomGranularity).toEqual('month');
+        expect(result.dateZoomConfig).toEqual(existingConfig.dateZoomConfig);
+    });
+
+    it('replaces changed values instead of carrying the old ones', () => {
+        const result = buildDashboardConfig({
+            ...baseArgs,
+            existingConfig: {
+                isDateZoomDisabled: false,
+                parameterOrder: ['old'],
+            },
+            parameterOrder: ['new'],
+            hasParameterOrderChanged: true,
+        });
+
+        expect(result.parameterOrder).toEqual(['new']);
+    });
+
+    it('produces a value for every DashboardConfig key', () => {
+        // A key missing from the built object is deleted on save — this
+        // pins the landmine the extraction exists to defuse.
+        const result = buildDashboardConfig(baseArgs);
+        const expectedKeys: Record<keyof DashboardConfig, true> = {
+            isDateZoomDisabled: true,
+            isAddFilterDisabled: true,
+            pinnedParameters: true,
+            parameterOrder: true,
+            dateZoomGranularities: true,
+            defaultDateZoomGranularity: true,
+            dateZoomConfig: true,
+            requiredFiltersNote: true,
+            customMetrics: true,
+        };
+        expect(Object.keys(result).sort()).toEqual(
+            Object.keys(expectedKeys).sort(),
+        );
+    });
+});

--- a/packages/frontend/src/utils/dashboardConfig.ts
+++ b/packages/frontend/src/utils/dashboardConfig.ts
@@ -1,0 +1,74 @@
+import {
+    isEmptyDateZoomConfig,
+    pruneDateZoomConfig,
+    type AdditionalMetric,
+    type DashboardConfig,
+    type DateGranularity,
+    type DateZoomConfig,
+} from '@lightdash/common';
+
+type BuildDashboardConfigArgs = {
+    existingConfig: DashboardConfig | undefined;
+    isDateZoomDisabled: boolean;
+    isAddFilterDisabled: boolean;
+    pinnedParameters: string[];
+    parameterOrder: string[];
+    hasParameterOrderChanged: boolean;
+    dateZoomGranularities: (DateGranularity | string)[];
+    haveDateZoomGranularitiesChanged: boolean;
+    defaultDateZoomGranularity: DateGranularity | string | undefined;
+    hasDefaultDateZoomGranularityChanged: boolean;
+    dateZoomConfig: DateZoomConfig;
+    hasDateZoomConfigChanged: boolean;
+    requiredFiltersNote: string | undefined;
+    stagedCustomMetrics?: AdditionalMetric[];
+};
+
+/**
+ * Builds the full `dashboard.config` payload for a save. Every DashboardConfig
+ * key must be produced here — a key that isn't is silently deleted on save.
+ */
+export const buildDashboardConfig = ({
+    existingConfig,
+    isDateZoomDisabled,
+    isAddFilterDisabled,
+    pinnedParameters,
+    parameterOrder,
+    hasParameterOrderChanged,
+    dateZoomGranularities,
+    haveDateZoomGranularitiesChanged,
+    defaultDateZoomGranularity,
+    hasDefaultDateZoomGranularityChanged,
+    dateZoomConfig,
+    hasDateZoomConfigChanged,
+    requiredFiltersNote,
+    stagedCustomMetrics,
+}: BuildDashboardConfigArgs): DashboardConfig => {
+    // Prune empty controls + dangling targets on save; omit the field
+    // entirely when no controls remain so untouched dashboards don't churn.
+    const prunedDateZoomConfig = pruneDateZoomConfig(dateZoomConfig);
+    const savedDateZoomConfig = hasDateZoomConfigChanged
+        ? isEmptyDateZoomConfig(prunedDateZoomConfig)
+            ? undefined
+            : prunedDateZoomConfig
+        : existingConfig?.dateZoomConfig;
+
+    return {
+        isDateZoomDisabled,
+        isAddFilterDisabled,
+        pinnedParameters,
+        parameterOrder: hasParameterOrderChanged
+            ? parameterOrder
+            : existingConfig?.parameterOrder,
+        dateZoomGranularities: haveDateZoomGranularitiesChanged
+            ? dateZoomGranularities
+            : existingConfig?.dateZoomGranularities,
+        defaultDateZoomGranularity: hasDefaultDateZoomGranularityChanged
+            ? defaultDateZoomGranularity
+            : existingConfig?.defaultDateZoomGranularity,
+        dateZoomConfig: savedDateZoomConfig,
+        requiredFiltersNote: requiredFiltersNote || undefined,
+        // Staged edits win; otherwise carry the persisted registry forward.
+        customMetrics: stagedCustomMetrics ?? existingConfig?.customMetrics,
+    };
+};


### PR DESCRIPTION
Closes: GLITCH-724

### Description:

Dashboard save builds `config` as an object literal that enumerates every known key — any `DashboardConfig` key not listed there is silently deleted on save. With the `customMetrics` registry now living on `DashboardConfig` (#28518), every save (moving a tile, changing a filter) would wipe it.

- Extracts the literal into a pure `buildDashboardConfig()` (`utils/dashboardConfig.ts`) so the round-trip is testable without rendering the page.
- Carries `customMetrics` forward: staged edits win, otherwise the persisted registry is preserved (`stagedCustomMetrics ?? existingConfig?.customMetrics`). Nothing stages metrics yet — that lands in GLITCH-725.
- Tests: registry survives an unrelated save, staged metrics overwrite, staged `[]` clears, unchanged values carry forward, and a key-exhaustiveness test that fails when a new `DashboardConfig` key is added without a value produced here.

No behaviour change for existing config keys — pure extraction.

### Risk assessment:

- [ ] This is a high-risk change

High-risk changes require approval from a reviewer other than the author before merging.
