### PR TITLE
feat(dashboard): stage the custom metrics registry alongside tiles

### DIFF
--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -111,6 +111,18 @@ const Dashboard: FC = () => {
     const setHaveTilesChanged = useDashboardContext(
         (c) => c.setHaveTilesChanged,
     );
+    const dashboardCustomMetrics = useDashboardContext(
+        (c) => c.dashboardCustomMetrics,
+    );
+    const setDashboardCustomMetrics = useDashboardContext(
+        (c) => c.setDashboardCustomMetrics,
+    );
+    const haveCustomMetricsChanged = useDashboardContext(
+        (c) => c.haveCustomMetricsChanged,
+    );
+    const setHaveCustomMetricsChanged = useDashboardContext(
+        (c) => c.setHaveCustomMetricsChanged,
+    );
 
     const haveTabsChanged = useDashboardContext((c) => c.haveTabsChanged);
     const setHaveTabsChanged = useDashboardContext((c) => c.setHaveTabsChanged);
@@ -397,6 +409,7 @@ const Dashboard: FC = () => {
     useEffect(() => {
         if (isSuccess) {
             setHaveTilesChanged(false);
+            setHaveCustomMetricsChanged(false);
             setHaveFiltersChanged(false);
             setHavePinnedParametersChanged(false);
             setHaveDateZoomGranularitiesChanged(false);
@@ -431,6 +444,7 @@ const Dashboard: FC = () => {
         setDashboardTemporaryFilters,
         setHaveFiltersChanged,
         setHaveTilesChanged,
+        setHaveCustomMetricsChanged,
         setHavePinnedParametersChanged,
         setHaveDateZoomGranularitiesChanged,
         setHasDefaultDateZoomGranularityChanged,
@@ -641,6 +655,8 @@ const Dashboard: FC = () => {
 
         setDashboardTiles(dashboard.tiles);
         setHaveTilesChanged(false);
+        setDashboardCustomMetrics(dashboard.config?.customMetrics ?? []);
+        setHaveCustomMetricsChanged(false);
         setDashboardFilters(dashboard.filters);
         setHaveFiltersChanged(false);
         setHaveTabsChanged(false);
@@ -682,6 +698,8 @@ const Dashboard: FC = () => {
         setHaveFiltersChanged,
         setDashboardFilters,
         setHaveTilesChanged,
+        setDashboardCustomMetrics,
+        setHaveCustomMetricsChanged,
         setHaveTabsChanged,
         setDashboardTabs,
         dashboardTabs,
@@ -719,7 +737,12 @@ const Dashboard: FC = () => {
 
     useEffect(() => {
         const checkReload = (event: BeforeUnloadEvent) => {
-            if (isEditMode && (haveTilesChanged || haveFiltersChanged)) {
+            if (
+                isEditMode &&
+                (haveTilesChanged ||
+                    haveFiltersChanged ||
+                    haveCustomMetricsChanged)
+            ) {
                 const message =
                     'You have unsaved changes to your dashboard! Are you sure you want to leave without saving?';
                 event.returnValue = message;
@@ -728,13 +751,21 @@ const Dashboard: FC = () => {
         };
         window.addEventListener('beforeunload', checkReload);
         return () => window.removeEventListener('beforeunload', checkReload);
-    }, [haveTilesChanged, haveFiltersChanged, isEditMode]);
+    }, [
+        haveTilesChanged,
+        haveFiltersChanged,
+        haveCustomMetricsChanged,
+        isEditMode,
+    ]);
 
     // Block navigating away if there are unsaved changes
     const blocker = useBlocker(({ nextLocation }) => {
         if (
             isEditMode &&
-            (haveTilesChanged || haveFiltersChanged || haveTabsChanged) &&
+            (haveTilesChanged ||
+                haveFiltersChanged ||
+                haveTabsChanged ||
+                haveCustomMetricsChanged) &&
             // A URL may carry either the uuid or the slug for both the project
             // and the dashboard, so accept any combination — but compare whole
             // segments, and require the project to match too: dashboard slugs
@@ -908,6 +939,9 @@ const Dashboard: FC = () => {
                 dateZoomConfig,
                 hasDateZoomConfigChanged,
                 requiredFiltersNote,
+                stagedCustomMetrics: haveCustomMetricsChanged
+                    ? dashboardCustomMetrics
+                    : undefined,
             }),
             parameters: dashboardParameters,
             ...(preserveVerification !== undefined
@@ -934,6 +968,7 @@ const Dashboard: FC = () => {
         onToggleFullscreen: handleToggleFullscreen,
         hasDashboardChanged:
             haveTilesChanged ||
+            haveCustomMetricsChanged ||
             haveFiltersChanged ||
             hasTemporaryFilters ||
             haveTabsChanged ||

--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -18,6 +18,7 @@ import {
     normalizeDateZoomConfig,
     normalizeGranularityParam,
     stripOverridesForLockedFiltersOnTab,
+    type AdditionalMetric,
     type ChartZoomableField,
     type Dashboard,
     type DashboardFilterableField,
@@ -224,6 +225,11 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
 
     const [dashboardTiles, setDashboardTiles] = useState<Dashboard['tiles']>();
     const [haveTilesChanged, setHaveTilesChanged] = useState<boolean>(false);
+    const [dashboardCustomMetrics, setDashboardCustomMetrics] = useState<
+        AdditionalMetric[]
+    >([]);
+    const [haveCustomMetricsChanged, setHaveCustomMetricsChanged] =
+        useState<boolean>(false);
     const [haveTabsChanged, setHaveTabsChanged] = useState<boolean>(false);
     const [dashboardTabs, setDashboardTabsInternal] = useState<
         Dashboard['tabs']
@@ -481,6 +487,13 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         currentDashboardConfig?.dateZoomGranularities,
         defaultStandardGranularities,
     ]);
+
+    // Seed the staged custom-metrics registry from config; keep user edits
+    // until save/cancel resets the changed flag.
+    useEffect(() => {
+        if (haveCustomMetricsChanged) return;
+        setDashboardCustomMetrics(currentDashboardConfig?.customMetrics ?? []);
+    }, [currentDashboardConfig?.customMetrics, haveCustomMetricsChanged]);
 
     // Sync default date zoom granularity from dashboard config
     useEffect(() => {
@@ -1823,6 +1836,10 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         setDashboardTiles,
         haveTilesChanged,
         setHaveTilesChanged,
+        dashboardCustomMetrics,
+        setDashboardCustomMetrics,
+        haveCustomMetricsChanged,
+        setHaveCustomMetricsChanged,
         haveTabsChanged,
         setHaveTabsChanged,
         dashboardTabs,

--- a/packages/frontend/src/providers/Dashboard/types.ts
+++ b/packages/frontend/src/providers/Dashboard/types.ts
@@ -1,4 +1,5 @@
 import {
+    type AdditionalMetric,
     type ApiError,
     type ChartZoomableField,
     type Dashboard,
@@ -50,6 +51,11 @@ export type DashboardContextType = {
     setDashboardTiles: Dispatch<SetStateAction<Dashboard['tiles'] | undefined>>;
     haveTilesChanged: boolean;
     setHaveTilesChanged: Dispatch<SetStateAction<boolean>>;
+    /** Staged registry of dashboard custom metrics; follows the tiles lifecycle */
+    dashboardCustomMetrics: AdditionalMetric[];
+    setDashboardCustomMetrics: Dispatch<SetStateAction<AdditionalMetric[]>>;
+    haveCustomMetricsChanged: boolean;
+    setHaveCustomMetricsChanged: Dispatch<SetStateAction<boolean>>;
     haveTabsChanged: boolean;
     setHaveTabsChanged: Dispatch<SetStateAction<boolean>>;
     dashboardTabs: Dashboard['tabs'];


### PR DESCRIPTION
Closes: GLITCH-725

### Description:

Chart 2 has to see a custom metric created in chart 1 **before** the dashboard is saved, so the registry follows the same staged lifecycle as tiles instead of mutating the loaded dashboard:

- `DashboardProvider` gains `dashboardCustomMetrics` / `setDashboardCustomMetrics` / `haveCustomMetricsChanged` / `setHaveCustomMetricsChanged`, mirroring the `haveTilesChanged` pattern.
- Seeded from `dashboard.config?.customMetrics ?? []`; the sync effect skips while edits are staged so a refetch can't clobber them.
- Save passes `stagedCustomMetrics` into `buildDashboardConfig()` (from the parent PR) and counts toward `hasDashboardChanged`; save success and cancel both reset the flag, and cancel restores the persisted registry exactly as it restores tiles.

Nothing writes to the staged registry yet — the modal wiring lands next.

### Risk assessment:

- [ ] This is a high-risk change

High-risk changes require approval from a reviewer other than the author before merging.
