### PR TITLE
feat(dashboard): merge chart custom metrics into the dashboard registry

### DIFF
--- a/packages/common/src/utils/additionalMetrics.test.ts
+++ b/packages/common/src/utils/additionalMetrics.test.ts
@@ -1,8 +1,12 @@
 import { type CompiledTable } from '../types/explore';
 import { CustomFormatType, DimensionType, MetricType } from '../types/field';
+import { type AdditionalMetric } from '../types/metricQuery';
 import { buildPopAdditionalMetric } from '../types/periodOverPeriodComparison';
 import { TimeFrames } from '../types/timeFrames';
-import { convertAdditionalMetric } from './additionalMetrics';
+import {
+    convertAdditionalMetric,
+    mergeDashboardCustomMetrics,
+} from './additionalMetrics';
 
 const baseTable: CompiledTable = {
     name: 'orders',
@@ -148,5 +152,96 @@ describe('convertAdditionalMetric — baseDimensionType plumbing', () => {
         });
         expect(result.baseDimensionType).toEqual(DimensionType.TIMESTAMP);
         expect(result.baseDimensionTimeInterval).toBeUndefined();
+    });
+});
+
+describe('mergeDashboardCustomMetrics', () => {
+    const metric = (
+        table: string,
+        name: string,
+        overrides: Partial<AdditionalMetric> = {},
+    ): AdditionalMetric => ({
+        table,
+        name,
+        label: name,
+        sql: '${TABLE}.amount',
+        type: MetricType.SUM,
+        ...overrides,
+    });
+
+    it('adds new chart metrics to the registry', () => {
+        const registry = [metric('orders', 'total_revenue')];
+        const result = mergeDashboardCustomMetrics(registry, [
+            metric('orders', 'avg_basket'),
+        ]);
+
+        expect(result.map((m) => m.name)).toEqual([
+            'total_revenue',
+            'avg_basket',
+        ]);
+    });
+
+    it('is idempotent for an identical definition', () => {
+        const registry = [metric('orders', 'total_revenue')];
+        const result = mergeDashboardCustomMetrics(registry, [
+            metric('orders', 'total_revenue'),
+        ]);
+
+        expect(result).toBe(registry);
+    });
+
+    it('keeps the existing registry definition when the same (table, name) reappears', () => {
+        const registry = [metric('orders', 'total_revenue')];
+        const result = mergeDashboardCustomMetrics(registry, [
+            metric('orders', 'total_revenue', { sql: '${TABLE}.other_column' }),
+        ]);
+
+        expect(result).toBe(registry);
+        expect(result[0].sql).toEqual('${TABLE}.amount');
+    });
+
+    it('lets the same name coexist on different tables', () => {
+        const registry = [metric('orders', 'total')];
+        const result = mergeDashboardCustomMetrics(registry, [
+            metric('payments', 'total'),
+        ]);
+
+        expect(result).toHaveLength(2);
+        expect(result.map((m) => m.table)).toEqual(['orders', 'payments']);
+    });
+
+    it('never admits system-generated metrics', () => {
+        const result = mergeDashboardCustomMetrics(
+            [],
+            [
+                metric('orders', 'total_revenue_previous_week', {
+                    generationType: 'periodOverPeriod',
+                }),
+            ],
+        );
+
+        expect(result).toEqual([]);
+    });
+
+    it('returns the original array identity when nothing was added', () => {
+        const registry = [metric('orders', 'total_revenue')];
+        const result = mergeDashboardCustomMetrics(registry, []);
+
+        expect(result).toBe(registry);
+    });
+
+    it('deduplicates within the incoming chart metrics', () => {
+        const result = mergeDashboardCustomMetrics(
+            [],
+            [
+                metric('orders', 'total_revenue'),
+                metric('orders', 'total_revenue', {
+                    sql: '${TABLE}.other_column',
+                }),
+            ],
+        );
+
+        expect(result).toHaveLength(1);
+        expect(result[0].sql).toEqual('${TABLE}.amount');
     });
 });

--- a/packages/common/src/utils/additionalMetrics.ts
+++ b/packages/common/src/utils/additionalMetrics.ts
@@ -10,6 +10,7 @@ import {
     isPeriodOverPeriodAdditionalMetric,
     type AdditionalMetric,
 } from '../types/metricQuery';
+import { getItemId } from './item';
 
 type ConvertAdditionalMetricArgs = {
     additionalMetric: AdditionalMetric;
@@ -90,4 +91,26 @@ export const getCustomMetricType = (type: DimensionType): MetricType[] => {
         default:
             return [];
     }
+};
+
+/**
+ * Merges a chart's custom metrics into a dashboard registry, keyed by
+ * `getItemId()`. Existing registry definitions win (frozen once saved) and
+ * system-generated metrics (e.g. period-over-period) are skipped. Returns the
+ * original array identity when nothing was added.
+ */
+export const mergeDashboardCustomMetrics = (
+    registry: AdditionalMetric[],
+    fromChart: AdditionalMetric[],
+): AdditionalMetric[] => {
+    const seenIds = new Set(registry.map(getItemId));
+    const additions = fromChart.filter((metric) => {
+        if (metric.generationType !== undefined) return false;
+        const id = getItemId(metric);
+        if (seenIds.has(id)) return false;
+        seenIds.add(id);
+        return true;
+    });
+
+    return additions.length === 0 ? registry : [...registry, ...additions];
 };


### PR DESCRIPTION
Closes: GLITCH-726

### Description:

Pure `mergeDashboardCustomMetrics(registry, fromChart)` in `@lightdash/common`, keyed on `getItemId()` (`${table}_${name}`), written test-first:

- Idempotent for an identical definition.
- The **existing** registry definition wins when the same `(table, name)` reappears — registry metrics are frozen once saved.
- Same name on different tables coexists.
- System-generated metrics (`generationType: 'periodOverPeriod'`) never enter the registry — they're query implementation details, not reusable user-authored fields.
- Returns the original array identity when nothing was added, so `haveCustomMetricsChanged` can be set by identity instead of a deep diff.
- Dedupes within the incoming chart metrics.

Not called from anywhere yet — the modal's save path wires it up next. Adding a pre-existing saved chart as a tile deliberately won't import its metrics.

### Risk assessment:

- [ ] This is a high-risk change

High-risk changes require approval from a reviewer other than the author before merging.
