### PR TITLE
feat(dashboard): filter registry metrics to the selected explore

### DIFF
--- a/packages/common/src/utils/additionalMetrics.test.ts
+++ b/packages/common/src/utils/additionalMetrics.test.ts
@@ -1,10 +1,11 @@
-import { type CompiledTable } from '../types/explore';
+import { type CompiledTable, type Explore } from '../types/explore';
 import { CustomFormatType, DimensionType, MetricType } from '../types/field';
 import { type AdditionalMetric } from '../types/metricQuery';
 import { buildPopAdditionalMetric } from '../types/periodOverPeriodComparison';
 import { TimeFrames } from '../types/timeFrames';
 import {
     convertAdditionalMetric,
+    getCompatibleDashboardMetrics,
     mergeDashboardCustomMetrics,
 } from './additionalMetrics';
 
@@ -243,5 +244,160 @@ describe('mergeDashboardCustomMetrics', () => {
 
         expect(result).toHaveLength(1);
         expect(result[0].sql).toEqual('${TABLE}.amount');
+    });
+});
+
+describe('getCompatibleDashboardMetrics', () => {
+    const explore = {
+        tables: {
+            orders: {
+                dimensions: {
+                    amount: {},
+                    status: {},
+                    order_id: {},
+                },
+                metrics: {
+                    total_amount: {},
+                },
+            },
+            customers: {
+                dimensions: {
+                    customer_id: {},
+                },
+                metrics: {},
+            },
+        },
+    } as unknown as Explore;
+
+    const metric = (
+        overrides: Partial<AdditionalMetric> = {},
+    ): AdditionalMetric => ({
+        table: 'orders',
+        name: 'custom_metric',
+        label: 'Custom metric',
+        sql: '${TABLE}.amount',
+        type: MetricType.SUM,
+        ...overrides,
+    });
+
+    it('returns nothing without an explore', () => {
+        expect(getCompatibleDashboardMetrics([metric()], undefined)).toEqual(
+            [],
+        );
+    });
+
+    it('omits metrics whose owning table is missing', () => {
+        const result = getCompatibleDashboardMetrics(
+            [metric(), metric({ table: 'payments', name: 'other' })],
+            explore,
+        );
+        expect(result.map((m) => m.name)).toEqual(['custom_metric']);
+    });
+
+    it('requires the base dimension to exist on the owning table', () => {
+        const result = getCompatibleDashboardMetrics(
+            [
+                metric({ baseDimensionName: 'amount' }),
+                metric({ name: 'bad', baseDimensionName: 'deleted_column' }),
+            ],
+            explore,
+        );
+        expect(result.map((m) => m.name)).toEqual(['custom_metric']);
+    });
+
+    it('requires the base metric to exist on the owning table', () => {
+        const result = getCompatibleDashboardMetrics(
+            [
+                metric({ baseMetricName: 'total_amount' }),
+                metric({ name: 'bad', baseMetricName: 'deleted_metric' }),
+            ],
+            explore,
+        );
+        expect(result.map((m) => m.name)).toEqual(['custom_metric']);
+    });
+
+    it('requires every filter target field to exist', () => {
+        const filterOn = (fieldRef: string) =>
+            [
+                {
+                    id: 'f1',
+                    target: { fieldRef },
+                    operator: 'equals',
+                    values: ['x'],
+                },
+            ] as AdditionalMetric['filters'];
+
+        const result = getCompatibleDashboardMetrics(
+            [
+                metric({ filters: filterOn('orders.status') }),
+                // Bare ref resolves against the owning table
+                metric({ name: 'bare', filters: filterOn('status') }),
+                metric({
+                    name: 'joined',
+                    filters: filterOn('customers.customer_id'),
+                }),
+                metric({
+                    name: 'bad',
+                    filters: filterOn('orders.deleted_column'),
+                }),
+                metric({
+                    name: 'bad_table',
+                    filters: filterOn('payments.status'),
+                }),
+            ],
+            explore,
+        );
+        expect(result.map((m) => m.name)).toEqual([
+            'custom_metric',
+            'bare',
+            'joined',
+        ]);
+    });
+
+    it('resolves references case-insensitively like the compiler (uppercased timeframe keys)', () => {
+        const exploreWithTimeframes = {
+            tables: {
+                orders: {
+                    dimensions: { order_date_DAY: {} },
+                    metrics: {},
+                },
+            },
+        } as unknown as Explore;
+
+        const result = getCompatibleDashboardMetrics(
+            [
+                metric({
+                    filters: [
+                        {
+                            id: 'f1',
+                            target: { fieldRef: 'orders.order_date_day' },
+                            operator: 'equals',
+                            values: ['2026-01-01'],
+                        },
+                    ] as AdditionalMetric['filters'],
+                }),
+            ],
+            exploreWithTimeframes,
+        );
+
+        expect(result.map((m) => m.name)).toEqual(['custom_metric']);
+    });
+
+    it('requires every distinctKeys field to exist', () => {
+        const result = getCompatibleDashboardMetrics(
+            [
+                metric({ distinctKeys: ['orders.order_id'] }),
+                metric({
+                    name: 'wrapped',
+                    distinctKeys: ['${orders.order_id}'],
+                }),
+                metric({
+                    name: 'bad',
+                    distinctKeys: ['orders.deleted_column'],
+                }),
+            ],
+            explore,
+        );
+        expect(result.map((m) => m.name)).toEqual(['custom_metric', 'wrapped']);
     });
 });

--- a/packages/common/src/utils/additionalMetrics.ts
+++ b/packages/common/src/utils/additionalMetrics.ts
@@ -1,5 +1,6 @@
+import { getReferencedDimensionCaseInsensitive } from '../compiler/referenceLookup';
 import { convertColumnMetric } from '../types/dbt';
-import { type CompiledTable } from '../types/explore';
+import { type CompiledTable, type Explore } from '../types/explore';
 import {
     DimensionType,
     getMinMaxBaseDimensionMetadata,
@@ -113,4 +114,78 @@ export const mergeDashboardCustomMetrics = (
     });
 
     return additions.length === 0 ? registry : [...registry, ...additions];
+};
+
+// Accepts `table.field`, bare `field` (owning table), or a `${...}`-wrapped
+// ref. Resolution is case-insensitive to match the compiler: compiled
+// timeframe dimension keys are uppercased (e.g. order_date_DAY, #5998).
+const dimensionRefExistsInExplore = (
+    ref: string,
+    explore: Explore,
+    owningTable: string,
+): boolean => {
+    const strippedRef = ref.replace(/^\$\{(.+)\}$/, '$1');
+    const [refTable, refName] = strippedRef.includes('.')
+        ? strippedRef.split('.')
+        : [owningTable, strippedRef];
+    return (
+        getReferencedDimensionCaseInsensitive(
+            refTable,
+            refName,
+            explore.tables,
+        ) !== undefined
+    );
+};
+
+const isMetricCompatibleWithExplore = (
+    metric: AdditionalMetric,
+    explore: Explore,
+): boolean => {
+    const table = explore.tables[metric.table];
+    if (!table) return false;
+    if (
+        metric.baseDimensionName &&
+        !table.dimensions[metric.baseDimensionName]
+    ) {
+        return false;
+    }
+    if (metric.baseMetricName && !table.metrics[metric.baseMetricName]) {
+        return false;
+    }
+    if (
+        metric.filters?.some(
+            (filter) =>
+                !dimensionRefExistsInExplore(
+                    filter.target.fieldRef,
+                    explore,
+                    metric.table,
+                ),
+        )
+    ) {
+        return false;
+    }
+    if (
+        metric.distinctKeys?.some(
+            (keyRef) =>
+                !dimensionRefExistsInExplore(keyRef, explore, metric.table),
+        )
+    ) {
+        return false;
+    }
+    return true;
+};
+
+/**
+ * Registry metrics usable in the given compiled Explore: the owning table and
+ * every field the metric depends on must exist. Incompatible metrics must never
+ * execute as partial definitions.
+ */
+export const getCompatibleDashboardMetrics = (
+    registry: AdditionalMetric[],
+    explore: Explore | undefined,
+): AdditionalMetric[] => {
+    if (!explore) return [];
+    return registry.filter((metric) =>
+        isMetricCompatibleWithExplore(metric, explore),
+    );
 };


### PR DESCRIPTION
Closes: GLITCH-727

### Description:

A dashboard hosts charts on many Explores, so a registry metric on `orders` is only usable in an Explore that actually contains `orders` and everything the metric depends on. Seeding blindly would offer a field that can't run.

Pure `getCompatibleDashboardMetrics(registry, explore)` in `@lightdash/common`. A metric is compatible when, in the compiled Explore (joined tables included):

- its owning table exists,
- its base dimension / base metric (when set) exists on that table,
- every filter target field resolves (`table.field` or bare refs against the owning table),
- every `distinctKeys` ref resolves (`sum_distinct` dedup keys, `${...}`-wrapped accepted).

Incompatible metrics are omitted — they must never execute as partial definitions. This extends the table + base-dimension check that `selectMissingCustomMetrics` already applies, rather than inventing new machinery.

Not called from anywhere yet — the seeding path (GLITCH-728) consumes it next.

### Risk assessment:

- [ ] This is a high-risk change

High-risk changes require approval from a reviewer other than the author before merging.
