### PR TITLE
feat(dashboard): seed in-dashboard charts with the registry

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartEditorModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartEditorModal.tsx
@@ -1,5 +1,6 @@
 import {
     ChartType,
+    mergeDashboardCustomMetrics,
     type AdditionalMetric,
     type SavedChart,
 } from '@lightdash/common';
@@ -11,6 +12,7 @@ import {
     createExplorerStore,
 } from '../../features/explorer/store';
 import { MergeProvider } from '../../features/mergeQuery/context/MergeContext';
+import { useDashboardCustomMetricSeed } from '../../hooks/dashboard/useDashboardCustomMetricSeed';
 import { useExplore } from '../../hooks/useExplore';
 import { useExplorerQueryEffects } from '../../hooks/useExplorerQueryEffects';
 import { ExplorerSection } from '../../providers/Explorer/types';
@@ -19,6 +21,7 @@ import MantineModal from '../common/MantineModal';
 import Page from '../common/Page/Page';
 import Explorer from '../Explorer';
 import ExploreSideBar from '../Explorer/ExploreSideBar';
+import PageSpinner from '../PageSpinner';
 
 type ContentProps = {
     exploreId: string;
@@ -52,17 +55,29 @@ const DashboardChartEditorContent: FC<ContentProps> = ({
                     savedChart: editChart,
                     unsavedChartVersion: {
                         tableName: exploreId,
-                        metricQuery: editChart?.metricQuery ?? {
-                            exploreName: exploreId,
-                            dimensions: [],
-                            metrics: [],
-                            filters: {},
-                            sorts: [],
-                            limit: 500,
-                            tableCalculations: [],
-                            additionalMetrics: seededMetrics,
-                            timezone: undefined,
-                        },
+                        // Editing: seeded metrics fill gaps, the chart's own
+                        // snapshot wins on collision.
+                        metricQuery: editChart
+                            ? {
+                                  ...editChart.metricQuery,
+                                  additionalMetrics:
+                                      mergeDashboardCustomMetrics(
+                                          editChart.metricQuery
+                                              .additionalMetrics ?? [],
+                                          seededMetrics,
+                                      ),
+                              }
+                            : {
+                                  exploreName: exploreId,
+                                  dimensions: [],
+                                  metrics: [],
+                                  filters: {},
+                                  sorts: [],
+                                  limit: 500,
+                                  tableCalculations: [],
+                                  additionalMetrics: seededMetrics,
+                                  timezone: undefined,
+                              },
                         chartConfig: editChart?.chartConfig ?? {
                             type: ChartType.CARTESIAN,
                             config: {
@@ -118,7 +133,6 @@ type Props = {
     dashboardUuid: string;
     dashboardName: string;
     editChart?: SavedChart;
-    seededMetrics?: AdditionalMetric[];
     onChartSaved: (chart: SavedChart) => void;
     onClose: () => void;
 };
@@ -132,20 +146,32 @@ const DashboardChartEditorModal: FC<Props> = ({
     dashboardUuid,
     dashboardName,
     editChart,
-    seededMetrics = [],
     onChartSaved,
     onClose,
 }) => {
     const [pickedExploreId, setPickedExploreId] = useState<string>();
     const exploreId = editChart ? editChart.tableName : pickedExploreId;
 
+    const { seededMetrics, isLoading: isSeedLoading } =
+        useDashboardCustomMetricSeed(exploreId);
+
+    // Saving closes the modal via the host, bypassing handleClose — reset the
+    // picked explore here too so the next New chart starts at the picker.
+    const handleChartSaved = useCallback(
+        (chart: SavedChart) => {
+            setPickedExploreId(undefined);
+            onChartSaved(chart);
+        },
+        [onChartSaved],
+    );
+
     const modalHostValue = useMemo(
         () => ({
             isModalHosted: true,
-            onChartSaved,
+            onChartSaved: handleChartSaved,
             dashboard: { uuid: dashboardUuid, name: dashboardName },
         }),
-        [onChartSaved, dashboardUuid, dashboardName],
+        [handleChartSaved, dashboardUuid, dashboardName],
     );
 
     const handleClose = useCallback(() => {
@@ -164,16 +190,20 @@ const DashboardChartEditorModal: FC<Props> = ({
             modalBodyProps={{ px: 0, py: 0 }}
         >
             <ModalHostedContext.Provider value={modalHostValue}>
-                <DashboardChartEditorContent
-                    key={`${dashboardUuid}-${exploreId ?? 'picker'}-${
-                        editChart?.uuid ?? 'new'
-                    }`}
-                    exploreId={exploreId ?? ''}
-                    editChart={editChart}
-                    seededMetrics={seededMetrics}
-                    onExploreSelect={setPickedExploreId}
-                    onBackToTables={() => setPickedExploreId(undefined)}
-                />
+                {isSeedLoading ? (
+                    <PageSpinner />
+                ) : (
+                    <DashboardChartEditorContent
+                        key={`${dashboardUuid}-${exploreId ?? 'picker'}-${
+                            editChart?.uuid ?? 'new'
+                        }`}
+                        exploreId={exploreId ?? ''}
+                        editChart={editChart}
+                        seededMetrics={seededMetrics}
+                        onExploreSelect={setPickedExploreId}
+                        onBackToTables={() => setPickedExploreId(undefined)}
+                    />
+                )}
             </ModalHostedContext.Provider>
         </MantineModal>
     );

--- a/packages/frontend/src/hooks/dashboard/useDashboardCustomMetricSeed.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardCustomMetricSeed.ts
@@ -1,0 +1,27 @@
+import { getCompatibleDashboardMetrics, getItemId } from '@lightdash/common';
+import { useMemo } from 'react';
+import useDashboardContext from '../../providers/Dashboard/useDashboardContext';
+import { useExplore } from '../useExplore';
+
+/**
+ * Registry metrics compatible with the given Explore, ready to seed a chart
+ * built inside the dashboard. Host-agnostic: reads the staged registry from
+ * the dashboard context and knows nothing about who hosts the Explorer.
+ */
+export const useDashboardCustomMetricSeed = (
+    exploreName: string | undefined,
+) => {
+    const registry = useDashboardContext((c) => c.dashboardCustomMetrics);
+    const { data: explore, isInitialLoading } = useExplore(
+        registry.length > 0 ? exploreName : undefined,
+    );
+
+    return useMemo(() => {
+        const seededMetrics = getCompatibleDashboardMetrics(registry, explore);
+        return {
+            seededMetrics,
+            dashboardMetricIds: new Set(seededMetrics.map(getItemId)),
+            isLoading: registry.length > 0 && !!exploreName && isInitialLoading,
+        };
+    }, [registry, explore, exploreName, isInitialLoading]);
+};

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -4,6 +4,7 @@ import {
     excludeTilesFromTabScopedFilters,
     getDefaultChartTileSize,
     getShadowedReservedNames,
+    mergeDashboardCustomMetrics,
     normalizeDateZoomConfig,
     removeDateZoomTileTargets,
     ChartType,
@@ -827,6 +828,16 @@ const Dashboard: FC = () => {
 
     const handleChartEditorSaved = useCallback(
         (chart: SavedChart) => {
+            // Only the in-dashboard builder contributes to the registry.
+            const mergedCustomMetrics = mergeDashboardCustomMetrics(
+                dashboardCustomMetrics,
+                chart.metricQuery.additionalMetrics ?? [],
+            );
+            if (mergedCustomMetrics !== dashboardCustomMetrics) {
+                setDashboardCustomMetrics(mergedCustomMetrics);
+                setHaveCustomMetricsChanged(true);
+            }
+
             // New uuid means a brand-new chart; an existing tile refreshes
             // itself via the update mutation's query cache reset.
             if (chart.uuid !== chartToEdit?.uuid) {
@@ -852,7 +863,14 @@ const Dashboard: FC = () => {
             setChartToEdit(undefined);
             setIsNewChartOpen(false);
         },
-        [chartToEdit, handleAddTiles, activeTab?.uuid],
+        [
+            chartToEdit,
+            handleAddTiles,
+            activeTab?.uuid,
+            dashboardCustomMetrics,
+            setDashboardCustomMetrics,
+            setHaveCustomMetricsChanged,
+        ],
     );
 
     if (isDashboardLoading) {


### PR DESCRIPTION
Closes: GLITCH-728

### Description:

The payoff slice — a custom metric created in chart 1 is offered when building chart 2 in the same dashboard, before the dashboard is even saved.

- `useDashboardCustomMetricSeed(exploreName)` — host-agnostic hook: reads the staged registry from the dashboard context, filters it to the selected Explore via `getCompatibleDashboardMetrics()`, returns `{ seededMetrics, dashboardMetricIds, isLoading }`. Skips the explore fetch entirely when the registry is empty.
- `DashboardChartEditorModal` seeds the Explorer's initial state through the existing `initialState` hatch: new charts start with the compatible metrics in `additionalMetrics`; edited charts **fill gaps only** — the chart's own snapshot wins on collision, preserving the no-propagation rule. The modal waits for the seed before creating the store (it initialises once per session).
- The modal's save path merges the saved chart's custom metrics back into the staged registry (`mergeDashboardCustomMetrics`) and marks it changed. Only the builder contributes — adding a pre-existing saved chart as a tile imports nothing.

Done-when (pending local verification once the dev stack is back): build chart 1 with a new metric → save → open New chart on the same Explore → the metric is in the field tree without saving the dashboard first; an Explore lacking its table doesn't offer it.

### Risk assessment:

- [ ] This is a high-risk change

High-risk changes require approval from a reviewer other than the author before merging.
