### PR TITLE
fix(frontend): dashboard filter autocomplete uses active parameter values

### DIFF
--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardFilters.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardFilters.tsx
@@ -28,6 +28,7 @@ const EmbedDashboardFilters: FC<Props> = ({ canAddFilters = false }) => {
         (c) => c.allFilterableFieldsMap,
     );
     const dashboardTiles = useDashboardContext((c) => c.dashboardTiles);
+    const parameterValues = useDashboardContext((c) => c.parameterValues);
     const filterableFieldsByTileUuid = useDashboardContext(
         (c) => c.filterableFieldsByTileUuid,
     );
@@ -102,6 +103,7 @@ const EmbedDashboardFilters: FC<Props> = ({ canAddFilters = false }) => {
             dashboardTiles={dashboardTiles}
             filterableFieldsByTileUuid={filterableFieldsByTileUuid}
             activeTabUuid={activeTab?.uuid}
+            parameterValues={parameterValues}
         >
             <>
                 {canAddFilters && (

--- a/packages/frontend/src/features/dashboardFilters/index.tsx
+++ b/packages/frontend/src/features/dashboardFilters/index.tsx
@@ -43,6 +43,7 @@ const DashboardFilters: FC<Props> = ({ isEditMode, activeTabUuid }) => {
         (c) => c.allFilterableMetrics,
     );
     const dashboardTiles = useDashboardContext((c) => c.dashboardTiles);
+    const parameterValues = useDashboardContext((c) => c.parameterValues);
     const filterableFieldsByTileUuid = useDashboardContext(
         (c) => c.filterableFieldsByTileUuid,
     );
@@ -100,6 +101,7 @@ const DashboardFilters: FC<Props> = ({ isEditMode, activeTabUuid }) => {
             dashboardTiles={dashboardTiles}
             filterableFieldsByTileUuid={filterableFieldsByTileUuid}
             activeTabUuid={activeTabUuid}
+            parameterValues={parameterValues}
         >
             <AddFilterButton
                 isEditMode={isEditMode}


### PR DESCRIPTION
## Problem

Dashboard filter value autocomplete ignored the dashboard's active parameter selection. Changing a parameter updated the charts, but the filter dropdown kept listing values computed against the parameter default.

Repro on jaffle `events` (`event_status` param, Liquid-driven `filtered_event` dim): set param to `song_played`, chart collapses to `song_played` + null, but the filter dropdown still offers `playlist_created` / `playlist_deleted`.

## Cause

The field-values request never carried `parameters`. The hook and autocomplete already thread `parameterValues` from `FiltersProvider`, and Explorer passes them, but the two dashboard providers didn't:

```diff
 <DashboardFilters> (features/dashboardFilters/index.tsx)
   useDashboardContext(c => c.parameterValues)
   <FiltersProvider
     dashboardFilters, dashboardTiles, ...
+    parameterValues={parameterValues}
   >
     <FilterStringAutoComplete>
       useFieldValues(..., parameterValues)   # already supported
```

Same wiring added to `EmbedDashboardFilters.tsx`. The backend already resolves `parameters` on both the project and embed search endpoints (embed side landed in #27326).

## After

Request now sends `"parameters":{"events.event_status":"song_played"}` and the dropdown returns only `song_played`. The react-query key already includes `parameterValues`, so changing a parameter invalidates cached suggestions.

Closes: PROD-8986
Closes: #25749
