### PR TITLE
fix: let impersonate:User custom roles read the impersonation setting

### DIFF
--- a/packages/backend/src/services/OrganizationService/OrganizationService.test.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.test.ts
@@ -42,6 +42,9 @@ const organizationModel = {
     get: vi.fn(async () => organization),
     create: vi.fn<OrganizationModel['create']>(async () => organization),
     hasOrgs: vi.fn<OrganizationModel['hasOrgs']>(async () => false),
+    getImpersonationEnabled: vi.fn<
+        OrganizationModel['getImpersonationEnabled']
+    >(async () => true),
 };
 const userModel = {
     hasUsers: vi.fn<UserModel['hasUsers']>(async () => false),
@@ -331,5 +334,43 @@ describe('organization service', () => {
         // the member keeps their own org role (no system-role conversion).
         expect(result.data).toHaveLength(1);
         expect(result.data[0].role).toBe(OrganizationMemberRole.MEMBER);
+    });
+
+    describe('getImpersonationEnabled', () => {
+        const orgCondition = { organizationUuid: user.organizationUuid };
+
+        it('lets a user with only impersonate:User read the setting', async () => {
+            const impersonatorAbility = new Ability<PossibleAbilities>([
+                {
+                    action: 'impersonate',
+                    subject: 'User',
+                    conditions: { ...orgCondition, isActive: true },
+                },
+            ]);
+
+            await expect(
+                organizationService.getImpersonationEnabled({
+                    ...user,
+                    ability: impersonatorAbility,
+                }),
+            ).resolves.toBe(true);
+        });
+
+        it('rejects a user who can neither update the org nor impersonate', async () => {
+            const memberAbility = new Ability<PossibleAbilities>([
+                {
+                    action: 'manage',
+                    subject: 'OrganizationMemberProfile',
+                    conditions: orgCondition,
+                },
+            ]);
+
+            await expect(
+                organizationService.getImpersonationEnabled({
+                    ...user,
+                    ability: memberAbility,
+                }),
+            ).rejects.toBeInstanceOf(ForbiddenError);
+        });
     });
 });

--- a/packages/backend/src/services/OrganizationService/OrganizationService.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.ts
@@ -1200,13 +1200,18 @@ export class OrganizationService extends BaseService {
         if (organizationUuid === undefined) {
             throw new NotFoundError('Organization not found');
         }
+        // Impersonators need to read the setting to know the action is available
         const auditedAbility = this.createAuditedAbility(user);
-        if (
-            auditedAbility.cannot(
+        const canReadSetting =
+            auditedAbility.can(
                 'update',
                 subject('Organization', { organizationUuid }),
-            )
-        ) {
+            ) ||
+            auditedAbility.can(
+                'impersonate',
+                subject('User', { organizationUuid, isActive: true }),
+            );
+        if (!canReadSetting) {
             throw new ForbiddenError();
         }
         const flag = await this.featureFlagModel.get({

--- a/packages/common/src/authorization/scopes.test.ts
+++ b/packages/common/src/authorization/scopes.test.ts
@@ -11,6 +11,16 @@ import {
 } from './scopes';
 
 describe('scope dependency graph helpers', () => {
+    it('impersonate:User depends on managing member profiles to reach Users & groups', () => {
+        const scope = getScopes({ isEnterprise: true }).find(
+            ({ name }) => name === 'impersonate:User',
+        );
+
+        expect(scope?.dependencies.map(({ name }) => name)).toEqual([
+            'manage:OrganizationMemberProfile',
+        ]);
+    });
+
     it('declares the Deep Research core and conditional dependencies', () => {
         const scope = getScopes({ isEnterprise: true }).find(
             ({ name }) => name === 'create:AiDeepResearch',

--- a/packages/common/src/authorization/scopes.ts
+++ b/packages/common/src/authorization/scopes.ts
@@ -1054,7 +1054,13 @@ const scopes: Scope[] = [
         description: 'Impersonate other users in the organization',
         isEnterprise: false,
         group: ScopeGroup.ORGANIZATION_MANAGEMENT,
-        dependencies: [],
+        dependencies: [
+            {
+                name: 'manage:OrganizationMemberProfile',
+                description:
+                    'Open Users & groups to pick a user to impersonate',
+            },
+        ],
         level: 'organization',
         getConditions: (context) => [
             { ...addUuidCondition(context), isActive: true },


### PR DESCRIPTION
A custom organization role granted only `impersonate:User` never saw the "Impersonate user" action in Users & groups. The backend already allowed that role to start an impersonation session; the UI hid the action because the settings read it depends on required `update:Organization`.

```diff
 UsersActionMenu
   GET /api/v1/org/impersonation
     OrganizationService.getImpersonationEnabled
-      require update:Organization        → 403 for impersonate-only roles → action hidden
+      require update:Organization
+        OR impersonate:User              → 200 → action shown
   POST /api/v1/impersonation/start       (unchanged, already accepted impersonate:User)
```

## Changes

- `getImpersonationEnabled` accepts callers who can `impersonate:User` in the org. The write path (`updateImpersonationEnabled`) still requires `update:Organization`.
- `impersonate:User` now declares `manage:OrganizationMemberProfile` as a dependency, so the role editor tells admins the role also needs it to open Users & groups.
- Tests: settings read passes for an impersonate-only ability and is forbidden for a member-profile-only ability; scope dependency pinned.

## Verified locally

Custom role with `impersonate:User` + `manage:OrganizationMemberProfile`, impersonation enabled on the org: row menu now shows "Impersonate user" and starting a session works.

Closes: PROD-10887
Closes: #28555

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYqCC1cLQv5apggPng7HgQ
