### PR TITLE
fix(ai): default optional secondary axis fields

### DIFF
--- a/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
@@ -2412,12 +2412,28 @@ Notes:
                 "type": "string",
               },
               "secondaryYAxisLabel": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                  },
+                  {
+                    "type": "null",
+                  },
+                ],
+                "default": null,
                 "description": "A helpful label for the secondary y-axis",
-                "type": "string",
               },
               "secondaryYAxisMetric": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                  },
+                  {
+                    "type": "null",
+                  },
+                ],
+                "default": null,
                 "description": "(Optional) A single metric field ID to display on a secondary (right) y-axis. Must NOT be included in yAxisMetrics. Use when one metric has a very different scale than others (e.g., percentage vs count).",
-                "type": "string",
               },
               "stackBars": {
                 "description": "If groupBy is provided then this will stack the bars on top of each other instead of side by side. Applies to bar and horizontal charts.",
@@ -7012,12 +7028,28 @@ Response shape (MCP CallToolResult):
                 "type": "string",
               },
               "secondaryYAxisLabel": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                  },
+                  {
+                    "type": "null",
+                  },
+                ],
+                "default": null,
                 "description": "A helpful label for the secondary y-axis",
-                "type": "string",
               },
               "secondaryYAxisMetric": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                  },
+                  {
+                    "type": "null",
+                  },
+                ],
+                "default": null,
                 "description": "(Optional) A single metric field ID to display on a secondary (right) y-axis. Must NOT be included in yAxisMetrics. Use when one metric has a very different scale than others (e.g., percentage vs count).",
-                "type": "string",
               },
               "stackBars": {
                 "description": "If groupBy is provided then this will stack the bars on top of each other instead of side by side. Applies to bar and horizontal charts.",
@@ -11224,12 +11256,28 @@ Grammar: <field> <operator form>
             "type": "string",
           },
           "secondaryYAxisLabel": {
+            "anyOf": [
+              {
+                "type": "string",
+              },
+              {
+                "type": "null",
+              },
+            ],
+            "default": null,
             "description": "A helpful label for the secondary y-axis",
-            "type": "string",
           },
           "secondaryYAxisMetric": {
+            "anyOf": [
+              {
+                "type": "string",
+              },
+              {
+                "type": "null",
+              },
+            ],
+            "default": null,
             "description": "(Optional) A single metric field ID to display on a secondary (right) y-axis. Must NOT be included in yAxisMetrics. Use when one metric has a very different scale than others (e.g., percentage vs count).",
-            "type": "string",
           },
           "stackBars": {
             "description": "If groupBy is provided then this will stack the bars on top of each other instead of side by side. Applies to bar and horizontal charts.",

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -1781,6 +1781,7 @@ Recommended Dashboard Structure:
                   ],
                 },
                 "secondaryYAxisLabel": {
+                  "default": null,
                   "description": "A helpful label for the secondary y-axis",
                   "type": [
                     "string",
@@ -1788,6 +1789,7 @@ Recommended Dashboard Structure:
                   ],
                 },
                 "secondaryYAxisMetric": {
+                  "default": null,
                   "description": "(Optional) A single metric field ID to display on a secondary (right) y-axis. Must NOT be included in yAxisMetrics. Use when one metric has a very different scale than others (e.g., percentage vs count).",
                   "type": [
                     "string",
@@ -1850,8 +1852,6 @@ Recommended Dashboard Structure:
                 "lineType",
                 "xAxisLabel",
                 "yAxisLabel",
-                "secondaryYAxisMetric",
-                "secondaryYAxisLabel",
               ],
               "type": [
                 "object",
@@ -7056,6 +7056,7 @@ Example B — "Revenue by month with year-over-year comparison"
                   ],
                 },
                 "secondaryYAxisLabel": {
+                  "default": null,
                   "description": "A helpful label for the secondary y-axis",
                   "type": [
                     "string",
@@ -7063,6 +7064,7 @@ Example B — "Revenue by month with year-over-year comparison"
                   ],
                 },
                 "secondaryYAxisMetric": {
+                  "default": null,
                   "description": "(Optional) A single metric field ID to display on a secondary (right) y-axis. Must NOT be included in yAxisMetrics. Use when one metric has a very different scale than others (e.g., percentage vs count).",
                   "type": [
                     "string",
@@ -7125,8 +7127,6 @@ Example B — "Revenue by month with year-over-year comparison"
                 "lineType",
                 "xAxisLabel",
                 "yAxisLabel",
-                "secondaryYAxisMetric",
-                "secondaryYAxisLabel",
               ],
               "type": "object",
             },
@@ -9526,6 +9526,7 @@ Example B — "Revenue by month with year-over-year comparison"
                 ],
               },
               "secondaryYAxisLabel": {
+                "default": null,
                 "description": "A helpful label for the secondary y-axis",
                 "type": [
                   "string",
@@ -9533,6 +9534,7 @@ Example B — "Revenue by month with year-over-year comparison"
                 ],
               },
               "secondaryYAxisMetric": {
+                "default": null,
                 "description": "(Optional) A single metric field ID to display on a secondary (right) y-axis. Must NOT be included in yAxisMetrics. Use when one metric has a very different scale than others (e.g., percentage vs count).",
                 "type": [
                   "string",
@@ -9595,8 +9597,6 @@ Example B — "Revenue by month with year-over-year comparison"
               "lineType",
               "xAxisLabel",
               "yAxisLabel",
-              "secondaryYAxisMetric",
-              "secondaryYAxisLabel",
             ],
             "type": "object",
           },

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolRunQueryArgs.test.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolRunQueryArgs.test.ts
@@ -275,6 +275,30 @@ const uuidEnrichedChartConfig = {
     optionValues: { showLegend: true },
 };
 
+describe('chartConfig builtin defaults', () => {
+    it('defaults omitted secondary axis fields to null', () => {
+        const parsed = toolRunQueryArgsSchema.parse({
+            ...buildV2Args(),
+            chartConfig: {
+                defaultVizType: 'bar',
+                xAxisDimension: 'orders_order_date_month',
+                yAxisMetrics: ['orders_revenue'],
+                groupBy: null,
+                xAxisType: 'time',
+                stackBars: null,
+                lineType: null,
+                xAxisLabel: 'Month',
+                yAxisLabel: 'Revenue',
+            },
+        });
+
+        expect(parsed.chartConfig).toMatchObject({
+            secondaryYAxisMetric: null,
+            secondaryYAxisLabel: null,
+        });
+    });
+});
+
 describe('chartConfig custom chart type union', () => {
     it('advertised schema accepts a custom chart type config', () => {
         const result = toolRunQueryArgsSchema.safeParse({

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolRunQueryArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolRunQueryArgs.ts
@@ -208,13 +208,15 @@ const chartConfigBuiltinSchema = z.object({
     yAxisLabel: z.string().describe('A helpful label to explain the y-axis'),
     secondaryYAxisMetric: z
         .string()
-        .nullable()
+        .nullish()
+        .default(null)
         .describe(
             '(Optional) A single metric field ID to display on a secondary (right) y-axis. Must NOT be included in yAxisMetrics. Use when one metric has a very different scale than others (e.g., percentage vs count).',
         ),
     secondaryYAxisLabel: z
         .string()
-        .nullable()
+        .nullish()
+        .default(null)
         .describe('A helpful label for the secondary y-axis'),
 });
 

--- a/packages/common/src/schemas/json/mcp-tools-1.0.json
+++ b/packages/common/src/schemas/json/mcp-tools-1.0.json
@@ -2403,12 +2403,28 @@
                                 "type": "string"
                             },
                             "secondaryYAxisLabel": {
-                                "description": "A helpful label for the secondary y-axis",
-                                "type": "string"
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ],
+                                "default": null,
+                                "description": "A helpful label for the secondary y-axis"
                             },
                             "secondaryYAxisMetric": {
-                                "description": "(Optional) A single metric field ID to display on a secondary (right) y-axis. Must NOT be included in yAxisMetrics. Use when one metric has a very different scale than others (e.g., percentage vs count).",
-                                "type": "string"
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ],
+                                "default": null,
+                                "description": "(Optional) A single metric field ID to display on a secondary (right) y-axis. Must NOT be included in yAxisMetrics. Use when one metric has a very different scale than others (e.g., percentage vs count)."
                             },
                             "stackBars": {
                                 "description": "If groupBy is provided then this will stack the bars on top of each other instead of side by side. Applies to bar and horizontal charts.",
@@ -3018,12 +3034,28 @@
                                 "type": "string"
                             },
                             "secondaryYAxisLabel": {
-                                "description": "A helpful label for the secondary y-axis",
-                                "type": "string"
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ],
+                                "default": null,
+                                "description": "A helpful label for the secondary y-axis"
                             },
                             "secondaryYAxisMetric": {
-                                "description": "(Optional) A single metric field ID to display on a secondary (right) y-axis. Must NOT be included in yAxisMetrics. Use when one metric has a very different scale than others (e.g., percentage vs count).",
-                                "type": "string"
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ],
+                                "default": null,
+                                "description": "(Optional) A single metric field ID to display on a secondary (right) y-axis. Must NOT be included in yAxisMetrics. Use when one metric has a very different scale than others (e.g., percentage vs count)."
                             },
                             "stackBars": {
                                 "description": "If groupBy is provided then this will stack the bars on top of each other instead of side by side. Applies to bar and horizontal charts.",


### PR DESCRIPTION
## Summary
- accept omitted secondary-axis metric and label fields
- normalize omitted values to null
- update agent tool contracts and add regression coverage

Fixes LIGHTDASH-BACKEND-DBK

## Tests
- pnpm -F common test src/ee/AiAgent/schemas/tools/toolRunQueryArgs.test.ts
- pnpm -F common typecheck
- pnpm -F common lint
- pnpm -F backend test src/ee/services/ai/tools/agentToolContracts.snapshot.test.ts