### PR TITLE
feat(ai): add selectable OpenRouter models

### DIFF
--- a/packages/backend/src/config/aiConfigSchema.ts
+++ b/packages/backend/src/config/aiConfigSchema.ts
@@ -101,6 +101,7 @@ export const aiCopilotConfigSchema = z
                     modelName: z
                         .string()
                         .default(DEFAULT_OPENROUTER_MODEL_NAME),
+                    availableModels: z.array(z.string()).optional(),
                     customHeaders: customHeadersSchema,
                     supportsStreaming: supportsStreamingSchema,
                 })

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -1111,6 +1111,18 @@ test('Should parse AI provider custom headers from env', () => {
     });
 });
 
+test('Should parse selectable OpenRouter models from env', () => {
+    process.env.OPENROUTER_API_KEY = 'test-openrouter-key';
+    process.env.OPENROUTER_MODEL_NAME = 'qwen/qwen3.5-9b';
+    process.env.OPENROUTER_AVAILABLE_MODELS =
+        'qwen/qwen3.5-9b,moonshotai/kimi-k3';
+
+    expect(parseConfig().ai.copilot.providers.openrouter).toMatchObject({
+        modelName: 'qwen/qwen3.5-9b',
+        availableModels: ['qwen/qwen3.5-9b', 'moonshotai/kimi-k3'],
+    });
+});
+
 describe('AI provider supportsStreaming', () => {
     beforeEach(() => {
         process.env.OPENAI_API_KEY = 'test-openai-key';

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1348,6 +1348,9 @@ export const getAiConfig = () => ({
                   modelName:
                       process.env.OPENROUTER_MODEL_NAME ||
                       DEFAULT_OPENROUTER_MODEL_NAME,
+                  availableModels: getArrayFromCommaSeparatedList(
+                      'OPENROUTER_AVAILABLE_MODELS',
+                  ),
                   sortOrder: process.env.OPENROUTER_SORT_ORDER,
                   allowedProviders: getArrayFromCommaSeparatedList(
                       'OPENROUTER_ALLOWED_PROVIDERS',

--- a/packages/backend/src/ee/services/AiOrganizationSettingsService.ts
+++ b/packages/backend/src/ee/services/AiOrganizationSettingsService.ts
@@ -36,14 +36,14 @@ import {
 import {
     matchesPreset,
     type ModelPreset,
-    type ModelPresetProvider,
+    type SelectableModelProvider,
 } from './ai/models/presets';
 import {
     OrgAiCopilotConfigResolver,
     type ReviewJudgeAvailability,
 } from './ai/OrgAiCopilotConfigResolver';
 
-type AvailableModelPreset = ModelPreset<ModelPresetProvider>;
+type AvailableModelPreset = ModelPreset<SelectableModelProvider>;
 
 /**
  * Whether a stored model config still resolves to one of the models left

--- a/packages/backend/src/ee/services/ai/models/index.test.ts
+++ b/packages/backend/src/ee/services/ai/models/index.test.ts
@@ -253,6 +253,35 @@ describe('getModel', () => {
         expect(model.modelId).toBe('run-selected/model');
     });
 
+    it('honors an allowlisted OpenRouter model selection', () => {
+        const { model } = getModel(
+            {
+                ...baseCopilotConfig,
+                defaultProvider: 'openrouter',
+                providers: {
+                    openrouter: {
+                        apiKey: 'test',
+                        modelName: 'qwen/qwen3.8-flash',
+                        availableModels: [
+                            'qwen/qwen3.8-flash',
+                            'moonshotai/kimi-k3',
+                        ],
+                        allowedProviders: [],
+                        sortOrder: 'latency',
+                        customHeaders: {},
+                        supportsStreaming: true,
+                    },
+                },
+            },
+            {
+                provider: 'openrouter',
+                modelName: 'moonshotai/kimi-k3',
+            },
+        );
+
+        expect(model.modelId).toBe('moonshotai/kimi-k3');
+    });
+
     it('ignores untrusted Azure and OpenRouter model-name overrides', () => {
         const azure = getModel(
             {
@@ -346,6 +375,57 @@ describe('getModel', () => {
 
         expect(wrapLanguageModel).toHaveBeenCalledTimes(1);
         expect(model).toBe(vi.mocked(wrapLanguageModel).mock.results[0].value);
+    });
+});
+
+describe('OpenRouter model options', () => {
+    it('surfaces the default and allowlisted models for the picker', () => {
+        const models = getAvailableModels({
+            ...baseCopilotConfig,
+            defaultProvider: 'openrouter',
+            providers: {
+                openrouter: {
+                    apiKey: 'test',
+                    modelName: 'qwen/qwen3.5-9b',
+                    availableModels: [
+                        'qwen/qwen3.5-9b',
+                        'moonshotai/kimi-k3',
+                        'z-ai/glm-5.3-flash',
+                    ],
+                    allowedProviders: [],
+                    sortOrder: 'latency',
+                    customHeaders: {},
+                    supportsStreaming: true,
+                },
+            },
+        });
+
+        expect(models).toMatchObject([
+            {
+                provider: 'openrouter',
+                name: 'qwen/qwen3.5-9b',
+                displayName: 'Qwen3.5 9B',
+                groupLabel: 'Qwen',
+                description:
+                    'Compact multimodal model for affordable reasoning, coding, and visual analysis',
+            },
+            {
+                provider: 'openrouter',
+                name: 'moonshotai/kimi-k3',
+                displayName: 'Kimi K3',
+                groupLabel: 'Moonshot AI',
+                description:
+                    'Open-weight multimodal model for complex coding and long-running agents',
+            },
+            {
+                provider: 'openrouter',
+                name: 'z-ai/glm-5.3-flash',
+                displayName: 'GLM 5.3 Flash',
+                groupLabel: 'Z.ai',
+                description:
+                    'Efficient multimodal model for coding and long-context agent tasks',
+            },
+        ]);
     });
 });
 

--- a/packages/backend/src/ee/services/ai/models/index.ts
+++ b/packages/backend/src/ee/services/ai/models/index.ts
@@ -23,6 +23,7 @@ import {
     MODEL_PRESETS,
     ModelPreset,
     ModelPresetProvider,
+    openRouterPreset,
 } from './presets';
 import { AiModel, AiProvider } from './types';
 
@@ -136,18 +137,33 @@ export const getDefaultModel = (
 
 export const getAvailableModels = (
     config: LightdashConfig['ai']['copilot'],
-): ModelPreset<'openai' | 'anthropic' | 'bedrock'>[] => {
+): ModelPreset<'openai' | 'anthropic' | 'openrouter' | 'bedrock'>[] => {
     const { defaultProvider, providers } = config;
 
-    if (['azure', 'openrouter'].includes(defaultProvider)) {
+    if (defaultProvider === 'azure') {
         return [];
     }
 
-    const configuredProviders = ['openai', 'anthropic', 'bedrock'] as const;
-
-    return configuredProviders.flatMap((provider) => {
+    const configuredProviders = [
+        'openai',
+        'anthropic',
+        'openrouter',
+        'bedrock',
+    ] as const;
+    return configuredProviders.flatMap<
+        ModelPreset<'openai' | 'anthropic' | 'openrouter' | 'bedrock'>
+    >((provider) => {
         const providerConfig = providers[provider];
         if (!providerConfig) return [];
+
+        if (provider === 'openrouter') {
+            return [
+                ...new Set([
+                    providerConfig.modelName,
+                    ...(providerConfig.availableModels ?? []),
+                ]),
+            ].map(openRouterPreset);
+        }
 
         const { availableModels, modelName } = providerConfig;
 
@@ -189,7 +205,7 @@ export const getAvailableModels = (
 };
 
 export const presetToModelOption = (
-    preset: ModelPreset<'openai' | 'anthropic' | 'bedrock'>,
+    preset: ModelPreset<'openai' | 'anthropic' | 'openrouter' | 'bedrock'>,
     defaultModel: { name: string; provider: string } | null,
 ): AiModelOption => ({
     name: preset.name,
@@ -197,6 +213,7 @@ export const presetToModelOption = (
     displayName: preset.displayName,
     description: preset.description,
     provider: preset.provider,
+    ...(preset.groupLabel ? { groupLabel: preset.groupLabel } : {}),
     default:
         defaultModel !== null &&
         preset.provider === defaultModel.provider &&
@@ -219,9 +236,9 @@ export type OrgModelOverrides = {
  * keep working (grandfathered); they just can't be selected again.
  */
 export const filterModelsForOrg = (
-    presets: ModelPreset<'openai' | 'anthropic' | 'bedrock'>[],
+    presets: ModelPreset<'openai' | 'anthropic' | 'openrouter' | 'bedrock'>[],
     overrides: OrgModelOverrides,
-): ModelPreset<'openai' | 'anthropic' | 'bedrock'>[] =>
+): ModelPreset<'openai' | 'anthropic' | 'openrouter' | 'bedrock'>[] =>
     presets.filter((preset) => {
         // Only BYO-able providers can unlock hidden models or be restricted
         const byoProvider = isByoAiProvider(preset.provider)
@@ -409,13 +426,22 @@ export const getModel = (
                     'OpenRouter configuration is required',
                 );
             }
-            // OpenRouter doesn't use presets - uses model name directly
+            const requestedModelName = options?.modelName;
+            const configuredModelNames = new Set([
+                openrouterConfig.modelName,
+                ...(openrouterConfig.availableModels ?? []),
+            ]);
+            const canUseRequestedModel =
+                requestedModelName !== undefined &&
+                (options?.trustPinnedModelName === true ||
+                    configuredModelNames.has(requestedModelName));
+
             return withKeyManagement(
                 applyStreamingCapability(
                     getOpenRouterModel({
                         ...openrouterConfig,
-                        modelName: options?.trustPinnedModelName
-                            ? (options.modelName ?? openrouterConfig.modelName)
+                        modelName: canUseRequestedModel
+                            ? requestedModelName
                             : openrouterConfig.modelName,
                     }),
                     openrouterConfig.supportsStreaming,

--- a/packages/backend/src/ee/services/ai/models/presets.ts
+++ b/packages/backend/src/ee/services/ai/models/presets.ts
@@ -2,15 +2,17 @@ import { CallSettings } from 'ai';
 import { ProviderOptionsMap } from './types';
 
 export type ModelPresetProvider = 'openai' | 'anthropic' | 'bedrock';
+export type SelectableModelProvider = ModelPresetProvider | 'openrouter';
 
 export type ReasoningStyle = 'budget' | 'adaptive';
 
-export type ModelPreset<P extends ModelPresetProvider> = {
+export type ModelPreset<P extends SelectableModelProvider> = {
     name: string;
     provider: P;
     modelId: string;
     displayName: string;
     description: string;
+    groupLabel?: string;
     supportsReasoning: boolean;
     // How the provider exposes extended reasoning. 'budget' uses the original
     // `thinking.type: 'enabled'` + `budgetTokens` API; 'adaptive' uses the newer
@@ -355,8 +357,89 @@ export function customGatewayPreset(modelName: string): ModelPreset<'openai'> {
     };
 }
 
+const OPENROUTER_MODEL_METADATA: Record<
+    string,
+    {
+        displayName: string;
+        description: string;
+        groupLabel: string;
+        contextWindowTokens: number;
+        supportsReasoning: boolean;
+    }
+> = {
+    'qwen/qwen3.5-9b': {
+        displayName: 'Qwen3.5 9B',
+        description:
+            'Compact multimodal model for affordable reasoning, coding, and visual analysis',
+        groupLabel: 'Qwen',
+        contextWindowTokens: 262_144,
+        supportsReasoning: false,
+    },
+    'moonshotai/kimi-k3': {
+        displayName: 'Kimi K3',
+        description:
+            'Open-weight multimodal model for complex coding and long-running agents',
+        groupLabel: 'Moonshot AI',
+        contextWindowTokens: 1_048_576,
+        supportsReasoning: false,
+    },
+    'minimax/minimax-m3': {
+        displayName: 'MiniMax M3',
+        description:
+            'Multimodal 1M-context model for coding and long-horizon agent work',
+        groupLabel: 'MiniMax',
+        contextWindowTokens: 1_048_576,
+        supportsReasoning: false,
+    },
+    'deepseek/deepseek-v4-flash-0731': {
+        displayName: 'DeepSeek V4 Flash',
+        description:
+            'Fast mixture-of-experts reasoning for coding and tool-driven workflows',
+        groupLabel: 'DeepSeek',
+        contextWindowTokens: 1_310_720,
+        supportsReasoning: false,
+    },
+    'z-ai/glm-5.3-flash': {
+        displayName: 'GLM 5.3 Flash',
+        description:
+            'Efficient multimodal model for coding and long-context agent tasks',
+        groupLabel: 'Z.ai',
+        contextWindowTokens: 1_310_720,
+        supportsReasoning: false,
+    },
+};
+
+export function openRouterPreset(modelName: string): ModelPreset<'openrouter'> {
+    const metadata = OPENROUTER_MODEL_METADATA[modelName];
+
+    if (metadata) {
+        return {
+            name: modelName,
+            provider: 'openrouter',
+            modelId: modelName,
+            ...metadata,
+            custom: false,
+            callOptions: {},
+            providerOptions: undefined,
+        };
+    }
+
+    return {
+        name: modelName,
+        provider: 'openrouter',
+        modelId: modelName,
+        displayName: modelName,
+        description: 'Model served through OpenRouter',
+        custom: true,
+        contextWindowTokens: null,
+        supportsReasoning: false,
+        callOptions: {},
+        providerOptions: undefined,
+    };
+}
+
 export function matchesPreset(
-    preset: ModelPreset<ModelPresetProvider>,
+    preset: ModelPreset<SelectableModelProvider>,
     name: string,
 ): boolean {
     return preset.name === name || preset.modelId === name;

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -1334,6 +1334,7 @@ export type AiModelOption = {
     displayName: string;
     description: string;
     provider: string;
+    groupLabel?: string;
     default: boolean;
     supportsReasoning: boolean;
     deprecated: boolean;

--- a/packages/frontend/src/components/common/ModelSelector/ModelSelector.tsx
+++ b/packages/frontend/src/components/common/ModelSelector/ModelSelector.tsx
@@ -1,5 +1,6 @@
 import type { AiModelOption } from '@lightdash/common';
 import {
+    Box,
     Button,
     Group,
     Menu,
@@ -11,7 +12,11 @@ import {
 import { IconCheck, IconChevronDown } from '@tabler/icons-react';
 import { useMemo, type FC } from 'react';
 import MantineIcon from '../MantineIcon';
-import { filterDeprecatedModelsForPicker, getModelKey } from './utils';
+import {
+    filterDeprecatedModelsForPicker,
+    getModelGroupLabel,
+    getModelKey,
+} from './utils';
 
 interface Props extends Omit<ButtonProps, 'value' | 'onChange'> {
     models: AiModelOption[];
@@ -42,13 +47,18 @@ export const ModelSelector: FC<Props> = ({
     const groupedModels = useMemo(() => {
         const groups = new Map<string, AiModelOption[]>();
         visibleModels.forEach((model) => {
-            const existing = groups.get(model.provider) ?? [];
-            groups.set(model.provider, [...existing, model]);
+            const groupLabel = getModelGroupLabel(model);
+            const existing = groups.get(groupLabel);
+            if (existing) {
+                existing.push(model);
+            } else {
+                groups.set(groupLabel, [model]);
+            }
         });
         return groups;
     }, [visibleModels]);
 
-    const providerGroups = useMemo(
+    const modelGroups = useMemo(
         () => Array.from(groupedModels.keys()),
         [groupedModels],
     );
@@ -63,7 +73,7 @@ export const ModelSelector: FC<Props> = ({
     }
 
     return (
-        <Menu width={280} position="top-end" offset={8}>
+        <Menu width={340} position="top-end" offset={8}>
             <Menu.Target>
                 <Button
                     px="xs"
@@ -125,16 +135,15 @@ export const ModelSelector: FC<Props> = ({
                     </>
                 )}
                 <ScrollArea.Autosize mah={200}>
-                    {providerGroups.map((provider, groupIndex) => {
-                        const providerModels =
-                            groupedModels.get(provider) ?? [];
+                    {modelGroups.map((groupLabel, groupIndex) => {
+                        const groupModels = groupedModels.get(groupLabel) ?? [];
                         return (
-                            <div key={provider}>
-                                {providerGroups.length > 1 && (
-                                    <Menu.Label>{provider}</Menu.Label>
+                            <Box key={groupLabel}>
+                                {modelGroups.length > 1 && (
+                                    <Menu.Label>{groupLabel}</Menu.Label>
                                 )}
 
-                                {providerModels.map((model) => {
+                                {groupModels.map((model) => {
                                     const modelKey = getModelKey(model);
                                     const isSelected = modelKey === value;
                                     return (
@@ -165,10 +174,10 @@ export const ModelSelector: FC<Props> = ({
                                     );
                                 })}
 
-                                {groupIndex < providerGroups.length - 1 && (
+                                {groupIndex < modelGroups.length - 1 && (
                                     <Menu.Divider />
                                 )}
-                            </div>
+                            </Box>
                         );
                     })}
                 </ScrollArea.Autosize>

--- a/packages/frontend/src/components/common/ModelSelector/utils.test.ts
+++ b/packages/frontend/src/components/common/ModelSelector/utils.test.ts
@@ -1,5 +1,9 @@
 import type { AiModelOption } from '@lightdash/common';
-import { filterDeprecatedModelsForPicker, matchesModelConfig } from './utils';
+import {
+    filterDeprecatedModelsForPicker,
+    getModelGroupLabel,
+    matchesModelConfig,
+} from './utils';
 
 const model = (name: string, deprecated = false): AiModelOption => ({
     name,
@@ -40,5 +44,17 @@ describe('matchesModelConfig', () => {
                 modelProvider: 'openai',
             }),
         ).toBe(true);
+    });
+});
+
+describe('getModelGroupLabel', () => {
+    it('uses a model-specific group label when provided', () => {
+        expect(
+            getModelGroupLabel({ ...current, groupLabel: 'Moonshot AI' }),
+        ).toBe('Moonshot AI');
+    });
+
+    it('falls back to a human-readable provider label', () => {
+        expect(getModelGroupLabel(current)).toBe('OpenAI');
     });
 });

--- a/packages/frontend/src/components/common/ModelSelector/utils.ts
+++ b/packages/frontend/src/components/common/ModelSelector/utils.ts
@@ -4,6 +4,16 @@ import type { AiAgentModelConfig, AiModelOption } from '@lightdash/common';
 export const getModelKey = (model: AiModelOption): string =>
     `${model.provider}:${model.name}`;
 
+const MODEL_PROVIDER_LABELS: Record<string, string> = {
+    anthropic: 'Anthropic',
+    bedrock: 'Amazon Bedrock',
+    openai: 'OpenAI',
+    openrouter: 'OpenRouter',
+};
+
+export const getModelGroupLabel = (model: AiModelOption): string =>
+    model.groupLabel ?? MODEL_PROVIDER_LABELS[model.provider] ?? model.provider;
+
 export const matchesModelConfig = (
     model: AiModelOption,
     modelConfig: AiAgentModelConfig,


### PR DESCRIPTION
## Summary

- expose configured OpenRouter models in the AI model picker
- validate model overrides against the configured allowlist
- add curated display metadata and publisher grouping
- preserve existing OpenAI, Anthropic, and Bedrock choices

## Configuration

OPENROUTER_AVAILABLE_MODELS accepts a comma-separated model list. The configured default is included and duplicates are removed.

## Validation

- backend focused suite: 270 tests passed
- frontend model-selector suite: 5 tests passed
- common, backend, and frontend typechecks passed
- targeted backend, frontend, and common lint passed
- all five deployment models completed forced named-tool calls through OpenRouter with data collection denied and parameter support required
- local model endpoint verified 7 OpenAI, 9 Anthropic, and 5 OpenRouter choices

No API keys or local environment files are included.