### PR TITLE
fix: use FOR NO KEY UPDATE when locking project for validation writes

### DIFF
--- a/packages/backend/src/models/ValidationModel/ValidationModel.ts
+++ b/packages/backend/src/models/ValidationModel/ValidationModel.ts
@@ -102,11 +102,14 @@ export class ValidationModel {
         jobId?: string;
     }): Promise<void> {
         await this.database.transaction(async (trx) => {
-            // Lock the project to avoid concurrent validation updates
+            // Lock the project to avoid concurrent validation updates.
+            // FOR NO KEY UPDATE doesn't block foreign key checks, so inserts
+            // into query_history and other project-referencing tables can
+            // still proceed while validations are stored.
             await trx(ProjectTableName)
                 .select('project_uuid')
                 .where('project_uuid', projectUuid)
-                .forUpdate();
+                .forNoKeyUpdate();
 
             if (validations.length > 0) {
                 await ValidationModel.create(trx, validations, jobId);
@@ -185,11 +188,14 @@ export class ValidationModel {
         validations: CreateValidation[],
     ): Promise<void> {
         await this.database.transaction(async (trx) => {
-            // Lock the project to avoid concurrent validation updates
+            // Lock the project to avoid concurrent validation updates.
+            // FOR NO KEY UPDATE doesn't block foreign key checks, so inserts
+            // into query_history and other project-referencing tables can
+            // still proceed while validations are stored.
             await trx(ProjectTableName)
                 .select('project_uuid')
                 .where('project_uuid', projectUuid)
-                .forUpdate();
+                .forNoKeyUpdate();
 
             await trx(ValidationTableName)
                 .where({ project_uuid: projectUuid })


### PR DESCRIPTION
`ValidationModel.create` and `ValidationModel.replaceProjectValidations` lock the `projects` row with `SELECT ... FOR UPDATE` before deleting and batch-inserting validation rows. `FOR UPDATE` conflicts with the `FOR KEY SHARE` lock that foreign key checks take, so every `INSERT INTO query_history` (and any other insert with an FK to `projects`) waits on `Lock:transactionid` until the validation transaction commits — stalling query execution for the whole project after each deploy/compile.

Switched both locks to `forNoKeyUpdate()`. That still serialises concurrent validation writers for the project (which is all the lock was there for) but no longer blocks foreign key readers. The same lock mode is already used against `projects` in `DirectAccessModel`.

Verified `pnpm -F backend test src/models/ValidationModel/ValidationModel.test.ts` passes (15 tests).