### PR TITLE
feat: add tabs to chart type gallery

### DIFF
--- a/packages/frontend/src/features/chartTypes/components/ChartTypeLibrarySection.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeLibrarySection.tsx
@@ -9,6 +9,7 @@ import ChartTypeLibraryDetailModal from './ChartTypeLibraryDetailModal';
 
 type Props = {
     projectUuid: string;
+    withHeader?: boolean;
 };
 
 /**
@@ -17,7 +18,10 @@ type Props = {
  * flag, a disabled registry, or an org that hasn't configured one all render
  * nothing rather than an empty section nobody asked for.
  */
-const ChartTypeLibrarySection: FC<Props> = ({ projectUuid }) => {
+const ChartTypeLibrarySection: FC<Props> = ({
+    projectUuid,
+    withHeader = true,
+}) => {
     const flagQuery = useServerFeatureFlag(FeatureFlags.ChartTypeRegistry);
     const flagEnabled = flagQuery.data?.enabled ?? false;
     const registryQuery = useRegistryChartTypes(projectUuid, flagEnabled);
@@ -40,18 +44,20 @@ const ChartTypeLibrarySection: FC<Props> = ({ projectUuid }) => {
 
     return (
         <Stack gap="md">
-            <Group justify="space-between" align="center">
-                <Group gap={6} align="baseline">
-                    <Text size="md" fw={600} c="ldGray.8">
-                        Chart type library
-                    </Text>
-                    {registryQuery.data && (
-                        <Text fz="xs" c="dimmed">
-                            ({charts.length})
+            {withHeader && (
+                <Group justify="space-between" align="center">
+                    <Group gap={6} align="baseline">
+                        <Text size="md" fw={600} c="ldGray.8">
+                            Chart type library
                         </Text>
-                    )}
+                        {registryQuery.data && (
+                            <Text fz="xs" c="dimmed">
+                                ({charts.length})
+                            </Text>
+                        )}
+                    </Group>
                 </Group>
-            </Group>
+            )}
 
             {registryQuery.isInitialLoading ? (
                 <EmptyStateLoader title="Loading chart type library…" />

--- a/packages/frontend/src/pages/ChartTypeGallery.test.tsx
+++ b/packages/frontend/src/pages/ChartTypeGallery.test.tsx
@@ -91,11 +91,26 @@ const setData = (data: DataAppViz[]) => {
     } as unknown as ReturnType<typeof useDataAppVisualizations>);
 };
 
-const setFlag = (enabled: boolean) => {
-    vi.mocked(useServerFeatureFlag).mockReturnValue({
-        data: { id: FeatureFlags.EnableDataApps, enabled },
-        isLoading: false,
-    } as ReturnType<typeof useServerFeatureFlag>);
+const setFlags = ({
+    dataApps = true,
+    chartTypeRegistry = true,
+}: {
+    dataApps?: boolean;
+    chartTypeRegistry?: boolean;
+} = {}) => {
+    vi.mocked(useServerFeatureFlag).mockImplementation(
+        (flag) =>
+            ({
+                data: {
+                    id: flag,
+                    enabled:
+                        flag === FeatureFlags.EnableDataApps
+                            ? dataApps
+                            : chartTypeRegistry,
+                },
+                isLoading: false,
+            }) as ReturnType<typeof useServerFeatureFlag>,
+    );
 };
 
 const renderPage = () =>
@@ -119,7 +134,7 @@ const mockedDeleteApp = vi.fn();
 describe('ChartTypeGallery', () => {
     beforeEach(() => {
         vi.clearAllMocks();
-        setFlag(true);
+        setFlags();
         vi.mocked(useCanEditDataApp).mockReturnValue(true);
         vi.mocked(useCanCreateDataApp).mockReturnValue(true);
         vi.mocked(useDuplicateApp).mockReturnValue({
@@ -167,6 +182,37 @@ describe('ChartTypeGallery', () => {
         );
         expect(screen.getByText('v3')).toBeInTheDocument();
         expect(screen.getByText('Value')).toBeInTheDocument();
+    });
+
+    it('separates chart types and the library into top-level tabs', () => {
+        setData([makeDataAppViz({})]);
+        renderPage();
+
+        const chartTypesTab = screen.getByRole('tab', {
+            name: 'Chart types (1)',
+        });
+        const libraryTab = screen.getByRole('tab', { name: 'Library' });
+
+        expect(chartTypesTab).toHaveAttribute('aria-selected', 'true');
+        expect(libraryTab).toHaveAttribute('aria-selected', 'false');
+        expect(screen.getByText('Radial gauge')).toBeInTheDocument();
+
+        fireEvent.click(libraryTab);
+
+        expect(libraryTab).toHaveAttribute('aria-selected', 'true');
+        expect(
+            screen.queryByRole('button', { name: 'Radial gauge' }),
+        ).not.toBeInTheDocument();
+    });
+
+    it('hides the library tab when the chart type registry is disabled', () => {
+        setFlags({ chartTypeRegistry: false });
+        setData([makeDataAppViz({})]);
+        renderPage();
+
+        expect(
+            screen.queryByRole('tab', { name: 'Library' }),
+        ).not.toBeInTheDocument();
     });
 
     it('shows origin author and last update in the detail modal', () => {
@@ -308,7 +354,7 @@ describe('ChartTypeGallery', () => {
 
     it('redirects home when data apps are disabled', () => {
         setData([]);
-        setFlag(false);
+        setFlags({ dataApps: false });
         renderPage();
 
         expect(screen.getByText('home')).toBeInTheDocument();

--- a/packages/frontend/src/pages/ChartTypeGallery.tsx
+++ b/packages/frontend/src/pages/ChartTypeGallery.tsx
@@ -6,6 +6,7 @@ import {
     Paper,
     SimpleGrid,
     Stack,
+    Tabs,
     Text,
     TextInput,
 } from '@mantine/core';
@@ -34,6 +35,9 @@ const ChartTypeGallery = () => {
     const projectUuid = useProjectUuid();
     const { user } = useApp();
     const dataAppsFlag = useServerFeatureFlag(FeatureFlags.EnableDataApps);
+    const chartTypeRegistryFlag = useServerFeatureFlag(
+        FeatureFlags.ChartTypeRegistry,
+    );
 
     const [search, setSearch] = useState('');
     const [debouncedSearch] = useDebouncedValue(search, 300);
@@ -69,6 +73,7 @@ const ChartTypeGallery = () => {
     // types at all yet: the empty state below carries its own CTA.
     const isEmptyGallery =
         !isInitialLoading && !error && !debouncedSearch && totalCount === 0;
+    const isLibraryEnabled = chartTypeRegistryFlag.data?.enabled === true;
 
     if (!projectUuid) {
         return null;
@@ -90,7 +95,7 @@ const ChartTypeGallery = () => {
             withXLargePaddedContent
             withLargeContent
         >
-            <Stack gap="xxl" w="100%">
+            <Stack gap="xl" w="100%">
                 <PageBreadcrumbs
                     items={[
                         { title: 'Home', to: '/home' },
@@ -98,118 +103,136 @@ const ChartTypeGallery = () => {
                     ]}
                 />
 
-                <Stack gap="md">
-                    {/* A section rather than the page title: the gallery holds
-                        only chart types today, other kinds sit beside them. */}
-                    <Group justify="space-between" align="center">
-                        <Group gap={6} align="baseline">
-                            <Text size="md" fw={600} c="ldGray.8">
+                <Tabs defaultValue="chart-types" keepMounted={false}>
+                    <Tabs.List>
+                        <Tabs.Tab value="chart-types">
+                            <Group gap={6} wrap="nowrap">
                                 Chart types
-                            </Text>
-                            {!isEmptyGallery && totalCount !== null && (
-                                <Text fz="xs" c="dimmed">
-                                    ({totalCount})
-                                </Text>
-                            )}
-                        </Group>
+                                {!isEmptyGallery && totalCount !== null && (
+                                    <Text span fz="xs" c="dimmed">
+                                        ({totalCount})
+                                    </Text>
+                                )}
+                            </Group>
+                        </Tabs.Tab>
+                        {isLibraryEnabled && (
+                            <Tabs.Tab value="library">Library</Tabs.Tab>
+                        )}
+                    </Tabs.List>
 
-                        {!isEmptyGallery && (
-                            <Group gap="xs">
-                                <TextInput
-                                    size="xs"
-                                    w={220}
-                                    placeholder="Search by name or description"
-                                    leftSection={
-                                        <MantineIcon
-                                            icon={IconSearch}
-                                            size={15}
-                                        />
-                                    }
-                                    value={search}
-                                    onChange={(e) =>
-                                        setSearch(e.currentTarget.value)
-                                    }
-                                />
-                                <Can
-                                    I="create"
-                                    this={subject('DataApp', {
-                                        organizationUuid:
-                                            user.data?.organizationUuid,
-                                        projectUuid,
-                                    })}
-                                >
-                                    <Button
+                    <Tabs.Panel value="chart-types" pt="xl">
+                        <Stack gap="md">
+                            {!isEmptyGallery && (
+                                <Group justify="flex-end" gap="xs">
+                                    <TextInput
                                         size="xs"
-                                        component={Link}
-                                        to={chartTypeBuilderPath(projectUuid)}
+                                        w={220}
+                                        placeholder="Search by name or description"
                                         leftSection={
                                             <MantineIcon
-                                                icon={IconPlus}
+                                                icon={IconSearch}
                                                 size={15}
                                             />
                                         }
-                                    >
-                                        New chart type
-                                    </Button>
-                                </Can>
-                            </Group>
-                        )}
-                    </Group>
-
-                    {isInitialLoading ? (
-                        <EmptyStateLoader title="Loading chart types…" />
-                    ) : error ? (
-                        <InlineErrorState
-                            message="Failed to load chart types"
-                            onRetry={() => refetch()}
-                        />
-                    ) : dataAppVizs.length === 0 ? (
-                        debouncedSearch ? (
-                            <Paper variant="dotted" p="xl">
-                                <Text ta="center" fz="xs" c="dimmed">
-                                    No chart types match &ldquo;
-                                    {debouncedSearch}&rdquo;
-                                </Text>
-                            </Paper>
-                        ) : (
-                            <ChartTypeGalleryEmptyState
-                                projectUuid={projectUuid}
-                            />
-                        )
-                    ) : (
-                        <>
-                            <SimpleGrid
-                                cols={{ base: 1, sm: 2, lg: 3 }}
-                                spacing="md"
-                            >
-                                {dataAppVizs.map((viz) => (
-                                    <ChartTypeGalleryCard
-                                        key={viz.dataAppVizUuid}
-                                        dataAppViz={viz}
-                                        onClick={() =>
-                                            setSelectedUuid(viz.dataAppVizUuid)
-                                        }
-                                        onDelete={() =>
-                                            setDeleteUuid(viz.dataAppVizUuid)
+                                        value={search}
+                                        onChange={(e) =>
+                                            setSearch(e.currentTarget.value)
                                         }
                                     />
-                                ))}
-                            </SimpleGrid>
-                            {hasNextPage && (
-                                <Button
-                                    variant="default"
-                                    loading={isFetchingNextPage}
-                                    onClick={() => fetchNextPage()}
-                                    mx="auto"
-                                >
-                                    Load more
-                                </Button>
+                                    <Can
+                                        I="create"
+                                        this={subject('DataApp', {
+                                            organizationUuid:
+                                                user.data?.organizationUuid,
+                                            projectUuid,
+                                        })}
+                                    >
+                                        <Button
+                                            size="xs"
+                                            component={Link}
+                                            to={chartTypeBuilderPath(
+                                                projectUuid,
+                                            )}
+                                            leftSection={
+                                                <MantineIcon
+                                                    icon={IconPlus}
+                                                    size={15}
+                                                />
+                                            }
+                                        >
+                                            New chart type
+                                        </Button>
+                                    </Can>
+                                </Group>
                             )}
-                        </>
-                    )}
-                </Stack>
 
-                <ChartTypeLibrarySection projectUuid={projectUuid} />
+                            {isInitialLoading ? (
+                                <EmptyStateLoader title="Loading chart types…" />
+                            ) : error ? (
+                                <InlineErrorState
+                                    message="Failed to load chart types"
+                                    onRetry={() => refetch()}
+                                />
+                            ) : dataAppVizs.length === 0 ? (
+                                debouncedSearch ? (
+                                    <Paper variant="dotted" p="xl">
+                                        <Text ta="center" fz="xs" c="dimmed">
+                                            No chart types match &ldquo;
+                                            {debouncedSearch}&rdquo;
+                                        </Text>
+                                    </Paper>
+                                ) : (
+                                    <ChartTypeGalleryEmptyState
+                                        projectUuid={projectUuid}
+                                    />
+                                )
+                            ) : (
+                                <>
+                                    <SimpleGrid
+                                        cols={{ base: 1, sm: 2, lg: 3 }}
+                                        spacing="md"
+                                    >
+                                        {dataAppVizs.map((viz) => (
+                                            <ChartTypeGalleryCard
+                                                key={viz.dataAppVizUuid}
+                                                dataAppViz={viz}
+                                                onClick={() =>
+                                                    setSelectedUuid(
+                                                        viz.dataAppVizUuid,
+                                                    )
+                                                }
+                                                onDelete={() =>
+                                                    setDeleteUuid(
+                                                        viz.dataAppVizUuid,
+                                                    )
+                                                }
+                                            />
+                                        ))}
+                                    </SimpleGrid>
+                                    {hasNextPage && (
+                                        <Button
+                                            variant="default"
+                                            loading={isFetchingNextPage}
+                                            onClick={() => fetchNextPage()}
+                                            mx="auto"
+                                        >
+                                            Load more
+                                        </Button>
+                                    )}
+                                </>
+                            )}
+                        </Stack>
+                    </Tabs.Panel>
+
+                    {isLibraryEnabled && (
+                        <Tabs.Panel value="library" pt="xl">
+                            <ChartTypeLibrarySection
+                                projectUuid={projectUuid}
+                                withHeader={false}
+                            />
+                        </Tabs.Panel>
+                    )}
+                </Tabs>
             </Stack>
 
             {selected && (


### PR DESCRIPTION
Closes:

### Description:

- Adds top-level Chart types and Library tabs to make the import library more discoverable.
- Keeps Chart types selected by default and preserves the existing search, creation, pagination, and empty states.
- Keeps the Library tab behind the chart type registry feature flag and removes the duplicate section heading inside the tab.
- Adds coverage for tab switching and feature-flag behavior.

### Testing:

- pnpm exec vitest run src/pages/ChartTypeGallery.test.tsx src/features/chartTypes/components/ChartTypeLibrarySection.test.tsx
- pnpm -F frontend lint
- pnpm -F frontend typecheck

### Risk assessment:

- [ ] This is a high-risk change