### PR TITLE
feat(frontend): open chart type authoring in a fullscreen modal

### DIFF
--- a/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoring.test.tsx
+++ b/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoring.test.tsx
@@ -93,6 +93,14 @@ vi.mock(
         },
     }),
 );
+// The modal's config column needs the chart card's viz context, which this
+// container test does not mount.
+vi.mock(
+    '../../VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs',
+    () => ({
+        ConfigTabs: () => <div data-testid="config-tabs" />,
+    }),
+);
 
 const itemsMap = {
     orders_status: {

--- a/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoring.test.tsx
+++ b/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoring.test.tsx
@@ -307,6 +307,14 @@ describe('ExplorerChartTypeAuthoring', () => {
         } as unknown as ReturnType<typeof useExplorerResultsData>);
     });
 
+    it('opens the builder in a modal with the chart configuration beside it', () => {
+        renderAuthoring();
+
+        expect(screen.getByText('Chart type builder')).toBeInTheDocument();
+        expect(screen.getByTestId('workspace')).toBeInTheDocument();
+        expect(screen.getByTestId('config-tabs')).toBeInTheDocument();
+    });
+
     it('binds the chart to the type once its schema is known', () => {
         const store = renderAuthoring();
 

--- a/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoring.tsx
+++ b/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoring.tsx
@@ -275,40 +275,54 @@ const ExplorerChartTypeAuthoring: FC<Props> = ({ authoring }) => {
 
     return (
         <>
-            <ExplorerChartTypeAuthoringView
-                projectUuid={projectUuid}
-                app={
-                    dataAppViz
-                        ? {
-                              appUuid: dataAppViz.dataAppVizUuid,
-                              name: dataAppViz.name,
-                              description: dataAppViz.description,
-                          }
-                        : null
-                }
-                upgrade={
-                    dataAppVizUuid !== null &&
-                    history.latestReadyVersion !== null
-                        ? {
-                              ...workspace.sdkUpgradeOffer,
-                              disabled: workspace.isBuilding,
-                          }
-                        : null
-                }
-                workspace={workspace}
-                previewContext={previewContext}
-                warning={
-                    <VisualizationWarning
-                        dirtyPivotConfiguration={dirtyPivotConfiguration}
-                        chartConfig={chartConfig}
-                        resultsData={resultsData}
-                        isLoading={isLoadingQueryResults}
-                        maxColumnLimit={health.data?.pivotTable?.maxColumnLimit}
-                    />
-                }
-                onDetailsSaved={handleDetailsSaved}
-                onDone={handleDone}
-            />
+            {/* Esc routes through the same exit flow as Done; a stray click
+                outside must not dump a running build. */}
+            <MantineModal
+                opened
+                onClose={handleDone}
+                title="Chart type builder"
+                fullScreen
+                cancelLabel={false}
+                modalRootProps={{ closeOnClickOutside: false }}
+                modalBodyProps={{ px: 'md', py: 'md' }}
+            >
+                <ExplorerChartTypeAuthoringView
+                    projectUuid={projectUuid}
+                    app={
+                        dataAppViz
+                            ? {
+                                  appUuid: dataAppViz.dataAppVizUuid,
+                                  name: dataAppViz.name,
+                                  description: dataAppViz.description,
+                              }
+                            : null
+                    }
+                    upgrade={
+                        dataAppVizUuid !== null &&
+                        history.latestReadyVersion !== null
+                            ? {
+                                  ...workspace.sdkUpgradeOffer,
+                                  disabled: workspace.isBuilding,
+                              }
+                            : null
+                    }
+                    workspace={workspace}
+                    previewContext={previewContext}
+                    warning={
+                        <VisualizationWarning
+                            dirtyPivotConfiguration={dirtyPivotConfiguration}
+                            chartConfig={chartConfig}
+                            resultsData={resultsData}
+                            isLoading={isLoadingQueryResults}
+                            maxColumnLimit={
+                                health.data?.pivotTable?.maxColumnLimit
+                            }
+                        />
+                    }
+                    onDetailsSaved={handleDetailsSaved}
+                    onDone={handleDone}
+                />
+            </MantineModal>
             {isExitConfirmOpen && (
                 <MantineModal
                     opened

--- a/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoringView.module.css
+++ b/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoringView.module.css
@@ -1,14 +1,28 @@
 .root {
     container: authoring / inline-size;
-    /* Basis 0 sizes the builder to the viewport's share, not its content,
-       so history and canvas scroll internally; the floor keeps it usable
-       on short windows, where the page scrolls instead. */
-    flex: 1 1 0;
+    height: 100%;
     min-height: 380px;
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
     border: 1px solid var(--mantine-color-ldGray-2);
     border-radius: var(--mantine-radius-md);
     background: var(--mantine-color-ldGray-0);
     overflow: hidden;
+}
+
+.builderColumn {
+    flex: 1 1 0;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.configColumn {
+    width: 340px;
+    flex-shrink: 0;
+    border-left: 1px solid var(--mantine-color-ldGray-2);
+    background: var(--mantine-color-body);
+    overflow-y: auto;
+    padding: var(--mantine-spacing-md);
 }

--- a/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoringView.tsx
+++ b/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoringView.tsx
@@ -5,6 +5,8 @@ import { type SdkUpgradeOffer } from '../../../features/apps/hooks/useSdkUpgrade
 import { type ChartTypeAppMeta } from '../../../features/chartTypes/builder/appMeta';
 import ChartTypeBuilderWorkspace from '../../../features/chartTypes/builder/ChartTypeBuilderWorkspace';
 import { type ChartTypeBuilderWorkspaceState } from '../../../features/chartTypes/builder/useChartTypeBuilderWorkspace';
+import { ChartGalleryContext } from '../../common/ChartGallery/ChartGalleryContext';
+import { ConfigTabs as DataAppVizConfigTabs } from '../../VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs';
 import { deriveAuthoringStatus } from './authoringStatus';
 import ExplorerChartTypeAuthoringHeader from './ExplorerChartTypeAuthoringHeader';
 import classes from './ExplorerChartTypeAuthoringView.module.css';
@@ -40,27 +42,40 @@ const ExplorerChartTypeAuthoringView: FC<Props> = ({
             aria-labelledby={titleId}
             data-testid="chart-type-authoring"
         >
-            <ExplorerChartTypeAuthoringHeader
-                projectUuid={projectUuid}
-                titleId={titleId}
-                app={app}
-                status={deriveAuthoringStatus(workspace)}
-                upgrade={upgrade}
-                hasHistory={workspace.hasHistory}
-                isHistoryOpen={workspace.isHistoryOpen}
-                warning={warning}
-                onToggleHistory={workspace.toggleHistory}
-                onUpgradeStarted={workspace.openHistory}
-                onDetailsSaved={onDetailsSaved}
-                onDone={onDone}
-            />
-            <ChartTypeBuilderWorkspace
-                projectUuid={projectUuid}
-                workspace={workspace}
-                previewContext={previewContext}
-                syncPreviewUrlState={false}
-                configurePanel={null}
-            />
+            <Box className={classes.builderColumn}>
+                <ExplorerChartTypeAuthoringHeader
+                    projectUuid={projectUuid}
+                    titleId={titleId}
+                    app={app}
+                    status={deriveAuthoringStatus(workspace)}
+                    upgrade={upgrade}
+                    hasHistory={workspace.hasHistory}
+                    isHistoryOpen={workspace.isHistoryOpen}
+                    warning={warning}
+                    onToggleHistory={workspace.toggleHistory}
+                    onUpgradeStarted={workspace.openHistory}
+                    onDetailsSaved={onDetailsSaved}
+                    onDone={onDone}
+                />
+                <ChartTypeBuilderWorkspace
+                    projectUuid={projectUuid}
+                    workspace={workspace}
+                    previewContext={previewContext}
+                    syncPreviewUrlState={false}
+                    configurePanel={null}
+                />
+            </Box>
+            {/* The chart's real configuration (field mapping + generated
+                options); the gallery context hides the type picker inside. */}
+            <Box
+                component="aside"
+                className={classes.configColumn}
+                aria-label="Chart type configuration"
+            >
+                <ChartGalleryContext.Provider value={true}>
+                    <DataAppVizConfigTabs />
+                </ChartGalleryContext.Provider>
+            </Box>
         </Box>
     );
 };

--- a/packages/frontend/src/components/Explorer/Explorer.authoring.test.tsx
+++ b/packages/frontend/src/components/Explorer/Explorer.authoring.test.tsx
@@ -19,9 +19,6 @@ vi.mock('./VisualizationCard/VisualizationCard', () => ({
         return <div data-testid="visualization-card" />;
     },
 }));
-vi.mock('./ChartTypeAuthoring/ExplorerChartTypeAuthoring', () => ({
-    default: () => <div data-testid="chart-type-authoring" />,
-}));
 vi.mock('./ExplorerHeader', () => ({
     default: () => <div data-testid="explorer-header" />,
 }));
@@ -121,19 +118,16 @@ describe('Explorer while a chart type is authored', () => {
         expect(cardProps.at(-1)?.renderVisualization).toBe(true);
     });
 
-    it('puts the builder in the chart’s place and keeps the card alive without drawing it', async () => {
+    it('keeps the page as-is behind the builder modal and pauses the chart', () => {
         renderExplorer({ authoring: true });
 
-        // The builder chunk is lazy-loaded, so its mount is a tick away.
-        expect(
-            await screen.findByTestId('chart-type-authoring'),
-        ).toBeInTheDocument();
-        // The query controls stay where they always are.
+        // The modal opens over an unchanged page; the card hosts the modal
+        // itself (covered by its own tests) and only pauses the chart render.
         expect(screen.getByTestId('explorer-header')).toBeInTheDocument();
-        expect(screen.queryByTestId('results-card')).not.toBeInTheDocument();
-        expect(screen.queryByTestId('filters-card')).not.toBeInTheDocument();
+        expect(screen.getByTestId('results-card')).toBeInTheDocument();
+        expect(screen.getByTestId('filters-card')).toBeInTheDocument();
         expect(screen.getByTestId('merge-auto-run')).toBeInTheDocument();
-        expect(screen.getByTestId('visualization-card')).not.toBeVisible();
+        expect(screen.getByTestId('visualization-card')).toBeVisible();
         expect(cardProps.at(-1)?.renderVisualization).toBe(false);
     });
 });

--- a/packages/frontend/src/components/Explorer/Explorer.module.css
+++ b/packages/frontend/src/components/Explorer/Explorer.module.css
@@ -1,9 +1,3 @@
 .stack {
     flex-grow: 1;
 }
-
-/* While authoring, the builder must be viewport-bounded so its history and
-   canvas scroll internally; the stack yields instead of growing to content. */
-.stackAuthoring {
-    min-height: 0;
-}

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -15,7 +15,9 @@ import {
     IconLayoutSidebarLeftExpand,
 } from '@tabler/icons-react';
 import {
+    lazy,
     memo,
+    Suspense,
     useCallback,
     useLayoutEffect,
     useMemo,
@@ -26,6 +28,7 @@ import { createPortal } from 'react-dom';
 import ErrorBoundary from '../../../features/errorBoundary/ErrorBoundary';
 import {
     explorerActions,
+    selectChartTypeAuthoring,
     selectIsEditMode,
     selectIsVisualizationConfigOpen,
     selectIsVisualizationExpanded,
@@ -63,6 +66,11 @@ import useVisualizationConfigPortalTarget from './useVisualizationConfigPortalTa
 import VisualizationTimezone from './VisualizationTimezone';
 import VisualizationWarning from './VisualizationWarning';
 
+// Lazy-load so the Explorer bundle stays small when nothing is authored.
+const ExplorerChartTypeAuthoring = lazy(
+    () => import('../ChartTypeAuthoring/ExplorerChartTypeAuthoring'),
+);
+
 export type EchartsClickEvent = {
     event: EchartsSeriesClickEvent;
     dimensions: string[];
@@ -96,6 +104,10 @@ const VisualizationCard: FC<Props> = memo((props) => {
 
     // Get savedChart from Redux
     const savedChart = useExplorerSelector(selectSavedChart);
+
+    // Authoring opens the builder modal from inside this card's provider
+    // tree, so the modal's config column shares the chart's viz context.
+    const chartTypeAuthoring = useExplorerSelector(selectChartTypeAuthoring);
 
     const sorts = useExplorerSelector(selectSorts);
 
@@ -410,6 +422,10 @@ const VisualizationCard: FC<Props> = memo((props) => {
                                  * TODO: use Mantine Portal with reuseTargetNode flag to avoid rendering additional divs
                                  */}
                                 {portalTarget &&
+                                    // The modal owns the config while a type
+                                    // is authored; a second mount in the
+                                    // sidebar would echo its state.
+                                    !chartTypeAuthoring &&
                                     createPortal(
                                         isChartGalleryEnabled ? (
                                             <ExplorerChartSidebar
@@ -479,6 +495,13 @@ const VisualizationCard: FC<Props> = memo((props) => {
                         </>
                     )}
                 </CollapsableCard>
+                {chartTypeAuthoring && (
+                    <Suspense fallback={null}>
+                        <ExplorerChartTypeAuthoring
+                            authoring={chartTypeAuthoring}
+                        />
+                    </Suspense>
+                )}
             </VisualizationProvider>
         </ErrorBoundary>
     );

--- a/packages/frontend/src/components/Explorer/index.tsx
+++ b/packages/frontend/src/components/Explorer/index.tsx
@@ -3,12 +3,9 @@ import {
     getExploreParameterDefinitions,
     getReferencedParameterDefinitions,
 } from '@lightdash/common';
-import { Box, Stack } from '@mantine/core';
-import clsx from 'clsx';
+import { Stack } from '@mantine/core';
 import {
-    lazy,
     memo,
-    Suspense,
     useCallback,
     useEffect,
     useMemo,
@@ -19,7 +16,6 @@ import {
 import {
     explorerActions,
     selectAdditionalMetricModal,
-    selectChartTypeAuthoring,
     selectColumnOrder,
     selectDimensions,
     selectFormatModal,
@@ -69,11 +65,6 @@ import { WriteBackModal } from './WriteBackModal';
 
 const EMPTY_PARAMETER_REFERENCES: string[] = [];
 
-// Lazy-load to keep the flag-off Explorer bundle small.
-const ExplorerChartTypeAuthoring = lazy(
-    () => import('./ChartTypeAuthoring/ExplorerChartTypeAuthoring'),
-);
-
 const Explorer: FC<{ hideHeader?: boolean; chartView?: boolean }> = memo(
     ({ hideHeader = false, chartView = false }) => {
         const tableName = useExplorerSelector(selectTableName);
@@ -85,11 +76,8 @@ const Explorer: FC<{ hideHeader?: boolean; chartView?: boolean }> = memo(
         const isEditMode = useExplorerSelector(selectIsEditMode);
         const showQueryBuilder = isEditMode || !chartView;
         const showMinimalChart = chartView && !isEditMode;
-        // Authoring a chart type takes the chart's place; the query keeps
-        // running underneath so the preview renders against it.
-        const chartTypeAuthoring = useExplorerSelector(
-            selectChartTypeAuthoring,
-        );
+        // Authoring a chart type opens the builder modal over the page; the
+        // query keeps running underneath so the preview renders against it.
         const isAuthoring = useExplorerSelector(selectIsChartTypeAuthoring);
         const parameterReferencesFromRedux = useExplorerSelector(
             selectParameterReferences,
@@ -283,39 +271,22 @@ const Explorer: FC<{ hideHeader?: boolean; chartView?: boolean }> = memo(
                 parameters={parameters}
                 resolvedTimezone={query.data?.resolvedTimezone}
             >
-                <Stack
-                    className={clsx(
-                        classes.stack,
-                        isAuthoring && classes.stackAuthoring,
-                    )}
-                >
+                <Stack className={classes.stack}>
                     <MergeAutoRun />
-                    {/* The query controls keep their usual spot while a chart
-                        type is authored; only the cards below make way. */}
                     {!hideHeader &&
                         (isEditMode ? (
                             <ExplorerHeader />
                         ) : (
                             !savedChart && <RefreshDbtButton />
                         ))}
-                    {isAuthoring && chartTypeAuthoring && (
-                        <Suspense fallback={null}>
-                            <ExplorerChartTypeAuthoring
-                                authoring={chartTypeAuthoring}
-                            />
-                        </Suspense>
-                    )}
 
-                    {!isAuthoring && !isFullscreen && showQueryBuilder && (
-                        <MergeReadOnlyBar />
-                    )}
+                    {!isFullscreen && showQueryBuilder && <MergeReadOnlyBar />}
 
-                    {!isAuthoring && !isFullscreen && showQueryBuilder && (
+                    {!isFullscreen && showQueryBuilder && (
                         <MergeRelationshipCard />
                     )}
 
-                    {!isAuthoring &&
-                        !isFullscreen &&
+                    {!isFullscreen &&
                         showQueryBuilder &&
                         !!tableName &&
                         hasReferencedUserParameters && (
@@ -326,23 +297,20 @@ const Explorer: FC<{ hideHeader?: boolean; chartView?: boolean }> = memo(
                             />
                         )}
 
-                    {!isAuthoring && !isFullscreen && showQueryBuilder && (
-                        <FiltersCard />
-                    )}
+                    {!isFullscreen && showQueryBuilder && <FiltersCard />}
 
-                    {/* Stays mounted while authoring: it hosts the sidebar
-                        that configures the type being built. */}
-                    <Box display={isAuthoring ? 'none' : 'contents'}>
-                        <VisualizationCard
-                            projectUuid={projectUuid}
-                            renderVisualization={!isAuthoring}
-                            onScreenshotReady={handleScreenshotReady}
-                            onScreenshotError={handleScreenshotError}
-                            minimal={showMinimalChart}
-                        />
-                    </Box>
+                    {/* The card also hosts the authoring modal, which needs
+                        its visualization context. The chart itself pauses
+                        while the type is authored so it doesn't render twice. */}
+                    <VisualizationCard
+                        projectUuid={projectUuid}
+                        renderVisualization={!isAuthoring}
+                        onScreenshotReady={handleScreenshotReady}
+                        onScreenshotError={handleScreenshotError}
+                        minimal={showMinimalChart}
+                    />
 
-                    {!isAuthoring && !isFullscreen && showQueryBuilder && (
+                    {!isFullscreen && showQueryBuilder && (
                         <>
                             <ResultsCard />
 


### PR DESCRIPTION
## Summary

Editing or creating a chart type from the explorer used to morph the explore page in place: the query cards vanished, the builder took over the main column, and the generated options lived separately in the right gallery sidebar. It read as "the page broke" rather than "you entered the builder".

Now every in-explorer authoring entry point (gallery card edit, config-tab edit, create-new) opens a fullscreen **Chart type builder** modal containing the whole activity:

- **Left**: the existing authoring header (name, status, version history toggle, Back to chart) above the builder workspace — preview canvas with the build chat docked below, history panel still available.
- **Right column**: the chart's *real* configuration — field mapping and generated options via `DataAppVizConfigTabs`, wired to the chart so edits persist after Done (the gallery context wrapper hides its type-picker section).

The explore page stays fully rendered behind the dimmed overlay; the chart itself pauses (`renderVisualization={false}`) so the viz doesn't render twice. The sidebar portal is skipped while the modal owns the config, avoiding a double mount.

**Mechanically**: the authoring container moved from `Explorer`'s stack into `VisualizationCard`'s `VisualizationProvider` tree (which already stays mounted chart-less during authoring precisely to keep that context alive), and its view gained the modal shell + config column. Container logic — workspace, binding-on-first-schema, claim, forbidden-exit guard, keep-vs-restore exit, build-in-progress confirm — is unchanged. Esc routes through the same exit flow as Done; click-outside is disabled so a stray click can't discard a running build.

Untouched: the standalone builder route, the non-gallery world (authoring entry points are gallery-only), backend.

Known small trade-offs, accepted deliberately: the build-in-progress confirm stacks a modal on the modal, and the config column is sparse for types with no generated options.

## Validation

- Local E2E through the real UI: edit an existing custom type (registry-official types still refuse authoring by design), create-new from the chooser, Done (keep-type toast fires), Esc (prior chart config restored exactly).
- 248 tests green across Explorer / VisualizationConfigs / LightdashVisualization suites; `Explorer.authoring.test.tsx` re-pinned to the new behavior (page stays intact, chart pauses) and a new test pins the modal shell + config column. Frontend typecheck clean.

Closes: PROD-10920
Relates: PROD-10458

🤖 Generated with [Claude Code](https://claude.com/claude-code)