### PR TITLE
feat(ai-agents): battle mode behind a feature flag with response timings

### DIFF
--- a/packages/backend/src/database/migrations/20260903120000_add_response_timing_to_ai_prompt.ts
+++ b/packages/backend/src/database/migrations/20260903120000_add_response_timing_to_ai_prompt.ts
@@ -1,0 +1,15 @@
+import { Knex } from 'knex';
+
+const AiPromptTableName = 'ai_prompt';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(AiPromptTableName, (table) => {
+        table.jsonb('response_timing').nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(AiPromptTableName, (table) => {
+        table.dropColumn('response_timing');
+    });
+}

--- a/packages/backend/src/ee/database/entities/ai.ts
+++ b/packages/backend/src/ee/database/entities/ai.ts
@@ -5,6 +5,7 @@ import {
     type AiDeepResearchLimits,
     type AiOrgModelVisibility,
     type AiPromptExternalSourceSnapshot,
+    type AiPromptResponseTiming,
     type AiPromptTokenUsage,
     type AiProviderApiKeyHints,
     type AiThreadCreatedFrom,
@@ -237,6 +238,7 @@ export type DbAiPrompt = {
     saved_query_uuid: string | null;
     model_config: { modelName: string; modelProvider: string } | null;
     token_usage: AiPromptTokenUsage | null;
+    response_timing: AiPromptResponseTiming | null;
     execution_mode: 'standard' | 'deep_research' | null;
     needs_user_input: boolean | null;
     needs_user_input_metadata: AiPromptNeedsUserInputMetadata | null;
@@ -265,6 +267,7 @@ export type AiPromptTable = Knex.CompositeTableType<
             | 'saved_query_uuid'
             | 'model_config'
             | 'token_usage'
+            | 'response_timing'
             | 'execution_mode'
             | 'needs_user_input'
             | 'needs_user_input_metadata'

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -4321,6 +4321,7 @@ export class AiAgentModel {
                     | 'saved_query_uuid'
                     | 'model_config'
                     | 'token_usage'
+                    | 'response_timing'
                     | 'hidden'
                 > &
                     Pick<DbUser, 'user_uuid'> &
@@ -4345,6 +4346,7 @@ export class AiAgentModel {
                 `${AiPromptTableName}.saved_query_uuid`,
                 `${AiPromptTableName}.model_config`,
                 `${AiPromptTableName}.token_usage`,
+                `${AiPromptTableName}.response_timing`,
                 `${AiPromptTableName}.hidden`,
                 `${UserTableName}.user_uuid`,
                 `${AiThreadTableName}.ai_thread_uuid`,
@@ -4450,6 +4452,7 @@ export class AiAgentModel {
                 referencedArtifacts: referencedArtifacts ?? null,
                 modelConfig: row.model_config,
                 tokenUsage: row.token_usage,
+                responseTiming: row.response_timing,
                 toolCalls: toolCalls
                     .filter((tc) => isParseableToolName(tc.tool_name))
                     .map((tc) => this.parseToolCall(tc)),
@@ -5039,6 +5042,7 @@ export class AiAgentModel {
                     | 'saved_query_uuid'
                     | 'model_config'
                     | 'token_usage'
+                    | 'response_timing'
                     | 'hidden'
                 > &
                     Pick<DbUser, 'user_uuid'> &
@@ -5063,6 +5067,7 @@ export class AiAgentModel {
                 `${AiPromptTableName}.saved_query_uuid`,
                 `${AiPromptTableName}.model_config`,
                 `${AiPromptTableName}.token_usage`,
+                `${AiPromptTableName}.response_timing`,
                 `${AiPromptTableName}.hidden`,
                 `${UserTableName}.user_uuid`,
                 `${AiThreadTableName}.ai_thread_uuid`,
@@ -5208,6 +5213,7 @@ export class AiAgentModel {
                     referencedArtifacts,
                     modelConfig: row.model_config,
                     tokenUsage: row.token_usage,
+                    responseTiming: row.response_timing,
                     toolCalls: toolCalls
                         .filter((tc) => isParseableToolName(tc.tool_name))
                         .map((tc) => this.parseToolCall(tc)),
@@ -5571,6 +5577,9 @@ export class AiAgentModel {
                     : {}),
                 ...(data.tokenUsage !== undefined
                     ? { token_usage: data.tokenUsage }
+                    : {}),
+                ...(data.responseTiming !== undefined
+                    ? { response_timing: data.responseTiming }
                     : {}),
             })
             .where({

--- a/packages/backend/src/ee/services/ai/agents/agentV2.test.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.test.ts
@@ -417,6 +417,11 @@ describe('generateAgentResponse token usage persistence', () => {
                 totalTokens: 31000,
                 finalStepTotalTokens: 31000,
             },
+            responseTiming: {
+                startedAt: expect.any(String),
+                firstTokenAt: null,
+                finishedAt: expect.any(String),
+            },
         });
     });
 });

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -1862,6 +1862,11 @@ export const generateAgentResponse = async ({
                 promptUuid: args.promptUuid,
                 response: result.text,
                 tokenUsage: finalStepPromptTokenUsage(result.usage.totalTokens),
+                responseTiming: {
+                    startedAt: new Date(startTime).toISOString(),
+                    firstTokenAt: null,
+                    finishedAt: new Date().toISOString(),
+                },
             });
         }
 
@@ -2266,6 +2271,14 @@ export const streamAgentResponse = async ({
                 const interrupted = isEmptyResponse
                     ? await dependencies.isPromptInterrupted(args.promptUuid)
                     : false;
+                const responseTiming = {
+                    startedAt: new Date(startTime).toISOString(),
+                    firstTokenAt:
+                        firstChunkTime === null
+                            ? null
+                            : new Date(firstChunkTime).toISOString(),
+                    finishedAt: new Date().toISOString(),
+                };
                 if (isEmptyResponse && !interrupted) {
                     const emptyResponseError = stepCapReached
                         ? new AiAgentStepCapReachedError(steps.length)
@@ -2294,6 +2307,7 @@ export const streamAgentResponse = async ({
                         tokenUsage: finalStepPromptTokenUsage(
                             usage.totalTokens,
                         ),
+                        responseTiming,
                     });
                 } else {
                     await persistPrompt({
@@ -2302,6 +2316,7 @@ export const streamAgentResponse = async ({
                         tokenUsage: finalStepPromptTokenUsage(
                             usage.totalTokens,
                         ),
+                        responseTiming,
                     });
                 }
 

--- a/packages/backend/src/ee/services/ai/compaction.test.ts
+++ b/packages/backend/src/ee/services/ai/compaction.test.ts
@@ -161,6 +161,7 @@ describe('AI context compaction helpers', () => {
                 referencedArtifacts: null,
                 modelConfig: null,
                 tokenUsage: null,
+                responseTiming: null,
             },
         ]);
 
@@ -193,6 +194,7 @@ describe('AI context compaction helpers', () => {
                     referencedArtifacts: null,
                     modelConfig: null,
                     tokenUsage: null,
+                    responseTiming: null,
                 },
             ];
         const serializeWithLegacyReportOption =

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -27,6 +27,7 @@ import {
     type AiAgentModelConfig,
     type AiPromptContext,
     type AiPromptContextInput,
+    type AiPromptResponseTiming,
     type AiPromptTokenUsage,
     type AiThreadCreatedFrom,
 } from './requestTypes';
@@ -313,6 +314,7 @@ export type AiAgentMessageAssistant = {
     referencedArtifacts: AiAgentMessageAssistantArtifact[] | null;
     modelConfig: AiAgentModelConfig | null;
     tokenUsage: AiPromptTokenUsage | null;
+    responseTiming: AiPromptResponseTiming | null;
 };
 
 export type AiAgentMessage<TUser extends AiAgentUser = AiAgentUser> =

--- a/packages/common/src/ee/AiAgent/requestTypes.ts
+++ b/packages/common/src/ee/AiAgent/requestTypes.ts
@@ -77,6 +77,14 @@ export type AiPromptTokenUsage = {
 /** Write shape: both figures are required so a writer can't omit the compaction input. */
 export type AiPromptTokenUsageUpdate = Required<AiPromptTokenUsage>;
 
+/** Wall-clock timing of one model run, stamped by the agent loop. ISO strings. */
+export type AiPromptResponseTiming = {
+    startedAt: string;
+    /** First chunk the model produced (text, reasoning, or tool input). Null when nothing streamed. */
+    firstTokenAt: string | null;
+    finishedAt: string;
+};
+
 /**
  * Every origin an ai_thread can be created from. Canonical source for the
  * DB column type and the admin/list filters — add new origins here.
@@ -380,6 +388,7 @@ export type UpdateSlackResponse = {
     errorMessage?: string;
     humanScore?: number | null;
     tokenUsage?: AiPromptTokenUsageUpdate | null;
+    responseTiming?: AiPromptResponseTiming;
 };
 
 export type UpdateWebAppResponse = {
@@ -388,6 +397,7 @@ export type UpdateWebAppResponse = {
     errorMessage?: string;
     humanScore?: number | null;
     tokenUsage?: AiPromptTokenUsageUpdate | null;
+    responseTiming?: AiPromptResponseTiming;
 };
 
 export type UpdateSlackResponseTs = {

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -341,6 +341,13 @@ export enum FeatureFlags {
      * Off by default.
      */
     DashboardCustomMetrics = 'dashboard-custom-metrics',
+
+    /**
+     * AI agent battle mode: send one prompt to two models in paired threads
+     * and compare the answers side by side with response timings. Internal
+     * experiment, off by default.
+     */
+    AiAgentBattleMode = 'ai-agent-battle-mode',
 }
 
 export type FeatureFlag = {

--- a/packages/frontend/src/ee/CommercialRoutes.tsx
+++ b/packages/frontend/src/ee/CommercialRoutes.tsx
@@ -467,6 +467,18 @@ const COMMERCIAL_AI_AGENTS_ROUTES: RouteObject[] = [
                                 },
                             },
                             {
+                                path: 'battle/:threadUuidA/:threadUuidB',
+                                lazy: async () => {
+                                    const AiAgentBattlePage =
+                                        await loadLazyRouteDefault(
+                                            './pages/AiAgents/AiAgentBattlePage',
+                                            () =>
+                                                import('./pages/AiAgents/AiAgentBattlePage'),
+                                        );
+                                    return { Component: AiAgentBattlePage };
+                                },
+                            },
+                            {
                                 path: ':threadUuid',
                                 lazy: async () => {
                                     const AiAgentThreadPage =

--- a/packages/frontend/src/ee/features/aiCopilot/components/Battle/BattleModeSetup.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Battle/BattleModeSetup.tsx
@@ -1,0 +1,82 @@
+import type { AiModelOption } from '@lightdash/common';
+import { Group, Paper, Switch, Text } from '@mantine/core';
+import { IconSwords } from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import { ModelSelector } from '../../../../../components/common/ModelSelector/ModelSelector';
+
+interface Props {
+    enabled: boolean;
+    onEnabledChange: (enabled: boolean) => void;
+    models: AiModelOption[];
+    modelAKey: string | null;
+    modelBKey: string | null;
+    onModelAChange: (modelKey: string) => void;
+    onModelBChange: (modelKey: string) => void;
+}
+
+export const BattleModeSetup: FC<Props> = ({
+    enabled,
+    onEnabledChange,
+    models,
+    modelAKey,
+    modelBKey,
+    onModelAChange,
+    onModelBChange,
+}) => (
+    <Paper withBorder radius="md" px="sm" py="xs">
+        <Group justify="space-between" wrap="wrap" gap="sm">
+            <Switch
+                size="sm"
+                checked={enabled}
+                onChange={(event) =>
+                    onEnabledChange(event.currentTarget.checked)
+                }
+                label={
+                    <Group gap={6} wrap="nowrap">
+                        <MantineIcon icon={IconSwords} />
+                        <Text size="sm" fw={500}>
+                            Battle mode
+                        </Text>
+                    </Group>
+                }
+            />
+            {enabled && (
+                <Group gap="xs" wrap="nowrap">
+                    <Text size="xs" c="dimmed">
+                        A
+                    </Text>
+                    <ModelSelector
+                        models={models}
+                        value={modelAKey}
+                        onChange={onModelAChange}
+                        variant="subtle"
+                        color="gray"
+                        size="xs"
+                    />
+                    <Text size="xs" c="dimmed">
+                        vs
+                    </Text>
+                    <Text size="xs" c="dimmed">
+                        B
+                    </Text>
+                    <ModelSelector
+                        models={models}
+                        value={modelBKey}
+                        onChange={onModelBChange}
+                        variant="subtle"
+                        color="gray"
+                        size="xs"
+                    />
+                </Group>
+            )}
+        </Group>
+        {enabled && (
+            <Text size="xs" c="dimmed" mt={6}>
+                Your prompt is sent to both models in separate threads. You will
+                see both answers side by side with time to first token and total
+                response time.
+            </Text>
+        )}
+    </Paper>
+);

--- a/packages/frontend/src/ee/features/aiCopilot/components/Battle/BattleThreadPane.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Battle/BattleThreadPane.tsx
@@ -1,0 +1,189 @@
+import type { AiAgentThread } from '@lightdash/common';
+import { Anchor, Badge, Box, Group, Stack, Text } from '@mantine/core';
+import { useEffect, useMemo, useState, type FC } from 'react';
+import { Link } from 'react-router';
+import { matchesModelConfig } from '../../../../../components/common/ModelSelector/utils';
+import { getAiAgentPageBase } from '../../hooks/aiAgentRouting';
+import { useModelOptions } from '../../hooks/useModelOptions';
+import { useAiAgentThreadStreamQuery } from '../../streaming/useAiAgentThreadStreamQuery';
+import {
+    formatDurationMs,
+    getResponseTimingMetrics,
+} from '../../utils/responseTiming';
+import { AgentChatDisplay } from '../ChatElements/AgentChatDisplay';
+
+interface Props {
+    label: string;
+    projectUuid: string;
+    agentUuid: string;
+    agentName: string;
+    thread: AiAgentThread;
+}
+
+const useTicking = (active: boolean) => {
+    const [now, setNow] = useState(() => Date.now());
+    useEffect(() => {
+        if (!active) return undefined;
+        const interval = setInterval(() => setNow(Date.now()), 100);
+        return () => clearInterval(interval);
+    }, [active]);
+    return now;
+};
+
+type TimingSummary = {
+    source: 'live' | 'server';
+    ttftMs: number | null;
+    totalMs: number;
+};
+
+export const BattleThreadPane: FC<Props> = ({
+    label,
+    projectUuid,
+    agentUuid,
+    agentName,
+    thread,
+}) => {
+    const stream = useAiAgentThreadStreamQuery(thread.uuid);
+    const isStreaming = stream?.connection.status === 'streaming';
+    const now = useTicking(isStreaming);
+
+    const lastAssistantMessage = useMemo(
+        () =>
+            [...thread.messages]
+                .reverse()
+                .find((message) => message.role === 'assistant'),
+        [thread.messages],
+    );
+
+    const { data: modelOptions } = useModelOptions({ projectUuid, agentUuid });
+    // The thread's model never changes, so the first persisted config wins
+    // over the optimistic (still streaming) message that has none yet.
+    const modelConfig = useMemo(
+        () =>
+            thread.messages.flatMap((message) =>
+                message.role === 'assistant' && message.modelConfig
+                    ? [message.modelConfig]
+                    : [],
+            )[0] ?? null,
+        [thread.messages],
+    );
+    const modelDisplayName = useMemo(() => {
+        if (!modelConfig) return null;
+        const option = modelOptions?.find((model) =>
+            matchesModelConfig(model, modelConfig),
+        );
+        return option?.displayName ?? modelConfig.modelName;
+    }, [modelConfig, modelOptions]);
+
+    const timing = useMemo<TimingSummary | null>(() => {
+        const liveTiming = stream?.timing;
+        // Live stopwatch while streaming, and the client-observed figure
+        // right after until the persisted server timing lands.
+        if (isStreaming && liveTiming) {
+            return {
+                source: 'live',
+                ttftMs:
+                    liveTiming.firstTokenAt === null
+                        ? null
+                        : liveTiming.firstTokenAt - liveTiming.startedAt,
+                totalMs: now - liveTiming.startedAt,
+            };
+        }
+        const persisted =
+            lastAssistantMessage?.responseTiming &&
+            lastAssistantMessage.status !== 'pending'
+                ? getResponseTimingMetrics(lastAssistantMessage.responseTiming)
+                : null;
+        if (persisted) return { source: 'server', ...persisted };
+        if (liveTiming && liveTiming.finishedAt !== null) {
+            return {
+                source: 'live',
+                ttftMs:
+                    liveTiming.firstTokenAt === null
+                        ? null
+                        : liveTiming.firstTokenAt - liveTiming.startedAt,
+                totalMs: liveTiming.finishedAt - liveTiming.startedAt,
+            };
+        }
+        return null;
+    }, [isStreaming, lastAssistantMessage, now, stream?.timing]);
+
+    const status = isStreaming
+        ? 'Streaming'
+        : lastAssistantMessage?.status === 'error'
+          ? 'Failed'
+          : lastAssistantMessage?.status === 'pending'
+            ? 'Waiting'
+            : 'Done';
+
+    return (
+        <Stack h="100%" gap={0} miw={0}>
+            <Group
+                justify="space-between"
+                px="sm"
+                py={6}
+                wrap="nowrap"
+                style={{
+                    borderBottom:
+                        '1px solid var(--mantine-color-default-border)',
+                }}
+            >
+                <Group gap="xs" wrap="nowrap" miw={0}>
+                    <Badge size="sm" variant="light" color="ldGray">
+                        {label}
+                    </Badge>
+                    <Text size="sm" fw={600} truncate>
+                        {modelDisplayName ?? 'Default model'}
+                    </Text>
+                    <Text size="xs" c="dimmed">
+                        {status}
+                    </Text>
+                </Group>
+                <Group gap="sm" wrap="nowrap">
+                    {timing && (
+                        <Group gap={4} wrap="nowrap">
+                            <Text size="xs" c="dimmed">
+                                first token
+                            </Text>
+                            <Text size="xs" fw={600} ff="monospace">
+                                {timing.ttftMs === null
+                                    ? '…'
+                                    : formatDurationMs(timing.ttftMs)}
+                            </Text>
+                            <Text size="xs" c="dimmed" ml={4}>
+                                total
+                            </Text>
+                            <Text size="xs" fw={600} ff="monospace">
+                                {formatDurationMs(timing.totalMs)}
+                            </Text>
+                            <Text size="xs" c="dimmed" ml={2}>
+                                {timing.source === 'live'
+                                    ? '(client)'
+                                    : '(server)'}
+                            </Text>
+                        </Group>
+                    )}
+                    <Anchor
+                        component={Link}
+                        to={`${getAiAgentPageBase(
+                            projectUuid,
+                        )}/${agentUuid}/threads/${thread.uuid}`}
+                        size="xs"
+                    >
+                        Open
+                    </Anchor>
+                </Group>
+            </Group>
+            <Box flex={1} mih={0}>
+                <AgentChatDisplay
+                    thread={thread}
+                    agentName={agentName}
+                    enableAutoScroll
+                    projectUuid={projectUuid}
+                    agentUuid={agentUuid}
+                    renderArtifactsInline
+                />
+            </Box>
+        </Stack>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
@@ -80,6 +80,7 @@ import {
     MessageSourcesToggle,
 } from './MessageMemorySources';
 import { MessageModelIndicator } from './MessageModelIndicator';
+import { MessageTimingIndicator } from './MessageTimingIndicator';
 import { isContentType, rehypeAiAgentContentLinks } from './rehypeContentLinks';
 import { rehypeMemoryCitationIndices } from './rehypeMemoryCitations';
 import { StreamRecoveryAlert } from './StreamRecoveryAlert';
@@ -1318,6 +1319,9 @@ export const AssistantBubble: FC<Props> = memo(
                             agentUuid={agentUuid}
                             modelConfig={message.modelConfig}
                             totalTokens={message.tokenUsage?.totalTokens}
+                        />
+                        <MessageTimingIndicator
+                            responseTiming={message.responseTiming}
                         />
                     </Group>
                 )}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.restore.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.restore.test.tsx
@@ -80,6 +80,7 @@ const assistantMessage = (
     referencedArtifacts: null,
     modelConfig: null,
     tokenUsage: null,
+    responseTiming: null,
     ...overrides,
 });
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.test.tsx
@@ -89,6 +89,7 @@ const getAssistantMessage = (
     referencedArtifacts: null,
     modelConfig: null,
     tokenUsage: null,
+    responseTiming: null,
 });
 
 const followUpUserMessage: AiAgentMessageUser = {

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentLink.dataApp.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentLink.dataApp.test.tsx
@@ -30,6 +30,7 @@ const message: AiAgentMessageAssistant = {
     referencedArtifacts: null,
     modelConfig: null,
     tokenUsage: null,
+    responseTiming: null,
 };
 
 const renderDataAppChip = () =>

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MessageTimingIndicator.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MessageTimingIndicator.tsx
@@ -1,0 +1,37 @@
+import type { AiPromptResponseTiming } from '@lightdash/common';
+import { Badge, Tooltip } from '@mantine/core';
+import { type FC } from 'react';
+import { useAiAgentBattleModeEnabled } from '../../hooks/useAiAgentBattleModeEnabled';
+import {
+    formatDurationMs,
+    getResponseTimingMetrics,
+} from '../../utils/responseTiming';
+
+interface Props {
+    responseTiming: AiPromptResponseTiming | null;
+}
+
+export const MessageTimingIndicator: FC<Props> = ({ responseTiming }) => {
+    const battleModeEnabled = useAiAgentBattleModeEnabled();
+    if (!battleModeEnabled || !responseTiming) return null;
+
+    const metrics = getResponseTimingMetrics(responseTiming);
+    if (!metrics) return null;
+
+    const ttft =
+        metrics.ttftMs === null ? 'n/a' : formatDurationMs(metrics.ttftMs);
+
+    return (
+        <Tooltip
+            label={`Time to first token ${ttft}, total ${formatDurationMs(
+                metrics.totalMs,
+            )}. Measured on the server from the model call, so context loading is excluded.`}
+            maw={320}
+            multiline
+        >
+            <Badge variant="transparent" size="sm" fz="xs" c="dimmed">
+                {ttft} · {formatDurationMs(metrics.totalMs)}
+            </Badge>
+        </Tooltip>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentBattleModeEnabled.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentBattleModeEnabled.ts
@@ -1,0 +1,7 @@
+import { FeatureFlags } from '@lightdash/common';
+import { useServerFeatureFlag } from '../../../../hooks/useServerOrClientFeatureFlag';
+
+export const useAiAgentBattleModeEnabled = (): boolean => {
+    const flag = useServerFeatureFlag(FeatureFlags.AiAgentBattleMode);
+    return flag.data?.enabled === true;
+};

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/usePendingThreadRefetch.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/usePendingThreadRefetch.test.tsx
@@ -73,6 +73,7 @@ const threadWithAssistantStatus = (status: AiAgentMessageAssistant['status']) =>
                 referencedArtifacts: null,
                 modelConfig: null,
                 tokenUsage: null,
+                responseTiming: null,
             },
         ],
     }) satisfies NonNullable<Parameters<typeof usePendingThreadRefetch>[0]>;

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
@@ -1,6 +1,10 @@
 import type {
     AiAgent,
+    AiAgentModelConfig,
     AiAgentThreadFilters,
+    AiPromptContext,
+    AiPromptContextItem,
+    AiPromptContextItemInput,
     ApiAiAgentArtifactVizQuery,
     ApiAiAgentAvatarUploadResponse,
     ApiAiAgentProjectThreadSummaryListResponse,
@@ -20,14 +24,11 @@ import type {
     ApiAiAgentThreadShareResponse,
     ApiAiAgentThreadWorkstreamsResponse,
     ApiAiAgentVerifiedQuestionsResponse,
-    AiPromptContext,
-    AiPromptContextItem,
-    AiPromptContextItemInput,
+    ApiAiMcpServerListResponse,
+    ApiCloneAiAgentThreadShareResponse,
     ApiCreateAiAgent,
     ApiCreateAiAgentResponse,
-    ApiCloneAiAgentThreadShareResponse,
     ApiError,
-    ApiAiMcpServerListResponse,
     ApiSuccessEmpty,
     ApiUpdateAiAgent,
 } from '@lightdash/common';
@@ -820,6 +821,7 @@ const createOptimisticMessages = (
     context: AiPromptContext = [],
     hidden = false,
     includeAssistantResponse = true,
+    modelConfig: AiAgentModelConfig | null = null,
 ) => {
     const userMessage = {
         role: 'user' as const,
@@ -866,8 +868,9 @@ const createOptimisticMessages = (
             savedQueryUuid: null,
             artifacts: null,
             referencedArtifacts: null,
-            modelConfig: null,
+            modelConfig,
             tokenUsage: null,
+            responseTiming: null,
         },
     ];
 };
@@ -1046,6 +1049,7 @@ export const useCreateAgentThreadMutation = (
                                 variables.context?.map(toOptimisticContextItem),
                             false,
                             !variables.skipAgentResponse,
+                            variables.modelConfig ?? null,
                         ),
                         createdAt: new Date().toISOString(),
                         user: {
@@ -1233,6 +1237,7 @@ export const useCreateAgentThreadMessageMutation = (
                                     data.context?.map(toOptimisticContextItem),
                                 data.hidden,
                                 !data.skipAgentResponse,
+                                data.modelConfig ?? null,
                             ),
                         ],
                     };

--- a/packages/frontend/src/ee/features/aiCopilot/store/aiAgentThreadStreamSlice.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/store/aiAgentThreadStreamSlice.ts
@@ -29,6 +29,13 @@ export type StepProgressMessage = {
     progressStatus: 'in_progress' | 'complete' | 'error' | null;
 };
 
+/** Client-clock stopwatch for the live stream; ms since epoch. */
+export type StreamTiming = {
+    startedAt: number;
+    firstTokenAt: number | null;
+    finishedAt: number | null;
+};
+
 export type StreamPart =
     | { type: 'text'; text: string }
     | (ToolCall & { type: 'toolCall' });
@@ -112,6 +119,7 @@ export interface AiAgentThreadStreamingState {
      * hover, etc.) without changing the wire protocol.
      */
     stepProgressMessages: StepProgressMessage[];
+    timing: StreamTiming;
 }
 
 type State = Record<string, AiAgentThreadStreamingState>;
@@ -119,7 +127,7 @@ type State = Record<string, AiAgentThreadStreamingState>;
 const initialState: State = {};
 const initialThread: Omit<
     AiAgentThreadStreamingState,
-    'threadUuid' | 'messageUuid'
+    'threadUuid' | 'messageUuid' | 'timing'
 > = {
     content: '',
     parts: [],
@@ -144,7 +152,24 @@ export const aiAgentThreadStreamSlice = createSlice({
                 threadUuid,
                 messageUuid,
                 ...initialThread,
+                timing: {
+                    startedAt: Date.now(),
+                    firstTokenAt: null,
+                    finishedAt: null,
+                },
             };
+        },
+        markFirstToken: (
+            state,
+            action: PayloadAction<{ threadUuid: string }>,
+        ) => {
+            const streamingThread = state[action.payload.threadUuid];
+            if (
+                streamingThread &&
+                streamingThread.timing.firstTokenAt === null
+            ) {
+                streamingThread.timing.firstTokenAt = Date.now();
+            }
         },
         setMessage: {
             reducer: (
@@ -236,6 +261,7 @@ export const aiAgentThreadStreamSlice = createSlice({
             const streamingThread = state[action.payload.threadUuid];
             if (streamingThread) {
                 streamingThread.connection = { status: 'complete' };
+                streamingThread.timing.finishedAt ??= Date.now();
             }
         },
         addToolCall: {
@@ -271,6 +297,7 @@ export const aiAgentThreadStreamSlice = createSlice({
             const streamingThread = state[threadUuid];
             if (streamingThread) {
                 streamingThread.connection = { status: 'error', error };
+                streamingThread.timing.finishedAt ??= Date.now();
             }
         },
         addReasoning: {
@@ -383,6 +410,7 @@ export const aiAgentThreadStreamSlice = createSlice({
 
 export const {
     startStreaming,
+    markFirstToken,
     setMessage,
     setParts,
     markToolCallDecided,

--- a/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.ts
@@ -14,6 +14,7 @@ import {
     addReasoning,
     addToolCall,
     appendStepProgress,
+    markFirstToken,
     markStreamRecovering,
     markToolCallDecided,
     setError,
@@ -278,6 +279,15 @@ export const getStepProgressFromChunk = (
     return null;
 };
 
+const FIRST_TOKEN_CHUNK_TYPES = new Set<UIMessageChunk['type']>([
+    'text-start',
+    'text-delta',
+    'reasoning-start',
+    'reasoning-delta',
+    'tool-input-start',
+    'tool-input-available',
+]);
+
 export function useAiAgentThreadStreamMutation() {
     const dispatch = useAiAgentStoreDispatch();
     const { setAbortController, abort } =
@@ -347,6 +357,7 @@ export function useAiAgentThreadStreamMutation() {
                 const notifiedToolCallIds = new Set<string>();
                 const notifiedToolOutputIds = new Set<string>();
                 let receivedTerminalChunk = false;
+                let receivedFirstToken = false;
                 const handleStreamReadError = () => {
                     if (
                         !receivedTerminalChunk &&
@@ -374,6 +385,13 @@ export function useAiAgentThreadStreamMutation() {
                         inactivityMonitor.reset();
                         if (value.type === 'finish') {
                             receivedTerminalChunk = true;
+                        }
+                        if (
+                            !receivedFirstToken &&
+                            FIRST_TOKEN_CHUNK_TYPES.has(value.type)
+                        ) {
+                            receivedFirstToken = true;
+                            dispatch(markFirstToken({ threadUuid }));
                         }
 
                         const stepProgress = getStepProgressFromChunk(value);

--- a/packages/frontend/src/ee/features/aiCopilot/utils/responseTiming.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/utils/responseTiming.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { formatDurationMs, getResponseTimingMetrics } from './responseTiming';
+
+describe('getResponseTimingMetrics', () => {
+    it('derives first-token and total durations from the timestamps', () => {
+        expect(
+            getResponseTimingMetrics({
+                startedAt: '2026-09-03T10:00:00.000Z',
+                firstTokenAt: '2026-09-03T10:00:01.250Z',
+                finishedAt: '2026-09-03T10:00:12.000Z',
+            }),
+        ).toEqual({ ttftMs: 1250, totalMs: 12000 });
+    });
+
+    it('returns a null first-token figure when nothing streamed', () => {
+        expect(
+            getResponseTimingMetrics({
+                startedAt: '2026-09-03T10:00:00.000Z',
+                firstTokenAt: null,
+                finishedAt: '2026-09-03T10:00:03.000Z',
+            }),
+        ).toEqual({ ttftMs: null, totalMs: 3000 });
+    });
+
+    it('rejects unparseable timestamps instead of producing NaN', () => {
+        expect(
+            getResponseTimingMetrics({
+                startedAt: 'not a date',
+                firstTokenAt: null,
+                finishedAt: '2026-09-03T10:00:03.000Z',
+            }),
+        ).toBeNull();
+    });
+});
+
+describe('formatDurationMs', () => {
+    it.each([
+        [0, '0ms'],
+        [850, '850ms'],
+        [1250, '1.3s'],
+        [59_940, '59.9s'],
+        [61_000, '1m 1s'],
+        [125_500, '2m 6s'],
+    ])('formats %d ms as %s', (ms, expected) => {
+        expect(formatDurationMs(ms)).toBe(expected);
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/utils/responseTiming.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/utils/responseTiming.ts
@@ -1,0 +1,32 @@
+import type { AiPromptResponseTiming } from '@lightdash/common';
+
+export type ResponseTimingMetrics = {
+    ttftMs: number | null;
+    totalMs: number;
+};
+
+export const getResponseTimingMetrics = (
+    timing: AiPromptResponseTiming,
+): ResponseTimingMetrics | null => {
+    const startedAt = Date.parse(timing.startedAt);
+    const finishedAt = Date.parse(timing.finishedAt);
+    if (Number.isNaN(startedAt) || Number.isNaN(finishedAt)) return null;
+
+    const firstTokenAt =
+        timing.firstTokenAt === null ? null : Date.parse(timing.firstTokenAt);
+    return {
+        ttftMs:
+            firstTokenAt === null || Number.isNaN(firstTokenAt)
+                ? null
+                : firstTokenAt - startedAt,
+        totalMs: finishedAt - startedAt,
+    };
+};
+
+export const formatDurationMs = (ms: number): string => {
+    if (ms < 1000) return `${Math.max(0, Math.round(ms))}ms`;
+    if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+    const minutes = Math.floor(ms / 60_000);
+    const seconds = Math.round((ms % 60_000) / 1000);
+    return `${minutes}m ${seconds}s`;
+};

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentBattlePage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentBattlePage.tsx
@@ -1,0 +1,140 @@
+import { Box, Center, Divider, Flex, Loader, Stack } from '@mantine/core';
+import { useCallback, type FC } from 'react';
+import { useOutletContext, useParams } from 'react-router';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
+import { BattleThreadPane } from '../../features/aiCopilot/components/Battle/BattleThreadPane';
+import { AgentChatInput } from '../../features/aiCopilot/components/ChatElements/AgentChatInput';
+import { ChatElementsUtils } from '../../features/aiCopilot/components/ChatElements/utils';
+import { usePendingThreadRefetch } from '../../features/aiCopilot/hooks/usePendingThreadRefetch';
+import {
+    useAiAgentThread,
+    useCreateAgentThreadMessageMutation,
+} from '../../features/aiCopilot/hooks/useProjectAiAgents';
+import { type AgentContext } from './AgentPage';
+
+const getThreadModelConfig = (
+    thread: ReturnType<typeof useAiAgentThread>['data'],
+) =>
+    thread?.messages.find((message) => message.role === 'assistant')
+        ?.modelConfig ?? undefined;
+
+const AiAgentBattlePage: FC = () => {
+    const { agentUuid, threadUuidA, threadUuidB } = useParams();
+    const projectUuid = useProjectUuid();
+    const { agent } = useOutletContext<AgentContext>();
+
+    const threadAQuery = useAiAgentThread(projectUuid!, agentUuid, threadUuidA);
+    const threadBQuery = useAiAgentThread(projectUuid!, agentUuid, threadUuidB);
+
+    const pendingA = usePendingThreadRefetch(
+        threadAQuery.data,
+        threadUuidA!,
+        threadAQuery.refetch,
+    );
+    const pendingB = usePendingThreadRefetch(
+        threadBQuery.data,
+        threadUuidB!,
+        threadBQuery.refetch,
+    );
+
+    const messageA = useCreateAgentThreadMessageMutation(
+        projectUuid!,
+        agentUuid,
+        threadUuidA,
+    );
+    const messageB = useCreateAgentThreadMessageMutation(
+        projectUuid!,
+        agentUuid,
+        threadUuidB,
+    );
+
+    const threadA = threadAQuery.data;
+    const threadB = threadBQuery.data;
+
+    const handleSubmit = useCallback(
+        ({
+            message,
+            toolHints,
+            context,
+            optimisticContext,
+        }: {
+            message: string;
+            toolHints: string[];
+            context?: Parameters<typeof messageA.mutateAsync>[0]['context'];
+            optimisticContext?: Parameters<
+                typeof messageA.mutateAsync
+            >[0]['optimisticContext'];
+        }) => {
+            const shared = {
+                prompt: message,
+                toolHints,
+                context,
+                optimisticContext,
+            };
+            void messageA.mutateAsync({
+                ...shared,
+                modelConfig: getThreadModelConfig(threadA),
+            });
+            void messageB.mutateAsync({
+                ...shared,
+                modelConfig: getThreadModelConfig(threadB),
+            });
+        },
+        [messageA, messageB, threadA, threadB],
+    );
+
+    const isBusy =
+        messageA.isLoading ||
+        messageB.isLoading ||
+        pendingA.isStreaming ||
+        pendingA.isThreadPending ||
+        pendingB.isStreaming ||
+        pendingB.isThreadPending;
+
+    if (!projectUuid || !agentUuid || !threadA || !threadB) {
+        return (
+            <Center h="100%">
+                <Loader color="gray" />
+            </Center>
+        );
+    }
+
+    return (
+        <Stack h="100%" gap={0}>
+            <Flex flex={1} mih={0} wrap="nowrap" align="stretch">
+                <Box flex={1} miw={0} h="100%">
+                    <BattleThreadPane
+                        label="A"
+                        projectUuid={projectUuid}
+                        agentUuid={agentUuid}
+                        agentName={agent.name}
+                        thread={threadA}
+                    />
+                </Box>
+                <Divider orientation="vertical" />
+                <Box flex={1} miw={0} h="100%">
+                    <BattleThreadPane
+                        label="B"
+                        projectUuid={projectUuid}
+                        agentUuid={agentUuid}
+                        agentName={agent.name}
+                        thread={threadB}
+                    />
+                </Box>
+            </Flex>
+            <Box {...ChatElementsUtils.centeredElementProps} h="unset" py="sm">
+                <AgentChatInput
+                    onSubmit={handleSubmit}
+                    loading={isBusy}
+                    placeholder="Ask both models a follow-up..."
+                    projectUuid={projectUuid}
+                    agentUuid={agentUuid}
+                    messageCount={threadA.messages.length}
+                    showSuggestions={false}
+                />
+            </Box>
+        </Stack>
+    );
+};
+
+export default AiAgentBattlePage;

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
@@ -11,12 +11,26 @@ import {
     Title,
 } from '@mantine/core';
 import { IconInfoCircle } from '@tabler/icons-react';
-import { useCallback, useEffect, useRef, useState, type FC } from 'react';
-import { useOutletContext, useParams, useSearchParams } from 'react-router';
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    type FC,
+} from 'react';
+import {
+    useNavigate,
+    useOutletContext,
+    useParams,
+    useSearchParams,
+} from 'react-router';
 import { LightdashUserAvatar } from '../../../components/Avatar';
 import MantineIcon from '../../../components/common/MantineIcon';
+import { getModelKey } from '../../../components/common/ModelSelector/utils';
 import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { AiAgentNewThreadMcpConnections } from '../../features/aiCopilot/components/AiAgentNewThreadMcpConnections';
+import { BattleModeSetup } from '../../features/aiCopilot/components/Battle/BattleModeSetup';
 import { AgentChatInput } from '../../features/aiCopilot/components/ChatElements/AgentChatInput';
 import {
     mergeAiPromptContextInput,
@@ -30,9 +44,17 @@ import { PinnedContextCard } from '../../features/aiCopilot/components/PinnedCon
 import { SuggestedQuestions } from '../../features/aiCopilot/components/SuggestedQuestions/SuggestedQuestions';
 import { ThreadRetentionNotice } from '../../features/aiCopilot/components/ThreadRetentionNotice';
 import { type StartDeepResearchArgs } from '../../features/aiCopilot/deepResearch/types';
-import { isEmbedAiAgentRoute } from '../../features/aiCopilot/hooks/aiAgentRouting';
+import {
+    getAiAgentPageBase,
+    isEmbedAiAgentRoute,
+} from '../../features/aiCopilot/hooks/aiAgentRouting';
 import { emitEmbedAiAgentThreadChange } from '../../features/aiCopilot/hooks/embedAiAgentThreadChange';
-import { useAiAgentModelSelection } from '../../features/aiCopilot/hooks/useAiAgentModelSelection';
+import { useAiAgentBattleModeEnabled } from '../../features/aiCopilot/hooks/useAiAgentBattleModeEnabled';
+import {
+    getAiAgentModelConfig,
+    getModelOptionByKey,
+    useAiAgentModelSelection,
+} from '../../features/aiCopilot/hooks/useAiAgentModelSelection';
 import { useAiAgentSqlModeAvailable } from '../../features/aiCopilot/hooks/useAiAgentSqlModeAvailable';
 import { useStartDeepResearchForThreadMutation } from '../../features/aiCopilot/hooks/useDeepResearch';
 import { useDeepResearchAccess } from '../../features/aiCopilot/hooks/useDeepResearchAccess';
@@ -69,6 +91,10 @@ const AiAgentNewThreadPage: FC = () => {
 
     const { agent, agents, navigateFromAgentChat } =
         useOutletContext<AgentContext>();
+    const navigate = useNavigate();
+    const battleModeAvailable = useAiAgentBattleModeEnabled() && !isEmbed;
+    const [battleMode, setBattleMode] = useState(false);
+    const [battleModelBKey, setBattleModelBKey] = useState<string | null>(null);
     const sqlModeAvailable = useAiAgentSqlModeAvailable(projectUuid);
     const canStartDeepResearch = useDeepResearchAccess(projectUuid);
     const [sqlModeOverride, setSqlModeOverride] = useState<boolean>();
@@ -126,6 +152,13 @@ const AiAgentNewThreadPage: FC = () => {
             },
             onToolResult: handleToolResult,
         });
+    const {
+        mutateAsync: createBattleThread,
+        isLoading: isCreatingBattleThreads,
+    } = useCreateAgentThreadMutation(projectUuid!, {
+        skipNavigation: true,
+        onToolResult: handleToolResult,
+    });
     const { data: verifiedQuestions } = useVerifiedQuestions(
         projectUuid,
         agentUuid,
@@ -140,6 +173,7 @@ const AiAgentNewThreadPage: FC = () => {
         handleSelectedModelKeyChange,
         modelConfig,
         modelOptions,
+        selectedModel,
         selectedModelKey,
         showExtendedThinking,
     } = useAiAgentModelSelection({
@@ -148,6 +182,18 @@ const AiAgentNewThreadPage: FC = () => {
         defaultModelConfig: agent.modelConfig,
         organizationSettingsEnabled: !isEmbed,
     });
+    const battleModels = useMemo(
+        () => modelOptions?.filter((model) => !model.deprecated) ?? [],
+        [modelOptions],
+    );
+    const showBattleSetup = battleModeAvailable && battleModels.length > 1;
+    // Model B defaults to the first option that isn't model A, and falls
+    // back to that whenever A is changed to match the current B.
+    const effectiveBattleModelBKey =
+        (battleModelBKey !== selectedModelKey ? battleModelBKey : null) ??
+        battleModels.map(getModelKey).find((key) => key !== selectedModelKey) ??
+        null;
+    const isBattle = showBattleSetup && battleMode;
 
     const { pendingPrompt, setPendingPrompt } = usePendingPrompt();
     const [composerSeedKey, setComposerSeedKey] = useState(0);
@@ -182,6 +228,42 @@ const AiAgentNewThreadPage: FC = () => {
                 previewItems,
                 optimisticContext,
             );
+            if (isBattle && projectUuid) {
+                const shared = {
+                    agentUuid,
+                    prompt: message,
+                    context: mergedContext,
+                    optimisticContext: mergedOptimisticContext,
+                    enableSqlMode: sqlModeAvailable && sqlMode,
+                    toolHints,
+                };
+                void Promise.all([
+                    createBattleThread({
+                        ...shared,
+                        modelConfig: getAiAgentModelConfig(
+                            selectedModel,
+                            false,
+                        ),
+                    }),
+                    createBattleThread({
+                        ...shared,
+                        modelConfig: getAiAgentModelConfig(
+                            getModelOptionByKey(
+                                battleModels,
+                                effectiveBattleModelBKey,
+                            ),
+                            false,
+                        ),
+                    }),
+                ]).then(([threadA, threadB]) =>
+                    navigate(
+                        `${getAiAgentPageBase(
+                            projectUuid,
+                        )}/${agentUuid}/threads/battle/${threadA.uuid}/${threadB.uuid}`,
+                    ),
+                );
+                return;
+            }
             void createAgentThread({
                 agentUuid,
                 prompt: message,
@@ -196,12 +278,19 @@ const AiAgentNewThreadPage: FC = () => {
             agentUuid,
             setPendingPrompt,
             createAgentThread,
+            createBattleThread,
             contextInput,
             previewItems,
             sqlModeAvailable,
             sqlMode,
             modelConfig,
             isPinnedContextReady,
+            isBattle,
+            projectUuid,
+            selectedModel,
+            battleModels,
+            effectiveBattleModelBKey,
+            navigate,
         ],
     );
 
@@ -356,29 +445,47 @@ const AiAgentNewThreadPage: FC = () => {
                         </Stack>
                     )}
 
+                    {showBattleSetup && (
+                        <BattleModeSetup
+                            enabled={battleMode}
+                            onEnabledChange={setBattleMode}
+                            models={battleModels}
+                            modelAKey={selectedModelKey}
+                            modelBKey={effectiveBattleModelBKey}
+                            onModelAChange={handleSelectedModelKeyChange}
+                            onModelBChange={setBattleModelBKey}
+                        />
+                    )}
+
                     <AgentChatInput
                         key={composerSeedKey}
                         onSubmit={onSubmit}
                         onStartDeepResearch={
-                            canStartDeepResearch
+                            canStartDeepResearch && !isBattle
                                 ? onStartDeepResearch
                                 : undefined
                         }
-                        loading={isCreatingThread}
+                        loading={isCreatingThread || isCreatingBattleThreads}
                         disabled={!isPinnedContextReady}
-                        placeholder={`Ask ${agent.name} anything about your data...`}
+                        placeholder={
+                            isBattle
+                                ? `Ask both models anything about your data...`
+                                : `Ask ${agent.name} anything about your data...`
+                        }
                         projectUuid={projectUuid}
                         agentUuid={agent.uuid}
                         agents={agents}
                         selectedAgent={agent}
-                        models={modelOptions}
+                        models={isBattle ? undefined : modelOptions}
                         selectedModelId={selectedModelKey}
                         onModelChange={handleSelectedModelKeyChange}
                         extendedThinking={
-                            showExtendedThinking ? extendedThinking : undefined
+                            showExtendedThinking && !isBattle
+                                ? extendedThinking
+                                : undefined
                         }
                         onExtendedThinkingChange={
-                            showExtendedThinking
+                            showExtendedThinking && !isBattle
                                 ? handleExtendedThinkingChange
                                 : undefined
                         }

--- a/packages/frontend/src/stories/AiAgentChatWorkbench.stories.tsx
+++ b/packages/frontend/src/stories/AiAgentChatWorkbench.stories.tsx
@@ -933,6 +933,7 @@ const makeThread = (scenario: ThreadScenario): AiAgentThread => {
                 reasoning: true,
             },
             tokenUsage: null,
+            responseTiming: null,
         };
     });
 


### PR DESCRIPTION
## Description

Internal experiment: send one prompt to two models and compare the answers side by side, with time to first token and total response time per answer.

**How it works**

- **Battle = two paired threads.** The new-thread page gets a "Battle mode" switch with model A / model B pickers. Submitting creates two threads, each with its own model config (which already existed per prompt), and navigates to `threads/battle/:threadUuidA/:threadUuidB`.
- **Battle page.** Two panes render their thread with inline artifacts; one shared composer fans follow-ups out to both threads. Each pane header shows the model, status, first-token and total time, and an "Open" link to the standalone thread.
- **Timing.** New nullable `ai_prompt.response_timing` jsonb (`startedAt`, `firstTokenAt`, `finishedAt`) stamped by the agent loop for both the streaming and generate paths, exposed as `responseTiming` on assistant messages. While streaming the pane shows a client-side stopwatch labelled "(client)"; once the persisted row lands it switches to the server figures labelled "(server)". Finished bubbles also get a small timing badge next to the model badge.
- **Gate.** `FeatureFlags.AiAgentBattleMode` (`ai-agent-battle-mode`), off by default. Enable per org via the feature flag override endpoint. Only the UI is gated; timing is persisted for every prompt.

**Design notes**

- "First token" is the first chunk of any kind from the model, including tool-call input, because agents often call tools before writing text.
- Battle threads run without extended thinking and without deep research.
- Server timing only exists for prompts answered after the migration; older threads show no badge.

## Regression analysis

- **Thread streaming.** The stream slice gains a `timing` field set on `startStreaming`, a `markFirstToken` reducer, and `finishedAt` on stop/error. No existing reducer changes behaviour; existing slice and stream-mutation tests pass.
- **Optimistic messages** now carry the chosen `modelConfig` (previously always `null`). The persisted refetch overwrote it before and still does; the thread page reads the model from the first persisted assistant message, unchanged.
- **Persistence.** `updateModelResponse` writes `response_timing` only when the update carries it, so Slack and other callers are unaffected. The two thread-message selects add the column; `AiAgentMessageAssistant` gains a required `responseTiming` field, and every constructor (backend mapping, optimistic messages, test factories, stories) sets it.
- **Migration** adds one nullable jsonb column; no data mutation, safe on large tables.
- **Routes.** The battle route is a static-prefixed sibling of `:threadUuid`, so existing thread URLs resolve as before. Not added to embed routes.

## Verification

Verified live on an isolated dev instance: battle setup, both models streaming with live timers, persisted server timings after finish, bubble timing badge, and a follow-up fanned out to both threads. Unit: `agentV2`, `compaction`, thread stream slice, stream mutation, `AgentChatDisplay`, `usePendingThreadRefetch`. Typecheck, lint and format clean on common, backend and frontend.

Ticket: none, confirmed with the author — internal experiment.

### Risk assessment:

- [ ] This is a high-risk change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ned3P5Sqh7j1Vx1BiT3Qoh
