### PR TITLE
fix(redshift): restore Authentication type menu and project IAM fields

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -2452,6 +2452,71 @@ describe('ProjectService', () => {
             );
         });
 
+        test('should not give a legacy Redshift password credential the project IAM mode', async () => {
+            service.warehouseClients = {};
+
+            const projectRedshiftCredentials = {
+                type: WarehouseTypes.REDSHIFT,
+                host: 'cluster.redshift.amazonaws.com',
+                user: 'shared_project_user',
+                password: 'shared-project-password',
+                port: 5439,
+                dbname: 'dev',
+                schema: 'public',
+                authenticationType: RedshiftAuthenticationType.IAM,
+                region: 'us-east-1',
+                clusterIdentifier: 'analytics-cluster',
+                requireUserCredentials: true,
+            };
+            (
+                projectModel.getWarehouseCredentialsForProject as import('vitest').Mock
+            ).mockImplementation(async () => projectRedshiftCredentials);
+
+            // Stored before authenticationType was persisted: no auth type.
+            const userCredentials = {
+                uuid: 'legacy-redshift-creds-uuid',
+                credentials: {
+                    type: WarehouseTypes.REDSHIFT,
+                    user: 'analyst',
+                    password: 'analyst-password',
+                },
+            };
+            (
+                service as unknown as {
+                    userWarehouseCredentialsModel: {
+                        findForProjectWithSecrets: import('vitest').Mock;
+                    };
+                }
+            ).userWarehouseCredentialsModel.findForProjectWithSecrets = vi.fn(
+                async () => userCredentials,
+            );
+
+            const mergedCredentials = await (
+                service as unknown as {
+                    getWarehouseCredentials: (args: {
+                        projectUuid: string;
+                        userId: string;
+                        isRegisteredUser: boolean;
+                    }) => Promise<Record<string, unknown>>;
+                }
+            ).getWarehouseCredentials({
+                projectUuid,
+                userId: sessionAccount.user.id,
+                isRegisteredUser: true,
+            });
+
+            // Absent, not 'iam': the client then falls back to password auth
+            // instead of minting IAM credentials for a user identity that
+            // was never configured for IAM.
+            expect(mergedCredentials.authenticationType).toBeUndefined();
+            expect(mergedCredentials).toEqual(
+                expect.objectContaining({
+                    user: 'analyst',
+                    password: 'analyst-password',
+                }),
+            );
+        });
+
         test('should use user refreshToken instead of project refreshToken when requireUserCredentials is true', async () => {
             // clear in memory cache so new mock is applied
             service.warehouseClients = {};

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1907,8 +1907,9 @@ export class ProjectService extends BaseService {
                 };
             }
             case WarehouseTypes.REDSHIFT: {
+                const { authenticationType, ...rest } = credentials;
                 return {
-                    ...credentials,
+                    ...rest,
                     user: '',
                     password: '',
                     accessKeyId: '',

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/RedshiftForm.test.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/RedshiftForm.test.tsx
@@ -1,0 +1,162 @@
+import {
+    DbtProjectType,
+    RedshiftAuthenticationType,
+    type CreateRedshiftCredentials,
+} from '@lightdash/common';
+import { waitFor } from '@testing-library/react';
+import { type FC } from 'react';
+import { renderWithProviders } from '../../../testing/testUtils';
+import ProjectFormContext from '../context';
+import { dbtDefaults } from '../DbtForms/defaultValues';
+import {
+    FormProvider,
+    useForm,
+    useFormContext,
+    type Form,
+} from '../formContext';
+import { RedshiftDefaultValues } from './defaultValues';
+import RedshiftForm from './RedshiftForm';
+
+const FormProbe: FC<{ formRef: { current: Form | null } }> = ({ formRef }) => {
+    formRef.current = useFormContext();
+    return null;
+};
+
+const renderRedshiftForm = (
+    authenticationType: RedshiftAuthenticationType | undefined,
+) => {
+    const formRef: { current: Form | null } = { current: null };
+
+    const Wrapper: FC = () => {
+        const form = useForm({
+            initialValues: {
+                name: 'test project',
+                dbt: { type: DbtProjectType.NONE },
+                warehouse: {
+                    ...RedshiftDefaultValues,
+                    authenticationType,
+                },
+                dbtVersion: dbtDefaults.dbtVersion,
+            },
+        });
+
+        return (
+            <ProjectFormContext.Provider value={{}}>
+                <FormProvider form={form}>
+                    <RedshiftForm disabled={false} />
+                    <FormProbe formRef={formRef} />
+                </FormProvider>
+            </ProjectFormContext.Provider>
+        );
+    };
+
+    const renderResult = renderWithProviders(<Wrapper />);
+
+    return { formRef, ...renderResult };
+};
+
+const getAuthenticationType = (formRef: { current: Form | null }) =>
+    (formRef.current?.values.warehouse as CreateRedshiftCredentials)
+        ?.authenticationType;
+
+describe('RedshiftForm', () => {
+    it('defaults the authentication type when it is unset', async () => {
+        const { formRef } = renderRedshiftForm(undefined);
+
+        await waitFor(() => {
+            expect(getAuthenticationType(formRef)).toBe(
+                RedshiftAuthenticationType.PASSWORD,
+            );
+        });
+    });
+
+    it('keeps an existing IAM authentication type when the form opens', async () => {
+        const { formRef } = renderRedshiftForm(RedshiftAuthenticationType.IAM);
+
+        await waitFor(() => {
+            expect(getAuthenticationType(formRef)).toBe(
+                RedshiftAuthenticationType.IAM,
+            );
+        });
+    });
+
+    it('keeps an existing IAM browser authentication type when the form opens', async () => {
+        const { formRef } = renderRedshiftForm(
+            RedshiftAuthenticationType.IAM_BROWSER,
+        );
+
+        await waitFor(() => {
+            expect(getAuthenticationType(formRef)).toBe(
+                RedshiftAuthenticationType.IAM_BROWSER,
+            );
+        });
+    });
+
+    it('renders the username and password fields for password authentication', async () => {
+        const { findByLabelText, queryByLabelText } = renderRedshiftForm(
+            RedshiftAuthenticationType.PASSWORD,
+        );
+
+        expect(await findByLabelText(/^User\b/)).toBeInTheDocument();
+        expect(await findByLabelText(/^Password\b/)).toBeInTheDocument();
+        expect(
+            queryByLabelText('AWS region', { exact: false }),
+        ).not.toBeInTheDocument();
+        expect(
+            queryByLabelText('AWS access portal URL', { exact: false }),
+        ).not.toBeInTheDocument();
+    });
+
+    it('renders the shared-identity IAM fields for AWS IAM authentication', async () => {
+        const { findByLabelText, findByText, queryByLabelText } =
+            renderRedshiftForm(RedshiftAuthenticationType.IAM);
+
+        expect(
+            await findByLabelText('AWS region', { exact: false }),
+        ).toBeInTheDocument();
+        expect(await findByText('Redshift Serverless')).toBeInTheDocument();
+        expect(
+            await findByLabelText('Cluster identifier', { exact: false }),
+        ).toBeInTheDocument();
+        expect(
+            await findByLabelText('Database user', { exact: false }),
+        ).toBeInTheDocument();
+        expect(
+            await findByLabelText('Assume role ARN', { exact: false }),
+        ).toBeInTheDocument();
+        expect(queryByLabelText('Password')).not.toBeInTheDocument();
+        expect(
+            queryByLabelText('AWS access portal URL', { exact: false }),
+        ).not.toBeInTheDocument();
+    });
+
+    it('renders the AWS region and IAM Identity Center fields for browser IAM authentication', async () => {
+        const { findByLabelText, queryByLabelText } = renderRedshiftForm(
+            RedshiftAuthenticationType.IAM_BROWSER,
+        );
+
+        expect(
+            await findByLabelText('AWS region', { exact: false }),
+        ).toBeInTheDocument();
+        expect(
+            await findByLabelText('AWS access portal URL', {
+                exact: false,
+            }),
+        ).toBeInTheDocument();
+        expect(
+            await findByLabelText('IAM Identity Center region', {
+                exact: false,
+            }),
+        ).toBeInTheDocument();
+        expect(
+            await findByLabelText('AWS account ID', { exact: false }),
+        ).toBeInTheDocument();
+        expect(
+            await findByLabelText('AWS role name', { exact: false }),
+        ).toBeInTheDocument();
+        expect(queryByLabelText('Password')).not.toBeInTheDocument();
+        expect(
+            queryByLabelText('Cluster identifier', { exact: false }),
+        ).not.toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/RedshiftForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/RedshiftForm.tsx
@@ -86,6 +86,122 @@ const RedshiftAwsSsoFields: FC<{
     );
 };
 
+const RedshiftIamFields: FC<{
+    disabled: boolean;
+    isServerless: boolean;
+}> = ({ disabled, isServerless }) => {
+    const form = useFormContext();
+
+    return (
+        <>
+            <TextInput
+                name="warehouse.region"
+                label="AWS region"
+                description="The AWS region where your Redshift cluster or serverless workgroup is located."
+                required
+                placeholder="us-east-1"
+                {...form.getInputProps('warehouse.region')}
+                disabled={disabled}
+            />
+            <BooleanSwitch
+                name="warehouse.isServerless"
+                label="Redshift Serverless"
+                description="Enable if connecting to a Redshift Serverless workgroup rather than a provisioned cluster."
+                {...form.getInputProps('warehouse.isServerless', {
+                    type: 'checkbox',
+                })}
+                disabled={disabled}
+            />
+            {isServerless ? (
+                <TextInput
+                    name="warehouse.workgroupName"
+                    label="Workgroup name"
+                    description="The name of your Redshift Serverless workgroup."
+                    required
+                    {...form.getInputProps('warehouse.workgroupName')}
+                    disabled={disabled}
+                />
+            ) : (
+                <TextInput
+                    name="warehouse.clusterIdentifier"
+                    label="Cluster identifier"
+                    description="The identifier of your provisioned Redshift cluster."
+                    required
+                    {...form.getInputProps('warehouse.clusterIdentifier')}
+                    disabled={disabled}
+                />
+            )}
+            <TextInput
+                name="warehouse.user"
+                label="Database user"
+                description="The Redshift database user to request temporary credentials for."
+                required={!isServerless}
+                {...form.getInputProps('warehouse.user')}
+                disabled={disabled}
+            />
+            <TextInput
+                name="warehouse.assumeRoleArn"
+                label="Assume role ARN"
+                description="Recommended: an IAM role Lightdash assumes to mint Redshift credentials. Leave blank to use the host's IAM role (self-hosted), or provide AWS access keys under Advanced."
+                placeholder="arn:aws:iam::123456789012:role/my-redshift-role"
+                {...form.getInputProps('warehouse.assumeRoleArn')}
+                disabled={disabled}
+            />
+            <TextInput
+                name="warehouse.assumeRoleExternalId"
+                label="Assume role external ID"
+                description="External ID required by the assume-role trust policy, if configured."
+                {...form.getInputProps('warehouse.assumeRoleExternalId')}
+                disabled={disabled}
+            />
+        </>
+    );
+};
+
+const RedshiftIamAdvancedFields: FC<{
+    disabled: boolean;
+    isServerless: boolean;
+    requireSecrets: boolean;
+}> = ({ disabled, isServerless, requireSecrets }) => {
+    const form = useFormContext();
+
+    return (
+        <>
+            <TextInput
+                name="warehouse.accessKeyId"
+                label="AWS access key ID"
+                description="Advanced: static IAM user access key, only if you are not using an assume-role ARN or the host's IAM role. Long-lived secret — prefer assume-role where possible."
+                placeholder={
+                    disabled || !requireSecrets ? '**************' : undefined
+                }
+                {...form.getInputProps('warehouse.accessKeyId')}
+                disabled={disabled}
+            />
+            <PasswordInput
+                name="warehouse.secretAccessKey"
+                label="AWS secret access key"
+                description="Secret access key paired with the access key ID above."
+                placeholder={
+                    disabled || !requireSecrets ? '**************' : undefined
+                }
+                {...form.getInputProps('warehouse.secretAccessKey')}
+                disabled={disabled}
+            />
+            {!isServerless && (
+                <BooleanSwitch
+                    name="warehouse.autoCreate"
+                    label="Auto-create database user"
+                    description="Create the database user automatically if it does not already exist (GetClusterCredentials AutoCreate)."
+                    {...form.getInputProps('warehouse.autoCreate', {
+                        type: 'checkbox',
+                    })}
+                    disabled={disabled}
+                />
+            )}
+        </>
+    );
+};
+
 const RedshiftForm: FC<{
     disabled: boolean;
 }> = ({ disabled }) => {
@@ -104,12 +220,18 @@ const RedshiftForm: FC<{
 
     const warehouse = form.values.warehouse;
 
-    const defaultAuthenticationType = RedshiftAuthenticationType.PASSWORD;
+    const savedAuthenticationType =
+        savedProject?.warehouseConnection?.type === WarehouseTypes.REDSHIFT
+            ? savedProject.warehouseConnection.authenticationType
+            : undefined;
+
+    const defaultAuthenticationType =
+        savedAuthenticationType ?? RedshiftAuthenticationType.PASSWORD;
 
     useEffect(() => {
         const currentType = warehouse.authenticationType;
 
-        if (currentType !== defaultAuthenticationType) {
+        if (!currentType) {
             form.setFieldValue(
                 'warehouse.authenticationType',
                 defaultAuthenticationType,
@@ -117,8 +239,16 @@ const RedshiftForm: FC<{
         }
     }, [defaultAuthenticationType, form, warehouse.authenticationType]);
 
-    const requireUserCredentials =
-        form.values.warehouse.requireUserCredentials ?? false;
+    const authenticationType =
+        warehouse.authenticationType ?? defaultAuthenticationType;
+
+    const isPasswordAuthentication =
+        authenticationType === RedshiftAuthenticationType.PASSWORD;
+    const isIamAuthentication =
+        authenticationType === RedshiftAuthenticationType.IAM;
+    const isIamBrowserAuthentication =
+        authenticationType === RedshiftAuthenticationType.IAM_BROWSER;
+    const isServerless = warehouse.isServerless ?? false;
 
     const showSshTunnelConfiguration: boolean =
         form.values.warehouse.useSshTunnel ??
@@ -150,32 +280,79 @@ const RedshiftForm: FC<{
                     disabled={disabled}
                     labelProps={{ style: { marginTop: '8px' } }}
                 />
-                <TextInput
-                    name="warehouse.user"
-                    label="User"
-                    description="This is the database user name."
-                    required={requireSecrets}
-                    {...form.getInputProps('warehouse.user')}
-                    placeholder={
-                        disabled || !requireSecrets
-                            ? '**************'
-                            : undefined
-                    }
+                <Select
+                    name="warehouse.authenticationType"
+                    label="Authentication type"
+                    description="Choose whether to authenticate with a database username and password, AWS IAM (temporary credentials), or AWS IAM Identity Center (browser sign-in)."
+                    data={[
+                        {
+                            value: RedshiftAuthenticationType.PASSWORD,
+                            label: 'Username & password',
+                        },
+                        {
+                            value: RedshiftAuthenticationType.IAM,
+                            label: 'AWS IAM',
+                        },
+                        {
+                            value: RedshiftAuthenticationType.IAM_BROWSER,
+                            label: 'AWS IAM Identity Center',
+                        },
+                    ]}
+                    defaultValue={defaultAuthenticationType}
+                    {...form.getInputProps('warehouse.authenticationType')}
+                    required
                     disabled={disabled}
                 />
-                <PasswordInput
-                    name="warehouse.password"
-                    label="Password"
-                    description="This is the database user password."
-                    required={requireSecrets}
-                    placeholder={
-                        disabled || !requireSecrets
-                            ? '**************'
-                            : undefined
-                    }
-                    {...form.getInputProps('warehouse.password')}
-                    disabled={disabled}
-                />
+                {isPasswordAuthentication && (
+                    <>
+                        <TextInput
+                            name="warehouse.user"
+                            label="User"
+                            description="This is the database user name."
+                            required={requireSecrets}
+                            {...form.getInputProps('warehouse.user')}
+                            placeholder={
+                                disabled || !requireSecrets
+                                    ? '**************'
+                                    : undefined
+                            }
+                            disabled={disabled}
+                        />
+                        <PasswordInput
+                            name="warehouse.password"
+                            label="Password"
+                            description="This is the database user password."
+                            required={requireSecrets}
+                            placeholder={
+                                disabled || !requireSecrets
+                                    ? '**************'
+                                    : undefined
+                            }
+                            {...form.getInputProps('warehouse.password')}
+                            disabled={disabled}
+                        />
+                    </>
+                )}
+                {isIamAuthentication && (
+                    <RedshiftIamFields
+                        disabled={disabled}
+                        isServerless={isServerless}
+                    />
+                )}
+                {isIamBrowserAuthentication && (
+                    <>
+                        <TextInput
+                            name="warehouse.region"
+                            label="AWS region"
+                            description="The AWS region where your Redshift cluster or serverless workgroup is located."
+                            required
+                            placeholder="us-east-1"
+                            {...form.getInputProps('warehouse.region')}
+                            disabled={disabled}
+                        />
+                        <RedshiftAwsSsoFields disabled={disabled} />
+                    </>
+                )}
                 <TextInput
                     name="warehouse.dbname"
                     label="DB name"
@@ -201,8 +378,12 @@ const RedshiftForm: FC<{
                             disabled={disabled}
                         />
 
-                        {requireUserCredentials && (
-                            <RedshiftAwsSsoFields disabled={disabled} />
+                        {isIamAuthentication && (
+                            <RedshiftIamAdvancedFields
+                                disabled={disabled}
+                                isServerless={isServerless}
+                                requireSecrets={requireSecrets}
+                            />
                         )}
 
                         <NumberInput

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/RedshiftForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/RedshiftForm.tsx
@@ -142,7 +142,7 @@ const RedshiftIamFields: FC<{
             <TextInput
                 name="warehouse.assumeRoleArn"
                 label="Assume role ARN"
-                description="Recommended: an IAM role Lightdash assumes to mint Redshift credentials. Leave blank to use the host's IAM role (self-hosted), or provide AWS access keys under Advanced."
+                description="An IAM role Lightdash assumes to mint Redshift credentials for queries. Not yet supported for dbt compilation. Leave blank to use the host's IAM role (self-hosted), or provide AWS access keys under Advanced."
                 placeholder="arn:aws:iam::123456789012:role/my-redshift-role"
                 {...form.getInputProps('warehouse.assumeRoleArn')}
                 disabled={disabled}

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/validators.test.ts
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/validators.test.ts
@@ -1,4 +1,9 @@
-import { WarehouseTypes } from '@lightdash/common';
+import {
+    DbtProjectType,
+    RedshiftAuthenticationType,
+    WarehouseTypes,
+    type CreateRedshiftCredentials,
+} from '@lightdash/common';
 import { describe, expect, it } from 'vitest';
 import { type ProjectConnectionForm } from '../types';
 import { PostgresDefaultValues, RedshiftDefaultValues } from './defaultValues';
@@ -51,4 +56,95 @@ describe.each([
             expect(validate('', values)).toBeUndefined();
         },
     );
+});
+
+const redshiftValues = (
+    warehouse: Partial<CreateRedshiftCredentials>,
+): ProjectConnectionForm => ({
+    name: 'test project',
+    dbt: { type: DbtProjectType.NONE },
+    warehouse: {
+        type: WarehouseTypes.REDSHIFT,
+        host: 'host',
+        user: '',
+        password: '',
+        dbname: 'dev',
+        schema: 'public',
+        port: 5439,
+        ...warehouse,
+    },
+    dbtVersion: 'v1.10' as ProjectConnectionForm['dbtVersion'],
+});
+
+const { user, password, region, clusterIdentifier, workgroupName } =
+    createWarehouseValueValidators[WarehouseTypes.REDSHIFT];
+
+describe('createWarehouseValueValidators[REDSHIFT]', () => {
+    it('requires user and password for password authentication', () => {
+        const values = redshiftValues({
+            authenticationType: RedshiftAuthenticationType.PASSWORD,
+        });
+
+        expect(user('', values)).toBe('User is required');
+        expect(password('', values)).toBe('Password is required');
+    });
+
+    it('does not require user or password for IAM authentication', () => {
+        const values = redshiftValues({
+            authenticationType: RedshiftAuthenticationType.IAM,
+            isServerless: false,
+        });
+
+        expect(password('', values)).toBeUndefined();
+    });
+
+    it('requires the database user for a provisioned IAM cluster but not for serverless', () => {
+        const provisioned = redshiftValues({
+            authenticationType: RedshiftAuthenticationType.IAM,
+            isServerless: false,
+        });
+        const serverless = redshiftValues({
+            authenticationType: RedshiftAuthenticationType.IAM,
+            isServerless: true,
+        });
+
+        expect(user('', provisioned)).toBe('User is required');
+        expect(user('', serverless)).toBeUndefined();
+    });
+
+    it('requires region and a cluster identifier for a provisioned IAM cluster', () => {
+        const values = redshiftValues({
+            authenticationType: RedshiftAuthenticationType.IAM,
+            isServerless: false,
+        });
+
+        expect(region('', values)).toBe('AWS region is required');
+        expect(clusterIdentifier('', values)).toBe(
+            'Cluster identifier is required',
+        );
+        expect(workgroupName('', values)).toBeUndefined();
+    });
+
+    it('requires region and a workgroup name for a serverless IAM connection', () => {
+        const values = redshiftValues({
+            authenticationType: RedshiftAuthenticationType.IAM,
+            isServerless: true,
+        });
+
+        expect(region('', values)).toBe('AWS region is required');
+        expect(workgroupName('', values)).toBe('Workgroup name is required');
+        expect(clusterIdentifier('', values)).toBeUndefined();
+    });
+
+    it('requires region but not a cluster identifier or workgroup name for IAM Identity Center', () => {
+        const values = redshiftValues({
+            authenticationType: RedshiftAuthenticationType.IAM_BROWSER,
+        });
+
+        expect(region('', values)).toBe('AWS region is required');
+        expect(clusterIdentifier('', values)).toBeUndefined();
+        expect(workgroupName('', values)).toBeUndefined();
+        expect(user('', values)).toBeUndefined();
+        expect(password('', values)).toBeUndefined();
+    });
 });

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/validators.ts
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/validators.ts
@@ -2,6 +2,7 @@ import {
     AthenaAuthenticationType,
     DatabricksAuthenticationType,
     DuckdbConnectionType,
+    RedshiftAuthenticationType,
     SnowflakeAuthenticationType,
     WarehouseTypes,
 } from '@lightdash/common';
@@ -143,6 +144,30 @@ const athenaAuthIs =
         values.warehouse.authenticationType !== undefined &&
         types.includes(values.warehouse.authenticationType);
 
+const redshiftAuthIs =
+    (...types: RedshiftAuthenticationType[]) =>
+    (values: ProjectConnectionForm) =>
+        values.warehouse.type === WarehouseTypes.REDSHIFT &&
+        values.warehouse.authenticationType !== undefined &&
+        types.includes(values.warehouse.authenticationType);
+
+const isRedshiftServerless = (values: ProjectConnectionForm) =>
+    values.warehouse.type === WarehouseTypes.REDSHIFT &&
+    (values.warehouse.isServerless ?? false);
+
+const redshiftUserIsRequired = (values: ProjectConnectionForm) =>
+    redshiftAuthIs(RedshiftAuthenticationType.PASSWORD)(values) ||
+    (redshiftAuthIs(RedshiftAuthenticationType.IAM)(values) &&
+        !isRedshiftServerless(values));
+
+const redshiftClusterIdentifierIsRequired = (values: ProjectConnectionForm) =>
+    redshiftAuthIs(RedshiftAuthenticationType.IAM)(values) &&
+    !isRedshiftServerless(values);
+
+const redshiftWorkgroupNameIsRequired = (values: ProjectConnectionForm) =>
+    redshiftAuthIs(RedshiftAuthenticationType.IAM)(values) &&
+    isRedshiftServerless(values);
+
 const isMotherduck = (values: ProjectConnectionForm) =>
     values.warehouse.type === WarehouseTypes.DUCKDB &&
     values.warehouse.connectionType === DuckdbConnectionType.MOTHERDUCK;
@@ -188,10 +213,28 @@ export const createWarehouseValueValidators: Record<
     [WarehouseTypes.REDSHIFT]: {
         schema: required('Schema', hasNoWhiteSpaces),
         host: required('Host', hasNoWhiteSpaces),
-        user: required('User', hasNoWhiteSpaces),
-        password: required('Password'),
+        user: requiredWhen('User', redshiftUserIsRequired, hasNoWhiteSpaces),
+        password: requiredWhen(
+            'Password',
+            redshiftAuthIs(RedshiftAuthenticationType.PASSWORD),
+        ),
         dbname: required('Database name', hasNoWhiteSpaces),
         sshTunnelPublicKey: sshTunnelPublicKeyValidator,
+        region: requiredWhen(
+            'AWS region',
+            redshiftAuthIs(
+                RedshiftAuthenticationType.IAM,
+                RedshiftAuthenticationType.IAM_BROWSER,
+            ),
+        ),
+        clusterIdentifier: requiredWhen(
+            'Cluster identifier',
+            redshiftClusterIdentifierIsRequired,
+        ),
+        workgroupName: requiredWhen(
+            'Workgroup name',
+            redshiftWorkgroupNameIsRequired,
+        ),
     },
     [WarehouseTypes.SNOWFLAKE]: {
         schema: required('Schema', hasNoWhiteSpaces),


### PR DESCRIPTION
## What breaks

An admin cannot pick AWS IAM authentication for a Redshift project. The Connection settings page has no Authentication type menu.

## Cause

A past change removed the Authentication type menu and the project-level AWS IAM fields from the Redshift connection form. The change added per-user browser AWS SSO login and removed the project menu by accident.

## Fix

This PR restores the Authentication type menu with three options:

- Username & password (existing fields)
- AWS IAM (region, serverless toggle, workgroup or cluster identifier, database user, assume-role ARN, and access keys under Advanced)
- AWS IAM Identity Center (the browser sign-in fields, plus a required AWS region field)

It also stops a form-open bug: the form used to reset a saved `iam` or `iam_browser` connection back to `password` every time an admin opened the settings page. The form now keeps the saved authentication type and only defaults to `password` when the field is unset.

This PR does not add a feature flag. The AWS IAM feature already shipped and is announced.

This PR also fixes two follow-on defects found in review:

- Creating a new Redshift project with AWS IAM or AWS IAM Identity Center used to fail submit with "Password is required". The user and password fields are now required only for username & password authentication. Region is required for both IAM modes. The cluster identifier or workgroup name is required to match the serverless toggle.
- The backend used to keep a project's authentication type when it removed the other Redshift credential fields for a per-user credential. A per-user credential with no authentication type of its own could end up merged with the project's `iam` mode and no real AWS identity. This now clears the authentication type with the other fields, matching the Snowflake behaviour, so a per-user credential is not merged onto the project's authentication mode.

It also rewords the assume-role ARN field description: the setting works for queries but is not yet supported for dbt compilation, so the field no longer says "Recommended".

## Screenshots

**Username & password**

![Password authentication](https://github.com/user-attachments/assets/93ad2773-0f65-498e-9023-9036cb7670ed)

**AWS IAM**

![AWS IAM authentication](https://github.com/user-attachments/assets/97a30992-6387-43a7-80ec-8a1cb9f4b5e5)

**AWS IAM Identity Center**

![AWS IAM Identity Center authentication](https://github.com/user-attachments/assets/c118d5b8-839f-4b9e-af52-286b39a035bd)

## Open questions for review

These two states are tracked in SPK-1968. This PR does not change their behaviour and adds no validation for them.

This form serves both the project connection and the per-user credential. Two states are not resolved in this PR and are left as-is on purpose:

1. A project set to `IAM` with "require users to provide their own credentials" on. Today the per-user value wins over the project value. Is that the intended behaviour?
2. A project set to `IAM_BROWSER` with "require users to provide their own credentials" off. This combination has no clear meaning today. Should the form reject it, or should it set the flag on automatically?

## Overlapping PR

Draft PR #26421 (SPK-597) fixes the same form-open reset bug with a one-line change and its own regression test file. This PR needs that fix too, so it is included here. The two PRs need to be reconciled before either merges. This PR's author leaves that decision to the project owner.

## Known limitation

`react-doctor` flags `RedshiftForm` as a large component (over 300 lines). Restoring the three-way menu unavoidably grows the file. Two field groups were pulled into their own local components to keep the diff manageable, matching the pattern the file already uses. The component still exceeds the line count guideline. A further split (for example, pulling out the SSH tunnel section) would grow the diff well past what this fix needs, so it is left as a follow-up rather than folded into this change.

Linear: SPK-1879

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PAGF1duvWNgqbjMGxSdZ7V


