### PR TITLE
fix(ai-agents): hide error bubbles for unanswered Slack context turns

### DIFF
--- a/packages/backend/src/ee/models/AiAgentModel.threadMessages.test.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.threadMessages.test.ts
@@ -1,0 +1,51 @@
+import { AiAgentModel } from './AiAgentModel';
+
+describe('AiAgentModel.hasAssistantMessage', () => {
+    const unanswered = {
+        row: {
+            response: null,
+            responded_at: null,
+            error_message: null,
+            interrupted: false,
+        },
+        isLatestPrompt: false,
+        toolCallCount: 0,
+        reasoningCount: 0,
+    };
+
+    it('drops unanswered past turns, e.g. Slack messages backfilled as context', () => {
+        expect(AiAgentModel.hasAssistantMessage(unanswered)).toBe(false);
+    });
+
+    it('keeps the latest prompt so it can still show pending or error', () => {
+        expect(
+            AiAgentModel.hasAssistantMessage({
+                ...unanswered,
+                isLatestPrompt: true,
+            }),
+        ).toBe(true);
+    });
+
+    it.each([
+        ['a response', { response: 'here you go' }],
+        ['a responded_at', { responded_at: new Date() }],
+        ['an error message', { error_message: 'boom' }],
+        ['an interrupt', { interrupted: true }],
+    ])('keeps past turns that have %s', (_label, overrides) => {
+        expect(
+            AiAgentModel.hasAssistantMessage({
+                ...unanswered,
+                row: { ...unanswered.row, ...overrides },
+            }),
+        ).toBe(true);
+    });
+
+    it.each([
+        ['tool calls', { toolCallCount: 1 }],
+        ['reasoning', { reasoningCount: 1 }],
+    ])('keeps past turns that have %s', (_label, overrides) => {
+        expect(
+            AiAgentModel.hasAssistantMessage({ ...unanswered, ...overrides }),
+        ).toBe(true);
+    });
+});

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -4390,6 +4390,7 @@ export class AiAgentModel {
         );
         const contextMap = await this.getContextForPromptUuids(promptUuids);
         const steersMap = await this.findPromptSteers(promptUuids);
+        const latestPromptUuid = promptUuids.at(-1);
 
         const messagesPromises = promptRows.map(async (row) => {
             const messages: AiAgentMessage<{
@@ -4430,6 +4431,17 @@ export class AiAgentModel {
             const referencedArtifacts = referencedArtifactsMap.get(
                 row.ai_prompt_uuid,
             );
+
+            if (
+                !AiAgentModel.hasAssistantMessage({
+                    row,
+                    isLatestPrompt: row.ai_prompt_uuid === latestPromptUuid,
+                    toolCallCount: toolCalls.length,
+                    reasoningCount: reasoning.length,
+                })
+            ) {
+                return messages;
+            }
 
             messages.push({
                 role: 'assistant',
@@ -4963,6 +4975,35 @@ export class AiAgentModel {
             chartConfig: row.chart_config!,
             artifactType: row.artifact_type,
         }));
+    }
+
+    /**
+     * Slack backfills messages posted before the agent was mentioned as prompts
+     * that never get answered. Once a later prompt exists the agent can no
+     * longer answer them, so they must not render an assistant message.
+     */
+    static hasAssistantMessage({
+        row,
+        isLatestPrompt,
+        toolCallCount,
+        reasoningCount,
+    }: {
+        row: Pick<DbAiPrompt, 'responded_at' | 'response' | 'error_message'> & {
+            interrupted: boolean;
+        };
+        isLatestPrompt: boolean;
+        toolCallCount: number;
+        reasoningCount: number;
+    }): boolean {
+        return (
+            isLatestPrompt ||
+            row.response != null ||
+            row.responded_at != null ||
+            row.error_message != null ||
+            row.interrupted ||
+            toolCallCount > 0 ||
+            reasoningCount > 0
+        );
     }
 
     static getThreadMessageStatus(


### PR DESCRIPTION
Closes:

### Description:

When an agent is mentioned in a Slack thread, the earlier messages in that thread are backfilled as prompts (`storeThreadContextMessages` → `bulkCreateSlackPrompts`) so the agent has conversation context. Those prompts never get a response, so on the web every one of them rendered an assistant bubble that `getThreadMessageStatus` marked `error` after the 5-minute pending timeout — a run of "Failed to generate response. Please try again." errors above the real conversation.

`findThreadMessages` now skips the assistant message for a prompt that has no response, no `responded_at`, no error, no interrupt, and no tool calls or reasoning — unless it is the thread's latest prompt, which must still be able to show pending/error. An unanswered turn followed by a later prompt can no longer be answered, so there is nothing to render. This also cleans up existing affected threads without a backfill.

### Risk assessment:

- [ ] This is a high-risk change

Read-only change to how thread messages are assembled for the API; no schema or write-path changes.
