### PR TITLE
feat(frontend): explain chart type library availability

### DIFF
--- a/packages/frontend/src/features/chartTypes/components/ChartTypeLibrarySection.test.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeLibrarySection.test.tsx
@@ -174,6 +174,27 @@ describe('ChartTypeLibrarySection', () => {
         ).not.toBeInTheDocument();
     });
 
+    it('explains how library chart types become available to the organization', () => {
+        setFlag(true);
+        setRegistryData([makeItem({})]);
+
+        renderWithProviders(
+            <ChartTypeLibrarySection
+                projectUuid={PROJECT_UUID}
+                withHeader={false}
+            />,
+        );
+
+        expect(
+            screen.getByText(
+                'These chart types are available to add to your instance. Once installed, they can be used by anyone building charts in your organization.',
+            ),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByText('Chart type library'),
+        ).not.toBeInTheDocument();
+    });
+
     it('renders cards with state badges for the happy path', () => {
         setFlag(true);
         setRegistryData([

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeLibrarySection.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeLibrarySection.tsx
@@ -59,6 +59,12 @@ const ChartTypeLibrarySection: FC<Props> = ({
                 </Group>
             )}
 
+            <Text fz="sm" c="dimmed">
+                These chart types are available to add to your instance. Once
+                installed, they can be used by anyone building charts in your
+                organization.
+            </Text>
+
             {registryQuery.isInitialLoading ? (
                 <EmptyStateLoader title="Loading chart type library…" />
             ) : isOffline ? (


### PR DESCRIPTION
## Summary

- Explain that Library chart types can be installed on an instance.
- Clarify that installed chart types are available to chart builders across the organization.
- Cover the headerless Library tab variant with a focused test.

## Testing

- pnpm -F frontend test src/features/chartTypes/components/ChartTypeLibrarySection.test.tsx
- pnpm -F frontend exec oxfmt --check src/features/chartTypes/components/ChartTypeLibrarySection.tsx src/features/chartTypes/components/ChartTypeLibrarySection.test.tsx
- pnpm -F frontend exec oxlint -c .oxlintrc.json src/features/chartTypes/components/ChartTypeLibrarySection.tsx src/features/chartTypes/components/ChartTypeLibrarySection.test.tsx

## Risk assessment

- [ ] This is a high-risk change