### PR TITLE
fix: log a failed compile as failed

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -3489,6 +3489,104 @@ describe('ProjectService', () => {
             expect(projectModel.tryAcquireProjectLock).not.toHaveBeenCalled();
         });
 
+        const failureLogUser: SessionUser = {
+            ...user,
+            ability: new Ability<PossibleAbilities>([
+                { subject: 'Job', action: ['create'] },
+                { subject: 'CompileProject', action: ['manage'] },
+                { subject: 'Project', action: ['update', 'view'] },
+            ]),
+        };
+
+        test('logs a compile that fails inside the compiling step as failed', async () => {
+            const compileJobUuid = 'compile-job-uuid';
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const { logger } = service as any;
+            const errorSpy = vi
+                .spyOn(logger, 'error')
+                .mockImplementation(() => undefined);
+            const infoSpy = vi
+                .spyOn(logger, 'info')
+                .mockImplementation(() => undefined);
+            (
+                jobModel.tryJobStep as import('vitest').Mock
+            ).mockRejectedValueOnce(
+                new ParameterError(
+                    'Cannot compile explores as this project was created via CLI and has no dbt connection configured',
+                ),
+            );
+
+            await service.compileProject(
+                failureLogUser,
+                projectUuid,
+                RequestMethod.WEB_APP,
+                compileJobUuid,
+            );
+
+            // the inner catch still marks the job, and no longer swallows the failure silently
+            expect(jobModel.update).toHaveBeenCalledWith(compileJobUuid, {
+                jobStatus: JobStatusType.ERROR,
+            });
+            expect(errorSpy).toHaveBeenCalledWith(
+                expect.stringContaining('dbt.compile.failed'),
+                expect.objectContaining({ event: 'dbt.compile.failed' }),
+            );
+            const endCall = infoSpy.mock.calls.find(([, meta]) =>
+                String((meta as { event?: string })?.event ?? '').startsWith(
+                    'dbt.compile.end',
+                ),
+            );
+            expect(endCall?.[1]).toEqual(
+                expect.objectContaining({ event: 'dbt.compile.end.failed' }),
+            );
+            expect(endCall?.[0]).toEqual(
+                expect.stringContaining('compileProject failed after'),
+            );
+
+            errorSpy.mockRestore();
+            infoSpy.mockRestore();
+        });
+
+        test('logs a compile blocked by lock contention as failed', async () => {
+            const compileJobUuid = 'compile-job-uuid';
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const { logger } = service as any;
+            const errorSpy = vi
+                .spyOn(logger, 'error')
+                .mockImplementation(() => undefined);
+            const infoSpy = vi
+                .spyOn(logger, 'info')
+                .mockImplementation(() => undefined);
+            (
+                projectModel.tryAcquireProjectLock as import('vitest').Mock
+            ).mockRejectedValueOnce(
+                new ParameterError('Compilation is already in progress'),
+            );
+
+            await service.compileProject(
+                failureLogUser,
+                projectUuid,
+                RequestMethod.WEB_APP,
+                compileJobUuid,
+            );
+
+            expect(errorSpy).toHaveBeenCalledWith(
+                expect.stringContaining('dbt.compile.failed'),
+                expect.objectContaining({ event: 'dbt.compile.failed' }),
+            );
+            const endCall = infoSpy.mock.calls.find(([, meta]) =>
+                String((meta as { event?: string })?.event ?? '').startsWith(
+                    'dbt.compile.end',
+                ),
+            );
+            expect(endCall?.[1]).toEqual(
+                expect.objectContaining({ event: 'dbt.compile.end.failed' }),
+            );
+
+            errorSpy.mockRestore();
+            infoSpy.mockRestore();
+        });
+
         test('syncs YAML tags during compilation without manage tag permissions', async () => {
             const compileJobUuid = 'compile-job-uuid';
             const previewProjectUuid = 'preview-project-uuid';

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -9003,6 +9003,43 @@ export class ProjectService extends BaseService {
             cacheExplores: { start: 0, end: 0 },
         };
 
+        let compileFailed = false;
+        // Called from both catches. The inner one marks the job ERROR and does not rethrow, so
+        // a failure inside the compiling step never reaches the outer catch, and that is the
+        // common case: a bad dbt connection, a dbt error, a warehouse error, a merge failure.
+        const recordCompileFailure = (e: unknown) => {
+            compileFailed = true;
+            if (!(e instanceof LightdashError)) {
+                Sentry.captureException(e);
+            }
+            // The default log format renders the message only and drops metadata, so the
+            // decisive numbers ride in the message too. Typed fields stay for json format.
+            this.logger.error(
+                `dbt.compile.failed projectUuid=${projectUuid} jobUuid=${
+                    job.jobUuid
+                } elapsedMs=${Math.round(
+                    performance.now() - totalStartTime,
+                )} error=${getErrorMessage(e)}`,
+                {
+                    event: 'dbt.compile.failed',
+                    projectUuid,
+                    jobUuid: job.jobUuid,
+                    organizationUuid,
+                    error: getErrorMessage(e),
+                    stack: e instanceof Error ? e.stack : undefined,
+                    elapsedMs: performance.now() - totalStartTime,
+                    sections: {
+                        yamlMs: timings.yaml.end - timings.yaml.start,
+                        parametersMs:
+                            timings.parameters.end - timings.parameters.start,
+                        cacheExploresMs:
+                            timings.cacheExplores.end -
+                            timings.cacheExplores.start,
+                    },
+                },
+            );
+        };
+
         const onLockAcquired = async () => {
             try {
                 await this.jobModel.update(job.jobUuid, {
@@ -9103,47 +9140,15 @@ export class ProjectService extends BaseService {
                     jobResults: compileResult,
                 });
             } catch (e) {
+                recordCompileFailure(e);
                 await this.jobModel.update(job.jobUuid, {
                     jobStatus: JobStatusType.ERROR,
                 });
             }
         };
-        let compileFailed = false;
         await this.projectModel
             .tryAcquireProjectLock(projectUuid, onLockAcquired, onLockFailed)
-            .catch((e) => {
-                compileFailed = true;
-                if (!(e instanceof LightdashError)) {
-                    Sentry.captureException(e);
-                }
-                // The default log format renders the message only and drops metadata, so the
-                // decisive numbers ride in the message too. Typed fields stay for json format.
-                this.logger.error(
-                    `dbt.compile.failed projectUuid=${projectUuid} jobUuid=${
-                        job.jobUuid
-                    } elapsedMs=${Math.round(
-                        performance.now() - totalStartTime,
-                    )} error=${getErrorMessage(e)}`,
-                    {
-                        event: 'dbt.compile.failed',
-                        projectUuid,
-                        jobUuid: job.jobUuid,
-                        organizationUuid,
-                        error: getErrorMessage(e),
-                        stack: e instanceof Error ? e.stack : undefined,
-                        elapsedMs: performance.now() - totalStartTime,
-                        sections: {
-                            yamlMs: timings.yaml.end - timings.yaml.start,
-                            parametersMs:
-                                timings.parameters.end -
-                                timings.parameters.start,
-                            cacheExploresMs:
-                                timings.cacheExplores.end -
-                                timings.cacheExplores.start,
-                        },
-                    },
-                );
-            });
+            .catch(recordCompileFailure);
         const totalTime = performance.now() - totalStartTime;
         const durationYaml = timings.yaml.end - timings.yaml.start;
         const durationParameters =


### PR DESCRIPTION
Linear: SPK-1881

**Base**: `main`. Fixes a defect introduced by SPK-1864 (#28557), found by the production
regression monitor on the first staging soak of 2.104.x, before any customer instance ran it.

## What breaks

A compile that fails inside the compiling step is logged as a success.

`ProjectService.compileProject` catches inside the `onLockAcquired` callback, marks the job row
ERROR, and does not rethrow. SPK-1864 added `compileFailed`, the `dbt.compile.failed` line and
the `end.ok` / `end.failed` branch, but attached them to the `.catch` on
`tryAcquireProjectLock`, which sits outside that catch. So the lock call resolves normally, the
flag stays false, and the end line says the compile completed.

The result is that `dbt.compile.failed` fires **only for lock contention**, because
`onLockFailed` rethrows. Every failure inside the compiling step reports as `end.ok` with a
plausible duration and section timings for phases that never ran. That is the common case: a bad
dbt connection, a dbt error, a warehouse error, a manifest merge failure.

## Before and after, from the staging soak

Before, the two lines 90 ms apart, project uuid redacted:

```
error: Cannot compile explores as this project was created via CLI and has no dbt connection configured
info:  compileProject completed in 262.95ms  { event: 'dbt.compile.end.ok', projectUuid: '<redacted>' }
```

No `dbt.compile.failed` line was written at all.

After, the same failure:

```
error: dbt.compile.failed projectUuid=<redacted> jobUuid=<redacted> elapsedMs=262 error=Cannot compile explores as this project was created via CLI and has no dbt connection configured
info:  compileProject failed after 262.95ms projectUuid=<redacted> jobUuid=<redacted>  { event: 'dbt.compile.end.failed' }
```

## What changed

`compileFailed` and a single `recordCompileFailure(e)` helper are declared **before**
`onLockAcquired`. The helper does exactly what the previous `.catch` did: set the flag, capture
to Sentry when the error is not a `LightdashError`, and write the `dbt.compile.failed` line with
the partial section timings.

It is called from both places a compile can fail: the inner catch, and the outer `.catch` on
`tryAcquireProjectLock`.

The inner catch still marks the job row ERROR and still does not rethrow, so job status and
graphile behaviour are unchanged. This changes what is logged, nothing else.

## Tests

Two cases in `ProjectService.test.ts`, both under `describe('compileProject')`:

- `logs a compile that fails inside the compiling step as failed` — `tryJobStep` rejects with
  the staging error. Asserts the job is still marked ERROR, that `dbt.compile.failed` is
  logged, and that the end line carries `dbt.compile.end.failed` and reads
  `compileProject failed after`, not `end.ok`.
- `logs a compile blocked by lock contention as failed` — `tryAcquireProjectLock` rejects.
  Asserts the contention path still logs both lines, so the fix does not trade one path for the
  other.

The first test fails against the previous code and passes with this change, which is the check
that it pins the reported defect rather than the implementation.

194 tests in the file pass. Typecheck, lint and format clean on the touched paths.
