### PR TITLE
chore(rainbow): allow egress to api.keygen.sh for the online licence check

### DIFF
--- a/rainbow.toml
+++ b/rainbow.toml
@@ -107,6 +107,15 @@ memory = "12gb"
 name = "app"
 watch = ["**"]                     # Vite HMR, tsx watch and the tsc watchers notice the write
 
+# Outbound access, exactly these flows and nothing else (the platform builds
+# the uplink and a default-deny policy around them). The backend validates its
+# licence key online at startup; with no offline certificate stored, Keygen
+# must be reachable from every environment, the parent's readiness gate
+# included.
+[[egress.allow]]
+host = "api.keygen.sh"
+port = 443
+
 # The browser learns its origin from one field of one response, so the ingress
 # corrects it in flight; nothing is re-execed on fork.
 [origin]


### PR DESCRIPTION
The backend validates `LIGHTDASH_LICENSE_KEY` online at startup when no offline certificate is set. Previews declare that one outbound flow (`[[egress.allow]] api.keygen.sh:443`) so the licence check works in every environment, the parent's readiness gate included; everything else stays default-deny.

🤖 Generated with [Claude Code](https://claude.com/claude-code)