### PR TITLE
feat(backend): keep the mobile session alive and stop notifications after sign-out

### DIFF
--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -2288,6 +2288,8 @@ export type AuthConfig = {
     oauthServer?: {
         accessTokenLifetime: number; // in seconds (default = 1 hour)
         refreshTokenLifetime: number; // in seconds (default = 2 weeks)
+        mobileRefreshTokenLifetime: number; // in seconds (default = 90 days)
+        refreshTokenRotationGrace: number; // in seconds (default = 1 minute)
     };
 };
 
@@ -3164,6 +3166,14 @@ export const parseConfig = (): LightdashConfig => {
                     getIntegerFromEnvironmentVariable(
                         'AUTH_OAUTH_SERVER_REFRESH_TOKEN_LIFETIME',
                     ) || 60 * 60 * 24 * 14, // 2 weeks
+                mobileRefreshTokenLifetime:
+                    getIntegerFromEnvironmentVariable(
+                        'AUTH_OAUTH_SERVER_MOBILE_REFRESH_TOKEN_LIFETIME',
+                    ) || 60 * 60 * 24 * 90, // 90 days
+                refreshTokenRotationGrace:
+                    getIntegerFromEnvironmentVariable(
+                        'AUTH_OAUTH_SERVER_REFRESH_TOKEN_ROTATION_GRACE',
+                    ) || 60, // 1 minute
             },
         },
         intercom: {

--- a/packages/backend/src/database/migrations/20260903120000_add_oauth2_refresh_token_revoked_at.ts
+++ b/packages/backend/src/database/migrations/20260903120000_add_oauth2_refresh_token_revoked_at.ts
@@ -1,0 +1,53 @@
+import type { Knex } from 'knex';
+
+export const classification = {
+    kind: 'safe',
+    reason: 'Adds a nullable revoked_at column and a concurrent lookup index to oauth2_refresh_tokens',
+} as const;
+
+export const config = { transaction: false };
+
+const tableName = 'oauth2_refresh_tokens';
+const userClientIndex = 'oauth2_refresh_tokens_user_id_client_id_idx';
+
+const dropInvalidIndex = async (knex: Knex): Promise<void> => {
+    const invalid = await knex.raw(
+        `SELECT 1 FROM pg_class c JOIN pg_index i ON i.indexrelid = c.oid WHERE c.relname = '${userClientIndex}' AND NOT i.indisvalid`,
+    );
+    if (invalid.rows.length > 0) {
+        await knex.raw(`DROP INDEX CONCURRENTLY IF EXISTS ${userClientIndex}`);
+    }
+};
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw('SET statement_timeout = 0');
+    try {
+        await knex.raw(`SET lock_timeout = '5s'`);
+        await knex.raw(
+            `ALTER TABLE ${tableName} ADD COLUMN IF NOT EXISTS revoked_at TIMESTAMP NULL`,
+        );
+        await knex.raw('RESET lock_timeout');
+
+        await dropInvalidIndex(knex);
+        await knex.raw(
+            `CREATE INDEX CONCURRENTLY IF NOT EXISTS ${userClientIndex} ON ${tableName} (user_id, client_id)`,
+        );
+    } finally {
+        await knex.raw('RESET statement_timeout');
+        await knex.raw('RESET lock_timeout');
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw('SET statement_timeout = 0');
+    try {
+        await knex.raw(`DROP INDEX CONCURRENTLY IF EXISTS ${userClientIndex}`);
+        await knex.raw(`SET lock_timeout = '5s'`);
+        await knex.raw(
+            `ALTER TABLE ${tableName} DROP COLUMN IF EXISTS revoked_at`,
+        );
+    } finally {
+        await knex.raw('RESET statement_timeout');
+        await knex.raw('RESET lock_timeout');
+    }
+}

--- a/packages/backend/src/database/migrations/__tests__/20260903120000_add_oauth2_refresh_token_revoked_at.test.ts
+++ b/packages/backend/src/database/migrations/__tests__/20260903120000_add_oauth2_refresh_token_revoked_at.test.ts
@@ -1,0 +1,80 @@
+import knex from 'knex';
+import { getTracker, MockClient, type Tracker } from 'knex-mock-client';
+import {
+    classification,
+    config,
+    down,
+    up,
+} from '../20260903120000_add_oauth2_refresh_token_revoked_at';
+
+describe('OAuth refresh token revoked_at migration', () => {
+    const database = knex({ client: MockClient, dialect: 'pg' });
+    let tracker: Tracker;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    afterEach(() => {
+        tracker.reset();
+    });
+
+    it('is safe for a rolling deployment and runs outside a transaction', () => {
+        expect(classification).toEqual({
+            kind: 'safe',
+            reason: 'Adds a nullable revoked_at column and a concurrent lookup index to oauth2_refresh_tokens',
+        });
+        expect(config).toEqual({ transaction: false });
+    });
+
+    it('adds the column and builds the index concurrently', async () => {
+        tracker.on.any(() => true).response({ rows: [] });
+
+        await up(database);
+
+        const migrationSql = tracker.history.all.map(({ sql }) => sql);
+        expect(migrationSql).toContain('SET statement_timeout = 0');
+        expect(migrationSql).toContain(`SET lock_timeout = '5s'`);
+        expect(migrationSql).toContain(
+            'ALTER TABLE oauth2_refresh_tokens ADD COLUMN IF NOT EXISTS revoked_at TIMESTAMP NULL',
+        );
+        expect(migrationSql).toContain(
+            'CREATE INDEX CONCURRENTLY IF NOT EXISTS oauth2_refresh_tokens_user_id_client_id_idx ON oauth2_refresh_tokens (user_id, client_id)',
+        );
+        expect(migrationSql).toContain('RESET statement_timeout');
+        expect(migrationSql).not.toContain(
+            'DROP INDEX CONCURRENTLY IF EXISTS oauth2_refresh_tokens_user_id_client_id_idx',
+        );
+    });
+
+    it('replaces an index a previous run left invalid', async () => {
+        tracker.on
+            .any((query) => query.sql.includes('indisvalid'))
+            .response({ rows: [{ '?column?': 1 }] });
+        tracker.on.any(() => true).response({ rows: [] });
+
+        await up(database);
+
+        const migrationSql = tracker.history.all.map(({ sql }) => sql);
+        expect(migrationSql).toContain(
+            'DROP INDEX CONCURRENTLY IF EXISTS oauth2_refresh_tokens_user_id_client_id_idx',
+        );
+        expect(migrationSql).toContain(
+            'CREATE INDEX CONCURRENTLY IF NOT EXISTS oauth2_refresh_tokens_user_id_client_id_idx ON oauth2_refresh_tokens (user_id, client_id)',
+        );
+    });
+
+    it('reverses the index and the column', async () => {
+        tracker.on.any(() => true).response({ rows: [] });
+
+        await down(database);
+
+        const migrationSql = tracker.history.all.map(({ sql }) => sql);
+        expect(migrationSql).toContain(
+            'DROP INDEX CONCURRENTLY IF EXISTS oauth2_refresh_tokens_user_id_client_id_idx',
+        );
+        expect(migrationSql).toContain(
+            'ALTER TABLE oauth2_refresh_tokens DROP COLUMN IF EXISTS revoked_at',
+        );
+    });
+});

--- a/packages/backend/src/ee/controllers/mobilePushNotificationController.test.ts
+++ b/packages/backend/src/ee/controllers/mobilePushNotificationController.test.ts
@@ -118,3 +118,77 @@ describe('MobilePushNotificationController.registerLiveActivityPushToStartToken'
         expect(JSON.stringify(response)).not.toContain('push-to-start-token');
     });
 });
+
+describe('MobilePushNotificationController.registerInstallation', () => {
+    const buildController = () => {
+        const registerInstallation = vi.fn<
+            MobilePushNotificationService['registerInstallation']
+        >(async () => undefined);
+        const services = {
+            getMobilePushNotificationService: () => ({
+                registerInstallation,
+            }),
+        } as unknown as ServiceRepository;
+        return {
+            registerInstallation,
+            controller: new MobilePushNotificationController(services),
+        };
+    };
+
+    const buildRequest = (authentication: Record<string, unknown>): Request =>
+        ({
+            account: {
+                user: {
+                    type: 'registered',
+                    id: 'user-uuid',
+                    userUuid: 'user-uuid',
+                },
+                organization: {
+                    organizationUuid: 'organization-uuid',
+                    name: 'Organization',
+                    createdAt: new Date('2026-08-31T12:00:00.000Z'),
+                },
+                authentication,
+            },
+        }) as unknown as Request;
+
+    const installationUuid = '10000000-0000-4000-8000-000000000003' as UUID;
+    const body = {
+        environment: 'sandbox' as const,
+        deviceToken: 'device-token',
+    };
+
+    it('records the OAuth client that registered the installation', async () => {
+        const { controller, registerInstallation } = buildController();
+
+        await controller.registerInstallation(
+            buildRequest({
+                type: 'oauth',
+                clientId: 'oauth-mobile',
+                token: 'oauth-token',
+                scopes: ['read'],
+                source: 'oauth-token',
+            }),
+            installationUuid,
+            body,
+        );
+
+        expect(registerInstallation).toHaveBeenCalledWith(
+            expect.objectContaining({ oauthClientId: 'oauth-mobile' }),
+        );
+    });
+
+    it('records no OAuth client for a session request', async () => {
+        const { controller, registerInstallation } = buildController();
+
+        await controller.registerInstallation(
+            buildRequest({ type: 'session', source: 'cookie' }),
+            installationUuid,
+            body,
+        );
+
+        expect(registerInstallation).toHaveBeenCalledWith(
+            expect.objectContaining({ oauthClientId: null }),
+        );
+    });
+});

--- a/packages/backend/src/ee/controllers/mobilePushNotificationController.ts
+++ b/packages/backend/src/ee/controllers/mobilePushNotificationController.ts
@@ -64,12 +64,17 @@ export class MobilePushNotificationController extends BaseController {
         @Body() body: ApiMobilePushInstallationRequest,
     ): Promise<ApiMobilePushInstallationResponse> {
         assertRegisteredAccount(req.account);
+        const { authentication } = req.account;
         await this.getMobilePushNotificationService().registerInstallation({
             user: toSessionUser(req.account),
             installationUuid,
             platform: body.platform ?? 'ios',
             environment: body.environment,
             deviceToken: body.deviceToken,
+            oauthClientId:
+                authentication.type === 'oauth'
+                    ? authentication.clientId
+                    : null,
         });
         this.setStatus(200);
         return { status: 'ok', results: undefined };

--- a/packages/backend/src/ee/database/entities/mobilePushNotifications.ts
+++ b/packages/backend/src/ee/database/entities/mobilePushNotifications.ts
@@ -29,6 +29,7 @@ export type DbMobilePushInstallation = {
     device_token_fingerprint: string;
     encrypted_push_to_start_token: Buffer | null;
     push_to_start_token_fingerprint: string | null;
+    oauth_client_id: string | null;
     created_at: Date;
     updated_at: Date;
 };
@@ -40,6 +41,7 @@ export type MobilePushInstallationTable = Knex.CompositeTableType<
         | 'mobile_push_installation_uuid'
         | 'encrypted_push_to_start_token'
         | 'push_to_start_token_fingerprint'
+        | 'oauth_client_id'
         | 'created_at'
         | 'updated_at'
     > &
@@ -48,6 +50,7 @@ export type MobilePushInstallationTable = Knex.CompositeTableType<
                 DbMobilePushInstallation,
                 | 'encrypted_push_to_start_token'
                 | 'push_to_start_token_fingerprint'
+                | 'oauth_client_id'
             >
         >,
     Partial<

--- a/packages/backend/src/ee/database/migrations/20260903121000_add_oauth_client_id_to_mobile_push_installations.ts
+++ b/packages/backend/src/ee/database/migrations/20260903121000_add_oauth_client_id_to_mobile_push_installations.ts
@@ -1,0 +1,33 @@
+import type { Knex } from 'knex';
+
+export const classification = {
+    kind: 'safe',
+    reason: 'Adds a nullable oauth_client_id column that existing installations leave empty',
+} as const;
+
+const installationsTable = 'mobile_push_installations';
+const oauthClientForeign = 'mobile_push_installations_oauth_client_id_foreign';
+const oauthClientIndex = 'mobile_push_installations_oauth_client_id_idx';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '5s'`);
+
+    await knex.schema.alterTable(installationsTable, (table) => {
+        table
+            .text('oauth_client_id')
+            .nullable()
+            .references('client_id')
+            .inTable('oauth2_clients')
+            .onDelete('CASCADE')
+            .withKeyName(oauthClientForeign)
+            .index(oauthClientIndex);
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '5s'`);
+
+    await knex.schema.alterTable(installationsTable, (table) => {
+        table.dropColumn('oauth_client_id');
+    });
+}

--- a/packages/backend/src/ee/database/migrations/__tests__/20260903121000_add_oauth_client_id_to_mobile_push_installations.test.ts
+++ b/packages/backend/src/ee/database/migrations/__tests__/20260903121000_add_oauth_client_id_to_mobile_push_installations.test.ts
@@ -1,0 +1,57 @@
+import knex from 'knex';
+import { getTracker, MockClient, type Tracker } from 'knex-mock-client';
+import {
+    classification,
+    down,
+    up,
+} from '../20260903121000_add_oauth_client_id_to_mobile_push_installations';
+
+describe('Mobile push installation oauth client migration', () => {
+    const database = knex({ client: MockClient, dialect: 'pg' });
+    let tracker: Tracker;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    afterEach(() => {
+        tracker.reset();
+    });
+
+    it('is safe for a rolling deployment', () => {
+        expect(classification).toEqual({
+            kind: 'safe',
+            reason: 'Adds a nullable oauth_client_id column that existing installations leave empty',
+        });
+    });
+
+    it('links an installation to its OAuth client and indexes the column', async () => {
+        tracker.on.any(() => true).response({});
+
+        await up(database);
+
+        const migrationSql = tracker.history.all
+            .map(({ sql }) => sql)
+            .join('\n');
+        expect(migrationSql).toContain(`SET LOCAL lock_timeout = '5s'`);
+        expect(migrationSql).toContain('add column "oauth_client_id" text');
+        expect(migrationSql).not.toContain('"oauth_client_id" text not null');
+        expect(migrationSql).toContain(
+            'foreign key ("oauth_client_id") references "oauth2_clients" ("client_id") on delete CASCADE',
+        );
+        expect(migrationSql).toContain(
+            'create index "mobile_push_installations_oauth_client_id_idx" on "mobile_push_installations" ("oauth_client_id")',
+        );
+    });
+
+    it('reverses the column', async () => {
+        tracker.on.any(() => true).response({});
+
+        await down(database);
+
+        const migrationSql = tracker.history.all
+            .map(({ sql }) => sql)
+            .join('\n');
+        expect(migrationSql).toContain('drop column "oauth_client_id"');
+    });
+});

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -20,6 +20,7 @@ import { DeployService } from '../services/DeployService';
 import { InstanceConfigurationService } from '../services/InstanceConfigurationService/InstanceConfigurationService';
 import { JiraAppService } from '../services/JiraAppService/JiraAppService';
 import { LinearAppService } from '../services/LinearAppService/LinearAppService';
+import { OAuthService } from '../services/OAuthService/OAuthService';
 import { OrganizationService } from '../services/OrganizationService/OrganizationService';
 import { ProjectService } from '../services/ProjectService/ProjectService';
 import { QuerySourceRegistry } from '../services/QuerySourceService/QuerySourceRegistry';
@@ -199,6 +200,19 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     apnsClient,
                 });
             },
+            oauthService: ({ models, context }) =>
+                new OAuthService({
+                    userModel: models.getUserModel(),
+                    oauthModel: models.getOauthModel(),
+                    lightdashConfig: context.lightdashConfig,
+                    onGrantRevoked: ({ userId, clientId }) =>
+                        models
+                            .getMobilePushNotificationModel<MobilePushNotificationModel>()
+                            .deleteInstallationsWithoutLiveGrant({
+                                userId,
+                                clientId,
+                            }),
+                }),
             linearAppService: ({ models, context }) => {
                 const aiAgentReviewNotificationModel =
                     models.getAiAgentReviewNotificationModel<AiAgentReviewNotificationModel>();

--- a/packages/backend/src/ee/models/MobilePushNotificationModel.test.ts
+++ b/packages/backend/src/ee/models/MobilePushNotificationModel.test.ts
@@ -56,6 +56,7 @@ describe('MobilePushNotificationModel', () => {
             platform: 'ios',
             environment: 'sandbox',
             deviceToken: 'device-token',
+            oauthClientId: null,
         });
 
         const insert = tracker.history.insert.find((query) =>
@@ -114,6 +115,7 @@ describe('MobilePushNotificationModel', () => {
             platform: 'ios',
             environment: 'production',
             deviceToken: 'new-device-token',
+            oauthClientId: 'oauth-mobile',
         });
 
         const statements = tracker.history.all.map(({ sql }) => sql);
@@ -154,6 +156,7 @@ describe('MobilePushNotificationModel', () => {
                 platform: 'ios',
                 environment: 'sandbox',
                 deviceToken: 'guessed-device-token',
+                oauthClientId: null,
             }),
         ).resolves.toEqual({ status: 'owner_mismatch' });
 
@@ -198,6 +201,7 @@ describe('MobilePushNotificationModel', () => {
                 platform: 'ios',
                 environment: 'sandbox',
                 deviceToken: 'owner-device-token',
+                oauthClientId: null,
             }),
         ).resolves.toEqual({
             status: 'stored',
@@ -254,6 +258,7 @@ describe('MobilePushNotificationModel', () => {
             platform: 'ios',
             environment: 'sandbox',
             deviceToken: 'rotated-token',
+            oauthClientId: null,
         });
 
         expect(result.status).toBe('stored');
@@ -299,6 +304,7 @@ describe('MobilePushNotificationModel', () => {
             platform: 'ios',
             environment: 'production',
             deviceToken: 'new-device-token',
+            oauthClientId: 'oauth-mobile',
         });
 
         expect(
@@ -343,6 +349,7 @@ describe('MobilePushNotificationModel', () => {
             platform: 'android',
             environment: 'production',
             deviceToken: 'shared-device-token',
+            oauthClientId: null,
         });
 
         const cleanup = tracker.history.delete.find((query) =>
@@ -719,5 +726,88 @@ describe('MobilePushNotificationModel', () => {
             'select "live_activity_uuid" as "liveActivityUuid", "organization_uuid" as "organizationUuid", "project_uuid" as "projectUuid", "user_uuid" as "userUuid" from "ai_agent_live_activities" where "thread_uuid" = $1 and "ended_at" is null',
         );
         expect(tracker.history.select[0].bindings).toEqual(['thread-uuid']);
+    });
+});
+
+describe('MobilePushNotificationModel grant checks', () => {
+    it('treats an installation without an oauth client as always granted', async () => {
+        tracker.on.select(MobilePushInstallationsTableName).responseOnce({
+            oauth_client_id: null,
+            user_uuid: 'user-uuid',
+        });
+
+        const result =
+            await model.installationHasLiveGrant('installation-uuid');
+
+        expect(result).toBe(true);
+        expect(tracker.history.select).toHaveLength(1);
+    });
+
+    it('accepts an installation whose client still holds a live refresh token', async () => {
+        tracker.on.select(MobilePushInstallationsTableName).responseOnce({
+            oauth_client_id: 'oauth-mobile',
+            user_uuid: 'user-uuid',
+        });
+        tracker.on
+            .select('oauth2_refresh_tokens')
+            .responseOnce({ refresh_token: 'refresh-token' });
+
+        const result =
+            await model.installationHasLiveGrant('installation-uuid');
+
+        expect(result).toBe(true);
+        const grantQuery = tracker.history.select[1];
+        expect(grantQuery.sql).toContain('"revoked_at" is null');
+        expect(grantQuery.sql).toContain('"expires_at" > CURRENT_TIMESTAMP');
+        expect(grantQuery.bindings.slice(0, 2)).toEqual([
+            'user-uuid',
+            'oauth-mobile',
+        ]);
+    });
+
+    it('rejects an installation whose client has no live refresh token', async () => {
+        tracker.on.select(MobilePushInstallationsTableName).responseOnce({
+            oauth_client_id: 'oauth-mobile',
+            user_uuid: 'user-uuid',
+        });
+        tracker.on.select('oauth2_refresh_tokens').responseOnce(undefined);
+
+        const result =
+            await model.installationHasLiveGrant('installation-uuid');
+
+        expect(result).toBe(false);
+    });
+
+    it('rejects an installation that no longer exists', async () => {
+        tracker.on
+            .select(MobilePushInstallationsTableName)
+            .responseOnce(undefined);
+
+        const result =
+            await model.installationHasLiveGrant('installation-uuid');
+
+        expect(result).toBe(false);
+        expect(tracker.history.select).toHaveLength(1);
+    });
+
+    it('deletes installations of a client the user no longer holds a grant for', async () => {
+        tracker.on.delete(MobilePushInstallationsTableName).responseOnce(1);
+
+        await model.deleteInstallationsWithoutLiveGrant({
+            userId: 42,
+            clientId: 'oauth-mobile',
+        });
+
+        expect(tracker.history.delete).toHaveLength(1);
+        const deleteQuery = tracker.history.delete[0];
+        expect(deleteQuery.sql).toContain('not exists');
+        expect(deleteQuery.sql).toContain('"oauth2_refresh_tokens"');
+        expect(deleteQuery.sql).toContain('"revoked_at" is null');
+        expect(deleteQuery.bindings).toEqual([
+            'oauth-mobile',
+            42,
+            42,
+            'oauth-mobile',
+        ]);
     });
 });

--- a/packages/backend/src/ee/models/MobilePushNotificationModel.ts
+++ b/packages/backend/src/ee/models/MobilePushNotificationModel.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'crypto';
 import { Knex } from 'knex';
+import { UserTableName } from '../../database/entities/users';
 import { type EncryptionUtil } from '../../utils/EncryptionUtil/EncryptionUtil';
 import { AiPromptTableName, AiThreadTableName } from '../database/entities/ai';
 import {
@@ -76,6 +77,8 @@ export type SchedulableLiveActivityStartAttempt = {
     userUuid: string;
 };
 
+const OAuth2RefreshTokensTableName = 'oauth2_refresh_tokens';
+
 const tokenFingerprint = (token: string): string =>
     createHash('sha256').update(token).digest('hex');
 
@@ -107,6 +110,65 @@ export class MobilePushNotificationModel {
             .first();
     }
 
+    async installationHasLiveGrant(installationUuid: string): Promise<boolean> {
+        const installation = await this.database<DbMobilePushInstallation>(
+            MobilePushInstallationsTableName,
+        )
+            .select('oauth_client_id', 'user_uuid')
+            .where('installation_uuid', installationUuid)
+            .first();
+
+        if (installation === undefined) return false;
+        if (installation.oauth_client_id === null) return true;
+
+        const grant = await this.database(OAuth2RefreshTokensTableName)
+            .join(
+                UserTableName,
+                `${OAuth2RefreshTokensTableName}.user_id`,
+                `${UserTableName}.user_id`,
+            )
+            .where(`${UserTableName}.user_uuid`, installation.user_uuid)
+            .where(
+                `${OAuth2RefreshTokensTableName}.client_id`,
+                installation.oauth_client_id,
+            )
+            .whereNull(`${OAuth2RefreshTokensTableName}.revoked_at`)
+            .where(
+                `${OAuth2RefreshTokensTableName}.expires_at`,
+                '>',
+                this.database.fn.now(),
+            )
+            .first();
+
+        return grant !== undefined;
+    }
+
+    async deleteInstallationsWithoutLiveGrant(args: {
+        userId: number;
+        clientId: string;
+    }): Promise<void> {
+        await this.database<DbMobilePushInstallation>(
+            MobilePushInstallationsTableName,
+        )
+            .where('oauth_client_id', args.clientId)
+            .whereIn(
+                'user_uuid',
+                this.database(UserTableName)
+                    .select('user_uuid')
+                    .where('user_id', args.userId),
+            )
+            .whereNotExists((query) => {
+                void query
+                    .select(this.database.raw('1'))
+                    .from(OAuth2RefreshTokensTableName)
+                    .where('user_id', args.userId)
+                    .where('client_id', args.clientId)
+                    .whereNull('revoked_at')
+                    .where('expires_at', '>', this.database.fn.now());
+            })
+            .delete();
+    }
+
     async upsertInstallation(args: {
         installationUuid: string;
         organizationUuid: string;
@@ -114,6 +176,7 @@ export class MobilePushNotificationModel {
         platform: MobilePushPlatform;
         environment: MobilePushEnvironment;
         deviceToken: string;
+        oauthClientId: string | null;
     }): Promise<UpsertInstallationResult> {
         const fingerprint = tokenFingerprint(args.deviceToken);
         const encryptedDeviceToken = this.encryptionUtil.encrypt(
@@ -201,6 +264,7 @@ export class MobilePushNotificationModel {
                     environment: args.environment,
                     encrypted_device_token: encryptedDeviceToken,
                     device_token_fingerprint: fingerprint,
+                    oauth_client_id: args.oauthClientId,
                 })
                 .onConflict('installation_uuid')
                 .merge({
@@ -210,6 +274,7 @@ export class MobilePushNotificationModel {
                     environment: args.environment,
                     encrypted_device_token: encryptedDeviceToken,
                     device_token_fingerprint: fingerprint,
+                    oauth_client_id: args.oauthClientId,
                     ...(ownershipChanged || environmentChanged
                         ? {
                               encrypted_push_to_start_token: null,

--- a/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationReconciler.test.ts
+++ b/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationReconciler.test.ts
@@ -50,6 +50,7 @@ const workingSignals = (): AiAgentThreadLiveStateSignals => ({
 const createDependencies = () => {
     const notificationStore = {
         findLiveActivity: vi.fn(async () => activity),
+        installationHasLiveGrant: vi.fn(async () => true),
         markLiveActivityDelivered: vi.fn(async () => undefined),
         markCompletionAlertCompleted: vi.fn(async () => undefined),
         deleteLiveActivity: vi.fn(async () => undefined),
@@ -642,5 +643,68 @@ describe('MobilePushNotificationReconciler platform routing', () => {
         expect(
             dependencies.notificationStore.markLiveActivityDelivered,
         ).not.toHaveBeenCalled();
+    });
+});
+
+describe('MobilePushNotificationReconciler grant checks', () => {
+    it('delivers to an installation whose OAuth grant is live', async () => {
+        const dependencies = createDependencies();
+        const reconciler = new MobilePushNotificationReconciler(dependencies);
+
+        await reconciler.reconcileLiveActivity(activity.liveActivityUuid);
+
+        expect(
+            dependencies.notificationStore.installationHasLiveGrant,
+        ).toHaveBeenCalledWith(activity.installationUuid);
+        expect(dependencies.apnsClient.sendLiveActivity).toHaveBeenCalled();
+        expect(
+            dependencies.notificationStore.deleteInstallation,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('removes the installation and sends nothing once the grant is gone', async () => {
+        const dependencies = createDependencies();
+        dependencies.notificationStore.installationHasLiveGrant.mockResolvedValue(
+            false,
+        );
+        const reconciler = new MobilePushNotificationReconciler(dependencies);
+
+        await reconciler.reconcileLiveActivity(activity.liveActivityUuid);
+
+        expect(
+            dependencies.notificationStore.deleteInstallation,
+        ).toHaveBeenCalledWith({
+            installationUuid: activity.installationUuid,
+            organizationUuid: activity.organizationUuid,
+            userUuid: activity.userUuid,
+        });
+        expect(dependencies.apnsClient.sendLiveActivity).not.toHaveBeenCalled();
+        expect(dependencies.apnsClient.sendAlert).not.toHaveBeenCalled();
+        expect(
+            dependencies.fcmClient.sendAgentRunUpdate,
+        ).not.toHaveBeenCalled();
+        expect(dependencies.fcmClient.sendAgentRunAlert).not.toHaveBeenCalled();
+    });
+
+    it('sends no completion alert for an ended activity without a grant', async () => {
+        const dependencies = createDependencies();
+        dependencies.notificationStore.findLiveActivity.mockResolvedValue({
+            ...activity,
+            endedAt: new Date('2026-08-30T12:00:30.000Z'),
+        });
+        dependencies.notificationStore.installationHasLiveGrant.mockResolvedValue(
+            false,
+        );
+        const reconciler = new MobilePushNotificationReconciler({
+            ...dependencies,
+            completionAlert: { title: 'Done', body: 'Your agent finished' },
+        });
+
+        await reconciler.reconcileLiveActivity(activity.liveActivityUuid);
+
+        expect(dependencies.apnsClient.sendAlert).not.toHaveBeenCalled();
+        expect(
+            dependencies.notificationStore.deleteInstallation,
+        ).toHaveBeenCalled();
     });
 });

--- a/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationReconciler.ts
+++ b/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationReconciler.ts
@@ -50,6 +50,7 @@ export type MobilePushReconciliationStore = {
     findLiveActivity(
         liveActivityUuid: string,
     ): Promise<ReconciliationActivity | undefined>;
+    installationHasLiveGrant(installationUuid: string): Promise<boolean>;
     markLiveActivityDelivered(args: {
         liveActivityUuid: string;
         state: 'working' | 'waiting_for_you' | 'idle';
@@ -270,6 +271,26 @@ export class MobilePushNotificationReconciler {
         const activity =
             await this.notificationStore.findLiveActivity(liveActivityUuid);
         if (activity === undefined) return;
+
+        if (
+            !(await this.notificationStore.installationHasLiveGrant(
+                activity.installationUuid,
+            ))
+        ) {
+            await this.notificationStore.deleteInstallation({
+                installationUuid: activity.installationUuid,
+                organizationUuid: activity.organizationUuid,
+                userUuid: activity.userUuid,
+            });
+            Logger.info(
+                'Removed a mobile push installation without a live grant',
+                {
+                    installationUuid: activity.installationUuid,
+                    userUuid: activity.userUuid,
+                },
+            );
+            return;
+        }
 
         const ownership = await this.threadStore.findThreadOwnership({
             organizationUuid: activity.organizationUuid,

--- a/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationService.test.ts
+++ b/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationService.test.ts
@@ -84,6 +84,9 @@ const createDependencies = () => {
         findLiveActivityOwner: vi.fn<
             MobilePushNotificationStore['findLiveActivityOwner']
         >(async () => undefined),
+        installationHasLiveGrant: vi.fn<
+            MobilePushNotificationStore['installationHasLiveGrant']
+        >(async () => true),
         upsertInstallation: vi.fn<
             MobilePushNotificationStore['upsertInstallation']
         >(async () => ({ status: 'stored', installation })),
@@ -1199,6 +1202,7 @@ describe('MobilePushNotificationService installation lifecycle', () => {
             platform: 'ios',
             environment: 'sandbox',
             deviceToken: validDeviceToken,
+            oauthClientId: null,
         });
 
         expect(
@@ -1210,6 +1214,7 @@ describe('MobilePushNotificationService installation lifecycle', () => {
             platform: 'ios',
             environment: 'sandbox',
             deviceToken: validDeviceToken,
+            oauthClientId: null,
         });
         expect(dependencies.analytics.track).toHaveBeenCalledWith({
             event: 'mobile_push.installation_registered',
@@ -1240,6 +1245,7 @@ describe('MobilePushNotificationService installation lifecycle', () => {
                 platform: 'ios',
                 environment: 'sandbox',
                 deviceToken: validDeviceToken,
+                oauthClientId: null,
             }),
         ).rejects.toBeInstanceOf(NotFoundError);
         expect(dependencies.analytics.track).not.toHaveBeenCalled();
@@ -1256,6 +1262,7 @@ describe('MobilePushNotificationService installation lifecycle', () => {
                 platform: 'android',
                 environment: 'production',
                 deviceToken: 'fcm-registration:token_value',
+                oauthClientId: null,
             }),
         ).rejects.toBeInstanceOf(NotFoundError);
         expect(
@@ -1278,6 +1285,7 @@ describe('MobilePushNotificationService installation lifecycle', () => {
             platform: 'android',
             environment: 'production',
             deviceToken: 'fcm-registration:token_value',
+            oauthClientId: null,
         });
 
         expect(
@@ -1289,6 +1297,7 @@ describe('MobilePushNotificationService installation lifecycle', () => {
             platform: 'android',
             environment: 'production',
             deviceToken: 'fcm-registration:token_value',
+            oauthClientId: null,
         });
     });
 
@@ -1336,6 +1345,7 @@ describe('MobilePushNotificationService installation lifecycle', () => {
                     platform: 'ios',
                     environment: 'sandbox',
                     deviceToken,
+                    oauthClientId: null,
                 }),
             ).rejects.toBeInstanceOf(ParameterError);
             expect(
@@ -1355,6 +1365,7 @@ describe('MobilePushNotificationService installation lifecycle', () => {
             platform: 'ios',
             environment: 'sandbox',
             deviceToken: 'device-token',
+            oauthClientId: null,
         });
 
         expect(
@@ -1404,5 +1415,77 @@ describe('MobilePushNotificationService installation lifecycle', () => {
             threadUuid,
             liveActivityUuid,
         });
+    });
+});
+
+describe('MobilePushNotificationService mobile grant lifecycle', () => {
+    it('stores the OAuth client that registered the installation', async () => {
+        const dependencies = createDependencies();
+        const service = new MobilePushNotificationService(dependencies);
+
+        await service.registerInstallation({
+            user: { userUuid, organizationUuid },
+            installationUuid,
+            platform: 'ios',
+            environment: 'sandbox',
+            deviceToken: validDeviceToken,
+            oauthClientId: 'oauth-mobile',
+        });
+
+        expect(
+            dependencies.mobilePushNotificationStore.upsertInstallation,
+        ).toHaveBeenCalledWith(
+            expect.objectContaining({ oauthClientId: 'oauth-mobile' }),
+        );
+    });
+
+    it('sends a Live Activity start while the grant is live', async () => {
+        const dependencies = createDependencies();
+        dependencies.mobilePushNotificationStore.claimLiveActivityStartAttempt.mockResolvedValue(
+            claimedStartAttempt,
+        );
+        const service = new MobilePushNotificationService(dependencies);
+
+        await service.deliverLiveActivityStart(liveActivityStartAttemptUuid);
+
+        expect(
+            dependencies.mobilePushNotificationStore.installationHasLiveGrant,
+        ).toHaveBeenCalledWith(installationUuid);
+        expect(
+            dependencies.apnsClient.sendLiveActivityStart,
+        ).toHaveBeenCalled();
+        expect(
+            dependencies.mobilePushNotificationStore.deleteInstallation,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('removes the installation and sends nothing once the grant is gone', async () => {
+        const dependencies = createDependencies();
+        dependencies.mobilePushNotificationStore.claimLiveActivityStartAttempt.mockResolvedValue(
+            claimedStartAttempt,
+        );
+        dependencies.mobilePushNotificationStore.installationHasLiveGrant.mockResolvedValue(
+            false,
+        );
+        const service = new MobilePushNotificationService(dependencies);
+
+        await service.deliverLiveActivityStart(liveActivityStartAttemptUuid);
+
+        expect(
+            dependencies.mobilePushNotificationStore.deleteInstallation,
+        ).toHaveBeenCalledWith({
+            installationUuid,
+            organizationUuid,
+            userUuid,
+        });
+        expect(
+            dependencies.apnsClient.sendLiveActivityStart,
+        ).not.toHaveBeenCalled();
+        expect(
+            JSON.stringify(
+                dependencies.mobilePushNotificationStore.deleteInstallation.mock
+                    .calls,
+            ),
+        ).not.toContain('push-to-start-token');
     });
 });

--- a/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationService.ts
+++ b/packages/backend/src/ee/services/MobilePushNotificationService/MobilePushNotificationService.ts
@@ -89,6 +89,7 @@ export type MobilePushNotificationStore = {
     findLiveActivityOwner(
         liveActivityUuid: string,
     ): Promise<LiveActivityOwner | undefined>;
+    installationHasLiveGrant(installationUuid: string): Promise<boolean>;
     upsertInstallation(args: {
         installationUuid: string;
         organizationUuid: string;
@@ -96,6 +97,7 @@ export type MobilePushNotificationStore = {
         platform: MobilePushPlatform;
         environment: MobilePushEnvironment;
         deviceToken: string;
+        oauthClientId: string | null;
     }): Promise<UpsertInstallationResult>;
     registerPushToStartToken(args: {
         installationUuid: string;
@@ -415,6 +417,7 @@ export class MobilePushNotificationService {
         platform: MobilePushPlatform;
         environment: MobilePushEnvironment;
         deviceToken: string;
+        oauthClientId: string | null;
     }): Promise<void> {
         if (!this.config.enabled) return;
         validateDeviceToken(args.platform, args.deviceToken);
@@ -434,6 +437,7 @@ export class MobilePushNotificationService {
                 platform: args.platform,
                 environment: args.environment,
                 deviceToken: args.deviceToken,
+                oauthClientId: args.oauthClientId,
             });
         if (result.status === 'owner_mismatch') {
             throw new NotFoundError('Mobile push registration not found');
@@ -649,6 +653,26 @@ export class MobilePushNotificationService {
                 },
             );
         if (attempt === undefined) return;
+
+        if (
+            !(await this.mobilePushNotificationStore.installationHasLiveGrant(
+                attempt.installationUuid,
+            ))
+        ) {
+            await this.mobilePushNotificationStore.deleteInstallation({
+                installationUuid: attempt.installationUuid,
+                organizationUuid: attempt.organizationUuid,
+                userUuid: attempt.userUuid,
+            });
+            Logger.info(
+                'Removed a mobile push installation without a live grant',
+                {
+                    installationUuid: attempt.installationUuid,
+                    userUuid: attempt.userUuid,
+                },
+            );
+            return;
+        }
 
         const prompt = await this.threadStore.findWebAppPrompt(
             attempt.promptUuid,

--- a/packages/backend/src/models/ModelRepository.ts
+++ b/packages/backend/src/models/ModelRepository.ts
@@ -526,7 +526,7 @@ export class ModelRepository
     public getOauthModel(): OAuth2Model {
         return this.getModel(
             'oauthModel',
-            () => new OAuth2Model(this.database),
+            () => new OAuth2Model(this.database, this.lightdashConfig),
         );
     }
 

--- a/packages/backend/src/models/OAuth2Model.test.ts
+++ b/packages/backend/src/models/OAuth2Model.test.ts
@@ -1,8 +1,25 @@
 import { AnyType } from '@lightdash/common';
-import { OAuth2Model } from './OAuth2Model';
+import knex, { type Knex } from 'knex';
+import { getTracker, MockClient, type Tracker } from 'knex-mock-client';
+import { type LightdashConfig } from '../config/parseConfig';
+import { isMobileOAuthClient, OAuth2Model } from './OAuth2Model';
+
+const lightdashConfig = {
+    auth: {
+        oauthServer: {
+            accessTokenLifetime: 60 * 60,
+            refreshTokenLifetime: 60 * 60 * 24 * 14,
+            mobileRefreshTokenLifetime: 60 * 60 * 24 * 90,
+            refreshTokenRotationGrace: 60,
+        },
+    },
+} as LightdashConfig;
+
+const mobileRedirectUri = 'com.lightdash.mobile://oauth/callback';
+const cliRedirectUri = 'http://localhost:*/callback';
 
 describe('OAuth2Model.validateRedirectUri', () => {
-    const model = new OAuth2Model({} as AnyType);
+    const model = new OAuth2Model({} as AnyType, lightdashConfig);
     const client = {
         redirectUris: [
             'http://localhost:8100/callback',
@@ -57,5 +74,209 @@ describe('OAuth2Model.validateRedirectUri', () => {
             client as AnyType,
         );
         expect(result).toBe(false);
+    });
+});
+
+describe('isMobileOAuthClient', () => {
+    it.each([
+        [[mobileRedirectUri], true],
+        [['COM.LIGHTDASH.MOBILE://oauth/callback'], true],
+        [[cliRedirectUri, mobileRedirectUri], true],
+        [[cliRedirectUri], false],
+        [['https://com.lightdash.mobile/callback'], false],
+        [[], false],
+    ] as [string[], boolean][])(
+        'reads %j as mobile=%s',
+        (redirectUris, expected) => {
+            expect(isMobileOAuthClient(redirectUris)).toBe(expected);
+        },
+    );
+
+    it('reads an absent redirect uri list as not mobile', () => {
+        expect(isMobileOAuthClient(null)).toBe(false);
+        expect(isMobileOAuthClient(undefined)).toBe(false);
+    });
+});
+
+describe('OAuth2Model refresh token rotation', () => {
+    const database = knex({ client: MockClient, dialect: 'pg' });
+    const model = new OAuth2Model(database as unknown as Knex, lightdashConfig);
+    let tracker: Tracker;
+
+    const refreshTokenRow = (overrides: Record<string, unknown> = {}) => ({
+        refresh_token: 'refresh-token',
+        expires_at: new Date('2026-12-01T00:00:00.000Z'),
+        revoked_at: null,
+        scope: ['read'],
+        client_id: 'oauth-mobile',
+        redirect_uris: [mobileRedirectUri],
+        grants: ['authorization_code', 'refresh_token'],
+        user_id: 42,
+        organization_uuid: 'organization-uuid',
+        ...overrides,
+    });
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    afterEach(() => {
+        tracker.reset();
+    });
+
+    it('marks a rotated refresh token revoked instead of deleting it', async () => {
+        tracker.on.update('oauth2_refresh_tokens').responseOnce(1);
+
+        const revoked = await model.revokeToken({
+            refreshToken: 'refresh-token',
+        } as AnyType);
+
+        expect(revoked).toBe(true);
+        expect(tracker.history.delete).toHaveLength(0);
+        expect(tracker.history.update[0].sql).toContain(
+            'coalesce(revoked_at, now())',
+        );
+    });
+
+    it('keeps the first revocation timestamp when a client retries', async () => {
+        tracker.on.update('oauth2_refresh_tokens').response(1);
+
+        await model.revokeToken({ refreshToken: 'refresh-token' } as AnyType);
+        await model.revokeToken({ refreshToken: 'refresh-token' } as AnyType);
+
+        expect(tracker.history.update).toHaveLength(2);
+        tracker.history.update.forEach((query) => {
+            expect(query.sql).toContain('coalesce(revoked_at, now())');
+        });
+    });
+
+    it('accepts a refresh token revoked inside the grace window', async () => {
+        tracker.on.select('oauth2_refresh_tokens').responseOnce(
+            refreshTokenRow({
+                revoked_at: new Date(Date.now() - 10 * 1000),
+            }),
+        );
+
+        const token = await model.getRefreshToken('refresh-token');
+
+        expect(token).not.toBe(false);
+        expect(token && token.refreshToken).toBe('refresh-token');
+    });
+
+    it('rejects a refresh token revoked before the grace window', async () => {
+        tracker.on.select('oauth2_refresh_tokens').responseOnce(
+            refreshTokenRow({
+                revoked_at: new Date(Date.now() - 10 * 60 * 1000),
+            }),
+        );
+
+        const token = await model.getRefreshToken('refresh-token');
+
+        expect(token).toBe(false);
+    });
+
+    it('deletes a refresh token outright when a user revokes it', async () => {
+        tracker.on.delete('oauth2_refresh_tokens').responseOnce(1);
+
+        const deleted = await model.deleteRefreshToken('refresh-token');
+
+        expect(deleted).toBe(true);
+        expect(tracker.history.update).toHaveLength(0);
+        expect(tracker.history.delete[0].bindings).toContain('refresh-token');
+    });
+
+    it('deletes an access token outright when a user revokes it', async () => {
+        tracker.on.delete('oauth2_access_tokens').responseOnce(1);
+
+        const deleted = await model.deleteAccessToken('access-token');
+
+        expect(deleted).toBe(true);
+        expect(tracker.history.delete[0].bindings).toContain('access-token');
+    });
+
+    it('removes expired and long revoked tokens of the same user on save', async () => {
+        tracker.on.insert('oauth2_access_tokens').responseOnce([]);
+        tracker.on.insert('oauth2_refresh_tokens').responseOnce([]);
+        tracker.on.delete('oauth2_refresh_tokens').responseOnce(2);
+
+        await model.saveToken(
+            {
+                accessToken: 'access-token',
+                accessTokenExpiresAt: new Date('2026-12-01T00:00:00.000Z'),
+                refreshToken: 'new-refresh-token',
+                refreshTokenExpiresAt: new Date('2027-01-01T00:00:00.000Z'),
+                scope: ['read'],
+            } as AnyType,
+            { id: 'oauth-mobile' } as AnyType,
+            {
+                userId: 42,
+                organizationUuid: 'organization-uuid',
+            } as AnyType,
+        );
+
+        expect(tracker.history.delete).toHaveLength(1);
+        const housekeeping = tracker.history.delete[0];
+        expect(housekeeping.sql).toContain('"user_id" = $1');
+        expect(housekeeping.sql).toContain('"expires_at" < CURRENT_TIMESTAMP');
+        expect(housekeeping.sql).toContain("now() - interval '1 day'");
+        expect(housekeeping.bindings).toContain(42);
+    });
+});
+
+describe('OAuth2Model mobile refresh token lifetime', () => {
+    const database = knex({ client: MockClient, dialect: 'pg' });
+    const model = new OAuth2Model(database as unknown as Knex, lightdashConfig);
+    let tracker: Tracker;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    afterEach(() => {
+        tracker.reset();
+    });
+
+    it('gives a mobile client the long refresh token lifetime', async () => {
+        tracker.on.select('oauth2_clients').responseOnce({
+            client_id: 'oauth-mobile',
+            redirect_uris: [mobileRedirectUri],
+            grants: ['authorization_code', 'refresh_token'],
+        });
+
+        const client = await model.getClient('oauth-mobile');
+
+        expect(client && client.refreshTokenLifetime).toBe(60 * 60 * 24 * 90);
+    });
+
+    it('leaves a non-mobile client on the server default', async () => {
+        tracker.on.select('oauth2_clients').responseOnce({
+            client_id: 'lightdash-cli',
+            redirect_uris: [cliRedirectUri],
+            grants: ['authorization_code', 'refresh_token'],
+        });
+
+        const client = await model.getClient('lightdash-cli');
+
+        expect(client && client.refreshTokenLifetime).toBeUndefined();
+    });
+
+    it('reports the mobile lifetime on the refresh token client', async () => {
+        tracker.on.select('oauth2_refresh_tokens').responseOnce({
+            refresh_token: 'refresh-token',
+            expires_at: new Date('2026-12-01T00:00:00.000Z'),
+            revoked_at: null,
+            scope: ['read'],
+            client_id: 'oauth-mobile',
+            redirect_uris: [mobileRedirectUri],
+            grants: ['authorization_code', 'refresh_token'],
+            user_id: 42,
+            organization_uuid: 'organization-uuid',
+        });
+
+        const token = await model.getRefreshToken('refresh-token');
+
+        expect(token && token.client.refreshTokenLifetime).toBe(
+            60 * 60 * 24 * 90,
+        );
     });
 });

--- a/packages/backend/src/models/OAuth2Model.ts
+++ b/packages/backend/src/models/OAuth2Model.ts
@@ -14,11 +14,42 @@ import type {
 import { Knex } from 'knex';
 import { nanoid } from 'nanoid';
 import { Scope } from 'oauth2-server';
+import { LightdashConfig } from '../config/parseConfig';
 
 export const DEFAULT_OAUTH_CLIENT_ID = 'lightdash-cli';
 
+export const MOBILE_OAUTH_REDIRECT_SCHEME = 'com.lightdash.mobile';
+
+export const isMobileOAuthClient = (
+    redirectUris: string[] | string | null | undefined,
+): boolean => {
+    if (redirectUris === null || redirectUris === undefined) return false;
+    const uris = Array.isArray(redirectUris) ? redirectUris : [redirectUris];
+    return uris.some((uri) =>
+        uri.toLowerCase().startsWith(`${MOBILE_OAUTH_REDIRECT_SCHEME}:`),
+    );
+};
+
 export class OAuth2Model implements AuthorizationCodeModel {
-    constructor(private database: Knex) {}
+    constructor(
+        private database: Knex,
+        private lightdashConfig: LightdashConfig,
+    ) {}
+
+    private getRefreshTokenLifetime(
+        redirectUris: string[] | string | null | undefined,
+    ): number | undefined {
+        if (!isMobileOAuthClient(redirectUris)) return undefined;
+        return this.lightdashConfig.auth.oauthServer
+            ?.mobileRefreshTokenLifetime;
+    }
+
+    private getRotationGraceMs(): number {
+        return (
+            (this.lightdashConfig.auth.oauthServer?.refreshTokenRotationGrace ??
+                0) * 1000
+        );
+    }
 
     async getClient(
         clientId: string,
@@ -43,6 +74,9 @@ export class OAuth2Model implements AuthorizationCodeModel {
             id: client.client_id,
             redirectUris: client.redirect_uris,
             grants: client.grants,
+            refreshTokenLifetime: this.getRefreshTokenLifetime(
+                client.redirect_uris,
+            ),
         };
     }
 
@@ -177,6 +211,19 @@ export class OAuth2Model implements AuthorizationCodeModel {
                 user_id: user.userId,
                 organization_uuid: user.organizationUuid,
             });
+
+            await this.database('oauth2_refresh_tokens')
+                .where('user_id', user.userId)
+                .where((query) =>
+                    query
+                        .where('expires_at', '<', this.database.fn.now())
+                        .orWhere(
+                            'revoked_at',
+                            '<',
+                            this.database.raw("now() - interval '1 day'"),
+                        ),
+                )
+                .del();
         }
 
         return { ...token, client, user };
@@ -231,6 +278,24 @@ export class OAuth2Model implements AuthorizationCodeModel {
 
         const result = await this.database('oauth2_refresh_tokens')
             .where('refresh_token', token.refreshToken)
+            .update({
+                revoked_at: this.database.raw('coalesce(revoked_at, now())'),
+            });
+
+        return result > 0;
+    }
+
+    async deleteRefreshToken(refreshToken: string): Promise<boolean> {
+        const result = await this.database('oauth2_refresh_tokens')
+            .where('refresh_token', refreshToken)
+            .del();
+
+        return result > 0;
+    }
+
+    async deleteAccessToken(accessToken: string): Promise<boolean> {
+        const result = await this.database('oauth2_access_tokens')
+            .where('access_token', accessToken)
             .del();
 
         return result > 0;
@@ -259,6 +324,15 @@ export class OAuth2Model implements AuthorizationCodeModel {
             return false;
         }
 
+        if (
+            result.revoked_at !== null &&
+            result.revoked_at !== undefined &&
+            Date.now() - new Date(result.revoked_at).getTime() >
+                this.getRotationGraceMs()
+        ) {
+            return false;
+        }
+
         return {
             accessToken: '',
             refreshToken: result.refresh_token,
@@ -268,6 +342,9 @@ export class OAuth2Model implements AuthorizationCodeModel {
                 id: result.client_id,
                 redirectUris: result.redirect_uris,
                 grants: result.grants,
+                refreshTokenLifetime: this.getRefreshTokenLifetime(
+                    result.redirect_uris,
+                ),
             },
             user: {
                 userId: result.user_id,

--- a/packages/backend/src/services/OAuthService/OAuthService.test.ts
+++ b/packages/backend/src/services/OAuthService/OAuthService.test.ts
@@ -28,8 +28,11 @@ describe('OAuthService edge cases', () => {
         mockOAuthModel = {
             getAccessToken: vi.fn(),
             getClient: vi.fn(),
+            getRefreshToken: vi.fn(),
             revokeToken: vi.fn(),
             revokeRefreshToken: vi.fn(),
+            deleteRefreshToken: vi.fn(),
+            deleteAccessToken: vi.fn(),
             validateRedirectUri: vi.fn(),
         } as AnyType;
         mockLightdashConfig = {
@@ -157,6 +160,88 @@ describe('OAuthService edge cases', () => {
             expect(mockOAuthModel.validateRedirectUri).toHaveBeenCalledWith(
                 'https://example.com/callback',
                 client,
+            );
+        });
+    });
+
+    describe('revokeToken', () => {
+        const refreshToken = {
+            refreshToken: 'refresh-token',
+            refreshTokenExpiresAt: new Date('2026-12-01T00:00:00.000Z'),
+            client: { id: 'oauth-mobile', grants: ['refresh_token'] },
+            user: { userId: 42, organizationUuid: 'organization-uuid' },
+        } as AnyType;
+
+        it('deletes a refresh token outright and never softly revokes it', async () => {
+            vi.mocked(mockOAuthModel.getRefreshToken).mockResolvedValue(
+                refreshToken,
+            );
+            vi.mocked(mockOAuthModel.deleteRefreshToken).mockResolvedValue(
+                true,
+            );
+
+            await expect(
+                oauthService.revokeToken('refresh-token'),
+            ).resolves.toBe(true);
+            expect(mockOAuthModel.deleteRefreshToken).toHaveBeenCalledWith(
+                'refresh-token',
+            );
+            expect(mockOAuthModel.revokeToken).not.toHaveBeenCalled();
+        });
+
+        it('tells the listener which grant the user revoked', async () => {
+            const onGrantRevoked = vi.fn(async () => undefined);
+            const service = new TestOAuthService({
+                userModel: mockUserModel,
+                oauthModel: mockOAuthModel,
+                lightdashConfig: mockLightdashConfig,
+                onGrantRevoked,
+            });
+            vi.mocked(mockOAuthModel.getRefreshToken).mockResolvedValue(
+                refreshToken,
+            );
+            vi.mocked(mockOAuthModel.deleteRefreshToken).mockResolvedValue(
+                true,
+            );
+
+            await service.revokeToken('refresh-token');
+
+            expect(onGrantRevoked).toHaveBeenCalledWith({
+                userId: 42,
+                clientId: 'oauth-mobile',
+            });
+        });
+
+        it('leaves the listener alone when no row was deleted', async () => {
+            const onGrantRevoked = vi.fn(async () => undefined);
+            const service = new TestOAuthService({
+                userModel: mockUserModel,
+                oauthModel: mockOAuthModel,
+                lightdashConfig: mockLightdashConfig,
+                onGrantRevoked,
+            });
+            vi.mocked(mockOAuthModel.getRefreshToken).mockResolvedValue(
+                refreshToken,
+            );
+            vi.mocked(mockOAuthModel.deleteRefreshToken).mockResolvedValue(
+                false,
+            );
+
+            await expect(service.revokeToken('refresh-token')).resolves.toBe(
+                false,
+            );
+            expect(onGrantRevoked).not.toHaveBeenCalled();
+        });
+
+        it('deletes an access token when the value is not a refresh token', async () => {
+            vi.mocked(mockOAuthModel.getRefreshToken).mockResolvedValue(false);
+            vi.mocked(mockOAuthModel.deleteAccessToken).mockResolvedValue(true);
+
+            await expect(
+                oauthService.revokeToken('access-token'),
+            ).resolves.toBe(true);
+            expect(mockOAuthModel.deleteAccessToken).toHaveBeenCalledWith(
+                'access-token',
             );
         });
     });

--- a/packages/backend/src/services/OAuthService/OAuthService.ts
+++ b/packages/backend/src/services/OAuthService/OAuthService.ts
@@ -22,10 +22,16 @@ export enum OAuthScope {
     MCP_WRITE = 'mcp:write',
 }
 
+export type OAuthGrantRevokedHandler = (args: {
+    userId: number;
+    clientId: string;
+}) => Promise<void>;
+
 type OAuthServiceArguments = {
     userModel: UserModel;
     oauthModel: OAuth2Model;
     lightdashConfig: LightdashConfig;
+    onGrantRevoked?: OAuthGrantRevokedHandler;
 };
 
 export class OAuthService extends BaseService {
@@ -37,15 +43,19 @@ export class OAuthService extends BaseService {
 
     private lightdashConfig: LightdashConfig;
 
+    private onGrantRevoked: OAuthGrantRevokedHandler | undefined;
+
     constructor({
         userModel,
         oauthModel,
         lightdashConfig,
+        onGrantRevoked,
     }: OAuthServiceArguments) {
         super();
         this.userModel = userModel;
         this.oauthModel = oauthModel;
         this.lightdashConfig = lightdashConfig;
+        this.onGrantRevoked = onGrantRevoked;
         this.initializeOAuthServer();
     }
 
@@ -107,10 +117,19 @@ export class OAuthService extends BaseService {
     }
 
     public async revokeToken(token: string): Promise<boolean> {
-        // Try to revoke as access token first
         const refreshToken = await this.oauthModel.getRefreshToken(token);
-        if (refreshToken) return this.oauthModel.revokeToken(refreshToken);
-        return false;
+        if (refreshToken) {
+            const deleted = await this.oauthModel.deleteRefreshToken(token);
+            const { userId } = refreshToken.user as UserWithOrganizationUuid;
+            if (deleted && this.onGrantRevoked !== undefined) {
+                await this.onGrantRevoked({
+                    userId,
+                    clientId: refreshToken.client.id,
+                });
+            }
+            return deleted;
+        }
+        return this.oauthModel.deleteAccessToken(token);
     }
 
     public async getClientDisplayName(clientId: string): Promise<string> {


### PR DESCRIPTION
## What breaks today

Someone signs in on the phone, uses the app for a week, opens it on the train and is signed out. Two things cause this.

The first is refresh token rotation. Every refresh deletes the old token and issues a new one. When the app is backgrounded or the connection drops, the new token never arrives. The app retries with the token it still has, the server says the grant is invalid, and the user has to sign in again. The second is the refresh token lifetime. Fourteen days is short for a phone that a person opens now and then.

The other half is the opposite problem. When the grant does go, the app can no longer call the endpoint that removes its push registration, because that endpoint needs a valid token. The registration stays in the database forever, and the phone keeps getting agent notifications for an account it is signed out of.

## Changes

### 1. A grace period for a rotated refresh token

- `packages/backend/src/database/migrations/20260903120000_add_oauth2_refresh_token_revoked_at.ts` adds a nullable `revoked_at` to `oauth2_refresh_tokens` and an index on `(user_id, client_id)`.
- `packages/backend/src/models/OAuth2Model.ts` — `revokeToken`, the rotation hook the OAuth library calls, now sets `revoked_at = coalesce(revoked_at, now())` instead of deleting the row. `getRefreshToken` returns the token while `revoked_at` is inside the grace period and refuses it after. A retry that arrives inside the window therefore succeeds and the user stays signed in.
- `saveToken` deletes that user's expired tokens and tokens revoked more than a day ago, so the table does not grow. This is bounded per user and needs no scheduled job.

### 2. A longer refresh token lifetime for the mobile apps

- `packages/backend/src/models/OAuth2Model.ts` sets `refreshTokenLifetime` on the client that `getClient` and `getRefreshToken` return. `@node-oauth/oauth2-server` 5.3.0 prefers a per-client value: `token-handler.js:253` reads `client.refreshTokenLifetime || this.refreshTokenLifetime`, and `abstract-grant-type.js:91` turns it into the expiry date.
- A mobile client is a client with a redirect URI in the `com.lightdash.mobile` scheme. The check is the exported `isMobileOAuthClient` helper.
- The access token lifetime does not change.

### 3. A push needs a live grant

- `packages/backend/src/ee/database/migrations/20260903121000_add_oauth_client_id_to_mobile_push_installations.ts` adds a nullable `oauth_client_id` to `mobile_push_installations`, referencing `oauth2_clients` with `ON DELETE CASCADE`, indexed.
- `packages/backend/src/ee/controllers/mobilePushNotificationController.ts` passes the client id when the request is OAuth authenticated, and `null` otherwise. `packages/backend/src/ee/models/MobilePushNotificationModel.ts` stores it on every upsert.
- `installationHasLiveGrant` reports `true` for an installation with no client id, and otherwise only when that user still holds a refresh token for that client that is neither revoked nor expired. A row inside the rotation grace counts as dead — the replacement row is what keeps the grant alive.
- The check runs before every APNs and FCM send. `MobilePushNotificationService.deliverLiveActivityStart` covers the Live Activity start push. `MobilePushNotificationReconciler.reconcileLiveActivity` covers the Live Activity update and the completion alert, because both sends sit behind that one entry point. Without a live grant the installation is deleted, the send is skipped, and a line is logged with the installation and user uuids only, never a token. Deleting the installation cascades to its live activities and start attempts, so it reuses the existing delete rather than repeating it.
- On an explicit revoke, `OAuthService` calls an optional `onGrantRevoked` handler. `packages/backend/src/ee/index.ts` supplies it, so sign-out removes the installations immediately instead of waiting for the next push. The delivery-time check is what guarantees the behaviour; this only makes it instant.

`/api/v1/oauth/revoke` also now deletes the row for an access token. It only handled refresh tokens before.

### Why an optional handler for the core to EE hook

`OAuthService` is core and the push model is EE, so core cannot import it. The repo already solves this the same way: `packages/backend/src/ee/index.ts` re-provides a core service with an extra callback, exactly as `organizationService` does with `onOrganizationCreated`. There is no event bus to reuse, and adding one for a single call would be heavier than the callback. Without a licence the handler is absent and the code path is inert, which is correct — there are no push installations to remove.

## New environment variables

| Variable | Default |
|---|---|
| `AUTH_OAUTH_SERVER_MOBILE_REFRESH_TOKEN_LIFETIME` | 90 days |
| `AUTH_OAUTH_SERVER_REFRESH_TOKEN_ROTATION_GRACE` | 60 seconds |

The existing `AUTH_OAUTH_SERVER_ACCESS_TOKEN_LIFETIME` and `AUTH_OAUTH_SERVER_REFRESH_TOKEN_LIFETIME` are not documented anywhere in the repository, so there was no place to document these two beside them. They are listed here instead.

## Verification

| Command | Result |
|---|---|
| `pnpm -F backend typecheck` | passes |
| `pnpm -F backend test` | 577 files, 9444 passed, 1 skipped |
| `pnpm --filter backend run linter <touched paths>` | passes |
| `pnpm -F common build` | passes (needed to typecheck a fresh checkout; no source change in `common`) |

New tests cover the soft revoke and the grace window in both directions, the hard delete on an explicit revoke, the mobile lifetime on `getClient` and `getRefreshToken`, the housekeeping delete, the live and dead grant paths in the service and the reconciler, the client id the controller records for an OAuth and a session request, and both migrations.

Neither migration is breaking. Both add a nullable column. The core one builds its index with `CREATE INDEX CONCURRENTLY` outside a transaction, and replaces an index that an interrupted run left invalid.

Linear: SPK-1885

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HRtoooifta1wy8vSEzXXh1


---

## End-to-end proof (iOS client against this branch)

A local EE instance on this branch served the real iOS app (lightdash/lightdash-ios#251) on a
simulator, signed in as the seeded demo user through the app's own OAuth2 browser flow. Refresh
token values below are shown as their first 12 characters. Times are UTC on 2026-09-03.

### The mobile lifetime reaches a real client

The app registers itself, and its redirect URI carries the mobile scheme:

```
      client_id       |  client_name  |              redirect_uris              |            grants
----------------------+---------------+-----------------------------------------+------------------------------
 lightdash-cli        | Lightdash CLI | {http://localhost:*/callback}           | {authorization_code,refresh_token,client_credentials}
 mcp-uin-cthWoLRLFBfK | Lightdash iOS | {com.lightdash.mobile://oauth/callback} | {authorization_code,refresh_token}
```

Its refresh token was issued for 90 days, with `AUTH_OAUTH_SERVER_REFRESH_TOKEN_LIFETIME` unset so
the generic default stayed at 14 days:

```
 token_prefix |      client_id       |         created_at         |       expires_at        | revoked_at |        remaining
--------------+----------------------+----------------------------+-------------------------+------------+-------------------------
 ldref_       | mcp-uin-cthWoLRLFBfK | 2026-09-03 17:53:11.923213 | 2026-12-02 17:53:11.926 |            | 89 days 23:59:41.718762
```

Setting `AUTH_OAUTH_SERVER_MOBILE_REFRESH_TOKEN_LIFETIME=120` and nothing else moved this same
client to `00:01:59.99`, so the mobile setting is what drives the value:

```
    prefix    |      client_id       |         created_at         |       expires_at        |    lifetime
--------------+----------------------+----------------------------+-------------------------+-----------------
 ldref_Rpb_4C | mcp-uin-cthWoLRLFBfK | 2026-09-03 18:13:14.006665 | 2026-09-03 18:15:13.997 | 00:01:59.990335
```

### The rotation grace holds for 60 seconds, then closes

`AUTH_OAUTH_SERVER_REFRESH_TOKEN_ROTATION_GRACE` was left unset, so this measured the shipped
default. Three `POST /api/v1/oauth/token` calls with `grant_type=refresh_token` and the **same**
token:

```
### Call 1 - rotate the token   18:10:03Z
HTTP 200
{"access_token":"ldapp_uGXnp-...","token_type":"Bearer","expires_in":3599,"refresh_token":"ldref_2jYHbI...","scope":"read write"}

### Call 2 - reuse the OLD token, +1 s   18:10:04Z
HTTP 200
{"access_token":"ldapp_Yxy-1D...","token_type":"Bearer","expires_in":3599,"refresh_token":"ldref_ps3lBQ...","scope":"read write"}

### Call 3 - reuse the OLD token, +77 s   18:11:20Z
HTTP 401
{"error":"Invalid grant: refresh token is invalid"}
```

`revoked_at` stayed at the first revocation across the second use, so a reuse inside the grace does
not extend it:

```
    prefix    |         created_at         |        revoked_at         |  since_revoked
--------------+----------------------------+---------------------------+-----------------
 ldref_S7QI89 | 2026-09-03 18:09:49.729316 | 2026-09-03 18:10:03.52814 | 00:01:17.199281
 ldref_2jYHbI | 2026-09-03 18:10:03.542959 |                           |
 ldref_ps3lBQ | 2026-09-03 18:10:04.588504 |                           |
```

### Sign out deletes the grant and the installation

The simulator produces no APNs device token, so one `mobile_push_installations` row was inserted by
hand for the demo user against the app's client id, with dummy token bytes and fingerprint. The
access token lifetime was raised to an hour first, so no rotation could land between the two reads.

Before, after a fresh sign-in at 18:08:02:

```
    prefix    |      client_id       |         created_at         |       expires_at       | revoked_at
--------------+----------------------+----------------------------+------------------------+------------
 ldref_Nry0jN | mcp-uin-cthWoLRLFBfK | 2026-09-03 18:08:02.025314 | 2026-12-02 18:08:02.01 |

          installation_uuid           |   oauth_client_id
--------------------------------------+----------------------
 99362523-639f-4d0e-bc25-55e014509b52 | mcp-uin-cthWoLRLFBfK
```

Then Profile - Sign out in the app. After, 39 seconds later:

```
 prefix | client_id | created_at | expires_at | revoked_at
--------+-----------+------------+------------+------------
(0 rows)

 installation_uuid | user_uuid | oauth_client_id
-------------------+-----------+-----------------
(0 rows)

2026-09-03 18:08:48 http: POST /api/v1/oauth/revoke 200 - 21 ms
```

The row is deleted, not stamped, and `onGrantRevoked` took the installation with it.

### An expired grant is refused, and the installation reads as dead

With the two minute lifetime above, the app was left in the background until both tokens expired,
then brought forward:

```
2026-09-03 18:18:02 error: Token endpoint error: invalid_grant: Invalid grant: refresh token has expired
2026-09-03 18:18:02 http:  POST /api/v1/oauth/token 401 - 102 ms
```

An expired grant is neither revoked nor deleted, so the installation row survives - which is the
case the delivery-time check exists for. `installationHasLiveGrant`, run by hand as the model
writes it:

```sql
select i.installation_uuid, i.oauth_client_id,
       exists(select 1 from oauth2_refresh_tokens rt
                join users u on u.user_id = rt.user_id
               where u.user_uuid = i.user_uuid
                 and rt.client_id = i.oauth_client_id
                 and rt.revoked_at is null
                 and rt.expires_at > now()) as has_live_grant
  from mobile_push_installations i;

          installation_uuid           |   oauth_client_id    | has_live_grant
--------------------------------------+----------------------+----------------
 36ffed37-673b-44df-9b9a-5b7cfd9085ee | mcp-uin-cthWoLRLFBfK | f
```

**Not proven end to end:** the delivery-time deletion itself, in
`MobilePushNotificationService` and `MobilePushNotificationReconciler`. It needs a live AI agent
thread with a live-activity start attempt, which needs the full EE AI profile this instance does
not carry. It stays covered by unit tests. What is proven here is the predicate both call sites
branch on.
