### PR TITLE
feat(explorer): graduate custom bin write-back

### DIFF
--- a/packages/backend/src/controllers/gitIntegrationController.ts
+++ b/packages/backend/src/controllers/gitIntegrationController.ts
@@ -1,11 +1,13 @@
 import {
     AdditionalMetric,
+    ApiCustomDimensionWriteBackPreview,
     ApiErrorPayload,
     ApiGitFileContent,
     assertRegisteredAccount,
     CustomDimension,
     ForbiddenError,
     PullRequestCreated,
+    UUID,
 } from '@lightdash/common';
 import {
     Body,
@@ -78,6 +80,42 @@ export class GitIntegrationController extends BaseController {
                         type: 'customMetrics',
                         fields: body.customMetrics,
                     },
+                ),
+        };
+    }
+
+    /**
+     * Preview custom dimensions using the project's dbt model and warehouse dialect
+     * @summary Preview custom dimension YAML
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Post('/pull-requests/custom-dimensions/preview')
+    @OperationId('PreviewPullRequestForCustomDimensions')
+    async PreviewPullRequestForCustomDimensions(
+        @Path() projectUuid: UUID,
+        @Body()
+        body: {
+            customDimensions: CustomDimension[];
+            quoteChar?: `"` | `'`;
+        },
+        @Request() req: express.Request,
+    ): Promise<ApiCustomDimensionWriteBackPreview> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getGitIntegrationService()
+                .previewCustomDimensions(
+                    req.account,
+                    projectUuid,
+                    body.customDimensions,
+                    body.quoteChar || '"',
                 ),
         };
     }

--- a/packages/backend/src/services/GitIntegrationService/GitIntegrationService.test.ts
+++ b/packages/backend/src/services/GitIntegrationService/GitIntegrationService.test.ts
@@ -1,9 +1,13 @@
 import {
+    BinType,
+    CustomDimensionType,
     DbtProjectType,
+    GroupValueMatchType,
     NotFoundError,
     SupportedDbtVersions,
 } from '@lightdash/common';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
+import { fromSession } from '../../auth/account';
 import {
     createBranch,
     createPullRequest,
@@ -161,6 +165,82 @@ describe('GitIntegrationService', () => {
         });
     });
 
+    describe('previewCustomDimensions', () => {
+        it('uses the model SQL and project warehouse dialect without placeholders', async () => {
+            vi.mocked(getFileContent).mockResolvedValueOnce({
+                content: `version: 2
+models:
+  - name: table_a
+    columns:
+      - name: dim_a
+        meta:
+          dimension:
+            sql: \${TABLE}.dim_a * 2`,
+                sha: 'sha',
+            });
+
+            const result = await service.previewCustomDimensions(
+                fromSession(
+                    { ...user, organizationUuid: 'organizationUuid' },
+                    'session-cookie',
+                ),
+                'projectUuid',
+                [
+                    {
+                        id: 'amount_range',
+                        name: 'Amount range',
+                        table: 'table_a',
+                        type: CustomDimensionType.BIN,
+                        dimensionId: 'table_a_dim_a',
+                        binType: BinType.FIXED_WIDTH,
+                        binWidth: 10,
+                    },
+                    {
+                        id: 'custom_range',
+                        name: 'Custom range',
+                        table: 'table_a',
+                        type: CustomDimensionType.BIN,
+                        dimensionId: 'table_a_dim_a',
+                        binType: BinType.CUSTOM_RANGE,
+                        customRange: [
+                            { from: undefined, to: 10 },
+                            { from: 10, to: undefined },
+                        ],
+                    },
+                    {
+                        id: 'custom_group',
+                        name: 'Custom group',
+                        table: 'table_a',
+                        type: CustomDimensionType.BIN,
+                        dimensionId: 'table_a_dim_a',
+                        binType: BinType.CUSTOM_GROUP,
+                        customGroups: [
+                            {
+                                name: 'High',
+                                values: [
+                                    {
+                                        matchType: GroupValueMatchType.EXACT,
+                                        value: '20',
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+                '"',
+            );
+
+            expect(result.yaml).toContain('${TABLE}.dim_a * 2');
+            expect(result.yaml).toContain("|| ' - ' ||");
+            expect(result.yaml).toContain('custom_range:');
+            expect(result.yaml).toContain('custom_group:');
+            expect(result.yaml).not.toContain('${reference_column}');
+            expect(getFileContent).toHaveBeenCalledWith(
+                expect.objectContaining({ branch: 'main' }),
+            );
+        });
+    });
+
     describe('createPullRequest', () => {
         const writebackUser = {
             ...user,
@@ -174,6 +254,54 @@ describe('GitIntegrationService', () => {
                 type: DbtProjectType.GITHUB,
             },
         };
+
+        it('refuses fixed-number bins before creating a branch', async () => {
+            await expect(
+                service.createPullRequest(writebackUser, 'projectUuid', "'", {
+                    type: 'customDimensions',
+                    fields: [
+                        {
+                            id: 'amount_range',
+                            name: 'Amount range',
+                            table: 'table_a',
+                            type: CustomDimensionType.BIN,
+                            dimensionId: 'table_a_dim_a',
+                            binType: BinType.FIXED_NUMBER,
+                            binNumber: 5,
+                        },
+                    ],
+                }),
+            ).rejects.toThrow(
+                'Fixed-number bins cannot be written back because they require a dbt model CTE',
+            );
+
+            expect(createBranch).not.toHaveBeenCalled();
+        });
+
+        it('keeps saved-chart bin replacement disabled to preserve ordering', async () => {
+            await service.createPullRequest(writebackUser, 'projectUuid', "'", {
+                type: 'customDimensions',
+                fields: [
+                    {
+                        id: 'amount_range',
+                        name: 'Amount range',
+                        table: 'table_a',
+                        type: CustomDimensionType.BIN,
+                        dimensionId: 'table_a_dim_a',
+                        binType: BinType.FIXED_WIDTH,
+                        binWidth: 10,
+                    },
+                ],
+            });
+
+            expect(createPullRequest).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    body: expect.stringContaining(
+                        'Existing saved charts keep their custom bin dimensions',
+                    ),
+                }),
+            );
+        });
 
         it('refuses write-back for an explore from an additional source without calling Git', async () => {
             PROJECT_DBT_SOURCES_MODEL.getSources.mockResolvedValueOnce([

--- a/packages/backend/src/services/GitIntegrationService/GitIntegrationService.ts
+++ b/packages/backend/src/services/GitIntegrationService/GitIntegrationService.ts
@@ -2,6 +2,7 @@
 import { subject } from '@casl/ability';
 import {
     AdditionalMetric,
+    ApiCustomDimensionWriteBackPreview,
     ApiGithubDbtWritePreview,
     CustomDimension,
     DbtGithubProjectConfig,
@@ -11,11 +12,13 @@ import {
     DbtVersionOptionLatest,
     ForbiddenError,
     friendlyName,
+    getCustomDimensionWriteBackError,
     getErrorMessage,
     getLatestSupportDbtVersion,
     GitBranch,
     GitFileOrDirectory,
     GitIntegrationConfiguration,
+    isCustomBinDimension,
     isUserWithOrg,
     NotFoundError,
     ParameterError,
@@ -25,18 +28,22 @@ import {
     PullRequestProvider,
     PullRequestSource,
     QueryExecutionContext,
+    RegisteredAccount,
     SavedChart,
     SessionUser,
     snakeCaseName,
     SupportedDbtVersions,
     UnexpectedServerError,
+    UUID,
     VizColumn,
 } from '@lightdash/common';
+import * as yaml from 'js-yaml';
 import { nanoid } from 'nanoid';
 import {
     LightdashAnalytics,
     WriteBackEvent,
 } from '../../analytics/LightdashAnalytics';
+import { toSessionUser } from '../../auth/account';
 import * as GithubClient from '../../clients/github/Github';
 import * as GitlabClient from '../../clients/gitlab/Gitlab';
 import { LightdashConfig } from '../../config/parseConfig';
@@ -634,6 +641,80 @@ Affected charts:
         return gitProps;
     }
 
+    private static assertCustomDimensionsSupported(
+        customDimensions: CustomDimension[],
+    ): void {
+        const error = customDimensions
+            .map(getCustomDimensionWriteBackError)
+            .find((message): message is string => message !== null);
+        if (error) {
+            throw new ParameterError(error);
+        }
+    }
+
+    async previewCustomDimensions(
+        account: RegisteredAccount,
+        projectUuid: UUID,
+        customDimensions: CustomDimension[],
+        quoteChar: `"` | `'`,
+    ): Promise<ApiCustomDimensionWriteBackPreview['results']> {
+        if (customDimensions.length === 0) {
+            throw new ParameterError('No custom dimensions found');
+        }
+
+        const auditedAbility = this.createAuditedAbility(account);
+        if (
+            auditedAbility.cannot(
+                'manage',
+                subject('CustomFields', {
+                    organizationUuid: account.organization.organizationUuid!,
+                    projectUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+
+        GitIntegrationService.assertCustomDimensionsSupported(customDimensions);
+        await this.assertExploreWritebackSourceIsUnambiguous(projectUuid);
+
+        const user = toSessionUser(account);
+        const gitProps = await this.getGitProps(user, projectUuid, quoteChar);
+        const warehouseCredentials =
+            await this.projectModel.getWarehouseCredentialsForProject(
+                projectUuid,
+            );
+        const warehouseClient =
+            this.projectModel.getWarehouseClientFromCredentials(
+                warehouseCredentials,
+            );
+        const definitions: Record<string, unknown> = {};
+
+        for (const table of new Set(
+            customDimensions.map((dimension) => dimension.table),
+        )) {
+            const { yamlSchema } = await this.getYamlForTable({
+                ...gitProps,
+                branch: gitProps.mainBranch,
+                projectUuid,
+                table,
+            });
+            customDimensions
+                .filter((dimension) => dimension.table === table)
+                .forEach((dimension) => {
+                    definitions[dimension.id] =
+                        yamlSchema.getCustomDimensionDefinition(
+                            dimension,
+                            warehouseClient,
+                        );
+                });
+        }
+
+        return {
+            yaml: yaml.dump(definitions, { quotingType: quoteChar }),
+        };
+    }
+
     // Keep backward compatibility
     private async getGithubProps(
         user: SessionUser,
@@ -676,6 +757,9 @@ Affected charts:
             throw new ForbiddenError();
         }
 
+        if (args.type === 'customDimensions') {
+            GitIntegrationService.assertCustomDimensionsSupported(args.fields);
+        }
         await this.assertExploreWritebackSourceIsUnambiguous(projectUuid);
         const gitProps = await this.getGitProps(user, projectUuid, quoteChar);
 
@@ -700,6 +784,12 @@ Affected charts:
             fields.length === 1
                 ? `\`${fields[0].name}\` ${typeName}`
                 : `${fields.length} ${typeName}s`;
+        const containsCustomBins =
+            args.type === 'customDimensions' &&
+            args.fields.some(isCustomBinDimension);
+        const replacementGuidance = containsCustomBins
+            ? '> ℹ️ **Existing saved charts keep their custom bin dimensions.** Lightdash does not automatically replace them with these YAML dimensions, so their current bin ordering remains unchanged. Use the new dimensions after refreshing the project, and define a separate numeric ordering dimension in dbt when bin order matters.'
+            : `> ⚠️ **Note: Do not change the \`label\` or \`id\` of your ${typeName}s in this pull request.** Your ${typeName}s _will not be replaced_ with YAML ${typeName}s if you change the \`label\` or \`id\` of the ${typeName}s in this pull request. Lightdash requires the IDs and labels to match 1:1 in order to replace custom ${typeName}s with YAML ${typeName}s.`;
         const eventProperties: WriteBackEvent['properties'] = {
             name: fieldsInfo,
             projectId: projectUuid,
@@ -721,7 +811,7 @@ Affected charts:
                 body: `Created by Lightdash, this pull request adds ${fieldsInfo} to the dbt model.
 Triggered by user ${user.firstName} ${user.lastName} (${user.email})
 
-> ⚠️ **Note: Do not change the \`label\` or \`id\` of your ${typeName}s in this pull request.** Your ${typeName}s _will not be replaced_ with YAML ${typeName}s if you change the \`label\` or \`id\` of the ${typeName}s in this pull request. Lightdash requires the IDs and labels to match 1:1 in order to replace custom ${typeName}s with YAML ${typeName}s.`,
+${replacementGuidance}`,
                 head: gitProps.branch,
                 base: gitProps.mainBranch,
             });

--- a/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.test.ts
+++ b/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.test.ts
@@ -56,6 +56,25 @@ describe('DbtSchemaEditor', () => {
         );
     });
 
+    it('returns a warehouse-aware custom bin definition for previews', () => {
+        const editor = new DbtSchemaEditor(`version: 2
+models:
+  - name: table_a
+    columns:
+      - name: dim_a
+        meta:
+          dimension:
+            sql: \${TABLE}.dim_a * 2`);
+
+        const definition = editor.getCustomDimensionDefinition(
+            FIXED_WIDTH_BIN_DIMENSION,
+            warehouseClientMock,
+        );
+
+        expect(definition.sql).toContain('${TABLE}.dim_a * 2');
+        expect(definition.sql).not.toContain('${reference_column}');
+    });
+
     it('should create a new file', () => {
         const editor = new DbtSchemaEditor('');
         // confirm it has no models

--- a/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.ts
+++ b/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.ts
@@ -12,6 +12,7 @@ import {
 } from 'yaml';
 import { parseAllReferences } from '../../compiler/exploreCompiler';
 import lightdashDbtYamlSchema from '../../schemas/json/lightdash-dbt-2.0.json';
+import { type DbtColumnLightdashAdditionalDimension } from '../../types/dbt';
 import { ParseError } from '../../types/errors';
 import {
     defaultSql,
@@ -275,11 +276,14 @@ export default class DbtSchemaEditor {
         return this;
     }
 
-    private addCustomBinDimension(
-        customDimension: CustomBinDimension,
+    getCustomDimensionDefinition(
+        customDimension: CustomDimension,
         warehouseSqlBuilder: WarehouseSqlBuilder,
-    ): DbtSchemaEditor {
-        // Extract base dimension name from custom dimension id. Eg: `table_a_dim_a` -> `dim_a`
+    ): DbtColumnLightdashAdditionalDimension {
+        if (isCustomSqlDimension(customDimension)) {
+            return convertCustomSqlDimensionToDbt(customDimension);
+        }
+
         const baseDimensionName = customDimension.dimensionId.replace(
             `${customDimension.table}_`,
             '',
@@ -294,32 +298,53 @@ export default class DbtSchemaEditor {
             );
         }
 
-        // Generate base dimension SQL
         let baseDimensionSql = defaultSql(baseDimensionName);
-        // Use base dimension custom SQL if exists
-        const columnSql = column.getIn(['meta', 'dimension', 'sql']);
+        const columnSql =
+            column.getIn(['config', 'meta', 'dimension', 'sql'], true) ??
+            column.getIn(['meta', 'dimension', 'sql'], true);
         if (isScalar(columnSql) && typeof columnSql.value === 'string') {
             baseDimensionSql = columnSql.value;
         }
+
+        return convertCustomBinDimensionToDbt({
+            customDimension,
+            baseDimensionSql,
+            warehouseSqlBuilder,
+        });
+    }
+
+    private addCustomBinDimension(
+        customDimension: CustomBinDimension,
+        warehouseSqlBuilder: WarehouseSqlBuilder,
+    ): DbtSchemaEditor {
+        const baseDimensionName = customDimension.dimensionId.replace(
+            `${customDimension.table}_`,
+            '',
+        );
+        const column = this.findColumnByName(
+            customDimension.table,
+            baseDimensionName,
+        );
+        if (!column) {
+            throw new Error(
+                `Column ${baseDimensionName} not found in model ${customDimension.table}`,
+            );
+        }
+        const definition = this.getCustomDimensionDefinition(
+            customDimension,
+            warehouseSqlBuilder,
+        );
 
         // For dbt >= 1.10, meta should be inside config
         if (isDbtVersion110OrHigher(this.dbtVersion)) {
             column.setIn(
                 ['config', 'meta', 'additional_dimensions', customDimension.id],
-                convertCustomBinDimensionToDbt({
-                    customDimension,
-                    baseDimensionSql,
-                    warehouseSqlBuilder,
-                }),
+                definition,
             );
         } else {
             column.setIn(
                 ['meta', 'additional_dimensions', customDimension.id],
-                convertCustomBinDimensionToDbt({
-                    customDimension,
-                    baseDimensionSql,
-                    warehouseSqlBuilder,
-                }),
+                definition,
             );
         }
         return this;

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -377,6 +377,7 @@ import {
 import {
     type ApiCreateSqlChart,
     type ApiCreateVirtualView,
+    type ApiCustomDimensionWriteBackPreview,
     type ApiGithubDbtWritePreview,
     type ApiSqlChart,
     type ApiSqlRunnerJobStatusResponse,
@@ -1396,6 +1397,7 @@ type ApiResults =
     | ApiChartContentResponse['results']
     | ApiSqlRunnerJobStatusResponse['results']
     | ApiCreateVirtualView['results']
+    | ApiCustomDimensionWriteBackPreview['results']
     | ApiGithubDbtWritePreview['results']
     | ApiMetricsCatalog['results']
     | ApiMetricsExplorerQueryResults['results']

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -21,11 +21,6 @@ export enum FeatureFlags {
     CalculateSeriesColor = 'calculate-series-color',
 
     /**
-     * Enable the ability to write back custom bin dimensions to dbt.
-     */
-    WriteBackCustomBinDimensions = 'write-back-custom-bin-dimensions',
-
-    /**
      * Enable the ability to show the warehouse execution time and total time in the chart tile.
      */
     ShowExecutionTime = 'show-execution-time',

--- a/packages/common/src/types/sqlRunner.ts
+++ b/packages/common/src/types/sqlRunner.ts
@@ -333,6 +333,13 @@ export type ApiGithubDbtWriteBack = {
     results: PullRequestCreated;
 };
 
+export type ApiCustomDimensionWriteBackPreview = {
+    status: 'ok';
+    results: {
+        yaml: string;
+    };
+};
+
 export type ApiGithubDbtWritePreview = {
     status: 'ok';
     results: {

--- a/packages/common/src/utils/charts.test.ts
+++ b/packages/common/src/utils/charts.test.ts
@@ -1,0 +1,52 @@
+import {
+    BinType,
+    CustomDimensionType,
+    MetricType,
+    type CreateSavedChartVersion,
+    type CustomBinDimension,
+} from '..';
+import { maybeReplaceFieldsInChartVersion } from './charts';
+
+it('preserves custom bins and their sorts while replacing custom metrics', () => {
+    const customBin: CustomBinDimension = {
+        id: 'amount_range',
+        name: 'Amount range',
+        table: 'orders',
+        type: CustomDimensionType.BIN,
+        dimensionId: 'orders_amount',
+        binType: BinType.FIXED_WIDTH,
+        binWidth: 10,
+    };
+    const chartVersion = {
+        metricQuery: {
+            additionalMetrics: [
+                {
+                    name: 'revenue',
+                    label: 'Revenue',
+                    table: 'orders',
+                    type: MetricType.SUM,
+                    sql: '${TABLE}.revenue',
+                },
+            ],
+            customDimensions: [customBin],
+            sorts: [{ fieldId: customBin.id, descending: false }],
+        },
+    } as CreateSavedChartVersion;
+
+    const result = maybeReplaceFieldsInChartVersion({
+        chartVersion,
+        fieldsToReplace: {
+            customMetrics: {
+                orders_revenue: { replaceWithFieldId: 'orders_revenue' },
+            },
+        },
+    });
+
+    expect(result.hasChanges).toBe(true);
+    expect(result.chartVersion.metricQuery.customDimensions).toEqual([
+        customBin,
+    ]);
+    expect(result.chartVersion.metricQuery.sorts).toEqual([
+        { fieldId: customBin.id, descending: false },
+    ]);
+});

--- a/packages/common/src/utils/convertCustomDimensionsToYaml.ts
+++ b/packages/common/src/utils/convertCustomDimensionsToYaml.ts
@@ -9,19 +9,24 @@ import {
     type CustomDimension,
     type CustomSqlDimension,
 } from '../types/field';
-import { type CreateWarehouseCredentials } from '../types/projects';
-import {
-    type TimeIntervalUnit,
-    type WarehouseClient,
-    type WarehouseSqlBuilder,
-} from '../types/warehouse';
+import { type WarehouseSqlBuilder } from '../types/warehouse';
 import assertUnreachable from './assertUnreachable';
 import {
     getCustomGroupSelectSql,
     getCustomRangeSelectSql,
     getFixedWidthBinSelectSql,
 } from './customDimensions';
-import { defaultNullSafeEqualSql } from './warehouse';
+
+export const FIXED_NUMBER_BIN_WRITE_BACK_ERROR =
+    'Fixed-number bins cannot be written back because they require a dbt model CTE. Use a fixed-width, custom-range, or custom-group bin instead.';
+
+export const getCustomDimensionWriteBackError = (
+    customDimension: CustomDimension,
+): string | null =>
+    isCustomBinDimension(customDimension) &&
+    customDimension.binType === BinType.FIXED_NUMBER
+        ? FIXED_NUMBER_BIN_WRITE_BACK_ERROR
+        : null;
 
 export const convertCustomSqlDimensionToDbt = (
     field: CustomSqlDimension,
@@ -82,110 +87,13 @@ export const convertCustomBinDimensionToDbt = ({
     }
 };
 
-// Mock Bigquery warehouse client for preview
-const warehouseClientMock: WarehouseClient = {
-    getSessionTimezone: async () => null,
-    credentials: undefined as unknown as CreateWarehouseCredentials,
-    getCatalog() {
-        throw new NotImplementedError('getCatalog not implemented');
-    },
-    getAdapterType() {
-        throw new NotImplementedError('getCatalog not implemented');
-    },
-    supportsCteMaterialization: () => true,
-    getAllTables() {
-        throw new NotImplementedError('getCatalog not implemented');
-    },
-    getFields() {
-        throw new NotImplementedError('getCatalog not implemented');
-    },
-    getMetricSql() {
-        throw new NotImplementedError('getMetricSql not implemented');
-    },
-    getStartOfWeek() {
-        throw new NotImplementedError('getCatalog not implemented');
-    },
-    parseError() {
-        throw new NotImplementedError('getCatalog not implemented');
-    },
-    parseWarehouseCatalog() {
-        throw new NotImplementedError('getCatalog not implemented');
-    },
-    runQuery() {
-        throw new NotImplementedError('getCatalog not implemented');
-    },
-    streamQuery() {
-        throw new NotImplementedError('getCatalog not implemented');
-    },
-    executeAsyncQuery() {
-        throw new NotImplementedError('getCatalog not implemented');
-    },
-    test() {
-        throw new NotImplementedError('getCatalog not implemented');
-    },
-    concatString(...args: string[]): string {
-        return `CONCAT(${args.join(', ')})`;
-    },
-    getStringQuoteChar() {
-        return "'";
-    },
-    getEscapeStringQuoteChar() {
-        return '\\';
-    },
-    getFieldQuoteChar() {
-        return '"';
-    },
-    getFloatingType() {
-        return 'FLOAT';
-    },
-    getNullSafeEqualSql: defaultNullSafeEqualSql,
-    getNullSafeEqualJoinSql: defaultNullSafeEqualSql,
-    escapeString(value) {
-        return value;
-    },
-    castToTimestamp(date) {
-        return `CAST('${date.toISOString()}' AS TIMESTAMP)`;
-    },
-    castToDate(date) {
-        return `CAST('${date.toISOString().slice(0, 10)}' AS DATE)`;
-    },
-    castToNaiveTimestamp(date) {
-        return `CAST('${date.toISOString()}' AS TIMESTAMP)`;
-    },
-    getIntervalSql(value: number, unit: TimeIntervalUnit) {
-        return `INTERVAL '${value} ${unit}'`;
-    },
-    getTimestampDiffSeconds(startTimestampSql, endTimestampSql) {
-        return `EXTRACT(EPOCH FROM (${endTimestampSql} - ${startTimestampSql}))`;
-    },
-    getMedianSql(valueSql) {
-        return `PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY ${valueSql})`;
-    },
-    buildArray(elements) {
-        return `ARRAY[${elements.join(', ')}]`;
-    },
-    buildArrayAgg(expression, orderBy) {
-        return orderBy
-            ? `ARRAY_AGG(${expression} ORDER BY ${orderBy})`
-            : `ARRAY_AGG(${expression})`;
-    },
-};
-
 export const previewConvertCustomDimensionToDbt = (
     field: CustomDimension,
 ): DbtColumnLightdashAdditionalDimension => {
     if (isCustomBinDimension(field)) {
-        // Mock base dimension SQL and warehouse client for preview
-        const preview = convertCustomBinDimensionToDbt({
-            customDimension: field,
-            baseDimensionSql: '${reference_column}',
-            warehouseSqlBuilder: warehouseClientMock,
-        });
-        return {
-            ...preview,
-            // Add a comment at the top of the multiline string to indicate that this is a preview
-            sql: `/* This is a preview! Replace column references and confirm SQL before using in production. */\n${preview.sql}`,
-        };
+        throw new NotImplementedError(
+            'Custom bin previews require the project warehouse and dbt model SQL',
+        );
     }
     return convertCustomSqlDimensionToDbt(field);
 };

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNodeActions.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNodeActions.tsx
@@ -2,6 +2,7 @@ import {
     DimensionType,
     FeatureFlags,
     friendlyName,
+    getCustomDimensionWriteBackError,
     getCustomMetricType,
     getItemId,
     isAdditionalMetric,
@@ -77,18 +78,15 @@ const TreeSingleNodeActions: FC<Props> = ({
     const { track } = useTracking();
 
     const dispatch = useExplorerDispatch();
+    const customDimensionWriteBackError = isCustomDimension(item)
+        ? getCustomDimensionWriteBackError(item)
+        : null;
     const customMetrics = useMemo(() => {
         if (isCustomSqlDimension(item)) {
             return getCustomMetricType(item.dimensionType);
         }
         return isDimension(item) ? getCustomMetricType(item.type) : [];
     }, [item]);
-
-    const { data: writeBackCustomBinDimensionsFlag } = useServerFeatureFlag(
-        FeatureFlags.WriteBackCustomBinDimensions,
-    );
-    const isWriteBackCustomBinDimensionsEnabled =
-        writeBackCustomBinDimensionsFlag?.enabled ?? false;
 
     const { data: customGroupBinsFlag } = useServerFeatureFlag(
         FeatureFlags.CustomGroupBins,
@@ -347,47 +345,59 @@ const TreeSingleNodeActions: FC<Props> = ({
                                 >
                                     Duplicate custom dimension
                                 </Menu.Item>
-                                {(isCustomSqlDimension(item) ||
-                                    isWriteBackCustomBinDimensionsEnabled) && (
-                                    <Menu.Item
-                                        component="button"
-                                        leftSection={
-                                            <MantineIcon icon={IconCode} />
-                                        }
-                                        onClick={(
-                                            e: React.MouseEvent<HTMLButtonElement>,
-                                        ) => {
-                                            e.stopPropagation();
-                                            if (
-                                                projectUuid &&
-                                                user.data?.organizationUuid
-                                            ) {
-                                                track({
-                                                    name: EventName.WRITE_BACK_FROM_CUSTOM_DIMENSION_CLICKED,
-                                                    properties: {
-                                                        userId: user.data
-                                                            .userUuid,
-                                                        projectId: projectUuid,
-                                                        organizationId:
-                                                            user.data
-                                                                .organizationUuid,
-                                                        customDimensionsCount: 1,
-                                                    },
-                                                });
+                                <Tooltip
+                                    label={customDimensionWriteBackError}
+                                    disabled={!customDimensionWriteBackError}
+                                >
+                                    <Box component="span">
+                                        <Menu.Item
+                                            component="button"
+                                            disabled={
+                                                !!customDimensionWriteBackError
                                             }
+                                            leftSection={
+                                                <MantineIcon icon={IconCode} />
+                                            }
+                                            onClick={(
+                                                e: React.MouseEvent<HTMLButtonElement>,
+                                            ) => {
+                                                e.stopPropagation();
+                                                if (
+                                                    customDimensionWriteBackError
+                                                )
+                                                    return;
+                                                if (
+                                                    projectUuid &&
+                                                    user.data?.organizationUuid
+                                                ) {
+                                                    track({
+                                                        name: EventName.WRITE_BACK_FROM_CUSTOM_DIMENSION_CLICKED,
+                                                        properties: {
+                                                            userId: user.data
+                                                                .userUuid,
+                                                            projectId:
+                                                                projectUuid,
+                                                            organizationId:
+                                                                user.data
+                                                                    .organizationUuid,
+                                                            customDimensionsCount: 1,
+                                                        },
+                                                    });
+                                                }
 
-                                            dispatch(
-                                                explorerActions.toggleWriteBackModal(
-                                                    {
-                                                        items: [item],
-                                                    },
-                                                ),
-                                            );
-                                        }}
-                                    >
-                                        Write back to dbt
-                                    </Menu.Item>
-                                )}
+                                                dispatch(
+                                                    explorerActions.toggleWriteBackModal(
+                                                        {
+                                                            items: [item],
+                                                        },
+                                                    ),
+                                                );
+                                            }}
+                                        >
+                                            Write back to dbt
+                                        </Menu.Item>
+                                    </Box>
+                                </Tooltip>
                             </>
                         )}
 

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualSectionHeader.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualSectionHeader.tsx
@@ -1,5 +1,4 @@
 import { subject } from '@casl/ability';
-import { FeatureFlags, isCustomSqlDimension } from '@lightdash/common';
 import { Button, Group, Text, ActionIcon, Tooltip } from '@mantine/core';
 import { IconCode, IconPlus } from '@tabler/icons-react';
 import { memo, useCallback, useMemo, type FC } from 'react';
@@ -11,12 +10,12 @@ import {
     useExplorerSelector,
 } from '../../../../../features/explorer/store';
 import { useProjectUuid } from '../../../../../hooks/useProjectUuid';
-import { useServerFeatureFlag } from '../../../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../../../providers/App/useApp';
 import useTracking from '../../../../../providers/Tracking/useTracking';
 import { EventName } from '../../../../../types/Events';
 import MantineIcon from '../../../../common/MantineIcon';
 import DocumentationHelpButton from '../../../../DocumentationHelpButton';
+import { getCustomDimensionsForWriteBack } from '../../../WriteBackModal/writeBackSupport';
 import { TreeSection, type SectionHeaderItem } from './types';
 
 interface VirtualSectionHeaderProps {
@@ -46,13 +45,6 @@ const VirtualSectionHeaderComponent: FC<VirtualSectionHeaderProps> = ({
         [additionalMetrics],
     );
 
-    // Feature flag for bin dimensions write-back
-    const { data: writeBackCustomBinDimensionsFlag } = useServerFeatureFlag(
-        FeatureFlags.WriteBackCustomBinDimensions,
-    );
-    const isWriteBackCustomBinDimensionsEnabled =
-        writeBackCustomBinDimensionsFlag?.enabled ?? false;
-
     const canManageCustomFields = user.data?.ability?.can(
         'manage',
         subject('CustomFields', {
@@ -61,19 +53,14 @@ const VirtualSectionHeaderComponent: FC<VirtualSectionHeaderProps> = ({
         }),
     );
 
-    const customDimensionsToWriteBack = useMemo(() => {
-        if (!allCustomDimensions) return [];
-        const baseList = isWriteBackCustomBinDimensionsEnabled
-            ? allCustomDimensions
-            : allCustomDimensions.filter(isCustomSqlDimension);
-        return canManageCustomFields
-            ? baseList
-            : baseList.filter((dim) => !isCustomSqlDimension(dim));
-    }, [
-        allCustomDimensions,
-        isWriteBackCustomBinDimensionsEnabled,
-        canManageCustomFields,
-    ]);
+    const customDimensionsToWriteBack = useMemo(
+        () =>
+            getCustomDimensionsForWriteBack(
+                allCustomDimensions,
+                !!canManageCustomFields,
+            ),
+        [allCustomDimensions, canManageCustomFields],
+    );
 
     const handleAddCustomDimension = useCallback(() => {
         dispatch(

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/writeBack.test.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/writeBack.test.tsx
@@ -1,0 +1,154 @@
+import {
+    BinType,
+    CustomDimensionType,
+    type CustomBinDimension,
+} from '@lightdash/common';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Provider } from 'react-redux';
+import {
+    createExplorerStore,
+    explorerActions,
+} from '../../../../features/explorer/store';
+import { renderWithProviders } from '../../../../testing/testUtils';
+import TreeSingleNodeActions from './Tree/TreeSingleNodeActions';
+import {
+    ITEM_HEIGHTS,
+    TreeSection,
+    type SectionHeaderItem,
+} from './Virtualization/types';
+import VirtualSectionHeader from './Virtualization/VirtualSectionHeader';
+
+vi.mock('../../../../hooks/useProjectUuid', () => ({
+    useProjectUuid: () => 'project-uuid',
+}));
+vi.mock('../../../../hooks/user/useCannotAuthorCustomSql', () => ({
+    useCannotAuthorCustomSql: () => false,
+}));
+vi.mock('../../../../hooks/useFilters', () => ({
+    useFilteredFields: () => ({ addFilter: vi.fn() }),
+}));
+vi.mock('../../../../hooks/useServerOrClientFeatureFlag', () => ({
+    useServerFeatureFlag: () => ({ data: { enabled: true } }),
+}));
+vi.mock('../../../../hooks/toaster/useToaster', () => ({
+    default: () => ({ showToastSuccess: vi.fn() }),
+}));
+vi.mock('../../../../providers/Tracking/useTracking', () => ({
+    default: () => ({ track: vi.fn() }),
+}));
+vi.mock('../../../../providers/App/useApp', () => ({
+    default: () => ({
+        health: { data: undefined },
+        user: {
+            data: {
+                userUuid: 'user-uuid',
+                organizationUuid: 'organization-uuid',
+                ability: { can: () => true },
+            },
+        },
+    }),
+}));
+
+const makeBin = (binType: BinType): CustomBinDimension => {
+    const base = {
+        id: 'amount_range',
+        name: 'Amount range',
+        table: 'orders',
+        type: CustomDimensionType.BIN as const,
+        dimensionId: 'orders_amount',
+    };
+    switch (binType) {
+        case BinType.FIXED_NUMBER:
+            return { ...base, binType, binNumber: 5 };
+        case BinType.FIXED_WIDTH:
+            return { ...base, binType, binWidth: 10 };
+        case BinType.CUSTOM_RANGE:
+            return { ...base, binType, customRange: [] };
+        case BinType.CUSTOM_GROUP:
+            return { ...base, binType, customGroups: [] };
+    }
+};
+
+const renderNodeActions = (item: CustomBinDimension) => {
+    const store = createExplorerStore();
+    renderWithProviders(
+        <Provider store={store}>
+            <TreeSingleNodeActions
+                item={item}
+                isHovered
+                isSelected={false}
+                hasDescription={false}
+                isOpened
+                onMenuChange={vi.fn()}
+                onViewDescription={vi.fn()}
+            />
+        </Provider>,
+    );
+    return store;
+};
+
+describe('custom bin write-back in Explorer trees', () => {
+    it('opens write-back for supported bins from standard tree node actions', async () => {
+        const user = userEvent.setup();
+        const item = makeBin(BinType.FIXED_WIDTH);
+        const store = renderNodeActions(item);
+
+        await user.click(
+            screen.getByRole('menuitem', { name: 'Write back to dbt' }),
+        );
+
+        expect(store.getState().explorer.modals.writeBack.items).toEqual([
+            item,
+        ]);
+    });
+
+    it('shows why fixed-number bins are unavailable in standard tree node actions', async () => {
+        const user = userEvent.setup();
+        renderNodeActions(makeBin(BinType.FIXED_NUMBER));
+        const action = screen.getByRole('menuitem', {
+            name: 'Write back to dbt',
+        });
+
+        expect(action).toBeDisabled();
+        await user.hover(action.parentElement!);
+        expect(
+            await screen.findByText(
+                /Fixed-number bins cannot be written back because they require a dbt model CTE/,
+            ),
+        ).toBeVisible();
+    });
+
+    it('includes supported bins in virtualized section write-back', async () => {
+        const user = userEvent.setup();
+        const item = makeBin(BinType.CUSTOM_RANGE);
+        const store = createExplorerStore();
+        store.dispatch(explorerActions.setCustomDimensions([item]));
+        const sectionItem: SectionHeaderItem = {
+            id: 'orders-custom-dimensions',
+            type: 'section-header',
+            estimatedHeight: ITEM_HEIGHTS.SECTION_HEADER,
+            data: {
+                tableName: 'orders',
+                treeSection: TreeSection.CustomDimensions,
+                label: 'Custom dimensions',
+                color: 'blue.9',
+            },
+        };
+
+        renderWithProviders(
+            <Provider store={store}>
+                <VirtualSectionHeader item={sectionItem} />
+            </Provider>,
+        );
+        await user.click(
+            screen.getByTestId(
+                'VirtualSectionHeader/WriteBackCustomDimensionsButton',
+            ),
+        );
+
+        expect(store.getState().explorer.modals.writeBack.items).toEqual([
+            item,
+        ]);
+    });
+});

--- a/packages/frontend/src/components/Explorer/WriteBackModal/hooks.ts
+++ b/packages/frontend/src/components/Explorer/WriteBackModal/hooks.ts
@@ -1,12 +1,13 @@
 import {
     DbtProjectType,
     type AdditionalMetric,
+    type ApiCustomDimensionWriteBackPreview,
     type ApiError,
     type CustomDimension,
     type PullRequestCreated,
 } from '@lightdash/common';
 import { IconArrowRight } from '@tabler/icons-react';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { lightdashApi } from '../../../api';
 import useToaster from '../../../hooks/toaster/useToaster';
 import { useProject } from '../../../hooks/useProject';
@@ -23,6 +24,32 @@ const writeBackCustomDimensions = async (
         }),
     });
 };
+
+const getCustomDimensionsWriteBackPreview = async (
+    projectUuid: string,
+    customDimensions: CustomDimension[],
+): Promise<ApiCustomDimensionWriteBackPreview['results']> =>
+    lightdashApi<ApiCustomDimensionWriteBackPreview['results']>({
+        url: `/projects/${projectUuid}/git-integration/pull-requests/custom-dimensions/preview`,
+        method: 'POST',
+        body: JSON.stringify({ customDimensions }),
+    });
+
+export const useCustomDimensionsWriteBackPreview = (
+    projectUuid: string,
+    customDimensions: CustomDimension[],
+) =>
+    useQuery<ApiCustomDimensionWriteBackPreview['results'], ApiError>({
+        queryKey: [
+            'custom_dimension_write_back_preview',
+            projectUuid,
+            customDimensions,
+        ],
+        queryFn: () =>
+            getCustomDimensionsWriteBackPreview(projectUuid, customDimensions),
+        enabled: customDimensions.length > 0,
+        retry: false,
+    });
 
 export const useWriteBackCustomDimensions = (projectUuid: string) => {
     const { showToastSuccess, showToastApiError } = useToaster();

--- a/packages/frontend/src/components/Explorer/WriteBackModal/index.tsx
+++ b/packages/frontend/src/components/Explorer/WriteBackModal/index.tsx
@@ -1,6 +1,9 @@
 import {
     capitalize,
+    getCustomDimensionWriteBackError,
     getErrorMessage,
+    isCustomBinDimension,
+    isCustomDimension,
     NotImplementedError,
     type AdditionalMetric,
     type CustomDimension,
@@ -24,17 +27,20 @@ import {
     useExplorerSelector,
 } from '../../../features/explorer/store';
 import { useProjectUuid } from '../../../hooks/useProjectUuid';
+import Callout from '../../common/Callout';
 import CodeBlock from '../../common/CodeBlock/CodeBlock';
 import CollapsableCard from '../../common/CollapsableCard/CollapsableCard';
 import MantineModal from '../../common/MantineModal';
 import { PolymorphicGroupButton } from '../../common/PolymorphicGroupButton';
 import { CreatedPullRequestModalContent } from './CreatedPullRequestModalContent';
 import {
+    useCustomDimensionsWriteBackPreview,
     useIsGitProject,
     useWriteBackCustomDimensions,
     useWriteBackCustomMetrics,
 } from './hooks';
 import { convertToDbt, getItemId, getItemLabel, match } from './utils';
+import { BIN_ORDERING_WRITE_BACK_WARNING } from './writeBackSupport';
 
 const prDisabledMessage =
     'Pull requests can only be opened for Git connected projects (GitHub/GitLab)';
@@ -102,25 +108,38 @@ export const SingleItemModalContent = ({
     );
 
     const [showDiff, setShowDiff] = useState(true);
-    const [error, setError] = useState<string | undefined>();
-
     const isGitProject = useIsGitProject(projectUuid);
-
-    const previewCode = useMemo(() => {
+    const writeBackError = isCustomDimension(item)
+        ? getCustomDimensionWriteBackError(item)
+        : null;
+    const customDimensionsForPreview = useMemo(
+        () =>
+            isCustomDimension(item) && !writeBackError
+                ? [item]
+                : ([] as CustomDimension[]),
+        [item, writeBackError],
+    );
+    const previewQuery = useCustomDimensionsWriteBackPreview(
+        projectUuid,
+        customDimensionsForPreview,
+    );
+    const metricPreview = useMemo(() => {
+        if (isCustomDimension(item)) return { code: '', error: null };
         try {
             const { key, value } = convertToDbt(item);
-
-            const code = yaml.dump({
-                [key]: value,
-            });
-
-            setError(undefined);
-            return code;
+            return { code: yaml.dump({ [key]: value }), error: null };
         } catch (e) {
-            setError(parseError(e, type));
-            return '';
+            return { code: '', error: parseError(e, type) };
         }
     }, [item, type]);
+    const previewError =
+        writeBackError ??
+        (previewQuery.error
+            ? getErrorMessage(previewQuery.error.error)
+            : metricPreview.error);
+    const previewCode = isCustomDimension(item)
+        ? (previewQuery.data?.yaml ?? '')
+        : metricPreview.code;
 
     if (data) {
         // Return a simple confirmation modal with the PR URL
@@ -129,13 +148,12 @@ export const SingleItemModalContent = ({
         );
     }
 
-    const disableErrorTooltip = isGitProject && !error;
+    const disableErrorTooltip = isGitProject && !previewError;
 
-    const errorTooltipLabel = error
-        ? `Unsupported ${texts[type].baseName} definition`
-        : prDisabledMessage;
+    const errorTooltipLabel = previewError || prDisabledMessage;
 
-    const buttonDisabled = isLoading || !disableErrorTooltip;
+    const buttonDisabled =
+        isLoading || previewQuery.isLoading || !disableErrorTooltip;
 
     const itemLabel = getItemLabel(item);
 
@@ -187,6 +205,11 @@ export const SingleItemModalContent = ({
                         {itemLabel}
                     </List.Item>
                 </List>
+                {isCustomBinDimension(item) && !previewError ? (
+                    <Callout variant="info">
+                        {BIN_ORDERING_WRITE_BACK_WARNING}
+                    </Callout>
+                ) : null}
                 <CollapsableCard
                     isOpen={showDiff}
                     title={`Show ${texts[type].baseName} code`}
@@ -194,7 +217,12 @@ export const SingleItemModalContent = ({
                 >
                     <Stack ml={36}>
                         <CodeBlock
-                            code={error || previewCode}
+                            code={
+                                previewError ||
+                                (previewQuery.isLoading
+                                    ? 'Generating warehouse-aware preview...'
+                                    : previewCode)
+                            }
                             language="yaml"
                             withLineNumbers
                         />
@@ -252,28 +280,38 @@ const MultipleItemsModalContent = ({
         [items, selectedItemIds],
     );
 
-    const [error, setError] = useState<string | undefined>();
-
-    const previewCode = useMemo(() => {
-        if (selectedItems.length === 0) return '';
+    const selectedCustomDimensions = useMemo(
+        () => selectedItems.filter(isCustomDimension) as CustomDimension[],
+        [selectedItems],
+    );
+    const previewQuery = useCustomDimensionsWriteBackPreview(
+        projectUuid,
+        selectedCustomDimensions,
+    );
+    const metricPreview = useMemo(() => {
+        if (selectedItems.length === 0 || selectedCustomDimensions.length > 0)
+            return { code: '', error: null };
         try {
             const code = yaml.dump(
-                selectedItems
+                (selectedItems as AdditionalMetric[])
                     .map((item) => {
                         const { key, value } = convertToDbt(item);
-                        return {
-                            [key]: value,
-                        };
+                        return { [key]: value };
                     })
                     .reduce((acc, curr) => ({ ...acc, ...curr }), {}),
             );
-            setError(undefined);
-            return code;
+            return { code, error: null };
         } catch (e) {
-            setError(parseError(e, type));
-            return '';
+            return { code: '', error: parseError(e, type) };
         }
-    }, [selectedItems, type]);
+    }, [selectedCustomDimensions.length, selectedItems, type]);
+    const previewError = previewQuery.error
+        ? getErrorMessage(previewQuery.error.error)
+        : metricPreview.error;
+    const previewCode =
+        selectedCustomDimensions.length > 0
+            ? (previewQuery.data?.yaml ?? '')
+            : metricPreview.code;
 
     if (data) {
         // Return a simple confirmation modal with the PR URL
@@ -283,16 +321,19 @@ const MultipleItemsModalContent = ({
     }
 
     const disableErrorTooltip =
-        isGitProject && selectedItemIds.length > 0 && !error;
+        isGitProject && selectedItemIds.length > 0 && !previewError;
 
-    const errorTooltipLabel = error
-        ? `Unsupported ${texts[type].baseName} definition`
+    const errorTooltipLabel = previewError
+        ? previewError
         : !isGitProject
           ? prDisabledMessage
           : `Select ${texts[type].baseName}s to open a pull request`;
 
     const buttonDisabled =
-        isLoading || !disableErrorTooltip || selectedItemIds.length === 0;
+        isLoading ||
+        previewQuery.isLoading ||
+        !disableErrorTooltip ||
+        selectedItemIds.length === 0;
     return (
         <MantineModal
             size="auto"
@@ -354,16 +395,21 @@ const MultipleItemsModalContent = ({
                         {items.map((item) => {
                             const itemId = getItemId(item);
                             const itemLabel = getItemLabel(item);
+                            const itemWriteBackError = isCustomDimension(item)
+                                ? getCustomDimensionWriteBackError(item)
+                                : null;
                             return (
                                 <Tooltip
-                                    label={itemLabel}
+                                    label={itemWriteBackError || itemLabel}
                                     key={itemId}
                                     position="right"
                                 >
                                     <PolymorphicGroupButton
                                         wrap="nowrap"
                                         key={itemId}
-                                        onClick={() =>
+                                        disabled={!!itemWriteBackError}
+                                        onClick={() => {
+                                            if (itemWriteBackError) return;
                                             setSelectedItemIds(
                                                 !selectedItemIds.includes(
                                                     itemId,
@@ -376,11 +422,12 @@ const MultipleItemsModalContent = ({
                                                           (name) =>
                                                               name !== itemId,
                                                       ),
-                                            )
-                                        }
+                                            );
+                                        }}
                                     >
                                         <Checkbox
                                             size="xs"
+                                            disabled={!!itemWriteBackError}
                                             checked={selectedItemIds.includes(
                                                 itemId,
                                             )}
@@ -396,10 +443,19 @@ const MultipleItemsModalContent = ({
                     <Text>
                         {capitalize(texts[type].baseName)} YAML to be created:
                     </Text>
-
+                    {selectedCustomDimensions.some(isCustomBinDimension) ? (
+                        <Callout variant="info">
+                            {BIN_ORDERING_WRITE_BACK_WARNING}
+                        </Callout>
+                    ) : null}
                     <Paper h="100%" className="ld-scroll-y">
                         <CodeBlock
-                            code={error || previewCode}
+                            code={
+                                previewError ||
+                                (previewQuery.isLoading
+                                    ? 'Generating warehouse-aware preview...'
+                                    : previewCode)
+                            }
                             language="yaml"
                             withCopyButton={previewCode !== ''}
                         />

--- a/packages/frontend/src/components/Explorer/WriteBackModal/utils.ts
+++ b/packages/frontend/src/components/Explorer/WriteBackModal/utils.ts
@@ -2,7 +2,6 @@ import {
     convertCustomMetricToDbt,
     isAdditionalMetric,
     isCustomDimension,
-    previewConvertCustomDimensionToDbt,
     type AdditionalMetric,
     type CustomDimension,
 } from '@lightdash/common';
@@ -19,24 +18,10 @@ export const match = <T, U = T>(
     throw new Error(`Invalid item type: ${JSON.stringify(item)}`);
 };
 
-export const convertToDbt = (item: CustomDimension | AdditionalMetric) => {
-    const key = match(
-        item,
-        (customDimension) => customDimension.id,
-        (customMetric) => customMetric.name,
-    );
-
-    const value = match(
-        item,
-        (i) => previewConvertCustomDimensionToDbt(i),
-        (i) => convertCustomMetricToDbt(i),
-    );
-
-    return {
-        key,
-        value,
-    };
-};
+export const convertToDbt = (item: AdditionalMetric) => ({
+    key: item.name,
+    value: convertCustomMetricToDbt(item),
+});
 
 export const getItemId = (item: CustomDimension | AdditionalMetric) => {
     return match(

--- a/packages/frontend/src/components/Explorer/WriteBackModal/writeBackSupport.test.ts
+++ b/packages/frontend/src/components/Explorer/WriteBackModal/writeBackSupport.test.ts
@@ -1,0 +1,69 @@
+import {
+    BinType,
+    CustomDimensionType,
+    DimensionType,
+    FIXED_NUMBER_BIN_WRITE_BACK_ERROR,
+    getCustomDimensionWriteBackError,
+    type CustomBinDimension,
+    type CustomSqlDimension,
+} from '@lightdash/common';
+import { getCustomDimensionsForWriteBack } from './writeBackSupport';
+
+const makeBin = (binType: BinType): CustomBinDimension => {
+    const base = {
+        id: 'amount_range',
+        name: 'Amount range',
+        table: 'orders',
+        type: CustomDimensionType.BIN as const,
+        dimensionId: 'orders_amount',
+    };
+    switch (binType) {
+        case BinType.FIXED_NUMBER:
+            return { ...base, binType, binNumber: 5 };
+        case BinType.FIXED_WIDTH:
+            return { ...base, binType, binWidth: 10 };
+        case BinType.CUSTOM_RANGE:
+            return { ...base, binType, customRange: [] };
+        case BinType.CUSTOM_GROUP:
+            return { ...base, binType, customGroups: [] };
+    }
+};
+
+describe('custom dimension write-back support', () => {
+    it('explains why fixed-number bins are unavailable', () => {
+        expect(
+            getCustomDimensionWriteBackError(makeBin(BinType.FIXED_NUMBER)),
+        ).toBe(FIXED_NUMBER_BIN_WRITE_BACK_ERROR);
+    });
+
+    it.each([BinType.FIXED_WIDTH, BinType.CUSTOM_RANGE, BinType.CUSTOM_GROUP])(
+        'supports %s bins in node actions',
+        (binType) => {
+            expect(
+                getCustomDimensionWriteBackError(makeBin(binType)),
+            ).toBeNull();
+        },
+    );
+
+    it('includes bin dimensions in the virtualized section write-back list after graduation', () => {
+        const sqlDimension: CustomSqlDimension = {
+            id: 'custom_sql',
+            name: 'Custom SQL',
+            table: 'orders',
+            type: CustomDimensionType.SQL,
+            sql: '${orders.amount}',
+            dimensionType: DimensionType.NUMBER,
+        };
+        const binDimension = makeBin(BinType.FIXED_WIDTH);
+
+        expect(
+            getCustomDimensionsForWriteBack([sqlDimension, binDimension], true),
+        ).toEqual([sqlDimension, binDimension]);
+        expect(
+            getCustomDimensionsForWriteBack(
+                [sqlDimension, binDimension],
+                false,
+            ),
+        ).toEqual([binDimension]);
+    });
+});

--- a/packages/frontend/src/components/Explorer/WriteBackModal/writeBackSupport.ts
+++ b/packages/frontend/src/components/Explorer/WriteBackModal/writeBackSupport.ts
@@ -1,0 +1,16 @@
+import { isCustomSqlDimension, type CustomDimension } from '@lightdash/common';
+
+export const BIN_ORDERING_WRITE_BACK_WARNING =
+    'Existing saved charts will keep using this custom bin so their ordering is unchanged. After merging and refreshing your project, use the new dbt dimension in new charts and add a separate numeric ordering dimension in dbt when bin order matters.';
+
+export const getCustomDimensionsForWriteBack = (
+    customDimensions: CustomDimension[] | undefined,
+    canManageCustomFields: boolean,
+): CustomDimension[] => {
+    if (!customDimensions) return [];
+    return canManageCustomFields
+        ? customDimensions
+        : customDimensions.filter(
+              (dimension) => !isCustomSqlDimension(dimension),
+          );
+};

--- a/release-safety.declarations.json
+++ b/release-safety.declarations.json
@@ -17,10 +17,6 @@
             "reason": "The graduated WriteBackCustomBinDimensions member is removed from the exported FeatureFlags enum. TypeScript consumers referencing this temporary rollout flag must remove it when upgrading; supported custom-bin write-back is now available without a flag.",
             "requiredStop": false
         },
-        "client-custom-bin-preview-disabled": {
-            "reason": "The exported previewConvertCustomDimensionToDbt utility now rejects bin dimensions instead of returning placeholder, BigQuery-like SQL. Consumers that preview bins client-side must use the authenticated backend preview so model SQL and the project warehouse dialect are applied.",
-            "requiredStop": false
-        },
         "mobile-push-installation-uuid-path-params": {
             "reason": "PUT and DELETE /api/v1/mobile/push-notifications/installations/{installationUuid} now validate installationUuid as a UUID and reject other strings with a 400. Installation identifiers are server-generated UUIDs, and only the Lightdash mobile apps call these endpoints with the identifier they received, so no existing caller is affected.",
             "requiredStop": false

--- a/release-safety.declarations.json
+++ b/release-safety.declarations.json
@@ -13,6 +13,14 @@
             "reason": "The retired ReplaceCustomMetricsOnCompile member is removed from the exported FeatureFlags enum. TypeScript consumers referencing this temporary rollout flag must remove it when upgrading; runtime custom-metric replacement after eligible compiles is now unconditional.",
             "requiredStop": false
         },
+        "write-back-custom-bin-dimensions-flag-removed": {
+            "reason": "The graduated WriteBackCustomBinDimensions member is removed from the exported FeatureFlags enum. TypeScript consumers referencing this temporary rollout flag must remove it when upgrading; supported custom-bin write-back is now available without a flag.",
+            "requiredStop": false
+        },
+        "client-custom-bin-preview-disabled": {
+            "reason": "The exported previewConvertCustomDimensionToDbt utility now rejects bin dimensions instead of returning placeholder, BigQuery-like SQL. Consumers that preview bins client-side must use the authenticated backend preview so model SQL and the project warehouse dialect are applied.",
+            "requiredStop": false
+        },
         "mobile-push-installation-uuid-path-params": {
             "reason": "PUT and DELETE /api/v1/mobile/push-notifications/installations/{installationUuid} now validate installationUuid as a UUID and reject other strings with a 400. Installation identifiers are server-generated UUIDs, and only the Lightdash mobile apps call these endpoints with the identifier they received, so no existing caller is affected.",
             "requiredStop": false


### PR DESCRIPTION
## What changed

- feat(explorer): graduate custom bin write-back


- chore(release): remove client bin preview declaration

## Verification

- `pnpm exec oxfmt release-safety.declarations.json --check` — passed
- `pnpm exec tsx scripts/release-safety-declarations.test.ts` — passed (12 tests)
- `git diff --check` — passed

## Development environment

[Open the public Lightdash development environment](https://ld-runner-prod-10854-de0e28ef7fd9.exe.xyz) (anyone with the URL can access it)

Login: `demo@lightdash.com` / `demo_password!`

## References

Closes: PROD-10854

