### PR TITLE
fix(bigquery): surface a rejected refresh token as a reconnect error

### DIFF
--- a/packages/common/src/types/errors.test.ts
+++ b/packages/common/src/types/errors.test.ts
@@ -1,0 +1,29 @@
+import {
+    BIGQUERY_TOKEN_ERROR_MESSAGE_MARKER,
+    BigqueryTokenError,
+    isBigqueryTokenErrorMessage,
+} from './errors';
+
+describe('isBigqueryTokenErrorMessage', () => {
+    it('matches the message a BigqueryTokenError carries', () => {
+        const error = new BigqueryTokenError(
+            `${BIGQUERY_TOKEN_ERROR_MESSAGE_MARKER} (invalid_grant: Token has been expired or revoked.; invalid_rapt). Reconnect your BigQuery account in personal settings.`,
+        );
+
+        expect(isBigqueryTokenErrorMessage(error.message)).toBe(true);
+    });
+
+    it('does not match the service account credential rejection', () => {
+        expect(
+            isBigqueryTokenErrorMessage(
+                'Google rejected the BigQuery credentials (invalid_grant: Invalid grant: account not found).',
+            ),
+        ).toBe(false);
+    });
+
+    it('does not match an unrelated query failure', () => {
+        expect(isBigqueryTokenErrorMessage('BigQuery quota exceeded.')).toBe(
+            false,
+        );
+    });
+});

--- a/packages/common/src/types/errors.ts
+++ b/packages/common/src/types/errors.ts
@@ -823,6 +823,12 @@ export class BigqueryTokenError extends LightdashError {
     }
 }
 
+export const BIGQUERY_TOKEN_ERROR_MESSAGE_MARKER =
+    'Google rejected the BigQuery refresh token';
+
+export const isBigqueryTokenErrorMessage = (message: string): boolean =>
+    message.includes(BIGQUERY_TOKEN_ERROR_MESSAGE_MARKER);
+
 /* This specific error will be used in the frontend
 to show a "reauthenticate" button in the UI
 */

--- a/packages/frontend/src/hooks/useInfiniteQueryResults.test.tsx
+++ b/packages/frontend/src/hooks/useInfiniteQueryResults.test.tsx
@@ -204,6 +204,71 @@ describe('useInfiniteQueryResults', () => {
         expect(result.current.error?.error?.name).toBe('RedshiftIamTokenError');
     });
 
+    it('surfaces a rejected BigQuery refresh token as a token error', async () => {
+        const errorResponse: ApiGetAsyncQueryResults = {
+            queryUuid: 'q1',
+            status: QueryHistoryStatus.ERROR,
+            error: 'Google rejected the BigQuery refresh token (invalid_grant: Token has been expired or revoked.; invalid_rapt). Reconnect your BigQuery account in personal settings.',
+            erroredAt: new Date(),
+        };
+        mockGetResultsPage.mockResolvedValue(errorResponse);
+
+        const { result } = renderHook(
+            () => useInfiniteQueryResults('p1', 'q1'),
+            { wrapper: createWrapper() },
+        );
+
+        await waitFor(() => {
+            expect(result.current.error).not.toBeNull();
+        });
+
+        expect(result.current.error?.error?.name).toBe('BigqueryTokenError');
+        expect(result.current.error?.error?.statusCode).toBe(401);
+    });
+
+    it('leaves a bare invalid_grant message as a generic error', async () => {
+        const errorResponse: ApiGetAsyncQueryResults = {
+            queryUuid: 'q1',
+            status: QueryHistoryStatus.ERROR,
+            error: 'invalid_grant',
+            erroredAt: new Date(),
+        };
+        mockGetResultsPage.mockResolvedValue(errorResponse);
+
+        const { result } = renderHook(
+            () => useInfiniteQueryResults('p1', 'q1'),
+            { wrapper: createWrapper() },
+        );
+
+        await waitFor(() => {
+            expect(result.current.error).not.toBeNull();
+        });
+
+        expect(result.current.error?.error?.name).toBe('Error');
+        expect(result.current.error?.error?.statusCode).toBe(500);
+    });
+
+    it('leaves an unrelated query failure as a generic error', async () => {
+        const errorResponse: ApiGetAsyncQueryResults = {
+            queryUuid: 'q1',
+            status: QueryHistoryStatus.ERROR,
+            error: 'BigQuery quota exceeded. Query exceeded the daily quota',
+            erroredAt: new Date(),
+        };
+        mockGetResultsPage.mockResolvedValue(errorResponse);
+
+        const { result } = renderHook(
+            () => useInfiniteQueryResults('p1', 'q1'),
+            { wrapper: createWrapper() },
+        );
+
+        await waitFor(() => {
+            expect(result.current.error).not.toBeNull();
+        });
+
+        expect(result.current.error?.error?.name).toBe('Error');
+    });
+
     it('resets pages when queryUuid changes', async () => {
         const page1Q1 = makeReadyPage(1, { queryUuid: 'q1', rows: 5 });
         const page1Q2 = makeReadyPage(1, { queryUuid: 'q2', rows: 3 });

--- a/packages/frontend/src/hooks/useQueryResults.ts
+++ b/packages/frontend/src/hooks/useQueryResults.ts
@@ -2,6 +2,7 @@ import {
     assertUnreachable,
     DEFAULT_RESULTS_PAGE_SIZE,
     DownloadFileType,
+    isBigqueryTokenErrorMessage,
     LightdashCustomSqlProvenanceChartUuidHeader,
     MAX_SAFE_INTEGER,
     ParameterError,
@@ -65,16 +66,21 @@ const isRedshiftIamTokenErrorMessage = (message: string): boolean => {
     );
 };
 
-const getAsyncQueryError = (message: string | null): ApiError => {
+const getAsyncQueryErrorName = (message: string): ApiError['error']['name'] => {
+    if (isRedshiftIamTokenErrorMessage(message)) return 'RedshiftIamTokenError';
+    if (isBigqueryTokenErrorMessage(message)) return 'BigqueryTokenError';
+    return 'Error';
+};
+
+export const getAsyncQueryError = (message: string | null): ApiError => {
     const errorMessage = message || 'Query failed';
-    const isRedshiftIamTokenError =
-        isRedshiftIamTokenErrorMessage(errorMessage);
+    const name = getAsyncQueryErrorName(errorMessage);
 
     return {
         status: 'error',
         error: {
-            name: isRedshiftIamTokenError ? 'RedshiftIamTokenError' : 'Error',
-            statusCode: isRedshiftIamTokenError ? 401 : 500,
+            name,
+            statusCode: name === 'Error' ? 500 : 401,
             message: errorMessage,
             data: {},
         },

--- a/packages/frontend/src/hooks/useQueryResults.ts
+++ b/packages/frontend/src/hooks/useQueryResults.ts
@@ -66,21 +66,27 @@ const isRedshiftIamTokenErrorMessage = (message: string): boolean => {
     );
 };
 
-const getAsyncQueryErrorName = (message: string): ApiError['error']['name'] => {
-    if (isRedshiftIamTokenErrorMessage(message)) return 'RedshiftIamTokenError';
-    if (isBigqueryTokenErrorMessage(message)) return 'BigqueryTokenError';
-    return 'Error';
+const getAsyncQueryErrorType = (
+    message: string,
+): Pick<ApiError['error'], 'name' | 'statusCode'> => {
+    if (isRedshiftIamTokenErrorMessage(message)) {
+        return { name: 'RedshiftIamTokenError', statusCode: 401 };
+    }
+    if (isBigqueryTokenErrorMessage(message)) {
+        return { name: 'BigqueryTokenError', statusCode: 401 };
+    }
+    return { name: 'Error', statusCode: 500 };
 };
 
 export const getAsyncQueryError = (message: string | null): ApiError => {
     const errorMessage = message || 'Query failed';
-    const name = getAsyncQueryErrorName(errorMessage);
+    const { name, statusCode } = getAsyncQueryErrorType(errorMessage);
 
     return {
         status: 'error',
         error: {
             name,
-            statusCode: name === 'Error' ? 500 : 401,
+            statusCode,
             message: errorMessage,
             data: {},
         },

--- a/packages/frontend/src/hooks/useUnderlyingDataResults.ts
+++ b/packages/frontend/src/hooks/useUnderlyingDataResults.ts
@@ -18,6 +18,7 @@ import { useQuery } from '@tanstack/react-query';
 import { lightdashApi } from '../api';
 import { convertDateFilters } from '../utils/dateFilter';
 import { useProjectUuid } from './useProjectUuid';
+import { getAsyncQueryError } from './useQueryResults';
 
 type UnderlyingDataResults = ApiQueryResults & {
     queryUuid: string;
@@ -95,15 +96,7 @@ export const getUnderlyingDataResults = async (
                 };
             case QueryHistoryStatus.ERROR:
             case QueryHistoryStatus.EXPIRED:
-                throw <ApiError>{
-                    status: 'error',
-                    error: {
-                        name: 'Error',
-                        statusCode: 500,
-                        message: currentPage.error ?? 'Query failed',
-                        data: {},
-                    },
-                };
+                throw getAsyncQueryError(currentPage.error);
             case QueryHistoryStatus.READY:
                 allRows = allRows.concat(currentPage.rows);
                 break;

--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.test.ts
@@ -4,7 +4,15 @@ import {
     type DatasetsResponse,
     type QueryRowsResponse,
 } from '@google-cloud/bigquery';
-import { DimensionType, type BigqueryProject } from '@lightdash/common';
+import {
+    BigqueryAuthenticationType,
+    BigqueryTokenError,
+    DimensionType,
+    WarehouseConnectionError,
+    WarehouseQueryError,
+    type BigqueryProject,
+    type CreateBigqueryCredentials,
+} from '@lightdash/common';
 import type { Mock, MockInstance } from 'vitest';
 import {
     BigquerySqlBuilder,
@@ -555,5 +563,204 @@ describe('BigquerySqlBuilder temporal literals', () => {
         expect(builder.castToNaiveTimestamp(epoch)).toBe(
             "DATETIME '1970-01-01 00:00:00'",
         );
+    });
+});
+
+describe('BigqueryWarehouseClient Google OAuth token errors', () => {
+    type GaxiosErrorData = {
+        error: string;
+        error_description?: string;
+        error_subtype?: string;
+    };
+
+    const createGaxiosError = (
+        data: GaxiosErrorData,
+        message = data.error,
+        status = 400,
+    ) =>
+        Object.assign(new Error(message), {
+            status,
+            response: { status, data },
+        });
+
+    const invalidGrant = {
+        error: 'invalid_grant',
+        error_description: 'Token has been expired or revoked.',
+        error_subtype: 'invalid_rapt',
+    };
+
+    const userCredentials: CreateBigqueryCredentials = {
+        ...credentials,
+        authenticationType: BigqueryAuthenticationType.SSO,
+        keyfileContents: {
+            type: 'authorized_user',
+            client_id: 'client-id',
+            client_secret: 'client-secret',
+            refresh_token: 'refresh-token',
+        },
+    };
+
+    const serviceAccountCredentials: CreateBigqueryCredentials = {
+        ...credentials,
+        authenticationType: BigqueryAuthenticationType.PRIVATE_KEY,
+        keyfileContents: {
+            type: 'service_account',
+            client_email: 'robot@example.iam.gserviceaccount.com',
+            private_key: 'private-key',
+        },
+    };
+
+    const createWarehouseRejectingQueries = (
+        warehouseCredentials: CreateBigqueryCredentials,
+        error: unknown,
+    ) => {
+        const warehouse = new BigqueryWarehouseClient(warehouseCredentials);
+        const createQueryJob = vi.fn<() => Promise<never>>();
+        vi.mocked(createQueryJob).mockRejectedValue(error);
+        warehouse.client.createQueryJob =
+            createQueryJob as unknown as BigQuery['createQueryJob'];
+        return warehouse;
+    };
+
+    const executeAsyncQuery = (warehouse: BigqueryWarehouseClient) =>
+        warehouse.executeAsyncQuery({
+            sql: 'SELECT 1',
+            tags: {},
+        });
+
+    it('translates an invalid_grant rejection of a user keyfile into a BigqueryTokenError', async () => {
+        const warehouse = createWarehouseRejectingQueries(
+            userCredentials,
+            createGaxiosError(invalidGrant),
+        );
+
+        await expect(executeAsyncQuery(warehouse)).rejects.toThrow(
+            BigqueryTokenError,
+        );
+        await expect(executeAsyncQuery(warehouse)).rejects.toThrow(
+            'Google rejected the BigQuery refresh token (invalid_grant: Token has been expired or revoked.; invalid_rapt). Reconnect your BigQuery account in personal settings.',
+        );
+    });
+
+    it('translates an invalid_grant rejection of a service account keyfile into a connection error', async () => {
+        const warehouse = createWarehouseRejectingQueries(
+            serviceAccountCredentials,
+            createGaxiosError(invalidGrant),
+        );
+
+        await expect(executeAsyncQuery(warehouse)).rejects.toThrow(
+            WarehouseConnectionError,
+        );
+        await expect(executeAsyncQuery(warehouse)).rejects.not.toThrow(
+            BigqueryTokenError,
+        );
+        await expect(executeAsyncQuery(warehouse)).rejects.toThrow(
+            'Google rejected the BigQuery credentials (invalid_grant: Token has been expired or revoked.; invalid_rapt).',
+        );
+    });
+
+    it('omits the subtype clause and falls back to invalid_grant alone', async () => {
+        const warehouse = createWarehouseRejectingQueries(
+            userCredentials,
+            createGaxiosError({ error: 'invalid_grant' }),
+        );
+
+        await expect(executeAsyncQuery(warehouse)).rejects.toThrow(
+            'Google rejected the BigQuery refresh token (invalid_grant). Reconnect your BigQuery account in personal settings.',
+        );
+    });
+
+    it('leaves other 400 responses untranslated', async () => {
+        const original = createGaxiosError({
+            error: 'invalid_request',
+            error_description: 'Missing required parameter: refresh_token',
+        });
+        const warehouse = createWarehouseRejectingQueries(
+            userCredentials,
+            original,
+        );
+
+        await expect(executeAsyncQuery(warehouse)).rejects.toBe(original);
+    });
+
+    it('detects invalid_grant from the response body, not the error message', async () => {
+        const warehouse = createWarehouseRejectingQueries(
+            userCredentials,
+            createGaxiosError(
+                invalidGrant,
+                'Token has been expired or revoked.',
+            ),
+        );
+
+        await expect(executeAsyncQuery(warehouse)).rejects.toThrow(
+            BigqueryTokenError,
+        );
+    });
+
+    it('leaves a bare invalid_grant error without a response untranslated', async () => {
+        const original = new Error('invalid_grant');
+        const warehouse = createWarehouseRejectingQueries(
+            userCredentials,
+            original,
+        );
+
+        await expect(executeAsyncQuery(warehouse)).rejects.toBe(original);
+    });
+
+    it('still translates structured BigQuery errors', async () => {
+        const warehouse = createWarehouseRejectingQueries(userCredentials, {
+            errors: [
+                {
+                    reason: 'quotaExceeded',
+                    message: 'Query exceeded the daily quota',
+                },
+            ],
+        });
+
+        await expect(executeAsyncQuery(warehouse)).rejects.toThrow(
+            WarehouseQueryError,
+        );
+        await expect(executeAsyncQuery(warehouse)).rejects.toThrow(
+            'BigQuery quota exceeded. Query exceeded the daily quota',
+        );
+    });
+
+    it('translates an invalid_grant rejection raised while fetching table metadata', async () => {
+        const warehouse = new BigqueryWarehouseClient(userCredentials);
+        const getMetadata = vi.fn<() => Promise<never>>();
+        vi.mocked(getMetadata).mockRejectedValue(
+            createGaxiosError(invalidGrant),
+        );
+        Dataset.prototype.table = vi.fn(() => ({ getMetadata })) as never;
+
+        await expect(
+            warehouse.getFields('myTable', 'mySchema', 'myDatabase'),
+        ).rejects.toThrow(BigqueryTokenError);
+        await expect(warehouse.getCatalog(config)).rejects.toThrow(
+            BigqueryTokenError,
+        );
+    });
+
+    it('translates an invalid_grant rejection raised while listing datasets', async () => {
+        const warehouse = new BigqueryWarehouseClient(userCredentials);
+        const getDatasets = vi.fn<() => Promise<never>>();
+        vi.mocked(getDatasets).mockRejectedValue(
+            createGaxiosError(invalidGrant),
+        );
+        warehouse.client.getDatasets =
+            getDatasets as unknown as BigQuery['getDatasets'];
+
+        await expect(warehouse.getAllTables()).rejects.toThrow(
+            BigqueryTokenError,
+        );
+    });
+
+    it('translates an invalid_grant rejection from the connection test', async () => {
+        const warehouse = createWarehouseRejectingQueries(
+            userCredentials,
+            createGaxiosError(invalidGrant),
+        );
+
+        await expect(warehouse.test()).rejects.toThrow(BigqueryTokenError);
     });
 });

--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
@@ -14,10 +14,12 @@ import {
 import bigquery from '@google-cloud/bigquery/build/src/types';
 import {
     AnyType,
+    BIGQUERY_TOKEN_ERROR_MESSAGE_MARKER,
     BigqueryAuthenticationType,
     BigqueryDataset,
     BigqueryProject,
     BigqueryProjectRecommendation,
+    BigqueryTokenError,
     CreateBigqueryCredentials,
     DimensionType,
     getErrorMessage,
@@ -278,6 +280,41 @@ export class BigquerySqlBuilder extends WarehouseBaseSqlBuilder {
     }
 }
 
+type UnknownRecord = { [key: string]: unknown };
+
+type GoogleOauthTokenError = {
+    error: string;
+    errorDescription: string | undefined;
+    errorSubtype: string | undefined;
+};
+
+const isRecord = (value: unknown): value is UnknownRecord =>
+    typeof value === 'object' && value !== null;
+
+const readString = (record: UnknownRecord, key: string): string | undefined => {
+    const value = record[key];
+    return typeof value === 'string' ? value : undefined;
+};
+
+const getGoogleOauthTokenError = (
+    error: unknown,
+): GoogleOauthTokenError | undefined => {
+    if (!isRecord(error)) return undefined;
+    const response = isRecord(error.response) ? error.response : undefined;
+    const status = response?.status ?? error.status;
+    if (status !== 400) return undefined;
+    const data =
+        response && isRecord(response.data) ? response.data : undefined;
+    if (!data) return undefined;
+    const code = readString(data, 'error');
+    if (code === undefined) return undefined;
+    return {
+        error: code,
+        errorDescription: readString(data, 'error_description'),
+        errorSubtype: readString(data, 'error_subtype'),
+    };
+};
+
 export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryCredentials> {
     private static readonly MAX_LABELS = 64;
 
@@ -312,6 +349,43 @@ export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryC
 
     static isBigqueryError(error: unknown): error is BigqueryError {
         return error !== null && typeof error === 'object' && 'errors' in error;
+    }
+
+    private usesUserRefreshToken(): boolean {
+        return (
+            this.credentials.authenticationType !==
+                BigqueryAuthenticationType.ADC &&
+            this.credentials.keyfileContents?.type === 'authorized_user'
+        );
+    }
+
+    private translateGoogleOauthTokenError(error: unknown): Error | undefined {
+        const tokenError = getGoogleOauthTokenError(error);
+        if (tokenError?.error !== 'invalid_grant') {
+            return undefined;
+        }
+        const details = [
+            tokenError.errorDescription
+                ? `invalid_grant: ${tokenError.errorDescription}`
+                : 'invalid_grant',
+            ...(tokenError.errorSubtype ? [tokenError.errorSubtype] : []),
+        ].join('; ');
+
+        if (this.usesUserRefreshToken()) {
+            return new BigqueryTokenError(
+                `${BIGQUERY_TOKEN_ERROR_MESSAGE_MARKER} (${details}). Reconnect your BigQuery account in personal settings.`,
+            );
+        }
+        return new WarehouseConnectionError(
+            `Google rejected the BigQuery credentials (${details}).`,
+        );
+    }
+
+    private throwIfGoogleOauthTokenError(error: unknown): void {
+        const translated = this.translateGoogleOauthTokenError(error);
+        if (translated) {
+            throw translated;
+        }
     }
 
     /**
@@ -472,6 +546,7 @@ export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryC
                 streamCallback({ fields, rows: [chunk] }),
             );
         } catch (e: unknown) {
+            this.throwIfGoogleOauthTokenError(e);
             if (BigqueryWarehouseClient.isBigqueryError(e)) {
                 const responseError: bigquery.IErrorProto | undefined =
                     e?.errors[0];
@@ -516,6 +591,7 @@ export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryC
                     dataset,
                     table,
                 ).catch((e) => {
+                    this.throwIfGoogleOauthTokenError(e);
                     if (e?.code === 404) {
                         return undefined;
                     }
@@ -553,6 +629,15 @@ export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryC
     }
 
     async getAllTables() {
+        try {
+            return await this.getAllTablesFromClient();
+        } catch (e: unknown) {
+            this.throwIfGoogleOauthTokenError(e);
+            throw e;
+        }
+    }
+
+    private async getAllTablesFromClient() {
         const [datasets] = await this.client.getDatasets();
         const datasetTablesResponses = await Promise.all(
             datasets.map((d) => d.getTables()),
@@ -626,7 +711,10 @@ export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryC
         const schemas = await BigqueryWarehouseClient.getTableMetadata(
             dataset,
             tableName,
-        );
+        ).catch((e: unknown) => {
+            this.throwIfGoogleOauthTokenError(e);
+            throw e;
+        });
         return this.parseWarehouseCatalog(
             schemas[3].fields.map((column) => ({
                 table_catalog: schemas[0],
@@ -796,6 +884,7 @@ export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryC
                 phaseTimings: { query: queryMs, fetch: fetchMs },
             };
         } catch (e: unknown) {
+            this.throwIfGoogleOauthTokenError(e);
             if (BigqueryWarehouseClient.isBigqueryError(e)) {
                 const responseError: bigquery.IErrorProto | undefined =
                     e?.errors[0];


### PR DESCRIPTION
Linear: SPK-1898

Fixes PROD-10935
Fixes #28623

## What breaks

A user who connects to BigQuery with their own Google account sees "Something went wrong" on every query once Google stops accepting their refresh token. Lightdash never asks them to reconnect. The dead token is reused for every later query, so the failure lasts until the user deletes and recreates the connection in personal settings on their own.

Google rejects the token with `400 invalid_grant`. The warehouse client rethrew that raw. The reconnect error (`BigqueryTokenError`) was only thrown when the stored token was missing, never when Google rejected a present one. The log line and the Sentry title carried only `invalid_grant`, without Google's reason.

Over the last 90 days this hit 12 organisations, 51 users and 2,391 failed queries on one shared instance. One customer's users were affected for eleven days.

## What changed

**Warehouse client (the seam).** `BigqueryWarehouseClient` reads the Google OAuth error out of the response body (`response.status === 400` and `response.data.error === 'invalid_grant'`). It does not rely on the error message. It runs before the existing BigQuery structured-error branch in `streamQuery` (which covers `runQuery` and `test`), `executeAsyncQuery`, `getCatalog`, `getAllTables` and `getFields`.

- A user keyfile (`authorized_user`) becomes a `BigqueryTokenError`. The message names Google's `error_description` and `error_subtype` and asks the user to reconnect.
- A service account keyfile becomes a `WarehouseConnectionError` with the same detail.
- Other 400 responses are not translated.

The credential check uses the keyfile type, not `authenticationType`. The user credential is merged over the project credential and its schema does not require `authenticationType`, so the keyfile shape is the only reliable signal. ADC is excluded because the client sends no credentials under ADC.

**Shared marker.** Async queries persist only the error message. `@lightdash/common` exports the message marker and `isBigqueryTokenErrorMessage()` so the backend message and the frontend matcher cannot drift.

**Frontend.** `getAsyncQueryError` in `useQueryResults.ts` now recognises the BigQuery message beside the Redshift IAM rule and returns `BigqueryTokenError` with status 401. That opens the existing reconnect modal in `UserCredentialsSwitcher` on projects that require user credentials. `useUnderlyingDataResults` uses the shared helper instead of its own generic error.

## Surfaces covered

Every surface builds the BigQuery client at one site (`warehouseClientFromCredentials.ts`) through `ProjectService._getWarehouseClient`, and resolves user credentials at one site (`ProjectService.getWarehouseCredentials`). Explore, dashboards and SQL runner go through `AsyncQueryService.runAsyncWarehouseQuery`. The AI agent thread stream and the MCP query tools share `AiAgentToolsService.runAsyncQuery`, which calls the same method. All of them now get the typed error and the descriptive message.

Two static onboarding helpers in the same file (`getDatabases`, `getProjectRecommendation`) build their own client from a bare refresh token. They are not on the query path and are unchanged.

## Logging and Sentry

The `Query <uuid> execution error` log line now carries Google's reason and `errorName: BigqueryTokenError`. No Sentry configuration changed. The async query path never reached Sentry. The AI agent and MCP paths capture the rethrown message explicitly, and its title changes from `Error: invalid_grant` to `Error: Google rejected the BigQuery refresh token (invalid_grant: ...)`, so those issues will regroup under a title that names the cause.

## Tests

- `packages/warehouses`: 10 new tests. A user keyfile maps to `BigqueryTokenError` with description and subtype. A service account keyfile maps to `WarehouseConnectionError`. `invalid_request` is not translated. Detection reads the response body, not the message. An error without a response is not translated. The existing BigQuery `errors[]` translation still works. Covered on `executeAsyncQuery` and a catalog method.
- `packages/frontend`: 3 new tests in `useInfiniteQueryResults.test.tsx`.
- `packages/common`: 3 unit tests for the message helper.
- Mutation check: matching on the message only, always throwing the token error, and removing the frontend rule each broke exactly one intended test.

## Not in this PR

- Persisting a "needs re-auth" mark on the stored credential. The recommended follow-up is on SPK-1898: write it only from the user-token branch after a repeat failure, keep it advisory (attempt the query, clear on success), and use it to explain failures on surfaces with no modal (scheduled deliveries, AI agent runs, MCP).
- Refresh-token rotation persistence. Google does not rotate refresh tokens on exchange.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018kBrAnLPjDdz38SrfuCLbr

