### PR TITLE
chore(deps): move to the renamed @trinodb/trino-js-client

### DIFF
--- a/packages/formula-tests/package.json
+++ b/packages/formula-tests/package.json
@@ -15,10 +15,10 @@
     "@databricks/sql": "1.10.0",
     "@google-cloud/bigquery": "7.9.2",
     "@lightdash/formula": "workspace:*",
+    "@trinodb/trino-js-client": "0.3.2",
     "duckdb": "1.4.2",
     "pg": "8.13.1",
     "snowflake-sdk": "2.3.4",
-    "trino-client": "0.2.9",
     "tsx": "4.19.4"
   },
   "devDependencies": {

--- a/packages/formula-tests/runner/warehouse-connections.ts
+++ b/packages/formula-tests/runner/warehouse-connections.ts
@@ -440,13 +440,13 @@ export async function createTrinoConnection(
     }
 
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { BasicAuth, Trino } = require('trino-client');
+    const { BasicAuth, Trino } = require('@trinodb/trino-js-client');
 
     const client = Trino.create({
         server: `${config.protocol}://${config.host}:${config.port}`,
         catalog: config.catalog,
         schema: config.schema,
-        // trino-client treats `undefined` auth as no auth (anonymous).
+        // the client treats `undefined` auth as no auth (anonymous).
         // Wire BasicAuth only when a password is set so a single-user dev
         // cluster (no auth) still works.
         ...(config.password
@@ -498,7 +498,7 @@ export async function createTrinoConnection(
             }
         },
         async close() {
-            // trino-client has no explicit close — connections are per-query.
+            // the client has no explicit close — connections are per-query.
         },
     };
 }

--- a/packages/warehouses/package.json
+++ b/packages/warehouses/package.json
@@ -36,13 +36,13 @@
     "@duckdb/node-api": "1.5.2-r.2",
     "@google-cloud/bigquery": "8.3.1",
     "@lightdash/common": "workspace:*",
+    "@trinodb/trino-js-client": "0.3.2",
     "node-fetch": "2.7.0",
     "pg": "8.13.1",
     "pg-cursor": "2.10.0",
     "pg-protocol": "1.10.3",
     "snowflake-sdk": "2.3.4",
-    "ssh2": "1.14.0",
-    "trino-client": "0.2.9"
+    "ssh2": "1.14.0"
   },
   "devDependencies": {
     "oxlint": "1.75.0",

--- a/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.test.ts
@@ -4,7 +4,7 @@ import {
     DimensionType,
     QueryExecutionContext,
 } from '@lightdash/common';
-import { Columns, Iterator, QueryData, QueryResult, Trino } from 'trino-client';
+import { Columns, Iterator, QueryData, QueryResult, Trino } from '@trinodb/trino-js-client';
 import {
     TrinoSqlBuilder,
     TrinoTypes,
@@ -19,7 +19,7 @@ import * as warehouseClient from './WarehouseClient.mock';
 
 const queryResultMock = vi.fn();
 
-vi.mock('trino-client', () => ({
+vi.mock('@trinodb/trino-js-client', () => ({
     BasicAuth: vi.fn(),
     Trino: {
         create: vi.fn(() =>

--- a/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.ts
@@ -21,7 +21,7 @@ import {
     QueryError,
     QueryResult,
     Trino,
-} from 'trino-client';
+} from '@trinodb/trino-js-client';
 import { WarehouseCatalog } from '../types';
 import { coerceTagToString, DriftedTagValue } from '../utils/coerceTagToString';
 import {
@@ -403,7 +403,7 @@ export class TrinoWarehouseClient extends WarehouseBaseClient<CreateTrinoCredent
             while (!queryResult.done) {
                 // Per Trino protocol, absence of nextUri means the query is complete.
                 // Some setups (like Honeydew semantic layer) return done=false with no nextUri,
-                // which causes the trino-client library to return duplicate data on subsequent next() calls.
+                // which causes the client library to return duplicate data on subsequent next() calls.
                 // See: https://trino.io/docs/current/develop/client-protocol.html
                 if (!queryResult.value.nextUri) {
                     // eslint-disable-next-line no-await-in-loop


### PR DESCRIPTION
Closes: <!-- no related issue -->

### Description:

The Trino client was republished under the `trinodb` scope. Versions up to 0.2.9 shipped as the unscoped `trino-client`; the scoped `@trinodb/trino-js-client` starts at 0.3.0. The unscoped package is no longer maintained and will not receive further updates.

I am a Trino maintainer, and we are working through the downstream consumers of the client as part of that move.

Renames the dependency and its import specifiers in `packages/warehouses` and `packages/formula-tests`.

### :warning: This will fail CI for the next three days, on purpose

`pnpm-lock.yaml` is **not** updated in this PR, and CI will fail until it is.

`pnpm-workspace.yaml` sets `minimumReleaseAge: 4320`, three days of supply-chain quarantine. `@trinodb/trino-js-client@0.3.2` was published 2026-09-03 21:57 UTC, so `pnpm install --lockfile-only` currently stops with:

```
ERR_PNPM_NO_MATURE_MATCHING_VERSION
  @trinodb/trino-js-client@0.3.2 was published at 2026-09-03T21:57:02.483Z,
  within the minimumReleaseAge cutoff
```

It becomes installable on **2026-09-06 21:57 UTC**. I did not touch `minimumReleaseAgeExclude`, since that list is clearly reserved for Renovate security updates and this is not one.

I am opening it now rather than waiting, so the work is not forgotten on my side after cutting the release. Entirely reasonable to leave it sitting until it goes green — I will push the lockfile regeneration once the window passes, or say the word and I will close it and re-open a complete one then.

### Risk assessment:

- [ ] This is a high-risk change

Low risk. The declaration files of `trino-client@0.2.9` and `@trinodb/trino-js-client@0.3.2` are identical byte for byte:

```
$ npm pack trino-client@0.2.9 && tar xzf trino-client-0.2.9.tgz
$ diff -u package/dist/index.d.ts node_modules/@trinodb/trino-js-client/dist/index.d.ts
$ echo $?
0
```

Same twenty exports, same shapes. `Columns`, `Iterator`, `QueryData`, `QueryResult`, `Trino`, `BasicAuth`, and `ConnectionOptions` all behave as before, so `TrinoWarehouseClient` needs no logic changes and the `vi.mock` in its test only needs the specifier renamed.

Note this brings no axios change for you. Your root `overrides` block already forces `axios: 1.18.0`, so the client's own pin has never applied here. That override can probably go once the next major of the client drops axios entirely in favour of native `fetch`.

### Verification

I did not run the Trino warehouse tests, which need a live coordinator. I did verify 0.3.2 against a real Trino using a harness built from `TrinoWarehouseClient`'s own call patterns, including the manual `next()` streaming loop with the missing-`nextUri` guard your code carries for the Honeydew case, `columns[].typeSignature.rawType`, client tags through `extraHeaders`, and reading errors off `queryResult.value.error`. All checks pass. That harness now runs in the client's CI on every commit (trinodb/trino-js-client#970).