### PR TITLE
feat(dashboard): edit registry custom metrics with an impact preview

### DIFF
--- a/packages/backend/src/controllers/dashboardController.ts
+++ b/packages/backend/src/controllers/dashboardController.ts
@@ -5,7 +5,9 @@ import {
     ApiPromoteDashboardResponse,
     ApiPromotionChangesResponse,
     ApiSuccessEmpty,
+    ApiUpdateDashboardCustomMetricResponse,
     assertRegisteredAccount,
+    UpdateDashboardCustomMetric,
     type ApiCreateDashboardSchedulerResponse,
     type ApiDashboardSchedulersResponse,
     type ApiGetDashboardHistoryResponse,
@@ -14,11 +16,13 @@ import {
     type UuidOrSlug,
 } from '@lightdash/common';
 import {
+    Body,
     Delete,
     Deprecated,
     Get,
     Middlewares,
     OperationId,
+    Patch,
     Path,
     Post,
     Query,
@@ -101,6 +105,44 @@ export class DashboardController extends BaseController {
                 .getPromoteDashboardDiff(
                     toSessionUser(req.account),
                     dashboardUuidOrSlug,
+                    { projectUuid },
+                ),
+        };
+    }
+
+    /**
+     * Edit a dashboard registry custom metric. Swaps the registry entry and
+     * re-versions every dashboard-owned chart that references it, atomically.
+     * With `dryRun` it only reports the charts that would change.
+     * @summary Update dashboard custom metric
+     * @param dashboardUuidOrSlug uuid or slug for the dashboard
+     * @param projectUuid project to resolve a slug in, required when the slug exists in multiple projects (e.g. preview projects)
+     * @param req express request
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Patch('/custom-metrics')
+    @OperationId('updateDashboardCustomMetric')
+    async updateDashboardCustomMetric(
+        @Path() dashboardUuidOrSlug: UuidOrSlug,
+        @Body() body: UpdateDashboardCustomMetric,
+        @Request() req: express.Request,
+        @Query() projectUuid?: UUID,
+    ): Promise<ApiUpdateDashboardCustomMetricResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getDashboardService()
+                .updateCustomMetric(
+                    toSessionUser(req.account),
+                    dashboardUuidOrSlug,
+                    body,
                     { projectUuid },
                 ),
         };

--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -37,6 +37,7 @@ import {
     UpdateMultipleDashboards,
     UserDashboardsSummary,
     type DashboardBasicDetailsWithTileTypes,
+    type DashboardConfig,
     type DashboardFilters,
     type DashboardParameters,
     type DashboardVersionSummary,
@@ -76,8 +77,10 @@ import {
     ProjectTableName,
 } from '../../database/entities/projects';
 import {
+    SavedChartAdditionalMetricTableName,
     SavedChartsTableName,
     SavedChartTable,
+    SavedChartVersionsTableName,
 } from '../../database/entities/savedCharts';
 import { SavedSqlTableName } from '../../database/entities/savedSql';
 import { SpaceTableName } from '../../database/entities/spaces';
@@ -1866,6 +1869,79 @@ export class DashboardModel {
         }
 
         return this.getByIdOrSlug(dashboardUuid);
+    }
+
+    /**
+     * Charts created inside this dashboard whose latest version snapshots the
+     * given custom metric — the only charts a registry edit may rewrite.
+     * Single query so the write-through doesn't fan out over every chart.
+     */
+    async getDashboardOwnedChartUuidsUsingMetric(
+        dashboardUuid: string,
+        metricTable: string,
+        metricName: string,
+    ): Promise<string[]> {
+        const { rows } = await this.database.raw<{
+            rows: { saved_query_uuid: string }[];
+        }>(
+            `
+            WITH latest_versions AS (
+                SELECT DISTINCT ON (v.saved_query_id)
+                    v.saved_query_id,
+                    v.saved_queries_version_id
+                FROM :versionsTable: v
+                JOIN :chartsTable: sq ON sq.saved_query_id = v.saved_query_id
+                WHERE sq.dashboard_uuid = :dashboardUuid
+                    AND sq.deleted_at IS NULL
+                ORDER BY v.saved_query_id, v.created_at DESC
+            )
+            SELECT sq.saved_query_uuid
+            FROM latest_versions lv
+            JOIN :chartsTable: sq ON sq.saved_query_id = lv.saved_query_id
+            JOIN :metricsTable: m
+                ON m.saved_queries_version_id = lv.saved_queries_version_id
+            WHERE m.name = :metricName AND m.table = :metricTable
+            `,
+            {
+                versionsTable: SavedChartVersionsTableName,
+                chartsTable: SavedChartsTableName,
+                metricsTable: SavedChartAdditionalMetricTableName,
+                dashboardUuid,
+                metricName,
+                metricTable,
+            },
+        );
+        return rows.map((row) => row.saved_query_uuid);
+    }
+
+    /**
+     * Rewrites the latest version's config in place. Used by the registry
+     * edit write-through, which must not duplicate tiles/filters the way a
+     * full addVersion would.
+     */
+    async updateLatestVersionConfig(
+        dashboardUuid: string,
+        config: DashboardConfig,
+        tx?: Knex.Transaction,
+    ): Promise<void> {
+        const db = tx ?? this.database;
+        const latest = await db(DashboardVersionsTableName)
+            .leftJoin(
+                DashboardsTableName,
+                `${DashboardsTableName}.dashboard_id`,
+                `${DashboardVersionsTableName}.dashboard_id`,
+            )
+            .select(`${DashboardVersionsTableName}.dashboard_version_id`)
+            .where(`${DashboardsTableName}.dashboard_uuid`, dashboardUuid)
+            .whereNull(`${DashboardsTableName}.deleted_at`)
+            .orderBy(`${DashboardVersionsTableName}.created_at`, 'desc')
+            .first();
+        if (!latest) {
+            throw new NotFoundError('Dashboard version not found');
+        }
+        await db(DashboardVersionsTableName)
+            .update({ config })
+            .where('dashboard_version_id', latest.dashboard_version_id);
     }
 
     /*

--- a/packages/backend/src/services/DashboardService/DashboardService.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.test.ts
@@ -77,6 +77,12 @@ const dashboardModel = {
 
     getOrphanedCharts: vi.fn(async () => []),
 
+    getDashboardOwnedChartUuidsUsingMetric: vi.fn(
+        async (): Promise<string[]> => [],
+    ),
+
+    updateLatestVersionConfig: vi.fn(async () => undefined),
+
     getDashboardsSummaryByOwner: vi.fn(async () => ({
         totalCount: 2,
         byProject: [
@@ -100,6 +106,10 @@ const analyticsModel = {
 };
 const savedChartModel = {
     get: vi.fn(async () => chart),
+    transaction: vi.fn(async (cb: (tx: never) => Promise<void>) =>
+        cb(undefined as never),
+    ),
+    createVersion: vi.fn(async () => chart),
     create: vi.fn(async () => ({ ...chart, uuid: 'duplicated-chart-uuid' })),
     permanentDelete: vi.fn(async () => ({
         uuid: 'chart_uuid',
@@ -150,6 +160,9 @@ const dashboardChartsResult = {
 const searchModel = {
     getDashboardCharts: vi.fn(async () => dashboardChartsResult),
 };
+
+const contentAsCodeProjectSettingsModel = { get: vi.fn() };
+const contentAsCodeSnapshotModel = { get: vi.fn() };
 
 const contentVerificationModel = {
     getByContent: vi.fn(
@@ -227,8 +240,9 @@ describe('DashboardService', () => {
         projectModel: projectModel as unknown as ProjectModel,
         slackClient: slackClient as unknown as SlackClient,
         schedulerClient: schedulerClient as unknown as SchedulerClient,
-        contentAsCodeProjectSettingsModel: { get: vi.fn() } as never,
-        contentAsCodeSnapshotModel: { get: vi.fn() } as never,
+        contentAsCodeProjectSettingsModel:
+            contentAsCodeProjectSettingsModel as never,
+        contentAsCodeSnapshotModel: contentAsCodeSnapshotModel as never,
         contentDraftModel: {
             findOpenDraft: vi.fn(),
             listOpenForContent: vi.fn(async () => []),
@@ -1677,6 +1691,125 @@ describe('DashboardService', () => {
                 ['projectUuid'],
             );
             expect(result).toEqual({ reassignedCount: 2 });
+        });
+    });
+
+    describe('updateCustomMetric', () => {
+        const registryMetric = {
+            name: 'amount_avg',
+            table: 'orders',
+            label: 'Avg amount',
+            sql: '${TABLE}.amount',
+            type: 'average',
+        };
+        const dashboardWithRegistry = {
+            ...dashboard,
+            config: {
+                isDateZoomDisabled: false,
+                customMetrics: [registryMetric],
+            },
+        };
+        const affectedChart = {
+            ...chart,
+            uuid: 'affected_chart_uuid',
+            name: 'Affected chart',
+            metricQuery: {
+                ...chart.metricQuery,
+                additionalMetrics: [registryMetric],
+            },
+        };
+        const updatedMetric = { ...registryMetric, label: 'Avg amount (net)' };
+
+        beforeEach(() => {
+            dashboardModel.getByIdOrSlug.mockResolvedValue(
+                dashboardWithRegistry as never,
+            );
+            dashboardModel.getDashboardOwnedChartUuidsUsingMetric.mockResolvedValue(
+                [affectedChart.uuid],
+            );
+            savedChartModel.get.mockResolvedValue(affectedChart as never);
+        });
+
+        test('swaps the registry entry and re-versions the affected charts', async () => {
+            const result = await service.updateCustomMetric(
+                user,
+                dashboardUuid,
+                { metric: updatedMetric as never },
+            );
+
+            expect(result.dryRun).toBe(false);
+            expect(result.customMetrics).toEqual([updatedMetric]);
+            expect(result.affectedCharts).toEqual([
+                { uuid: affectedChart.uuid, name: affectedChart.name },
+            ]);
+            expect(
+                dashboardModel.updateLatestVersionConfig,
+            ).toHaveBeenCalledWith(
+                dashboardUuid,
+                expect.objectContaining({ customMetrics: [updatedMetric] }),
+                undefined,
+            );
+            expect(savedChartModel.createVersion).toHaveBeenCalledTimes(1);
+            expect(savedChartModel.createVersion).toHaveBeenCalledWith(
+                affectedChart.uuid,
+                expect.objectContaining({
+                    metricQuery: expect.objectContaining({
+                        additionalMetrics: [updatedMetric],
+                    }),
+                }),
+                user,
+                undefined,
+            );
+        });
+
+        test('dryRun reports affected charts without writing', async () => {
+            const result = await service.updateCustomMetric(
+                user,
+                dashboardUuid,
+                { metric: updatedMetric as never, dryRun: true },
+            );
+
+            expect(result.dryRun).toBe(true);
+            expect(result.affectedCharts).toEqual([
+                { uuid: affectedChart.uuid, name: affectedChart.name },
+            ]);
+            expect(
+                dashboardModel.updateLatestVersionConfig,
+            ).not.toHaveBeenCalled();
+            expect(savedChartModel.createVersion).not.toHaveBeenCalled();
+        });
+
+        test('blocks dashboards managed as code', async () => {
+            contentAsCodeProjectSettingsModel.get.mockResolvedValueOnce({
+                syncEnabled: true,
+            });
+            contentAsCodeSnapshotModel.get.mockResolvedValueOnce({
+                snapshot: {},
+                snapshotHash: 'hash',
+            });
+
+            await expect(
+                service.updateCustomMetric(user, dashboardUuid, {
+                    metric: updatedMetric as never,
+                }),
+            ).rejects.toThrowError(
+                'Shared metrics cannot be edited on a dashboard managed as code',
+            );
+            expect(
+                dashboardModel.updateLatestVersionConfig,
+            ).not.toHaveBeenCalled();
+        });
+
+        test('rejects identity changes and unknown metrics as not-in-registry', async () => {
+            // Identity is the lookup key, so a rename can never match an entry
+            await expect(
+                service.updateCustomMetric(user, dashboardUuid, {
+                    metric: {
+                        ...updatedMetric,
+                        name: 'renamed_metric',
+                    } as never,
+                }),
+            ).rejects.toThrowError(NotFoundError);
         });
     });
 });

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -22,6 +22,7 @@ import {
     ExportContentRequest,
     ForbiddenError,
     generateSlug,
+    getItemId,
     getSchedulerResourceTypeAndId,
     hasChartsInDashboard,
     isDashboardChartTileType,
@@ -57,12 +58,14 @@ import {
     type ContentVerificationInfo,
     type CreateDashboardSqlChartTile,
     type DashboardBasicDetailsWithTileTypes,
+    type DashboardCustomMetricUpdateResult,
     type DashboardHistory,
     type DashboardTileTarget,
     type DashboardVersion,
     type DuplicateDashboardParams,
     type Explore,
     type ExploreError,
+    type UpdateDashboardCustomMetric,
     type UUID,
     type UuidOrSlug,
 } from '@lightdash/common';
@@ -2354,6 +2357,138 @@ export class DashboardService
         }
 
         return null;
+    }
+
+    /**
+     * Write-through edit of a dashboard registry custom metric: swaps the
+     * registry entry and re-versions every dashboard-owned chart whose
+     * snapshot references it, atomically. `dryRun` reports the affected
+     * charts without writing (the impact preview).
+     */
+    async updateCustomMetric(
+        user: SessionUser,
+        dashboardUuidOrSlug: UuidOrSlug,
+        payload: UpdateDashboardCustomMetric,
+        options?: { projectUuid?: string },
+    ): Promise<DashboardCustomMetricUpdateResult> {
+        const dashboard = await this.dashboardModel.getByIdOrSlug(
+            dashboardUuidOrSlug,
+            { projectUuid: options?.projectUuid },
+        );
+
+        const currentSpace = await this.spacePermissionService.resolveAccess(
+            user.userUuid,
+            {
+                type: 'dashboard',
+                dashboardUuid: dashboard.uuid,
+                spaceUuid: dashboard.spaceUuid,
+            },
+        );
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            !auditedAbility.can(
+                'update',
+                subject('Dashboard', {
+                    ...currentSpace,
+                    metadata: { dashboardUuid: dashboard.uuid },
+                }),
+            )
+        ) {
+            throw new ForbiddenError(
+                "You don't have access to the space this dashboard belongs to",
+            );
+        }
+        await this.assertCanMutateVerifiedDashboard({
+            user,
+            dashboardUuid: dashboard.uuid,
+            projectUuid: dashboard.projectUuid,
+            organizationUuid: dashboard.organizationUuid,
+        });
+
+        // The write-through mutates published content and chart versions
+        // directly, which the content-as-code draft lifecycle can't represent.
+        if ((await this.resolveDraftBase(dashboard)) !== null) {
+            throw new ParameterError(
+                'Shared metrics cannot be edited on a dashboard managed as code. Publish or discard its draft workflow first.',
+            );
+        }
+
+        const { metric, dryRun = false } = payload;
+        const registry = dashboard.config?.customMetrics ?? [];
+        const metricId = getItemId(metric);
+        const existingIndex = registry.findIndex(
+            (entry) => getItemId(entry) === metricId,
+        );
+        // Identity is the lookup key, so a rename or table change can never
+        // match an entry — chart sorts/filters/config reference the field id.
+        if (existingIndex < 0) {
+            throw new NotFoundError(
+                `Custom metric "${metric.name}" is not in this dashboard's registry. A metric's name and table identify it and cannot be changed`,
+            );
+        }
+
+        // One query finds the affected charts; full chart data is fetched
+        // only for those, since each needs a rewritten version anyway.
+        const affectedChartUuids =
+            await this.dashboardModel.getDashboardOwnedChartUuidsUsingMetric(
+                dashboard.uuid,
+                metric.table,
+                metric.name,
+            );
+        const affected = await Promise.all(
+            affectedChartUuids.map((chartUuid) =>
+                this.savedChartModel.get(chartUuid),
+            ),
+        );
+
+        const updatedRegistry = [
+            ...registry.slice(0, existingIndex),
+            metric,
+            ...registry.slice(existingIndex + 1),
+        ];
+        const affectedCharts = affected.map((chart) => ({
+            uuid: chart.uuid,
+            name: chart.name,
+        }));
+
+        if (!dryRun) {
+            await this.savedChartModel.transaction(async (tx) => {
+                await this.dashboardModel.updateLatestVersionConfig(
+                    dashboard.uuid,
+                    {
+                        isDateZoomDisabled: false,
+                        ...dashboard.config,
+                        customMetrics: updatedRegistry,
+                    },
+                    tx,
+                );
+                await Promise.all(
+                    affected.map((chart) =>
+                        this.savedChartModel.createVersion(
+                            chart.uuid,
+                            {
+                                ...chart,
+                                metricQuery: {
+                                    ...chart.metricQuery,
+                                    additionalMetrics: (
+                                        chart.metricQuery.additionalMetrics ??
+                                        []
+                                    ).map((chartMetric) =>
+                                        getItemId(chartMetric) === metricId
+                                            ? metric
+                                            : chartMetric,
+                                    ),
+                                },
+                            },
+                            user,
+                            tx,
+                        ),
+                    ),
+                );
+            });
+        }
+
+        return { customMetrics: updatedRegistry, affectedCharts, dryRun };
     }
 
     private async assertCanMutateVerifiedDashboard({

--- a/packages/common/src/schemas/json/dashboard-as-code-1.0.json
+++ b/packages/common/src/schemas/json/dashboard-as-code-1.0.json
@@ -340,7 +340,7 @@
         "DashboardConfig": {
             "properties": {
                 "customMetrics": {
-                    "description": "Custom metrics offered to charts built inside this dashboard",
+                    "description": "Custom metrics offered to charts built inside this dashboard. Interim\nstore — moves to a semantic-layer draft later; don't read it elsewhere.",
                     "items": {
                         "$ref": "#/$defs/AdditionalMetric"
                     },

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -190,6 +190,7 @@ import {
     type Dashboard,
     type DashboardAvailableFilters,
     type DashboardBasicDetails,
+    type DashboardCustomMetricUpdateResult,
     type DashboardHistory,
     type DashboardVersion,
 } from './dashboard';
@@ -1333,6 +1334,7 @@ type ApiResults =
     | ChartHistory
     | ChartVersion
     | DashboardHistory
+    | DashboardCustomMetricUpdateResult
     | DashboardVersion
     | EmbedUrl
     | DecodedEmbed

--- a/packages/common/src/types/dashboard.ts
+++ b/packages/common/src/types/dashboard.ts
@@ -510,6 +510,30 @@ export type ApiGetDashboardHistoryResponse = {
     results: DashboardHistory;
 };
 
+export type DashboardCustomMetricAffectedChart = {
+    uuid: string;
+    name: string;
+};
+
+export type UpdateDashboardCustomMetric = {
+    /** Replacement definition; must keep the existing table and name */
+    metric: AdditionalMetric;
+    /** Report affected charts without writing anything */
+    dryRun?: boolean;
+};
+
+export type DashboardCustomMetricUpdateResult = {
+    customMetrics: AdditionalMetric[];
+    /** Dashboard-owned charts whose snapshot references the metric */
+    affectedCharts: DashboardCustomMetricAffectedChart[];
+    dryRun: boolean;
+};
+
+export type ApiUpdateDashboardCustomMetricResponse = {
+    status: 'ok';
+    results: DashboardCustomMetricUpdateResult;
+};
+
 export type ApiGetDashboardVersionResponse = {
     status: 'ok';
     results: DashboardVersion;

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartEditorModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartEditorModal.tsx
@@ -134,6 +134,7 @@ type Props = {
     dashboardName: string;
     editChart?: SavedChart;
     onChartSaved: (chart: SavedChart) => void;
+    onRegistryMetricEdited: (metric: AdditionalMetric) => void;
     onClose: () => void;
 };
 
@@ -147,6 +148,7 @@ const DashboardChartEditorModal: FC<Props> = ({
     dashboardName,
     editChart,
     onChartSaved,
+    onRegistryMetricEdited,
     onClose,
 }) => {
     const [pickedExploreId, setPickedExploreId] = useState<string>();
@@ -174,8 +176,15 @@ const DashboardChartEditorModal: FC<Props> = ({
             onChartSaved: handleChartSaved,
             dashboard: { uuid: dashboardUuid, name: dashboardName },
             dashboardMetricIds,
+            onRegistryMetricEdited,
         }),
-        [handleChartSaved, dashboardUuid, dashboardName, dashboardMetricIds],
+        [
+            handleChartSaved,
+            dashboardUuid,
+            dashboardName,
+            dashboardMetricIds,
+            onRegistryMetricEdited,
+        ],
     );
 
     const handleClose = useCallback(() => {

--- a/packages/frontend/src/components/Explorer/CustomMetricModal/RegistryImpactPreviewModal.tsx
+++ b/packages/frontend/src/components/Explorer/CustomMetricModal/RegistryImpactPreviewModal.tsx
@@ -1,0 +1,91 @@
+import { type DashboardCustomMetricAffectedChart } from '@lightdash/common';
+import { Button, Group, List, Stack, Text } from '@mantine/core';
+import { IconChartBar, IconShare2 } from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineIcon from '../../common/MantineIcon';
+import MantineModal from '../../common/MantineModal';
+
+type Props = {
+    opened: boolean;
+    metricLabel: string;
+    affectedCharts: DashboardCustomMetricAffectedChart[];
+    isSaving: boolean;
+    onBack: () => void;
+    onConfirm: () => void;
+};
+
+/**
+ * Impact preview for a registry metric edit: names every chart the
+ * write-through will rewrite before anything is committed.
+ */
+const RegistryImpactPreviewModal: FC<Props> = ({
+    opened,
+    metricLabel,
+    affectedCharts,
+    isSaving,
+    onBack,
+    onConfirm,
+}) => (
+    <MantineModal
+        opened={opened}
+        onClose={onBack}
+        title="Update metric in this dashboard"
+        icon={IconShare2}
+        cancelLabel={false}
+        actions={
+            <Group gap="xs">
+                <Button variant="default" onClick={onBack} disabled={isSaving}>
+                    Back
+                </Button>
+                <Button onClick={onConfirm} loading={isSaving}>
+                    {affectedCharts.length > 0
+                        ? `Update metric and ${affectedCharts.length} chart${
+                              affectedCharts.length === 1 ? '' : 's'
+                          }`
+                        : 'Update metric'}
+                </Button>
+            </Group>
+        }
+    >
+        <Stack gap="sm">
+            <Text size="sm">
+                <Text span fw={600}>
+                    {metricLabel}
+                </Text>{' '}
+                is shared with every chart in this dashboard.
+            </Text>
+            {affectedCharts.length > 0 ? (
+                <>
+                    <Text size="sm">
+                        These charts use it and will be updated:
+                    </Text>
+                    <List spacing="xs" size="sm" center>
+                        {affectedCharts.map((chart) => (
+                            <List.Item
+                                key={chart.uuid}
+                                icon={
+                                    <MantineIcon
+                                        icon={IconChartBar}
+                                        color="dimmed"
+                                    />
+                                }
+                            >
+                                {chart.name}
+                            </List.Item>
+                        ))}
+                    </List>
+                </>
+            ) : (
+                <Text size="sm" c="dimmed">
+                    No saved charts use it yet — only the shared definition
+                    changes.
+                </Text>
+            )}
+            <Text size="xs" c="dimmed">
+                Charts outside this dashboard are not affected.
+            </Text>
+        </Stack>
+    </MantineModal>
+);
+
+export default RegistryImpactPreviewModal;

--- a/packages/frontend/src/components/Explorer/CustomMetricModal/index.tsx
+++ b/packages/frontend/src/components/Explorer/CustomMetricModal/index.tsx
@@ -17,6 +17,7 @@ import {
     NumberSeparator,
     type AdditionalMetric,
     type CustomFormat,
+    type DashboardCustomMetricUpdateResult,
     type Dimension,
     type FilterableDimension,
 } from '@lightdash/common';
@@ -41,8 +42,14 @@ import {
     useExplorerDispatch,
     useExplorerSelector,
 } from '../../../features/explorer/store';
+import { useUpdateDashboardCustomMetric } from '../../../hooks/dashboard/useUpdateDashboardCustomMetric';
 import useToaster from '../../../hooks/toaster/useToaster';
 import { useExplore } from '../../../hooks/useExplore';
+import {
+    useModalHostedDashboard,
+    useModalHostedDashboardMetricIds,
+    useModalHostedRegistryMetricEdited,
+} from '../../../providers/Explorer/useIsModalHosted';
 import Callout from '../../common/Callout';
 import FieldIcon from '../../common/Filters/FieldIcon';
 import FiltersProvider from '../../common/Filters/FiltersProvider';
@@ -51,6 +58,7 @@ import { NumberInput } from '../../common/NumberInput';
 import { FormatForm } from '../FormatForm';
 import { FilterForm, type MetricFilterRuleWithFieldId } from './FilterForm';
 import { useDataForFiltersProvider } from './hooks/useDataForFiltersProvider';
+import RegistryImpactPreviewModal from './RegistryImpactPreviewModal';
 import {
     addFieldIdToMetricFilterRule,
     getCustomMetricName,
@@ -73,7 +81,24 @@ export const CustomMetricModal = memo(() => {
 
     const { data: exploreData } = useExplore(tableName);
 
-    const { showToastSuccess } = useToaster();
+    const { showToastSuccess, showToastError } = useToaster();
+
+    // Dashboard registry metrics write through the host dashboard instead of
+    // only editing the chart-local copy.
+    const hostDashboard = useModalHostedDashboard();
+    const dashboardMetricIds = useModalHostedDashboardMetricIds();
+    const onRegistryMetricEdited = useModalHostedRegistryMetricEdited();
+    const updateRegistryMetric = useUpdateDashboardCustomMetric(
+        hostDashboard?.uuid,
+    );
+    const [registryEditPreview, setRegistryEditPreview] = useState<{
+        metric: AdditionalMetric;
+        affectedCharts: DashboardCustomMetricUpdateResult['affectedCharts'];
+    } | null>(null);
+    const isRegistryMetric =
+        !!isEditing &&
+        isAdditionalMetric(item) &&
+        (dashboardMetricIds?.has(getItemId(item)) ?? false);
 
     let dimensionToCheck: Dimension | undefined;
 
@@ -364,8 +389,47 @@ export const CustomMetricModal = memo(() => {
 
     const handleClose = useCallback(() => {
         form.reset();
+        setRegistryEditPreview(null);
         dispatch(explorerActions.toggleAdditionalMetricModal());
     }, [form, dispatch]);
+
+    const handleConfirmRegistryEdit = useCallback(() => {
+        if (!registryEditPreview) return;
+        const { metric } = registryEditPreview;
+        updateRegistryMetric.mutate(
+            { metric },
+            {
+                onSuccess: () => {
+                    // Keep the open chart's local copy in sync with the registry.
+                    dispatch(
+                        explorerActions.editAdditionalMetric({
+                            additionalMetric: metric,
+                            previousAdditionalMetricName: getItemId(metric),
+                        }),
+                    );
+                    onRegistryMetricEdited?.(metric);
+                    showToastSuccess({
+                        title: 'Custom metric updated across this dashboard',
+                    });
+                    handleClose();
+                },
+                onError: (error) => {
+                    showToastError({
+                        title: 'Failed to update custom metric',
+                        subtitle: error.error?.message,
+                    });
+                },
+            },
+        );
+    }, [
+        registryEditPreview,
+        updateRegistryMetric,
+        dispatch,
+        onRegistryMetricEdited,
+        showToastSuccess,
+        showToastError,
+        handleClose,
+    ]);
 
     const handleOnSubmit = form.onSubmit(
         ({ customMetricLabel, percentile, format }) => {
@@ -404,6 +468,48 @@ export const CustomMetricModal = memo(() => {
                     baseDimensionChanged && selectedBaseDimension
                         ? { baseDimensionName: selectedBaseDimension.name }
                         : {};
+
+                if (isRegistryMetric && hostDashboard) {
+                    // A shared metric can't move to another table: its
+                    // (table, name) identity is how every chart references it.
+                    if (data.table !== item.table) {
+                        showToastError({
+                            title: 'Shared metrics cannot move to another table',
+                            subtitle:
+                                'Pick a source field from the same table, or create a new metric instead.',
+                        });
+                        return;
+                    }
+                    // Dry-run first: the impact preview names the charts the
+                    // write-through will rewrite before anything commits.
+                    // Identity is pinned — a label change must not rename it.
+                    const updatedMetric: AdditionalMetric = {
+                        ...item,
+                        ...data,
+                        ...updatedBaseDimensionName,
+                        name: item.name,
+                        table: item.table,
+                    };
+                    updateRegistryMetric.mutate(
+                        { metric: updatedMetric, dryRun: true },
+                        {
+                            onSuccess: (result) => {
+                                setRegistryEditPreview({
+                                    metric: updatedMetric,
+                                    affectedCharts: result.affectedCharts,
+                                });
+                            },
+                            onError: (error) => {
+                                showToastError({
+                                    title: 'Failed to prepare metric update',
+                                    subtitle: error.error?.message,
+                                });
+                            },
+                        },
+                    );
+                    return;
+                }
+
                 dispatch(
                     explorerActions.editAdditionalMetric({
                         additionalMetric: {
@@ -496,199 +602,229 @@ export const CustomMetricModal = memo(() => {
     }
 
     return item ? (
-        <MantineModal
-            size="xl"
-            opened={isOpen}
-            onClose={handleClose}
-            title={`${isEditing ? 'Edit' : 'Create'} Custom Metric`}
-            icon={IconSparkles}
-            actions={
-                <Button
-                    type="submit"
-                    form={CUSTOM_METRIC_FORM_ID}
-                    disabled={!form.isValid()}
-                >
-                    {isEditing ? 'Save changes' : 'Create'}
-                </Button>
-            }
-        >
-            <form
-                id={CUSTOM_METRIC_FORM_ID}
-                onSubmit={handleOnSubmit}
-                onClick={(e) => e.stopPropagation()}
+        <>
+            <MantineModal
+                size="xl"
+                opened={isOpen}
+                onClose={handleClose}
+                title={`${isEditing ? 'Edit' : 'Create'} Custom Metric`}
+                icon={IconSparkles}
+                actions={
+                    <Button
+                        type="submit"
+                        form={CUSTOM_METRIC_FORM_ID}
+                        disabled={!form.isValid()}
+                    >
+                        {isEditing ? 'Save changes' : 'Create'}
+                    </Button>
+                }
             >
-                <Stack gap="md">
-                    <TextInput
-                        label="Label"
-                        required
-                        placeholder="Enter custom metric label"
-                        {...form.getInputProps('customMetricLabel')}
-                    />
-                    {showBaseDimensionPicker && customMetricType && (
-                        <Stack gap="xs">
-                            <Select
-                                label="Source field"
-                                description={
-                                    isEditing
-                                        ? `The field this metric aggregates over. Pick a different one to rebuild it without recreating it.`
-                                        : 'The field this metric aggregates over.'
-                                }
-                                data={baseDimensionOptions.map(
-                                    ({ value, label }) => ({ value, label }),
-                                )}
-                                value={selectedBaseDimensionName}
-                                onChange={setSelectedBaseDimensionName}
-                                readOnly={!isEditing}
-                                searchable={isEditing}
-                                allowDeselect={false}
-                                renderOption={renderBaseDimensionOption}
+                <form
+                    id={CUSTOM_METRIC_FORM_ID}
+                    onSubmit={handleOnSubmit}
+                    onClick={(e) => e.stopPropagation()}
+                >
+                    <Stack gap="md">
+                        <TextInput
+                            label="Label"
+                            required
+                            placeholder="Enter custom metric label"
+                            {...form.getInputProps('customMetricLabel')}
+                        />
+                        {showBaseDimensionPicker && customMetricType && (
+                            <Stack gap="xs">
+                                <Select
+                                    label="Source field"
+                                    description={
+                                        isEditing
+                                            ? `The field this metric aggregates over. Pick a different one to rebuild it without recreating it.`
+                                            : 'The field this metric aggregates over.'
+                                    }
+                                    data={baseDimensionOptions.map(
+                                        ({ value, label }) => ({
+                                            value,
+                                            label,
+                                        }),
+                                    )}
+                                    value={selectedBaseDimensionName}
+                                    onChange={setSelectedBaseDimensionName}
+                                    readOnly={!isEditing}
+                                    searchable={isEditing}
+                                    allowDeselect={false}
+                                    renderOption={renderBaseDimensionOption}
+                                    leftSection={
+                                        selectedBaseDimension ? (
+                                            <FieldIcon
+                                                item={selectedBaseDimension}
+                                                size="sm"
+                                            />
+                                        ) : null
+                                    }
+                                    nothingFoundMessage="No compatible fields on this table"
+                                    comboboxProps={{ withinPortal: true }}
+                                />
+                                {baseDimensionChanged &&
+                                selectedBaseDimension ? (
+                                    <Callout
+                                        variant="info"
+                                        title="Source field will change"
+                                    >
+                                        This metric will be rebuilt to aggregate{' '}
+                                        <Text span fw={600}>
+                                            {selectedBaseDimension.label ||
+                                                selectedBaseDimension.name}
+                                        </Text>
+                                        . Filters and format options are
+                                        preserved, and the metric ID stays the
+                                        same so saved charts and dashboards keep
+                                        working.
+                                    </Callout>
+                                ) : null}
+                            </Stack>
+                        )}
+                        {isMetricDerived && sourceMetricLabel && (
+                            <TextInput
+                                label="Source metric"
+                                value={sourceMetricLabel}
+                                readOnly
+                                description="The metric this custom metric is based on."
                                 leftSection={
-                                    selectedBaseDimension ? (
+                                    sourceMetric ? (
                                         <FieldIcon
-                                            item={selectedBaseDimension}
+                                            item={sourceMetric}
                                             size="sm"
                                         />
                                     ) : null
                                 }
-                                nothingFoundMessage="No compatible fields on this table"
-                                comboboxProps={{ withinPortal: true }}
-                            />
-                            {baseDimensionChanged && selectedBaseDimension ? (
-                                <Callout
-                                    variant="info"
-                                    title="Source field will change"
-                                >
-                                    This metric will be rebuilt to aggregate{' '}
-                                    <Text span fw={600}>
-                                        {selectedBaseDimension.label ||
-                                            selectedBaseDimension.name}
-                                    </Text>
-                                    . Filters and format options are preserved,
-                                    and the metric ID stays the same so saved
-                                    charts and dashboards keep working.
-                                </Callout>
-                            ) : null}
-                        </Stack>
-                    )}
-                    {isMetricDerived && sourceMetricLabel && (
-                        <TextInput
-                            label="Source metric"
-                            value={sourceMetricLabel}
-                            readOnly
-                            description="The metric this custom metric is based on."
-                            leftSection={
-                                sourceMetric ? (
-                                    <FieldIcon item={sourceMetric} size="sm" />
-                                ) : null
-                            }
-                        />
-                    )}
-                    {customMetricType && (
-                        <TextInput
-                            label="Type"
-                            value={friendlyName(customMetricType)}
-                            readOnly
-                            description="Metric type"
-                        />
-                    )}
-                    {isMetricDerived &&
-                        (isMetric(item) || isAdditionalMetric(item)) &&
-                        item.sql && (
-                            <TextInput
-                                label="SQL"
-                                value={item.sql}
-                                readOnly
-                                description="SQL this metric aggregates"
                             />
                         )}
-                    {isEditing &&
-                        isAdditionalMetric(item) &&
-                        item.sql &&
-                        isNonAggregateMetricType(item.type) && (
+                        {customMetricType && (
                             <TextInput
-                                label="SQL"
-                                value={item.sql}
+                                label="Type"
+                                value={friendlyName(customMetricType)}
                                 readOnly
-                                description="SQL"
+                                description="Metric type"
                             />
                         )}
-                    {customMetricType === MetricType.PERCENTILE && (
-                        <NumberInput
-                            w={100}
-                            max={100}
-                            min={0}
-                            decimalScale={2}
-                            required
-                            label="Percentile"
-                            {...form.getInputProps('percentile')}
-                        />
-                    )}
-                    <Accordion
-                        chevronPosition="left"
-                        chevronSize="xs"
-                        variant="separated"
-                        radius="md"
-                    >
-                        {canApplyFormatting && (
-                            <Accordion.Item value="format">
+                        {isMetricDerived &&
+                            (isMetric(item) || isAdditionalMetric(item)) &&
+                            item.sql && (
+                                <TextInput
+                                    label="SQL"
+                                    value={item.sql}
+                                    readOnly
+                                    description="SQL this metric aggregates"
+                                />
+                            )}
+                        {isEditing &&
+                            isAdditionalMetric(item) &&
+                            item.sql &&
+                            isNonAggregateMetricType(item.type) && (
+                                <TextInput
+                                    label="SQL"
+                                    value={item.sql}
+                                    readOnly
+                                    description="SQL"
+                                />
+                            )}
+                        {customMetricType === MetricType.PERCENTILE && (
+                            <NumberInput
+                                w={100}
+                                max={100}
+                                min={0}
+                                decimalScale={2}
+                                required
+                                label="Percentile"
+                                {...form.getInputProps('percentile')}
+                            />
+                        )}
+                        <Accordion
+                            chevronPosition="left"
+                            chevronSize="xs"
+                            variant="separated"
+                            radius="md"
+                        >
+                            {canApplyFormatting && (
+                                <Accordion.Item value="format">
+                                    <Accordion.Control>
+                                        <Text fw={500} fz="sm">
+                                            Format
+                                        </Text>
+                                    </Accordion.Control>
+                                    <Accordion.Panel>
+                                        <FormatForm
+                                            formatInputProps={
+                                                getFormatInputProps
+                                            }
+                                            format={form.values.format}
+                                            setFormatFieldValue={
+                                                setFormatFieldValue
+                                            }
+                                        />
+                                    </Accordion.Panel>
+                                </Accordion.Item>
+                            )}
+                            <Accordion.Item value="filters">
                                 <Accordion.Control>
                                     <Text fw={500} fz="sm">
-                                        Format
+                                        Filters
+                                        <Text span fw={400} fz="xs">
+                                            {customMetricFiltersWithIds.length >
+                                            0
+                                                ? `(${customMetricFiltersWithIds.length}) `
+                                                : ' '}
+                                        </Text>
+                                        <Text
+                                            span
+                                            fz="xs"
+                                            c="ldGray.5"
+                                            fw={400}
+                                        >
+                                            (optional)
+                                        </Text>
                                     </Text>
                                 </Accordion.Control>
                                 <Accordion.Panel>
-                                    <FormatForm
-                                        formatInputProps={getFormatInputProps}
-                                        format={form.values.format}
-                                        setFormatFieldValue={
-                                            setFormatFieldValue
-                                        }
-                                    />
+                                    <FiltersProvider<
+                                        Record<string, FilterableDimension>
+                                    >
+                                        projectUuid={projectUuid}
+                                        itemsMap={dimensionsMap}
+                                        startOfWeek={startOfWeek ?? undefined}
+                                        popoverProps={{
+                                            withinPortal: true,
+                                        }}
+                                    >
+                                        <FilterForm
+                                            defaultFilterRuleFieldId={
+                                                defaultFilterRuleFieldId
+                                            }
+                                            customMetricFiltersWithIds={
+                                                customMetricFiltersWithIds
+                                            }
+                                            setCustomMetricFiltersWithIds={
+                                                setCustomMetricFiltersWithIds
+                                            }
+                                        />
+                                    </FiltersProvider>
                                 </Accordion.Panel>
                             </Accordion.Item>
-                        )}
-                        <Accordion.Item value="filters">
-                            <Accordion.Control>
-                                <Text fw={500} fz="sm">
-                                    Filters
-                                    <Text span fw={400} fz="xs">
-                                        {customMetricFiltersWithIds.length > 0
-                                            ? `(${customMetricFiltersWithIds.length}) `
-                                            : ' '}
-                                    </Text>
-                                    <Text span fz="xs" c="ldGray.5" fw={400}>
-                                        (optional)
-                                    </Text>
-                                </Text>
-                            </Accordion.Control>
-                            <Accordion.Panel>
-                                <FiltersProvider<
-                                    Record<string, FilterableDimension>
-                                >
-                                    projectUuid={projectUuid}
-                                    itemsMap={dimensionsMap}
-                                    startOfWeek={startOfWeek ?? undefined}
-                                    popoverProps={{
-                                        withinPortal: true,
-                                    }}
-                                >
-                                    <FilterForm
-                                        defaultFilterRuleFieldId={
-                                            defaultFilterRuleFieldId
-                                        }
-                                        customMetricFiltersWithIds={
-                                            customMetricFiltersWithIds
-                                        }
-                                        setCustomMetricFiltersWithIds={
-                                            setCustomMetricFiltersWithIds
-                                        }
-                                    />
-                                </FiltersProvider>
-                            </Accordion.Panel>
-                        </Accordion.Item>
-                    </Accordion>
-                </Stack>
-            </form>
-        </MantineModal>
+                        </Accordion>
+                    </Stack>
+                </form>
+            </MantineModal>
+            <RegistryImpactPreviewModal
+                opened={registryEditPreview !== null}
+                metricLabel={
+                    registryEditPreview?.metric.label ??
+                    registryEditPreview?.metric.name ??
+                    ''
+                }
+                affectedCharts={registryEditPreview?.affectedCharts ?? []}
+                isSaving={updateRegistryMetric.isLoading}
+                onBack={() => setRegistryEditPreview(null)}
+                onConfirm={handleConfirmRegistryEdit}
+            />
+        </>
     ) : null;
 });

--- a/packages/frontend/src/components/Explorer/ExploreTree/SelectedFieldsSection.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/SelectedFieldsSection.tsx
@@ -11,7 +11,13 @@ import {
     type Dimension,
     type FilterableField,
 } from '@lightdash/common';
-import { ActionIcon, HoverCard, Tooltip, UnstyledButton } from '@mantine/core';
+import {
+    ActionIcon,
+    Badge,
+    HoverCard,
+    Tooltip,
+    UnstyledButton,
+} from '@mantine/core';
 import { IconFilter, IconTrash } from '@tabler/icons-react';
 import {
     Fragment,
@@ -289,6 +295,13 @@ const SelectedFieldRow: FC<RowProps> = memo(({ row, onDeselect }) => {
                     />
                 </HoverCard.Dropdown>
             </HoverCard>
+            {isDashboardMetric && (
+                <Tooltip label="Only available in this dashboard">
+                    <Badge size="xs" radius="sm" px={4} className="ld-shrink-0">
+                        =
+                    </Badge>
+                </Tooltip>
+            )}
             <span className={classes.actions}>
                 {showFilterAction && (
                     <Tooltip
@@ -318,6 +331,7 @@ const SelectedFieldRow: FC<RowProps> = memo(({ row, onDeselect }) => {
                 {/* Mounted on hover only so the labels get the space at rest */}
                 {!hideActions &&
                     (!basicActionsOnly ||
+                        isDashboardMetric ||
                         !!description ||
                         (!isAdditionalMetric(item) &&
                             isFilterableField(item))) &&
@@ -334,6 +348,7 @@ const SelectedFieldRow: FC<RowProps> = memo(({ row, onDeselect }) => {
                             basicActionsOnly={
                                 basicActionsOnly || isDashboardMetric
                             }
+                            allowRegistryEdit={isDashboardMetric}
                         />
                     )}
             </span>

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
@@ -558,6 +558,7 @@ const TreeSingleNodeComponent: FC<Props> = ({ node }) => {
                     isOpened={isMenuOpen}
                     hasDescription={!!description}
                     basicActionsOnly={isDashboardMetric}
+                    allowRegistryEdit={isDashboardMetric}
                     onViewDescription={onOpenDescriptionView}
                     onMenuChange={onToggleMenu}
                 />

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNodeActions.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNodeActions.tsx
@@ -55,6 +55,8 @@ type Props = {
     onViewDescription: () => void;
     onAddFilter?: (field: FilterableField) => void;
     basicActionsOnly?: boolean;
+    /** Registry metrics stay basicActionsOnly but keep the edit entry point */
+    allowRegistryEdit?: boolean;
 };
 
 const TreeSingleNodeActions: FC<Props> = ({
@@ -67,6 +69,7 @@ const TreeSingleNodeActions: FC<Props> = ({
     onViewDescription,
     onAddFilter,
     basicActionsOnly = false,
+    allowRegistryEdit = false,
 }) => {
     const projectUuid = useProjectUuid();
     const cannotAuthorCustomSql = useCannotAuthorCustomSql(projectUuid);
@@ -186,28 +189,28 @@ const TreeSingleNodeActions: FC<Props> = ({
                     </Menu.Item>
                 ) : null}
 
+                {(!basicActionsOnly || allowRegistryEdit) &&
+                isAdditionalMetric(item) ? (
+                    <Menu.Item
+                        component="button"
+                        leftSection={<MantineIcon icon={IconEdit} />}
+                        onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+                            e.stopPropagation();
+                            dispatch(
+                                explorerActions.toggleAdditionalMetricModal({
+                                    type: item.type,
+                                    item,
+                                    isEditing: true,
+                                }),
+                            );
+                        }}
+                    >
+                        Edit custom metric
+                    </Menu.Item>
+                ) : null}
+
                 {!basicActionsOnly && isAdditionalMetric(item) ? (
                     <>
-                        <Menu.Item
-                            component="button"
-                            leftSection={<MantineIcon icon={IconEdit} />}
-                            onClick={(
-                                e: React.MouseEvent<HTMLButtonElement>,
-                            ) => {
-                                e.stopPropagation();
-                                dispatch(
-                                    explorerActions.toggleAdditionalMetricModal(
-                                        {
-                                            type: item.type,
-                                            item,
-                                            isEditing: true,
-                                        },
-                                    ),
-                                );
-                            }}
-                        >
-                            Edit custom metric
-                        </Menu.Item>
                         <Menu.Item
                             component="button"
                             leftSection={<MantineIcon icon={IconCopy} />}

--- a/packages/frontend/src/hooks/dashboard/useUpdateDashboardCustomMetric.ts
+++ b/packages/frontend/src/hooks/dashboard/useUpdateDashboardCustomMetric.ts
@@ -1,0 +1,31 @@
+import {
+    type ApiError,
+    type DashboardCustomMetricUpdateResult,
+    type UpdateDashboardCustomMetric,
+} from '@lightdash/common';
+import { useMutation } from '@tanstack/react-query';
+import { lightdashApi } from '../../api';
+
+const updateDashboardCustomMetric = (
+    dashboardUuid: string,
+    payload: UpdateDashboardCustomMetric,
+) =>
+    lightdashApi<DashboardCustomMetricUpdateResult>({
+        url: `/dashboards/${dashboardUuid}/custom-metrics`,
+        method: 'PATCH',
+        body: JSON.stringify(payload),
+    });
+
+export const useUpdateDashboardCustomMetric = (
+    dashboardUuid: string | undefined,
+) =>
+    useMutation<
+        DashboardCustomMetricUpdateResult,
+        ApiError,
+        UpdateDashboardCustomMetric
+    >((payload) => {
+        if (!dashboardUuid) {
+            throw new Error('Missing dashboard uuid');
+        }
+        return updateDashboardCustomMetric(dashboardUuid, payload);
+    });

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -3,6 +3,7 @@ import {
     copyDateZoomTileTargets,
     excludeTilesFromTabScopedFilters,
     getDefaultChartTileSize,
+    getItemId,
     getShadowedReservedNames,
     mergeDashboardCustomMetrics,
     normalizeDateZoomConfig,
@@ -12,6 +13,7 @@ import {
     DashboardTileTypes,
     DateGranularity,
     FeatureFlags,
+    type AdditionalMetric,
     type DashboardFilterRule,
     type UpdateDashboard,
     type DashboardTile,
@@ -25,6 +27,7 @@ import {
     captureException,
 } from '@sentry/react';
 import { IconAlertCircle, IconCircleCheckFilled } from '@tabler/icons-react';
+import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
 import { type Layout } from 'react-grid-layout';
 import { useBlocker, useNavigate, useParams } from 'react-router';
@@ -826,6 +829,26 @@ const Dashboard: FC = () => {
     const [isNewChartOpen, setIsNewChartOpen] = useState(false);
     const [chartToEdit, setChartToEdit] = useState<SavedChart | undefined>();
 
+    const queryClient = useQueryClient();
+    const handleRegistryMetricEdited = useCallback(
+        (metric: AdditionalMetric) => {
+            // Server already persisted the swap; mirror it into the staged
+            // registry without clobbering other staged additions.
+            setDashboardCustomMetrics((current) =>
+                current.map((entry) =>
+                    getItemId(entry) === getItemId(metric) ? metric : entry,
+                ),
+            );
+            // Affected charts got new versions; refetch so tiles pick them up.
+            void queryClient.invalidateQueries(['saved_query']);
+            void queryClient.invalidateQueries(['dashboard_chart_ready_query']);
+            // And refresh the dashboard itself: a later save builds its config
+            // from the cached dashboard, which now holds a stale registry.
+            void queryClient.invalidateQueries(['saved_dashboard_query']);
+        },
+        [setDashboardCustomMetrics, queryClient],
+    );
+
     const handleChartEditorSaved = useCallback(
         (chart: SavedChart) => {
             // Only the in-dashboard builder contributes to the registry.
@@ -1134,6 +1157,7 @@ const Dashboard: FC = () => {
                             dashboardName={dashboard.name}
                             editChart={chartToEdit}
                             onChartSaved={handleChartEditorSaved}
+                            onRegistryMetricEdited={handleRegistryMetricEdited}
                             onClose={() => {
                                 setIsNewChartOpen(false);
                                 setChartToEdit(undefined);

--- a/packages/frontend/src/providers/Explorer/useIsModalHosted.ts
+++ b/packages/frontend/src/providers/Explorer/useIsModalHosted.ts
@@ -1,4 +1,4 @@
-import { type SavedChart } from '@lightdash/common';
+import { type AdditionalMetric, type SavedChart } from '@lightdash/common';
 import { createContext, useContext } from 'react';
 
 type ModalHostedValue = {
@@ -10,6 +10,8 @@ type ModalHostedValue = {
     dashboard?: { uuid: string; name: string };
     /** Registry metric ids: badged and frozen in the field tree. */
     dashboardMetricIds?: Set<string>;
+    /** Syncs a write-through registry edit back into the host's staged state. */
+    onRegistryMetricEdited?: (metric: AdditionalMetric) => void;
 };
 
 export const ModalHostedContext = createContext<ModalHostedValue>({
@@ -29,3 +31,7 @@ export const useModalHostedDashboard = ():
 
 export const useModalHostedDashboardMetricIds = (): Set<string> | undefined =>
     useContext(ModalHostedContext).dashboardMetricIds;
+
+export const useModalHostedRegistryMetricEdited = ():
+    | ((metric: AdditionalMetric) => void)
+    | undefined => useContext(ModalHostedContext).onRegistryMetricEdited;


### PR DESCRIPTION
Closes: GLITCH-733

### Description:

Registry custom metrics (the `=` badge) get their edit entry point back — with the guarantee the freeze existed to protect, and the thing neither reference product offers: an **impact preview** showing exactly what a change touches before it commits.

**Backend** — `PATCH /dashboards/:uuidOrSlug/custom-metrics`:
- Write-through: swaps the registry entry in `config.customMetrics` and re-versions every dashboard-owned chart whose snapshot references it, in **one transaction** (mirrors the dashboard-rollback pattern). Chart version history is preserved.
- `dryRun` returns the affected chart list without writing — this feeds the preview.
- Identity `(table, name)` is the lookup key, so it structurally cannot change; a rename attempt reads as not-in-registry.
- Only dashboard-owned charts are candidates — charts outside the dashboard can't reference a registry metric, so the blast radius is always fully enumerable.
- 4 service unit tests: swap + re-version scoping, dryRun writes nothing, rename → 404, unknown metric → 404.

**Frontend**:
- `TreeSingleNodeActions` gains `allowRegistryEdit`: registry metrics show "Edit custom metric" + "View description" only (duplicate/delete/write-back stay frozen), in the field tree and the selected section.
- The existing `CustomMetricModal` handles the edit; for registry metrics the save runs the dry-run and shows the preview modal ("These charts use it and will be updated: …", "Update metric and N charts"). Back returns to the form with no writes.
- Identity pinned on the client too — a label change must not rename the metric (the default edit flow recomputes `name` from the label), and a source-field swap to another table is blocked with a clear error.
- On confirm: the open Explorer session's local copy, the host dashboard's staged registry, and the tile queries (`saved_query` + `dashboard_chart_ready_query`) all sync, so tiles re-render with the new definition without a reload.

Verified end-to-end in the browser: edit → preview lists both affected charts → confirm → registry + both chart versions written atomically (same tx timestamp), tiles update live, badge/tree reflect the new label, Back path writes nothing.

Why now: the customer told us calculated fields live in workbooks forever precisely because promoted fields "are quite hard to edit, and there is no way of seeing what would 'break' if they were changed". This is that missing piece.

### Risk assessment:

- [ ] This is a high-risk change

High-risk changes require approval from a reviewer other than the author before merging.
