### PR TITLE
docs: add chart type registry domain docs

### DIFF
--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -11,6 +11,7 @@ collisions with other contexts' or repo-wide meanings.
 ## Contexts
 
 - [Data apps](./docs/data-apps/CONTEXT.md) — AI-generated interactive apps built on the semantic layer by a coding agent in a sandbox, versioned per prompt, found and read by the AI agent
+- [Chart type registry](./docs/chart-types/CONTEXT.md) — official project chart types published as prebuilt artifacts in a public registry and installed read-only per project, with explicit fork for customization
 - [Pre-aggregates](./docs/pre-aggregates/CONTEXT.md) — user-defined, pre-computed summaries of explores that serve matching queries from materialized files instead of the warehouse
 - [AI agent](./docs/ai-agent/CONTEXT.md) — the in-app conversational agent (Ask AI), what users pin to its prompts, and where it opens from
 - [AI agent memory](./docs/ai-agent-memory/CONTEXT.md) — per-user, per-project knowledge the AI agent distills from a user's threads and recalls on their future threads

--- a/docs/chart-types.md
+++ b/docs/chart-types.md
@@ -1,0 +1,115 @@
+# Chart type registry architecture
+
+How official chart types get from the public registry into a project: the
+registry contract, listing, install, and the read-only/fork/upgrade model.
+Vocabulary is defined in [`docs/chart-types/CONTEXT.md`](./chart-types/CONTEXT.md).
+Project chart types themselves (viz schema, explorer behaviour, saved-chart
+version pinning) are data apps — see the "Project chart types" section of
+[`docs/data-apps.md`](./data-apps.md). The registry's own repo, publish
+pipeline, and authoring runbook are documented in
+[lightdash/lightdash-gallery](https://github.com/lightdash/lightdash-gallery).
+
+---
+
+## What it is
+
+- The official registry (`lightdash/lightdash-gallery`, served from GitHub
+  Pages) publishes prebuilt project chart types. A Lightdash deployment
+  points at one registry URL; the in-product chart type gallery gains a
+  **chart type library** section to browse them and install them per
+  project.
+- Installs use prebuilt artifacts — **no build ever runs on the customer
+  instance**, so installing needs no sandbox and takes seconds.
+- Installed official chart types are **read-only**; customizing one is an
+  explicit, irreversible **fork** into a normal editable app.
+
+## The registry contract
+
+- A registry is fully static: a top-level `index.json` plus, per
+  `<slug>/<version>`, a `dist.tar` (the same Vite production build the data
+  apps pipeline produces), a `source.tar`, sha256 digests for both, and
+  screenshots.
+- The contract is shared code: `chartRegistryIndexSchema` and the semver
+  helpers in `packages/common/src/ee/apps/registry.ts` validate the index
+  both in the product (on fetch) and in the gallery repo's CI (on publish).
+  Entries carry slug, name, description, semver version, tags, changelog,
+  `minLightdashVersion`, the viz schema, screenshots, and artifact digests.
+- Published versions are immutable in their entirety — artifacts,
+  screenshots, and metadata. Changes ship as a new semver version; the
+  publish pipeline digest-verifies already-published versions and hard-fails
+  on drift rather than overwriting. Old versions stay served forever.
+- Registry charts are template-deps-only: no dependencies beyond the data
+  app template's own `package.json`, enforced by gallery CI.
+
+## Listing in product
+
+- `ChartRegistryClient` (backend) fetches and validates `index.json`.
+  `GET /api/v1/ee/projects/{projectUuid}/apps/registry/charts` merges the
+  index with the project's installed apps into per-chart state:
+  `not_installed`, `installed`, `update_available`, or `incompatible`
+  (instance older than `minLightdashVersion`).
+- Screenshots and other registry assets reach the browser through the
+  backend proxy at `/api/v1/ee/chart-registry` — the browser never talks to
+  the registry directly.
+
+## Install
+
+- `POST /api/v1/ee/projects/{projectUuid}/apps/registry/charts/{chartSlug}/install`
+  handles both first install and upgrade. The server downloads the
+  artifacts, verifies their sha256 digests against the index, and imports
+  the prebuilt dist through the data app import path via a server-internal
+  `prebuiltDist` option. That option is never reachable from the HTTP
+  upload endpoint — uploaded code always goes through the build sandbox;
+  only registry installs skip it. Install is idempotent under concurrent
+  requests.
+- The result is a project-owned app with provenance: `apps.registry_slug`
+  and `apps.registry_url` identify the upstream chart, and each installed
+  version records `app_versions.registry_version` (the semver it came
+  from). Once installed, the chart type behaves like any project chart type
+  in the explorer.
+
+## Read-only, fork, upgrade, uninstall
+
+- Official chart types refuse iterate/edit/rename (thumbnail editing is
+  deliberately still allowed). There is no computed "modified" state —
+  read-only until forked is the model.
+- **Fork** copies the current source into a new, fully-editable app.
+  Lineage is recorded on `apps.origin_app_uuid`/`origin_app_version` —
+  distinct from promotion's `upstream_app_uuid`. A fork never syncs with
+  the registry again.
+- **Upgrade** appends the newer registry version as a new app version on
+  the same installed app. Which saved charts move is governed by
+  saved-chart version pinning (see `docs/data-apps.md`): pinned charts keep
+  the version they were saved with, unpinned charts follow latest.
+- **Uninstall** is a standard app delete of the installed app, with the
+  usual delete confirmation.
+
+## Configuration and gating
+
+- `LIGHTDASH_CHART_REGISTRY_URL` — the registry a deployment reads.
+  Defaults to the official Pages URL; empty hides the library entirely.
+- `LIGHTDASH_CHART_REGISTRY_ALLOW_INSECURE` — permits plain-http registries
+  (local fixture servers, air-gapped mirrors). Logs a startup security
+  warning; never set it against a registry you don't control.
+- The feature sits on top of data apps (enterprise + its config/flags) and
+  is additionally gated by the `chart-type-registry` feature flag.
+
+## Where to look
+
+- `packages/common/src/ee/apps/registry.ts` — the contract: index schema,
+  semver helpers, API and state types.
+- `packages/backend/src/ee/clients/ChartRegistryClient.ts` — fetching and
+  validating the registry, transport guards.
+- `packages/backend/src/ee/controllers/appGenerateController.ts` — the
+  `/registry/charts` list and install routes.
+- `packages/backend/src/ee/services/AppGenerateService/` — install,
+  upgrade, and fork implementation.
+- `packages/backend/src/ee/routers/chartRegistryAssetRouter.ts` — the
+  registry asset proxy.
+- `packages/frontend/src/features/chartTypes/` — the gallery, library
+  section, and detail/fork/uninstall modals.
+- `packages/backend/src/database/migrations/20260831121540_add_chart_registry_provenance.ts`
+  — provenance and fork-lineage columns.
+- [lightdash/lightdash-gallery](https://github.com/lightdash/lightdash-gallery)
+  — the official registry: seed charts, publish pipeline, validation CI,
+  and the authoring/publishing runbook.

--- a/docs/chart-types/CONTEXT.md
+++ b/docs/chart-types/CONTEXT.md
@@ -1,0 +1,67 @@
+# Chart type registry
+
+Official, installable project chart types. Two halves make the feature: a
+public **chart registry** that publishes prebuilt chart types as static
+artifacts, and the in-product **chart type library** that lists them and
+installs them into a project. Installed official chart types are read-only;
+making one editable is an explicit fork.
+
+Project chart types themselves — the viz schema, the explorer behaviour,
+saved-chart version pinning — belong to the data apps context; use its
+vocabulary (see `docs/data-apps/CONTEXT.md`, "Project chart type") for the
+app/viz side and this glossary for the registry/library side.
+
+## Language
+
+**Chart registry**:
+The static index and artifacts a Lightdash deployment reads installable
+chart types from: an `index.json` catalog plus, per published version,
+prebuilt `dist.tar`/`source.tar` with sha256 digests and screenshots. The
+official registry is the `lightdash/lightdash-gallery` repo served from
+GitHub Pages; a deployment points at exactly one registry URL.
+_Avoid_: marketplace, store, hub, gallery (that is the in-product page)
+
+**Chart type library**:
+The in-product section of the chart type gallery that lists the registry's
+chart types with their per-project install state (not installed, installed,
+update available, incompatible).
+_Avoid_: registry (for the UI), marketplace, app store
+
+**Official chart type**:
+A chart type installed from the registry. Read-only in the project — no
+iterating, editing, or renaming — and carries provenance back to its
+registry slug and version.
+_Avoid_: built-in chart type (those are the native chart kinds), stock
+chart, library chart
+
+**Install**:
+Importing a chart's prebuilt artifacts server-side into the project as a
+read-only app, digest-verified against the registry index. No build runs on
+the instance; install is per project.
+_Avoid_: import, add, download (downloading is what the CLI does)
+
+**Registry version**:
+The semver of a published chart in the registry, recorded on each installed
+app version. Distinct from the app's own integer version timeline: one
+registry version becomes one appended app version on install or upgrade.
+_Avoid_: release, build number
+
+**Upgrade**:
+Installing a newer registry version onto an already-installed official
+chart type, appending a new app version. Which saved charts move is
+governed by saved-chart version pinning (data apps context): pinned charts
+keep their version, unpinned charts follow latest.
+_Avoid_: update (as the verb; "update available" is only the list state),
+reinstall
+
+**Fork**:
+The explicit, irreversible copy of an official chart type into a new,
+fully-editable app owned by the project. Lineage is recorded (origin app
+and version); the fork never syncs with the registry again. There is no
+computed "modified" state — read-only until forked is the whole model.
+_Avoid_: duplicate, customize, detach, eject
+
+**Uninstall**:
+Deleting the installed official chart type's app, with the standard app
+delete confirmation. Reinstalling later is a fresh install.
+_Avoid_: remove from library, deactivate

--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -223,6 +223,10 @@ queries: the explorer hands it rows and a field mapping, and it renders. They sh
 permissions of data apps but are excluded from app listings, have their own gallery and builder, and are downloaded
 as code separately.
 
+Official chart types can also be installed prebuilt from a chart registry, are read-only once installed, and are
+customized by forking — the registry, library, install and fork model is documented in
+[`docs/chart-types.md`](./chart-types.md).
+
 A saved chart pins the version of the type it was saved with, so iterating on a type never changes existing charts.
 Charts saved before pins exist follow the latest version until they are next edited and saved. When a newer version
 exists, the explorer's configure panel offers an upgrade that lists the field, option and palette changes; upgrading


### PR DESCRIPTION
## What

Adds repo documentation for the chart type registry feature so agents (and humans) can get caught up without reading the code:

- `docs/chart-types/CONTEXT.md` — new glossary context: chart registry, chart type library, official chart type, install, registry version, upgrade, fork, uninstall (with `_Avoid_` aliases).
- `docs/chart-types.md` — architecture doc following the `docs/data-apps.md` pattern: the static registry contract and immutability model, in-product listing and per-project state, the prebuilt install path (no instance-side build, `prebuiltDist` invariant), read-only/fork/upgrade/uninstall semantics, configuration and gating, and a where-to-look file map including the lightdash-gallery repo.
- Wired into `CONTEXT-MAP.md` and cross-linked from the "Project chart types" section of `docs/data-apps.md` (which keeps ownership of the viz-schema/pinning vocabulary).

Docs only — no code changes.

Relates: GLITCH-714

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8sCUbSEj5R8babs36CnDN