### PR TITLE
feat(chart-registry): next channel reads index-next.json for staged charts

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -529,7 +529,7 @@ export const lightdashConfigMock: LightdashConfig = {
         // Off in the test fixture (real default is `true`) so tests never make
         // a live OSV call.
         dependencyMalwareCheckEnabled: false,
-        chartRegistry: { url: null, allowInsecure: false },
+        chartRegistry: { url: null, allowInsecure: false, channel: 'stable' },
     },
     enabledFeatureFlags: new Set<string>(),
     disabledFeatureFlags: new Set<string>(),

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -2144,6 +2144,8 @@ export type AppRuntimeConfig = {
         url: string | null;
         /** dev-only: allow http/private addresses for a local fixture registry */
         allowInsecure: boolean;
+        /** which index the client reads: stable (index.json) or next (index-next.json, includes beta charts) */
+        channel: 'stable' | 'next';
     };
 };
 
@@ -2606,6 +2608,15 @@ const parseAppRuntimeConfig = (siteUrl: string): AppRuntimeConfig => {
             // local dev fixtures and trusted internal registry mirrors —
             // never with a registry URL you do not fully control.
             allowInsecure: parseChartRegistryAllowInsecure(),
+            channel: ((raw) => {
+                const normalized = raw?.trim().toLowerCase();
+                if (!normalized || normalized === 'stable')
+                    return 'stable' as const;
+                if (normalized === 'next') return 'next' as const;
+                throw new ParseError(
+                    `Cannot parse environment variable "LIGHTDASH_CHART_REGISTRY_CHANNEL". Value must be one of stable, next but LIGHTDASH_CHART_REGISTRY_CHANNEL=${raw}`,
+                );
+            })(process.env.LIGHTDASH_CHART_REGISTRY_CHANNEL),
         },
     };
 };

--- a/packages/backend/src/ee/clients/ChartRegistryClient.test.ts
+++ b/packages/backend/src/ee/clients/ChartRegistryClient.test.ts
@@ -56,10 +56,13 @@ const jsonResponse = (body: unknown) => ({
 const makeClient = (
     fetchImpl: ReturnType<typeof vi.fn>,
     url: string | null = BASE,
+    channel: 'stable' | 'next' = 'stable',
 ) =>
     new ChartRegistryClient({
         lightdashConfig: {
-            appRuntime: { chartRegistry: { url, allowInsecure: false } },
+            appRuntime: {
+                chartRegistry: { url, allowInsecure: false, channel },
+            },
         } as never,
         fetchImpl: fetchImpl as unknown as ChartRegistryFetchType,
     });
@@ -92,6 +95,21 @@ describe('ChartRegistryClient', () => {
             `${BASE}/index.json`,
             expect.any(Number),
         );
+    });
+
+    it('fetches index-next.json on the next channel and keeps beta entries', async () => {
+        const betaIndex = {
+            ...index,
+            charts: [{ ...index.charts[0], channel: 'beta' }],
+        };
+        const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(betaIndex));
+        const client = makeClient(fetchImpl, BASE, 'next');
+        const result = await client.getIndex();
+        expect(fetchImpl).toHaveBeenCalledWith(
+            `${BASE}/index-next.json`,
+            expect.any(Number),
+        );
+        expect(result.charts[0].channel).toBe('beta');
     });
 
     it('serves the stale cache when a refetch fails', async () => {

--- a/packages/backend/src/ee/clients/ChartRegistryClient.ts
+++ b/packages/backend/src/ee/clients/ChartRegistryClient.ts
@@ -223,6 +223,8 @@ export class ChartRegistryClient {
 
     private readonly allowInsecure: boolean;
 
+    private readonly indexFileName: string;
+
     private readonly fetchImpl: ChartRegistryFetch;
 
     private cache: { index: ChartRegistryIndex; fetchedAt: number } | null =
@@ -235,6 +237,13 @@ export class ChartRegistryClient {
         this.baseUrl = args.lightdashConfig.appRuntime.chartRegistry.url;
         this.allowInsecure =
             args.lightdashConfig.appRuntime.chartRegistry.allowInsecure;
+        // The next channel's index additionally lists charts whose latest
+        // version is a beta (entries carry `channel`); the stable index
+        // only ever lists stable versions.
+        this.indexFileName =
+            args.lightdashConfig.appRuntime.chartRegistry.channel === 'next'
+                ? 'index-next.json'
+                : 'index.json';
         this.fetchImpl = args.fetchImpl ?? this.defaultFetch.bind(this);
     }
 
@@ -269,7 +278,7 @@ export class ChartRegistryClient {
         }
         try {
             const { body } = await this.fetchImpl(
-                this.resolveUrl('index.json').toString(),
+                this.resolveUrl(this.indexFileName).toString(),
                 MAX_INDEX_BYTES,
             );
             const index = this.parseIndex(body);

--- a/packages/common/src/ee/apps/registry.ts
+++ b/packages/common/src/ee/apps/registry.ts
@@ -61,6 +61,8 @@ export type ChartRegistryEntry = {
     tags: string[];
     changelog: string;
     minLightdashVersion: string | null;
+    /** Release channel; absent = stable (the stable index omits the field) */
+    channel?: 'stable' | 'beta';
     vizSchema: DataAppVizSchema;
     thumbnail: string | null;
     screenshots: string[];
@@ -79,6 +81,7 @@ const registryEntrySchema = z.object({
     tags: z.array(z.string()).default([]),
     changelog: z.string().default(''),
     minLightdashVersion: semverString.nullable().default(null),
+    channel: z.enum(['stable', 'beta']).optional(),
     vizSchema: dataAppVizSchema,
     thumbnail: z.string().nullable().default(null),
     screenshots: z.array(z.string()).default([]),


### PR DESCRIPTION
## What

The product half of chart registry release channels (gallery half: lightdash/lightdash-gallery#4). Lets internal instances see staged/beta chart types in the library while customer instances only ever see stable releases.

- New config `LIGHTDASH_CHART_REGISTRY_CHANNEL` (`stable` default | `next`, invalid values fail boot with a ParseError). On the `next` channel, `ChartRegistryClient` fetches `index-next.json` instead of `index.json` from the same registry base — same artifact tree, same digests, same SSRF guards.
- `ChartRegistryEntry` + zod schema gain an optional `channel: 'stable' | 'beta'` field (absent = stable). The stable index never carries the field, so nothing changes for existing deployments; old backends reading a channel-tagged index strip it harmlessly (non-strict zod).
- No behavior change unless the env var is set. Rollout: gallery PR publishes `index-next.json` first, then this releases, then analytics opts in via customer-deployments.

## Testing

- `ChartRegistryClient` tests: new case pinning that the `next` channel fetches `index-next.json` and preserves `channel` on entries; 26/26 pass.
- Backend + common typecheck clean; `pnpm generate-api` clean; MCP tool snapshot unaffected (verified via generate hook — no diff).

Closes: GLITCH-749

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8sCUbSEj5R8babs36CnDN