### PR TITLE
fix(chart-registry): serve thumbnails across index cache generations

### DIFF
--- a/packages/backend/src/ee/clients/ChartRegistryClient.test.ts
+++ b/packages/backend/src/ee/clients/ChartRegistryClient.test.ts
@@ -204,10 +204,50 @@ describe('ChartRegistryClient', () => {
         ).rejects.toThrow(/outside/i);
     });
 
-    it('only serves assets enumerated in the index', async () => {
+    it('only serves assets under chart slugs present in the index', async () => {
         const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(index));
         const client = makeClient(fetchImpl);
-        expect(await client.getAsset('charts/other/steal.png')).toBeUndefined();
+        expect(
+            await client.getAsset('charts/other/1.0.0/steal.png'),
+        ).toBeUndefined();
+    });
+
+    it('serves a previous version screenshot no longer enumerated in the index', async () => {
+        // The index lists only each chart's latest version, and the listing
+        // and asset requests can be served from different index cache
+        // generations across a publish — older versions are immutable and
+        // still served by the registry, so they must stay proxyable.
+        const oldBytes = Buffer.from('old-version-bytes');
+        const fetchImpl = vi
+            .fn()
+            .mockResolvedValueOnce(jsonResponse(index))
+            .mockResolvedValueOnce({
+                status: 200,
+                body: oldBytes,
+                contentType: 'image/png',
+            });
+        const client = makeClient(fetchImpl);
+        const asset = await client.getAsset(
+            'charts/sankey/1.1.0/screenshot-1.png',
+        );
+        expect(asset?.buffer.equals(oldBytes)).toBe(true);
+    });
+
+    it('rejects non-image and malformed asset paths without fetching', async () => {
+        const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(index));
+        const client = makeClient(fetchImpl);
+        expect(
+            await client.getAsset('charts/sankey/1.2.0/dist.tar'),
+        ).toBeUndefined();
+        expect(
+            await client.getAsset('charts/sankey/1.2.0/../../../etc/pw.png'),
+        ).toBeUndefined();
+        expect(
+            await client.getAsset('charts/sankey/not-semver/shot.png'),
+        ).toBeUndefined();
+        expect(await client.getAsset('index.json')).toBeUndefined();
+        // Shape-rejected paths short-circuit before any fetch, index included.
+        expect(fetchImpl).toHaveBeenCalledTimes(0);
     });
 
     it('serves an asset path enumerated in the index', async () => {
@@ -354,15 +394,10 @@ describe('ChartRegistryClient real network (defaultFetch)', () => {
         const baseUrl = await startServer((req, res) => {
             if (req.url === '/index.json') {
                 res.writeHead(200, { 'content-type': 'application/json' });
-                res.end(
-                    JSON.stringify({
-                        ...index,
-                        charts: [{ ...entry, thumbnail: 'thumb.png' }],
-                    }),
-                );
+                res.end(JSON.stringify(index));
                 return;
             }
-            if (req.url === '/thumb.png') {
+            if (req.url === '/charts/sankey/1.2.0/thumb.png') {
                 res.writeHead(404, { 'content-type': 'text/html' });
                 res.end('<html>not found</html>');
                 return;
@@ -371,7 +406,9 @@ describe('ChartRegistryClient real network (defaultFetch)', () => {
             res.end();
         });
         const client = makeRealClient(baseUrl);
-        expect(await client.getAsset('thumb.png')).toBeUndefined();
+        expect(
+            await client.getAsset('charts/sankey/1.2.0/thumb.png'),
+        ).toBeUndefined();
     });
 
     it('round-trips a binary asset byte-for-byte', async () => {
@@ -381,15 +418,10 @@ describe('ChartRegistryClient real network (defaultFetch)', () => {
         const baseUrl = await startServer((req, res) => {
             if (req.url === '/index.json') {
                 res.writeHead(200, { 'content-type': 'application/json' });
-                res.end(
-                    JSON.stringify({
-                        ...index,
-                        charts: [{ ...entry, thumbnail: 'thumb.png' }],
-                    }),
-                );
+                res.end(JSON.stringify(index));
                 return;
             }
-            if (req.url === '/thumb.png') {
+            if (req.url === '/charts/sankey/1.2.0/thumb.png') {
                 res.writeHead(200, { 'content-type': 'image/png' });
                 res.end(imageBytes);
                 return;
@@ -398,7 +430,7 @@ describe('ChartRegistryClient real network (defaultFetch)', () => {
             res.end();
         });
         const client = makeRealClient(baseUrl);
-        const asset = await client.getAsset('thumb.png');
+        const asset = await client.getAsset('charts/sankey/1.2.0/thumb.png');
         expect(asset?.buffer.equals(imageBytes)).toBe(true);
         expect(asset?.contentType).toBe('image/png');
     });

--- a/packages/backend/src/ee/clients/ChartRegistryClient.ts
+++ b/packages/backend/src/ee/clients/ChartRegistryClient.ts
@@ -29,6 +29,18 @@ const ALLOWED_ASSET_CONTENT_TYPES = new Set([
     'image/gif',
 ]);
 
+// Servable asset shape: one image filename under a published version dir of
+// an indexed chart. Validated structurally (plus a slug check against the
+// index) rather than by exact enumeration: the index only lists each chart's
+// latest version, and its per-process TTL cache means the listing and asset
+// requests can straddle a publish on different cache generations — exact
+// matching 404s thumbnails for up to the TTL on every publish. Published
+// versions are immutable and served forever, so older versions' screenshots
+// are always safe to proxy; resolveUrl and the content-type allowlist bound
+// everything else.
+const ASSET_PATH_PATTERN =
+    /^charts\/([a-z0-9][a-z0-9-]*)\/\d+\.\d+\.\d+\/[A-Za-z0-9][A-Za-z0-9._-]*\.(?:png|jpe?g|webp|gif)$/;
+
 const normalizeContentType = (contentType: string): string =>
     contentType.split(';')[0].trim().toLowerCase();
 
@@ -339,12 +351,15 @@ export class ChartRegistryClient {
     async getAsset(
         path: string,
     ): Promise<{ buffer: Buffer; contentType: string } | undefined> {
+        const match = path.match(ASSET_PATH_PATTERN);
+        if (!match) {
+            return undefined;
+        }
         const index = await this.getIndex();
-        const isKnownAsset = index.charts.some(
-            (chart) =>
-                chart.thumbnail === path || chart.screenshots.includes(path),
+        const isKnownChart = index.charts.some(
+            (chart) => chart.slug === match[1],
         );
-        if (!isKnownAsset) {
+        if (!isKnownChart) {
             return undefined;
         }
         const { status, body, contentType } = await this.fetchImpl(


### PR DESCRIPTION
## What

Fixes broken chart-library thumbnails after every registry publish (first seen on internal analytics right after publishing kpi-delta 0.1.1).

**Root cause:** `getAsset` validated screenshot paths by exact enumeration against the cached registry index. The index only lists each chart's **latest** version, and the cache is per-process with a 1-hour TTL — so during any publish transition, the library listing and the asset request can be served from different cache generations (across API pods, or a browser-cached list vs a fresh pod). The referenced path isn't in the validating process's index → 404 → broken image, for up to an hour, on every publish. The underlying files are fine: published versions are immutable and served forever.

**Fix:** structural validation — the path must match `charts/<slug>/<x.y.z>/<image filename>.(png|jpe?g|webp|gif)` and the slug must be present in the index. Older versions' screenshots become proxyable, which is correct under the registry's immutability model. Security bounds unchanged: base-URL containment (`resolveUrl`), image-only content-type allowlist (svg still excluded), byte cap, and shape-rejected paths short-circuit before any fetch.

## Testing

- New tests: previous-version screenshot served across a cache generation; non-image/traversal/malformed paths rejected with zero fetches; slug-level rejection kept.
- Real-network round-trip tests updated to realistic registry paths (they previously used a synthetic flat `thumb.png`, which the structural rule correctly rejects).
- 27/27 client tests, 6/6 asset-router tests, backend typecheck clean.

Closes: GLITCH-750

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8sCUbSEj5R8babs36CnDN