### PR TITLE
fix(data-apps): pin the org template kind on the app and derive the edit scope from it

### DIFF
--- a/packages/backend/src/database/entities/apps.ts
+++ b/packages/backend/src/database/entities/apps.ts
@@ -5,6 +5,7 @@ import {
     type AppVersionStatusHistoryEntry,
     type DataAppGenerationUsage,
     type DataAppTemplate,
+    type DataAppTemplateKind,
     type DataAppVizSchema,
     type PersistedDataAppDataReferences,
 } from '@lightdash/common';
@@ -35,8 +36,11 @@ export type DbApp = {
     // in-flight old code during a deploy.
     sandbox_id: string | null;
     template: Exclude<DataAppTemplate, 'custom'> | null;
-    // Organization template (uploaded package) the app was built from.
+    // Organization template (uploaded package) the app was built from, and
+    // its kind as pinned when the app was created: the template's current
+    // files may change or vanish, the app's contract must not.
     template_slug: string | null;
+    template_kind: DataAppTemplateKind | null;
     design_uuid: string | null;
     // The production app this (preview) app was promoted into. Null until the
     // app is first promoted. Lives on the preview side so a single production
@@ -69,6 +73,7 @@ export type AppsTable = Knex.CompositeTableType<
                 | 'sandbox_id'
                 | 'template'
                 | 'template_slug'
+                | 'template_kind'
                 | 'design_uuid'
                 | 'upstream_app_uuid'
                 | 'registry_slug'

--- a/packages/backend/src/database/migrations/20260904000100_add_template_kind_to_apps.ts
+++ b/packages/backend/src/database/migrations/20260904000100_add_template_kind_to_apps.ts
@@ -1,0 +1,48 @@
+import { Knex } from 'knex';
+
+const AppsTable = 'apps';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(AppsTable, (table) => {
+        // Kind of the organization template the app was built from
+        // ('seeded' | 'instructions'), pinned at creation. The pipeline
+        // reads it instead of re-deriving the kind from the template's
+        // current files, so republishing or deleting a template never
+        // changes what the apps already built from it may do.
+        table.text('template_kind').nullable();
+    });
+    // Backfill from the template's current files, the same rule the
+    // service uses (any src/ file besides the manifest means seeded). An
+    // app whose template is already gone was built when only seeded
+    // templates existed, so it pins as seeded.
+    await knex.raw(`
+        UPDATE ${AppsTable} a
+        SET template_kind = CASE
+            WHEN EXISTS (
+                SELECT 1
+                FROM data_app_template_files f
+                WHERE f.template_uuid = t.template_uuid
+                  AND f.filename LIKE 'src/%'
+                  AND f.filename <> 'src/template.json'
+            ) THEN 'seeded'
+            ELSE 'instructions'
+        END
+        FROM projects p
+        JOIN organizations o ON o.organization_id = p.organization_id
+        JOIN data_app_templates t
+          ON t.organization_uuid = o.organization_uuid
+        WHERE p.project_uuid = a.project_uuid
+          AND a.template_slug = t.slug
+    `);
+    await knex.raw(`
+        UPDATE ${AppsTable}
+        SET template_kind = 'seeded'
+        WHERE template_slug IS NOT NULL AND template_kind IS NULL
+    `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(AppsTable, (table) => {
+        table.dropColumn('template_kind');
+    });
+}

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.orgTemplate.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.orgTemplate.test.ts
@@ -53,13 +53,34 @@ const buildUser = (role: OrganizationMemberRole): SessionUser =>
 const buildService = ({
     flagEnabled = true,
     template = TEMPLATE as typeof TEMPLATE | null,
+    codingAgent = 'claude' as 'claude' | 'codex',
+    guardrails = 'Keep the methodology.' as string | null,
 } = {}) =>
     new AppGenerateService({
         dataAppTemplateService: {
             // findForBuild resolves undefined for an unknown slug
             findForBuild: vi.fn().mockResolvedValue(template ?? undefined),
+            getSourceFiles: vi.fn().mockImplementation(async () => {
+                if (!template) throw new NotFoundError('gone');
+                return {
+                    template,
+                    files: [
+                        { filename: 'src/App.tsx', contents: 'export {}' },
+                        { filename: 'src/template.json', contents: '{}' },
+                        { filename: 'AGENTS.md', contents: guardrails ?? '' },
+                    ],
+                    guardrails,
+                };
+            }),
+            getGuardrails: vi
+                .fn()
+                .mockImplementation(async () =>
+                    template ? { template, guardrails } : undefined,
+                ),
         } as never,
-        lightdashConfig: {} as never,
+        lightdashConfig: {
+            appRuntime: { dataAppCodingAgent: codingAgent },
+        } as never,
         analytics: {} as never,
         analyticsModel: {} as never,
         catalogModel: {} as never,
@@ -133,5 +154,133 @@ describe('AppGenerateService: building from an organization template', () => {
                 buildUser(OrganizationMemberRole.EDITOR),
             ),
         ).rejects.toThrow(NotFoundError);
+    });
+});
+
+const fakeSandbox = () => ({
+    files: { write: vi.fn().mockResolvedValue(undefined) },
+    commands: {
+        run: vi.fn().mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' }),
+    },
+});
+
+const prepare = (
+    service: AppGenerateService,
+    sandbox: ReturnType<typeof fakeSandbox>,
+    orgTemplate: {
+        slug: string;
+        kind: 'seeded' | 'instructions';
+        version: number;
+    },
+) =>
+    (
+        service as unknown as {
+            prepareOrgTemplate: (
+                sandbox: unknown,
+                appUuid: string,
+                orgTemplate: {
+                    organizationUuid: string;
+                    slug: string;
+                    kind: 'seeded' | 'instructions';
+                    version: number;
+                },
+            ) => Promise<string>;
+        }
+    ).prepareOrgTemplate(sandbox, 'app-1', {
+        organizationUuid: ORG_UUID,
+        ...orgTemplate,
+    });
+
+const templateService = (service: AppGenerateService) =>
+    (
+        service as unknown as {
+            dataAppTemplateService: {
+                getSourceFiles: ReturnType<typeof vi.fn>;
+                getGuardrails: ReturnType<typeof vi.fn>;
+            };
+        }
+    ).dataAppTemplateService;
+
+describe('AppGenerateService: preparing the sandbox for an organization template', () => {
+    it('seeds the source on the first build of a seeded template and asks the agent to bind it', async () => {
+        const service = buildService();
+        const sandbox = fakeSandbox();
+        const instructions = await prepare(service, sandbox, {
+            slug: 'metric-forecaster',
+            kind: 'seeded',
+            version: 1,
+        });
+        expect(sandbox.files.write).toHaveBeenCalledWith(
+            '/tmp/template-src.tar',
+            expect.any(Buffer),
+        );
+        expect(sandbox.commands.run.mock.calls[0][0]).toMatch(
+            /tar -xf \/tmp\/template-src\.tar -C \/app/,
+        );
+        expect(instructions).toMatch(/BIND/);
+        expect(instructions).toContain('Keep the methodology.');
+        expect(templateService(service).getGuardrails).not.toHaveBeenCalled();
+    });
+
+    it('reads only the guardrails on iterations, never the package', async () => {
+        const service = buildService();
+        const sandbox = fakeSandbox();
+        const instructions = await prepare(service, sandbox, {
+            slug: 'metric-forecaster',
+            kind: 'seeded',
+            version: 2,
+        });
+        expect(templateService(service).getSourceFiles).not.toHaveBeenCalled();
+        expect(sandbox.files.write).not.toHaveBeenCalled();
+        expect(instructions).not.toMatch(/already contains the finished/);
+        expect(instructions).toContain('Keep the methodology.');
+    });
+
+    it('keeps iterating an app whose template has been deleted', async () => {
+        const service = buildService({ template: null });
+        const sandbox = fakeSandbox();
+        const instructions = await prepare(service, sandbox, {
+            slug: 'metric-forecaster',
+            kind: 'seeded',
+            version: 3,
+        });
+        expect(instructions).toContain('metric-forecaster');
+        expect(instructions).toContain('src/template.json');
+        expect(instructions).not.toContain('Template guardrails');
+    });
+
+    it('does not claim a tool restriction the Codex path cannot enforce', async () => {
+        const claude = await prepare(buildService(), fakeSandbox(), {
+            slug: 'metric-forecaster',
+            kind: 'seeded',
+            version: 1,
+        });
+        expect(claude).toContain('the only file you can write');
+        const codex = await prepare(
+            buildService({ codingAgent: 'codex' }),
+            fakeSandbox(),
+            { slug: 'metric-forecaster', kind: 'seeded', version: 1 },
+        );
+        expect(codex).not.toContain('the only file you can write');
+    });
+
+    it('builds an instructions-only template from its AGENTS.md without seeding', async () => {
+        const service = buildService({
+            template: {
+                ...TEMPLATE,
+                kind: 'instructions',
+                slug: 'exec-summary',
+            },
+            guardrails: 'One page. Three KPIs.',
+        });
+        const sandbox = fakeSandbox();
+        const instructions = await prepare(service, sandbox, {
+            slug: 'exec-summary',
+            kind: 'instructions',
+            version: 1,
+        });
+        expect(templateService(service).getSourceFiles).not.toHaveBeenCalled();
+        expect(instructions).toContain('One page. Three KPIs.');
+        expect(instructions).not.toMatch(/src\/template\.json/);
     });
 });

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.sandboxOutputRedaction.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.sandboxOutputRedaction.test.ts
@@ -32,6 +32,8 @@ type PrivateAppGenerateService = {
         model: 'sonnet',
         effort: 'low',
         structuredOutputSchema: string | null,
+        onTelemetry: undefined,
+        editScope: 'source' | 'manifest',
     ) => Promise<GenerationResult>;
 };
 
@@ -138,6 +140,8 @@ describe.each([
                 'sonnet',
                 'low',
                 null,
+                undefined,
+                'source',
             );
 
             expect(result.responseText).toBe('finished with [redacted]');
@@ -185,6 +189,8 @@ describe.each([
             'sonnet',
             'low',
             null,
+            undefined,
+            'source',
         );
         void generation.catch(() => undefined);
 

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -92,6 +92,7 @@ import {
     type DataAppGenerationUsage,
     type DataAppManifestExternalConnection,
     type DataAppTemplate,
+    type DataAppTemplateKind,
     type DataAppTemplateSummary,
     type DataAppViz,
     type DataAppVizRenderMetadata,
@@ -309,6 +310,8 @@ import {
 import { getTemplateInstructions } from './templates';
 import {
     buildOrgTemplateInstructions,
+    orgTemplateBuildFixNote,
+    orgTemplateEditScope,
     shouldSeedOrgTemplate,
 } from './templateSources';
 
@@ -349,6 +352,17 @@ type AppExternalConnectionDoc = {
 };
 
 type AppRuntimeS3 = { client: S3Client; bucket: string };
+
+/**
+ * An organization template as the pipeline sees it: identity from the app
+ * row (slug + the kind pinned at creation) plus the version being built.
+ */
+type OrgTemplateBuildContext = {
+    organizationUuid: string;
+    slug: string;
+    kind: DataAppTemplateKind;
+    version: number;
+};
 
 type AppGenerateServiceDeps = {
     lightdashConfig: LightdashConfig;
@@ -2932,14 +2946,13 @@ export class AppGenerateService extends BaseService {
         dashboardBlueprint: DashboardBlueprint | undefined,
         template: DataAppTemplate | undefined,
         isDataAppViz: boolean,
-        orgTemplate?: { organizationUuid: string; slug: string; seed: boolean },
+        orgTemplate?: OrgTemplateBuildContext,
     ): Promise<{
         durationMs: number;
         tableCount: number;
         dimensionCount: number;
         metricCount: number;
         yamlBytes: number;
-        editScope: CodingAgentEditScope;
     }> {
         const start = performance.now();
 
@@ -2997,64 +3010,11 @@ export class AppGenerateService extends BaseService {
             );
         }
 
-        // Organization template: seed the workspace with the template's
-        // source from the org's template storage so the agent binds it
-        // (template.json edits against the real explores) instead of
-        // regenerating an app. The tar overwrites the scaffold's overlapping
-        // files and leaves the rest of the scaffold (src/lib,
-        // src/components/ui, css) untouched. The package's AGENTS.md is not
-        // a sandbox file; it travels as the template's prompt instructions.
-        let orgTemplateInstructions: string | null = null;
-        let editScope: CodingAgentEditScope = 'source';
-        if (orgTemplate) {
-            const resolved = await this.dataAppTemplateService.getSourceFiles(
-                orgTemplate.organizationUuid,
-                orgTemplate.slug,
-            );
-            // Instructions-only templates carry no source: nothing to seed,
-            // and AGENTS.md is the build prompt itself.
-            const isSeededKind = resolved.template.kind === 'seeded';
-            if (orgTemplate.seed && isSeededKind) {
-                const sourceFiles = resolved.files.filter((file) =>
-                    file.filename.startsWith('src/'),
-                );
-                if (sourceFiles.length > 0) {
-                    await sandbox.files.write(
-                        '/tmp/template-src.tar',
-                        await AppGenerateService.packModelFiles(sourceFiles),
-                    );
-                    const seededRoots = [
-                        ...new Set(
-                            sourceFiles.map(
-                                (file) => `/app/${file.filename.split('/')[0]}`,
-                            ),
-                        ),
-                    ].join(' ');
-                    await sandbox.commands.run(
-                        `tar -xf /tmp/template-src.tar -C /app && chmod -R a+rwX ${seededRoots} && rm -f /tmp/template-src.tar`,
-                        { timeoutMs: 60_000 },
-                    );
-                    this.logger.info(
-                        `App ${appUuid}: seeded ${sourceFiles.length} files from org template ${orgTemplate.slug}`,
-                    );
-                }
-            }
-            orgTemplateInstructions = buildOrgTemplateInstructions({
-                name: resolved.template.name,
-                guardrails: resolved.guardrails,
-                seeded: orgTemplate.seed && isSeededKind,
-                kind: resolved.template.kind,
-                iteration: !orgTemplate.seed,
-            });
-            // An app built from a seeded template stays an instance of that
-            // template: on every version the agent may only write the
-            // manifest. Changing what the template can do belongs to the
-            // template author; a user who wants a free copy duplicates the
-            // app or starts from scratch.
-            if (isSeededKind) {
-                editScope = 'manifest';
-            }
-        }
+        // Organization template: seed the workspace and/or prepend the
+        // template's instructions. See prepareOrgTemplate.
+        const orgTemplateInstructions = orgTemplate
+            ? await this.prepareOrgTemplate(sandbox, appUuid, orgTemplate)
+            : null;
 
         // Write chart reference files and prepend summary to prompt
         let finalPrompt = prompt;
@@ -3171,8 +3131,88 @@ export class AppGenerateService extends BaseService {
             dimensionCount,
             metricCount,
             yamlBytes: totalBytes,
-            editScope,
         };
+    }
+
+    /**
+     * Prepares a build for an app made from an organization template and
+     * returns the prompt block to prepend. The template's kind and the
+     * version come from the app row, not from the template's current files,
+     * so a republish or deletion never changes what an existing app is:
+     *
+     * - first build of a seeded template: the package's src/** is unpacked
+     *   over the scaffold (overlapping files replaced, the rest untouched)
+     *   and the agent is asked to bind the manifest. Re-runs on a retried
+     *   first build are safe: the catalog stage only runs before generation.
+     * - every other build (iterations, instructions-only templates): only
+     *   AGENTS.md is fetched. A deleted template degrades to the pinned kind
+     *   with no guardrails instead of failing the build.
+     *
+     * AGENTS.md is not a sandbox file; it travels as prompt text.
+     */
+    private async prepareOrgTemplate(
+        sandbox: SandboxHandle,
+        appUuid: string,
+        orgTemplate: OrgTemplateBuildContext,
+    ): Promise<string> {
+        const { organizationUuid, slug, kind, version } = orgTemplate;
+        const seed = shouldSeedOrgTemplate({ version, kind });
+        let name = slug;
+        let guardrails: string | null = null;
+        if (seed) {
+            const resolved = await this.dataAppTemplateService.getSourceFiles(
+                organizationUuid,
+                slug,
+            );
+            name = resolved.template.name;
+            guardrails = resolved.guardrails;
+            const sourceFiles = resolved.files.filter((file) =>
+                file.filename.startsWith('src/'),
+            );
+            if (sourceFiles.length > 0) {
+                await sandbox.files.write(
+                    '/tmp/template-src.tar',
+                    await AppGenerateService.packModelFiles(sourceFiles),
+                );
+                const seededRoots = [
+                    ...new Set(
+                        sourceFiles.map(
+                            (file) => `/app/${file.filename.split('/')[0]}`,
+                        ),
+                    ),
+                ].join(' ');
+                await sandbox.commands.run(
+                    `tar -xf /tmp/template-src.tar -C /app && chmod -R a+rwX ${seededRoots} && rm -f /tmp/template-src.tar`,
+                    { timeoutMs: 60_000 },
+                );
+                this.logger.info(
+                    `App ${appUuid}: seeded ${sourceFiles.length} files from org template ${slug}`,
+                );
+            }
+        } else {
+            const resolved = await this.dataAppTemplateService.getGuardrails(
+                organizationUuid,
+                slug,
+            );
+            if (resolved) {
+                name = resolved.template.name;
+                guardrails = resolved.guardrails;
+            } else {
+                this.logger.warn(
+                    `App ${appUuid}: org template ${slug} no longer exists; building v${version} from the kind pinned on the app without guardrails`,
+                );
+            }
+        }
+        return buildOrgTemplateInstructions({
+            name,
+            guardrails,
+            seeded: seed,
+            kind,
+            iteration: version > 1,
+            // Codex keeps its own sandbox policy, so the manifest-only scope
+            // is asked for there rather than enforced by tool permissions.
+            enforced: this.dataAppCodingAgent !== 'codex',
+        });
     }
 
     private static packModelFiles(files: ModelFile[]): Promise<Buffer> {
@@ -3552,8 +3592,10 @@ export class AppGenerateService extends BaseService {
         // failure) and emits the parsed object on the result event. `null`
         // for runs that don't collect a structured schema (metadata, builds).
         structuredOutputSchema: string | null,
-        onTelemetry?: (telemetry: ClaudeGenerationTelemetry) => void,
-        editScope: CodingAgentEditScope = 'source',
+        onTelemetry:
+            | ((telemetry: ClaudeGenerationTelemetry) => void)
+            | undefined,
+        editScope: CodingAgentEditScope,
     ): Promise<CodingAgentGenerationResult> {
         const start = performance.now();
         let telemetry = ZERO_CLAUDE_GENERATION_TELEMETRY;
@@ -4046,10 +4088,15 @@ export class AppGenerateService extends BaseService {
         claudeModel: DataAppClaudeModel,
         reasoningEffort: DataAppClaudeEffort,
         structuredOutputSchema: string | null,
-        onTelemetry?: (telemetry: ClaudeGenerationTelemetry) => void,
-        // Claude only: Codex keeps its own sandbox policy, so a seeded
-        // template build under Codex is guided by the prompt alone.
-        editScope: CodingAgentEditScope = 'source',
+        onTelemetry:
+            | ((telemetry: ClaudeGenerationTelemetry) => void)
+            | undefined,
+        // Required rather than defaulted: a forgotten call site would
+        // silently hand a seeded-template app full source access. Claude
+        // enforces it through tool permissions; Codex keeps its own sandbox
+        // policy, so there the prompt asks for the scope instead of
+        // claiming it (see buildOrgTemplateInstructions' `enforced`).
+        editScope: CodingAgentEditScope,
     ): Promise<CodingAgentGenerationResult> {
         if (this.dataAppCodingAgent === 'codex') {
             return this.runCodexGeneration(
@@ -4253,8 +4300,10 @@ export class AppGenerateService extends BaseService {
         codingAgentEnv: Record<string, string>,
         claudeModel: DataAppClaudeModel,
         claudeEffort: DataAppClaudeEffort,
-        onTelemetry?: (telemetry: DataAppBuildFixTelemetry) => void,
-        editScope: CodingAgentEditScope = 'source',
+        onTelemetry:
+            | ((telemetry: DataAppBuildFixTelemetry) => void)
+            | undefined,
+        editScope: CodingAgentEditScope,
     ): Promise<{
         buildMs: number;
         fixAttempts: number;
@@ -4327,13 +4376,13 @@ export class AppGenerateService extends BaseService {
                     `The code you just produced failed to build with \`pnpm build\`. ` +
                     `Analyze the build output below, identify the compilation errors, ` +
                     `and fix the code so it builds cleanly. Do not ask questions — ` +
-                    `apply the fix directly.\n\n` +
+                    `apply the fix directly.${orgTemplateBuildFixNote(editScope)}\n\n` +
                     `Build output:\n${errorOutput}`;
             } else {
                 fixPrompt =
                     `The code you just produced compiles, but it ships a blank page. ` +
                     `${blankAppProblem ?? ''} ` +
-                    `Do not ask questions — apply the fix directly.`;
+                    `Do not ask questions — apply the fix directly.${orgTemplateBuildFixNote(editScope)}`;
             }
             // Remove the previous prompt file first — after the Claude CLI
             // ran, it may be owned by a different user and writing would
@@ -4965,9 +5014,18 @@ export class AppGenerateService extends BaseService {
         const pipelineApp = await this.appModel.getApp(appUuid, projectUuid);
         const isDataAppViz = pipelineApp.template === DATA_APP_VIZ_TEMPLATE;
         // Org template: the payload carries it on the seeding build; the app
-        // row is the source of truth on iterations and retries.
+        // row is the source of truth on iterations and retries. The kind is
+        // pinned on the row at creation so a republished or deleted template
+        // never changes what an existing app is allowed to do.
         const orgTemplateSlug =
             payload.templateSlug ?? pipelineApp.template_slug ?? undefined;
+        const orgTemplateKind = orgTemplateSlug
+            ? (pipelineApp.template_kind ?? 'seeded')
+            : null;
+        // What the coding agent may write, on every stage of every version.
+        // Derived here rather than in the catalog stage so a retry that
+        // resumes past catalog (pod death mid-generation) keeps the lock.
+        const editScope = orgTemplateEditScope(orgTemplateKind);
         // Resolve the model once per pipeline run. Jobs enqueued before the
         // picker shipped (or any future caller that omits the field) fall back
         // to the default so we never run with `--model undefined`.
@@ -5088,9 +5146,6 @@ export class AppGenerateService extends BaseService {
             await AppGenerateService.prepareCodexProjectContext(sandbox);
         }
 
-        // Narrowed to the manifest by the catalog stage for a seeded
-        // template's first build; every other build writes anywhere in src.
-        let editScope: CodingAgentEditScope = 'source';
         let catalogStats = {
             tableCount: 0,
             dimensionCount: 0,
@@ -5183,19 +5238,16 @@ export class AppGenerateService extends BaseService {
                     payload.dashboardBlueprint,
                     template,
                     isDataAppViz,
-                    orgTemplateSlug
+                    orgTemplateSlug && orgTemplateKind
                         ? {
                               organizationUuid: payload.organizationUuid,
                               slug: orgTemplateSlug,
-                              seed: shouldSeedOrgTemplate({
-                                  version,
-                                  wasResumed,
-                              }),
+                              kind: orgTemplateKind,
+                              version,
                           }
                         : undefined,
                 );
                 durations.catalogMs = catalogResult.durationMs;
-                editScope = catalogResult.editScope;
                 catalogStats = {
                     tableCount: catalogResult.tableCount,
                     dimensionCount: catalogResult.dimensionCount,
@@ -5452,13 +5504,24 @@ export class AppGenerateService extends BaseService {
                 );
                 // Auto-fix runs Claude too — a classified upstream failure
                 // there (quota, spend limit, auth) is not a compile problem.
+                let buildUserMessage =
+                    "The generated code couldn't be compiled. Try again or simplify your request.";
+                if (
+                    error instanceof ClaudeGenerationError &&
+                    error.userMessage
+                ) {
+                    buildUserMessage = error.userMessage;
+                } else if (editScope === 'manifest' && orgTemplateSlug) {
+                    // The fixer could only touch the manifest, so a component
+                    // that no longer compiles (the scaffold moved under a
+                    // stored template) is the template author's to repair.
+                    buildUserMessage = `The "${orgTemplateSlug}" template's code couldn't be compiled. Ask the template's author to re-upload it after checking it builds.`;
+                }
                 const marked = await this.markError(
                     appUuid,
                     version,
                     error,
-                    error instanceof ClaudeGenerationError && error.userMessage
-                        ? error.userMessage
-                        : "The generated code couldn't be compiled. Try again or simplify your request.",
+                    buildUserMessage,
                 );
                 if (marked) {
                     await this.trackVersionFailed(
@@ -6490,6 +6553,7 @@ export class AppGenerateService extends BaseService {
                     created_by_user_uuid: user.userUuid,
                     template: persistedTemplate,
                     template_slug: orgTemplate?.slug ?? null,
+                    template_kind: orgTemplate?.kind ?? null,
                     space_uuid: spaceUuid ?? null,
                     design_uuid: resolvedDesignUuid,
                 },

--- a/packages/backend/src/ee/services/AppGenerateService/templateSources.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/templateSources.test.ts
@@ -1,21 +1,58 @@
 import { describe, expect, it } from 'vitest';
 import {
     buildOrgTemplateInstructions,
+    orgTemplateBuildFixNote,
+    orgTemplateEditScope,
     shouldSeedOrgTemplate,
 } from './templateSources';
 
 describe('template sources', () => {
     describe('organization templates', () => {
-        it('seeds only the first build of a fresh sandbox', () => {
+        it('seeds the first build of a seeded template, resumed sandbox or not', () => {
+            // The catalog stage only runs while generation has not started,
+            // so re-extracting the tar on a retried first build is safe and
+            // the only way a crash before seeding still produces a seeded app.
+            expect(shouldSeedOrgTemplate({ version: 1, kind: 'seeded' })).toBe(
+                true,
+            );
+            expect(shouldSeedOrgTemplate({ version: 2, kind: 'seeded' })).toBe(
+                false,
+            );
             expect(
-                shouldSeedOrgTemplate({ version: 1, wasResumed: false }),
-            ).toBe(true);
-            expect(
-                shouldSeedOrgTemplate({ version: 2, wasResumed: false }),
+                shouldSeedOrgTemplate({ version: 1, kind: 'instructions' }),
             ).toBe(false);
-            expect(
-                shouldSeedOrgTemplate({ version: 1, wasResumed: true }),
-            ).toBe(false);
+        });
+
+        it('locks the manifest for seeded-template apps from the kind pinned on the app', () => {
+            expect(orgTemplateEditScope('seeded')).toBe('manifest');
+            expect(orgTemplateEditScope('instructions')).toBe('source');
+            expect(orgTemplateEditScope(null)).toBe('source');
+        });
+
+        it('tells a manifest-scoped fixer what it can and cannot repair', () => {
+            expect(orgTemplateBuildFixNote('source')).toBe('');
+            const note = orgTemplateBuildFixNote('manifest');
+            expect(note).toContain('src/template.json');
+            expect(note).toMatch(/template/i);
+        });
+
+        it('softens the read-only claim when the agent cannot be held to it', () => {
+            const enforced = buildOrgTemplateInstructions({
+                name: 'Metric Forecaster',
+                guardrails: null,
+                seeded: true,
+                enforced: true,
+            });
+            expect(enforced).toContain('the only file you can write');
+            const unenforced = buildOrgTemplateInstructions({
+                name: 'Metric Forecaster',
+                guardrails: null,
+                seeded: true,
+                enforced: false,
+            });
+            expect(unenforced).not.toContain('the only file you can write');
+            expect(unenforced).toContain('src/template.json');
+            expect(unenforced).toMatch(/only edit|edit only/i);
         });
 
         it('binds a seeded org template and carries its guardrails verbatim', () => {

--- a/packages/backend/src/ee/services/AppGenerateService/templateSources.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/templateSources.ts
@@ -1,4 +1,5 @@
 import { type DataAppTemplateKind } from '@lightdash/common';
+import type { CodingAgentEditScope } from './claudeAllowedTools';
 
 /**
  * Organization data app templates: uploaded packages whose source is seeded
@@ -8,14 +9,43 @@ import { type DataAppTemplateKind } from '@lightdash/common';
  */
 
 /**
- * Seed only the first build of a fresh sandbox: iterations own their source,
- * and a resumed sandbox has `/app/src` restored from its snapshot — seeding
- * either would clobber user work.
+ * Seed the first build of a seeded template. Iterations own their source
+ * (the sandbox restores `/app/src` from the app's snapshot), so seeding one
+ * would clobber user work. A retried first build re-seeds even when its
+ * sandbox was resumed: the catalog stage only runs while generation has not
+ * started, so re-extracting the tar is safe, and it is the only way a crash
+ * before seeding still ends in a seeded app. The kind comes from the app row
+ * (pinned at creation), not from the template's current files.
  */
 export const shouldSeedOrgTemplate = (context: {
     version: number;
-    wasResumed: boolean;
-}): boolean => context.version === 1 && !context.wasResumed;
+    kind: DataAppTemplateKind;
+}): boolean => context.version === 1 && context.kind === 'seeded';
+
+/**
+ * What the coding agent may write for an app built from an org template,
+ * from the kind pinned on the app row. Seeded-template apps stay instances
+ * of their template on every version, so the manifest is the only writable
+ * file; instructions-only templates and apps without a template write
+ * anywhere in src. Deriving this from the row (not from a pipeline stage)
+ * keeps it true on retries that resume past the catalog stage.
+ */
+export const orgTemplateEditScope = (
+    kind: DataAppTemplateKind | null | undefined,
+): CodingAgentEditScope => (kind === 'seeded' ? 'manifest' : 'source');
+
+/**
+ * Appended to the build-fix prompt when the fixer can only write the
+ * manifest: a component that fails to compile is the template author's to
+ * repair, so the agent should say so instead of thrashing on files it
+ * cannot touch.
+ */
+export const orgTemplateBuildFixNote = (
+    editScope: CodingAgentEditScope,
+): string =>
+    editScope === 'manifest'
+        ? ` This app is an instance of an organization template and src/template.json is the only file you can write. If the failure is in the manifest (a wrong binding, an invalid value), fix it there. If the failure is in a component, do not try to work around it: state plainly that the template's code does not build and that its author needs to fix it.`
+        : '';
 
 /**
  * Prompt block for an app built from an organization template. The
@@ -34,13 +64,24 @@ export const buildOrgTemplateInstructions = ({
     seeded,
     kind = 'seeded',
     iteration = false,
+    enforced = true,
 }: {
     name: string;
     guardrails: string | null;
     seeded: boolean;
     kind?: DataAppTemplateKind;
     iteration?: boolean;
+    /**
+     * Whether the manifest-only scope is enforced by the agent's tool
+     * permissions (Claude) or only asked for (Codex keeps its own sandbox
+     * policy). The prompt must not claim a restriction that does not exist:
+     * the agent would either refuse valid work or break it silently.
+     */
+    enforced?: boolean;
 }): string => {
+    const manifestOnly = enforced
+        ? 'src/template.json is the only file you can write; component files are read-only'
+        : 'edit only src/template.json and leave component files untouched';
     const guidance = guardrails?.trim() ?? '';
     if (kind === 'instructions') {
         const header = iteration
@@ -57,13 +98,13 @@ ${guidance}`
     }
     const header = seeded
         ? `[Template: ${name} — seeded organization template]
-The workspace already contains the finished "${name}" app: components under src/ and a src/template.json manifest holding everything that is meant to vary (data bindings, parameters, labels, theme). Your job is to BIND this app to the user's request, not to rebuild it. In this build src/template.json is the only file you can write; component files are read-only.
+The workspace already contains the finished "${name}" app: components under src/ and a src/template.json manifest holding everything that is meant to vary (data bindings, parameters, labels, theme). Your job is to BIND this app to the user's request, not to rebuild it. In this build ${manifestOnly}.
 - Read src/template.json first. Resolve the user's request (and any clarification answers) against the real data models in /tmp/dbt-repo/models and set the manifest's bindings accordingly, using explore, metric, and dimension names exactly as declared in the YAML.
 - Adjust parameters, labels, and theme in src/template.json. Do not attempt to edit components or the manifest loader.
 - If part of the request needs something the manifest cannot express, do not work around it: say plainly what this template supports, bind the rest, and tell the user they can ask for the extra behaviour in a follow-up message once the app is built.
 - Verify every binding against the model YAML — a wrong field id fails loudly on the app page.`
         : `[Template: ${name} — organization template]
-This app is an instance of the "${name}" template: its src/template.json manifest holds the data bindings, parameters, labels, and theme, and src/template.json is the only file you can write. Make the requested change there. If the request needs a component change, do not attempt it: explain that this app follows the template, that the change belongs to the template's author, and that the user can duplicate the app or start from scratch for a free copy.`;
+This app is an instance of the "${name}" template: its src/template.json manifest holds the data bindings, parameters, labels, and theme, and ${manifestOnly}. Make the requested change there. If the request needs a component change, do not attempt it: explain that this app follows the template, that the change belongs to the template's author, and that the user can duplicate the app or start from scratch for a free copy.`;
     if (guidance.length === 0) {
         return header;
     }

--- a/packages/backend/src/ee/services/DataAppTemplateService/DataAppTemplateService.test.ts
+++ b/packages/backend/src/ee/services/DataAppTemplateService/DataAppTemplateService.test.ts
@@ -390,6 +390,18 @@ describe('DataAppTemplateService.importPackage', () => {
         expect(bare.model.upsert).not.toHaveBeenCalled();
     });
 
+    it('rejects an instructions-only package whose AGENTS.md is blank', async () => {
+        const { service, model } = buildService();
+        const blank = await packFiles({
+            'src/template.json': MANIFEST,
+            'AGENTS.md': '   \n\n',
+        });
+        await expect(importArchive(service, blank)).rejects.toThrow(
+            /AGENTS\.md/,
+        );
+        expect(model.upsert).not.toHaveBeenCalled();
+    });
+
     it('rejects a package without a manifest', async () => {
         const { service, model } = buildService();
         const archive = await packFiles({ 'src/App.jsx': '// no manifest' });
@@ -526,5 +538,66 @@ describe('DataAppTemplateService.importFromApp', () => {
                 { path: 'package.json', contentBase64: b64('{}') },
             ]),
         ).rejects.toThrow(ParameterError);
+    });
+});
+
+describe('DataAppTemplateService.getGuardrails', () => {
+    const summary = {
+        templateUuid: 'tpl-1',
+        organizationUuid: 'test-org-uuid',
+        slug: 'forecaster',
+        name: 'Forecaster',
+        description: 'x',
+        category: 'Forecasting',
+        questions: [],
+        kind: 'seeded' as const,
+        fileCount: 3,
+        createdByUserUuid: 'u',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+    };
+
+    it('reads only AGENTS.md, not the whole package', async () => {
+        const { service, send } = buildService({
+            findBySlug: vi.fn().mockResolvedValue(summary),
+            listFiles: vi
+                .fn()
+                .mockResolvedValue([
+                    { filename: 'src/App.tsx' },
+                    { filename: 'src/template.json' },
+                    { filename: 'AGENTS.md' },
+                ]),
+        });
+        send.mockImplementation(async () => ({
+            Body: Readable.from([Buffer.from('Keep the methodology.\n')]),
+        }));
+        const result = await service.getGuardrails(
+            'test-org-uuid',
+            'forecaster',
+        );
+        expect(result).toEqual({
+            template: summary,
+            guardrails: 'Keep the methodology.\n',
+        });
+        expect(send).toHaveBeenCalledTimes(1);
+        expect(
+            (send.mock.calls[0][0] as { input: { Key: string } }).input.Key,
+        ).toMatch(/AGENTS\.md$/);
+    });
+
+    it('returns no guardrails when the package has none, and nothing when the template is gone', async () => {
+        const { service, send } = buildService({
+            findBySlug: vi.fn().mockResolvedValue(summary),
+            listFiles: vi.fn().mockResolvedValue([{ filename: 'src/App.tsx' }]),
+        });
+        await expect(
+            service.getGuardrails('test-org-uuid', 'forecaster'),
+        ).resolves.toEqual({ template: summary, guardrails: null });
+        expect(send).not.toHaveBeenCalled();
+
+        const gone = buildService();
+        await expect(
+            gone.service.getGuardrails('test-org-uuid', 'forecaster'),
+        ).resolves.toBeUndefined();
     });
 });

--- a/packages/backend/src/ee/services/DataAppTemplateService/DataAppTemplateService.ts
+++ b/packages/backend/src/ee/services/DataAppTemplateService/DataAppTemplateService.ts
@@ -420,12 +420,15 @@ export class DataAppTemplateService extends BaseService {
         }
         // An instructions-only template has nothing to build from without
         // AGENTS.md; a seeded one can omit it (the source is the template).
+        // The file must carry text: a blank AGENTS.md would pass an
+        // existence check and free-generate from a header-only prompt.
+        const guardrailsFile = files.find(
+            (file) => file.filename === DATA_APP_TEMPLATE_GUARDRAILS_PATH,
+        );
         if (
             getDataAppTemplateKind(files.map((file) => file.filename)) ===
                 'instructions' &&
-            !files.some(
-                (file) => file.filename === DATA_APP_TEMPLATE_GUARDRAILS_PATH,
-            )
+            (guardrailsFile?.body.toString('utf-8').trim() ?? '').length === 0
         ) {
             throw new ParameterError(
                 `A template without source files must include ${DATA_APP_TEMPLATE_GUARDRAILS_PATH} with the instructions to build from`,
@@ -595,6 +598,50 @@ export class DataAppTemplateService extends BaseService {
         slug: string,
     ): Promise<DataAppTemplateSummary | undefined> {
         return this.dataAppTemplateModel.findBySlug(organizationUuid, slug);
+    }
+
+    /**
+     * The template's summary and AGENTS.md alone, for builds that do not
+     * seed (iterations, instructions-only templates): one row lookup and at
+     * most one storage read instead of the whole package. Undefined when the
+     * template has been deleted, so the caller can degrade instead of
+     * failing every later version of the apps built from it.
+     */
+    async getGuardrails(
+        organizationUuid: string,
+        slug: string,
+    ): Promise<
+        | { template: DataAppTemplateSummary; guardrails: string | null }
+        | undefined
+    > {
+        const template = await this.dataAppTemplateModel.findBySlug(
+            organizationUuid,
+            slug,
+        );
+        if (!template) {
+            return undefined;
+        }
+        const rows = await this.dataAppTemplateModel.listFiles(
+            template.templateUuid,
+        );
+        if (
+            !rows.some(
+                (row) => row.filename === DATA_APP_TEMPLATE_GUARDRAILS_PATH,
+            )
+        ) {
+            return { template, guardrails: null };
+        }
+        const { client, bucket } = this.getS3Client();
+        const buffer = await readS3ObjectAsBuffer(
+            client,
+            bucket,
+            templateS3Key(
+                organizationUuid,
+                template.templateUuid,
+                DATA_APP_TEMPLATE_GUARDRAILS_PATH,
+            ),
+        );
+        return { template, guardrails: buffer.toString('utf-8') };
     }
 
     /**

--- a/packages/backend/src/models/AppModel.test.ts
+++ b/packages/backend/src/models/AppModel.test.ts
@@ -21,6 +21,7 @@ const appRow: DbApp = {
     sandbox_id: null,
     template: null,
     template_slug: null,
+    template_kind: null,
     design_uuid: null,
     upstream_app_uuid: null,
     registry_slug: null,

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -90,6 +90,7 @@ export class AppModel {
                     | 'description'
                     | 'template'
                     | 'template_slug'
+                    | 'template_kind'
                     | 'space_uuid'
                     | 'design_uuid'
                 >


### PR DESCRIPTION
Follow-up to #28492 from Marshall's security pass on the stack (CS-191). No security hole; one bug class: template state was resolved live on every build with nothing pinned per app. Four symptoms, one fix.

## What was wrong

1. **Retry past catalog dropped the manifest lock.** `editScope` lived in a local that only the catalog stage wrote. A worker retry resuming at `generating` or `building` skipped catalog and the seeded-template agent got `Write(//app/src/**)` back.
2. **A retried first build never seeded, yet still locked the manifest.** Seeding required a fresh sandbox; a crash in catalog before the tar landed retried into a bare scaffold with manifest-only tools and an "iteration" prompt.
3. **Republishing a template as the other kind flipped every existing app's contract**, because `kind` was re-derived from the template's current files on each build.
4. **Deleting a template failed every later version of the apps built from it** (`getSourceFiles` threw `NotFoundError` in catalog).

## What changed

- `apps.template_kind` (migration backfills existing template apps from their template's current files, same rule as the service; apps whose template is gone pin as `seeded`). Set at creation from the resolved template. The pipeline derives `editScope` from the row before any stage runs, so it holds on every stage of every version, retries included. The three generation helpers take `editScope` as a required parameter (no defaults to fall back on).
- `shouldSeedOrgTemplate` keys on version + pinned kind, not on whether the sandbox was resumed. The catalog stage only runs before generation, so re-extracting the tar on a retried first build is safe. `iteration` is `version > 1`, not "did not seed".
- New `prepareOrgTemplate` (extracted from `writeCatalogAndPrompt`): seeding builds read the package; every other build calls `DataAppTemplateService.getGuardrails`, one row lookup plus at most one object read, instead of up to 200 sequential S3 GETs per iteration. A deleted template degrades to the pinned kind with no guardrails and a warning, instead of failing the build.
- Prompt: the "only file you can write" claim is only made when tool permissions enforce it (Claude); on Codex the prompt asks for the scope instead of asserting it.
- Build-fix loop: a manifest-scoped fixer is told what it can repair and to say so when a component does not compile; the build failure message names the template.
- Import rejects an instructions-only package whose `AGENTS.md` is blank (trimmed content, not existence).
- Stale comment claiming first-build-only narrowing removed.

Not done (agreed note-and-ignore): pre-PR manifest-only packages reclassifying as `instructions`; only dev orgs on the stack can hold such rows.

## Tests

- `templateSources.test.ts`: seed decision on version + kind; edit scope from pinned kind; fixer note; unenforced wording.
- `AppGenerateService.orgTemplate.test.ts`: `prepareOrgTemplate` seeds on v1, reads only guardrails on iterations, survives a deleted template, softens the claim on Codex, builds instructions-only templates without seeding.
- `DataAppTemplateService.test.ts`: blank `AGENTS.md` rejected; `getGuardrails` reads one object, returns `null` guardrails when the package has none and `undefined` when the template is gone.
- Backend: 858 tests green, `tsc` and oxlint clean.

## Evidence

docker-dev (EE, MinIO, docker sandbox), 2026-09-04, app `c253689d-c640-4fb2-87e7-4206428d95e7` in Jaffle shop:

1. **v1 from a seeded org template** (`ui-saved-mtjxnf81`): app row pinned `template_kind = seeded` at creation; scheduler log `seeded 42 files from org template`; agent bound the manifest (`orders.total_order_amount` over `order_date_month`, 12-month horizon), no component edits; ready in 57s.
2. **Template deleted** via `DELETE /api/v1/org/data-app-templates/ui-saved-mtjxnf81` (200; GET now 404).
3. **v2 iteration after deletion** ("6-month horizon + weekly grain toggle"): scheduler log `org template ui-saved-mtjxnf81 no longer exists; building v2 from the kind pinned on the app without guardrails`; horizon applied in `src/template.json`, weekly toggle declined as a template-author change with the duplicate-for-a-free-copy hint; 1 tool call, ready in 14s. Before this PR the same iteration failed at catalog with `NotFoundError`.

Migration backfill run on the dev DB: 23 template apps classified (16 seeded, 7 instructions, matching their templates' kinds); the first cut of the backfill pinned everything `seeded`, which would have manifest-locked the prompt-template apps, caught on the demo instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FPop6iu9NFtsGb66rjHw5J
