### PR TITLE
chore: rename gallery tabs

### DIFF
--- a/packages/frontend/src/pages/ChartTypeGallery.test.tsx
+++ b/packages/frontend/src/pages/ChartTypeGallery.test.tsx
@@ -184,14 +184,16 @@ describe('ChartTypeGallery', () => {
         expect(screen.getByText('Value')).toBeInTheDocument();
     });
 
-    it('separates chart types and the library into top-level tabs', () => {
+    it('separates installed charts and the chart library into top-level tabs', () => {
         setData([makeDataAppViz({})]);
         renderPage();
 
         const chartTypesTab = screen.getByRole('tab', {
-            name: 'Chart types (1)',
+            name: 'Installed charts (1)',
         });
-        const libraryTab = screen.getByRole('tab', { name: 'Library' });
+        const libraryTab = screen.getByRole('tab', {
+            name: 'Chart library',
+        });
 
         expect(chartTypesTab).toHaveAttribute('aria-selected', 'true');
         expect(libraryTab).toHaveAttribute('aria-selected', 'false');
@@ -211,7 +213,7 @@ describe('ChartTypeGallery', () => {
         renderPage();
 
         expect(
-            screen.queryByRole('tab', { name: 'Library' }),
+            screen.queryByRole('tab', { name: 'Chart library' }),
         ).not.toBeInTheDocument();
     });
 

--- a/packages/frontend/src/pages/ChartTypeGallery.tsx
+++ b/packages/frontend/src/pages/ChartTypeGallery.tsx
@@ -107,7 +107,7 @@ const ChartTypeGallery = () => {
                     <Tabs.List>
                         <Tabs.Tab value="chart-types">
                             <Group gap={6} wrap="nowrap">
-                                Chart types
+                                Installed charts
                                 {!isEmptyGallery && totalCount !== null && (
                                     <Text span fz="xs" c="dimmed">
                                         ({totalCount})
@@ -116,7 +116,7 @@ const ChartTypeGallery = () => {
                             </Group>
                         </Tabs.Tab>
                         {isLibraryEnabled && (
-                            <Tabs.Tab value="library">Library</Tabs.Tab>
+                            <Tabs.Tab value="library">Chart library</Tabs.Tab>
                         )}
                     </Tabs.List>
 


### PR DESCRIPTION
## Summary
- rename Chart types to Installed charts
- rename Library to Chart library
- update the focused gallery page tests

## Testing
- pnpm -F frontend test src/pages/ChartTypeGallery.test.tsx
- pnpm -F frontend run linter src/pages/ChartTypeGallery.tsx src/pages/ChartTypeGallery.test.tsx
- pnpm -F frontend exec oxfmt --check src/pages/ChartTypeGallery.tsx src/pages/ChartTypeGallery.test.tsx