### PR TITLE
fix(pgwire): accept SHOW TRANSACTION ISOLATION LEVEL

### DIFF
--- a/packages/backend/src/ee/postgresWire/lightdashHandlers.test.ts
+++ b/packages/backend/src/ee/postgresWire/lightdashHandlers.test.ts
@@ -184,6 +184,34 @@ describe('lightdash pgwire handlers: describe vs query', () => {
         ).resolves.toMatchObject({ type: 'rows', commandTag: 'SHOW' });
     });
 
+    it('answers the multiword SHOW spellings drivers send', async () => {
+        await expect(
+            handlers.query(session, 'SHOW TRANSACTION ISOLATION LEVEL;'),
+        ).resolves.toEqual({
+            type: 'rows',
+            fields: [{ name: 'transaction_isolation', oid: 25 }],
+            rows: [['read committed']],
+            commandTag: 'SHOW',
+        });
+        await expect(
+            handlers.query(session, 'SHOW transaction_isolation'),
+        ).resolves.toMatchObject({ rows: [['read committed']] });
+        await expect(
+            handlers.query(session, 'SHOW TIME ZONE'),
+        ).resolves.toEqual({
+            type: 'rows',
+            fields: [{ name: 'timezone', oid: 25 }],
+            rows: [['UTC']],
+            commandTag: 'SHOW',
+        });
+        await expect(
+            handlers.query(session, 'SHOW nonsense'),
+        ).rejects.toMatchObject({
+            code: '42704',
+            message: 'unrecognized configuration parameter "nonsense"',
+        });
+    });
+
     it('answers schema probes without touching the warehouse', async () => {
         runExploreQuery.mockClear();
         await expect(

--- a/packages/backend/src/ee/postgresWire/lightdashHandlers.ts
+++ b/packages/backend/src/ee/postgresWire/lightdashHandlers.ts
@@ -89,6 +89,16 @@ const SHOW_PARAMETERS: Record<string, string> = {
 };
 
 /**
+ * Postgres accepts multiword spellings for a few settings, and drivers use
+ * them: pgjdbc's `getTransactionIsolation()` sends
+ * `SHOW TRANSACTION ISOLATION LEVEL`.
+ */
+const SHOW_PARAMETER_ALIASES: Record<string, string> = {
+    'transaction isolation level': 'transaction_isolation',
+    'time zone': 'timezone',
+};
+
+/**
  * Handle transaction/session statements that BI tools and drivers send but
  * that have no meaning against the semantic layer. Returns null when the
  * statement should be compiled as a real query.
@@ -122,7 +132,12 @@ const tryHandleSessionStatement = (sql: string): PgWireQueryResult | null => {
         case 'DEALLOCATE':
             return { type: 'command', commandTag: 'DEALLOCATE' };
         case 'SHOW': {
-            const param = secondWord.toLowerCase();
+            const argument = trimmed
+                .slice(firstWord.length)
+                .trim()
+                .replace(/\s+/g, ' ')
+                .toLowerCase();
+            const param = SHOW_PARAMETER_ALIASES[argument] ?? argument;
             const value = SHOW_PARAMETERS[param];
             if (value === undefined) {
                 throw new PgWireServerError(


### PR DESCRIPTION
Closes: #28634

### Description:

pgjdbc calls `getTransactionIsolation()` on a fresh connection, which sends `SHOW TRANSACTION ISOLATION LEVEL`. The session-statement shortcut only read the second word, looked up `SHOW_PARAMETERS["transaction"]`, and returned `42704 unrecognized configuration parameter "transaction"` — Looker Studio swallows that and spins forever.

`SHOW` now takes the whole argument and maps the multiword spellings Postgres accepts onto their canonical parameter names, so `SHOW TRANSACTION ISOLATION LEVEL` returns `read committed` (and `SHOW TIME ZONE` → `UTC`), same as the underscore spellings already did.

```diff
 SHOW
-  secondWord            → "transaction"   → 42704
+  argument              → "transaction isolation level"
+  SHOW_PARAMETER_ALIASES → "transaction_isolation"
+  SHOW_PARAMETERS        → "read committed"
```

Unknown parameters still error with 42704, now naming the full argument.

### Risk assessment:

- [ ] This is a high-risk change
