### PR TITLE
fix(ai): clarify expression value quoting

### DIFF
--- a/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
@@ -11172,7 +11172,7 @@ Notes:
 
 Filter expression syntax:
 - Join flat rules with AND or OR. Do not mix both connectors in one expression.
-- Quote delimiters/reserved values; commas/braces are literal in quotes; backslash escapes.
+- Bare scalars work. Double-quote reserved and whitespace/punctuation strings (apostrophes/parentheses); quote when unsure. Quoted commas/braces literal; backslash escapes. E.g. \`orders_product_name equals="Coffee Filters (100pk)"\`.
 - Limits: 256 rules; 256 values including settings/rule; 256 characters/literal; 16384 characters/expression.
 
 ### string
@@ -11813,7 +11813,7 @@ Usage Tips:
 
 Filter expression syntax:
 - Join flat rules with AND only. OR is not supported by this tool.
-- Quote delimiters/reserved values; commas/braces are literal in quotes; backslash escapes.
+- Bare scalars work. Double-quote reserved and whitespace/punctuation strings (apostrophes/parentheses); quote when unsure. Quoted commas/braces literal; backslash escapes. E.g. \`orders_product_name equals="Coffee Filters (100pk)"\`.
 - Limits: 256 rules; 256 values including settings/rule; 256 characters/literal; 16384 characters/expression.
 
 ### string

--- a/packages/backend/src/ee/services/ai/prompts/__snapshots__/systemV2.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/prompts/__snapshots__/systemV2.test.ts.snap
@@ -23,7 +23,7 @@ Raw placement examples:
 - tableCalculations: rank lessThanOrEqual=10
 
 - Join flat rules with AND or OR. Do not mix both connectors in one expression.
-- Quote delimiters/reserved values; commas/braces are literal in quotes; backslash escapes.
+- Bare scalars work. Double-quote reserved and whitespace/punctuation strings (apostrophes/parentheses); quote when unsure. Quoted commas/braces literal; backslash escapes. E.g. \`orders_product_name equals="Coffee Filters (100pk)"\`.
 - Limits: 256 rules; 256 values including settings/rule; 256 characters/literal; 16384 characters/expression.
 
 ### string

--- a/packages/backend/src/ee/services/ai/prompts/systemV2FilterGuidance.test.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2FilterGuidance.test.ts
@@ -1,5 +1,6 @@
 import {
     FILTER_EXPRESSION_GRAMMAR_DESCRIPTION,
+    FILTER_EXPRESSION_PUNCTUATED_STRING_EXAMPLE,
     parseFilterExpression,
 } from '@lightdash/common';
 import { describe, expect, it } from 'vitest';
@@ -25,5 +26,16 @@ describe('filter expression prompt guidance', () => {
                 success: true,
             });
         }
+    });
+
+    it('includes the canonical punctuated-string example exactly once', () => {
+        expect(
+            FILTER_EXPRESSION_GUIDANCE_SECTION.split(
+                FILTER_EXPRESSION_PUNCTUATED_STRING_EXAMPLE,
+            ),
+        ).toHaveLength(2);
+        expect(
+            parseFilterExpression(FILTER_EXPRESSION_PUNCTUATED_STRING_EXAMPLE),
+        ).toMatchObject({ success: true });
     });
 });

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -8773,7 +8773,7 @@ Usage Tips:
 
 Filter expression syntax:
 - Join flat rules with AND only. OR is not supported by this tool.
-- Quote delimiters/reserved values; commas/braces are literal in quotes; backslash escapes.
+- Bare scalars work. Double-quote reserved and whitespace/punctuation strings (apostrophes/parentheses); quote when unsure. Quoted commas/braces literal; backslash escapes. E.g. \`orders_product_name equals="Coffee Filters (100pk)"\`.
 - Limits: 256 rules; 256 values including settings/rule; 256 characters/literal; 16384 characters/expression.
 
 ### string
@@ -8933,7 +8933,7 @@ Notes:
 
 Filter expression syntax:
 - Join flat rules with AND or OR. Do not mix both connectors in one expression.
-- Quote delimiters/reserved values; commas/braces are literal in quotes; backslash escapes.
+- Bare scalars work. Double-quote reserved and whitespace/punctuation strings (apostrophes/parentheses); quote when unsure. Quoted commas/braces literal; backslash escapes. E.g. \`orders_product_name equals="Coffee Filters (100pk)"\`.
 - Limits: 256 rules; 256 values including settings/rule; 256 characters/literal; 16384 characters/expression.
 
 ### string

--- a/packages/common/src/ee/AiAgent/schemas/filterExpressions/examples.test.ts
+++ b/packages/common/src/ee/AiAgent/schemas/filterExpressions/examples.test.ts
@@ -3,6 +3,7 @@ import { DimensionType } from '../../../../types/field';
 import { FilterOperator, FilterType } from '../../../../types/filter';
 import { type AiFilterExample } from '../filters/filterExamples';
 import {
+    FILTER_EXPRESSION_PUNCTUATED_STRING_EXAMPLE,
     formatFilterExpressionExample,
     getFilterExpressionExamples,
 } from './examples';
@@ -47,6 +48,37 @@ describe('filter expression examples', () => {
                 success: true,
             });
         }
+    });
+
+    it('generates a parseable canonical punctuated-string example', () => {
+        expect(FILTER_EXPRESSION_PUNCTUATED_STRING_EXAMPLE).toBe(
+            'orders_product_name equals="Coffee Filters (100pk)"',
+        );
+        expect(
+            parseFilterExpression(FILTER_EXPRESSION_PUNCTUATED_STRING_EXAMPLE),
+        ).toMatchObject({
+            success: true,
+            expression: {
+                rules: [
+                    {
+                        field: { value: 'orders_product_name' },
+                        arguments: [{ value: 'Coffee Filters (100pk)' }],
+                    },
+                ],
+            },
+        });
+    });
+
+    it('double-quotes apostrophes in string values', () => {
+        expect(
+            formatFilterExpressionExample({
+                fieldId: 'orders_product_name',
+                fieldType: DimensionType.STRING,
+                fieldFilterType: FilterType.STRING,
+                operator: FilterOperator.EQUALS,
+                values: ["Valentine's Special"],
+            }),
+        ).toBe('orders_product_name equals="Valentine\'s Special"');
     });
 
     it('quotes protected lexical content without changing its value', () => {

--- a/packages/common/src/ee/AiAgent/schemas/filterExpressions/examples.ts
+++ b/packages/common/src/ee/AiAgent/schemas/filterExpressions/examples.ts
@@ -119,6 +119,15 @@ export const formatFilterExpressionExample = (
     }
 };
 
+export const FILTER_EXPRESSION_PUNCTUATED_STRING_EXAMPLE =
+    formatFilterExpressionExample({
+        fieldId: 'orders_product_name',
+        fieldType: DimensionType.STRING,
+        fieldFilterType: FilterType.STRING,
+        operator: FilterOperator.EQUALS,
+        values: ['Coffee Filters (100pk)'],
+    });
+
 const expandFiniteExamplePermutations = (
     example: AiFilterExample,
     argumentCount: (typeof filterExpressionOperatorDefinitions)[number]['argumentCountByFilterType'][FilterType],

--- a/packages/common/src/ee/AiAgent/schemas/filterExpressions/expressionSchemas.test.ts
+++ b/packages/common/src/ee/AiAgent/schemas/filterExpressions/expressionSchemas.test.ts
@@ -17,6 +17,7 @@ import {
     queryConfigBaseSchema,
     toolRunQueryArgsSchemaV4,
 } from '../tools/toolRunQueryArgs';
+import { FILTER_EXPRESSION_PUNCTUATED_STRING_EXAMPLE } from './examples';
 import {
     aggregationCustomMetricExpressionSchema,
     customMetricsExpressionSchema,
@@ -277,13 +278,23 @@ describe('filter expression input schemas', () => {
         );
     });
 
-    it('documents quoting syntax characters without punctuation escapes', () => {
-        expect(FILTER_EXPRESSION_GRAMMAR_DESCRIPTION).toContain(
-            'Quote delimiters/reserved values',
-        );
-        expect(FILTER_EXPRESSION_GRAMMAR_DESCRIPTION).toContain(
-            'commas/braces are literal in quotes',
-        );
+    it('documents string quoting with one canonical punctuated example', () => {
+        for (const description of [
+            FILTER_EXPRESSION_GRAMMAR_DESCRIPTION,
+            FILTER_EXPRESSION_AND_ONLY_GRAMMAR_DESCRIPTION,
+        ]) {
+            expect(description).toContain('Bare scalars work.');
+            expect(description).toContain(
+                'Double-quote reserved and whitespace/punctuation strings (apostrophes/parentheses)',
+            );
+            expect(description).toContain('when unsure');
+            expect(description).toContain(
+                'Quoted commas/braces literal; backslash escapes.',
+            );
+            expect(
+                description.split(FILTER_EXPRESSION_PUNCTUATED_STRING_EXAMPLE),
+            ).toHaveLength(2);
+        }
     });
 
     it('keeps live runtime inputs separate from persisted V2 compatibility', () => {

--- a/packages/common/src/ee/AiAgent/schemas/filterExpressions/expressionSchemas.ts
+++ b/packages/common/src/ee/AiAgent/schemas/filterExpressions/expressionSchemas.ts
@@ -19,6 +19,7 @@ import {
 } from '../tools/toolRunQueryArgs';
 import { createToolSchema } from '../toolSchemaBuilder';
 import visualizationMetadataSchema from '../visualizationMetadata';
+import { FILTER_EXPRESSION_PUNCTUATED_STRING_EXAMPLE } from './examples';
 import {
     filterExpressionDateUnits,
     filterExpressionOperatorDefinitions,
@@ -92,7 +93,7 @@ const getFilterTypeGrammar = (filterType: FilterType): string => {
 export const getFilterExpressionGrammarDescription = (
     connectorPolicy: FilterExpressionConnectorPolicy,
 ): string => `- ${connectorInstructionByPolicy[connectorPolicy]}
-- Quote delimiters/reserved values; commas/braces are literal in quotes; backslash escapes.
+- Bare scalars work. Double-quote reserved and whitespace/punctuation strings (apostrophes/parentheses); quote when unsure. Quoted commas/braces literal; backslash escapes. E.g. \`${FILTER_EXPRESSION_PUNCTUATED_STRING_EXAMPLE}\`.
 - Limits: ${FILTER_EXPRESSION_MAX_RULES} rules; ${FILTER_EXPRESSION_MAX_VALUES_PER_RULE} values including settings/rule; ${FILTER_EXPRESSION_MAX_LITERAL_LENGTH} characters/literal; ${FILTER_EXPRESSION_MAX_LENGTH} characters/expression.
 
 ${Object.values(FilterType).map(getFilterTypeGrammar).join('\n\n')}`;


### PR DESCRIPTION
Related: ZAP-963, ZAP-920, #28262

## Summary
- clarify when filter-expression string values require double quotes
- generate one canonical punctuated-string example through the shared formatter
- keep Agent and runtime Model Context Protocol (MCP) guidance aligned

## Why
Sonnet repeatedly emitted unquoted values containing spaces, parentheses, or apostrophes. Those calls passed the tool schema but failed expression parsing and retried. The parser already supports the intended quoted values, so this changes guidance rather than guessing intent through runtime repair.

## Contract impact
Only expression-mode guidance and its runtime contract snapshots change. Parser acceptance, query validation, authorization, query execution, Structured Query Language compilation, structured flag-off behavior, and the stable/default MCP JSON remain unchanged.

## Verification
- 97 focused common tests
- 147 focused backend tests
- common/backend typecheck, lint, format, and build
- `pnpm check:mcp-tools-snapshot`
- expression contract byte/token budgets and reduction ratios
- `git diff --check`

Targeted direct-base benchmark: 8 strictly sequential fresh threads across Q13 and Q18, comparing `277fe71670d8a69214c9d0c333365275cc36e946` with `77bcb96204757d5e6bfc0269a219725585b8fea7`. Direct Anthropic telemetry verified exact model `claude-sonnet-5`, and the authenticated expression feature flag was ON before every thread. The base produced 4/4 punctuation-related expression parse failures; the head produced 0/4, with every first expression accepted. All 8 runs retained the requested query semantics. Aggregate tokens fell 33.7% and mean stream time fell 24.5% in this targeted sample.

Risk: high — this changes model guidance used to construct semantic-layer queries. Human peer review is required before merge.

Rollback: revert this PR to restore the previous quoting guidance.
