### PR TITLE
fix(data-apps): expose safe external fetch response headers

### DIFF
--- a/packages/backend/src/clients/GoogleChat/GoogleChatClient.test.ts
+++ b/packages/backend/src/clients/GoogleChat/GoogleChatClient.test.ts
@@ -11,6 +11,7 @@ const mockedPostSchedulerWebhook = vi.mocked(postSchedulerWebhook);
 const successfulWebhookResponse = {
     status: 200,
     contentType: '',
+    headers: {},
     bodyText: '',
     truncated: false,
 };

--- a/packages/backend/src/clients/MicrosoftTeams/MicrosoftTeamsClient.test.ts
+++ b/packages/backend/src/clients/MicrosoftTeams/MicrosoftTeamsClient.test.ts
@@ -15,6 +15,7 @@ const mockedPostSchedulerWebhook = vi.mocked(postSchedulerWebhook);
 const successfulWebhookResponse = {
     status: 200,
     contentType: '',
+    headers: {},
     bodyText: '',
     truncated: false,
 };

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -2845,7 +2845,7 @@ export class AppGenerateService extends BaseService {
                     alias: doc.alias,
                     ...(instructions ? { instructions } : {}),
                     signature:
-                        "externalFetch(alias: string, opts: { method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'; path: string; query?: Record<string, string>; body?: unknown }): Promise<{ status: number; contentType: string; body: unknown; truncated: boolean }>",
+                        "externalFetch(alias: string, opts: { method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'; path: string; query?: Record<string, string>; body?: unknown }): Promise<{ status: number; contentType: string; headers: Record<string, string>; body: unknown; truncated: boolean }>",
                     origin: doc.origin,
                     browserImageOrigin: doc.browserImageOrigin,
                     // The single most-misread thing: `path` is the COMPLETE path from
@@ -2856,7 +2856,7 @@ export class AppGenerateService extends BaseService {
                         "query is Record<string, string> — EVERY value must be a string. Write { latitude: '52.52' }, never { latitude: 52.52 }. Numbers and booleans are rejected with a 422.",
                         `path is the COMPLETE path appended to the origin (requestUrl = origin + path). Pass the full path starting from the origin — e.g. "${examplePath}" — and make sure it starts with one of allowedPathPrefixes. Do NOT shorten it to the trailing segment and do NOT assume the origin or prefix is auto-prepended.`,
                         'method must be one of allowedMethods.',
-                        'Read the response from result.body. result.status is the upstream HTTP status; result.truncated is true if the response was capped.',
+                        'Read the response from result.body. result.status is the upstream HTTP status; result.headers contains safe upstream response headers with lowercase names; result.truncated is true if the response was capped.',
                         'Auth is injected by Lightdash — never include credentials, API keys, or headers.',
                         ...(doc.browserImageOrigin
                             ? [

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.proxy.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.proxy.test.ts
@@ -184,6 +184,7 @@ beforeEach(() => {
     mockSecureFetch.mockResolvedValue({
         status: 200,
         contentType: 'application/json',
+        headers: {},
         bodyText: '{"ok":true}',
         truncated: false,
     });
@@ -409,6 +410,7 @@ describe('ExternalConnectionService.proxyFetch', () => {
         expect(res).toEqual({
             status: 200,
             contentType: 'application/json',
+            headers: {},
             body: { ok: true },
             truncated: false,
         });
@@ -717,6 +719,7 @@ describe('ExternalConnectionService.proxyFetch', () => {
         mockSecureFetch.mockResolvedValueOnce({
             status: 400,
             contentType: 'application/json',
+            headers: { 'retry-after': '5' },
             bodyText: '{"error":"anthropic-version header is required"}',
             truncated: false,
         });
@@ -731,6 +734,7 @@ describe('ExternalConnectionService.proxyFetch', () => {
         expect(res.body).toEqual({
             error: 'anthropic-version header is required',
         });
+        expect(res.headers).toEqual({ 'retry-after': '5' });
         expect(analytics.trackAccount).toHaveBeenCalledWith(
             user,
             expect.objectContaining({
@@ -776,6 +780,7 @@ describe('ExternalConnectionService.proxyFetch', () => {
         mockSecureFetch.mockResolvedValueOnce({
             status: 200,
             contentType: 'text/plain',
+            headers: {},
             bodyText: 'plain text',
             truncated: false,
         });
@@ -795,6 +800,7 @@ describe('ExternalConnectionService.proxyFetch', () => {
         mockSecureFetch.mockResolvedValueOnce({
             status: 200,
             contentType: 'application/json',
+            headers: {},
             bodyText: 'not json{',
             truncated: false,
         });
@@ -810,6 +816,7 @@ describe('ExternalConnectionService.proxyFetch', () => {
         mockSecureFetch.mockResolvedValueOnce({
             status: 200,
             contentType: 'application/geo+json; charset=utf-8',
+            headers: {},
             bodyText: '{"type":"FeatureCollection","features":[]}',
             truncated: false,
         });

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.test.ts
@@ -94,6 +94,7 @@ const fakeSample: ExternalConnectionSample = {
 const fetchResponse: ExternalFetchResponse = {
     status: 200,
     contentType: 'application/json',
+    headers: {},
     body: { temp: 21 },
     truncated: false,
 };

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
@@ -55,6 +55,7 @@ import {
     assertSafeApiKeyHeaderName,
     buildOutboundUrl,
     computeMinuteWindow,
+    filterExternalResponseHeaders,
     normalizeAndValidatePath,
     serializeRequestBody,
     validateCustomHeaders,
@@ -964,6 +965,15 @@ export class ExternalConnectionService extends BaseService {
             response: {
                 status: fetched.status,
                 contentType: fetched.contentType,
+                headers: filterExternalResponseHeaders({
+                    headers: fetched.headers,
+                    requestUrl: url,
+                    queryApiKeyName:
+                        connection.type === 'api_key' &&
+                        connection.apiKeyLocation === 'query'
+                            ? connection.apiKeyName
+                            : null,
+                }),
                 body: parsedBody,
                 // Reserved for future use; always false in v1 — oversize responses
                 // are rejected (SecureFetchError too_large), not truncated.

--- a/packages/backend/src/ee/services/ExternalConnectionService/proxyValidation.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/proxyValidation.test.ts
@@ -3,6 +3,8 @@ import {
     assertSafeApiKeyHeaderName,
     buildOutboundUrl,
     computeMinuteWindow,
+    EXTERNAL_RESPONSE_HEADER_MAX_BYTES,
+    filterExternalResponseHeaders,
     normalizeAndValidatePath,
     serializeRequestBody,
     validateCustomHeaders,
@@ -389,6 +391,69 @@ describe('validateCustomHeaders', () => {
     it('rejects a collision with the api key header (case-insensitive)', () => {
         expect(() =>
             validateCustomHeaders({ 'x-service-key': 'v' }, 'X-Service-Key'),
+        ).toThrow(ParameterError);
+    });
+});
+
+describe('filterExternalResponseHeaders', () => {
+    const requestUrl = 'https://api.example.com/v1/items?page=1';
+
+    it('exposes supported cache, pagination, and rate-limit headers only', () => {
+        expect(
+            filterExternalResponseHeaders({
+                headers: {
+                    'Retry-After': '3',
+                    'X-RateLimit-Remaining': '9',
+                    ETag: '"abc"',
+                    'Set-Cookie': 'session=secret',
+                    Server: 'internal-proxy',
+                    'Content-Length': '123',
+                },
+                requestUrl,
+                queryApiKeyName: null,
+            }),
+        ).toEqual({
+            'retry-after': '3',
+            'x-ratelimit-remaining': '9',
+            etag: '"abc"',
+        });
+    });
+
+    it('removes an injected query API key from reusable Link targets', () => {
+        expect(
+            filterExternalResponseHeaders({
+                headers: {
+                    Link: '<https://api.example.com/v1/items?page=2&api_key=secret>; rel="next", <https://docs.example.com/items?api_key=secret>; rel="help"',
+                },
+                requestUrl: `${requestUrl}&api_key=secret`,
+                queryApiKeyName: 'api_key',
+            }),
+        ).toEqual({
+            link: '</v1/items?page=2>; rel="next", <https://docs.example.com/items>; rel="help"',
+        });
+    });
+
+    it('omits malformed Link values instead of exposing them unsanitized', () => {
+        expect(
+            filterExternalResponseHeaders({
+                headers: { Link: 'https://api.example.com/v1/items?page=2' },
+                requestUrl,
+                queryApiKeyName: 'api_key',
+            }),
+        ).toEqual({});
+    });
+
+    it('rejects exposed response metadata over the aggregate byte cap', () => {
+        expect(() =>
+            filterExternalResponseHeaders({
+                headers: {
+                    'Retry-After': '1'.repeat(
+                        EXTERNAL_RESPONSE_HEADER_MAX_BYTES,
+                    ),
+                },
+                requestUrl,
+                queryApiKeyName: null,
+            }),
         ).toThrow(ParameterError);
     });
 });

--- a/packages/backend/src/ee/services/ExternalConnectionService/proxyValidation.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/proxyValidation.ts
@@ -301,3 +301,118 @@ export function validateCustomHeaders(
         }
     }
 }
+
+/** Keep the public response-header contract intentionally small. External
+ * connection credentials are injected by Lightdash, so arbitrary upstream
+ * headers are not safe to expose to app code even though they arrived over an
+ * admin-approved connection. */
+const EXPOSED_RESPONSE_HEADER_NAMES = new Set([
+    'accept-ranges',
+    'cache-control',
+    'content-range',
+    'etag',
+    'expires',
+    'last-modified',
+    'link',
+    'ratelimit',
+    'retry-after',
+]);
+
+const EXPOSED_RESPONSE_HEADER_PREFIXES = [
+    'ratelimit-',
+    'x-ratelimit-',
+    'x-rate-limit-',
+] as const;
+
+/** Matches Node's default maximum inbound response-header size. Keep a local
+ * cap as well so the API contract does not depend on a process-wide Node flag. */
+export const EXTERNAL_RESPONSE_HEADER_MAX_BYTES = 16 * 1024;
+
+const shouldExposeResponseHeader = (name: string): boolean =>
+    EXPOSED_RESPONSE_HEADER_NAMES.has(name) ||
+    EXPOSED_RESPONSE_HEADER_PREFIXES.some((prefix) => name.startsWith(prefix));
+
+/**
+ * Sanitize RFC 8288 Link targets before exposing them to app code. A
+ * query-authenticated upstream commonly builds pagination links from the
+ * request URL, which would otherwise reflect the injected API key. Same-origin
+ * absolute links become relative paths, which are also directly reusable with
+ * externalFetch.
+ */
+const sanitizeLinkHeader = (
+    value: string,
+    requestUrl: string,
+    queryApiKeyName: string | null,
+): string | null => {
+    const requestOrigin = new URL(requestUrl).origin;
+    let foundTarget = false;
+    let invalidTarget = false;
+
+    const sanitized = value.replace(/<([^<>]*)>/g, (_match, target: string) => {
+        foundTarget = true;
+        try {
+            const url = new URL(target, requestUrl);
+            if (url.username || url.password) {
+                invalidTarget = true;
+                return '';
+            }
+            if (queryApiKeyName) {
+                url.searchParams.delete(queryApiKeyName);
+            }
+            const safeTarget =
+                url.origin === requestOrigin
+                    ? `${url.pathname}${url.search}${url.hash}`
+                    : url.toString();
+            return `<${safeTarget}>`;
+        } catch {
+            invalidTarget = true;
+            return '';
+        }
+    });
+
+    return foundTarget && !invalidTarget ? sanitized : null;
+};
+
+/**
+ * Select the response metadata app code may consume. Header names are
+ * case-insensitive and returned lowercase. Malformed Link values are omitted;
+ * oversized exposed metadata rejects the response instead of silently losing
+ * a rate-limit or pagination header.
+ */
+export function filterExternalResponseHeaders(args: {
+    headers: Record<string, string>;
+    requestUrl: string;
+    queryApiKeyName: string | null;
+}): Record<string, string> {
+    const exposed = Object.create(null) as Record<string, string>;
+    let exposedBytes = 0;
+
+    for (const [name, rawValue] of Object.entries(args.headers)) {
+        const normalizedName = name.toLowerCase();
+        if (shouldExposeResponseHeader(normalizedName)) {
+            const value =
+                normalizedName === 'link'
+                    ? sanitizeLinkHeader(
+                          rawValue,
+                          args.requestUrl,
+                          args.queryApiKeyName,
+                      )
+                    : rawValue;
+
+            if (value !== null) {
+                exposedBytes += Buffer.byteLength(
+                    `${normalizedName}: ${value}\r\n`,
+                    'utf8',
+                );
+                if (exposedBytes > EXTERNAL_RESPONSE_HEADER_MAX_BYTES) {
+                    throw new ParameterError(
+                        `Upstream response headers exceed the maximum of ${EXTERNAL_RESPONSE_HEADER_MAX_BYTES} bytes`,
+                    );
+                }
+                exposed[normalizedName] = value;
+            }
+        }
+    }
+
+    return exposed;
+}

--- a/packages/backend/src/utils/schedulerWebhookValidation.test.ts
+++ b/packages/backend/src/utils/schedulerWebhookValidation.test.ts
@@ -112,6 +112,7 @@ describe('postSchedulerWebhook', () => {
         mockedSecureFetch.mockResolvedValueOnce({
             status: 202,
             contentType: '',
+            headers: {},
             bodyText: '',
             truncated: false,
         });

--- a/packages/backend/src/utils/secureFetch/secureFetch.test.ts
+++ b/packages/backend/src/utils/secureFetch/secureFetch.test.ts
@@ -210,6 +210,7 @@ describe('secureFetch GET behavior', () => {
         expect(result).toEqual({
             status: 503,
             contentType: 'application/json',
+            headers: { 'content-type': 'application/json' },
             bodyText: 'nope',
             truncated: false,
         });
@@ -217,7 +218,10 @@ describe('secureFetch GET behavior', () => {
 
     it('returns a SecureFetchResult on a happy-path GET', async () => {
         mockedFetch.mockResolvedValue(
-            jsonResponse('{"hello":"world"}', { status: 200 }),
+            jsonResponse('{"hello":"world"}', {
+                status: 200,
+                headers: { 'Retry-After': '3' },
+            }),
         );
         const result = await secureFetch(
             'https://example.com/x.json',
@@ -226,6 +230,10 @@ describe('secureFetch GET behavior', () => {
         expect(result).toEqual({
             status: 200,
             contentType: 'application/json',
+            headers: {
+                'content-type': 'application/json',
+                'retry-after': '3',
+            },
             bodyText: '{"hello":"world"}',
             truncated: false,
         });
@@ -261,6 +269,7 @@ describe('secureFetch POST behavior', () => {
         expect(result).toEqual({
             status: 200,
             contentType: 'application/json',
+            headers: { 'content-type': 'application/json' },
             bodyText: '{"accepted":true}',
             truncated: false,
         });
@@ -523,6 +532,7 @@ describe('secureFetch size and content-type', () => {
             ok: true,
             headers: {
                 get: (name: string) => (name === 'content-type' ? null : null),
+                forEach: () => undefined,
             },
             text: vi.fn().mockResolvedValue('{}'),
         };

--- a/packages/backend/src/utils/secureFetch/secureFetch.ts
+++ b/packages/backend/src/utils/secureFetch/secureFetch.ts
@@ -40,6 +40,9 @@ export type SecureFetchOptions = {
 export type SecureFetchResult = {
     status: number;
     contentType: string;
+    /** Upstream response headers, normalized to lowercase names. Callers must
+     *  still apply their own exposure policy before returning these to users. */
+    headers: Record<string, string>;
     bodyText: string;
     truncated: boolean;
 };
@@ -244,9 +247,15 @@ export async function secureFetch(
         throw new SecureFetchError('request_failed', 'Failed to read response');
     }
 
+    const headers = Object.create(null) as Record<string, string>;
+    response.headers.forEach((value, name) => {
+        headers[name.toLowerCase()] = value;
+    });
+
     return {
         status: response.status,
         contentType,
+        headers,
         bodyText,
         truncated: false,
     };

--- a/packages/common/src/ee/externalConnections/types.ts
+++ b/packages/common/src/ee/externalConnections/types.ts
@@ -170,6 +170,8 @@ export type ExternalFetchRequest = {
 export type ExternalFetchResponse = {
     status: number;
     contentType: string;
+    /** Safe upstream response headers, normalized to lowercase names. */
+    headers: Record<string, string>;
     body: unknown;
     truncated: boolean;
 };

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionExamplesPanel.test.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionExamplesPanel.test.tsx
@@ -176,6 +176,7 @@ describe('ConnectionExamplesPanel draft config', () => {
         mocks.testResult = {
             status: 200,
             contentType: 'application/json',
+            headers: {},
             body: { id: 1 },
             truncated: false,
         };
@@ -201,6 +202,7 @@ describe('ConnectionExamplesPanel draft config', () => {
         mocks.testResult = {
             status: 200,
             contentType: 'application/json',
+            headers: {},
             body: { id: 1 },
             truncated: false,
         };

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
@@ -931,6 +931,7 @@ describe('external-fetch branch', () => {
             results: {
                 status: 200,
                 contentType: 'application/json',
+                headers: {},
                 body: { ok: true },
                 truncated: false,
             },
@@ -973,6 +974,7 @@ describe('external-fetch branch', () => {
             results: {
                 status: 200,
                 contentType: 'application/json',
+                headers: {},
                 body: { temperature: 18 },
                 truncated: false,
             },
@@ -999,6 +1001,7 @@ describe('external-fetch branch', () => {
         const result = {
             status: 200,
             contentType: 'application/json',
+            headers: { 'retry-after': '2' },
             body: 1,
             truncated: false,
         };

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
@@ -15,6 +15,7 @@ import {
     type AppColorScheme,
     type DashboardFilters,
     type DataAppVizContext,
+    type ExternalFetchResponse,
     type QueryExecutionContext,
 } from '@lightdash/common';
 import { useCallback, useEffect, useRef, type RefObject } from 'react';
@@ -653,12 +654,7 @@ export function useAppSdkBridge({
                     const json = await res.json();
                     if (json.status === 'ok') {
                         const result = json.results as
-                            | {
-                                  status?: number;
-                                  contentType?: string;
-                                  body?: unknown;
-                                  truncated?: boolean;
-                              }
+                            | ExternalFetchResponse
                             | undefined;
                         emitExternal({
                             status: 'ready',

--- a/packages/query-sdk/src/client.ts
+++ b/packages/query-sdk/src/client.ts
@@ -42,7 +42,8 @@ export class LightdashClient {
      *
      * Supply only the connection `alias` and a relative request — Lightdash
      * resolves the alias to a stored connection, attaches its credentials,
-     * and proxies the call. The app never sees the URL, headers, or secrets.
+     * and proxies the call. The app never sees the request URL, request
+     * headers, or secrets. Safe response headers are available on `res.headers`.
      *
      *   const res = await lightdash.externalFetch('stripe', {
      *       path: '/v1/charges',
@@ -104,7 +105,9 @@ function configFromEnv(): LightdashClientConfig | null {
 export function createClient(): LightdashClient {
     // 1. postMessage transport (iframe hosted by Lightdash parent)
     if (typeof window !== 'undefined' && window.location.hash) {
-        const params = new URLSearchParams(window.location.hash.replace(/^#/, ''));
+        const params = new URLSearchParams(
+            window.location.hash.replace(/^#/, ''),
+        );
         if (params.get('transport') === 'postMessage') {
             const projectUuid = params.get('projectUuid') ?? '';
             mountInspector(window.parent);
@@ -112,7 +115,10 @@ export function createClient(): LightdashClient {
             mountColorScheme(window.parent);
             return new LightdashClient(
                 { apiKey: '', baseUrl: '', projectUuid },
-                createPostMessageTransport({ targetWindow: window.parent, projectUuid }),
+                createPostMessageTransport({
+                    targetWindow: window.parent,
+                    projectUuid,
+                }),
             );
         }
     }

--- a/packages/query-sdk/src/externalFetch.test.ts
+++ b/packages/query-sdk/src/externalFetch.test.ts
@@ -21,6 +21,7 @@ describe('externalFetch types', () => {
         const r: ExternalFetchResult = {
             status: 200,
             contentType: 'application/json',
+            headers: { 'retry-after': '2' },
             body: { ok: true },
             truncated: false,
         };
@@ -99,6 +100,7 @@ describe('LightdashClient.externalFetch', () => {
         const result = {
             status: 200,
             contentType: 'application/json',
+            headers: {},
             body: 1,
             truncated: false,
         };
@@ -130,6 +132,7 @@ describe('postMessageTransport.externalFetch', () => {
             return {
                 status: 201,
                 contentType: 'application/json',
+                headers: { 'x-ratelimit-remaining': '9' },
                 body: { id: 'ch_1' },
                 truncated: false,
             };
@@ -148,6 +151,7 @@ describe('postMessageTransport.externalFetch', () => {
             expect(out).toEqual({
                 status: 201,
                 contentType: 'application/json',
+                headers: { 'x-ratelimit-remaining': '9' },
                 body: { id: 'ch_1' },
                 truncated: false,
             });
@@ -217,6 +221,7 @@ describe('postMessageTransport.externalFetch', () => {
                     result: {
                         status: 999,
                         contentType: 'application/json',
+                        headers: {},
                         body: { spoofed: true },
                         truncated: false,
                     },
@@ -231,6 +236,7 @@ describe('postMessageTransport.externalFetch', () => {
                     result: {
                         status: 200,
                         contentType: 'application/json',
+                        headers: {},
                         body: { real: true },
                         truncated: false,
                     },

--- a/packages/query-sdk/src/types.ts
+++ b/packages/query-sdk/src/types.ts
@@ -321,6 +321,8 @@ export type ExternalFetchResult = {
     status: number;
     /** Upstream `Content-Type` (e.g. `application/json`). */
     contentType: string;
+    /** Safe upstream response headers, with lowercase names. */
+    headers: Record<string, string>;
     /** Parsed JSON body when JSON, otherwise the raw text. */
     body: unknown;
     /** True when Lightdash truncated an oversized response body. */

--- a/sandboxes/data-apps/template/references/external-apis.md
+++ b/sandboxes/data-apps/template/references/external-apis.md
@@ -5,6 +5,7 @@
 If the app is linked to one or more **external connections** (third-party HTTP APIs the project admin configured), you'll see a `[Linked external connections — each file in /tmp/external-data/ ...]` block at the top of this prompt and one JSON file per connection at **`/tmp/external-data/{alias}.json`**.
 
 Each file documents one connection:
+
 - `instructions` — admin-authored notes on how to use this API (auth quirks, pagination, which endpoints matter, response caveats). Present only when the admin wrote them; when present, read and follow them.
 - `signature` / `howToCall` — the exact typed SDK call. Auth is injected by Lightdash — never include credentials or API keys.
 - `origin` / `requestUrl` — the connection's base origin (host only) and how the URL is formed: **the full request URL is `origin + path`.** Your `path` is appended to the origin verbatim — the origin and the path prefix are NOT auto-prepended.
@@ -24,20 +25,24 @@ Lightdash that stores the origin (host) and credentials. The app references it b
 
 ```tsx
 const res = await lightdash.externalFetch('stripe', {
-    method: 'GET',          // 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' — defaults to 'GET'. Must be one of the connection's allowed methods.
-    path: '/v1/charges',    // COMPLETE path appended to the connection's origin (host). Full URL = origin + path. Must start with an allowed prefix; it is NOT relative to the prefix.
+    method: 'GET', // 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' — defaults to 'GET'. Must be one of the connection's allowed methods.
+    path: '/v1/charges', // COMPLETE path appended to the connection's origin (host). Full URL = origin + path. Must start with an allowed prefix; it is NOT relative to the prefix.
     query: { limit: '10' }, // Record<string, string> — values MUST be strings
     // body: { ... },       // JSON body — sent for every method except GET
 });
 
 // res.status      — upstream HTTP status (number)
 // res.contentType — upstream Content-Type
+// res.headers     — safe upstream response headers (lowercase names)
 // res.body        — parsed JSON (or raw text for non-JSON)
 // res.truncated   — true if Lightdash truncated an oversized response
 ```
 
 Lightdash resolves the alias to the stored connection, attaches its
 credentials, makes the request server-side, and returns the response.
+`res.headers` includes lowercase cache, pagination, and rate-limit headers such
+as `retry-after`, `ratelimit-*`, `x-ratelimit-*`, `etag`, and `link`. Other
+upstream headers are deliberately omitted.
 
 **Rules — follow exactly:**
 


### PR DESCRIPTION
Closes: #28570

Linear: [PROD-10908](https://linear.app/lightdash/issue/PROD-10908/data-apps-externalfetch-omits-response-headers-so-apps-cant-honor)

### Description:

```diff
 externalFetch response
- status, contentType, body, truncated
+ status, contentType, safe response headers, body, truncated
```

- Exposes lower-cased caching, pagination, range, retry, and rate-limit response headers, including `Retry-After`, `Link`, `ETag`, and common `RateLimit`/`X-RateLimit` variants.
- Preserves the credential boundary: cookies and arbitrary upstream headers are not exposed; configured query API keys are removed from `Link` URLs, same-origin links are made relative, malformed links are omitted, and exposed header metadata is capped at 16 KiB.
- Keeps the runtime change backwards-compatible for deployed apps because the existing SDK bridge already forwards the response object unchanged. Apps pinned to older SDK typings only need an SDK update (or local type refinement) when authoring code that reads `response.headers`.
- Updates generated-app guidance and the external API reference so new apps can honor throttling and pagination metadata.

Validation:

- Focused Vitest suites: 218 backend tests, 10 app-generation tests, 59 frontend tests, and 7 Query SDK tests passed.
- The full backend build passed, including API generation and compilation of test sources; typechecks also passed for `common`, `frontend`, and `query-sdk`.
- Focused backend/common/frontend lint, formatting, commit hooks, `git diff --check`, and `pnpm generate-api` passed; generated API artifacts are unchanged.
- Query SDK ESLint is blocked before file evaluation by its existing reference to the absent root `.eslintrc.js`; its tests, typecheck, and formatting passed.
- Live-tested on `localhost:3000` with a freshly generated E2B app and a query-authenticated `httpbingo.org` connection: the app received lowercase `etag`, `link`, `retry-after`, and `x-ratelimit-remaining`; `set-cookie`, `x-private-test`, `server`, and `content-type` were omitted; the same-origin `Link` became relative with the injected API key removed; and the response body remained available.
- An existing pre-template app also ran unchanged: its saved `world_map` external request returned HTTP 200 and rendered the map, confirming the additive response does not require deployed apps to upgrade their SDK runtime.
- Local-only test app and connection data were persisted for reproducibility. A non-2xx response was not exercised live; upstream error-header forwarding is covered by the focused service test.

### Risk assessment:

- [ ] This is a high-risk change

Low risk and backwards-compatible: this adds a filtered response field without changing request authorization, host/path/method controls, secret ownership, persistence, or existing response fields. The new metadata path is bounded and covered by focused leakage, sanitization, malformed-input, and size-cap tests.
