### PR TITLE
fix(merge): refuse a merge over a result source cut short at its own limit

### DIFF
--- a/docs/merge-queries/CONTEXT.md
+++ b/docs/merge-queries/CONTEXT.md
@@ -68,6 +68,12 @@ before the join, naming the source, never silently trimmed, because a join over
 a trimmed side returns numbers that look complete and are not. It is known only
 once the leg has run, so unlike other refusals it arrives as the merged query's
 error.
+A result source is never re-run, so the row cap never bounded it: the only
+bound that matters for it is the limit its own query ran with. A referenced
+result that returned as many rows as that limit is refused at compile time,
+naming the source, with re-running that query (higher limit or none) as the
+remedy rather than a filter. Both checks refuse on evidence only: an
+unrecorded limit or row count never refuses.
 _Avoid_: limit (collides with the merged result's own limit), truncation
 
 **Compose engine**:

--- a/docs/merge-queries/architecture.md
+++ b/docs/merge-queries/architecture.md
@@ -142,6 +142,10 @@ These exist because getting them wrong produces confident wrong numbers.
 - **A leg that reaches the row cap is refused before the join**, from the leg's
   own `query_history` row count. On the compose path the legs run at the cap,
   so no guard inside the join SQL could ever see past it.
+- **A result source cut short at its own limit is refused at compile time**,
+  from the referenced query's stored limit and row count. It is checked
+  against its own limit only, never the row cap: it was never run at the cap,
+  and the remedy is re-running that query, not filtering it.
 - **Table calculations that depend on a source's own row set are refused**,
   because merging changes those rows.
 
@@ -158,7 +162,8 @@ Known gaps in that coverage, so you do not assume it is proving more than it is:
 the parity suite compares values numerically, so it cannot catch a formatting
 regression; there is no end-to-end test of merging at all; and a live row-cap
 trip needs more rows than the seed carries (the refusal itself is proven in
-`AsyncQueryService.test.ts` with the cap lowered through config).
+`AsyncQueryService.test.ts` with the cap lowered through config, and the
+result-source refusal the same way with the referenced query's limit lowered).
 
 ## Current work
 

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -14,6 +14,7 @@ import {
     FilterOperator,
     ForbiddenError,
     MergeJoinType,
+    MergeQueryErrorKind,
     MetricType,
     MissingConfigError,
     NotFoundError,
@@ -6485,5 +6486,213 @@ describe('query sources carry the execution context', () => {
                 userAttributeOverrides: { region: ['EU'] },
             }),
         ).rejects.toThrow(ParameterError);
+    });
+});
+
+describe('executeAsyncMergeQuery over a result source', () => {
+    // Lowered on the referenced query rather than by seeding limit-many rows:
+    // the check reads the limit that query ran with.
+    const REFERENCED_LIMIT = 3;
+    const resultQueryUuids = {
+        a: '3c8b2b0e-4f5a-4b6c-8d7e-9f0a1b2c3d4e',
+        b: '4d9c3c1f-5a6b-4c7d-9e8f-0a1b2c3d4e5f',
+    };
+
+    const storedFields = (table: string, metric: string): ItemsMap => ({
+        [`${table}_month`]: {
+            fieldType: FieldType.DIMENSION,
+            type: DimensionType.DATE,
+            name: 'month',
+            label: 'Month',
+            table,
+            tableLabel: table,
+            sql: '',
+            hidden: false,
+            groups: [],
+        },
+        [`${table}_${metric}`]: {
+            fieldType: FieldType.METRIC,
+            type: MetricType.SUM,
+            name: metric,
+            label: metric,
+            table,
+            tableLabel: table,
+            sql: '',
+            hidden: false,
+            groups: [],
+        },
+    });
+
+    const storedResult = ({
+        queryUuid,
+        table,
+        metric,
+        limit,
+        totalRowCount,
+    }: {
+        queryUuid: string;
+        table: string;
+        metric: string;
+        limit: number;
+        totalRowCount: number | null;
+    }): QueryHistory => ({
+        createdAt: new Date(),
+        organizationUuid: projectSummary.organizationUuid,
+        createdByUserUuid: sessionAccount.user.id,
+        createdBy: sessionAccount.user.id,
+        createdByAccount: null,
+        createdByActorType: 'session',
+        queryUuid,
+        projectUuid,
+        status: QueryHistoryStatus.READY,
+        error: null,
+        erroredAt: null,
+        metricQuery: {
+            ...metricQueryMock,
+            exploreName: table,
+            dimensions: [`${table}_month`],
+            metrics: [`${table}_${metric}`],
+            tableCalculations: [],
+            limit,
+        },
+        context: QueryExecutionContext.AI,
+        fields: storedFields(table, metric),
+        compiledSql: 'SELECT 1',
+        warehouseQueryId: null,
+        warehouseQueryMetadata: null,
+        requestParameters: {} as ExecuteAsyncQueryRequestParams,
+        usedParameters: null,
+        totalRowCount,
+        warehouseExecutionTimeMs: null,
+        defaultPageSize: null,
+        cacheKey: `${queryUuid}-cache-key`,
+        pivotConfiguration: null,
+        pivotTotalColumnCount: null,
+        pivotValuesColumns: null,
+        resultsFileName: `${queryUuid}.jsonl`,
+        resultsCreatedAt: new Date(),
+        resultsUpdatedAt: new Date(),
+        resultsExpiresAt: null,
+        columns: null,
+        originalColumns: null,
+        preAggregateCompiledSql: null,
+        preAggregateExecution: null,
+        preAggregateFallbackReason: null,
+        processingStartedAt: null,
+    });
+
+    const mergeQuery: MergeQuery = {
+        sources: [
+            { id: 'a', queryUuid: resultQueryUuids.a },
+            { id: 'b', queryUuid: resultQueryUuids.b },
+        ],
+        joinKey: [
+            {
+                name: 'month',
+                fieldIdBySourceId: { a: 'orders_month', b: 'payments_month' },
+            },
+        ],
+        joinType: MergeJoinType.FULL,
+        tableCalculations: [],
+        limit: 500,
+    };
+
+    const buildService = ({
+        aRowCount,
+        bRowCount,
+    }: {
+        aRowCount: number | null;
+        bRowCount: number | null;
+    }) => {
+        const storedByUuid: Record<string, QueryHistory> = {
+            [resultQueryUuids.a]: storedResult({
+                queryUuid: resultQueryUuids.a,
+                table: 'orders',
+                metric: 'count',
+                limit: REFERENCED_LIMIT,
+                totalRowCount: aRowCount,
+            }),
+            [resultQueryUuids.b]: storedResult({
+                queryUuid: resultQueryUuids.b,
+                table: 'payments',
+                metric: 'sum',
+                limit: REFERENCED_LIMIT,
+                totalRowCount: bRowCount,
+            }),
+        };
+        const service = getMockedAsyncQueryService(lightdashConfigMock);
+        service.queryHistoryModel.get = vi.fn(async (queryUuid: string) => {
+            const stored = storedByUuid[queryUuid];
+            if (stored === undefined) {
+                throw new NotFoundError(`No stored result ${queryUuid}`);
+            }
+            return stored;
+        });
+        const runLeg = vi.spyOn(service, 'executeAsyncMetricQuery');
+        return {
+            service,
+            runLeg,
+            create: service.queryHistoryModel.create as import('vitest').Mock,
+        };
+    };
+
+    it('refuses before any leg or the join when a referenced result returned as many rows as its own limit, naming the source', async () => {
+        const { service, runLeg, create } = buildService({
+            aRowCount: REFERENCED_LIMIT - 1,
+            bRowCount: REFERENCED_LIMIT,
+        });
+
+        const outcome = await service.executeAsyncMergeQuery({
+            account: sessionAccount,
+            projectUuid,
+            mergeQuery,
+            context: QueryExecutionContext.AI,
+            mode: { type: 'interactive' },
+        });
+
+        expect(outcome).toMatchObject({
+            outcome: 'refused',
+            errors: [
+                {
+                    kind: MergeQueryErrorKind.RESULT_SOURCE_UNAVAILABLE,
+                    sourceId: 'b',
+                    fieldIds: [],
+                    message: `Query "b" cannot back a merge: its results were cut short at their own limit of ${REFERENCED_LIMIT} rows, so the merged results would be missing data. Re-run that query with a higher limit or without one, then merge again.`,
+                },
+            ],
+        });
+        expect(runLeg).not.toHaveBeenCalled();
+        expect(create).not.toHaveBeenCalled();
+    });
+
+    it('compiles a merge whose referenced results are all under their own limits', async () => {
+        const { service } = buildService({
+            aRowCount: REFERENCED_LIMIT - 1,
+            bRowCount: REFERENCED_LIMIT - 1,
+        });
+
+        const compiled = await service.compileMergeQuery({
+            account: sessionAccount,
+            projectUuid,
+            mergeQuery,
+        });
+
+        expect(compiled.errors).toEqual([]);
+        expect(compiled.requiresCompose).toBe(true);
+    });
+
+    it('leaves a referenced result with no recorded row count alone', async () => {
+        const { service } = buildService({
+            aRowCount: REFERENCED_LIMIT - 1,
+            bRowCount: null,
+        });
+
+        const compiled = await service.compileMergeQuery({
+            account: sessionAccount,
+            projectUuid,
+            mergeQuery,
+        });
+
+        expect(compiled.errors).toEqual([]);
     });
 });

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -255,6 +255,7 @@ import {
     applyMergeExportLimit,
     buildComposeMergeOriginalColumns,
     buildMergeRowCapGuard,
+    getMergeResultSourceCutShortError,
     getMergeSourceLabels,
 } from './mergeQueryExecution';
 import {
@@ -8442,6 +8443,13 @@ export class AsyncQueryService extends ProjectService {
             throw new ParameterError(
                 'its results have expired. Re-run the query and merge the new result.',
             );
+        }
+        const cutShortError = getMergeResultSourceCutShortError({
+            limit: queryHistory.metricQuery.limit,
+            totalRowCount: queryHistory.totalRowCount,
+        });
+        if (cutShortError !== null) {
+            throw new ParameterError(cutShortError);
         }
         if (Object.keys(queryHistory.fields).length === 0) {
             throw new ParameterError(

--- a/packages/backend/src/services/AsyncQueryService/mergeQueryExecution.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/mergeQueryExecution.test.ts
@@ -15,6 +15,7 @@ import {
     buildComposeMergeOriginalColumns,
     buildMergeRowCapGuard,
     getMergeOutputColumnCount,
+    getMergeResultSourceCutShortError,
     getMergeRowCapError,
     getMergeSourceLabels,
 } from './mergeQueryExecution';
@@ -278,6 +279,49 @@ describe('getMergeRowCapError', () => {
             getMergeRowCapError({
                 legs: [{ label: 'Orders', rowCount: null }],
                 sourceRowCap: 500,
+            }),
+        ).toBeNull();
+    });
+});
+
+describe('getMergeResultSourceCutShortError', () => {
+    test('refuses a result that returned as many rows as its own limit', () => {
+        expect(
+            getMergeResultSourceCutShortError({
+                limit: 500,
+                totalRowCount: 500,
+            }),
+        ).toBe(
+            'its results were cut short at their own limit of 500 rows, so the merged results would be missing data. Re-run that query with a higher limit or without one, then merge again.',
+        );
+    });
+
+    test('allows a result under its own limit, whatever the instance cap', () => {
+        expect(
+            getMergeResultSourceCutShortError({
+                limit: 500,
+                totalRowCount: 499,
+            }),
+        ).toBeNull();
+        expect(
+            getMergeResultSourceCutShortError({
+                limit: 5000,
+                totalRowCount: 0,
+            }),
+        ).toBeNull();
+    });
+
+    test('leaves a result with no recorded limit or row count alone', () => {
+        expect(
+            getMergeResultSourceCutShortError({
+                limit: null,
+                totalRowCount: 500,
+            }),
+        ).toBeNull();
+        expect(
+            getMergeResultSourceCutShortError({
+                limit: 500,
+                totalRowCount: null,
             }),
         ).toBeNull();
     });

--- a/packages/backend/src/services/AsyncQueryService/mergeQueryExecution.ts
+++ b/packages/backend/src/services/AsyncQueryService/mergeQueryExecution.ts
@@ -153,15 +153,7 @@ export const getMergeRowCapError = ({
         : `${capped.join(' and ')} each ${consequence} Add a filter to each, then merge again.`;
 };
 
-/**
- * A referenced result that returned as many rows as the limit it ran with may
- * have had more rows behind it, and the join would report totals that look
- * complete and are not. The row cap never bounded it (it was never re-run at
- * the cap), so its own limit is the only bound that matters. Known from its
- * query_history row before anything runs, so it refuses at compile time,
- * phrased as a fragment the compiler prefixes with the source at fault.
- * A missing limit or row count is not evidence, so it never refuses.
- */
+// A result that filled its own limit may hold more rows behind it; a missing limit or count is not evidence.
 export const getMergeResultSourceCutShortError = ({
     limit,
     totalRowCount,

--- a/packages/backend/src/services/AsyncQueryService/mergeQueryExecution.ts
+++ b/packages/backend/src/services/AsyncQueryService/mergeQueryExecution.ts
@@ -154,6 +154,28 @@ export const getMergeRowCapError = ({
 };
 
 /**
+ * A referenced result that returned as many rows as the limit it ran with may
+ * have had more rows behind it, and the join would report totals that look
+ * complete and are not. The row cap never bounded it (it was never re-run at
+ * the cap), so its own limit is the only bound that matters. Known from its
+ * query_history row before anything runs, so it refuses at compile time,
+ * phrased as a fragment the compiler prefixes with the source at fault.
+ * A missing limit or row count is not evidence, so it never refuses.
+ */
+export const getMergeResultSourceCutShortError = ({
+    limit,
+    totalRowCount,
+}: {
+    limit: number | null;
+    totalRowCount: number | null;
+}): string | null => {
+    if (limit === null || totalRowCount === null || totalRowCount < limit) {
+        return null;
+    }
+    return `its results were cut short at their own limit of ${limit} rows, so the merged results would be missing data. Re-run that query with a higher limit or without one, then merge again.`;
+};
+
+/**
  * The guard a merge hands the execution tail: once the legs complete, refuse
  * before the join when one of them reached the row cap.
  */


### PR DESCRIPTION
## What breaks today

A merge can reference an existing query result (`queryUuid`) as a source. That result source is never re-run: the merge joins the rows it already holds. PR #28572 made a merge refuse when a leg it ran reached the source row cap, and deliberately checked only those legs, so a result source is outside that check.

That leaves the same under-reporting through a different door. A result that ran with the user's own limit of 500 under an instance cap of 5000 holds only its top 500 rows. The merge joins those and reports totals that look complete and are not. The row-cap check cannot catch it because 500 is well under the cap.

## What changes

The referenced query's `query_history` row already records the limit it ran with (`metric_query.limit`) and the rows it returned (`total_row_count`). When the row count reaches that limit the result may have been cut short, so the merge is refused.

- `getMergeResultSourceCutShortError` in `mergeQueryExecution.ts`: a pure function over those two facts that returns the refusal fragment or `null`. It refuses on evidence only: a missing limit or row count never refuses.
- `AsyncQueryService.getMergeResultSourceMetadata` calls it while resolving the result source at compile time. The compile already wraps a fragment thrown there as a `result_source_unavailable` refusal that names the source, so the refusal lands before any leg is submitted and before the join, as a structured refusal rather than the merged query's error.
- The remedy copy fits the surface that can reach a result source (the AI agent path): re-run that query with a higher limit or without one, then merge again. "Add a filter" is the leg remedy and is wrong for a referenced result.
- `docs/merge-queries/CONTEXT.md` and `architecture.md` record the decision: a result source is checked against its own limit only, never the instance row cap. The cap never bounded it (it was never re-run at the cap), and a result that ran at the cap and filled it is caught by the same equality check anyway.

Full refusal text as the agent sees it:

> This merge cannot be run: Query "b" cannot back a merge: its results were cut short at their own limit of 500 rows, so the merged results would be missing data. Re-run that query with a higher limit or without one, then merge again.

## How it was verified

- `pnpm -F backend test src/services/AsyncQueryService/mergeQueryExecution.test.ts`: 1 file, 18 tests pass (3 new: refuses at equality, allows under its limit whatever the cap, leaves a missing limit or row count alone).
- `pnpm -F backend test src/services/AsyncQueryService/AsyncQueryService.test.ts`: 1 file, 102 tests pass (3 new). The refusal test lowers the referenced query's limit to 3 rather than growing seed data, runs the merge through `executeAsyncMergeQuery` over two result sources, and asserts the structured refusal names source `b`, that `executeAsyncMetricQuery` never ran a leg, and that no merged `query_history` row was created. The other two prove a merge whose result sources are under their limits compiles clean, and that a result with no recorded row count is left alone.
- `pnpm -F backend typecheck` and `pnpm -F backend lint` clean; changed files formatted with oxfmt.

No migrations, no generated API files, no frontend changes.

## Regression analysis

`getMergeResultSourceMetadata` has one implementation with query-history access (`AsyncQueryService`) and two callers, both in `ProjectService`: `compileMergeQuery` (returns the thrown fragment as a refusal) and `getMergeFieldTypesForQuery` (throws through). Every merge submission compiles first, so the compile refusal is what a caller sees; the field-types path only runs after a clean compile and cannot newly throw for the same row. The base `ProjectService` override still throws its "not available" error unchanged.

Metric sources never pass through this function, so Explorer merges and the warehouse merge path are untouched. The leg row-cap guard (`getMergeRowCapError`, `buildMergeRowCapGuard`) keeps its signature and behaviour; the only edit to `AsyncQueryService.ts` is one import and six lines inside `getMergeResultSourceMetadata`. The other existing checks in that method (status, expiry, empty fields) run in the same order as before, with the new check placed after expiry and before the empty-fields check.

The stored `metricQuery.limit` is the limit the query actually ran with: a limit above the instance cap is refused at submission, and export clamps are applied before the row is written. A result source that ran with a large limit and legitimately returned fewer rows is unaffected.

Closes: PROD-10909

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvtHaH3fbzSX2ebMgfFKFS
