### PR TITLE
feat(dashboard): badge dashboard custom metrics from creation

### DIFF
--- a/packages/frontend/src/components/Explorer/ExploreTree/SelectedFieldsSection.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/SelectedFieldsSection.tsx
@@ -40,7 +40,10 @@ import {
 } from '../../../features/explorer/store';
 import { useExplore } from '../../../hooks/useExplore';
 import { useAddFilter } from '../../../hooks/useFilters';
-import { useModalHostedDashboardMetricIds } from '../../../providers/Explorer/useIsModalHosted';
+import {
+    useIsModalHosted,
+    useModalHostedDashboardMetricIds,
+} from '../../../providers/Explorer/useIsModalHosted';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
 import FieldIcon from '../../common/Filters/FieldIcon';
@@ -130,11 +133,14 @@ const SelectedFieldRow: FC<RowProps> = memo(({ row, onDeselect }) => {
     const [isHover, toggleHover] = useToggle(false);
     const [isMenuOpen, toggleMenu] = useToggle(false);
 
-    // Registry metrics stay frozen in the selected section too.
+    // Registry metrics stay frozen here too; the badge marks provenance
     const dashboardMetricIds = useModalHostedDashboardMetricIds();
-    const isDashboardMetric =
+    const isModalHosted = useIsModalHosted();
+    const isRegistryMetric =
         isAdditionalMetric(item) &&
         (dashboardMetricIds?.has(getItemId(item)) ?? false);
+    const isDashboardMetric =
+        isRegistryMetric || (isModalHosted && isAdditionalMetric(item));
 
     const selectIsFiltered = useMemo(
         () => (state: ExplorerStoreState) =>
@@ -156,7 +162,7 @@ const SelectedFieldRow: FC<RowProps> = memo(({ row, onDeselect }) => {
         useCustomMetricDelete({
             item,
             fieldId,
-            isHover: isHover && !isDashboardMetric,
+            isHover: isHover && !isRegistryMetric,
         });
     const showDeleteAction = !hideActions && canShowDeleteAction;
 
@@ -331,7 +337,7 @@ const SelectedFieldRow: FC<RowProps> = memo(({ row, onDeselect }) => {
                 {/* Mounted on hover only so the labels get the space at rest */}
                 {!hideActions &&
                     (!basicActionsOnly ||
-                        isDashboardMetric ||
+                        isRegistryMetric ||
                         !!description ||
                         (!isAdditionalMetric(item) &&
                             isFilterableField(item))) &&
@@ -346,9 +352,9 @@ const SelectedFieldRow: FC<RowProps> = memo(({ row, onDeselect }) => {
                             onMenuChange={onToggleMenu}
                             onAddFilter={fieldOnAddFilter}
                             basicActionsOnly={
-                                basicActionsOnly || isDashboardMetric
+                                basicActionsOnly || isRegistryMetric
                             }
-                            allowRegistryEdit={isDashboardMetric}
+                            allowRegistryEdit={isRegistryMetric}
                         />
                     )}
             </span>

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
@@ -50,6 +50,7 @@ import {
 import { useExplore } from '../../../../../hooks/useExplore';
 import { useAddFilter } from '../../../../../hooks/useFilters';
 import { useServerFeatureFlag } from '../../../../../hooks/useServerOrClientFeatureFlag';
+import { useIsModalHosted } from '../../../../../providers/Explorer/useIsModalHosted';
 import useTracking from '../../../../../providers/Tracking/useTracking';
 import { EventName } from '../../../../../types/Events';
 import {
@@ -174,6 +175,7 @@ const TreeSingleNodeComponent: FC<Props> = ({ node }) => {
     const dashboardMetricIds = useTableTree(
         (context) => context.dashboardMetricIds,
     );
+    const isModalHosted = useIsModalHosted();
     const itemsAlerts = useTableTree((context) => context.itemsAlerts);
     const missingCustomDimensions = useTableTree(
         (context) => context.missingCustomDimensions,
@@ -283,10 +285,13 @@ const TreeSingleNodeComponent: FC<Props> = ({ node }) => {
         return false;
     }, [description, isMissing, item, metricInfo]);
 
-    // Registry metric: badged with '=' and frozen (no edit/duplicate/delete).
-    const isDashboardMetric =
+    // Shared with the dashboard: edits go via impact preview, actions reduced
+    const isRegistryMetric =
         isAdditionalMetric(item) &&
         (dashboardMetricIds?.has(getItemId(item)) ?? false);
+    // The '=' badge marks provenance: dashboard-local from creation
+    const isDashboardMetric =
+        isRegistryMetric || (isModalHosted && isAdditionalMetric(item));
 
     const itemColors = getFieldColors(item);
     const alerts = itemsAlerts?.[getItemId(item)];
@@ -298,7 +303,7 @@ const TreeSingleNodeComponent: FC<Props> = ({ node }) => {
     const { showDeleteAction, handleDeleteClick } = useCustomMetricDelete({
         item,
         fieldId,
-        isHover: isHover && !isDashboardMetric,
+        isHover: isHover && !isRegistryMetric,
     });
 
     const timeIntervalLabel =
@@ -557,8 +562,8 @@ const TreeSingleNodeComponent: FC<Props> = ({ node }) => {
                     isSelected={isSelected}
                     isOpened={isMenuOpen}
                     hasDescription={!!description}
-                    basicActionsOnly={isDashboardMetric}
-                    allowRegistryEdit={isDashboardMetric}
+                    basicActionsOnly={isRegistryMetric}
+                    allowRegistryEdit={isRegistryMetric}
                     onViewDescription={onOpenDescriptionView}
                     onMenuChange={onToggleMenu}
                 />


### PR DESCRIPTION
Relates: GLITCH-733

### Description:

Follow-up to #28625. The `=` badge now marks **provenance** (local to this dashboard), not registry membership — matching what the badge means in the products users recognize it from, where a workbook-local field carries it from the moment of creation.

- Any custom metric created in the in-dashboard editor badges immediately, before the chart is saved.
- The reduced actions menu (edit-via-preview, no duplicate/delete/write-back) still applies only once the metric enters the shared registry — a freshly created metric keeps the full menu until the chart introducing it is saved.

Verified in the browser: new metric shows the badge instantly with full actions; registry metrics unchanged (badge + reduced menu).

### Risk assessment:

- [ ] This is a high-risk change

High-risk changes require approval from a reviewer other than the author before merging.
