### PR TITLE
feat(merge): track merge execution and refusal events

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -19,6 +19,8 @@ import {
     LightdashPage,
     LightdashRequestMethodHeader,
     LightdashUser,
+    MergeJoinType,
+    MergeQueryErrorKind,
     OpenIdIdentityIssuerType,
     OrganizationMemberRole,
     PinnedItem,
@@ -583,6 +585,52 @@ type ResultsCacheDeleteEvent = BaseTrack & {
         queryId: string;
         projectId: string;
         cacheKey: string;
+    };
+};
+
+export type MergeEngine = 'compose' | 'warehouse';
+export type MergeSourceKind = 'metric' | 'result';
+/** The row cap has no compile-time kind: a leg is known to have reached it only once it has run. */
+export type MergeRefusalKind = MergeQueryErrorKind | 'row_cap';
+
+export type MergeQueryShapeProperties = {
+    organizationId: string;
+    projectId: string;
+    context: QueryExecutionContext;
+    joinType: MergeJoinType;
+    sourceKinds: MergeSourceKind[];
+    sourceCount: number;
+    joinKeyCount: number;
+    tableCalculationCount: number;
+};
+
+export type MergeQueryExecutedEvent = BaseTrack & {
+    event: 'merge_query.executed';
+    properties: MergeQueryShapeProperties & {
+        queryId: string;
+        engine: MergeEngine;
+        /** `ready` and `error` are terminal; `started` is a warehouse merge whose outcome is not tracked. */
+        status: 'started' | 'ready' | 'error';
+        /** Whether the merged result itself was served from cache. */
+        cacheHit: boolean;
+        /** Legs this merge ran; referenced results run nothing. */
+        legCount: number;
+        legCacheHitCount: number;
+        rowCount: number | null;
+        /** Submission to terminal state, including waiting on the legs. */
+        durationMs: number | null;
+        joinExecutionTimeMs: number | null;
+    };
+};
+
+export type MergeQueryRefusedEvent = BaseTrack & {
+    event: 'merge_query.refused';
+    properties: MergeQueryShapeProperties & {
+        kind: MergeRefusalKind;
+        kinds: MergeRefusalKind[];
+        refusalCount: number;
+        /** Set when the refusal arrived as the merged query's error, as the row cap does. */
+        queryId: string | null;
     };
 };
 
@@ -3636,6 +3684,8 @@ type TypedEvent =
     | CategoriesAppliedEvent
     | CustomFieldsReplaced
     | SubtotalQueryEvent
+    | MergeQueryExecutedEvent
+    | MergeQueryRefusedEvent
     | DeprecatedRouteCalled
     | AiAgentCreatedEvent
     | AiAgentThreadDeletedEvent

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -14,6 +14,7 @@ import {
     FilterOperator,
     ForbiddenError,
     MergeJoinType,
+    MergeQueryErrorKind,
     MetricType,
     MissingConfigError,
     NotFoundError,
@@ -813,11 +814,14 @@ describe('AsyncQueryService', () => {
 
         test('returns validation errors without starting execution', async () => {
             const service = getMockedAsyncQueryService(lightdashConfigMock);
+            const trackAccount = vi.spyOn(analyticsMock, 'trackAccount');
             vi.spyOn(service, 'compileMergeQuery').mockResolvedValue({
                 coreSql: null,
                 typedColumns: null,
                 terminalWrapper: null,
-                errors: [{ message: 'Fan-out' }],
+                errors: [
+                    { kind: MergeQueryErrorKind.FAN_OUT, message: 'Fan-out' },
+                ],
                 parameterReferences: ['date'],
                 fieldOrigins: {},
             } as never);
@@ -835,6 +839,19 @@ describe('AsyncQueryService', () => {
                 parameterReferences: ['date'],
                 errors: [{ message: 'Fan-out' }],
             });
+            expect(trackAccount).toHaveBeenCalledWith(sessionAccount, {
+                event: 'merge_query.refused',
+                properties: expect.objectContaining({
+                    projectId: projectUuid,
+                    context: QueryExecutionContext.EXPLORE,
+                    joinType: 'full',
+                    kind: MergeQueryErrorKind.FAN_OUT,
+                    kinds: [MergeQueryErrorKind.FAN_OUT],
+                    refusalCount: 1,
+                    queryId: null,
+                }),
+            });
+            trackAccount.mockRestore();
         });
     });
 
@@ -6053,6 +6070,8 @@ describe('executeAsyncMergeQuery on the compose engine', () => {
             context: QueryExecutionContext.EXPLORE,
             status: QueryHistoryStatus.READY,
             totalRowCount,
+            warehouseExecutionTimeMs: 12,
+            error: null,
             resultsFileName: `${queryUuid}.jsonl`,
             resultsExpiresAt: null,
             columns: {},
@@ -6102,24 +6121,42 @@ describe('executeAsyncMergeQuery on the compose engine', () => {
         ).mockResolvedValue(fieldTypes);
         vi.spyOn(service, 'executeAsyncMetricQuery').mockImplementation(
             async ({ metricQuery }) =>
-                ({
-                    queryUuid:
-                        metricQuery.exploreName === 'orders'
-                            ? legQueryUuidBySourceId.a
-                            : legQueryUuidBySourceId.b,
-                }) as never,
+                (metricQuery.exploreName === 'orders'
+                    ? {
+                          queryUuid: legQueryUuidBySourceId.a,
+                          cacheMetadata: { cacheHit: true },
+                      }
+                    : {
+                          queryUuid: legQueryUuidBySourceId.b,
+                          cacheMetadata: { cacheHit: false },
+                      }) as never,
         );
         const runWarehouseQuery = vi
             .spyOn(service, 'runAsyncWarehouseQuery')
             .mockResolvedValue(undefined);
+        const trackAccount = vi
+            .spyOn(analyticsMock, 'trackAccount')
+            .mockImplementation(() => {});
         return {
             service,
             streamQuery,
             runWarehouseQuery,
+            trackAccount,
             create: service.queryHistoryModel.create as import('vitest').Mock,
             update: service.queryHistoryModel.update as import('vitest').Mock,
         };
     };
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    const mergeEvents = (
+        trackAccount: ReturnType<typeof buildService>['trackAccount'],
+    ) =>
+        trackAccount.mock.calls
+            .map(([, event]) => event)
+            .filter(({ event }) => event.startsWith('merge_query.'));
 
     const execute = (service: AsyncQueryService) =>
         service.executeAsyncMergeQuery({
@@ -6172,11 +6209,66 @@ describe('executeAsyncMergeQuery on the compose engine', () => {
         );
     });
 
-    it('refuses before the join when a leg reached the row cap, naming the source', async () => {
-        const { service, streamQuery, runWarehouseQuery, update } =
-            buildService({ config: cappedConfig, legRowCount: SOURCE_ROW_CAP });
+    it('tracks the merge once it is ready, with leg cache hits and the merged row count', async () => {
+        const { service, trackAccount } = buildService({
+            config: lightdashConfigMock,
+            legRowCount: 2,
+        });
 
         await execute(service);
+
+        await vi.waitFor(() =>
+            expect(mergeEvents(trackAccount)).toHaveLength(1),
+        );
+        expect(mergeEvents(trackAccount)[0]).toEqual({
+            event: 'merge_query.executed',
+            properties: {
+                organizationId: projectSummary.organizationUuid,
+                projectId: projectUuid,
+                context: QueryExecutionContext.EXPLORE,
+                joinType: MergeJoinType.FULL,
+                sourceKinds: ['metric', 'metric'],
+                sourceCount: 2,
+                joinKeyCount: 1,
+                tableCalculationCount: 0,
+                queryId: 'merge-query-uuid',
+                engine: 'compose',
+                status: 'ready',
+                cacheHit: false,
+                legCount: 2,
+                legCacheHitCount: 1,
+                rowCount: 2,
+                durationMs: expect.any(Number),
+                joinExecutionTimeMs: 12,
+            },
+        });
+    });
+
+    it('refuses before the join when a leg reached the row cap, naming the source', async () => {
+        const {
+            service,
+            streamQuery,
+            runWarehouseQuery,
+            update,
+            trackAccount,
+        } = buildService({ config: cappedConfig, legRowCount: SOURCE_ROW_CAP });
+
+        await execute(service);
+
+        await vi.waitFor(() =>
+            expect(mergeEvents(trackAccount)).toHaveLength(1),
+        );
+        expect(mergeEvents(trackAccount)[0]).toMatchObject({
+            event: 'merge_query.refused',
+            properties: {
+                kind: 'row_cap',
+                kinds: ['row_cap'],
+                refusalCount: 1,
+                queryId: 'merge-query-uuid',
+                joinType: MergeJoinType.FULL,
+                sourceKinds: ['metric', 'metric'],
+            },
+        });
 
         await vi.waitFor(() =>
             expect(update).toHaveBeenCalledWith(

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -258,6 +258,15 @@ import {
     getMergeSourceLabels,
 } from './mergeQueryExecution';
 import {
+    buildMergeExecutedEvent,
+    buildMergeRefusedEvent,
+    buildMergeRefusedEventFromErrors,
+    describeMergeQueryShape,
+    observeRowCapRefusal,
+    resolveComposeMergeOutcome,
+    type MergeSubmission,
+} from './mergeQueryTelemetry';
+import {
     NoOpPreAggregateStrategy,
     type PreAggregateExecutionResolution,
     type PreAggregateStrategy,
@@ -7892,7 +7901,47 @@ export class AsyncQueryService extends ProjectService {
         });
     }
 
-    private async executeAsyncMergeQueryInternal({
+    /**
+     * Every surface that runs a merge passes through here, so this is where
+     * a merge becomes visible: a Sentry transaction that keeps its failures
+     * apart from ordinary query failures, and a refusal event per refused
+     * submission. Executed events fire from the engine that ran the merge.
+     */
+    private async executeAsyncMergeQueryInternal(
+        args: ExecuteMergeQueryInternalArgs,
+    ): Promise<ApiExecuteAsyncMergeQueryResults> {
+        const { account, projectUuid, mergeQuery, context, mode } = args;
+        assertIsAccountWithOrg(account);
+        const submission: MergeSubmission = {
+            organizationUuid: account.organization.organizationUuid,
+            projectUuid,
+            context,
+            mergeQuery,
+        };
+        return wrapSentryTransaction(
+            'merge_query.submit',
+            {
+                projectUuid,
+                context,
+                mode: mode.type,
+                joinType: mergeQuery.joinType,
+                sourceCount: mergeQuery.sources.length,
+            },
+            async () => {
+                const outcome = await this.submitAsyncMergeQuery(args);
+                if (outcome.outcome === 'refused') {
+                    const refused = buildMergeRefusedEventFromErrors({
+                        submission,
+                        errors: outcome.errors,
+                    });
+                    if (refused) this.analytics.trackAccount(account, refused);
+                }
+                return outcome;
+            },
+        );
+    }
+
+    private async submitAsyncMergeQuery({
         account,
         projectUuid,
         mergeQuery,
@@ -8127,6 +8176,27 @@ export class AsyncQueryService extends ProjectService {
             },
             requestParameters,
         );
+        // The warehouse statement completes in the shared background tail,
+        // which has no merge hook, so this engine reports submission only
+        this.analytics.trackAccount(
+            account,
+            buildMergeExecutedEvent({
+                submission: {
+                    organizationUuid,
+                    projectUuid,
+                    context,
+                    mergeQuery,
+                },
+                queryId: queryUuid,
+                engine: 'warehouse',
+                status: 'started',
+                cacheHit: cacheMetadata.cacheHit,
+                legCacheHits: [],
+                rowCount: null,
+                durationMs: null,
+                joinExecutionTimeMs: null,
+            }),
+        );
 
         return {
             queryUuid,
@@ -8204,7 +8274,11 @@ export class AsyncQueryService extends ProjectService {
         const legs = await Promise.all(
             mergeQuery.sources.map(async (source) => {
                 if (isMergeResultSource(source)) {
-                    return [source.id, source.queryUuid] as const;
+                    return {
+                        sourceId: source.id,
+                        queryUuid: source.queryUuid,
+                        cacheHit: null,
+                    };
                 }
                 const leg = await this.executeAsyncMetricQuery({
                     account,
@@ -8219,10 +8293,19 @@ export class AsyncQueryService extends ProjectService {
                         limit: sourceRowCap,
                     },
                 });
-                return [source.id, leg.queryUuid] as const;
+                return {
+                    sourceId: source.id,
+                    queryUuid: leg.queryUuid,
+                    cacheHit: leg.cacheMetadata.cacheHit,
+                };
             }),
         );
-        const legQueryUuidBySourceId = Object.fromEntries(legs);
+        const legQueryUuidBySourceId = Object.fromEntries(
+            legs.map(({ sourceId, queryUuid }) => [sourceId, queryUuid]),
+        );
+        const legCacheHits = legs.flatMap(({ cacheHit }) =>
+            cacheHit === null ? [] : [cacheHit],
+        );
 
         const fieldTypes = await this.getMergeFieldTypesForQuery(
             account,
@@ -8363,44 +8446,74 @@ export class AsyncQueryService extends ProjectService {
             organizationUuid,
         });
 
-        void this.runDuckdbQuery({
-            account,
-            projectUuid,
+        const submission: MergeSubmission = {
             organizationUuid,
-            isPreviewProject:
-                projectSummary.type === ProjectType.PREVIEW ||
-                projectSummary.provisioningSource === 'playground',
-            onboardingFlow,
-            queryUuid,
-            sql,
-            references: {
-                kind: 'queries',
-                references,
-                guard: buildMergeRowCapGuard({
-                    legLabelByReferenceTable,
-                    sourceRowCap,
-                }),
-            },
-            columns: {
-                mode: 'supplied',
-                fieldsMap,
-                usedParameters: composer.getUsedParameters(),
-                originalColumns,
-                pivotConfiguration,
-            },
-            storedCompiledSql: null,
-            warehouseClient,
-            queryTags,
-            queryCreatedAt,
-            cacheKey,
+            projectUuid,
             context,
-        }).catch((e) => {
-            this.logger.error(
-                `Async compose merge query ${queryUuid} failed: ${getErrorMessage(
-                    e,
-                )}`,
-            );
-        });
+            mergeQuery,
+        };
+        const rowCap = observeRowCapRefusal(
+            buildMergeRowCapGuard({ legLabelByReferenceTable, sourceRowCap }),
+        );
+        void traceSpan(
+            {
+                op: 'merge_query.execute',
+                name: 'merge_query.execute.compose',
+                attributes: {
+                    'lightdash.queryUuid': queryUuid,
+                    'lightdash.projectUuid': projectUuid,
+                    'lightdash.queryContext': context,
+                    'lightdash.joinType': mergeQuery.joinType,
+                },
+            },
+            () =>
+                this.runDuckdbQuery({
+                    account,
+                    projectUuid,
+                    organizationUuid,
+                    isPreviewProject:
+                        projectSummary.type === ProjectType.PREVIEW ||
+                        projectSummary.provisioningSource === 'playground',
+                    onboardingFlow,
+                    queryUuid,
+                    sql,
+                    references: {
+                        kind: 'queries',
+                        references,
+                        guard: rowCap.guard,
+                    },
+                    columns: {
+                        mode: 'supplied',
+                        fieldsMap,
+                        usedParameters: composer.getUsedParameters(),
+                        originalColumns,
+                        pivotConfiguration,
+                    },
+                    storedCompiledSql: null,
+                    warehouseClient,
+                    queryTags,
+                    queryCreatedAt,
+                    cacheKey,
+                    context,
+                }),
+        )
+            .then(() =>
+                this.reportComposeMergeOutcome({
+                    account,
+                    submission,
+                    queryUuid,
+                    queryCreatedAt,
+                    legCacheHits,
+                    rowCapRefused: rowCap.wasRefused(),
+                }),
+            )
+            .catch((e) => {
+                this.logger.error(
+                    `Async compose merge query ${queryUuid} failed: ${getErrorMessage(
+                        e,
+                    )}`,
+                );
+            });
 
         return {
             queryUuid,
@@ -8412,6 +8525,101 @@ export class AsyncQueryService extends ProjectService {
             usedParametersValues: composer.getUsedParameters(),
             resolvedTimezone: composer.getDisplayTimezone(),
         };
+    }
+
+    /**
+     * The shared tail writes the merged query's terminal state, so the merge
+     * reads it back once the run settles: a row-cap refusal is a refusal, a
+     * ready query is an execution, and anything else is a failure that gets
+     * a Sentry issue of its own rather than vanishing into query history.
+     */
+    private async reportComposeMergeOutcome({
+        account,
+        submission,
+        queryUuid,
+        queryCreatedAt,
+        legCacheHits,
+        rowCapRefused,
+    }: {
+        account: Account;
+        submission: MergeSubmission;
+        queryUuid: string;
+        queryCreatedAt: Date;
+        legCacheHits: boolean[];
+        rowCapRefused: boolean;
+    }): Promise<void> {
+        const history = await this.queryHistoryModel.get(
+            queryUuid,
+            submission.projectUuid,
+            account,
+        );
+        const outcome = resolveComposeMergeOutcome({ history, rowCapRefused });
+        const durationMs = Date.now() - queryCreatedAt.getTime();
+        switch (outcome.kind) {
+            case 'refused_row_cap':
+                this.analytics.trackAccount(
+                    account,
+                    buildMergeRefusedEvent({
+                        submission,
+                        kinds: ['row_cap'],
+                        queryId: queryUuid,
+                    }),
+                );
+                return;
+            case 'ready':
+                this.analytics.trackAccount(
+                    account,
+                    buildMergeExecutedEvent({
+                        submission,
+                        queryId: queryUuid,
+                        engine: 'compose',
+                        status: 'ready',
+                        cacheHit: false,
+                        legCacheHits,
+                        rowCount: outcome.rowCount,
+                        durationMs,
+                        joinExecutionTimeMs: outcome.joinExecutionTimeMs,
+                    }),
+                );
+                return;
+            case 'error':
+                this.analytics.trackAccount(
+                    account,
+                    buildMergeExecutedEvent({
+                        submission,
+                        queryId: queryUuid,
+                        engine: 'compose',
+                        status: 'error',
+                        cacheHit: false,
+                        legCacheHits,
+                        rowCount: null,
+                        durationMs,
+                        joinExecutionTimeMs: null,
+                    }),
+                );
+                Sentry.withScope((scope) => {
+                    scope.setTag('lightdash.mergeQuery', 'true');
+                    scope.setTag('lightdash.queryUuid', queryUuid);
+                    scope.setTag(
+                        'lightdash.projectUuid',
+                        submission.projectUuid,
+                    );
+                    scope.setContext('merge_query', {
+                        ...describeMergeQueryShape(submission),
+                        error: outcome.error,
+                    });
+                    Sentry.captureException(
+                        new UnexpectedServerError(
+                            `Merge query ${queryUuid} failed on the compose engine: ${
+                                outcome.error ?? 'unknown error'
+                            }`,
+                        ),
+                    );
+                });
+                return;
+            default:
+                assertUnreachable(outcome, 'Unknown compose merge outcome');
+        }
     }
 
     /**

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -7901,12 +7901,7 @@ export class AsyncQueryService extends ProjectService {
         });
     }
 
-    /**
-     * Every surface that runs a merge passes through here, so this is where
-     * a merge becomes visible: a Sentry transaction that keeps its failures
-     * apart from ordinary query failures, and a refusal event per refused
-     * submission. Executed events fire from the engine that ran the merge.
-     */
+    /** Every merge surface passes through here; executed events fire from the engine that ran it. */
     private async executeAsyncMergeQueryInternal(
         args: ExecuteMergeQueryInternalArgs,
     ): Promise<ApiExecuteAsyncMergeQueryResults> {
@@ -8176,8 +8171,7 @@ export class AsyncQueryService extends ProjectService {
             },
             requestParameters,
         );
-        // The warehouse statement completes in the shared background tail,
-        // which has no merge hook, so this engine reports submission only
+        // The shared background tail has no merge hook, so this engine reports submission only
         this.analytics.trackAccount(
             account,
             buildMergeExecutedEvent({
@@ -8527,12 +8521,7 @@ export class AsyncQueryService extends ProjectService {
         };
     }
 
-    /**
-     * The shared tail writes the merged query's terminal state, so the merge
-     * reads it back once the run settles: a row-cap refusal is a refusal, a
-     * ready query is an execution, and anything else is a failure that gets
-     * a Sentry issue of its own rather than vanishing into query history.
-     */
+    /** Reads the terminal state the shared tail wrote, once the background run settled. */
     private async reportComposeMergeOutcome({
         account,
         submission,

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -7913,14 +7913,18 @@ export class AsyncQueryService extends ProjectService {
             context,
             mergeQuery,
         };
-        return wrapSentryTransaction(
-            'merge_query.submit',
+        // A span, not wrapSentryTransaction: refusals throw and must not become Sentry issues
+        return traceSpan(
             {
-                projectUuid,
-                context,
-                mode: mode.type,
-                joinType: mergeQuery.joinType,
-                sourceCount: mergeQuery.sources.length,
+                op: 'merge_query.submit',
+                name: 'merge_query.submit',
+                attributes: {
+                    'lightdash.projectUuid': projectUuid,
+                    'lightdash.queryContext': context,
+                    'lightdash.mergeMode': mode.type,
+                    'lightdash.joinType': mergeQuery.joinType,
+                    'lightdash.sourceCount': mergeQuery.sources.length,
+                },
             },
             async () => {
                 const outcome = await this.submitAsyncMergeQuery(args);
@@ -8586,25 +8590,6 @@ export class AsyncQueryService extends ProjectService {
                         joinExecutionTimeMs: null,
                     }),
                 );
-                Sentry.withScope((scope) => {
-                    scope.setTag('lightdash.mergeQuery', 'true');
-                    scope.setTag('lightdash.queryUuid', queryUuid);
-                    scope.setTag(
-                        'lightdash.projectUuid',
-                        submission.projectUuid,
-                    );
-                    scope.setContext('merge_query', {
-                        ...describeMergeQueryShape(submission),
-                        error: outcome.error,
-                    });
-                    Sentry.captureException(
-                        new UnexpectedServerError(
-                            `Merge query ${queryUuid} failed on the compose engine: ${
-                                outcome.error ?? 'unknown error'
-                            }`,
-                        ),
-                    );
-                });
                 return;
             default:
                 assertUnreachable(outcome, 'Unknown compose merge outcome');

--- a/packages/backend/src/services/AsyncQueryService/mergeQueryTelemetry.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/mergeQueryTelemetry.test.ts
@@ -1,0 +1,247 @@
+import {
+    MergeJoinType,
+    MergeQueryErrorKind,
+    QueryExecutionContext,
+    QueryHistoryStatus,
+    type MergeQuery,
+    type MetricQuery,
+} from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import {
+    buildMergeExecutedEvent,
+    buildMergeRefusedEvent,
+    buildMergeRefusedEventFromErrors,
+    describeMergeQueryShape,
+    observeRowCapRefusal,
+    resolveComposeMergeOutcome,
+    type MergeSubmission,
+} from './mergeQueryTelemetry';
+
+const metricQuery: MetricQuery = {
+    exploreName: 'orders',
+    dimensions: ['orders_month'],
+    metrics: ['orders_count'],
+    filters: {},
+    sorts: [],
+    limit: 500,
+    tableCalculations: [],
+};
+
+const mergeQuery: MergeQuery = {
+    sources: [
+        { id: 'a', metricQuery },
+        { id: 'b', queryUuid: 'result-query-uuid' },
+    ],
+    joinKey: [
+        {
+            name: 'month',
+            fieldIdBySourceId: { a: 'orders_month', b: 'payments_month' },
+        },
+    ],
+    joinType: MergeJoinType.LEFT,
+    tableCalculations: [{ name: 'ratio', displayName: 'Ratio', sql: '1' }],
+    limit: 500,
+};
+
+const submission: MergeSubmission = {
+    organizationUuid: 'org-uuid',
+    projectUuid: 'project-uuid',
+    context: QueryExecutionContext.EXPLORE,
+    mergeQuery,
+};
+
+const shape = {
+    organizationId: 'org-uuid',
+    projectId: 'project-uuid',
+    context: QueryExecutionContext.EXPLORE,
+    joinType: MergeJoinType.LEFT,
+    sourceKinds: ['metric', 'result'],
+    sourceCount: 2,
+    joinKeyCount: 1,
+    tableCalculationCount: 1,
+};
+
+describe('describeMergeQueryShape', () => {
+    it('names the join type and the kind of each source in order', () => {
+        expect(describeMergeQueryShape(submission)).toEqual(shape);
+    });
+});
+
+describe('buildMergeExecutedEvent', () => {
+    it('counts leg cache hits from the legs that ran', () => {
+        const event = buildMergeExecutedEvent({
+            submission,
+            queryId: 'merge-query-uuid',
+            engine: 'compose',
+            status: 'ready',
+            cacheHit: false,
+            legCacheHits: [true, false, true],
+            rowCount: 42,
+            durationMs: 1200,
+            joinExecutionTimeMs: 80,
+        });
+
+        expect(event).toEqual({
+            event: 'merge_query.executed',
+            properties: {
+                ...shape,
+                queryId: 'merge-query-uuid',
+                engine: 'compose',
+                status: 'ready',
+                cacheHit: false,
+                legCount: 3,
+                legCacheHitCount: 2,
+                rowCount: 42,
+                durationMs: 1200,
+                joinExecutionTimeMs: 80,
+            },
+        });
+    });
+
+    it('reports a warehouse merge with no legs and no outcome', () => {
+        const event = buildMergeExecutedEvent({
+            submission,
+            queryId: 'merge-query-uuid',
+            engine: 'warehouse',
+            status: 'started',
+            cacheHit: true,
+            legCacheHits: [],
+            rowCount: null,
+            durationMs: null,
+            joinExecutionTimeMs: null,
+        });
+
+        expect(event.properties).toMatchObject({
+            engine: 'warehouse',
+            status: 'started',
+            cacheHit: true,
+            legCount: 0,
+            legCacheHitCount: 0,
+            rowCount: null,
+            durationMs: null,
+        });
+    });
+});
+
+describe('buildMergeRefusedEvent', () => {
+    it('leads with the first kind and lists each distinct kind once', () => {
+        const event = buildMergeRefusedEvent({
+            submission,
+            kinds: [
+                MergeQueryErrorKind.FAN_OUT,
+                MergeQueryErrorKind.FAN_OUT,
+                MergeQueryErrorKind.JOIN_KEY_TYPE_MISMATCH,
+            ],
+            queryId: null,
+        });
+
+        expect(event).toEqual({
+            event: 'merge_query.refused',
+            properties: {
+                ...shape,
+                kind: MergeQueryErrorKind.FAN_OUT,
+                kinds: [
+                    MergeQueryErrorKind.FAN_OUT,
+                    MergeQueryErrorKind.JOIN_KEY_TYPE_MISMATCH,
+                ],
+                refusalCount: 3,
+                queryId: null,
+            },
+        });
+    });
+
+    it('carries the merged query id for a row cap refusal', () => {
+        const event = buildMergeRefusedEvent({
+            submission,
+            kinds: ['row_cap'],
+            queryId: 'merge-query-uuid',
+        });
+
+        expect(event.properties).toMatchObject({
+            kind: 'row_cap',
+            kinds: ['row_cap'],
+            refusalCount: 1,
+            queryId: 'merge-query-uuid',
+        });
+    });
+
+    it('builds from compile errors and tracks nothing when there are none', () => {
+        const event = buildMergeRefusedEventFromErrors({
+            submission,
+            errors: [
+                {
+                    kind: MergeQueryErrorKind.JOIN_KEY_NOT_SELECTED,
+                    sourceId: 'a',
+                    fieldIds: ['orders_month'],
+                    message: 'not selected',
+                },
+            ],
+        });
+
+        expect(event?.properties).toMatchObject({
+            kind: MergeQueryErrorKind.JOIN_KEY_NOT_SELECTED,
+            queryId: null,
+        });
+        expect(
+            buildMergeRefusedEventFromErrors({ submission, errors: [] }),
+        ).toBeNull();
+    });
+});
+
+describe('observeRowCapRefusal', () => {
+    it('passes the guard result through and remembers a refusal', () => {
+        const observed = observeRowCapRefusal(() => 'Query A hit the cap');
+
+        expect(observed.wasRefused()).toBe(false);
+        expect(observed.guard({})).toBe('Query A hit the cap');
+        expect(observed.wasRefused()).toBe(true);
+    });
+
+    it('stays clear when the guard lets the join proceed', () => {
+        const observed = observeRowCapRefusal(() => null);
+
+        expect(observed.guard({})).toBeNull();
+        expect(observed.wasRefused()).toBe(false);
+    });
+});
+
+describe('resolveComposeMergeOutcome', () => {
+    const ready = {
+        status: QueryHistoryStatus.READY,
+        totalRowCount: 10,
+        warehouseExecutionTimeMs: 55,
+        error: null,
+    };
+
+    it('is a refusal when the row cap guard fired, whatever the row says', () => {
+        expect(
+            resolveComposeMergeOutcome({
+                history: { ...ready, status: QueryHistoryStatus.ERROR },
+                rowCapRefused: true,
+            }),
+        ).toEqual({ kind: 'refused_row_cap' });
+    });
+
+    it('is an execution with the join row count and time when ready', () => {
+        expect(
+            resolveComposeMergeOutcome({
+                history: ready,
+                rowCapRefused: false,
+            }),
+        ).toEqual({ kind: 'ready', rowCount: 10, joinExecutionTimeMs: 55 });
+    });
+
+    it('is a failure carrying the stored error otherwise', () => {
+        expect(
+            resolveComposeMergeOutcome({
+                history: {
+                    status: QueryHistoryStatus.ERROR,
+                    totalRowCount: null,
+                    warehouseExecutionTimeMs: null,
+                    error: 'Conversion error',
+                },
+                rowCapRefused: false,
+            }),
+        ).toEqual({ kind: 'error', error: 'Conversion error' });
+    });
+});

--- a/packages/backend/src/services/AsyncQueryService/mergeQueryTelemetry.ts
+++ b/packages/backend/src/services/AsyncQueryService/mergeQueryTelemetry.ts
@@ -116,11 +116,7 @@ export const buildMergeExecutedEvent = ({
     },
 });
 
-/**
- * Wraps the row-cap guard so the reporter can tell a refusal from a join
- * failure: both end as the merged query's error, and only the guard knows
- * which it was.
- */
+/** A refusal and a join failure both end as the query's error; only the guard knows which. */
 export const observeRowCapRefusal = (
     guard: DuckdbQueryReferenceGuard,
 ): { guard: DuckdbQueryReferenceGuard; wasRefused: () => boolean } => {

--- a/packages/backend/src/services/AsyncQueryService/mergeQueryTelemetry.ts
+++ b/packages/backend/src/services/AsyncQueryService/mergeQueryTelemetry.ts
@@ -1,0 +1,167 @@
+import {
+    isMergeMetricSource,
+    QueryHistoryStatus,
+    type MergeQuery,
+    type MergeQueryError,
+    type QueryExecutionContext,
+    type QueryHistory,
+} from '@lightdash/common';
+import type {
+    MergeEngine,
+    MergeQueryExecutedEvent,
+    MergeQueryRefusedEvent,
+    MergeQueryShapeProperties,
+    MergeRefusalKind,
+    MergeSourceKind,
+} from '../../analytics/LightdashAnalytics';
+import type { DuckdbQueryReferenceGuard } from './types';
+
+/** What every merge event says about the merge that was submitted. */
+export type MergeSubmission = {
+    organizationUuid: string;
+    projectUuid: string;
+    context: QueryExecutionContext;
+    mergeQuery: MergeQuery;
+};
+
+export const describeMergeQueryShape = ({
+    organizationUuid,
+    projectUuid,
+    context,
+    mergeQuery,
+}: MergeSubmission): MergeQueryShapeProperties => ({
+    organizationId: organizationUuid,
+    projectId: projectUuid,
+    context,
+    joinType: mergeQuery.joinType,
+    sourceKinds: mergeQuery.sources.map(
+        (source): MergeSourceKind =>
+            isMergeMetricSource(source) ? 'metric' : 'result',
+    ),
+    sourceCount: mergeQuery.sources.length,
+    joinKeyCount: mergeQuery.joinKey.length,
+    tableCalculationCount: mergeQuery.tableCalculations.length,
+});
+
+export const buildMergeRefusedEvent = ({
+    submission,
+    kinds,
+    queryId,
+}: {
+    submission: MergeSubmission;
+    kinds: [MergeRefusalKind, ...MergeRefusalKind[]];
+    queryId: string | null;
+}): MergeQueryRefusedEvent => ({
+    event: 'merge_query.refused',
+    properties: {
+        ...describeMergeQueryShape(submission),
+        kind: kinds[0],
+        kinds: Array.from(new Set(kinds)),
+        refusalCount: kinds.length,
+        queryId,
+    },
+});
+
+/** Null when the refusal carries no errors, so nothing empty is tracked. */
+export const buildMergeRefusedEventFromErrors = ({
+    submission,
+    errors,
+}: {
+    submission: MergeSubmission;
+    errors: MergeQueryError[];
+}): MergeQueryRefusedEvent | null => {
+    const [first, ...rest] = errors;
+    if (first === undefined) return null;
+    return buildMergeRefusedEvent({
+        submission,
+        kinds: [first.kind, ...rest.map((error) => error.kind)],
+        queryId: null,
+    });
+};
+
+export const buildMergeExecutedEvent = ({
+    submission,
+    queryId,
+    engine,
+    status,
+    cacheHit,
+    legCacheHits,
+    rowCount,
+    durationMs,
+    joinExecutionTimeMs,
+}: {
+    submission: MergeSubmission;
+    queryId: string;
+    engine: MergeEngine;
+    status: MergeQueryExecutedEvent['properties']['status'];
+    cacheHit: boolean;
+    /** One entry per leg this merge ran. */
+    legCacheHits: boolean[];
+    rowCount: number | null;
+    durationMs: number | null;
+    joinExecutionTimeMs: number | null;
+}): MergeQueryExecutedEvent => ({
+    event: 'merge_query.executed',
+    properties: {
+        ...describeMergeQueryShape(submission),
+        queryId,
+        engine,
+        status,
+        cacheHit,
+        legCount: legCacheHits.length,
+        legCacheHitCount: legCacheHits.filter(Boolean).length,
+        rowCount,
+        durationMs,
+        joinExecutionTimeMs,
+    },
+});
+
+/**
+ * Wraps the row-cap guard so the reporter can tell a refusal from a join
+ * failure: both end as the merged query's error, and only the guard knows
+ * which it was.
+ */
+export const observeRowCapRefusal = (
+    guard: DuckdbQueryReferenceGuard,
+): { guard: DuckdbQueryReferenceGuard; wasRefused: () => boolean } => {
+    let refused = false;
+    return {
+        guard: (completed) => {
+            const refusal = guard(completed);
+            if (refusal !== null) refused = true;
+            return refusal;
+        },
+        wasRefused: () => refused,
+    };
+};
+
+export type ComposeMergeOutcome =
+    | { kind: 'refused_row_cap' }
+    | {
+          kind: 'ready';
+          rowCount: number | null;
+          joinExecutionTimeMs: number | null;
+      }
+    | { kind: 'error'; error: string | null };
+
+/** Reads the merged query's terminal state once its background run settled. */
+export const resolveComposeMergeOutcome = ({
+    history,
+    rowCapRefused,
+}: {
+    history: Pick<
+        QueryHistory,
+        'status' | 'totalRowCount' | 'warehouseExecutionTimeMs' | 'error'
+    >;
+    rowCapRefused: boolean;
+}): ComposeMergeOutcome => {
+    if (rowCapRefused) return { kind: 'refused_row_cap' };
+    if (history.status === QueryHistoryStatus.READY) {
+        return {
+            kind: 'ready',
+            rowCount: history.totalRowCount,
+            joinExecutionTimeMs: history.warehouseExecutionTimeMs,
+        };
+    }
+    return { kind: 'error', error: history.error };
+};


### PR DESCRIPTION
## What is invisible today

There are no merge analytics events and no merge-specific Sentry issues. A merge fails or is refused inside the ordinary query path, so adoption, latency, error rate and refusal reasons cannot be measured, and none of the rollout gates on merge queries can be verified.

## Events added

Both events are emitted through `analytics.trackAccount` and typed in `LightdashAnalytics.ts`. Payloads are built by the new `mergeQueryTelemetry.ts` helper next to `mergeQueryExecution.ts`.

Shared properties on both events: `organizationId`, `projectId`, `context` (the `QueryExecutionContext` of the surface that ran the merge), `joinType` (`full` | `left` | `inner`), `sourceKinds` (`metric` | `result`, per source in order), `sourceCount`, `joinKeyCount`, `tableCalculationCount`.

`merge_query.executed`
- `queryId`: the merged query's uuid
- `engine`: `compose` | `warehouse`
- `status`: `ready` | `error` (terminal, compose engine) | `started` (warehouse engine, submission only)
- `cacheHit`: whether the merged result itself was served from cache
- `legCount`, `legCacheHitCount`: legs this merge ran and how many hit the metric-query cache; referenced results run no leg
- `rowCount`: merged row count (null until terminal)
- `durationMs`: submission to terminal state, including waiting on the legs (null until terminal)
- `joinExecutionTimeMs`: the DuckDB join's own execution time (null until terminal)

`merge_query.refused`
- `kind`: primary refusal kind, `MergeQueryErrorKind` or `row_cap`
- `kinds`: every distinct kind in the refusal
- `refusalCount`: number of errors in the refusal
- `queryId`: null for compile-time refusals; the merged query's uuid for a row-cap refusal, which arrives as that query's error

The row cap has no `MergeQueryErrorKind` member because it is known only once a leg has run; `row_cap` is the telemetry name for it, matching the glossary term.

## Sentry

- Submission runs inside a `merge_query.submit` span carrying the project, context, mode, join type and source count, so merge traces are separable from ordinary query traces in Sentry performance.
- Thrown errors are not captured by the span. A refusal (fan-out, missing parameter, unavailable result source) throws a `ParameterError`, and capturing those would make every user refusal a Sentry issue. They reach the API error handler like any other query error, which applies the usual reporting rule.
- The compose engine's background run is a `merge_query.execute` span. `runDuckdbQuery` swallows the join's error after writing it to `query_history`, so the outcome reader cannot tell an engine failure from a user-caused one (a bad table calculation, say). It therefore records the failure as `merge_query.executed` with `status: error` and does not raise a Sentry issue, matching how a failed ordinary query is treated.

## Surfaces

Every caller goes through `executeAsyncMergeQueryInternal`, so all of them now emit:

- `POST /api/v2/projects/{projectUuid}/query/merge-query` and `/compose-merge-query` (Explorer)
- `POST /api/v1/projects/{projectUuid}/mergeQuery/run` (v1 Explorer route)
- saved merge charts run through `executeAsyncSavedChartQuery` (chart view, dashboards, exports, scheduled deliveries)
- AI agent: `AiAgentService.executeAsyncAiMergeQuery` and `AiAgentToolsService.runAsyncMergeQuery`

The warehouse engine reports `status: started` at submission only, because its statement completes in the shared background tail that has no merge hook; that engine is being deleted, so it was not extended.

## Verification

- `pnpm -F backend typecheck`, `pnpm -F backend lint`, `pnpm -F backend format` clean
- `pnpm -F backend test src/services/AsyncQueryService/mergeQueryTelemetry.test.ts`: 11 passed
- `pnpm -F backend test src/services/AsyncQueryService/AsyncQueryService.test.ts`: 100 passed, including new assertions that the compose path emits `merge_query.executed` with leg cache hits and the merged row count once ready, `merge_query.refused` with `row_cap` when a leg hit the cap, and that a compile refusal emits `merge_query.refused` with its kind

## Regression analysis

- The merge submission body is unchanged; it moved into `submitAsyncMergeQuery` and is called from the wrapper. Outcomes returned to callers are identical.
- The compose path's leg collection now carries each leg's `cacheMetadata.cacheHit`; the uuid mapping used for references is built from the same entries.
- The row-cap guard is wrapped by an observer that only records whether it refused; the refusal message and behaviour are the guard's own.
- Outcome reporting runs after `runDuckdbQuery` settles, on the same void chain, and is caught by the same `.catch`, so a failure to report never affects the query. It costs one `query_history` read per compose merge.
- The submit span rethrows, so error semantics for callers do not change.
- No changes to `mergeQueryExecution.ts`, routes, controllers or common types.

Closes: PROD-10892

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvtHaH3fbzSX2ebMgfFKFS

