### PR TITLE
fix(pgwire): compile EXTRACT/DATE_TRUNC over date dimensions to time frames

### DIFF
--- a/packages/backend/src/ee/postgresWire/lightdashHandlers.test.ts
+++ b/packages/backend/src/ee/postgresWire/lightdashHandlers.test.ts
@@ -1,4 +1,4 @@
-import { type Account } from '@lightdash/common';
+import { SupportedDbtAdapter, type Account } from '@lightdash/common';
 import { describe, expect, it, vi } from 'vitest';
 import type { ServiceRepository } from '../../services/ServiceRepository';
 import {
@@ -12,6 +12,7 @@ const catalog: PgWireTable[] = [
     {
         name: 'orders',
         description: null,
+        targetDatabase: SupportedDbtAdapter.POSTGRES,
         fields: [
             {
                 fieldId: 'orders_status',
@@ -20,6 +21,7 @@ const catalog: PgWireTable[] = [
                 kind: 'dimension',
                 type: 'string',
                 description: null,
+                timeInterval: null,
             },
             {
                 fieldId: 'orders_amount',
@@ -28,6 +30,7 @@ const catalog: PgWireTable[] = [
                 kind: 'dimension',
                 type: 'number',
                 description: null,
+                timeInterval: null,
             },
             {
                 fieldId: 'orders_is_completed',
@@ -36,6 +39,7 @@ const catalog: PgWireTable[] = [
                 kind: 'dimension',
                 type: 'boolean',
                 description: null,
+                timeInterval: null,
             },
             {
                 fieldId: 'orders_order_date',
@@ -44,6 +48,7 @@ const catalog: PgWireTable[] = [
                 kind: 'dimension',
                 type: 'date',
                 description: null,
+                timeInterval: null,
             },
             {
                 fieldId: 'orders_total',
@@ -52,6 +57,7 @@ const catalog: PgWireTable[] = [
                 kind: 'metric',
                 type: 'sum',
                 description: null,
+                timeInterval: null,
             },
             {
                 fieldId: 'orders_count',
@@ -60,6 +66,7 @@ const catalog: PgWireTable[] = [
                 kind: 'metric',
                 type: 'count',
                 description: null,
+                timeInterval: null,
             },
         ],
     },
@@ -267,6 +274,7 @@ describe('lightdash pgwire handlers: end to end through authenticate', () => {
         name: 'orders',
         label: 'Orders',
         baseTable: 'orders',
+        targetDatabase: SupportedDbtAdapter.POSTGRES,
         joinedTables: [],
         tables: {
             orders: {
@@ -287,6 +295,7 @@ describe('lightdash pgwire handlers: end to end through authenticate', () => {
                         sql: '${TABLE}.status',
                         hidden: false,
                         description: 'Order status',
+                        timeInterval: null,
                     },
                     secret: {
                         fieldType: 'dimension',
@@ -297,6 +306,18 @@ describe('lightdash pgwire handlers: end to end through authenticate', () => {
                         tableLabel: 'Orders',
                         sql: '${TABLE}.secret',
                         hidden: true,
+                    },
+                    order_date_year: {
+                        fieldType: 'dimension',
+                        type: 'date',
+                        name: 'order_date_year',
+                        label: 'Order date year',
+                        table: 'orders',
+                        tableLabel: 'Orders',
+                        sql: "DATE_TRUNC('YEAR', ${TABLE}.order_date)",
+                        hidden: false,
+                        timeInterval: 'YEAR',
+                        timeIntervalBaseDimensionName: 'order_date',
                     },
                 },
                 metrics: {
@@ -345,6 +366,7 @@ describe('lightdash pgwire handlers: end to end through authenticate', () => {
             {
                 name: 'orders',
                 description: 'Orders placed by customers',
+                targetDatabase: SupportedDbtAdapter.POSTGRES,
                 fields: [
                     {
                         fieldId: 'orders_status',
@@ -353,6 +375,19 @@ describe('lightdash pgwire handlers: end to end through authenticate', () => {
                         kind: 'dimension',
                         type: 'string',
                         description: 'Order status',
+                        timeInterval: null,
+                    },
+                    {
+                        fieldId: 'orders_order_date_year',
+                        table: 'orders',
+                        name: 'order_date_year',
+                        kind: 'dimension',
+                        type: 'date',
+                        description: 'Order date year',
+                        timeInterval: {
+                            frame: 'YEAR',
+                            baseDimensionName: 'order_date',
+                        },
                     },
                     {
                         fieldId: 'orders_total',
@@ -361,6 +396,7 @@ describe('lightdash pgwire handlers: end to end through authenticate', () => {
                         kind: 'metric',
                         type: 'sum',
                         description: 'Total amount',
+                        timeInterval: null,
                     },
                 ],
             },
@@ -383,6 +419,12 @@ describe('lightdash pgwire handlers: end to end through authenticate', () => {
                     'Orders placed by customers',
                     'orders_status',
                     'Order status',
+                ],
+                [
+                    'orders',
+                    'Orders placed by customers',
+                    'orders_order_date_year',
+                    'Order date year',
                 ],
                 [
                     'orders',

--- a/packages/backend/src/ee/postgresWire/lightdashHandlers.ts
+++ b/packages/backend/src/ee/postgresWire/lightdashHandlers.ts
@@ -310,6 +310,15 @@ export const createLightdashPgWireHandlers = (
                                 kind: 'dimension' as const,
                                 type: d.type,
                                 description: describe(d),
+                                timeInterval:
+                                    d.timeInterval &&
+                                    d.timeIntervalBaseDimensionName
+                                        ? {
+                                              frame: d.timeInterval,
+                                              baseDimensionName:
+                                                  d.timeIntervalBaseDimensionName,
+                                          }
+                                        : null,
                             })),
                         ...getMetrics(explore)
                             .filter((m) => !m.hidden)
@@ -320,10 +329,12 @@ export const createLightdashPgWireHandlers = (
                                 kind: 'metric' as const,
                                 type: m.type,
                                 description: describe(m),
+                                timeInterval: null,
                             })),
                     ];
                     return {
                         name: explore.name,
+                        targetDatabase: explore.targetDatabase,
                         fields,
                         description:
                             explore.tables[

--- a/packages/backend/src/ee/postgresWire/pgCatalog/catalogEvaluator.test.ts
+++ b/packages/backend/src/ee/postgresWire/pgCatalog/catalogEvaluator.test.ts
@@ -1,3 +1,4 @@
+import { SupportedDbtAdapter } from '@lightdash/common';
 import { parse, type SelectStatement } from 'pgsql-ast-parser';
 import { describe, expect, it, vi } from 'vitest';
 import { type PgWireTable } from '../types';
@@ -9,6 +10,7 @@ const catalog: PgWireTable[] = [
     {
         name: 'orders',
         description: 'Orders',
+        targetDatabase: SupportedDbtAdapter.POSTGRES,
         fields: [
             {
                 fieldId: 'orders_status',
@@ -17,6 +19,7 @@ const catalog: PgWireTable[] = [
                 kind: 'dimension',
                 type: 'string',
                 description: 'Status',
+                timeInterval: null,
             },
             {
                 fieldId: 'orders_amount',
@@ -25,6 +28,7 @@ const catalog: PgWireTable[] = [
                 kind: 'dimension',
                 type: 'number',
                 description: null,
+                timeInterval: null,
             },
             {
                 fieldId: 'orders_count',
@@ -33,12 +37,14 @@ const catalog: PgWireTable[] = [
                 kind: 'metric',
                 type: 'count',
                 description: null,
+                timeInterval: null,
             },
         ],
     },
     {
         name: 'customers',
         description: null,
+        targetDatabase: SupportedDbtAdapter.POSTGRES,
         fields: [
             {
                 fieldId: 'customers_id',
@@ -47,6 +53,7 @@ const catalog: PgWireTable[] = [
                 kind: 'dimension',
                 type: 'number',
                 description: null,
+                timeInterval: null,
             },
         ],
     },

--- a/packages/backend/src/ee/postgresWire/pgCatalog/catalogQuery.test.ts
+++ b/packages/backend/src/ee/postgresWire/pgCatalog/catalogQuery.test.ts
@@ -1,3 +1,4 @@
+import { SupportedDbtAdapter } from '@lightdash/common';
 import { readFileSync } from 'fs';
 import path from 'path';
 import { describe, expect, it } from 'vitest';
@@ -11,6 +12,7 @@ const catalog: PgWireTable[] = [
     {
         name: 'orders',
         description: 'Orders placed',
+        targetDatabase: SupportedDbtAdapter.POSTGRES,
         fields: [
             {
                 fieldId: 'orders_status',
@@ -19,6 +21,7 @@ const catalog: PgWireTable[] = [
                 kind: 'dimension',
                 type: 'string',
                 description: 'Status',
+                timeInterval: null,
             },
             {
                 fieldId: 'orders_amount',
@@ -27,6 +30,7 @@ const catalog: PgWireTable[] = [
                 kind: 'dimension',
                 type: 'number',
                 description: null,
+                timeInterval: null,
             },
             {
                 fieldId: 'orders_order_date',
@@ -35,6 +39,7 @@ const catalog: PgWireTable[] = [
                 kind: 'dimension',
                 type: 'date',
                 description: 'Date',
+                timeInterval: null,
             },
             {
                 fieldId: 'orders_is_completed',
@@ -43,6 +48,7 @@ const catalog: PgWireTable[] = [
                 kind: 'dimension',
                 type: 'boolean',
                 description: null,
+                timeInterval: null,
             },
             {
                 fieldId: 'orders_total',
@@ -51,6 +57,7 @@ const catalog: PgWireTable[] = [
                 kind: 'metric',
                 type: 'sum',
                 description: 'Total',
+                timeInterval: null,
             },
             {
                 fieldId: 'orders_count',
@@ -59,12 +66,14 @@ const catalog: PgWireTable[] = [
                 kind: 'metric',
                 type: 'count',
                 description: null,
+                timeInterval: null,
             },
         ],
     },
     {
         name: 'customers',
         description: null,
+        targetDatabase: SupportedDbtAdapter.POSTGRES,
         fields: [
             {
                 fieldId: 'customers_id',
@@ -73,6 +82,7 @@ const catalog: PgWireTable[] = [
                 kind: 'dimension',
                 type: 'number',
                 description: null,
+                timeInterval: null,
             },
             {
                 fieldId: 'customers_created',
@@ -81,6 +91,7 @@ const catalog: PgWireTable[] = [
                 kind: 'dimension',
                 type: 'timestamp',
                 description: null,
+                timeInterval: null,
             },
         ],
     },
@@ -436,6 +447,7 @@ describe('large projects', () => {
             (_, t) => ({
                 name: `explore_${t}`,
                 description: null,
+                targetDatabase: SupportedDbtAdapter.POSTGRES,
                 fields: Array.from({ length: 150 }, (__, f) => ({
                     fieldId: `explore_${t}_field_${f}`,
                     table: `explore_${t}`,
@@ -443,6 +455,7 @@ describe('large projects', () => {
                     kind: 'dimension' as const,
                     type: 'string',
                     description: null,
+                    timeInterval: null,
                 })),
             }),
         );

--- a/packages/backend/src/ee/postgresWire/sqlToMetricQuery.test.ts
+++ b/packages/backend/src/ee/postgresWire/sqlToMetricQuery.test.ts
@@ -1,4 +1,10 @@
-import { FilterOperator, type Filters } from '@lightdash/common';
+import {
+    CustomDimensionType,
+    FilterOperator,
+    SupportedDbtAdapter,
+    TimeFrames,
+    type Filters,
+} from '@lightdash/common';
 import {
     compileSqlToMetricQuery,
     PGWIRE_DEFAULT_LIMIT,
@@ -9,6 +15,7 @@ import { type PgWireTable } from './types';
 const ORDERS: PgWireTable = {
     name: 'orders',
     description: null,
+    targetDatabase: SupportedDbtAdapter.POSTGRES,
     fields: [
         {
             fieldId: 'orders_status',
@@ -17,6 +24,7 @@ const ORDERS: PgWireTable = {
             kind: 'dimension',
             type: 'string',
             description: null,
+            timeInterval: null,
         },
         {
             fieldId: 'orders_order_date',
@@ -25,6 +33,7 @@ const ORDERS: PgWireTable = {
             kind: 'dimension',
             type: 'date',
             description: null,
+            timeInterval: null,
         },
         {
             fieldId: 'orders_created_at',
@@ -33,6 +42,44 @@ const ORDERS: PgWireTable = {
             kind: 'dimension',
             type: 'timestamp',
             description: null,
+            timeInterval: null,
+        },
+        // time-interval dimensions generated from orders_order_date
+        {
+            fieldId: 'orders_order_date_day',
+            table: 'orders',
+            name: 'order_date_day',
+            kind: 'dimension',
+            type: 'date',
+            description: null,
+            timeInterval: {
+                frame: TimeFrames.DAY,
+                baseDimensionName: 'order_date',
+            },
+        },
+        {
+            fieldId: 'orders_order_date_year',
+            table: 'orders',
+            name: 'order_date_year',
+            kind: 'dimension',
+            type: 'date',
+            description: null,
+            timeInterval: {
+                frame: TimeFrames.YEAR,
+                baseDimensionName: 'order_date',
+            },
+        },
+        {
+            fieldId: 'orders_order_date_month_num',
+            table: 'orders',
+            name: 'order_date_month_num',
+            kind: 'dimension',
+            type: 'number',
+            description: null,
+            timeInterval: {
+                frame: TimeFrames.MONTH_NUM,
+                baseDimensionName: 'order_date',
+            },
         },
         {
             fieldId: 'orders_is_completed',
@@ -41,6 +88,7 @@ const ORDERS: PgWireTable = {
             kind: 'dimension',
             type: 'boolean',
             description: null,
+            timeInterval: null,
         },
         {
             fieldId: 'orders_amount',
@@ -49,6 +97,7 @@ const ORDERS: PgWireTable = {
             kind: 'dimension',
             type: 'number',
             description: null,
+            timeInterval: null,
         },
         // fields from a joined table in the explore
         {
@@ -58,6 +107,7 @@ const ORDERS: PgWireTable = {
             kind: 'dimension',
             type: 'string',
             description: null,
+            timeInterval: null,
         },
         // same column name as orders_amount, different table
         {
@@ -67,6 +117,7 @@ const ORDERS: PgWireTable = {
             kind: 'dimension',
             type: 'number',
             description: null,
+            timeInterval: null,
         },
         {
             fieldId: 'orders_total_order_amount',
@@ -75,6 +126,7 @@ const ORDERS: PgWireTable = {
             kind: 'metric',
             type: 'sum',
             description: null,
+            timeInterval: null,
         },
         {
             fieldId: 'orders_unique_order_count',
@@ -83,6 +135,7 @@ const ORDERS: PgWireTable = {
             kind: 'metric',
             type: 'count_distinct',
             description: null,
+            timeInterval: null,
         },
         {
             fieldId: 'orders_avg_amount',
@@ -91,6 +144,7 @@ const ORDERS: PgWireTable = {
             kind: 'metric',
             type: 'average',
             description: null,
+            timeInterval: null,
         },
     ],
 };
@@ -98,6 +152,7 @@ const ORDERS: PgWireTable = {
 const CUSTOMERS: PgWireTable = {
     name: 'customers',
     description: null,
+    targetDatabase: SupportedDbtAdapter.POSTGRES,
     fields: [
         {
             fieldId: 'customers_customer_id',
@@ -106,6 +161,7 @@ const CUSTOMERS: PgWireTable = {
             kind: 'dimension',
             type: 'number',
             description: null,
+            timeInterval: null,
         },
         {
             fieldId: 'customers_days_since_last_order',
@@ -114,6 +170,7 @@ const CUSTOMERS: PgWireTable = {
             kind: 'metric',
             type: 'min',
             description: null,
+            timeInterval: null,
         },
     ],
 };
@@ -196,6 +253,9 @@ describe('compileSqlToMetricQuery', () => {
                 'orders_status',
                 'orders_order_date',
                 'orders_created_at',
+                'orders_order_date_day',
+                'orders_order_date_year',
+                'orders_order_date_month_num',
                 'orders_is_completed',
                 'orders_amount',
                 'customers_first_name',
@@ -1813,5 +1873,205 @@ describe('schema probes', () => {
         );
         expect(query.alwaysEmpty).toBe(false);
         expect(query.metricQuery.filters.dimensions).toBeDefined();
+    });
+});
+
+describe('date parts', () => {
+    const YEAR_NUM_ID = 'orders_order_date_pgwire_year_num';
+
+    it('compiles the Looker Studio year column to a synthesised YEAR_NUM dimension', () => {
+        const result = compile(
+            `SELECT "T1"."orders_order_date_day",
+                    CAST(EXTRACT(YEAR FROM "T1"."orders_order_date"::TIMESTAMP) AS INT) AS "Year"
+             FROM orders "T1"
+             WHERE "T1"."orders_order_date" IS NOT NULL
+             ORDER BY CAST(EXTRACT(YEAR FROM "T1"."orders_order_date"::TIMESTAMP) AS INT)
+             LIMIT 2`,
+        );
+        expect(result.metricQuery).toMatchObject({
+            dimensions: ['orders_order_date_day', YEAR_NUM_ID],
+            metrics: [],
+            tableCalculations: [],
+            customDimensions: [
+                {
+                    id: YEAR_NUM_ID,
+                    name: 'order_date_pgwire_year_num',
+                    table: 'orders',
+                    type: CustomDimensionType.SQL,
+                    sql: "DATE_PART('YEAR', ${orders.order_date})",
+                    dimensionType: 'number',
+                },
+            ],
+            sorts: [{ fieldId: YEAR_NUM_ID, descending: false }],
+            limit: 2,
+        });
+        expect(result.columns[1]).toEqual({
+            name: 'Year',
+            source: YEAR_NUM_ID,
+            kind: 'dimension',
+            type: 'number',
+        });
+    });
+
+    it('uses the explore warehouse dialect for the synthesised SQL', () => {
+        const bigquery = compileSqlToMetricQuery(
+            'SELECT EXTRACT(YEAR FROM orders_order_date) AS y FROM orders',
+            [{ ...ORDERS, targetDatabase: SupportedDbtAdapter.BIGQUERY }],
+        );
+        expect(bigquery.metricQuery.customDimensions?.[0]).toMatchObject({
+            sql: 'EXTRACT(YEAR FROM ${orders.order_date})',
+        });
+    });
+
+    it('selects the existing interval dimension when the explore has one', () => {
+        const result = compile(
+            `SELECT EXTRACT(MONTH FROM orders_order_date) AS m,
+                    DATE_TRUNC('year', orders_order_date) AS y
+             FROM orders ORDER BY m`,
+        );
+        expect(result.metricQuery.dimensions).toEqual([
+            'orders_order_date_month_num',
+            'orders_order_date_year',
+        ]);
+        expect(result.metricQuery.customDimensions).toBeUndefined();
+        expect(result.metricQuery.sorts).toEqual([
+            { fieldId: 'orders_order_date_month_num', descending: false },
+        ]);
+        expect(result.columns.map((c) => c.name)).toEqual(['m', 'y']);
+    });
+
+    it('resolves sibling intervals when the part is taken from an interval dimension', () => {
+        const result = compile(
+            'SELECT EXTRACT(MONTH FROM orders_order_date_day) AS m FROM orders',
+        );
+        expect(result.metricQuery.dimensions).toEqual([
+            'orders_order_date_month_num',
+        ]);
+    });
+
+    it('synthesises truncating frames and date_part parts the explore lacks', () => {
+        const result = compile(
+            `SELECT DATE_TRUNC('quarter', orders_order_date)::DATE AS q,
+                    date_part('doy', orders_order_date) AS d
+             FROM orders`,
+        );
+        expect(result.metricQuery.customDimensions).toEqual([
+            {
+                id: 'orders_order_date_pgwire_quarter',
+                name: 'order_date_pgwire_quarter',
+                table: 'orders',
+                type: CustomDimensionType.SQL,
+                sql: "DATE_TRUNC('QUARTER', ${orders.order_date})",
+                dimensionType: 'date',
+            },
+            {
+                id: 'orders_order_date_pgwire_day_of_year_num',
+                name: 'order_date_pgwire_day_of_year_num',
+                table: 'orders',
+                type: CustomDimensionType.SQL,
+                sql: "DATE_PART('DOY', ${orders.order_date})",
+                dimensionType: 'number',
+            },
+        ]);
+        expect(result.columns.map((c) => c.type)).toEqual(['date', 'number']);
+    });
+
+    it('truncates timestamps to sub-day frames', () => {
+        const result = compile(
+            `SELECT DATE_TRUNC('second', orders_created_at) AS s,
+                    DATE_TRUNC('milliseconds', orders_created_at) AS ms
+             FROM orders`,
+        );
+        expect(result.metricQuery.dimensions).toEqual([
+            'orders_created_at_pgwire_second',
+            'orders_created_at_pgwire_millisecond',
+        ]);
+        expect(result.columns.map((c) => c.type)).toEqual([
+            'timestamp',
+            'timestamp',
+        ]);
+    });
+
+    it('extracts time parts from timestamp dimensions', () => {
+        const result = compile(
+            'SELECT EXTRACT(HOUR FROM orders_created_at) AS h FROM orders',
+        );
+        expect(result.metricQuery.customDimensions?.[0]).toMatchObject({
+            id: 'orders_created_at_pgwire_hour_of_day_num',
+            sql: "DATE_PART('HOUR', ${orders.created_at})",
+        });
+    });
+
+    it('selects the same date part once when repeated', () => {
+        const result = compile(
+            `SELECT EXTRACT(YEAR FROM orders_order_date) AS a,
+                    EXTRACT(YEAR FROM orders_order_date) AS b
+             FROM orders`,
+        );
+        expect(result.metricQuery.dimensions).toEqual([YEAR_NUM_ID]);
+        expect(result.metricQuery.customDimensions).toHaveLength(1);
+        expect(result.columns.map((c) => c.source)).toEqual([
+            YEAR_NUM_ID,
+            YEAR_NUM_ID,
+        ]);
+    });
+
+    it('accepts GROUP BY on the date part expression', () => {
+        const result = compile(
+            `SELECT EXTRACT(YEAR FROM orders_order_date) AS y, orders_total_order_amount
+             FROM orders GROUP BY EXTRACT(YEAR FROM orders_order_date)`,
+        );
+        expect(result.metricQuery.dimensions).toEqual([YEAR_NUM_ID]);
+    });
+
+    it('names unaliased date parts like Postgres', () => {
+        const result = compile(
+            "SELECT EXTRACT(YEAR FROM orders_order_date), DATE_TRUNC('month', orders_order_date) FROM orders",
+        );
+        expect(result.columns.map((c) => c.name)).toEqual([
+            'extract',
+            'date_trunc',
+        ]);
+    });
+
+    it('rejects ORDER BY expressions that are not in the SELECT list', () => {
+        expect(() =>
+            compile(
+                'SELECT orders_status FROM orders ORDER BY EXTRACT(YEAR FROM orders_order_date)',
+            ),
+        ).toThrow(/ORDER BY expression must appear in the SELECT list/);
+    });
+
+    it('rejects day-of-week parts explicitly', () => {
+        expect(() =>
+            compile('SELECT EXTRACT(DOW FROM orders_order_date) FROM orders'),
+        ).toThrow(/EXTRACT\(DOW\) is not supported/);
+        expect(() =>
+            compile(
+                'SELECT EXTRACT(ISODOW FROM orders_order_date) FROM orders',
+            ),
+        ).toThrow(/EXTRACT\(ISODOW\) is not supported/);
+    });
+
+    it('rejects time parts of date dimensions', () => {
+        expect(() =>
+            compile('SELECT EXTRACT(HOUR FROM orders_order_date) FROM orders'),
+        ).toThrow(/has no time component/);
+    });
+
+    it('rejects date parts of non-date columns', () => {
+        expect(() =>
+            compile('SELECT EXTRACT(YEAR FROM orders_status) FROM orders'),
+        ).toThrow(/is not a date or timestamp dimension/);
+    });
+
+    it('leaves parts without a time frame on the table calculation path', () => {
+        expect(() =>
+            compile('SELECT EXTRACT(EPOCH FROM orders_order_date) FROM orders'),
+        ).toThrow(/not in the SELECT list/);
+        const result = compile(
+            'SELECT orders_order_date, EXTRACT(EPOCH FROM orders_order_date) AS e FROM orders',
+        );
+        expect(result.metricQuery.tableCalculations).toHaveLength(1);
     });
 });

--- a/packages/backend/src/ee/postgresWire/sqlToMetricQuery.ts
+++ b/packages/backend/src/ee/postgresWire/sqlToMetricQuery.ts
@@ -1,8 +1,12 @@
 import {
+    CustomDimensionType,
     FilterOperator,
     getCustomMetricType,
     MetricType,
+    timeFrameConfigs,
+    TimeFrames,
     type AdditionalMetric,
+    type CustomSqlDimension,
     type DimensionType,
     type FilterGroup,
     type FilterGroupItem,
@@ -17,6 +21,7 @@ import {
     parse,
     toSql,
     type Expr,
+    type ExprCast,
     type ExprRef,
     type SelectedColumn,
     type SelectFromStatement,
@@ -107,6 +112,129 @@ const isLiteralExpr = (expr: Expr): boolean => {
 };
 
 type LiteralValue = string | number | boolean | null;
+
+const castTargetName = (cast: ExprCast): string =>
+    'name' in cast.to && typeof cast.to.name === 'string'
+        ? cast.to.name.toLowerCase()
+        : '';
+
+const isDateTypeName = (name: string): boolean =>
+    name === 'date' || name.startsWith('timestamp');
+
+const NUMERIC_TYPE_NAMES = new Set([
+    'int',
+    'int2',
+    'int4',
+    'int8',
+    'integer',
+    'smallint',
+    'bigint',
+    'numeric',
+    'decimal',
+    'real',
+    'float',
+    'float4',
+    'float8',
+    'double precision',
+]);
+
+/** EXTRACT / DATE_PART fields that read as a Lightdash time frame of the same dimension */
+const EXTRACT_PART_FRAMES: Record<string, TimeFrames> = {
+    year: TimeFrames.YEAR_NUM,
+    quarter: TimeFrames.QUARTER_NUM,
+    month: TimeFrames.MONTH_NUM,
+    week: TimeFrames.WEEK_NUM,
+    day: TimeFrames.DAY_OF_MONTH_NUM,
+    doy: TimeFrames.DAY_OF_YEAR_NUM,
+    hour: TimeFrames.HOUR_OF_DAY_NUM,
+    minute: TimeFrames.MINUTE_OF_HOUR_NUM,
+};
+
+const DATE_TRUNC_PART_FRAMES: Record<string, TimeFrames> = {
+    year: TimeFrames.YEAR,
+    quarter: TimeFrames.QUARTER,
+    month: TimeFrames.MONTH,
+    week: TimeFrames.WEEK,
+    day: TimeFrames.DAY,
+    hour: TimeFrames.HOUR,
+    minute: TimeFrames.MINUTE,
+    second: TimeFrames.SECOND,
+    milliseconds: TimeFrames.MILLISECOND,
+};
+
+/** frames that need a time of day, so a DATE dimension cannot provide them */
+const TIME_OF_DAY_FRAMES = new Set<TimeFrames>([
+    TimeFrames.HOUR,
+    TimeFrames.MINUTE,
+    TimeFrames.SECOND,
+    TimeFrames.MILLISECOND,
+    TimeFrames.HOUR_OF_DAY_NUM,
+    TimeFrames.MINUTE_OF_HOUR_NUM,
+]);
+
+type DatePartExpr = {
+    frame: TimeFrames;
+    ref: ExprRef;
+};
+
+type DatePartFunction = 'extract' | 'date_trunc';
+
+const DATE_PART_FRAMES: Record<DatePartFunction, Record<string, TimeFrames>> = {
+    extract: EXTRACT_PART_FRAMES,
+    date_trunc: DATE_TRUNC_PART_FRAMES,
+};
+
+/**
+ * `[CAST(]EXTRACT(part FROM col[::TIMESTAMP])[ AS INT)]`, `DATE_PART('part', col)`
+ * and `DATE_TRUNC('part', col)[::DATE]`: BI tools derive date parts from a date
+ * column this way. They read as the column's Lightdash time frame, so the
+ * warehouse computes them at the query grain instead of a table calculation.
+ */
+const datePartExpr = (expr: Expr): DatePartExpr | null => {
+    const inner = expr.type === 'cast' ? expr.operand : expr;
+    let part: string;
+    let source: Expr;
+    let fn: DatePartFunction;
+    if (inner.type === 'extract') {
+        part = inner.field.name.toLowerCase();
+        source = inner.from;
+        fn = 'extract';
+    } else if (
+        inner.type === 'call' &&
+        !inner.over &&
+        inner.args.length === 2 &&
+        inner.args[0].type === 'string'
+    ) {
+        const name = inner.function.name.toLowerCase();
+        if (name !== 'date_part' && name !== 'date_trunc') return null;
+        part = inner.args[0].value.toLowerCase();
+        [, source] = inner.args;
+        fn = name === 'date_trunc' ? 'date_trunc' : 'extract';
+    } else {
+        return null;
+    }
+    // an outer cast is only dropped when it keeps the value domain
+    if (expr.type === 'cast') {
+        const to = castTargetName(expr);
+        const keepsDomain =
+            fn === 'date_trunc'
+                ? isDateTypeName(to)
+                : NUMERIC_TYPE_NAMES.has(to);
+        if (!keepsDomain) return null;
+    }
+    if (source.type === 'cast' && isDateTypeName(castTargetName(source))) {
+        source = source.operand;
+    }
+    if (source.type !== 'ref' || source.name === '*') return null;
+    if (fn === 'extract' && (part === 'dow' || part === 'isodow')) {
+        throw new SqlCompileError(
+            `EXTRACT(${part.toUpperCase()}) is not supported`,
+            "Postgres numbers weekdays 0-6 from Sunday while Lightdash uses 1-7 from the project start of week; select the dimension's day-of-week interval column instead",
+        );
+    }
+    const frame = DATE_PART_FRAMES[fn][part];
+    return frame ? { frame, ref: source } : null;
+};
 
 /** Extract a literal filter value, unwrapping casts (e.g. '2024-01-01'::date) */
 const literalValue = (expr: Expr): LiteralValue => {
@@ -842,10 +970,7 @@ function compileSelect(
             return { ref: arg.args[0], castTo: 'date' };
         }
         if (arg.type === 'cast' && arg.operand.type === 'ref') {
-            const to =
-                'name' in arg.to && typeof arg.to.name === 'string'
-                    ? arg.to.name.toLowerCase()
-                    : '';
+            const to = castTargetName(arg);
             if (to === 'date') return { ref: arg.operand, castTo: 'date' };
             if (to.startsWith('timestamp')) {
                 return { ref: arg.operand, castTo: 'timestamp' };
@@ -855,11 +980,24 @@ function compileSelect(
     };
 
     /** Postgres-style default output name for an unaliased expression, unique within the statement */
+    const autoNameBase = (expr: Expr): string => {
+        switch (expr.type) {
+            case 'call':
+                return expr.function.name.toLowerCase();
+            case 'extract':
+                return 'extract';
+            case 'cast':
+                return expr.operand.type === 'call' ||
+                    expr.operand.type === 'extract'
+                    ? autoNameBase(expr.operand)
+                    : '?column?';
+            default:
+                return '?column?';
+        }
+    };
+
     const autoName = (ctx: CompilerContext, expr: Expr): string => {
-        const base =
-            expr.type === 'call'
-                ? expr.function.name.toLowerCase()
-                : '?column?';
+        const base = autoNameBase(expr);
         let name = base;
         for (
             let n = 2;
@@ -941,8 +1079,11 @@ function compileSelect(
     const additionalMetrics: AdditionalMetric[] = [];
     const rowCountFieldId = `${table.name}_${ROW_COUNT_METRIC_NAME}`;
     const tableCalculations: TableCalculation[] = [];
+    const customDimensions: CustomSqlDimension[] = [];
     const columns: PgWireColumn[] = [];
     const selectedSources = new Set<string>();
+    /** SELECT expressions by SQL text, so ORDER BY / GROUP BY can repeat them */
+    const selectExprColumns = new Map<string, PgWireColumn>();
 
     const addField = (resolved: ResolvedColumn, outputName: string) => {
         if (resolved.kind === 'dimension') {
@@ -1035,6 +1176,86 @@ function compileSelect(
         return true;
     };
 
+    /**
+     * Compile a date part of a date/timestamp dimension to its time frame: the
+     * explore's own interval dimension when it has one, else a custom SQL
+     * dimension from the same time-frame SQL the model compiler uses. The
+     * project's start of week is not applied, so a synthesised WEEK follows
+     * the warehouse default like the SQL the client wrote.
+     */
+    const tryDatePart = (col: SelectedColumn): boolean => {
+        const part = datePartExpr(col.expr);
+        if (!part) return false;
+        const resolved = resolveRefOrThrow(ctx, part.ref);
+        const { field } = resolved;
+        if (
+            !field ||
+            field.kind !== 'dimension' ||
+            (field.type !== 'date' && field.type !== 'timestamp')
+        ) {
+            throw new SqlCompileError(
+                `"${resolved.source}" is not a date or timestamp dimension`,
+                'Date parts can only be taken from date or timestamp columns',
+            );
+        }
+        if (field.type === 'date' && TIME_OF_DAY_FRAMES.has(part.frame)) {
+            throw new SqlCompileError(
+                `Date dimension "${field.fieldId}" has no time component`,
+                'Hours and minutes can only be taken from timestamp columns',
+            );
+        }
+        const baseDimensionName =
+            field.timeInterval?.baseDimensionName ?? field.name;
+        const existing = table.fields.find(
+            (f) =>
+                f.kind === 'dimension' &&
+                f.table === field.table &&
+                f.timeInterval?.baseDimensionName === baseDimensionName &&
+                f.timeInterval.frame === part.frame,
+        );
+        let column: ResolvedColumn;
+        if (existing) {
+            column = {
+                source: existing.fieldId,
+                kind: 'dimension',
+                type: existing.type,
+                field: existing,
+            };
+        } else {
+            const config = timeFrameConfigs[part.frame];
+            const fieldType = field.type as DimensionType;
+            const name = `${field.name}_pgwire_${part.frame.toLowerCase()}`;
+            const id = `${field.table}_${name}`;
+            const dimensionType = config.getDimensionType(fieldType);
+            if (!customDimensions.some((d) => d.id === id)) {
+                customDimensions.push({
+                    id,
+                    name,
+                    table: field.table,
+                    type: CustomDimensionType.SQL,
+                    sql: config.getSql(
+                        table.targetDatabase,
+                        part.frame,
+                        `\${${field.table}.${field.name}}`,
+                        fieldType,
+                    ),
+                    dimensionType,
+                });
+            }
+            column = {
+                source: id,
+                kind: 'dimension',
+                type: dimensionType,
+                field: null,
+            };
+        }
+        addField(column, col.alias?.name ?? autoName(ctx, col.expr));
+        if (col.alias) {
+            ctx.aliasMap.set(col.alias.name, column);
+        }
+        return true;
+    };
+
     const handleSelectedColumn = (col: SelectedColumn): void => {
         const { expr } = col;
         // count(*): a system COUNT(*) metric on the explore's base table
@@ -1090,7 +1311,7 @@ function compileSelect(
             }
             // aggregates over dimension columns become additional metrics below
         }
-        if (tryDimensionAggregate(col)) {
+        if (tryDimensionAggregate(col) || tryDatePart(col)) {
             return;
         }
         if (expr.type === 'ref') {
@@ -1154,7 +1375,35 @@ function compileSelect(
             type: null,
         });
     };
-    selectColumns.forEach(handleSelectedColumn);
+    selectColumns.forEach((col) => {
+        const before = columns.length;
+        handleSelectedColumn(col);
+        // SELECT * adds many columns and has no single expression to repeat
+        if (columns.length === before + 1) {
+            selectExprColumns.set(toSql.expr(col.expr), columns[before]);
+        }
+    });
+
+    const resolvedFromColumn = (column: PgWireColumn): ResolvedColumn => ({
+        source: column.source,
+        kind: column.kind,
+        type: column.type,
+        field: null,
+    });
+
+    const requireSelectExpr = (
+        expr: Expr,
+        clause: 'GROUP BY' | 'ORDER BY',
+    ): PgWireColumn => {
+        const column = selectExprColumns.get(toSql.expr(expr));
+        if (!column) {
+            throw new SqlCompileError(
+                `${clause} expression must appear in the SELECT list`,
+                `Only column names, positions and expressions repeated from the SELECT list can be used in ${clause}`,
+            );
+        }
+        return column;
+    };
 
     // constants-only probes (SELECT 1 FROM t) still need a field to query by;
     // carry the first dimension without exposing it as an output column
@@ -1233,18 +1482,12 @@ function compileSelect(
                         `GROUP BY position ${ordinal} is not in the select list`,
                     );
                 }
-                const column = columns[ordinal - 1];
-                resolved = {
-                    source: column.source,
-                    kind: column.kind,
-                    type: column.type,
-                    field: null,
-                };
+                resolved = resolvedFromColumn(columns[ordinal - 1]);
             } else if (groupExpr.type === 'ref') {
                 resolved = resolveRefOrThrow(ctx, groupExpr);
             } else {
-                throw new SqlCompileError(
-                    'GROUP BY only supports column names or positions',
+                resolved = resolvedFromColumn(
+                    requireSelectExpr(groupExpr, 'GROUP BY'),
                 );
             }
             if (resolved.kind !== 'dimension') {
@@ -1284,9 +1527,7 @@ function compileSelect(
             const resolved = resolveRefOrThrow(ctx, orderBy.by);
             source = resolved.source;
         } else {
-            throw new SqlCompileError(
-                'ORDER BY only supports column names or positions',
-            );
+            source = requireSelectExpr(orderBy.by, 'ORDER BY').source;
         }
         if (!selectedSources.has(source) && !ctx.tableCalcNames.has(source)) {
             throw new SqlCompileError(
@@ -1329,6 +1570,7 @@ function compileSelect(
         limit,
         tableCalculations,
         ...(additionalMetrics.length > 0 ? { additionalMetrics } : {}),
+        ...(customDimensions.length > 0 ? { customDimensions } : {}),
     };
 
     return {

--- a/packages/backend/src/ee/postgresWire/types.ts
+++ b/packages/backend/src/ee/postgresWire/types.ts
@@ -1,6 +1,17 @@
-import { type MetricQuery } from '@lightdash/common';
+import {
+    type MetricQuery,
+    type SupportedDbtAdapter,
+    type TimeFrames,
+} from '@lightdash/common';
 
 export type PgWireFieldKind = 'dimension' | 'metric';
+
+/** A dimension generated from a date/timestamp dimension at a fixed time frame (e.g. `order_date_year`) */
+export type PgWireTimeInterval = {
+    frame: TimeFrames;
+    /** name of the date/timestamp dimension the interval was derived from, within the same table */
+    baseDimensionName: string;
+};
 
 export type PgWireField = {
     /** Lightdash field id, exposed to clients as the column name (e.g. `orders_status`) */
@@ -14,6 +25,7 @@ export type PgWireField = {
     type: string;
     /** Shown as the column comment by schema browsers */
     description: string | null;
+    timeInterval: PgWireTimeInterval | null;
 };
 
 /** One explore exposed as a Postgres table */
@@ -22,6 +34,8 @@ export type PgWireTable = {
     fields: PgWireField[];
     /** Shown as the table comment by schema browsers */
     description: string | null;
+    /** warehouse dialect the explore compiles to; used for synthesised time-frame SQL */
+    targetDatabase: SupportedDbtAdapter;
 };
 
 export type PgWireColumnKind = PgWireFieldKind | 'table_calculation';


### PR DESCRIPTION
## Problem

BI tools derive date parts from a date field as `CAST(EXTRACT(YEAR FROM <dim>::TIMESTAMP) AS INT)` and sort by the same expression, while selecting only the field's interval columns. The Metrics SQL API compiled that as a table calculation, which can only reference selected fields, so the statement failed with `42601 Expression references "<dim>" which is not in the SELECT list` and the chart never loaded.

## Change

Date parts now compile to the dimension's Lightdash time frame, at the query grain, in the warehouse:

```diff
 compileSelect
   SELECT item
     plain ref                                        → dimension / metric
+    [CAST(]EXTRACT(part FROM dim[::TIMESTAMP])[ AS INT)]
+    DATE_PART('part', dim) / DATE_TRUNC('part', dim)[::DATE]
+      part → TimeFrames (YEAR→YEAR_NUM, DATE_TRUNC('month')→MONTH, …)
+      explore has dim_<frame>       → select that field
+      else                          → customDimensions[] (sql from timeFrameConfigs[frame].getSql(explore.targetDatabase, …))
+      DOW / ISODOW                  → explicit "not supported" error
     anything else                                    → table calculation (unchanged)
   ORDER BY / GROUP BY
     integer | ref                                    → existing paths
-    expression                                       → "only column names or positions"
+    expression repeated from the SELECT list         → that column
```

```mermaid
sequenceDiagram
    participant L as BI tool
    participant P as pgwire
    participant C as sqlToMetricQuery
    participant W as warehouse
    L->>P: SELECT date_day, CAST(EXTRACT(YEAR FROM date)…) AS "Year" … ORDER BY CAST(EXTRACT(…))
    P->>C: compile against catalog
    C-->>P: MetricQuery { dimensions: [date_day, <year_num>], customDimensions?: [...], sorts: [<year_num>] }
    P->>W: DATE_PART('YEAR', "orders".order_date) grouped with date_day
    W-->>L: rows sorted by year
```

- The catalog now records each field's time interval (`frame` + base dimension name) so an existing `_year_num` / `_year` column is reused, including when the part is taken from a sibling interval like `<dim>_day`. Tables record the explore's `targetDatabase` so synthesised SQL matches the warehouse dialect.
- Synthesised parts are custom SQL dimensions and go through the same custom-fields permission as calculated expressions already do on the wire server; parts the model lists as intervals work for every role.
- Parts without a frame (`EPOCH`, `CENTURY`, …) keep the table-calculation path. A synthesised `WEEK` follows the warehouse default rather than the project start of week, like the SQL the client wrote.

## Verified

- Unit tests for every mapping, reuse vs synthesis, dialect, ORDER BY / GROUP BY expressions, dedup, and each error case.
- End to end through the local wire server with psql: the exact statement from the issue returns `orders_order_date_day | Year` sorted by year; quarter/day-of-year/month shapes work; DOW and non-date columns return explicit errors.

## Proof of work

Baseline `ab0f81fafc` and this branch run side by side against the same seeded project, each statement sent over the wire protocol with `psql`. Compiled warehouse SQL captured from the warehouse statement log.

| Scenario | Baseline | This branch |
| --- | --- | --- |
| Interval columns, `ORDER BY 1` (control) | rows | identical rows |
| Looker Studio shape: `CAST(EXTRACT(YEAR FROM d::TIMESTAMP) AS INT)` selected + sorted, base dim not selected | `42601` not in SELECT list | `_day, Year` sorted by year; warehouse gets `DATE_PART('YEAR', "orders".order_date) … GROUP BY 1,2 ORDER BY <year>` |
| Base dim selected, `ORDER BY <expr> DESC` | `ORDER BY only supports column names or positions` | rows sorted by year |
| `DATE_TRUNC('month', d)` in SELECT / GROUP BY / ORDER BY | `42601` | month buckets; reuses the model's `orders_order_date_month` |
| `QUARTER`, `DOY`, `DATE_PART('month')`, `DATE_TRUNC('quarter')::DATE`, none in the model | `42601` | correct values via synthesised `orders_order_date_pgwire_*` dimensions |
| `EXTRACT(DOW)` | generic `42601` | `EXTRACT(DOW) is not supported` + hint |
| `EXTRACT(EPOCH)` | table-calc error | unchanged (by design) |
| `ORDER BY` expression absent from SELECT | old error | `ORDER BY expression must appear in the SELECT list` |

Not exercised end to end: non-Postgres warehouses (covered by a unit test for the BigQuery dialect), timestamp `HOUR`/`MINUTE` parts, week-start alignment of a synthesised `WEEK`.

Docs: lightdash/mintlify-docs#1211

Closes: PROD-10942
Closes: #28635
