### PR TITLE
test(merge): pin value fidelity through the compose engine and the unasserted refusal kinds

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -23,6 +23,8 @@ import {
     JobStatusType,
     JobStepType,
     JobType,
+    MergeJoinType,
+    MergeQueryErrorKind,
     MetricType,
     NotFoundError,
     OrganizationMemberRole,
@@ -43,6 +45,8 @@ import {
     type DownloadFile,
     type Explore,
     type Job,
+    type MergeQuery,
+    type MergeQuerySource,
     type PossibleAbilities,
     type Project,
     type ProjectDbtSource,
@@ -179,7 +183,11 @@ vi.mock('worker_threads', async () => {
     };
 });
 
-vi.mock('@lightdash/warehouses', () => ({
+vi.mock('@lightdash/warehouses', async (importOriginal) => ({
+    // The merge compiler needs the real dialect builder, not a stub
+    warehouseSqlBuilderFromType: (
+        await importOriginal<typeof import('@lightdash/warehouses')>()
+    ).warehouseSqlBuilderFromType,
     SshTunnel: vi.fn().mockImplementation(
         // eslint-disable-next-line prefer-arrow-callback
         function MockSshTunnel() {
@@ -5265,6 +5273,92 @@ describe('ProjectService', () => {
                     projectWithSnowflakeAuth(authenticationType),
                 ),
             ).not.toThrowError();
+        });
+    });
+
+    describe('compileMergeQuery', () => {
+        const source = (
+            id: string,
+            tableCalculations: MergeQuery['tableCalculations'] = [],
+        ): MergeQuerySource => ({
+            id,
+            metricQuery: {
+                exploreName: validExplore.name,
+                dimensions: ['a_dim1'],
+                metrics: ['a_met1'],
+                filters: {},
+                sorts: [],
+                limit: 500,
+                tableCalculations,
+            },
+        });
+
+        const mergeQuery = (
+            overrides: Partial<MergeQuery> = {},
+        ): MergeQuery => ({
+            sources: [source('a'), source('b')],
+            joinKey: [
+                {
+                    name: 'dim1',
+                    fieldIdBySourceId: { a: 'a_dim1', b: 'a_dim1' },
+                },
+            ],
+            joinType: MergeJoinType.FULL,
+            tableCalculations: [],
+            limit: 500,
+            ...overrides,
+        });
+
+        test('refuses a source calculation that depends on its own row set', async () => {
+            const result = await service.compileMergeQuery({
+                account: sessionAccount,
+                projectUuid,
+                mergeQuery: mergeQuery({
+                    sources: [
+                        source('a', [
+                            {
+                                name: 'running_total',
+                                displayName: 'Running total',
+                                sql: 'SUM(${a.met1}) OVER (ORDER BY ${a.dim1})',
+                            },
+                        ]),
+                        source('b'),
+                    ],
+                }),
+            });
+
+            expect(result.sql).toBeNull();
+            expect(result.errors).toContainEqual(
+                expect.objectContaining({
+                    kind: MergeQueryErrorKind.UNSUPPORTED_TABLE_CALCULATION,
+                    sourceId: 'a',
+                    fieldIds: ['running_total'],
+                }),
+            );
+        });
+
+        test('refuses a merge calculation referencing a column the merged result does not have', async () => {
+            const result = await service.compileMergeQuery({
+                account: sessionAccount,
+                projectUuid,
+                mergeQuery: mergeQuery({
+                    tableCalculations: [
+                        {
+                            name: 'ghost',
+                            displayName: 'Ghost',
+                            sql: '${a.a_met1} + ${b.ghost_metric}',
+                        },
+                    ],
+                }),
+            });
+
+            expect(result.sql).toBeNull();
+            expect(result.errors).toContainEqual(
+                expect.objectContaining({
+                    kind: MergeQueryErrorKind.UNRESOLVED_CALCULATION_REFERENCE,
+                    fieldIds: ['b.ghost_metric'],
+                }),
+            );
         });
     });
 });

--- a/packages/backend/src/utils/QueryBuilder/composeMergeFidelity.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/composeMergeFidelity.test.ts
@@ -35,6 +35,7 @@ beforeAll(async () => {
 });
 
 afterAll(() => {
+    instance.closeSync();
     rmSync(dir, { recursive: true, force: true });
 });
 

--- a/packages/backend/src/utils/QueryBuilder/composeMergeFidelity.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/composeMergeFidelity.test.ts
@@ -1,0 +1,291 @@
+import { DuckDBInstance } from '@duckdb/node-api';
+import {
+    DimensionType,
+    getErrorMessage,
+    MergeJoinType,
+    type MergeFieldTypes,
+    type ResultColumns,
+} from '@lightdash/common';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+    getJsonlSqlTable,
+    quoteDuckdbIdentifier,
+    resultFieldTypeToDuckdbType,
+} from '../duckdb/duckdbSqlTables';
+import { buildComposeMergeSql } from './composeMergeSql';
+import { applyMergeTerminalWrapper } from './MergeQueryBuilder';
+
+/**
+ * Round-trips typed values through the compose engine exactly as a merge leg
+ * travels: a result file on disk, bound with the read_json CTE a referenced
+ * query gets, joined by the generated merge statement, read back. Cases that
+ * are wrong on the JSONL path carry the correct expectation under test.fails,
+ * so the parquet cutover (PROD-10894) flips them rather than leaving them red.
+ */
+
+let dir: string;
+let instance: DuckDBInstance;
+let fileCounter = 0;
+
+beforeAll(async () => {
+    dir = mkdtempSync(join(tmpdir(), 'compose-merge-fidelity-'));
+    instance = await DuckDBInstance.create(':memory:');
+});
+
+afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+});
+
+// Raw JSON text per line, as the results writer emits JSON.stringify(row) per
+// row; writing the text directly lets the file carry a value a JS number cannot.
+const writeJsonl = (lines: string[]): string => {
+    fileCounter += 1;
+    const file = join(dir, `leg-${fileCounter}.jsonl`);
+    writeFileSync(file, `${lines.join('\n')}\n`);
+    return file;
+};
+
+/** The CTE a referenced query result is bound as (buildQueryReferenceCtes). */
+const bindReference = (
+    tableName: string,
+    uri: string,
+    columns: ResultColumns,
+): string =>
+    `${quoteDuckdbIdentifier(tableName)} AS (SELECT * FROM ${getJsonlSqlTable(
+        uri,
+        columns,
+    )})`;
+
+/** The wrap that keeps reference CTEs ahead of the statement's own WITH chain. */
+const wrapWithReferences = (sql: string, referenceCtes: string[]): string =>
+    `WITH ${referenceCtes.join(
+        ',\n',
+    )}\nSELECT * FROM (\n${sql}\n) AS lightdash_user_query`;
+
+const run = async (sql: string): Promise<Record<string, unknown>[]> => {
+    const connection = await instance.connect();
+    try {
+        const reader = await connection.runAndReadAll(sql);
+        return reader.getRowObjects();
+    } finally {
+        connection.closeSync();
+    }
+};
+
+const readBack = (value: unknown): string | null =>
+    value === null ? null : String(value);
+
+const joinKey = [{ name: 'key', fieldIdBySourceId: { a: 'key', b: 'key' } }];
+
+const fieldTypes: MergeFieldTypes = {
+    a: { key: { type: DimensionType.NUMBER, timeInterval: null } },
+    b: { key: { type: DimensionType.NUMBER, timeInterval: null } },
+};
+
+const keyColumn: ResultColumns = {
+    key: { reference: 'key', type: DimensionType.NUMBER },
+};
+
+/**
+ * Leg A carries the value under test in `measured`; leg B is a plain second
+ * side so the statement is a real two-source join. Returns `measured` as the
+ * merged row reads it.
+ */
+const mergeRoundTrip = async (
+    type: DimensionType,
+    json: string,
+): Promise<string | null> => {
+    const legA = writeJsonl([`{"key":1,"measured":${json}}`]);
+    const legB = writeJsonl(['{"key":1,"other":true}']);
+    const built = buildComposeMergeSql({
+        sources: [
+            { id: 'a', valueColumns: ['measured'] },
+            { id: 'b', valueColumns: ['other'] },
+        ],
+        joinKey,
+        joinType: MergeJoinType.FULL,
+        tableCalculations: [],
+        fieldTypes,
+        outputAliasByColumn: {
+            key: 'merge_key',
+            c0_0: 'a_measured',
+            c1_0: 'b_other',
+        },
+        limit: 500,
+    });
+    const referenceCtes = [
+        bindReference(built.referenceTableBySourceId.a, legA, {
+            ...keyColumn,
+            measured: { reference: 'measured', type },
+        }),
+        bindReference(built.referenceTableBySourceId.b, legB, {
+            ...keyColumn,
+            other: { reference: 'other', type: DimensionType.BOOLEAN },
+        }),
+    ];
+    const rows = await run(
+        wrapWithReferences(
+            applyMergeTerminalWrapper(built.coreSql, built.terminalWrapper),
+            referenceCtes,
+        ),
+    );
+    expect(rows).toHaveLength(1);
+    return readBack(rows[0].a_measured);
+};
+
+describe('value fidelity through the compose engine', () => {
+    test('a small integer round-trips', async () => {
+        expect(await mergeRoundTrip(DimensionType.NUMBER, '42')).toBe('42');
+    });
+
+    test('a decimal with four places round-trips', async () => {
+        expect(await mergeRoundTrip(DimensionType.NUMBER, '1234567.8901')).toBe(
+            '1234567.8901',
+        );
+    });
+
+    // Red until PROD-10894: re-typed through DOUBLE, the value reads 9007199254740992
+    test.fails('a bigint above 2^53 round-trips unchanged', async () => {
+        expect(
+            await mergeRoundTrip(DimensionType.NUMBER, '9007199254740993'),
+        ).toBe('9007199254740993');
+    });
+
+    test('a date round-trips', async () => {
+        expect(await mergeRoundTrip(DimensionType.DATE, '"2024-02-29"')).toBe(
+            '2024-02-29',
+        );
+    });
+
+    test('a string round-trips with quotes and non-ascii intact', async () => {
+        const value = 'héllo "quoted" \\ back';
+        expect(
+            await mergeRoundTrip(DimensionType.STRING, JSON.stringify(value)),
+        ).toBe(value);
+    });
+
+    test('a boolean round-trips', async () => {
+        expect(await mergeRoundTrip(DimensionType.BOOLEAN, 'false')).toBe(
+            'false',
+        );
+    });
+
+    test('a null round-trips as null', async () => {
+        expect(await mergeRoundTrip(DimensionType.NUMBER, 'null')).toBeNull();
+    });
+
+    test('a UTC timestamp lands at its instant', async () => {
+        // The shape JSON.stringify gives a Date, which is what most warehouses return
+        expect(
+            await mergeRoundTrip(
+                DimensionType.TIMESTAMP,
+                '"2024-01-01T08:00:00.000Z"',
+            ),
+        ).toBe('2024-01-01 08:00:00');
+    });
+
+    // Red until PROD-10894: the offset is discarded and the value reads 10:00:00
+    test.fails('a timestamp with a non-UTC offset lands at the correct instant', async () => {
+        expect(
+            await mergeRoundTrip(
+                DimensionType.TIMESTAMP,
+                '"2024-01-01T10:00:00+02:00"',
+            ),
+        ).toBe('2024-01-01 08:00:00');
+    });
+
+    // Red until PROD-10894: read_json refuses a named zone as "not UTC"
+    test.fails('a named-zone timestamp reads without erroring', async () => {
+        expect(
+            await mergeRoundTrip(
+                DimensionType.TIMESTAMP,
+                '"2024-01-01 00:00:00 Europe/Lisbon"',
+            ),
+        ).toBe('2024-01-01 00:00:00');
+    });
+
+    // Red until PROD-10894: the engine's raw "JSON transform error" surfaces, naming no column
+    test.fails('an uncastable value refuses with an error naming the column', async () => {
+        const message = await mergeRoundTrip(
+            DimensionType.NUMBER,
+            '"not a number"',
+        ).then(
+            () => null,
+            (error: unknown) => getErrorMessage(error),
+        );
+        expect(message).toContain('measured');
+        expect(message).not.toContain('JSON transform error');
+    });
+});
+
+/**
+ * The five-value map is what re-types a JSONL value on the way back in. One
+ * case per entry pins what it does, so deleting the map (PROD-10894) removes
+ * these with it rather than leaving behaviour undocumented.
+ */
+const readThroughMap = async (
+    type: DimensionType,
+    json: string,
+): Promise<unknown> => {
+    const file = writeJsonl([`{"measured":${json}}`]);
+    const rows = await run(
+        `SELECT * FROM ${getJsonlSqlTable(file, {
+            measured: { reference: 'measured', type },
+        })}`,
+    );
+    return rows[0].measured;
+};
+
+describe('the five-value JSONL type map', () => {
+    test('covers every dimension type', () => {
+        expect(
+            Object.values(DimensionType).map(resultFieldTypeToDuckdbType),
+        ).toEqual(['VARCHAR', 'DOUBLE', 'TIMESTAMP', 'DATE', 'BOOLEAN']);
+    });
+
+    test('NUMBER binds as DOUBLE and reads a serialised decimal as a number', async () => {
+        expect(resultFieldTypeToDuckdbType(DimensionType.NUMBER)).toBe(
+            'DOUBLE',
+        );
+        expect(
+            await readThroughMap(DimensionType.NUMBER, '"1234567.8901"'),
+        ).toBe(1234567.8901);
+    });
+
+    test('BOOLEAN binds as BOOLEAN and reads a JSON boolean', async () => {
+        expect(resultFieldTypeToDuckdbType(DimensionType.BOOLEAN)).toBe(
+            'BOOLEAN',
+        );
+        expect(await readThroughMap(DimensionType.BOOLEAN, 'true')).toBe(true);
+    });
+
+    test('DATE binds as DATE and reads an ISO date', async () => {
+        expect(resultFieldTypeToDuckdbType(DimensionType.DATE)).toBe('DATE');
+        expect(
+            readBack(await readThroughMap(DimensionType.DATE, '"2024-02-29"')),
+        ).toBe('2024-02-29');
+    });
+
+    test('TIMESTAMP binds as TIMESTAMP and reads a UTC ISO instant', async () => {
+        expect(resultFieldTypeToDuckdbType(DimensionType.TIMESTAMP)).toBe(
+            'TIMESTAMP',
+        );
+        expect(
+            readBack(
+                await readThroughMap(
+                    DimensionType.TIMESTAMP,
+                    '"2024-01-01T08:00:00.000Z"',
+                ),
+            ),
+        ).toBe('2024-01-01 08:00:00');
+    });
+
+    test('STRING binds as VARCHAR and reads a JSON number as text', async () => {
+        expect(resultFieldTypeToDuckdbType(DimensionType.STRING)).toBe(
+            'VARCHAR',
+        );
+        expect(await readThroughMap(DimensionType.STRING, '42')).toBe('42');
+    });
+});

--- a/packages/common/src/types/mergeQuery.test.ts
+++ b/packages/common/src/types/mergeQuery.test.ts
@@ -252,6 +252,51 @@ describe('validateMergeQuery', () => {
                 ]),
             );
         });
+
+        it('rejects a join key naming a field a source does not group by', () => {
+            const errors = validateMergeQuery(
+                mergeQuery({
+                    joinKey: [
+                        {
+                            name: 'date_day',
+                            fieldIdBySourceId: {
+                                a: 'followers_signup_date',
+                                b: 'follower_snapshots_date',
+                            },
+                        },
+                    ],
+                }),
+            );
+
+            expect(errors).toContainEqual(
+                expect.objectContaining({
+                    kind: MergeQueryErrorKind.JOIN_KEY_NOT_SELECTED,
+                    sourceId: 'a',
+                    fieldIds: ['followers_signup_date'],
+                }),
+            );
+        });
+    });
+
+    describe('merge calculations', () => {
+        it('rejects two calculations sharing a name', () => {
+            const errors = validateMergeQuery(
+                mergeQuery({
+                    tableCalculations: [
+                        { name: 'net', displayName: 'Net', sql: '1' },
+                        { name: 'net', displayName: 'Net again', sql: '2' },
+                    ],
+                }),
+            );
+
+            expect(errors).toEqual([
+                expect.objectContaining({
+                    kind: MergeQueryErrorKind.DUPLICATE_CALCULATION_NAME,
+                    sourceId: null,
+                    fieldIds: ['net'],
+                }),
+            ]);
+        });
     });
 });
 


### PR DESCRIPTION
Tests only. No production code changes.

## What was untested

- The four measured JSONL fidelity defects named in `docs/merge-queries/architecture.md` (bigint above 2^53, ISO offset discarded, Trino named-zone timestamp errors on read, uncastable value hard-errors with the raw engine message) had no regression test. Nothing pinned the values that do survive the path either, so the parquet cutover had no acceptance test.
- The five-value type map in `utils/duckdb/duckdbSqlTables.ts` was only asserted as SQL text, never for what it does to a value on a real engine.
- Four `MergeQueryErrorKind` values were produced but asserted nowhere: `join_key_not_selected`, `unsupported_table_calculation`, `duplicate_calculation_name`, `unresolved_calculation_reference`.

## What each test pins

### `packages/backend/src/utils/QueryBuilder/composeMergeFidelity.test.ts` (new)

Writes a typed value into a JSONL result file, binds it with the same `getJsonlSqlTable` read_json CTE a referenced query leg gets (the `"merge_source_N" AS (SELECT * FROM read_json(...))` shape from `buildQueryReferenceCtes`, wrapped the way `wrapSqlWithReferenceCtes` does), joins it through `buildComposeMergeSql` + `applyMergeTerminalWrapper` on an in-memory DuckDB, and reads the merged row back. No credentials, runs in Build & Test.

Green today, guarding the cutover: small integer, four-place decimal, date, string with quotes and non-ascii, boolean, null, UTC timestamp.

Red by design, `test.fails`, each with the correct expected value. Vitest fails a `test.fails` case the moment it passes, so PROD-10894 has to flip them:

| Case | Expected | Observed today on read_json |
|---|---|---|
| bigint above 2^53 (`9007199254740993`) | unchanged | `9007199254740992` (re-typed through DOUBLE) |
| timestamp with `+02:00` offset (`2024-01-01T10:00:00+02:00`) | `2024-01-01 08:00:00` | `2024-01-01 10:00:00` (offset discarded) |
| named-zone timestamp (`2024-01-01 00:00:00 Europe/Lisbon`) | reads, `2024-01-01 00:00:00` | `Invalid Input Error: ... has a timestamp that is not UTC` |
| uncastable value (`"not a number"` as NUMBER) | error names the column, no engine internals | `JSON transform error in file "...": Failed to cast value to numerical` (no column name) |

The four-place decimal was in the acceptance criteria but is not one of the measured defects; it round-trips today (`1234567.8901`), so it is a normal passing test.

The five-value map gets one test per entry (NUMBER -> DOUBLE, BOOLEAN -> BOOLEAN, DATE -> DATE, TIMESTAMP -> TIMESTAMP, STRING -> VARCHAR), each showing what that binding does to a value on the engine, plus an exhaustiveness check over `DimensionType`. Deleting the map in PROD-10894 removes these with it instead of leaving behaviour undocumented.

### `packages/common/src/types/mergeQuery.test.ts`

- `join_key_not_selected`: a join key naming a field a metric source does not group by is refused for that source, with the field id.
- `duplicate_calculation_name`: two merge calculations sharing a name produce exactly one refusal naming it.

### `packages/backend/src/services/ProjectService/ProjectService.test.ts`

- `unsupported_table_calculation`: a source table calculation with a window clause (`SUM(...) OVER (...)`) is refused by `compileMergeQuery` with `sql: null`. This is the named correctness property in architecture.md: table calculations that depend on a source's own row set are refused.
- `unresolved_calculation_reference`: a merge calculation referencing `${b.ghost_metric}` is refused with that reference in `fieldIds`.

The file's `@lightdash/warehouses` mock now passes through the real `warehouseSqlBuilderFromType` so the compiler can reach the reference check; everything else in the mock is unchanged.

## How verified

- `pnpm -F backend test src/utils/QueryBuilder/composeMergeFidelity.test.ts`: 1 file, 13 passed, 4 expected fail.
- `pnpm -F backend test src/services/ProjectService/ProjectService.test.ts`: 1 file, 197 passed.
- `pnpm -F common test src/types/mergeQuery.test.ts`: 1 file, 25 passed.
- `pnpm -F backend typecheck`, `pnpm -F backend lint`, `pnpm -F common lint`: clean.
- Each defect was first reproduced on the current path with a standalone DuckDB probe before being written as `test.fails`; the observed values in the table above are from that run.

Closes: PROD-10947
Relates: PROD-10894

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvtHaH3fbzSX2ebMgfFKFS
