### PR TITLE
test(merge): pivoted value parity, saved merged chart run, formatted cells and required warehouses

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -571,6 +571,9 @@ jobs:
           TRINO_PORT: ${{ secrets.TRINO_PORT }}
           TRINO_USER: ${{ secrets.TRINO_USER }}
           TRINO_PASSWORD: ${{ secrets.TRINO_PASSWORD }}
+          # Warehouses this job's secrets provide; a missing one fails the run
+          # instead of silently narrowing the parity suites to Postgres.
+          REQUIRED_WAREHOUSES: "snowflake,bigquery,trino"
           TZ: "UTC"
 
   app-tests:

--- a/packages/api-tests/helpers/projects.ts
+++ b/packages/api-tests/helpers/projects.ts
@@ -130,10 +130,55 @@ export type WarehouseTestEntry = {
     config: Record<string, unknown>;
 };
 
+const WAREHOUSE_NAMES = [
+    'postgres',
+    'snowflake',
+    'bigquery',
+    'databricks',
+    'trino',
+] as const;
+
+type WarehouseName = (typeof WAREHOUSE_NAMES)[number];
+
+const isWarehouseName = (name: string): name is WarehouseName =>
+    (WAREHOUSE_NAMES as readonly string[]).includes(name);
+
+const hasWarehouseCredentials: Record<WarehouseName, () => boolean> = {
+    postgres: () => true,
+    snowflake: hasSnowflakeCredentials,
+    bigquery: hasBigqueryCredentials,
+    databricks: hasDatabricksCredentials,
+    trino: hasTrinoCredentials,
+};
+
+/**
+ * `REQUIRED_WAREHOUSES` (comma-separated names) turns a credential-less skip
+ * into a failure naming the warehouse; unset, nothing is required.
+ */
+function assertRequiredWarehousesAvailable(): void {
+    const required = (process.env.REQUIRED_WAREHOUSES ?? '')
+        .split(',')
+        .map((name) => name.trim())
+        .filter((name) => name.length > 0);
+    required.forEach((name) => {
+        if (!isWarehouseName(name)) {
+            throw new Error(
+                `REQUIRED_WAREHOUSES names "${name}", which is not a warehouse these suites know. Known: ${WAREHOUSE_NAMES.join(', ')}.`,
+            );
+        }
+        if (!hasWarehouseCredentials[name]()) {
+            throw new Error(
+                `REQUIRED_WAREHOUSES requires ${name}, but its credentials are not available, so every warehouse-parameterized suite would silently skip it.`,
+            );
+        }
+    });
+}
+
 /**
  * The warehouses whose credentials are currently available, ready to drive a
  * parameterized suite. Postgres and Databricks are included by default and can
- * be excluded per suite through options.
+ * be excluded per suite through options. Throws when a warehouse named in
+ * `REQUIRED_WAREHOUSES` has no credentials.
  */
 export function getAvailableWarehouseConfigs(
     options: {
@@ -141,6 +186,7 @@ export function getAvailableWarehouseConfigs(
         includeDatabricks?: boolean;
     } = {},
 ): WarehouseTestEntry[] {
+    assertRequiredWarehousesAvailable();
     const { includePostgres = true, includeDatabricks = true } = options;
     const entries: WarehouseTestEntry[] = [];
     if (includePostgres) {

--- a/packages/api-tests/tests/mergeQuery.test.ts
+++ b/packages/api-tests/tests/mergeQuery.test.ts
@@ -1,10 +1,20 @@
 import {
+    assertUnreachable,
+    ChartType,
     FilterOperator,
+    isField,
+    MergeJoinType,
     MergeQueryErrorKind,
     QueryExecutionContext,
     SEED_PROJECT,
     type ApiCompiledMergeQueryResults,
     type ApiExecuteAsyncMergeQueryResults,
+    type ApiExecuteAsyncMetricQueryResults,
+    type CreateChartInSpace,
+    type ItemsMap,
+    type ResultRow,
+    type SavedChart,
+    type SavedMergeQuery,
 } from '@lightdash/common';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { ApiClient, Body } from '../helpers/api-client';
@@ -14,14 +24,16 @@ import {
     deleteProjectsByName,
     getAvailableWarehouseConfigs,
 } from '../helpers/projects';
+import { uniqueName } from '../helpers/test-isolation';
 
 // Two independent aggregations of the jaffle dataset, joined on the order
 // month. The payments explore joins orders, so both sides expose the same
-// month dimension. Preview environments force-enable merge-queries and
-// merge-engine-warehouse-native, so on a verified adapter (Postgres) these
-// merges execute warehouse-native — one statement on the project warehouse —
-// while unverified adapters run the DuckDB engine. This suite green on an
-// adapter is the gate for flipping its verified capability.
+// month dimension. Two flags touch merges: `merge-queries` gates the Explorer
+// entry point only, and `merge-on-compose` runs each source as its own leg
+// and joins the results on the compose engine instead of in one warehouse
+// statement. Whichever path a warehouse takes, every merged value must equal
+// what its source query returns on its own; this suite is that bar, and a
+// warehouse going green here is the gate for changing how its merges run.
 const ordersByMonth = {
     exploreName: 'orders',
     dimensions: ['orders_order_date_month'],
@@ -69,11 +81,37 @@ const KEY_FIELD_ID = 'merge_order_month';
 const ORDERS_FIELD_ID = 'orders_orders_total_order_amount';
 const PAYMENTS_FIELD_ID = 'payments_payments_unique_payment_count';
 
+type PivotedValuesColumn = {
+    referenceField: string;
+    pivotColumnName: string;
+    pivotValues: { referenceField: string; value: unknown }[];
+};
+
 type QueryResultsBody = Body<{
     status: string;
-    rows: Record<string, unknown>[];
+    rows: ResultRow[];
     totalResults: number;
+    pivotDetails: { valuesColumns: PivotedValuesColumn[] } | null;
 }>;
+
+const cellOf = (
+    row: ResultRow,
+    fieldId: string,
+): { raw: unknown; formatted: string } => {
+    const cell = row[fieldId];
+    if (cell === undefined) {
+        throw new Error(
+            `No "${fieldId}" cell in row ${JSON.stringify(Object.keys(row))}`,
+        );
+    }
+    return { raw: cell.value.raw, formatted: cell.value.formatted };
+};
+
+const MERGE_JOIN_TYPES = [
+    MergeJoinType.FULL,
+    MergeJoinType.LEFT,
+    MergeJoinType.INNER,
+] as const;
 
 // hasSubscriptionsModel: whether the warehouse dataset carries a current
 // build of the jaffle `subscriptions` model. The staging datasets reliably
@@ -179,28 +217,49 @@ function registerMergeQueryTests(getContext: () => MergeTestContext) {
         });
     }, 60_000);
 
+    // Saved charts this suite persists; deleted even when a test fails.
+    const createdChartUuids: string[] = [];
+
+    afterAll(async () => {
+        for (const uuid of createdChartUuids) {
+            await admin
+                .delete(`/api/v1/saved/${uuid}`, { failOnStatusCode: false })
+                .catch(() => {});
+        }
+    });
+
     /**
      * Runs a metric query through the ordinary async path and returns its
-     * rows keyed by raw values — the independent baseline every merged
-     * number is checked against.
+     * fields and formatted rows — the independent baseline every merged
+     * cell is checked against.
      */
-    const runSourceQuery = async (
+    const runSourceQueryWithFields = async (
         metricQuery: Record<string, unknown>,
-    ): Promise<Record<string, unknown>[]> => {
-        const started = await admin.post<Body<{ queryUuid: string }>>(
-            `/api/v2/projects/${projectUuid}/query/metric-query`,
-            { context: 'exploreView', query: metricQuery },
-        );
+    ): Promise<{ fields: ItemsMap; rows: ResultRow[] }> => {
+        const started = await admin.post<
+            Body<ApiExecuteAsyncMetricQueryResults>
+        >(`/api/v2/projects/${projectUuid}/query/metric-query`, {
+            context: 'exploreView',
+            query: metricQuery,
+        });
         expect(started.status).toBe(200);
         const results = await pollQueryResults(
             admin,
             started.body.results.queryUuid,
         );
-        return results.rows.map((row) =>
+        return { fields: started.body.results.fields, rows: results.rows };
+    };
+
+    /** The same baseline, keyed by raw values only. */
+    const runSourceQuery = async (
+        metricQuery: Record<string, unknown>,
+    ): Promise<Record<string, unknown>[]> => {
+        const { rows } = await runSourceQueryWithFields(metricQuery);
+        return rows.map((row) =>
             Object.fromEntries(
                 Object.entries(row).map(([column, cell]) => [
                     column,
-                    (cell as { value: { raw: unknown } }).value.raw,
+                    cell.value.raw,
                 ]),
             ),
         );
@@ -624,72 +683,306 @@ function registerMergeQueryTests(getContext: () => MergeTestContext) {
         expect(results.totalResults).toBeGreaterThan(0);
     }, 60_000);
 
-    it('runs a pivoted merge through the standard pivot stage', async () => {
-        // Widen the key with the order status, shared by both explores, and
-        // pivot the merged result by it.
-        const withStatus = {
-            ...mergeQuery,
-            sources: [
-                {
-                    id: 'orders',
-                    metricQuery: {
-                        ...ordersByMonth,
-                        dimensions: [
-                            'orders_order_date_month',
-                            'orders_status',
-                        ],
-                    },
-                },
-                {
-                    id: 'payments',
-                    metricQuery: {
-                        ...paymentsByMonth,
-                        dimensions: [
-                            'orders_order_date_month',
-                            'orders_status',
-                        ],
-                    },
-                },
-            ],
-            joinKey: [
-                ...mergeQuery.joinKey,
-                {
-                    name: 'status',
-                    fieldIdBySourceId: {
-                        orders: 'orders_status',
-                        payments: 'orders_status',
-                    },
-                },
-            ],
-        };
-
-        const runResp = await admin.post<Body<{ queryUuid: string }>>(
-            `/api/v1/projects/${projectUuid}/mergeQuery/run`,
+    // Widen the key with the order status, shared by both explores, so the
+    // merged result can be pivoted by it.
+    const ordersByMonthAndStatus = {
+        ...ordersByMonth,
+        dimensions: ['orders_order_date_month', 'orders_status'],
+    };
+    const paymentsByMonthAndStatus = {
+        ...paymentsByMonth,
+        dimensions: ['orders_order_date_month', 'orders_status'],
+    };
+    const withStatus = {
+        ...mergeQuery,
+        sources: [
+            { id: 'orders', metricQuery: ordersByMonthAndStatus },
+            { id: 'payments', metricQuery: paymentsByMonthAndStatus },
+        ],
+        joinKey: [
+            ...mergeQuery.joinKey,
             {
-                mergeQuery: withStatus,
-                pivotConfiguration: {
-                    indexColumn: { reference: KEY_FIELD_ID, type: 'time' },
-                    valuesColumns: [
-                        { reference: ORDERS_FIELD_ID, aggregation: 'any' },
-                        { reference: PAYMENTS_FIELD_ID, aggregation: 'any' },
-                    ],
-                    groupByColumns: [{ reference: 'merge_status' }],
-                    sortBy: undefined,
+                name: 'status',
+                fieldIdBySourceId: {
+                    orders: 'orders_status',
+                    payments: 'orders_status',
                 },
             },
+        ],
+    };
+    const pivotByStatus = {
+        indexColumn: { reference: KEY_FIELD_ID, type: 'time' },
+        valuesColumns: [
+            { reference: ORDERS_FIELD_ID, aggregation: 'any' },
+            { reference: PAYMENTS_FIELD_ID, aggregation: 'any' },
+        ],
+        groupByColumns: [{ reference: 'merge_status' }],
+        sortBy: undefined,
+    };
+
+    const monthAndStatus = (month: unknown, status: unknown) =>
+        `${monthOf(month)}|${String(status)}`;
+    const monthPart = (key: string) => key.slice(0, key.indexOf('|'));
+    const statusPart = (key: string) => key.slice(key.indexOf('|') + 1);
+    const pivotStatus = (column: PivotedValuesColumn) =>
+        column.pivotValues.map(({ value }) => String(value)).join('_');
+
+    // The (month, status) keys a join type keeps, from the standalone key
+    // sets alone.
+    const keptKeysFor = (
+        joinType: MergeJoinType,
+        ordersKeys: Set<string>,
+        paymentsKeys: Set<string>,
+    ): Set<string> => {
+        switch (joinType) {
+            case MergeJoinType.FULL:
+                return new Set([...ordersKeys, ...paymentsKeys]);
+            case MergeJoinType.LEFT:
+                return ordersKeys;
+            case MergeJoinType.INNER:
+                return new Set(
+                    [...ordersKeys].filter((key) => paymentsKeys.has(key)),
+                );
+            default:
+                return assertUnreachable(joinType, 'Unknown join type');
+        }
+    };
+
+    // A pivoted row carries a cell only for the combinations its month has.
+    const pivotedRaw = (row: ResultRow, columnName: string): unknown =>
+        row[columnName] === undefined ? null : row[columnName].value.raw;
+
+    // Same bar as the flat merge: every pivoted cell equals the standalone
+    // value for its month and status, derived from the sources, not a second merge.
+    it('pivots every merged cell to the value its source returns for that month and status', async () => {
+        const [ordersRows, paymentsRows] = await Promise.all([
+            runSourceQuery(ordersByMonthAndStatus),
+            runSourceQuery(paymentsByMonthAndStatus),
+        ]);
+        const ordersValues = new Map(
+            ordersRows.map((row) => [
+                monthAndStatus(row.orders_order_date_month, row.orders_status),
+                row.orders_total_order_amount,
+            ]),
         );
-        expect(runResp.status).toBe(200);
+        const paymentsValues = new Map(
+            paymentsRows.map((row) => [
+                monthAndStatus(row.orders_order_date_month, row.orders_status),
+                row.payments_unique_payment_count,
+            ]),
+        );
+        const sourceValues = (referenceField: string): Map<string, unknown> => {
+            if (referenceField === ORDERS_FIELD_ID) return ordersValues;
+            if (referenceField === PAYMENTS_FIELD_ID) return paymentsValues;
+            throw new Error(`Pivoted an unexpected field: ${referenceField}`);
+        };
+
+        for (const joinType of MERGE_JOIN_TYPES) {
+            const kept = keptKeysFor(
+                joinType,
+                new Set(ordersValues.keys()),
+                new Set(paymentsValues.keys()),
+            );
+            const runResp = await admin.post<Body<{ queryUuid: string }>>(
+                `/api/v1/projects/${projectUuid}/mergeQuery/run`,
+                {
+                    mergeQuery: { ...withStatus, joinType },
+                    pivotConfiguration: pivotByStatus,
+                },
+            );
+            expect(runResp.status).toBe(200);
+            const results = await pollQueryResults(
+                admin,
+                runResp.body.results.queryUuid,
+            );
+            const valuesColumns = results.pivotDetails?.valuesColumns ?? [];
+
+            // One row per kept month, one pivoted column per kept status.
+            expect(results.totalResults, `${joinType} rows`).toBe(
+                new Set([...kept].map(monthPart)).size,
+            );
+            expect(
+                new Set(valuesColumns.map(pivotStatus)),
+                `${joinType} statuses`,
+            ).toEqual(new Set([...kept].map(statusPart)));
+
+            results.rows.forEach((row) => {
+                const month = monthOf(cellOf(row, KEY_FIELD_ID).raw);
+                valuesColumns.forEach((column) => {
+                    const key = `${month}|${pivotStatus(column)}`;
+                    const expected = kept.has(key)
+                        ? (sourceValues(column.referenceField).get(key) ?? null)
+                        : null;
+                    expect(
+                        numeric(pivotedRaw(row, column.pivotColumnName)),
+                        `${joinType} ${column.pivotColumnName} at ${key}`,
+                    ).toEqual(numeric(expected));
+                });
+            });
+        }
+    }, 180_000);
+
+    const byMonth = (rows: Record<string, unknown>[], valueField: string) =>
+        new Map(
+            rows.map((row) => [
+                monthOf(row.orders_order_date_month),
+                row[valueField],
+            ]),
+        );
+
+    const expectMergedValues = (
+        rows: ResultRow[],
+        ordersByKey: Map<string, unknown>,
+        paymentsByKey: Map<string, unknown>,
+    ) => {
+        rows.forEach((row) => {
+            const key = monthOf(cellOf(row, KEY_FIELD_ID).raw);
+            expect(numeric(cellOf(row, ORDERS_FIELD_ID).raw)).toEqual(
+                numeric(ordersByKey.get(key) ?? null),
+            );
+            expect(numeric(cellOf(row, PAYMENTS_FIELD_ID).raw)).toEqual(
+                numeric(paymentsByKey.get(key) ?? null),
+            );
+        });
+    };
+
+    // A saved merge is rebuilt from the chart's query plus the stored merge
+    // when the chart runs, so it must open intact and run to the source values.
+    it('opens a saved merged chart and runs it to the values its sources return', async () => {
+        const merge: SavedMergeQuery = {
+            primarySourceId: 'orders',
+            sources: [
+                { id: 'orders', kind: 'chart' },
+                { id: 'payments', kind: 'query', metricQuery: paymentsByMonth },
+            ],
+            joinKey: mergeQuery.joinKey,
+            joinType: MergeJoinType.FULL,
+            tableCalculations: [],
+        };
+        const created = await admin.post<Body<SavedChart>>(
+            `/api/v1/projects/${projectUuid}/saved`,
+            {
+                name: uniqueName('Merged chart parity'),
+                tableName: 'orders',
+                metricQuery: ordersByMonth,
+                chartConfig: { type: ChartType.TABLE },
+                tableConfig: { columnOrder: [] },
+                merge,
+                dashboardUuid: null,
+                spaceUuid: undefined,
+            } satisfies CreateChartInSpace,
+        );
+        expect(created.status).toBe(200);
+        const chartUuid = created.body.results.uuid;
+        createdChartUuids.push(chartUuid);
+
+        const opened = await admin.get<Body<SavedChart>>(
+            `/api/v1/saved/${chartUuid}`,
+        );
+        expect(opened.status).toBe(200);
+        expect(opened.body.results.merge).toEqual(merge);
+
+        const [ordersRows, paymentsRows, started] = await Promise.all([
+            runSourceQuery(ordersByMonth),
+            runSourceQuery(paymentsByMonth),
+            admin.post<Body<ApiExecuteAsyncMetricQueryResults>>(
+                `/api/v2/projects/${projectUuid}/query/chart`,
+                { chartUuid, context: QueryExecutionContext.CHART },
+            ),
+        ]);
+        expect(started.status).toBe(200);
+        expect(Object.keys(started.body.results.fields)).toEqual(
+            expect.arrayContaining([
+                KEY_FIELD_ID,
+                ORDERS_FIELD_ID,
+                PAYMENTS_FIELD_ID,
+            ]),
+        );
 
         const results = await pollQueryResults(
             admin,
-            runResp.body.results.queryUuid,
+            started.body.results.queryUuid,
         );
+        const ordersByKey = byMonth(ordersRows, 'orders_total_order_amount');
+        const paymentsByKey = byMonth(
+            paymentsRows,
+            'payments_unique_payment_count',
+        );
+        expect(results.totalResults).toBe(
+            new Set([...ordersByKey.keys(), ...paymentsByKey.keys()]).size,
+        );
+        expectMergedValues(results.rows, ordersByKey, paymentsByKey);
+    }, 90_000);
 
+    // Raw parity lets a formatting or labelling regression through: merged
+    // cells and fields must format and label as the source the response names.
+    it('formats merged cells and labels merged fields as their source fields', async () => {
+        const [orders, payments, runResp] = await Promise.all([
+            runSourceQueryWithFields(ordersByMonth),
+            runSourceQueryWithFields(paymentsByMonth),
+            admin.post<Body<ApiExecuteAsyncMergeQueryResults>>(
+                `/api/v2/projects/${projectUuid}/query/merge-query`,
+                { mergeQuery, context: QueryExecutionContext.EXPLORE },
+            ),
+        ]);
+        expect(runResp.body.results.outcome).toBe('started');
+        if (runResp.body.results.outcome !== 'started') {
+            throw new Error(
+                `Merge was refused: ${JSON.stringify(runResp.body.results.errors)}`,
+            );
+        }
+        const { fieldOrigins } = runResp.body.results;
+        const mergedFields = runResp.body.results.query.fields;
+        const results = await pollQueryResults(
+            admin,
+            runResp.body.results.query.queryUuid,
+        );
         expect(results.totalResults).toBeGreaterThan(0);
-        // Pivoted rows are indexed by the key with one column per status.
-        const columns = Object.keys(results.rows[0]);
-        expect(columns).toEqual(expect.arrayContaining([KEY_FIELD_ID]));
-        expect(columns.length).toBeGreaterThan(2);
+
+        [
+            { fieldId: ORDERS_FIELD_ID, standalone: orders },
+            { fieldId: PAYMENTS_FIELD_ID, standalone: payments },
+        ].forEach(({ fieldId, standalone }) => {
+            const origin = fieldOrigins[fieldId];
+            if (origin === undefined || origin.kind !== 'source') {
+                throw new Error(
+                    `${fieldId} is not attributed to a source: ${JSON.stringify(origin)}`,
+                );
+            }
+            const mergedField = mergedFields[fieldId];
+            const sourceField = standalone.fields[origin.sourceFieldId];
+            if (
+                mergedField === undefined ||
+                !isField(mergedField) ||
+                sourceField === undefined ||
+                !isField(sourceField)
+            ) {
+                throw new Error(
+                    `${fieldId} or ${origin.sourceFieldId} is missing from its fields map`,
+                );
+            }
+            expect(mergedField.label).toBe(sourceField.label);
+            expect(mergedField.tableLabel).toBe(sourceField.tableLabel);
+
+            const formattedByKey = new Map(
+                standalone.rows.map((row) => [
+                    monthOf(cellOf(row, 'orders_order_date_month').raw),
+                    cellOf(row, origin.sourceFieldId).formatted,
+                ]),
+            );
+            results.rows.forEach((row) => {
+                const key = monthOf(cellOf(row, KEY_FIELD_ID).raw);
+                const expected = formattedByKey.get(key);
+                if (expected === undefined) {
+                    expect(cellOf(row, fieldId).raw).toBeNull();
+                    return;
+                }
+                expect(
+                    cellOf(row, fieldId).formatted,
+                    `${fieldId} at ${key}`,
+                ).toBe(expected);
+            });
+        });
     }, 60_000);
 }
 


### PR DESCRIPTION
## What the parity suite did not assert

`packages/api-tests/tests/mergeQuery.test.ts` is the gate for deleting the warehouse merge engine (PROD-10901), but three of that ticket's acceptance criteria had no assertion in it:

- The pivoted case checked shape only: the index column exists and there are more than two columns. Any wrong number in a pivoted cell passed.
- No test persisted a merged chart and ran it. The saved path rebuilds the merge from the chart's query plus the stored merge and goes through `executeAsyncSavedChartQuery`, none of which was exercised.
- Every comparison was on `value.raw`, so a merged column that lost its format or its label passed as long as the number was right.

Separately, `getAvailableWarehouseConfigs` drops a warehouse when its credentials are absent, so a CI run with a missing secret went green on Postgres alone without anyone noticing.

## What each new assertion pins

**`pivots every merged cell to the value its source returns for that month and status`**
Runs orders and payments standalone by month and status, then for each join type (`full`, `left`, `inner`) runs the pivoted merge and checks every pivoted cell against the standalone value for that month and status with the same `numeric` comparison the flat case uses. The expected grid is derived from the two standalone responses and the join type's key rules, never from a second merge run. It also pins that the pivot keeps one row per kept month and one column per kept status.

**`opens a saved merged chart and runs it to the values its sources return`**
Persists a chart whose merge stores the chart as the primary source and payments as a query source (`SavedMergeQuery`), reopens it and checks the merge round-trips, then runs it through `POST /api/v2/projects/{uuid}/query/chart`, pages the results and asserts value parity against the standalone sources. The chart is deleted in `afterAll` even on failure.

**`formats merged cells and labels merged fields as their source fields`**
For one metric per source, asserts `value.formatted` equals the standalone response's formatted value for the same month, and that the merged field's `label` and `tableLabel` equal those of the source field. The source field is looked up through the response's `fieldOrigins`, so the test reads whatever attribution the merge applies rather than hard-coding it.

The stale header naming a `merge-engine-warehouse-native` flag now names the flags that exist (`merge-queries`, `merge-on-compose`).

## Required warehouses guard

`REQUIRED_WAREHOUSES` (comma-separated names matching the helper's config names) makes `getAvailableWarehouseConfigs` throw a clear error naming the missing warehouse when one is required but has no credentials, and also rejects an unknown name so a typo cannot require nothing. It is unset by default, so local runs are unchanged. The `api-tests` job in `pr.yml` sets it to `snowflake,bigquery,trino`, the warehouses whose secrets that job wires; Databricks is deliberately not required.

Fork PRs are unaffected: on `pull_request` a fork gets no secrets, so the preview deploy cannot run and `api-tests` (`needs: preview`) never starts.

## How this was verified

- `pnpm -F api-tests typecheck`, `lint` and `oxfmt --check` pass; `ts-unused-exports` passes in the pre-commit hook.
- The guard was exercised through vitest collection with no server: `REQUIRED_WAREHOUSES=snowflake` fails naming snowflake, `REQUIRED_WAREHOUSES=nope` fails naming the unknown name, and unset falls through to the ordinary health check.
- The suite itself has not been run live: there was no reachable API in this environment. This PR includes `test-backend` so the `api-tests` job runs it on the preview against Postgres, Snowflake, BigQuery and Trino.

test-backend

Closes: PROD-10948
Relates: PROD-10901

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvtHaH3fbzSX2ebMgfFKFS
