### PR TITLE
fix(dashboard): open the chart editor modal from the empty-state Add tile

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/EmptyStateNoTiles/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/EmptyStateNoTiles/index.tsx
@@ -26,6 +26,7 @@ interface SavedChartsAvailableProps {
         tileUuidMapping?: Record<string, string>,
     ) => void;
     emptyContainerType?: 'dashboard' | 'tab';
+    onNewChart?: () => void;
     isEditMode: boolean;
     setAddingTab: (value: React.SetStateAction<boolean>) => void;
     activeTabUuid?: string;
@@ -35,6 +36,7 @@ interface SavedChartsAvailableProps {
 const EmptyStateNoTiles: FC<SavedChartsAvailableProps> = ({
     onAddTiles,
     emptyContainerType = 'dashboard',
+    onNewChart,
     isEditMode,
     setAddingTab,
     activeTabUuid,
@@ -80,6 +82,7 @@ const EmptyStateNoTiles: FC<SavedChartsAvailableProps> = ({
                             userCanCreateDashboard && isEditMode ? (
                                 <AddTileButton
                                     onAddTiles={onAddTiles}
+                                    onNewChart={onNewChart}
                                     setAddingTab={setAddingTab}
                                     activeTabUuid={activeTabUuid}
                                     dashboardTabs={dashboardTabs}

--- a/packages/frontend/src/features/dashboardTabs/index.tsx
+++ b/packages/frontend/src/features/dashboardTabs/index.tsx
@@ -215,6 +215,7 @@ type DashboardTabsProps = {
     handleEditTile: (tiles: IDashboard['tiles'][number]) => void;
     setAddingTab: (value: React.SetStateAction<boolean>) => void;
     setGridWidth: (value: React.SetStateAction<number>) => void;
+    onNewChart?: () => void;
 
     // parameters
     hasTilesThatSupportFilters: boolean;
@@ -242,6 +243,7 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
     handleEditTile,
     setGridWidth,
     setAddingTab,
+    onNewChart,
     // parameters
     hasTilesThatSupportFilters,
     parameterValues,
@@ -1382,6 +1384,7 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
                                     !currentTabHasTiles) && (
                                     <EmptyStateNoTiles
                                         onAddTiles={handleAddTiles}
+                                        onNewChart={onNewChart}
                                         emptyContainerType={
                                             dashboardTabs &&
                                             dashboardTabs.length

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -849,6 +849,10 @@ const Dashboard: FC = () => {
         [setDashboardCustomMetrics, queryClient],
     );
 
+    const handleOpenNewChart = useCallback(() => {
+        setIsNewChartOpen(true);
+    }, []);
+
     const handleChartEditorSaved = useCallback(
         (chart: SavedChart) => {
             // Only the in-dashboard builder contributes to the registry.
@@ -1025,7 +1029,7 @@ const Dashboard: FC = () => {
         onAddTiles: handleAddTiles,
         onNewChart:
             isDashboardCustomMetricsEnabled && isEditMode
-                ? () => setIsNewChartOpen(true)
+                ? handleOpenNewChart
                 : undefined,
         onSaveDashboard: () => {
             if (shouldShowVerificationSaveOptions) {
@@ -1234,6 +1238,12 @@ const Dashboard: FC = () => {
                                 handleEditTile={handleEditTiles}
                                 setGridWidth={setGridWidth}
                                 setAddingTab={setAddingTab}
+                                onNewChart={
+                                    isDashboardCustomMetricsEnabled &&
+                                    isEditMode
+                                        ? handleOpenNewChart
+                                        : undefined
+                                }
                             />
                         </FilterBarPopoversProvider>
                     </DashboardChartEditContext.Provider>


### PR DESCRIPTION
Relates: GLITCH-722

### Description:

On an empty dashboard, the centered "Add tile" renders its own `AddTileButton` (via `EmptyStateNoTiles`) which never received `onNewChart` — so with the `dashboard-custom-metrics` flag on, "New chart" from the empty state still navigated away instead of opening the in-dashboard editor modal. The header's Add tile worked; the empty state didn't.

Threads the same flag-gated handler through `DashboardTabs` → `EmptyStateNoTiles` → `AddTileButton`, and hoists it into a stable `handleOpenNewChart` callback shared with the header. Flag off: `onNewChart` stays `undefined`, behaviour unchanged.

### Risk assessment:

- [ ] This is a high-risk change

High-risk changes require approval from a reviewer other than the author before merging.
