### PR TITLE
feat(chart-registry): beta badge on beta-channel library charts

### DIFF
--- a/packages/frontend/src/features/chartTypes/components/ChartTypeBetaBadge.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeBetaBadge.tsx
@@ -1,0 +1,11 @@
+import { Badge } from '@mantine/core';
+import { type FC } from 'react';
+
+/** Marks a registry chart type published on the beta channel. */
+const ChartTypeBetaBadge: FC = () => (
+    <Badge size="xs" variant="light" color="yellow">
+        Beta
+    </Badge>
+);
+
+export default ChartTypeBetaBadge;

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeDeleteModal.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeDeleteModal.tsx
@@ -1,4 +1,8 @@
-import { getAppDisplayName, type DataAppViz } from '@lightdash/common';
+import {
+    getAppDisplayName,
+    isOfficialChartType,
+    type DataAppViz,
+} from '@lightdash/common';
 import { type FC } from 'react';
 import MantineModal from '../../../components/common/MantineModal';
 import useApp from '../../../providers/App/useApp';
@@ -23,6 +27,11 @@ const ChartTypeDeleteModal: FC<Props> = ({
 
     const { mutateAsync: deleteApp, isLoading: isDeleting } = useDeleteApp();
 
+    // Registry-official chart types are "uninstalled" (they can be
+    // reinstalled from the library); the underlying operation is the same
+    // app delete either way.
+    const isOfficial = isOfficialChartType(dataAppViz);
+
     const description = softDeleteEnabled
         ? `This chart type will be moved to Recently deleted and permanently removed after ${retentionDays} days.`
         : 'This chart type and all of its versions will be permanently deleted, including any built artifacts in storage.';
@@ -31,7 +40,8 @@ const ChartTypeDeleteModal: FC<Props> = ({
         <MantineModal
             opened
             onClose={onClose}
-            title="Delete chart type"
+            title={isOfficial ? 'Uninstall chart type' : 'Delete chart type'}
+            confirmLabel={isOfficial ? 'Uninstall' : undefined}
             variant="delete"
             resourceType="chart type"
             resourceLabel={getAppDisplayName(
@@ -43,7 +53,9 @@ const ChartTypeDeleteModal: FC<Props> = ({
                 await deleteApp({
                     projectUuid,
                     appUuid: dataAppViz.dataAppVizUuid,
-                    successTitle: 'Chart type deleted',
+                    successTitle: isOfficial
+                        ? 'Chart type uninstalled'
+                        : 'Chart type deleted',
                 });
                 onDeleted();
             }}

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeDetailModal.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeDetailModal.tsx
@@ -82,7 +82,7 @@ const ChartTypeDetailModal: FC<Props> = ({
                             leftSection={<MantineIcon icon={IconTrash} />}
                             onClick={onDelete}
                         >
-                            Delete
+                            {isOfficial ? 'Uninstall' : 'Delete'}
                         </Button>
                     )
                 }

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeLibraryCard.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeLibraryCard.tsx
@@ -8,6 +8,7 @@ import { type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { PolymorphicPaperButton } from '../../../components/common/PolymorphicPaperButton';
 import { registryAssetUrl } from '../utils/registryAssetUrl';
+import ChartTypeBetaBadge from './ChartTypeBetaBadge';
 import classes from './ChartTypeLibraryCard.module.css';
 import OfficialChartTypeBadge from './OfficialChartTypeBadge';
 
@@ -80,7 +81,10 @@ const ChartTypeLibraryCard: FC<Props> = ({ item, onClick }) => (
                 <Text fz={13} fw={600} truncate="end">
                     {item.name}
                 </Text>
-                <OfficialChartTypeBadge />
+                <Group gap={4} wrap="nowrap" className="ld-shrink-0">
+                    {item.channel === 'beta' && <ChartTypeBetaBadge />}
+                    <OfficialChartTypeBadge />
+                </Group>
             </Group>
             <Text fz="xs" c="dimmed" lh={1.35} lineClamp={2}>
                 {item.description || 'No description'}

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeLibraryDetailModal.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeLibraryDetailModal.tsx
@@ -21,9 +21,9 @@ import { useTimeAgo } from '../../../hooks/useTimeAgo';
 import { Can } from '../../../providers/Ability';
 import useApp from '../../../providers/App/useApp';
 import { useCanEditDataApp } from '../../apps/hooks/useCanEditDataApp';
-import ChartTypeBetaBadge from './ChartTypeBetaBadge';
 import { useInstallRegistryChartType } from '../hooks/useInstallRegistryChartType';
 import { registryAssetUrl } from '../utils/registryAssetUrl';
+import ChartTypeBetaBadge from './ChartTypeBetaBadge';
 import classes from './ChartTypeLibraryDetailModal.module.css';
 import ChartTypeUninstallModal from './ChartTypeUninstallModal';
 import DataAppVizFieldTypeBadge from './DataAppVizFieldTypeBadge';
@@ -104,18 +104,14 @@ const ChartTypeLibraryDetailModal: FC<Props> = ({
                 };
             case 'update_available':
                 return {
-                    actions: (
-                        <Group gap="sm" wrap="nowrap">
-                            {uninstallButton}
-                            {canInstallGate(
-                                <Button
-                                    loading={installMutation.isLoading}
-                                    onClick={handleInstall}
-                                >
-                                    Upgrade to v{item.version}
-                                </Button>,
-                            )}
-                        </Group>
+                    leftActions: uninstallButton,
+                    actions: canInstallGate(
+                        <Button
+                            loading={installMutation.isLoading}
+                            onClick={handleInstall}
+                        >
+                            Upgrade to v{item.version}
+                        </Button>,
                     ),
                 };
             case 'installed':

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeLibraryDetailModal.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeLibraryDetailModal.tsx
@@ -21,6 +21,7 @@ import { useTimeAgo } from '../../../hooks/useTimeAgo';
 import { Can } from '../../../providers/Ability';
 import useApp from '../../../providers/App/useApp';
 import { useCanEditDataApp } from '../../apps/hooks/useCanEditDataApp';
+import ChartTypeBetaBadge from './ChartTypeBetaBadge';
 import { useInstallRegistryChartType } from '../hooks/useInstallRegistryChartType';
 import { registryAssetUrl } from '../utils/registryAssetUrl';
 import classes from './ChartTypeLibraryDetailModal.module.css';
@@ -241,9 +242,14 @@ const ChartTypeLibraryDetailModal: FC<Props> = ({
                             <Text fz={12} fw={600} c="ldGray.6">
                                 Version
                             </Text>
-                            <Text fz="sm" fw={500} c="ldGray.8">
-                                v{item.version}
-                            </Text>
+                            <Group gap="xs" wrap="nowrap">
+                                <Text fz="sm" fw={500} c="ldGray.8">
+                                    v{item.version}
+                                </Text>
+                                {item.channel === 'beta' && (
+                                    <ChartTypeBetaBadge />
+                                )}
+                            </Group>
                         </Box>
                         <Box>
                             <Text fz={12} fw={600} c="ldGray.6">

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeLibrarySection.test.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeLibrarySection.test.tsx
@@ -237,6 +237,19 @@ describe('ChartTypeLibrarySection', () => {
         ).toBeInTheDocument();
     });
 
+    it('shows a beta badge only on beta-channel charts', () => {
+        setFlag(true);
+        setRegistryData([
+            makeItem({ slug: 'a', name: 'Stable chart', channel: 'stable' }),
+            makeItem({ slug: 'b', name: 'Untagged chart' }),
+            makeItem({ slug: 'c', name: 'Beta chart', channel: 'beta' }),
+        ]);
+        renderSection();
+
+        expect(screen.getByText('Beta chart')).toBeInTheDocument();
+        expect(screen.getAllByText('Beta')).toHaveLength(1);
+    });
+
     it('renders each card as a keyboard-focusable button', () => {
         setFlag(true);
         setRegistryData([makeItem({ slug: 'radial-gauge' })]);

--- a/packages/frontend/src/pages/ChartTypeGallery.test.tsx
+++ b/packages/frontend/src/pages/ChartTypeGallery.test.tsx
@@ -295,6 +295,34 @@ describe('ChartTypeGallery', () => {
         expect(screen.getByText('Delete chart type')).toBeInTheDocument();
     });
 
+    it('labels the action Uninstall for official chart types', async () => {
+        setData([makeDataAppViz({ registrySlug: 'radial-gauge' })]);
+        renderPage();
+
+        fireEvent.click(screen.getByText('Radial gauge'));
+        expect(
+            screen.queryByRole('button', { name: 'Delete' }),
+        ).not.toBeInTheDocument();
+        fireEvent.click(screen.getByRole('button', { name: 'Uninstall' }));
+
+        expect(screen.getByText('Uninstall chart type')).toBeInTheDocument();
+
+        // Both modals are open and both buttons say Uninstall; the confirm
+        // modal portals in after the detail modal, so its CTA is last.
+        const uninstallButtons = screen.getAllByRole('button', {
+            name: 'Uninstall',
+        });
+        fireEvent.click(uninstallButtons[uninstallButtons.length - 1]);
+
+        await waitFor(() =>
+            expect(mockedDeleteApp).toHaveBeenCalledWith({
+                projectUuid: 'project-1',
+                appUuid: 'data-app-viz-1',
+                successTitle: 'Chart type uninstalled',
+            }),
+        );
+    });
+
     it('hides edit and delete actions from non-editors', () => {
         vi.mocked(useCanEditDataApp).mockReturnValue(false);
         setData([makeDataAppViz({})]);


### PR DESCRIPTION
Follows #28628 (merged), which added the `channel` field to registry entries.

Next-channel instances (internal Lightdash, local dev) list beta and stable charts in the same library grid; this adds a yellow **Beta** badge so they're distinguishable:

- New `ChartTypeBetaBadge` (mirrors `OfficialChartTypeBadge`), shown on the library card's name row and next to the version in the detail modal's meta panel.
- Renders only when `entry.channel === 'beta'` — stable-channel instances never receive the field, so nothing changes for them.
- Test pins the badge appears exactly once across stable/untagged/beta fixtures (18/18 section tests pass; frontend typecheck clean).

Relates: GLITCH-749

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8sCUbSEj5R8babs36CnDN