### PR TITLE
fix(query-history): reserve space while loading so the page stops shifting

### DIFF
--- a/packages/frontend/src/components/common/ContentTable/ContentTable.module.css
+++ b/packages/frontend/src/components/common/ContentTable/ContentTable.module.css
@@ -15,6 +15,8 @@
     flex: 0 0 auto;
 }
 
+/* Overlays the container's top edge instead of taking a row of layout, so
+   toggling it between fetches never shifts the table. */
 .progress {
     background: linear-gradient(
         90deg,
@@ -23,8 +25,10 @@
         transparent
     );
     height: 1px;
+    margin-bottom: -1px;
     overflow: hidden;
     position: relative;
+    z-index: 3;
 }
 
 .progress::before {

--- a/packages/frontend/src/features/queryHistory/QueryHistory.module.css
+++ b/packages/frontend/src/features/queryHistory/QueryHistory.module.css
@@ -8,6 +8,13 @@
     overflow: hidden;
 }
 
+/* Reserved so the table does not drop a line when the subtitle arrives. */
+.subtitleLine {
+    display: flex;
+    align-items: center;
+    height: calc(var(--mantine-font-size-sm) * var(--mantine-line-height-sm));
+}
+
 /* ---------- table ---------- */
 
 /* Grows with its rows and only scrolls once it hits the viewport. */
@@ -34,6 +41,49 @@
 
 .showMoreRow :global(td) {
     background: var(--mantine-color-body);
+}
+
+/* Placeholder rows mirror a query row's two text lines so the row height
+   matches the real row that replaces them. */
+.skeletonRow {
+    pointer-events: none;
+}
+
+.skeletonLines {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.skeletonTitleLine,
+.skeletonSubLine {
+    display: flex;
+    align-items: center;
+}
+
+/* 1.35 is the ContentTable body cell line-height, which both lines inherit. */
+.skeletonTitleLine {
+    height: calc(var(--mantine-font-size-sm) * 1.35);
+}
+
+.skeletonSubLine {
+    height: calc(var(--mantine-font-size-xs) * 1.35);
+}
+
+.resultsSkeletonLine {
+    display: flex;
+    align-items: center;
+    height: calc(var(--mantine-font-size-xs) * var(--mantine-line-height));
+}
+
+.skeletonAlignEnd {
+    justify-content: flex-end;
+}
+
+/* Matches the count slot in the trigger segmented control. */
+.countSkeleton {
+    display: inline-flex;
+    align-items: center;
 }
 
 /* ---------- detail panel ---------- */

--- a/packages/frontend/src/features/queryHistory/components/QueryHistoryDetailPanel.tsx
+++ b/packages/frontend/src/features/queryHistory/components/QueryHistoryDetailPanel.tsx
@@ -57,6 +57,7 @@ import { QueryStatusBadge } from './QueryHistoryQueryCell';
 
 const RESULTS_PREVIEW_COLUMNS = 6;
 const RESULTS_PREVIEW_ROWS = 8;
+const RESULTS_SKELETON_DEFAULT_COLUMNS = 4;
 const SQL_COLLAPSED_HEIGHT = 260;
 
 type Props = {
@@ -82,6 +83,58 @@ const TimingCell: FC<{
         </Text>
     </Box>
 );
+
+/**
+ * Same Table props as the real preview so the skeleton is the height of the
+ * table that replaces it; column and row counts come from the run itself.
+ */
+const ResultsSkeleton: FC<{ columns: number; rows: number }> = ({
+    columns,
+    rows,
+}) => {
+    const columnKeys = Array.from({ length: columns }, (_, i) => `c${i}`);
+    return (
+        <Paper className={styles.resultsTable} aria-busy>
+            <Table fz="xs" verticalSpacing="xs" horizontalSpacing="sm">
+                <Table.Thead>
+                    <Table.Tr>
+                        {columnKeys.map((key) => (
+                            <Table.Th key={key}>
+                                <Box className={styles.resultsSkeletonLine}>
+                                    <Skeleton h={10} w="60%" radius="xl" />
+                                </Box>
+                            </Table.Th>
+                        ))}
+                    </Table.Tr>
+                </Table.Thead>
+                <Table.Tbody>
+                    {Array.from({ length: rows }, (_, rowIndex) => (
+                        // eslint-disable-next-line react/no-array-index-key
+                        <Table.Tr key={rowIndex}>
+                            {columnKeys.map((key, columnIndex) => (
+                                <Table.Td key={key}>
+                                    <Box className={styles.resultsSkeletonLine}>
+                                        <Skeleton
+                                            h={10}
+                                            w={
+                                                (rowIndex + columnIndex) % 2 ===
+                                                0
+                                                    ? '72%'
+                                                    : '48%'
+                                            }
+                                            radius="xl"
+                                            opacity={0.6}
+                                        />
+                                    </Box>
+                                </Table.Td>
+                            ))}
+                        </Table.Tr>
+                    ))}
+                </Table.Tbody>
+            </Table>
+        </Paper>
+    );
+};
 
 const ResultsPlaceholder: FC<{ children: React.ReactNode }> = ({
     children,
@@ -283,12 +336,22 @@ export const QueryHistoryDetailPanel: FC<Props> = ({
             );
         }
         if (resultsPreviewQuery.isInitialLoading) {
+            const expectedColumns = item.metricQuery
+                ? item.metricQuery.dimensions.length +
+                  item.metricQuery.metrics.length +
+                  item.metricQuery.tableCalculations.length
+                : RESULTS_SKELETON_DEFAULT_COLUMNS;
             return (
-                <Stack gap="xs">
-                    <Skeleton h={28} />
-                    <Skeleton h={28} />
-                    <Skeleton h={28} />
-                </Stack>
+                <ResultsSkeleton
+                    columns={Math.min(
+                        Math.max(expectedColumns, 1),
+                        RESULTS_PREVIEW_COLUMNS,
+                    )}
+                    rows={Math.min(
+                        item.totalRowCount ?? RESULTS_PREVIEW_ROWS,
+                        RESULTS_PREVIEW_ROWS,
+                    )}
+                />
             );
         }
         return (

--- a/packages/frontend/src/features/queryHistory/components/QueryHistoryPage.tsx
+++ b/packages/frontend/src/features/queryHistory/components/QueryHistoryPage.tsx
@@ -9,14 +9,17 @@ import {
     type QueryLanguage,
     QueryTrigger,
 } from '@lightdash/common';
-import { Box, Stack, Text, Title } from '@mantine/core';
+import { Box, Skeleton, Stack, Text, Title } from '@mantine/core';
 import { useDebouncedValue } from '@mantine/hooks';
 import { useCallback, useMemo, useRef, useState, type FC } from 'react';
 import { type ContentTableSortingState } from '../../../components/common/ContentTable';
 import Page from '../../../components/common/Page/Page';
 import { useProject } from '../../../hooks/useProject';
 import { useProjectUuid } from '../../../hooks/useProjectUuid';
-import { useInfiniteQueryHistory } from '../hooks/useQueryHistory';
+import {
+    getQueryHistoryHasNextPage,
+    useInfiniteQueryHistory,
+} from '../hooks/useQueryHistory';
 import styles from '../QueryHistory.module.css';
 import { formatWarehouseTime } from '../utils/format';
 import {
@@ -133,6 +136,7 @@ export const QueryHistoryPage: FC = () => {
                     previous &&
                     previous.hasNextPage === meta.hasNextPage &&
                     previous.isFetching === meta.isFetching &&
+                    previous.isFetchingNextPage === meta.isFetchingNextPage &&
                     previous.remaining === meta.remaining
                 ) {
                     return current;
@@ -246,13 +250,21 @@ export const QueryHistoryPage: FC = () => {
         .filter(Boolean)
         .join(' · ');
 
+    // Before the first response nothing is known about which windows exist,
+    // so the table shows generic skeletons; per-window skeletons take over
+    // once counts arrive.
     const isInitialLoading = isFlatSort
         ? flatQuery.isLoading && flatItems.length === 0
-        : !counts &&
+        : counts === undefined &&
           QUERY_HISTORY_WINDOWS_ORDERED.some((window) =>
               expandedWindows.has(window),
-          ) &&
-          tableData.every((row) => row.kind !== 'query');
+          );
+
+    const isRefetching = isFlatSort
+        ? flatQuery.isFetching
+        : Object.values(windowMeta).some(
+              (meta) => meta.isFetching && !meta.isFetchingNextPage,
+          );
 
     return (
         <Page
@@ -301,11 +313,15 @@ export const QueryHistoryPage: FC = () => {
 
                 <Stack gap={2}>
                     <Title order={4}>My query history</Title>
-                    {subtitle ? (
-                        <Text fz="sm" c="dimmed">
-                            {subtitle}
-                        </Text>
-                    ) : null}
+                    <Box className={styles.subtitleLine}>
+                        {subtitle ? (
+                            <Text fz="sm" c="dimmed">
+                                {subtitle}
+                            </Text>
+                        ) : (
+                            <Skeleton h={10} w={320} radius="xl" />
+                        )}
+                    </Box>
                 </Stack>
 
                 <QueryHistoryTable
@@ -317,8 +333,8 @@ export const QueryHistoryPage: FC = () => {
                     sorting={sorting}
                     onSortingChange={setSorting}
                     isLoading={isInitialLoading}
-                    isFetching={isFlatSort && flatQuery.isFetching}
-                    hasNextPage={Boolean(flatQuery.hasNextPage)}
+                    isFetching={isRefetching}
+                    hasNextPage={getQueryHistoryHasNextPage(flatQuery.data)}
                     fetchNextPage={() => {
                         void flatQuery.fetchNextPage();
                     }}

--- a/packages/frontend/src/features/queryHistory/components/QueryHistorySkeletonCell.tsx
+++ b/packages/frontend/src/features/queryHistory/components/QueryHistorySkeletonCell.tsx
@@ -1,0 +1,40 @@
+import { Box, Skeleton } from '@mantine/core';
+import { type FC } from 'react';
+import styles from '../QueryHistory.module.css';
+
+type Props = {
+    width: string | number;
+    align?: 'start' | 'end';
+    /** Adds the dimmed second line that query rows render under the title. */
+    withSubline?: boolean;
+    sublineWidth?: string | number;
+};
+
+/**
+ * Placeholder for one table cell while a window's page is in flight. The
+ * wrappers reproduce the line boxes of a real query cell, so a skeleton row
+ * is exactly as tall as the row that replaces it.
+ */
+export const QueryHistorySkeletonCell: FC<Props> = ({
+    width,
+    align = 'start',
+    withSubline = false,
+    sublineWidth = '40%',
+}) => (
+    <Box className={styles.skeletonLines}>
+        <Box
+            className={
+                align === 'end'
+                    ? `${styles.skeletonTitleLine} ${styles.skeletonAlignEnd}`
+                    : styles.skeletonTitleLine
+            }
+        >
+            <Skeleton h={12} w={width} radius="xl" />
+        </Box>
+        {withSubline ? (
+            <Box className={styles.skeletonSubLine}>
+                <Skeleton h={10} w={sublineWidth} radius="xl" opacity={0.6} />
+            </Box>
+        ) : null}
+    </Box>
+);

--- a/packages/frontend/src/features/queryHistory/components/QueryHistoryTable.tsx
+++ b/packages/frontend/src/features/queryHistory/components/QueryHistoryTable.tsx
@@ -33,6 +33,7 @@ import {
     type QueryHistoryTableRow,
 } from '../utils/tableRows';
 import { QueryHistoryQueryCell } from './QueryHistoryQueryCell';
+import { QueryHistorySkeletonCell } from './QueryHistorySkeletonCell';
 
 type Props = {
     data: QueryHistoryTableRow[];
@@ -59,6 +60,12 @@ const isRuntimeSort = (sorting: ContentTableSortingState) =>
     sorting[0]?.id === QueryHistorySortBy.RUNTIME;
 
 const ROW_HEIGHT_ESTIMATE = 52;
+
+/* Vary placeholder widths per row so a block of skeletons reads as rows. */
+const SKELETON_TITLE_WIDTHS = ['62%', '48%', '71%', '55%', '44%'];
+const SKELETON_SUBLINE_WIDTHS = ['84%', '66%', '90%', '58%', '74%'];
+const skeletonWidth = (widths: string[], index: number) =>
+    widths[index % widths.length];
 
 export const QueryHistoryTable: FC<Props> = ({
     data,
@@ -148,6 +155,21 @@ export const QueryHistoryTable: FC<Props> = ({
                             </Button>
                         );
                     }
+                    if (original.kind === 'skeleton') {
+                        return (
+                            <QueryHistorySkeletonCell
+                                width={skeletonWidth(
+                                    SKELETON_TITLE_WIDTHS,
+                                    original.index,
+                                )}
+                                withSubline
+                                sublineWidth={skeletonWidth(
+                                    SKELETON_SUBLINE_WIDTHS,
+                                    original.index,
+                                )}
+                            />
+                        );
+                    }
                     return <QueryHistoryQueryCell item={original.item} />;
                 },
             },
@@ -159,6 +181,9 @@ export const QueryHistoryTable: FC<Props> = ({
                 enableSorting: false,
                 size: 100,
                 Cell: ({ row }) => {
+                    if (row.original.kind === 'skeleton') {
+                        return <QueryHistorySkeletonCell width={44} />;
+                    }
                     if (row.original.kind !== 'query') return null;
                     return (
                         <Badge size="xs">
@@ -175,6 +200,9 @@ export const QueryHistoryTable: FC<Props> = ({
                 enableSorting: false,
                 size: 110,
                 Cell: ({ row }) => {
+                    if (row.original.kind === 'skeleton') {
+                        return <QueryHistorySkeletonCell width={56} />;
+                    }
                     if (row.original.kind !== 'query') return null;
                     return (
                         <Text c="dimmed">
@@ -195,6 +223,11 @@ export const QueryHistoryTable: FC<Props> = ({
                 mantineTableHeadCellProps: { ta: 'right' },
                 mantineTableBodyCellProps: { ta: 'right' },
                 Cell: ({ row }) => {
+                    if (row.original.kind === 'skeleton') {
+                        return (
+                            <QueryHistorySkeletonCell width={40} align="end" />
+                        );
+                    }
                     if (row.original.kind !== 'query') return null;
                     const { warehouseExecutionTimeMs, status } =
                         row.original.item;
@@ -222,6 +255,11 @@ export const QueryHistoryTable: FC<Props> = ({
                 mantineTableHeadCellProps: { ta: 'right' },
                 mantineTableBodyCellProps: { ta: 'right' },
                 Cell: ({ row }) => {
+                    if (row.original.kind === 'skeleton') {
+                        return (
+                            <QueryHistorySkeletonCell width={32} align="end" />
+                        );
+                    }
                     if (row.original.kind !== 'query') return null;
                     const { totalRowCount } = row.original.item;
                     return (
@@ -254,6 +292,11 @@ export const QueryHistoryTable: FC<Props> = ({
                             <Text fz="xs" c="dimmed" className="ld-nowrap">
                                 {getWindowRangeLabel(row.original.window)}
                             </Text>
+                        );
+                    }
+                    if (row.original.kind === 'skeleton') {
+                        return (
+                            <QueryHistorySkeletonCell width={64} align="end" />
                         );
                     }
                     if (row.original.kind !== 'query') return null;
@@ -334,6 +377,9 @@ export const QueryHistoryTable: FC<Props> = ({
             }
             if (original.kind === 'showMore') {
                 return { className: styles.showMoreRow };
+            }
+            if (original.kind === 'skeleton') {
+                return { className: styles.skeletonRow, 'aria-busy': true };
             }
             return {
                 className:

--- a/packages/frontend/src/features/queryHistory/components/QueryHistoryToolbar.tsx
+++ b/packages/frontend/src/features/queryHistory/components/QueryHistoryToolbar.tsx
@@ -4,7 +4,14 @@ import {
     QueryTrigger,
     type QueryHistoryCounts,
 } from '@lightdash/common';
-import { Button, Group, SegmentedControl, Text } from '@mantine/core';
+import {
+    Box,
+    Button,
+    Group,
+    SegmentedControl,
+    Skeleton,
+    Text,
+} from '@mantine/core';
 import {
     IconClock,
     IconLayoutDashboard,
@@ -68,7 +75,11 @@ const TriggerLabel: FC<{
             <Text component="span" fz="xs" c="dimmed">
                 {count.toLocaleString()}
             </Text>
-        ) : null}
+        ) : (
+            <Box component="span" className={styles.countSkeleton}>
+                <Skeleton h={8} w={18} radius="xl" />
+            </Box>
+        )}
     </Group>
 );
 

--- a/packages/frontend/src/features/queryHistory/components/QueryHistoryWindowSection.tsx
+++ b/packages/frontend/src/features/queryHistory/components/QueryHistoryWindowSection.tsx
@@ -5,7 +5,10 @@ import {
     type QueryHistoryWindow,
 } from '@lightdash/common';
 import { useEffect, useMemo, type FC } from 'react';
-import { useInfiniteQueryHistory } from '../hooks/useQueryHistory';
+import {
+    getQueryHistoryHasNextPage,
+    useInfiniteQueryHistory,
+} from '../hooks/useQueryHistory';
 import {
     QUERY_HISTORY_WINDOW_PAGE_SIZE,
     type QueryHistoryWindowMeta,
@@ -47,7 +50,7 @@ export const QueryHistoryWindowSection: FC<Props> = ({
     onMetaChange,
     onRegisterFetchNext,
 }) => {
-    const { data, isFetching, hasNextPage, fetchNextPage } =
+    const { data, isFetching, isFetchingNextPage, fetchNextPage } =
         useInfiniteQueryHistory(
             projectUuid,
             { ...filters, window },
@@ -56,6 +59,7 @@ export const QueryHistoryWindowSection: FC<Props> = ({
         );
 
     const lastPage = data?.pages[data.pages.length - 1];
+    const hasNextPage = getQueryHistoryHasNextPage(data);
     const items = useMemo(
         () => data?.pages.flatMap((page) => page.data) ?? [],
         [data],
@@ -78,11 +82,19 @@ export const QueryHistoryWindowSection: FC<Props> = ({
 
     useEffect(() => {
         onMetaChange(window, {
-            hasNextPage: Boolean(hasNextPage),
+            hasNextPage,
             isFetching,
+            isFetchingNextPage,
             remaining,
         });
-    }, [window, hasNextPage, isFetching, remaining, onMetaChange]);
+    }, [
+        window,
+        hasNextPage,
+        isFetching,
+        isFetchingNextPage,
+        remaining,
+        onMetaChange,
+    ]);
 
     useEffect(() => {
         onRegisterFetchNext(window, () => {

--- a/packages/frontend/src/features/queryHistory/hooks/useQueryHistory.ts
+++ b/packages/frontend/src/features/queryHistory/hooks/useQueryHistory.ts
@@ -5,6 +5,7 @@ import {
 } from '@lightdash/common';
 import {
     useInfiniteQuery,
+    type InfiniteData,
     type UseInfiniteQueryOptions,
 } from '@tanstack/react-query';
 import { lightdashApi } from '../../../api';
@@ -44,6 +45,17 @@ const getQueryHistory = async (
         method: 'GET',
         body: undefined,
     });
+
+/**
+ * Derived from the data being rendered rather than react-query's
+ * `hasNextPage`, which resets while `keepPreviousData` shows the old pages.
+ */
+export const getQueryHistoryHasNextPage = (
+    data: InfiniteData<QueryHistoryListResults> | undefined,
+): boolean => {
+    const pagination = data?.pages[data.pages.length - 1]?.pagination;
+    return pagination ? pagination.page < pagination.totalPageCount : false;
+};
 
 export const useInfiniteQueryHistory = (
     projectUuid: string | undefined,

--- a/packages/frontend/src/features/queryHistory/utils/tableRows.test.ts
+++ b/packages/frontend/src/features/queryHistory/utils/tableRows.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from 'vitest';
 import {
     buildQueryHistoryTableRows,
     isQueryHistoryQueryRow,
+    type QueryHistoryWindowMeta,
 } from './tableRows';
 
 const item = (queryUuid: string): QueryHistoryListItem =>
@@ -15,6 +16,16 @@ const item = (queryUuid: string): QueryHistoryListItem =>
         queryUuid,
         title: queryUuid,
     }) as QueryHistoryListItem;
+
+const meta = (
+    overrides: Partial<QueryHistoryWindowMeta> = {},
+): QueryHistoryWindowMeta => ({
+    hasNextPage: false,
+    isFetching: false,
+    isFetchingNextPage: false,
+    remaining: 0,
+    ...overrides,
+});
 
 const counts = (
     windows: Partial<Record<QueryHistoryWindow, number>>,
@@ -35,6 +46,9 @@ const counts = (
     total: Object.values(windows).reduce((sum, count) => sum + count, 0),
     warehouseTimeMsLast7Days: 0,
 });
+
+const kinds = (rows: ReturnType<typeof buildQueryHistoryTableRows>) =>
+    rows.map((row) => row.kind);
 
 describe('buildQueryHistoryTableRows', () => {
     it('flattens query rows when sorting by runtime', () => {
@@ -60,11 +74,10 @@ describe('buildQueryHistoryTableRows', () => {
                 [QueryHistoryWindow.LAST_HOUR]: [item('q1')],
             },
             windowMeta: {
-                [QueryHistoryWindow.LAST_HOUR]: {
+                [QueryHistoryWindow.LAST_HOUR]: meta({
                     hasNextPage: true,
-                    isFetching: false,
                     remaining: 4,
-                },
+                }),
             },
             counts: counts({
                 [QueryHistoryWindow.LAST_FEW_MINUTES]: 0,
@@ -100,6 +113,118 @@ describe('buildQueryHistoryTableRows', () => {
                 window: QueryHistoryWindow.LAST_24_HOURS,
             },
         ]);
+    });
+
+    it('sizes first-page skeletons to the window count, capped at a page', () => {
+        const rows = buildQueryHistoryTableRows({
+            isFlatSort: false,
+            flatItems: [],
+            expandedWindows: new Set([
+                QueryHistoryWindow.LAST_HOUR,
+                QueryHistoryWindow.LAST_24_HOURS,
+            ]),
+            windowItems: {},
+            windowMeta: {
+                [QueryHistoryWindow.LAST_HOUR]: meta({ isFetching: true }),
+            },
+            counts: counts({
+                [QueryHistoryWindow.LAST_HOUR]: 3,
+                [QueryHistoryWindow.LAST_24_HOURS]: 40,
+            }),
+        });
+
+        expect(kinds(rows)).toEqual([
+            'window',
+            'skeleton',
+            'skeleton',
+            'skeleton',
+            'window',
+            ...Array<'skeleton'>(10).fill('skeleton'),
+            'showMore',
+        ]);
+    });
+
+    it('reserves the show-more row when the count exceeds a page', () => {
+        const rows = buildQueryHistoryTableRows({
+            isFlatSort: false,
+            flatItems: [],
+            expandedWindows: new Set([QueryHistoryWindow.LAST_7_DAYS]),
+            windowItems: {},
+            windowMeta: {},
+            counts: counts({ [QueryHistoryWindow.LAST_7_DAYS]: 54 }),
+        });
+
+        expect(kinds(rows)).toEqual([
+            'window',
+            ...Array<'skeleton'>(10).fill('skeleton'),
+            'showMore',
+        ]);
+        expect(rows.at(-1)).toMatchObject({ remaining: 44, isFetching: true });
+    });
+
+    it('falls back to a page of skeletons before counts are known', () => {
+        const rows = buildQueryHistoryTableRows({
+            isFlatSort: false,
+            flatItems: [],
+            expandedWindows: new Set([QueryHistoryWindow.LAST_HOUR]),
+            windowItems: {},
+            windowMeta: {},
+            counts: undefined,
+        });
+
+        expect(
+            rows.filter(
+                (row) =>
+                    row.kind === 'skeleton' &&
+                    row.window === QueryHistoryWindow.LAST_HOUR,
+            ),
+        ).toHaveLength(10);
+    });
+
+    it('shows no skeletons for a fetched window with rows', () => {
+        const rows = buildQueryHistoryTableRows({
+            isFlatSort: false,
+            flatItems: [],
+            expandedWindows: new Set([QueryHistoryWindow.LAST_HOUR]),
+            windowItems: {
+                [QueryHistoryWindow.LAST_HOUR]: [item('q1')],
+            },
+            windowMeta: {
+                [QueryHistoryWindow.LAST_HOUR]: meta({ isFetching: true }),
+            },
+            counts: counts({ [QueryHistoryWindow.LAST_HOUR]: 1 }),
+        });
+
+        expect(kinds(rows)).toEqual(['window', 'query']);
+    });
+
+    it('reserves the next page with skeletons while showing more', () => {
+        const rows = buildQueryHistoryTableRows({
+            isFlatSort: false,
+            flatItems: [],
+            expandedWindows: new Set([QueryHistoryWindow.LAST_HOUR]),
+            windowItems: {
+                [QueryHistoryWindow.LAST_HOUR]: [item('q1')],
+            },
+            windowMeta: {
+                [QueryHistoryWindow.LAST_HOUR]: meta({
+                    hasNextPage: true,
+                    isFetching: true,
+                    isFetchingNextPage: true,
+                    remaining: 2,
+                }),
+            },
+            counts: counts({ [QueryHistoryWindow.LAST_HOUR]: 3 }),
+        });
+
+        expect(kinds(rows)).toEqual([
+            'window',
+            'query',
+            'skeleton',
+            'skeleton',
+            'showMore',
+        ]);
+        expect(rows.at(-1)).toMatchObject({ isFetching: true });
     });
 });
 

--- a/packages/frontend/src/features/queryHistory/utils/tableRows.ts
+++ b/packages/frontend/src/features/queryHistory/utils/tableRows.ts
@@ -10,6 +10,7 @@ export const QUERY_HISTORY_WINDOW_PAGE_SIZE = 10;
 export type QueryHistoryWindowMeta = {
     hasNextPage: boolean;
     isFetching: boolean;
+    isFetchingNextPage: boolean;
     remaining: number;
 };
 
@@ -26,6 +27,12 @@ export type QueryHistoryTableRow =
       }
     | {
           id: string;
+          kind: 'skeleton';
+          window: QueryHistoryWindow;
+          index: number;
+      }
+    | {
+          id: string;
           kind: 'showMore';
           window: QueryHistoryWindow;
           remaining: number;
@@ -36,6 +43,45 @@ export const isQueryHistoryQueryRow = (
     row: QueryHistoryTableRow,
 ): row is Extract<QueryHistoryTableRow, { kind: 'query' }> =>
     row.kind === 'query';
+
+const buildSkeletonRows = (
+    window: QueryHistoryWindow,
+    count: number,
+    offset: number,
+): QueryHistoryTableRow[] =>
+    Array.from({ length: count }, (_, index) => ({
+        id: `skeleton-${window}-${offset + index}`,
+        kind: 'skeleton',
+        window,
+        index: offset + index,
+    }));
+
+/**
+ * Placeholder rows sized to what the window will render once its page lands,
+ * so the table does not grow when the real rows replace them.
+ */
+const getPendingRowCount = ({
+    items,
+    meta,
+    windowCount,
+}: {
+    items: QueryHistoryListItem[];
+    meta: QueryHistoryWindowMeta | undefined;
+    windowCount: number | undefined;
+}): number => {
+    const isFirstPagePending =
+        items.length === 0 && (meta === undefined || meta.isFetching);
+    if (isFirstPagePending) {
+        return Math.min(
+            windowCount ?? QUERY_HISTORY_WINDOW_PAGE_SIZE,
+            QUERY_HISTORY_WINDOW_PAGE_SIZE,
+        );
+    }
+    if (meta?.isFetchingNextPage) {
+        return Math.min(meta.remaining, QUERY_HISTORY_WINDOW_PAGE_SIZE);
+    }
+    return 0;
+};
 
 export const buildQueryHistoryTableRows = ({
     isFlatSort,
@@ -85,13 +131,37 @@ export const buildQueryHistoryTableRows = ({
             })),
         );
 
-        if (meta?.hasNextPage) {
+        rows.push(
+            ...buildSkeletonRows(
+                window,
+                getPendingRowCount({ items, meta, windowCount }),
+                items.length,
+            ),
+        );
+
+        // Before the first page lands, the count alone says whether a
+        // show-more row will follow, so reserve it rather than let it pop in.
+        const isFirstPagePending = items.length === 0;
+        const expectsMore =
+            isFirstPagePending &&
+            windowCount !== undefined &&
+            windowCount > QUERY_HISTORY_WINDOW_PAGE_SIZE;
+
+        if (expectsMore) {
+            rows.push({
+                id: `more-${window}`,
+                kind: 'showMore',
+                window,
+                remaining: windowCount - QUERY_HISTORY_WINDOW_PAGE_SIZE,
+                isFetching: true,
+            });
+        } else if (meta?.hasNextPage) {
             rows.push({
                 id: `more-${window}`,
                 kind: 'showMore',
                 window,
                 remaining: meta.remaining,
-                isFetching: meta.isFetching,
+                isFetching: meta.isFetchingNextPage,
             });
         }
 


### PR DESCRIPTION
## Summary

The query history page reflowed several times while loading. This PR reserves the space up front so the layout is settled from the first response onwards.

### What was shifting

- The subtitle line rendered only once the project and counts loaded, so the whole table dropped by a line.
- Trigger counts in the segmented control appeared after the first response and pushed the Language and Status facets sideways.
- In grouped mode each time window fetches independently: generic skeleton, then window headers with no rows, then rows popping in per window. Expanding a collapsed window and "Show more" had the same pop-in, and the show-more row itself appeared only after the page landed.
- Filter and search refetches in grouped mode gave no loading feedback, and the show-more rows vanished during the refetch because react-query's `hasNextPage` resets while `keepPreviousData` still shows the old pages.
- The shared ContentTable progress bar occupied a 1px layout row, so toggling it nudged every table.
- The detail panel results skeleton was three thin bars, far shorter than the preview table that replaced it.

### Changes

- `tableRows.ts` emits a `skeleton` row kind. An expanded window with no rows yet gets `min(windowCount, 10)` placeholder rows, and a show-more row is reserved whenever the count exceeds a page. While "Show more" is in flight, `min(remaining, 10)` placeholders sit above the button. `QueryHistoryWindowMeta` gains `isFetchingNextPage` so a filter refetch is not mistaken for a next-page fetch.
- `QueryHistorySkeletonCell` reproduces the two line boxes of a real query cell (both inherit the ContentTable cell line-height), so skeleton rows are pixel-height equal to real rows.
- `hasNextPage` is now derived from the rendered data (`getQueryHistoryHasNextPage`) in both grouped and flat mode.
- `QueryHistoryPage` always renders the subtitle line at a fixed height with a skeleton until text is available, and the progress bar reflects any grouped-mode refetch.
- `QueryHistoryToolbar` keeps a small count placeholder in each trigger tab until counts arrive.
- `QueryHistoryDetailPanel` results skeleton is a real `Table` with the same spacing props, sized from the run's metric query field count and row count.
- `ContentTable.module.css`: the progress bar overlays the container's top edge via a negative margin instead of taking a layout row.

### Verification

Measured in the browser with the history endpoint delayed per window (Playwright route interception):

| State | Table height | Rows |
|---|---|---|
| Counts landed, 24h window still loading | 217px | header, 2 skeletons |
| 24h window loaded | 217px | header, 2 rows |
| "Last 7 days" expanded, page in flight | 753px | 10 skeletons + reserved show-more |
| "Last 7 days" loaded | 753px | 10 rows + show-more |
| "Show more" in flight | 1254px | 10 skeletons above the button |
| "Show more" loaded | 1254px | 20 rows |

Skeleton rows and real rows both measure 50.1px. During a trigger filter refetch the progress bar is visible and the show-more row stays in place.

### Regression analysis

- `tableRows.test.ts` covers the new skeleton and reserved show-more cases (9 tests).
- The ContentTable progress bar change is global. It is a 1px strip that now overlaps the first pixel of the table container with `z-index: 3`, above the sticky header (`z-index: 2`); no other consumer positions content in that pixel.
- Behaviour for the very first response is unchanged: the generic ContentTable skeleton shows until counts are known, then the per-window structure takes over.
- Flat (runtime) sort is unaffected apart from `hasNextPage` now coming from the data, which only stops the bottom toolbar flipping to "All results loaded" mid-refetch.

Closes: PROD-10953

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GdtHfobwRVhtZM661AtFUB
