### PR TITLE
fix(chart-registry): consistent left-aligned Uninstall across chart type modals

### DIFF
--- a/packages/frontend/src/features/chartTypes/components/ChartTypeDeleteModal.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeDeleteModal.tsx
@@ -1,4 +1,8 @@
-import { getAppDisplayName, type DataAppViz } from '@lightdash/common';
+import {
+    getAppDisplayName,
+    isOfficialChartType,
+    type DataAppViz,
+} from '@lightdash/common';
 import { type FC } from 'react';
 import MantineModal from '../../../components/common/MantineModal';
 import useApp from '../../../providers/App/useApp';
@@ -23,6 +27,11 @@ const ChartTypeDeleteModal: FC<Props> = ({
 
     const { mutateAsync: deleteApp, isLoading: isDeleting } = useDeleteApp();
 
+    // Registry-official chart types are "uninstalled" (they can be
+    // reinstalled from the library); the underlying operation is the same
+    // app delete either way.
+    const isOfficial = isOfficialChartType(dataAppViz);
+
     const description = softDeleteEnabled
         ? `This chart type will be moved to Recently deleted and permanently removed after ${retentionDays} days.`
         : 'This chart type and all of its versions will be permanently deleted, including any built artifacts in storage.';
@@ -31,7 +40,8 @@ const ChartTypeDeleteModal: FC<Props> = ({
         <MantineModal
             opened
             onClose={onClose}
-            title="Delete chart type"
+            title={isOfficial ? 'Uninstall chart type' : 'Delete chart type'}
+            confirmLabel={isOfficial ? 'Uninstall' : undefined}
             variant="delete"
             resourceType="chart type"
             resourceLabel={getAppDisplayName(
@@ -43,7 +53,9 @@ const ChartTypeDeleteModal: FC<Props> = ({
                 await deleteApp({
                     projectUuid,
                     appUuid: dataAppViz.dataAppVizUuid,
-                    successTitle: 'Chart type deleted',
+                    successTitle: isOfficial
+                        ? 'Chart type uninstalled'
+                        : 'Chart type deleted',
                 });
                 onDeleted();
             }}

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeDetailModal.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeDetailModal.tsx
@@ -82,7 +82,7 @@ const ChartTypeDetailModal: FC<Props> = ({
                             leftSection={<MantineIcon icon={IconTrash} />}
                             onClick={onDelete}
                         >
-                            Delete
+                            {isOfficial ? 'Uninstall' : 'Delete'}
                         </Button>
                     )
                 }

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeLibraryDetailModal.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeLibraryDetailModal.tsx
@@ -21,9 +21,9 @@ import { useTimeAgo } from '../../../hooks/useTimeAgo';
 import { Can } from '../../../providers/Ability';
 import useApp from '../../../providers/App/useApp';
 import { useCanEditDataApp } from '../../apps/hooks/useCanEditDataApp';
-import ChartTypeBetaBadge from './ChartTypeBetaBadge';
 import { useInstallRegistryChartType } from '../hooks/useInstallRegistryChartType';
 import { registryAssetUrl } from '../utils/registryAssetUrl';
+import ChartTypeBetaBadge from './ChartTypeBetaBadge';
 import classes from './ChartTypeLibraryDetailModal.module.css';
 import ChartTypeUninstallModal from './ChartTypeUninstallModal';
 import DataAppVizFieldTypeBadge from './DataAppVizFieldTypeBadge';
@@ -104,18 +104,14 @@ const ChartTypeLibraryDetailModal: FC<Props> = ({
                 };
             case 'update_available':
                 return {
-                    actions: (
-                        <Group gap="sm" wrap="nowrap">
-                            {uninstallButton}
-                            {canInstallGate(
-                                <Button
-                                    loading={installMutation.isLoading}
-                                    onClick={handleInstall}
-                                >
-                                    Upgrade to v{item.version}
-                                </Button>,
-                            )}
-                        </Group>
+                    leftActions: uninstallButton,
+                    actions: canInstallGate(
+                        <Button
+                            loading={installMutation.isLoading}
+                            onClick={handleInstall}
+                        >
+                            Upgrade to v{item.version}
+                        </Button>,
                     ),
                 };
             case 'installed':

--- a/packages/frontend/src/pages/ChartTypeGallery.test.tsx
+++ b/packages/frontend/src/pages/ChartTypeGallery.test.tsx
@@ -295,6 +295,34 @@ describe('ChartTypeGallery', () => {
         expect(screen.getByText('Delete chart type')).toBeInTheDocument();
     });
 
+    it('labels the action Uninstall for official chart types', async () => {
+        setData([makeDataAppViz({ registrySlug: 'radial-gauge' })]);
+        renderPage();
+
+        fireEvent.click(screen.getByText('Radial gauge'));
+        expect(
+            screen.queryByRole('button', { name: 'Delete' }),
+        ).not.toBeInTheDocument();
+        fireEvent.click(screen.getByRole('button', { name: 'Uninstall' }));
+
+        expect(screen.getByText('Uninstall chart type')).toBeInTheDocument();
+
+        // Both modals are open and both buttons say Uninstall; the confirm
+        // modal portals in after the detail modal, so its CTA is last.
+        const uninstallButtons = screen.getAllByRole('button', {
+            name: 'Uninstall',
+        });
+        fireEvent.click(uninstallButtons[uninstallButtons.length - 1]);
+
+        await waitFor(() =>
+            expect(mockedDeleteApp).toHaveBeenCalledWith({
+                projectUuid: 'project-1',
+                appUuid: 'data-app-viz-1',
+                successTitle: 'Chart type uninstalled',
+            }),
+        );
+    });
+
     it('hides edit and delete actions from non-editors', () => {
         vi.mocked(useCanEditDataApp).mockReturnValue(false);
         setData([makeDataAppViz({})]);


### PR DESCRIPTION
Second PR in the library-polish stack (on top of #28649).

Removing an installed official chart type looked different depending on where you opened it: the library detail modal (update-available state) put **Uninstall** in the right-side actions next to Cancel, while the gallery detail modal showed a left-aligned **Delete**. Now:

- Library detail modal: Uninstall moves to `leftActions` in the update-available state (the installed state already had it there).
- Gallery detail modal: the left action reads **Uninstall** for registry-official chart types (`isOfficialChartType`); plain custom chart types keep **Delete**.
- The shared confirm modal follows suit for officials — "Uninstall chart type" title, Uninstall CTA, "Chart type uninstalled" toast — self-detected from `registrySlug`, no prop plumbing. The underlying app delete is unchanged.

## Testing

New gallery-page test: official chart type shows Uninstall (no Delete), confirm modal carries the uninstall copy, delete mutation fires with the uninstall toast. 199/199 chartTypes+gallery tests pass; frontend typecheck clean.

Relates: GLITCH-753

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8sCUbSEj5R8babs36CnDN