### PR TITLE
fix(warehouses): retry databricks operations while the SQL warehouse starts

### DIFF
--- a/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.test.ts
@@ -28,35 +28,93 @@ vi.mock('@databricks/sql', async () => ({
     }),
 }));
 
+const statusError = (errorMessage: string) =>
+    new StatusError({ statusCode: TStatusCode.ERROR_STATUS, errorMessage });
+const sessionLostError = () =>
+    statusError(
+        'requirement failed: Session handle: SessionHandle [01f19fd1-ac81-1e09-bb7c-357018ed26f1] has not been initialized or had already closed.',
+    );
+const sessionLostMessage = sessionLostError().message;
+
+type MockFn = ReturnType<typeof vi.fn>;
+type OperationOverrides = Partial<
+    Record<'getSchema' | 'fetchChunk' | 'fetchAll' | 'hasMoreRows', MockFn>
+>;
+type SessionOverrides = Partial<
+    Record<'executeStatement' | 'getColumns', MockFn>
+>;
+
+const createOperation = (overrides: OperationOverrides = {}) => ({
+    getSchema: vi.fn(async () => schema),
+    fetchChunk: mocks.fetchChunk,
+    fetchAll: vi.fn(async () => []),
+    hasMoreRows: vi.fn(async () => false),
+    close: vi.fn(async () => undefined),
+    ...overrides,
+});
+
+const createSession = (overrides: SessionOverrides = {}) => ({
+    executeStatement: vi.fn(async () => createOperation()),
+    getColumns: vi.fn(async () => createOperation()),
+    close: vi.fn(async () => undefined),
+    ...overrides,
+});
+
+// Retries sleep with real backoff; drive the timers while the promise settles.
+const withTimers = async <T>(run: () => Promise<T>): Promise<T> => {
+    const settled = run().then(
+        (value) => ({ ok: true as const, value }),
+        (error: unknown) => ({ ok: false as const, error }),
+    );
+    await vi.runAllTimersAsync();
+    const result = await settled;
+    if (result.ok) return result.value;
+    throw result.error;
+};
+
+const tableRequest = (table: string) => ({
+    database: 'database',
+    schema: 'schema',
+    table,
+});
+
 describe('DatabricksWarehouseClient', () => {
     beforeEach(() => {
+        vi.useFakeTimers();
+        vi.spyOn(console, 'warn').mockImplementation(() => {});
         mocks.fetchChunk.mockReset().mockResolvedValue(rows);
         mocks.closeConnection.mockReset().mockResolvedValue(undefined);
-        mocks.openSession.mockReset().mockResolvedValue({
-            executeStatement: vi.fn(() => ({
-                getSchema: vi.fn(async () => schema),
-                fetchChunk: mocks.fetchChunk,
-                hasMoreRows: vi.fn(async () => false),
-                close: vi.fn(async () => undefined),
-            })),
-            close: vi.fn(async () => undefined),
-        });
+        mocks.openSession.mockReset().mockResolvedValue(createSession());
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.restoreAllMocks();
     });
 
     it('surfaces Databricks status messages when opening a session fails', async () => {
         const message =
-            'SQL warehouse xyz is not ready to accept connections (current state: STARTING)';
-        mocks.openSession.mockRejectedValueOnce(
-            new StatusError({
-                statusCode: TStatusCode.ERROR_STATUS,
-                errorMessage: message,
-            }),
-        );
+            'PERMISSION_DENIED: User does not have USE CATALOG on Catalog';
+        mocks.openSession.mockRejectedValueOnce(statusError(message));
         const warehouse = new DatabricksWarehouseClient(credentials);
 
         await expect(warehouse.runQuery('fake sql')).rejects.toMatchObject({
             message,
         });
+        expect(mocks.openSession).toHaveBeenCalledOnce();
+    });
+
+    it('retries opening a session while the warehouse is starting, then surfaces the error', async () => {
+        const message =
+            'SQL warehouse xyz is not ready to accept connections (current state: STARTING)';
+        mocks.openSession.mockRejectedValue(statusError(message));
+        const warehouse = new DatabricksWarehouseClient(credentials);
+
+        await expect(
+            withTimers(() => warehouse.runQuery('fake sql')),
+        ).rejects.toMatchObject({ message });
+        // 2+4+8+16 then 30s waits fit 23 retries in the 10 minute deadline
+        expect(mocks.openSession).toHaveBeenCalledTimes(24);
     });
 
     it('expect query fields and rows', async () => {
@@ -74,6 +132,249 @@ describe('DatabricksWarehouseClient', () => {
         await warehouse.runQuery('fake sql');
 
         expect(mocks.fetchChunk).toHaveBeenCalledWith({ maxRows: 5000 });
+    });
+
+    describe('session lost before rows are streamed', () => {
+        it('reopens the session and re-runs the query', async () => {
+            const firstSession = createSession({
+                executeStatement: vi.fn(() =>
+                    Promise.reject(sessionLostError()),
+                ),
+            });
+            mocks.openSession
+                .mockResolvedValueOnce(firstSession)
+                .mockResolvedValueOnce(createSession());
+            const warehouse = new DatabricksWarehouseClient(credentials);
+
+            const results = await withTimers(() =>
+                warehouse.runQuery('fake sql'),
+            );
+
+            expect(results.rows).toEqual(rows);
+            expect(mocks.openSession).toHaveBeenCalledTimes(2);
+            expect(firstSession.close).toHaveBeenCalledOnce();
+        });
+
+        it('re-runs the query when only an empty chunk was emitted', async () => {
+            mocks.openSession
+                .mockResolvedValueOnce(
+                    createSession({
+                        executeStatement: vi.fn(async () =>
+                            createOperation({
+                                fetchChunk: vi.fn(async () => []),
+                                hasMoreRows: vi.fn(() =>
+                                    Promise.reject(sessionLostError()),
+                                ),
+                            }),
+                        ),
+                    }),
+                )
+                .mockResolvedValueOnce(createSession());
+            const warehouse = new DatabricksWarehouseClient(credentials);
+
+            const results = await withTimers(() =>
+                warehouse.runQuery('fake sql'),
+            );
+
+            expect(results.rows).toEqual(rows);
+            expect(mocks.openSession).toHaveBeenCalledTimes(2);
+        });
+
+        it('gives up once the retry budget is spent', async () => {
+            mocks.openSession.mockResolvedValue(
+                createSession({
+                    executeStatement: vi.fn(() =>
+                        Promise.reject(sessionLostError()),
+                    ),
+                }),
+            );
+            const warehouse = new DatabricksWarehouseClient(credentials);
+
+            await expect(
+                withTimers(() => warehouse.runQuery('fake sql')),
+            ).rejects.toMatchObject({ message: sessionLostMessage });
+            expect(mocks.openSession).toHaveBeenCalledTimes(24);
+        });
+    });
+
+    it('does not re-run the query once rows have been streamed', async () => {
+        const streamCallback = vi.fn();
+        mocks.openSession.mockResolvedValueOnce(
+            createSession({
+                executeStatement: vi.fn(async () =>
+                    createOperation({
+                        hasMoreRows: vi.fn(() =>
+                            Promise.reject(sessionLostError()),
+                        ),
+                    }),
+                ),
+            }),
+        );
+        const warehouse = new DatabricksWarehouseClient(credentials);
+
+        await expect(
+            withTimers(() =>
+                warehouse.streamQuery('fake sql', streamCallback, {}),
+            ),
+        ).rejects.toMatchObject({ message: sessionLostMessage });
+        expect(streamCallback).toHaveBeenCalledOnce();
+        expect(mocks.openSession).toHaveBeenCalledOnce();
+    });
+
+    it('does not retry SQL errors', async () => {
+        mocks.openSession.mockResolvedValueOnce(
+            createSession({
+                executeStatement: vi.fn(() =>
+                    Promise.reject(statusError('Syntax error near FROM')),
+                ),
+            }),
+        );
+        const warehouse = new DatabricksWarehouseClient(credentials);
+
+        await expect(
+            withTimers(() => warehouse.runQuery('fake sql')),
+        ).rejects.toMatchObject({ message: 'Syntax error near FROM' });
+        expect(mocks.openSession).toHaveBeenCalledOnce();
+    });
+
+    describe('getCatalog', () => {
+        const columns = (name: string, type: string) => [
+            { COLUMN_NAME: name, TYPE_NAME: type },
+        ];
+        const columnsSession = (
+            resolve: (
+                table: string,
+            ) => { COLUMN_NAME: string; TYPE_NAME: string }[],
+            lostTables: Set<string>,
+        ) =>
+            createSession({
+                getColumns: vi.fn(
+                    async ({ tableName }: { tableName: string }) =>
+                        lostTables.has(tableName)
+                            ? Promise.reject(sessionLostError())
+                            : createOperation({
+                                  fetchAll: vi.fn(async () =>
+                                      resolve(tableName),
+                                  ),
+                              }),
+                ),
+            });
+
+        it('resumes the remaining tables on a replacement session', async () => {
+            const firstSession = columnsSession(
+                () => columns('id', 'BIGINT'),
+                new Set(['table_two', 'table_three']),
+            );
+            const secondSession = columnsSession(
+                () => columns('name', 'STRING'),
+                new Set(),
+            );
+            mocks.openSession
+                .mockResolvedValueOnce(firstSession)
+                .mockResolvedValueOnce(secondSession);
+            const warehouse = new DatabricksWarehouseClient(credentials);
+
+            const catalog = await withTimers(() =>
+                warehouse.getCatalog([
+                    tableRequest('table_one'),
+                    tableRequest('table_two'),
+                    tableRequest('table_three'),
+                ]),
+            );
+
+            expect(catalog.DEFAULT.schema).toEqual({
+                table_one: { id: 'number' },
+                table_two: { name: 'string' },
+                table_three: { name: 'string' },
+            });
+            expect(firstSession.getColumns).toHaveBeenCalledTimes(3);
+            expect(firstSession.close).toHaveBeenCalledOnce();
+            expect(
+                secondSession.getColumns.mock.calls.map(
+                    (call) => (call[0] as { tableName: string }).tableName,
+                ),
+            ).toEqual(['table_two', 'table_three']);
+        });
+
+        it('lets the in-flight batch settle before closing the lost session', async () => {
+            const order: string[] = [];
+            const firstSession = createSession({
+                getColumns: vi.fn(
+                    ({ tableName }: { tableName: string }) =>
+                        new Promise((resolve, reject) => {
+                            setTimeout(
+                                () => {
+                                    order.push(`getColumns:${tableName}`);
+                                    reject(sessionLostError());
+                                },
+                                tableName === 'table_one' ? 10 : 100,
+                            );
+                        }),
+                ),
+            });
+            firstSession.close.mockImplementation(async () => {
+                order.push('close');
+            });
+            mocks.openSession
+                .mockResolvedValueOnce(firstSession)
+                .mockResolvedValueOnce(createSession());
+            const warehouse = new DatabricksWarehouseClient(credentials);
+
+            await withTimers(() =>
+                warehouse.getCatalog([
+                    tableRequest('table_one'),
+                    tableRequest('table_two'),
+                ]),
+            );
+
+            expect(order).toEqual([
+                'getColumns:table_one',
+                'getColumns:table_two',
+                'close',
+            ]);
+        });
+
+        it('shares one retry budget across the whole fetch', async () => {
+            mocks.openSession.mockResolvedValue(
+                columnsSession(() => [], new Set(['table_one'])),
+            );
+            const warehouse = new DatabricksWarehouseClient(credentials);
+
+            await expect(
+                withTimers(() =>
+                    warehouse.getCatalog([tableRequest('table_one')]),
+                ),
+            ).rejects.toMatchObject({ message: sessionLostMessage });
+            expect(mocks.openSession).toHaveBeenCalledTimes(24);
+        });
+
+        it('fails fast on errors that are not warehouse startup errors', async () => {
+            const session = createSession({
+                getColumns: vi.fn(
+                    async ({ tableName }: { tableName: string }) =>
+                        tableName === 'table_two'
+                            ? Promise.reject(
+                                  statusError('PERMISSION_DENIED on table_two'),
+                              )
+                            : createOperation(),
+                ),
+            });
+            mocks.openSession.mockResolvedValueOnce(session);
+            const warehouse = new DatabricksWarehouseClient(credentials);
+
+            await expect(
+                withTimers(() =>
+                    warehouse.getCatalog([
+                        tableRequest('table_one'),
+                        tableRequest('table_two'),
+                    ]),
+                ),
+            ).rejects.toMatchObject({
+                message: 'PERMISSION_DENIED on table_two',
+            });
+            expect(mocks.openSession).toHaveBeenCalledOnce();
+            expect(session.close).toHaveBeenCalledOnce();
+        });
     });
 });
 

--- a/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.ts
@@ -27,11 +27,12 @@ import {
 } from '@lightdash/common';
 import fetch from 'node-fetch';
 import { WarehouseCatalog } from '../types';
-import {
-    DEFAULT_BATCH_SIZE,
-    processPromisesInBatches,
-} from '../utils/processPromisesInBatches';
+import { DEFAULT_BATCH_SIZE } from '../utils/processPromisesInBatches';
 import { normalizeUnicode } from '../utils/sql';
+import {
+    DatabricksWarehouseStartupRetry,
+    isDatabricksWarehouseStartingError,
+} from './DatabricksWarehouseStartupRetry';
 import WarehouseBaseClient from './WarehouseBaseClient';
 import WarehouseBaseSqlBuilder from './WarehouseBaseSqlBuilder';
 
@@ -299,6 +300,20 @@ const getDatabricksErrorMessage = (error: unknown) =>
         ? error.message
         : getErrorMessage(error);
 
+// Don't let close errors override the original error
+const closeQuietly = async (close: () => Promise<void>, context: string) => {
+    try {
+        await close();
+    } catch (e: unknown) {
+        console.error(`Error closing Databricks session on ${context}`, e);
+    }
+};
+
+type DatabricksSession = {
+    session: IDBSQLSession;
+    close: () => Promise<void>;
+};
+
 export class DatabricksWarehouseClient extends WarehouseBaseClient<CreateDatabricksCredentials> {
     schema: string;
 
@@ -357,7 +372,9 @@ export class DatabricksWarehouseClient extends WarehouseBaseClient<CreateDatabri
         }
     }
 
-    private async getSession() {
+    private async openSession(
+        retry: DatabricksWarehouseStartupRetry,
+    ): Promise<DatabricksSession> {
         const client = new DBSQLClient({});
         let connection: IDBSQLClient;
         let session: IDBSQLSession;
@@ -382,41 +399,39 @@ export class DatabricksWarehouseClient extends WarehouseBaseClient<CreateDatabri
                     closeError,
                 );
             }
+            if (await retry.waitBeforeRetry(e)) {
+                return this.openSession(retry);
+            }
             throw new WarehouseConnectionError(getDatabricksErrorMessage(e));
         }
 
         return {
             session,
             close: async () => {
-                await session.close();
-                await connection.close();
+                try {
+                    await session.close();
+                } finally {
+                    await connection.close();
+                }
             },
         };
     }
 
-    async streamQuery(
+    private async streamQueryOnSession(
+        session: IDBSQLSession,
         sql: string,
         streamCallback: (data: WarehouseResults) => void | Promise<void>,
         options: {
             values?: AnyType[];
-            tags?: Record<string, string>;
             timezone?: string;
         },
+        onRowsStreamed: () => void,
     ): Promise<void> {
-        const { session, close } = await this.getSession();
         let query: IOperation | null = null;
-
-        let alteredQuery = sql;
-        if (options?.tags) {
-            alteredQuery = `${alteredQuery}\n-- ${JSON.stringify(
-                options?.tags,
-            )}`;
-        }
-
         try {
-            if (options?.timezone) {
+            if (options.timezone) {
                 console.debug(
-                    `Setting databricks timezone to ${options?.timezone}`,
+                    `Setting databricks timezone to ${options.timezone}`,
                 );
                 const setTimezoneOp = await session.executeStatement(
                     `SET TIME ZONE '${options.timezone}'`,
@@ -428,15 +443,15 @@ export class DatabricksWarehouseClient extends WarehouseBaseClient<CreateDatabri
                 }
             }
 
-            query = await session.executeStatement(alteredQuery, {
+            query = await session.executeStatement(sql, {
                 ...(this.enableTimeouts && {
                     queryTimeout: DATABRICKS_QUERY_TIMEOUT_SECONDS,
                 }),
-                ordinalParameters: options?.values,
+                ordinalParameters: options.values,
             });
 
-            const schema = await query.getSchema();
-            const fields = (schema?.columns ?? []).reduce<
+            const querySchema = await query.getSchema();
+            const fields = (querySchema?.columns ?? []).reduce<
                 Record<string, { type: DimensionType }>
             >(
                 (acc, column) => ({
@@ -456,20 +471,84 @@ export class DatabricksWarehouseClient extends WarehouseBaseClient<CreateDatabri
                 const chunk = await query.fetchChunk({
                     maxRows: DATABRICKS_FETCH_CHUNK_MAX_ROWS,
                 });
+                if (chunk.length > 0) onRowsStreamed();
                 // eslint-disable-next-line no-await-in-loop
                 await streamCallback({ fields, rows: chunk });
                 // eslint-disable-next-line no-await-in-loop
             } while (await query.hasMoreRows());
-        } catch (e: unknown) {
-            throw new WarehouseQueryError(getDatabricksErrorMessage(e));
         } finally {
             try {
                 if (query) await query.close();
-                await close();
             } catch (e: unknown) {
-                // Only console error. Don't allow close errors to override the original error
                 console.error(
-                    'Error closing Databricks session on streamQuery',
+                    'Error closing Databricks query on streamQuery',
+                    e,
+                );
+            }
+        }
+    }
+
+    async streamQuery(
+        sql: string,
+        streamCallback: (data: WarehouseResults) => void | Promise<void>,
+        options: {
+            values?: AnyType[];
+            tags?: Record<string, string>;
+            timezone?: string;
+        },
+    ): Promise<void> {
+        const alteredQuery = options.tags
+            ? `${sql}\n-- ${JSON.stringify(options.tags)}`
+            : sql;
+        const retry = new DatabricksWarehouseStartupRetry();
+        let rowsStreamed = false;
+        const onRowsStreamed = () => {
+            rowsStreamed = true;
+        };
+
+        /* eslint-disable no-await-in-loop */
+        for (;;) {
+            const { session, close } = await this.openSession(retry);
+            let error: unknown = null;
+            try {
+                await this.streamQueryOnSession(
+                    session,
+                    alteredQuery,
+                    streamCallback,
+                    options,
+                    onRowsStreamed,
+                );
+                return;
+            } catch (e: unknown) {
+                error = e;
+            } finally {
+                await closeQuietly(close, 'streamQuery');
+            }
+            // Re-running is only safe while nothing has reached the caller
+            if (rowsStreamed || !(await retry.waitBeforeRetry(error))) {
+                throw new WarehouseQueryError(getDatabricksErrorMessage(error));
+            }
+        }
+        /* eslint-enable no-await-in-loop */
+    }
+
+    private static async getTableColumns(
+        session: IDBSQLSession,
+        request: { database: string; schema: string; table: string },
+    ): Promise<SchemaResult[]> {
+        const query = await session.getColumns({
+            catalogName: request.database,
+            schemaName: request.schema,
+            tableName: request.table,
+        });
+        try {
+            return (await query.fetchAll()) as SchemaResult[];
+        } finally {
+            try {
+                await query.close();
+            } catch (e: unknown) {
+                console.error(
+                    'Error closing Databricks query on getCatalog',
                     e,
                 );
             }
@@ -483,61 +562,69 @@ export class DatabricksWarehouseClient extends WarehouseBaseClient<CreateDatabri
             table: string;
         }[],
     ) {
-        const { session, close } = await this.getSession();
-        let results: SchemaResult[][];
+        const retry = new DatabricksWarehouseStartupRetry();
+        const results = new Map<number, SchemaResult[]>();
+        let pending = requests.map((request, index) => ({ request, index }));
 
-        try {
-            results = await processPromisesInBatches(
-                requests,
-                DEFAULT_BATCH_SIZE,
-                async (request) => {
-                    let query: IOperation | null = null;
-                    try {
-                        query = await session.getColumns({
-                            catalogName: request.database,
-                            schemaName: request.schema,
-                            tableName: request.table,
-                        });
-                        return (await query.fetchAll()) as SchemaResult[];
-                    } catch (e: unknown) {
-                        throw new WarehouseQueryError(
-                            getDatabricksErrorMessage(e),
-                        );
-                    } finally {
-                        try {
-                            if (query) await query.close();
-                        } catch (e: unknown) {
-                            // Only console error. Don't allow close errors to override the original error
-                            console.error(
-                                'Error closing Databricks query on getCatalog',
-                                e,
+        /* eslint-disable no-await-in-loop */
+        while (pending.length > 0) {
+            const { session, close } = await this.openSession(retry);
+            // Batches run on one session; a lost session fails the rest of the batch,
+            // so let it settle, keep what succeeded and resume on a new session.
+            let startupError: unknown = null;
+            try {
+                for (
+                    let start = 0;
+                    start < pending.length && startupError === null;
+                    start += DEFAULT_BATCH_SIZE
+                ) {
+                    const batch = pending.slice(
+                        start,
+                        start + DEFAULT_BATCH_SIZE,
+                    );
+                    const settled = await Promise.allSettled(
+                        batch.map(({ request }) =>
+                            DatabricksWarehouseClient.getTableColumns(
+                                session,
+                                request,
+                            ),
+                        ),
+                    );
+                    for (const [i, outcome] of settled.entries()) {
+                        if (outcome.status === 'fulfilled') {
+                            results.set(batch[i].index, outcome.value);
+                        } else if (
+                            !isDatabricksWarehouseStartingError(outcome.reason)
+                        ) {
+                            throw new WarehouseQueryError(
+                                getDatabricksErrorMessage(outcome.reason),
                             );
+                        } else {
+                            startupError = startupError ?? outcome.reason;
                         }
                     }
-                },
-            );
-        } catch (e: unknown) {
-            throw new WarehouseQueryError(getDatabricksErrorMessage(e));
-        } finally {
-            try {
-                await close();
-            } catch (e: unknown) {
-                // Only console error. Don't allow close errors to override the original error
-                console.error(
-                    'Error closing Databricks session on getCatalog',
-                    e,
+                }
+            } finally {
+                await closeQuietly(close, 'getCatalog');
+            }
+            pending = pending.filter(({ index }) => !results.has(index));
+            if (
+                startupError !== null &&
+                !(await retry.waitBeforeRetry(startupError))
+            ) {
+                throw new WarehouseQueryError(
+                    getDatabricksErrorMessage(startupError),
                 );
             }
         }
+        /* eslint-enable no-await-in-loop */
 
         const catalog = this.catalog || 'DEFAULT';
-        return results.reduce<WarehouseCatalog>(
-            (acc, result, index) => {
-                const { schema, table } = requests[index];
-
+        return requests.reduce<WarehouseCatalog>(
+            (acc, { schema, table }, index) => {
                 acc[catalog][schema] = acc[catalog][schema] || {};
                 acc[catalog][schema][table] = {};
-                result.forEach((col) => {
+                (results.get(index) ?? []).forEach((col) => {
                     acc[catalog][schema][table][col.COLUMN_NAME] = mapFieldType(
                         col.TYPE_NAME,
                     );

--- a/packages/warehouses/src/warehouseClients/DatabricksWarehouseStartupRetry.test.ts
+++ b/packages/warehouses/src/warehouseClients/DatabricksWarehouseStartupRetry.test.ts
@@ -1,0 +1,187 @@
+import HiveDriverError from '@databricks/sql/dist/errors/HiveDriverError';
+import OperationStateError, {
+    OperationStateErrorCode,
+} from '@databricks/sql/dist/errors/OperationStateError';
+import StatusError from '@databricks/sql/dist/errors/StatusError';
+import { TStatusCode } from '@databricks/sql/thrift/TCLIService_types';
+import {
+    DATABRICKS_WAREHOUSE_STARTUP_RETRY,
+    DatabricksWarehouseStartupRetry,
+    getDatabricksWarehouseStartupRetryDelayMs,
+    isDatabricksWarehouseStartingError,
+} from './DatabricksWarehouseStartupRetry';
+
+const statusError = (errorMessage: string) =>
+    new StatusError({ statusCode: TStatusCode.ERROR_STATUS, errorMessage });
+
+const sessionHandleError = statusError(
+    'requirement failed: Session handle: SessionHandle [01f19fd1-ac81-1e09-bb7c-357018ed26f1] has not been initialized or had already closed.',
+);
+const diskDirectoryError = statusError(
+    "Couldn't create directory /local_disk0/tmp/a1b2c3d4-0000-1111-2222-333344445555/_resources",
+);
+const warehouseStartingError = statusError(
+    'SQL warehouse xyz is not ready to accept connections (current state: STARTING)',
+);
+// Pro/classic warehouse in STARTING: 503s until the driver's own HTTP retries give up
+const driverRetriesExhaustedError = new HiveDriverError(
+    'Hive driver: 503 when connecting to resource. Max retry count exceeded.',
+);
+
+describe('isDatabricksWarehouseStartingError', () => {
+    it('matches the errors Databricks returns while a SQL warehouse is stopped or starting', () => {
+        expect(isDatabricksWarehouseStartingError(sessionHandleError)).toBe(
+            true,
+        );
+        expect(isDatabricksWarehouseStartingError(diskDirectoryError)).toBe(
+            true,
+        );
+        expect(isDatabricksWarehouseStartingError(warehouseStartingError)).toBe(
+            true,
+        );
+        expect(
+            isDatabricksWarehouseStartingError(driverRetriesExhaustedError),
+        ).toBe(true);
+    });
+
+    it('does not match other HTTP failures the driver gave up on', () => {
+        expect(
+            isDatabricksWarehouseStartingError(
+                new HiveDriverError(
+                    'Hive driver: 500 when connecting to resource. Max retry count exceeded.',
+                ),
+            ),
+        ).toBe(false);
+    });
+
+    it('matches the same messages when the operation fails during polling', () => {
+        const error = new OperationStateError(OperationStateErrorCode.Error, {
+            displayMessage: diskDirectoryError.message,
+        } as ConstructorParameters<typeof OperationStateError>[1]);
+
+        expect(isDatabricksWarehouseStartingError(error)).toBe(true);
+        expect(
+            isDatabricksWarehouseStartingError(
+                new OperationStateError(OperationStateErrorCode.Timeout),
+            ),
+        ).toBe(false);
+    });
+
+    it('does not match SQL, permission or auth failures', () => {
+        expect(
+            isDatabricksWarehouseStartingError(
+                statusError(
+                    '[PARSE_SYNTAX_ERROR] Syntax error at or near FROM',
+                ),
+            ),
+        ).toBe(false);
+        expect(
+            isDatabricksWarehouseStartingError(
+                statusError(
+                    'PERMISSION_DENIED: User does not have USE SCHEMA on Schema',
+                ),
+            ),
+        ).toBe(false);
+        expect(
+            isDatabricksWarehouseStartingError(
+                new Error('Request failed with status 401: Unauthorized'),
+            ),
+        ).toBe(false);
+    });
+
+    it('only matches driver status errors, not other errors with the same text', () => {
+        expect(
+            isDatabricksWarehouseStartingError(
+                new Error(sessionHandleError.message),
+            ),
+        ).toBe(false);
+    });
+});
+
+describe('getDatabricksWarehouseStartupRetryDelayMs', () => {
+    it('backs off exponentially from 2s, capped at 30s', () => {
+        const delays = [1, 2, 3, 4, 5, 6].map((attempt) =>
+            getDatabricksWarehouseStartupRetryDelayMs(attempt, 0),
+        );
+
+        expect(delays).toEqual([2_000, 4_000, 8_000, 16_000, 30_000, 30_000]);
+    });
+
+    it('stops once the next wait would pass the deadline', () => {
+        const { deadlineMs } = DATABRICKS_WAREHOUSE_STARTUP_RETRY;
+
+        expect(
+            getDatabricksWarehouseStartupRetryDelayMs(9, deadlineMs - 30_000),
+        ).toBe(30_000);
+        expect(
+            getDatabricksWarehouseStartupRetryDelayMs(9, deadlineMs - 29_999),
+        ).toBeNull();
+    });
+});
+
+describe('DatabricksWarehouseStartupRetry', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+    });
+
+    // Drains the backoff timer so the wait resolves under fake timers
+    const waitBeforeRetry = async (
+        retry: DatabricksWarehouseStartupRetry,
+        error: unknown,
+    ) => {
+        const result = retry.waitBeforeRetry(error);
+        await vi.runAllTimersAsync();
+        return result;
+    };
+
+    it('waits with backoff before retrying a warehouse startup error', async () => {
+        const retry = new DatabricksWarehouseStartupRetry();
+
+        const start = Date.now();
+        await expect(waitBeforeRetry(retry, sessionHandleError)).resolves.toBe(
+            true,
+        );
+        expect(Date.now() - start).toBe(2_000);
+        await expect(waitBeforeRetry(retry, diskDirectoryError)).resolves.toBe(
+            true,
+        );
+        expect(Date.now() - start).toBe(6_000);
+
+        expect(console.warn).toHaveBeenCalledTimes(2);
+        expect(vi.mocked(console.warn).mock.calls[0][0]).toContain(
+            'has not been initialized',
+        );
+    });
+
+    it('does not wait for errors that are not warehouse startup errors', async () => {
+        const retry = new DatabricksWarehouseStartupRetry();
+
+        await expect(
+            retry.waitBeforeRetry(statusError('Syntax error near FROM')),
+        ).resolves.toBe(false);
+        expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it('counts time spent outside the wait against the deadline', async () => {
+        const retry = new DatabricksWarehouseStartupRetry();
+        const start = Date.now();
+
+        let retries = 0;
+        // eslint-disable-next-line no-await-in-loop
+        while (await waitBeforeRetry(retry, sessionHandleError)) {
+            retries += 1;
+            vi.advanceTimersByTime(31_000); // the driver's own HTTP retries per attempt
+        }
+
+        expect(retries).toBe(11);
+        expect(Date.now() - start).toBeLessThanOrEqual(
+            DATABRICKS_WAREHOUSE_STARTUP_RETRY.deadlineMs + 31_000,
+        );
+    });
+});

--- a/packages/warehouses/src/warehouseClients/DatabricksWarehouseStartupRetry.ts
+++ b/packages/warehouses/src/warehouseClients/DatabricksWarehouseStartupRetry.ts
@@ -1,0 +1,80 @@
+import HiveDriverError from '@databricks/sql/dist/errors/HiveDriverError';
+import OperationStateError from '@databricks/sql/dist/errors/OperationStateError';
+import StatusError from '@databricks/sql/dist/errors/StatusError';
+
+// The driver surfaces server errors with no usable code, so the message is the only
+// signal. Explicit allowlist so auth, permission and SQL errors fail fast.
+const DATABRICKS_WAREHOUSE_STARTING_MESSAGES: readonly RegExp[] = [
+    // Pro/classic: OpenSession succeeds while stopped, then every op is rejected
+    /Session handle: SessionHandle \[[^\]]*\] has not been initialized or had already closed/,
+    // Cluster nodes still booting when the session is initialised
+    /Couldn't create directory \/local_disk0\//,
+    /is not ready to accept connections \(current state: STARTING\)/,
+    // Pro/classic STARTING: 503 until up; the driver gives up after ~30s of HTTP retries
+    /^Hive driver: 503 when connecting to resource/,
+];
+
+export const isDatabricksWarehouseStartingError = (
+    error: unknown,
+): error is StatusError | HiveDriverError =>
+    (error instanceof StatusError ||
+        error instanceof OperationStateError ||
+        error instanceof HiveDriverError) &&
+    DATABRICKS_WAREHOUSE_STARTING_MESSAGES.some((pattern) =>
+        pattern.test(error.message),
+    );
+
+// Serverless starts in seconds; pro/classic take minutes and can be "Start-up Delayed".
+// The deadline is wall clock from the first failure, since each attempt also spends
+// time inside the driver's own HTTP retries.
+export const DATABRICKS_WAREHOUSE_STARTUP_RETRY = {
+    initialDelayMs: 2_000,
+    maxDelayMs: 30_000,
+    deadlineMs: 600_000,
+} as const;
+
+/** Delay before retry `attempt` (1-based), or null once the deadline would pass. */
+export const getDatabricksWarehouseStartupRetryDelayMs = (
+    attempt: number,
+    elapsedMs: number,
+): number | null => {
+    const { initialDelayMs, maxDelayMs, deadlineMs } =
+        DATABRICKS_WAREHOUSE_STARTUP_RETRY;
+    const delayMs = Math.min(initialDelayMs * 2 ** (attempt - 1), maxDelayMs);
+    return elapsedMs + delayMs <= deadlineMs ? delayMs : null;
+};
+
+const sleep = (ms: number) =>
+    new Promise<void>((resolve) => {
+        setTimeout(resolve, ms);
+    });
+
+/** One retry budget, shared across every session opened for a single operation. */
+export class DatabricksWarehouseStartupRetry {
+    private attempt = 0;
+
+    private firstFailureAt: number | null = null;
+
+    /** Waits with backoff if the error is a warehouse startup error and budget remains. */
+    async waitBeforeRetry(error: unknown): Promise<boolean> {
+        if (!isDatabricksWarehouseStartingError(error)) return false;
+        this.firstFailureAt = this.firstFailureAt ?? Date.now();
+        const elapsedMs = Date.now() - this.firstFailureAt;
+        const delayMs = getDatabricksWarehouseStartupRetryDelayMs(
+            this.attempt + 1,
+            elapsedMs,
+        );
+        if (delayMs === null) return false;
+
+        this.attempt += 1;
+        console.warn(
+            `Databricks SQL warehouse is not ready (${error.message}). Waiting ${
+                delayMs / 1000
+            }s before retry ${this.attempt} (${Math.round(elapsedMs / 1000)}s of ${
+                DATABRICKS_WAREHOUSE_STARTUP_RETRY.deadlineMs / 1000
+            }s deadline used)`,
+        );
+        await sleep(delayMs);
+        return true;
+    }
+}


### PR DESCRIPTION
## Problem

Databricks accepts `OpenSession` while a SQL warehouse is stopped or starting, then rejects every operation on that handle. On pro/classic warehouses this shows up as a Thrift `ERROR_STATUS` inside an HTTP 200 (`requirement failed: Session handle ... has not been initialized or had already closed`, or `Couldn't create directory /local_disk0/tmp/.../_resources` while nodes boot), or as HTTP 503 until the driver's own 5 HTTP retries give up after ~30 s (`Hive driver: 503 when connecting to resource. Max retry count exceeded.`). Nothing retried on top, so one cold start failed the whole compile / `lightdash deploy`. The "client closed the session immediately" seen in Databricks logs was our `finally` cleanup after the first rejected `GetColumns`, not the cause.

## Fix

Bounded retry on an explicit allowlist of cold-start errors, shared across every session opened for one operation.

```text
getCatalog(requests)
  retry = startup retry budget (2s, 4s, 8s, 16s, then 30s; 10 min wall-clock deadline)
  while tables pending
    open session                      # openSession itself retries on the same budget
    for each batch of 100 pending tables
      allSettled(getColumns)          # in-flight batch settles before we close
      store fulfilled results
      non-startup error  -> throw     # auth / permission / SQL fail fast
      startup error      -> stop batching
    close session
    if startup error: wait (logged) or throw once the deadline passes

streamQuery(sql)
  same loop, but never re-run once a non-empty chunk reached the caller
```

```mermaid
sequenceDiagram
    participant LD as Lightdash
    participant DB as Databricks
    LD->>DB: OpenSession
    DB-->>LD: handle (warehouse starting)
    LD->>DB: GetColumns x N
    DB-->>LD: 503 / ERROR_STATUS session handle not initialized
    LD->>DB: CloseSession
    Note over LD: warn "not ready, waiting 2s before retry 1 (0s of 600s deadline used)"
    LD->>DB: OpenSession
    DB-->>LD: handle (warehouse running)
    LD->>DB: GetColumns for remaining tables
    DB-->>LD: OK
```

Why message matching: the driver turns the Thrift status into a `StatusError` with `errorCode || -1`, operation-state failures into `OperationStateError` carrying only `displayMessage`, and exhausted HTTP retries into a `HiveDriverError` with the status code in the text. There is no code to key on, so the allowlist is narrow and matches those three driver classes only. The deadline is wall clock because each attempt also spends ~30 s inside the driver's HTTP retries.

## Verification

Unit tests: pure classifier/backoff tests, plus fake-timer client tests for session reopen, rows-streamed guard, catalog resume, shared budget, fail-fast on SQL/permission errors.

Real `@databricks/sql` 1.13.0 driver against a fake Thrift-over-HTTPS warehouse (10 tables, 150 ms per call):

| Scenario | main | this PR |
| -- | -- | -- |
| Warehouse stopped for whole run | fail | fail at deadline, original message surfaced |
| Cold start, warehouse up after 1.2 s | fail | ok, resumed on 2nd session |
| Cold start + `Couldn't create directory` | fail | ok, resumed on 2nd session |
| Session lost after 6/10 tables | fail | ok, remaining 4 tables resumed |

Real Databricks (staging workspace):

| Warehouse | Scenario | Result |
| -- | -- | -- |
| Serverless, STOPPED | `getCatalog` 19 tables | ok in 8.7 s; `GetColumns` blocks until started, no error, no retry needed |
| Serverless, RUNNING | bad SQL | fails in 1.6 s with the SQL error, one session, no retry |
| Serverless, RUNNING | stop API mid 114-table fetch | fetch still completes, serverless never drops the session |
| PRO non-serverless, STARTING | `getCatalog` on main | fails at 32 s: `Hive driver: 503 ... Max retry count exceeded` |
| PRO non-serverless, STARTING | `getCatalog` on this PR | 11 logged retries on the 503 path, then the same 503 surfaced at the 10 min deadline (the test cluster never got AWS capacity, so recovery could not be observed live) |

So the cold-start failure is specific to pro/classic warehouses; serverless queues operations server-side. Cold start from STOPPED on a pro warehouse, and the exact session-handle message, could not be reproduced live in staging.

Supersedes #27957.

Closes: PROD-10521
Closes: #27953
