### PR TITLE
chore(rainbow): seed the Jaffle shop warehouse into the base image

### DIFF
--- a/rainbow.toml
+++ b/rainbow.toml
@@ -74,8 +74,23 @@ EMAIL_SMTP_SENDER_EMAIL = "noreply@lightdash.local"
 # LIGHTDASH_MODE=pr; LIGHTDASH_MODE=development here, so set it outright.
 LIGHTDASH_PREVIEW_FEATURE_FLAGS_ENABLED = "true"
 
+# Two seeds, in the order CONTRIBUTING gives them. First the warehouse the
+# seeded project points at: dbt loads examples/full-jaffle-shop-demo into the
+# `jaffle` schema of the same Postgres. That is scripts/seed-jaffle.sh spelled
+# out rather than called, because the script pins dbt1.7 and the image carries
+# dbt1.12 — the version the seeded project itself compiles with. Then the
+# application database: the org, the admin user, the Jaffle shop project and
+# its charts and dashboards; the migrate rung has already run by now.
+#
+# Both are needed. With only the second, an environment boots looking seeded —
+# project, charts and dashboards all present — and every query against it fails
+# with `relation "jaffle.orders" does not exist`.
 [seed]
-run = "pnpm -F backend seed"       # the migrate rung has already run by now
+run = """
+dbt1.12 deps --project-dir examples/full-jaffle-shop-demo/dbt --profiles-dir examples/full-jaffle-shop-demo/profiles &&
+dbt1.12 seed --project-dir examples/full-jaffle-shop-demo/dbt --profiles-dir examples/full-jaffle-shop-demo/profiles --full-refresh &&
+dbt1.12 run --project-dir examples/full-jaffle-shop-demo/dbt --profiles-dir examples/full-jaffle-shop-demo/profiles --full-refresh --exclude fanouts_sales_targets &&
+pnpm -F backend seed"""
 env = { LIGHTDASH_LICENSE_KEY = "dummy-build-key" }  # loaded by the config; enables nothing
 
 # Readiness, in the app's own frame. http polls during boot; paints drives


### PR DESCRIPTION
## The bug

`[seed]` in `rainbow.toml` ran one command:

```toml
run = "pnpm -F backend seed"
```

That is `knex seed:run` — the **application** database. It creates the org, the admin user, the Jaffle shop project, and every chart and dashboard. The project it creates points at schema `jaffle` of the same Postgres (`01_initial_user.ts`), and nothing ever created that schema.

So a preview boots looking fully seeded, and the first warehouse query fails. Reproduced just now against a live PR environment:

```
$ POST /api/v1/projects/3675b69e.../sqlQuery {"sql":"select count(*) from jaffle.orders"}
{"status":"error","error":{"name":"WarehouseQueryError",
 "message":"relation \"jaffle.orders\" does not exist"}}
```

`select nspname from pg_namespace` in a fresh fork lists `public`, `graphile_worker` and the system schemas. No `jaffle`.

## The fix

Run both seeds, in the order [CONTRIBUTING](.github/CONTRIBUTING.md) gives them: the demo warehouse first, then the app database. The dbt commands are `scripts/seed-jaffle.sh` spelled out rather than called, because that script pins `dbt1.7` and the base image carries `dbt1.12` — the version the seeded project itself compiles with (`SupportedDbtVersions.V1_12`).

Order matters beyond taste: the backend seed's project compile does a `warehouseCatalogFetch`, so it wants the warehouse already there.

## Verification

In a fork of the current parent (`p-01dc80` @ `393e2de`), running the new seed block's four commands in order finished `EXIT=0`, and then:

- `select count(*) from jaffle.orders` → `151`
- metric query on the `orders` explore → `completed 97`, `shipped 26`, `placed …`

The same queries against an untouched fork fail as above.

The generated compile script was rendered from this file and shell-syntax-checked; the multi-line `run` survives the TOML → `chroot bash -c` path intact, and the script runs under `set -euo pipefail`, so a failed load fails the build rather than shipping an empty warehouse again.

## Cost

The warehouse load is about 2.5 minutes (46 seeds, ~150s; 62 models, ~2s), paid once per base-image compile, not per preview. Merging this changes the image declaration, so the daemon recompiles the base and cold-boots the next parent by itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)