### PR TITLE
fix(merge): surface a forbidden result source as forbidden, not unavailable

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -48,6 +48,8 @@ import type { SshTunnel } from '@lightdash/warehouses';
 import ExecutionContext from 'node-execution-context';
 import { Readable } from 'stream';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
+import { fromJwt } from '../../auth/account/account';
+import { defaultJwtToken } from '../../auth/account/account.mock';
 import type { S3CacheClient } from '../../clients/Aws/S3CacheClient';
 import EmailClient from '../../clients/EmailClient/EmailClient';
 import type { FileStorageClient } from '../../clients/FileStorage/FileStorageClient';
@@ -5918,6 +5920,29 @@ describe('runDuckdbQuery', () => {
     });
 });
 
+// An explore whose base table is row-filtered by a user attribute, so a
+// different attribute value is a different WHERE clause in the compiled SQL
+const attributeScopedExplore: Explore = {
+    ...validExplore,
+    tables: {
+        ...validExplore.tables,
+        a: {
+            ...validExplore.tables.a,
+            sqlWhere: 'region = ${lightdash.attribute.region}',
+            dimensions: {
+                ...validExplore.tables.a.dimensions,
+                region_param: {
+                    ...validExplore.tables.a.dimensions.dim1,
+                    name: 'region_param',
+                    label: 'region_param',
+                    sql: '${ld.parameters.region}',
+                    compiledSql: '${ld.parameters.region}',
+                },
+            },
+        },
+    },
+};
+
 describe('executeAsyncMergeQuery on the compose engine', () => {
     const SOURCE_ROW_CAP = 3;
     // Lowered through config rather than by seeding cap-many rows: the run
@@ -6061,6 +6086,37 @@ describe('executeAsyncMergeQuery on the compose engine', () => {
         limit: 500,
     };
 
+    // Both sources over the attribute-scoped explore, so each leg compiles
+    // its own row filter from the submission's overrides
+    const attributeScopedMergeQuery: MergeQuery = {
+        ...mergeQuery,
+        sources: [
+            {
+                id: 'a',
+                metricQuery: {
+                    ...metricQueryMock,
+                    exploreName: 'orders',
+                    dimensions: ['a_dim1'],
+                    metrics: [],
+                    tableCalculations: [],
+                },
+            },
+            {
+                id: 'b',
+                metricQuery: {
+                    ...metricQueryMock,
+                    exploreName: 'payments',
+                    dimensions: ['a_dim1'],
+                    metrics: [],
+                    tableCalculations: [],
+                },
+            },
+        ],
+        joinKey: [
+            { name: 'dim1', fieldIdBySourceId: { a: 'a_dim1', b: 'a_dim1' } },
+        ],
+    };
+
     const legHistory = (queryUuid: string, totalRowCount: number) =>
         ({
             queryUuid,
@@ -6078,7 +6134,18 @@ describe('executeAsyncMergeQuery on the compose engine', () => {
             metricQuery: metricQueryMock,
         }) as unknown as QueryHistory;
 
-    const buildService = ({
+    const legResultByExploreName = (exploreName: string) =>
+        exploreName === 'orders'
+            ? {
+                  queryUuid: legQueryUuidBySourceId.a,
+                  cacheMetadata: { cacheHit: true },
+              }
+            : {
+                  queryUuid: legQueryUuidBySourceId.b,
+                  cacheMetadata: { cacheHit: false },
+              };
+
+    const createComposeService = ({
         config,
         legRowCount,
     }: {
@@ -6119,18 +6186,6 @@ describe('executeAsyncMergeQuery on the compose engine', () => {
             service as AnyType,
             'getMergeFieldTypesForQuery',
         ).mockResolvedValue(fieldTypes);
-        vi.spyOn(service, 'executeAsyncMetricQuery').mockImplementation(
-            async ({ metricQuery }) =>
-                (metricQuery.exploreName === 'orders'
-                    ? {
-                          queryUuid: legQueryUuidBySourceId.a,
-                          cacheMetadata: { cacheHit: true },
-                      }
-                    : {
-                          queryUuid: legQueryUuidBySourceId.b,
-                          cacheMetadata: { cacheHit: false },
-                      }) as never,
-        );
         const runWarehouseQuery = vi
             .spyOn(service, 'runAsyncWarehouseQuery')
             .mockResolvedValue(undefined);
@@ -6145,6 +6200,61 @@ describe('executeAsyncMergeQuery on the compose engine', () => {
             create: service.queryHistoryModel.create as import('vitest').Mock,
             update: service.queryHistoryModel.update as import('vitest').Mock,
         };
+    };
+
+    const buildService = (args: {
+        config: LightdashConfig;
+        legRowCount: number;
+    }) => {
+        const built = createComposeService(args);
+        vi.spyOn(built.service, 'executeAsyncMetricQuery').mockImplementation(
+            async ({ metricQuery }) =>
+                legResultByExploreName(metricQuery.exploreName) as never,
+        );
+        return built;
+    };
+
+    // Legs compile for real against the attribute-scoped explore; only the
+    // execution tail is captured, so each leg's compiled SQL is observable
+    const buildServiceWithCompiledLegs = () => {
+        const built = createComposeService({
+            config: lightdashConfigMock,
+            legRowCount: 2,
+        });
+        const { service } = built;
+        vi.spyOn(
+            service as AnyType,
+            'assertCustomSqlAuthorizedForQuery',
+        ).mockResolvedValue(undefined);
+        service.getExploreWithUserAccessControls = vi.fn(
+            async (
+                _account: Account,
+                _projectUuid: string,
+                exploreName: string,
+            ) => ({
+                explore: { ...attributeScopedExplore, name: exploreName },
+                userAccessControls: {
+                    userAttributes: { region: ['base'] },
+                    intrinsicUserAttributes: {},
+                },
+            }),
+        );
+        (service as AnyType).getWarehouseCredentials = vi
+            .fn()
+            .mockResolvedValue(warehouseClientMock.credentials);
+        const executeAsyncQuery = vi.fn(
+            async ({ queryComposer }: { queryComposer: QueryComposer }) =>
+                legResultByExploreName(
+                    queryComposer.getMetricQuery().exploreName,
+                ),
+        );
+        service['executeAsyncQuery'] = executeAsyncQuery as never;
+        const compiledLegs = () =>
+            executeAsyncQuery.mock.calls.map(([{ queryComposer }]) => ({
+                exploreName: queryComposer.getMetricQuery().exploreName,
+                sql: queryComposer.getSql({ columnLimit: 100 }),
+            }));
+        return { ...built, executeAsyncQuery, compiledLegs };
     };
 
     afterEach(() => {
@@ -6303,6 +6413,43 @@ describe('executeAsyncMergeQuery on the compose engine', () => {
             expect.anything(),
         );
     });
+
+    it("compiles every leg with the submission's user attribute overrides, a different query per override", async () => {
+        const { service, executeAsyncQuery, compiledLegs } =
+            buildServiceWithCompiledLegs();
+        const submit = (region: string) =>
+            service.executeAsyncMergeQuery({
+                account: sessionAccount,
+                projectUuid,
+                mergeQuery: attributeScopedMergeQuery,
+                context: QueryExecutionContext.EXPLORE,
+                mode: { type: 'interactive' },
+                userAttributeOverrides: { region: [region] },
+            });
+
+        const eu = await submit('EU');
+        const us = await submit('US');
+
+        expect(eu.outcome).toBe('started');
+        expect(us.outcome).toBe('started');
+        expect(executeAsyncQuery).toHaveBeenCalledTimes(4);
+        const legs = compiledLegs();
+        const [euLegs, usLegs] = [legs.slice(0, 2), legs.slice(2)];
+        for (const exploreName of ['orders', 'payments']) {
+            const euSql = euLegs.find(
+                (leg) => leg.exploreName === exploreName,
+            )?.sql;
+            const usSql = usLegs.find(
+                (leg) => leg.exploreName === exploreName,
+            )?.sql;
+            expect(euSql).toContain("region = 'EU'");
+            expect(usSql).toContain("region = 'US'");
+            expect(euSql).not.toEqual(usSql);
+            // The override replaces the account's own value rather than adding to it
+            expect(euSql).not.toContain('base');
+            expect(usSql).not.toContain('base');
+        }
+    });
 });
 
 /**
@@ -6312,27 +6459,6 @@ describe('executeAsyncMergeQuery on the compose engine', () => {
  * value lands in the SQL, and a missing one refuses.
  */
 describe('query sources carry the execution context', () => {
-    const attributeScopedExplore: Explore = {
-        ...validExplore,
-        tables: {
-            ...validExplore.tables,
-            a: {
-                ...validExplore.tables.a,
-                sqlWhere: 'region = ${lightdash.attribute.region}',
-                dimensions: {
-                    ...validExplore.tables.a.dimensions,
-                    region_param: {
-                        ...validExplore.tables.a.dimensions.dim1,
-                        name: 'region_param',
-                        label: 'region_param',
-                        sql: '${ld.parameters.region}',
-                        compiledSql: '${ld.parameters.region}',
-                    },
-                },
-            },
-        },
-    };
-
     const submissionDefaults: Omit<SubmitSourceQueryArgs, 'query'> = {
         account: sessionAccount,
         projectUuid,
@@ -6786,4 +6912,77 @@ describe('executeAsyncMergeQuery over a result source', () => {
 
         expect(compiled.errors).toEqual([]);
     });
+
+    const buildServiceWithForbiddenResult = (forbiddenQueryUuid: string) => {
+        const built = buildService({
+            aRowCount: REFERENCED_LIMIT - 1,
+            bRowCount: REFERENCED_LIMIT - 1,
+        });
+        const readable = built.service.queryHistoryModel.get;
+        built.service.queryHistoryModel.get = vi.fn(
+            async (queryUuid: string, ...rest: [string, Account]) => {
+                if (queryUuid === forbiddenQueryUuid) {
+                    throw new ForbiddenError(
+                        'User is not authorized to access this query',
+                    );
+                }
+                return readable(queryUuid, ...rest);
+            },
+        );
+        return built;
+    };
+
+    // The v1 mergeQuery routes cannot carry an embed account until PROD-10899 lands, so this pins the v2 service path
+    const embedAccount = fromJwt({
+        decodedToken: defaultJwtToken,
+        embed: {
+            projectUuid,
+            organization: {
+                organizationUuid: projectSummary.organizationUuid,
+                name: 'Test Organization',
+                createdAt: new Date('2024-01-01'),
+            },
+            encodedSecret: 'test-encoded-secret',
+            dashboardUuids: [],
+            allowAllDashboards: true,
+            chartUuids: [],
+            allowAllCharts: true,
+            allowAllApps: false,
+            appUuids: [],
+            createdAt: '2024-01-01',
+            user: null,
+        },
+        source: 'test-jwt-token',
+        content: {
+            type: 'dashboard',
+            dashboardUuid: 'test-dashboard-uuid',
+            chartUuids: [],
+            explores: [],
+        },
+        userAttributes: { userAttributes: {}, intrinsicUserAttributes: {} },
+    });
+
+    it.each([
+        ['a session account', sessionAccount],
+        ['an embed account', embedAccount],
+    ])(
+        'refuses a merge over a referenced result %s cannot read as forbidden, never as unavailable',
+        async (_label, account) => {
+            const { service, runLeg, create } = buildServiceWithForbiddenResult(
+                resultQueryUuids.b,
+            );
+
+            await expect(
+                service.executeAsyncMergeQuery({
+                    account,
+                    projectUuid,
+                    mergeQuery,
+                    context: QueryExecutionContext.AI,
+                    mode: { type: 'interactive' },
+                }),
+            ).rejects.toThrow(ForbiddenError);
+            expect(runLeg).not.toHaveBeenCalled();
+            expect(create).not.toHaveBeenCalled();
+        },
+    );
 });

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -5844,6 +5844,8 @@ export class ProjectService extends BaseService {
                             explore: null,
                         };
                     } catch (e) {
+                        // Access denial surfaces as the same 403 that fetching the results would
+                        if (e instanceof ForbiddenError) throw e;
                         resolutionErrors.push({
                             kind: MergeQueryErrorKind.RESULT_SOURCE_UNAVAILABLE,
                             sourceId: source.id,


### PR DESCRIPTION
## What was untested

`docs/merge-queries/architecture.md` records that user-attribute overrides were once silently dropped on the merge path and fixed as an embed row-level-security risk. The override contract was proven on the query source DAG (`QuerySourceService.test.ts`) but never through a merge submission, and the result-source authorization on `compose-merge-query` was tested only for the unavailable case (`RESULT_SOURCE_UNAVAILABLE`), never the forbidden one.

## What each test pins

**`executeAsyncMergeQuery on the compose engine` > compiles every leg with the submission's user attribute overrides, a different query per override**
Submits the same merge twice with `userAttributeOverrides: { region: ['EU'] }` and `['US']` over an explore whose base table is filtered by `${lightdash.attribute.region}`. Legs compile for real (mocked explore and credentials, captured execution tail); the test asserts that for each leg the EU SQL contains `region = 'EU'`, the US SQL contains `region = 'US'`, the two differ, and neither contains the account's own value `base`. Same proof shape as the DAG test, now through the merge submission.

**`executeAsyncMergeQuery over a result source` > refuses a merge over a referenced result [a session account | an embed account] cannot read as forbidden, never as unavailable**
The query-history lookup throws `ForbiddenError` for one referenced `queryUuid`. The submission must reject with `ForbiddenError`, run no leg and create no query-history row. Parameterised over the session account and an embed-style JWT account built with `fromJwt`, exercised through the service path the v2 route calls. The embed case on the v1 `mergeQuery` routes waits on PROD-10899 (one-line note in the test).

## Defect found and change made

Yes. `ProjectService.compileMergeQuery` wraps `getMergeResultSourceMetadata` in a blanket catch that maps every lookup failure to `RESULT_SOURCE_UNAVAILABLE`, including the `ForbiddenError` that `QueryHistoryModel.get` throws when the row exists but the account may not read it. The red run showed the refusal payload: `Query "b" cannot back a merge: User is not authorized to access this query` under kind `result_source_unavailable`.

The fix is two lines in that catch: rethrow `ForbiddenError`, so the merge answers with the same 403 that fetching those results would. A not-found row (the creator-scoped lookup for a registered user) still refuses as unavailable, which is the documented contract for that kind. No new `MergeQueryErrorKind`, so `common` and the generated API are untouched.

Note on placement: the ticket asked for the change inside `getMergeResultSourceMetadata` in `AsyncQueryService.ts`, but the downgrade happens in the caller's catch, so nothing inside that method could surface the error. The change is in `ProjectService.compileMergeQuery` instead, and `AsyncQueryService.ts` is not restructured.

## Regression analysis

Only merges whose result-source lookup throws `ForbiddenError` change behaviour: they now return 403 instead of a refusal payload. Every other error keeps mapping to `RESULT_SOURCE_UNAVAILABLE`. `getMergeFieldTypesForQuery` already let this error through, so the compose execution path was already 403 for the same condition once past compile; this makes compile consistent with it.

## Verification

- `pnpm -F backend test src/services/AsyncQueryService/AsyncQueryService.test.ts`: 1 file, 106 passed (the two forbidden tests were red before the fix)
- `pnpm -F backend typecheck`: clean
- `pnpm -F backend lint`: clean
- No migrations, no dev database, no app or browser; `generated/*` not committed.

Closes: PROD-10949

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvtHaH3fbzSX2ebMgfFKFS