### PR TITLE
feat(dashboard): track custom metric creation and reuse

### DIFF
--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -71,6 +71,8 @@ import { DashboardChartEditContext } from '../providers/Dashboard/useDashboardCh
 import useDashboardContext from '../providers/Dashboard/useDashboardContext';
 import useDashboardTileStatusContext from '../providers/Dashboard/useDashboardTileStatusContext';
 import useNativeFullscreenToggle from '../providers/Fullscreen/useNativeFullscreenToggle';
+import useTracking from '../providers/Tracking/useTracking';
+import { EventName } from '../types/Events';
 import { buildDashboardConfig } from '../utils/dashboardConfig';
 import { isSameDashboardRoute } from '../utils/dashboardRoutes';
 import '../styles/react-grid.css';
@@ -830,6 +832,7 @@ const Dashboard: FC = () => {
     const [chartToEdit, setChartToEdit] = useState<SavedChart | undefined>();
 
     const queryClient = useQueryClient();
+    const { track } = useTracking();
     const handleRegistryMetricEdited = useCallback(
         (metric: AdditionalMetric) => {
             // Server already persisted the swap; mirror it into the staged
@@ -856,6 +859,9 @@ const Dashboard: FC = () => {
     const handleChartEditorSaved = useCallback(
         (chart: SavedChart) => {
             // Only the in-dashboard builder contributes to the registry.
+            const previousRegistryIds = new Set(
+                dashboardCustomMetrics.map(getItemId),
+            );
             const mergedCustomMetrics = mergeDashboardCustomMetrics(
                 dashboardCustomMetrics,
                 chart.metricQuery.additionalMetrics ?? [],
@@ -863,6 +869,43 @@ const Dashboard: FC = () => {
             if (mergedCustomMetrics !== dashboardCustomMetrics) {
                 setDashboardCustomMetrics(mergedCustomMetrics);
                 setHaveCustomMetricsChanged(true);
+            }
+
+            if (dashboardUuid) {
+                const workbookEventProperties = {
+                    projectUuid,
+                    dashboardUuid,
+                    exploreName: chart.tableName,
+                    registrySize: mergedCustomMetrics.length,
+                    // Distinct base tables — the closest explore proxy we hold
+                    distinctExploreCount: new Set(
+                        mergedCustomMetrics.map((metric) => metric.table),
+                    ).size,
+                };
+                mergedCustomMetrics.forEach((metric) => {
+                    if (!previousRegistryIds.has(getItemId(metric))) {
+                        track({
+                            name: EventName.DASHBOARD_CUSTOM_METRIC_CREATED,
+                            properties: workbookEventProperties,
+                        });
+                    }
+                });
+                // Selected metrics that were already shared = duplication avoided
+                (chart.metricQuery.metrics ?? []).forEach((metricId) => {
+                    if (previousRegistryIds.has(metricId)) {
+                        track({
+                            name: EventName.DASHBOARD_CUSTOM_METRIC_REUSED,
+                            properties: workbookEventProperties,
+                        });
+                    }
+                });
+                track({
+                    name:
+                        chart.uuid !== chartToEdit?.uuid
+                            ? EventName.DASHBOARD_CHART_CREATED_IN_PLACE
+                            : EventName.DASHBOARD_CHART_EDITED_IN_PLACE,
+                    properties: workbookEventProperties,
+                });
             }
 
             // New uuid means a brand-new chart; an existing tile refreshes
@@ -897,6 +940,9 @@ const Dashboard: FC = () => {
             dashboardCustomMetrics,
             setDashboardCustomMetrics,
             setHaveCustomMetricsChanged,
+            dashboardUuid,
+            projectUuid,
+            track,
         ],
     );
 

--- a/packages/frontend/src/providers/Tracking/types.ts
+++ b/packages/frontend/src/providers/Tracking/types.ts
@@ -921,8 +921,26 @@ type MapTileFallbackEvent = {
     };
 };
 
+// Workbook POC telemetry. Payload deliberately excludes metric SQL,
+// labels, descriptions and filter values.
+type DashboardWorkbookEvent = {
+    name:
+        | EventName.DASHBOARD_CUSTOM_METRIC_CREATED
+        | EventName.DASHBOARD_CUSTOM_METRIC_REUSED
+        | EventName.DASHBOARD_CHART_CREATED_IN_PLACE
+        | EventName.DASHBOARD_CHART_EDITED_IN_PLACE;
+    properties: {
+        projectUuid: string | undefined;
+        dashboardUuid: string;
+        exploreName: string;
+        registrySize: number;
+        distinctExploreCount: number;
+    };
+};
+
 export type EventData =
     | GenericEvent
+    | DashboardWorkbookEvent
     | MapTileUsageEvent
     | MapTileFallbackEvent
     | AgentOnboardingDemoOfferShownEvent

--- a/packages/frontend/src/types/Events.ts
+++ b/packages/frontend/src/types/Events.ts
@@ -130,6 +130,10 @@ export enum EventName {
     DASHBOARD_FILTER_REQUIREMENTS_SAVED = 'dashboard_filter_requirements.saved',
     GO_TO_LINK_CLICKED = 'go_to_link.click',
     ADD_CUSTOM_METRIC_CLICKED = 'add_custom_metric.click',
+    DASHBOARD_CUSTOM_METRIC_CREATED = 'dashboard_custom_metric.created',
+    DASHBOARD_CUSTOM_METRIC_REUSED = 'dashboard_custom_metric.reused',
+    DASHBOARD_CHART_CREATED_IN_PLACE = 'dashboard_chart.created_in_place',
+    DASHBOARD_CHART_EDITED_IN_PLACE = 'dashboard_chart.edited_in_place',
     REMOVE_CUSTOM_METRIC_CLICKED = 'remove_custom_metric.click',
     // Headway-related notifications
     NOTIFICATIONS_CLICKED = 'notifications.clicked',


### PR DESCRIPTION
Closes: GLITCH-730

### Description:

Instrumentation for the workbook POC — the hypothesis is "shared metrics replace chart duplication", and `dashboard_custom_metric.reused` measures it directly.

Four typed Rudder events, all emitted from `handleChartEditorSaved` (the flag-gated in-dashboard save path, so nothing fires with the flag off):

- `dashboard_custom_metric.created` — one per metric newly entering the registry on this save
- `dashboard_custom_metric.reused` — one per **selected** metric that was already in the registry before this save (duplication avoided)
- `dashboard_chart.created_in_place` / `dashboard_chart.edited_in_place` — one per save, by chart identity

Payload (enforced by a dedicated `EventData` union member): `projectUuid`, `dashboardUuid`, `exploreName`, `registrySize`, `distinctExploreCount` — never metric SQL, labels, descriptions or filter values. `distinctExploreCount` counts distinct base tables across the registry (the closest explore proxy the registry holds).

Live-verified against the Rudder dataplane: building a chart with a shared metric produced `dashboard_custom_metric.reused` + `dashboard_chart.created_in_place` with exactly the spec payload; `.created` correctly absent when no new metric was introduced.

### Risk assessment:

- [ ] This is a high-risk change

High-risk changes require approval from a reviewer other than the author before merging.
