### PR TITLE
feat(chart-registry): 'Built by Lightdash' badge replaces 'Official'

### DIFF
--- a/packages/frontend/src/features/chartTypes/components/ChartTypeLibrarySection.test.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeLibrarySection.test.tsx
@@ -226,7 +226,7 @@ describe('ChartTypeLibrarySection', () => {
         // Installed chart types — upgradable ones included — are hidden from
         // the library; they live in the installed tab.
         expect(screen.getByText('(2)')).toBeInTheDocument();
-        expect(screen.getAllByText('Official')).toHaveLength(2);
+        expect(screen.getAllByText('Built by Lightdash')).toHaveLength(2);
 
         expect(screen.getByText('Not installed chart')).toBeInTheDocument();
         expect(screen.queryByText('Installed chart')).not.toBeInTheDocument();

--- a/packages/frontend/src/features/chartTypes/components/OfficialChartTypeBadge.tsx
+++ b/packages/frontend/src/features/chartTypes/components/OfficialChartTypeBadge.tsx
@@ -3,8 +3,8 @@ import { type FC } from 'react';
 
 /** Marks a chart type installed from the official chart registry. */
 const OfficialChartTypeBadge: FC = () => (
-    <Badge size="xs" variant="light" color="blue">
-        Official
+    <Badge size="xs" variant="light" color="violet">
+        Built by Lightdash
     </Badge>
 );
 

--- a/packages/frontend/src/pages/ChartTypeGallery.test.tsx
+++ b/packages/frontend/src/pages/ChartTypeGallery.test.tsx
@@ -513,7 +513,7 @@ describe('ChartTypeGallery', () => {
             setData([makeDataAppViz({ registrySlug: 'radial-gauge' })]);
             renderPage();
 
-            expect(screen.getByText('Official')).toBeInTheDocument();
+            expect(screen.getByText('Built by Lightdash')).toBeInTheDocument();
             expect(
                 screen.queryByLabelText('Edit Radial gauge'),
             ).not.toBeInTheDocument();


### PR DESCRIPTION
Third PR of the library/installed-split stack (on top of #28661, GLITCH-755).

The `OfficialChartTypeBadge` now reads **Built by Lightdash** in violet (`variant="light" color="violet"`) everywhere it renders — library cards, gallery cards, and both detail modal titles. Test assertions updated; 199/199 pass.

One adjacent wrinkle flagged (not changed here): the gallery detail modal's meta panel shows "Built by <installing user>" for official chart types — the origin-version author of a registry install is whoever clicked Install, which now reads oddly next to a "Built by Lightdash" badge. Candidate for the next stack item if we want to hide or reword that row for officials.

Relates: GLITCH-755

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8sCUbSEj5R8babs36CnDN