### PR TITLE
feat(chart-registry): show the registry version for installed official chart types

### DIFF
--- a/packages/frontend/src/features/chartTypes/components/ChartTypeDetailModal.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeDetailModal.tsx
@@ -25,8 +25,8 @@ import OfficialChartTypeBadge from './OfficialChartTypeBadge';
 type Props = {
     projectUuid: string;
     dataAppViz: DataAppViz;
-    /** The newer registry version when this official chart type is upgradable */
-    registryUpdate: RegistryChartTypeListItem | null;
+    /** This chart type's registry entry, when it is a registry install */
+    registryEntry: RegistryChartTypeListItem | null;
     onClose: () => void;
     onDelete: () => void;
 };
@@ -34,7 +34,7 @@ type Props = {
 const ChartTypeDetailModal: FC<Props> = ({
     projectUuid,
     dataAppViz,
-    registryUpdate,
+    registryEntry,
     onClose,
     onDelete,
 }) => {
@@ -44,6 +44,8 @@ const ChartTypeDetailModal: FC<Props> = ({
     const isOfficial = isOfficialChartType(dataAppViz);
     const [isForkOpen, setIsForkOpen] = useState(false);
     const upgradeMutation = useInstallRegistryChartType();
+    const registryUpdate =
+        registryEntry?.state === 'update_available' ? registryEntry : null;
     const { latestReadyVersion, oldest, latest, hasOrigin } =
         useAppVersionHistory(projectUuid, dataAppViz.dataAppVizUuid);
 
@@ -204,9 +206,15 @@ const ChartTypeDetailModal: FC<Props> = ({
                                 Version
                             </Text>
                             <Text fz="sm" fw={500} c="ldGray.8">
-                                {latestReadyVersion !== null
-                                    ? `v${latestReadyVersion}`
-                                    : '—'}
+                                {/* Officials show the registry semver, matching
+                                    the library; the internal app version only
+                                    describes locally built types. */}
+                                {isOfficial &&
+                                registryEntry?.installedRegistryVersion
+                                    ? `v${registryEntry.installedRegistryVersion}`
+                                    : latestReadyVersion !== null
+                                      ? `v${latestReadyVersion}`
+                                      : '—'}
                             </Text>
                         </Box>
                     </SimpleGrid>

--- a/packages/frontend/src/pages/ChartTypeGallery.test.tsx
+++ b/packages/frontend/src/pages/ChartTypeGallery.test.tsx
@@ -153,13 +153,19 @@ const mockedDeleteApp = vi.fn();
 const mockedUpgradeMutate = vi.fn();
 
 const setRegistryCharts = (
-    charts: Array<{ slug: string; state: string; version: string }>,
+    charts: Array<{
+        slug: string;
+        state: string;
+        version: string;
+        installedRegistryVersion?: string;
+    }>,
 ) => {
     vi.mocked(useRegistryChartTypes).mockReturnValue({
         data: {
             registryEnabled: true,
             charts: charts.map((chart) => ({
                 changelog: 'Adds things.',
+                installedRegistryVersion: null,
                 ...chart,
             })),
         },
@@ -423,6 +429,25 @@ describe('ChartTypeGallery', () => {
             projectUuid: 'project-1',
             chartSlug: 'radial-gauge',
         });
+    });
+
+    it('shows the registry version for installed official chart types', () => {
+        setData([makeDataAppViz({ registrySlug: 'radial-gauge' })]);
+        setRegistryCharts([
+            {
+                slug: 'radial-gauge',
+                state: 'installed',
+                version: '1.2.0',
+                installedRegistryVersion: '1.2.0',
+            },
+        ]);
+        renderPage();
+
+        fireEvent.click(screen.getByText('Radial gauge'));
+
+        // Registry semver, not the internal app version (v3 in the mock).
+        expect(screen.getByText('v1.2.0')).toBeInTheDocument();
+        expect(screen.queryByText('v3')).not.toBeInTheDocument();
     });
 
     it('shows no update affordance when the installed version is current', () => {

--- a/packages/frontend/src/pages/ChartTypeGallery.tsx
+++ b/packages/frontend/src/pages/ChartTypeGallery.tsx
@@ -70,21 +70,19 @@ const ChartTypeGallery = () => {
         () => data?.pages.flatMap((page) => page.data) ?? [],
         [data?.pages],
     );
-    // Upgrades for installed official chart types are offered here in the
-    // installed tab (the library hides installed charts entirely).
+    // Registry context for installed official chart types: upgrade offers
+    // and the registry (semver) version live here in the installed tab.
     const registryQuery = useRegistryChartTypes(projectUuid, isLibraryEnabled);
-    const registryUpdatesBySlug = useMemo(() => {
-        const updates = new Map<string, RegistryChartTypeListItem>();
+    const registryEntriesBySlug = useMemo(() => {
+        const entries = new Map<string, RegistryChartTypeListItem>();
         for (const chart of registryQuery.data?.charts ?? []) {
-            if (chart.state === 'update_available') {
-                updates.set(chart.slug, chart);
-            }
+            entries.set(chart.slug, chart);
         }
-        return updates;
+        return entries;
     }, [registryQuery.data?.charts]);
-    const registryUpdateFor = (viz: DataAppViz) =>
+    const registryEntryFor = (viz: DataAppViz) =>
         viz.registrySlug
-            ? (registryUpdatesBySlug.get(viz.registrySlug) ?? null)
+            ? (registryEntriesBySlug.get(viz.registrySlug) ?? null)
             : null;
     const selected = dataAppVizs.find(
         (viz) => viz.dataAppVizUuid === selectedUuid,
@@ -244,8 +242,9 @@ const ChartTypeGallery = () => {
                                                 key={viz.dataAppVizUuid}
                                                 dataAppViz={viz}
                                                 hasRegistryUpdate={
-                                                    registryUpdateFor(viz) !==
-                                                    null
+                                                    registryEntryFor(viz)
+                                                        ?.state ===
+                                                    'update_available'
                                                 }
                                                 onClick={() =>
                                                     setSelectedUuid(
@@ -290,7 +289,7 @@ const ChartTypeGallery = () => {
                 <ChartTypeDetailModal
                     projectUuid={projectUuid}
                     dataAppViz={selected}
-                    registryUpdate={registryUpdateFor(selected)}
+                    registryEntry={registryEntryFor(selected)}
                     onClose={() => setSelectedUuid(null)}
                     onDelete={() => setDeleteUuid(selected.dataAppVizUuid)}
                 />


### PR DESCRIPTION
Fourth PR of the library/installed-split stack (on top of #28664, GLITCH-755).

The two tabs disagreed about versions: the library speaks registry semver (v0.1.2) while the installed tab showed the app's internal version counter (v2) for the same chart. Now:

- Official (registry-installed, unforked) chart types display their **installed registry semver** in the detail modal's Version box — same number the library and upgrade flow use. Locally built chart types and forks keep the internal app version (their registry lineage is severed by design).
- Plumbing: the page passes the chart's full registry entry down (`registryEntry`) and the modal derives both the upgrade offer and the display version from it — replaces the narrower `registryUpdate` prop.
- Falls back to the internal version if the registry entry is unavailable (fetch failure, chart dropped from the index).

Test pins registry semver shown and internal version absent for an installed official; 200/200 chartTypes+gallery tests; typecheck clean.

Relates: GLITCH-755

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8sCUbSEj5R8babs36CnDN