### PR TITLE
feat(chart-registry): typed field breakdown in the installed detail modal

### DIFF
--- a/packages/frontend/src/features/chartTypes/components/ChartTypeDetailModal.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeDetailModal.tsx
@@ -20,6 +20,7 @@ import { chartTypeBuilderPath } from '../utils/chartTypeBuilderPath';
 import classes from './ChartTypeDetailModal.module.css';
 import ChartTypeForkModal from './ChartTypeForkModal';
 import ChartTypeSamplePreview from './ChartTypeSamplePreview';
+import DataAppVizFieldsList from './DataAppVizFieldsList';
 import OfficialChartTypeBadge from './OfficialChartTypeBadge';
 
 type Props = {
@@ -170,6 +171,11 @@ const ChartTypeDetailModal: FC<Props> = ({
                             </Stack>
                         </Callout>
                     )}
+                    {dataAppViz.schema !== null && (
+                        <DataAppVizFieldsList
+                            fields={dataAppViz.schema.fields}
+                        />
+                    )}
                     <SimpleGrid cols={2} className={classes.metaPanel}>
                         {builtBy !== null && (
                             <Box>
@@ -187,18 +193,6 @@ const ChartTypeDetailModal: FC<Props> = ({
                             </Text>
                             <Text fz="sm" fw={500} c="ldGray.8">
                                 {lastUpdatedAgo}
-                            </Text>
-                        </Box>
-                        <Box>
-                            <Text fz="xs" fw={600} c="dimmed">
-                                Inputs
-                            </Text>
-                            <Text fz="sm" fw={500} c="ldGray.8">
-                                {dataAppViz.schema !== null
-                                    ? dataAppViz.schema.fields
-                                          .map((field) => field.label)
-                                          .join(', ')
-                                    : '—'}
                             </Text>
                         </Box>
                         <Box>

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeLibraryDetailModal.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeLibraryDetailModal.tsx
@@ -24,7 +24,7 @@ import { useInstallRegistryChartType } from '../hooks/useInstallRegistryChartTyp
 import { registryAssetUrl } from '../utils/registryAssetUrl';
 import ChartTypeBetaBadge from './ChartTypeBetaBadge';
 import classes from './ChartTypeLibraryDetailModal.module.css';
-import DataAppVizFieldTypeBadge from './DataAppVizFieldTypeBadge';
+import DataAppVizFieldsList from './DataAppVizFieldsList';
 
 type Props = {
     projectUuid: string;
@@ -181,19 +181,7 @@ const ChartTypeLibraryDetailModal: FC<Props> = ({
                     </Callout>
                 )}
 
-                <Box>
-                    <Text fz={12} fw={600} c="ldGray.6" mb={4}>
-                        Fields
-                    </Text>
-                    <Group gap="sm">
-                        {item.vizSchema.fields.map((field) => (
-                            <Group key={field.name} gap={4} wrap="nowrap">
-                                <DataAppVizFieldTypeBadge type={field.type} />
-                                <Text fz="sm">{field.label}</Text>
-                            </Group>
-                        ))}
-                    </Group>
-                </Box>
+                <DataAppVizFieldsList fields={item.vizSchema.fields} />
 
                 <SimpleGrid cols={2} className={classes.metaPanel}>
                     <Box>

--- a/packages/frontend/src/features/chartTypes/components/DataAppVizFieldsList.tsx
+++ b/packages/frontend/src/features/chartTypes/components/DataAppVizFieldsList.tsx
@@ -1,0 +1,25 @@
+import { type DataAppVizField } from '@lightdash/common';
+import { Box, Group, Text } from '@mantine/core';
+import { type FC } from 'react';
+import DataAppVizFieldTypeBadge from './DataAppVizFieldTypeBadge';
+
+/** The typed field breakdown shared by the library and installed detail modals. */
+const DataAppVizFieldsList: FC<{ fields: DataAppVizField[] }> = ({
+    fields,
+}) => (
+    <Box>
+        <Text fz={12} fw={600} c="ldGray.6" mb={4}>
+            Fields
+        </Text>
+        <Group gap="sm">
+            {fields.map((field) => (
+                <Group key={field.name} gap={4} wrap="nowrap">
+                    <DataAppVizFieldTypeBadge type={field.type} />
+                    <Text fz="sm">{field.label}</Text>
+                </Group>
+            ))}
+        </Group>
+    </Box>
+);
+
+export default DataAppVizFieldsList;

--- a/packages/frontend/src/pages/ChartTypeGallery.test.tsx
+++ b/packages/frontend/src/pages/ChartTypeGallery.test.tsx
@@ -229,7 +229,9 @@ describe('ChartTypeGallery', () => {
             '/projects/project-1/chart-types/data-app-viz-1',
         );
         expect(screen.getByText('v3')).toBeInTheDocument();
+        // Typed field breakdown, matching the library modal.
         expect(screen.getByText('Value')).toBeInTheDocument();
+        expect(screen.getByText('metric')).toBeInTheDocument();
     });
 
     it('separates installed charts and the chart library into top-level tabs', () => {


### PR DESCRIPTION
Fifth PR of the library/installed-split stack (on top of #28665, GLITCH-755).

The library detail modal shows each field with its typed badge (metric/dimension, canonical `LD_FIELD_COLORS`); the installed modal showed a plain comma-joined "Inputs" row. Now both render the same **Fields** breakdown:

- Extracted the library's block as `DataAppVizFieldsList` and use it in both modals — one source of truth for the presentation.
- The installed modal's Inputs meta box is removed; the Fields section renders above the meta panel (hidden when the chart type has no finished version, which the existing empty-state note covers).

Test pins the typed badge in the installed modal; 200/200 chartTypes+gallery tests; typecheck clean.

Relates: GLITCH-755

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8sCUbSEj5R8babs36CnDN