### PR TITLE
fix(chart-registry): honest uninstall copy — saved charts are kept, not deleted

### DIFF
--- a/packages/frontend/src/components/DataAppVizRenderer/index.test.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.test.tsx
@@ -358,12 +358,12 @@ describe('DataAppVizRenderer', () => {
         [
             'metadata',
             404,
-            'This custom chart type could not be found. It may have been deleted.',
+            'The chart type this chart was based on has been removed.',
         ],
         [
             'token',
             404,
-            'This custom chart type could not be found. It may have been deleted.',
+            'The chart type this chart was based on has been removed.',
         ],
     ])(
         'maps a %s HTTP %s response to its explicit state',

--- a/packages/frontend/src/components/DataAppVizRenderer/index.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.tsx
@@ -69,7 +69,7 @@ const getTerminalRequestErrorMessage = (
     }
 
     if (errors.some((error) => error?.error.statusCode === 404)) {
-        return 'This custom chart type could not be found. It may have been deleted.';
+        return 'The chart type this chart was based on has been removed.';
     }
 
     return undefined;

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeDeleteModal.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeDeleteModal.tsx
@@ -32,9 +32,11 @@ const ChartTypeDeleteModal: FC<Props> = ({
     // app delete either way.
     const isOfficial = isOfficialChartType(dataAppViz);
 
+    // Saved charts built on the chart type are never deleted with it — they
+    // keep existing and show an error until the chart type is restored.
     const description = softDeleteEnabled
-        ? `This chart type will be moved to Recently deleted and permanently removed after ${retentionDays} days.`
-        : 'This chart type and all of its versions will be permanently deleted, including any built artifacts in storage.';
+        ? `Saved charts built on this chart type are kept, but they'll show an error until it is restored. The chart type moves to Recently deleted and is permanently removed after ${retentionDays} days.`
+        : "Saved charts built on this chart type are kept, but they'll show an error. The chart type and all of its versions will be permanently deleted, including any built artifacts in storage.";
 
     return (
         <MantineModal


### PR DESCRIPTION
Sixth PR of the library/installed-split stack (on top of #28666, GLITCH-755).

Investigation first: uninstall (app delete) **never deletes saved charts** — the backend soft/permanent-deletes the app only, and orphaned charts already render a graceful placeholder. The problem was the words on both ends:

- **Uninstall/delete confirm** now states the real semantics: "Saved charts built on this chart type are kept, but they'll show an error until it is restored…" (soft-delete copy; the permanent-delete copy matches). Applies to official uninstall and custom delete alike — the truth is the same.
- **Renderer placeholder** for a missing chart type now reads: **"The chart type this chart was based on has been removed."** (was "This custom chart type could not be found. It may have been deleted.").

No backend changes needed — behavior was already keep-and-error; this aligns the copy with it.

254/254 tests across renderer + chartTypes + gallery suites.

Relates: GLITCH-755

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8sCUbSEj5R8babs36CnDN