### PR TITLE
fix(explorer): show an empty state, not a spinner, when a merge is refused

### DIFF
--- a/packages/frontend/src/features/mergeQuery/components/MergeAutoRun.test.tsx
+++ b/packages/frontend/src/features/mergeQuery/components/MergeAutoRun.test.tsx
@@ -1,0 +1,104 @@
+import { MergeQueryErrorKind, type MergeQueryError } from '@lightdash/common';
+import { render } from '@testing-library/react';
+import { MergeAutoRun } from './MergeAutoRun';
+
+type FanOut = { sourceId: string; fields: string[] };
+
+const state = vi.hoisted(() => ({
+    merge: {
+        wasRestored: true,
+        isRunning: false,
+        mergeResults: null as { queryUuid: string } | null,
+        refuseRestoredRun: vi.fn(),
+    },
+    setup: {
+        canRun: true,
+        handleRun: vi.fn(),
+        mergeQuery: { sources: [] } as { sources: unknown[] } | null,
+        setupStep: null as string | null,
+        joinKeyErrors: [] as MergeQueryError[],
+        fanOut: [] as FanOut[],
+    },
+}));
+
+vi.mock('../context/useMerge', () => ({
+    useMergeSafe: () => state.merge,
+}));
+
+vi.mock('../hooks/useMergeSetup', () => ({
+    useMergeSetup: () => state.setup,
+}));
+
+const fanOut: FanOut[] = [
+    { sourceId: 'b', fields: ['payments_payment_method'] },
+];
+
+describe('MergeAutoRun', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        state.merge.wasRestored = true;
+        state.merge.isRunning = false;
+        state.merge.mergeResults = null;
+        state.setup.canRun = true;
+        state.setup.mergeQuery = { sources: [] };
+        state.setup.setupStep = null;
+        state.setup.joinKeyErrors = [];
+        state.setup.fanOut = [];
+    });
+
+    it('runs a restored merge that passes the rules', () => {
+        render(<MergeAutoRun />);
+
+        expect(state.setup.handleRun).toHaveBeenCalledTimes(1);
+        expect(state.merge.refuseRestoredRun).not.toHaveBeenCalled();
+    });
+
+    it('refuses a restored merge that fans out instead of running it', () => {
+        state.setup.canRun = false;
+        state.setup.fanOut = fanOut;
+
+        render(<MergeAutoRun />);
+
+        expect(state.merge.refuseRestoredRun).toHaveBeenCalledTimes(1);
+        expect(state.setup.handleRun).not.toHaveBeenCalled();
+    });
+
+    it('refuses a restored merge whose join key types do not match', () => {
+        state.setup.canRun = false;
+        state.setup.joinKeyErrors = [
+            {
+                kind: MergeQueryErrorKind.JOIN_KEY_TYPE_MISMATCH,
+                sourceId: null,
+                fieldIds: ['orders_status', 'payments_amount'],
+                message: 'Those hold different kinds of value.',
+            },
+        ];
+
+        render(<MergeAutoRun />);
+
+        expect(state.merge.refuseRestoredRun).toHaveBeenCalledTimes(1);
+        expect(state.setup.handleRun).not.toHaveBeenCalled();
+    });
+
+    it('keeps waiting while the restored merge is still hydrating', () => {
+        state.setup.canRun = false;
+        state.setup.setupStep = 'Pick a field from each query to join on';
+        state.setup.fanOut = fanOut;
+
+        render(<MergeAutoRun />);
+
+        expect(state.merge.refuseRestoredRun).not.toHaveBeenCalled();
+        expect(state.setup.handleRun).not.toHaveBeenCalled();
+    });
+
+    it('leaves a merge built here alone', () => {
+        state.merge.wasRestored = false;
+        state.setup.canRun = false;
+        state.setup.fanOut = fanOut;
+
+        render(<MergeAutoRun />);
+
+        expect(state.merge.refuseRestoredRun).not.toHaveBeenCalled();
+        expect(state.setup.handleRun).not.toHaveBeenCalled();
+    });
+});

--- a/packages/frontend/src/features/mergeQuery/components/MergeAutoRun.tsx
+++ b/packages/frontend/src/features/mergeQuery/components/MergeAutoRun.tsx
@@ -9,21 +9,44 @@ import { useMergeSetup } from '../hooks/useMergeSetup';
  * merged chart opens showing only the primary source's results — the wrong numbers, presented
  * as the chart that was saved. It lives in the main column rather than the
  * sidebar because the saved-chart view opens with the sidebar closed.
+ *
+ * A restored merge the rules refuse cannot run itself. Saying so is what lets
+ * the chart and results stop waiting for a run that will never start.
  */
 export const MergeAutoRun: FC = () => {
     const merge = useMergeSafe();
-    const { canRun, handleRun } = useMergeSetup();
+    const { canRun, handleRun, mergeQuery, setupStep, joinKeyErrors, fanOut } =
+        useMergeSetup();
     const wasRestored = merge?.wasRestored ?? false;
     const isRunning = merge?.isRunning ?? false;
     const mergeResults = merge?.mergeResults ?? null;
+    const refuseRestoredRun = merge?.refuseRestoredRun;
+    // Only a built merge can be refused; an incomplete one is still hydrating.
+    const isRefused =
+        mergeQuery !== null &&
+        setupStep === null &&
+        (joinKeyErrors.length > 0 || fanOut.length > 0);
 
     const hasAutoRun = useRef(false);
     useEffect(() => {
         if (!wasRestored || hasAutoRun.current || isRunning) return;
-        if (!canRun || mergeResults) return;
+        if (mergeResults) return;
+        if (isRefused) {
+            refuseRestoredRun?.();
+            return;
+        }
+        if (!canRun) return;
         hasAutoRun.current = true;
         handleRun();
-    }, [wasRestored, canRun, isRunning, mergeResults, handleRun]);
+    }, [
+        wasRestored,
+        canRun,
+        isRunning,
+        mergeResults,
+        handleRun,
+        isRefused,
+        refuseRestoredRun,
+    ]);
 
     return null;
 };

--- a/packages/frontend/src/features/mergeQuery/context/MergeContext.test.tsx
+++ b/packages/frontend/src/features/mergeQuery/context/MergeContext.test.tsx
@@ -13,17 +13,20 @@ import {
 } from '@lightdash/common';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { type PropsWithChildren } from 'react';
+import { PRIMARY_SOURCE_ID } from '../constants';
 import { MergeProvider } from './MergeContext';
+import { MERGE_URL_PARAM, serializeMergeState } from './mergeUrlState';
 import { useMerge } from './useMerge';
 
 const setSearchParams = vi.fn();
-const { executeMergeQuery } = vi.hoisted(() => ({
+const { executeMergeQuery, searchParams } = vi.hoisted(() => ({
     executeMergeQuery: vi.fn(),
+    searchParams: new URLSearchParams(),
 }));
 
 vi.mock('react-router', () => ({
     useParams: () => ({ projectUuid: 'project-uuid' }),
-    useSearchParams: () => [new URLSearchParams(), setSearchParams],
+    useSearchParams: () => [searchParams, setSearchParams],
 }));
 
 vi.mock('../../../hooks/useQueryResults', () => ({
@@ -111,6 +114,48 @@ const wrapper = ({ children }: PropsWithChildren) => (
 describe('MergeProvider', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        searchParams.delete(MERGE_URL_PARAM);
+    });
+
+    it('stops waiting for a restored merge once it is refused before execution', () => {
+        searchParams.set(
+            MERGE_URL_PARAM,
+            serializeMergeState({
+                focus: { kind: 'join' },
+                additionalSources: [
+                    {
+                        id: 'b',
+                        exploreName: 'payments',
+                        dimensions: [
+                            'orders_status',
+                            'payments_payment_method',
+                        ],
+                        metrics: ['payments_total_revenue'],
+                        filters: {},
+                    },
+                ],
+                joinParts: [
+                    {
+                        fieldIdBySourceId: {
+                            [PRIMARY_SOURCE_ID]: 'orders_status',
+                            b: 'orders_status',
+                        },
+                    },
+                ],
+                joinType: MergeJoinType.FULL,
+            }),
+        );
+        const { result } = renderHook(() => useMerge(), { wrapper });
+        expect(result.current.wasRestored).toBe(true);
+
+        act(() => result.current.refuseRestoredRun());
+
+        expect(result.current.wasRestored).toBe(false);
+        expect(result.current.isRunning).toBe(false);
+        expect(result.current.mergeResults).toBeNull();
+        expect(result.current.runErrors).toEqual([]);
+        expect(result.current.runError).toBeNull();
+        expect(executeMergeQuery).not.toHaveBeenCalled();
     });
 
     it('publishes join type changes immediately', () => {

--- a/packages/frontend/src/features/mergeQuery/context/MergeContext.tsx
+++ b/packages/frontend/src/features/mergeQuery/context/MergeContext.tsx
@@ -61,6 +61,12 @@ export const MergeProvider: FC<
             parseMergeState(searchParams.get(MERGE_URL_PARAM)) ??
             (savedMerge ? restoreSavedMerge(savedMerge) : null),
     );
+    // A restored merge the rules refuse never runs, so nothing may wait on it.
+    const [restoredRunRefused, setRestoredRunRefused] = useState(false);
+    const refuseRestoredRun = useCallback(
+        () => setRestoredRunRefused(true),
+        [],
+    );
 
     const [focus, setFocus] = useState<MergeFocus>(
         restored?.focus ?? {
@@ -492,7 +498,8 @@ export const MergeProvider: FC<
         () => ({
             isMerging,
             readOnly,
-            wasRestored: restored !== null,
+            wasRestored: restored !== null && !restoredRunRefused,
+            refuseRestoredRun,
             run,
             getDownloadQueryUuid,
             isRunning: runState.isRunning,
@@ -521,6 +528,8 @@ export const MergeProvider: FC<
             isMerging,
             readOnly,
             restored,
+            restoredRunRefused,
+            refuseRestoredRun,
             run,
             getDownloadQueryUuid,
             runState.isRunning,

--- a/packages/frontend/src/features/mergeQuery/context/context.ts
+++ b/packages/frontend/src/features/mergeQuery/context/context.ts
@@ -61,9 +61,13 @@ export type MergeContextValue = {
     readOnly: boolean;
     /**
      * The merge arrived with the chart or the link rather than being built
-     * here, so it should run without being asked.
+     * here, so it should run without being asked. Cleared once that run is
+     * refused before execution: from then on it is in the user's hands, like
+     * a merge built here.
      */
     wasRestored: boolean;
+    /** The restored merge was refused before it could run, so stop waiting for it. */
+    refuseRestoredRun: () => void;
     /** Runs a merge, replacing any run already on screen. */
     run: (
         mergeQuery: MergeQuery,


### PR DESCRIPTION
## What the user saw

Open the Explorer on the Jaffle `orders` explore with a merge whose second source (`payments`) carries a dimension the first does not (`payments_payment_method`). The Relationship card shows the fan-out refusal and Run query is disabled, but the Chart panel sits on a "Loading chart" spinner indefinitely and the Results panel spins too. A refused merge is not loading anything.

## Cause

A merge restored from the link or the saved chart runs itself (`MergeAutoRun`), and the chart and results panels wait for that run: `useExplorerResultsData`, `ExplorerResults` and `useGroupedResultsAvailability` all treat `wasRestored && !mergeResults` as pending. `wasRestored` is set once on mount and never changes. When the client-side rules refuse the restored merge before execution (fan-out, join key type or grain mismatch), `canRun` is false, `MergeAutoRun` never runs it, the context never gets a result or an error, and the panels wait forever.

This only bites restored merges. Any merge that has been built is mirrored into the URL, so reloading the Explorer restores it and triggers the bug.

## Change

- `MergeContextValue` gains `refuseRestoredRun()`. Calling it clears `wasRestored`, so the merge is in the user's hands like one built in the Explorer: the panels fall back to the primary query's state (the idle "Run query" empty state when nothing has run), no spinner, and no auto-run until the user fixes the relationship and presses Run.
- `MergeAutoRun` calls it when the restored merge is built (`mergeQuery` present, no setup step outstanding) but refused by the rules (`fanOut` or `joinKeyErrors`). Gating on a built merge with no setup step avoids a false refusal while the store and explores are still hydrating; the type checks already skip fields whose type is not yet known.

No consumer changes, no new strings, no restructuring of the context.

## Regression analysis

- A restored merge that passes the rules: unchanged, still auto-runs once.
- A restored merge that is refused: previously spinner forever; now settles to the idle state. If the user then fixes the relationship it no longer auto-runs mid-edit; they press Run, as with a hand-built merge.
- A merge built in the Explorer (`wasRestored` false): untouched, `MergeAutoRun` returns early as before.
- Run-time refusals (server-side, via `runErrors`): untouched.

## How verified

- `pnpm -F frontend test src/features/mergeQuery/context/MergeContext.test.tsx`: 1 file, 7 passed (new: "stops waiting for a restored merge once it is refused before execution").
- `pnpm -F frontend test src/features/mergeQuery/components/MergeAutoRun.test.tsx`: 1 file, 5 passed (new file: runs when valid, refuses on fan-out, refuses on join key mismatch, keeps waiting while hydrating, ignores hand-built merges).
- `pnpm -F frontend typecheck`: clean.
- `pnpm -F frontend run linter` on the five changed files: 0 warnings, 0 errors.

Closes: PROD-10963

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvtHaH3fbzSX2ebMgfFKFS
