### PR TITLE
fix: global search stays fast on projects with many dashboards

### DIFF
--- a/packages/backend/src/models/SearchModel/index.ts
+++ b/packages/backend/src/models/SearchModel/index.ts
@@ -222,7 +222,148 @@ export class SearchModel {
             fullTextSearchOperator,
         });
 
-        let subquery = this.database(DashboardsTableName)
+        const firstVersionJoin = {
+            table: this.database.raw(
+                `${DashboardVersionsTableName} as first_version`,
+            ),
+            on: this.database.raw(
+                `first_version.dashboard_id = ${DashboardsTableName}.dashboard_id AND first_version.dashboard_version_id = (SELECT MIN(dashboard_version_id) FROM ${DashboardVersionsTableName} WHERE dashboard_id = ${DashboardsTableName}.dashboard_id)`,
+            ),
+        };
+        const lastVersionJoin = {
+            table: this.database.raw(
+                `${DashboardVersionsTableName} as last_version`,
+            ),
+            on: this.database.raw(
+                `last_version.dashboard_id = ${DashboardsTableName}.dashboard_id AND last_version.dashboard_version_id = (SELECT MAX(dashboard_version_id) FROM ${DashboardVersionsTableName} WHERE dashboard_id = ${DashboardsTableName}.dashboard_id)`,
+            ),
+        };
+
+        // Each branch is driven by its own search_vector GIN index and yields
+        // (dashboard_id, rank) for matches only, so the work scales with matches
+        // rather than with every dashboard × tile in the project. Chart branches
+        // deliberately avoid joining dashboards so the planner cannot start from
+        // the whole project; dashboard-level filters are applied once below.
+        const nameMatches = this.database(DashboardsTableName)
+            .select(
+                `${DashboardsTableName}.dashboard_id`,
+                this.database.raw('? as search_rank', [
+                    dashboardSearchRankRawSql,
+                ]),
+            )
+            .where(`${DashboardsTableName}.project_uuid`, projectUuid)
+            .whereNull(`${DashboardsTableName}.deleted_at`)
+            .where(dashboardSearchFilterSql);
+
+        const directChartMatches = this.database(
+            `${SavedChartsTableName} as direct_charts`,
+        )
+            .innerJoin(
+                DashboardsTableName,
+                `${DashboardsTableName}.dashboard_uuid`,
+                'direct_charts.dashboard_uuid',
+            )
+            .select(
+                `${DashboardsTableName}.dashboard_id`,
+                this.database.raw('? as search_rank', [
+                    directChartSearchRankRawSql,
+                ]),
+            )
+            .where('direct_charts.project_uuid', projectUuid)
+            .whereNull('direct_charts.deleted_at')
+            .where(directChartSearchFilterSql);
+
+        const tileChartMatches = this.database(
+            `${SavedChartsTableName} as tile_charts`,
+        )
+            .innerJoin(
+                'dashboard_tile_charts',
+                'dashboard_tile_charts.saved_chart_id',
+                'tile_charts.saved_query_id',
+            )
+            .innerJoin(
+                `${DashboardVersionsTableName} as current_version`,
+                'current_version.dashboard_version_id',
+                'dashboard_tile_charts.dashboard_version_id',
+            )
+            .select(
+                'current_version.dashboard_id',
+                this.database.raw('? as search_rank', [
+                    tileChartSearchRankRawSql,
+                ]),
+            )
+            .where('tile_charts.project_uuid', projectUuid)
+            .whereNull('tile_charts.deleted_at')
+            .whereRaw(
+                `current_version.dashboard_version_id = (SELECT MAX(dashboard_version_id) FROM ${DashboardVersionsTableName} WHERE dashboard_id = current_version.dashboard_id)`,
+            )
+            .where(tileChartSearchFilterSql);
+
+        let rankedCandidates = this.database
+            .from(
+                nameMatches
+                    .unionAll([directChartMatches, tileChartMatches], true)
+                    .as('matches'),
+            )
+            .innerJoin(
+                DashboardsTableName,
+                `${DashboardsTableName}.dashboard_id`,
+                'matches.dashboard_id',
+            )
+            .innerJoin(
+                SpaceTableName,
+                `${DashboardsTableName}.space_id`,
+                `${SpaceTableName}.space_id`,
+            )
+            .select(`${DashboardsTableName}.dashboard_id`)
+            .select(
+                this.database.raw(
+                    'GREATEST(?, MAX(matches.search_rank)) as search_rank',
+                    [dashboardSearchRankRawSql],
+                ),
+            )
+            .where(`${DashboardsTableName}.project_uuid`, projectUuid)
+            .whereNull(`${DashboardsTableName}.deleted_at`)
+            .whereNull(`${SpaceTableName}.deleted_at`)
+            .groupBy(`${DashboardsTableName}.dashboard_id`)
+            .orderBy('search_rank', 'desc')
+            .limit(SEARCH_LIMIT_PER_ITEM_TYPE);
+
+        rankedCandidates = filterByCreatedAt(
+            DashboardsTableName,
+            rankedCandidates,
+            filters,
+        );
+        if (filters?.createdByUuid) {
+            rankedCandidates = filterByCreatedByUuid(
+                rankedCandidates.leftJoin(
+                    firstVersionJoin.table,
+                    firstVersionJoin.on,
+                ),
+                {
+                    tableName: 'first_version',
+                    tableUserUuidColumnName: 'updated_by_user_uuid',
+                },
+                filters,
+            );
+        }
+        if (verifiedOnly) {
+            rankedCandidates = rankedCandidates.whereExists(
+                this.verifiedContentExists(
+                    projectUuid,
+                    ContentType.DASHBOARD,
+                    `${DashboardsTableName}.dashboard_uuid`,
+                ),
+            );
+        }
+
+        const dashboards = await this.database
+            .from(rankedCandidates.as('dashboards_with_rank'))
+            .innerJoin(
+                DashboardsTableName,
+                `${DashboardsTableName}.dashboard_id`,
+                'dashboards_with_rank.dashboard_id',
+            )
             .leftJoin(
                 SpaceTableName,
                 `${DashboardsTableName}.space_id`,
@@ -233,22 +374,8 @@ export class SearchModel {
                 `${ProjectTableName}.project_id`,
                 `${SpaceTableName}.project_id`,
             )
-            .leftJoin(
-                this.database.raw(
-                    `${DashboardVersionsTableName} as first_version`,
-                ),
-                this.database.raw(
-                    `first_version.dashboard_id = ${DashboardsTableName}.dashboard_id AND first_version.dashboard_version_id = (SELECT MIN(dashboard_version_id) FROM ${DashboardVersionsTableName} WHERE dashboard_id = ${DashboardsTableName}.dashboard_id)`,
-                ),
-            )
-            .leftJoin(
-                this.database.raw(
-                    `${DashboardVersionsTableName} as last_version`,
-                ),
-                this.database.raw(
-                    `last_version.dashboard_id = ${DashboardsTableName}.dashboard_id AND last_version.dashboard_version_id = (SELECT MAX(dashboard_version_id) FROM ${DashboardVersionsTableName} WHERE dashboard_id = ${DashboardsTableName}.dashboard_id)`,
-                ),
-            )
+            .leftJoin(firstVersionJoin.table, firstVersionJoin.on)
+            .leftJoin(lastVersionJoin.table, lastVersionJoin.on)
             .leftJoin(
                 `${UserTableName} as created_by_user`,
                 `created_by_user.user_uuid`,
@@ -259,49 +386,6 @@ export class SearchModel {
                 `updated_by_user.user_uuid`,
                 `last_version.updated_by_user_uuid`,
             )
-            // Join with charts that belong directly to dashboard
-            .leftJoin(
-                `${SavedChartsTableName} as direct_charts`,
-                function nonDeletedChartJoin() {
-                    this.on(
-                        `${DashboardsTableName}.dashboard_uuid`,
-                        '=',
-                        'direct_charts.dashboard_uuid',
-                    ).andOnNull('direct_charts.deleted_at');
-                },
-            )
-            // Join with charts that are in dashboard through tiles
-            .leftJoin('dashboard_tiles', function joinDashboardTiles() {
-                this.on(
-                    'dashboard_tiles.dashboard_version_id',
-                    '=',
-                    `last_version.dashboard_version_id`,
-                );
-            })
-            .leftJoin(
-                'dashboard_tile_charts',
-                function joinDashboardTileCharts() {
-                    this.on(
-                        'dashboard_tile_charts.dashboard_version_id',
-                        '=',
-                        'dashboard_tiles.dashboard_version_id',
-                    ).andOn(
-                        'dashboard_tile_charts.dashboard_tile_uuid',
-                        '=',
-                        'dashboard_tiles.dashboard_tile_uuid',
-                    );
-                },
-            )
-            .leftJoin(
-                `${SavedChartsTableName} as tile_charts`,
-                function nonDeletedChartJoin() {
-                    this.on(
-                        'tile_charts.saved_query_id',
-                        '=',
-                        'dashboard_tile_charts.saved_chart_id',
-                    ).andOnNull('tile_charts.deleted_at');
-                },
-            )
             .column(
                 { uuid: `${DashboardsTableName}.dashboard_uuid` },
                 `${DashboardsTableName}.slug`,
@@ -309,18 +393,7 @@ export class SearchModel {
                 `${DashboardsTableName}.description`,
                 { projectUuid: `${ProjectTableName}.project_uuid` },
                 { spaceUuid: `${SpaceTableName}.space_uuid` },
-                this.database.raw(
-                    `GREATEST(
-                        ?,
-                        COALESCE(MAX(?), 0),
-                        COALESCE(MAX(?), 0)
-                    ) as search_rank`,
-                    [
-                        dashboardSearchRankRawSql,
-                        directChartSearchRankRawSql,
-                        tileChartSearchRankRawSql,
-                    ],
-                ),
+                'dashboards_with_rank.search_rank',
                 { viewsCount: `${DashboardsTableName}.views_count` },
                 { firstViewedAt: `${DashboardsTableName}.first_viewed_at` },
                 { lastModified: `last_version.created_at` },
@@ -331,60 +404,7 @@ export class SearchModel {
                 { lastUpdatedByLastName: 'updated_by_user.last_name' },
                 { lastUpdatedByUserUuid: 'updated_by_user.user_uuid' },
             )
-            .where(`${ProjectTableName}.project_uuid`, projectUuid)
-            .whereNull(`${DashboardsTableName}.deleted_at`)
-            .whereNull(`${SpaceTableName}.deleted_at`)
-            // Use GIN index filters to reduce rows before computing ts_rank_cd.
-            // COALESCE is needed for chart filters because they come from LEFT JOINed tables -
-            // if a dashboard has no charts, search_vector is NULL and `NULL @@ tsquery` returns NULL.
-            // The dashboard filter doesn't need COALESCE since it's on the main table (always has a value).
-            .whereRaw(
-                `(${dashboardSearchFilterSql} OR COALESCE(${directChartSearchFilterSql}, false) OR COALESCE(${tileChartSearchFilterSql}, false))`,
-            )
-            .groupBy(
-                `${DashboardsTableName}.dashboard_id`,
-                `${DashboardsTableName}.dashboard_uuid`,
-                `${DashboardsTableName}.slug`,
-                `${DashboardsTableName}.name`,
-                `${DashboardsTableName}.description`,
-                `${ProjectTableName}.project_uuid`,
-                `${SpaceTableName}.space_uuid`,
-                `${DashboardsTableName}.views_count`,
-                `${DashboardsTableName}.first_viewed_at`,
-                `last_version.created_at`,
-                'created_by_user.first_name',
-                'created_by_user.last_name',
-                'created_by_user.user_uuid',
-                'updated_by_user.first_name',
-                'updated_by_user.last_name',
-                'updated_by_user.user_uuid',
-            )
-            .orderBy('search_rank', 'desc');
-
-        subquery = filterByCreatedAt(DashboardsTableName, subquery, filters);
-        subquery = filterByCreatedByUuid(
-            subquery,
-            {
-                tableName: 'first_version',
-                tableUserUuidColumnName: 'updated_by_user_uuid',
-            },
-            filters,
-        );
-
-        if (verifiedOnly) {
-            subquery = subquery.whereExists(
-                this.verifiedContentExists(
-                    projectUuid,
-                    ContentType.DASHBOARD,
-                    `${DashboardsTableName}.dashboard_uuid`,
-                ),
-            );
-        }
-
-        const dashboards = await this.database(DashboardsTableName)
-            .select()
-            .from(subquery.as('dashboards_with_rank'))
-            .limit(10);
+            .orderBy('dashboards_with_rank.search_rank', 'desc');
 
         const dashboardUuids = dashboards.map((dashboard) => dashboard.uuid);
 

--- a/packages/backend/src/models/SearchModel/utils/filters.ts
+++ b/packages/backend/src/models/SearchModel/utils/filters.ts
@@ -39,7 +39,7 @@ export function filterByCreatedAt<T extends {}, R>(
             throw new ParameterError('fromDate cannot be in the future');
         }
 
-        void filteredQuery.whereRaw('Date(:createdAtColumn:) >= :date', {
+        void filteredQuery.whereRaw(':createdAtColumn: >= :date', {
             createdAtColumn: `${tableName}.created_at`,
             date: fromDateObj.startOf('day').toDate(),
         });
@@ -54,9 +54,11 @@ export function filterByCreatedAt<T extends {}, R>(
             throw new ParameterError('toDate cannot be in the future');
         }
 
-        void filteredQuery.whereRaw('Date(:createdAtColumn:) <= :date', {
+        // Half-open bound on the raw column keeps the comparison sargable so the
+        // planner can use created_at statistics; equivalent to Date(col) <= toDate.
+        void filteredQuery.whereRaw(':createdAtColumn: < :date', {
             createdAtColumn: `${tableName}.created_at`,
-            date: toDateObj.endOf('day').toDate(),
+            date: toDateObj.add(1, 'day').startOf('day').toDate(),
         });
     }
 


### PR DESCRIPTION
Global search took several seconds on projects with thousands of dashboards even when the query matched only a handful of items. The dashboard search joined every dashboard in the project to its tiles and charts before applying the text filter, so the cost grew with dashboards × tiles rather than with matches and the search_vector indexes were never used. The date-range search filter compared Date(created_at), which hid column statistics from the planner and produced nested-loop plans over the candidates.

Closes: #28590