### PR TITLE
feat(data-apps): support OAuth client credentials

### DIFF
--- a/packages/backend/src/ee/database/entities/externalConnections.ts
+++ b/packages/backend/src/ee/database/entities/externalConnections.ts
@@ -2,6 +2,7 @@ import {
     type ApiKeyLocation,
     type ExternalConnectionAuthType,
     type ExternalConnectionMethod,
+    type OAuthClientAuthMethod,
 } from '@lightdash/common';
 import { type Knex } from 'knex';
 
@@ -34,6 +35,9 @@ export type DbExternalConnection = {
     api_key_name: string | null;
     api_key_location: ApiKeyLocation | null;
     oauth_scopes: string[] | null;
+    oauth_token_url: string | null;
+    oauth_client_id: string | null;
+    oauth_client_auth_method: OAuthClientAuthMethod | null;
     custom_headers: Record<string, string> | null;
     created_by_user_uuid: string | null;
     updated_by_user_uuid: string | null;
@@ -70,6 +74,9 @@ export type ExternalConnectionsTable = Knex.CompositeTableType<
                 | 'rate_limit_per_minute'
                 | 'api_key_name'
                 | 'api_key_location'
+                | 'oauth_token_url'
+                | 'oauth_client_id'
+                | 'oauth_client_auth_method'
                 | 'allow_browser_images'
                 | 'allow_data_app_builder_linking'
                 | 'created_by_user_uuid'
@@ -89,6 +96,9 @@ export type ExternalConnectionsTable = Knex.CompositeTableType<
             | 'rate_limit_per_minute'
             | 'api_key_name'
             | 'api_key_location'
+            | 'oauth_token_url'
+            | 'oauth_client_id'
+            | 'oauth_client_auth_method'
             | 'allow_browser_images'
             | 'allow_data_app_builder_linking'
             | 'updated_by_user_uuid'

--- a/packages/backend/src/ee/database/migrations/20260904120000_add_external_connection_oauth_client_credentials.ts
+++ b/packages/backend/src/ee/database/migrations/20260904120000_add_external_connection_oauth_client_credentials.ts
@@ -1,0 +1,23 @@
+import { type Knex } from 'knex';
+
+const ExternalConnectionsTableName = 'external_connections';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '5s'`);
+    await knex.schema.alterTable(ExternalConnectionsTableName, (table) => {
+        table.text('oauth_token_url').nullable();
+        table.text('oauth_client_id').nullable();
+        table.text('oauth_client_auth_method').nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '5s'`);
+    await knex.schema.alterTable(ExternalConnectionsTableName, (table) => {
+        table.dropColumns(
+            'oauth_token_url',
+            'oauth_client_id',
+            'oauth_client_auth_method',
+        );
+    });
+}

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -98,6 +98,7 @@ import { EmbedService } from './services/EmbedService/EmbedService';
 import { ExternalConnectionCoderService } from './services/ExternalConnectionCoderService/ExternalConnectionCoderService';
 import { ExternalConnectionService } from './services/ExternalConnectionService/ExternalConnectionService';
 import { GoogleServiceAccountTokenProvider } from './services/ExternalConnectionService/GoogleServiceAccountTokenProvider';
+import { OAuthClientCredentialsTokenProvider } from './services/ExternalConnectionService/OAuthClientCredentialsTokenProvider';
 import { ExternalQuerySource } from './services/ExternalSourceService/ExternalQuerySource';
 import { ExternalSourceService } from './services/ExternalSourceService/ExternalSourceService';
 import { HomepageRecommendedActionSkipsService } from './services/HomepageRecommendedActionSkipsService';
@@ -913,6 +914,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         repository.getSpacePermissionService(),
                     googleTokenProvider:
                         new GoogleServiceAccountTokenProvider(),
+                    oauthClientCredentialsTokenProvider:
+                        new OAuthClientCredentialsTokenProvider(),
                     orgAiCopilotConfigResolver: new OrgAiCopilotConfigResolver({
                         lightdashConfig: context.lightdashConfig,
                         aiOrganizationSettingsModel:

--- a/packages/backend/src/ee/models/ExternalConnectionModel.test.ts
+++ b/packages/backend/src/ee/models/ExternalConnectionModel.test.ts
@@ -46,6 +46,9 @@ const makeDbConnection = (overrides: Record<string, unknown> = {}) => ({
     api_key_name: null,
     api_key_location: null,
     oauth_scopes: null,
+    oauth_token_url: null,
+    oauth_client_id: null,
+    oauth_client_auth_method: null,
     created_by_user_uuid: USER_UUID,
     updated_by_user_uuid: USER_UUID,
     created_at: new Date('2026-01-01T00:00:00Z'),
@@ -322,10 +325,15 @@ describe('ExternalConnectionModel', () => {
     });
 
     describe('copyConnectionsToProject', () => {
-        it('carries the source slug onto the cloned connection', async () => {
+        it('carries portable OAuth config onto the cloned connection', async () => {
             tracker.on.select(ExternalConnectionsTableName).responseOnce([
                 makeDbConnection({
+                    type: 'oauth_client_credentials',
                     allow_data_app_builder_linking: true,
+                    oauth_scopes: ['read:data'],
+                    oauth_token_url: 'https://auth.example.com/oauth/token',
+                    oauth_client_id: 'client-1',
+                    oauth_client_auth_method: 'basic',
                 }),
             ]);
             tracker.on
@@ -351,6 +359,14 @@ describe('ExternalConnectionModel', () => {
             );
             expect(cloneInsert?.bindings).toContain('acme-api');
             expect(cloneInsert?.bindings).toContain(true);
+            expect(cloneInsert?.bindings).toContain(
+                'https://auth.example.com/oauth/token',
+            );
+            expect(cloneInsert?.bindings).toContain('client-1');
+            expect(cloneInsert?.bindings).toContain('basic');
+            expect(cloneInsert?.bindings).toContain(
+                JSON.stringify(['read:data']),
+            );
         });
     });
 
@@ -521,6 +537,28 @@ describe('ExternalConnectionModel', () => {
 
             await model.update(CONNECTION_UUID, USER_UUID, {
                 origin: 'https://attacker.example.com',
+            });
+
+            expect(tracker.history.delete).toHaveLength(1);
+            expect(tracker.history.delete[0].sql).toContain(
+                ExternalConnectionSecretsTableName,
+            );
+        });
+
+        it('deletes the stored secret when an OAuth credential destination changes without a replacement', async () => {
+            tracker.on.select(ExternalConnectionsTableName).response([
+                makeDbConnection({
+                    type: 'oauth_client_credentials',
+                    oauth_token_url: 'https://auth.example.com/oauth/token',
+                    oauth_client_id: 'client-1',
+                    oauth_client_auth_method: 'basic',
+                }),
+            ]);
+            tracker.on.update(ExternalConnectionsTableName).response(1);
+            tracker.on.delete(ExternalConnectionSecretsTableName).response(1);
+
+            await model.update(CONNECTION_UUID, USER_UUID, {
+                oauthTokenUrl: 'https://other.example.com/oauth/token',
             });
 
             expect(tracker.history.delete).toHaveLength(1);

--- a/packages/backend/src/ee/models/ExternalConnectionModel.ts
+++ b/packages/backend/src/ee/models/ExternalConnectionModel.ts
@@ -21,7 +21,10 @@ import {
     type DbApp as DbDataApp,
 } from '../../database/entities/apps';
 import { SpaceTableName } from '../../database/entities/spaces';
-import { normalizeCredentialUrlOrigin } from '../../utils/credentialDestination';
+import {
+    normalizeCredentialUrlHref,
+    normalizeCredentialUrlOrigin,
+} from '../../utils/credentialDestination';
 import { EncryptionUtil } from '../../utils/EncryptionUtil/EncryptionUtil';
 import {
     AppExternalConnectionsTableName,
@@ -88,6 +91,9 @@ export class ExternalConnectionModel {
             apiKeyName: row.api_key_name,
             apiKeyLocation: row.api_key_location,
             oauthScopes: row.oauth_scopes,
+            oauthTokenUrl: row.oauth_token_url,
+            oauthClientId: row.oauth_client_id,
+            oauthClientAuthMethod: row.oauth_client_auth_method,
             customHeaders: row.custom_headers,
             hasSecret,
             createdByUserUuid: row.created_by_user_uuid,
@@ -194,6 +200,10 @@ export class ExternalConnectionModel {
                         oauth_scopes: data.oauthScopes?.length
                             ? JSON.stringify(data.oauthScopes)
                             : null,
+                        oauth_token_url: data.oauthTokenUrl ?? null,
+                        oauth_client_id: data.oauthClientId ?? null,
+                        oauth_client_auth_method:
+                            data.oauthClientAuthMethod ?? null,
                         custom_headers:
                             data.customHeaders &&
                             Object.keys(data.customHeaders).length
@@ -290,6 +300,9 @@ export class ExternalConnectionModel {
                         oauth_scopes: src.oauth_scopes
                             ? JSON.stringify(src.oauth_scopes)
                             : null,
+                        oauth_token_url: src.oauth_token_url,
+                        oauth_client_id: src.oauth_client_id,
+                        oauth_client_auth_method: src.oauth_client_auth_method,
                         custom_headers: src.custom_headers
                             ? JSON.stringify(src.custom_headers)
                             : null,
@@ -719,6 +732,13 @@ export class ExternalConnectionModel {
                 updatePayload.oauth_scopes = data.oauthScopes?.length
                     ? JSON.stringify(data.oauthScopes)
                     : null;
+            if (data.oauthTokenUrl !== undefined)
+                updatePayload.oauth_token_url = data.oauthTokenUrl;
+            if (data.oauthClientId !== undefined)
+                updatePayload.oauth_client_id = data.oauthClientId;
+            if (data.oauthClientAuthMethod !== undefined)
+                updatePayload.oauth_client_auth_method =
+                    data.oauthClientAuthMethod;
             if (data.customHeaders !== undefined)
                 updatePayload.custom_headers =
                     data.customHeaders && Object.keys(data.customHeaders).length
@@ -731,7 +751,7 @@ export class ExternalConnectionModel {
 
             // Secret tri-state: `null` clears it, a non-empty string sets it,
             // and undefined/blank leaves it unchanged unless the credential's
-            // auth type or origin changes.
+            // auth type or credential destination changes.
             const resultingType = data.type ?? existing.type;
             const typeChanged =
                 data.type !== undefined && data.type !== existing.type;
@@ -739,10 +759,26 @@ export class ExternalConnectionModel {
                 data.origin !== undefined &&
                 normalizeCredentialUrlOrigin(data.origin) !==
                     normalizeCredentialUrlOrigin(existing.origin);
+            const keepsOAuthClientCredentialsType =
+                existing.type === 'oauth_client_credentials' &&
+                resultingType === 'oauth_client_credentials';
+            const oauthTokenUrlChanged =
+                keepsOAuthClientCredentialsType &&
+                data.oauthTokenUrl !== undefined &&
+                normalizeCredentialUrlHref(data.oauthTokenUrl ?? '') !==
+                    normalizeCredentialUrlHref(existing.oauth_token_url ?? '');
+            const oauthClientIdChanged =
+                keepsOAuthClientCredentialsType &&
+                data.oauthClientId !== undefined &&
+                data.oauthClientId !== existing.oauth_client_id;
             if (
                 resultingType === 'none' ||
                 data.secret === null ||
-                ((typeChanged || originChanged) && !data.secret)
+                ((typeChanged ||
+                    originChanged ||
+                    oauthTokenUrlChanged ||
+                    oauthClientIdChanged) &&
+                    !data.secret)
             ) {
                 await ExternalConnectionModel.deleteSecret(trx, uuid);
             } else if (data.secret) {

--- a/packages/backend/src/ee/services/ExternalConnectionCoderService/ExternalConnectionCoderService.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionCoderService/ExternalConnectionCoderService.test.ts
@@ -179,6 +179,33 @@ describe('ExternalConnectionCoderService downloads', () => {
         ]);
         expect(result.missingSlugs).toEqual(['not-there']);
     });
+
+    it('exports OAuth client configuration without the client secret', async () => {
+        const oauthConnection: ExternalConnection = {
+            ...connection,
+            type: 'oauth_client_credentials',
+            oauthTokenUrl: 'https://auth.example.com/oauth/token',
+            oauthClientId: 'client-1',
+            oauthClientAuthMethod: 'body',
+            oauthScopes: ['read:data'],
+        };
+        const { service } = buildService({ connections: [oauthConnection] });
+        mockAbility(service, fullAbility);
+
+        const result = await service.downloadExternalConnections(
+            account,
+            projectUuid,
+        );
+
+        expect(result.externalConnections[0]).toMatchObject({
+            authType: 'oauth_client_credentials',
+            oauthTokenUrl: 'https://auth.example.com/oauth/token',
+            oauthClientId: 'client-1',
+            oauthClientAuthMethod: 'body',
+            oauthScopes: ['read:data'],
+        });
+        expect(result.externalConnections[0]).not.toHaveProperty('secret');
+    });
 });
 
 describe('ExternalConnectionCoderService upserts', () => {
@@ -284,6 +311,45 @@ describe('ExternalConnectionCoderService upserts', () => {
                 type: 'api_key',
                 allowDataAppBuilderLinking: true,
                 secret: 'sk-secret',
+            }),
+            { slug: 'stripe-api' },
+        );
+    });
+
+    it('restores OAuth client configuration through the domain service', async () => {
+        const oauthDocument: ExternalConnectionAsCode = {
+            ...connectionAsCode,
+            authType: 'oauth_client_credentials',
+            apiKeyName: null,
+            apiKeyLocation: null,
+            oauthTokenUrl: 'https://auth.example.com/oauth/token',
+            oauthClientId: 'client-1',
+            oauthClientAuthMethod: 'basic',
+            oauthScopes: ['read:data'],
+        };
+        const { service, externalConnectionService } = buildService({
+            existing: null,
+        });
+        mockAbility(service, fullAbility);
+
+        await service.upsertExternalConnection(
+            account,
+            projectUuid,
+            'stripe-api',
+            oauthDocument,
+            'client-secret',
+        );
+
+        expect(externalConnectionService.create).toHaveBeenCalledWith(
+            account,
+            projectUuid,
+            expect.objectContaining({
+                type: 'oauth_client_credentials',
+                oauthTokenUrl: 'https://auth.example.com/oauth/token',
+                oauthClientId: 'client-1',
+                oauthClientAuthMethod: 'basic',
+                oauthScopes: ['read:data'],
+                secret: 'client-secret',
             }),
             { slug: 'stripe-api' },
         );

--- a/packages/backend/src/ee/services/ExternalConnectionCoderService/ExternalConnectionCoderService.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionCoderService/ExternalConnectionCoderService.ts
@@ -74,6 +74,13 @@ const toExternalConnectionAsCode = (
     oauthScopes: connection.oauthScopes?.length
         ? [...connection.oauthScopes].sort()
         : null,
+    ...(connection.type === 'oauth_client_credentials'
+        ? {
+              oauthTokenUrl: connection.oauthTokenUrl ?? null,
+              oauthClientId: connection.oauthClientId ?? null,
+              oauthClientAuthMethod: connection.oauthClientAuthMethod ?? null,
+          }
+        : {}),
     customHeaders: sortHeaders(connection.customHeaders),
 });
 
@@ -97,6 +104,9 @@ const getComparableConnection = (document: ExternalConnectionAsCode) => ({
     oauthScopes: document.oauthScopes?.length
         ? [...document.oauthScopes].sort()
         : null,
+    oauthTokenUrl: document.oauthTokenUrl ?? null,
+    oauthClientId: document.oauthClientId ?? null,
+    oauthClientAuthMethod: document.oauthClientAuthMethod ?? null,
     customHeaders: sortHeaders(document.customHeaders),
 });
 
@@ -309,6 +319,9 @@ export class ExternalConnectionCoderService extends BaseService {
                 apiKeyName: connection.apiKeyName,
                 apiKeyLocation: connection.apiKeyLocation,
                 oauthScopes: connection.oauthScopes,
+                oauthTokenUrl: connection.oauthTokenUrl,
+                oauthClientId: connection.oauthClientId,
+                oauthClientAuthMethod: connection.oauthClientAuthMethod,
                 customHeaders: connection.customHeaders,
                 ...(secret !== undefined ? { secret } : {}),
             };
@@ -369,6 +382,9 @@ export class ExternalConnectionCoderService extends BaseService {
             apiKeyName: connection.apiKeyName,
             apiKeyLocation: connection.apiKeyLocation,
             oauthScopes: connection.oauthScopes,
+            oauthTokenUrl: connection.oauthTokenUrl,
+            oauthClientId: connection.oauthClientId,
+            oauthClientAuthMethod: connection.oauthClientAuthMethod,
             customHeaders: connection.customHeaders,
             ...(secret !== undefined ? { secret } : {}),
         };

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.proxy.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.proxy.test.ts
@@ -133,6 +133,10 @@ function buildService(opts: {
             .fn()
             .mockResolvedValue(opts.googleToken ?? 'test-access-token'),
     };
+    const oauthClientCredentialsTokenProvider = {
+        getAccessToken: vi.fn().mockResolvedValue('test-oauth-access-token'),
+        invalidateAccessToken: vi.fn(),
+    };
     const appModel = {
         getApp: vi.fn().mockResolvedValue(baseApp()),
         findApp: vi
@@ -159,6 +163,7 @@ function buildService(opts: {
         spacePermissionService,
         analytics,
         googleTokenProvider,
+        oauthClientCredentialsTokenProvider,
     } as never);
 
     // Force the CASL view decision deterministically.
@@ -176,6 +181,7 @@ function buildService(opts: {
         appModel,
         analytics,
         googleTokenProvider,
+        oauthClientCredentialsTokenProvider,
     };
 }
 
@@ -633,6 +639,128 @@ describe('ExternalConnectionService.proxyFetch', () => {
             }),
         ).rejects.toBeInstanceOf(ParameterError);
         expect(mockSecureFetch).not.toHaveBeenCalled();
+    });
+
+    const OAUTH_CONNECTION = baseConnection({
+        type: 'oauth_client_credentials',
+        oauthTokenUrl: 'https://auth.example.com/oauth/token',
+        oauthClientId: 'client-1',
+        oauthClientAuthMethod: 'basic',
+        oauthScopes: ['read:data'],
+    });
+
+    it('mints and injects an OAuth client-credentials access token', async () => {
+        const { service, oauthClientCredentialsTokenProvider } = buildService({
+            connection: OAUTH_CONNECTION,
+            secret: 'client-secret',
+        });
+
+        await service.proxyFetch(user, 'proj-1', 'app-1', {
+            connectionAlias: 'weather',
+            path: '/v1/x',
+        });
+
+        expect(
+            oauthClientCredentialsTokenProvider.getAccessToken,
+        ).toHaveBeenCalledWith(
+            {
+                tokenUrl: 'https://auth.example.com/oauth/token',
+                clientId: 'client-1',
+                clientAuthMethod: 'basic',
+                scopes: ['read:data'],
+            },
+            'client-secret',
+        );
+        expect(mockSecureFetch.mock.calls[0][1].headers!.Authorization).toBe(
+            'Bearer test-oauth-access-token',
+        );
+    });
+
+    it('redacts an OAuth access token echoed by the resource server', async () => {
+        mockSecureFetch.mockResolvedValue({
+            status: 200,
+            contentType: 'application/json',
+            headers: {},
+            bodyText:
+                '{"authenticated":true,"token":"test-oauth-access-token"}',
+            truncated: false,
+        });
+        const { service } = buildService({
+            connection: OAUTH_CONNECTION,
+            secret: 'client-secret',
+        });
+
+        await expect(
+            service.proxyFetch(user, 'proj-1', 'app-1', {
+                connectionAlias: 'weather',
+                path: '/v1/x',
+            }),
+        ).resolves.toMatchObject({
+            body: { authenticated: true, token: '[REDACTED]' },
+        });
+    });
+
+    it('refreshes a rejected OAuth token and retries the resource request once', async () => {
+        const authorizations: Array<string | undefined> = [];
+        mockSecureFetch.mockImplementation(async (_url, options) => {
+            authorizations.push(options.headers?.Authorization);
+            return {
+                status: authorizations.length === 1 ? 401 : 200,
+                contentType: 'application/json',
+                headers: {},
+                bodyText: '{}',
+                truncated: false,
+            };
+        });
+        const { service, oauthClientCredentialsTokenProvider } = buildService({
+            connection: OAUTH_CONNECTION,
+            secret: 'client-secret',
+        });
+        oauthClientCredentialsTokenProvider.getAccessToken
+            .mockResolvedValueOnce('expired-token')
+            .mockResolvedValueOnce('fresh-token');
+
+        await expect(
+            service.proxyFetch(user, 'proj-1', 'app-1', {
+                connectionAlias: 'weather',
+                path: '/v1/x',
+            }),
+        ).resolves.toMatchObject({ status: 200 });
+
+        expect(authorizations).toEqual([
+            'Bearer expired-token',
+            'Bearer fresh-token',
+        ]);
+        expect(
+            oauthClientCredentialsTokenProvider.invalidateAccessToken,
+        ).toHaveBeenCalledWith(
+            expect.objectContaining({ clientId: 'client-1' }),
+            'client-secret',
+            'expired-token',
+        );
+        expect(mockSecureFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not retry a persistent OAuth 401 more than once', async () => {
+        mockSecureFetch.mockResolvedValue({
+            status: 401,
+            contentType: 'application/json',
+            headers: {},
+            bodyText: '{}',
+            truncated: false,
+        });
+        const { service } = buildService({
+            connection: OAUTH_CONNECTION,
+            secret: 'client-secret',
+        });
+
+        await expect(
+            service.proxyFetch(user, 'proj-1', 'app-1', {
+                connectionAlias: 'weather',
+                path: '/v1/x',
+            }),
+        ).resolves.toMatchObject({ status: 401 });
+        expect(mockSecureFetch).toHaveBeenCalledTimes(2);
     });
 
     it('sends the connection custom headers alongside the injected auth', async () => {

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.test.ts
@@ -193,6 +193,10 @@ function buildService(opts: {
         googleTokenProvider: {
             getAccessToken: vi.fn().mockResolvedValue('test-access-token'),
         } as never,
+        oauthClientCredentialsTokenProvider: {
+            getAccessToken: vi.fn().mockResolvedValue('test-oauth-token'),
+            invalidateAccessToken: vi.fn(),
+        } as never,
         orgAiCopilotConfigResolver: orgAiCopilotConfigResolver as never,
     });
     return { service, model, orgAiCopilotConfigResolver };
@@ -445,6 +449,17 @@ describe('ExternalConnectionService.update type switches', () => {
         oauthScopes: null,
         hasSecret: true,
     };
+    const oauthConnection: ExternalConnection = {
+        ...connection,
+        type: 'oauth_client_credentials',
+        oauthScopes: ['read:data'],
+        oauthTokenUrl: 'https://auth.example.com/oauth/token',
+        oauthClientId: 'client-1',
+        oauthClientAuthMethod: 'basic',
+        apiKeyName: null,
+        apiKeyLocation: null,
+        hasSecret: true,
+    };
     const keyfile = JSON.stringify({
         type: 'service_account',
         client_email: 'sa@proj.iam.gserviceaccount.com',
@@ -528,6 +543,55 @@ describe('ExternalConnectionService.update type switches', () => {
             }),
         ).rejects.toThrow(ParameterError);
         expect(model.update).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        {
+            field: 'token URL',
+            patch: {
+                oauthTokenUrl: 'https://other.example.com/oauth/token',
+            },
+        },
+        { field: 'client ID', patch: { oauthClientId: 'client-2' } },
+    ])(
+        'rejects changing the OAuth $field without a new secret',
+        async ({ patch }) => {
+            const { service, model } = buildService({
+                connection: oauthConnection,
+            });
+            mockAbility(service, true);
+
+            await expect(
+                service.update(
+                    adminAccount,
+                    projectUuid,
+                    connectionUuid,
+                    patch,
+                ),
+            ).rejects.toThrow(ParameterError);
+            expect(model.update).not.toHaveBeenCalled();
+        },
+    );
+
+    it('keeps the OAuth secret when scopes or auth method change', async () => {
+        const { service, model } = buildService({
+            connection: oauthConnection,
+        });
+        mockAbility(service, true);
+
+        await service.update(adminAccount, projectUuid, connectionUuid, {
+            oauthScopes: ['read:other'],
+            oauthClientAuthMethod: 'body',
+        });
+
+        expect(model.update).toHaveBeenCalledWith(
+            connectionUuid,
+            expect.anything(),
+            expect.objectContaining({
+                oauthScopes: ['read:other'],
+                oauthClientAuthMethod: 'body',
+            }),
+        );
     });
 
     it('keeps the stored secret for a normalized-equivalent origin', async () => {

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
@@ -30,7 +30,10 @@ import { toSessionUser } from '../../../auth/account';
 import { type AppModel } from '../../../models/AppModel';
 import { BaseService } from '../../../services/BaseService';
 import type { SpacePermissionService } from '../../../services/SpaceService/SpacePermissionService';
-import { normalizeCredentialUrlOrigin } from '../../../utils/credentialDestination';
+import {
+    normalizeCredentialUrlHref,
+    normalizeCredentialUrlOrigin,
+} from '../../../utils/credentialDestination';
 import {
     secureFetch,
     SecureFetchError,
@@ -52,6 +55,10 @@ import {
 } from './externalConnectionConfigValidation';
 import { type GoogleServiceAccountTokenProvider } from './GoogleServiceAccountTokenProvider';
 import {
+    type OAuthClientCredentialsConfig,
+    type OAuthClientCredentialsTokenProvider,
+} from './OAuthClientCredentialsTokenProvider';
+import {
     assertSafeApiKeyHeaderName,
     buildOutboundUrl,
     computeMinuteWindow,
@@ -67,6 +74,7 @@ type ExternalConnectionServiceArguments = {
     appModel: AppModel;
     spacePermissionService: SpacePermissionService;
     googleTokenProvider: GoogleServiceAccountTokenProvider;
+    oauthClientCredentialsTokenProvider: OAuthClientCredentialsTokenProvider;
     orgAiCopilotConfigResolver: OrgAiCopilotConfigResolver;
 };
 
@@ -81,6 +89,8 @@ export class ExternalConnectionService extends BaseService {
 
     private readonly googleTokenProvider: GoogleServiceAccountTokenProvider;
 
+    private readonly oauthClientCredentialsTokenProvider: OAuthClientCredentialsTokenProvider;
+
     private readonly orgAiCopilotConfigResolver: OrgAiCopilotConfigResolver;
 
     private static readonly DEFAULT_RATE_LIMIT_PER_MINUTE = 60;
@@ -94,6 +104,8 @@ export class ExternalConnectionService extends BaseService {
         this.appModel = args.appModel;
         this.spacePermissionService = args.spacePermissionService;
         this.googleTokenProvider = args.googleTokenProvider;
+        this.oauthClientCredentialsTokenProvider =
+            args.oauthClientCredentialsTokenProvider;
         this.orgAiCopilotConfigResolver = args.orgAiCopilotConfigResolver;
     }
 
@@ -360,9 +372,21 @@ export class ExternalConnectionService extends BaseService {
             data.origin !== undefined &&
             normalizeCredentialUrlOrigin(data.origin) !==
                 normalizeCredentialUrlOrigin(existing.origin);
+        const keepsOAuthClientCredentialsType =
+            existing.type === 'oauth_client_credentials' &&
+            resultingType === 'oauth_client_credentials';
+        const oauthTokenUrlChanged =
+            keepsOAuthClientCredentialsType &&
+            data.oauthTokenUrl !== undefined &&
+            normalizeCredentialUrlHref(data.oauthTokenUrl ?? '') !==
+                normalizeCredentialUrlHref(existing.oauthTokenUrl ?? '');
+        const oauthClientIdChanged =
+            keepsOAuthClientCredentialsType &&
+            data.oauthClientId !== undefined &&
+            data.oauthClientId !== existing.oauthClientId;
 
-        // A stored secret is valid only for its current auth type and origin.
-        // Changing either requires the caller to supply a new one.
+        // A stored secret is valid only for its current auth type and credential
+        // destinations. Changing one requires the caller to supply a new one.
         let hasSecretAfter: boolean;
         if (data.secret === null) {
             hasSecretAfter = false;
@@ -370,7 +394,11 @@ export class ExternalConnectionService extends BaseService {
             hasSecretAfter = true;
         } else {
             hasSecretAfter =
-                !typeChanged && !originChanged && existing.hasSecret;
+                !typeChanged &&
+                !originChanged &&
+                !oauthTokenUrlChanged &&
+                !oauthClientIdChanged &&
+                existing.hasSecret;
         }
 
         // Type-specific fields never carry across auth type changes and are
@@ -395,9 +423,25 @@ export class ExternalConnectionService extends BaseService {
             existing.apiKeyLocation,
         );
         const oauthScopes = resolveTypeField(
-            resultingType === 'google_service_account',
+            resultingType === 'google_service_account' ||
+                resultingType === 'oauth_client_credentials',
             data.oauthScopes,
             existing.oauthScopes,
+        );
+        const oauthTokenUrl = resolveTypeField(
+            resultingType === 'oauth_client_credentials',
+            data.oauthTokenUrl,
+            existing.oauthTokenUrl,
+        );
+        const oauthClientId = resolveTypeField(
+            resultingType === 'oauth_client_credentials',
+            data.oauthClientId,
+            existing.oauthClientId,
+        );
+        const oauthClientAuthMethod = resolveTypeField(
+            resultingType === 'oauth_client_credentials',
+            data.oauthClientAuthMethod,
+            existing.oauthClientAuthMethod,
         );
 
         const resolved: ExternalConnection = {
@@ -430,6 +474,9 @@ export class ExternalConnectionService extends BaseService {
             apiKeyName,
             apiKeyLocation,
             oauthScopes,
+            oauthTokenUrl,
+            oauthClientId,
+            oauthClientAuthMethod,
             customHeaders:
                 data.customHeaders !== undefined
                     ? data.customHeaders
@@ -472,6 +519,9 @@ export class ExternalConnectionService extends BaseService {
                 apiKeyName: resolved.apiKeyName,
                 apiKeyLocation: resolved.apiKeyLocation,
                 oauthScopes: resolved.oauthScopes,
+                oauthTokenUrl: resolved.oauthTokenUrl,
+                oauthClientId: resolved.oauthClientId,
+                oauthClientAuthMethod: resolved.oauthClientAuthMethod,
             },
         );
         this.analytics.track({
@@ -815,6 +865,7 @@ export class ExternalConnectionService extends BaseService {
         // Start from the app's query; add api_key-in-query if configured.
         const query: Record<string, string> = { ...(req.query ?? {}) };
         const headers: Record<string, string> = {};
+        let oauthAccessToken: string | null = null;
 
         // Admin-configured static headers (e.g. anthropic-version), applied
         // BEFORE auth and Content-Type so proxy-set headers always win.
@@ -884,6 +935,32 @@ export class ExternalConnectionService extends BaseService {
                 );
             }
             headers.Authorization = `Bearer ${accessToken}`;
+        } else if (connection.type === 'oauth_client_credentials') {
+            if (
+                !secret ||
+                !connection.oauthTokenUrl ||
+                !connection.oauthClientId ||
+                !connection.oauthClientAuthMethod
+            ) {
+                throw new ParameterError(
+                    'Connection is missing its OAuth client credentials configuration',
+                );
+            }
+            try {
+                oauthAccessToken =
+                    await this.oauthClientCredentialsTokenProvider.getAccessToken(
+                        {
+                            tokenUrl: connection.oauthTokenUrl,
+                            clientId: connection.oauthClientId,
+                            clientAuthMethod: connection.oauthClientAuthMethod,
+                            scopes: connection.oauthScopes ?? [],
+                        },
+                        secret,
+                    );
+                headers.Authorization = `Bearer ${oauthAccessToken}`;
+            } catch {
+                throw new ParameterError('Failed to obtain OAuth access token');
+            }
         }
         // type === 'none' → no auth injected.
 
@@ -925,9 +1002,8 @@ export class ExternalConnectionService extends BaseService {
         }
 
         // Delegate to the SSRF-hardened fetch.
-        let fetched;
-        try {
-            fetched = await secureFetch(url, {
+        const fetchResource = () =>
+            secureFetch(url, {
                 method: req.method,
                 body,
                 headers,
@@ -935,6 +1011,42 @@ export class ExternalConnectionService extends BaseService {
                 maxResponseBytes: connection.responseMaxBytes,
                 allowedContentTypes: connection.allowedContentTypes,
             });
+
+        let fetched;
+        try {
+            fetched = await fetchResource();
+
+            // A resource server can revoke a cached token before its advertised
+            // expiry. Refresh and replay once; never loop on persistent 401s.
+            if (
+                fetched.status === 401 &&
+                connection.type === 'oauth_client_credentials' &&
+                secret &&
+                connection.oauthTokenUrl &&
+                connection.oauthClientId &&
+                connection.oauthClientAuthMethod
+            ) {
+                const oauthConfig: OAuthClientCredentialsConfig = {
+                    tokenUrl: connection.oauthTokenUrl,
+                    clientId: connection.oauthClientId,
+                    clientAuthMethod: connection.oauthClientAuthMethod,
+                    scopes: connection.oauthScopes ?? [],
+                };
+                if (oauthAccessToken) {
+                    this.oauthClientCredentialsTokenProvider.invalidateAccessToken(
+                        oauthConfig,
+                        secret,
+                        oauthAccessToken,
+                    );
+                }
+                oauthAccessToken =
+                    await this.oauthClientCredentialsTokenProvider.getAccessToken(
+                        oauthConfig,
+                        secret,
+                    );
+                headers.Authorization = `Bearer ${oauthAccessToken}`;
+                fetched = await fetchResource();
+            }
         } catch (error) {
             // SecureFetchError propagates: the caller decides how much detail
             // to expose (runtime proxy: reason only; admin test tool: message).
@@ -952,12 +1064,17 @@ export class ExternalConnectionService extends BaseService {
             .toLowerCase();
         const isJson =
             mediaType === 'application/json' || mediaType.endsWith('+json');
-        let parsedBody: unknown = fetched.bodyText;
+        // An upstream can echo request headers. Remove the exact minted token
+        // before any response reaches an app, browser, or saved test sample.
+        const safeBodyText = oauthAccessToken
+            ? fetched.bodyText.split(oauthAccessToken).join('[REDACTED]')
+            : fetched.bodyText;
+        let parsedBody: unknown = safeBodyText;
         if (isJson) {
             try {
-                parsedBody = JSON.parse(fetched.bodyText);
+                parsedBody = JSON.parse(safeBodyText);
             } catch {
-                parsedBody = fetched.bodyText; // fall back to raw string
+                parsedBody = safeBodyText; // fall back to raw string
             }
         }
 
@@ -1351,6 +1468,9 @@ export class ExternalConnectionService extends BaseService {
             apiKeyName: data.apiKeyName ?? null,
             apiKeyLocation: data.apiKeyLocation ?? null,
             oauthScopes: data.oauthScopes ?? null,
+            oauthTokenUrl: data.oauthTokenUrl ?? null,
+            oauthClientId: data.oauthClientId ?? null,
+            oauthClientAuthMethod: data.oauthClientAuthMethod ?? null,
             customHeaders: data.customHeaders ?? null,
             hasSecret: Boolean(data.secret),
             createdByUserUuid: null,

--- a/packages/backend/src/ee/services/ExternalConnectionService/OAuthClientCredentialsTokenProvider.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/OAuthClientCredentialsTokenProvider.test.ts
@@ -1,0 +1,163 @@
+import { type SecureFetchOptions } from '../../../utils/secureFetch/secureFetch';
+import { OAuthClientCredentialsTokenProvider } from './OAuthClientCredentialsTokenProvider';
+
+const config = {
+    tokenUrl: 'https://auth.example.com/oauth/token',
+    clientId: 'client id',
+    clientAuthMethod: 'basic' as const,
+    scopes: ['read:data', 'https://api.example.com/.default'],
+};
+
+const tokenResponse = (token: string, expiresIn: number | string = 3600) => ({
+    status: 200,
+    contentType: 'application/json',
+    headers: {},
+    bodyText: JSON.stringify({
+        access_token: token,
+        token_type: 'Bearer',
+        expires_in: expiresIn,
+    }),
+    truncated: false,
+});
+
+beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-09-04T12:00:00.000Z'));
+});
+
+afterEach(() => {
+    vi.useRealTimers();
+});
+
+describe('OAuthClientCredentialsTokenProvider', () => {
+    it('mints with Basic authentication and caches the token', async () => {
+        const fetchToken = vi.fn().mockResolvedValue(tokenResponse('token-1'));
+        const provider = new OAuthClientCredentialsTokenProvider(fetchToken);
+
+        await expect(
+            provider.getAccessToken(config, 'client secret'),
+        ).resolves.toBe('token-1');
+        await expect(
+            provider.getAccessToken(config, 'client secret'),
+        ).resolves.toBe('token-1');
+
+        expect(fetchToken).toHaveBeenCalledTimes(1);
+        const [url, options] = fetchToken.mock.calls[0];
+        expect(url).toBe(config.tokenUrl);
+        expect(options).toMatchObject({
+            method: 'POST',
+            timeoutMs: 10_000,
+            maxResponseBytes: 64 * 1024,
+            allowedContentTypes: ['application/json'],
+        });
+        expect(options.headers.Authorization).toBe(
+            `Basic ${Buffer.from('client+id:client+secret').toString('base64')}`,
+        );
+        expect(new URLSearchParams(options.body)).toEqual(
+            new URLSearchParams({
+                grant_type: 'client_credentials',
+                scope: 'read:data https://api.example.com/.default',
+            }),
+        );
+    });
+
+    it('supports credentials in the request body and coalesces concurrent mints', async () => {
+        let resolveFetch: (value: ReturnType<typeof tokenResponse>) => void;
+        const fetchToken = vi.fn(
+            (_url: string, _options: SecureFetchOptions) =>
+                new Promise<ReturnType<typeof tokenResponse>>((resolve) => {
+                    resolveFetch = resolve;
+                }),
+        );
+        const provider = new OAuthClientCredentialsTokenProvider(fetchToken);
+        const bodyConfig = {
+            ...config,
+            clientAuthMethod: 'body' as const,
+            scopes: [],
+        };
+
+        const first = provider.getAccessToken(bodyConfig, 'secret');
+        const second = provider.getAccessToken(bodyConfig, 'secret');
+        expect(fetchToken).toHaveBeenCalledTimes(1);
+        resolveFetch!(tokenResponse('token-2', '120'));
+
+        await expect(Promise.all([first, second])).resolves.toEqual([
+            'token-2',
+            'token-2',
+        ]);
+        const options = fetchToken.mock.calls[0][1];
+        expect(options.headers!.Authorization).toBeUndefined();
+        expect(Object.fromEntries(new URLSearchParams(options.body))).toEqual({
+            grant_type: 'client_credentials',
+            client_id: 'client id',
+            client_secret: 'secret',
+        });
+    });
+
+    it('refreshes the cached token when it reaches the expiry skew', async () => {
+        const fetchToken = vi
+            .fn()
+            .mockResolvedValueOnce(tokenResponse('token-1', 100))
+            .mockResolvedValueOnce(tokenResponse('token-2', 100));
+        const provider = new OAuthClientCredentialsTokenProvider(fetchToken);
+
+        await expect(provider.getAccessToken(config, 'secret')).resolves.toBe(
+            'token-1',
+        );
+
+        vi.advanceTimersByTime(89_999);
+        await expect(provider.getAccessToken(config, 'secret')).resolves.toBe(
+            'token-1',
+        );
+
+        vi.advanceTimersByTime(1);
+        await expect(provider.getAccessToken(config, 'secret')).resolves.toBe(
+            'token-2',
+        );
+        expect(fetchToken).toHaveBeenCalledTimes(2);
+    });
+
+    it('invalidates only the rejected cached token', async () => {
+        const fetchToken = vi
+            .fn()
+            .mockResolvedValueOnce(tokenResponse('token-1'))
+            .mockResolvedValueOnce(tokenResponse('token-2'));
+        const provider = new OAuthClientCredentialsTokenProvider(fetchToken);
+
+        await provider.getAccessToken(config, 'secret');
+        provider.invalidateAccessToken(config, 'secret', 'newer-token');
+        await expect(provider.getAccessToken(config, 'secret')).resolves.toBe(
+            'token-1',
+        );
+
+        provider.invalidateAccessToken(config, 'secret', 'token-1');
+        await expect(provider.getAccessToken(config, 'secret')).resolves.toBe(
+            'token-2',
+        );
+        expect(fetchToken).toHaveBeenCalledTimes(2);
+    });
+
+    it('rejects unsuccessful or malformed token responses', async () => {
+        const fetchToken = vi
+            .fn()
+            .mockResolvedValueOnce({
+                ...tokenResponse('unused'),
+                status: 401,
+            })
+            .mockResolvedValueOnce({
+                ...tokenResponse('unused'),
+                bodyText: '{bad json',
+            })
+            .mockResolvedValueOnce({
+                ...tokenResponse('unused'),
+                bodyText: JSON.stringify({ token_type: 'Bearer' }),
+            });
+        const provider = new OAuthClientCredentialsTokenProvider(fetchToken);
+
+        await expect(provider.getAccessToken(config, 'one')).rejects.toThrow();
+        await expect(provider.getAccessToken(config, 'two')).rejects.toThrow();
+        await expect(
+            provider.getAccessToken(config, 'three'),
+        ).rejects.toThrow();
+    });
+});

--- a/packages/backend/src/ee/services/ExternalConnectionService/OAuthClientCredentialsTokenProvider.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/OAuthClientCredentialsTokenProvider.ts
@@ -24,7 +24,11 @@ const MAX_EXPIRY_SKEW_MS = 60_000;
 const formEncode = (value: string): string =>
     new URLSearchParams({ value }).toString().slice('value='.length);
 
-/** Mints and caches OAuth 2.0 client-credentials bearer tokens in memory. */
+/**
+ * Mints and caches OAuth 2.0 client-credentials bearer tokens in process
+ * memory. Each backend process has an independent cache, and a restart remints
+ * tokens on the next request.
+ */
 export class OAuthClientCredentialsTokenProvider {
     private readonly cache = new Map<
         string,

--- a/packages/backend/src/ee/services/ExternalConnectionService/OAuthClientCredentialsTokenProvider.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/OAuthClientCredentialsTokenProvider.ts
@@ -1,0 +1,177 @@
+import { createHash } from 'crypto';
+import {
+    secureFetch,
+    type SecureFetchResult,
+} from '../../../utils/secureFetch/secureFetch';
+
+export type OAuthClientCredentialsConfig = {
+    tokenUrl: string;
+    clientId: string;
+    clientAuthMethod: 'basic' | 'body';
+    scopes: string[];
+};
+
+type FetchToken = (
+    url: string,
+    options: Parameters<typeof secureFetch>[1],
+) => Promise<SecureFetchResult>;
+
+const TOKEN_TIMEOUT_MS = 10_000;
+const TOKEN_RESPONSE_MAX_BYTES = 64 * 1024;
+const FALLBACK_TTL_MS = 5 * 60_000;
+const MAX_EXPIRY_SKEW_MS = 60_000;
+
+const formEncode = (value: string): string =>
+    new URLSearchParams({ value }).toString().slice('value='.length);
+
+/** Mints and caches OAuth 2.0 client-credentials bearer tokens in memory. */
+export class OAuthClientCredentialsTokenProvider {
+    private readonly cache = new Map<
+        string,
+        { token: string; usableUntil: number }
+    >();
+
+    private readonly inFlight = new Map<string, Promise<string>>();
+
+    constructor(private readonly fetchToken: FetchToken = secureFetch) {}
+
+    private static getCacheKey(
+        config: OAuthClientCredentialsConfig,
+        clientSecret: string,
+    ): string {
+        return createHash('sha256')
+            .update(
+                JSON.stringify({
+                    ...config,
+                    scopes: [...config.scopes].sort(),
+                    clientSecret,
+                }),
+            )
+            .digest('hex');
+    }
+
+    async getAccessToken(
+        config: OAuthClientCredentialsConfig,
+        clientSecret: string,
+    ): Promise<string> {
+        const cacheKey = OAuthClientCredentialsTokenProvider.getCacheKey(
+            config,
+            clientSecret,
+        );
+        const cached = this.cache.get(cacheKey);
+        if (cached && cached.usableUntil > Date.now()) return cached.token;
+
+        const pending = this.inFlight.get(cacheKey);
+        if (pending) return pending;
+
+        const mint = this.mint(config, clientSecret, cacheKey);
+        this.inFlight.set(cacheKey, mint);
+        try {
+            return await mint;
+        } finally {
+            this.inFlight.delete(cacheKey);
+        }
+    }
+
+    invalidateAccessToken(
+        config: OAuthClientCredentialsConfig,
+        clientSecret: string,
+        rejectedToken: string,
+    ): void {
+        const cacheKey = OAuthClientCredentialsTokenProvider.getCacheKey(
+            config,
+            clientSecret,
+        );
+        if (this.cache.get(cacheKey)?.token === rejectedToken) {
+            this.cache.delete(cacheKey);
+        }
+    }
+
+    private async mint(
+        config: OAuthClientCredentialsConfig,
+        clientSecret: string,
+        cacheKey: string,
+    ): Promise<string> {
+        const body = new URLSearchParams({ grant_type: 'client_credentials' });
+        if (config.scopes.length > 0) {
+            body.set('scope', config.scopes.join(' '));
+        }
+
+        const headers: Record<string, string> = {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            Accept: 'application/json',
+        };
+        if (config.clientAuthMethod === 'basic') {
+            const credentials = `${formEncode(config.clientId)}:${formEncode(
+                clientSecret,
+            )}`;
+            headers.Authorization = `Basic ${Buffer.from(credentials).toString(
+                'base64',
+            )}`;
+        } else {
+            body.set('client_id', config.clientId);
+            body.set('client_secret', clientSecret);
+        }
+
+        const response = await this.fetchToken(config.tokenUrl, {
+            method: 'POST',
+            body: body.toString(),
+            headers,
+            timeoutMs: TOKEN_TIMEOUT_MS,
+            maxResponseBytes: TOKEN_RESPONSE_MAX_BYTES,
+            allowedContentTypes: ['application/json'],
+        });
+        if (response.status < 200 || response.status >= 300) {
+            throw new Error('OAuth token endpoint rejected the request');
+        }
+
+        let payload: unknown;
+        try {
+            payload = JSON.parse(response.bodyText);
+        } catch {
+            throw new Error('OAuth token endpoint returned invalid JSON');
+        }
+        if (!payload || typeof payload !== 'object') {
+            throw new Error(
+                'OAuth token endpoint returned an invalid response',
+            );
+        }
+        const tokenResponse = payload as Record<string, unknown>;
+        if (
+            typeof tokenResponse.access_token !== 'string' ||
+            tokenResponse.access_token.length === 0
+        ) {
+            throw new Error(
+                'OAuth token endpoint did not return an access token',
+            );
+        }
+        if (
+            tokenResponse.token_type !== undefined &&
+            (typeof tokenResponse.token_type !== 'string' ||
+                tokenResponse.token_type.toLowerCase() !== 'bearer')
+        ) {
+            throw new Error('OAuth token endpoint returned a non-bearer token');
+        }
+
+        let parsedExpiresIn = Number.NaN;
+        if (typeof tokenResponse.expires_in === 'number') {
+            parsedExpiresIn = tokenResponse.expires_in;
+        } else if (typeof tokenResponse.expires_in === 'string') {
+            parsedExpiresIn = Number(tokenResponse.expires_in);
+        }
+        const ttlMs =
+            Number.isFinite(parsedExpiresIn) && parsedExpiresIn > 0
+                ? parsedExpiresIn * 1_000
+                : FALLBACK_TTL_MS;
+        const skewMs = Math.min(MAX_EXPIRY_SKEW_MS, ttlMs * 0.1);
+        const now = Date.now();
+        for (const [key, entry] of this.cache) {
+            if (entry.usableUntil <= now) this.cache.delete(key);
+        }
+        this.cache.set(cacheKey, {
+            token: tokenResponse.access_token,
+            usableUntil: now + ttlMs - skewMs,
+        });
+        return tokenResponse.access_token;
+    }
+}

--- a/packages/backend/src/ee/services/ExternalConnectionService/externalConnectionConfigValidation.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/externalConnectionConfigValidation.test.ts
@@ -236,7 +236,7 @@ describe('validateExternalConnectionConfig', () => {
             ).not.toThrow();
         });
 
-        it('rejects oauthScopes on a non-google type', () => {
+        it('rejects oauthScopes on a non-OAuth type', () => {
             expect(() =>
                 validateExternalConnectionConfig(
                     {
@@ -247,6 +247,90 @@ describe('validateExternalConnectionConfig', () => {
                     true,
                 ),
             ).toThrow(ParameterError);
+        });
+
+        const oauthClientCredentials = {
+            ...base,
+            type: 'oauth_client_credentials' as const,
+            oauthTokenUrl: 'https://auth.example.com/oauth/token',
+            oauthClientId: 'client-1',
+            oauthClientAuthMethod: 'basic' as const,
+            oauthScopes: ['read:data'],
+        };
+
+        it('accepts OAuth client credentials with Basic or body authentication', () => {
+            expect(() =>
+                validateExternalConnectionConfig(oauthClientCredentials, true),
+            ).not.toThrow();
+            expect(() =>
+                validateExternalConnectionConfig(
+                    {
+                        ...oauthClientCredentials,
+                        oauthClientAuthMethod: 'body',
+                        oauthScopes: [],
+                    },
+                    true,
+                ),
+            ).not.toThrow();
+        });
+
+        it('requires a complete OAuth client-credentials configuration and secret', () => {
+            expect(() =>
+                validateExternalConnectionConfig(oauthClientCredentials, false),
+            ).toThrow(/requires a client secret/);
+            expect(() =>
+                validateExternalConnectionConfig(
+                    { ...oauthClientCredentials, oauthClientId: null },
+                    true,
+                ),
+            ).toThrow(/requires a valid client ID/);
+            expect(() =>
+                validateExternalConnectionConfig(
+                    { ...oauthClientCredentials, oauthTokenUrl: null },
+                    true,
+                ),
+            ).toThrow(/requires a valid token URL/);
+        });
+
+        it('rejects unsafe OAuth token URLs and invalid scopes', () => {
+            expect(() =>
+                validateExternalConnectionConfig(
+                    {
+                        ...oauthClientCredentials,
+                        oauthTokenUrl: 'http://auth.example.com/oauth/token',
+                    },
+                    true,
+                ),
+            ).toThrow(/must use https/);
+            expect(() =>
+                validateExternalConnectionConfig(
+                    {
+                        ...oauthClientCredentials,
+                        oauthTokenUrl:
+                            'https://client:secret@auth.example.com/oauth/token',
+                    },
+                    true,
+                ),
+            ).toThrow(/must not contain credentials/);
+            expect(() =>
+                validateExternalConnectionConfig(
+                    { ...oauthClientCredentials, oauthScopes: ['read data'] },
+                    true,
+                ),
+            ).toThrow(/Invalid OAuth scope/);
+        });
+
+        it('rejects OAuth client fields on another authentication type', () => {
+            expect(() =>
+                validateExternalConnectionConfig(
+                    {
+                        ...base,
+                        type: 'bearer_token',
+                        oauthTokenUrl: 'https://auth.example.com/oauth/token',
+                    },
+                    true,
+                ),
+            ).toThrow(/only valid for type "oauth_client_credentials"/);
         });
     });
 

--- a/packages/backend/src/ee/services/ExternalConnectionService/externalConnectionConfigValidation.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/externalConnectionConfigValidation.ts
@@ -4,6 +4,7 @@ import {
     ParameterError,
     type ApiKeyLocation,
     type ExternalConnectionAuthType,
+    type OAuthClientAuthMethod,
 } from '@lightdash/common';
 import { validateCustomHeaders } from './proxyValidation';
 
@@ -14,14 +15,18 @@ const MAX_REQUEST_BYTES = 10 * 1024 * 1024; // 10 MiB
 const MAX_TIMEOUT_MS = 120_000; // 2 minutes
 const MAX_RATE_LIMIT = 100_000;
 const MAX_INSTRUCTIONS_CHARS = 10_000;
+const MAX_OAUTH_TOKEN_URL_CHARS = 2_048;
+const MAX_OAUTH_CLIENT_ID_CHARS = 512;
+const MAX_OAUTH_SCOPES = 50;
+const MAX_OAUTH_SCOPE_CHARS = 2_048;
 
 const SUPPORTED_METHODS = new Set<string>(EXTERNAL_CONNECTION_METHODS);
 // RFC 7230 token chars — valid for HTTP header names and a safe set for query keys.
 const HTTP_TOKEN = /^[A-Za-z0-9!#$%&'*+.^_`|~-]+$/;
 const CONTENT_TYPE = /^[a-z0-9*]+\/[a-z0-9.+*-]+$/i;
-// Google OAuth scopes are full https URLs, except the OIDC scopes
-// openid/email/profile which Google's token endpoint accepts as bare names.
-export const OAUTH_SCOPE = /^(https:\/\/\S+|openid|email|profile)$/;
+// RFC 6749 scope-token: printable ASCII except double quote and backslash.
+export const OAUTH_SCOPE = /^[\x21\x23-\x5B\x5D-\x7E]+$/;
+const GOOGLE_OAUTH_SCOPE = /^(https:\/\/\S+|openid|email|profile)$/;
 // Must be an absolute path with no whitespace, query, or fragment.
 const PATH_PREFIX = /^\/[^\s?#]*$/;
 
@@ -45,6 +50,9 @@ export type ValidatableExternalConnectionConfig = {
     apiKeyName?: string | null;
     apiKeyLocation?: ApiKeyLocation | null;
     oauthScopes?: string[] | null;
+    oauthTokenUrl?: string | null;
+    oauthClientId?: string | null;
+    oauthClientAuthMethod?: OAuthClientAuthMethod | null;
     customHeaders?: Record<string, string> | null;
 };
 
@@ -223,13 +231,26 @@ export function validateExternalConnectionConfig(
     );
 
     // --- auth invariants ---
+    const usesOAuthScopes =
+        config.type === 'google_service_account' ||
+        config.type === 'oauth_client_credentials';
     if (
-        config.type !== 'google_service_account' &&
+        !usesOAuthScopes &&
         config.oauthScopes &&
         config.oauthScopes.length > 0
     ) {
         throw new ParameterError(
-            'OAuth scopes are only valid for type "google_service_account"',
+            'OAuth scopes are only valid for OAuth authentication types',
+        );
+    }
+    if (
+        config.type !== 'oauth_client_credentials' &&
+        (config.oauthTokenUrl ||
+            config.oauthClientId ||
+            config.oauthClientAuthMethod)
+    ) {
+        throw new ParameterError(
+            'OAuth client configuration is only valid for type "oauth_client_credentials"',
         );
     }
     switch (config.type) {
@@ -285,13 +306,89 @@ export function validateExternalConnectionConfig(
                 );
             }
             config.oauthScopes.forEach((scope) => {
-                if (typeof scope !== 'string' || !OAUTH_SCOPE.test(scope)) {
+                if (
+                    typeof scope !== 'string' ||
+                    scope.length > MAX_OAUTH_SCOPE_CHARS ||
+                    !GOOGLE_OAUTH_SCOPE.test(scope)
+                ) {
                     throw new ParameterError(
                         `Invalid OAuth scope: ${JSON.stringify(scope)}`,
                     );
                 }
             });
             break;
+        case 'oauth_client_credentials': {
+            if (!hasSecretAfter) {
+                throw new ParameterError(
+                    'type "oauth_client_credentials" requires a client secret',
+                );
+            }
+            if (config.apiKeyName || config.apiKeyLocation) {
+                throw new ParameterError(
+                    'type "oauth_client_credentials" must not set an api key name or location',
+                );
+            }
+            if (
+                !config.oauthClientId?.trim() ||
+                config.oauthClientId.length > MAX_OAUTH_CLIENT_ID_CHARS
+            ) {
+                throw new ParameterError(
+                    'type "oauth_client_credentials" requires a valid client ID',
+                );
+            }
+            if (
+                config.oauthClientAuthMethod !== 'basic' &&
+                config.oauthClientAuthMethod !== 'body'
+            ) {
+                throw new ParameterError(
+                    'type "oauth_client_credentials" requires client authentication method "basic" or "body"',
+                );
+            }
+            if (
+                !config.oauthTokenUrl ||
+                config.oauthTokenUrl.length > MAX_OAUTH_TOKEN_URL_CHARS
+            ) {
+                throw new ParameterError(
+                    'type "oauth_client_credentials" requires a valid token URL',
+                );
+            }
+            let tokenUrl: URL;
+            try {
+                tokenUrl = new URL(config.oauthTokenUrl);
+            } catch {
+                throw new ParameterError('OAuth token URL must be a valid URL');
+            }
+            if (tokenUrl.protocol !== 'https:') {
+                throw new ParameterError('OAuth token URL must use https');
+            }
+            if (tokenUrl.username || tokenUrl.password) {
+                throw new ParameterError(
+                    'OAuth token URL must not contain credentials',
+                );
+            }
+            if (!tokenUrl.hostname || tokenUrl.hash) {
+                throw new ParameterError(
+                    'OAuth token URL must include a host and must not contain a fragment',
+                );
+            }
+            if ((config.oauthScopes?.length ?? 0) > MAX_OAUTH_SCOPES) {
+                throw new ParameterError(
+                    `OAuth scopes must contain at most ${MAX_OAUTH_SCOPES} values`,
+                );
+            }
+            config.oauthScopes?.forEach((scope) => {
+                if (
+                    typeof scope !== 'string' ||
+                    scope.length > MAX_OAUTH_SCOPE_CHARS ||
+                    !OAUTH_SCOPE.test(scope)
+                ) {
+                    throw new ParameterError(
+                        `Invalid OAuth scope: ${JSON.stringify(scope)}`,
+                    );
+                }
+            });
+            break;
+        }
         default:
             assertUnreachable(
                 config.type,

--- a/packages/backend/src/ee/services/ai/agents/externalConnectionConfigGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/externalConnectionConfigGenerator.ts
@@ -231,6 +231,9 @@ export const normalizeProposal = (
         apiKeyName: isApiKey ? normalizeString(raw.apiKeyName) : null,
         apiKeyLocation: isApiKey ? (raw.apiKeyLocation ?? 'header') : null,
         oauthScopes,
+        oauthTokenUrl: null,
+        oauthClientId: null,
+        oauthClientAuthMethod: null,
         customHeaders: normalizeCustomHeaders(raw.customHeaders),
         allowedMethods: normalizeMethods(
             raw.allowedMethods,
@@ -263,6 +266,9 @@ const toValidatableConfig = (
     apiKeyName: proposal.apiKeyName,
     apiKeyLocation: proposal.apiKeyLocation,
     oauthScopes: proposal.oauthScopes,
+    oauthTokenUrl: proposal.oauthTokenUrl,
+    oauthClientId: proposal.oauthClientId,
+    oauthClientAuthMethod: proposal.oauthClientAuthMethod,
     customHeaders: proposal.customHeaders,
 });
 

--- a/packages/backend/src/utils/credentialDestination.ts
+++ b/packages/backend/src/utils/credentialDestination.ts
@@ -33,6 +33,10 @@ const normalizeUrl = (value: string): URL | undefined => {
 export const normalizeCredentialUrlOrigin = (value: string): string =>
     normalizeUrl(value)?.origin.toLowerCase() ?? value.trim().toLowerCase();
 
+/** Normalize a complete credential destination, including its path and query. */
+export const normalizeCredentialUrlHref = (value: string): string =>
+    normalizeUrl(value)?.href ?? value.trim();
+
 const normalizeCredentialBaseUrl = (value: string | undefined): string => {
     if (!value?.trim()) {
         return '';

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -1243,6 +1243,7 @@ const EXTERNAL_CONNECTION_SECRET_TYPES = new Set([
     'api_key',
     'bearer_token',
     'google_service_account',
+    'oauth_client_credentials',
 ]);
 
 /**

--- a/packages/common/src/ee/externalConnections/coder.ts
+++ b/packages/common/src/ee/externalConnections/coder.ts
@@ -4,6 +4,7 @@ import type {
     ApiKeyLocation,
     ExternalConnectionAuthType,
     ExternalConnectionMethod,
+    OAuthClientAuthMethod,
 } from './types';
 
 /**
@@ -34,6 +35,12 @@ export type ExternalConnectionAsCode = {
     apiKeyName: string | null;
     apiKeyLocation: ApiKeyLocation | null;
     oauthScopes: string[] | null;
+    /** Optional for compatibility with documents from older servers. */
+    oauthTokenUrl?: string | null;
+    /** Optional for compatibility with documents from older servers. */
+    oauthClientId?: string | null;
+    /** Optional for compatibility with documents from older servers. */
+    oauthClientAuthMethod?: OAuthClientAuthMethod | null;
     customHeaders: Record<string, string> | null;
 };
 

--- a/packages/common/src/ee/externalConnections/types.ts
+++ b/packages/common/src/ee/externalConnections/types.ts
@@ -2,7 +2,10 @@ export type ExternalConnectionAuthType =
     | 'none'
     | 'api_key'
     | 'bearer_token'
-    | 'google_service_account';
+    | 'google_service_account'
+    | 'oauth_client_credentials';
+
+export type OAuthClientAuthMethod = 'basic' | 'body';
 
 /** HTTP methods an admin can opt a connection into. Single source of truth for
  *  the backend validation allowlist and the frontend method pickers. */
@@ -74,8 +77,14 @@ export type ExternalConnection = {
     rateLimitPerMinute: number | null;
     apiKeyName: string | null;
     apiKeyLocation: ApiKeyLocation | null;
-    // OAuth scopes for type 'google_service_account'; null for other types.
+    // OAuth scopes for Google service accounts and OAuth client credentials.
     oauthScopes: string[] | null;
+    /** Optional for compatibility with older servers during rolling upgrades. */
+    oauthTokenUrl?: string | null;
+    /** Optional for compatibility with older servers during rolling upgrades. */
+    oauthClientId?: string | null;
+    /** Optional for compatibility with older servers during rolling upgrades. */
+    oauthClientAuthMethod?: OAuthClientAuthMethod | null;
     // Static non-secret headers sent on every proxied request, applied before
     // auth so the injected credential always wins (e.g. anthropic-version).
     customHeaders: Record<string, string> | null;
@@ -132,9 +141,12 @@ export type CreateExternalConnection = {
     rateLimitPerMinute?: number | null;
     apiKeyName?: string | null;
     apiKeyLocation?: ApiKeyLocation | null;
-    oauthScopes?: string[] | null; // OAuth scopes for type 'google_service_account'
+    oauthScopes?: string[] | null;
+    oauthTokenUrl?: string | null;
+    oauthClientId?: string | null;
+    oauthClientAuthMethod?: OAuthClientAuthMethod | null;
     customHeaders?: Record<string, string> | null; // static non-secret headers sent on every request
-    secret?: string | null; // bearer token, api key, or service account keyfile JSON; null for type 'none'
+    secret?: string | null; // bearer token, api key, client secret, or service-account keyfile JSON; null for type 'none'
 };
 
 /** Omitted/blank `secret` means the stored secret is left unchanged. */
@@ -220,6 +232,9 @@ export type ExternalConnectionConfigProposal = {
     apiKeyName: string | null;
     apiKeyLocation: ApiKeyLocation | null;
     oauthScopes: string[] | null;
+    oauthTokenUrl?: string | null;
+    oauthClientId?: string | null;
+    oauthClientAuthMethod?: OAuthClientAuthMethod | null;
     customHeaders: Record<string, string> | null;
     allowedMethods: ExternalConnectionMethod[];
     allowedPathPrefixes: string[];

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/AddConnectionWizard.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/AddConnectionWizard.tsx
@@ -31,6 +31,7 @@ import {
     isValidGoogleOAuthScope,
     isValidOAuthScope,
     SUGGESTED_GOOGLE_SCOPES,
+    validateOAuthTokenUrl,
 } from '../../../features/externalConnections/constants';
 import { useCreateExternalConnection } from '../../../features/externalConnections/hooks/useCreateExternalConnection';
 import { useProposeConnectionConfig } from '../../../features/externalConnections/hooks/useProposeConnectionConfig';
@@ -88,20 +89,6 @@ const validateOrigin = (value: string): string | null => {
     }
     if ((url.pathname && url.pathname !== '/') || url.search || url.hash) {
         return 'Enter just the base URL, with no path or query';
-    }
-    return null;
-};
-
-const validateOAuthTokenUrl = (value: string): string | null => {
-    let url: URL;
-    try {
-        url = new URL(value);
-    } catch {
-        return 'Enter a valid token URL';
-    }
-    if (url.protocol !== 'https:') return 'Token URL must start with https://';
-    if (url.username || url.password || url.hash) {
-        return 'Token URL must not contain credentials or a fragment';
     }
     return null;
 };

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/AddConnectionWizard.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/AddConnectionWizard.tsx
@@ -28,6 +28,7 @@ import { CustomHeadersField } from '../../../features/externalConnections/compon
 import { MethodsField } from '../../../features/externalConnections/components/MethodsField';
 import { PathRulesField } from '../../../features/externalConnections/components/PathRulesField';
 import {
+    isValidGoogleOAuthScope,
     isValidOAuthScope,
     SUGGESTED_GOOGLE_SCOPES,
 } from '../../../features/externalConnections/constants';
@@ -91,6 +92,20 @@ const validateOrigin = (value: string): string | null => {
     return null;
 };
 
+const validateOAuthTokenUrl = (value: string): string | null => {
+    let url: URL;
+    try {
+        url = new URL(value);
+    } catch {
+        return 'Enter a valid token URL';
+    }
+    if (url.protocol !== 'https:') return 'Token URL must start with https://';
+    if (url.username || url.password || url.hash) {
+        return 'Token URL must not contain credentials or a fragment';
+    }
+    return null;
+};
+
 const toCreatePayload = (values: WizardValues): CreateExternalConnection => ({
     name: values.name.trim(),
     origin: values.origin,
@@ -101,7 +116,22 @@ const toCreatePayload = (values: WizardValues): CreateExternalConnection => ({
     apiKeyName: values.type === 'api_key' ? values.apiKeyName.trim() : null,
     apiKeyLocation: values.type === 'api_key' ? values.apiKeyLocation : null,
     oauthScopes:
-        values.type === 'google_service_account' ? values.oauthScopes : null,
+        values.type === 'google_service_account' ||
+        values.type === 'oauth_client_credentials'
+            ? values.oauthScopes
+            : null,
+    oauthTokenUrl:
+        values.type === 'oauth_client_credentials'
+            ? values.oauthTokenUrl.trim()
+            : null,
+    oauthClientId:
+        values.type === 'oauth_client_credentials'
+            ? values.oauthClientId.trim()
+            : null,
+    oauthClientAuthMethod:
+        values.type === 'oauth_client_credentials'
+            ? values.oauthClientAuthMethod
+            : null,
     customHeaders: customHeaderRowsToRecord(values.customHeaders),
     allowedMethods: values.allowedMethods,
     allowedPathPrefixes: resolvePathPrefixes(
@@ -157,6 +187,10 @@ const AuthStep: FC<{
                         { value: 'api_key', label: 'API key' },
                         { value: 'bearer_token', label: 'Bearer token' },
                         { value: 'google_service_account', label: 'Google' },
+                        {
+                            value: 'oauth_client_credentials',
+                            label: 'OAuth 2',
+                        },
                     ]}
                     value={type}
                     onChange={(value) =>
@@ -199,7 +233,7 @@ const AuthStep: FC<{
                 </Callout>
             )}
 
-            {type !== 'none' && type !== 'google_service_account' && (
+            {(type === 'api_key' || type === 'bearer_token') && (
                 <PasswordInput
                     required
                     label={type === 'api_key' ? 'API key' : 'Bearer token'}
@@ -210,6 +244,46 @@ const AuthStep: FC<{
                     }
                     {...form.getInputProps('secret')}
                 />
+            )}
+
+            {type === 'oauth_client_credentials' && (
+                <>
+                    <TextInput
+                        required
+                        label="Token URL"
+                        description="The OAuth server endpoint used to obtain access tokens"
+                        placeholder="https://api.example.com/oauth/token"
+                        {...form.getInputProps('oauthTokenUrl')}
+                    />
+                    <TextInput
+                        required
+                        label="Client ID"
+                        placeholder="Your OAuth client ID"
+                        {...form.getInputProps('oauthClientId')}
+                    />
+                    <PasswordInput
+                        required
+                        label="Client secret"
+                        placeholder="Your OAuth client secret"
+                        {...form.getInputProps('secret')}
+                    />
+                    <Select
+                        required
+                        allowDeselect={false}
+                        label="Send client credentials as"
+                        data={[
+                            { value: 'basic', label: 'Authorization header' },
+                            { value: 'body', label: 'Request body' },
+                        ]}
+                        {...form.getInputProps('oauthClientAuthMethod')}
+                    />
+                    <TagsInput
+                        label="OAuth scopes (optional)"
+                        description="Sent as a space-separated token request parameter"
+                        placeholder="Add a scope"
+                        {...form.getInputProps('oauthScopes')}
+                    />
+                </>
             )}
 
             {type === 'google_service_account' && (
@@ -349,6 +423,9 @@ export const AddConnectionWizard: FC<Props> = ({
             apiKeyName: '',
             apiKeyLocation: 'header',
             oauthScopes: [],
+            oauthTokenUrl: '',
+            oauthClientId: '',
+            oauthClientAuthMethod: 'basic',
             customHeaders: [],
             allowedMethods: ['GET'],
             pathMode: 'all',
@@ -373,13 +450,32 @@ export const AddConnectionWizard: FC<Props> = ({
                 return null;
             },
             oauthScopes: (value, values) => {
-                if (values.type !== 'google_service_account') return null;
-                if (value.length === 0) return 'Add at least one OAuth scope';
-                const invalid = value.find((s) => !isValidOAuthScope(s));
-                return invalid
-                    ? `Invalid OAuth scope: ${invalid} (use an https:// scope)`
-                    : null;
+                if (
+                    values.type !== 'google_service_account' &&
+                    values.type !== 'oauth_client_credentials'
+                )
+                    return null;
+                if (
+                    values.type === 'google_service_account' &&
+                    value.length === 0
+                )
+                    return 'Add at least one OAuth scope';
+                const isValid =
+                    values.type === 'google_service_account'
+                        ? isValidGoogleOAuthScope
+                        : isValidOAuthScope;
+                const invalid = value.find((s) => !isValid(s));
+                return invalid ? `Invalid OAuth scope: ${invalid}` : null;
             },
+            oauthTokenUrl: (value, values) =>
+                values.type === 'oauth_client_credentials'
+                    ? validateOAuthTokenUrl(value)
+                    : null,
+            oauthClientId: (value, values) =>
+                values.type === 'oauth_client_credentials' &&
+                value.trim().length === 0
+                    ? 'Client ID is required'
+                    : null,
             apiKeyName: (value, values) => {
                 if (values.type !== 'api_key') return null;
                 if (value.trim().length === 0)
@@ -461,11 +557,15 @@ export const AddConnectionWizard: FC<Props> = ({
         const secret = form.validateField('secret');
         const apiKeyName = form.validateField('apiKeyName');
         const oauthScopes = form.validateField('oauthScopes');
+        const oauthTokenUrl = form.validateField('oauthTokenUrl');
+        const oauthClientId = form.validateField('oauthClientId');
         const customHeaders = form.validateField('customHeaders');
         if (
             !secret.hasError &&
             !apiKeyName.hasError &&
             !oauthScopes.hasError &&
+            !oauthTokenUrl.hasError &&
+            !oauthClientId.hasError &&
             !customHeaders.hasError
         ) {
             setActive(2);

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionsTable.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionsTable.tsx
@@ -46,6 +46,8 @@ const authLabel = (type: ExternalConnection['type']): string => {
             return 'Bearer token';
         case 'google_service_account':
             return 'Google service account';
+        case 'oauth_client_credentials':
+            return 'OAuth 2.0 client credentials';
         default:
             return assertUnreachable(type, `Unknown auth type ${type}`);
     }

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/EditConnectionModal.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/EditConnectionModal.tsx
@@ -7,7 +7,10 @@ import { Button, Stack, Tabs, Text, Textarea } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { IconPencil } from '@tabler/icons-react';
 import { type FC, useState } from 'react';
-import { isValidOAuthScope } from '../../../features/externalConnections/constants';
+import {
+    isValidGoogleOAuthScope,
+    isValidOAuthScope,
+} from '../../../features/externalConnections/constants';
 import { useSaveConnectionSample } from '../../../features/externalConnections/hooks/useSaveConnectionSample';
 import { useUpdateExternalConnection } from '../../../features/externalConnections/hooks/useUpdateExternalConnection';
 import {
@@ -52,7 +55,22 @@ const toUpdateExternalConnection = (
     apiKeyName: values.type === 'api_key' ? values.apiKeyName : null,
     apiKeyLocation: values.type === 'api_key' ? values.apiKeyLocation : null,
     oauthScopes:
-        values.type === 'google_service_account' ? values.oauthScopes : null,
+        values.type === 'google_service_account' ||
+        values.type === 'oauth_client_credentials'
+            ? values.oauthScopes
+            : null,
+    oauthTokenUrl:
+        values.type === 'oauth_client_credentials'
+            ? values.oauthTokenUrl.trim()
+            : null,
+    oauthClientId:
+        values.type === 'oauth_client_credentials'
+            ? values.oauthClientId.trim()
+            : null,
+    oauthClientAuthMethod:
+        values.type === 'oauth_client_credentials'
+            ? values.oauthClientAuthMethod
+            : null,
     customHeaders: customHeaderRowsToRecord(values.customHeaders),
     // Blank => omit so the stored secret is unchanged. A non-blank value on a
     // non-"none" type is used for both testing and credential rotation.
@@ -97,6 +115,9 @@ const EditConnectionModalContent: FC<Props> = ({
             apiKeyName: connection.apiKeyName ?? '',
             apiKeyLocation: connection.apiKeyLocation ?? 'header',
             oauthScopes: connection.oauthScopes ?? [],
+            oauthTokenUrl: connection.oauthTokenUrl ?? '',
+            oauthClientId: connection.oauthClientId ?? '',
+            oauthClientAuthMethod: connection.oauthClientAuthMethod ?? 'basic',
             customHeaders: recordToCustomHeaderRows(connection.customHeaders),
             allowedMethods: connection.allowedMethods,
             pathMode: pathRules.mode,
@@ -123,16 +144,64 @@ const EditConnectionModalContent: FC<Props> = ({
                         return 'Paste valid service account JSON';
                     }
                 }
+                if (values.type === 'oauth_client_credentials' && !value) {
+                    if (
+                        connection.type !== 'oauth_client_credentials' ||
+                        !connection.hasSecret
+                    ) {
+                        return 'Client secret is required';
+                    }
+                    if (
+                        values.oauthTokenUrl.trim() !==
+                            (connection.oauthTokenUrl ?? '') ||
+                        values.oauthClientId.trim() !==
+                            (connection.oauthClientId ?? '')
+                    ) {
+                        return 'Re-enter the client secret when changing the token URL or client ID';
+                    }
+                }
                 return null;
             },
             oauthScopes: (value, values) => {
-                if (values.type !== 'google_service_account') return null;
-                if (value.length === 0) return 'Add at least one OAuth scope';
-                const invalid = value.find((s) => !isValidOAuthScope(s));
-                return invalid
-                    ? `Invalid OAuth scope: ${invalid} (use an https:// scope)`
-                    : null;
+                if (
+                    values.type !== 'google_service_account' &&
+                    values.type !== 'oauth_client_credentials'
+                )
+                    return null;
+                if (
+                    values.type === 'google_service_account' &&
+                    value.length === 0
+                )
+                    return 'Add at least one OAuth scope';
+                const isValid =
+                    values.type === 'google_service_account'
+                        ? isValidGoogleOAuthScope
+                        : isValidOAuthScope;
+                const invalid = value.find((s) => !isValid(s));
+                return invalid ? `Invalid OAuth scope: ${invalid}` : null;
             },
+            oauthTokenUrl: (value, values) => {
+                if (values.type !== 'oauth_client_credentials') return null;
+                try {
+                    const url = new URL(value);
+                    if (
+                        url.protocol !== 'https:' ||
+                        url.username ||
+                        url.password ||
+                        url.hash
+                    ) {
+                        return 'Enter a valid HTTPS token URL';
+                    }
+                } catch {
+                    return 'Enter a valid HTTPS token URL';
+                }
+                return null;
+            },
+            oauthClientId: (value, values) =>
+                values.type === 'oauth_client_credentials' &&
+                value.trim().length === 0
+                    ? 'Client ID is required'
+                    : null,
             customHeaders: validateCustomHeaderRows,
             allowedMethods: (value, values) =>
                 value.length === 0 && !values.allowBrowserImages

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/EditConnectionModal.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/EditConnectionModal.tsx
@@ -10,6 +10,7 @@ import { type FC, useState } from 'react';
 import {
     isValidGoogleOAuthScope,
     isValidOAuthScope,
+    validateOAuthTokenUrl,
 } from '../../../features/externalConnections/constants';
 import { useSaveConnectionSample } from '../../../features/externalConnections/hooks/useSaveConnectionSample';
 import { useUpdateExternalConnection } from '../../../features/externalConnections/hooks/useUpdateExternalConnection';
@@ -180,23 +181,10 @@ const EditConnectionModalContent: FC<Props> = ({
                 const invalid = value.find((s) => !isValid(s));
                 return invalid ? `Invalid OAuth scope: ${invalid}` : null;
             },
-            oauthTokenUrl: (value, values) => {
-                if (values.type !== 'oauth_client_credentials') return null;
-                try {
-                    const url = new URL(value);
-                    if (
-                        url.protocol !== 'https:' ||
-                        url.username ||
-                        url.password ||
-                        url.hash
-                    ) {
-                        return 'Enter a valid HTTPS token URL';
-                    }
-                } catch {
-                    return 'Enter a valid HTTPS token URL';
-                }
-                return null;
-            },
+            oauthTokenUrl: (value, values) =>
+                values.type === 'oauth_client_credentials'
+                    ? validateOAuthTokenUrl(value)
+                    : null,
             oauthClientId: (value, values) =>
                 values.type === 'oauth_client_credentials' &&
                 value.trim().length === 0

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ExternalConnectionForm.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ExternalConnectionForm.tsx
@@ -41,6 +41,9 @@ export type ExternalConnectionFormValues = {
     apiKeyName: string;
     apiKeyLocation: 'header' | 'query';
     oauthScopes: string[];
+    oauthTokenUrl: string;
+    oauthClientId: string;
+    oauthClientAuthMethod: 'basic' | 'body';
     customHeaders: CustomHeaderRow[];
     allowedMethods: ExternalConnectionMethod[];
     pathMode: PathMode;
@@ -117,17 +120,65 @@ export const ExternalConnectionForm: FC<Props> = ({
                         value: 'google_service_account',
                         label: 'Google service account',
                     },
+                    {
+                        value: 'oauth_client_credentials',
+                        label: 'OAuth 2.0 client credentials',
+                    },
                 ]}
                 {...form.getInputProps('type')}
             />
 
-            {type !== 'none' && type !== 'google_service_account' && (
+            {(type === 'api_key' || type === 'bearer_token') && (
                 <PasswordInput
                     label={type === 'api_key' ? 'API key' : 'Bearer token'}
                     placeholder={secretPlaceholder}
                     disabled={disabled}
                     {...form.getInputProps('secret')}
                 />
+            )}
+
+            {type === 'oauth_client_credentials' && (
+                <>
+                    <TextInput
+                        required
+                        label="Token URL"
+                        description="The OAuth server endpoint used to obtain access tokens"
+                        placeholder="https://api.example.com/oauth/token"
+                        disabled={disabled}
+                        {...form.getInputProps('oauthTokenUrl')}
+                    />
+                    <TextInput
+                        required
+                        label="Client ID"
+                        placeholder="Your OAuth client ID"
+                        disabled={disabled}
+                        {...form.getInputProps('oauthClientId')}
+                    />
+                    <PasswordInput
+                        label="Client secret"
+                        placeholder={secretPlaceholder}
+                        disabled={disabled}
+                        {...form.getInputProps('secret')}
+                    />
+                    <Select
+                        required
+                        allowDeselect={false}
+                        label="Send client credentials as"
+                        data={[
+                            { value: 'basic', label: 'Authorization header' },
+                            { value: 'body', label: 'Request body' },
+                        ]}
+                        disabled={disabled}
+                        {...form.getInputProps('oauthClientAuthMethod')}
+                    />
+                    <TagsInput
+                        label="OAuth scopes (optional)"
+                        description="Sent as a space-separated token request parameter"
+                        placeholder="Add a scope"
+                        disabled={disabled}
+                        {...form.getInputProps('oauthScopes')}
+                    />
+                </>
             )}
 
             {type === 'google_service_account' && (

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/wizardValues.ts
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/wizardValues.ts
@@ -24,6 +24,9 @@ export type WizardValues = {
     apiKeyName: string;
     apiKeyLocation: ApiKeyLocation;
     oauthScopes: string[];
+    oauthTokenUrl: string;
+    oauthClientId: string;
+    oauthClientAuthMethod: 'basic' | 'body';
     customHeaders: CustomHeaderRow[];
     allowedMethods: ExternalConnectionMethod[];
     pathMode: PathMode;
@@ -80,6 +83,9 @@ export const applyProposalToWizardValues = (
         apiKeyName: proposal.apiKeyName ?? '',
         apiKeyLocation: proposal.apiKeyLocation ?? 'header',
         oauthScopes: proposal.oauthScopes ?? [],
+        oauthTokenUrl: proposal.oauthTokenUrl ?? '',
+        oauthClientId: proposal.oauthClientId ?? '',
+        oauthClientAuthMethod: proposal.oauthClientAuthMethod ?? 'basic',
         customHeaders: recordToCustomHeaderRows(proposal.customHeaders),
         allowedMethods: proposal.allowedMethods,
         pathMode: mode,

--- a/packages/frontend/src/features/externalConnections/constants.ts
+++ b/packages/frontend/src/features/externalConnections/constants.ts
@@ -15,3 +15,17 @@ export const isValidOAuthScope = (scope: string): boolean =>
 
 export const isValidGoogleOAuthScope = (scope: string): boolean =>
     GOOGLE_OAUTH_SCOPE_REGEX.test(scope);
+
+export const validateOAuthTokenUrl = (value: string): string | null => {
+    let url: URL;
+    try {
+        url = new URL(value);
+    } catch {
+        return 'Enter a valid token URL';
+    }
+    if (url.protocol !== 'https:') return 'Token URL must start with https://';
+    if (url.username || url.password || url.hash) {
+        return 'Token URL must not contain credentials or a fragment';
+    }
+    return null;
+};

--- a/packages/frontend/src/features/externalConnections/constants.ts
+++ b/packages/frontend/src/features/externalConnections/constants.ts
@@ -5,10 +5,13 @@ export const SUGGESTED_GOOGLE_SCOPES = [
     'https://www.googleapis.com/auth/cloud-platform',
 ];
 
-// Mirrors the backend OAUTH_SCOPE validator so bad scopes are caught inline
-// (externalConnectionConfigValidation.ts). Google scopes are full https URLs,
-// except the OIDC scopes openid/email/profile.
-const OAUTH_SCOPE_REGEX = /^(https:\/\/\S+|openid|email|profile)$/;
+// Mirrors the backend RFC 6749 scope-token validator so bad scopes are caught
+// inline for both Google and client-credentials connections.
+const OAUTH_SCOPE_REGEX = /^[\x21\x23-\x5B\x5D-\x7E]+$/;
+const GOOGLE_OAUTH_SCOPE_REGEX = /^(https:\/\/\S+|openid|email|profile)$/;
 
 export const isValidOAuthScope = (scope: string): boolean =>
     OAUTH_SCOPE_REGEX.test(scope);
+
+export const isValidGoogleOAuthScope = (scope: string): boolean =>
+    GOOGLE_OAUTH_SCOPE_REGEX.test(scope);


### PR DESCRIPTION
Closes: [GLITCH-752](https://linear.app/lightdash/issue/GLITCH-752/data-app-external-connections-support-oauth2-client-credentials-auth)

### Description:

```diff
 External connection authentication
- mint expiring OAuth tokens externally and paste them into Lightdash
+ configure client credentials once and let Lightdash mint and refresh bearer tokens server-side
```

- Adds OAuth 2.0 client-credentials connections with HTTP Basic or form-body client authentication and optional scopes.
- Caches tokens in the backend, refreshes before `expires_in`, and invalidates/retries once when a resource request returns `401`.
- Keeps client secrets and minted access tokens server-side; token endpoints use the SSRF-hardened HTTPS fetch path with redirects disabled, and echoed tokens are redacted before responses reach apps or saved samples.
- Preserves credentials only while the auth type, resource origin, token URL, and client ID remain unchanged; destination changes require a replacement secret.
- Persists the new configuration through project copy and content-as-code import/export while keeping the secret out of exported documents.

Validation:

- `pnpm -F backend test` against the 6 affected test files: 208 tests passed.
- `pnpm -F {common,backend,frontend,cli} typecheck`.
- `pnpm -F {common,backend,frontend,cli} lint`.
- `pnpm -F {common,backend,frontend,cli} format`.
- `pnpm exec tsx scripts/sql-migration-lint.ts --last-tag origin/main --enforce`: 1 migration checked, 0 errors, 0 warnings.
- `pnpm generate-api` completed; generated route/spec artifacts were intentionally excluded from the commit.
- Persisted localhost E2E with the Duende OAuth demo: created and linked an OAuth connection to a new Data App, verified Basic authentication, then edited it to request-body authentication without re-entering the stored secret. The Data App minted a fresh token and rendered `GET /api/test` as HTTP 200 with `client_id=m2m`, `scope=api`, and Bearer authorization. Test data remains persisted.
- Not tested with real Sigma credentials or across multiple backend replicas. Expiry refresh is covered with a fake-clock regression test; each backend process maintains its own token cache.

### Risk assessment:

- [ ] This is a high-risk change

Low risk: the migration only adds nullable columns and passes the release-safety linter. Existing authentication types are unchanged. OAuth credentials remain encrypted/server-side, credential destinations are validated, redirects are rejected, and a failed refresh or persistent `401` is bounded to one resource retry.
