### PR TITLE
fix: validate SSH tunnel public key before saving project

### DIFF
--- a/packages/backend/src/models/SshKeyPairModel.ts
+++ b/packages/backend/src/models/SshKeyPairModel.ts
@@ -1,4 +1,4 @@
-import { type SshKeyPair } from '@lightdash/common';
+import { ParameterError, type SshKeyPair } from '@lightdash/common';
 import { Knex } from 'knex';
 import { generateOpenSshKeyPair } from '../utils';
 import { type EncryptionUtil } from '../utils/EncryptionUtil/EncryptionUtil';
@@ -36,7 +36,9 @@ export class SshKeyPairModel {
             .where({ public_key: publicKey })
             .first();
         if (row === undefined) {
-            throw new Error('Public SSH Key not recognised');
+            throw new ParameterError(
+                'SSH public key not found. Generate a new key in the SSH tunnel settings and save again.',
+            );
         }
         const privateKey = this.encryptionUtil.decrypt(row.private_key);
         return {

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -1630,6 +1630,46 @@ describe('ProjectService', () => {
         );
     });
 
+    test('rejects an SSH tunnel connection without a generated public key', async () => {
+        await expect(
+            service.createWithoutCompile(
+                {
+                    ...user,
+                    organizationUuid:
+                        projectWithSensitiveFields.organizationUuid,
+                    organizationName: 'Organization',
+                    organizationCreatedAt: new Date(),
+                    ability: new Ability<PossibleAbilities>([
+                        { subject: 'Project', action: 'create' },
+                    ]),
+                },
+                {
+                    name: 'SSH project',
+                    type: ProjectType.DEFAULT,
+                    dbtConnection: { type: DbtProjectType.NONE },
+                    dbtVersion: projectWithSensitiveFields.dbtVersion,
+                    warehouseConnection: {
+                        type: WarehouseTypes.POSTGRES,
+                        host: 'localhost',
+                        user: 'user',
+                        password: 'password',
+                        port: 5432,
+                        dbname: 'db',
+                        schema: 'public',
+                        useSshTunnel: true,
+                        sshTunnelHost: 'bastion',
+                        sshTunnelPort: 22,
+                        sshTunnelUser: 'ssh-user',
+                        sshTunnelPublicKey: '',
+                    },
+                },
+                RequestMethod.WEB_APP,
+            ),
+        ).rejects.toThrow(
+            'SSH tunnel is enabled but no public key was generated',
+        );
+    });
+
     describe('default AI agent provisioning', () => {
         test('provisions a default AI agent for a playground when the organization already has another project', async () => {
             const createdProjectUuid = 'created-playground-project-uuid';

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1547,7 +1547,12 @@ export class ProjectService extends BaseService {
                 args.warehouseConnection.type === WarehouseTypes.POSTGRES) &&
             args.warehouseConnection.useSshTunnel
         ) {
-            const publicKey = args.warehouseConnection.sshTunnelPublicKey || '';
+            const publicKey = args.warehouseConnection.sshTunnelPublicKey;
+            if (!publicKey) {
+                throw new ParameterError(
+                    'SSH tunnel is enabled but no public key was generated. Generate a public key and save again.',
+                );
+            }
             const { privateKey } = await this.sshKeyPairModel.get(publicKey);
             return {
                 ...args,

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/PostgresForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/PostgresForm.tsx
@@ -6,6 +6,7 @@ import {
     Anchor,
     Select,
     PasswordInput,
+    Input,
 } from '@mantine/core';
 import React, { type FC, type ReactNode } from 'react';
 import { useToggle } from 'react-use';
@@ -65,6 +66,7 @@ const PostgresForm: FC<{
         (savedProject?.warehouseConnection?.type === WarehouseTypes.POSTGRES
             ? savedProject?.warehouseConnection?.sshTunnelPublicKey
             : undefined);
+    const sshTunnelPublicKeyError = form.errors['warehouse.sshTunnelPublicKey'];
 
     const sslMode: string | undefined =
         form.values.warehouse.sslmode ??
@@ -387,6 +389,11 @@ const PostgresForm: FC<{
                                         ? 'Regenerate key'
                                         : 'Generate public key'}
                                 </Button>
+                                {sshTunnelPublicKeyError && (
+                                    <Input.Error>
+                                        {sshTunnelPublicKeyError}
+                                    </Input.Error>
+                                )}
                             </Stack>
                         </FormSection>
                     </Stack>

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/RedshiftForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/RedshiftForm.tsx
@@ -6,6 +6,7 @@ import {
     Anchor,
     Select,
     PasswordInput,
+    Input,
 } from '@mantine/core';
 import { useEffect, type FC, type ReactNode } from 'react';
 import { useToggle } from 'react-use';
@@ -131,6 +132,7 @@ const RedshiftForm: FC<{
         (savedProject?.warehouseConnection?.type === WarehouseTypes.REDSHIFT
             ? savedProject?.warehouseConnection?.sshTunnelPublicKey
             : undefined);
+    const sshTunnelPublicKeyError = form.errors['warehouse.sshTunnelPublicKey'];
 
     const { mutate, isLoading } = useCreateSshKeyPair({
         onSuccess: (data) => {
@@ -382,6 +384,11 @@ const RedshiftForm: FC<{
                                         ? 'Regenerate key'
                                         : 'Generate public key'}
                                 </Button>
+                                {sshTunnelPublicKeyError && (
+                                    <Input.Error>
+                                        {sshTunnelPublicKeyError}
+                                    </Input.Error>
+                                )}
                             </Stack>
                         </FormSection>
                     </Stack>

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/validators.ts
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/validators.ts
@@ -15,11 +15,53 @@ import {
 } from '../../../utils/fieldValidators';
 import { type ProjectConnectionForm } from '../types';
 
-type Validator = (value: string) => string | undefined;
+type CreateValidator = (
+    value: string,
+    values: ProjectConnectionForm,
+) => string | undefined;
+
+const required = (
+    fieldName: string,
+    ...validators: FieldValidator<string>[]
+): CreateValidator => everyValidator(fieldName, isRequired, ...validators);
+
+const requiredWhen =
+    (
+        fieldName: string,
+        predicate: (values: ProjectConnectionForm) => boolean,
+        ...validators: FieldValidator<string>[]
+    ): CreateValidator =>
+    (value, values) =>
+        everyValidator(
+            fieldName,
+            ...(predicate(values) ? [isRequired, ...validators] : validators),
+        )(value);
+
+const sshTunnelEnabled = (values: ProjectConnectionForm) =>
+    (values.warehouse.type === WarehouseTypes.POSTGRES ||
+        values.warehouse.type === WarehouseTypes.REDSHIFT) &&
+    values.warehouse.useSshTunnel === true;
+
+const sshTunnelValidators: Record<string, CreateValidator> = {
+    sshTunnelHost: requiredWhen(
+        'SSH Remote Host',
+        sshTunnelEnabled,
+        hasNoWhiteSpaces,
+    ),
+    sshTunnelUser: requiredWhen(
+        'SSH Username',
+        sshTunnelEnabled,
+        hasNoWhiteSpaces,
+    ),
+    sshTunnelPublicKey: (value, values) =>
+        sshTunnelEnabled(values) && (!value || value.trim() === '')
+            ? 'Generate an SSH public key before saving'
+            : undefined,
+};
 
 export const warehouseValueValidators: Record<
     WarehouseTypes,
-    Record<string, Validator>
+    Record<string, CreateValidator>
 > = {
     [WarehouseTypes.BIGQUERY]: {
         dataset: hasNoWhiteSpaces('Data set'),
@@ -38,12 +80,14 @@ export const warehouseValueValidators: Record<
         host: hasNoWhiteSpaces('Host'),
         user: hasNoWhiteSpaces('User'),
         dbname: hasNoWhiteSpaces('Database name'),
+        ...sshTunnelValidators,
     },
     [WarehouseTypes.REDSHIFT]: {
         schema: hasNoWhiteSpaces('Schema'),
         host: hasNoWhiteSpaces('Host'),
         user: hasNoWhiteSpaces('User'),
         dbname: hasNoWhiteSpaces('Database name'),
+        ...sshTunnelValidators,
     },
     [WarehouseTypes.SNOWFLAKE]: {
         schema: hasNoWhiteSpaces('Schema'),
@@ -81,28 +125,6 @@ export const warehouseValueValidators: Record<
         token: hasNoWhiteSpaces('Service token'),
     },
 } as const;
-
-type CreateValidator = (
-    value: string,
-    values: ProjectConnectionForm,
-) => string | undefined;
-
-const required = (
-    fieldName: string,
-    ...validators: FieldValidator<string>[]
-): CreateValidator => everyValidator(fieldName, isRequired, ...validators);
-
-const requiredWhen =
-    (
-        fieldName: string,
-        predicate: (values: ProjectConnectionForm) => boolean,
-        ...validators: FieldValidator<string>[]
-    ): CreateValidator =>
-    (value, values) =>
-        everyValidator(
-            fieldName,
-            ...(predicate(values) ? [isRequired, ...validators] : validators),
-        )(value);
 
 const snowflakeAuthIs =
     (...types: SnowflakeAuthenticationType[]) =>
@@ -165,6 +187,7 @@ export const createWarehouseValueValidators: Record<
         user: required('User', hasNoWhiteSpaces),
         password: required('Password'),
         dbname: required('Database name', hasNoWhiteSpaces),
+        ...sshTunnelValidators,
     },
     [WarehouseTypes.REDSHIFT]: {
         schema: required('Schema', hasNoWhiteSpaces),
@@ -172,6 +195,7 @@ export const createWarehouseValueValidators: Record<
         user: required('User', hasNoWhiteSpaces),
         password: required('Password'),
         dbname: required('Database name', hasNoWhiteSpaces),
+        ...sshTunnelValidators,
     },
     [WarehouseTypes.SNOWFLAKE]: {
         schema: required('Schema', hasNoWhiteSpaces),


### PR DESCRIPTION
## What

Saving a Postgres/Redshift connection with **Use SSH tunnel** on but no generated public key returned a 500 and the generic "Something went wrong" toast. The form never required the key, so the request went through and `SshKeyPairModel.get('')` threw a bare `Error`.

## Changes

- **Frontend** (`WarehouseForms/validators.ts`): when `useSshTunnel` is on for Postgres/Redshift, require `sshTunnelHost`, `sshTunnelUser` and `sshTunnelPublicKey` in both the create and update validator maps. The key error ("Generate an SSH public key before saving") also renders inline under the **Generate public key** button, since the read-only key input is only shown once a key exists.
- **Backend**: `ProjectService._resolveWarehouseClientCredentials` throws a `ParameterError` (400) with an actionable message when the tunnel is enabled and the key is empty, instead of querying the DB with `''`. `SshKeyPairModel.get` throws `ParameterError` for unknown keys instead of a bare `Error`.
- Focused unit test in `ProjectService.test.ts` for the missing-key rejection.

## How to test

1. Project settings → Postgres/Redshift connection → Advanced → toggle **Use SSH tunnel**.
2. Fill in host/port/user, do **not** click **Generate public key**.
3. Click **Test & deploy** / **Save** → inline validation error under the button (and in the form-errors toast) instead of a 500.
4. Send the request directly via API with `useSshTunnel: true` and no `sshTunnelPublicKey` → 400 `ParameterError` with the message.

Closes: #28618
