### PR TITLE
fix(data-apps): preserve method chip contrast in dark mode

### DIFF
--- a/packages/frontend/src/features/externalConnections/components/MethodsField.tsx
+++ b/packages/frontend/src/features/externalConnections/components/MethodsField.tsx
@@ -36,7 +36,12 @@ export const MethodsField: FC<Props> = ({
         >
             <Group gap="xs" mt={4}>
                 {METHOD_OPTIONS.map((method) => (
-                    <Chip key={method} value={method} disabled={disabled}>
+                    <Chip
+                        key={method}
+                        value={method}
+                        variant="filled"
+                        disabled={disabled}
+                    >
                         {method}
                     </Chip>
                 ))}


### PR DESCRIPTION
### Description:

```diff
 External connection settings → Allowed methods
- selected methods use white text on a near-white background in dark mode
+ selected methods use automatic high-contrast text in dark mode
```

- Makes the HTTP method chips opt into the theme's filled-variant contrast calculation.
- Covers both the connection onboarding wizard and edit form through their shared field.

Validation:

- `pnpm -F frontend typecheck`
- `pnpm -F frontend exec oxfmt --check src/features/externalConnections/components/MethodsField.tsx`
- `pnpm -F frontend exec oxlint src/features/externalConnections/components/MethodsField.tsx`
- `git diff --check`
- Live browser validation not run because no environment URL was provided.

### Risk assessment:

- [ ] This is a high-risk change

Low risk: this only makes the existing chip variant explicit so the theme computes a readable foreground color. Selection behavior and persisted connection settings are unchanged.
