### PR TITLE
fix(dashboards): run merged charts as merges on dashboard tiles and deliveries

### DIFF
--- a/docs/merge-queries/CONTEXT.md
+++ b/docs/merge-queries/CONTEXT.md
@@ -99,6 +99,18 @@ _Avoid_: connector, provider, data source (collides with warehouse connections)
 - The `merge-queries` flag gates the feature. Composition itself is not
   flagged: it is the plumbing under merges and external sources both.
 
+## Dashboards
+
+A merged chart is an ordinary `saved_chart` tile. A tile's dashboard filters
+are pushed into every source that has the field before the join (dimension
+filters as WHERE, metric filters as HAVING), so a join-key filter reaches both
+sides and the join stays aligned; a filter no source has is dropped as it is
+for any tile, except one that names a merged output column, which is refused
+because the merge has no post-join filter stage. The tile echo attributes the
+applied filters per source. Dashboard sorts and date zoom are left unapplied
+on merged tiles: a merge carries no sort input and a grain cannot be applied
+to one side only without misaligning the join.
+
 ## Related
 
 - `architecture.md` in this directory: execution paths and the current

--- a/packages/api-tests/tests/mergeQuery.test.ts
+++ b/packages/api-tests/tests/mergeQuery.test.ts
@@ -1,6 +1,7 @@
 import {
     assertUnreachable,
     ChartType,
+    DashboardTileTypes,
     FilterOperator,
     isField,
     MergeJoinType,
@@ -8,9 +9,13 @@ import {
     QueryExecutionContext,
     SEED_PROJECT,
     type ApiCompiledMergeQueryResults,
+    type ApiExecuteAsyncDashboardChartQueryResults,
     type ApiExecuteAsyncMergeQueryResults,
     type ApiExecuteAsyncMetricQueryResults,
     type CreateChartInSpace,
+    type CreateDashboard,
+    type Dashboard,
+    type DashboardFilters,
     type ItemsMap,
     type ResultRow,
     type SavedChart,
@@ -73,6 +78,35 @@ const mergeQuery = {
     joinType: 'full',
     tableCalculations: [],
     limit: 500,
+};
+
+// The same narrowing expressed as a chart filter and as a dashboard filter,
+// so a merge filtered either way is checked against one filtered baseline.
+const completedOnly = {
+    dimensions: {
+        id: 'merge-status-filter-group',
+        and: [
+            {
+                id: 'merge-status-filter',
+                target: { fieldId: 'orders_status' },
+                operator: FilterOperator.EQUALS,
+                values: ['completed'],
+            },
+        ],
+    },
+};
+const completedOnlyDashboardFilters: DashboardFilters = {
+    dimensions: [
+        {
+            id: 'dashboard-status-filter',
+            target: { fieldId: 'orders_status', tableName: 'orders' },
+            operator: FilterOperator.EQUALS,
+            values: ['completed'],
+            label: undefined,
+        },
+    ],
+    metrics: [],
+    tableCalculations: [],
 };
 
 // Merged columns are keyed by field id: the join key belongs to the merge
@@ -217,10 +251,19 @@ function registerMergeQueryTests(getContext: () => MergeTestContext) {
         });
     }, 60_000);
 
-    // Saved charts this suite persists; deleted even when a test fails.
+    // Saved charts and dashboards this suite persists; deleted even when a
+    // test fails.
     const createdChartUuids: string[] = [];
+    const createdDashboardUuids: string[] = [];
 
     afterAll(async () => {
+        for (const uuid of createdDashboardUuids) {
+            await admin
+                .delete(`/api/v1/dashboards/${uuid}`, {
+                    failOnStatusCode: false,
+                })
+                .catch(() => {});
+        }
         for (const uuid of createdChartUuids) {
             await admin
                 .delete(`/api/v1/saved/${uuid}`, { failOnStatusCode: false })
@@ -340,19 +383,6 @@ function registerMergeQueryTests(getContext: () => MergeTestContext) {
     }, 60_000);
 
     it('applies each source filter before aggregation and merging', async () => {
-        const completedOnly = {
-            dimensions: {
-                id: 'merge-status-filter-group',
-                and: [
-                    {
-                        id: 'merge-status-filter',
-                        target: { fieldId: 'orders_status' },
-                        operator: FilterOperator.EQUALS,
-                        values: ['completed'],
-                    },
-                ],
-            },
-        };
         const filteredOrders = {
             ...ordersByMonth,
             filters: completedOnly,
@@ -913,6 +943,116 @@ function registerMergeQueryTests(getContext: () => MergeTestContext) {
         );
         expectMergedValues(results.rows, ordersByKey, paymentsByKey);
     }, 90_000);
+
+    // On a dashboard the merged chart is an ordinary saved_chart tile, and a
+    // dashboard filter both sources have is pushed into each of them before
+    // the join. The bar is the same filtered baseline the chart-filter case
+    // uses: every merged value equals what its source returns with that
+    // filter, and the echo says which source each filter reached.
+    it('runs a merged chart as a merge on a dashboard tile, with the tile filter on both sources', async () => {
+        const merge: SavedMergeQuery = {
+            primarySourceId: 'orders',
+            sources: [
+                { id: 'orders', kind: 'chart' },
+                { id: 'payments', kind: 'query', metricQuery: paymentsByMonth },
+            ],
+            joinKey: mergeQuery.joinKey,
+            joinType: MergeJoinType.FULL,
+            tableCalculations: [],
+        };
+        const createdChart = await admin.post<Body<SavedChart>>(
+            `/api/v1/projects/${projectUuid}/saved`,
+            {
+                name: uniqueName('Merged chart on a dashboard'),
+                tableName: 'orders',
+                metricQuery: ordersByMonth,
+                chartConfig: { type: ChartType.TABLE },
+                tableConfig: { columnOrder: [] },
+                merge,
+                dashboardUuid: null,
+                spaceUuid: undefined,
+            } satisfies CreateChartInSpace,
+        );
+        expect(createdChart.status).toBe(200);
+        const chartUuid = createdChart.body.results.uuid;
+        createdChartUuids.push(chartUuid);
+
+        const createdDashboard = await admin.post<Body<Dashboard>>(
+            `/api/v1/projects/${projectUuid}/dashboards`,
+            {
+                name: uniqueName('Merged chart dashboard'),
+                tiles: [
+                    {
+                        type: DashboardTileTypes.SAVED_CHART,
+                        x: 0,
+                        y: 0,
+                        w: 12,
+                        h: 6,
+                        tabUuid: null,
+                        properties: { savedChartUuid: chartUuid },
+                    },
+                ],
+                tabs: [],
+            } satisfies CreateDashboard,
+        );
+        expect(createdDashboard.status).toBe(201);
+        const dashboardUuid = createdDashboard.body.results.uuid;
+        createdDashboardUuids.push(dashboardUuid);
+        const [tile] = createdDashboard.body.results.tiles;
+        expect(tile).toBeDefined();
+
+        const [ordersRows, paymentsRows, started] = await Promise.all([
+            runSourceQuery({ ...ordersByMonth, filters: completedOnly }),
+            runSourceQuery({ ...paymentsByMonth, filters: completedOnly }),
+            admin.post<Body<ApiExecuteAsyncDashboardChartQueryResults>>(
+                `/api/v2/projects/${projectUuid}/query/dashboard-chart`,
+                {
+                    chartUuid,
+                    tileUuid: tile.uuid,
+                    dashboardUuid,
+                    dashboardFilters: completedOnlyDashboardFilters,
+                    dashboardSorts: [],
+                    context: QueryExecutionContext.DASHBOARD,
+                },
+            ),
+        ]);
+        expect(started.status).toBe(200);
+        // The tile carries the merged columns, not the primary source alone.
+        expect(Object.keys(started.body.results.fields)).toEqual(
+            expect.arrayContaining([
+                KEY_FIELD_ID,
+                ORDERS_FIELD_ID,
+                PAYMENTS_FIELD_ID,
+            ]),
+        );
+        expect(
+            started.body.results.appliedDashboardFilters.dimensions.map(
+                (rule) => rule.id,
+            ),
+        ).toEqual(['dashboard-status-filter']);
+        const bySourceId =
+            started.body.results.appliedDashboardFiltersBySourceId ?? {};
+        expect(Object.keys(bySourceId).sort()).toEqual(['orders', 'payments']);
+        Object.values(bySourceId).forEach((applied) => {
+            expect(applied.dimensions.map((rule) => rule.id)).toEqual([
+                'dashboard-status-filter',
+            ]);
+        });
+
+        const results = await pollQueryResults(
+            admin,
+            started.body.results.queryUuid,
+        );
+        const ordersByKey = byMonth(ordersRows, 'orders_total_order_amount');
+        const paymentsByKey = byMonth(
+            paymentsRows,
+            'payments_unique_payment_count',
+        );
+        expect(results.totalResults).toBe(
+            new Set([...ordersByKey.keys(), ...paymentsByKey.keys()]).size,
+        );
+        expectMergedValues(results.rows, ordersByKey, paymentsByKey);
+    }, 120_000);
 
     // Raw parity lets a formatting or labelling regression through: merged
     // cells and fields must format and label as the source the response names.

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -13,6 +13,7 @@ import {
     FieldType,
     FilterOperator,
     ForbiddenError,
+    getFilterRulesFromGroup,
     MergeJoinType,
     MergeQueryErrorKind,
     MetricType,
@@ -5382,6 +5383,234 @@ describe('AsyncQueryService', () => {
             expect(mergedJson).toContain('chart-value');
             // …the out-of-explore rule is dropped without failing the run.
             expect(mergedJson).not.toContain('customers_segment');
+        });
+    });
+
+    describe('executeAsyncDashboardChartQuery with a merged chart', () => {
+        const authorizedAccount = {
+            ...sessionAccount,
+            user: {
+                ...sessionAccount.user,
+                ability: new Ability<PossibleAbilities>([
+                    { subject: 'Project', action: ['view'] },
+                    { subject: 'SavedChart', action: ['view'] },
+                ]),
+            },
+        } as unknown as Account;
+
+        const chartQuery = { ...metricQueryMock, tableCalculations: [] };
+        const otherQuery = {
+            ...metricQueryMock,
+            metrics: [],
+            tableCalculations: [],
+        };
+        const mergedChart = {
+            uuid: 'mergedChartUuid',
+            name: 'Merged chart',
+            organizationUuid: projectSummary.organizationUuid,
+            projectUuid,
+            spaceUuid: 'spaceUuid',
+            dashboardUuid: null,
+            tableName: validExplore.name,
+            metricQuery: chartQuery,
+            parameters: undefined,
+            pivotConfig: undefined,
+            chartConfig: { type: ChartType.TABLE },
+            merge: {
+                primarySourceId: 'a',
+                sources: [
+                    { id: 'a', kind: 'chart' },
+                    { id: 'b', kind: 'query', metricQuery: otherQuery },
+                ],
+                joinKey: [
+                    {
+                        name: 'dim1',
+                        fieldIdBySourceId: { a: 'a_dim1', b: 'a_dim1' },
+                    },
+                ],
+                joinType: MergeJoinType.FULL,
+                tableCalculations: [],
+            },
+        };
+
+        const startedOutcome = {
+            outcome: 'started' as const,
+            query: {
+                queryUuid: 'merge-query-uuid',
+                cacheMetadata: { cacheHit: false },
+                metricQuery: chartQuery,
+                fields: {},
+                parameterReferences: [],
+                usedParametersValues: {},
+                resolvedTimezone: null,
+                warnings: [],
+            },
+            parameterReferences: [],
+            fieldOrigins: {},
+        };
+
+        const buildService = () => {
+            const service = getMockedAsyncQueryService(lightdashConfigMock, {
+                savedChartModel: {
+                    get: vi.fn(async () => mergedChart),
+                } as unknown as SavedChartModel,
+                analyticsModel: {
+                    addChartViewEvent: vi.fn(async () => {}),
+                } as unknown as AnalyticsModel,
+                spaceModel: {
+                    getSpaceSummary: vi.fn(async () => ({
+                        uuid: 'spaceUuid',
+                        organizationUuid: projectSummary.organizationUuid,
+                        projectUuid,
+                    })),
+                } as unknown as SpaceModel,
+                dashboardModel: {
+                    getDashboardParametersByIdOrSlug: vi.fn(
+                        async () => undefined,
+                    ),
+                } as unknown as DashboardModel,
+            });
+            service.getExploreWithUserAccessControls = vi
+                .fn()
+                .mockResolvedValue({
+                    explore: validExplore,
+                    userAccessControls: {
+                        userAttributes: {},
+                        intrinsicUserAttributes: {},
+                    },
+                });
+            const mergeSpy = vi.fn().mockResolvedValue(startedOutcome);
+            service.executeAsyncMergeQuery = mergeSpy;
+            const prepareSpy = vi.fn();
+            (service as AnyType).prepareMetricQueryAsyncQueryArgs = prepareSpy;
+            return { service, mergeSpy, prepareSpy };
+        };
+
+        const tileFilter = {
+            id: 'dash-rule',
+            target: { fieldId: 'b_dim1', tableName: 'b' },
+            operator: FilterOperator.EQUALS,
+            values: ['dashboard-value'],
+            label: undefined,
+        };
+
+        test('runs the merge with the tile filter pushed into both sources', async () => {
+            const { service, mergeSpy, prepareSpy } = buildService();
+
+            const result = await service.executeAsyncDashboardChartQuery({
+                account: authorizedAccount,
+                projectUuid,
+                tileUuid: 'tile-1',
+                chartUuid: mergedChart.uuid,
+                dashboardUuid: 'dashboard-uuid',
+                dashboardFilters: {
+                    dimensions: [tileFilter],
+                    metrics: [],
+                    tableCalculations: [],
+                },
+                dashboardSorts: [],
+                context: QueryExecutionContext.DASHBOARD,
+                invalidateCache: false,
+                limit: undefined,
+                parameters: undefined,
+                pivotResults: false,
+            });
+
+            // The primary source never ran on its own.
+            expect(prepareSpy).not.toHaveBeenCalled();
+            expect(mergeSpy).toHaveBeenCalledTimes(1);
+            const args = mergeSpy.mock.calls[0][0];
+            expect(args.context).toBe(QueryExecutionContext.DASHBOARD);
+            expect(args.mode).toEqual({ type: 'interactive' });
+            const sources: { id: string; metricQuery: MetricQuery }[] =
+                args.mergeQuery.sources;
+            expect(sources.map((source) => source.id)).toEqual(['a', 'b']);
+            sources.forEach((source) => {
+                expect(
+                    getFilterRulesFromGroup(
+                        source.metricQuery.filters.dimensions,
+                    ).map((rule) => rule.target.fieldId),
+                ).toEqual(['b_dim1']);
+            });
+
+            expect(result.queryUuid).toBe('merge-query-uuid');
+            expect(result.dateZoomApplied).toBe(false);
+            expect(
+                result.appliedDashboardFilters.dimensions.map((r) => r.id),
+            ).toEqual(['dash-rule']);
+            expect(
+                Object.keys(result.appliedDashboardFiltersBySourceId ?? {}),
+            ).toEqual(['a', 'b']);
+        });
+
+        test('refuses a tile filter that names a merged column instead of dropping it', async () => {
+            const { service, mergeSpy } = buildService();
+
+            await expect(
+                service.executeAsyncDashboardChartQuery({
+                    account: authorizedAccount,
+                    projectUuid,
+                    tileUuid: 'tile-1',
+                    chartUuid: mergedChart.uuid,
+                    dashboardUuid: 'dashboard-uuid',
+                    dashboardFilters: {
+                        dimensions: [
+                            {
+                                ...tileFilter,
+                                id: 'merged-column-rule',
+                                target: { fieldId: 'a_a_met1', tableName: 'a' },
+                            },
+                        ],
+                        metrics: [],
+                        tableCalculations: [],
+                    },
+                    dashboardSorts: [],
+                    context: QueryExecutionContext.DASHBOARD,
+                    invalidateCache: false,
+                    limit: undefined,
+                    parameters: undefined,
+                    pivotResults: false,
+                }),
+            ).rejects.toThrow(ParameterError);
+            expect(mergeSpy).not.toHaveBeenCalled();
+        });
+
+        test('surfaces a merge refusal the way the chart page does', async () => {
+            const { service, mergeSpy } = buildService();
+            mergeSpy.mockResolvedValue({
+                outcome: 'refused',
+                errors: [
+                    {
+                        kind: MergeQueryErrorKind.FAN_OUT,
+                        sourceId: 'b',
+                        fieldIds: [],
+                        message: 'Fan-out',
+                    },
+                ],
+                parameterReferences: [],
+                fieldOrigins: {},
+            });
+
+            await expect(
+                service.executeAsyncDashboardChartQuery({
+                    account: authorizedAccount,
+                    projectUuid,
+                    tileUuid: 'tile-1',
+                    chartUuid: mergedChart.uuid,
+                    dashboardUuid: 'dashboard-uuid',
+                    dashboardFilters: {
+                        dimensions: [],
+                        metrics: [],
+                        tableCalculations: [],
+                    },
+                    dashboardSorts: [],
+                    context: QueryExecutionContext.DASHBOARD,
+                    invalidateCache: false,
+                    limit: undefined,
+                    parameters: undefined,
+                    pivotResults: false,
+                }),
+            ).rejects.toThrow('This saved merge cannot be run: Fan-out');
         });
     });
 

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -134,7 +134,9 @@ import {
     type ExecuteAsyncSavedChartRequestParams,
     type ExecuteAsyncUnderlyingDataRequestParams,
     type ExternalSourceTableReference,
+    type Filters,
     type MergeQueryChart,
+    type MergeQueryExecutionMode,
     type Organization,
     type ParameterDefinitions,
     type ParametersValuesMap,
@@ -147,6 +149,7 @@ import {
     type ResultColumns,
     type RunQueryTags,
     type SavedChartDAO,
+    type SavedMergeQuery,
     type SessionUser,
     type SpaceSummaryBase,
     type UserAttributeValueMap,
@@ -251,6 +254,12 @@ import { type ComposeEngineClient } from './ComposeEngineClient';
 import { getValidatedDashboardSorts } from './dashboardSorts';
 import { getPivotedColumns } from './getPivotedColumns';
 import { getUnpivotedColumns } from './getUnpivotedColumns';
+import {
+    applyDashboardFiltersToMergeQuery,
+    applyFilterOverridesToMergeQuery,
+    formatRefusedMergeDashboardFilters,
+    type MergeSourceExplores,
+} from './mergeDashboardFilters';
 import {
     applyMergeExportLimit,
     buildComposeMergeOriginalColumns,
@@ -5697,6 +5706,7 @@ export class AsyncQueryService extends ProjectService {
         pivotResults,
         filterOverrides,
         dashboardFilters,
+        userAttributeOverrides,
     }: ExecuteAsyncSavedChartQueryArgs): Promise<ApiExecuteAsyncMetricQueryResults> {
         // Check user is in organization
         assertIsAccountWithOrg(account);
@@ -5818,41 +5828,20 @@ export class AsyncQueryService extends ProjectService {
         };
 
         if (savedChart.merge) {
-            const mergeQuery = buildMergeQueryFromSaved(
-                metricQuery,
-                savedChart.merge,
-            );
-            const combinedParameters = {
-                ...savedChartParameters,
-                ...parameters,
-            };
-            const outcome = await this.executeAsyncMergeQuery({
+            return this.executeAsyncSavedMergeQuery({
                 account,
                 projectUuid,
-                mergeQuery,
+                savedChart,
+                merge: savedChart.merge,
                 context,
                 invalidateCache,
-                parameters: combinedParameters,
-                mode:
-                    limit === undefined
-                        ? { type: 'interactive' }
-                        : { type: 'export', limit },
-                chart: pivotResults
-                    ? {
-                          chartConfig: savedChart.chartConfig,
-                          pivotConfig: savedChart.pivotConfig,
-                      }
-                    : undefined,
+                limit,
+                parameters,
+                pivotResults,
+                filterOverrides,
+                dashboardFilters,
+                userAttributeOverrides,
             });
-            if (outcome.outcome === 'refused') {
-                throw new ParameterError(
-                    `This saved merge cannot be run: ${outcome.errors
-                        .map((error) => error.message)
-                        .join(' ')}`,
-                    { errors: outcome.errors },
-                );
-            }
-            return outcome.query;
         }
 
         const { maxLimit, csvCellsLimit } =
@@ -6199,6 +6188,271 @@ export class AsyncQueryService extends ProjectService {
         }
     }
 
+    /** Explores of every metric source, so filters can be resolved per side. */
+    private async getMergeSourceExplores({
+        account,
+        projectUuid,
+        organizationUuid,
+        mergeQuery,
+        preloadedExploresByName,
+    }: {
+        account: Account;
+        projectUuid: string;
+        organizationUuid: string;
+        mergeQuery: MergeQuery;
+        preloadedExploresByName: Record<string, Explore>;
+    }): Promise<MergeSourceExplores> {
+        const entries = await Promise.all(
+            mergeQuery.sources
+                .filter(isMergeMetricSource)
+                .map(
+                    async (source): Promise<[string, Explore]> => [
+                        source.id,
+                        preloadedExploresByName[
+                            source.metricQuery.exploreName
+                        ] ??
+                            (await this.getExplore(
+                                account,
+                                projectUuid,
+                                source.metricQuery.exploreName,
+                                organizationUuid,
+                            )),
+                    ],
+                ),
+        );
+        return Object.fromEntries(entries);
+    }
+
+    private static getSavedMergeExecutionMode(
+        limit: number | null | undefined,
+    ): MergeQueryExecutionMode {
+        return limit === undefined
+            ? { type: 'interactive' }
+            : { type: 'export', limit };
+    }
+
+    private static getSavedMergeChart(
+        savedChart: SavedChartDAO,
+        pivotResults: boolean | undefined,
+    ): MergeQueryChart | undefined {
+        return pivotResults
+            ? {
+                  chartConfig: savedChart.chartConfig,
+                  pivotConfig: savedChart.pivotConfig,
+              }
+            : undefined;
+    }
+
+    private static assertSavedMergeStarted(
+        outcome: ApiExecuteAsyncMergeQueryResults,
+    ): ApiExecuteAsyncMetricQueryResults {
+        if (outcome.outcome === 'refused') {
+            throw new ParameterError(
+                `This saved merge cannot be run: ${outcome.errors
+                    .map((error) => error.message)
+                    .join(' ')}`,
+                { errors: outcome.errors },
+            );
+        }
+        return outcome.query;
+    }
+
+    /**
+     * A saved chart's merge on its own page or as a chart delivery. Filter
+     * overrides and data-app dashboard filters reach every source that has
+     * the field, so the join stays aligned.
+     */
+    private async executeAsyncSavedMergeQuery({
+        account,
+        projectUuid,
+        savedChart,
+        merge,
+        context,
+        invalidateCache,
+        limit,
+        parameters,
+        pivotResults,
+        filterOverrides,
+        dashboardFilters,
+        userAttributeOverrides,
+    }: Pick<
+        ExecuteAsyncSavedChartQueryArgs,
+        | 'account'
+        | 'projectUuid'
+        | 'context'
+        | 'invalidateCache'
+        | 'limit'
+        | 'parameters'
+        | 'pivotResults'
+        | 'filterOverrides'
+        | 'dashboardFilters'
+        | 'userAttributeOverrides'
+    > & {
+        savedChart: SavedChartDAO;
+        merge: SavedMergeQuery;
+    }): Promise<ApiExecuteAsyncMetricQueryResults> {
+        const baseMergeQuery = buildMergeQueryFromSaved(
+            savedChart.metricQuery,
+            merge,
+        );
+        const exploreBySourceId = await this.getMergeSourceExplores({
+            account,
+            projectUuid,
+            organizationUuid: savedChart.organizationUuid,
+            mergeQuery: baseMergeQuery,
+            preloadedExploresByName: {},
+        });
+        const withOverrides = filterOverrides
+            ? applyFilterOverridesToMergeQuery({
+                  mergeQuery: baseMergeQuery,
+                  filterOverrides,
+                  exploreBySourceId,
+              })
+            : baseMergeQuery;
+        const { mergeQuery, refusedDashboardFilters } = dashboardFilters
+            ? applyDashboardFiltersToMergeQuery({
+                  tileUuid: null,
+                  mergeQuery: withOverrides,
+                  dashboardFilters,
+                  exploreBySourceId,
+              })
+            : { mergeQuery: withOverrides, refusedDashboardFilters: [] };
+        if (refusedDashboardFilters.length > 0) {
+            throw new ParameterError(
+                formatRefusedMergeDashboardFilters(refusedDashboardFilters),
+            );
+        }
+        const outcome = await this.executeAsyncMergeQuery({
+            account,
+            projectUuid,
+            mergeQuery,
+            context,
+            invalidateCache,
+            parameters: { ...savedChart.parameters, ...parameters },
+            userAttributeOverrides,
+            mode: AsyncQueryService.getSavedMergeExecutionMode(limit),
+            chart: AsyncQueryService.getSavedMergeChart(
+                savedChart,
+                pivotResults,
+            ),
+        });
+        return AsyncQueryService.assertSavedMergeStarted(outcome);
+    }
+
+    /**
+     * A merged chart on a dashboard tile: the tile's dashboard filters are
+     * pushed into each source before the join. Dashboard sorts and date zoom
+     * have no merge-level input yet, so they are left unapplied rather than
+     * applied to one side only.
+     */
+    private async executeAsyncDashboardMergeQuery({
+        account,
+        projectUuid,
+        savedChart,
+        merge,
+        primaryExplore,
+        tileUuid,
+        dashboardUuid,
+        dashboardFilters,
+        context,
+        invalidateCache,
+        limit,
+        parameters,
+        pivotResults,
+        userAttributeOverrides,
+    }: Pick<
+        ExecuteAsyncDashboardChartQueryArgs,
+        | 'account'
+        | 'projectUuid'
+        | 'tileUuid'
+        | 'dashboardUuid'
+        | 'dashboardFilters'
+        | 'context'
+        | 'invalidateCache'
+        | 'limit'
+        | 'parameters'
+        | 'pivotResults'
+        | 'userAttributeOverrides'
+    > & {
+        savedChart: SavedChartDAO;
+        merge: SavedMergeQuery;
+        primaryExplore: Explore;
+    }): Promise<ApiExecuteAsyncDashboardChartQueryResults> {
+        const baseMergeQuery = buildMergeQueryFromSaved(
+            savedChart.metricQuery,
+            merge,
+        );
+        const exploreBySourceId = await this.getMergeSourceExplores({
+            account,
+            projectUuid,
+            organizationUuid: savedChart.organizationUuid,
+            mergeQuery: baseMergeQuery,
+            preloadedExploresByName: { [primaryExplore.name]: primaryExplore },
+        });
+        const {
+            mergeQuery,
+            appliedDashboardFilters,
+            appliedDashboardFiltersBySourceId,
+            refusedDashboardFilters,
+        } = applyDashboardFiltersToMergeQuery({
+            tileUuid,
+            mergeQuery: baseMergeQuery,
+            dashboardFilters,
+            exploreBySourceId,
+        });
+        if (refusedDashboardFilters.length > 0) {
+            throw new ParameterError(
+                formatRefusedMergeDashboardFilters(refusedDashboardFilters),
+            );
+        }
+        const rawDashboardParameters =
+            await this.dashboardModel.getDashboardParametersByIdOrSlug(
+                dashboardUuid,
+                projectUuid,
+            );
+        const outcome = await this.executeAsyncMergeQuery({
+            account,
+            projectUuid,
+            mergeQuery,
+            context,
+            invalidateCache,
+            parameters: {
+                ...savedChart.parameters,
+                ...convertDashboardParametersToValuesMap(
+                    rawDashboardParameters,
+                ),
+                ...parameters,
+            },
+            userAttributeOverrides,
+            mode: AsyncQueryService.getSavedMergeExecutionMode(limit),
+            chart: AsyncQueryService.getSavedMergeChart(
+                savedChart,
+                pivotResults,
+            ),
+        });
+        const {
+            queryUuid,
+            cacheMetadata,
+            metricQuery,
+            fields,
+            parameterReferences,
+            usedParametersValues,
+            resolvedTimezone,
+        } = AsyncQueryService.assertSavedMergeStarted(outcome);
+        return {
+            queryUuid,
+            cacheMetadata,
+            metricQuery,
+            fields,
+            parameterReferences,
+            usedParametersValues,
+            resolvedTimezone,
+            appliedDashboardFilters,
+            appliedDashboardFiltersBySourceId,
+            dateZoomApplied: false,
+        };
+    }
+
     async executeAsyncDashboardChartQuery({
         account,
         projectUuid,
@@ -6217,6 +6471,7 @@ export class AsyncQueryService extends ProjectService {
         sessionTimezone,
         preloadedSavedChart,
         preloadedProjectParameters,
+        userAttributeOverrides,
     }: ExecuteAsyncDashboardChartQueryArgs): Promise<ApiExecuteAsyncDashboardChartQueryResults> {
         assertIsAccountWithOrg(account);
 
@@ -6288,6 +6543,25 @@ export class AsyncQueryService extends ProjectService {
                     error: e,
                 }),
             );
+
+        if (savedChart.merge) {
+            return this.executeAsyncDashboardMergeQuery({
+                account,
+                projectUuid,
+                savedChart,
+                merge: savedChart.merge,
+                primaryExplore: explore,
+                tileUuid,
+                dashboardUuid: resolvedDashboardUuid,
+                dashboardFilters,
+                context,
+                invalidateCache,
+                limit,
+                parameters,
+                pivotResults,
+                userAttributeOverrides,
+            });
+        }
 
         const { metricQuery: metricQueryWithFilters, appliedDashboardFilters } =
             applyDashboardFiltersForTile({

--- a/packages/backend/src/services/AsyncQueryService/mergeDashboardFilters.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/mergeDashboardFilters.test.ts
@@ -1,0 +1,507 @@
+import {
+    DimensionType,
+    ExploreType,
+    FieldType,
+    FilterOperator,
+    getFilterRulesFromGroup,
+    isMergeMetricSource,
+    MergeJoinType,
+    MetricType,
+    SupportedDbtAdapter,
+    type DashboardFilterRule,
+    type DashboardFilters,
+    type Explore,
+    type MergeQuery,
+    type MergeQuerySource,
+    type MetricQuery,
+} from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import {
+    applyDashboardFiltersToMergeQuery,
+    applyFilterOverridesToMergeQuery,
+    getMergeOutputFieldIds,
+} from './mergeDashboardFilters';
+
+const buildExplore = (
+    name: string,
+    tables: Record<string, { dimensions: string[]; metrics: string[] }>,
+): Explore => ({
+    targetDatabase: SupportedDbtAdapter.POSTGRES,
+    name,
+    label: name,
+    tags: [],
+    baseTable: name,
+    type: ExploreType.DEFAULT,
+    joinedTables: Object.keys(tables)
+        .filter((table) => table !== name)
+        .map((table) => ({
+            table,
+            sqlOn: '',
+            compiledSqlOn: '',
+            type: undefined,
+        })),
+    tables: Object.fromEntries(
+        Object.entries(tables).map(([table, { dimensions, metrics }]) => [
+            table,
+            {
+                name: table,
+                label: table,
+                database: 'db',
+                schema: 'schema',
+                sqlTable: table,
+                lineageGraph: {},
+                dimensions: Object.fromEntries(
+                    dimensions.map((dimension) => [
+                        dimension,
+                        {
+                            fieldType: FieldType.DIMENSION,
+                            type: DimensionType.STRING,
+                            name: dimension,
+                            label: dimension,
+                            table,
+                            tableLabel: table,
+                            sql: '',
+                            compiledSql: '',
+                            hidden: false,
+                            tablesReferences: [table],
+                        },
+                    ]),
+                ),
+                metrics: Object.fromEntries(
+                    metrics.map((metric) => [
+                        metric,
+                        {
+                            fieldType: FieldType.METRIC,
+                            type: MetricType.SUM,
+                            name: metric,
+                            label: metric,
+                            table,
+                            tableLabel: table,
+                            sql: '',
+                            compiledSql: '',
+                            hidden: false,
+                            tablesReferences: [table],
+                        },
+                    ]),
+                ),
+            },
+        ]),
+    ),
+});
+
+const ordersExplore = buildExplore('orders', {
+    orders: {
+        dimensions: ['order_date_month', 'status'],
+        metrics: ['total_order_amount'],
+    },
+});
+
+const paymentsExplore = buildExplore('payments', {
+    payments: {
+        dimensions: ['payment_method'],
+        metrics: ['unique_payment_count'],
+    },
+    orders: { dimensions: ['order_date_month', 'status'], metrics: [] },
+});
+
+const ordersByMonth: MetricQuery = {
+    exploreName: 'orders',
+    dimensions: ['orders_order_date_month'],
+    metrics: ['orders_total_order_amount'],
+    filters: {},
+    sorts: [],
+    limit: 500,
+    tableCalculations: [],
+};
+
+const paymentsByMonth: MetricQuery = {
+    exploreName: 'payments',
+    dimensions: ['orders_order_date_month'],
+    metrics: ['payments_unique_payment_count'],
+    filters: {},
+    sorts: [],
+    limit: 500,
+    tableCalculations: [],
+};
+
+const mergeQuery: MergeQuery = {
+    sources: [
+        { id: 'orders', metricQuery: ordersByMonth },
+        { id: 'payments', metricQuery: paymentsByMonth },
+    ],
+    joinKey: [
+        {
+            name: 'order_month',
+            fieldIdBySourceId: {
+                orders: 'orders_order_date_month',
+                payments: 'orders_order_date_month',
+            },
+        },
+    ],
+    joinType: MergeJoinType.FULL,
+    tableCalculations: [],
+    limit: 500,
+};
+
+const exploreBySourceId = { orders: ordersExplore, payments: paymentsExplore };
+
+const TILE = 'tile-1';
+
+const rule = (
+    id: string,
+    fieldId: string,
+    tableName: string,
+    extra: Partial<DashboardFilterRule> = {},
+): DashboardFilterRule => ({
+    id,
+    target: { fieldId, tableName },
+    operator: FilterOperator.EQUALS,
+    values: ['completed'],
+    label: undefined,
+    ...extra,
+});
+
+const filters = (partial: Partial<DashboardFilters>): DashboardFilters => ({
+    dimensions: [],
+    metrics: [],
+    tableCalculations: [],
+    ...partial,
+});
+
+const sourceById = (query: MergeQuery, id: string): MergeQuerySource => {
+    const source = query.sources.find((s) => s.id === id);
+    if (source === undefined) throw new Error(`No source ${id}`);
+    return source;
+};
+
+const dimensionFilterFieldIds = (query: MergeQuery, id: string): string[] => {
+    const source = sourceById(query, id);
+    if (!isMergeMetricSource(source)) throw new Error('Not a metric source');
+    return getFilterRulesFromGroup(source.metricQuery.filters.dimensions).map(
+        (r) => r.target.fieldId,
+    );
+};
+
+const metricFilterFieldIds = (query: MergeQuery, id: string): string[] => {
+    const source = sourceById(query, id);
+    if (!isMergeMetricSource(source)) throw new Error('Not a metric source');
+    return getFilterRulesFromGroup(source.metricQuery.filters.metrics).map(
+        (r) => r.target.fieldId,
+    );
+};
+
+describe('applyDashboardFiltersToMergeQuery', () => {
+    it('pushes a field both sources have into both, before the join', () => {
+        const status = rule('status', 'orders_status', 'orders');
+        const result = applyDashboardFiltersToMergeQuery({
+            tileUuid: TILE,
+            mergeQuery,
+            dashboardFilters: filters({ dimensions: [status] }),
+            exploreBySourceId,
+        });
+
+        expect(dimensionFilterFieldIds(result.mergeQuery, 'orders')).toEqual([
+            'orders_status',
+        ]);
+        expect(dimensionFilterFieldIds(result.mergeQuery, 'payments')).toEqual([
+            'orders_status',
+        ]);
+        expect(result.appliedDashboardFilters.dimensions).toEqual([status]);
+        expect(result.appliedDashboardFiltersBySourceId).toEqual({
+            orders: filters({ dimensions: [status] }),
+            payments: filters({ dimensions: [status] }),
+        });
+        expect(result.refusedDashboardFilters).toEqual([]);
+        // The merge itself is untouched apart from the sources.
+        expect(result.mergeQuery.joinKey).toBe(mergeQuery.joinKey);
+    });
+
+    it('applies a join-key filter to every side so the join stays aligned', () => {
+        const month = rule('month', 'orders_order_date_month', 'orders');
+        const result = applyDashboardFiltersToMergeQuery({
+            tileUuid: TILE,
+            mergeQuery,
+            dashboardFilters: filters({ dimensions: [month] }),
+            exploreBySourceId,
+        });
+
+        expect(dimensionFilterFieldIds(result.mergeQuery, 'orders')).toEqual([
+            'orders_order_date_month',
+        ]);
+        expect(dimensionFilterFieldIds(result.mergeQuery, 'payments')).toEqual([
+            'orders_order_date_month',
+        ]);
+    });
+
+    it('applies a field only one source has to that source alone', () => {
+        const method = rule('method', 'payments_payment_method', 'payments');
+        const result = applyDashboardFiltersToMergeQuery({
+            tileUuid: TILE,
+            mergeQuery,
+            dashboardFilters: filters({ dimensions: [method] }),
+            exploreBySourceId,
+        });
+
+        expect(dimensionFilterFieldIds(result.mergeQuery, 'orders')).toEqual(
+            [],
+        );
+        expect(dimensionFilterFieldIds(result.mergeQuery, 'payments')).toEqual([
+            'payments_payment_method',
+        ]);
+        expect(result.appliedDashboardFilters.dimensions).toEqual([method]);
+        expect(
+            result.appliedDashboardFiltersBySourceId.orders.dimensions,
+        ).toEqual([]);
+        expect(
+            result.appliedDashboardFiltersBySourceId.payments.dimensions,
+        ).toEqual([method]);
+    });
+
+    it('applies a filter on a field no source selects, as any tile does', () => {
+        const status = rule('status', 'orders_status', 'orders');
+        const result = applyDashboardFiltersToMergeQuery({
+            tileUuid: TILE,
+            mergeQuery,
+            dashboardFilters: filters({ dimensions: [status] }),
+            exploreBySourceId,
+        });
+        const orders = sourceById(result.mergeQuery, 'orders');
+        if (!isMergeMetricSource(orders))
+            throw new Error('Not a metric source');
+        expect(orders.metricQuery.dimensions).toEqual([
+            'orders_order_date_month',
+        ]);
+        expect(dimensionFilterFieldIds(result.mergeQuery, 'orders')).toEqual([
+            'orders_status',
+        ]);
+    });
+
+    it('drops a field neither source has without refusing', () => {
+        const segment = rule('segment', 'customers_segment', 'customers');
+        const result = applyDashboardFiltersToMergeQuery({
+            tileUuid: TILE,
+            mergeQuery,
+            dashboardFilters: filters({ dimensions: [segment] }),
+            exploreBySourceId,
+        });
+
+        expect(result.mergeQuery.sources).toEqual(mergeQuery.sources);
+        expect(result.appliedDashboardFilters).toEqual(filters({}));
+        expect(result.refusedDashboardFilters).toEqual([]);
+    });
+
+    it('refuses a filter that names a merged output column instead of ignoring it', () => {
+        const merged = rule(
+            'merged',
+            'orders_orders_total_order_amount',
+            'orders',
+        );
+        const key = rule('key', 'merge_order_month', 'merge');
+        const result = applyDashboardFiltersToMergeQuery({
+            tileUuid: TILE,
+            mergeQuery,
+            dashboardFilters: filters({ dimensions: [merged, key] }),
+            exploreBySourceId,
+        });
+
+        expect(result.refusedDashboardFilters).toEqual([merged, key]);
+        expect(result.appliedDashboardFilters).toEqual(filters({}));
+    });
+
+    it('pushes a metric filter into the source as a HAVING filter', () => {
+        const amount = rule('amount', 'orders_total_order_amount', 'orders', {
+            operator: FilterOperator.GREATER_THAN,
+            values: [10],
+        });
+        const result = applyDashboardFiltersToMergeQuery({
+            tileUuid: TILE,
+            mergeQuery,
+            dashboardFilters: filters({ metrics: [amount] }),
+            exploreBySourceId,
+        });
+
+        expect(metricFilterFieldIds(result.mergeQuery, 'orders')).toEqual([
+            'orders_total_order_amount',
+        ]);
+        expect(dimensionFilterFieldIds(result.mergeQuery, 'orders')).toEqual(
+            [],
+        );
+        expect(metricFilterFieldIds(result.mergeQuery, 'payments')).toEqual([]);
+        expect(result.appliedDashboardFilters.metrics).toEqual([amount]);
+    });
+
+    it('honours tile targets: an opted-out tile gets nothing, an override retargets', () => {
+        const optedOut = rule('out', 'orders_status', 'orders', {
+            tileTargets: { [TILE]: false },
+        });
+        const retargeted = rule('retarget', 'orders_status', 'orders', {
+            tileTargets: {
+                [TILE]: {
+                    fieldId: 'payments_payment_method',
+                    tableName: 'payments',
+                },
+            },
+        });
+        const result = applyDashboardFiltersToMergeQuery({
+            tileUuid: TILE,
+            mergeQuery,
+            dashboardFilters: filters({ dimensions: [optedOut, retargeted] }),
+            exploreBySourceId,
+        });
+
+        expect(dimensionFilterFieldIds(result.mergeQuery, 'orders')).toEqual(
+            [],
+        );
+        expect(dimensionFilterFieldIds(result.mergeQuery, 'payments')).toEqual([
+            'payments_payment_method',
+        ]);
+        expect(
+            result.appliedDashboardFilters.dimensions.map((r) => r.id),
+        ).toEqual(['retarget']);
+    });
+
+    it('ignores tile targets when the filters were not authored for a tile', () => {
+        const optedOut = rule('out', 'orders_status', 'orders', {
+            tileTargets: { [TILE]: false },
+        });
+        const result = applyDashboardFiltersToMergeQuery({
+            tileUuid: null,
+            mergeQuery,
+            dashboardFilters: filters({ dimensions: [optedOut] }),
+            exploreBySourceId,
+        });
+
+        expect(dimensionFilterFieldIds(result.mergeQuery, 'orders')).toEqual([
+            'orders_status',
+        ]);
+    });
+
+    it('leaves a result source untouched', () => {
+        const withResult: MergeQuery = {
+            ...mergeQuery,
+            sources: [
+                { id: 'orders', metricQuery: ordersByMonth },
+                { id: 'payments', queryUuid: 'query-uuid' },
+            ],
+        };
+        const status = rule('status', 'orders_status', 'orders');
+        const result = applyDashboardFiltersToMergeQuery({
+            tileUuid: TILE,
+            mergeQuery: withResult,
+            dashboardFilters: filters({ dimensions: [status] }),
+            exploreBySourceId: { orders: ordersExplore },
+        });
+
+        expect(sourceById(result.mergeQuery, 'payments')).toEqual({
+            id: 'payments',
+            queryUuid: 'query-uuid',
+        });
+        expect(dimensionFilterFieldIds(result.mergeQuery, 'orders')).toEqual([
+            'orders_status',
+        ]);
+        expect(Object.keys(result.appliedDashboardFiltersBySourceId)).toEqual([
+            'orders',
+        ]);
+    });
+});
+
+describe('getMergeOutputFieldIds', () => {
+    it('names join keys, source values and merge calculations as compilation does', () => {
+        const ids = getMergeOutputFieldIds({
+            ...mergeQuery,
+            tableCalculations: [{ name: 'ratio', displayName: '', sql: '1' }],
+        });
+        expect([...ids]).toEqual([
+            'merge_order_month',
+            'orders_orders_total_order_amount',
+            'payments_payments_unique_payment_count',
+            'merge_ratio',
+        ]);
+    });
+});
+
+describe('applyFilterOverridesToMergeQuery', () => {
+    const statusRule = {
+        id: 'status',
+        target: { fieldId: 'orders_status' },
+        operator: FilterOperator.EQUALS,
+        values: ['completed'],
+    };
+    const methodRule = {
+        id: 'method',
+        target: { fieldId: 'payments_payment_method' },
+        operator: FilterOperator.EQUALS,
+        values: ['card'],
+    };
+    const unknownRule = {
+        id: 'unknown',
+        target: { fieldId: 'customers_segment' },
+        operator: FilterOperator.EQUALS,
+        values: ['enterprise'],
+    };
+
+    it('ANDs the overrides onto every source that has the field, whole on the primary', () => {
+        const result = applyFilterOverridesToMergeQuery({
+            mergeQuery,
+            filterOverrides: {
+                dimensions: {
+                    id: 'root',
+                    and: [statusRule, methodRule, unknownRule],
+                },
+            },
+            exploreBySourceId,
+        });
+
+        // The primary keeps the group whole, so an unknown field still fails
+        // the run where the chart alone would.
+        expect(dimensionFilterFieldIds(result, 'orders')).toEqual([
+            'orders_status',
+            'payments_payment_method',
+            'customers_segment',
+        ]);
+        expect(dimensionFilterFieldIds(result, 'payments')).toEqual([
+            'orders_status',
+            'payments_payment_method',
+        ]);
+    });
+
+    it('drops an OR group a source cannot evaluate rather than narrowing it', () => {
+        const result = applyFilterOverridesToMergeQuery({
+            mergeQuery,
+            filterOverrides: {
+                dimensions: {
+                    id: 'root',
+                    and: [
+                        {
+                            id: 'either',
+                            or: [statusRule, unknownRule],
+                        },
+                        methodRule,
+                    ],
+                },
+            },
+            exploreBySourceId,
+        });
+
+        expect(dimensionFilterFieldIds(result, 'payments')).toEqual([
+            'payments_payment_method',
+        ]);
+        expect(dimensionFilterFieldIds(result, 'orders')).toEqual([
+            'orders_status',
+            'customers_segment',
+            'payments_payment_method',
+        ]);
+    });
+
+    it('leaves a source untouched when nothing resolves there', () => {
+        const result = applyFilterOverridesToMergeQuery({
+            mergeQuery,
+            filterOverrides: {
+                dimensions: { id: 'root', and: [unknownRule] },
+            },
+            exploreBySourceId,
+        });
+
+        expect(sourceById(result, 'payments')).toBe(mergeQuery.sources[1]);
+    });
+});

--- a/packages/backend/src/services/AsyncQueryService/mergeDashboardFilters.ts
+++ b/packages/backend/src/services/AsyncQueryService/mergeDashboardFilters.ts
@@ -1,0 +1,280 @@
+import {
+    addDashboardFiltersToMetricQuery,
+    addFiltersToMetricQuery,
+    getAvailableFilterFieldIds,
+    getDashboardFilterRulesForTables,
+    getDashboardFiltersForTile,
+    getFilterRulesFromGroup,
+    isAndFilterGroup,
+    isFilterGroup,
+    isMergeMetricSource,
+    MERGE_TABLE_NAME,
+    type DashboardFilterRule,
+    type DashboardFilters,
+    type Explore,
+    type FilterGroup,
+    type FilterGroupItem,
+    type Filters,
+    type MergeQuery,
+    type MergeQuerySource,
+} from '@lightdash/common';
+
+/** Explores of the merge's metric sources, keyed by source id. */
+export type MergeSourceExplores = Record<string, Explore>;
+
+export type MergeDashboardFiltersResult = {
+    mergeQuery: MergeQuery;
+    /** Every rule that applied to at least one source: the existing tile echo. */
+    appliedDashboardFilters: DashboardFilters;
+    /** The same rules, keyed by the source they were pushed into. */
+    appliedDashboardFiltersBySourceId: Record<string, DashboardFilters>;
+    /**
+     * Rules that target a merged output column rather than a source field.
+     * The merge has no post-join filter stage, so they are refused instead of
+     * silently ignored; rules matching neither are dropped like any tile.
+     */
+    refusedDashboardFilters: DashboardFilterRule[];
+};
+
+/** Field ids the merged result exposes, derived the way compilation names them. */
+export const getMergeOutputFieldIds = (mergeQuery: MergeQuery): Set<string> =>
+    new Set([
+        ...mergeQuery.joinKey.map((part) => `${MERGE_TABLE_NAME}_${part.name}`),
+        ...mergeQuery.sources.flatMap((source) =>
+            isMergeMetricSource(source)
+                ? [
+                      ...source.metricQuery.metrics,
+                      ...source.metricQuery.tableCalculations.map(
+                          (calculation) => calculation.name,
+                      ),
+                  ].map((fieldId) => `${source.id}_${fieldId}`)
+                : [],
+        ),
+        ...mergeQuery.tableCalculations.map(
+            (calculation) => `${MERGE_TABLE_NAME}_${calculation.name}`,
+        ),
+    ]);
+
+const uniqueRules = (rules: DashboardFilterRule[]): DashboardFilterRule[] =>
+    rules.filter(
+        (rule, index) => rules.findIndex((r) => r.id === rule.id) === index,
+    );
+
+const unionDashboardFilters = (
+    bySourceId: Record<string, DashboardFilters>,
+): DashboardFilters => {
+    const all = Object.values(bySourceId);
+    return {
+        dimensions: uniqueRules(all.flatMap((f) => f.dimensions)),
+        metrics: uniqueRules(all.flatMap((f) => f.metrics)),
+        tableCalculations: uniqueRules(all.flatMap((f) => f.tableCalculations)),
+    };
+};
+
+const filtersForExplore = (
+    explore: Explore,
+    rules: DashboardFilters,
+): DashboardFilters => {
+    const availableFieldIds = getAvailableFilterFieldIds(explore);
+    return {
+        dimensions: getDashboardFilterRulesForTables(
+            availableFieldIds,
+            rules.dimensions,
+        ),
+        metrics: getDashboardFilterRulesForTables(
+            availableFieldIds,
+            rules.metrics,
+        ),
+        tableCalculations: getDashboardFilterRulesForTables(
+            availableFieldIds,
+            rules.tableCalculations,
+        ),
+    };
+};
+
+/**
+ * Pushes a tile's dashboard filters down into every source that has the
+ * field, before the join, with the semantics an ordinary tile gets: dimension
+ * filters as WHERE, metric filters as HAVING, same-field dashboard filters
+ * overriding chart filters. A join-key filter therefore reaches every side
+ * and the join stays aligned. Result sources are already materialized and
+ * cannot be re-filtered, so they are left untouched.
+ *
+ * `tileUuid` is null when the filters were not authored against a tile (a
+ * data-app chart), in which case tile targets are not consulted.
+ */
+export const applyDashboardFiltersToMergeQuery = ({
+    tileUuid,
+    mergeQuery,
+    dashboardFilters,
+    exploreBySourceId,
+}: {
+    tileUuid: string | null;
+    mergeQuery: MergeQuery;
+    dashboardFilters: DashboardFilters;
+    exploreBySourceId: MergeSourceExplores;
+}): MergeDashboardFiltersResult => {
+    const tileFilters =
+        tileUuid === null
+            ? dashboardFilters
+            : getDashboardFiltersForTile(tileUuid, dashboardFilters);
+
+    const appliedDashboardFiltersBySourceId: Record<string, DashboardFilters> =
+        {};
+    const sources = mergeQuery.sources.map((source): MergeQuerySource => {
+        const explore = isMergeMetricSource(source)
+            ? exploreBySourceId[source.id]
+            : undefined;
+        if (!isMergeMetricSource(source) || explore === undefined) {
+            return source;
+        }
+        const applied = filtersForExplore(explore, tileFilters);
+        appliedDashboardFiltersBySourceId[source.id] = applied;
+        if (
+            applied.dimensions.length === 0 &&
+            applied.metrics.length === 0 &&
+            applied.tableCalculations.length === 0
+        ) {
+            return source;
+        }
+        return {
+            ...source,
+            metricQuery: addDashboardFiltersToMetricQuery(
+                source.metricQuery,
+                applied,
+                explore,
+            ),
+        };
+    });
+
+    const appliedDashboardFilters = unionDashboardFilters(
+        appliedDashboardFiltersBySourceId,
+    );
+    const appliedIds = new Set(
+        [
+            ...appliedDashboardFilters.dimensions,
+            ...appliedDashboardFilters.metrics,
+            ...appliedDashboardFilters.tableCalculations,
+        ].map((rule) => rule.id),
+    );
+    const outputFieldIds = getMergeOutputFieldIds(mergeQuery);
+    const refusedDashboardFilters = [
+        ...tileFilters.dimensions,
+        ...tileFilters.metrics,
+        ...tileFilters.tableCalculations,
+    ].filter(
+        (rule) =>
+            !appliedIds.has(rule.id) && outputFieldIds.has(rule.target.fieldId),
+    );
+
+    return {
+        mergeQuery: { ...mergeQuery, sources },
+        appliedDashboardFilters,
+        appliedDashboardFiltersBySourceId,
+        refusedDashboardFilters,
+    };
+};
+
+/** The message a refused merged-column filter surfaces with. */
+export const formatRefusedMergeDashboardFilters = (
+    refused: DashboardFilterRule[],
+): string =>
+    `This merged chart cannot apply the dashboard filter on ${refused
+        .map((rule) => rule.label ?? rule.target.fieldId)
+        .join(
+            ', ',
+        )}: it targets a merged column, and merged charts can only be filtered on their sources' fields. Remove it from this tile.`;
+
+/**
+ * Keeps the part of a filter group a source can evaluate. AND members are
+ * independent narrowings, so unknown ones drop out; an OR group is one
+ * predicate, so it is kept whole or not at all.
+ */
+const pruneFilterGroup = (
+    group: FilterGroup | undefined,
+    availableFieldIds: Set<string>,
+): FilterGroup | undefined => {
+    if (group === undefined) return undefined;
+    if (!isAndFilterGroup(group)) {
+        const resolvable = getFilterRulesFromGroup(group).every((rule) =>
+            availableFieldIds.has(rule.target.fieldId),
+        );
+        return resolvable ? group : undefined;
+    }
+    const and = group.and.flatMap((item): FilterGroupItem[] => {
+        if (isFilterGroup(item)) {
+            const pruned = pruneFilterGroup(item, availableFieldIds);
+            return pruned === undefined ? [] : [pruned];
+        }
+        return availableFieldIds.has(item.target.fieldId) ? [item] : [];
+    });
+    return and.length === 0 ? undefined : { id: group.id, and };
+};
+
+/**
+ * ANDs saved-chart filter overrides (a scheduler's chart filters) onto every
+ * source that has the field, so the narrowing reaches both sides of the join.
+ * The primary source takes the overrides whole, as the chart does on its own,
+ * so an unknown field still fails the run the way an ordinary chart run does.
+ */
+export const applyFilterOverridesToMergeQuery = ({
+    mergeQuery,
+    filterOverrides,
+    exploreBySourceId,
+}: {
+    mergeQuery: MergeQuery;
+    filterOverrides: Filters;
+    exploreBySourceId: MergeSourceExplores;
+}): MergeQuery => {
+    const sources = mergeQuery.sources.map(
+        (source, index): MergeQuerySource => {
+            const explore = isMergeMetricSource(source)
+                ? exploreBySourceId[source.id]
+                : undefined;
+            if (!isMergeMetricSource(source) || explore === undefined) {
+                return source;
+            }
+            if (index === 0) {
+                return {
+                    ...source,
+                    metricQuery: addFiltersToMetricQuery(
+                        source.metricQuery,
+                        filterOverrides,
+                    ),
+                };
+            }
+            const availableFieldIds = new Set(
+                getAvailableFilterFieldIds(explore),
+            );
+            const pruned: Filters = {
+                dimensions: pruneFilterGroup(
+                    filterOverrides.dimensions,
+                    availableFieldIds,
+                ),
+                metrics: pruneFilterGroup(
+                    filterOverrides.metrics,
+                    availableFieldIds,
+                ),
+                tableCalculations: pruneFilterGroup(
+                    filterOverrides.tableCalculations,
+                    availableFieldIds,
+                ),
+            };
+            if (
+                pruned.dimensions === undefined &&
+                pruned.metrics === undefined &&
+                pruned.tableCalculations === undefined
+            ) {
+                return source;
+            }
+            return {
+                ...source,
+                metricQuery: addFiltersToMetricQuery(
+                    source.metricQuery,
+                    pruned,
+                ),
+            };
+        },
+    );
+    return { ...mergeQuery, sources };
+};

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -1014,6 +1014,12 @@ export type ApiExecuteAsyncDashboardChartQueryResults =
         metricQuery: MetricQuery;
         fields: ItemsMap;
         appliedDashboardFilters: DashboardFilters;
+        /**
+         * For a merged chart, the applied filters keyed by the merge source
+         * they were pushed into (source ids match `fieldOrigins`). Absent on
+         * ordinary tiles.
+         */
+        appliedDashboardFiltersBySourceId?: Record<string, DashboardFilters>;
         dateZoomApplied: boolean;
     };
 


### PR DESCRIPTION
## What a user saw

A saved chart with a merge ran correctly on its own page, but on a dashboard the same chart showed only the primary source's columns, with numbers that looked complete. Every delivery that re-runs tile queries inherited the gap: CSV/XLSX scheduled deliveries, Google Sheets sync, image/PDF deliveries (the headless browser renders the dashboard through the same tile endpoint) and threshold alerts on a merged chart.

Cause: `executeAsyncSavedChartQuery` branches on `savedChart.merge` and runs the merge, but `executeAsyncDashboardChartQuery` had no such branch and ran `savedChart.metricQuery` (the primary source) alone.

## What changes

- `executeAsyncDashboardChartQuery` gains a merge branch mirroring the chart-page one (context stays whatever the caller passed, `DASHBOARD` for tiles). It runs through `executeAsyncMergeQuery`, so the merge internals are untouched and PROD-10901 can keep rewriting execution underneath.
- New module `packages/backend/src/services/AsyncQueryService/mergeDashboardFilters.ts` pushes a tile's dashboard filters into each source of the merge and returns the per-source echo. Both the dashboard branch and the saved-chart branch use it (the saved-chart merge branch previously ignored `filterOverrides` for the second source and `dashboardFilters` entirely).
- `ApiExecuteAsyncDashboardChartQueryResults` gains an optional `appliedDashboardFiltersBySourceId` (additive; `appliedDashboardFilters` keeps its shape). Source ids match the existing `fieldOrigins` keys.
- `docs/merge-queries/CONTEXT.md` gets a short "Dashboards" note.

## Filter rules (PROD-9396, dashboard side)

- Each dashboard filter is resolved against every source's explore and applied as an ordinary metric-query filter on that source, before the join: dimension filters as WHERE, metric filters as HAVING, same-field dashboard filters overriding chart filters, exactly as on an ordinary tile.
- A filter applies to every source that has the field. A filter on a join-key dimension therefore reaches every side and the join stays aligned.
- A field a source does not select is still applied as a filter, as on any tile.
- A field that resolves in no source is dropped, as on any tile (dashboards routinely carry filters for other explores). The exception is a field that names a merged output column (`merge_<key>`, `<sourceId>_<fieldId>`): that is refused with a clear `ParameterError` naming the filter rather than silently ignored. The post-join WHERE fallback was not cheap to wire, since `MergeQueryBuilder` has no filter input and PROD-10901 is rewriting that layer.
- `tileTargets` are honoured through the existing `getDashboardFiltersForTile`, so opting a tile out or retargeting a rule works as before; merged charts remain `saved_chart` tiles.
- Result sources (existing query results) are already materialized and are left untouched.
- Scheduler chart filter overrides (`filterOverrides`, a nested `Filters` group): the primary source takes the group whole, as today, so an unknown field fails the run the way an ordinary chart run does; other sources take the group pruned to the fields they have (AND members drop out individually, an OR group is kept whole or not at all, so an OR is never silently narrowed).
- Dashboard sorts and date zoom are left unapplied on merged tiles and documented: a `MergeQuery` carries no sort input today (neither compile path passes `sorts` to `MergeQueryBuilder`), and a grain cannot be applied to one side only without misaligning the join.

## Delivery paths verified

All reach the fixed entry points; none runs its own query path for chart tiles.

| Path | Entry | Reaches |
| --- | --- | --- |
| Dashboard tile (browser, headless image/PDF render) | `packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts:32` -> `packages/backend/src/controllers/v2/QueryController.ts:491` | `executeAsyncDashboardChartQuery` |
| Embed dashboard tile | `packages/backend/src/ee/services/EmbedService/EmbedService.ts:1334` | `executeAsyncDashboardChartQuery` |
| Dashboard CSV/XLSX scheduled delivery | `packages/backend/src/scheduler/SchedulerTask.ts:1639` (`downloadChartTileResults`) | `executeAsyncDashboardChartQuery` |
| Dashboard tile CSV (single tile download task) | `packages/backend/src/scheduler/SchedulerTask.ts:6354` | `executeAsyncDashboardChartQuery` |
| Google Sheets dashboard sync | `packages/backend/src/scheduler/SchedulerTask.ts:4311` | `executeDashboardChartQueryAndGetResults` -> `executeAsyncDashboardChartQuery` (`AsyncQueryService.ts:9639`) |
| Chart CSV/XLSX scheduled delivery | `packages/backend/src/scheduler/SchedulerTask.ts:1451` | `executeAsyncSavedChartQuery` |
| Google Sheets chart sync | `packages/backend/src/scheduler/SchedulerTask.ts:4127` | `executeSavedChartQueryAndGetResults` -> `executeAsyncSavedChartQuery` (`AsyncQueryService.ts:9551`) |
| Threshold alerts (chart schedulers, with `filterOverrides`) | `packages/backend/src/scheduler/SchedulerTask.ts:5059` | `executeSavedChartQueryAndGetResults` -> `executeAsyncSavedChartQuery` |
| AI agent / AI augmentation chart and tile results | `packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts:2686,2726`, `packages/backend/src/ee/services/SchedulerAiAugmentationService/SchedulerAiAugmentationService.ts:396,460` | the same two `AndGetResults` wrappers |

The GSheets gap where SQL tiles fall out of dashboard exports is not repeated: `uploadGsheets` iterates `saved_chart` tiles and a merged chart is one.

## How verified

- `pnpm -F backend test src/services/AsyncQueryService/mergeDashboardFilters.test.ts`: 14 passed (same field on both sides, join-key filter, one side only, neither side, merged-column refusal, metric filter as HAVING, tile targets, no-tile mode, result source untouched, output-id naming, override pruning).
- `pnpm -F backend test src/services/AsyncQueryService/AsyncQueryService.test.ts`: 106 passed, including three new cases: a merged chart on a tile runs through `executeAsyncMergeQuery` with the tile filter pushed into both sources and never prepares the primary alone; a merged-column filter is refused before execution; a merge refusal surfaces the same way as on the chart page.
- api-test `packages/api-tests/tests/mergeQuery.test.ts` gains a case that saves a merged chart, creates a dashboard with it as a `saved_chart` tile, runs the tile through `POST /api/v2/projects/:uuid/query/dashboard-chart` with a dashboard filter `orders_status = completed`, asserts the tile carries the merged columns and the per-source echo, and checks value parity against the two standalone sources run with the same filter (reusing the existing filtered baseline). The dashboard is cleaned up in `afterAll`.
- `pnpm -F common typecheck`, `pnpm -F backend typecheck`, `pnpm -F frontend typecheck`, `pnpm -F api-tests typecheck`, `pnpm -F backend lint`, `pnpm -F api-tests lint`, formatter check on changed files, and `pnpm generate-api` (generation succeeds; generated files not committed).

## Regression note for ordinary tiles

Non-merge tiles take exactly the code they took before: the new branch is guarded by `savedChart.merge` and sits after permission checks and analytics, before `applyDashboardFiltersForTile`. The only shared change is the optional response field, which ordinary tiles omit. The saved-chart path for non-merge charts is unchanged; for merged charts the primary source still receives `filterOverrides` whole, so its failure mode on unknown fields is preserved.

Not verified here: no browser or live app run (agent constraints). The api-test case runs in CI on the seeded Postgres project and every credentialed warehouse.

test-backend

Closes: PROD-9397
Relates: PROD-9396

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvtHaH3fbzSX2ebMgfFKFS
