### PR TITLE
fix(navbar): re-anchor navbar modals to the app color scheme

### DIFF
--- a/packages/frontend/src/components/NavBar/AppColorSchemeScope.tsx
+++ b/packages/frontend/src/components/NavBar/AppColorSchemeScope.tsx
@@ -1,0 +1,15 @@
+import { type FC, type PropsWithChildren } from 'react';
+import MantineBaseProvider from '../../providers/MantineBaseProvider';
+
+/**
+ * The navbar renders inside a forced-dark provider, but modals opened from it
+ * portal onto the page. Re-anchor them to the app's real color scheme so
+ * JS-resolved component colors (e.g. filled Button text) match the page.
+ */
+const AppColorSchemeScope: FC<PropsWithChildren> = ({ children }) => (
+    <MantineBaseProvider withCssVariables={false}>
+        {children}
+    </MantineBaseProvider>
+);
+
+export default AppColorSchemeScope;

--- a/packages/frontend/src/components/NavBar/AutopilotNavButton.tsx
+++ b/packages/frontend/src/components/NavBar/AutopilotNavButton.tsx
@@ -23,6 +23,7 @@ import { ManagedAgentSetupModal } from '../../ee/features/managedAgent/ManagedAg
 import { useServerFeatureFlag } from '../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../providers/App/useApp';
 import MantineIcon from '../common/MantineIcon';
+import AppColorSchemeScope from './AppColorSchemeScope';
 import classes from './AutopilotNavButton.module.css';
 
 const resumeSettings = async (projectUuid: string, schedule: string) =>
@@ -199,15 +200,17 @@ export const AutopilotNavButton = ({ projectUuid }: Props) => {
                         </button>
                     </div>
                 </HoverCard.Dropdown>
-                <ManagedAgentSetupModal
-                    projectUuid={projectUuid}
-                    opened={setupOpen}
-                    onClose={() => setSetupOpen(false)}
-                    onEnabled={() => {
-                        setSetupOpen(false);
-                        goToAutopilot();
-                    }}
-                />
+                <AppColorSchemeScope>
+                    <ManagedAgentSetupModal
+                        projectUuid={projectUuid}
+                        opened={setupOpen}
+                        onClose={() => setSetupOpen(false)}
+                        onEnabled={() => {
+                            setSetupOpen(false);
+                            goToAutopilot();
+                        }}
+                    />
+                </AppColorSchemeScope>
             </HoverCard>
         );
     }

--- a/packages/frontend/src/components/NavBar/ExploreMenu.tsx
+++ b/packages/frontend/src/components/NavBar/ExploreMenu.tsx
@@ -22,6 +22,7 @@ import MantineIcon from '../common/MantineIcon';
 import DashboardCreateModal from '../common/modal/DashboardCreateModal';
 import SpaceActionModal from '../common/SpaceActionModal';
 import { ActionType } from '../common/SpaceActionModal/types';
+import AppColorSchemeScope from './AppColorSchemeScope';
 
 type Props = {
     projectUuid: string;
@@ -175,35 +176,39 @@ const ExploreMenu: FC<Props> = memo((props) => {
             </Can>
 
             {isCreateSpaceOpen && (
-                <SpaceActionModal
-                    projectUuid={projectUuid}
-                    actionType={ActionType.CREATE}
-                    title="Create new space"
-                    confirmButtonLabel="Create"
-                    icon={IconFolderPlus}
-                    onClose={() => setIsCreateSpaceOpen(false)}
-                    onSubmitForm={(space) => {
-                        if (space)
-                            void navigate(
-                                `/projects/${projectUrlIdentifier}/spaces/${space.uuid}`,
-                            );
-                    }}
-                    parentSpaceUuid={null}
-                />
+                <AppColorSchemeScope>
+                    <SpaceActionModal
+                        projectUuid={projectUuid}
+                        actionType={ActionType.CREATE}
+                        title="Create new space"
+                        confirmButtonLabel="Create"
+                        icon={IconFolderPlus}
+                        onClose={() => setIsCreateSpaceOpen(false)}
+                        onSubmitForm={(space) => {
+                            if (space)
+                                void navigate(
+                                    `/projects/${projectUrlIdentifier}/spaces/${space.uuid}`,
+                                );
+                        }}
+                        parentSpaceUuid={null}
+                    />
+                </AppColorSchemeScope>
             )}
             {isCreateDashboardOpen && (
-                <DashboardCreateModal
-                    projectUuid={projectUuid}
-                    opened={isCreateDashboardOpen}
-                    onClose={() => setIsCreateDashboardOpen(false)}
-                    onConfirm={(dashboard) => {
-                        void navigate(
-                            `/projects/${projectUrlIdentifier}/dashboards/${dashboard.slug}/edit`,
-                        );
+                <AppColorSchemeScope>
+                    <DashboardCreateModal
+                        projectUuid={projectUuid}
+                        opened={isCreateDashboardOpen}
+                        onClose={() => setIsCreateDashboardOpen(false)}
+                        onConfirm={(dashboard) => {
+                            void navigate(
+                                `/projects/${projectUrlIdentifier}/dashboards/${dashboard.slug}/edit`,
+                            );
 
-                        setIsCreateDashboardOpen(false);
-                    }}
-                />
+                            setIsCreateDashboardOpen(false);
+                        }}
+                    />
+                </AppColorSchemeScope>
             )}
         </>
     );

--- a/packages/frontend/src/components/NavBar/ProjectSwitcher.tsx
+++ b/packages/frontend/src/components/NavBar/ProjectSwitcher.tsx
@@ -43,6 +43,7 @@ import { useProjects } from '../../hooks/useProjects';
 import useApp from '../../providers/App/useApp';
 import { getProjectUrlIdentifier } from '../../utils/projectUrl';
 import MantineIcon from '../common/MantineIcon';
+import AppColorSchemeScope from './AppColorSchemeScope';
 import { CreatePreviewModal } from './CreatePreviewProjectModal';
 import classes from './ProjectSwitcher.module.css';
 
@@ -862,11 +863,13 @@ const ProjectSwitcher: FC<ProjectSwitcherProps> = ({ portalTarget }) => {
             </Menu>
 
             {isCreatePreviewOpen && (
-                <CreatePreviewModal
-                    isOpened={isCreatePreviewOpen}
-                    onClose={() => setIsCreatePreview(false)}
-                    preselectedProjectUuid={drilledProjectUuid ?? undefined}
-                />
+                <AppColorSchemeScope>
+                    <CreatePreviewModal
+                        isOpened={isCreatePreviewOpen}
+                        onClose={() => setIsCreatePreview(false)}
+                        preselectedProjectUuid={drilledProjectUuid ?? undefined}
+                    />
+                </AppColorSchemeScope>
             )}
         </>
     );

--- a/packages/frontend/src/components/NavBar/UserCredentialsSwitcher.tsx
+++ b/packages/frontend/src/components/NavBar/UserCredentialsSwitcher.tsx
@@ -15,6 +15,7 @@ import useApp from '../../providers/App/useApp';
 import MantineIcon from '../common/MantineIcon';
 import { getWarehouseLabel } from '../ProjectConnection/ProjectConnectFlow/utils';
 import { CreateCredentialsModal } from '../UserSettings/MyWarehouseConnectionsPanel/CreateCredentialsModal';
+import AppColorSchemeScope from './AppColorSchemeScope';
 
 const routesThatNeedWarehouseCredentials = [
     '/projects/:projectUuid/tables/:tableId',
@@ -235,42 +236,44 @@ const UserCredentialsSwitcher = () => {
                 </Menu.Dropdown>
             </Menu>
             {isCreatingCredentials && (
-                <CreateCredentialsModal
-                    opened={isCreatingCredentials}
-                    title={
-                        showCreateModalOnPageLoad
-                            ? `Login to ${getWarehouseLabel(
-                                  activeProject.warehouseConnection?.type,
-                              )}`
-                            : undefined
-                    }
-                    description={
-                        showCreateModalOnPageLoad ? (
-                            <Text>
-                                The admin of your organization "
-                                {user.data?.organizationName}" requires that you
-                                login to{' '}
-                                {getWarehouseLabel(
-                                    activeProject.warehouseConnection?.type,
-                                )}{' '}
-                                to continue.
-                            </Text>
-                        ) : undefined
-                    }
-                    nameValue={
-                        showCreateModalOnPageLoad ? 'Default' : undefined
-                    }
-                    warehouseType={activeProject.warehouseConnection?.type}
-                    projectUuid={activeProjectUuid}
-                    projectName={activeProject.name}
-                    onSuccess={(data) => {
-                        mutate({
-                            projectUuid: activeProjectUuid,
-                            userWarehouseCredentialsUuid: data.uuid,
-                        });
-                    }}
-                    onClose={() => setIsCreatingCredentials(false)}
-                />
+                <AppColorSchemeScope>
+                    <CreateCredentialsModal
+                        opened={isCreatingCredentials}
+                        title={
+                            showCreateModalOnPageLoad
+                                ? `Login to ${getWarehouseLabel(
+                                      activeProject.warehouseConnection?.type,
+                                  )}`
+                                : undefined
+                        }
+                        description={
+                            showCreateModalOnPageLoad ? (
+                                <Text>
+                                    The admin of your organization "
+                                    {user.data?.organizationName}" requires that
+                                    you login to{' '}
+                                    {getWarehouseLabel(
+                                        activeProject.warehouseConnection?.type,
+                                    )}{' '}
+                                    to continue.
+                                </Text>
+                            ) : undefined
+                        }
+                        nameValue={
+                            showCreateModalOnPageLoad ? 'Default' : undefined
+                        }
+                        warehouseType={activeProject.warehouseConnection?.type}
+                        projectUuid={activeProjectUuid}
+                        projectName={activeProject.name}
+                        onSuccess={(data) => {
+                            mutate({
+                                projectUuid: activeProjectUuid,
+                                userWarehouseCredentialsUuid: data.uuid,
+                            });
+                        }}
+                        onClose={() => setIsCreatingCredentials(false)}
+                    />
+                </AppColorSchemeScope>
             )}
         </>
     );


### PR DESCRIPTION
## Problem

In light mode, the confirm button in **Create a preview project** renders near-black text on a near-black fill. The same happens in every other modal launched from the navbar: create space, create dashboard, warehouse credentials, and Autopilot setup.

## Cause

`NavBar/index.tsx` wraps the navbar in `MantineBaseProvider forceColorScheme="dark"`, with CSS variables scoped to `#navbar-header`. Modals rendered by navbar children portal onto the page, so:

- their **CSS** variables resolve from the page-level (light) scheme, where `primary` is near-black;
- their **React theme context** is still the navbar's dark theme.

The theme sets `autoContrast: true`, so Mantine computes a filled button's text colour in JS from the theme's primary shade. In the dark theme that shade is near-white, so it picks black text and writes it as an inline `--button-color`. The background resolves through CSS to the light page's near-black primary. Result: black on black.

It is invisible in dark mode because both sides agree, and CSS-module overrides cannot fix it because the inline variable wins.

## Fix

Add `AppColorSchemeScope`, a thin wrapper around `MantineBaseProvider withCssVariables={false}`, and wrap each navbar modal mount point with it. The nested provider re-reads the real app scheme from `ColorSchemeContext` and fixes JS-resolved colours without emitting a second CSS-variables stylesheet. This is the same mechanism the Omnibar already uses (`Omnibar.tsx`).

## Why not fix it in `MantineModal`

A nested provider inside the shared `MantineModal` would cover every modal, but `MantineBaseProvider` rebuilds the theme from `getMantineThemeOverride`, so any parent `themeOverride` (the SDK's embed theming) would be dropped inside modals. Scoping the fix to the navbar keeps embed modals untouched.

## Regression analysis

- Only the five navbar modal mount points change. Their props and behaviour are untouched; they gain one wrapper in the tree.
- Dark-mode users see no change: the nested provider resolves to dark, matching what the modal already rendered.
- The wrapper renders only while a modal is open (the mounts are already conditional on their `open` state, except Autopilot setup, which was already always mounted).
- `withCssVariables={false}` means no new `<style>` tag; page-level variables stay authoritative.

## Verification

- `pnpm -F frontend typecheck` passes.
- oxlint and oxfmt clean on the touched files.

Closes: PROD-10964

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MbDwx5AvC4WU3X2F5cqTk5
