### PR TITLE
feat(ai-agents): rename threads from the sidebar

### DIFF
--- a/packages/backend/src/ee/controllers/aiAgentController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentController.ts
@@ -42,6 +42,7 @@ import {
     ApiAiAgentThreadShareResponse,
     ApiAiAgentThreadStreamRequest,
     ApiAiAgentThreadSummaryListResponse,
+    ApiAiAgentThreadUpdateRequest,
     ApiAiAgentThreadWorkstreamsResponse,
     ApiAiAgentVerifiedArtifactsResponse,
     ApiAiAgentVerifiedQuestionsResponse,
@@ -1054,6 +1055,34 @@ export class AiAgentController extends BaseController {
             toSessionUser(req.account),
             agentUuid,
             threadUuid,
+        );
+
+        return {
+            status: 'ok',
+            results: undefined,
+        };
+    }
+
+    /**
+     * Rename a thread. Only the thread owner or a project admin may do this.
+     * @summary Update AI agent thread
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Patch('/{agentUuid}/threads/{threadUuid}')
+    @OperationId('updateAgentThread')
+    async updateAgentThread(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() agentUuid: UUID,
+        @Path() threadUuid: UUID,
+        @Body() body: ApiAiAgentThreadUpdateRequest,
+    ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        await this.getAiAgentService().updateAgentThreadTitle(
+            toSessionUser(req.account),
+            { agentUuid, threadUuid, title: body.title },
         );
 
         return {

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -2,6 +2,7 @@ import { subject } from '@casl/ability';
 import {
     AgentSuggestion,
     AgentSummaryContext,
+    AI_AGENT_THREAD_TITLE_MAX_LENGTH,
     AI_DEEP_RESEARCH_MAX_CONTEXT_ROWS,
     AiAgent,
     AiAgentEvalRunJobPayload,
@@ -3441,6 +3442,64 @@ export class AiAgentService extends BaseService {
      * feature flag blocks this endpoint entirely; the admin threads view uses a
      * separate path and keeps working.
      */
+    async updateAgentThreadTitle(
+        user: SessionUser,
+        {
+            agentUuid,
+            threadUuid,
+            title,
+        }: { agentUuid: string; threadUuid: string; title: string },
+    ): Promise<void> {
+        const { organizationUuid } = user;
+        if (!organizationUuid) {
+            throw new ForbiddenError('Organization not found');
+        }
+
+        const trimmedTitle = title.trim();
+        if (trimmedTitle.length === 0) {
+            throw new ParameterError('Thread title cannot be empty');
+        }
+        if (trimmedTitle.length > AI_AGENT_THREAD_TITLE_MAX_LENGTH) {
+            throw new ParameterError(
+                `Thread title cannot exceed ${AI_AGENT_THREAD_TITLE_MAX_LENGTH} characters`,
+            );
+        }
+
+        const agent = await this.aiAgentModel.getAgent({
+            organizationUuid,
+            agentUuid,
+        });
+        if (!agent) {
+            throw new NotFoundError(`Agent not found: ${agentUuid}`);
+        }
+
+        const thread = await this.aiAgentModel.getThread({
+            organizationUuid,
+            agentUuid,
+            threadUuid,
+        });
+
+        if (
+            this.createAuditedAbility(user).cannot(
+                'manage',
+                subject('AiAgentThread', {
+                    organizationUuid,
+                    projectUuid: agent.projectUuid,
+                    userUuid: thread.user.uuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'Insufficient permissions to rename this thread',
+            );
+        }
+
+        await this.aiAgentModel.updateThreadTitle({
+            threadUuid,
+            title: trimmedTitle,
+        });
+    }
+
     async deleteAgentThread(
         user: SessionUser,
         agentUuid: string,

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -901,6 +901,12 @@ export type ApiAiAgentThreadGenerateTitleResponse = {
     };
 };
 
+export const AI_AGENT_THREAD_TITLE_MAX_LENGTH = 200;
+
+export type ApiAiAgentThreadUpdateRequest = {
+    title: string;
+};
+
 export type ApiAiAgentThreadMessageViz = {
     type: AiResultType;
     metricQuery: AiMetricQuery;

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AgentSidebar.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AgentSidebar.tsx
@@ -1,4 +1,5 @@
 import {
+    AI_AGENT_THREAD_TITLE_MAX_LENGTH,
     FeatureFlags,
     type AiAgent,
     type AiAgentProjectThreadSummary,
@@ -9,22 +10,26 @@ import {
     Box,
     Button,
     Group,
+    Menu,
+    NavLink,
     Paper,
     rem,
     Stack,
     Text,
+    TextInput,
     Title,
     Tooltip,
-    NavLink,
 } from '@mantine/core';
 import {
     IconBrandSlack,
     IconChevronDown,
     IconCirclePlus,
+    IconDots,
     IconInfoCircle,
-    IconX,
+    IconPencil,
+    IconTrash,
 } from '@tabler/icons-react';
-import { useState, type FC } from 'react';
+import { useRef, useState, type FC } from 'react';
 import { Link } from 'react-router';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import MantineModal from '../../../../../components/common/MantineModal';
@@ -34,11 +39,66 @@ import { useAiOrganizationSettings } from '../../hooks/useAiOrganizationSettings
 import {
     useDeleteAiAgentThreadMutation,
     useInfiniteAiAgentThreads,
+    useRenameAiAgentThreadMutation,
 } from '../../hooks/useProjectAiAgents';
 import { AgentNamePill } from '../AgentNamePill';
 import { AiAgentIcon } from '../AiAgentIcon';
 import classes from './agentSidebar.module.css';
 import { SidebarButton } from './SidebarButton';
+
+type ThreadRenameInputProps = {
+    initialTitle: string;
+    onSubmit: (title: string) => void;
+    onCancel: () => void;
+};
+
+const ThreadRenameInput: FC<ThreadRenameInputProps> = ({
+    initialTitle,
+    onSubmit,
+    onCancel,
+}) => {
+    const [draft, setDraft] = useState(initialTitle);
+    const settledRef = useRef(false);
+
+    const settle = (action: () => void) => {
+        if (settledRef.current) return;
+        settledRef.current = true;
+        action();
+    };
+
+    const commit = () => {
+        const title = draft.trim();
+        if (title.length === 0 || title === initialTitle) {
+            settle(onCancel);
+            return;
+        }
+        settle(() => onSubmit(title));
+    };
+
+    return (
+        <Box px="xs" py={rem(4)}>
+            <TextInput
+                size="xs"
+                autoFocus
+                aria-label="Thread title"
+                maxLength={AI_AGENT_THREAD_TITLE_MAX_LENGTH}
+                value={draft}
+                onChange={(event) => setDraft(event.currentTarget.value)}
+                onFocus={(event) => event.currentTarget.select()}
+                onBlur={commit}
+                onKeyDown={(event) => {
+                    if (event.key === 'Enter') {
+                        event.preventDefault();
+                        commit();
+                    } else if (event.key === 'Escape') {
+                        event.preventDefault();
+                        settle(onCancel);
+                    }
+                }}
+            />
+        </Box>
+    );
+};
 
 type ThreadNavLinkProps = {
     thread: AiAgentProjectThreadSummary;
@@ -47,6 +107,7 @@ type ThreadNavLinkProps = {
     showAgentName?: boolean;
     deletionDisabled: boolean;
     onDelete: (thread: AiAgentProjectThreadSummary) => void;
+    onRename: (thread: AiAgentProjectThreadSummary, title: string) => void;
 };
 
 const ThreadNavLink: FC<ThreadNavLinkProps> = ({
@@ -56,6 +117,7 @@ const ThreadNavLink: FC<ThreadNavLinkProps> = ({
     showAgentName = false,
     deletionDisabled,
     onDelete,
+    onRename,
 }) => {
     const threadTitle = (thread.title || thread.firstMessage.message).trim();
     const hasTitle = threadTitle.length > 0;
@@ -66,6 +128,20 @@ const ThreadNavLink: FC<ThreadNavLinkProps> = ({
     // Deleting a Slack thread here would not remove it from Slack itself
     const canDelete =
         !deletionDisabled && canManageThread && thread.createdFrom !== 'slack';
+    const [isRenaming, setIsRenaming] = useState(false);
+
+    if (isRenaming) {
+        return (
+            <ThreadRenameInput
+                initialTitle={threadTitle}
+                onSubmit={(title) => {
+                    setIsRenaming(false);
+                    onRename(thread, title);
+                }}
+                onCancel={() => setIsRenaming(false)}
+            />
+        );
+    }
 
     return (
         <NavLink
@@ -106,22 +182,55 @@ const ThreadNavLink: FC<ThreadNavLinkProps> = ({
                             <IconBrandSlack size={18} stroke={1} />
                         </Tooltip>
                     )}
-                    {canDelete && (
-                        <Tooltip label="Delete thread" openDelay={300}>
-                            <ActionIcon
-                                size="xs"
-                                color="ldGray"
-                                className={classes.threadDeleteButton}
-                                aria-label="Delete thread"
+                    {canManageThread && (
+                        <Menu
+                            position="bottom-end"
+                            width={160}
+                            returnFocus={false}
+                        >
+                            <Menu.Target>
+                                <ActionIcon
+                                    size="xs"
+                                    color="ldGray"
+                                    variant="subtle"
+                                    className={classes.threadMenuButton}
+                                    aria-label="Thread options"
+                                    onClick={(event) => {
+                                        event.preventDefault();
+                                        event.stopPropagation();
+                                    }}
+                                >
+                                    <MantineIcon icon={IconDots} size={12} />
+                                </ActionIcon>
+                            </Menu.Target>
+                            {/* Clicks bubble through the portal to the row link */}
+                            <Menu.Dropdown
                                 onClick={(event) => {
                                     event.preventDefault();
                                     event.stopPropagation();
-                                    onDelete(thread);
                                 }}
                             >
-                                <MantineIcon icon={IconX} size={12} />
-                            </ActionIcon>
-                        </Tooltip>
+                                <Menu.Item
+                                    leftSection={
+                                        <MantineIcon icon={IconPencil} />
+                                    }
+                                    onClick={() => setIsRenaming(true)}
+                                >
+                                    Rename
+                                </Menu.Item>
+                                {canDelete && (
+                                    <Menu.Item
+                                        color="red"
+                                        leftSection={
+                                            <MantineIcon icon={IconTrash} />
+                                        }
+                                        onClick={() => onDelete(thread)}
+                                    >
+                                        Delete
+                                    </Menu.Item>
+                                )}
+                            </Menu.Dropdown>
+                        </Menu>
                     )}
                 </Group>
             }
@@ -157,6 +266,8 @@ const ThreadList: FC<ThreadListProps> = ({
         useState<AiAgentProjectThreadSummary | null>(null);
     const { mutateAsync: deleteThread, isLoading: isDeletingThread } =
         useDeleteAiAgentThreadMutation(projectUuid);
+    const { mutate: renameThread } =
+        useRenameAiAgentThreadMutation(projectUuid);
     const handleConfirmDelete = async () => {
         if (!threadToDelete) return;
         await deleteThread({
@@ -195,6 +306,13 @@ const ThreadList: FC<ThreadListProps> = ({
                             showAgentName={showAgentName}
                             deletionDisabled={deletionDisabled}
                             onDelete={setThreadToDelete}
+                            onRename={(thread, title) =>
+                                renameThread({
+                                    agentUuid: thread.agentUuid,
+                                    threadUuid: thread.uuid,
+                                    title,
+                                })
+                            }
                         />
                     ))}
                 </Box>

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/agentSidebar.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/agentSidebar.module.css
@@ -75,12 +75,13 @@
     }
 }
 
-.threadDeleteButton {
+.threadMenuButton {
     opacity: 0;
     transition: opacity 150ms ease;
 
     .threadNavLink:hover &,
-    &:focus-visible {
+    &:focus-visible,
+    &[data-expanded] {
         opacity: 1;
     }
 }

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
@@ -1,6 +1,7 @@
 import type {
     AiAgent,
     AiAgentModelConfig,
+    AiAgentProjectThreadSummary,
     AiAgentThreadFilters,
     AiPromptContext,
     AiPromptContextItem,
@@ -15,6 +16,7 @@ import type {
     ApiAiAgentThreadDataAppRestoreRequest,
     ApiAiAgentThreadDataAppRestoreResponse,
     ApiAiAgentThreadGenerateTitleResponse,
+    ApiAiAgentThreadUpdateRequest,
     ApiAiAgentThreadMessageCreateRequest,
     ApiAiAgentThreadMessageCreateResponse,
     ApiAiAgentThreadMessageInterruptResponse,
@@ -40,6 +42,7 @@ import {
     useQuery,
     useQueryClient,
     type InfiniteData,
+    type QueryClient,
     type UseInfiniteQueryOptions,
     type UseQueryOptions,
 } from '@tanstack/react-query';
@@ -632,6 +635,114 @@ export const useDeleteAiAgentThreadMutation = (projectUuid: string) => {
     });
 };
 
+type ProjectThreadsInfiniteData = InfiniteData<
+    ApiAiAgentProjectThreadSummaryListResponse['results']
+>;
+
+const getProjectThreadsQueryKey = (projectUuid: string) =>
+    [AI_AGENTS_KEY, projectUuid, PROJECT_THREADS_KEY] as const;
+
+// Snapshot every cached sidebar list (one per filter set) so a failed
+// mutation can restore them.
+const snapshotProjectThreads = (
+    queryClient: QueryClient,
+    projectUuid: string,
+) =>
+    queryClient.getQueriesData<ProjectThreadsInfiniteData | undefined>({
+        queryKey: getProjectThreadsQueryKey(projectUuid),
+    });
+
+const restoreProjectThreads = (
+    queryClient: QueryClient,
+    snapshot: ReturnType<typeof snapshotProjectThreads>,
+) => {
+    snapshot.forEach(([queryKey, data]) => {
+        queryClient.setQueryData(queryKey, data);
+    });
+};
+
+const patchProjectThread = (
+    queryClient: QueryClient,
+    projectUuid: string,
+    threadUuid: string,
+    patch: Partial<AiAgentProjectThreadSummary>,
+) => {
+    queryClient.setQueriesData<ProjectThreadsInfiniteData | undefined>(
+        { queryKey: getProjectThreadsQueryKey(projectUuid) },
+        (currentData) => {
+            if (!currentData) return currentData;
+            return {
+                ...currentData,
+                pages: currentData.pages.map((page) => ({
+                    ...page,
+                    data: page.data.map((thread) =>
+                        thread.uuid === threadUuid
+                            ? { ...thread, ...patch }
+                            : thread,
+                    ),
+                })),
+            };
+        },
+    );
+};
+
+const updateAgentThread = async (
+    projectUuid: string,
+    agentUuid: string,
+    threadUuid: string,
+    data: ApiAiAgentThreadUpdateRequest,
+) =>
+    lightdashApi<ApiSuccessEmpty>({
+        version: 'v1',
+        url: `/projects/${projectUuid}/aiAgents/${agentUuid}/threads/${threadUuid}`,
+        method: 'PATCH',
+        body: JSON.stringify(data),
+    });
+
+export const useRenameAiAgentThreadMutation = (projectUuid: string) => {
+    const queryClient = useQueryClient();
+    const { showToastApiError } = useToaster();
+
+    return useMutation<
+        ApiSuccessEmpty,
+        ApiError,
+        { agentUuid: string; threadUuid: string; title: string },
+        { snapshot: ReturnType<typeof snapshotProjectThreads> }
+    >({
+        mutationFn: ({ agentUuid, threadUuid, title }) =>
+            updateAgentThread(projectUuid, agentUuid, threadUuid, { title }),
+        onMutate: async ({ threadUuid, title }) => {
+            await queryClient.cancelQueries({
+                queryKey: getProjectThreadsQueryKey(projectUuid),
+            });
+            const snapshot = snapshotProjectThreads(queryClient, projectUuid);
+            patchProjectThread(queryClient, projectUuid, threadUuid, { title });
+            return { snapshot };
+        },
+        onError: ({ error }, _variables, context) => {
+            if (context) restoreProjectThreads(queryClient, context.snapshot);
+            showToastApiError({
+                title: 'Failed to rename thread',
+                apiError: error,
+            });
+        },
+        onSettled: async (_result, _error, { agentUuid, threadUuid }) => {
+            await Promise.all([
+                queryClient.invalidateQueries({
+                    queryKey: getProjectThreadsQueryKey(projectUuid),
+                }),
+                queryClient.invalidateQueries({
+                    queryKey: getAiAgentThreadQueryKey(
+                        projectUuid,
+                        agentUuid,
+                        threadUuid,
+                    ),
+                }),
+            ]);
+        },
+    });
+};
+
 export const getAiAgentThreadQueryKey = (
     projectUuid: string,
     agentUuid: string | undefined,
@@ -926,28 +1037,9 @@ const useGenerateAgentThreadTitleMutation = (projectUuid: string) => {
         mutationFn: ({ agentUuid, threadUuid }) =>
             generateAgentThreadTitle(projectUuid, agentUuid, threadUuid),
         onSuccess: (data, { threadUuid }) => {
-            queryClient.setQueriesData<
-                | InfiniteData<
-                      ApiAiAgentProjectThreadSummaryListResponse['results']
-                  >
-                | undefined
-            >(
-                { queryKey: [AI_AGENTS_KEY, projectUuid, PROJECT_THREADS_KEY] },
-                (currentData) => {
-                    if (!currentData) return currentData;
-                    return {
-                        ...currentData,
-                        pages: currentData.pages.map((page) => ({
-                            ...page,
-                            data: page.data.map((thread) =>
-                                thread.uuid === threadUuid
-                                    ? { ...thread, title: data.title }
-                                    : thread,
-                            ),
-                        })),
-                    };
-                },
-            );
+            patchProjectThread(queryClient, projectUuid, threadUuid, {
+                title: data.title,
+            });
         },
         onError: ({ error }) => {
             // Silently fail - don't show error toast or navigate for background title generation


### PR DESCRIPTION
## Summary

Threads in the Ask AI / AI agents sidebar can now be renamed in place. This is the first of two PRs; the second (#28681) adds pinning on top.

- New `PATCH /api/v1/projects/{projectUuid}/aiAgents/{agentUuid}/threads/{threadUuid}` taking `{ title }`. Trims the title, rejects empty or over 200 characters, and requires the same `manage` ability on `AiAgentThread` that thread deletion uses (owner or project admin).
- The existing `updateThreadTitle` model method is reused. It stamps `title_generated_at`, so a manual rename is never overwritten by the automatic title generator.
- The sidebar row's hover trash icon is replaced by a hover "..." menu with **Rename** and **Delete**. Delete keeps its existing gating (feature flag, not for Slack threads) and confirm modal. Rename swaps the title for an inline input saved on Enter or blur, cancelled with Escape, and skipped when unchanged.
- The rename mutation patches the sidebar list cache and invalidates the thread detail query.

## Regression analysis

- Delete behaviour is unchanged: same mutation, same modal, same gating. Only the trigger moved from an icon to a menu item.
- The menu dropdown is portaled, and React synthetic events still bubble through portals to the row's `Link`. The dropdown handler calls `preventDefault` and `stopPropagation`, so choosing a menu item does not navigate. The menu target does the same.
- No API breaks: additive route only. `generated/routes.ts` and `swagger.json` are intentionally not committed.
- No migration.

## Testing

- `pnpm -F backend typecheck`, `pnpm -F frontend typecheck`, lint on changed files, `pnpm generate-api` all pass.
- Not yet clicked through in the browser, hence draft.

Relates: ZAP-99

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CbgpnzYHBDeDbd5B3PrnBZ
