### PR TITLE
feat(ai-agents): pin threads to the top of the sidebar

### DIFF
--- a/packages/backend/src/ee/controllers/aiAgentController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentController.ts
@@ -1092,6 +1092,60 @@ export class AiAgentController extends BaseController {
     }
 
     /**
+     * Pin a thread to the top of the sidebar.
+     * @summary Pin AI agent thread
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('/{agentUuid}/threads/{threadUuid}/pin')
+    @OperationId('pinAgentThread')
+    async pinAgentThread(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() agentUuid: UUID,
+        @Path() threadUuid: UUID,
+    ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        await this.getAiAgentService().setAgentThreadPinned(
+            toSessionUser(req.account),
+            { agentUuid, threadUuid, pinned: true },
+        );
+
+        return {
+            status: 'ok',
+            results: undefined,
+        };
+    }
+
+    /**
+     * Unpin a thread.
+     * @summary Unpin AI agent thread
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Delete('/{agentUuid}/threads/{threadUuid}/pin')
+    @OperationId('unpinAgentThread')
+    async unpinAgentThread(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() agentUuid: UUID,
+        @Path() threadUuid: UUID,
+    ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        await this.getAiAgentService().setAgentThreadPinned(
+            toSessionUser(req.account),
+            { agentUuid, threadUuid, pinned: false },
+        );
+
+        return {
+            status: 'ok',
+            results: undefined,
+        };
+    }
+
+    /**
      * Get the writeback pull request associated with a thread — the PR the
      * agent opened in this thread, or the PR a verification thread verifies.
      * @summary Get AI agent thread pull request

--- a/packages/backend/src/ee/database/entities/ai.ts
+++ b/packages/backend/src/ee/database/entities/ai.ts
@@ -32,6 +32,7 @@ export type DbAiThread = {
     title: string | null;
     title_generated_at: Date | null;
     sql_auto_approved_at: Date | null;
+    pinned_at: Date | null;
 };
 
 export type AiThreadTable = Knex.CompositeTableType<
@@ -49,6 +50,7 @@ export type AiThreadTable = Knex.CompositeTableType<
             | 'project_uuid'
             | 'share_source_thread_share_uuid'
             | 'sql_auto_approved_at'
+            | 'pinned_at'
         > & { updated_at: Date | Knex.Raw }
     >
 >;

--- a/packages/backend/src/ee/database/migrations/20260904140000_add_pinned_at_to_ai_thread.ts
+++ b/packages/backend/src/ee/database/migrations/20260904140000_add_pinned_at_to_ai_thread.ts
@@ -1,0 +1,15 @@
+import { Knex } from 'knex';
+
+const AiThreadTableName = 'ai_thread';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(AiThreadTableName, (table) => {
+        table.timestamp('pinned_at', { useTz: false }).nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(AiThreadTableName, (table) => {
+        table.dropColumn('pinned_at');
+    });
+}

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -411,6 +411,7 @@ type AiThreadSummaryRow = Pick<
     | 'created_from'
     | 'title'
     | 'title_generated_at'
+    | 'pinned_at'
 > &
     Pick<DbAiPrompt, 'prompt' | 'ai_prompt_uuid'> & {
         user_uuid: DbUser['user_uuid'] | null;
@@ -3024,6 +3025,7 @@ export class AiAgentModel {
                 `${AiThreadTableName}.created_from`,
                 `${AiThreadTableName}.title`,
                 `${AiThreadTableName}.title_generated_at`,
+                `${AiThreadTableName}.pinned_at`,
                 `${AiPromptTableName}.prompt`,
                 `${AiPromptTableName}.ai_prompt_uuid`,
                 `${UserTableName}.user_uuid`,
@@ -3051,6 +3053,7 @@ export class AiAgentModel {
             createdFrom: row.created_from,
             title: row.title,
             titleGeneratedAt: row.title_generated_at?.toString() ?? null,
+            pinnedAt: row.pinned_at?.toString() ?? null,
             firstMessage: {
                 uuid: row.ai_prompt_uuid,
                 message: row.prompt,
@@ -3411,7 +3414,16 @@ export class AiAgentModel {
     > {
         const query = this.buildThreadSummaryQuery(organizationUuid)
             .andWhere(`${AiThreadTableName}.project_uuid`, projectUuid)
-            .andWhere(`${UserTableName}.user_uuid`, userUuid);
+            .andWhere(`${UserTableName}.user_uuid`, userUuid)
+            .clearOrder()
+            .orderBy([
+                {
+                    column: `${AiThreadTableName}.pinned_at`,
+                    order: 'desc',
+                    nulls: 'last',
+                },
+                { column: `${AiThreadTableName}.created_at`, order: 'desc' },
+            ]);
 
         if (agentUuids) {
             void query.whereIn(`${AiThreadTableName}.agent_uuid`, agentUuids);
@@ -8754,6 +8766,18 @@ export class AiAgentModel {
                 title,
                 title_generated_at: new Date(),
             });
+    }
+
+    async setThreadPinned({
+        threadUuid,
+        pinned,
+    }: {
+        threadUuid: string;
+        pinned: boolean;
+    }): Promise<void> {
+        await this.database(AiThreadTableName)
+            .where('ai_thread_uuid', threadUuid)
+            .update({ pinned_at: pinned ? new Date() : null });
     }
 
     async appendInstruction(data: {

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -3442,27 +3442,17 @@ export class AiAgentService extends BaseService {
      * feature flag blocks this endpoint entirely; the admin threads view uses a
      * separate path and keeps working.
      */
-    async updateAgentThreadTitle(
+    private async getManagedThread(
         user: SessionUser,
         {
             agentUuid,
             threadUuid,
-            title,
-        }: { agentUuid: string; threadUuid: string; title: string },
-    ): Promise<void> {
+            action,
+        }: { agentUuid: string; threadUuid: string; action: string },
+    ) {
         const { organizationUuid } = user;
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
-        }
-
-        const trimmedTitle = title.trim();
-        if (trimmedTitle.length === 0) {
-            throw new ParameterError('Thread title cannot be empty');
-        }
-        if (trimmedTitle.length > AI_AGENT_THREAD_TITLE_MAX_LENGTH) {
-            throw new ParameterError(
-                `Thread title cannot exceed ${AI_AGENT_THREAD_TITLE_MAX_LENGTH} characters`,
-            );
         }
 
         const agent = await this.aiAgentModel.getAgent({
@@ -3490,14 +3480,58 @@ export class AiAgentService extends BaseService {
             )
         ) {
             throw new ForbiddenError(
-                'Insufficient permissions to rename this thread',
+                `Insufficient permissions to ${action} this thread`,
             );
         }
+
+        return thread;
+    }
+
+    async updateAgentThreadTitle(
+        user: SessionUser,
+        {
+            agentUuid,
+            threadUuid,
+            title,
+        }: { agentUuid: string; threadUuid: string; title: string },
+    ): Promise<void> {
+        const trimmedTitle = title.trim();
+        if (trimmedTitle.length === 0) {
+            throw new ParameterError('Thread title cannot be empty');
+        }
+        if (trimmedTitle.length > AI_AGENT_THREAD_TITLE_MAX_LENGTH) {
+            throw new ParameterError(
+                `Thread title cannot exceed ${AI_AGENT_THREAD_TITLE_MAX_LENGTH} characters`,
+            );
+        }
+
+        await this.getManagedThread(user, {
+            agentUuid,
+            threadUuid,
+            action: 'rename',
+        });
 
         await this.aiAgentModel.updateThreadTitle({
             threadUuid,
             title: trimmedTitle,
         });
+    }
+
+    async setAgentThreadPinned(
+        user: SessionUser,
+        {
+            agentUuid,
+            threadUuid,
+            pinned,
+        }: { agentUuid: string; threadUuid: string; pinned: boolean },
+    ): Promise<void> {
+        await this.getManagedThread(user, {
+            agentUuid,
+            threadUuid,
+            action: pinned ? 'pin' : 'unpin',
+        });
+
+        await this.aiAgentModel.setThreadPinned({ threadUuid, pinned });
     }
 
     async deleteAgentThread(

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -343,6 +343,7 @@ export type AiAgentThreadSummary<TUser extends AiAgentUser = AiAgentUser> = {
     createdFrom: AiThreadCreatedFrom;
     title: string | null;
     titleGeneratedAt: string | null;
+    pinnedAt: string | null;
     firstMessage: {
         uuid: string;
         message: string;

--- a/packages/frontend/sdk/index.test.tsx
+++ b/packages/frontend/sdk/index.test.tsx
@@ -630,6 +630,7 @@ describe('SDK API client', () => {
                 createdFrom: 'web_app',
                 title: 'Revenue check',
                 titleGeneratedAt: null,
+                pinnedAt: null,
                 firstMessage: {
                     uuid: 'test-message-uuid',
                     message: 'How is revenue looking?',

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ThreadPreviewSidebar.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ThreadPreviewSidebar.test.tsx
@@ -119,6 +119,7 @@ vi.mock('../../hooks/useProjectAiAgents', () => ({
             createdFrom: 'web_app',
             title: 'Dense review thread',
             titleGeneratedAt: null,
+            pinnedAt: null,
             firstMessage: {
                 uuid: 'prompt-1',
                 message: 'What does active user mean?',

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AgentSidebar.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AgentSidebar.tsx
@@ -27,6 +27,8 @@ import {
     IconDots,
     IconInfoCircle,
     IconPencil,
+    IconPin,
+    IconPinnedOff,
     IconTrash,
 } from '@tabler/icons-react';
 import { useRef, useState, type FC } from 'react';
@@ -39,6 +41,7 @@ import { useAiOrganizationSettings } from '../../hooks/useAiOrganizationSettings
 import {
     useDeleteAiAgentThreadMutation,
     useInfiniteAiAgentThreads,
+    usePinAiAgentThreadMutation,
     useRenameAiAgentThreadMutation,
 } from '../../hooks/useProjectAiAgents';
 import { AgentNamePill } from '../AgentNamePill';
@@ -108,6 +111,7 @@ type ThreadNavLinkProps = {
     deletionDisabled: boolean;
     onDelete: (thread: AiAgentProjectThreadSummary) => void;
     onRename: (thread: AiAgentProjectThreadSummary, title: string) => void;
+    onTogglePin: (thread: AiAgentProjectThreadSummary) => void;
 };
 
 const ThreadNavLink: FC<ThreadNavLinkProps> = ({
@@ -118,7 +122,9 @@ const ThreadNavLink: FC<ThreadNavLinkProps> = ({
     deletionDisabled,
     onDelete,
     onRename,
+    onTogglePin,
 }) => {
+    const isPinned = thread.pinnedAt !== null;
     const threadTitle = (thread.title || thread.firstMessage.message).trim();
     const hasTitle = threadTitle.length > 0;
     const canManageThread = useCanManageAiAgentThread({
@@ -212,6 +218,20 @@ const ThreadNavLink: FC<ThreadNavLinkProps> = ({
                             >
                                 <Menu.Item
                                     leftSection={
+                                        <MantineIcon
+                                            icon={
+                                                isPinned
+                                                    ? IconPinnedOff
+                                                    : IconPin
+                                            }
+                                        />
+                                    }
+                                    onClick={() => onTogglePin(thread)}
+                                >
+                                    {isPinned ? 'Unpin' : 'Pin'}
+                                </Menu.Item>
+                                <Menu.Item
+                                    leftSection={
                                         <MantineIcon icon={IconPencil} />
                                     }
                                     onClick={() => setIsRenaming(true)}
@@ -239,6 +259,51 @@ const ThreadNavLink: FC<ThreadNavLinkProps> = ({
     );
 };
 
+type ThreadGroupProps = {
+    title: string;
+    threads: AiAgentProjectThreadSummary[];
+    projectUuid: string;
+    threadUuid?: string;
+    showAgentName: boolean;
+    deletionDisabled: boolean;
+    onDelete: (thread: AiAgentProjectThreadSummary) => void;
+    onRename: (thread: AiAgentProjectThreadSummary, title: string) => void;
+    onTogglePin: (thread: AiAgentProjectThreadSummary) => void;
+};
+
+const ThreadGroup: FC<ThreadGroupProps> = ({
+    title,
+    threads,
+    projectUuid,
+    threadUuid,
+    showAgentName,
+    deletionDisabled,
+    onDelete,
+    onRename,
+    onTogglePin,
+}) => (
+    <Stack gap="xs">
+        <Title order={6} c="dimmed" size="xs" ml="xs">
+            {title}
+        </Title>
+        <Box>
+            {threads.map((thread) => (
+                <ThreadNavLink
+                    key={thread.uuid}
+                    thread={thread}
+                    isActive={thread.uuid === threadUuid}
+                    projectUuid={projectUuid}
+                    showAgentName={showAgentName}
+                    deletionDisabled={deletionDisabled}
+                    onDelete={onDelete}
+                    onRename={onRename}
+                    onTogglePin={onTogglePin}
+                />
+            ))}
+        </Box>
+    </Stack>
+);
+
 type ThreadListProps = {
     projectUuid: string;
     threadUuid?: string;
@@ -256,6 +321,8 @@ const ThreadList: FC<ThreadListProps> = ({
         useInfiniteAiAgentThreads(projectUuid, { agentUuid });
 
     const threads = data?.pages.flatMap((page) => page.data) ?? [];
+    const pinnedThreads = threads.filter((thread) => thread.pinnedAt !== null);
+    const recentThreads = threads.filter((thread) => thread.pinnedAt === null);
 
     const deletionDisabledFlag = useServerFeatureFlag(
         FeatureFlags.AiDisableThreadDeletion,
@@ -268,6 +335,8 @@ const ThreadList: FC<ThreadListProps> = ({
         useDeleteAiAgentThreadMutation(projectUuid);
     const { mutate: renameThread } =
         useRenameAiAgentThreadMutation(projectUuid);
+    const { mutate: setThreadPinned } =
+        usePinAiAgentThreadMutation(projectUuid);
     const handleConfirmDelete = async () => {
         if (!threadToDelete) return;
         await deleteThread({
@@ -281,41 +350,62 @@ const ThreadList: FC<ThreadListProps> = ({
         return null;
     }
 
+    const groupHandlers = {
+        projectUuid,
+        threadUuid,
+        showAgentName,
+        deletionDisabled,
+        onDelete: setThreadToDelete,
+        onRename: (thread: AiAgentProjectThreadSummary, title: string) =>
+            renameThread({
+                agentUuid: thread.agentUuid,
+                threadUuid: thread.uuid,
+                title,
+            }),
+        onTogglePin: (thread: AiAgentProjectThreadSummary) =>
+            setThreadPinned({
+                agentUuid: thread.agentUuid,
+                threadUuid: thread.uuid,
+                pinned: thread.pinnedAt === null,
+            }),
+    };
+
     return (
-        <Stack gap="xs" className={classes.threadList}>
-            <Title order={6} c="dimmed" tt="uppercase" size="xs" ml="xs">
-                Recent
-            </Title>
+        <Stack gap="md" className={classes.threadList}>
+            {pinnedThreads.length > 0 && (
+                <ThreadGroup
+                    title="Pinned"
+                    threads={pinnedThreads}
+                    {...groupHandlers}
+                />
+            )}
 
-            <Stack gap={2} className={classes.threadItems}>
-                {threads.length === 0 && (
-                    <Paper variant="dotted" p="sm">
-                        <Text truncate="end" size="sm" c="dimmed" ta="center">
-                            No threads yet
-                        </Text>
-                    </Paper>
-                )}
-
-                <Box>
-                    {threads.map((thread) => (
-                        <ThreadNavLink
-                            key={thread.uuid}
-                            thread={thread}
-                            isActive={thread.uuid === threadUuid}
-                            projectUuid={projectUuid}
-                            showAgentName={showAgentName}
-                            deletionDisabled={deletionDisabled}
-                            onDelete={setThreadToDelete}
-                            onRename={(thread, title) =>
-                                renameThread({
-                                    agentUuid: thread.agentUuid,
-                                    threadUuid: thread.uuid,
-                                    title,
-                                })
-                            }
+            <Stack gap="xs" className={classes.threadItems}>
+                {threads.length === 0 ? (
+                    <>
+                        <Title order={6} c="dimmed" size="xs" ml="xs">
+                            Recent
+                        </Title>
+                        <Paper variant="dotted" p="sm">
+                            <Text
+                                truncate="end"
+                                size="sm"
+                                c="dimmed"
+                                ta="center"
+                            >
+                                No threads yet
+                            </Text>
+                        </Paper>
+                    </>
+                ) : (
+                    recentThreads.length > 0 && (
+                        <ThreadGroup
+                            title="Recent"
+                            threads={recentThreads}
+                            {...groupHandlers}
                         />
-                    ))}
-                </Box>
+                    )
+                )}
             </Stack>
 
             <Box>

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.restore.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.restore.test.tsx
@@ -91,6 +91,7 @@ const thread: AiAgentThread = {
     createdFrom: 'web_app',
     title: 'Revenue app',
     titleGeneratedAt: null,
+    pinnedAt: null,
     liveStatus: null,
     firstMessage: { uuid: 'prompt-1', message: 'Build me a revenue app' },
     user: { uuid: 'user-1', name: 'Demo User' },

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.test.tsx
@@ -106,6 +106,7 @@ const thread: AiAgentThread = {
     createdFrom: 'web_app',
     title: 'Deep research chronology',
     titleGeneratedAt: null,
+    pinnedAt: null,
     liveStatus: null,
     firstMessage: {
         uuid: 'deep-research-prompt',

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/usePendingThreadRefetch.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/usePendingThreadRefetch.test.tsx
@@ -50,6 +50,7 @@ const threadWithAssistantStatus = (status: AiAgentMessageAssistant['status']) =>
         createdFrom: 'web_app',
         title: null,
         titleGeneratedAt: null,
+        pinnedAt: null,
         liveStatus: null,
         firstMessage: { uuid: 'message-1', message: 'Question' },
         user: { uuid: 'user-1', name: 'User' },

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
@@ -743,6 +743,59 @@ export const useRenameAiAgentThreadMutation = (projectUuid: string) => {
     });
 };
 
+const setAgentThreadPinned = async (
+    projectUuid: string,
+    agentUuid: string,
+    threadUuid: string,
+    pinned: boolean,
+) =>
+    lightdashApi<ApiSuccessEmpty>({
+        version: 'v1',
+        url: `/projects/${projectUuid}/aiAgents/${agentUuid}/threads/${threadUuid}/pin`,
+        method: pinned ? 'POST' : 'DELETE',
+        body: undefined,
+    });
+
+export const usePinAiAgentThreadMutation = (projectUuid: string) => {
+    const queryClient = useQueryClient();
+    const { showToastApiError } = useToaster();
+
+    return useMutation<
+        ApiSuccessEmpty,
+        ApiError,
+        { agentUuid: string; threadUuid: string; pinned: boolean },
+        { snapshot: ReturnType<typeof snapshotProjectThreads> }
+    >({
+        mutationFn: ({ agentUuid, threadUuid, pinned }) =>
+            setAgentThreadPinned(projectUuid, agentUuid, threadUuid, pinned),
+        onMutate: async ({ threadUuid, pinned }) => {
+            await queryClient.cancelQueries({
+                queryKey: getProjectThreadsQueryKey(projectUuid),
+            });
+            const snapshot = snapshotProjectThreads(queryClient, projectUuid);
+            patchProjectThread(queryClient, projectUuid, threadUuid, {
+                pinnedAt: pinned ? new Date().toISOString() : null,
+            });
+            return { snapshot };
+        },
+        onError: ({ error }, { pinned }, context) => {
+            if (context) restoreProjectThreads(queryClient, context.snapshot);
+            showToastApiError({
+                title: pinned
+                    ? 'Failed to pin thread'
+                    : 'Failed to unpin thread',
+                apiError: error,
+            });
+        },
+        // The server owns the pinned ordering, so refetch once settled
+        onSettled: async () => {
+            await queryClient.invalidateQueries({
+                queryKey: getProjectThreadsQueryKey(projectUuid),
+            });
+        },
+    });
+};
+
 export const getAiAgentThreadQueryKey = (
     projectUuid: string,
     agentUuid: string | undefined,
@@ -1133,6 +1186,7 @@ export const useCreateAgentThreadMutation = (
                         uuid: thread.uuid,
                         title: null,
                         titleGeneratedAt: null,
+                        pinnedAt: null,
                         liveStatus: null,
                         compactions: [],
                         messages: createOptimisticMessages(

--- a/packages/frontend/src/stories/AiAgentChatWorkbench.stories.tsx
+++ b/packages/frontend/src/stories/AiAgentChatWorkbench.stories.tsx
@@ -944,6 +944,7 @@ const makeThread = (scenario: ThreadScenario): AiAgentThread => {
         createdFrom: 'web_app',
         title: scenario.title,
         titleGeneratedAt: createdAt,
+        pinnedAt: null,
         liveStatus: null,
         firstMessage: {
             uuid: 'prompt-0',


### PR DESCRIPTION
## Summary

Stacked on #28680. Threads can be pinned to the top of the Ask AI / AI agents sidebar.

- EE migration adds a nullable `pinned_at` timestamp to `ai_thread`, exposed as `pinnedAt: string | null` on `AiAgentThreadSummary`.
- `POST` and `DELETE /api/v1/projects/{projectUuid}/aiAgents/{agentUuid}/threads/{threadUuid}/pin` set and clear it, behind the same `manage` ability on `AiAgentThread` as rename and delete. The rename and pin guards now share a private `getManagedThread` helper in the service.
- The sidebar's paginated thread query orders by `pinned_at DESC NULLS LAST, created_at DESC`, so pinned threads always arrive in the first page.
- The sidebar shows a **Pinned** group above **Recent**, and the row menu gains **Pin** / **Unpin**. Pinning invalidates the list rather than patching it, since the order changes.

## Regression analysis

- Only `findThreadsPaginated` (the sidebar list) changes ordering. `buildThreadSummaryQuery`'s default `created_at DESC` is cleared and replaced there; other callers (thread detail lookup, admin lists) keep their ordering.
- Adding a nullable column with no default is additive and rolling-safe. `AiThreadTable`'s update type gains `pinned_at`; the insert type is untouched.
- Every fixture constructing a thread summary (frontend tests, the SDK test, the chat workbench story) gets `pinnedAt: null`, so the type change is fully propagated.
- `pnpm -F frontend test src/ee/features/aiCopilot/hooks/usePendingThreadRefetch.test.tsx` passes. Typecheck and lint pass on both packages.
- Not yet run against a migrated dev database or clicked through in the browser, hence draft.

Relates: ZAP-99

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CbgpnzYHBDeDbd5B3PrnBZ
