### PR TITLE
fix: keep generated SSH public key across reloads and guard unsaved connection changes

### DIFF
--- a/packages/frontend/src/components/ProjectConnection/UpdateProjectConnection.tsx
+++ b/packages/frontend/src/components/ProjectConnection/UpdateProjectConnection.tsx
@@ -7,7 +7,11 @@ import {
     type Project,
 } from '@lightdash/common';
 import { Alert, Anchor, Box, Button, Flex, Card } from '@mantine/core';
-import { IconExclamationCircle, IconExternalLink } from '@tabler/icons-react';
+import {
+    IconAlertCircle,
+    IconExclamationCircle,
+    IconExternalLink,
+} from '@tabler/icons-react';
 import { type FC } from 'react';
 import {
     useProject,
@@ -15,11 +19,13 @@ import {
     useUpdateWarehouseCredentialsMutation,
 } from '../../hooks/useProject';
 import { useProjectCompileLogs } from '../../hooks/useProjectCompileLogs';
+import { useUnsavedChangesGuard } from '../../hooks/useUnsavedChangesGuard';
 import { useAbilityContext } from '../../providers/Ability/useAbilityContext';
 import useApp from '../../providers/App/useApp';
 import useTracking from '../../providers/Tracking/useTracking';
 import { EventName } from '../../types/Events';
 import MantineIcon from '../common/MantineIcon';
+import MantineModal from '../common/MantineModal';
 import { dbtDefaults } from './DbtForms/defaultValues';
 import { dbtFormValidators } from './DbtForms/validators';
 import { FormContainer } from './FormContainer';
@@ -31,7 +37,29 @@ import { type ProjectConnectionForm } from './types';
 import classes from './UpdateProjectConnection.module.css';
 import { useOnProjectError } from './useOnProjectError';
 import { warehouseDefaultValues } from './WarehouseForms/defaultValues';
+import {
+    clearSshPublicKeyDraft,
+    readSshPublicKeyDraft,
+} from './WarehouseForms/sshPublicKeyDraft';
 import { warehouseValueValidators } from './WarehouseForms/validators';
+
+// A key generated before a reload was never saved; restore it so the user
+// does not save without the key they already installed on the bastion.
+const restoreSshPublicKeyDraft = (
+    projectUuid: string,
+    project: Project,
+): { sshTunnelPublicKey: string } | undefined => {
+    const connection = project.warehouseConnection;
+    if (
+        connection?.type !== WarehouseTypes.POSTGRES &&
+        connection?.type !== WarehouseTypes.REDSHIFT
+    ) {
+        return undefined;
+    }
+    if (connection.sshTunnelPublicKey) return undefined;
+    const draft = readSshPublicKeyDraft(projectUuid);
+    return draft ? { sshTunnelPublicKey: draft } : undefined;
+};
 
 const UpdateProjectConnection: FC<{
     projectUuid: string;
@@ -79,6 +107,7 @@ const UpdateProjectConnection: FC<{
             warehouse: {
                 ...warehouseDefaultValues[warehouseType],
                 ...project.warehouseConnection,
+                ...restoreSshPublicKeyDraft(projectUuid, project),
             } as CreateWarehouseCredentials,
             dbtVersion: project.dbtVersion,
         },
@@ -88,6 +117,7 @@ const UpdateProjectConnection: FC<{
         },
         validateInputOnBlur: true,
     });
+    const leaveGuard = useUnsavedChangesGuard(form.isDirty() && !isSaving);
 
     const showSaveCredentials = !!health.data?.isSaveCredentialsFormEnabled;
     const {
@@ -117,6 +147,8 @@ const UpdateProjectConnection: FC<{
                 warehouseConnection: warehouseConnection,
                 dbtVersion,
             });
+            clearSshPublicKeyDraft(projectUuid);
+            form.resetDirty();
         }
     };
 
@@ -126,6 +158,17 @@ const UpdateProjectConnection: FC<{
 
     return (
         <FormProvider form={form}>
+            <MantineModal
+                opened={leaveGuard.isBlocked}
+                onClose={leaveGuard.reset}
+                role="alertdialog"
+                title="Unsaved changes"
+                icon={IconAlertCircle}
+                description="You have unsaved changes to this connection. Are you sure you want to leave without saving?"
+                confirmLabel="Leave"
+                cancelLabel="Stay"
+                onConfirm={leaveGuard.proceed}
+            />
             {project?.type === ProjectType.PREVIEW && (
                 <Alert
                     color="orange"

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/PostgresForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/PostgresForm.tsx
@@ -2,7 +2,6 @@ import { WarehouseTypes } from '@lightdash/common';
 import {
     TextInput,
     Stack,
-    Button,
     Anchor,
     Select,
     PasswordInput,
@@ -21,7 +20,7 @@ import StartOfWeekSelect from '../Inputs/StartOfWeekSelect';
 import { useProjectFormContext } from '../useProjectFormContext';
 import DataTimezoneField from './DataTimezoneField';
 import { PostgresDefaultValues } from './defaultValues';
-import { useCreateSshKeyPair } from './sshHooks';
+import SshPublicKeyButton from './SshPublicKeyButton';
 
 export const PostgresSchemaInput: FC<{
     disabled: boolean;
@@ -73,12 +72,6 @@ const PostgresForm: FC<{
         (savedProject?.warehouseConnection?.type === WarehouseTypes.POSTGRES
             ? savedProject?.warehouseConnection?.sslmode
             : undefined);
-
-    const { mutate, isLoading } = useCreateSshKeyPair({
-        onSuccess: (data) => {
-            form.setFieldValue('warehouse.sshTunnelPublicKey', data.publicKey);
-        },
-    });
 
     return (
         <>
@@ -380,15 +373,10 @@ const PostgresForm: FC<{
                                         }
                                     />
                                 )}
-                                <Button
-                                    onClick={() => mutate()}
-                                    loading={isLoading}
-                                    disabled={disabled || isLoading}
-                                >
-                                    {sshTunnelPublicKey
-                                        ? 'Regenerate key'
-                                        : 'Generate public key'}
-                                </Button>
+                                <SshPublicKeyButton
+                                    disabled={disabled}
+                                    hasKey={!!sshTunnelPublicKey}
+                                />
                                 {sshTunnelPublicKeyError && (
                                     <Input.Error>
                                         {sshTunnelPublicKeyError}

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/RedshiftForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/RedshiftForm.tsx
@@ -2,7 +2,6 @@ import { RedshiftAuthenticationType, WarehouseTypes } from '@lightdash/common';
 import {
     TextInput,
     Stack,
-    Button,
     Anchor,
     Select,
     PasswordInput,
@@ -20,7 +19,7 @@ import StartOfWeekSelect from '../Inputs/StartOfWeekSelect';
 import { useProjectFormContext } from '../useProjectFormContext';
 import DataTimezoneField from './DataTimezoneField';
 import { RedshiftDefaultValues } from './defaultValues';
-import { useCreateSshKeyPair } from './sshHooks';
+import SshPublicKeyButton from './SshPublicKeyButton';
 
 export const RedshiftSchemaInput: FC<{
     disabled: boolean;
@@ -133,12 +132,6 @@ const RedshiftForm: FC<{
             ? savedProject?.warehouseConnection?.sshTunnelPublicKey
             : undefined);
     const sshTunnelPublicKeyError = form.errors['warehouse.sshTunnelPublicKey'];
-
-    const { mutate, isLoading } = useCreateSshKeyPair({
-        onSuccess: (data) => {
-            form.setFieldValue('warehouse.sshTunnelPublicKey', data.publicKey);
-        },
-    });
 
     return (
         <>
@@ -375,15 +368,10 @@ const RedshiftForm: FC<{
                                         }
                                     />
                                 )}
-                                <Button
-                                    onClick={() => mutate()}
-                                    loading={isLoading}
-                                    disabled={disabled || isLoading}
-                                >
-                                    {sshTunnelPublicKey
-                                        ? 'Regenerate key'
-                                        : 'Generate public key'}
-                                </Button>
+                                <SshPublicKeyButton
+                                    disabled={disabled}
+                                    hasKey={!!sshTunnelPublicKey}
+                                />
                                 {sshTunnelPublicKeyError && (
                                     <Input.Error>
                                         {sshTunnelPublicKeyError}

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/SshPublicKeyButton.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/SshPublicKeyButton.tsx
@@ -1,0 +1,57 @@
+import { Button } from '@mantine/core';
+import { IconKey } from '@tabler/icons-react';
+import { useState, type FC } from 'react';
+import MantineModal from '../../common/MantineModal';
+import { useFormContext } from '../formContext';
+import { useProjectFormContext } from '../useProjectFormContext';
+import { useCreateSshKeyPair } from './sshHooks';
+import { writeSshPublicKeyDraft } from './sshPublicKeyDraft';
+
+const SshPublicKeyButton: FC<{
+    disabled: boolean;
+    hasKey: boolean;
+}> = ({ disabled, hasKey }) => {
+    const form = useFormContext();
+    const { savedProject } = useProjectFormContext();
+    const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+
+    const { mutate, isLoading } = useCreateSshKeyPair({
+        onSuccess: (data) => {
+            form.setFieldValue('warehouse.sshTunnelPublicKey', data.publicKey);
+            if (savedProject) {
+                writeSshPublicKeyDraft(
+                    savedProject.projectUuid,
+                    data.publicKey,
+                );
+            }
+        },
+    });
+
+    return (
+        <>
+            <Button
+                onClick={() => (hasKey ? setIsConfirmOpen(true) : mutate())}
+                loading={isLoading}
+                disabled={disabled || isLoading}
+            >
+                {hasKey ? 'Regenerate key' : 'Generate public key'}
+            </Button>
+            <MantineModal
+                opened={isConfirmOpen}
+                onClose={() => setIsConfirmOpen(false)}
+                role="alertdialog"
+                title="Regenerate SSH key?"
+                icon={IconKey}
+                description="The key currently installed on your bastion host will stop working. You will need to add the new public key to its authorized_keys before saving."
+                confirmLabel="Regenerate"
+                cancelLabel="Keep current key"
+                onConfirm={() => {
+                    setIsConfirmOpen(false);
+                    mutate();
+                }}
+            />
+        </>
+    );
+};
+
+export default SshPublicKeyButton;

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/sshPublicKeyDraft.test.ts
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/sshPublicKeyDraft.test.ts
@@ -1,0 +1,60 @@
+import {
+    clearSshPublicKeyDraft,
+    readSshPublicKeyDraft,
+    writeSshPublicKeyDraft,
+} from './sshPublicKeyDraft';
+
+describe('sshPublicKeyDraft', () => {
+    beforeEach(() => {
+        window.localStorage.clear();
+    });
+
+    it('returns null when nothing has been drafted', () => {
+        expect(readSshPublicKeyDraft('project-a')).toBeNull();
+    });
+
+    it('round-trips a drafted key per project', () => {
+        writeSshPublicKeyDraft('project-a', 'ssh-rsa AAAA');
+        expect(readSshPublicKeyDraft('project-a')).toBe('ssh-rsa AAAA');
+        expect(readSshPublicKeyDraft('project-b')).toBeNull();
+    });
+
+    it('clears a drafted key', () => {
+        writeSshPublicKeyDraft('project-a', 'ssh-rsa AAAA');
+        clearSshPublicKeyDraft('project-a');
+        expect(readSshPublicKeyDraft('project-a')).toBeNull();
+    });
+
+    it('treats an empty draft as absent', () => {
+        writeSshPublicKeyDraft('project-a', '');
+        expect(readSshPublicKeyDraft('project-a')).toBeNull();
+    });
+
+    describe('when storage throws', () => {
+        const storage = window.localStorage;
+
+        beforeEach(() => {
+            Object.defineProperty(window, 'localStorage', {
+                configurable: true,
+                get: () => {
+                    throw new Error('storage disabled');
+                },
+            });
+        });
+
+        afterEach(() => {
+            Object.defineProperty(window, 'localStorage', {
+                configurable: true,
+                value: storage,
+            });
+        });
+
+        it('does not throw and reads as absent', () => {
+            expect(() =>
+                writeSshPublicKeyDraft('project-a', 'ssh-rsa AAAA'),
+            ).not.toThrow();
+            expect(() => clearSshPublicKeyDraft('project-a')).not.toThrow();
+            expect(readSshPublicKeyDraft('project-a')).toBeNull();
+        });
+    });
+});

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/sshPublicKeyDraft.ts
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/sshPublicKeyDraft.ts
@@ -1,0 +1,31 @@
+const draftKey = (projectUuid: string) =>
+    `lightdash.sshPublicKeyDraft.${projectUuid}`;
+
+// Generated public keys only live in form state until the project is saved;
+// drafting them in localStorage keeps them across reloads and new tabs.
+export const readSshPublicKeyDraft = (projectUuid: string): string | null => {
+    try {
+        return window.localStorage.getItem(draftKey(projectUuid)) || null;
+    } catch {
+        return null;
+    }
+};
+
+export const writeSshPublicKeyDraft = (
+    projectUuid: string,
+    publicKey: string,
+): void => {
+    try {
+        window.localStorage.setItem(draftKey(projectUuid), publicKey);
+    } catch {
+        // storage unavailable; the key still lives in form state
+    }
+};
+
+export const clearSshPublicKeyDraft = (projectUuid: string): void => {
+    try {
+        window.localStorage.removeItem(draftKey(projectUuid));
+    } catch {
+        // nothing to clear
+    }
+};

--- a/packages/frontend/src/hooks/useUnsavedChangesGuard.test.tsx
+++ b/packages/frontend/src/hooks/useUnsavedChangesGuard.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState, type FC } from 'react';
+import { createMemoryRouter, Link, RouterProvider } from 'react-router';
+import { useUnsavedChangesGuard } from './useUnsavedChangesGuard';
+
+const Editor: FC = () => {
+    const [isDirty, setIsDirty] = useState(false);
+    const guard = useUnsavedChangesGuard(isDirty);
+    return (
+        <>
+            <button onClick={() => setIsDirty(true)}>edit</button>
+            <Link to="/elsewhere">leave</Link>
+            {guard.isBlocked && (
+                <>
+                    <span>blocked</span>
+                    <button onClick={guard.proceed}>proceed</button>
+                    <button onClick={guard.reset}>stay</button>
+                </>
+            )}
+        </>
+    );
+};
+
+const renderEditor = () => {
+    const router = createMemoryRouter([
+        { path: '/', element: <Editor /> },
+        { path: '/elsewhere', element: <span>elsewhere</span> },
+    ]);
+    render(<RouterProvider router={router} />);
+    return router;
+};
+
+describe('useUnsavedChangesGuard', () => {
+    it('lets navigation through when there are no changes', async () => {
+        const router = renderEditor();
+        await userEvent.click(screen.getByText('leave'));
+        await waitFor(() =>
+            expect(router.state.location.pathname).toBe('/elsewhere'),
+        );
+    });
+
+    it('blocks navigation with changes until the user proceeds', async () => {
+        const router = renderEditor();
+        await userEvent.click(screen.getByText('edit'));
+        await userEvent.click(screen.getByText('leave'));
+        expect(await screen.findByText('blocked')).toBeInTheDocument();
+        expect(router.state.location.pathname).toBe('/');
+
+        await userEvent.click(screen.getByText('stay'));
+        await waitFor(() =>
+            expect(screen.queryByText('blocked')).not.toBeInTheDocument(),
+        );
+        expect(router.state.location.pathname).toBe('/');
+
+        await userEvent.click(screen.getByText('leave'));
+        await userEvent.click(await screen.findByText('proceed'));
+        await waitFor(() =>
+            expect(router.state.location.pathname).toBe('/elsewhere'),
+        );
+    });
+});

--- a/packages/frontend/src/hooks/useUnsavedChangesGuard.ts
+++ b/packages/frontend/src/hooks/useUnsavedChangesGuard.ts
@@ -1,0 +1,27 @@
+import { useEffect } from 'react';
+import { useBlocker } from 'react-router';
+
+// Prompts before leaving with unsaved changes: the browser's native prompt on
+// reload/close, and a blocker the caller renders a modal for on in-app routing.
+export const useUnsavedChangesGuard = (isDirty: boolean) => {
+    useEffect(() => {
+        if (!isDirty) return undefined;
+        const handler = (event: BeforeUnloadEvent) => {
+            event.preventDefault();
+            event.returnValue = '';
+        };
+        window.addEventListener('beforeunload', handler);
+        return () => window.removeEventListener('beforeunload', handler);
+    }, [isDirty]);
+
+    const blocker = useBlocker(
+        ({ currentLocation, nextLocation }) =>
+            isDirty && currentLocation.pathname !== nextLocation.pathname,
+    );
+
+    return {
+        isBlocked: blocker.state === 'blocked',
+        proceed: () => blocker.proceed?.(),
+        reset: () => blocker.reset?.(),
+    };
+};


### PR DESCRIPTION
Stacks on #28675.

## What

A public key generated with **Generate public key** on the Postgres/Redshift connection form lived only in Mantine form state. Any full page load before **Test & deploy** (reload, tab restore, opening the settings link again, a second tab) silently dropped it and the button reverted to **Generate public key**. Users who had already installed that key on their bastion then saved without it. Keys are cheap and never deleted server-side, and the public key is not secret, so keeping the unsaved one around is safe.

## Changes

- **Draft the generated key** (`WarehouseForms/sshPublicKeyDraft.ts`): the update form writes the generated key to `localStorage` per project; `UpdateProjectConnection` seeds `sshTunnelPublicKey` from that draft when the saved connection has none (other SSH fields, incl. `useSshTunnel`, stay as saved), and clears it after a successful update. Create flow is not drafted (a reload there loses the whole form anyway). Every storage access is try/catch.
- **Unsaved-changes guard** (`hooks/useUnsavedChangesGuard.ts`): `beforeunload` for reload/close plus a react-router `useBlocker` with a Stay/Leave modal for in-app navigation, wired to `form.isDirty()` on the update form. `form.resetDirty()` after a successful save so the prompt does not fire after deploying.
- **Regenerate confirmation**: the key input + button in both forms is now one `SshPublicKeyButton`; when a key already exists, **Regenerate key** asks for confirmation that the key installed on the bastion will stop working before calling the API.

Tests: `sshPublicKeyDraft.test.ts` (read/write/clear, throwing storage) and `useUnsavedChangesGuard.test.tsx` (memory router: passes through when clean, blocks/stays/proceeds when dirty).

## How to test

1. Project settings → Postgres/Redshift → Advanced → **Use SSH tunnel** → **Generate public key**. Reload the page, expand Advanced again: the key field is still populated and the button reads **Regenerate key**.
2. Edit any field and click another settings link → **Unsaved changes** modal; **Stay** keeps you, **Leave** navigates. Reload → browser's native prompt.
3. With a key present, click **Regenerate key** → confirmation modal; **Keep current key** does nothing, **Regenerate** fetches a new key.
4. Save the project → the draft is cleared (`localStorage` key `lightdash.sshPublicKeyDraft.<projectUuid>`), navigating away no longer prompts.

Relates: #28618
