### PR TITLE
feat(dashboard): add organizationUuid to workbook telemetry events

### DIFF
--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -873,6 +873,7 @@ const Dashboard: FC = () => {
 
             if (dashboardUuid) {
                 const workbookEventProperties = {
+                    organizationUuid: user.data?.organizationUuid,
                     projectUuid,
                     dashboardUuid,
                     exploreName: chart.tableName,
@@ -942,6 +943,7 @@ const Dashboard: FC = () => {
             setHaveCustomMetricsChanged,
             dashboardUuid,
             projectUuid,
+            user.data?.organizationUuid,
             track,
         ],
     );

--- a/packages/frontend/src/providers/Tracking/types.ts
+++ b/packages/frontend/src/providers/Tracking/types.ts
@@ -930,6 +930,7 @@ type DashboardWorkbookEvent = {
         | EventName.DASHBOARD_CHART_CREATED_IN_PLACE
         | EventName.DASHBOARD_CHART_EDITED_IN_PLACE;
     properties: {
+        organizationUuid: string | undefined;
         projectUuid: string | undefined;
         dashboardUuid: string;
         exploreName: string;


### PR DESCRIPTION
Relates: GLITCH-730

### Description:

Follow-up to #28663. Adds `organizationUuid` to the four workbook event payloads — org-level adoption reporting (and excluding our own org from the numbers) needs it, and the analytics staging models expect it. Uuids only; the no-SQL/labels rule unchanged.

### Risk assessment:

- [ ] This is a high-risk change

High-risk changes require approval from a reviewer other than the author before merging.