### PR TITLE
fix(dashboards): render merged fields on a chart tile

### DIFF
--- a/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.test.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.test.tsx
@@ -1,0 +1,214 @@
+import {
+    ChartType,
+    DimensionType,
+    FieldType,
+    MERGE_TABLE_NAME,
+    MetricType,
+    QueryHistoryStatus,
+    type Dimension,
+    type ItemsMap,
+    type Metric,
+    type MetricQuery,
+} from '@lightdash/common';
+import { cleanup, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import ChartColorMappingContextProvider from '../../hooks/useChartColorConfig/ChartColorMappingContextProvider';
+import { type InfiniteQueryResults } from '../../hooks/useQueryResults';
+import { renderWithProviders } from '../../testing/testUtils';
+import { isTableVisualizationConfig } from './types';
+import { useVisualizationContext } from './useVisualizationContext';
+import VisualizationProvider from './VisualizationProvider';
+
+vi.mock('@shopify/react-web-worker', () => ({
+    createWorkerFactory: () => () => ({}),
+    useWorker: () => ({}),
+}));
+
+vi.mock('../../hooks/useServerOrClientFeatureFlag', async (importOriginal) => ({
+    ...(await importOriginal<object>()),
+    useServerFeatureFlag: () => ({ data: undefined }),
+}));
+
+const dimension = (table: string, name: string, label: string): Dimension => ({
+    fieldType: FieldType.DIMENSION,
+    type: DimensionType.DATE,
+    name,
+    label,
+    table,
+    tableLabel: table,
+    sql: '',
+    hidden: false,
+});
+
+const metric = (table: string, name: string, label: string): Metric => ({
+    fieldType: FieldType.METRIC,
+    type: MetricType.SUM,
+    name,
+    label,
+    table,
+    tableLabel: table,
+    sql: '',
+    hidden: false,
+});
+
+const JOIN_KEY = 'merge_order_month';
+const SOURCE_A_METRIC = 'a_orders_total_order_amount';
+const SOURCE_B_METRIC = 'b_payments_unique_payment_count';
+
+const mergedFields: ItemsMap = {
+    [JOIN_KEY]: dimension(MERGE_TABLE_NAME, 'order_month', 'Order month'),
+    [SOURCE_A_METRIC]: metric('a', 'orders_total_order_amount', 'Total'),
+    [SOURCE_B_METRIC]: metric('b', 'payments_unique_payment_count', 'Count'),
+};
+
+const mergedMetricQuery: MetricQuery = {
+    exploreName: MERGE_TABLE_NAME,
+    dimensions: [JOIN_KEY],
+    metrics: [SOURCE_A_METRIC, SOURCE_B_METRIC],
+    filters: {},
+    sorts: [],
+    limit: 500,
+    tableCalculations: [],
+};
+
+const ordersFields: ItemsMap = {
+    orders_order_date_month: dimension(
+        'orders',
+        'order_date_month',
+        'Order month',
+    ),
+    orders_total_order_amount: metric('orders', 'total_order_amount', 'Total'),
+};
+
+const ordersMetricQuery: MetricQuery = {
+    exploreName: 'orders',
+    dimensions: ['orders_order_date_month'],
+    metrics: ['orders_total_order_amount'],
+    filters: {},
+    sorts: [],
+    limit: 500,
+    tableCalculations: [],
+};
+
+const resultsFor = (
+    metricQuery: MetricQuery,
+    fields: ItemsMap,
+): InfiniteQueryResults & { metricQuery: MetricQuery; fields: ItemsMap } => ({
+    queryUuid: 'query-uuid',
+    queryStatus: QueryHistoryStatus.READY,
+    rows: [
+        Object.fromEntries(
+            Object.keys(fields).map((fieldId) => [
+                fieldId,
+                { value: { raw: 1, formatted: '1' } },
+            ]),
+        ),
+    ],
+    totalResults: 1,
+    isInitialLoading: false,
+    isFetchingFirstPage: false,
+    isFetchingRows: false,
+    isFetchingAllPages: false,
+    fetchMoreRows: () => {},
+    refetchRows: async () => {},
+    setFetchAll: () => {},
+    fetchAll: false,
+    hasFetchedAllRows: true,
+    totalClientFetchTimeMs: undefined,
+    error: null,
+    metricQuery,
+    fields,
+});
+
+const Probe = () => {
+    const { columnOrder, visualizationConfig } = useVisualizationContext();
+    const columnIds = isTableVisualizationConfig(visualizationConfig)
+        ? visualizationConfig.chartConfig.columns.map((column) => column.id)
+        : [];
+    return (
+        <div
+            data-testid="probe"
+            data-column-order={columnOrder.join(',')}
+            data-columns={columnIds.join(',')}
+        />
+    );
+};
+
+const renderTable = (
+    resultsData: ReturnType<typeof resultsFor>,
+    columnOrder: string[],
+) => {
+    renderWithProviders(
+        <MemoryRouter>
+            <ChartColorMappingContextProvider>
+                <VisualizationProvider
+                    chartConfig={{ type: ChartType.TABLE, config: undefined }}
+                    initialPivotDimensions={undefined}
+                    resultsData={resultsData}
+                    isLoading={false}
+                    columnOrder={columnOrder}
+                    colorPalette={[]}
+                    isDashboard
+                >
+                    <Probe />
+                </VisualizationProvider>
+            </ChartColorMappingContextProvider>
+        </MemoryRouter>,
+    );
+    const probe = screen.getByTestId('probe');
+    return {
+        columnOrder: probe.getAttribute('data-column-order'),
+        columns: probe.getAttribute('data-columns'),
+    };
+};
+
+describe('VisualizationProvider column order', () => {
+    afterEach(() => {
+        cleanup();
+    });
+
+    it('renders merged columns when the saved order names the source query fields', () => {
+        const { columnOrder, columns } = renderTable(
+            resultsFor(mergedMetricQuery, mergedFields),
+            ['orders_order_date_month', 'orders_total_order_amount'],
+        );
+
+        const merged = [JOIN_KEY, SOURCE_A_METRIC, SOURCE_B_METRIC].join(',');
+        expect(columnOrder).toBe(merged);
+        expect(columns).toBe(merged);
+    });
+
+    it('keeps a saved order expressed in merged field ids', () => {
+        const saved = [SOURCE_B_METRIC, JOIN_KEY, SOURCE_A_METRIC];
+        const { columnOrder, columns } = renderTable(
+            resultsFor(mergedMetricQuery, mergedFields),
+            saved,
+        );
+
+        expect(columnOrder).toBe(saved.join(','));
+        expect(columns).toBe(saved.join(','));
+    });
+
+    it('falls back to the merged query order when nothing was saved', () => {
+        const { columns } = renderTable(
+            resultsFor(mergedMetricQuery, mergedFields),
+            [],
+        );
+
+        expect(columns).toBe(
+            [JOIN_KEY, SOURCE_A_METRIC, SOURCE_B_METRIC].join(','),
+        );
+    });
+
+    it('leaves an ordinary chart order untouched', () => {
+        const saved = ['orders_total_order_amount', 'orders_order_date_month'];
+        const { columnOrder, columns } = renderTable(
+            resultsFor(ordersMetricQuery, ordersFields),
+            saved,
+        );
+
+        expect(columnOrder).toBe(saved.join(','));
+        expect(columns).toBe(saved.join(','));
+    });
+});

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
@@ -2,6 +2,7 @@ import {
     assertUnreachable,
     ChartType,
     FeatureFlags,
+    MERGE_TABLE_NAME,
     type ApiErrorDetail,
     type ChartConfig,
     type DashboardFilters,
@@ -26,6 +27,7 @@ import {
     type FC,
     type RefObject,
 } from 'react';
+import { resolveMergeColumnOrder } from '../../features/mergeQuery/utils/resolveMergeColumnOrder';
 import { type CartesianTypeOptions } from '../../hooks/cartesianChartConfig/useCartesianChartConfig';
 import { type SeriesLike } from '../../hooks/useChartColorConfig/types';
 import { useChartColorConfig } from '../../hooks/useChartColorConfig/useChartColorConfig';
@@ -185,22 +187,20 @@ const VisualizationProvider: FC<
     // If we don't toggle any fields, (eg: when you `explore from here`) columnOrder on tableConfig might be empty
     // so we initialize it with the fields from resultData
     const defaultColumnOrder = useMemo(() => {
-        if (columnOrder.length > 0) {
-            return columnOrder;
-        } else {
-            const metricQuery = resultsData?.metricQuery;
-            const metricQueryFields =
-                metricQuery !== undefined
-                    ? [
-                          ...metricQuery.dimensions,
-                          ...metricQuery.metrics,
-                          ...metricQuery.tableCalculations.map(
-                              ({ name }) => name,
-                          ),
-                      ]
-                    : [];
-            return metricQueryFields;
+        const metricQuery = resultsData?.metricQuery;
+        const metricQueryFields =
+            metricQuery !== undefined
+                ? [
+                      ...metricQuery.dimensions,
+                      ...metricQuery.metrics,
+                      ...metricQuery.tableCalculations.map(({ name }) => name),
+                  ]
+                : [];
+        // A merged result is keyed by merged ids, which a chart saved before it was merged does not carry
+        if (metricQuery?.exploreName === MERGE_TABLE_NAME) {
+            return resolveMergeColumnOrder(metricQueryFields, columnOrder);
         }
+        return columnOrder.length > 0 ? columnOrder : metricQueryFields;
     }, [resultsData?.metricQuery, columnOrder]);
 
     /**


### PR DESCRIPTION
## What the user saw

A merged saved chart (table) placed on a dashboard tile rendered an empty card: no header row, no data rows, no errors. The tile's query ran as a merge and returned the merged result (`metricQuery.exploreName: 'merge'`, fields `merge_order_month`, `a_orders_total_order_amount`, `b_payments_unique_payment_count`, rows keyed by those ids, status `ready`). The same chart rendered correctly on its own chart page.

## Root cause

The saved chart's `tableConfig.columnOrder` still names its primary source's ids (`orders_order_date_month`, `orders_total_order_amount`), while the tile's result is keyed by merged ids. `VisualizationProvider` used the saved order verbatim whenever it was non-empty, so `getDataAndColumns` filtered every saved id against the merged `selectedItemIds` and produced zero columns. The chart page does not hit this because `VisualizationCard` and `ExplorerResults` pass the saved order through `resolveMergeColumnOrder` first; the tile (and every other `VisualizationProvider` consumer) did not.

Note for the ticket: on the instance used to verify, the saved chart's `columnOrder` was the two `orders_*` ids, not `[]`. With `[]` the old fallback to the response metric query would have rendered.

## The change

`VisualizationProvider` now reconciles the saved order against a merged result (`metricQuery.exploreName === MERGE_TABLE_NAME`) with the same `resolveMergeColumnOrder` the Explorer uses: saved ids the result carries keep their order, ids the result does not carry are dropped, and merged fields missing from the saved order are appended in query order (join key, then values). Any non-merge result keeps the previous behaviour exactly.

Because the fix sits in the provider, it covers the dashboard tile, the minimal tile (embed and screenshots), `EmbedChart` and `MinimalSavedExplorer`, which all passed the raw saved order.

Cartesian merged charts: a merged chart saved from the Explorer stores its layout (`xField`, `yField`, series) against merged ids, since the Explorer builds the chart config from the merged result. On the tile, `computeDashboardChartSeries` and `useCartesianChartConfig` resolve those ids against the response `fields` and rows, which are merged, so series already resolved; the tile's column order now matches too.

## How it was verified

- New `VisualizationProvider.test.tsx` renders the real provider with a merged result and a table chart: saved source-id order renders the merged columns (this test failed before the fix), a saved order in merged ids is kept as saved, an empty saved order falls back to query order, and an ordinary result keeps its saved order untouched. 4 tests pass.
- `resolveMergeColumnOrder.test.ts` (3) and `LightdashVisualization.interaction.test.tsx` (4) pass.
- `pnpm -F frontend typecheck` clean; oxlint and oxfmt clean on the changed files.
- Live, against an API built from `main` with the worktree frontend on Vite: before the fix the tile was an empty card (`table thead th` = 0, `tbody tr` = 0); after, it renders `Merged Order date month`, `Orders Total order amount`, `Payments Unique payment count` with 26 rows, the first `2023-03-01 / US$15.00 / 2`, matching the chart page.

## Regression note for ordinary tiles

The non-merge branch is unchanged: a non-empty saved `columnOrder` is used verbatim and an empty one falls back to the response metric query, as before. The merge branch is keyed on the response's explore name, so a chart with a saved `merge` whose backend run did not merge (flag off) still takes the ordinary path with the ordinary ids. Pivoted tables are not affected: `useTableConfig` returns no plain columns when pivot dimensions are set, and the pivot path reads the result's own column list.

Closes: PROD-10967
Relates: PROD-9397

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvtHaH3fbzSX2ebMgfFKFS
