### PR TITLE
fix(dashboards): show per-source filters and restore the merge from a merged tile

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.merge.test.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.merge.test.tsx
@@ -18,7 +18,7 @@ import {
     type MetricQuery,
     type SavedChart,
 } from '@lightdash/common';
-import { cleanup, waitFor } from '@testing-library/react';
+import { act, cleanup, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { type DashboardChartReadyQuery } from '../../hooks/dashboard/useDashboardChartReadyQuery';
@@ -397,7 +397,7 @@ describe('DashboardChartTile with a merged chart', () => {
     });
 
     it('renders the merged result columns under a dashboard filter', async () => {
-        const { container } = renderTile();
+        const { container, unmount } = renderTile();
 
         await waitFor(() => {
             expect(
@@ -413,5 +413,10 @@ describe('DashboardChartTile with a merged chart', () => {
             expect.stringContaining('Total order amount'),
             expect.stringContaining('Unique payment count'),
         ]);
+
+        // Unmount here and drain queued query notifications while the window
+        // still exists, so none fire after the environment is torn down.
+        unmount();
+        await act(() => new Promise((resolve) => setTimeout(resolve, 0)));
     });
 });

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.merge.test.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.merge.test.tsx
@@ -1,0 +1,417 @@
+import {
+    ChartType,
+    DashboardTileTypes,
+    DimensionType,
+    FieldType,
+    FilterOperator,
+    MERGE_TABLE_NAME,
+    MergeJoinType,
+    MetricType,
+    QueryHistoryStatus,
+    SupportedDbtAdapter,
+    type ApiExploreResults,
+    type CompiledDimension,
+    type CompiledMetric,
+    type DashboardChartTile as DashboardChartTileType,
+    type DashboardFilterRule,
+    type ItemsMap,
+    type MetricQuery,
+    type SavedChart,
+} from '@lightdash/common';
+import { cleanup, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { type DashboardChartReadyQuery } from '../../hooks/dashboard/useDashboardChartReadyQuery';
+import ChartColorMappingContextProvider from '../../hooks/useChartColorConfig/ChartColorMappingContextProvider';
+import { type InfiniteQueryResults } from '../../hooks/useQueryResults';
+import { renderWithProviders } from '../../testing/testUtils';
+import { GenericDashboardChartTile } from './DashboardChartTile';
+
+// The tile is rendered with its data already resolved; nothing may reach the network.
+vi.mock('../../api', () => ({
+    lightdashApi: vi.fn(() => new Promise(() => {})),
+}));
+vi.mock('@shopify/react-web-worker', () => ({
+    createWorkerFactory: () => () => ({}),
+    useWorker: () => ({}),
+}));
+vi.mock('../../hooks/useServerOrClientFeatureFlag', async (importOriginal) => ({
+    ...(await importOriginal<object>()),
+    useServerFeatureFlag: () => ({ data: undefined }),
+}));
+vi.mock('../../hooks/usePreAggregateRefresh', () => ({
+    useRefreshPreAggregateByDefinitionName: () => ({
+        mutate: () => {},
+        isLoading: false,
+    }),
+}));
+vi.mock('../../hooks/useProjectRoute', async (importOriginal) => ({
+    ...(await importOriginal<object>()),
+    useOptionalProjectRoute: () => null,
+    useProjectUrlIdentifier: () => 'project-uuid',
+}));
+vi.mock('../../providers/Dashboard/useDashboardContext', () => ({
+    default: vi.fn((selector: (value: Record<string, unknown>) => unknown) =>
+        selector({
+            dashboard: { uuid: 'dashboard-uuid', slug: 'dashboard' },
+            projectUuid: 'project-uuid',
+            hasTileComments: () => false,
+            dashboardCommentsCheck: undefined,
+            dashboardFilters: {
+                dimensions: [],
+                metrics: [],
+                tableCalculations: [],
+            },
+            dashboardTemporaryFilters: {
+                dimensions: [],
+                metrics: [],
+                tableCalculations: [],
+            },
+            dashboardTiles: [],
+            dashboardTabs: [],
+            dashboardCustomMetrics: [],
+            parameterDefinitions: {},
+            parameterValues: {},
+            tilesWithDateZoomApplied: new Set<string>(),
+            dateZoomGranularity: undefined,
+            dateZoomConfig: undefined,
+            chartSort: {},
+            addDimensionDashboardFilter: () => {},
+            setDashboardTiles: () => {},
+            setChartSort: () => {},
+            haveTilesChanged: false,
+            haveFiltersChanged: false,
+        }),
+    ),
+}));
+vi.mock('../../providers/Dashboard/useDashboardTileStatusContext', () => ({
+    default: vi.fn((selector: (value: Record<string, unknown>) => unknown) =>
+        selector({
+            markTileScreenshotErrored: () => {},
+            markTileScreenshotReady: () => {},
+            markEmbedTileComplete: () => {},
+            markTileLoaded: () => {},
+            addResultsCacheTime: () => {},
+            addAvailableCustomGranularities: () => {},
+            updateSqlChartTilesMetadata: () => {},
+            preAggregateStatuses: {},
+            invalidateCache: false,
+            isAutoRefresh: false,
+            refreshCounter: 0,
+        }),
+    ),
+}));
+
+const compiled = { compiledSql: '', tablesReferences: [] };
+
+const compiledDimension = (
+    table: string,
+    name: string,
+    label: string,
+    type: DimensionType,
+): CompiledDimension => ({
+    fieldType: FieldType.DIMENSION,
+    type,
+    name,
+    label,
+    table,
+    tableLabel: table,
+    sql: '',
+    hidden: false,
+    ...compiled,
+});
+
+const compiledMetric = (
+    table: string,
+    name: string,
+    label: string,
+): CompiledMetric => ({
+    fieldType: FieldType.METRIC,
+    type: MetricType.SUM,
+    name,
+    label,
+    table,
+    tableLabel: table,
+    sql: '',
+    hidden: false,
+    ...compiled,
+});
+
+const ordersExplore: ApiExploreResults = {
+    name: 'orders',
+    label: 'Orders',
+    tags: [],
+    baseTable: 'orders',
+    joinedTables: [],
+    targetDatabase: SupportedDbtAdapter.POSTGRES,
+    tables: {
+        orders: {
+            name: 'orders',
+            label: 'Orders',
+            database: 'db',
+            schema: 'public',
+            sqlTable: 'orders',
+            lineageGraph: {},
+            dimensions: {
+                order_date_month: compiledDimension(
+                    'orders',
+                    'order_date_month',
+                    'Order date month',
+                    DimensionType.DATE,
+                ),
+                status: compiledDimension(
+                    'orders',
+                    'status',
+                    'Status',
+                    DimensionType.STRING,
+                ),
+            },
+            metrics: {
+                total_order_amount: compiledMetric(
+                    'orders',
+                    'total_order_amount',
+                    'Total order amount',
+                ),
+            },
+        },
+    },
+};
+
+const JOIN_KEY = 'merge_order_date_month';
+const SOURCE_A_METRIC = 'a_orders_total_order_amount';
+const SOURCE_B_METRIC = 'b_payments_unique_payment_count';
+
+const mergedFields: ItemsMap = {
+    [JOIN_KEY]: compiledDimension(
+        MERGE_TABLE_NAME,
+        'order_date_month',
+        'Order date month',
+        DimensionType.DATE,
+    ),
+    [SOURCE_A_METRIC]: compiledMetric(
+        'a',
+        'orders_total_order_amount',
+        'Total order amount',
+    ),
+    [SOURCE_B_METRIC]: compiledMetric(
+        'b',
+        'payments_unique_payment_count',
+        'Unique payment count',
+    ),
+};
+
+const mergedMetricQuery: MetricQuery = {
+    exploreName: MERGE_TABLE_NAME,
+    dimensions: [JOIN_KEY],
+    metrics: [SOURCE_A_METRIC, SOURCE_B_METRIC],
+    filters: {},
+    sorts: [],
+    limit: 500,
+    tableCalculations: [],
+};
+
+const primaryMetricQuery: MetricQuery = {
+    exploreName: 'orders',
+    dimensions: ['orders_order_date_month'],
+    metrics: ['orders_total_order_amount'],
+    filters: {},
+    sorts: [],
+    limit: 500,
+    tableCalculations: [],
+};
+
+const statusFilter = (tableName: string): DashboardFilterRule => ({
+    id: 'status-filter',
+    label: 'Status',
+    target: { fieldId: `${tableName}_status`, tableName },
+    operator: FilterOperator.EQUALS,
+    values: ['completed'],
+});
+
+const chart: SavedChart = {
+    uuid: 'chart-uuid',
+    projectUuid: 'project-uuid',
+    organizationUuid: 'org-uuid',
+    name: 'Orders and payments by month',
+    tableName: 'orders',
+    metricQuery: primaryMetricQuery,
+    merge: {
+        primarySourceId: 'a',
+        sources: [
+            { id: 'a', kind: 'chart' },
+            {
+                id: 'b',
+                kind: 'query',
+                metricQuery: {
+                    exploreName: 'payments',
+                    dimensions: ['payments_payment_date_month'],
+                    metrics: ['payments_unique_payment_count'],
+                    filters: {},
+                    sorts: [],
+                    limit: 500,
+                    tableCalculations: [],
+                },
+            },
+        ],
+        joinKey: [
+            {
+                name: 'order_date_month',
+                fieldIdBySourceId: {
+                    a: 'orders_order_date_month',
+                    b: 'payments_payment_date_month',
+                },
+            },
+        ],
+        joinType: MergeJoinType.FULL,
+        tableCalculations: [],
+    },
+    chartConfig: { type: ChartType.TABLE, config: undefined },
+    // Saved before the merge: still names the primary source's own field ids.
+    tableConfig: {
+        columnOrder: ['orders_order_date_month', 'orders_total_order_amount'],
+    },
+    updatedAt: new Date('2026-01-01'),
+    spaceUuid: 'space-uuid',
+    spaceName: 'Space',
+    pinnedListUuid: null,
+    pinnedListOrder: null,
+    dashboardUuid: null,
+    dashboardName: null,
+    colorPalette: [],
+    colorPaletteUuid: null,
+    resolvedColorPalette: {
+        source: { type: 'default' },
+        paletteUuid: null,
+        paletteName: null,
+        colors: [],
+        darkColors: null,
+    },
+    inheritsFromOrgOrProject: true,
+    access: [],
+    slug: 'orders-and-payments-by-month',
+    verification: null,
+};
+
+const tile: DashboardChartTileType = {
+    uuid: 'tile-uuid',
+    type: DashboardTileTypes.SAVED_CHART,
+    x: 0,
+    y: 0,
+    h: 4,
+    w: 6,
+    tabUuid: undefined,
+    properties: { savedChartUuid: chart.uuid, title: chart.name },
+};
+
+const dashboardChartReadyQuery: DashboardChartReadyQuery = {
+    chart,
+    explore: ordersExplore,
+    dateZoom: undefined,
+    executeQueryResponse: {
+        queryUuid: 'query-uuid',
+        cacheMetadata: { cacheHit: false },
+        parameterReferences: [],
+        usedParametersValues: {},
+        resolvedTimezone: 'UTC',
+        metricQuery: mergedMetricQuery,
+        fields: mergedFields,
+        appliedDashboardFilters: {
+            dimensions: [statusFilter('orders'), statusFilter('payments')],
+            metrics: [],
+            tableCalculations: [],
+        },
+        appliedDashboardFiltersBySourceId: {
+            a: {
+                dimensions: [statusFilter('orders')],
+                metrics: [],
+                tableCalculations: [],
+            },
+            b: {
+                dimensions: [statusFilter('payments')],
+                metrics: [],
+                tableCalculations: [],
+            },
+        },
+        dateZoomApplied: false,
+    },
+};
+
+const resultsData: InfiniteQueryResults = {
+    queryUuid: 'query-uuid',
+    queryStatus: QueryHistoryStatus.READY,
+    rows: [
+        {
+            [JOIN_KEY]: { value: { raw: '2026-01-01', formatted: '2026-01' } },
+            [SOURCE_A_METRIC]: { value: { raw: 100, formatted: '100' } },
+            [SOURCE_B_METRIC]: { value: { raw: 3, formatted: '3' } },
+        },
+    ],
+    totalResults: 1,
+    isInitialLoading: false,
+    isFetchingFirstPage: false,
+    isFetchingRows: false,
+    isFetchingAllPages: false,
+    fetchMoreRows: () => {},
+    refetchRows: async () => {},
+    setFetchAll: () => {},
+    fetchAll: false,
+    hasFetchedAllRows: true,
+    totalClientFetchTimeMs: undefined,
+    error: null,
+};
+
+const renderTile = () =>
+    renderWithProviders(
+        <MemoryRouter
+            initialEntries={[
+                '/projects/project-uuid/dashboards/dashboard-uuid/view',
+            ]}
+        >
+            <Routes>
+                <Route
+                    path="/projects/:projectUuid/dashboards/:dashboardUuid/view"
+                    element={
+                        <ChartColorMappingContextProvider>
+                            <GenericDashboardChartTile
+                                tile={tile}
+                                isEditMode={false}
+                                isLoading={false}
+                                error={null}
+                                dashboardChartReadyQuery={
+                                    dashboardChartReadyQuery
+                                }
+                                resultsData={resultsData}
+                                onDelete={() => {}}
+                                onEdit={() => {}}
+                            />
+                        </ChartColorMappingContextProvider>
+                    }
+                />
+            </Routes>
+        </MemoryRouter>,
+    );
+
+describe('DashboardChartTile with a merged chart', () => {
+    afterEach(() => {
+        cleanup();
+    });
+
+    it('renders the merged result columns under a dashboard filter', async () => {
+        const { container } = renderTile();
+
+        await waitFor(() => {
+            expect(
+                container.querySelectorAll('thead th').length,
+            ).toBeGreaterThan(0);
+        });
+        // The row-number column comes first; the rest must be the merged result.
+        const headers = Array.from(container.querySelectorAll('thead th'))
+            .slice(1)
+            .map((th) => th.textContent?.trim());
+        expect(headers).toEqual([
+            expect.stringContaining('Order date month'),
+            expect.stringContaining('Total order amount'),
+            expect.stringContaining('Unique payment count'),
+        ]);
+    });
+});

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -123,6 +123,7 @@ import { DashboardTileComments } from '../../features/comments';
 import { FilterDashboardTo } from '../../features/dashboardFilters/FilterDashboardTo';
 import { DateZoomInfoOnTile } from '../../features/dateZoom';
 import { ExportToGoogleSheet } from '../../features/export';
+import { getExploreFromHereUrl } from '../../features/mergeQuery/utils/getExploreFromHereUrl';
 import {
     getExpectedSeriesMap,
     isPivotSeriesOrderDeterminedByQuery,
@@ -139,7 +140,7 @@ import { uploadGsheet } from '../../hooks/gdrive/useGdrive';
 import { useOrganization } from '../../hooks/organization/useOrganization';
 import useToaster from '../../hooks/toaster/useToaster';
 import { useContextMenuPermissions } from '../../hooks/useContextMenuPermissions';
-import { getExplorerUrlFromCreateSavedChartVersion } from '../../hooks/useExplorerRoute';
+import { useExplore } from '../../hooks/useExplore';
 import usePivotDimensions from '../../hooks/usePivotDimensions';
 import { useRefreshPreAggregateByDefinitionName } from '../../hooks/usePreAggregateRefresh';
 import { useProjectUrlIdentifier } from '../../hooks/useProjectRoute';
@@ -648,6 +649,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
         const {
             executeQueryResponse: {
                 appliedDashboardFilters,
+                appliedDashboardFiltersBySourceId,
                 cacheMetadata,
                 metricQuery,
                 resolvedTimezone,
@@ -656,6 +658,15 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
             chart,
             explore,
         } = dashboardChartReadyQuery;
+        const savedMerge = chart.merge ?? null;
+        // A merged tile's filters echo per source; the other source's explore
+        // is needed to label them.
+        const additionalExploreName = savedMerge?.sources.flatMap((source) =>
+            source.kind === 'query' ? [source.metricQuery.exploreName] : [],
+        )[0];
+        const { data: additionalExplore } = useExplore(additionalExploreName, {
+            refetchOnMount: false,
+        });
 
         const { totalResults, metadata } = resultsData;
         const performance = metadata?.performance;
@@ -1035,18 +1046,26 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
             },
             [explore, chart],
         );
-        const { appliedFilterRules, chartFilterItems } = useMemo(
+        const { appliedFilterItems, chartFilterItems } = useMemo(
             () =>
                 getDashboardTileFilterInfo({
                     chartFilters: chart.metricQuery.filters,
                     appliedDashboardFilters,
+                    appliedDashboardFiltersBySourceId,
+                    merge: savedMerge,
                     explore,
                 }),
-            [appliedDashboardFilters, chart.metricQuery.filters, explore],
+            [
+                appliedDashboardFilters,
+                appliedDashboardFiltersBySourceId,
+                savedMerge,
+                chart.metricQuery.filters,
+                explore,
+            ],
         );
 
         const hasFiltersToShow =
-            appliedFilterRules.length > 0 || chartFilterItems.length > 0;
+            appliedFilterItems.length > 0 || chartFilterItems.length > 0;
 
         const chartWithDashboardFilters = useMemo(
             () => ({
@@ -1059,13 +1078,15 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
             !userCanUseCustomFields &&
             chartWithDashboardFilters.metricQuery?.customDimensions;
 
-        const { pathname: chartPathname, search: chartSearch } = useMemo(() => {
-            return getExplorerUrlFromCreateSavedChartVersion(
-                chartWithDashboardFilters.projectUuid,
-                chartWithDashboardFilters,
-                true,
-            );
-        }, [chartWithDashboardFilters]);
+        // A merged result is not a query the Explorer can open; a merged
+        // chart reopens from its own primary query plus its merge instead.
+        const { pathname: chartPathname, search: chartSearch } = useMemo(
+            () =>
+                getExploreFromHereUrl(
+                    savedMerge ? chart : chartWithDashboardFilters,
+                ),
+            [savedMerge, chart, chartWithDashboardFilters],
+        );
 
         const [isCommentsMenuOpen, setIsCommentsMenuOpen] = useState(false);
         const showComments = useDashboardContext(
@@ -1156,7 +1177,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
                                 >
                                     <HoverCard.Dropdown>
                                         <Stack gap="xs" align="flex-start">
-                                            {appliedFilterRules.length > 0 && (
+                                            {appliedFilterItems.length > 0 && (
                                                 <>
                                                     <Text
                                                         c="ldGray.7"
@@ -1164,18 +1185,35 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
                                                         fz="xs"
                                                     >
                                                         Dashboard filter
-                                                        {appliedFilterRules.length >
+                                                        {appliedFilterItems.length >
                                                         1
                                                             ? 's'
                                                             : ''}{' '}
                                                         applied:
                                                     </Text>
-                                                    {appliedFilterRules.map(
-                                                        (filterRule) => {
+                                                    {appliedFilterItems.map(
+                                                        ({
+                                                            filterRule,
+                                                            sourceId,
+                                                            sourceExploreName,
+                                                        }) => {
+                                                            const sourceExplore =
+                                                                sourceExploreName ===
+                                                                    null ||
+                                                                sourceExploreName ===
+                                                                    explore?.name
+                                                                    ? explore
+                                                                    : additionalExplore;
+                                                            const sourceLabel =
+                                                                sourceExploreName ===
+                                                                null
+                                                                    ? null
+                                                                    : (sourceExplore?.label ??
+                                                                      sourceExploreName);
                                                             const fields: Field[] =
-                                                                explore
+                                                                sourceExplore
                                                                     ? getVisibleFields(
-                                                                          explore,
+                                                                          sourceExplore,
                                                                       )
                                                                     : [];
 
@@ -1208,9 +1246,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
                                                                 );
                                                             return (
                                                                 <Badge
-                                                                    key={
-                                                                        filterRule.id
-                                                                    }
+                                                                    key={`${sourceId ?? ''}:${filterRule.id}`}
                                                                     variant="outline"
                                                                     color="ldGray.4"
                                                                     size="lg"
@@ -1218,6 +1254,19 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
                                                                     fw="normal"
                                                                     c="black"
                                                                 >
+                                                                    {sourceLabel !==
+                                                                        null && (
+                                                                        <Text
+                                                                            span
+                                                                            inherit
+                                                                            c="ldGray.6"
+                                                                        >
+                                                                            {
+                                                                                sourceLabel
+                                                                            }{' '}
+                                                                            ·{' '}
+                                                                        </Text>
+                                                                    )}
                                                                     <Text
                                                                         fw={600}
                                                                         span

--- a/packages/frontend/src/components/DashboardTiles/getDashboardTileFilterInfo.test.ts
+++ b/packages/frontend/src/components/DashboardTiles/getDashboardTileFilterInfo.test.ts
@@ -1,12 +1,16 @@
 import {
     FilterOperator,
+    MergeJoinType,
+    type DashboardFilterRule,
     type DashboardFilters,
     type Explore,
     type Filters,
+    type SavedMergeQuery,
 } from '@lightdash/common';
 import { getDashboardTileFilterInfo } from './getDashboardTileFilterInfo';
 
 const explore = {
+    name: 'orders',
     tables: {
         orders: {
             dimensions: {
@@ -71,10 +75,12 @@ describe('getDashboardTileFilterInfo', () => {
         const result = getDashboardTileFilterInfo({
             chartFilters,
             appliedDashboardFilters,
+            appliedDashboardFiltersBySourceId: undefined,
+            merge: null,
             explore,
         });
 
-        expect(result.appliedFilterRules).toHaveLength(1);
+        expect(result.appliedFilterItems).toHaveLength(1);
         expect(result.chartFilterItems).toEqual([
             expect.objectContaining({
                 filterRule: expect.objectContaining({ id: 'month-filter' }),
@@ -86,6 +92,130 @@ describe('getDashboardTileFilterInfo', () => {
                 }),
                 isOverridden: false,
             }),
+        ]);
+    });
+
+    const yearFilter: DashboardFilterRule = {
+        id: 'year-filter',
+        label: 'Year Filter',
+        target: { fieldId: 'orders_order_date_year', tableName: 'orders' },
+        operator: FilterOperator.EQUALS,
+        values: ['2024'],
+    };
+    const paymentMonthFilter: DashboardFilterRule = {
+        id: 'payment-month-filter',
+        label: 'Payment month',
+        target: { fieldId: 'payments_payment_month', tableName: 'payments' },
+        operator: FilterOperator.EQUALS,
+        values: ['2024-03'],
+    };
+    const merge: SavedMergeQuery = {
+        primarySourceId: 'a',
+        sources: [
+            {
+                id: 'b',
+                kind: 'query',
+                metricQuery: {
+                    exploreName: 'payments',
+                    dimensions: ['payments_payment_month'],
+                    metrics: ['payments_unique_payment_count'],
+                    filters: {},
+                    sorts: [],
+                    limit: 500,
+                    tableCalculations: [],
+                },
+            },
+            { id: 'a', kind: 'chart' },
+        ],
+        joinKey: [
+            {
+                name: 'order_month',
+                fieldIdBySourceId: {
+                    a: 'orders_order_date_month',
+                    b: 'payments_payment_month',
+                },
+            },
+        ],
+        joinType: MergeJoinType.FULL,
+        tableCalculations: [],
+    };
+
+    test('lists an ordinary echo without a source', () => {
+        const result = getDashboardTileFilterInfo({
+            chartFilters: {},
+            appliedDashboardFilters: {
+                dimensions: [yearFilter],
+                metrics: [],
+                tableCalculations: [],
+            },
+            appliedDashboardFiltersBySourceId: undefined,
+            merge: null,
+            explore,
+        });
+
+        expect(result.appliedFilterItems).toEqual([
+            { filterRule: yearFilter, sourceId: null, sourceExploreName: null },
+        ]);
+    });
+
+    test('lists a merged echo per source, primary first', () => {
+        const result = getDashboardTileFilterInfo({
+            chartFilters: {},
+            appliedDashboardFilters: {
+                dimensions: [yearFilter, paymentMonthFilter],
+                metrics: [],
+                tableCalculations: [],
+            },
+            appliedDashboardFiltersBySourceId: {
+                b: {
+                    dimensions: [paymentMonthFilter, yearFilter],
+                    metrics: [],
+                    tableCalculations: [],
+                },
+                a: {
+                    dimensions: [yearFilter],
+                    metrics: [],
+                    tableCalculations: [],
+                },
+            },
+            merge,
+            explore,
+        });
+
+        expect(result.appliedFilterItems).toEqual([
+            {
+                filterRule: yearFilter,
+                sourceId: 'a',
+                sourceExploreName: 'orders',
+            },
+            {
+                filterRule: paymentMonthFilter,
+                sourceId: 'b',
+                sourceExploreName: 'payments',
+            },
+            {
+                filterRule: yearFilter,
+                sourceId: 'b',
+                sourceExploreName: 'payments',
+            },
+        ]);
+    });
+
+    test('falls back to the flat echo when a merged tile has no per-source echo', () => {
+        const result = getDashboardTileFilterInfo({
+            chartFilters: {},
+            appliedDashboardFilters: {
+                dimensions: [yearFilter],
+                metrics: [],
+                tableCalculations: [],
+            },
+            appliedDashboardFiltersBySourceId: undefined,
+            merge,
+            explore,
+        });
+
+        expect(result.appliedFilterItems).toEqual([
+            { filterRule: yearFilter, sourceId: null, sourceExploreName: null },
         ]);
     });
 });

--- a/packages/frontend/src/components/DashboardTiles/getDashboardTileFilterInfo.ts
+++ b/packages/frontend/src/components/DashboardTiles/getDashboardTileFilterInfo.ts
@@ -1,18 +1,90 @@
 import {
     getOverriddenChartFilterRuleIds,
     getTotalFilterRules,
+    type DashboardFilterRule,
     type DashboardFilters,
     type Explore,
     type Filters,
+    type SavedMergeQuery,
+    type SavedMergeQuerySource,
 } from '@lightdash/common';
+
+export type AppliedDashboardFilterItem = {
+    filterRule: DashboardFilterRule;
+    /** Merge source the filter was pushed into; null on an ordinary tile. */
+    sourceId: string | null;
+    /** Explore of that source, for labelling; null on an ordinary tile. */
+    sourceExploreName: string | null;
+};
+
+const rulesOf = (filters: DashboardFilters): DashboardFilterRule[] => [
+    ...filters.dimensions,
+    ...filters.metrics,
+];
+
+const sourceExploreNameOf = (
+    source: SavedMergeQuerySource,
+    primaryExploreName: string | null,
+): string | null =>
+    source.kind === 'chart'
+        ? primaryExploreName
+        : source.metricQuery.exploreName;
+
+/** Primary first, so the popover reads in the order the merge editor shows. */
+const orderedSources = (merge: SavedMergeQuery): SavedMergeQuerySource[] => [
+    ...merge.sources.filter((source) => source.id === merge.primarySourceId),
+    ...merge.sources.filter((source) => source.id !== merge.primarySourceId),
+];
+
+const getAppliedFilterItems = ({
+    appliedDashboardFilters,
+    appliedDashboardFiltersBySourceId,
+    merge,
+    primaryExploreName,
+}: {
+    appliedDashboardFilters: DashboardFilters | undefined;
+    appliedDashboardFiltersBySourceId:
+        | Record<string, DashboardFilters>
+        | undefined;
+    merge: SavedMergeQuery | null;
+    primaryExploreName: string | null;
+}): AppliedDashboardFilterItem[] => {
+    if (merge && appliedDashboardFiltersBySourceId) {
+        return orderedSources(merge).flatMap((source) => {
+            const applied = appliedDashboardFiltersBySourceId[source.id];
+            if (!applied) return [];
+            return rulesOf(applied).map((filterRule) => ({
+                filterRule,
+                sourceId: source.id,
+                sourceExploreName: sourceExploreNameOf(
+                    source,
+                    primaryExploreName,
+                ),
+            }));
+        });
+    }
+    return appliedDashboardFilters
+        ? rulesOf(appliedDashboardFilters).map((filterRule) => ({
+              filterRule,
+              sourceId: null,
+              sourceExploreName: null,
+          }))
+        : [];
+};
 
 export const getDashboardTileFilterInfo = ({
     chartFilters,
     appliedDashboardFilters,
+    appliedDashboardFiltersBySourceId,
+    merge,
     explore,
 }: {
     chartFilters: Filters;
     appliedDashboardFilters: DashboardFilters | undefined;
+    appliedDashboardFiltersBySourceId:
+        | Record<string, DashboardFilters>
+        | undefined;
+    merge: SavedMergeQuery | null;
     explore: Explore | undefined;
 }) => {
     const overriddenChartFilterRuleIds = getOverriddenChartFilterRuleIds({
@@ -22,12 +94,12 @@ export const getDashboardTileFilterInfo = ({
     });
 
     return {
-        appliedFilterRules: appliedDashboardFilters
-            ? [
-                  ...appliedDashboardFilters.dimensions,
-                  ...appliedDashboardFilters.metrics,
-              ]
-            : [],
+        appliedFilterItems: getAppliedFilterItems({
+            appliedDashboardFilters,
+            appliedDashboardFiltersBySourceId,
+            merge,
+            primaryExploreName: explore?.name ?? null,
+        }),
         chartFilterItems: getTotalFilterRules(chartFilters).map(
             (filterRule) => ({
                 filterRule,

--- a/packages/frontend/src/components/ExploreFromHereButton/index.tsx
+++ b/packages/frontend/src/components/ExploreFromHereButton/index.tsx
@@ -7,8 +7,8 @@ import {
     selectSavedChart,
     useExplorerSelector,
 } from '../../features/explorer/store';
+import { getExploreFromHereUrl } from '../../features/mergeQuery/utils/getExploreFromHereUrl';
 import useDashboardStorage from '../../hooks/dashboard/useDashboardStorage';
-import { getExplorerUrlFromCreateSavedChartVersion } from '../../hooks/useExplorerRoute';
 import { useCreateShareMutation } from '../../hooks/useShare';
 import useApp from '../../providers/App/useApp';
 import MantineIcon from '../common/MantineIcon';
@@ -16,15 +16,10 @@ import MantineIcon from '../common/MantineIcon';
 const ExploreFromHereButton = () => {
     // Get savedChart from Redux
     const savedChart = useExplorerSelector(selectSavedChart);
-    const exploreFromHereUrl = useMemo(() => {
-        if (savedChart) {
-            return getExplorerUrlFromCreateSavedChartVersion(
-                savedChart.projectUuid,
-                savedChart,
-                true,
-            );
-        }
-    }, [savedChart]);
+    const exploreFromHereUrl = useMemo(
+        () => (savedChart ? getExploreFromHereUrl(savedChart) : undefined),
+        [savedChart],
+    );
 
     const { user } = useApp();
     const navigate = useNavigate();

--- a/packages/frontend/src/features/mergeQuery/utils/getExploreFromHereUrl.test.ts
+++ b/packages/frontend/src/features/mergeQuery/utils/getExploreFromHereUrl.test.ts
@@ -1,0 +1,137 @@
+import {
+    ChartType,
+    MergeJoinType,
+    type SavedChart,
+    type SavedMergeQuery,
+} from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import { MERGE_URL_PARAM, parseMergeState } from '../context/mergeUrlState';
+import { getExploreFromHereUrl } from './getExploreFromHereUrl';
+
+type ChartFixture = Pick<
+    SavedChart,
+    | 'uuid'
+    | 'projectUuid'
+    | 'name'
+    | 'tableName'
+    | 'metricQuery'
+    | 'chartConfig'
+    | 'tableConfig'
+>;
+
+const chartFixture: ChartFixture = {
+    uuid: 'chart-uuid',
+    projectUuid: 'project-uuid',
+    name: 'Orders by month',
+    tableName: 'orders',
+    metricQuery: {
+        exploreName: 'orders',
+        dimensions: ['orders_order_month'],
+        metrics: ['orders_total_order_amount'],
+        filters: {},
+        sorts: [],
+        limit: 500,
+        tableCalculations: [],
+    },
+    chartConfig: { type: ChartType.TABLE },
+    tableConfig: { columnOrder: [] },
+};
+const chart = chartFixture as SavedChart;
+
+const merge: SavedMergeQuery = {
+    primarySourceId: 'a',
+    sources: [
+        { id: 'a', kind: 'chart' },
+        {
+            id: 'b',
+            kind: 'query',
+            metricQuery: {
+                exploreName: 'payments',
+                dimensions: ['payments_payment_month'],
+                metrics: ['payments_unique_payment_count'],
+                filters: {},
+                sorts: [],
+                limit: 500,
+                tableCalculations: [],
+            },
+        },
+    ],
+    joinKey: [
+        {
+            name: 'order_month',
+            fieldIdBySourceId: {
+                a: 'orders_order_month',
+                b: 'payments_payment_month',
+            },
+        },
+    ],
+    joinType: MergeJoinType.LEFT,
+    tableCalculations: [],
+};
+
+const parseChartParam = (search: string) =>
+    JSON.parse(
+        new URLSearchParams(search).get('create_saved_chart_version') ?? '',
+    ) as SavedChart;
+
+describe('getExploreFromHereUrl', () => {
+    it('opens an ordinary chart on its explore without a merge param', () => {
+        const url = getExploreFromHereUrl(chart);
+        const params = new URLSearchParams(url.search);
+
+        expect(url.pathname).toBe('/projects/project-uuid/tables/orders');
+        expect(params.get('isExploreFromHere')).toBe('true');
+        expect(params.has(MERGE_URL_PARAM)).toBe(false);
+        expect(parseChartParam(url.search).metricQuery).toEqual(
+            chart.metricQuery,
+        );
+    });
+
+    it('opens a merged chart on its primary explore with the merge restored', () => {
+        const url = getExploreFromHereUrl({ ...chart, merge });
+        const params = new URLSearchParams(url.search);
+
+        expect(url.pathname).toBe('/projects/project-uuid/tables/orders');
+        expect(parseChartParam(url.search).metricQuery.exploreName).toBe(
+            'orders',
+        );
+        expect(parseMergeState(params.get(MERGE_URL_PARAM))).toEqual({
+            focus: { kind: 'source', sourceId: 'a' },
+            additionalSources: [
+                {
+                    id: 'b',
+                    exploreName: 'payments',
+                    dimensions: ['payments_payment_month'],
+                    metrics: ['payments_unique_payment_count'],
+                    filters: {},
+                    additionalMetrics: undefined,
+                    customDimensions: undefined,
+                },
+            ],
+            joinParts: [
+                {
+                    fieldIdBySourceId: {
+                        a: 'orders_order_month',
+                        b: 'payments_payment_month',
+                    },
+                },
+            ],
+            joinType: MergeJoinType.LEFT,
+        });
+    });
+
+    it('falls back to the primary query when the stored merge is unreadable', () => {
+        const url = getExploreFromHereUrl({
+            ...chart,
+            merge: {
+                ...merge,
+                sources: [{ id: 'a', kind: 'chart' }],
+            },
+        });
+
+        expect(url.pathname).toBe('/projects/project-uuid/tables/orders');
+        expect(new URLSearchParams(url.search).has(MERGE_URL_PARAM)).toBe(
+            false,
+        );
+    });
+});

--- a/packages/frontend/src/features/mergeQuery/utils/getExploreFromHereUrl.ts
+++ b/packages/frontend/src/features/mergeQuery/utils/getExploreFromHereUrl.ts
@@ -1,0 +1,25 @@
+import { type SavedChart } from '@lightdash/common';
+import { getExplorerUrlFromCreateSavedChartVersion } from '../../../hooks/useExplorerRoute';
+import { MERGE_URL_PARAM, serializeMergeState } from '../context/mergeUrlState';
+import { restoreSavedMerge } from '../context/restoreSavedMerge';
+
+/**
+ * The Explorer URL that reopens a saved chart with its merge restored the way
+ * the merge editor restores it: the primary query as the chart, the other
+ * source and the join in the merge search param. An ordinary chart gets the
+ * same URL it always did.
+ */
+export const getExploreFromHereUrl = (
+    chart: SavedChart,
+): { pathname: string; search: string } => {
+    const url = getExplorerUrlFromCreateSavedChartVersion(
+        chart.projectUuid,
+        chart,
+        true,
+    );
+    const restored = chart.merge ? restoreSavedMerge(chart.merge) : null;
+    if (!restored) return url;
+    const search = new URLSearchParams(url.search);
+    search.set(MERGE_URL_PARAM, serializeMergeState(restored));
+    return { pathname: url.pathname, search: search.toString() };
+};


### PR DESCRIPTION
## What the user saw

On a dashboard tile holding a merged saved chart:

- **Filter info popover**: the applied dashboard filters were resolved against the primary explore only. A filter pushed into the second source (or into both) rendered as `Tried to reference field with unknown id: …` or was attributed to the wrong fields.
- **Explore from here**: the Explorer URL was built from the tile's *result* `metricQuery` (`exploreName: 'merge'`, merged field ids like `b_payments_unique_payment_count`), which the Explorer cannot open.

On the merged chart page, **Explore from here** opened the Explorer on the primary source only: the saved chart's `merge` rode along inside `create_saved_chart_version` but nothing reads it there, and `Explorer.tsx` mounts `MergeProvider` without a `savedMerge`, so the merge was silently dropped.

## Change

**Filter popover** (`getDashboardTileFilterInfo.ts`, `DashboardChartTile.tsx`)

- The popover model takes the per-source echo (`appliedDashboardFiltersBySourceId`, added in #28677) and the chart's `merge`. When both are present it lists each applied filter per source, primary first, carrying the source's explore name. Otherwise it returns the flat echo exactly as before.
- The tile fetches the other source's explore (`useExplore`, disabled on ordinary tiles), resolves each filter's field against the explore it applied to, and prefixes the badge with that explore's label (`Payments · Status: is completed`). The label is schema-derived content, so no new UI-chrome string is introduced and nothing new needs the `uiOverrides` registry.

**Explore from here** (`features/mergeQuery/utils/getExploreFromHereUrl.ts`)

- One builder for both entry points: `getExplorerUrlFromCreateSavedChartVersion` for the chart, plus `restoreSavedMerge` → `serializeMergeState` into the `merge=` search param, the same seam the merge editor and the AI chart quick options already use. The Explorer lands with both sources, the join key and the join type restored.
- The tile passes its saved chart (primary query + merge) when merged, and the dashboard-filtered result query otherwise, as before.
- `ExploreFromHereButton` (chart page) uses the same builder, so a merged chart's Explore from here now restores the merge too.

**Tile-level regression test** (`DashboardChartTile.merge.test.tsx`)

- Renders `GenericDashboardChartTile` with a merged query response, a saved column order in the primary source's field ids and a dashboard filter echoed per source, and asserts the table's columns are the merged result. It fails against a `VisualizationProvider` that passes the saved order through verbatim (the state before #28687), which is how a merged table tile rendered as an empty card.

## How verified

- Live, against the isolated API with the dashboard filter `orders_status = completed`: the merged table tile renders 4 header cells and 21 rows (matching main), the chart tile renders, and hovering the tile's filter button shows `Dashboard filters applied: Orders · Status: is completed / Payments · Status: is completed`. Explore from here opens `/tables/orders` with the merge param and both sources visible.
- `pnpm -F frontend test` on `getExploreFromHereUrl.test.ts`, `getDashboardTileFilterInfo.test.ts` and `DashboardChartTile.merge.test.tsx`: 3 files, 8 tests passing.
- `pnpm -F frontend typecheck`, `pnpm -F frontend run linter <changed files>`, `oxfmt`, and the pre-commit `unused-exports` gate all pass.

## Note on the rebase

The branch was cut before #28687 (merged fields on a chart tile). Without it a merged *table* tile renders empty regardless of this change, so an early comparison of this branch against main looked like a regression here. The branch is rebased onto main so it carries #28687; this PR's own diff is unchanged.

## Regression note for ordinary tiles and charts

- Popover: with no `merge` or no per-source echo the model returns the same flat list of rules (now as items with `sourceId: null`), the field lookup uses the tile's explore as before, and no source label is rendered. Covered by the ordinary-echo and fallback tests.
- Explore from here: for a chart without a merge the builder is `getExplorerUrlFromCreateSavedChartVersion(chart.projectUuid, chart, true)` with no `merge` param, which is byte-for-byte what both call sites did. The tile still passes the dashboard-filtered result query for ordinary tiles. Covered by the ordinary-chart URL test.
- `useExplore(undefined)` is disabled, so ordinary tiles make no extra request.

Closes: PROD-10969
Relates: PROD-9397

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvtHaH3fbzSX2ebMgfFKFS
