### PR TITLE
fix(merge): authorize merge table calculation SQL, register the v1 routes and scope the engine session

### DIFF
--- a/packages/backend/src/controllers/projectController.test.ts
+++ b/packages/backend/src/controllers/projectController.test.ts
@@ -1,3 +1,4 @@
+import { ForbiddenError, MergeJoinType } from '@lightdash/common';
 import { fetchMiddlewares } from '@tsoa/runtime';
 import express from 'express';
 import { PassThrough } from 'stream';
@@ -55,6 +56,88 @@ describe('ProjectController merged manifest', () => {
         expect(responseBody).toEqual(storedManifest);
         expect(JSON.parse(gunzipSync(responseBody).toString('utf8'))).toEqual(
             manifest,
+        );
+    });
+});
+
+describe('ProjectController merge routes', () => {
+    const mergeQuery = {
+        sources: [],
+        joinKey: [],
+        joinType: MergeJoinType.FULL,
+        tableCalculations: [],
+        limit: 500,
+    };
+
+    const buildController = () => {
+        const compileMergeQuery = vi.fn();
+        const executeLegacyAsyncMergeQuery = vi.fn();
+        const controller = new ProjectController({
+            getAsyncQueryService: () => ({
+                compileMergeQuery,
+                executeLegacyAsyncMergeQuery,
+            }),
+        } as unknown as ServiceRepository);
+        controller.setStatus = vi.fn();
+        return { controller, compileMergeQuery, executeLegacyAsyncMergeQuery };
+    };
+
+    const requestFor = (account: ReturnType<typeof buildAccount>) =>
+        ({
+            account,
+            headers: {},
+            header: vi.fn(),
+        }) as unknown as express.Request;
+
+    test('both routes refuse an unregistered account before reaching the service', async () => {
+        const { controller, compileMergeQuery, executeLegacyAsyncMergeQuery } =
+            buildController();
+        const embedRequest = requestFor(
+            buildAccount({ accountType: 'jwt', userType: 'anonymous' }),
+        );
+
+        await expect(
+            controller.CompileMergeQuery(
+                'project-uuid',
+                { mergeQuery },
+                embedRequest,
+            ),
+        ).rejects.toThrow(ForbiddenError);
+        await expect(
+            controller.RunMergeQuery(
+                'project-uuid',
+                { mergeQuery },
+                embedRequest,
+            ),
+        ).rejects.toThrow(ForbiddenError);
+
+        expect(compileMergeQuery).not.toHaveBeenCalled();
+        expect(executeLegacyAsyncMergeQuery).not.toHaveBeenCalled();
+    });
+
+    test('both routes forward a registered account to the service', async () => {
+        const { controller, compileMergeQuery, executeLegacyAsyncMergeQuery } =
+            buildController();
+        compileMergeQuery.mockResolvedValue({ sql: null, errors: [] });
+        executeLegacyAsyncMergeQuery.mockResolvedValue({
+            outcome: 'started',
+            query: { queryUuid: 'query-uuid' },
+        });
+        const account = buildAccount();
+        const request = requestFor(account);
+
+        await controller.CompileMergeQuery(
+            'project-uuid',
+            { mergeQuery },
+            request,
+        );
+        await controller.RunMergeQuery('project-uuid', { mergeQuery }, request);
+
+        expect(compileMergeQuery).toHaveBeenCalledWith(
+            expect.objectContaining({ account, projectUuid: 'project-uuid' }),
+        );
+        expect(executeLegacyAsyncMergeQuery).toHaveBeenCalledWith(
+            expect.objectContaining({ account, projectUuid: 'project-uuid' }),
         );
     });
 });

--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -580,6 +580,7 @@ Migrate to the v2 async query flow: [Execute SQL query](https://docs.lightdash.c
         status: 'ok';
         results: ApiCompiledMergeQueryResults;
     }> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
@@ -588,7 +589,7 @@ Migrate to the v2 async query flow: [Execute SQL query](https://docs.lightdash.c
             results: await this.services
                 .getAsyncQueryService()
                 .compileMergeQuery({
-                    account: req.account!,
+                    account: req.account,
                     projectUuid,
                     mergeQuery: body.mergeQuery,
                     parameters: body.parameters,
@@ -621,11 +622,12 @@ Migrate to the v2 async query flow: [Execute SQL query](https://docs.lightdash.c
         status: 'ok';
         results: ApiExecuteAsyncMetricQueryResults;
     }> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         const result = await this.services
             .getAsyncQueryService()
             .executeLegacyAsyncMergeQuery({
-                account: req.account!,
+                account: req.account,
                 projectUuid,
                 mergeQuery: body.mergeQuery,
                 parameters: body.parameters,

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -5961,7 +5961,7 @@ describe('runDuckdbQuery', () => {
         references: { kind: 'bound', referenceCtes: [] },
         columns: { mode: 'discover', limit: undefined, parameters: {} },
         storedCompiledSql: null,
-        warehouseClient: warehouseClientMock,
+        engine: { kind: 'client', warehouseClient: warehouseClientMock },
         queryTags: {} as AnyType,
         queryCreatedAt: new Date(),
         cacheKey: 'cache-key',
@@ -5975,7 +5975,7 @@ describe('runDuckdbQuery', () => {
         });
         const { run, runWarehouseQuery, update } = buildService();
 
-        await run(baseArgs({ warehouseClient }));
+        await run(baseArgs({ engine: { kind: 'client', warehouseClient } }));
 
         expect(streamQuery).toHaveBeenCalledTimes(1);
         expect(streamQuery.mock.calls[0][0]).toMatch(/LIMIT 1$/);
@@ -6046,7 +6046,7 @@ describe('runDuckdbQuery', () => {
 
         await run(
             baseArgs({
-                warehouseClient,
+                engine: { kind: 'client', warehouseClient },
                 sql: 'SELECT * FROM merge_source_0',
                 references: {
                     kind: 'queries',
@@ -6083,6 +6083,67 @@ describe('runDuckdbQuery', () => {
                 original_columns: originalColumns,
             },
             expect.anything(),
+        );
+    });
+
+    it('a session scoped to referenced results reaches exactly the bound leg files', async () => {
+        const createExecutionWarehouseClient = vi.fn(() => warehouseClientMock);
+        const service = getMockedAsyncQueryService(lightdashConfigMock, {
+            composeEngineClient: {
+                createExecutionWarehouseClient,
+            } as unknown as ComposeEngineClient,
+            resultsStorageClient: {
+                isEnabled: true,
+                configuration: { bucket: 'results-bucket' },
+            } as unknown as S3ResultsFileStorageClient,
+            queryHistoryModel: {
+                update: vi.fn(),
+                pollForQueryCompletion: vi.fn(
+                    async ({ queryUuid }: { queryUuid: string }) => ({
+                        ...legHistory(1),
+                        queryUuid,
+                        resultsFileName: `${queryUuid}-results`,
+                    }),
+                ),
+            } as unknown as QueryHistoryModel,
+        } as never);
+        const runWarehouseQuery = vi
+            .spyOn(service, 'runAsyncWarehouseQuery')
+            .mockResolvedValue(undefined);
+
+        await (service as unknown as DuckdbQueryRunner).runDuckdbQuery(
+            baseArgs({
+                engine: { kind: 'scopedToReferencedResults' },
+                sql: 'SELECT * FROM merge_source_0 JOIN merge_source_1 USING (k)',
+                references: {
+                    kind: 'queries',
+                    references: {
+                        merge_source_0: 'leg-a',
+                        merge_source_1: 'leg-b',
+                    },
+                    guard: null,
+                },
+                columns: {
+                    mode: 'supplied',
+                    fieldsMap: {},
+                    usedParameters: null,
+                    originalColumns: {},
+                    pivotConfiguration: undefined,
+                },
+            }),
+        );
+
+        expect(createExecutionWarehouseClient).toHaveBeenCalledTimes(1);
+        expect(createExecutionWarehouseClient).toHaveBeenCalledWith({
+            storage: 'results',
+            scope: [
+                's3://results-bucket/leg-a-results.jsonl',
+                's3://results-bucket/leg-b-results.jsonl',
+            ],
+        });
+        expect(runWarehouseQuery).toHaveBeenCalledTimes(1);
+        expect(runWarehouseQuery.mock.calls[0][0].warehouseClientOverride).toBe(
+            warehouseClientMock,
         );
     });
 
@@ -6125,7 +6186,7 @@ describe('runDuckdbQuery', () => {
 
         await run(
             baseArgs({
-                warehouseClient,
+                engine: { kind: 'client', warehouseClient },
                 references: {
                     kind: 'queries',
                     references: { orders: 'leg-uuid' },

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -286,9 +286,11 @@ import {
     ExecuteAsyncSqlQueryArgs,
     isExecuteAsyncDashboardSqlChartByUuid,
     isExecuteAsyncSqlChartByUuid,
+    type BoundDuckdbQueryReferences,
     type CommonAsyncQueryArgs,
     type DownloadAsyncQueryResultsArgs,
     type DuckdbQueryColumns,
+    type DuckdbQueryEngine,
     type DuckdbQueryReferences,
     type ExecuteAsyncComposeSqlQueryArgs,
     type ExecuteAsyncDashboardChartQueryArgs,
@@ -7325,12 +7327,13 @@ export class AsyncQueryService extends ProjectService {
     /**
      * Builds one CTE per completed reference so the user SQL can select from
      * semantically-named tables: {"orders": "<queryUuid>"} exposes that
-     * query's results as `orders`.
+     * query's results as `orders`. Also returns the result file each CTE
+     * reads, which is the whole of what a scoped session may reach.
      */
     private buildQueryReferenceCtes(
         queryHistoryByTableName: Record<string, QueryHistory>,
-    ): string[] {
-        return Object.entries(queryHistoryByTableName).map(
+    ): BoundDuckdbQueryReferences {
+        const bound = Object.entries(queryHistoryByTableName).map(
             ([tableName, queryHistory]) => {
                 if (
                     queryHistory.resultsExpiresAt &&
@@ -7356,16 +7359,24 @@ export class AsyncQueryService extends ProjectService {
                 const key = S3ResultsFileStorageClient.sanitizeFileExtension(
                     queryHistory.resultsFileName,
                 );
+                const resultFileUri = `s3://${bucket}/${key}`;
                 const table = getJsonlSqlTable(
-                    `s3://${bucket}/${key}`,
+                    resultFileUri,
                     queryHistory.columns,
                 );
 
-                return `${quoteDuckdbIdentifier(
-                    tableName,
-                )} AS (SELECT * FROM ${table})`;
+                return {
+                    referenceCte: `${quoteDuckdbIdentifier(
+                        tableName,
+                    )} AS (SELECT * FROM ${table})`,
+                    resultFileUri,
+                };
             },
         );
+        return {
+            referenceCtes: bound.map(({ referenceCte }) => referenceCte),
+            resultFileUris: bound.map(({ resultFileUri }) => resultFileUri),
+        };
     }
 
     /**
@@ -7456,6 +7467,7 @@ export class AsyncQueryService extends ProjectService {
         const warehouseClient =
             this.composeEngineClient.createExecutionWarehouseClient({
                 storage: 'results',
+                scope: null,
             });
 
         const combinedParameters = await this.combineParameters(
@@ -7554,7 +7566,7 @@ export class AsyncQueryService extends ProjectService {
                 parameters: combinedParameters,
             },
             storedCompiledSql: null,
-            warehouseClient,
+            engine: { kind: 'client', warehouseClient },
             queryTags,
             queryCreatedAt,
             cacheKey,
@@ -7792,7 +7804,7 @@ export class AsyncQueryService extends ProjectService {
             },
             // Only persist the user SQL; resolved SQL contains private URIs.
             storedCompiledSql: sql,
-            warehouseClient,
+            engine: { kind: 'client', warehouseClient },
             queryTags,
             queryCreatedAt,
             cacheKey,
@@ -7860,21 +7872,25 @@ export class AsyncQueryService extends ProjectService {
         references,
         columns,
         storedCompiledSql,
-        warehouseClient,
+        engine,
         queryTags,
         queryCreatedAt,
         cacheKey,
         context,
     }: RunDuckdbQueryArgs): Promise<void> {
         try {
-            const referenceCtes = await this.bindDuckdbQueryReferences({
+            const bound = await this.bindDuckdbQueryReferences({
                 account,
                 projectUuid,
                 references,
             });
+            const warehouseClient = this.resolveDuckdbQueryEngine(
+                engine,
+                bound,
+            );
             const resolvedSql = AsyncQueryService.wrapSqlWithReferenceCtes(
                 sql,
-                referenceCtes,
+                bound.referenceCtes,
             );
             const execution = await this.resolveDuckdbQueryColumns({
                 resolvedSql,
@@ -7942,6 +7958,28 @@ export class AsyncQueryService extends ProjectService {
     }
 
     /**
+     * The session a DuckDB query runs on. A scoped session is built only
+     * once the references are bound, because the result files it may reach
+     * are not known before the referenced queries complete.
+     */
+    private resolveDuckdbQueryEngine(
+        engine: DuckdbQueryEngine,
+        bound: BoundDuckdbQueryReferences,
+    ): WarehouseClient {
+        switch (engine.kind) {
+            case 'client':
+                return engine.warehouseClient;
+            case 'scopedToReferencedResults':
+                return this.composeEngineClient.createExecutionWarehouseClient({
+                    storage: 'results',
+                    scope: bound.resultFileUris,
+                });
+            default:
+                return assertUnreachable(engine, 'Unknown DuckDB query engine');
+        }
+    }
+
+    /**
      * Resolves a query's references to the CTEs that expose them. Referenced
      * queries are waited on, then the guard runs before anything is built,
      * so a refusal never costs an execution.
@@ -7954,10 +7992,13 @@ export class AsyncQueryService extends ProjectService {
         account: Account;
         projectUuid: string;
         references: DuckdbQueryReferences;
-    }): Promise<string[]> {
+    }): Promise<BoundDuckdbQueryReferences> {
         switch (references.kind) {
             case 'bound':
-                return references.referenceCtes;
+                return {
+                    referenceCtes: references.referenceCtes,
+                    resultFileUris: [],
+                };
             case 'queries': {
                 const completed = await this.waitForQueryReferences({
                     account,
@@ -8531,10 +8572,12 @@ export class AsyncQueryService extends ProjectService {
         if (!enabled) return null;
 
         // Throws MissingConfigError when results storage is not configured:
-        // a merge without an engine is refused, never silently downgraded
+        // a merge without an engine is refused, never silently downgraded.
+        // Dialect only: execution runs on a session scoped to the leg files
         const warehouseClient =
             this.composeEngineClient.createExecutionWarehouseClient({
                 storage: 'results',
+                scope: null,
             });
 
         const projectSummary = await this.projectModel.getSummary(projectUuid);
@@ -8763,7 +8806,9 @@ export class AsyncQueryService extends ProjectService {
                         pivotConfiguration,
                     },
                     storedCompiledSql: null,
-                    warehouseClient,
+                    // A merge calculation is user SQL: it runs on a session
+                    // that reaches only the leg files it joins
+                    engine: { kind: 'scopedToReferencedResults' },
                     queryTags,
                     queryCreatedAt,
                     cacheKey,

--- a/packages/backend/src/services/AsyncQueryService/ComposeEngineClient.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/ComposeEngineClient.test.ts
@@ -84,9 +84,11 @@ describe('ComposeEngineClient', () => {
 
         const first = client.createExecutionWarehouseClient({
             storage: 'results',
+            scope: null,
         });
         const second = client.createExecutionWarehouseClient({
             storage: 'results',
+            scope: null,
         });
 
         expect(first).toBe(warehouseClientMock);
@@ -107,7 +109,10 @@ describe('ComposeEngineClient', () => {
             createDuckdbWarehouseClient,
         });
 
-        client.createExecutionWarehouseClient({ storage: 'results' });
+        client.createExecutionWarehouseClient({
+            storage: 'results',
+            scope: null,
+        });
 
         expect(createDuckdbWarehouseClient).toHaveBeenCalledWith(
             expect.objectContaining({
@@ -135,6 +140,7 @@ describe('ComposeEngineClient', () => {
         });
         const results = client.createExecutionWarehouseClient({
             storage: 'results',
+            scope: null,
         });
 
         expect(second).toBe(first);
@@ -171,12 +177,66 @@ describe('ComposeEngineClient', () => {
 
         expect(createDuckdbWarehouseClient).toHaveBeenCalledTimes(2);
         expect(createDuckdbWarehouseClient).toHaveBeenCalledWith({
-            s3Config: { ...preAggregateSession, scope },
+            s3Config: { ...preAggregateSession, scope: [scope] },
             resourceLimits: { memoryLimit: '512MB', threads: 2 },
             organizationConcurrencyLimit:
                 withPreAggregateBucket.externalSources
                     .maxConcurrentDuckdbQueriesPerOrganization,
         });
+    });
+
+    test('a results session scoped to leg files is isolated, never cached and reaches no other result file', () => {
+        const createDuckdbWarehouseClient = vi.fn(() => warehouseClientMock);
+        const client = new ComposeEngineClient({
+            resolveCaCertFile,
+            lightdashConfig: withPreAggregateBucket,
+            createDuckdbWarehouseClient,
+        });
+        const legFiles = [
+            's3://results-bucket/leg-a.jsonl',
+            's3://results-bucket/leg-b.jsonl',
+        ];
+        const foreignResultFile = 's3://results-bucket/someone-else.jsonl';
+
+        client.createExecutionWarehouseClient({
+            storage: 'results',
+            scope: legFiles,
+        });
+        client.createExecutionWarehouseClient({
+            storage: 'results',
+            scope: legFiles,
+        });
+
+        expect(createDuckdbWarehouseClient).toHaveBeenCalledTimes(2);
+        expect(createDuckdbWarehouseClient).toHaveBeenCalledWith({
+            s3Config: { ...resultsSession, scope: legFiles },
+            resourceLimits: { memoryLimit: '512MB', threads: 2 },
+            organizationConcurrencyLimit: undefined,
+        });
+        expect(createDuckdbWarehouseClient).not.toHaveBeenCalledWith(
+            expect.objectContaining({
+                s3Config: expect.objectContaining({
+                    scope: expect.arrayContaining([foreignResultFile]),
+                }),
+            }),
+        );
+    });
+
+    test('refuses a results session scoped to nothing rather than widening it', () => {
+        const createDuckdbWarehouseClient = vi.fn(() => warehouseClientMock);
+        const client = new ComposeEngineClient({
+            resolveCaCertFile,
+            lightdashConfig: ossConfig,
+            createDuckdbWarehouseClient,
+        });
+
+        expect(() =>
+            client.createExecutionWarehouseClient({
+                storage: 'results',
+                scope: [],
+            }),
+        ).toThrow('A scoped compose engine session needs at least one URI');
+        expect(createDuckdbWarehouseClient).not.toHaveBeenCalled();
     });
 
     test('creates a real DuckDB client that may read result files', () => {
@@ -191,6 +251,7 @@ describe('ComposeEngineClient', () => {
 
         const warehouseClient = client.createExecutionWarehouseClient({
             storage: 'results',
+            scope: null,
         });
 
         expect(warehouseClient).toBeInstanceOf(DuckdbWarehouseClient);
@@ -217,7 +278,10 @@ describe('ComposeEngineClient', () => {
             createDuckdbWarehouseClient,
         });
 
-        client.createExecutionWarehouseClient({ storage: 'results' });
+        client.createExecutionWarehouseClient({
+            storage: 'results',
+            scope: null,
+        });
 
         expect(createDuckdbWarehouseClient).toHaveBeenCalledWith(
             expect.objectContaining({
@@ -238,7 +302,10 @@ describe('ComposeEngineClient', () => {
         });
 
         expect(() =>
-            client.createExecutionWarehouseClient({ storage: 'results' }),
+            client.createExecutionWarehouseClient({
+                storage: 'results',
+                scope: null,
+            }),
         ).toThrow(
             new MissingConfigError(
                 COMPOSE_ENGINE_MISSING_RESULTS_STORAGE_MESSAGE,
@@ -283,7 +350,10 @@ describe('ComposeEngineClient', () => {
         });
 
         expect(() =>
-            client.createExecutionWarehouseClient({ storage: 'results' }),
+            client.createExecutionWarehouseClient({
+                storage: 'results',
+                scope: null,
+            }),
         ).toThrow(
             new MissingConfigError(COMPOSE_ENGINE_MISSING_CA_BUNDLE_MESSAGE),
         );

--- a/packages/backend/src/services/AsyncQueryService/ComposeEngineClient.ts
+++ b/packages/backend/src/services/AsyncQueryService/ComposeEngineClient.ts
@@ -39,10 +39,11 @@ const SCOPED_SESSION_RESOURCE_LIMITS: DuckdbResourceLimits = {
  * Which S3 config owns the files a session reads. The DuckDB secret pins one
  * endpoint and region, so a session must be built from the config of the
  * bucket it reads: results storage for result files, the pre-aggregates
- * bucket for external-source files.
+ * bucket for external-source files. A scope limits the secret to the URIs
+ * the query is allowed to read; null is the shared warm instance.
  */
 export type ComposeEngineSession =
-    | { storage: 'results' }
+    | { storage: 'results'; scope: string[] | null }
     | { storage: 'externalSources'; scope: string | null };
 
 type ComposeEngineStorage = ComposeEngineSession['storage'];
@@ -181,25 +182,50 @@ export class ComposeEngineClient {
         }
     }
 
+    private static getSessionScope(
+        session: ComposeEngineSession,
+    ): string[] | null {
+        switch (session.storage) {
+            case 'results':
+                return session.scope;
+            case 'externalSources':
+                return session.scope === null ? null : [session.scope];
+            default:
+                return assertUnreachable(
+                    session,
+                    'Unknown compose engine storage',
+                );
+        }
+    }
+
     /**
      * A warehouse client on the compose engine for the given session. A
      * session without a scope is the shared warm instance of its storage; a
      * scoped one is an isolated, resource-limited session whose S3 secret
-     * only reaches that URI, and it is never cached.
+     * only reaches those URIs, and it is never cached.
      */
     createExecutionWarehouseClient(
         session: ComposeEngineSession,
     ): WarehouseClient {
         const s3Config = this.getSessionConfig(session.storage);
+        const scope = ComposeEngineClient.getSessionScope(session);
 
-        if (session.storage === 'externalSources' && session.scope !== null) {
+        if (scope !== null) {
+            if (scope.length === 0) {
+                throw new Error(
+                    'A scoped compose engine session needs at least one URI',
+                );
+            }
             return this.createDuckdbWarehouseClient({
-                s3Config: { ...s3Config, scope: session.scope },
+                s3Config: { ...s3Config, scope },
                 resourceLimits:
                     this.sharedResourceLimits ?? SCOPED_SESSION_RESOURCE_LIMITS,
+                // Only external sources carry a per-organization cap today
                 organizationConcurrencyLimit:
-                    this.lightdashConfig.externalSources
-                        .maxConcurrentDuckdbQueriesPerOrganization,
+                    session.storage === 'externalSources'
+                        ? this.lightdashConfig.externalSources
+                              .maxConcurrentDuckdbQueriesPerOrganization
+                        : undefined,
             });
         }
 

--- a/packages/backend/src/services/AsyncQueryService/types.ts
+++ b/packages/backend/src/services/AsyncQueryService/types.ts
@@ -334,6 +334,20 @@ export type DuckdbQueryReferences =
           guard: DuckdbQueryReferenceGuard | null;
       };
 
+/** Which compose engine session executes a DuckDB query. */
+export type DuckdbQueryEngine =
+    | { kind: 'client'; warehouseClient: WarehouseClient }
+    | {
+          /** An isolated results session whose credentials reach only the bound result files. */
+          kind: 'scopedToReferencedResults';
+      };
+
+/** A query's references, bound: the CTEs to attach and the result files they read. */
+export type BoundDuckdbQueryReferences = {
+    referenceCtes: string[];
+    resultFileUris: string[];
+};
+
 export type RunDuckdbQueryArgs = {
     account: Account;
     projectUuid: string;
@@ -347,7 +361,7 @@ export type RunDuckdbQueryArgs = {
     columns: DuckdbQueryColumns;
     /** Persisted instead of the executed SQL when that carries private URIs. */
     storedCompiledSql: string | null;
-    warehouseClient: WarehouseClient;
+    engine: DuckdbQueryEngine;
     queryTags: RunQueryTags;
     queryCreatedAt: Date;
     cacheKey: string;

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -5360,6 +5360,112 @@ describe('ProjectService', () => {
                 }),
             );
         });
+
+        describe('merge calculation SQL authorization', () => {
+            const withAbility = (
+                rules: ConstructorParameters<
+                    typeof Ability<PossibleAbilities>
+                >[0],
+            ) =>
+                ({
+                    ...sessionAccount,
+                    user: {
+                        ...sessionAccount.user,
+                        ability: new Ability<PossibleAbilities>(rules),
+                    },
+                }) as typeof sessionAccount;
+            const viewer = withAbility([
+                { subject: 'Project', action: 'view' },
+                { subject: 'Explore', action: 'view' },
+                { subject: 'Space', action: 'view' },
+            ]);
+            const author = withAbility([
+                { subject: 'Project', action: 'view' },
+                { subject: 'Explore', action: 'view' },
+                { subject: 'Space', action: 'view' },
+                { subject: 'CustomSqlTableCalculations', action: 'manage' },
+            ]);
+            const subqueryCalculation = {
+                name: 'leak',
+                displayName: 'Leak',
+                sql: '${a.a_met1} + (SELECT count(*) FROM information_schema.tables)',
+            };
+
+            test('refuses a viewer merge calculation with the custom SQL gate error', async () => {
+                await expect(
+                    service.compileMergeQuery({
+                        account: viewer,
+                        projectUuid,
+                        mergeQuery: mergeQuery({
+                            tableCalculations: [subqueryCalculation],
+                        }),
+                    }),
+                ).rejects.toThrow(ForbiddenError);
+            });
+
+            test('compiles the same calculation for an account allowed to author custom SQL', async () => {
+                const result = await service.compileMergeQuery({
+                    account: author,
+                    projectUuid,
+                    mergeQuery: mergeQuery({
+                        tableCalculations: [subqueryCalculation],
+                    }),
+                });
+
+                expect(result.errors).toEqual([]);
+                expect(result.sql).toContain('information_schema.tables');
+            });
+
+            test('a viewer merge without calculations still compiles', async () => {
+                const result = await service.compileMergeQuery({
+                    account: viewer,
+                    projectUuid,
+                    mergeQuery: mergeQuery(),
+                });
+
+                expect(result.errors).toEqual([]);
+                expect(result.sql).not.toBeNull();
+            });
+
+            test('gates only the merge-level calculations; source calculations are gated by their own compile', async () => {
+                const gate = vi.spyOn(
+                    service as unknown as {
+                        assertCustomSqlAuthorizedForQuery: (args: {
+                            metricQuery: {
+                                tableCalculations: { name: string }[];
+                            };
+                        }) => Promise<void>;
+                    },
+                    'assertCustomSqlAuthorizedForQuery',
+                );
+                const sourceCalculation = {
+                    name: 'ratio',
+                    displayName: 'Ratio',
+                    sql: '${a.met1} * 2',
+                };
+
+                await service.compileMergeQuery({
+                    account: author,
+                    projectUuid,
+                    mergeQuery: mergeQuery({
+                        sources: [
+                            source('a', [sourceCalculation]),
+                            source('b'),
+                        ],
+                        tableCalculations: [subqueryCalculation],
+                    }),
+                });
+
+                const gatedCalculations = gate.mock.calls.map(([args]) =>
+                    args.metricQuery.tableCalculations.map((tc) => tc.name),
+                );
+                expect(gatedCalculations).toContainEqual(['leak']);
+                expect(gatedCalculations).toContainEqual(['ratio']);
+                expect(gatedCalculations).not.toContainEqual(['ratio', 'leak']);
+                expect(gatedCalculations).not.toContainEqual(['leak', 'ratio']);
+                gate.mockRestore();
+            });
+        });
     });
 });
 

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -5969,6 +5969,24 @@ export class ProjectService extends BaseService {
             };
         }
 
+        // Merge calculations are user SQL, so they pass the custom SQL gate;
+        // each source's own calculations are gated by that source's compile
+        if (mergeQuery.tableCalculations.length > 0) {
+            const { organizationUuid } =
+                await this.projectModel.getSummary(projectUuid);
+            await this.assertCustomSqlAuthorizedForQuery({
+                account,
+                projectUuid,
+                organizationUuid,
+                exploreName: resolvedSources[0].metricQuery.exploreName,
+                metricQuery: {
+                    tableCalculations: mergeQuery.tableCalculations,
+                    customDimensions: [],
+                    additionalMetrics: [],
+                },
+            });
+        }
+
         const warehouseCredentials =
             await this.projectModel.getWarehouseCredentialsForProject(
                 projectUuid,

--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
@@ -905,8 +905,10 @@ describe('DuckdbWarehouseClient', () => {
                 runMock,
             ),
         );
-        const scope =
-            's3://bucket/external-sources/project/source/table/v1.parquet';
+        const scope = [
+            's3://bucket/external-sources/project/source/table/v1.parquet',
+            's3://bucket/external-sources/project/source/table/v2.parquet',
+        ];
         const client = DuckdbWarehouseClient.createForPreAggregate({
             type: 'duckdb_s3',
             s3Config: {
@@ -924,7 +926,7 @@ describe('DuckdbWarehouseClient', () => {
             .find((sql) =>
                 sql.includes('CREATE OR REPLACE SECRET __lightdash_s3'),
             );
-        expect(secretSql).toContain(`SCOPE '${scope}'`);
+        expect(secretSql).toContain(`SCOPE ('${scope[0]}', '${scope[1]}')`);
     });
 
     it('caps isolated S3 queries per organization', async () => {
@@ -950,7 +952,7 @@ describe('DuckdbWarehouseClient', () => {
                         endpoint: 's3.amazonaws.com',
                         forcePathStyle: false,
                         useSsl: true,
-                        scope: 's3://bucket/external-sources/object.parquet',
+                        scope: ['s3://bucket/external-sources/object.parquet'],
                     },
                 },
                 {

--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
@@ -104,8 +104,8 @@ export type DuckdbS3SessionConfig = {
     secretKey?: string;
     forcePathStyle: boolean;
     useSsl: boolean;
-    /** Limit this DuckDB secret to one trusted S3 URI or prefix. */
-    scope?: string;
+    /** Limit this DuckDB secret to trusted S3 URIs or prefixes. */
+    scope?: string[];
     /** PEM bundle httpfs verifies HTTPS object storage with. */
     caCertFile?: string;
 };
@@ -1350,7 +1350,9 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
             ? `SECRET '${escape(s3Config.secretKey)}',`
             : '';
         const scopeClause = s3Config.scope
-            ? `SCOPE '${escape(s3Config.scope)}',`
+            ? `SCOPE (${s3Config.scope
+                  .map((uri) => `'${escape(uri)}'`)
+                  .join(', ')}),`
             : '';
 
         return `CREATE OR REPLACE SECRET __lightdash_s3 (


### PR DESCRIPTION
## What

User-authored SQL in a merge now goes through the same authorization gate as every other custom-SQL path, the v1 merge routes require a registered account, and the compose engine executes a merge on a storage session scoped to the leg files it joins. Three parts, each proven by a test.

### 1. Merge table calculations pass the shared custom-SQL gate

Merge compilation validated only that a calculation's `${source.field}` references resolved. It never ran the calculation through `assertCustomSqlAuthorizedForQuery`, the check every ordinary query applies to SQL table calculations, custom dimensions and custom metrics. So an account that may build a merge could put arbitrary SQL into the merged statement without holding the `CustomSqlTableCalculations` scope.

`ProjectService.compileMergeQuery` now calls the shared gate on the merge-level calculations once the merge has passed structural validation and before any SQL is built. The refusal is the gate's own `ForbiddenError`, not a new merge refusal kind. Source-level table calculations are not gated a second time: they already go through `compileQuery` per source, which applies the gate.

Where the gate's semantics did not quite fit: the gate keys its saved-chart provenance exemption on an explore name, and a merged result is not an explore. The gate runs against the first source's explore. In practice merge calculations are stored in the merge definition, not in the per-chart table-calculation table the exemption reads, so the exemption rarely applies; the ability check is what decides.

Proof: `ProjectService.test.ts` > `compileMergeQuery` > `merge calculation SQL authorization`. A viewer-level account with a scalar-subquery calculation is refused with `ForbiddenError`; the same calculation compiles for an account holding the scope; a viewer merge without calculations still compiles; and a spy on the gate shows merge-level and source-level calculations arrive in separate calls, never together.

### 2. The v1 merge routes assert a registered account

`POST /projects/{uuid}/mergeQuery/compile` and `/run` used `req.account!` and never asserted registration, so embed JWTs could reach them. Both now call `assertRegisteredAccount(req.account)` exactly as the two v2 merge routes do.

Proof: `projectController.test.ts` > `ProjectController merge routes`. An anonymous JWT account gets `ForbiddenError` on both routes before the service is called; a registered account is forwarded to the service.

### 3. The engine session for a merge is scoped to its leg files

A merge ran on the shared results session, whose DuckDB S3 secret reached the whole results bucket while user SQL executed. The scope parameter the external-source path already uses is now applied to merges: `runDuckdbQuery` binds the leg references first, then builds an isolated, uncached session whose secret names exactly the bound result files. Nothing else in the bucket is reachable from that session.

Two supporting changes: `DuckdbS3SessionConfig.scope` becomes a list of URIs (DuckDB's `SCOPE` accepts a list) so a session can name both legs, and `ComposeEngineSession` gains a `scope` on the results session. A scoped results session refuses an empty scope rather than widening to the bucket. The per-organization concurrency cap stays external-source only; merges gain the isolated session's resource limits but no new refusal path.

Proof:
- `ComposeEngineClient.test.ts`: a results session scoped to two leg files is built with `scope: [legA, legB]`, is isolated (no instance cache key), is never cached, and is never built with a foreign result URI in scope. An empty scope is refused.
- `AsyncQueryService.test.ts` > `runDuckdbQuery`: a `scopedToReferencedResults` engine binds two legs and asks the engine client for `{ storage: 'results', scope: [<leg-a file>, <leg-b file>] }`, and the returned client is the one the query executes on.
- `DuckdbWarehouseClient.test.ts`: the secret DDL emits `SCOPE ('a', 'b')`.

I verified the DuckDB semantics by hand on the pinned engine (1.5.2): a secret with `SCOPE (legA, legB)` answers `which_secret(legA)` and `which_secret(legB)` with that secret and `which_secret(other)` with nothing. I did not add that as a test: the s3 secret type needs the httpfs extension, which the in-memory harness cannot load without a network install, and the client hardens instances with auto-install off.

## Regression notes

- Ordinary merges: no change for accounts that may author custom SQL, and no change for merges without merge-level calculations (the gate returns early on an empty list). A viewer who previously ran a merge with a merge-level calculation and no `CustomSqlTableCalculations` scope is now refused, which is the intended behaviour and matches what happens to the same calculation on a single query.
- Ordinary custom SQL: the gate itself is unchanged; it gains one more caller.
- Compose SQL runner and external SQL: still run on the sessions they used before (`engine: { kind: 'client' }`); the only behavioural change is the engine argument shape.
- External sources: the single-object scope is wrapped in a one-element list; the emitted secret is `SCOPE ('uri')`.
- Merges now pay an isolated DuckDB session per execution instead of sharing the warm results instance, the same cost the external-source path already pays.

Closes: PROD-10899

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvtHaH3fbzSX2ebMgfFKFS
