### PR TITLE
fix(table-calculation): guard tiptap editor effects against a destroyed instance

### DIFF
--- a/packages/frontend/src/ee/features/ambientAi/components/tableCalculation/components/AiPromptInput/AiPromptEditor.test.tsx
+++ b/packages/frontend/src/ee/features/ambientAi/components/tableCalculation/components/AiPromptInput/AiPromptEditor.test.tsx
@@ -1,0 +1,87 @@
+import {
+    DimensionType,
+    FieldType,
+    SupportedDbtAdapter,
+    type Explore,
+    type MetricQuery,
+} from '@lightdash/common';
+import type * as TiptapReact from '@tiptap/react';
+import { useState } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../../../../../testing/testUtils';
+import { AiPromptEditor } from './AiPromptEditor';
+
+// tiptap v3's useEditor arms a 1ms self-destruct timer at construction that is
+// only cancelled once the component's effects commit. When the commit lands
+// late the effects run against an already-destroyed instance, so hand the
+// component exactly that: a real Editor that has been destroyed.
+vi.mock('@tiptap/react', async (importOriginal) => {
+    const actual = await importOriginal<typeof TiptapReact>();
+    const useDestroyedEditor: typeof actual.useEditor = (options) => {
+        const [editor] = useState(() => {
+            const instance = new actual.Editor(options);
+            instance.destroy();
+            return instance;
+        });
+        return editor;
+    };
+    return { ...actual, useEditor: useDestroyedEditor };
+});
+
+const explore: Explore = {
+    name: 'orders',
+    label: 'Orders',
+    tags: [],
+    baseTable: 'orders',
+    joinedTables: [],
+    tables: {
+        orders: {
+            name: 'orders',
+            label: 'Orders',
+            database: '',
+            schema: '',
+            sqlTable: 'orders',
+            dimensions: {
+                status: {
+                    compiledSql: '',
+                    tablesReferences: [],
+                    fieldType: FieldType.DIMENSION,
+                    type: DimensionType.STRING,
+                    name: 'status',
+                    label: 'Status',
+                    table: 'orders',
+                    tableLabel: 'Orders',
+                    sql: '',
+                    hidden: false,
+                },
+            },
+            metrics: {},
+            lineageGraph: {},
+        },
+    },
+    targetDatabase: SupportedDbtAdapter.POSTGRES,
+};
+
+const metricQuery: MetricQuery = {
+    exploreName: 'orders',
+    dimensions: ['orders_status'],
+    metrics: [],
+    filters: {},
+    sorts: [],
+    limit: 500,
+    tableCalculations: [],
+};
+
+describe('AiPromptEditor', () => {
+    it('renders when the editor was destroyed before effects committed', () => {
+        expect(() =>
+            renderWithProviders(
+                <AiPromptEditor
+                    explore={explore}
+                    metricQuery={metricQuery}
+                    shouldClear
+                />,
+            ),
+        ).not.toThrow();
+    });
+});

--- a/packages/frontend/src/ee/features/ambientAi/components/tableCalculation/components/AiPromptInput/AiPromptEditor.tsx
+++ b/packages/frontend/src/ee/features/ambientAi/components/tableCalculation/components/AiPromptInput/AiPromptEditor.tsx
@@ -155,7 +155,7 @@ export const AiPromptEditor: FC<Props> = ({
 
     // Clear editor when shouldClear changes to true
     useEffect(() => {
-        if (shouldClear && editor) {
+        if (shouldClear && editor && !editor.isDestroyed) {
             editor.commands.clearContent();
             onCleared?.();
         }
@@ -163,7 +163,7 @@ export const AiPromptEditor: FC<Props> = ({
 
     // Update suggestions when fields change
     useEffect(() => {
-        if (editor && fieldSuggestions.length > 0) {
+        if (editor && !editor.isDestroyed && fieldSuggestions.length > 0) {
             // Update the mention extension's suggestion config
             editor.extensionManager.extensions.forEach((ext) => {
                 if (ext.name === 'mention') {

--- a/packages/frontend/src/features/tableCalculation/components/FormulaForm/FormulaEditor.test.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/FormulaForm/FormulaEditor.test.tsx
@@ -1,0 +1,89 @@
+import {
+    DimensionType,
+    FieldType,
+    SupportedDbtAdapter,
+    type Explore,
+    type MetricQuery,
+} from '@lightdash/common';
+import type * as TiptapReact from '@tiptap/react';
+import { useState } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../../testing/testUtils';
+import { FormulaEditor } from './FormulaEditor';
+
+// tiptap v3's useEditor arms a 1ms self-destruct timer at construction that is
+// only cancelled once the component's effects commit. When the commit lands
+// late the effects run against an already-destroyed instance, so hand the
+// component exactly that: a real Editor that has been destroyed.
+vi.mock('@tiptap/react', async (importOriginal) => {
+    const actual = await importOriginal<typeof TiptapReact>();
+    const useDestroyedEditor: typeof actual.useEditor = (options) => {
+        const [editor] = useState(() => {
+            const instance = new actual.Editor(options);
+            instance.destroy();
+            return instance;
+        });
+        return editor;
+    };
+    return { ...actual, useEditor: useDestroyedEditor };
+});
+
+const explore: Explore = {
+    name: 'orders',
+    label: 'Orders',
+    tags: [],
+    baseTable: 'orders',
+    joinedTables: [],
+    tables: {
+        orders: {
+            name: 'orders',
+            label: 'Orders',
+            database: '',
+            schema: '',
+            sqlTable: 'orders',
+            dimensions: {
+                status: {
+                    compiledSql: '',
+                    tablesReferences: [],
+                    fieldType: FieldType.DIMENSION,
+                    type: DimensionType.STRING,
+                    name: 'status',
+                    label: 'Status',
+                    table: 'orders',
+                    tableLabel: 'Orders',
+                    sql: '',
+                    hidden: false,
+                },
+            },
+            metrics: {},
+            lineageGraph: {},
+        },
+    },
+    targetDatabase: SupportedDbtAdapter.POSTGRES,
+};
+
+const metricQuery: MetricQuery = {
+    exploreName: 'orders',
+    dimensions: ['orders_status'],
+    metrics: [],
+    filters: {},
+    sorts: [],
+    limit: 500,
+    tableCalculations: [],
+};
+
+describe('FormulaEditor', () => {
+    it('renders when the editor was destroyed before effects committed', () => {
+        expect(() =>
+            renderWithProviders(
+                <FormulaEditor
+                    explore={explore}
+                    metricQuery={metricQuery}
+                    initialContent="1 + 1"
+                    referenceOpened={false}
+                    onReferenceToggle={() => {}}
+                />,
+            ),
+        ).not.toThrow();
+    });
+});

--- a/packages/frontend/src/features/tableCalculation/components/FormulaForm/FormulaEditor.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/FormulaForm/FormulaEditor.tsx
@@ -349,7 +349,8 @@ export const FormulaEditor: FC<Props> = ({
     }, [editor, editorRef]);
 
     useEffect(() => {
-        if (!editor || initialContent === undefined) return;
+        if (!editor || editor.isDestroyed || initialContent === undefined)
+            return;
         if (editor.getText() === initialContent) return;
         editor.commands.setContent(
             buildInitialContent(initialContent, fieldSuggestions),
@@ -358,7 +359,7 @@ export const FormulaEditor: FC<Props> = ({
     }, [editor, initialContent, fieldSuggestions]);
 
     useEffect(() => {
-        if (editor && fieldSuggestions.length > 0) {
+        if (editor && !editor.isDestroyed && fieldSuggestions.length > 0) {
             editor.extensionManager.extensions.forEach((ext) => {
                 if (ext.name === 'mention') {
                     ext.options.suggestion =


### PR DESCRIPTION
## Problem

Opening a table calculation in SQL mode with at least one field selected crashes the app to the "Something went wrong" boundary on any instance where the ambient AI slot renders:

```
TypeError: Cannot read properties of null (reading 'extensions')
    at AiPromptEditor.tsx:168
```

Regression from the `@tiptap` v2 → v3 bump in #28535.

## Root cause

Confirmed against the installed `@tiptap/react` and `@tiptap/core` 3.30.5 source:

- `useEditor` constructs the `Editor` during render and immediately arms a 1 ms self-destruct timer (`EditorInstanceManager.scheduleDestroy`). The timer is only cancelled when the component's effects commit.
- When the table calculation modal commits later than 1 ms, the timer fires first and destroys the instance. v3's `Editor.destroy()` now nulls `extensionManager`, `schema` and `commandManager` (v2 did not).
- The component's `useEffect`s in that same commit closed over the destroyed instance. Any of them that touches `extensionManager`, `commands` or `getText()` (which reads `schema`) dereferences null and throws.

The instance manager recreates the editor straight away and the store re-renders, so the effects re-run against the live instance. Skipping them on a destroyed instance loses nothing.

## Fix

Guard the affected effects with `editor.isDestroyed` in both editors that share this pattern:

- `AiPromptEditor`: the field-suggestion effect (the reported crash) and the `shouldClear` effect (`editor.commands` is null on a destroyed instance).
- `FormulaEditor`: the field-suggestion effect and the `initialContent` effect (`editor.getText()` reads the nulled `schema`).

The `registerPlugin` and `view.dispatch` effects in `FormulaEditor` are not guarded because tiptap falls back to a proxy view for an unmounted editor and `unregisterPlugin` already checks `isDestroyed` itself, so they do not throw.

## Regression analysis

- The guards only skip work on an instance that tiptap has already thrown away. The re-render with the fresh instance changes the `editor` dependency, so every guarded effect re-runs on the live editor. No suggestion, clear, or initial-content update is lost.
- `AiPromptEditor` is also rendered by the custom dimension AI input and the "Improve with AI" slot in the formula form. Both go through the same effects and can only benefit from the guard.
- No behaviour change on the happy path where effects commit before the timer fires: `isDestroyed` is false there and the code is unchanged.

## Tests

Added a unit test per editor that mocks `useEditor` to return a real `Editor` that has already been destroyed, which is exactly the state the timer leaves behind, and asserts the component renders. Both tests fail on `main` without the guards:

```
TypeError: Cannot read properties of null (reading 'commands')   # AiPromptEditor
TypeError: Cannot read properties of null (reading 'nodes')      # FormulaEditor (getText → schema)
```

and pass with them. Frontend lint, format, and typecheck are green.

Closes: #28651

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016omRrQdpR5xZFiCvF9PWwi
