### PR TITLE
fix(compose): bind referenced results with a typed read so values keep their precision

### DIFF
--- a/docs/merge-queries/architecture.md
+++ b/docs/merge-queries/architecture.md
@@ -82,14 +82,19 @@ complete, with a guard between "references complete" and "query builds" that
 carries the merge row-cap refusal. Merge is still the only caller absent from
 `QuerySourceRegistry`; the shared tail is what the DAG work plugs into.
 
-**Parquet versus JSONL is the entire fidelity story.** Ingested data is written
-as parquet and carries its own schema. Referenced query results are written as
-JSONL and must be re-typed on the way back in through a five-value map in
-`duckdbSqlTables.ts`. Every measured fidelity defect lives on the JSONL side:
-integers above 2^53 come back wrong, ISO offsets are discarded rather than
-converted, Trino named-zone timestamps error on read, and an uncastable value
-hard-errors the query with a raw engine message. This caps merges, the compose
-SQL runner and the DAG equally. It is not a merge bug.
+**Precision is lost in the drivers, not in the file format.** Ingested data is
+written as parquet and carries its own schema. Referenced query results are
+written as JSONL, which carries whatever digits the driver serialised; the
+parquet writer re-types through the same five-value map, so switching formats
+would have changed nothing. Referenced results are bound with a typed read
+(`getJsonlReferenceSelect` in `duckdbSqlTables.ts`): every column is read as
+text and cast in SQL, NUMBER by the per-column numeric kind the driver reports
+(`integer`, `decimal(scale)`, `float`), timestamps as instants unless naive,
+and an uncastable value refuses naming the column. Postgres and DuckDB report
+a kind; a column without one binds as DOUBLE. What that read cannot recover is
+what the driver already rounded: Postgres NUMERIC through `parseFloat`,
+BigQuery through `Number(toFixed)`, Snowflake without `fetchAsString`, Trino
+bigints through `JSON.parse`. Those are driver fixes, not merge bugs.
 
 ## Traps
 

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -195,7 +195,7 @@ import { wrapSentryTransaction } from '../../utils';
 import { metricQueryWithLimit as applyMetricQueryLimit } from '../../utils/csvLimitUtils';
 import {
     getDuckdbPreAggregateSqlTable,
-    getJsonlSqlTable,
+    getJsonlReferenceSelect,
     quoteDuckdbIdentifier,
 } from '../../utils/duckdb/duckdbSqlTables';
 import { getDuckdbRuntimeConfig } from '../../utils/duckdb/getDuckdbRuntimeConfig';
@@ -7360,15 +7360,13 @@ export class AsyncQueryService extends ProjectService {
                     queryHistory.resultsFileName,
                 );
                 const resultFileUri = `s3://${bucket}/${key}`;
-                const table = getJsonlSqlTable(
+                const select = getJsonlReferenceSelect(
                     resultFileUri,
                     queryHistory.columns,
                 );
 
                 return {
-                    referenceCte: `${quoteDuckdbIdentifier(
-                        tableName,
-                    )} AS (SELECT * FROM ${table})`,
+                    referenceCte: `${quoteDuckdbIdentifier(tableName)} AS (${select})`,
                     resultFileUri,
                 };
             },

--- a/packages/backend/src/services/AsyncQueryService/getUnpivotedColumns.ts
+++ b/packages/backend/src/services/AsyncQueryService/getUnpivotedColumns.ts
@@ -23,6 +23,9 @@ export function getUnpivotedColumns(
                 acc[key] = {
                     reference: key,
                     type: value.type,
+                    ...(value.numericKind
+                        ? { numericKind: value.numericKind }
+                        : {}),
                     ...getResultColumnMetadataFromItem(
                         itemsMap?.[key],
                         key,

--- a/packages/backend/src/utils/QueryBuilder/composeMergeFidelity.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/composeMergeFidelity.test.ts
@@ -5,11 +5,13 @@ import {
     MergeJoinType,
     type MergeFieldTypes,
     type ResultColumns,
+    type ResultNumericKind,
 } from '@lightdash/common';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
+    getJsonlReferenceSelect,
     getJsonlSqlTable,
     quoteDuckdbIdentifier,
     resultFieldTypeToDuckdbType,
@@ -19,10 +21,10 @@ import { applyMergeTerminalWrapper } from './MergeQueryBuilder';
 
 /**
  * Round-trips typed values through the compose engine exactly as a merge leg
- * travels: a result file on disk, bound with the read_json CTE a referenced
- * query gets, joined by the generated merge statement, read back. Cases that
- * are wrong on the JSONL path carry the correct expectation under test.fails,
- * so the parquet cutover (PROD-10894) flips them rather than leaving them red.
+ * travels: a result file on disk, bound with the typed-read CTE a referenced
+ * query gets, joined by the generated merge statement, read back. A case that
+ * is still wrong carries the correct expectation under test.fails so the fix
+ * flips it rather than leaving it red.
  */
 
 let dir: string;
@@ -54,7 +56,7 @@ const bindReference = (
     uri: string,
     columns: ResultColumns,
 ): string =>
-    `${quoteDuckdbIdentifier(tableName)} AS (SELECT * FROM ${getJsonlSqlTable(
+    `${quoteDuckdbIdentifier(tableName)} AS (${getJsonlReferenceSelect(
         uri,
         columns,
     )})`;
@@ -97,6 +99,7 @@ const keyColumn: ResultColumns = {
 const mergeRoundTrip = async (
     type: DimensionType,
     json: string,
+    numericKind?: ResultNumericKind,
 ): Promise<string | null> => {
     const legA = writeJsonl([`{"key":1,"measured":${json}}`]);
     const legB = writeJsonl(['{"key":1,"other":true}']);
@@ -119,7 +122,11 @@ const mergeRoundTrip = async (
     const referenceCtes = [
         bindReference(built.referenceTableBySourceId.a, legA, {
             ...keyColumn,
-            measured: { reference: 'measured', type },
+            measured: {
+                reference: 'measured',
+                type,
+                ...(numericKind ? { numericKind } : {}),
+            },
         }),
         bindReference(built.referenceTableBySourceId.b, legB, {
             ...keyColumn,
@@ -147,11 +154,37 @@ describe('value fidelity through the compose engine', () => {
         );
     });
 
-    // Red until PROD-10894: re-typed through DOUBLE, the value reads 9007199254740992
-    test.fails('a bigint above 2^53 round-trips unchanged', async () => {
+    test('a bigint above 2^53 round-trips unchanged when the column is integer-kinded', async () => {
+        expect(
+            await mergeRoundTrip(DimensionType.NUMBER, '9007199254740993', {
+                kind: 'integer',
+            }),
+        ).toBe('9007199254740993');
+    });
+
+    // Without a numeric kind NUMBER can only bind as DOUBLE, which reads 9007199254740992
+    test.fails('a bigint above 2^53 round-trips unchanged without a numeric kind', async () => {
         expect(
             await mergeRoundTrip(DimensionType.NUMBER, '9007199254740993'),
         ).toBe('9007199254740993');
+    });
+
+    test('a wide decimal serialised as text round-trips when the column is decimal-kinded', async () => {
+        expect(
+            await mergeRoundTrip(
+                DimensionType.NUMBER,
+                '"123456789012345678.8901"',
+                { kind: 'decimal', scale: 4 },
+            ),
+        ).toBe('123456789012345678.8901');
+    });
+
+    test('a float keeps its digits when the column is float-kinded', async () => {
+        expect(
+            await mergeRoundTrip(DimensionType.NUMBER, '3.14159265358979', {
+                kind: 'float',
+            }),
+        ).toBe('3.14159265358979');
     });
 
     test('a date round-trips', async () => {
@@ -187,8 +220,7 @@ describe('value fidelity through the compose engine', () => {
         ).toBe('2024-01-01 08:00:00');
     });
 
-    // Red until PROD-10894: the offset is discarded and the value reads 10:00:00
-    test.fails('a timestamp with a non-UTC offset lands at the correct instant', async () => {
+    test('a timestamp with a non-UTC offset lands at the correct instant', async () => {
         expect(
             await mergeRoundTrip(
                 DimensionType.TIMESTAMP,
@@ -197,8 +229,7 @@ describe('value fidelity through the compose engine', () => {
         ).toBe('2024-01-01 08:00:00');
     });
 
-    // Red until PROD-10894: read_json refuses a named zone as "not UTC"
-    test.fails('a named-zone timestamp reads without erroring', async () => {
+    test('a named-zone timestamp reads without erroring', async () => {
         expect(
             await mergeRoundTrip(
                 DimensionType.TIMESTAMP,
@@ -207,8 +238,25 @@ describe('value fidelity through the compose engine', () => {
         ).toBe('2024-01-01 00:00:00');
     });
 
-    // Red until PROD-10894: the engine's raw "JSON transform error" surfaces, naming no column
-    test.fails('an uncastable value refuses with an error naming the column', async () => {
+    test('a named-zone timestamp with a fraction, as Trino serialises it, lands at its instant', async () => {
+        expect(
+            await mergeRoundTrip(
+                DimensionType.TIMESTAMP,
+                '"2024-07-01 12:00:00.000 America/New_York"',
+            ),
+        ).toBe('2024-07-01 16:00:00');
+    });
+
+    test('a naive timestamp is read as-is whatever the session zone', async () => {
+        expect(
+            await mergeRoundTrip(
+                DimensionType.TIMESTAMP,
+                '"2024-01-01 08:00:00"',
+            ),
+        ).toBe('2024-01-01 08:00:00');
+    });
+
+    test('an uncastable value refuses with an error naming the column', async () => {
         const message = await mergeRoundTrip(
             DimensionType.NUMBER,
             '"not a number"',
@@ -222,9 +270,8 @@ describe('value fidelity through the compose engine', () => {
 });
 
 /**
- * The five-value map is what re-types a JSONL value on the way back in. One
- * case per entry pins what it does, so deleting the map (PROD-10894) removes
- * these with it rather than leaving behaviour undocumented.
+ * The five-value map still re-types JSONL for the parquet writer and pre-aggregate reads.
+ * One case per entry pins what it does; references no longer go through it.
  */
 const readThroughMap = async (
     type: DimensionType,

--- a/packages/backend/src/utils/duckdb/duckdbSqlTables.test.ts
+++ b/packages/backend/src/utils/duckdb/duckdbSqlTables.test.ts
@@ -1,9 +1,109 @@
 import { DimensionType, type ResultColumns } from '@lightdash/common';
 import {
     getDuckdbPreAggregateSqlTable,
+    getJsonlReferenceSelect,
     getPreAggregateDuckdbLocator,
+    resultColumnToDuckdbType,
     type PreAggregateDuckdbLocator,
 } from './duckdbSqlTables';
+
+describe('resultColumnToDuckdbType', () => {
+    test('NUMBER without a kind stays DOUBLE', () => {
+        expect(resultColumnToDuckdbType({ type: DimensionType.NUMBER })).toBe(
+            'DOUBLE',
+        );
+    });
+
+    test('NUMBER binds by its numeric kind', () => {
+        expect(
+            resultColumnToDuckdbType({
+                type: DimensionType.NUMBER,
+                numericKind: { kind: 'integer' },
+            }),
+        ).toBe('HUGEINT');
+        expect(
+            resultColumnToDuckdbType({
+                type: DimensionType.NUMBER,
+                numericKind: { kind: 'decimal', scale: 4 },
+            }),
+        ).toBe('DECIMAL(38,4)');
+        expect(
+            resultColumnToDuckdbType({
+                type: DimensionType.NUMBER,
+                numericKind: { kind: 'float' },
+            }),
+        ).toBe('DOUBLE');
+    });
+
+    test('a numeric kind on a non-NUMBER column is ignored', () => {
+        expect(
+            resultColumnToDuckdbType({
+                type: DimensionType.STRING,
+                numericKind: { kind: 'integer' },
+            }),
+        ).toBe('VARCHAR');
+    });
+});
+
+describe('getJsonlReferenceSelect', () => {
+    test('reads every column as text and casts it in the select list', () => {
+        const columns: ResultColumns = {
+            orders_total: {
+                reference: 'orders.total',
+                type: DimensionType.NUMBER,
+                numericKind: { kind: 'decimal', scale: 2 },
+            },
+            orders_name: {
+                reference: 'orders.name',
+                type: DimensionType.STRING,
+            },
+            orders_is_paid: {
+                reference: 'orders.is_paid',
+                type: DimensionType.BOOLEAN,
+            },
+        };
+
+        expect(
+            getJsonlReferenceSelect('s3://bucket/abc123.jsonl', columns),
+        ).toBe(
+            `SELECT COALESCE(TRY_CAST("orders_total" AS DECIMAL(38,2)), CASE WHEN "orders_total" IS NULL THEN NULL ELSE error('Referenced column orders_total holds a value that cannot be read as number: ' || left("orders_total", 100)) END) AS "orders_total", "orders_name", COALESCE(TRY_CAST("orders_is_paid" AS BOOLEAN), CASE WHEN "orders_is_paid" IS NULL THEN NULL ELSE error('Referenced column orders_is_paid holds a value that cannot be read as boolean: ' || left("orders_is_paid", 100)) END) AS "orders_is_paid" FROM read_json('s3://bucket/abc123.jsonl', columns={"orders_total": 'VARCHAR', "orders_name": 'VARCHAR', "orders_is_paid": 'VARCHAR'}, format='newline_delimited')`,
+        );
+    });
+
+    test('reads a timestamp as an instant unless it is naive', () => {
+        const select = getJsonlReferenceSelect('s3://bucket/abc123.jsonl', {
+            created_at: {
+                reference: 'created_at',
+                type: DimensionType.TIMESTAMP,
+            },
+        });
+        expect(select).toContain(
+            `CASE WHEN regexp_matches("created_at", '^\\d{4}-\\d{2}-\\d{2}([T ]\\d{2}:\\d{2}(:\\d{2}(\\.\\d+)?)?)?$') THEN TRY_CAST("created_at" AS TIMESTAMP) ELSE timezone('UTC', TRY_CAST("created_at" AS TIMESTAMPTZ)) END`,
+        );
+    });
+
+    test('falls back to read_json_auto when columns are empty or null', () => {
+        expect(getJsonlReferenceSelect('s3://bucket/abc123.jsonl', {})).toBe(
+            `SELECT * FROM read_json_auto('s3://bucket/abc123.jsonl')`,
+        );
+        expect(getJsonlReferenceSelect('s3://bucket/abc123.jsonl', null)).toBe(
+            `SELECT * FROM read_json_auto('s3://bucket/abc123.jsonl')`,
+        );
+    });
+
+    test('escapes the uri and the column name inside the refusal message', () => {
+        expect(
+            getJsonlReferenceSelect(`s3://bucket/o'hara.jsonl`, {
+                [`orders"status'value`]: {
+                    reference: 'orders.status',
+                    type: DimensionType.BOOLEAN,
+                },
+            }),
+        ).toBe(
+            `SELECT COALESCE(TRY_CAST("orders""status'value" AS BOOLEAN), CASE WHEN "orders""status'value" IS NULL THEN NULL ELSE error('Referenced column orders"status''value holds a value that cannot be read as boolean: ' || left("orders""status'value", 100)) END) AS "orders""status'value" FROM read_json('s3://bucket/o''hara.jsonl', columns={"orders""status'value": 'VARCHAR'}, format='newline_delimited')`,
+        );
+    });
+});
 
 const locator: PreAggregateDuckdbLocator = {
     storage: 's3',

--- a/packages/backend/src/utils/duckdb/duckdbSqlTables.ts
+++ b/packages/backend/src/utils/duckdb/duckdbSqlTables.ts
@@ -1,6 +1,7 @@
 import {
     assertUnreachable,
     DimensionType,
+    type ResultColumn,
     type ResultColumns,
 } from '@lightdash/common';
 
@@ -67,6 +68,89 @@ export const getJsonlSqlTable = (
         .join(', ');
 
     return `read_json('${escapedUri}', columns={${columnDefs}}, format='newline_delimited')`;
+};
+
+// NUMBER binds by its numeric kind; without one DOUBLE is the only type that fits every JSON number
+export const resultColumnToDuckdbType = (
+    column: Pick<ResultColumn, 'type' | 'numericKind'>,
+): string => {
+    if (column.type !== DimensionType.NUMBER) {
+        return resultFieldTypeToDuckdbType(column.type);
+    }
+    const kind = column.numericKind;
+    if (!kind) return 'DOUBLE';
+    switch (kind.kind) {
+        case 'integer':
+            return 'HUGEINT';
+        case 'decimal':
+            return `DECIMAL(38,${Math.min(Math.max(kind.scale, 0), 38)})`;
+        case 'float':
+            return 'DOUBLE';
+        default:
+            return assertUnreachable(kind, 'Unknown numeric kind');
+    }
+};
+
+// A date, or a date with wall-clock time and no zone; anything else is read as an instant
+const NAIVE_TIMESTAMP_PATTERN =
+    '^\\d{4}-\\d{2}-\\d{2}([T ]\\d{2}:\\d{2}(:\\d{2}(\\.\\d+)?)?)?$';
+
+// The cast from JSONL text to the column's type, or null when the text is the value
+const getReferenceColumnCast = (
+    raw: string,
+    column: Pick<ResultColumn, 'type' | 'numericKind'>,
+): string | null => {
+    switch (column.type) {
+        case DimensionType.TIMESTAMP:
+            return `CASE WHEN regexp_matches(${raw}, '${NAIVE_TIMESTAMP_PATTERN}') THEN TRY_CAST(${raw} AS TIMESTAMP) ELSE timezone('UTC', TRY_CAST(${raw} AS TIMESTAMPTZ)) END`;
+        case DimensionType.NUMBER:
+        case DimensionType.DATE:
+        case DimensionType.BOOLEAN:
+            return `TRY_CAST(${raw} AS ${resultColumnToDuckdbType(column)})`;
+        case DimensionType.STRING:
+            return null;
+        default:
+            return assertUnreachable(
+                column.type,
+                `Unknown DimensionType: ${column.type}`,
+            );
+    }
+};
+
+// A non-null value that does not cast refuses naming the column; read_json's own transform cannot
+const getReferenceColumnSelect = (
+    fieldId: string,
+    column: Pick<ResultColumn, 'type' | 'numericKind'>,
+): string => {
+    const raw = quoteDuckdbIdentifier(fieldId);
+    const cast = getReferenceColumnCast(raw, column);
+    if (cast === null) return raw;
+    const refusal = `error('Referenced column ${escapeSqlString(
+        fieldId,
+    )} holds a value that cannot be read as ${column.type}: ' || left(${raw}, 100))`;
+    return `COALESCE(${cast}, CASE WHEN ${raw} IS NULL THEN NULL ELSE ${refusal} END) AS ${raw}`;
+};
+
+/**
+ * The SELECT a referenced query result is exposed through: every column read as its JSONL
+ * text and cast in SQL, so the digits the driver serialised reach the typed value.
+ */
+export const getJsonlReferenceSelect = (
+    uri: string,
+    columns?: ResultColumns | null,
+): string => {
+    const escapedUri = escapeSqlString(uri);
+    const entries = Object.entries(columns ?? {});
+    if (entries.length === 0) {
+        return `SELECT * FROM read_json_auto('${escapedUri}')`;
+    }
+    const rawColumns = entries
+        .map(([fieldId]) => `${quoteDuckdbIdentifier(fieldId)}: 'VARCHAR'`)
+        .join(', ');
+    const selectList = entries
+        .map(([fieldId, column]) => getReferenceColumnSelect(fieldId, column))
+        .join(', ');
+    return `SELECT ${selectList} FROM read_json('${escapedUri}', columns={${rawColumns}}, format='newline_delimited')`;
 };
 
 const getParquetSqlTable = (uri: string): string => {

--- a/packages/common/src/types/results.ts
+++ b/packages/common/src/types/results.ts
@@ -85,9 +85,17 @@ export type ResultColumnProvenance = {
     sourceQueryUuid?: string;
 };
 
+/** How a NUMBER column is represented at the source, so a typed read binds it without loss. */
+export type ResultNumericKind =
+    | { kind: 'integer' }
+    | { kind: 'decimal'; scale: number }
+    | { kind: 'float' };
+
 export type ResultColumn = {
     reference: string;
     type: DimensionType; // Lightdash simple type. In the future, we might introduce the warehouse type as well, which provides more detail.
+    /** NUMBER columns only, when the driver reports it. Absent ⇒ unknown, read as DOUBLE. */
+    numericKind?: ResultNumericKind;
     /** Display label. Absent ⇒ consumers fall back to the reference. */
     label?: string;
     /**

--- a/packages/common/src/types/warehouse.ts
+++ b/packages/common/src/types/warehouse.ts
@@ -5,6 +5,7 @@ import { type SupportedDbtAdapter } from './dbt';
 import { type DimensionType, type Metric, type TimestampDomain } from './field';
 import { type CreateWarehouseCredentials } from './projects';
 import type { WarehouseQueryMetadata } from './queryHistory';
+import { type ResultNumericKind } from './results';
 import { type UserAttributeValueMap } from './userAttributes';
 
 const MAX_USER_ATTRIBUTE_QUERY_TAGS = 20;
@@ -184,8 +185,13 @@ export type WarehouseTables = {
     partitionColumn?: PartitionColumn;
 }[];
 
+export type WarehouseResultField = {
+    type: DimensionType;
+    numericKind?: ResultNumericKind;
+};
+
 export type WarehouseResults = {
-    fields: Record<string, { type: DimensionType }>;
+    fields: Record<string, WarehouseResultField>;
     rows: Record<string, AnyType>[];
 };
 

--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
@@ -98,7 +98,7 @@ const getMockStreamResult = (
     return {
         columnCount: columnNames.length,
         columnNames: () => columnNames,
-        columnTypeId: (i: number) => columnTypeIds[i] ?? 0,
+        columnType: (i: number) => ({ typeId: columnTypeIds[i] ?? 0 }),
         // eslint-disable-next-line object-shorthand, func-names, no-restricted-syntax
         yieldRowObjectJson: async function* () {
             // eslint-disable-next-line no-restricted-syntax
@@ -255,7 +255,10 @@ describe('DuckdbWarehouseClient', () => {
         expect(result.rows).toEqual(rows);
         expect(result.fields).toEqual({
             customer_name: { type: DimensionType.STRING },
-            order_count: { type: DimensionType.NUMBER },
+            order_count: {
+                type: DimensionType.NUMBER,
+                numericKind: { kind: 'integer' },
+            },
             last_order_at: { type: DimensionType.TIMESTAMP },
         });
     });
@@ -281,12 +284,14 @@ describe('DuckdbWarehouseClient', () => {
         );
 
         expect(streamCallback).toHaveBeenCalledTimes(2);
-        expect(streamCallback).toHaveBeenNthCalledWith(1, chunk1, {
-            id: { type: DimensionType.NUMBER },
-        });
-        expect(streamCallback).toHaveBeenNthCalledWith(2, chunk2, {
-            id: { type: DimensionType.NUMBER },
-        });
+        const idField = {
+            id: {
+                type: DimensionType.NUMBER,
+                numericKind: { kind: 'integer' },
+            },
+        };
+        expect(streamCallback).toHaveBeenNthCalledWith(1, chunk1, idField);
+        expect(streamCallback).toHaveBeenNthCalledWith(2, chunk2, idField);
         expect(result.totalRows).toBe(3);
     });
 
@@ -572,7 +577,7 @@ describe('DuckdbWarehouseClient', () => {
                 return {
                     columnCount: 1,
                     columnNames: () => ['val'],
-                    columnTypeId: () => DUCKDB_TYPE_IDS.INTEGER,
+                    columnType: () => ({ typeId: DUCKDB_TYPE_IDS.INTEGER }),
                     yieldRowObjectJson: () => iterator,
                 };
             });

--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
@@ -2,6 +2,7 @@ import {
     DuckDBInstance,
     DuckDBTypeId,
     version as duckdbVersion,
+    type DuckDBType,
 } from '@duckdb/node-api';
 import {
     AnyType,
@@ -25,6 +26,7 @@ import {
     WarehouseQueryError,
     WarehouseResults,
     WarehouseTypes,
+    type ResultNumericKind,
     type TimestampDomain,
     type WarehouseQueryPhase,
 } from '@lightdash/common';
@@ -41,7 +43,7 @@ import WarehouseBaseSqlBuilder from './WarehouseBaseSqlBuilder';
 type DuckdbStreamResult = {
     columnCount: number;
     columnNames: () => string[];
-    columnTypeId: (columnIndex: number) => number;
+    columnType: (columnIndex: number) => DuckDBType;
     yieldRowObjectJson: () => AsyncIterableIterator<Record<string, AnyType>[]>;
 };
 
@@ -190,6 +192,29 @@ export const mapFieldTypeFromTypeId = (typeId: number): DimensionType => {
             return DimensionType.NUMBER;
         default:
             return DimensionType.STRING;
+    }
+};
+
+const getNumericKindFromType = (type: DuckDBType): ResultNumericKind | null => {
+    switch (type.typeId) {
+        case DuckDBTypeId.TINYINT:
+        case DuckDBTypeId.SMALLINT:
+        case DuckDBTypeId.INTEGER:
+        case DuckDBTypeId.BIGINT:
+        case DuckDBTypeId.HUGEINT:
+        case DuckDBTypeId.UTINYINT:
+        case DuckDBTypeId.USMALLINT:
+        case DuckDBTypeId.UINTEGER:
+        case DuckDBTypeId.UBIGINT:
+        case DuckDBTypeId.UHUGEINT:
+            return { kind: 'integer' };
+        case DuckDBTypeId.FLOAT:
+        case DuckDBTypeId.DOUBLE:
+            return { kind: 'float' };
+        case DuckDBTypeId.DECIMAL:
+            return { kind: 'decimal', scale: type.scale };
+        default:
+            return null;
     }
 };
 
@@ -2067,8 +2092,11 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
         const columnNames = result.columnNames();
         const fields: WarehouseResults['fields'] = {};
         for (let i = 0; i < result.columnCount; i += 1) {
+            const columnType = result.columnType(i);
+            const numericKind = getNumericKindFromType(columnType);
             fields[columnNames[i]] = {
-                type: mapFieldTypeFromTypeId(result.columnTypeId(i)),
+                type: mapFieldTypeFromTypeId(columnType.typeId),
+                ...(numericKind ? { numericKind } : {}),
             };
         }
         return fields;

--- a/packages/warehouses/src/warehouseClients/MotherduckInstanceCache.security.test.ts
+++ b/packages/warehouses/src/warehouseClients/MotherduckInstanceCache.security.test.ts
@@ -16,7 +16,7 @@ vi.mock('@duckdb/node-api', () => ({
 const getMockStreamResult = (marker: string) => ({
     columnCount: 1,
     columnNames: () => ['marker'],
-    columnTypeId: () => 17,
+    columnType: () => ({ typeId: 17 }),
     yieldRowObjectJson: async function* yieldRows() {
         yield [{ marker }];
     },

--- a/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.ts
@@ -13,6 +13,7 @@ import {
     WarehouseQueryError,
     WarehouseResults,
     WarehouseTypes,
+    type ResultNumericKind,
     type TimestampDomain,
     type WarehouseQueryPhase,
 } from '@lightdash/common';
@@ -176,6 +177,29 @@ const convertDataTypeIdToDimensionType = (
     }
 };
 
+// numeric(p,s) encodes its typmod as ((p << 16) | s) + 4; -1 means unconstrained
+const getNumericKindFromDataType = (
+    dataTypeId: number,
+    dataTypeModifier: number,
+): ResultNumericKind | null => {
+    switch (dataTypeId) {
+        case builtins.INT2:
+        case builtins.INT4:
+        case builtins.INT8:
+            return { kind: 'integer' };
+        case builtins.FLOAT4:
+        case builtins.FLOAT8:
+            return { kind: 'float' };
+        case builtins.NUMERIC:
+            return dataTypeModifier >= 4
+                ? // eslint-disable-next-line no-bitwise
+                  { kind: 'decimal', scale: (dataTypeModifier - 4) & 0xffff }
+                : null;
+        default:
+            return null;
+    }
+};
+
 export class PostgresSqlBuilder extends WarehouseBaseSqlBuilder {
     type = WarehouseTypes.POSTGRES;
 
@@ -282,10 +306,19 @@ export class PostgresClient<
         fields: QueryResult<AnyType>['fields'],
     ): WarehouseResults['fields'] {
         return Object.fromEntries(
-            fields.map(({ name, dataTypeID }) => [
-                name,
-                { type: convertDataTypeIdToDimensionType(dataTypeID) },
-            ]),
+            fields.map(({ name, dataTypeID, dataTypeModifier }) => {
+                const numericKind = getNumericKindFromDataType(
+                    dataTypeID,
+                    dataTypeModifier,
+                );
+                return [
+                    name,
+                    {
+                        type: convertDataTypeIdToDimensionType(dataTypeID),
+                        ...(numericKind ? { numericKind } : {}),
+                    },
+                ];
+            }),
         );
     }
 


### PR DESCRIPTION
## Why this is not the Parquet change the ticket asked for

The ticket asked for query results written as Parquet so referenced results keep their types. A spike showed that premise is wrong for our writer: the Parquet writer re-types through the same five-value map (`getJsonlSqlTable`) as the JSONL read, and most precision is already gone inside the warehouse drivers before any file exists. What was missing was a typed read: the JSONL carries whatever digits the driver serialised, and the reference bind was collapsing every NUMBER to DOUBLE and every TIMESTAMP through a UTC-only parse.

## What changes

- `ResultNumericKind` (`integer | decimal(scale) | float`) on `WarehouseResults.fields` and, optionally, on `ResultColumn` (`packages/common/src/types/results.ts`, `warehouse.ts`). Additive API change: `numericKind?` is optional and `ResultColumn`'s required list is unchanged (confirmed with `pnpm generate-api`; generated files not committed). Optional rather than `null` because `ResultColumn` is persisted in `query_history.columns` and older rows lack it.
- The Postgres client reports the kind from the OID and the `numeric` typmod; the DuckDB client from `columnType(i)`. Other drivers report nothing and bind as DOUBLE, exactly as today.
- `getUnpivotedColumns` carries the kind from the fields map into the stored `columns`.
- `getJsonlReferenceSelect` (`packages/backend/src/utils/duckdb/duckdbSqlTables.ts`) replaces the `SELECT * FROM read_json(... five-value map ...)` bind in `buildQueryReferenceCtes`. Every referenced column is read as VARCHAR and cast in the select list: `HUGEINT` / `DECIMAL(38,s)` / `DOUBLE` by kind, `DATE`, `BOOLEAN`, and timestamps as `timezone('UTC', ::TIMESTAMPTZ)` unless the text is naive (a date, or date plus wall-clock time with no zone), which is read as-is. A non-null value that does not cast refuses with `error()` naming the column and the offending text, instead of the engine's raw "JSON transform error".
- The five-value map (`getJsonlSqlTable`) stays for the Parquet writer (`LocalParquetUploadStream.ts`) and pre-aggregate JSONL reads; references no longer go through it.
- `docs/merge-queries/architecture.md`: the "Parquet versus JSONL is the entire fidelity story" paragraph is rewritten to say where precision is lost (drivers) and how references are bound.

## Fidelity suite, before and after

`packages/backend/src/utils/QueryBuilder/composeMergeFidelity.test.ts` runs the real merge statement on an in-memory DuckDB over JSONL leg files. Before: 13 passed, 4 expected fail. After: 21 passed, 1 expected fail. No assertion was loosened.

| Case | Before | After |
| --- | --- | --- |
| small integer | pass | pass |
| decimal with four places | pass | pass |
| bigint above 2^53, integer-kinded | n/a | pass (`9007199254740993` exact) |
| bigint above 2^53, no numeric kind | expected fail | still expected fail (binds DOUBLE, reads `...992`) |
| wide decimal as text, decimal-kinded | n/a | pass |
| float keeps its digits, float-kinded | n/a | pass |
| date | pass | pass |
| string with quotes and non-ascii | pass | pass |
| boolean | pass | pass |
| null | pass | pass |
| UTC timestamp | pass | pass |
| non-UTC offset lands at the instant | expected fail | pass |
| named-zone timestamp reads | expected fail | pass |
| named zone with fraction (Trino shape) | n/a | pass |
| naive timestamp read as-is | n/a | pass |
| uncastable value refuses naming the column | expected fail | pass |
| five-value map pins (5 cases) | pass | pass |

## Behaviour shift to know about

Integer-kinded NUMBER columns now come out of the compose engine as exact integer strings (`HUGEINT`, serialised by the DuckDB client) rather than JS floating-point numbers. Postgres `int8` cells are already this class today (the pg driver parses them as `BigInt`, `PostgresWarehouseClient.ts:34`, and `BigInt.prototype.toJSON` in `App.ts:354` writes them as strings), so the row shape is not new, but it is new on the merge and compose SQL paths for `int2`/`int4` sources and for DuckDB integer columns.

Searched `packages/frontend/src` (mergeQuery, LightdashVisualization, tableVisualization, echarts hooks, pie/big number config) and `packages/common/src/utils/formatting.ts` for `typeof x === 'number'`, `Number(`, `isNumber`, `parseFloat` on raw cells:

- `formatting.ts:455-540` (`valueIsNaN` / `isNumber` / `applyDefaultFormat`) and `:866` (`formatItemValue`) go through `Number(value)`, so a numeric string formats as a number. Fine.
- `useTableConfig.ts:692`, `usePieChartConfig.ts:309`, `useEchartsFunnelConfig.ts:84`, `useEchartsCartesianConfig.ts:383-396,590-597` convert with `Number()` / `parseFloat`. Fine.
- `useEchartsCartesianConfig.ts:733` (`getMinAndMaxValues`, axis min/max for reference lines) falls to `localeCompare` when either side is a string, so string cells sort lexicographically there. Degrades, does not break, and is already the behaviour for pg `int8` today. Not changed here.
- `getDataAndColumns.tsx:149` (`typeof total === 'number'`) reads subtotal rows from the totals query, not merged cells. Unaffected.
- `formatting.ts:788` handles `bigint` raw values; a string above 2^53 is formatted through `Number()`, so display rounds while `raw` stays exact, same as int8 today.

No frontend or common change was needed.

## Results paging and exports are unaffected

Only the reference bind changes. Paging and every export still read the JSONL file directly and never go through `getJsonlReferenceSelect`:

- `getResultsPageFromS3` reads with `splitJsonlStream` + `JSON.parse` (`packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts:1053`, stream at `:1075`, parse loop at `:1083`).
- CSV/file exports: `packages/backend/src/utils/FileDownloadUtils/FileDownloadUtils.ts:169`, `packages/backend/src/clients/Aws/transformAndExportResults.ts:57`.
- Excel: `packages/backend/src/services/ExcelService/ExcelService.ts:779`, `:1045`, `:1058`.
- Pivot table export: `packages/backend/src/services/PivotTableService/PivotTableService.ts:154`.
- `getJsonlReferenceSelect` has one production caller, `buildQueryReferenceCtes` (`AsyncQueryService.ts:7359`), reached only from `bindDuckdbQueryReferences` inside `runDuckdbQuery`.

## Driver follow-ups this does not fix

The typed read recovers whatever the driver serialised; it cannot recover what the driver already rounded:

- Postgres `NUMERIC` parsed with `parseFloat` (`PostgresWarehouseClient.ts:33`).
- BigQuery numerics through `Number(value.toFixed(...))`.
- Snowflake without `fetchAsString`.
- Trino bigints through `JSON.parse`.

Only Postgres and DuckDB report a numeric kind in this PR; the other drivers are follow-ups.

## Verification

- `pnpm -F backend test src/utils/QueryBuilder/composeMergeFidelity.test.ts`: 21 passed, 1 expected fail.
- `pnpm -F backend test src/utils/duckdb/duckdbSqlTables.test.ts`: 11 passed.
- `pnpm -F backend test src/services/AsyncQueryService/AsyncQueryService.test.ts`: 109 passed.
- `pnpm -F warehouses test` for `PostgresWarehouseClient`, `DuckdbWarehouseClient`, `MotherduckInstanceCache.security`: 3 files, 121 passed.
- `typecheck` and `lint` clean for common, warehouses and backend.
- Not verified: a live merge against a real warehouse; `packages/api-tests/tests/mergeQuery.test.ts` (the parity bar) was not run locally.

test-backend

Relates: PROD-10894

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvtHaH3fbzSX2ebMgfFKFS
