### PR TITLE
fix(data-apps): paginate dashboard selector

### DIFF
--- a/packages/frontend/src/features/apps/AppResourcePicker.test.tsx
+++ b/packages/frontend/src/features/apps/AppResourcePicker.test.tsx
@@ -1,4 +1,4 @@
-import { type ExternalConnection } from '@lightdash/common';
+import { ContentType, type ExternalConnection } from '@lightdash/common';
 import { MantineProvider } from '@mantine/core';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { vi } from 'vitest';
@@ -8,6 +8,33 @@ import {
     ConnectionPickerView,
     SelectedQuerySection,
 } from './AppResourcePicker';
+
+const contentMocks = vi.hoisted(() => ({
+    fetchNextPage: vi.fn(),
+    useInfiniteContent: vi.fn(() => ({
+        data: {
+            pages: [
+                {
+                    data: [
+                        {
+                            contentType: 'dashboard',
+                            uuid: 'dashboard-1',
+                            name: 'Revenue dashboard',
+                        },
+                    ],
+                },
+            ],
+        },
+        isInitialLoading: false,
+        isFetching: false,
+        hasNextPage: true,
+        fetchNextPage: contentMocks.fetchNextPage,
+    })),
+}));
+
+vi.mock('../../hooks/useContent', () => ({
+    useInfiniteContent: contentMocks.useInfiniteContent,
+}));
 
 vi.mock('../../hooks/useProjectUuid', () => ({
     useProjectUuid: () => 'project-1',
@@ -81,6 +108,46 @@ const baseChart = {
     includeSampleData: false,
     linkLive: false,
 };
+
+it('loads the next page of dashboards from content search', () => {
+    contentMocks.fetchNextPage.mockClear();
+    contentMocks.useInfiniteContent.mockClear();
+
+    render(
+        <MantineProvider env="test">
+            <AttachButton
+                selectedCharts={[]}
+                onSelectChart={() => undefined}
+                onDeselectChart={() => undefined}
+                selectedDashboard={null}
+                onSelectDashboard={() => undefined}
+                onDeselectDashboard={() => undefined}
+                selectedConnections={[]}
+                onSelectConnection={() => undefined}
+                onDeselectConnection={() => undefined}
+                onAddFiles={() => undefined}
+                disabled={false}
+                filesDisabled={false}
+            />
+        </MantineProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Attach resources' }));
+    fireEvent.click(screen.getByRole('button', { name: /Dashboard/ }));
+
+    expect(screen.getByText('Revenue dashboard')).toBeInTheDocument();
+    expect(contentMocks.useInfiniteContent).toHaveBeenCalledWith(
+        expect.objectContaining({
+            projectUuids: ['project-1'],
+            contentTypes: [ContentType.DASHBOARD],
+            pageSize: 25,
+        }),
+        expect.objectContaining({ enabled: true }),
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Load more' }));
+    expect(contentMocks.fetchNextPage).toHaveBeenCalledOnce();
+});
 
 it('calls onToggleLink when the Link live button is clicked', () => {
     const onToggleLink = vi.fn();

--- a/packages/frontend/src/features/apps/AppResourcePicker.tsx
+++ b/packages/frontend/src/features/apps/AppResourcePicker.tsx
@@ -1,6 +1,7 @@
 import { subject } from '@casl/ability';
 import {
     ChartKind,
+    ContentType,
     type ChartContent,
     type AiModelOption,
     type AppVersionExternalConnectionResource,
@@ -57,8 +58,8 @@ import MantineModal from '../../components/common/MantineModal';
 import { ModelSelector } from '../../components/common/ModelSelector/ModelSelector';
 import { ChartIcon, IconBox } from '../../components/common/ResourceIcon';
 import { getChartIcon } from '../../components/common/ResourceIcon/utils';
-import { useDashboards } from '../../hooks/dashboard/useDashboards';
 import { useChartSummariesV2 } from '../../hooks/useChartSummariesV2';
+import { useInfiniteContent } from '../../hooks/useContent';
 import { useProject } from '../../hooks/useProject';
 import { useProjectUuid } from '../../hooks/useProjectUuid';
 import useApp from '../../providers/App/useApp';
@@ -776,16 +777,31 @@ const DashboardPickerView: FC<{
     const [searchQuery, setSearchQuery] = useState('');
     const [debouncedSearch] = useDebouncedValue(searchQuery, 300);
 
-    const { data: dashboards, isInitialLoading } = useDashboards(projectUuid, {
-        enabled,
-    });
+    const {
+        data: dashboardPages,
+        isInitialLoading,
+        isFetching,
+        hasNextPage,
+        fetchNextPage,
+    } = useInfiniteContent(
+        {
+            projectUuids: projectUuid ? [projectUuid] : [],
+            contentTypes: [ContentType.DASHBOARD],
+            page: 1,
+            pageSize: 25,
+            search: debouncedSearch,
+        },
+        { keepPreviousData: true, enabled: enabled && !!projectUuid },
+    );
 
-    const filteredDashboards = useMemo(() => {
-        if (!dashboards) return [];
-        const term = debouncedSearch.toLowerCase();
-        if (!term) return dashboards;
-        return dashboards.filter((d) => d.name.toLowerCase().includes(term));
-    }, [dashboards, debouncedSearch]);
+    const allDashboards = useMemo(
+        () =>
+            uniqBy(
+                dashboardPages?.pages.flatMap((page) => page.data) ?? [],
+                'uuid',
+            ),
+        [dashboardPages?.pages],
+    );
 
     const handleToggle = useCallback(
         (dashboard: { uuid: string; name: string }) => {
@@ -816,7 +832,9 @@ const DashboardPickerView: FC<{
                     placeholder="Search or paste a link..."
                     leftSection={<MantineIcon icon={IconSearch} size={14} />}
                     rightSection={
-                        isResolvingLink ? <Loader size={14} /> : undefined
+                        (isFetching && !isInitialLoading) || isResolvingLink ? (
+                            <Loader size={14} />
+                        ) : undefined
                     }
                     value={searchQuery}
                     onChange={(e) => setSearchQuery(e.currentTarget.value)}
@@ -829,44 +847,60 @@ const DashboardPickerView: FC<{
                     <Group justify="center" p="sm">
                         <Loader size="sm" />
                     </Group>
-                ) : filteredDashboards.length === 0 ? (
+                ) : allDashboards.length === 0 ? (
                     <Text size="xs" c="dimmed" ta="center" p="sm">
                         No dashboards found
                     </Text>
                 ) : (
-                    filteredDashboards.map((dashboard) => {
-                        const isSelected =
-                            selectedDashboard?.uuid === dashboard.uuid;
-                        return (
-                            <Box
-                                key={dashboard.uuid}
-                                className={`${classes.chartItem} ${
-                                    isSelected ? classes.chartItemSelected : ''
-                                }`}
-                                onClick={() => handleToggle(dashboard)}
-                            >
-                                <IconBox
-                                    icon={IconLayoutDashboard}
-                                    color="green.6"
-                                />
-                                <Text size="xs" fw={500} truncate flex={1}>
-                                    {dashboard.name}
-                                </Text>
-                                {isSelected && (
-                                    <Box
-                                        className={
-                                            classes.chartItemSelectedIcon
-                                        }
-                                    >
-                                        <MantineIcon
-                                            icon={IconCheck}
-                                            size={14}
-                                        />
-                                    </Box>
-                                )}
+                    <>
+                        {allDashboards.map((dashboard) => {
+                            const isSelected =
+                                selectedDashboard?.uuid === dashboard.uuid;
+                            return (
+                                <Box
+                                    key={dashboard.uuid}
+                                    className={`${classes.chartItem} ${
+                                        isSelected
+                                            ? classes.chartItemSelected
+                                            : ''
+                                    }`}
+                                    onClick={() => handleToggle(dashboard)}
+                                >
+                                    <IconBox
+                                        icon={IconLayoutDashboard}
+                                        color="green.6"
+                                    />
+                                    <Text size="xs" fw={500} truncate flex={1}>
+                                        {dashboard.name}
+                                    </Text>
+                                    {isSelected && (
+                                        <Box
+                                            className={
+                                                classes.chartItemSelectedIcon
+                                            }
+                                        >
+                                            <MantineIcon
+                                                icon={IconCheck}
+                                                size={14}
+                                            />
+                                        </Box>
+                                    )}
+                                </Box>
+                            );
+                        })}
+                        {hasNextPage && (
+                            <Box ta="center" py={4}>
+                                <Button
+                                    variant="subtle"
+                                    size="xs"
+                                    onClick={() => void fetchNextPage()}
+                                    loading={isFetching}
+                                >
+                                    Load more
+                                </Button>
                             </Box>
-                        );
-                    })
+                        )}
+                    </>
                 )}
             </ScrollArea.Autosize>
             <Box className={classes.attachPickerFooter}>


### PR DESCRIPTION
Closes: [GLITCH-754](https://linear.app/lightdash/issue/GLITCH-754/add-pagination-to-the-dashboard-selector)

### Description:

```diff
 Data App builder -> Attach -> Dashboard
- load one legacy dashboard collection and filter it in the browser
+ search dashboards through the paginated content API and load additional pages on demand
```

- Loads dashboard summaries in pages of 25 and exposes the same **Load more** interaction as the chart selector.
- Runs dashboard name searches through the content API so matches are not limited to pages already loaded in the browser.
- Keeps dashboard selection and pasted-link behavior unchanged. Selecting a dashboard only updates the composer state; this change does not persist or modify dashboards.
- Results remain scoped to dashboards the current user can view.

### Validation:

- `pnpm -F frontend test src/features/apps/AppResourcePicker.test.tsx` — 1 file, 11 tests passed
- `pnpm -F frontend typecheck`
- Focused Oxlint and Oxfmt checks for both changed files
- `git diff --check`
- Live browser validation on `localhost:3000`: confirmed the picker requests dashboard content with `pageSize=25` and server-side search; searching for `Jaffle` returned the matching dashboard without persisting data
- Untested live boundary: the local project has only 10 dashboards, so loading page two is covered by the focused component test rather than live data

### Risk assessment:

- [ ] This is a high-risk change

Low risk. This is a frontend-only switch to the existing paginated content endpoint already used by resource browsing. There are no API, database, permission, or persistence changes, and the prior dashboard selection flow remains intact.