### PR TITLE
feat(review-requests): rework the request page as a request thread

### DIFF
--- a/packages/frontend/src/ee/features/contentReview/components/ContentReviewStatusBadge.tsx
+++ b/packages/frontend/src/ee/features/contentReview/components/ContentReviewStatusBadge.tsx
@@ -10,7 +10,7 @@ const getStatusProps = (
 ): { color: string; label: string } => {
     switch (status) {
         case ContentReviewRequestStatus.PENDING:
-            return { color: 'yellow', label: 'Pending' };
+            return { color: 'yellow', label: 'Waiting for review' };
         case ContentReviewRequestStatus.APPROVED:
             return { color: 'green', label: 'Approved' };
         case ContentReviewRequestStatus.REJECTED:

--- a/packages/frontend/src/ee/features/contentReview/pages/ContentReviewRequestPage.module.css
+++ b/packages/frontend/src/ee/features/contentReview/pages/ContentReviewRequestPage.module.css
@@ -1,19 +1,28 @@
-.spaceChip {
-    min-width: 0;
-    padding: 4px var(--mantine-spacing-sm);
-    border: 1px solid var(--mantine-color-default-border);
-    border-radius: var(--mantine-radius-md);
-    background-color: var(--mantine-color-body);
+.page {
+    width: 100%;
+    max-width: 760px;
+    margin: 0 auto;
 }
 
 .list {
     margin: 0 calc(var(--mantine-spacing-sm) * -1);
 }
 
-.note {
-    white-space: pre-wrap;
-    padding: var(--mantine-spacing-sm) var(--mantine-spacing-md);
-    border-left: 3px solid var(--mantine-color-default-border);
-    background-color: var(--mantine-color-ldGray-0);
-    border-radius: 0 var(--mantine-radius-md) var(--mantine-radius-md) 0;
+.backLink {
+    align-self: flex-start;
+}
+
+.footer {
+    padding-top: var(--mantine-spacing-sm);
+    border-top: 1px solid var(--mantine-color-default-border);
+}
+
+.inlineToggle {
+    font-size: var(--mantine-font-size-xs);
+    font-weight: 500;
+    color: var(--mantine-color-text);
+}
+
+.inlineToggle:hover {
+    text-decoration: underline;
 }

--- a/packages/frontend/src/ee/features/contentReview/pages/ContentReviewRequestPage.test.tsx
+++ b/packages/frontend/src/ee/features/contentReview/pages/ContentReviewRequestPage.test.tsx
@@ -86,7 +86,7 @@ describe('ContentReviewRequestDetailView', () => {
     it('lists what will move and approves with the verify default', async () => {
         renderView();
 
-        expect(screen.getByText('What will move')).toBeInTheDocument();
+        expect(screen.getByText('Also moves 1 chart')).toBeInTheDocument();
         expect(screen.getByText('Revenue')).toBeInTheDocument();
         expect(screen.getByLabelText('Verify on approve')).toBeChecked();
 
@@ -144,7 +144,8 @@ describe('ContentReviewRequestDetailView', () => {
         expect(
             screen.queryByRole('button', { name: 'Approve and move' }),
         ).not.toBeInTheDocument();
-        expect(screen.getByText(/Rejected by Bob K/)).toBeInTheDocument();
+        expect(screen.getByText('Bob K')).toBeInTheDocument();
+        expect(screen.getByText('rejected this request')).toBeInTheDocument();
         expect(screen.getByText('Not yet')).toBeInTheDocument();
     });
 });

--- a/packages/frontend/src/ee/features/contentReview/pages/ContentReviewRequestPage.tsx
+++ b/packages/frontend/src/ee/features/contentReview/pages/ContentReviewRequestPage.tsx
@@ -3,42 +3,52 @@ import {
     ContentReviewContentType,
     ContentReviewRequestStatus,
     getContentReviewRequestsPath,
+    type ContentReviewMovedItem,
     type ContentReviewRequestDetail,
+    type ContentReviewUser,
 } from '@lightdash/common';
 import {
     Badge,
     Button,
     Checkbox,
-    Grid,
+    Collapse,
     Group,
     Paper,
     Stack,
     Text,
     Textarea,
-    Timeline,
     Title,
     Tooltip,
+    UnstyledButton,
 } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import {
     IconAlertCircle,
+    IconArrowLeft,
     IconArrowRight,
     IconCheck,
+    IconCopy,
     IconCircleCheckFilled,
     IconClockHour4,
+    IconEye,
     IconExternalLink,
-    IconFolder,
-    IconSend,
-    IconUser,
     IconX,
 } from '@tabler/icons-react';
-import { useState, type FC } from 'react';
+import { format } from 'date-fns';
+import {
+    useState,
+    type FC,
+    type PropsWithChildren,
+    type ReactNode,
+} from 'react';
 import { Link, useParams } from 'react-router';
+import { useLocalStorage } from 'react-use';
+import { LightdashUserAvatar } from '../../../../components/Avatar';
+import Callout from '../../../../components/common/Callout';
 import EmptyStateLoader from '../../../../components/common/EmptyStateLoader';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import MantineModal from '../../../../components/common/MantineModal';
 import Page from '../../../../components/common/Page/Page';
-import PageBreadcrumbs from '../../../../components/common/PageBreadcrumbs';
 import { IconBox } from '../../../../components/common/ResourceIcon';
 import { SettingsEmptyState } from '../../../../components/common/Settings/SettingsEmptyState';
 import { useProjectUuid } from '../../../../hooks/useProjectUuid';
@@ -46,7 +56,6 @@ import { useTimeAgo } from '../../../../hooks/useTimeAgo';
 import useApp from '../../../../providers/App/useApp';
 import ContentReviewItemRow from '../components/ContentReviewItemRow';
 import ContentReviewStatusBadge from '../components/ContentReviewStatusBadge';
-import ContentReviewUserChip from '../components/ContentReviewUserChip';
 import {
     useApproveContentReviewRequest,
     useCancelContentReviewRequest,
@@ -60,15 +69,19 @@ import {
     getContentTypeLabel,
     getContentTypeNoun,
     getUserFullName,
+    getUserInitials,
 } from '../utils';
 import classes from './ContentReviewRequestPage.module.css';
 
 const TimeAgo: FC<{ date: Date }> = ({ date }) => {
-    const ago = useTimeAgo(new Date(date));
+    const parsed = new Date(date);
+    const ago = useTimeAgo(parsed);
     return (
-        <Text fz="xs" c="dimmed">
-            {ago}
-        </Text>
+        <Tooltip label={format(parsed, 'PPpp')} withArrow>
+            <Text fz="xs" c="dimmed">
+                {ago}
+            </Text>
+        </Tooltip>
     );
 };
 
@@ -103,6 +116,7 @@ const RejectModal: FC<{
             <Textarea
                 label="Tell the requester why"
                 description="They will see this note and can resubmit after changes"
+                placeholder="Duplicate of Orders in June in Jaffle shop, use that one instead"
                 autosize
                 minRows={3}
                 value={note}
@@ -112,18 +126,6 @@ const RejectModal: FC<{
         </MantineModal>
     );
 };
-
-const SpaceChip: FC<{ name: string; personal?: boolean }> = ({
-    name,
-    personal = false,
-}) => (
-    <Group gap={6} wrap="nowrap" className={classes.spaceChip}>
-        <MantineIcon icon={personal ? IconUser : IconFolder} color="dimmed" />
-        <Text fz="sm" fw={500} truncate="end">
-            {name}
-        </Text>
-    </Group>
-);
 
 const DecisionCard: FC<{
     request: ContentReviewRequestDetail;
@@ -139,6 +141,9 @@ const DecisionCard: FC<{
         useRejectContentReviewRequest(projectUuid);
     const itemCount = request.moveSet.length;
     const target = request.targetSpaceName ?? 'the target space';
+    const noun = getContentTypeNoun(request.contentType);
+    const what = itemCount === 1 ? `this ${noun}` : `these ${itemCount} items`;
+    const requester = request.requestedBy.firstName;
 
     return (
         <Paper p="md">
@@ -146,9 +151,25 @@ const DecisionCard: FC<{
                 <Stack gap={4}>
                     <Title order={5}>Your decision</Title>
                     <Text fz="sm" c="dimmed">
-                        Approving moves{' '}
-                        {itemCount === 1 ? 'this item' : `${itemCount} items`}{' '}
-                        to {target} and releases the temporary access.
+                        You have temporary access to {what} so you can check it.
+                        Open the {noun}, check the numbers and the name, then
+                        decide.
+                    </Text>
+                </Stack>
+                <Stack gap={4}>
+                    <Text fz="sm">
+                        <Text span fw={500}>
+                            Approve
+                        </Text>{' '}
+                        moves {what} into {target}, where everyone with access
+                        to that space can find it.
+                    </Text>
+                    <Text fz="sm">
+                        <Text span fw={500}>
+                            Reject
+                        </Text>{' '}
+                        keeps it in {requester}&apos;s personal space. They see
+                        your note and can ask again after changes.
                     </Text>
                 </Stack>
                 <Tooltip
@@ -163,7 +184,7 @@ const DecisionCard: FC<{
                 >
                     <Checkbox
                         label="Verify on approve"
-                        description="Marks it as the trusted version in the shared space"
+                        description="Adds a verified badge and ranks it first for Ask AI and search"
                         checked={verify}
                         disabled={!request.canVerify}
                         onChange={(event) =>
@@ -171,9 +192,8 @@ const DecisionCard: FC<{
                         }
                     />
                 </Tooltip>
-                <Stack gap="xs">
+                <Group gap="xs">
                     <Button
-                        fullWidth
                         loading={isApproving}
                         leftSection={<MantineIcon icon={IconCheck} />}
                         onClick={() =>
@@ -186,7 +206,6 @@ const DecisionCard: FC<{
                         Approve and move
                     </Button>
                     <Button
-                        fullWidth
                         variant="default"
                         color="red"
                         onClick={rejectHandlers.open}
@@ -194,7 +213,7 @@ const DecisionCard: FC<{
                     >
                         Reject
                     </Button>
-                </Stack>
+                </Group>
             </Stack>
             <RejectModal
                 opened={isRejectOpen}
@@ -220,132 +239,374 @@ const WaitingCard: FC<{
         useCancelContentReviewRequest(projectUuid);
     return (
         <Paper p="md">
-            <Stack gap="md">
+            <Group justify="space-between" align="flex-start" wrap="nowrap">
                 <Stack gap={4}>
                     <Title order={5}>Waiting for a reviewer</Title>
                     <Text fz="sm" c="dimmed">
                         Reviewers for{' '}
-                        {request.targetSpaceName ?? 'the target space'} have
-                        been notified. You can pull the request back at any
-                        time.
+                        {request.targetSpaceName ?? 'the target space'} were
+                        notified and will see your note. You can cancel the
+                        request at any time.
                     </Text>
                 </Stack>
                 <Button
-                    fullWidth
                     variant="default"
                     loading={isCancelling}
                     onClick={() => cancel(request.uuid)}
+                    className="ld-shrink-0"
                 >
                     Cancel request
                 </Button>
-            </Stack>
+            </Group>
         </Paper>
     );
 };
 
-const getDecisionLabel = (status: ContentReviewRequestStatus): string => {
-    switch (status) {
-        case ContentReviewRequestStatus.APPROVED:
-            return 'Approved';
-        case ContentReviewRequestStatus.REJECTED:
-            return 'Rejected';
-        case ContentReviewRequestStatus.CANCELLED:
-            return 'Cancelled';
+// The route this request is about, shown once under the title
+const MoveRoute: FC<{
+    request: ContentReviewRequestDetail;
+    isRequester: boolean;
+}> = ({ request, isRequester }) => {
+    const owner = isRequester
+        ? 'your personal space'
+        : `${request.requestedBy.firstName}'s personal space`;
+    const typeLabel = getContentTypeLabel(request.contentType);
+    const target = request.targetSpaceName ?? 'a deleted space';
+    switch (request.status) {
         case ContentReviewRequestStatus.PENDING:
-            return 'Pending';
+            return (
+                <Group gap={6} wrap="nowrap">
+                    <Text fz="sm" c="dimmed">
+                        {typeLabel} in {owner}
+                    </Text>
+                    <MantineIcon
+                        icon={IconArrowRight}
+                        color="dimmed"
+                        size="sm"
+                    />
+                    <Text fz="sm" c="dimmed">
+                        {target}
+                    </Text>
+                </Group>
+            );
+        case ContentReviewRequestStatus.APPROVED:
+            return (
+                <Text fz="sm" c="dimmed">
+                    {typeLabel} in {target}, moved from {owner}
+                </Text>
+            );
+        case ContentReviewRequestStatus.REJECTED:
+        case ContentReviewRequestStatus.CANCELLED:
+            return (
+                <Text fz="sm" c="dimmed">
+                    {typeLabel} in {owner}, not moved
+                </Text>
+            );
         default:
-            return assertUnreachable(status, 'Unknown review request status');
+            return assertUnreachable(
+                request.status,
+                'Unknown review request status',
+            );
     }
 };
 
-const ActivityCard: FC<{ request: ContentReviewRequestDetail }> = ({
+// Shown once per user, the first time they land on a request they can review
+const FirstReviewCallout: FC<{ userUuid: string }> = ({ userUuid }) => {
+    const [dismissed, setDismissed] = useLocalStorage(
+        `content-review-first-review-dismissed-${userUuid}`,
+        false,
+    );
+    if (dismissed) return null;
+    return (
+        <Callout
+            variant="info"
+            icon={<MantineIcon icon={IconEye} />}
+            title="You are reviewing a request"
+            withCloseButton
+            onClose={() => setDismissed(true)}
+        >
+            Editors build charts and dashboards in their own space and ask to
+            move them into a shared space. You decide whether this one is ready
+            for everyone.
+        </Callout>
+    );
+};
+
+// What the requester should do now that the request is decided
+const RequesterNextStep: FC<{ request: ContentReviewRequestDetail }> = ({
     request,
 }) => {
-    const isPending = request.status === ContentReviewRequestStatus.PENDING;
-    const isApproved = request.status === ContentReviewRequestStatus.APPROVED;
-    const decisionLabel = getDecisionLabel(request.status);
+    const noun = getContentTypeNoun(request.contentType);
+    switch (request.status) {
+        case ContentReviewRequestStatus.APPROVED:
+            return (
+                <Paper p="md">
+                    <Stack gap={4}>
+                        <Title order={5}>
+                            Your {noun} is live in{' '}
+                            {request.targetSpaceName ?? 'the shared space'}
+                        </Title>
+                        <Text fz="sm" c="dimmed">
+                            Everyone with access to that space can find it now.
+                            Edits from here on follow that space&apos;s
+                            permissions.
+                        </Text>
+                    </Stack>
+                </Paper>
+            );
+        case ContentReviewRequestStatus.REJECTED:
+            return (
+                <Paper p="md">
+                    <Stack gap={4}>
+                        <Title order={5}>What next</Title>
+                        <Text fz="sm" c="dimmed">
+                            The note above says what to change. Open the {noun},
+                            edit it, then request a review again from its menu.
+                        </Text>
+                    </Stack>
+                </Paper>
+            );
+        case ContentReviewRequestStatus.PENDING:
+        case ContentReviewRequestStatus.CANCELLED:
+            return null;
+        default:
+            return assertUnreachable(
+                request.status,
+                'Unknown review request status',
+            );
+    }
+};
+
+// One entry in the request thread: who did what, when, and anything they said
+const ThreadMessage: FC<
+    PropsWithChildren<{
+        user: ContentReviewUser;
+        action: ReactNode;
+        date: Date;
+    }>
+> = ({ user, action, date, children }) => (
+    <Paper p="md">
+        <Group gap="sm" align="flex-start" wrap="nowrap">
+            <LightdashUserAvatar size={28} userUuid={user.userUuid} fz="xs">
+                {getUserInitials(user)}
+            </LightdashUserAvatar>
+            <Stack gap="sm" className="ld-grow">
+                <Group gap={6} wrap="wrap">
+                    <Text fz="sm" fw={500}>
+                        {getUserFullName(user)}
+                    </Text>
+                    <Text fz="sm" c="dimmed">
+                        {action}
+                    </Text>
+                    <Text fz="sm" c="dimmed">
+                        ·
+                    </Text>
+                    <TimeAgo date={date} />
+                </Group>
+                {children}
+            </Stack>
+        </Group>
+    </Paper>
+);
+
+const isChartType = (contentType: ContentReviewContentType): boolean =>
+    contentType === ContentReviewContentType.CHART ||
+    contentType === ContentReviewContentType.SQL_CHART;
+
+const pluralise = (count: number, noun: string): string =>
+    `${count} ${noun}${count === 1 ? '' : 's'}`;
+
+const RequestMessage: FC<{
+    request: ContentReviewRequestDetail;
+    extraItems: ContentReviewMovedItem[];
+    isPending: boolean;
+    isRequester: boolean;
+    projectUuid: string;
+}> = ({ request, extraItems, isPending, isRequester, projectUuid }) => {
+    const noun = getContentTypeNoun(request.contentType);
+    const target = request.targetSpaceName ?? 'a deleted space';
+    const extrasNoun = extraItems.every((item) => isChartType(item.contentType))
+        ? 'chart'
+        : 'item';
+    const extrasCount = pluralise(extraItems.length, extrasNoun);
+    const action =
+        extraItems.length > 0
+            ? `asked to move this ${noun} and ${extrasCount} it uses into ${target}`
+            : `asked to move this ${noun} into ${target}`;
 
     return (
-        <Paper p="md">
-            <Stack gap="md">
-                <Title order={5}>Activity</Title>
-                <Timeline
-                    active={isPending ? 0 : 1}
-                    bulletSize={22}
-                    lineWidth={2}
+        <ThreadMessage
+            user={request.requestedBy}
+            action={action}
+            date={request.createdAt}
+        >
+            {request.requestNote && (
+                <Text fz="sm" className="ld-pre-wrap">
+                    {request.requestNote}
+                </Text>
+            )}
+            {extraItems.length > 0 && (
+                <Stack gap={4}>
+                    <Text fz="xs" fw={500} c="dimmed">
+                        {isPending ? 'Also moves' : 'Also moved'} {extrasCount}
+                    </Text>
+                    <Stack gap={0} className={classes.list}>
+                        {extraItems.map((item) => (
+                            <ContentReviewItemRow
+                                key={item.contentUuid}
+                                contentType={item.contentType}
+                                name={item.name}
+                                compact
+                            />
+                        ))}
+                    </Stack>
+                </Stack>
+            )}
+            <SimilarContentFooter
+                request={request}
+                projectUuid={projectUuid}
+                isRequester={isRequester}
+            />
+        </ThreadMessage>
+    );
+};
+
+const OutcomeMessage: FC<{ request: ContentReviewRequestDetail }> = ({
+    request,
+}) => {
+    if (request.reviewedAt === null) return null;
+    const note = request.reviewNote && (
+        <Text fz="sm" className="ld-pre-wrap">
+            {request.reviewNote}
+        </Text>
+    );
+    switch (request.status) {
+        case ContentReviewRequestStatus.PENDING:
+            return null;
+        case ContentReviewRequestStatus.CANCELLED:
+            return (
+                <ThreadMessage
+                    user={request.requestedBy}
+                    action="cancelled this request"
+                    date={request.reviewedAt}
                 >
-                    <Timeline.Item
-                        bullet={<MantineIcon icon={IconSend} size={12} />}
-                        title={
-                            <Text fz="sm" fw={500}>
-                                Requested by{' '}
-                                {getUserFullName(request.requestedBy)}
-                            </Text>
-                        }
-                    >
-                        <TimeAgo date={request.createdAt} />
-                    </Timeline.Item>
-                    {isPending ? (
-                        <Timeline.Item
-                            bullet={
-                                <MantineIcon icon={IconClockHour4} size={12} />
-                            }
-                            title={
-                                <Text fz="sm" fw={500} c="dimmed">
-                                    Waiting for review
-                                </Text>
-                            }
-                        />
-                    ) : (
-                        <Timeline.Item
-                            bullet={
-                                <MantineIcon
-                                    icon={isApproved ? IconCheck : IconX}
-                                    size={12}
-                                />
-                            }
-                            color={isApproved ? 'green' : 'red'}
-                            title={
-                                <Group gap="xs">
-                                    <Text fz="sm" fw={500}>
-                                        {decisionLabel}
-                                        {request.reviewedBy
-                                            ? ` by ${getUserFullName(request.reviewedBy)}`
-                                            : ''}
-                                    </Text>
-                                    {request.verifiedOnApprove && (
-                                        <Badge
-                                            size="xs"
-                                            color="green"
-                                            variant="light"
-                                            leftSection={
-                                                <MantineIcon
-                                                    icon={IconCircleCheckFilled}
-                                                    size={10}
-                                                />
-                                            }
-                                        >
-                                            Verified
-                                        </Badge>
-                                    )}
-                                </Group>
-                            }
-                        >
-                            <Stack gap="xs">
-                                {request.reviewedAt && (
-                                    <TimeAgo date={request.reviewedAt} />
+                    {note}
+                </ThreadMessage>
+            );
+        case ContentReviewRequestStatus.APPROVED:
+        case ContentReviewRequestStatus.REJECTED: {
+            if (request.reviewedBy === null) return null;
+            const isApproved =
+                request.status === ContentReviewRequestStatus.APPROVED;
+            return (
+                <ThreadMessage
+                    user={request.reviewedBy}
+                    action={
+                        <Group gap={6} wrap="nowrap">
+                            <MantineIcon
+                                icon={isApproved ? IconCheck : IconX}
+                                color={isApproved ? 'green.6' : 'red.6'}
+                                size="sm"
+                            />
+                            {isApproved
+                                ? 'approved and moved it'
+                                : 'rejected this request'}
+                            {request.verifiedOnApprove && (
+                                <Badge
+                                    size="xs"
+                                    color="green"
+                                    variant="light"
+                                    leftSection={
+                                        <MantineIcon
+                                            icon={IconCircleCheckFilled}
+                                            size={10}
+                                        />
+                                    }
+                                >
+                                    Verified
+                                </Badge>
+                            )}
+                        </Group>
+                    }
+                    date={request.reviewedAt}
+                >
+                    {note}
+                </ThreadMessage>
+            );
+        }
+        default:
+            return assertUnreachable(
+                request.status,
+                'Unknown review request status',
+            );
+    }
+};
+
+// Lives at the foot of the request message: what the requester was shown
+const SimilarContentFooter: FC<{
+    request: ContentReviewRequestDetail;
+    projectUuid: string;
+    isRequester: boolean;
+}> = ({ request, projectUuid, isRequester }) => {
+    const [opened, { toggle }] = useDisclosure(false);
+    const items = request.similarContent;
+    if (items.length === 0) return null;
+    const noun = items.every((item) => isChartType(item.contentType))
+        ? 'chart'
+        : 'item';
+    const verifiedCount = items.filter((item) => item.isVerified).length;
+    const isPending = request.status === ContentReviewRequestStatus.PENDING;
+    const hint = isRequester
+        ? 'You saw these before submitting.'
+        : isPending
+          ? `If one of these already answers the question, reject and point ${request.requestedBy.firstName} to it.`
+          : 'The requester saw these before submitting.';
+    const verifiedHint =
+        verifiedCount > 0
+            ? ` ${verifiedCount === 1 ? 'One is' : `${verifiedCount} are`} verified.`
+            : '';
+    return (
+        <Stack gap="xs" className={classes.footer}>
+            <Group gap={6} wrap="nowrap">
+                <MantineIcon icon={IconCopy} color="dimmed" size="sm" />
+                <Text fz="xs" c="dimmed">
+                    {pluralise(items.length, `similar ${noun}`)} already in
+                    shared spaces.
+                </Text>
+                <UnstyledButton
+                    onClick={toggle}
+                    aria-expanded={opened}
+                    className={classes.inlineToggle}
+                >
+                    {opened ? 'Hide' : 'Show'}
+                </UnstyledButton>
+            </Group>
+            <Collapse in={opened}>
+                <Stack gap={4}>
+                    <Text fz="xs" c="dimmed">
+                        {hint}
+                        {verifiedHint}
+                    </Text>
+                    <Stack gap={0} className={classes.list}>
+                        {items.map((item) => (
+                            <ContentReviewItemRow
+                                key={item.contentUuid}
+                                contentType={item.contentType}
+                                name={item.name}
+                                meta={`in ${item.spaceName}`}
+                                href={getContentHref(
+                                    projectUuid,
+                                    item.contentType,
+                                    item,
                                 )}
-                                {request.reviewNote && (
-                                    <Text fz="sm" className={classes.note}>
-                                        {request.reviewNote}
-                                    </Text>
-                                )}
-                            </Stack>
-                        </Timeline.Item>
-                    )}
-                </Timeline>
-            </Stack>
-        </Paper>
+                                isVerified={item.isVerified}
+                                compact
+                            />
+                        ))}
+                    </Stack>
+                </Stack>
+            </Collapse>
+        </Stack>
     );
 };
 
@@ -355,24 +616,26 @@ export const ContentReviewRequestDetailView: FC<{
 }> = ({ projectUuid, request }) => {
     const { user } = useApp();
     const isPending = request.status === ContentReviewRequestStatus.PENDING;
+    const isApproved = request.status === ContentReviewRequestStatus.APPROVED;
     const isRequester = user.data?.userUuid === request.requestedBy.userUuid;
     const contentName = request.content?.name ?? 'Deleted content';
-    const typeLabel = getContentTypeLabel(request.contentType);
-    const isApproved = request.status === ContentReviewRequestStatus.APPROVED;
-    const moveTitle = isPending
-        ? 'What will move'
-        : isApproved
-          ? 'What moved'
-          : 'Requested move';
-    // Null means the request ended without a move
+    // Nothing moved on a rejected or cancelled request
     const moveItems = isPending
         ? request.moveSet
         : isApproved
           ? request.movedContent
-          : null;
+          : [];
+    const extraItems = moveItems.filter(
+        (item) => item.contentUuid !== request.contentUuid,
+    );
+    const showWaitingNotice = isPending && !request.canReview && !isRequester;
+    const isReviewing = isPending && request.canReview;
 
     return (
         <Stack gap="lg">
+            {isReviewing && user.data && (
+                <FirstReviewCallout userUuid={user.data.userUuid} />
+            )}
             <Group justify="space-between" align="flex-start" wrap="nowrap">
                 <Group gap="sm" align="flex-start" wrap="nowrap">
                     <IconBox
@@ -386,16 +649,10 @@ export const ContentReviewRequestDetailView: FC<{
                             <Title order={3}>{contentName}</Title>
                             <ContentReviewStatusBadge status={request.status} />
                         </Group>
-                        <Group gap="xs">
-                            <Text fz="sm" c="dimmed">
-                                {typeLabel} requested by
-                            </Text>
-                            <ContentReviewUserChip user={request.requestedBy} />
-                            <Text fz="sm" c="dimmed">
-                                ·
-                            </Text>
-                            <TimeAgo date={request.createdAt} />
-                        </Group>
+                        <MoveRoute
+                            request={request}
+                            isRequester={isRequester}
+                        />
                     </Stack>
                 </Group>
                 {request.content && (
@@ -406,134 +663,43 @@ export const ContentReviewRequestDetailView: FC<{
                             request.contentType,
                             request.content,
                         )}
-                        variant="default"
+                        variant={isReviewing ? 'filled' : 'default'}
                         size="xs"
                         leftSection={<MantineIcon icon={IconExternalLink} />}
+                        className="ld-shrink-0"
                     >
                         Open {getContentTypeNoun(request.contentType)}
                     </Button>
                 )}
             </Group>
 
-            <Grid gutter="lg">
-                <Grid.Col span={{ base: 12, md: 8 }}>
-                    <Stack gap="lg">
-                        <Paper p="md">
-                            <Stack gap="md">
-                                <Title order={5}>{moveTitle}</Title>
-                                <Group gap="sm" wrap="nowrap">
-                                    <SpaceChip
-                                        name={
-                                            request.sourceSpaceName ??
-                                            'Personal space'
-                                        }
-                                        personal
-                                    />
-                                    <MantineIcon
-                                        icon={IconArrowRight}
-                                        color="dimmed"
-                                    />
-                                    <SpaceChip
-                                        name={
-                                            request.targetSpaceName ??
-                                            'Deleted space'
-                                        }
-                                    />
-                                </Group>
-                                {moveItems === null ? (
-                                    <Text fz="sm" c="dimmed">
-                                        Nothing moved. It stayed in{' '}
-                                        {request.sourceSpaceName ??
-                                            'the personal space'}
-                                        .
-                                    </Text>
-                                ) : moveItems.length === 0 ? (
-                                    <Text fz="sm" c="dimmed">
-                                        Nothing
-                                    </Text>
-                                ) : (
-                                    <Stack gap={0} className={classes.list}>
-                                        {moveItems.map((item) => (
-                                            <ContentReviewItemRow
-                                                key={item.contentUuid}
-                                                contentType={item.contentType}
-                                                name={item.name}
-                                            />
-                                        ))}
-                                    </Stack>
-                                )}
-                            </Stack>
-                        </Paper>
+            <RequestMessage
+                request={request}
+                extraItems={extraItems}
+                isPending={isPending}
+                isRequester={isRequester}
+                projectUuid={projectUuid}
+            />
+            <OutcomeMessage request={request} />
+            {isRequester && <RequesterNextStep request={request} />}
 
-                        <Paper p="md">
-                            <Stack gap="sm">
-                                <Title order={5}>
-                                    Note from {request.requestedBy.firstName}
-                                </Title>
-                                {request.requestNote ? (
-                                    <Text fz="sm" className={classes.note}>
-                                        {request.requestNote}
-                                    </Text>
-                                ) : (
-                                    <Text fz="sm" c="dimmed">
-                                        No note was added.
-                                    </Text>
-                                )}
-                            </Stack>
-                        </Paper>
-
-                        {request.similarContent.length > 0 && (
-                            <Paper p="md">
-                                <Stack gap="sm">
-                                    <Stack gap={2}>
-                                        <Title order={5}>
-                                            Similar content the requester was
-                                            shown
-                                        </Title>
-                                        <Text fz="xs" c="dimmed">
-                                            These already lived in shared spaces
-                                            when the request was made.
-                                        </Text>
-                                    </Stack>
-                                    <Stack gap={0} className={classes.list}>
-                                        {request.similarContent.map((item) => (
-                                            <ContentReviewItemRow
-                                                key={item.contentUuid}
-                                                contentType={item.contentType}
-                                                name={item.name}
-                                                meta={`${getContentTypeLabel(item.contentType)} in ${item.spaceName}`}
-                                                href={getContentHref(
-                                                    projectUuid,
-                                                    item.contentType,
-                                                    item,
-                                                )}
-                                                isVerified={item.isVerified}
-                                            />
-                                        ))}
-                                    </Stack>
-                                </Stack>
-                            </Paper>
-                        )}
-                    </Stack>
-                </Grid.Col>
-                <Grid.Col span={{ base: 12, md: 4 }}>
-                    <Stack gap="lg">
-                        {isPending && request.canReview && (
-                            <DecisionCard
-                                request={request}
-                                projectUuid={projectUuid}
-                            />
-                        )}
-                        {isPending && isRequester && !request.canReview && (
-                            <WaitingCard
-                                request={request}
-                                projectUuid={projectUuid}
-                            />
-                        )}
-                        <ActivityCard request={request} />
-                    </Stack>
-                </Grid.Col>
-            </Grid>
+            {isPending && request.canReview && (
+                <DecisionCard request={request} projectUuid={projectUuid} />
+            )}
+            {isPending && isRequester && !request.canReview && (
+                <WaitingCard request={request} projectUuid={projectUuid} />
+            )}
+            {showWaitingNotice && (
+                <Paper variant="dotted" p="md">
+                    <Group gap="xs">
+                        <MantineIcon icon={IconClockHour4} color="dimmed" />
+                        <Text fz="sm" c="dimmed">
+                            Waiting for a reviewer from{' '}
+                            {request.targetSpaceName ?? 'the target space'}.
+                        </Text>
+                    </Group>
+                </Paper>
+            )}
         </Stack>
     );
 };
@@ -555,19 +721,17 @@ const ContentReviewRequestPage: FC = () => {
             withCenteredContent
             withXLargePaddedContent
         >
-            <Stack gap="lg">
-                <PageBreadcrumbs
-                    items={[
-                        {
-                            title: 'Review requests',
-                            to: getContentReviewRequestsPath(projectUuid),
-                        },
-                        {
-                            title: request?.content?.name ?? 'Request',
-                            active: true,
-                        },
-                    ]}
-                />
+            <Stack gap="lg" className={classes.page}>
+                <Button
+                    component={Link}
+                    to={getContentReviewRequestsPath(projectUuid)}
+                    variant="subtle"
+                    size="xs"
+                    leftSection={<MantineIcon icon={IconArrowLeft} />}
+                    className={classes.backLink}
+                >
+                    Review requests
+                </Button>
                 {isInitialLoading && <EmptyStateLoader />}
                 {error && (
                     <SettingsEmptyState

--- a/packages/frontend/src/ee/features/contentReview/pages/ContentReviewRequestsPage.tsx
+++ b/packages/frontend/src/ee/features/contentReview/pages/ContentReviewRequestsPage.tsx
@@ -47,7 +47,7 @@ const STATUS_OPTIONS: {
     label: string;
 }[] = [
     { value: 'all', label: 'All statuses' },
-    { value: ContentReviewRequestStatus.PENDING, label: 'Pending' },
+    { value: ContentReviewRequestStatus.PENDING, label: 'Waiting for review' },
     { value: ContentReviewRequestStatus.APPROVED, label: 'Approved' },
     { value: ContentReviewRequestStatus.REJECTED, label: 'Rejected' },
     { value: ContentReviewRequestStatus.CANCELLED, label: 'Cancelled' },


### PR DESCRIPTION
## What

The review request detail page now reads as a request thread instead of a grid of cards.

- Single narrow column. Back link to the queue replaces the breadcrumb, so the content title appears once.
- Route line under the title says where the content is and where it is going, and changes tense with the outcome: "in Editor's personal space → Jaffle shop" while pending, "in Jaffle shop, moved from Editor's personal space" once approved, "not moved" when rejected or cancelled.
- The request is a message: avatar, "asked to move this chart into Jaffle shop", timestamp, note. Dashboards say "and 3 charts it uses" and list them inside the message.
- The outcome is a second message: approved and moved (with the Verified badge), rejected with the reviewer's note, or cancelled by the requester.
- Similar content is a one-line footer inside the request message with an inline Show toggle, instead of its own card. The hint tells the reviewer what to do with a duplicate and how many are verified.
- The decision card reads as a briefing: you have temporary access, open the chart and check it, Approve moves it and Reject keeps it in the personal space with your note. Open chart is the primary header action for reviewers. Verify explains what it changes.
- A one-time dismissible callout explains what a review request is the first time someone lands on one they can review.
- Requesters get a closing card after a decision: where the chart now lives, or what to do after a rejection. Viewers who can neither review nor cancel see a quiet waiting notice instead of nothing.
- Status badge says "Waiting for review" instead of "Pending", here and in the queue filter. Timestamps show the full date on hover. The reject textarea has an example placeholder.

Walkthrough of every state, captured from the dev app for the reviewer, the requester and a bystander: https://claude.ai/code/artifact/5feefa3d-0efc-400e-ae11-ab5b017ff79d

## Why

First-time viewers could not tell who requested what or where it moved. The chart title appeared three times, "Requested by" appeared twice, the requester's note sat in its own card away from the request, and "releases the temporary access" was never explained.

## Regression analysis

Frontend only. No API, type or backend change.

- Approve, reject and cancel calls are unchanged in payload and hook usage. The page tests cover approve with the verify default, the disabled verify checkbox, the required reject note, and the hidden decision on a decided request.
- `movedContent` and `moveSet` are still used for the extra items list. The primary content is filtered out by uuid because it is already the title, so the list only shows the charts a dashboard brings along. A dashboard with no personal-space charts shows no list, which matches the old empty state in intent.
- Cancelled requests have no reviewer. The outcome message falls back to the requester as the actor, and the rejected/approved branch returns nothing if the reviewer is missing rather than crashing.
- The status badge label change affects the queue page's status column and filter. The enum values are untouched, so filtering and the API are unaffected.
- The first-review callout stores its dismissal in localStorage keyed by user uuid via react-use, which is already used for the homepage promo. No server state.
- Verified in light and dark for all eleven states.

Relates: PROD-9730
Relates: #26967

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q8MNS6E8GNAX9UhPEUZozL