### PR TITLE
fix(frontend): cut dev-server work off the first-paint path

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -35,9 +35,9 @@ installChunkLoadErrorHandler();
 // redirects. Keeping it off the entry graph means a signed-out visitor never
 // pays for the agent-onboarding hooks just to see the login page.
 const AgentOnboardingCompletionWatcher = lazy(() =>
-    import(
-        './ee/features/agentOnboarding/AgentOnboardingCompletionWatcher'
-    ).then((module) => ({ default: module.AgentOnboardingCompletionWatcher })),
+    import('./ee/features/agentOnboarding/AgentOnboardingCompletionWatcher').then(
+        (module) => ({ default: module.AgentOnboardingCompletionWatcher }),
+    ),
 );
 
 // const isMobile =

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { ModalsProvider } from '@mantine/modals';
 import { wrapCreateBrowserRouterV7 } from '@sentry/react';
+import { lazy, Suspense } from 'react';
 import { createBrowserRouter, Outlet, RouterProvider } from 'react-router';
 import { DocumentTitle } from './components/common/DocumentTitle';
 import VersionAutoUpdater from './components/VersionAutoUpdater/VersionAutoUpdater';
@@ -7,7 +8,6 @@ import {
     CommercialMobileRoutes,
     CommercialWebAppRoutes,
 } from './ee/CommercialRoutes';
-import { AgentOnboardingCompletionWatcher } from './ee/features/agentOnboarding/AgentOnboardingCompletionWatcher';
 import { AiAgentsGlobalProvider } from './ee/features/aiCopilot/components/Launcher/AiAgentsGlobalProvider';
 import { parseEmbedThemeParams } from './ee/providers/Embed/parseEmbedThemeParams';
 import BuildSkewRefresher from './features/buildHashHandshake/BuildSkewRefresher';
@@ -30,6 +30,15 @@ import Routes from './Routes';
 import { IS_MOBILE } from './utils/isMobile';
 
 installChunkLoadErrorHandler();
+
+// Renders nothing — it only watches for a finished onboarding run and
+// redirects. Keeping it off the entry graph means a signed-out visitor never
+// pays for the agent-onboarding hooks just to see the login page.
+const AgentOnboardingCompletionWatcher = lazy(() =>
+    import(
+        './ee/features/agentOnboarding/AgentOnboardingCompletionWatcher'
+    ).then((module) => ({ default: module.AgentOnboardingCompletionWatcher })),
+);
 
 // const isMobile =
 //     /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
@@ -73,7 +82,11 @@ const router = sentryCreateBrowserRouter([
                                                 <SourceCodeEditorProvider>
                                                     <AiAgentsGlobalProvider>
                                                         {!isMinimalPage && (
-                                                            <AgentOnboardingCompletionWatcher />
+                                                            <Suspense
+                                                                fallback={null}
+                                                            >
+                                                                <AgentOnboardingCompletionWatcher />
+                                                            </Suspense>
                                                         )}
                                                         <Outlet />
                                                     </AiAgentsGlobalProvider>

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -147,6 +147,21 @@ export default defineConfig({
         hmr: {
             overlay: true,
         },
+        // Transform the entry graph at startup instead of on the first
+        // request. Without this the browser discovers these modules one
+        // import at a time and each one is compiled while it waits, which is
+        // most visible on a remote dev server (a cloud devbox or a PR
+        // preview) where that cost is paid over the network.
+        warmup: {
+            clientFiles: [
+                './src/index.tsx',
+                './src/App.tsx',
+                './src/Routes.tsx',
+                './src/MobileRoutes.tsx',
+                './src/ee/CommercialRoutes.tsx',
+                './src/providers/**/*.tsx',
+            ],
+        },
         allowedHosts: [
             'lightdash-dev', // for local development with docker
             'host.docker.internal', // for headless browser in docker (scheduled deliveries)


### PR DESCRIPTION
## Summary

Two small changes aimed at how long the dev server takes to paint when it is **not** on localhost — a cloud devbox or a PR preview, read over a slow link.

- **`server.warmup`** transforms the entry graph at startup instead of on first request. Without it the browser discovers these modules one import at a time, and each one is compiled while the browser waits. That cost is invisible on localhost and very visible over a network.
- **`AgentOnboardingCompletionWatcher` is now lazy.** It renders `null` — it only watches for a finished onboarding run and redirects. Loading it lazily keeps the agent-onboarding hooks off the entry graph, so a signed-out visitor doesn't pay for them just to see the login page. It sits behind `Suspense fallback={null}`, so nothing about what renders changes.

`AiAgentsGlobalProvider` is deliberately left eager: it wraps `{children}`, so deferring it would put Suspense above the router `Outlet` and *delay* first paint rather than help. `CommercialRoutes` already lazy-loads its route components, so it needed nothing.

## Context

Found while debugging a slow first paint on a PR preview over a mobile connection. Measured on a live preview, one page load pulled **249 modules / 12.92 MB uncompressed**. Most of that turned out to be a missing-compression problem in the preview proxy rather than anything in this repo, and it's fixed there — these two changes are the part that belongs in Lightdash.

## Noted while measuring, not addressed here

`packages/common/src/index.ts` re-exports two things every frontend page then loads, login included:

- **line 84** `export * from './dbt/validation'` — that module eagerly imports 15 dbt JSON schemas totalling **3.6 MB** (`manifestV12.json` and `manifestV20.json` are 1.33 MB each; served as Vite modules, 1,546,650 bytes each). Its only export is `ManifestValidator`, used **only** by backend and CLI — the frontend uses none of it.
- **line 85** `export * from './ee'` — 40 exports, so every page pulls the whole EE tree.

I left both alone because the obvious fix isn't safe: `@lightdash/common` has no `exports` map and publishes only `dist/**`, the backend builds with `tsc --build` and `rootDir: src` (so a `@lightdash/common/src/...` import from backend production code would break the build), and `ManifestValidator` is called from the **sync** static `_validateDbtModel`, so async schema loading would ripple. Filing separately.

## Test plan

- [ ] CI lint + typecheck (I had no Node toolchain on the host I was working from, so formatting is unverified locally — please flag if prettier disagrees)
- [ ] Dev server starts and the app paints as before
- [ ] Onboarding-completion redirect still fires after an onboarding run finishes

🤖 Generated with [Claude Code](https://claude.com/claude-code)