### PR TITLE
fix(frontend): replace history entry on share redirect to prevent back navigation trap

### DIFF
--- a/packages/frontend/src/pages/ShareRedirect.test.tsx
+++ b/packages/frontend/src/pages/ShareRedirect.test.tsx
@@ -1,0 +1,83 @@
+import { MantineProvider } from '@mantine/core';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import type * as ReactRouter from 'react-router';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router', async (importOriginal) => {
+    const actual = await importOriginal<typeof ReactRouter>();
+    return {
+        ...actual,
+        useNavigate: () => mockNavigate,
+    };
+});
+
+const mockUseGetShare = vi.fn();
+
+vi.mock('../hooks/useShare', () => ({
+    useGetShare: (shareNanoid?: string) => mockUseGetShare(shareNanoid),
+}));
+
+import ShareRedirect from './ShareRedirect';
+
+const renderShareRedirect = (nanoid = 'test-share-id') =>
+    render(
+        <MantineProvider>
+            <MemoryRouter initialEntries={[`/share/${nanoid}`]}>
+                <Routes>
+                    <Route
+                        path="/share/:shareNanoid"
+                        element={<ShareRedirect />}
+                    />
+                </Routes>
+            </MemoryRouter>
+        </MantineProvider>,
+    );
+
+describe('ShareRedirect', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('redirects with replace: true when share data is loaded', () => {
+        mockUseGetShare.mockReturnValue({
+            data: { url: '/projects/test-project/tables/orders' },
+            error: null,
+        });
+
+        renderShareRedirect();
+
+        expect(mockNavigate).toHaveBeenCalledWith(
+            '/projects/test-project/tables/orders',
+            { replace: true },
+        );
+    });
+
+    it('shows loading state while fetching share link', () => {
+        mockUseGetShare.mockReturnValue({
+            data: undefined,
+            error: null,
+        });
+
+        renderShareRedirect();
+
+        expect(screen.getByText('Loading...')).toBeInTheDocument();
+        expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it('shows error state when share link does not exist', () => {
+        mockUseGetShare.mockReturnValue({
+            data: undefined,
+            error: new Error('Not found'),
+        });
+
+        renderShareRedirect();
+
+        expect(
+            screen.getByText('Shared link does not exist'),
+        ).toBeInTheDocument();
+        expect(mockNavigate).not.toHaveBeenCalled();
+    });
+});

--- a/packages/frontend/src/pages/ShareRedirect.tsx
+++ b/packages/frontend/src/pages/ShareRedirect.tsx
@@ -12,7 +12,7 @@ const ShareRedirect: FC = () => {
 
     useEffect(() => {
         if (data && data.url) {
-            void navigate(data.url);
+            void navigate(data.url, { replace: true });
         }
     }, [data, navigate]);
 


### PR DESCRIPTION
Closes: #28622 

### Description:
Fixes an issue where navigating via "Explore from here" inside the "View underlying data" modal trapped browser back navigation.

#### Root Cause:
When "Explore from here" is clicked, it creates a shortened `/share/:nanoid` link and navigates to it. In `ShareRedirect.tsx`, once the share target URL was retrieved, `navigate(data.url)` was executed with the default push behavior (`replace: false`). This left `/share/:nanoid` as an intermediate redirect page in the browser history stack:
`[Dashboard, /share/:nanoid, Explore]`

Clicking the browser's Back button popped back to `/share/:nanoid`, which immediately re-triggered `navigate(data.url)` and bounced the user right back into Explore, preventing them from returning to the dashboard in one click.

#### Solution:
- Updated `ShareRedirect.tsx` to use `navigate(data.url, { replace: true })`, replacing the `/share/:nanoid` history entry with the destination URL.
- Added unit tests in `ShareRedirect.test.tsx` verifying that `navigate` is called with `{ replace: true }`, as well as verifying loading and error states.
- Preserves expected behavior for direct visits to `/share/:nanoid` links (clicking back correctly returns to the referring site or previous page rather than re-redirecting).

### Risk assessment:
Low risk: routing fix.