### PR TITLE
fix(frontend): format move dialog content types

### DIFF
--- a/packages/frontend/src/components/common/TransferItemsModal/TransferItemsModal.tsx
+++ b/packages/frontend/src/components/common/TransferItemsModal/TransferItemsModal.tsx
@@ -147,7 +147,9 @@ const TransferItemsModal = <R extends ResourceViewItem, T extends Array<R>>({
 
     return (
         <MantineModal
-            title={title ?? `Move ${getItemsText(items).type}`}
+            title={
+                title ?? `Move ${getItemsText(items).type.replace(/_/g, ' ')}`
+            }
             opened={opened}
             onClose={onClose}
             icon={IconFolderShare}


### PR DESCRIPTION
## What changed

## Summary
- Format move-to-space modal content types for user-facing titles.
- Render `data_app` as `data app` while preserving explicit custom titles and existing bulk-item copy.

## Review notes
- A standards review noted that a centralized resource-label helper could avoid deriving copy from enum values. This patch intentionally uses the ticket-specified underscore replacement because it is the narrowest change and preserves the existing casing and bulk behavior; switching label sources would broaden scope and could alter copy for other resource types.

## Testing
- `pnpm -F frontend exec oxfmt src/components/common/TransferItemsModal/TransferItemsModal.tsx --check`
- `pnpm -F frontend lint`
- `pnpm -F frontend typecheck`
- `pnpm -F frontend exec vitest related src/components/common/TransferItemsModal/TransferItemsModal.tsx --run` (3 files, 12 tests passed)
- `git diff --check`

## Verification

Passed:
- `pnpm -F frontend exec oxfmt src/components/common/TransferItemsModal/TransferItemsModal.tsx --check`
- `pnpm -F frontend lint` — 0 warnings, 0 errors
- `pnpm -F frontend typecheck`
- `pnpm -F frontend exec vitest related src/components/common/TransferItemsModal/TransferItemsModal.tsx --run` — 3 test files, 12 tests passed
- `git diff --check`

## Development environment

[Open the public Lightdash development environment](https://ld-runner-prod-10977-e6870b1958bc.exe.xyz) (anyone with the URL can access it)

Login: `demo@lightdash.com` / `demo_password!`

## References

Closes: PROD-10977

