### PR TITLE
fix: refresh explores after creating virtual views

### DIFF
--- a/packages/frontend/src/features/virtualView/hooks/useVirtualView.test.tsx
+++ b/packages/frontend/src/features/virtualView/hooks/useVirtualView.test.tsx
@@ -1,0 +1,79 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { type FC, type PropsWithChildren } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { lightdashApi } from '../../../api';
+import { useCreateVirtualView } from './useVirtualView';
+
+vi.mock('../../../api', () => ({ lightdashApi: vi.fn() }));
+vi.mock('../../../hooks/toaster/useToaster', () => ({
+    default: () => ({
+        showToastSuccess: vi.fn(),
+        showToastApiError: vi.fn(),
+    }),
+}));
+
+const setup = () => {
+    const queryClient = new QueryClient({
+        defaultOptions: {
+            queries: { retry: false },
+            mutations: { retry: false },
+        },
+    });
+    queryClient.setQueryData(
+        ['tables', 'project-slug', 'filtered', 'without-pre-aggregates'],
+        [],
+    );
+    queryClient.setQueryData(
+        ['tables', 'project-uuid', 'all', 'without-pre-aggregates'],
+        [],
+    );
+
+    const wrapper: FC<PropsWithChildren> = ({ children }) => (
+        <QueryClientProvider client={queryClient}>
+            {children}
+        </QueryClientProvider>
+    );
+    const { result } = renderHook(
+        () => useCreateVirtualView({ projectUuid: 'project-uuid' }),
+        { wrapper },
+    );
+
+    return { queryClient, result };
+};
+
+describe('useCreateVirtualView', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('invalidates every explore list cache after creating a virtual view', async () => {
+        vi.mocked(lightdashApi).mockResolvedValue({ name: 'new_view' });
+        const { queryClient, result } = setup();
+
+        result.current.mutate({
+            projectUuid: 'project-uuid',
+            name: 'new_view',
+            sql: 'SELECT 1',
+            columns: [],
+        });
+
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+        expect(
+            queryClient.getQueryState([
+                'tables',
+                'project-slug',
+                'filtered',
+                'without-pre-aggregates',
+            ])?.isInvalidated,
+        ).toBe(true);
+        expect(
+            queryClient.getQueryState([
+                'tables',
+                'project-uuid',
+                'all',
+                'without-pre-aggregates',
+            ])?.isInvalidated,
+        ).toBe(true);
+    });
+});

--- a/packages/frontend/src/features/virtualView/hooks/useVirtualView.tsx
+++ b/packages/frontend/src/features/virtualView/hooks/useVirtualView.tsx
@@ -39,6 +39,7 @@ export const useCreateVirtualView = ({
 }: {
     projectUuid: string;
 }) => {
+    const queryClient = useQueryClient();
     const { showToastSuccess, showToastApiError } = useToaster();
     return useMutation<
         ApiCreateVirtualView['results'],
@@ -48,7 +49,8 @@ export const useCreateVirtualView = ({
         } & CreateVirtualViewPayload
     >({
         mutationFn: createVirtualView,
-        onSuccess: (data) => {
+        onSuccess: async (data) => {
+            await queryClient.invalidateQueries({ queryKey: ['tables'] });
             showToastSuccess({
                 title: 'Success! Virtual view created',
                 action: {


### PR DESCRIPTION
## What changed

## Summary
- invalidate all `tables` explore-list queries after a virtual view is created and before showing the success toast
- add regression coverage proving both slug- and UUID-keyed explore caches are invalidated

## Review
- Standards review: no findings
- Specification review: no findings

## Verification

- `pnpm -F frontend test src/features/virtualView/hooks/useVirtualView.test.tsx` — passed (1 test)
- `pnpm -F frontend exec oxfmt src/features/virtualView/hooks/useVirtualView.tsx src/features/virtualView/hooks/useVirtualView.test.tsx --check` — passed
- `pnpm -F frontend lint` — passed (0 warnings, 0 errors)
- `pnpm -F frontend typecheck` — passed
- `pnpm -F frontend exec vitest related src/features/virtualView/hooks/useVirtualView.tsx src/features/virtualView/hooks/useVirtualView.test.tsx --run` — passed (4 files, 34 tests)

## Development environment

[Open the public Lightdash development environment](https://ld-runner-prod-10976-26049d31fa56.exe.xyz) (anyone with the URL can access it)

Login: `demo@lightdash.com` / `demo_password!`

## References

Closes: PROD-10976

