### PR TITLE
feat(common): TRAINING project type and the trainee scope set

### DIFF
--- a/docs/learn/architecture.md
+++ b/docs/learn/architecture.md
@@ -1,0 +1,157 @@
+# Learn: in-product training on a sample project
+
+Learn gives every member of an organisation a place to practise Lightdash without touching real data: a
+**training project** seeded with sample content, and a library of **walkthroughs** that each teach one permission
+by having the learner click the real product, step by step, inside their own throwaway copy of that project.
+This is the architecture-level view: what it is, what is possible, how it functions, and where the boundaries sit.
+Code is the reference for anything finer-grained. Specs live in Linear (CS-207, CS-211, CS-257).
+
+---
+
+## What it is
+
+- **A project type.** `ProjectType.TRAINING` (`packages/common/src/types/projects.ts`) is a project like any other
+  in the database, created once per organisation from the same embedded DuckDB bundle the playground uses:
+  precompiled explores cached from JSON, no dbt, no warehouse. Seeding adds a public *Training* space, charts, a
+  dashboard, pins, a comment and catalog categories; on Enterprise it also adds a data app, an AI agent and a
+  finished deep-research report, so every walkthrough has something to show.
+- **A permission layer with no membership rows.** Every member of the organisation, whatever their org role,
+  can see the shared training project and gets a *trainee* set of permissions on their own copies of it. Nothing
+  is granted by an admin and new joiners are covered automatically.
+- **Walkthroughs generated from the product.** A walkthrough is not written by hand. Product components carry
+  `data-tour-*` markers beside the permission checks that gate them; a build-time script reads those markers and
+  the docs repository and writes each walkthrough's steps as data. The library, the titles, the explanatory text
+  and the checks that enforce the rules all derive from that.
+- **Off by default.** `LIGHTDASH_LEARN_ENABLED` (config `learn.enabled`) turns the whole thing on. When it is off
+  there is no Learn icon, no page, no endpoints and no permission layer, even if a training project already
+  exists.
+
+## Actors
+
+| Actor            | Role                                                                                              |
+| ---------------- | ------------------------------------------------------------------------------------------------- |
+| **Org admin**    | Presses Enable Learn once; becomes the training project's admin; the only one who can delete it.  |
+| **Learner**      | Any org member. Browses the shared project as a viewer, practises in their own copy as a trainee. |
+| **Seed**         | The playground bundle plus `content.json`: what every training project and every copy starts from. |
+| **Generator**    | Build-time script that turns product markers and docs sentences into walkthrough data; CI enforces it. |
+| **Tour kit**     | Renders one step at a time over the real product and advances on the learner's own click.         |
+
+
+## What is possible
+
+A learner opens the Learn library from the icon beside notifications, picks a module and presses Start. Lightdash
+makes a fresh copy of the training project for them, opens the walkthrough on the page where it begins, and
+highlights the one control to click at each step. Typed steps offer a suggestion so the learner never has to
+invent input. The last step shows the result, then *Got it* opens a completion dialog and *Back to library*
+deletes the copy and returns to the library, where the module is marked done.
+
+Inside their copy a trainee can do what a project admin can, minus anything that breaks the project or reaches
+outside it: explore, run SQL, save charts, dashboards and spaces, pin, comment, verify, categorise, export results,
+and on Enterprise, ask the seeded agent, run deep research, and build and share data apps. They cannot change
+project settings or the connection, compile, delete the project, send deliveries or Google Sheets syncs, use git,
+source code or external connections, give an agent Slack channels or MCP servers, or read other people's threads
+and analytics.
+
+On the shared training project itself, everyone is a viewer. Nothing anyone does in a copy reaches the seed the
+next learner copies from.
+
+## How it functions
+
+### Enabling
+
+An organisation admin opens the Learn page and presses **Enable Learn** (`POST /api/v1/org/training-project`,
+`organizationController.ts`). `provisionTrainingProject.ts` creates the project under a per-organisation advisory
+lock, loads the embedded bundle, seeds the content (`ee/services/ProjectService/seedPlaygroundContent.ts`, shared
+with the playground) and makes the admin who clicked the project's admin. If seeding fails the project is deleted
+and the error surfaces. Enabling takes a second or two: nothing deploys, the DuckDB file ships in the image and
+explores are precompiled.
+
+### Permissions
+
+`UserModel.applyTrainingProjectAbilities` runs when a session user's abilities are built. It finds the org's
+training project and the user's own copies, then applies `getTrainingProjectViewerScopes()` to the shared project
+and `getTrainingProjectScopes()` to the copies (`packages/common/src/authorization/roleToScopeMapping.ts`). The
+trainee set is the project-admin scope list with organisation-only scopes and the exclusions above removed. The
+layer only adds rights; it never removes any a user already holds. Service accounts and personal access tokens
+never receive it, and it resolves by the user's own organisation so no one gets it on another org's project.
+
+### Training copies
+
+A copy is an ordinary preview project marked `provisioning_source = 'training'`, created by
+`ProjectService.createTrainingPreview` (`POST /projects/{trainingProjectUuid}/training-previews`,
+`projectController.ts`) and deleted by its `DELETE` counterpart. Copies carry the seed's content only: the seed
+admin's charts, dashboards, comments and deep-research runs, never what a learner wrote on the shared project or
+in another copy. A learner has one copy at a time (a per-user advisory lock and a short cooldown enforce this),
+copies expire after 24 hours, and deleting a copy also removes its duplicated data-app files. Deleting the
+training project deletes its copies first. A copy cannot be minted from the outside: preview creation and
+metadata updates refuse a training project as upstream unless the call comes from the training path.
+
+The navbar shows a copy as *Training copy* and skips the preview banner, since a copy is not a preview in the
+engineering sense: no branch, nothing to promote.
+
+### Walkthroughs
+
+- **Markers.** A control that a scope unlocks carries `data-tour-scope`, `data-tour-step`, `data-tour-route`,
+  `data-tour-label` and `data-tour-docs` beside the ability check that hides it; the full vocabulary is documented
+  at the top of `scripts/scope-tours/generate.ts`. The first step's marker sits on the result the walkthrough
+  proves.
+- **Generation.** `scripts/scope-tours/generate.ts` reads the markers and the docs repository
+  (`LIGHTDASH_DOCS_DIR`) and writes `packages/frontend/src/features/scopeTours/generated.ts`: one tour per scope,
+  step text taken from cited docs sentences, links allowlisted to the docs site. `check.ts` enforces the rules
+  (one control per step, docs anchors exist, no typed steps without a suggestion, titles and bodies within
+  length, routes known) and CI runs it with `scope-tours-check.yml`; `smoke.ts` completes every tour on a running
+  instance by clicking only what it highlights, and `scope-tours-smoke.yml` runs that. The skill
+  `.claude/skills/add-scope-walkthrough` is the recipe for adding one.
+- **Host and kit.** `features/scopeTours/ScopeTourHost.tsx` mounts on project routes, reads the tour for the
+  scope in the URL, requests a copy when the current project is the training project, and drives
+  `components/common/GuidedTour`: an overlay that blocks everything but the highlighted control, a card with the
+  step's title and docs sentence, scrolling the target into view inside any scrolling ancestor, and the completion
+  dialog.
+- **Library.** `features/learn/LearnPage.tsx` lists one module per trainee scope from `catalogue.ts`: the title is
+  the scope registry's description, the group is the registry's group, the module is available when a generated
+  walkthrough exists, and its blurb is that walkthrough's opening docs sentence. Foundations (what a viewer can
+  already do) is the first section. Progress (`progress.ts`) is kept in the browser for now.
+
+## Boundaries and invariants
+
+| Boundary                         | Enforced by                                                                 |
+| -------------------------------- | --------------------------------------------------------------------------- |
+| Shared training project is read-only for learners | `getTrainingProjectViewerScopes()` on `ProjectType.TRAINING`             |
+| Trainee rights only in the learner's own copy     | copy = `PREVIEW` + `provisioning_source='training'` + `created_by` = user |
+| No real data reachable                            | embedded read-only DuckDB file, SELECT-only gate, no filesystem or network functions |
+| No way outside the copy                           | trainee set excludes deliveries, sheets, git, source, external connections; agents in training refuse Slack and MCP; moving an agent checks the destination |
+| One copy per learner, bounded lifetime            | per-user advisory lock, cooldown, 24 h expiry, app files deleted with the copy |
+| Nothing shows when Learn is off                   | `learn.enabled` gates the icon, page, endpoints and the permission layer   |
+
+## Traps
+
+- **The shared project is read-only on purpose.** A learner who cannot save a chart there is not missing a
+  permission; saving happens in the copy. Do not grant the trainee set on `ProjectType.TRAINING`.
+- **A copy is recognised by `provisioning_source`, not by `copied_from` or the upstream link.** Both of those can
+  be set from the public API; the provisioning source only by the internal path. Any new check for "is this a
+  training copy" must use `provisioning_source = 'training'`.
+- **Only the seed admin's content travels into a copy.** Comments and deep-research runs are filtered by the
+  training project's creator. Copying "everything in the project" would leak one learner's work into the next.
+- **The project-wide app listing answers 403 for learners by design.** `GET /ee/projects/{uuid}/apps` is the
+  admin, CLI and embed view; the browse page uses the access-filtered content listing. A 403 there is not a bug in
+  the viewer set.
+- **Enterprise modules disappear without a licence, and data apps need the flag as well.** The library hides
+  them; a walkthrough started by URL for a hidden module will stall on a control that is not rendered.
+- **A fresh checkout serves stale routes.** `routes.ts` is committed only by the release workflow; run
+  `pnpm -F backend generate-api` after checking out a branch that adds the Learn endpoints, or every one of them
+  answers 404. The Rainbow recipe does this in its build.
+- **`LIGHTDASH_LEARN_ENABLED` off is total.** No icon, no page, no endpoints and no trainee scopes, even with a
+  training project in the database. An instance that looks like "Learn vanished" almost always has the switch off.
+
+## Where it is going
+
+Stack 1 merges behind the switch and goes live on the internal instance first (CS-263), with the walkthrough
+content following in six further pull requests. Next on the product side: a playground badge and a deletion guard
+for the training project (CS-261), a visual pass on the kit and library (CS-262), library search and a "request a
+module" route (CS-258, CS-259), and progress stored server-side rather than in the browser.
+
+## Rollout
+
+Stack 1 (PRs #28710 to #28716) carries the type, the permission layer and copies, the seeded content, the tour
+kit, the host and generator, the library, and Enable Learn. Walkthrough content follows in further pull requests.
+Merging the stack changes nothing on an instance until `LIGHTDASH_LEARN_ENABLED=true` is set.

--- a/packages/backend/src/database/migrations/20260904160000_add_training_project_type.ts
+++ b/packages/backend/src/database/migrations/20260904160000_add_training_project_type.ts
@@ -1,0 +1,25 @@
+import { Knex } from 'knex';
+
+// Values copied here on purpose: migrations never import application enums.
+const ProjectTypeTableName = 'project_type';
+const ProjectTypeColumn = 'project_type';
+const TrainingProjectType = 'TRAINING';
+
+/**
+ * Registers the TRAINING project type (sample-data training project, one per
+ * organization, created only by internal provisioning). `projects.project_type`
+ * references this lookup table, so the value must exist before a training
+ * project can be inserted.
+ */
+export async function up(knex: Knex): Promise<void> {
+    await knex(ProjectTypeTableName)
+        .insert({ [ProjectTypeColumn]: TrainingProjectType })
+        .onConflict(ProjectTypeColumn)
+        .ignore();
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex(ProjectTypeTableName)
+        .where(ProjectTypeColumn, TrainingProjectType)
+        .delete();
+}

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -996,6 +996,11 @@ export class ProjectService extends BaseService {
                     },
                 );
 
+            case ProjectType.TRAINING:
+                throw new ForbiddenError(
+                    'Training projects are created by the training provisioner only.',
+                );
+
             case ProjectType.PREVIEW: {
                 let upstreamProject: Awaited<
                     ReturnType<ProjectModel['get']>

--- a/packages/cli/src/handlers/dbt/apiClient.ts
+++ b/packages/cli/src/handlers/dbt/apiClient.ts
@@ -285,6 +285,11 @@ export const checkProjectCreationPermission = async (
                         `Contact your organization admin to request access.`,
                 );
 
+            case ProjectType.TRAINING:
+                throw new ForbiddenError(
+                    `Training projects are created from the app by an organization admin, not from the CLI.`,
+                );
+
             case ProjectType.PREVIEW:
                 if (upstreamProjectUuid) {
                     if (

--- a/packages/common/src/authorization/roleToScopeMapping.test.ts
+++ b/packages/common/src/authorization/roleToScopeMapping.test.ts
@@ -9,6 +9,7 @@ import {
     getAllScopesForRole,
     getNonEnterpriseScopesForRole,
     getTrainingProjectScopes,
+    getTrainingProjectViewerScopes,
     isSystemRole,
     TRAINING_PROJECT_EXCLUDED_SCOPES,
 } from './roleToScopeMapping';
@@ -57,6 +58,34 @@ describe('roleToScopeMapping', () => {
             TRAINING_PROJECT_EXCLUDED_SCOPES.forEach((scope) =>
                 expect(known.has(scope)).toBe(true),
             );
+        });
+
+        it("never grants other people's threads, documents or analytics", () => {
+            [
+                'view:AiAgentThread',
+                'manage:AiAgentThread',
+                'view:AiAgentDocument',
+                'manage:AiAgentDocument',
+                'view:Analytics',
+            ].forEach((scope) => expect(trainee).not.toContain(scope));
+            expect(trainee).toContain('view:AiAgentThread@self');
+            expect(trainee).toContain('manage:AiAgentThread@self');
+        });
+
+        it("the shared training project gets a viewer's project scopes only", () => {
+            const shared = getTrainingProjectViewerScopes();
+            shared.forEach((scope) => expect(trainee).toContain(scope));
+            expect(shared).toContain('view:Project');
+            expect(shared).toContain('view:SavedChart');
+            expect(shared).toContain('view:DataApp');
+            expect(shared).toContain('view:AiAgent');
+            [
+                'manage:SavedChart',
+                'manage:SqlRunner',
+                'manage:AiAgent',
+                'create:DashboardComments',
+                'manage:Space',
+            ].forEach((scope) => expect(shared).not.toContain(scope));
         });
 
         it('keeps the controls training depends on', () => {

--- a/packages/common/src/authorization/roleToScopeMapping.test.ts
+++ b/packages/common/src/authorization/roleToScopeMapping.test.ts
@@ -8,16 +8,70 @@ import { PROJECT_EDITOR } from './projectMemberAbility.mock';
 import {
     getAllScopesForRole,
     getNonEnterpriseScopesForRole,
+    getTrainingProjectScopes,
     isSystemRole,
+    TRAINING_PROJECT_EXCLUDED_SCOPES,
 } from './roleToScopeMapping';
 import {
     debugRoleScopeMapping,
     validateRoleInheritance,
 } from './roleToScopeMapping.testUtils';
 import { buildAbilityFromScopes } from './scopeAbilityBuilder';
+import { getOrganizationOnlyScopes, getScopes } from './scopes';
 import { type MemberAbility } from './types';
 
 describe('roleToScopeMapping', () => {
+    describe('getTrainingProjectScopes', () => {
+        const trainee = getTrainingProjectScopes();
+        const admin = getAllScopesForRole(ProjectMemberRole.ADMIN);
+
+        it('is a subset of the project admin scope set', () => {
+            trainee.forEach((scope) => expect(admin).toContain(scope));
+        });
+
+        it('contains no organization-only scope', () => {
+            const orgOnly = new Set<string>(getOrganizationOnlyScopes());
+            trainee.forEach((scope) => expect(orgOnly.has(scope)).toBe(false));
+        });
+
+        it('omits every excluded scope', () => {
+            TRAINING_PROJECT_EXCLUDED_SCOPES.forEach((scope) =>
+                expect(trainee).not.toContain(scope),
+            );
+        });
+
+        it('grants every other admin scope, so admin-set changes are caught', () => {
+            const orgOnly = new Set<string>(getOrganizationOnlyScopes());
+            const expected = admin.filter(
+                (scope) =>
+                    !orgOnly.has(scope) &&
+                    !TRAINING_PROJECT_EXCLUDED_SCOPES.includes(scope),
+            );
+            expect(new Set(trainee)).toEqual(new Set(expected));
+        });
+
+        it('only excludes scopes that exist in the vocabulary', () => {
+            const known = new Set<string>(
+                getScopes({ isEnterprise: true }).map((scope) => scope.name),
+            );
+            TRAINING_PROJECT_EXCLUDED_SCOPES.forEach((scope) =>
+                expect(known.has(scope)).toBe(true),
+            );
+        });
+
+        it('keeps the controls training depends on', () => {
+            [
+                'manage:PinnedItems',
+                'manage:SavedChart',
+                'manage:Dashboard',
+                'manage:Space',
+                'manage:SqlRunner',
+                'manage:Validation',
+                'manage:DataApp',
+            ].forEach((scope) => expect(trainee).toContain(scope));
+        });
+    });
+
     describe('isSystemRole', () => {
         it('should return true for valid system role "developer"', () => {
             expect(isSystemRole('developer')).toBe(true);

--- a/packages/common/src/authorization/roleToScopeMapping.ts
+++ b/packages/common/src/authorization/roleToScopeMapping.ts
@@ -290,6 +290,14 @@ export const TRAINING_PROJECT_EXCLUDED_SCOPES: readonly string[] = [
     'create:Project@preview',
     'create:DataApp@preview',
     'manage:DataApp@preview',
+    // Other people's data: every learner's threads, the usage analytics of
+    // colleagues, and agent knowledge documents. A learner reads and manages
+    // their own threads (`@self`) only.
+    'view:AiAgentThread',
+    'manage:AiAgentThread',
+    'view:AiAgentDocument',
+    'manage:AiAgentDocument',
+    'view:Analytics',
 ];
 
 /**
@@ -304,6 +312,29 @@ export const getTrainingProjectScopes = (): string[] =>
             !isOrganizationOnlyScope(scope) &&
             !TRAINING_PROJECT_EXCLUDED_SCOPES.includes(scope),
     );
+
+/**
+ * What every org member holds on the shared training project itself: a
+ * viewer's project scopes, so the seed can be browsed and the library opened
+ * but nothing written. Writing happens in the learner's own copy, which gets
+ * `getTrainingProjectScopes()`; a shared project anyone could write to would
+ * leak every learner's edits into everyone else's copies.
+ */
+/**
+ * Read-only views of the seeded Enterprise content a plain viewer would not
+ * have, so learners can look at the shared project's data app and agent
+ * before practising on their own copy. Still nothing written.
+ */
+const TRAINING_PROJECT_VIEWER_EXTRA_SCOPES = ['view:DataApp', 'view:AiAgent'];
+
+export const getTrainingProjectViewerScopes = (): string[] => [
+    ...getAllScopesForRole(ProjectMemberRole.VIEWER).filter(
+        (scope) =>
+            !isOrganizationOnlyScope(scope) &&
+            !TRAINING_PROJECT_EXCLUDED_SCOPES.includes(scope),
+    ),
+    ...TRAINING_PROJECT_VIEWER_EXTRA_SCOPES,
+];
 
 /**
  * Gets only the non-enterprise scopes for a role (filters out enterprise-only features)

--- a/packages/common/src/authorization/roleToScopeMapping.ts
+++ b/packages/common/src/authorization/roleToScopeMapping.ts
@@ -3,6 +3,7 @@ import {
     ProjectMemberRoleLabels,
 } from '../types/projectMemberRole';
 import type { RoleWithScopes } from '../types/roles';
+import { isOrganizationOnlyScope } from './scopes';
 
 /**
  * Utility functions to convert project member roles to equivalent scope sets
@@ -248,6 +249,61 @@ export const PROJECT_ROLE_TO_SCOPES_MAP: Record<ProjectMemberRole, string[]> =
 export const getAllScopesForRole = (role: ProjectMemberRole): string[] => [
     ...PROJECT_ROLE_TO_SCOPES_MAP[role],
 ];
+
+/**
+ * Scopes a training project never grants, on top of every organization-only
+ * scope (those are filtered by `isOrganizationOnlyScope`). Grouped by the
+ * reason each is left out. Everything else in the project-admin set is
+ * granted to every org member on the org's training project.
+ */
+export const TRAINING_PROJECT_EXCLUDED_SCOPES: readonly string[] = [
+    // Break-the-project: deleting it, changing its settings or connection,
+    // refreshing or redeploying dbt, pre-aggregation jobs. `manage:Project`
+    // goes too: CASL's `manage` implies every action, so keeping it would
+    // hand back `update` and `delete` on the project.
+    'manage:Project',
+    'delete:Project',
+    'delete:Project@self',
+    'update:Project',
+    'update:Project@self',
+    'manage:CompileProject',
+    'manage:DeployProject',
+    'manage:DeployProject@self',
+    'create:Job',
+    'manage:Job',
+    'manage:PreAggregation',
+    // Outbound messaging: a viewer must not be able to email or Slack
+    // arbitrary recipients through the instance
+    'create:ScheduledDeliveries',
+    'manage:ScheduledDeliveries',
+    'manage:ScheduledDeliveries@self',
+    'manage:GoogleSheets',
+    // Egress and supply chain: custom npm deps, external connections and
+    // sources, git integration, source-code PRs, preview-project creation
+    'manage:DataAppDependency',
+    'manage:ExternalConnection',
+    'view:ExternalConnection',
+    'manage:ExternalSource',
+    'manage:GitIntegration',
+    'manage:SourceCode',
+    'view:SourceCode',
+    'create:Project@preview',
+    'create:DataApp@preview',
+    'manage:DataApp@preview',
+];
+
+/**
+ * The trainee scope set: project admin minus organization-only scopes minus
+ * `TRAINING_PROJECT_EXCLUDED_SCOPES`. Derived by rule so an addition to the
+ * admin set is granted on training projects unless it is org-only or
+ * explicitly excluded here.
+ */
+export const getTrainingProjectScopes = (): string[] =>
+    getAllScopesForRole(ProjectMemberRole.ADMIN).filter(
+        (scope) =>
+            !isOrganizationOnlyScope(scope) &&
+            !TRAINING_PROJECT_EXCLUDED_SCOPES.includes(scope),
+    );
 
 /**
  * Gets only the non-enterprise scopes for a role (filters out enterprise-only features)

--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -5,6 +5,13 @@ import { type ProjectGroupAccess } from './projectGroupAccess';
 export enum ProjectType {
     DEFAULT = 'DEFAULT',
     PREVIEW = 'PREVIEW',
+    /**
+     * Sample-data training project. One per organization, created only by
+     * internal provisioning. Every org member gets the trainee scope set on
+     * it (see `getTrainingProjectScopes` in authorization) so people can be
+     * taught controls they do not hold on real projects.
+     */
+    TRAINING = 'TRAINING',
 }
 
 export enum DbtProjectType {
@@ -1261,6 +1268,17 @@ export type PlaygroundProjectTrigger =
 
 export type EnsurePlaygroundProjectRequest = {
     trigger?: PlaygroundProjectTrigger;
+};
+
+/** A learner's own throwaway copy of the training project, made for one walkthrough. */
+export type CreateTrainingPreviewResults = {
+    projectUuid: string;
+    expiresAt: Date | null;
+};
+
+export type ApiCreateTrainingPreviewResponse = {
+    status: 'ok';
+    results: CreateTrainingPreviewResults;
 };
 
 export type ApiEnsurePlaygroundProjectResponse = {

--- a/packages/frontend/src/components/NavBar/ProjectSwitcher.tsx
+++ b/packages/frontend/src/components/NavBar/ProjectSwitcher.tsx
@@ -467,6 +467,7 @@ const ProjectSwitcher: FC<ProjectSwitcherProps> = ({ portalTarget }) => {
             const visiblePreviews = (projects ?? []).filter((project) => {
                 switch (project.type) {
                     case ProjectType.DEFAULT:
+                    case ProjectType.TRAINING:
                         return false;
                     case ProjectType.PREVIEW:
                         return (


### PR DESCRIPTION
## Description

Adds `ProjectType.TRAINING` and the trainee scope set: every member of an org gets a viewer's scopes on the org's shared training project and a fixed trainee set of project-admin scopes on their own copy of it, derived by rule from the admin set (organization-only scopes dropped, then the break-the-project, outbound-messaging and egress scopes listed in `TRAINING_PROJECT_EXCLUDED_SCOPES`). Includes the migration for the `project_type` lookup row and tests that the set is a subset of the admin set, contains no org-only scope and is missing exactly the excluded scopes.

Nothing uses the type yet; the next PR applies the scopes in the ability builder.

## How to test

`pnpm -F @lightdash/common test -- roleToScopeMapping`

## Security review (2026-09-07)

* The shared training project is **read-only** for learners: `getTrainingProjectViewerScopes()` (a viewer's scopes) applies there; the trainee set applies only to the learner's own copy (next PR).
* The trainee set also excludes `view:Analytics` and other users' `AiAgentThread` and `AiAgentDocument`.
* Adds `docs/learn/architecture.md`: what Learn is, what a learner can do, how it functions, and the boundaries.

**Stack (Lightdash Uni 2, CS-207 / CS-211 / CS-257), merge in order:**
1. `lu2/01-training-project-type` #28710
2. `lu2/02-trainee-layer-and-copies` #28711
3. `lu2/03-seed-training-content` #28712
4. `lu2/04-guided-tour-kit` #28713
5. `lu2/05-scope-tour-host` #28714
6. `lu2/06-learn-library` #28715
7. `lu2/07-enable-learn` #28716

Walkthrough content follows as separate PRs once these are in. Architecture doc: `docs/learn/architecture.md` (first PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PpC4h5RtPcbV5Bj7SeLYHf
