### PR TITLE
feat(backend): trainee permission layer, training copies and their endpoints

### DIFF
--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -1259,7 +1259,7 @@ Migrate to the v2 async query flow: [Execute SQL query](https://docs.lightdash.c
      * @summary Create training preview
      * @param projectUuid the training project
      */
-    @Middlewares([isAuthenticated])
+    @Middlewares([isAuthenticated, unauthorisedInDemo])
     @SuccessResponse('200', 'Success')
     @Post('{projectUuid}/training-previews')
     @OperationId('CreateTrainingPreview')
@@ -1281,7 +1281,7 @@ Migrate to the v2 async query flow: [Execute SQL query](https://docs.lightdash.c
      * @summary Delete training previews
      * @param projectUuid the training project
      */
-    @Middlewares([isAuthenticated])
+    @Middlewares([isAuthenticated, unauthorisedInDemo])
     @SuccessResponse('200', 'Success')
     @Delete('{projectUuid}/training-previews')
     @OperationId('DeleteTrainingPreviews')

--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -9,6 +9,7 @@ import {
     ApiChartListResponse,
     ApiChartSummaryListResponse,
     ApiCreateTagResponse,
+    ApiCreateTrainingPreviewResponse,
     ApiDashboardAsCodeListResponse,
     ApiDashboardAsCodeUpsertResponse,
     ApiDataTimezonePreview,
@@ -1249,6 +1250,51 @@ Migrate to the v2 async query flow: [Execute SQL query](https://docs.lightdash.c
             status: 'ok',
             results,
         };
+    }
+
+    /**
+     * Make (or remake) the caller's own throwaway copy of the training
+     * project for a walkthrough. The copy starts from the seeded state and
+     * expires on its own.
+     * @summary Create training preview
+     * @param projectUuid the training project
+     */
+    @Middlewares([isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('{projectUuid}/training-previews')
+    @OperationId('CreateTrainingPreview')
+    async createTrainingPreview(
+        @Path() projectUuid: string,
+        @Request() req: express.Request,
+    ): Promise<ApiCreateTrainingPreviewResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        const results = await this.services
+            .getProjectService()
+            .createTrainingPreview(toSessionUser(req.account), projectUuid);
+        return { status: 'ok', results };
+    }
+
+    /**
+     * Remove the caller's own copies of the training project, once a
+     * walkthrough is finished or abandoned.
+     * @summary Delete training previews
+     * @param projectUuid the training project
+     */
+    @Middlewares([isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Delete('{projectUuid}/training-previews')
+    @OperationId('DeleteTrainingPreviews')
+    async deleteTrainingPreviews(
+        @Path() projectUuid: string,
+        @Request() req: express.Request,
+    ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        await this.services
+            .getProjectService()
+            .deleteTrainingPreviews(toSessionUser(req.account), projectUuid);
+        return { status: 'ok', results: undefined };
     }
 
     /**

--- a/packages/backend/src/database/entities/comments.ts
+++ b/packages/backend/src/database/entities/comments.ts
@@ -24,7 +24,9 @@ type DbDashboardTileCommentsInsert = Pick<
     | 'saved_chart_uuid'
     | 'mentions'
     | 'text_html'
->;
+> &
+    // A clone (a training copy's comment) keeps the original's state.
+    Partial<Pick<DbDashboardTileComments, 'resolved' | 'created_at'>>;
 
 type DbDashboardTileCommentsUpdate = Pick<DbDashboardTileComments, 'resolved'>;
 

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -4085,6 +4085,7 @@ export class AiAgentService extends BaseService {
         ) {
             throw new ForbiddenError();
         }
+        await this.assertAgentStaysInsideTraining(body.projectUuid, body);
 
         if (body.threadRetentionHours != null) {
             await this.validateThreadRetentionUpdate(
@@ -4194,6 +4195,49 @@ export class AiAgentService extends BaseService {
 
             this.logger.warn(
                 `Failed to provision default AI agent for project ${projectUuid}: ${getErrorMessage(error)}`,
+            );
+        }
+    }
+
+    /**
+     * A training project, or a learner's copy of it, is a sandbox every org
+     * member can act in. Agents there must not reach outside it: no Slack
+     * channels and no MCP servers (which would post every colleague's
+     * prompts to an arbitrary host), and no moving an agent into another
+     * project.
+     */
+    private async assertAgentStaysInsideTraining(
+        projectUuid: string,
+        body: { integrations?: unknown[]; mcpServerUuids?: unknown[] },
+    ): Promise<void> {
+        const project = await this.projectModel.getSummary(projectUuid);
+        const isTraining =
+            project.type === ProjectType.TRAINING ||
+            (project.type === ProjectType.PREVIEW &&
+                project.provisioningSource === 'training');
+        if (!isTraining) return;
+        if (body.integrations?.length || body.mcpServerUuids?.length) {
+            throw new ForbiddenError(
+                'Agents in the training project cannot use integrations or MCP servers',
+            );
+        }
+    }
+
+    /**
+     * Reads (listing servers and tools) stay open in the training project so
+     * the agent pages render; only adding or connecting a server is refused.
+     */
+    private async assertMcpServersNotInTraining(
+        projectUuid: string,
+    ): Promise<void> {
+        const project = await this.projectModel.getSummary(projectUuid);
+        if (
+            project.type === ProjectType.TRAINING ||
+            (project.type === ProjectType.PREVIEW &&
+                project.provisioningSource === 'training')
+        ) {
+            throw new ForbiddenError(
+                'MCP servers cannot be added to the training project',
             );
         }
     }
@@ -4833,6 +4877,7 @@ export class AiAgentService extends BaseService {
         await this.assertCanManageMcpServers(user, projectUuid, {
             mcpServerName: body.name,
         });
+        await this.assertMcpServersNotInTraining(projectUuid);
 
         const name = body.name.trim();
         if (!name) {
@@ -5024,6 +5069,7 @@ export class AiAgentService extends BaseService {
         body: ApiUpdateAiMcpServerCredentialBody,
     ): Promise<AiMcpServer> {
         await this.assertCanManageMcpServers(user, projectUuid);
+        await this.assertMcpServersNotInTraining(projectUuid);
 
         const server = await this.getProjectMcpServerOrThrow(
             projectUuid,
@@ -5277,6 +5323,7 @@ export class AiAgentService extends BaseService {
         personalAccessToken: string,
         credentialScope: AiMcpCredentialScope,
     ) {
+        await this.assertMcpServersNotInTraining(projectUuid);
         const { organizationUuid } = user;
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
@@ -5361,6 +5408,7 @@ export class AiAgentService extends BaseService {
         }
 
         await this.assertCanManageMcpServers(user, projectUuid);
+        await this.assertMcpServersNotInTraining(projectUuid);
         // manage:GitIntegration so a project-level agent manager cannot
         // leverage an org-wide installation they don't control.
         const auditedAbility = this.createAuditedAbility(user);
@@ -5506,6 +5554,7 @@ export class AiAgentService extends BaseService {
                 );
             }
             await this.assertCanManageMcpServers(user, projectUuid);
+            await this.assertMcpServersNotInTraining(projectUuid);
         } else {
             await this.assertCanUsePersonalMcpCredentials(user, projectUuid);
         }
@@ -5676,6 +5725,7 @@ export class AiAgentService extends BaseService {
                 );
             }
             await this.assertCanManageMcpServers(user, projectUuid);
+            await this.assertMcpServersNotInTraining(projectUuid);
         } else {
             await this.assertCanUsePersonalMcpCredentials(user, projectUuid);
         }
@@ -5705,6 +5755,33 @@ export class AiAgentService extends BaseService {
     ) {
         const { organizationUuid, agent } =
             await this.getManageableAgentOrThrow(user, agentUuid);
+
+        // Moving an agent needs the same right on the project it lands in;
+        // managing it where it is says nothing about the destination.
+        if (body.projectUuid && body.projectUuid !== agent.projectUuid) {
+            const destination = await this.projectModel.getSummary(
+                body.projectUuid,
+            );
+            if (
+                destination.organizationUuid !== organizationUuid ||
+                this.createAuditedAbility(user).cannot(
+                    'manage',
+                    subject('AiAgent', {
+                        organizationUuid,
+                        projectUuid: body.projectUuid,
+                        metadata: { agentUuid, agentName: agent.name },
+                    }),
+                )
+            ) {
+                throw new ForbiddenError(
+                    'You cannot move an agent into that project',
+                );
+            }
+        }
+        await this.assertAgentStaysInsideTraining(
+            body.projectUuid ?? agent.projectUuid,
+            body,
+        );
 
         const nextEnableDataAccess =
             body.enableDataAccess ?? agent.enableDataAccess;

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -9626,6 +9626,19 @@ export class AppGenerateService extends BaseService {
      * uploads, version source tarballs, built dist tarballs, and per-version
      * assets.
      */
+    /**
+     * Remove the stored files of every app in a project. Deleting a project
+     * only removes rows; a training copy is deleted after each walkthrough,
+     * so its duplicated app files would otherwise pile up in the bucket.
+     */
+    async deleteProjectAppFiles(projectUuid: string): Promise<number> {
+        const apps = await this.appModel.listAppsByProject(projectUuid);
+        await Promise.all(
+            apps.map((app) => this.deleteAppS3Prefix(app.app_id)),
+        );
+        return apps.length;
+    }
+
     private async deleteAppS3Prefix(appUuid: string): Promise<void> {
         const { client, bucket } = this.getS3Client();
         const prefix = `apps/${appUuid}/`;

--- a/packages/backend/src/ee/services/ProjectService/provisionOnboardingHomepage.ts
+++ b/packages/backend/src/ee/services/ProjectService/provisionOnboardingHomepage.ts
@@ -22,7 +22,7 @@ export type ProvisionOnboardingHomepageArguments = {
     user: SessionUser;
     projectUuid: string;
     projectType: ProjectType;
-    provisioningSource?: 'playground';
+    provisioningSource?: 'playground' | 'training';
     featureFlagService: Pick<
         FeatureFlagService,
         'get' | 'ensureOrganizationOverrideEnabled'

--- a/packages/backend/src/models/OnboardingModel/OnboardingModel.ts
+++ b/packages/backend/src/models/OnboardingModel/OnboardingModel.ts
@@ -8,6 +8,9 @@ type OnboardingModelArguments = {
 };
 
 const PLAYGROUND_PROVISIONING_LOCK_NAMESPACE = 19350428;
+// One training copy at a time per learner: parallel requests would each
+// delete the others' copy and leave several live.
+const TRAINING_COPY_LOCK_NAMESPACE = 19350430;
 
 export class OnboardingModel {
     private database: Knex;
@@ -34,6 +37,31 @@ export class OnboardingModel {
                 organization.organization_id,
             ]);
             return callback(trx);
+        });
+    }
+
+    /**
+     * Serialises training copy creation per learner: the copy endpoint
+     * deletes the learner's previous copy before making a new one, so two
+     * requests at once must not interleave.
+     */
+    async runInTrainingCopyLock<T>(
+        userUuid: string,
+        callback: () => Promise<T>,
+    ): Promise<T> {
+        return this.database.transaction(async (trx) => {
+            const user = await trx('users')
+                .where('user_uuid', userUuid)
+                .select('user_id')
+                .first();
+            if (!user) {
+                throw new NotFoundError('Cannot find user');
+            }
+            await trx.raw('SELECT pg_advisory_xact_lock(?, ?)', [
+                TRAINING_COPY_LOCK_NAMESPACE,
+                user.user_id,
+            ]);
+            return callback();
         });
     }
 

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -75,9 +75,18 @@ import NodeCache from 'node-cache';
 import { DatabaseError } from 'pg';
 import { v4 as uuidv4 } from 'uuid';
 import { LightdashConfig } from '../../config/parseConfig';
+import { DashboardTileCommentsTableName } from '../../database/entities/comments';
 import {
     DashboardsTableName,
     DashboardTabsTableName,
+    DashboardTileChartTableName,
+    DashboardTileDataAppsTableName,
+    DashboardTileHeadingsTableName,
+    DashboardTileLoomsTableName,
+    DashboardTileMarkdownsTableName,
+    DashboardTileSqlChartTableName,
+    DashboardTilesTableName,
+    DashboardVersionsTableName,
     DashboardViewsTableName,
     DbDashboard,
     DbDashboardTabs,
@@ -94,7 +103,12 @@ import {
     DbOrganization,
     OrganizationTableName,
 } from '../../database/entities/organizations';
-import { PinnedListTableName } from '../../database/entities/pinnedList';
+import {
+    PinnedChartTableName,
+    PinnedDashboardTableName,
+    PinnedListTableName,
+    PinnedSpaceTableName,
+} from '../../database/entities/pinnedList';
 import { ProjectGroupAccessTableName } from '../../database/entities/projectGroupAccess';
 import { ProjectGroupAccessCustomRolesTableName } from '../../database/entities/projectGroupAccessCustomRoles';
 import { ProjectMembershipCustomRolesTableName } from '../../database/entities/projectMembershipCustomRoles';
@@ -130,8 +144,14 @@ import {
     SpaceTableName,
     SpaceUserAccessTableName,
 } from '../../database/entities/spaces';
+import { TagsTableName } from '../../database/entities/tags';
 import { DbUser, UserTableName } from '../../database/entities/users';
 import { WarehouseCredentialTableName } from '../../database/entities/warehouseCredentials';
+import {
+    AiPromptTableName,
+    AiThreadTableName,
+    AiWebAppThreadTableName,
+} from '../../ee/database/entities/ai';
 import {
     AiAgentGroupAccessTableName,
     AiAgentInstructionVersionsTableName,
@@ -141,6 +161,10 @@ import {
     AiAgentUserAccessTableName,
     type DbAiAgent,
 } from '../../ee/database/entities/aiAgent';
+import {
+    AiDeepResearchEventsTableName,
+    AiDeepResearchRunsTableName,
+} from '../../ee/database/entities/aiDeepResearch';
 import { ServiceAccountsTableName } from '../../ee/database/entities/serviceAccounts';
 import Logger from '../../logging/logger';
 import { wrapSentryTransaction, wrapSentryTransactionSync } from '../../utils';
@@ -1021,6 +1045,261 @@ export class ProjectModel {
             projectUuid: r.project_uuid,
             organizationUuid: r.organization_uuid,
         }));
+    }
+
+    /**
+     * Give a training copy the seeded deep research, as the learner's own:
+     * a run lives in a thread, and a thread belongs to the person who asked,
+     * so the copy's thread, prompt and run are owned by the learner (the
+     * source's stay with the seed user). The copy's agent is found by slug.
+     */
+    async copyDeepResearchForTrainingCopy(
+        sourceProjectUuid: string,
+        previewProjectUuid: string,
+        learnerUserUuid: string,
+    ): Promise<void> {
+        await this.database.transaction(async (trx) => {
+            const runs = await trx(AiDeepResearchRunsTableName).where(
+                'project_uuid',
+                sourceProjectUuid,
+            );
+            // eslint-disable-next-line no-restricted-syntax
+            for (const run of runs) {
+                // eslint-disable-next-line no-await-in-loop
+                const sourceAgent = await trx(AiAgentTableName)
+                    .where('ai_agent_uuid', run.agent_uuid)
+                    .first();
+                // eslint-disable-next-line no-await-in-loop
+                const agent = sourceAgent
+                    ? await trx(AiAgentTableName)
+                          .where({
+                              project_uuid: previewProjectUuid,
+                              slug: sourceAgent.slug,
+                          })
+                          .first()
+                    : undefined;
+                if (!agent) continue; // eslint-disable-line no-continue
+                // eslint-disable-next-line no-await-in-loop
+                const thread = await trx(AiThreadTableName)
+                    .where('ai_thread_uuid', run.ai_thread_uuid)
+                    .first();
+                // eslint-disable-next-line no-await-in-loop
+                const prompt = await trx(AiPromptTableName)
+                    .where('ai_prompt_uuid', run.prompt_uuid)
+                    .first();
+                if (!thread || !prompt) continue; // eslint-disable-line no-continue
+                const runUuid = uuidv4();
+                // eslint-disable-next-line no-await-in-loop
+                const [{ ai_thread_uuid: threadUuid }] = await trx(
+                    AiThreadTableName,
+                )
+                    .insert({
+                        organization_uuid: thread.organization_uuid,
+                        project_uuid: previewProjectUuid,
+                        created_from: thread.created_from,
+                        agent_uuid: agent.ai_agent_uuid,
+                    })
+                    .returning('ai_thread_uuid');
+                // eslint-disable-next-line no-await-in-loop
+                await trx(AiThreadTableName)
+                    .where('ai_thread_uuid', threadUuid)
+                    .update({
+                        title: thread.title,
+                        title_generated_at: thread.title_generated_at,
+                    });
+                // eslint-disable-next-line no-await-in-loop
+                await trx(AiWebAppThreadTableName).insert({
+                    ai_thread_uuid: threadUuid,
+                    user_uuid: learnerUserUuid,
+                });
+                // eslint-disable-next-line no-await-in-loop
+                const [{ ai_prompt_uuid: promptUuid }] = await trx(
+                    AiPromptTableName,
+                )
+                    .insert({
+                        ai_thread_uuid: threadUuid,
+                        created_by_user_uuid: learnerUserUuid,
+                        prompt: prompt.prompt,
+                        execution_mode: prompt.execution_mode,
+                    })
+                    .returning('ai_prompt_uuid');
+                const {
+                    ai_deep_research_run_uuid: _sourceRunUuid,
+                    created_at: _createdAt,
+                    updated_at: _updatedAt,
+                    ...runColumns
+                } = run;
+                // eslint-disable-next-line no-await-in-loop
+                await trx(AiDeepResearchRunsTableName).insert({
+                    ...runColumns,
+                    ai_deep_research_run_uuid: runUuid,
+                    project_uuid: previewProjectUuid,
+                    created_by_user_uuid: learnerUserUuid,
+                    agent_uuid: agent.ai_agent_uuid,
+                    ai_thread_uuid: threadUuid,
+                    prompt_uuid: promptUuid,
+                    budget_snapshot: JSON.stringify(run.budget_snapshot),
+                    execution_context_snapshot: JSON.stringify(
+                        run.execution_context_snapshot,
+                    ),
+                });
+                // eslint-disable-next-line no-await-in-loop
+                const events = await trx(AiDeepResearchEventsTableName)
+                    .where(
+                        'ai_deep_research_run_uuid',
+                        run.ai_deep_research_run_uuid,
+                    )
+                    .orderBy('created_at', 'asc');
+                if (events.length > 0) {
+                    // eslint-disable-next-line no-await-in-loop
+                    await trx(AiDeepResearchEventsTableName).insert(
+                        events.map((event) => ({
+                            ai_deep_research_run_uuid: runUuid,
+                            event_type: event.event_type,
+                            payload: JSON.stringify(event.payload),
+                            created_at: event.created_at,
+                        })),
+                    );
+                }
+            }
+        });
+    }
+
+    /**
+     * Give a training copy its own dashboard tile uuids, and its own copies
+     * of the comments on those tiles. A preview normally keeps the source's
+     * tile uuids, and tile comments are keyed by tile uuid alone, so a
+     * comment posted or resolved in one learner's copy would show in the
+     * shared training project and in every other copy. With their own
+     * uuids, a copy's comments start as clones of the seeded ones and stay
+     * its own; they go with the copy's charts when it is removed.
+     */
+    async giveTrainingCopyOwnTiles(previewProjectUuid: string): Promise<void> {
+        await this.database.transaction(async (trx) => {
+            const versions = await trx(DashboardVersionsTableName)
+                .join(
+                    DashboardsTableName,
+                    `${DashboardsTableName}.dashboard_id`,
+                    `${DashboardVersionsTableName}.dashboard_id`,
+                )
+                .join(
+                    SpaceTableName,
+                    `${SpaceTableName}.space_id`,
+                    `${DashboardsTableName}.space_id`,
+                )
+                .join(
+                    ProjectTableName,
+                    `${ProjectTableName}.project_id`,
+                    `${SpaceTableName}.project_id`,
+                )
+                .where(`${ProjectTableName}.project_uuid`, previewProjectUuid)
+                .select<{ dashboard_version_id: number; config: unknown }[]>(
+                    `${DashboardVersionsTableName}.dashboard_version_id`,
+                    `${DashboardVersionsTableName}.config`,
+                );
+            if (versions.length === 0) return;
+            const versionIds = versions.map((v) => v.dashboard_version_id);
+            const tiles = await trx(DashboardTilesTableName)
+                .whereIn('dashboard_version_id', versionIds)
+                .select('*');
+            const renamed = new Map<string, string>();
+            const childTables = [
+                DashboardTileChartTableName,
+                DashboardTileSqlChartTableName,
+                DashboardTileMarkdownsTableName,
+                DashboardTileLoomsTableName,
+                DashboardTileHeadingsTableName,
+                DashboardTileDataAppsTableName,
+            ];
+            // Child rows reference the tile by (version, uuid) without ON
+            // UPDATE, so the tile is re-inserted under the new uuid, the
+            // children moved across, and the old row removed last.
+            await tiles.reduce(async (previous, tile) => {
+                await previous;
+                const to = renamed.get(tile.dashboard_tile_uuid) ?? uuidv4();
+                renamed.set(tile.dashboard_tile_uuid, to);
+                await trx(DashboardTilesTableName).insert({
+                    ...tile,
+                    dashboard_tile_uuid: to,
+                });
+                await childTables.reduce(async (prev, table) => {
+                    await prev;
+                    await trx(table)
+                        .where({
+                            dashboard_version_id: tile.dashboard_version_id,
+                            dashboard_tile_uuid: tile.dashboard_tile_uuid,
+                        })
+                        .update({ dashboard_tile_uuid: to });
+                }, Promise.resolve());
+                await trx(DashboardTilesTableName)
+                    .where({
+                        dashboard_version_id: tile.dashboard_version_id,
+                        dashboard_tile_uuid: tile.dashboard_tile_uuid,
+                    })
+                    .delete();
+            }, Promise.resolve());
+            // Filters and date zoom target tiles by uuid inside the
+            // version's config; rewrite those references in place.
+            await versions.reduce(async (previous, version) => {
+                await previous;
+                if (!version.config) return;
+                let text = JSON.stringify(version.config);
+                renamed.forEach((to, from) => {
+                    text = text.split(from).join(to);
+                });
+                await trx(DashboardVersionsTableName)
+                    .where('dashboard_version_id', version.dashboard_version_id)
+                    .update({ config: JSON.parse(text) });
+            }, Promise.resolve());
+            // The copy's own comments: clones of the seeded ones, attached
+            // to the copy's charts so they are removed with the copy.
+            const chartOfTile = new Map<string, string>(
+                (
+                    await trx(DashboardTileChartTableName)
+                        .join(
+                            SavedChartsTableName,
+                            `${SavedChartsTableName}.saved_query_id`,
+                            `${DashboardTileChartTableName}.saved_chart_id`,
+                        )
+                        .whereIn(
+                            `${DashboardTileChartTableName}.dashboard_version_id`,
+                            versionIds,
+                        )
+                        .select<
+                            { dashboard_tile_uuid: string; uuid: string }[]
+                        >(
+                            `${DashboardTileChartTableName}.dashboard_tile_uuid`,
+                            `${SavedChartsTableName}.saved_query_uuid as uuid`,
+                        )
+                ).map((row) => [row.dashboard_tile_uuid, row.uuid]),
+            );
+            const comments = await trx(DashboardTileCommentsTableName)
+                .whereIn('dashboard_tile_uuid', [...renamed.keys()])
+                .orderBy('created_at', 'asc')
+                .select('*');
+            const clonedIds = new Map<string, string>();
+            await comments.reduce(async (previous, comment) => {
+                await previous;
+                const to = renamed.get(comment.dashboard_tile_uuid);
+                if (!to) return;
+                const [clone] = await trx(DashboardTileCommentsTableName)
+                    .insert({
+                        text: comment.text,
+                        text_html: comment.text_html,
+                        dashboard_tile_uuid: to,
+                        reply_to: comment.reply_to
+                            ? (clonedIds.get(comment.reply_to) ?? null)
+                            : null,
+                        user_uuid: comment.user_uuid,
+                        saved_chart_uuid: chartOfTile.get(to) ?? null,
+                        mentions: comment.mentions,
+                        resolved: comment.resolved,
+                        created_at: comment.created_at,
+                    })
+                    .returning('comment_id');
+                clonedIds.set(comment.comment_id, clone.comment_id);
+            }, Promise.resolve());
+        });
     }
 
     async delete(
@@ -4447,6 +4726,116 @@ export class ProjectModel {
                 Logger.debug(
                     `Skipping AI agent content copy: AI agent tables do not exist (likely non-EE instance)`,
                 );
+            }
+
+            // Categories (tags) belong to the project, not to content; copy
+            // them so the preview's catalog carries the same ones once it
+            // is indexed. Assignments are rebuilt by that index.
+            const tags = await trx(TagsTableName).where(
+                'project_uuid',
+                projectUuid,
+            );
+            Logger.info(`Copying ${tags.length} tags on ${previewProjectUuid}`);
+            if (tags.length > 0) {
+                await trx(TagsTableName).insert(
+                    tags.map(({ tag_uuid, created_at, ...tag }) => ({
+                        ...tag,
+                        project_uuid: previewProjectUuid,
+                    })),
+                );
+            }
+
+            // Pinned items: the preview's homepage shows what the project
+            // pins, mapped onto the copied dashboards, charts and spaces.
+            const [pinnedList] = await trx(PinnedListTableName).where(
+                'project_uuid',
+                projectUuid,
+            );
+            if (pinnedList) {
+                const [existingPreviewList] = await trx(
+                    PinnedListTableName,
+                ).where('project_uuid', previewProjectUuid);
+                const previewList =
+                    existingPreviewList ??
+                    (
+                        await trx(PinnedListTableName)
+                            .insert({ project_uuid: previewProjectUuid })
+                            .returning('*')
+                    )[0];
+                const pinnedDashboards = await trx(
+                    PinnedDashboardTableName,
+                ).where('pinned_list_uuid', pinnedList.pinned_list_uuid);
+                const pinnedCharts = await trx(PinnedChartTableName).where(
+                    'pinned_list_uuid',
+                    pinnedList.pinned_list_uuid,
+                );
+                const pinnedSpaces = await trx(PinnedSpaceTableName).where(
+                    'pinned_list_uuid',
+                    pinnedList.pinned_list_uuid,
+                );
+                Logger.info(
+                    `Copying ${
+                        pinnedDashboards.length +
+                        pinnedCharts.length +
+                        pinnedSpaces.length
+                    } pinned items on ${previewProjectUuid}`,
+                );
+                const dashboardInserts = pinnedDashboards.flatMap((pin) => {
+                    const mapped = dashboardMapping.find(
+                        (m) => m.uuid === pin.dashboard_uuid,
+                    );
+                    return mapped
+                        ? [
+                              {
+                                  pinned_list_uuid:
+                                      previewList.pinned_list_uuid,
+                                  dashboard_uuid: mapped.newUuid,
+                                  order: pin.order,
+                              },
+                          ]
+                        : [];
+                });
+                if (dashboardInserts.length > 0) {
+                    await trx(PinnedDashboardTableName).insert(
+                        dashboardInserts,
+                    );
+                }
+                const chartInserts = pinnedCharts.flatMap((pin) => {
+                    const mapped = chartUuidMapping.find(
+                        (m) => m.sourceChartUuid === pin.saved_chart_uuid,
+                    );
+                    return mapped
+                        ? [
+                              {
+                                  pinned_list_uuid:
+                                      previewList.pinned_list_uuid,
+                                  saved_chart_uuid: mapped.previewChartUuid,
+                                  order: pin.order,
+                              },
+                          ]
+                        : [];
+                });
+                if (chartInserts.length > 0) {
+                    await trx(PinnedChartTableName).insert(chartInserts);
+                }
+                const spaceInserts = pinnedSpaces.flatMap((pin) => {
+                    const mapped = spaceMapping.find(
+                        (m) => m.uuid === pin.space_uuid,
+                    );
+                    return mapped
+                        ? [
+                              {
+                                  pinned_list_uuid:
+                                      previewList.pinned_list_uuid,
+                                  space_uuid: mapped.newUuid,
+                                  order: pin.order,
+                              },
+                          ]
+                        : [];
+                });
+                if (spaceInserts.length > 0) {
+                    await trx(PinnedSpaceTableName).insert(spaceInserts);
+                }
             }
 
             const contentMapping: PreviewContentMapping = {

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -1057,27 +1057,29 @@ export class ProjectModel {
         sourceProjectUuid: string,
         previewProjectUuid: string,
         learnerUserUuid: string,
+        seedUserUuid: string | null,
     ): Promise<void> {
         await this.database.transaction(async (trx) => {
-            const runs = await trx(AiDeepResearchRunsTableName).where(
-                'project_uuid',
-                sourceProjectUuid,
-            );
+            // Only the seed's runs (made by whoever enabled Learn) travel
+            // into copies; nothing another learner or admin ran afterwards.
+            const runs = await trx(AiDeepResearchRunsTableName)
+                .where('project_uuid', sourceProjectUuid)
+                .where('created_by_user_uuid', seedUserUuid ?? '')
+                .where('status', 'completed');
             // eslint-disable-next-line no-restricted-syntax
             for (const run of runs) {
                 // eslint-disable-next-line no-await-in-loop
                 const sourceAgent = await trx(AiAgentTableName)
                     .where('ai_agent_uuid', run.agent_uuid)
                     .first();
+                if (!sourceAgent) continue; // eslint-disable-line no-continue
                 // eslint-disable-next-line no-await-in-loop
-                const agent = sourceAgent
-                    ? await trx(AiAgentTableName)
-                          .where({
-                              project_uuid: previewProjectUuid,
-                              slug: sourceAgent.slug,
-                          })
-                          .first()
-                    : undefined;
+                const agent = await trx(AiAgentTableName)
+                    .where({
+                        project_uuid: previewProjectUuid,
+                        slug: sourceAgent.slug,
+                    })
+                    .first();
                 if (!agent) continue; // eslint-disable-line no-continue
                 // eslint-disable-next-line no-await-in-loop
                 const thread = await trx(AiThreadTableName)
@@ -1138,6 +1140,8 @@ export class ProjectModel {
                     agent_uuid: agent.ai_agent_uuid,
                     ai_thread_uuid: threadUuid,
                     prompt_uuid: promptUuid,
+                    // A copy is a finished report, never a resumable run.
+                    resume_from_run_uuid: null,
                     budget_snapshot: JSON.stringify(run.budget_snapshot),
                     execution_context_snapshot: JSON.stringify(
                         run.execution_context_snapshot,
@@ -1174,7 +1178,10 @@ export class ProjectModel {
      * uuids, a copy's comments start as clones of the seeded ones and stay
      * its own; they go with the copy's charts when it is removed.
      */
-    async giveTrainingCopyOwnTiles(previewProjectUuid: string): Promise<void> {
+    async giveTrainingCopyOwnTiles(
+        previewProjectUuid: string,
+        seedUserUuid: string | null,
+    ): Promise<void> {
         await this.database.transaction(async (trx) => {
             const versions = await trx(DashboardVersionsTableName)
                 .join(
@@ -1273,8 +1280,11 @@ export class ProjectModel {
                         )
                 ).map((row) => [row.dashboard_tile_uuid, row.uuid]),
             );
+            // Only the seed's comments (made by whoever enabled Learn) come
+            // along; nothing anyone wrote on the shared project afterwards.
             const comments = await trx(DashboardTileCommentsTableName)
                 .whereIn('dashboard_tile_uuid', [...renamed.keys()])
+                .where('user_uuid', seedUserUuid ?? '')
                 .orderBy('created_at', 'asc')
                 .select('*');
             const clonedIds = new Map<string, string>();

--- a/packages/backend/src/models/UserModel.test.ts
+++ b/packages/backend/src/models/UserModel.test.ts
@@ -50,6 +50,17 @@ vi.mock('../utils/hash', () => ({
 
 type TestableUserModel = {
     hasAuthentication: (userUuid: string, trx?: Knex) => Promise<boolean>;
+    getTrainingProjects: (
+        organizationId: number,
+        userUuid: string,
+        trx?: Knex,
+    ) => Promise<
+        {
+            projectUuid: string;
+            projectType: ProjectType;
+            createdByUserUuid: string | null;
+        }[]
+    >;
     getUserProjectRoles: (
         userUuid: string,
         options?: { trx?: Knex },
@@ -132,6 +143,7 @@ const createUserModel = (): TestableUserModel => {
 
     model.hasAuthentication = vi.fn(async () => true);
     model.getUserProjectRoles = vi.fn(async () => []);
+    model.getTrainingProjects = vi.fn(async () => []);
     model.getUserGroupProjectRoles = vi.fn(async () => []);
     model.getOrganizationExtraRoleUuids = vi.fn(async () => []);
     model.findServiceAccountByUserUuid = vi.fn(async (userUuid) => ({
@@ -431,6 +443,7 @@ describe('UserModel', () => {
                 featureFlagModel,
             }) as unknown as TestableUserModel;
             model.hasAuthentication = vi.fn(async () => true);
+            model.getTrainingProjects = vi.fn(async () => []);
             model.getUserProjectRoles = vi.fn(async () => [
                 {
                     projectUuid: 'project-1',
@@ -452,6 +465,85 @@ describe('UserModel', () => {
             model.applyServiceAccountProjectMemberships = vi.fn(async () => {});
             return model;
         };
+
+        it('grants the trainee layer on the org training project only', async () => {
+            const model = createHumanModel();
+            model.getTrainingProjects = vi.fn(async () => [
+                {
+                    projectUuid: 'training-project',
+                    projectType: ProjectType.TRAINING,
+                    createdByUserUuid: 'someone-else',
+                },
+                {
+                    projectUuid: 'training-copy',
+                    projectType: ProjectType.PREVIEW,
+                    createdByUserUuid: humanDetails.user_uuid,
+                },
+            ]);
+
+            const { abilityBuilder } =
+                await model.generateUserAbilityBuilder(humanDetails);
+            const ability = abilityBuilder.build();
+
+            expect(model.getTrainingProjects).toHaveBeenCalledWith(
+                humanDetails.organization_id,
+                humanDetails.user_uuid,
+                expect.anything(),
+            );
+            // the learner's own copy of the training project gets the layer too
+            expect(
+                ability.can(
+                    'manage',
+                    subject('PinnedItems', { projectUuid: 'training-copy' }),
+                ),
+            ).toBe(true);
+            // a viewer can pin, save and run SQL on the training project
+            (
+                [
+                    ['manage', 'PinnedItems'],
+                    ['manage', 'SavedChart'],
+                    ['manage', 'SqlRunner'],
+                    ['manage', 'Validation'],
+                ] as const
+            ).forEach(([action, subjectName]) => {
+                expect(
+                    ability.can(
+                        action,
+                        subject(subjectName, {
+                            projectUuid: 'training-project',
+                        }),
+                    ),
+                ).toBe(true);
+            });
+            // but not on their real project
+            expect(
+                ability.can(
+                    'manage',
+                    subject('PinnedItems', { projectUuid: 'project-1' }),
+                ),
+            ).toBe(false);
+            // and never the excluded scopes on the training project
+            (
+                [
+                    ['delete', 'Project'],
+                    ['update', 'Project'],
+                    ['manage', 'CompileProject'],
+                    ['manage', 'ScheduledDeliveries'],
+                    ['manage', 'ExternalConnection'],
+                ] as const
+            ).forEach(([action, subjectName]) => {
+                expect({
+                    action,
+                    subjectName,
+                    can: ability.can(
+                        action,
+                        subject(subjectName, {
+                            projectUuid: 'training-project',
+                        }),
+                    ),
+                }).toEqual({ action, subjectName, can: false });
+            });
+        });
 
         it('unions org and project extra roles into a human user ability', async () => {
             const model = createHumanModel();
@@ -670,6 +762,7 @@ describe('UserModel', () => {
             }) as unknown as TestableUserModel;
             model.hasAuthentication = vi.fn(async () => true);
             model.getUserProjectRoles = vi.fn(async () => []);
+            model.getTrainingProjects = vi.fn(async () => []);
             model.getUserGroupProjectRoles = vi.fn(async () => []);
             model.getOrganizationExtraRoleUuids = vi.fn(async () => []);
             model.customRoleScopes = vi.fn(async () => ({
@@ -755,6 +848,7 @@ describe('UserModel', () => {
             }) as unknown as TestableUserModel;
             model.hasAuthentication = vi.fn(async () => true);
             model.getUserProjectRoles = vi.fn(async () => []);
+            model.getTrainingProjects = vi.fn(async () => []);
             model.getUserGroupProjectRoles = vi.fn(async () => []);
             model.getOrganizationExtraRoleUuids = vi.fn(async () => []);
             model.findServiceAccountByUserUuid = vi.fn(async () => undefined);
@@ -783,6 +877,7 @@ describe('UserModel', () => {
             }) as unknown as TestableUserModel;
             model.hasAuthentication = vi.fn(async () => true);
             model.getUserProjectRoles = vi.fn(async () => []);
+            model.getTrainingProjects = vi.fn(async () => []);
             model.getUserGroupProjectRoles = vi.fn(async () => []);
             model.getOrganizationExtraRoleUuids = vi.fn(async () => []);
             model.findServiceAccountByUserUuid = vi.fn(async () => undefined);

--- a/packages/backend/src/models/UserModel.test.ts
+++ b/packages/backend/src/models/UserModel.test.ts
@@ -497,7 +497,7 @@ describe('UserModel', () => {
                     subject('PinnedItems', { projectUuid: 'training-copy' }),
                 ),
             ).toBe(true);
-            // a viewer can pin, save and run SQL on the training project
+            // a viewer can pin, save and run SQL in their own copy
             (
                 [
                     ['manage', 'PinnedItems'],
@@ -510,10 +510,39 @@ describe('UserModel', () => {
                     ability.can(
                         action,
                         subject(subjectName, {
-                            projectUuid: 'training-project',
+                            projectUuid: 'training-copy',
                         }),
                     ),
                 ).toBe(true);
+            });
+            // the shared training project itself is read-only for them:
+            // browsable, so the library and the seed can be opened, but a
+            // write there would be cloned into every other learner's copy
+            expect(
+                ability.can(
+                    'view',
+                    subject('Project', { projectUuid: 'training-project' }),
+                ),
+            ).toBe(true);
+            (
+                [
+                    ['manage', 'PinnedItems'],
+                    ['manage', 'SavedChart'],
+                    ['manage', 'SqlRunner'],
+                    ['manage', 'AiAgent'],
+                    ['create', 'DashboardComments'],
+                ] as const
+            ).forEach(([action, subjectName]) => {
+                expect({
+                    action,
+                    subjectName,
+                    can: ability.can(
+                        action,
+                        subject(subjectName, {
+                            projectUuid: 'training-project',
+                        }),
+                    ),
+                }).toEqual({ action, subjectName, can: false });
             });
             // but not on their real project
             expect(

--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -10,6 +10,7 @@ import {
     CreateUserWithRole,
     ForbiddenError,
     getTrainingProjectScopes,
+    getTrainingProjectViewerScopes,
     getUserAbilityBuilder,
     getUserAvatarUrl,
     InvalidUser,
@@ -1195,12 +1196,16 @@ export class UserModel {
         if (!training) {
             return [];
         }
+        // Only copies the training service made: `copied_from` alone can be
+        // set through the project metadata API on a preview of a real
+        // project, which must never inherit the trainee set.
         const copies = await trx(ProjectTableName)
             .select<
                 { project_uuid: string; created_by_user_uuid: string | null }[]
             >('project_uuid', 'created_by_user_uuid')
             .where('organization_id', organizationId)
             .where('project_type', ProjectType.PREVIEW)
+            .where('provisioning_source', 'training')
             .where('copied_from_project_uuid', training.project_uuid)
             .where('created_by_user_uuid', userUuid);
         return [
@@ -1238,7 +1243,10 @@ export class UserModel {
             userUuid,
             trx,
         );
-        const scopes = getTrainingProjectScopes();
+        // The shared training project is read-only for learners; their own
+        // copy is where the trainee set applies.
+        const viewerScopes = getTrainingProjectViewerScopes();
+        const traineeScopes = getTrainingProjectScopes();
         trainingProjects.forEach((project) => {
             buildAbilityFromScopes(
                 {
@@ -1246,7 +1254,10 @@ export class UserModel {
                     projectType: project.projectType,
                     projectCreatedByUserUuid: project.createdByUserUuid,
                     userUuid,
-                    scopes,
+                    scopes:
+                        project.projectType === ProjectType.TRAINING
+                            ? viewerScopes
+                            : traineeScopes,
                     isEnterprise,
                     permissionsConfig: {
                         pat: this.lightdashConfig.auth.pat,

--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -9,6 +9,7 @@ import {
     CreateUserArgs,
     CreateUserWithRole,
     ForbiddenError,
+    getTrainingProjectScopes,
     getUserAbilityBuilder,
     getUserAvatarUrl,
     InvalidUser,
@@ -1153,10 +1154,107 @@ export class UserModel {
             );
         }
 
+        await this.applyTrainingProjectAbilities(
+            user.organization_id,
+            user.user_uuid,
+            isEnterprise,
+            abilityBuilder,
+            trx,
+        );
+
         return {
             abilityBuilder,
             lightdashUser,
         };
+    }
+
+    /**
+     * The organization's training project, if one has been provisioned, plus
+     * this user's own preview copies of it (made for walkthroughs). Other
+     * users' copies are not included.
+     */
+    private async getTrainingProjects(
+        organizationId: number,
+        userUuid: string,
+        trx: Knex = this.database,
+    ): Promise<
+        {
+            projectUuid: string;
+            projectType: ProjectType;
+            createdByUserUuid: string | null;
+        }[]
+    > {
+        const training = await trx(ProjectTableName)
+            .select<{
+                project_uuid: string;
+                created_by_user_uuid: string | null;
+            }>('project_uuid', 'created_by_user_uuid')
+            .where('organization_id', organizationId)
+            .where('project_type', ProjectType.TRAINING)
+            .first();
+        if (!training) {
+            return [];
+        }
+        const copies = await trx(ProjectTableName)
+            .select<
+                { project_uuid: string; created_by_user_uuid: string | null }[]
+            >('project_uuid', 'created_by_user_uuid')
+            .where('organization_id', organizationId)
+            .where('project_type', ProjectType.PREVIEW)
+            .where('copied_from_project_uuid', training.project_uuid)
+            .where('created_by_user_uuid', userUuid);
+        return [
+            {
+                projectUuid: training.project_uuid,
+                projectType: ProjectType.TRAINING,
+                createdByUserUuid: training.created_by_user_uuid,
+            },
+            ...copies.map((copy) => ({
+                projectUuid: copy.project_uuid,
+                projectType: ProjectType.PREVIEW,
+                createdByUserUuid: copy.created_by_user_uuid,
+            })),
+        ];
+    }
+
+    /**
+     * The trainee layer: every member of an organization, whatever their org
+     * role, gets `getTrainingProjectScopes()` on the org's training project
+     * (`projects.project_type = 'TRAINING'`) and on their own preview copies
+     * of it. No membership rows are involved,
+     * so new joiners are covered and admins grant nothing. Resolved by the
+     * user's own organization so no one gets the layer on another org's
+     * training project. Human users only; service accounts never get it.
+     */
+    private async applyTrainingProjectAbilities(
+        organizationId: number,
+        userUuid: string,
+        isEnterprise: boolean,
+        builder: AbilityBuilder<MemberAbility>,
+        trx: Knex = this.database,
+    ): Promise<void> {
+        const trainingProjects = await this.getTrainingProjects(
+            organizationId,
+            userUuid,
+            trx,
+        );
+        const scopes = getTrainingProjectScopes();
+        trainingProjects.forEach((project) => {
+            buildAbilityFromScopes(
+                {
+                    projectUuid: project.projectUuid,
+                    projectType: project.projectType,
+                    projectCreatedByUserUuid: project.createdByUserUuid,
+                    userUuid,
+                    scopes,
+                    isEnterprise,
+                    permissionsConfig: {
+                        pat: this.lightdashConfig.auth.pat,
+                    },
+                },
+                builder,
+            );
+        });
     }
 
     /**

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -215,6 +215,7 @@ import {
     supportsOptionalUserCredentials,
     TablesConfiguration,
     TableSelectionType,
+    TooManyRequestsError,
     UnexpectedServerError,
     UpdateAgentSqlScope,
     UpdateDefaultUserSpaces,
@@ -1053,6 +1054,13 @@ export class ProjectService extends BaseService {
                         upstreamProject.type === ProjectType.TRAINING
                     ) {
                         return true;
+                    }
+                    // Any other preview of the training project would look
+                    // like a training copy without being one.
+                    if (upstreamProject.type === ProjectType.TRAINING) {
+                        throw new ForbiddenError(
+                            'Previews of the training project are made by starting a walkthrough',
+                        );
                     }
                     if (
                         // checks if user has permission to create project from an upstream project on a project level
@@ -4405,6 +4413,24 @@ export class ProjectService extends BaseService {
         ) {
             throw new ForbiddenError(
                 `User does not have permission to delete project`,
+            );
+        }
+
+        if (project.type === ProjectType.TRAINING) {
+            // The copies exist only as sandboxes of this project; without it
+            // they would linger as ordinary previews until they expire.
+            const copies = (
+                await this.projectModel.getAllByOrganizationUuid(
+                    project.organizationUuid,
+                )
+            ).filter(
+                (candidate) =>
+                    candidate.type === ProjectType.PREVIEW &&
+                    candidate.provisioningSource === 'training' &&
+                    candidate.upstreamProjectUuid === projectUuid,
+            );
+            await Promise.all(
+                copies.map((copy) => this.deleteTrainingCopy(copy.projectUuid)),
             );
         }
 
@@ -10485,6 +10511,18 @@ export class ProjectService extends BaseService {
         ) {
             throw new ForbiddenError();
         }
+        if (data.upstreamProjectUuid) {
+            // Pointing a preview at the training project would dress it up
+            // as a training copy; only the training service makes those.
+            const upstream = await this.projectModel.getSummary(
+                data.upstreamProjectUuid,
+            );
+            if (upstream.type === ProjectType.TRAINING) {
+                throw new ForbiddenError(
+                    'A preview cannot be re-parented to the training project',
+                );
+            }
+        }
 
         await this.projectModel.updateMetadata(projectUuid, data);
     }
@@ -11118,12 +11156,54 @@ export class ProjectService extends BaseService {
             );
         }
 
+        // One copy at a time per learner, and not more often than a person
+        // clicks: a copy is a whole project duplicate, and a loop of them is
+        // the cheapest way to load the instance.
+        return this.onboardingModel.runInTrainingCopyLock(
+            user.userUuid,
+            async () => {
+                const existing = (
+                    await this.projectModel.getAllByOrganizationUuid(
+                        user.organizationUuid,
+                    )
+                ).filter(
+                    (project) =>
+                        project.type === ProjectType.PREVIEW &&
+                        project.provisioningSource === 'training' &&
+                        project.upstreamProjectUuid === trainingProjectUuid &&
+                        project.createdByUserUuid === user.userUuid,
+                );
+                const newest = existing
+                    .map((project) => new Date(project.createdAt).getTime())
+                    .sort((a, b) => b - a)[0];
+                if (
+                    newest !== undefined &&
+                    Date.now() - newest <
+                        ProjectService.TRAINING_COPY_COOLDOWN_MS
+                ) {
+                    throw new TooManyRequestsError(
+                        'A training copy was made moments ago; try again shortly',
+                    );
+                }
+                return this.makeTrainingCopy(user, training);
+            },
+        );
+    }
+
+    private static readonly TRAINING_COPY_COOLDOWN_MS = 15_000;
+
+    private async makeTrainingCopy(
+        user: SessionUser & { organizationUuid: string },
+        training: Awaited<ReturnType<ProjectModel['get']>>,
+    ): Promise<CreateTrainingPreviewResults> {
+        const trainingProjectUuid = training.projectUuid;
         await this.deleteTrainingPreviews(user, trainingProjectUuid);
 
         const creation = await this.createWithoutCompile(
             user,
             {
-                name: `Training copy for ${user.firstName}`.trim(),
+                // No personal data in the name: it lands in analytics.
+                name: 'Training copy',
                 type: ProjectType.PREVIEW,
                 upstreamProjectUuid: trainingProjectUuid,
                 copyContent: true,
@@ -11140,12 +11220,16 @@ export class ProjectService extends BaseService {
         const { projectUuid } = creation.project;
         // Comments are keyed by tile uuid, which a copy would share with the
         // training project; the copy gets its own tiles and its own comments.
-        await this.projectModel.giveTrainingCopyOwnTiles(projectUuid);
+        await this.projectModel.giveTrainingCopyOwnTiles(
+            projectUuid,
+            training.createdByUserUuid,
+        );
         // The seeded research thread becomes the learner's own.
         await this.projectModel.copyDeepResearchForTrainingCopy(
             trainingProjectUuid,
             projectUuid,
             user.userUuid,
+            training.createdByUserUuid,
         );
 
         // The training project's explores are a shipped bundle, never
@@ -11234,14 +11318,35 @@ export class ProjectService extends BaseService {
         const copies = projects.filter(
             (project) =>
                 project.type === ProjectType.PREVIEW &&
+                project.provisioningSource === 'training' &&
                 project.upstreamProjectUuid === trainingProjectUuid &&
                 project.createdByUserUuid === user.userUuid,
         );
         await Promise.all(
-            copies.map((copy) => this.projectModel.delete(copy.projectUuid)),
+            copies.map((copy) => this.deleteTrainingCopy(copy.projectUuid)),
         );
         this.userModel.invalidateSessionUserCache(user.userUuid);
         return { deleted: copies.length };
+    }
+
+    /**
+     * Remove a training copy and the app files it duplicated into the
+     * bucket, which deleting the project rows alone would leave behind.
+     */
+    private async deleteTrainingCopy(copyProjectUuid: string): Promise<void> {
+        try {
+            await this.getAppGenerateService?.()?.deleteProjectAppFiles(
+                copyProjectUuid,
+            );
+        } catch (error) {
+            Sentry.captureException(error);
+            this.logger.warn(
+                `Could not remove the app files of training copy ${copyProjectUuid}: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+        }
+        await this.projectModel.delete(copyProjectUuid);
     }
 
     /*

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -46,6 +46,7 @@ import {
     CreateProjectOptionalCredentials,
     CreateProjectTableConfiguration,
     CreateSnowflakeCredentials,
+    CreateTrainingPreviewResults,
     CreateVirtualViewPayload,
     CreateWarehouseCredentials,
     currentUtcWallClock,
@@ -239,6 +240,7 @@ import {
     WarehouseTypes,
     type AgentSqlScope,
     type ApiCreateProjectResults,
+    type ChartUsageIn,
     type CreateDatabricksCredentials,
     type DataTimezonePreviewRequest,
     type MergeCompiledLeg,
@@ -397,6 +399,14 @@ type RefreshTokenRotationSource =
       }
     | { kind: 'user'; userWarehouseCredentialsUuid: string };
 
+/**
+ * Projects created by Lightdash itself rather than by a user: the onboarding
+ * playground and the training project. Only these may use embedded DuckDB
+ * credentials or the `TRAINING` project type.
+ */
+export type InternalProvisioningSource = 'playground' | 'training';
+export type InternalProvisioning = { source: InternalProvisioningSource };
+
 export type ProjectServiceArguments = {
     lightdashConfig: LightdashConfig;
     analytics: LightdashAnalytics;
@@ -471,7 +481,7 @@ export type ProjectServiceArguments = {
         user: SessionUser;
         projectUuid: string;
         projectType: ProjectType;
-        provisioningSource?: 'playground';
+        provisioningSource?: InternalProvisioningSource;
     }) => Promise<void>;
     provisionPlaygroundProject?: (args: {
         user: SessionUser;
@@ -765,7 +775,7 @@ export class ProjectService extends BaseService {
         user: SessionUser,
         projectUuid: string,
         projectType: ProjectType,
-        provisioningSource?: 'playground',
+        provisioningSource?: InternalProvisioningSource,
     ): Promise<void> {
         if (projectType === ProjectType.PREVIEW) {
             return;
@@ -779,7 +789,7 @@ export class ProjectService extends BaseService {
         try {
             // Playgrounds are provisioned alongside a user's own project, so
             // they never pass the first-project check but still need an agent
-            if (provisioningSource !== 'playground') {
+            if (provisioningSource === undefined) {
                 const projects =
                     await this.projectModel.getAllByOrganizationUuid(
                         organizationUuid,
@@ -821,7 +831,7 @@ export class ProjectService extends BaseService {
         user: SessionUser,
         projectUuid: string,
         projectType: ProjectType,
-        provisioningSource?: 'playground',
+        provisioningSource?: InternalProvisioningSource,
     ): Promise<void> {
         await this.provisionDefaultAiAgent(
             user,
@@ -958,6 +968,7 @@ export class ProjectService extends BaseService {
     private async validateProjectCreationPermissions(
         user: SessionUser,
         data: Pick<CreateProject, 'type' | 'upstreamProjectUuid'>,
+        internalProvisioning?: InternalProvisioning,
     ) {
         if (!data.type) {
             throw new ParameterError('Project type must be provided');
@@ -996,9 +1007,9 @@ export class ProjectService extends BaseService {
                 );
 
             case ProjectType.TRAINING:
-                throw new ForbiddenError(
-                    'Training projects are created by the training provisioner only.',
-                );
+                // Only reachable from internal provisioning; see
+                // assertTrainingTypeIsInternal at both creation entry points.
+                return true;
 
             case ProjectType.PREVIEW: {
                 let upstreamProject: Awaited<
@@ -1033,6 +1044,15 @@ export class ProjectService extends BaseService {
                         throw new ForbiddenError(
                             'Cannot create a preview project from a preview project',
                         );
+                    }
+                    // A learner's own copy of the training project for a
+                    // walkthrough: provisioned internally, so the trainee
+                    // needs no preview-creation scope. See createTrainingPreview.
+                    if (
+                        internalProvisioning?.source === 'training' &&
+                        upstreamProject.type === ProjectType.TRAINING
+                    ) {
+                        return true;
                     }
                     if (
                         // checks if user has permission to create project from an upstream project on a project level
@@ -2678,12 +2698,16 @@ export class ProjectService extends BaseService {
         user: SessionUser,
         data: CreateProjectOptionalCredentials,
         method: RequestMethod,
-        internalProvisioning?: { source: 'playground' },
+        internalProvisioning?: InternalProvisioning,
     ): Promise<ApiCreateProjectResults> {
         if (!isUserWithOrg(user)) {
             throw new ForbiddenError('User is not part of an organization');
         }
 
+        ProjectService.assertTrainingTypeIsInternal(
+            data.type,
+            internalProvisioning,
+        );
         ProjectService.assertEmbeddedCredentialsAreInternal(
             data.warehouseConnection,
             internalProvisioning,
@@ -2692,7 +2716,11 @@ export class ProjectService extends BaseService {
             data.warehouseConnection,
         );
 
-        await this.validateProjectCreationPermissions(user, data);
+        await this.validateProjectCreationPermissions(
+            user,
+            data,
+            internalProvisioning,
+        );
         this.assertCanUseOrganizationWarehouseCredentials(
             user,
             user.organizationUuid,
@@ -2971,6 +2999,7 @@ export class ProjectService extends BaseService {
             throw new ForbiddenError('User is not part of an organization');
         }
 
+        ProjectService.assertTrainingTypeIsInternal(data.type);
         ProjectService.assertEmbeddedCredentialsAreInternal(
             data.warehouseConnection,
         );
@@ -3450,14 +3479,33 @@ export class ProjectService extends BaseService {
         });
     }
 
+    /**
+     * `TRAINING` projects are created by the training provisioner only. The
+     * public API must never create one, because every org member is granted
+     * the trainee scope set on a project of that type.
+     */
+    private static assertTrainingTypeIsInternal(
+        type: ProjectType | undefined,
+        internalProvisioning?: InternalProvisioning,
+    ): void {
+        if (
+            type === ProjectType.TRAINING &&
+            internalProvisioning?.source !== 'training'
+        ) {
+            throw new ForbiddenError(
+                'Training projects can only be provisioned internally',
+            );
+        }
+    }
+
     private static assertEmbeddedCredentialsAreInternal(
         credentials: CreateWarehouseCredentials | undefined,
-        internalProvisioning?: { source: 'playground' },
+        internalProvisioning?: InternalProvisioning,
     ): void {
         if (
             credentials?.type === WarehouseTypes.DUCKDB &&
             credentials.connectionType === DuckdbConnectionType.EMBEDDED &&
-            internalProvisioning?.source !== 'playground'
+            internalProvisioning === undefined
         ) {
             throw new ParameterError(
                 'Embedded DuckDB connections can only be provisioned internally',
@@ -11044,6 +11092,156 @@ export class ProjectService extends BaseService {
             projectUuid: previewProject.project.projectUuid,
             compileJobUuid: jobUuid,
         };
+    }
+
+    /**
+     * A learner's own throwaway copy of the training project, so a walkthrough
+     * always starts from the seeded state and never touches what other
+     * learners are doing. Any earlier copy the learner had is deleted first,
+     * so "start the tour again" means "start clean". Expires like any preview;
+     * the scheduler removes it.
+     */
+    async createTrainingPreview(
+        user: SessionUser,
+        trainingProjectUuid: string,
+    ): Promise<CreateTrainingPreviewResults> {
+        if (!isUserWithOrg(user)) {
+            throw new ForbiddenError('User is not part of an organization');
+        }
+        const training = await this.projectModel.get(trainingProjectUuid);
+        if (
+            training.type !== ProjectType.TRAINING ||
+            training.organizationUuid !== user.organizationUuid
+        ) {
+            throw new ForbiddenError(
+                "Training copies can only be made from your organization's training project",
+            );
+        }
+
+        await this.deleteTrainingPreviews(user, trainingProjectUuid);
+
+        const creation = await this.createWithoutCompile(
+            user,
+            {
+                name: `Training copy for ${user.firstName}`.trim(),
+                type: ProjectType.PREVIEW,
+                upstreamProjectUuid: trainingProjectUuid,
+                copyContent: true,
+                copyWarehouseConnectionFromUpstreamProject: true,
+                dbtConnection: { type: DbtProjectType.NONE },
+                dbtVersion: training.dbtVersion,
+                expiresInHours:
+                    ProjectService.TRAINING_PREVIEW_EXPIRES_IN_HOURS,
+            },
+            RequestMethod.BACKEND,
+            { source: 'training' },
+        );
+        await this.throwIfPreviewCopyFailed(creation);
+        const { projectUuid } = creation.project;
+        // Comments are keyed by tile uuid, which a copy would share with the
+        // training project; the copy gets its own tiles and its own comments.
+        await this.projectModel.giveTrainingCopyOwnTiles(projectUuid);
+        // The seeded research thread becomes the learner's own.
+        await this.projectModel.copyDeepResearchForTrainingCopy(
+            trainingProjectUuid,
+            projectUuid,
+            user.userUuid,
+        );
+
+        // The training project's explores are a shipped bundle, never
+        // compiled from dbt, so copy the cache instead of scheduling a compile.
+        const explores = Object.values(
+            await this.projectModel.getAllExploresFromCache(
+                trainingProjectUuid,
+            ),
+        );
+        await this.projectModel.saveExploresToCache(
+            projectUuid,
+            explores,
+            true,
+        );
+        // The metrics catalog is built from that cache before the copy is
+        // handed over, so its first page already knows it has metrics (the
+        // Metrics link in the bar depends on it). The copied YAML tags are
+        // assigned to metrics by reference; a fresh copy has nothing from a
+        // previous index to migrate, so no scheduler job is needed.
+        const cachedExploresMap = await this.projectModel.findExploresFromCache(
+            projectUuid,
+            'uuid',
+        );
+        const projectYamlTags = await this.tagsModel.getYamlTags(projectUuid);
+        const { catalogFieldMap } = await this.catalogModel.indexCatalog(
+            projectUuid,
+            cachedExploresMap,
+            projectYamlTags,
+            user.userUuid,
+        );
+        // Popularity (chart usage) orders the catalog; the copied charts
+        // count the same way the index job counts them.
+        const chartUsages = await this.savedChartModel.getChartCountPerField(
+            projectUuid,
+            Object.keys(catalogFieldMap),
+        );
+        await this.catalogModel.setChartUsages(
+            projectUuid,
+            chartUsages.flatMap<ChartUsageIn>(({ fieldId, count }) => {
+                const field = catalogFieldMap[fieldId];
+                if (!field || Number.isNaN(count)) return [];
+                return [
+                    {
+                        fieldName: field.fieldName,
+                        fieldType: field.fieldType,
+                        chartUsage: count,
+                        cachedExploreUuid: field.cachedExploreUuid,
+                    },
+                ];
+            }),
+        );
+
+        // The trainee layer on the new copy only exists in a freshly built
+        // ability; the cached session user still reflects the old copies.
+        this.userModel.invalidateSessionUserCache(user.userUuid);
+
+        const preview = await this.projectModel.get(projectUuid);
+        return { projectUuid, expiresAt: preview.expiresAt ?? null };
+    }
+
+    private static readonly TRAINING_PREVIEW_EXPIRES_IN_HOURS = 24;
+
+    /**
+     * Remove the caller's own copies of the training project (a finished or
+     * abandoned walkthrough). Other learners' copies are untouched.
+     */
+    async deleteTrainingPreviews(
+        user: SessionUser,
+        trainingProjectUuid: string,
+    ): Promise<{ deleted: number }> {
+        if (!isUserWithOrg(user)) {
+            throw new ForbiddenError('User is not part of an organization');
+        }
+        const training = await this.projectModel.get(trainingProjectUuid);
+        if (
+            training.type !== ProjectType.TRAINING ||
+            training.organizationUuid !== user.organizationUuid
+        ) {
+            throw new ForbiddenError(
+                "Only copies of your organization's training project can be removed this way",
+            );
+        }
+        const projects = await this.projectModel.getAllByOrganizationUuid(
+            user.organizationUuid,
+        );
+        const copies = projects.filter(
+            (project) =>
+                project.type === ProjectType.PREVIEW &&
+                project.upstreamProjectUuid === trainingProjectUuid &&
+                project.createdByUserUuid === user.userUuid,
+        );
+        await Promise.all(
+            copies.map((copy) => this.projectModel.delete(copy.projectUuid)),
+        );
+        this.userModel.invalidateSessionUserCache(user.userUuid);
+        return { deleted: copies.length };
     }
 
     /*

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -231,10 +231,12 @@ export {
 } from './types/projects';
 export type {
     AgentSqlScope,
+    ApiCreateTrainingPreviewResponse,
     ApiEnsurePlaygroundProjectResponse,
     ApiGetProjectGroupAccesses,
     ApiProjectResponse,
     EnsurePlaygroundProjectRequest,
+    CreateTrainingPreviewResults,
     EnsurePlaygroundProjectResults,
     PlaygroundProjectTrigger,
     AthenaCredentials,

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -316,6 +316,7 @@ import { type ProjectMemberProfile } from './projectMemberProfile';
 import { type ProjectMemberRole } from './projectMemberRole';
 import {
     DbtProjectType,
+    type CreateTrainingPreviewResults,
     type CreateWarehouseCredentials,
     type DbtProjectConfig,
     type EnsurePlaygroundProjectResults,
@@ -1260,6 +1261,7 @@ type ApiResults =
     | BigqueryProjectRecommendation
     | ApiScimRequestLogListResponse['results']
     | EnsurePlaygroundProjectResults
+    | CreateTrainingPreviewResults
     | ApiWarehouseConnectCodeResponse['results']
     | ApiWarehouseConnectCodeClaimResponse['results']
     | ApiQueryResults


### PR DESCRIPTION
## Description

* The ability builder gives every human user a viewer's scopes on their org's shared training project and the trainee scope set on their own training copies of it (`UserModel.getTrainingProjects`). Service accounts get no layer; org isolation is tested.
* Only internal provisioning may create a project of type TRAINING; the public API cannot create or convert one.
* Training copies: `POST`/`DELETE /api/v1/projects/{trainingProjectUuid}/training-previews` create a learner's personal preview of the training project (content copied from the seed, explores from the cache, 24h expiry, one live copy per learner, any earlier copy removed first) and delete it. Copies get their own dashboard tiles and carry the seeded deep research run re-owned to the learner, so every walkthrough starts from the same state.
* The project switcher marks training copies.

## How to test

`pnpm -F backend test -- UserModel`. Manually: as an org viewer with no project memberships, open the training project: you can browse it but not save; start a walkthrough and you can save a chart in your copy and not in any other project.

## Security review (2026-09-07)

* Shared project = viewer scopes; the learner's copy = trainee set. A copy is recognised by `provisioning_source = 'training'` (set only by the internal path), not by the mutable `copied_from`; preview creation and `updateMetadata` refuse a training project as upstream.
* Copies clone only the seed admin's completed deep research runs and comments, never other learners' content, and never a resumable run.
* One copy per learner under a per-user advisory lock with a 15 s cooldown; deleting a copy removes its data-app files from S3; deleting the training project deletes its copies first.
* Agents on a training project or copy cannot be given integrations or MCP servers (reads still work so the agent pages render); moving an agent checks `manage:AiAgent` on the destination project.
* The training-copy endpoints refuse in demo mode.

**Stack (Lightdash Uni 2, CS-207 / CS-211 / CS-257), merge in order:**
1. `lu2/01-training-project-type` #28710
2. `lu2/02-trainee-layer-and-copies` #28711
3. `lu2/03-seed-training-content` #28712
4. `lu2/04-guided-tour-kit` #28713
5. `lu2/05-scope-tour-host` #28714
6. `lu2/06-learn-library` #28715
7. `lu2/07-enable-learn` #28716

Walkthrough content follows as separate PRs once these are in. Architecture doc: `docs/learn/architecture.md` (first PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PpC4h5RtPcbV5Bj7SeLYHf
