### PR TITLE
feat(frontend): Learn library, one card per trainee scope

### DIFF
--- a/packages/frontend/src/Routes.tsx
+++ b/packages/frontend/src/Routes.tsx
@@ -612,6 +612,16 @@ const PROJECT_LAYOUT_ROUTES: RouteObject[] = [
     ...SPACES_ROUTES,
     ...METRICS_ROUTES,
     {
+        path: 'learn',
+        lazy: async () => {
+            const Learn = await loadLazyRouteDefault(
+                './pages/Learn',
+                () => import('./pages/Learn'),
+            );
+            return { Component: Learn };
+        },
+    },
+    {
         path: 'home',
         lazy: async () => {
             const Home = await loadLazyRouteDefault(

--- a/packages/frontend/src/components/NavBar/MainNavBarContent.tsx
+++ b/packages/frontend/src/components/NavBar/MainNavBarContent.tsx
@@ -1,6 +1,7 @@
 import { ActionIcon, Box, Button, Group } from '@mantine/core';
 import { lazy, Suspense, type FC } from 'react';
 import { Link } from 'react-router';
+import { LearnLink } from '../../features/learn/LearnLink';
 import { useHasMetricsInCatalog } from '../../features/metricsCatalog/hooks/useMetricsCatalog';
 import Omnibar from '../../features/omnibar';
 import { useOptionalProjectRoute } from '../../hooks/useProjectRoute';
@@ -95,7 +96,12 @@ export const MainNavBarContent: FC<Props> = ({
                     <SettingsMenu />
 
                     {!isLoadingActiveProject && activeProjectUuid && (
-                        <NotificationsMenu projectUuid={activeProjectUuid} />
+                        <>
+                            <LearnLink projectUuid={activeProjectUuid} />
+                            <NotificationsMenu
+                                projectUuid={activeProjectUuid}
+                            />
+                        </>
                     )}
 
                     <HelpMenu />

--- a/packages/frontend/src/features/learn/LearnDoneModal.tsx
+++ b/packages/frontend/src/features/learn/LearnDoneModal.tsx
@@ -3,6 +3,7 @@ import { type FC, useMemo } from 'react';
 import MantineModal from '../../components/common/MantineModal';
 import useApp from '../../providers/App/useApp';
 import { SCOPE_TOURS } from '../scopeTours/generated';
+import { useLearnAvailability } from './availability';
 import {
     buildLearnCatalogue,
     focusModules,
@@ -28,7 +29,11 @@ type Props = {
  */
 export const LearnDoneModal: FC<Props> = ({ scope, onBack, onNext }) => {
     const { user } = useApp();
-    const catalogue = useMemo(buildLearnCatalogue, []);
+    const { isOpen } = useLearnAvailability();
+    const catalogue = useMemo(
+        () => buildLearnCatalogue().filter(isOpen),
+        [isOpen],
+    );
     const { completed, lastStarted } = useLearnProgress();
     const tour = SCOPE_TOURS[scope];
     const available = catalogue.filter((m) => m.available);

--- a/packages/frontend/src/features/learn/LearnLink.tsx
+++ b/packages/frontend/src/features/learn/LearnLink.tsx
@@ -1,0 +1,41 @@
+import { ProjectType } from '@lightdash/common';
+import { Button, Tooltip } from '@mantine/core';
+import { IconSchool } from '@tabler/icons-react';
+import { type FC } from 'react';
+import { useNavigate } from 'react-router';
+import MantineIcon from '../../components/common/MantineIcon';
+import { useProjects } from '../../hooks/useProjects';
+
+/**
+ * Navbar entry to the library, an icon beside notifications and help;
+ * present once the org has a training project, and never on a preview (a
+ * learner's training copy included): a library opened inside a copy would
+ * start walkthroughs from the wrong place.
+ */
+export const LearnLink: FC<{ projectUuid: string }> = ({ projectUuid }) => {
+    const navigate = useNavigate();
+    const { data: projects } = useProjects();
+    const hasTrainingProject = projects?.some(
+        (project) => project.type === ProjectType.TRAINING,
+    );
+    const current = projects?.find(
+        (project) => project.projectUuid === projectUuid,
+    );
+    if (!hasTrainingProject || current?.type === ProjectType.PREVIEW)
+        return null;
+    return (
+        <Tooltip label="Learn" position="bottom" withinPortal>
+            <Button
+                aria-label="Learn"
+                variant="default"
+                size="xs"
+                onClick={() => void navigate(`/projects/${projectUuid}/learn`)}
+                // Navigation anchor for scope walkthroughs (data-tour-via).
+                data-tour-nav="learn"
+                data-tour-hint="Click Learn"
+            >
+                <MantineIcon icon={IconSchool} />
+            </Button>
+        </Tooltip>
+    );
+};

--- a/packages/frontend/src/features/learn/LearnPage.tsx
+++ b/packages/frontend/src/features/learn/LearnPage.tsx
@@ -1,0 +1,544 @@
+import {
+    type ProjectMemberRole,
+    ProjectType,
+    ScopeGroup,
+} from '@lightdash/common';
+import {
+    Box,
+    Button,
+    Checkbox,
+    Group,
+    Menu,
+    TextInput,
+    Tooltip,
+    UnstyledButton,
+} from '@mantine/core';
+import {
+    IconBuilding,
+    IconChartHistogram,
+    IconCompass,
+    IconChevronDown,
+    IconDatabase,
+    IconHelpCircle,
+    IconSearch,
+    IconSend,
+    IconSettings,
+    IconSparkles,
+    IconTelescope,
+    type Icon,
+} from '@tabler/icons-react';
+import { type FC, useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router';
+import MantineIcon from '../../components/common/MantineIcon';
+import { useOptionalProjectRoute } from '../../hooks/useProjectRoute';
+import { useProjects } from '../../hooks/useProjects';
+import useApp from '../../providers/App/useApp';
+import { SCOPE_TOURS } from '../scopeTours/generated';
+import { START_PARAM } from '../scopeTours/trainingCopy';
+import {
+    buildLearnCatalogue,
+    focusModules,
+    FOUNDATIONS,
+    GROUP_DESCRIPTIONS,
+    GROUP_LABELS,
+    GROUP_ORDER,
+    roleFromOrganizationRole,
+    roleHolds,
+    ROLE_LABELS,
+    ROLE_ORDER,
+    sortForRole,
+    type LearnGroup,
+    type LearnModule,
+} from './catalogue';
+import styles from './Learn.module.css';
+import { useLearnProgress } from './progress';
+import { thumbnailFor } from './thumbnails';
+import { useStartWalkthrough } from './useStartWalkthrough';
+
+const GROUP_ICONS: Record<LearnGroup, Icon> = {
+    [FOUNDATIONS]: IconCompass,
+    [ScopeGroup.CONTENT]: IconChartHistogram,
+    [ScopeGroup.SHARING]: IconSend,
+    [ScopeGroup.DATA]: IconDatabase,
+    [ScopeGroup.AI]: IconSparkles,
+    [ScopeGroup.PROJECT_MANAGEMENT]: IconSettings,
+    [ScopeGroup.SPOTLIGHT]: IconTelescope,
+    [ScopeGroup.ORGANIZATION_MANAGEMENT]: IconBuilding,
+};
+
+/** The library's band and glyph colours per group, as on learn.lightdash.com. */
+const GROUP_COLOURS: Record<LearnGroup, { band: string; fg: string }> = {
+    [FOUNDATIONS]: { band: '#f0dbd1', fg: '#b06a4c' },
+    [ScopeGroup.CONTENT]: { band: '#dfe8e2', fg: '#4f7d5d' },
+    [ScopeGroup.SHARING]: { band: '#dfe8e2', fg: '#4f7d5d' },
+    [ScopeGroup.DATA]: { band: '#ece3d1', fg: '#93743a' },
+    [ScopeGroup.AI]: { band: '#e2ddf1', fg: '#6b5bb8' },
+    [ScopeGroup.PROJECT_MANAGEMENT]: { band: '#d9e6e4', fg: '#41756f' },
+    [ScopeGroup.SPOTLIGHT]: { band: '#ece3d1', fg: '#93743a' },
+    [ScopeGroup.ORGANIZATION_MANAGEMENT]: { band: '#dfe1e6', fg: '#5b6478' },
+};
+
+const greeting = () => {
+    const hour = new Date().getHours();
+    if (hour < 12) return 'Good morning';
+    if (hour < 18) return 'Good afternoon';
+    return 'Good evening';
+};
+
+const groupVars = (group: LearnGroup) =>
+    ({
+        '--mi-band': GROUP_COLOURS[group].band,
+        '--mi-fg': GROUP_COLOURS[group].fg,
+    }) as React.CSSProperties;
+
+type CardState = 'soon' | 'ready' | 'started' | 'done';
+
+const stateOf = (
+    module: LearnModule,
+    started: string[],
+    completed: string[],
+): CardState =>
+    !module.available
+        ? 'soon'
+        : completed.includes(module.scope)
+          ? 'done'
+          : started.includes(module.scope)
+            ? 'started'
+            : 'ready';
+
+const ModuleCard: FC<{
+    module: LearnModule;
+    state: CardState;
+    heldByRole: boolean;
+    opening: boolean;
+    onStart: (scope: string) => void;
+}> = ({ module, state, heldByRole, opening, onStart }) => {
+    const Glyph = GROUP_ICONS[module.group];
+    const shot = thumbnailFor(module.scope);
+    return (
+        <Box
+            component="article"
+            className={`${styles.card} ${state === 'soon' ? styles.cardSoon : ''}`}
+            data-learn-module={module.scope}
+            data-learn-state={state === 'started' ? 'ready' : state}
+        >
+            <Box
+                className={styles.band}
+                style={groupVars(module.group)}
+                aria-hidden
+            >
+                <Box className={styles.blob}>
+                    <MantineIcon icon={Glyph} size={17} stroke={1.6} />
+                </Box>
+                {shot && (
+                    <Box className={styles.shot}>
+                        <img alt="" loading="lazy" src={shot} />
+                    </Box>
+                )}
+            </Box>
+            <h3 className={styles.title}>{module.title}</h3>
+            {module.blurb !== '' && (
+                <p className={styles.desc}>{module.blurb}</p>
+            )}
+            <Box className={styles.progressRow}>
+                <span>
+                    {state === 'soon'
+                        ? 'Coming soon'
+                        : state === 'done'
+                          ? 'Complete'
+                          : `${module.stepCount} steps`}
+                </span>
+                <span>
+                    {module.minRole && !heldByRole
+                        ? `${ROLE_LABELS[module.minRole]} and above`
+                        : module.isEnterprise
+                          ? 'Enterprise'
+                          : ''}
+                </span>
+            </Box>
+            <Box
+                className={styles.segments}
+                role="img"
+                aria-label={
+                    state === 'done'
+                        ? 'Walkthrough complete'
+                        : state === 'started'
+                          ? 'Walkthrough started'
+                          : 'Not started'
+                }
+            >
+                <span
+                    className={`${styles.seg} ${
+                        state === 'started' || state === 'done'
+                            ? styles.segOn
+                            : ''
+                    }`}
+                />
+                <span
+                    className={`${styles.seg} ${styles.segEnd} ${
+                        state === 'done' ? styles.segEndOn : ''
+                    }`}
+                />
+            </Box>
+            {state !== 'soon' && (
+                <Button
+                    className={styles.cta}
+                    size="compact-sm"
+                    variant="default"
+                    loading={opening}
+                    onClick={() => onStart(module.scope)}
+                >
+                    {state === 'done'
+                        ? 'Start again'
+                        : state === 'started'
+                          ? 'Resume'
+                          : 'Start'}
+                </Button>
+            )}
+        </Box>
+    );
+};
+
+/**
+ * The learner's library: every feature they can practise in the training
+ * project, one card each, grouped as the scope registry groups them. Start
+ * opens the walkthrough in a fresh copy of the training project and brings
+ * the learner back here when it ends.
+ */
+const LearnPage: FC = () => {
+    const navigate = useNavigate();
+    const { user } = useApp();
+    const { data: projects } = useProjects();
+    const trainingProject = projects?.find(
+        (project) => project.type === ProjectType.TRAINING,
+    );
+    // The library is never shown inside a preview (a training copy): it
+    // belongs to the shared training project, so a preview's /learn goes
+    // there instead.
+    const projectRoute = useOptionalProjectRoute();
+    useEffect(() => {
+        if (
+            projectRoute?.project.type === ProjectType.PREVIEW &&
+            trainingProject
+        ) {
+            void navigate(`/projects/${trainingProject.projectUuid}/learn`, {
+                replace: true,
+            });
+        }
+    }, [projectRoute?.project.type, trainingProject, navigate]);
+
+    const catalogue = useMemo(buildLearnCatalogue, []);
+    const { completed, started, lastStarted } = useLearnProgress();
+    const [role, setRole] = useState<ProjectMemberRole>(() =>
+        roleFromOrganizationRole(user.data?.role),
+    );
+    const [query, setQuery] = useState('');
+    const [showExtra, setShowExtra] = useState(true);
+    const [showSoon, setShowSoon] = useState(true);
+    const [activeGroup, setActiveGroup] = useState<LearnGroup | null>(null);
+
+    const visible = useMemo(() => {
+        const needle = query.trim().toLowerCase();
+        return sortForRole(role, catalogue).filter(
+            (module) =>
+                (showExtra || roleHolds(role, module)) &&
+                (showSoon || module.available) &&
+                (needle === '' ||
+                    module.title.toLowerCase().includes(needle) ||
+                    module.scope.toLowerCase().includes(needle)),
+        );
+    }, [catalogue, role, showExtra, showSoon, query]);
+    const groups = GROUP_ORDER.filter((group) =>
+        visible.some((module) => module.group === group),
+    );
+    const available = catalogue.filter((m) => m.available);
+    const doneCount = available.filter((m) =>
+        completed.includes(m.scope),
+    ).length;
+    // Training exists to teach what a learner cannot yet do, so the
+    // recommendation is the first unfinished walkthrough, held-by-role ones
+    // first (sortForRole), rather than nothing for a viewer.
+    const { resume, recommended } = focusModules(
+        role,
+        available,
+        completed,
+        lastStarted,
+    );
+
+    // Start makes the learner's copy and goes straight into it; the
+    // walkthrough brings them back to the library side when it ends.
+    const { start, opening } = useStartWalkthrough(
+        trainingProject?.projectUuid,
+    );
+    // Arriving with ?start=<scope> (the completion dialog's Next) goes
+    // straight into that module, once, the way its Start button would.
+    const [searchParams, setSearchParams] = useSearchParams();
+    const startOnArrival = searchParams.get(START_PARAM);
+    // Once only: a second copy request would remove the copy being opened.
+    const startedOnArrivalRef = useRef(false);
+    useEffect(() => {
+        if (!startOnArrival || !trainingProject) return;
+        if (startedOnArrivalRef.current) return;
+        startedOnArrivalRef.current = true;
+        setSearchParams(
+            (params) => {
+                params.delete(START_PARAM);
+                return params;
+            },
+            { replace: true },
+        );
+        if (SCOPE_TOURS[startOnArrival]) start(startOnArrival);
+    }, [startOnArrival, trainingProject, start, setSearchParams]);
+    const jumpTo = (group: LearnGroup) => {
+        setActiveGroup(group);
+        document
+            .getElementById(`learn-group-${group}`)
+            ?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    };
+
+    return (
+        <Box className={styles.shell}>
+            <Box component="aside" className={styles.sidebar}>
+                <Box className={styles.sidebarInner}>
+                    <h2 className={styles.sidebarTitle}>Library</h2>
+                    <Box
+                        component="nav"
+                        className={styles.nav}
+                        aria-label="Library"
+                    >
+                        {groups.map((group) => {
+                            const Glyph = GROUP_ICONS[group];
+                            return (
+                                <UnstyledButton
+                                    key={group}
+                                    type="button"
+                                    className={`${styles.navItem} ${
+                                        activeGroup === group
+                                            ? styles.navItemActive
+                                            : ''
+                                    }`}
+                                    aria-current={
+                                        activeGroup === group
+                                            ? 'true'
+                                            : undefined
+                                    }
+                                    onClick={() => jumpTo(group)}
+                                >
+                                    <span
+                                        className={styles.navIcon}
+                                        style={groupVars(group)}
+                                    >
+                                        <MantineIcon icon={Glyph} size={15} />
+                                    </span>
+                                    {GROUP_LABELS[group]}
+                                </UnstyledButton>
+                            );
+                        })}
+                    </Box>
+                </Box>
+            </Box>
+            <Box className={styles.main}>
+                <Box className={styles.homeHead}>
+                    <h1 className={styles.greeting}>{greeting()}</h1>
+                    <Box className={styles.stats} data-learn-role={role}>
+                        <Menu position="bottom-end" withinPortal>
+                            <Menu.Target>
+                                <UnstyledButton
+                                    type="button"
+                                    className={`${styles.stat} ${styles.statButton}`}
+                                    aria-haspopup="menu"
+                                >
+                                    Viewing as <b>{ROLE_LABELS[role]}</b>
+                                    <MantineIcon
+                                        icon={IconChevronDown}
+                                        size={14}
+                                    />
+                                </UnstyledButton>
+                            </Menu.Target>
+                            <Menu.Dropdown>
+                                {ROLE_ORDER.map((candidate) => (
+                                    <Menu.Item
+                                        key={candidate}
+                                        onClick={() => setRole(candidate)}
+                                        fw={
+                                            candidate === role ? 600 : undefined
+                                        }
+                                    >
+                                        {ROLE_LABELS[candidate]}
+                                    </Menu.Item>
+                                ))}
+                            </Menu.Dropdown>
+                        </Menu>
+                        <span
+                            className={styles.stat}
+                            data-learn-progress={`${doneCount}/${available.length}`}
+                        >
+                            Modules{' '}
+                            <b>
+                                {doneCount} of {available.length}
+                            </b>
+                        </span>
+                    </Box>
+                </Box>
+                <Box className={styles.focusGrid}>
+                    {resume ? (
+                        <Box
+                            component="article"
+                            className={styles.focusCard}
+                            data-learn-resume={resume.scope}
+                        >
+                            <span
+                                className={`${styles.overline} ${styles.overlineAccent}`}
+                            >
+                                Resume
+                            </span>
+                            <h2>{resume.title}</h2>
+                            <p>{resume.blurb}</p>
+                            <Button
+                                className={styles.focusAction}
+                                variant="light"
+                                size="compact-md"
+                                loading={opening === resume.scope}
+                                onClick={() => start(resume.scope)}
+                            >
+                                Resume module
+                            </Button>
+                        </Box>
+                    ) : (
+                        <Box component="article" className={styles.focusCard}>
+                            <span
+                                className={`${styles.overline} ${styles.overlineAccent}`}
+                            >
+                                Resume
+                            </span>
+                            <h2>No module in progress</h2>
+                            <p>Start a module from the library below.</p>
+                        </Box>
+                    )}
+                    {recommended ? (
+                        <Box
+                            component="article"
+                            className={styles.focusCard}
+                            data-learn-recommended={recommended.scope}
+                        >
+                            <span className={styles.overline}>
+                                Recommended next
+                            </span>
+                            <h2>{recommended.title}</h2>
+                            <p>{recommended.blurb}</p>
+                            <Button
+                                className={styles.focusAction}
+                                variant="default"
+                                size="compact-md"
+                                loading={opening === recommended.scope}
+                                onClick={() => start(recommended.scope)}
+                            >
+                                Start
+                            </Button>
+                        </Box>
+                    ) : (
+                        <Box component="article" className={styles.focusCard}>
+                            <span className={styles.overline}>
+                                Recommendation
+                            </span>
+                            <h2>Nothing new for {ROLE_LABELS[role]}</h2>
+                            <p>
+                                Use Show extra modules when you want to go
+                                beyond your role.
+                            </p>
+                        </Box>
+                    )}
+                </Box>
+                <Box className={styles.toolbar}>
+                    <TextInput
+                        className={styles.search}
+                        size="sm"
+                        placeholder="Search the library"
+                        aria-label="Search the library"
+                        leftSection={<MantineIcon icon={IconSearch} />}
+                        value={query}
+                        onChange={(event) =>
+                            setQuery(event.currentTarget.value)
+                        }
+                    />
+                    <Group className={styles.toggles} gap="md">
+                        <Group gap={6} wrap="nowrap">
+                            <Checkbox
+                                size="xs"
+                                label="Show extra modules"
+                                checked={showExtra}
+                                onChange={(event) =>
+                                    setShowExtra(event.currentTarget.checked)
+                                }
+                            />
+                            <Tooltip
+                                label="Modules for roles above yours, with the role they need"
+                                withArrow
+                            >
+                                <span
+                                    role="img"
+                                    aria-label="Modules for roles above yours, with the role they need"
+                                >
+                                    <MantineIcon
+                                        icon={IconHelpCircle}
+                                        size={14}
+                                        color="dimmed"
+                                    />
+                                </span>
+                            </Tooltip>
+                        </Group>
+                        <Checkbox
+                            size="xs"
+                            label="Coming soon"
+                            checked={showSoon}
+                            onChange={(event) =>
+                                setShowSoon(event.currentTarget.checked)
+                            }
+                        />
+                    </Group>
+                </Box>
+                {groups.length === 0 && (
+                    <Box className={styles.empty}>
+                        No modules match this search.
+                    </Box>
+                )}
+                {groups.map((group) => (
+                    <Box
+                        key={group}
+                        component="section"
+                        id={`learn-group-${group}`}
+                        className={styles.group}
+                        data-learn-group={group}
+                    >
+                        <h2 className={styles.groupTitle}>
+                            {GROUP_LABELS[group]}
+                        </h2>
+                        <p className={styles.groupDesc}>
+                            {GROUP_DESCRIPTIONS[group]}
+                        </p>
+                        <Box className={styles.grid}>
+                            {visible
+                                .filter((module) => module.group === group)
+                                .map((module) => (
+                                    <ModuleCard
+                                        key={module.scope}
+                                        module={module}
+                                        state={stateOf(
+                                            module,
+                                            started,
+                                            completed,
+                                        )}
+                                        heldByRole={roleHolds(role, module)}
+                                        opening={opening === module.scope}
+                                        onStart={start}
+                                    />
+                                ))}
+                        </Box>
+                    </Box>
+                ))}
+            </Box>
+        </Box>
+    );
+};
+
+export default LearnPage;

--- a/packages/frontend/src/features/learn/LearnPage.tsx
+++ b/packages/frontend/src/features/learn/LearnPage.tsx
@@ -35,6 +35,7 @@ import { useProjects } from '../../hooks/useProjects';
 import useApp from '../../providers/App/useApp';
 import { SCOPE_TOURS } from '../scopeTours/generated';
 import { START_PARAM } from '../scopeTours/trainingCopy';
+import { useLearnAvailability } from './availability';
 import {
     buildLearnCatalogue,
     focusModules,
@@ -151,9 +152,7 @@ const ModuleCard: FC<{
                 <span>
                     {module.minRole && !heldByRole
                         ? `${ROLE_LABELS[module.minRole]} and above`
-                        : module.isEnterprise
-                          ? 'Enterprise'
-                          : ''}
+                        : ''}
                 </span>
             </Box>
             <Box
@@ -227,7 +226,13 @@ const LearnPage: FC = () => {
         }
     }, [projectRoute?.project.type, trainingProject, navigate]);
 
-    const catalogue = useMemo(buildLearnCatalogue, []);
+    // Only modules this instance can run: a walkthrough clicks the real
+    // product, so a feature the instance hides has nothing to click.
+    const { isOpen } = useLearnAvailability();
+    const catalogue = useMemo(
+        () => buildLearnCatalogue().filter(isOpen),
+        [isOpen],
+    );
     const { completed, started, lastStarted } = useLearnProgress();
     const [role, setRole] = useState<ProjectMemberRole>(() =>
         roleFromOrganizationRole(user.data?.role),

--- a/packages/frontend/src/features/learn/availability.ts
+++ b/packages/frontend/src/features/learn/availability.ts
@@ -1,0 +1,44 @@
+import { FeatureFlags } from '@lightdash/common';
+import { useCallback } from 'react';
+import { useAiOrganizationSettings } from '../../ee/features/aiCopilot/hooks/useAiOrganizationSettings';
+import { useIsCopilotEnabled } from '../../ee/features/aiCopilot/hooks/useIsCopilotEnabled';
+import { useServerFeatureFlag } from '../../hooks/useServerOrClientFeatureFlag';
+import useApp from '../../providers/App/useApp';
+import { type LearnGate, type LearnModule } from './catalogue';
+
+/**
+ * Whether this instance can run a module. A walkthrough clicks the real
+ * product, so a module whose feature the instance hides (no Enterprise
+ * licence, or the feature's own switch off) would highlight a control that
+ * is not there; the library leaves it out rather than tagging it. The gates
+ * are the ones the product's own entry points use: the licence for
+ * Enterprise scopes, the licence plus the data apps flag behind the Data App
+ * menu item, the
+ * AI copilot switch and the agents' visibility setting behind Ask AI. Until
+ * a gate has answered, its modules stay out, so the library never shows a
+ * card it then takes away.
+ */
+export const useLearnAvailability = () => {
+    const { health } = useApp();
+    const dataApps = useServerFeatureFlag(FeatureFlags.EnableDataApps);
+    const copilot = useIsCopilotEnabled();
+    const aiSettings = useAiOrganizationSettings();
+    const isEnterprise = health.data?.license?.hasLicenseKey === true;
+    const open: Record<LearnGate, boolean> = {
+        enterprise: isEnterprise,
+        // Data apps are Enterprise as well as flagged: without a licence the
+        // app endpoints refuse and nothing seeds an app to practise on.
+        dataApps: isEnterprise && dataApps.data?.enabled === true,
+        aiAgents:
+            isEnterprise &&
+            copilot.isCopilotEnabled &&
+            aiSettings.data?.aiAgentsVisible === true,
+    };
+    const key = JSON.stringify(open);
+    const isOpen = useCallback(
+        (module: LearnModule) => module.gate === null || open[module.gate],
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [key],
+    );
+    return { isOpen };
+};

--- a/packages/frontend/src/features/learn/catalogue.test.ts
+++ b/packages/frontend/src/features/learn/catalogue.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { buildLearnCatalogue, gateFor } from './catalogue';
+
+describe('learn catalogue gates', () => {
+    it('gates data app modules on the data apps switch, not the licence', () => {
+        expect(gateFor({ name: 'create:DataApp', isEnterprise: false })).toBe(
+            'dataApps',
+        );
+        expect(gateFor({ name: 'manage:DataApp', isEnterprise: false })).toBe(
+            'dataApps',
+        );
+    });
+
+    it('gates every AI module on the agents being available', () => {
+        [
+            'manage:AiAgent',
+            'create:AiAgentThread',
+            'create:AiDeepResearch',
+        ].forEach((name) =>
+            expect(gateFor({ name, isEnterprise: true })).toBe('aiAgents'),
+        );
+    });
+
+    it('gates other Enterprise scopes on the licence and open-source ones on nothing', () => {
+        expect(
+            gateFor({ name: 'manage:MetricsTree', isEnterprise: true }),
+        ).toBe('enterprise');
+        expect(
+            gateFor({ name: 'manage:ProjectHomepage', isEnterprise: true }),
+        ).toBe('enterprise');
+        expect(
+            gateFor({ name: 'manage:SavedChart', isEnterprise: false }),
+        ).toBe(null);
+    });
+
+    it('leaves the core walkthroughs open on any instance', () => {
+        const open = buildLearnCatalogue().filter((m) => m.gate === null);
+        [
+            'manage:SavedChart',
+            'manage:Dashboard',
+            'manage:Space',
+            'manage:SqlRunner',
+        ].forEach((scope) => expect(open.map((m) => m.scope)).toContain(scope));
+    });
+});

--- a/packages/frontend/src/features/learn/catalogue.ts
+++ b/packages/frontend/src/features/learn/catalogue.ts
@@ -15,11 +15,32 @@ import { SCOPE_TOURS } from '../scopeTours/generated';
 export const FOUNDATIONS = 'foundations' as const;
 export type LearnGroup = ScopeGroup | typeof FOUNDATIONS;
 
+/**
+ * What an instance must have for a module's walkthrough to find its controls:
+ * an Enterprise licence, or one of the product's own feature switches on top
+ * of it. The library leaves a closed module out (see availability.ts).
+ */
+export type LearnGate = 'enterprise' | 'dataApps' | 'aiAgents';
+
+const SUBJECT_GATES: Record<string, LearnGate> = {
+    DataApp: 'dataApps',
+    AiAgent: 'aiAgents',
+    AiAgentThread: 'aiAgents',
+    AiDeepResearch: 'aiAgents',
+};
+
+export const gateFor = (scope: {
+    name: string;
+    isEnterprise: boolean;
+}): LearnGate | null =>
+    SUBJECT_GATES[scope.name.split(':')[1]] ??
+    (scope.isEnterprise ? 'enterprise' : null);
+
 export type LearnModule = {
     scope: string;
     title: string;
     group: LearnGroup;
-    isEnterprise: boolean;
+    gate: LearnGate | null;
     /** The lowest project role that holds the scope; null if none does. */
     minRole: ProjectMemberRole | null;
     available: boolean;
@@ -141,7 +162,7 @@ export const buildLearnCatalogue = (): LearnModule[] => {
                         minRole === ProjectMemberRole.VIEWER
                             ? FOUNDATIONS
                             : scope.group,
-                    isEnterprise: scope.isEnterprise,
+                    gate: gateFor(scope),
                     minRole,
                     available: tour !== undefined,
                     blurb: tour ? stripBold(tour.steps[0]?.body ?? '') : '',

--- a/packages/frontend/src/features/learn/catalogue.ts
+++ b/packages/frontend/src/features/learn/catalogue.ts
@@ -3,7 +3,7 @@ import {
     getScopes,
     getTrainingProjectScopes,
     ProjectMemberRole,
-    type ScopeGroup,
+    ScopeGroup,
 } from '@lightdash/common';
 import { SCOPE_TOURS } from '../scopeTours/generated';
 
@@ -12,7 +12,7 @@ import { SCOPE_TOURS } from '../scopeTours/generated';
  * taught in the same format, and the first section of the library. Every
  * other group is the scope registry's own.
  */
-const FOUNDATIONS = 'foundations' as const;
+export const FOUNDATIONS = 'foundations' as const;
 export type LearnGroup = ScopeGroup | typeof FOUNDATIONS;
 
 export type LearnModule = {
@@ -27,13 +27,57 @@ export type LearnModule = {
     stepCount: number;
 };
 
-const ROLE_ORDER: ProjectMemberRole[] = [
+export const ROLE_ORDER: ProjectMemberRole[] = [
     ProjectMemberRole.VIEWER,
     ProjectMemberRole.INTERACTIVE_VIEWER,
     ProjectMemberRole.EDITOR,
     ProjectMemberRole.DEVELOPER,
     ProjectMemberRole.ADMIN,
 ];
+
+export const ROLE_LABELS: Record<ProjectMemberRole, string> = {
+    [ProjectMemberRole.VIEWER]: 'Viewer',
+    [ProjectMemberRole.INTERACTIVE_VIEWER]: 'Interactive viewer',
+    [ProjectMemberRole.EDITOR]: 'Editor',
+    [ProjectMemberRole.DEVELOPER]: 'Developer',
+    [ProjectMemberRole.ADMIN]: 'Admin',
+};
+
+export const GROUP_ORDER: LearnGroup[] = [
+    FOUNDATIONS,
+    ScopeGroup.CONTENT,
+    ScopeGroup.SHARING,
+    ScopeGroup.DATA,
+    ScopeGroup.AI,
+    ScopeGroup.PROJECT_MANAGEMENT,
+    ScopeGroup.SPOTLIGHT,
+    ScopeGroup.ORGANIZATION_MANAGEMENT,
+];
+
+/** The library's one-line purpose per group, as on learn.lightdash.com. */
+export const GROUP_DESCRIPTIONS: Record<LearnGroup, string> = {
+    [FOUNDATIONS]: 'Become a knowledgeable Lightdash user',
+    [ScopeGroup.CONTENT]: 'Create and maintain charts, dashboards, and spaces',
+    [ScopeGroup.SHARING]: 'Send, schedule, and discuss trusted answers',
+    [ScopeGroup.DATA]:
+        'Shape, inspect, and extend the data available in Lightdash',
+    [ScopeGroup.AI]: 'Ask better questions and manage AI-powered workflows',
+    [ScopeGroup.PROJECT_MANAGEMENT]: 'Keep project access and delivery healthy',
+    [ScopeGroup.SPOTLIGHT]: 'Learn timely product areas and advanced workflows',
+    [ScopeGroup.ORGANIZATION_MANAGEMENT]:
+        'Administer people, roles, and organisation settings',
+};
+
+export const GROUP_LABELS: Record<LearnGroup, string> = {
+    [FOUNDATIONS]: 'Foundations',
+    [ScopeGroup.CONTENT]: 'Content',
+    [ScopeGroup.SHARING]: 'Sharing',
+    [ScopeGroup.DATA]: 'Data',
+    [ScopeGroup.AI]: 'AI',
+    [ScopeGroup.PROJECT_MANAGEMENT]: 'Project management',
+    [ScopeGroup.SPOTLIGHT]: 'Spotlight',
+    [ScopeGroup.ORGANIZATION_MANAGEMENT]: 'Organization',
+};
 
 const stripBold = (text: string) => text.replace(/\*\*/g, '');
 
@@ -113,7 +157,7 @@ export const buildLearnCatalogue = (): LearnModule[] => {
 };
 
 /** Available first, then modules the role holds, then by title. */
-const sortForRole = (
+export const sortForRole = (
     role: ProjectMemberRole,
     modules: LearnModule[],
 ): LearnModule[] =>
@@ -146,7 +190,10 @@ export const focusModules = (
 };
 
 /** Whether a role holds a module's scope (its rank is at or above the minimum). */
-const roleHolds = (role: ProjectMemberRole, module: LearnModule): boolean =>
+export const roleHolds = (
+    role: ProjectMemberRole,
+    module: LearnModule,
+): boolean =>
     module.minRole !== null &&
     ROLE_ORDER.indexOf(role) >= ROLE_ORDER.indexOf(module.minRole);
 

--- a/packages/frontend/src/features/learn/progress.ts
+++ b/packages/frontend/src/features/learn/progress.ts
@@ -46,6 +46,15 @@ export const markScopeCompleted = (scope: string) =>
         );
     });
 
+export const markScopeStarted = (scope: string) =>
+    write(() => {
+        localStorage.setItem(
+            STARTED_KEY,
+            JSON.stringify([...new Set([...readList(STARTED_KEY), scope])]),
+        );
+        localStorage.setItem(LAST_KEY, scope);
+    });
+
 export const useLearnProgress = () => {
     const [state, setState] = useState(() => ({
         completed: readList(COMPLETED_KEY),

--- a/packages/frontend/src/features/learn/thumbnails.ts
+++ b/packages/frontend/src/features/learn/thumbnails.ts
@@ -1,0 +1,13 @@
+/**
+ * A screenshot per module for the card's band, taken by the walkthrough
+ * smoke (`pnpm scope-tours:smoke --thumbnails`) at the moment the learner
+ * acts, and committed under ./thumbnails/<scope>.jpg. A
+ * module without one shows its band alone.
+ */
+const files = import.meta.glob<string>('./thumbnails/*.jpg', {
+    eager: true,
+    import: 'default',
+});
+
+export const thumbnailFor = (scope: string): string | undefined =>
+    files[`./thumbnails/${scope.replace(/[^A-Za-z0-9]/g, '_')}.jpg`];

--- a/packages/frontend/src/features/learn/useStartWalkthrough.ts
+++ b/packages/frontend/src/features/learn/useStartWalkthrough.ts
@@ -1,0 +1,55 @@
+import {
+    type ApiError,
+    type CreateTrainingPreviewResults,
+} from '@lightdash/common';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useCallback, useState } from 'react';
+import { useNavigate } from 'react-router';
+import {
+    createTrainingPreview,
+    tourUrlInCopy,
+} from '../scopeTours/trainingCopy';
+import { markScopeStarted } from './progress';
+
+/**
+ * Start a walkthrough the way the library does: make the learner's copy
+ * here and go straight into it, so nothing of the shared training project
+ * flashes past on the way. `from=learn` brings them back to the library
+ * side (the completion page on Got it, the library on Skip) when it ends.
+ * Shared by the library and the completion page so both start identically.
+ */
+export const useStartWalkthrough = (
+    trainingProjectUuid: string | undefined,
+) => {
+    const navigate = useNavigate();
+    const queryClient = useQueryClient();
+    const [opening, setOpening] = useState<string | null>(null);
+    const { mutate: openInCopy } = useMutation<
+        CreateTrainingPreviewResults,
+        ApiError,
+        { scope: string }
+    >(() => createTrainingPreview(trainingProjectUuid!), {
+        onMutate: ({ scope }) => setOpening(scope),
+        onError: () => setOpening(null),
+        onSuccess: async (copy, { scope }) => {
+            // The navbar resolves the active project from the cached project
+            // list, and the trainee permissions on the new copy only exist
+            // in a freshly built ability, so refresh both before moving there.
+            await Promise.all([
+                queryClient.invalidateQueries(['projects']),
+                queryClient.invalidateQueries(['user']),
+                queryClient.invalidateQueries(['account']),
+            ]);
+            void navigate(tourUrlInCopy(copy.projectUuid, scope, 'learn'));
+        },
+    });
+    const start = useCallback(
+        (scope: string) => {
+            if (!trainingProjectUuid || opening) return;
+            markScopeStarted(scope);
+            openInCopy({ scope });
+        },
+        [trainingProjectUuid, opening, openInCopy],
+    );
+    return { start, opening };
+};

--- a/packages/frontend/src/pages/Learn.tsx
+++ b/packages/frontend/src/pages/Learn.tsx
@@ -1,0 +1,11 @@
+import { type FC } from 'react';
+import Page from '../components/common/Page/Page';
+import LearnPage from '../features/learn/LearnPage';
+
+const Learn: FC = () => (
+    <Page title="Learn" withFooter noContentPadding>
+        <LearnPage />
+    </Page>
+);
+
+export default Learn;


### PR DESCRIPTION
## Description

A Learn icon beside notifications opens `/projects/:projectUuid/learn`, the library: one card per scope the trainee layer grants, grouped as the scope registry groups them (Foundations first), each Available or Coming soon from the generated walkthrough manifest, with a role picker, search, Resume and Recommended-next cards and a progress line. Start creates a fresh training copy and opens the walkthrough in it; finishing returns here. Learn is hidden on previews.

## How to test

Recorded flow `cs-207-learn-library.mjs` (green on the full stack). Manually: as any user, open Learn from the navbar of a real project, Start a module, finish it, Back to library.

## Only what the instance can run (2026-09-07)

Each module carries the gate its feature sits behind, taken from the product's own entry points: the Enterprise licence for Enterprise scopes, the licence plus the data apps flag for data app modules (the app endpoints refuse without a licence), and the AI copilot switch plus the agents' visibility setting for Ask AI, agent setup and deep research. Closed modules are left out of the library and the completion dialog's Next rather than tagged (the Enterprise card label is gone). On an open-source instance the AI and data app cards do not appear. `catalogue.test.ts` covers the mapping.

## Security review (2026-09-07)

No findings in the library. Start now always lands in a fresh copy (see #28714).

**Stack (Lightdash Uni 2, CS-207 / CS-211 / CS-257), merge in order:**
1. `lu2/01-training-project-type` #28710
2. `lu2/02-trainee-layer-and-copies` #28711
3. `lu2/03-seed-training-content` #28712
4. `lu2/04-guided-tour-kit` #28713
5. `lu2/05-scope-tour-host` #28714
6. `lu2/06-learn-library` #28715
7. `lu2/07-enable-learn` #28716

Walkthrough content follows as separate PRs once these are in. Architecture doc: `docs/learn/architecture.md` (first PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PpC4h5RtPcbV5Bj7SeLYHf


