### PR TITLE
feat(learn): Enable Learn from the Learn page; the enabling admin owns the training project

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -1122,6 +1122,41 @@ type PlaygroundProjectFailedEvent = BaseTrack & {
     };
 };
 
+type TrainingProjectProvisionedEvent = BaseTrack & {
+    event: 'training_project.provisioned';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        contentSeedErrorType: string | null;
+        catalogIndexErrorType: string | null;
+    };
+};
+
+export type TrainingProjectSkippedReason =
+    | 'learn_disabled'
+    | 'training_project_already_exists';
+
+type TrainingProjectSkippedEvent = BaseTrack & {
+    event: 'training_project.skipped';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string | null;
+        reason: TrainingProjectSkippedReason;
+    };
+};
+
+type TrainingProjectFailedEvent = BaseTrack & {
+    event: 'training_project.failed';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string | null;
+        errorType: string;
+    };
+};
+
 type ProjectDeletedEvent = BaseTrack & {
     event: 'project.deleted';
     userId: string;
@@ -3853,6 +3888,9 @@ type TypedEvent =
     | PlaygroundProjectProvisionedEvent
     | PlaygroundProjectSkippedEvent
     | PlaygroundProjectFailedEvent
+    | TrainingProjectProvisionedEvent
+    | TrainingProjectSkippedEvent
+    | TrainingProjectFailedEvent
     | ProjectDeletedEvent
     | ProjectCompiledEvent
     | DbtSourceEvent

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -464,6 +464,9 @@ export const lightdashConfigMock: LightdashConfig = {
         bufferMaxSize: 10000,
         s3: null,
     },
+    learn: {
+        enabled: false,
+    },
     appRuntime: {
         enabled: false,
         dataAppCodingAgent: 'claude',

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1829,6 +1829,14 @@ export type LightdashConfig = {
     dashboardComments: {
         enabled: boolean;
     };
+    /**
+     * Learn: the training project and its walkthroughs (CS-257). Off by
+     * default; switched on per instance with LIGHTDASH_LEARN_ENABLED=true,
+     * then enabled per org by an admin from the Learn page.
+     */
+    learn: {
+        enabled: boolean;
+    };
     preAggregates: {
         enabled: boolean;
         parquetEnabled: boolean;
@@ -3694,6 +3702,9 @@ export const parseConfig = (): LightdashConfig => {
         },
         dashboardComments: {
             enabled: process.env.DISABLE_DASHBOARD_COMMENTS !== 'true',
+        },
+        learn: {
+            enabled: process.env.LIGHTDASH_LEARN_ENABLED === 'true',
         },
         softDelete: {
             enabled: process.env.SOFT_DELETE_ENABLED === 'true',

--- a/packages/backend/src/controllers/organizationController.ts
+++ b/packages/backend/src/controllers/organizationController.ts
@@ -3,6 +3,7 @@ import {
     ApiColorPalettesResponse,
     ApiCreatedColorPaletteResponse,
     ApiCreateGroupResponse,
+    ApiEnableLearnResponse,
     ApiEnsurePlaygroundProjectResponse,
     ApiErrorPayload,
     ApiGroupListResponse,
@@ -864,6 +865,31 @@ export class OrganizationController extends BaseController {
             results: await this.services
                 .getProjectService()
                 .ensurePlaygroundProject(user, body?.trigger),
+        };
+    }
+
+    /**
+     * Enable Learn for the current organization: create the training project
+     * with the caller as its admin. Org admins only. Idempotent.
+     * @summary Enable Learn
+     * @param req express request
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @Post('/training-project')
+    @OperationId('EnableLearn')
+    async enableLearn(
+        @Request() req: express.Request,
+    ): Promise<ApiEnableLearnResponse> {
+        assertRegisteredAccount(req.account);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getProjectService()
+                .enableLearn(toSessionUser(req.account)),
         };
     }
 

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -23,6 +23,7 @@ import { LinearAppService } from '../services/LinearAppService/LinearAppService'
 import { OAuthService } from '../services/OAuthService/OAuthService';
 import { OrganizationService } from '../services/OrganizationService/OrganizationService';
 import { ProjectService } from '../services/ProjectService/ProjectService';
+import { provisionTrainingProject } from '../services/ProjectService/provisionTrainingProject';
 import { QuerySourceRegistry } from '../services/QuerySourceService/QuerySourceRegistry';
 import { QuerySourceService } from '../services/QuerySourceService/QuerySourceService';
 import { RolesService } from '../services/RolesService/RolesService';
@@ -1123,6 +1124,43 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                                     // belong to the training project.
                                 }),
                             analytics: context.lightdashAnalytics,
+                        }),
+                    provisionTrainingProject: ({ user, projectService }) =>
+                        provisionTrainingProject({
+                            user,
+                            projectService,
+                            learnEnabled: context.lightdashConfig.learn.enabled,
+                            projectModel: models.getProjectModel(),
+                            onboardingModel: models.getOnboardingModel(),
+                            catalogService: repository.getCatalogService(),
+                            analytics: context.lightdashAnalytics,
+                            seedTrainingContent: ({
+                                projectUuid,
+                                user: seedUser,
+                                content,
+                            }) =>
+                                seedPlaygroundContent({
+                                    projectUuid,
+                                    user: seedUser,
+                                    content,
+                                    publicSpace: true,
+                                    spaceModel: models.getSpaceModel(),
+                                    savedChartModel:
+                                        models.getSavedChartModel(),
+                                    dashboardModel: models.getDashboardModel(),
+                                    pinnedListModel:
+                                        models.getPinnedListModel(),
+                                    commentModel: models.getCommentModel(),
+                                    tagsModel: models.getTagsModel(),
+                                    appModel: models.getAppModel(),
+                                    aiAgentModel:
+                                        models.getAiAgentModel<AiAgentModel>(),
+                                    aiDeepResearchRunModel:
+                                        models.getAiDeepResearchRunModel<AiDeepResearchRunModel>(),
+                                    appFileStore: createPlaygroundAppFileStore(
+                                        lightdashConfig.appRuntime.s3,
+                                    ),
+                                }),
                         }),
                 }),
             instanceConfigurationService: ({

--- a/packages/backend/src/ee/services/ProjectService/provisionPlaygroundProject.ts
+++ b/packages/backend/src/ee/services/ProjectService/provisionPlaygroundProject.ts
@@ -61,7 +61,7 @@ export type ProvisionPlaygroundProjectArguments = {
     validatePlaygroundDatabase?: (databasePath: string) => Promise<void>;
 };
 
-const validatePlaygroundDatabaseBundle = async (): Promise<void> => {
+export const validatePlaygroundDatabaseBundle = async (): Promise<void> => {
     const client = new DuckdbWarehouseClient({
         type: WarehouseTypes.DUCKDB,
         connectionType: DuckdbConnectionType.EMBEDDED,
@@ -70,7 +70,7 @@ const validatePlaygroundDatabaseBundle = async (): Promise<void> => {
     await client.runQuery('SELECT count(*) FROM information_schema.tables');
 };
 
-const loadPlaygroundBundle = async (
+export const loadPlaygroundBundle = async (
     dataDirectory: string,
     validatePlaygroundDatabase: (databasePath: string) => Promise<void>,
 ): Promise<{

--- a/packages/backend/src/ee/services/ProjectService/seedPlaygroundContent.ts
+++ b/packages/backend/src/ee/services/ProjectService/seedPlaygroundContent.ts
@@ -23,6 +23,12 @@ type SeedPlaygroundContentArguments = {
     projectUuid: string;
     user: SessionUser;
     content: PlaygroundContent;
+    /**
+     * Whether the seeded root space is public (inherits the project's
+     * permissions). The playground keeps its private space; the training
+     * project's content must be visible to every role.
+     */
+    publicSpace?: boolean;
     spaceModel: {
         createSpace: (
             ...args: Parameters<SpaceModel['createSpace']>
@@ -130,6 +136,7 @@ export const seedPlaygroundContent = async ({
     projectUuid,
     user,
     content,
+    publicSpace = false,
     spaceModel,
     savedChartModel,
     dashboardModel,
@@ -144,7 +151,7 @@ export const seedPlaygroundContent = async ({
     const space = await spaceModel.createSpace(
         {
             name: content.space.name,
-            inheritParentPermissions: false,
+            inheritParentPermissions: publicSpace,
             parentSpaceUuid: null,
         },
         {

--- a/packages/backend/src/models/OnboardingModel/OnboardingModel.ts
+++ b/packages/backend/src/models/OnboardingModel/OnboardingModel.ts
@@ -8,6 +8,9 @@ type OnboardingModelArguments = {
 };
 
 const PLAYGROUND_PROVISIONING_LOCK_NAMESPACE = 19350428;
+// Distinct from the playground's, so enabling Learn and provisioning a
+// playground for the same org never wait on each other.
+const TRAINING_PROVISIONING_LOCK_NAMESPACE = 19350429;
 // One training copy at a time per learner: parallel requests would each
 // delete the others' copy and leave several live.
 const TRAINING_COPY_LOCK_NAMESPACE = 19350430;
@@ -41,9 +44,33 @@ export class OnboardingModel {
     }
 
     /**
-     * Serialises training copy creation per learner: the copy endpoint
-     * deletes the learner's previous copy before making a new one, so two
-     * requests at once must not interleave.
+     * Serialises training project creation per organization (CS-257): two
+     * admins clicking Enable Learn at once make one project.
+     */
+    async runInTrainingProvisioningLock<T>(
+        organizationUuid: string,
+        callback: (trx: Knex.Transaction) => Promise<T>,
+    ): Promise<T> {
+        return this.database.transaction(async (trx) => {
+            const organization = await trx(OrganizationTableName)
+                .where('organization_uuid', organizationUuid)
+                .select('organization_id')
+                .first();
+            if (!organization) {
+                throw new NotFoundError('Cannot find organization');
+            }
+
+            await trx.raw('SELECT pg_advisory_xact_lock(?, ?)', [
+                TRAINING_PROVISIONING_LOCK_NAMESPACE,
+                organization.organization_id,
+            ]);
+            return callback(trx);
+        });
+    }
+
+    /**
+     * Serialises training copy creation per learner (see
+     * ProjectService.createTrainingPreview).
      */
     async runInTrainingCopyLock<T>(
         userUuid: string,

--- a/packages/backend/src/models/UserModel.test.ts
+++ b/packages/backend/src/models/UserModel.test.ts
@@ -103,6 +103,7 @@ const lightdashConfig = {
     },
     license: {},
     customRoles: { enabled: false },
+    learn: { enabled: true },
     rudder: {},
 } as unknown as LightdashConfig;
 

--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -1238,6 +1238,9 @@ export class UserModel {
         builder: AbilityBuilder<MemberAbility>,
         trx: Knex = this.database,
     ): Promise<void> {
+        // Learn off for the instance: no trainee scopes, even if a training
+        // project is left over, so switching off also closes the sandbox.
+        if (!this.lightdashConfig.learn.enabled) return;
         const trainingProjects = await this.getTrainingProjects(
             organizationId,
             userUuid,

--- a/packages/backend/src/services/HealthService/HealthService.mock.ts
+++ b/packages/backend/src/services/HealthService/HealthService.mock.ts
@@ -157,6 +157,9 @@ export const BaseResponse: HealthState = {
     preAggregates: {
         enabled: false,
     },
+    learn: {
+        enabled: false,
+    },
     dataApps: {
         previewOrigin: null,
         sampleDataEnabled: true,

--- a/packages/backend/src/services/HealthService/HealthService.ts
+++ b/packages/backend/src/services/HealthService/HealthService.ts
@@ -306,6 +306,9 @@ export class HealthService extends BaseService {
             preAggregates: {
                 enabled: this.lightdashConfig.preAggregates.enabled,
             },
+            learn: {
+                enabled: this.lightdashConfig.learn.enabled,
+            },
             dataApps: {
                 previewOrigin: this.lightdashConfig.appRuntime.previewOrigin,
                 sampleDataEnabled:

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -75,6 +75,7 @@ import {
     DirectAccessResourceType,
     DownloadFileType,
     DuckdbConnectionType,
+    EnableLearnResults,
     EnsurePlaygroundProjectResults,
     Explore,
     ExploreError,
@@ -490,6 +491,15 @@ export type ProjectServiceArguments = {
         canViewProject: (project: OrganizationProject) => boolean;
         trigger: PlaygroundProjectTrigger;
     }) => Promise<EnsurePlaygroundProjectResults>;
+    /**
+     * Creates the org's training project when an admin enables Learn
+     * (CS-257). Wired by the service repository (core seeds what core can)
+     * and overridden by EE (adds the data app, agent and research run).
+     */
+    provisionTrainingProject?: (args: {
+        user: SessionUser;
+        projectService: ProjectService;
+    }) => Promise<EnableLearnResults>;
 };
 
 const isValidDbtCloudWebhookSignature = (
@@ -620,6 +630,8 @@ export class ProjectService extends BaseService {
 
     provisionPlaygroundProject: ProjectServiceArguments['provisionPlaygroundProject'];
 
+    provisionTrainingProject: ProjectServiceArguments['provisionTrainingProject'];
+
     constructor({
         lightdashConfig,
         analytics,
@@ -668,6 +680,7 @@ export class ProjectService extends BaseService {
         getAiAgentService,
         onProjectCreated,
         provisionPlaygroundProject,
+        provisionTrainingProject,
     }: ProjectServiceArguments) {
         super();
         this.lightdashConfig = lightdashConfig;
@@ -719,6 +732,44 @@ export class ProjectService extends BaseService {
         this.getAiAgentService = getAiAgentService;
         this.onProjectCreated = onProjectCreated;
         this.provisionPlaygroundProject = provisionPlaygroundProject;
+        this.provisionTrainingProject = provisionTrainingProject;
+    }
+
+    /**
+     * Enable Learn for the user's organization (CS-257): create the training
+     * project, seeded, with the caller as its assigned admin. Idempotent.
+     * Org admins only; 404 when the instance has Learn switched off.
+     */
+    async enableLearn(user: SessionUser): Promise<EnableLearnResults> {
+        if (!this.lightdashConfig.learn.enabled) {
+            throw new NotFoundError('Learn is not enabled on this instance');
+        }
+        if (!this.provisionTrainingProject) {
+            throw new NotFoundError('Learn is not available');
+        }
+        const { organizationUuid } = user;
+        if (!organizationUuid) {
+            throw new ForbiddenError('User is not part of an organization');
+        }
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'manage',
+                subject('Organization', { organizationUuid }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'Only an organization admin can enable Learn',
+            );
+        }
+        const result = await this.provisionTrainingProject({
+            user,
+            projectService: this,
+        });
+        // The admin's cached abilities predate the project; other users'
+        // entries expire on their own (per-pod TTL).
+        this.userModel.invalidateSessionUserCache(user.userUuid);
+        return result;
     }
 
     async ensurePlaygroundProject(
@@ -779,6 +830,12 @@ export class ProjectService extends BaseService {
         provisioningSource?: InternalProvisioningSource,
     ): Promise<void> {
         if (projectType === ProjectType.PREVIEW) {
+            return;
+        }
+        // The training project's agent comes with its seeded content (the
+        // walkthroughs name it); a second, default agent would make Ask AI
+        // land on either.
+        if (provisioningSource === 'training') {
             return;
         }
 
@@ -11143,6 +11200,10 @@ export class ProjectService extends BaseService {
         user: SessionUser,
         trainingProjectUuid: string,
     ): Promise<CreateTrainingPreviewResults> {
+        // Learn off for the instance closes the sandbox: no copies either.
+        if (!this.lightdashConfig.learn.enabled) {
+            throw new NotFoundError('Learn is not enabled on this instance');
+        }
         if (!isUserWithOrg(user)) {
             throw new ForbiddenError('User is not part of an organization');
         }
@@ -11300,6 +11361,9 @@ export class ProjectService extends BaseService {
         user: SessionUser,
         trainingProjectUuid: string,
     ): Promise<{ deleted: number }> {
+        if (!this.lightdashConfig.learn.enabled) {
+            throw new NotFoundError('Learn is not enabled on this instance');
+        }
         if (!isUserWithOrg(user)) {
             throw new ForbiddenError('User is not part of an organization');
         }

--- a/packages/backend/src/services/ProjectService/provisionTrainingProject.test.ts
+++ b/packages/backend/src/services/ProjectService/provisionTrainingProject.test.ts
@@ -1,0 +1,270 @@
+import { Ability } from '@casl/ability';
+import {
+    OrganizationMemberRole,
+    ProjectMemberRole,
+    ProjectType,
+    type OrganizationProject,
+    type PossibleAbilities,
+    type SessionUser,
+} from '@lightdash/common';
+import path from 'path';
+import { describe, expect, it, vi } from 'vitest';
+import {
+    provisionTrainingProject,
+    TRAINING_PROJECT_NAME,
+    type ProvisionTrainingProjectArguments,
+} from './provisionTrainingProject';
+
+const organizationUuid = '00000000-0000-0000-0000-000000000001';
+const projectUuid = '00000000-0000-0000-0000-000000000002';
+const now = new Date('2026-09-06T00:00:00Z');
+
+const user = {
+    userUuid: '00000000-0000-0000-0000-000000000003',
+    organizationUuid,
+    organizationName: 'Organization',
+    organizationCreatedAt: now,
+    email: 'admin@example.com',
+    firstName: 'Admin',
+    lastName: 'User',
+    userId: 1,
+    role: OrganizationMemberRole.ADMIN,
+    ability: new Ability<PossibleAbilities>([
+        { action: 'manage', subject: 'Organization' },
+    ]),
+    abilityRules: [],
+    isTrackingAnonymized: false,
+    isMarketingOptedIn: false,
+    avatarUrl: null,
+    avatarGradient: null,
+    isSetupComplete: true,
+    isActive: true,
+    createdAt: now,
+    updatedAt: now,
+    timezone: null,
+} satisfies SessionUser;
+
+const project = (type: ProjectType): OrganizationProject => ({
+    projectUuid,
+    slug: 'project',
+    name: 'Project',
+    type,
+    provisioningSource: type === ProjectType.TRAINING ? 'training' : null,
+    createdByUserUuid: user.userUuid,
+    createdByUserName: 'Admin User',
+    createdAt: now,
+    upstreamProjectUuid: null,
+    expiresAt: null,
+});
+
+const buildArguments = (
+    overrides: Partial<ProvisionTrainingProjectArguments> = {},
+) => {
+    const getAllByOrganizationUuid = vi.fn(
+        async (): Promise<OrganizationProject[]> => [
+            project(ProjectType.DEFAULT),
+        ],
+    );
+    const deleteProject = vi.fn(async () => undefined);
+    const saveExploresToCache = vi.fn(async () => ({ cachedExploreUuids: [] }));
+    const createProjectAccess = vi.fn(async () => undefined);
+    const runInTrainingProvisioningLock = vi.fn(
+        async (_org: string, callback: (trx: never) => Promise<unknown>) =>
+            callback(undefined as never),
+    );
+    const createWithoutCompile = vi.fn(async () => ({
+        project: { projectUuid },
+        hasContentCopy: false,
+    }));
+    const indexCatalog = vi.fn(async () => ({
+        totalIndexed: 0,
+        errors: [],
+        duration: 0,
+    }));
+    const seedTrainingContent = vi.fn(async () => undefined);
+    const validateTrainingDatabase = vi.fn(async () => undefined);
+    const track = vi.fn();
+    return {
+        args: {
+            user,
+            learnEnabled: true,
+            projectModel: {
+                getAllByOrganizationUuid,
+                delete: deleteProject,
+                saveExploresToCache,
+                createProjectAccess,
+            },
+            onboardingModel: { runInTrainingProvisioningLock },
+            projectService: { createWithoutCompile },
+            catalogService: { indexCatalog },
+            seedTrainingContent,
+            analytics: { track },
+            trainingDataDirectory: path.resolve(
+                __dirname,
+                '../../../assets/playground',
+            ),
+            validateTrainingDatabase,
+            ...overrides,
+        } as ProvisionTrainingProjectArguments,
+        getAllByOrganizationUuid,
+        deleteProject,
+        saveExploresToCache,
+        createProjectAccess,
+        runInTrainingProvisioningLock,
+        createWithoutCompile,
+        indexCatalog,
+        seedTrainingContent,
+        track,
+    };
+};
+
+describe('provisionTrainingProject', () => {
+    it('refuses when Learn is switched off for the instance', async () => {
+        const mocks = buildArguments({ learnEnabled: false });
+        await expect(provisionTrainingProject(mocks.args)).rejects.toThrow(
+            'Learn is not enabled on this instance',
+        );
+        expect(mocks.createWithoutCompile).not.toHaveBeenCalled();
+        expect(mocks.track).toHaveBeenCalledExactlyOnceWith(
+            expect.objectContaining({
+                event: 'training_project.skipped',
+                properties: expect.objectContaining({
+                    reason: 'learn_disabled',
+                }),
+            }),
+        );
+    });
+
+    it('returns the existing training project without creating another', async () => {
+        const mocks = buildArguments();
+        mocks.getAllByOrganizationUuid.mockResolvedValueOnce([
+            project(ProjectType.DEFAULT),
+            project(ProjectType.TRAINING),
+        ]);
+        await expect(provisionTrainingProject(mocks.args)).resolves.toEqual({
+            projectUuid,
+            created: false,
+        });
+        expect(mocks.createWithoutCompile).not.toHaveBeenCalled();
+        expect(mocks.seedTrainingContent).not.toHaveBeenCalled();
+        expect(mocks.track).toHaveBeenCalledExactlyOnceWith(
+            expect.objectContaining({
+                event: 'training_project.skipped',
+                properties: expect.objectContaining({
+                    reason: 'training_project_already_exists',
+                    projectId: projectUuid,
+                }),
+            }),
+        );
+    });
+
+    it('creates the training project under the org lock, with the caller as its admin', async () => {
+        const mocks = buildArguments();
+        await expect(provisionTrainingProject(mocks.args)).resolves.toEqual({
+            projectUuid,
+            created: true,
+        });
+        expect(mocks.runInTrainingProvisioningLock).toHaveBeenCalledWith(
+            organizationUuid,
+            expect.any(Function),
+        );
+        expect(mocks.createWithoutCompile).toHaveBeenCalledExactlyOnceWith(
+            user,
+            expect.objectContaining({
+                name: TRAINING_PROJECT_NAME,
+                type: ProjectType.TRAINING,
+            }),
+            expect.any(String),
+            { source: 'training' },
+        );
+        expect(mocks.saveExploresToCache).toHaveBeenCalledWith(
+            projectUuid,
+            expect.any(Array),
+            true,
+        );
+        expect(mocks.createProjectAccess).toHaveBeenCalledExactlyOnceWith(
+            projectUuid,
+            user.email,
+            ProjectMemberRole.ADMIN,
+        );
+        expect(mocks.seedTrainingContent).toHaveBeenCalledExactlyOnceWith({
+            projectUuid,
+            user,
+            content: expect.objectContaining({
+                version: 1,
+                space: { name: 'Training', path: 'training' },
+            }),
+        });
+        expect(mocks.indexCatalog).toHaveBeenCalledWith(
+            projectUuid,
+            user.userUuid,
+        );
+        expect(mocks.track).toHaveBeenCalledExactlyOnceWith({
+            event: 'training_project.provisioned',
+            userId: user.userUuid,
+            properties: {
+                organizationId: organizationUuid,
+                projectId: projectUuid,
+                contentSeedErrorType: null,
+                catalogIndexErrorType: null,
+            },
+        });
+    });
+
+    it('removes the project when the admin membership cannot be written', async () => {
+        const mocks = buildArguments();
+        mocks.createProjectAccess.mockRejectedValueOnce(
+            new Error('no such user'),
+        );
+        await expect(provisionTrainingProject(mocks.args)).rejects.toThrow(
+            'no such user',
+        );
+        expect(mocks.deleteProject).toHaveBeenCalledWith(projectUuid);
+        expect(mocks.seedTrainingContent).not.toHaveBeenCalled();
+        expect(mocks.track).toHaveBeenCalledExactlyOnceWith(
+            expect.objectContaining({
+                event: 'training_project.failed',
+                properties: expect.objectContaining({
+                    projectId: projectUuid,
+                    errorType: 'Error',
+                }),
+            }),
+        );
+    });
+
+    it('still provisions when seeding or indexing fails, recording the error types', async () => {
+        const mocks = buildArguments();
+        mocks.seedTrainingContent.mockRejectedValueOnce(
+            new TypeError('bad content'),
+        );
+        mocks.indexCatalog.mockRejectedValueOnce(new RangeError('no index'));
+        await expect(provisionTrainingProject(mocks.args)).resolves.toEqual({
+            projectUuid,
+            created: true,
+        });
+        expect(mocks.deleteProject).not.toHaveBeenCalled();
+        expect(mocks.track).toHaveBeenCalledExactlyOnceWith(
+            expect.objectContaining({
+                event: 'training_project.provisioned',
+                properties: expect.objectContaining({
+                    contentSeedErrorType: 'TypeError',
+                    catalogIndexErrorType: 'RangeError',
+                }),
+            }),
+        );
+    });
+
+    it('does not create a project when the bundle cannot be validated', async () => {
+        const mocks = buildArguments();
+        (
+            mocks.args.validateTrainingDatabase as ReturnType<typeof vi.fn>
+        ).mockRejectedValueOnce(new Error('bundle missing'));
+        await expect(provisionTrainingProject(mocks.args)).rejects.toThrow(
+            'bundle missing',
+        );
+        expect(mocks.createWithoutCompile).not.toHaveBeenCalled();
+        expect(mocks.track).toHaveBeenCalledExactlyOnceWith(
+            expect.objectContaining({ event: 'training_project.failed' }),
+        );
+    });
+});

--- a/packages/backend/src/services/ProjectService/provisionTrainingProject.test.ts
+++ b/packages/backend/src/services/ProjectService/provisionTrainingProject.test.ts
@@ -232,11 +232,26 @@ describe('provisionTrainingProject', () => {
         );
     });
 
-    it('still provisions when seeding or indexing fails, recording the error types', async () => {
+    it('removes the project when seeding fails, so the admin can enable again', async () => {
         const mocks = buildArguments();
         mocks.seedTrainingContent.mockRejectedValueOnce(
             new TypeError('bad content'),
         );
+        await expect(provisionTrainingProject(mocks.args)).rejects.toThrow(
+            'bad content',
+        );
+        expect(mocks.deleteProject).toHaveBeenCalledWith(projectUuid);
+        expect(mocks.indexCatalog).not.toHaveBeenCalled();
+        expect(mocks.track).toHaveBeenCalledExactlyOnceWith(
+            expect.objectContaining({
+                event: 'training_project.failed',
+                properties: expect.objectContaining({ errorType: 'TypeError' }),
+            }),
+        );
+    });
+
+    it('still provisions when catalog indexing fails, recording the error type', async () => {
+        const mocks = buildArguments();
         mocks.indexCatalog.mockRejectedValueOnce(new RangeError('no index'));
         await expect(provisionTrainingProject(mocks.args)).resolves.toEqual({
             projectUuid,
@@ -247,7 +262,7 @@ describe('provisionTrainingProject', () => {
             expect.objectContaining({
                 event: 'training_project.provisioned',
                 properties: expect.objectContaining({
-                    contentSeedErrorType: 'TypeError',
+                    contentSeedErrorType: null,
                     catalogIndexErrorType: 'RangeError',
                 }),
             }),

--- a/packages/backend/src/services/ProjectService/provisionTrainingProject.ts
+++ b/packages/backend/src/services/ProjectService/provisionTrainingProject.ts
@@ -193,7 +193,9 @@ export const provisionTrainingProject = async ({
                     throw error;
                 }
 
-                let contentSeedErrorType: string | null = null;
+                // A half-seeded training project has no repair path (the
+                // seed is not idempotent), so a failed seed removes the
+                // project and the admin enables again.
                 try {
                     await seedTrainingContent({
                         projectUuid,
@@ -201,14 +203,24 @@ export const provisionTrainingProject = async ({
                         content: { ...content, space: { ...TRAINING_SPACE } },
                     });
                 } catch (error) {
-                    Sentry.captureException(error);
                     Logger.error(
                         `Failed to seed training content for project ${projectUuid}: ${describe(
                             error,
                         )}`,
                     );
-                    contentSeedErrorType = getErrorType(error);
+                    await projectModel
+                        .delete(projectUuid)
+                        .catch((cleanupError) => {
+                            Sentry.captureException(cleanupError);
+                            Logger.error(
+                                `Failed to remove unseeded training project ${projectUuid}: ${describe(
+                                    cleanupError,
+                                )}`,
+                            );
+                        });
+                    throw error;
                 }
+                const contentSeedErrorType: string | null = null;
 
                 let catalogIndexErrorType: string | null = null;
                 try {

--- a/packages/backend/src/services/ProjectService/provisionTrainingProject.ts
+++ b/packages/backend/src/services/ProjectService/provisionTrainingProject.ts
@@ -1,0 +1,257 @@
+import {
+    DbtProjectType,
+    DefaultSupportedDbtVersion,
+    DuckdbConnectionType,
+    ForbiddenError,
+    NotFoundError,
+    ProjectMemberRole,
+    ProjectType,
+    RequestMethod,
+    WarehouseTypes,
+    type EnableLearnResults,
+    type SessionUser,
+} from '@lightdash/common';
+import * as Sentry from '@sentry/node';
+import path from 'path';
+import {
+    type LightdashAnalytics,
+    type TrainingProjectSkippedReason,
+} from '../../analytics/LightdashAnalytics';
+import { type PlaygroundContent } from '../../ee/services/ProjectService/playgroundContentTypes';
+import {
+    loadPlaygroundBundle,
+    validatePlaygroundDatabaseBundle,
+} from '../../ee/services/ProjectService/provisionPlaygroundProject';
+import Logger from '../../logging/logger';
+import { type OnboardingModel } from '../../models/OnboardingModel/OnboardingModel';
+import { type ProjectModel } from '../../models/ProjectModel/ProjectModel';
+import { type CatalogService } from '../CatalogService/CatalogService';
+import { type ProjectService } from './ProjectService';
+
+/** The seeded root space of a training project; public so every role sees it. */
+export const TRAINING_SPACE = { name: 'Training', path: 'training' } as const;
+export const TRAINING_PROJECT_NAME = 'Training (sample data)';
+
+export type SeedTrainingContentArguments = {
+    projectUuid: string;
+    user: SessionUser;
+    content: PlaygroundContent;
+};
+
+export type ProvisionTrainingProjectArguments = {
+    user: SessionUser;
+    learnEnabled: boolean;
+    projectModel: Pick<
+        ProjectModel,
+        | 'getAllByOrganizationUuid'
+        | 'saveExploresToCache'
+        | 'delete'
+        | 'createProjectAccess'
+    >;
+    onboardingModel: Pick<OnboardingModel, 'runInTrainingProvisioningLock'>;
+    projectService: Pick<ProjectService, 'createWithoutCompile'>;
+    catalogService: Pick<CatalogService, 'indexCatalog'>;
+    seedTrainingContent: (args: SeedTrainingContentArguments) => Promise<void>;
+    analytics: Pick<LightdashAnalytics, 'track'>;
+    trainingDataDirectory?: string;
+    validateTrainingDatabase?: (databasePath: string) => Promise<void>;
+};
+
+const getErrorType = (error: unknown): string =>
+    error instanceof Error ? error.name : 'Unknown';
+
+const describe = (error: unknown): string =>
+    error instanceof Error ? error.message : String(error);
+
+/**
+ * Enable Learn for an organization (CS-257): create its training project
+ * from the embedded bundle, seed the content the walkthroughs use, and make
+ * the admin who clicked the project's assigned admin. Idempotent under a
+ * per-organization lock: a second call returns the existing project.
+ *
+ * The bundle is the playground's (same DuckDB dataset and explores); only
+ * the project type, name and the seeded space differ. The training bundle
+ * of CS-207 Slice 1 replaces it when it lands.
+ */
+export const provisionTrainingProject = async ({
+    user,
+    learnEnabled,
+    projectModel,
+    onboardingModel,
+    projectService,
+    catalogService,
+    seedTrainingContent,
+    analytics,
+    trainingDataDirectory,
+    validateTrainingDatabase = validatePlaygroundDatabaseBundle,
+}: ProvisionTrainingProjectArguments): Promise<EnableLearnResults> => {
+    const { organizationUuid } = user;
+    if (!organizationUuid) {
+        throw new ForbiddenError('User is not part of an organization');
+    }
+    let outcomeTracked = false;
+    const trackSkipped = (
+        reason: TrainingProjectSkippedReason,
+        projectId: string | null,
+    ) => {
+        outcomeTracked = true;
+        analytics.track({
+            event: 'training_project.skipped',
+            userId: user.userUuid,
+            properties: { organizationId: organizationUuid, projectId, reason },
+        });
+    };
+    if (!learnEnabled) {
+        trackSkipped('learn_disabled', null);
+        throw new NotFoundError('Learn is not enabled on this instance');
+    }
+    if (!user.email) {
+        throw new ForbiddenError(
+            'The enabling user needs an email to be made the training project admin',
+        );
+    }
+    const { email } = user;
+
+    let lastKnownProjectUuid: string | null = null;
+    try {
+        return await onboardingModel.runInTrainingProvisioningLock(
+            organizationUuid,
+            async () => {
+                const projects =
+                    await projectModel.getAllByOrganizationUuid(
+                        organizationUuid,
+                    );
+                const existing = projects.find(
+                    (project) => project.type === ProjectType.TRAINING,
+                );
+                if (existing) {
+                    lastKnownProjectUuid = existing.projectUuid;
+                    trackSkipped(
+                        'training_project_already_exists',
+                        existing.projectUuid,
+                    );
+                    return {
+                        projectUuid: existing.projectUuid,
+                        created: false,
+                    };
+                }
+
+                const dataDirectory = path.resolve(
+                    trainingDataDirectory ??
+                        process.env.PLAYGROUND_DATA_DIR ??
+                        path.join(__dirname, '../../../assets/playground'),
+                );
+                const { explores, content } = await loadPlaygroundBundle(
+                    dataDirectory,
+                    validateTrainingDatabase,
+                );
+
+                const creation = await projectService.createWithoutCompile(
+                    user,
+                    {
+                        name: TRAINING_PROJECT_NAME,
+                        type: ProjectType.TRAINING,
+                        dbtConnection: { type: DbtProjectType.NONE },
+                        dbtVersion: DefaultSupportedDbtVersion,
+                        warehouseConnection: {
+                            type: WarehouseTypes.DUCKDB,
+                            connectionType: DuckdbConnectionType.EMBEDDED,
+                            dataset: 'jaffle_shop',
+                        },
+                    },
+                    RequestMethod.BACKEND,
+                    { source: 'training' },
+                );
+                const { projectUuid } = creation.project;
+                lastKnownProjectUuid = projectUuid;
+
+                // Explores and the assigned admin are what make the project
+                // usable; without either, remove it rather than leave a
+                // half-made training project the page cannot recover from.
+                try {
+                    await projectModel.saveExploresToCache(
+                        projectUuid,
+                        explores,
+                        true,
+                    );
+                    await projectModel.createProjectAccess(
+                        projectUuid,
+                        email,
+                        ProjectMemberRole.ADMIN,
+                    );
+                } catch (error) {
+                    await projectModel
+                        .delete(projectUuid)
+                        .catch((cleanupError) => {
+                            Sentry.captureException(cleanupError);
+                            Logger.error(
+                                `Failed to remove incomplete training project ${projectUuid}: ${describe(
+                                    cleanupError,
+                                )}`,
+                            );
+                        });
+                    throw error;
+                }
+
+                let contentSeedErrorType: string | null = null;
+                try {
+                    await seedTrainingContent({
+                        projectUuid,
+                        user,
+                        content: { ...content, space: { ...TRAINING_SPACE } },
+                    });
+                } catch (error) {
+                    Sentry.captureException(error);
+                    Logger.error(
+                        `Failed to seed training content for project ${projectUuid}: ${describe(
+                            error,
+                        )}`,
+                    );
+                    contentSeedErrorType = getErrorType(error);
+                }
+
+                let catalogIndexErrorType: string | null = null;
+                try {
+                    await catalogService.indexCatalog(
+                        projectUuid,
+                        user.userUuid,
+                    );
+                } catch (error) {
+                    Sentry.captureException(error);
+                    Logger.error(
+                        `Failed to index training catalog for project ${projectUuid}: ${describe(
+                            error,
+                        )}`,
+                    );
+                    catalogIndexErrorType = getErrorType(error);
+                }
+
+                outcomeTracked = true;
+                analytics.track({
+                    event: 'training_project.provisioned',
+                    userId: user.userUuid,
+                    properties: {
+                        organizationId: organizationUuid,
+                        projectId: projectUuid,
+                        contentSeedErrorType,
+                        catalogIndexErrorType,
+                    },
+                });
+                return { projectUuid, created: true };
+            },
+        );
+    } catch (error) {
+        if (!outcomeTracked) {
+            analytics.track({
+                event: 'training_project.failed',
+                userId: user.userUuid,
+                properties: {
+                    organizationId: organizationUuid,
+                    projectId: lastKnownProjectUuid,
+                    errorType: getErrorType(error),
+                },
+            });
+        }
+        throw error;
+    }
+};

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -14,6 +14,7 @@ import {
 import { LightdashConfig } from '../config/parseConfig';
 import { AppGenerateService } from '../ee/services/AppGenerateService/AppGenerateService';
 import { PreAggregateMaterializationService } from '../ee/services/PreAggregateMaterializationService/PreAggregateMaterializationService';
+import { seedPlaygroundContent } from '../ee/services/ProjectService/seedPlaygroundContent';
 import { ModelRepository } from '../models/ModelRepository';
 import PrometheusMetrics from '../prometheus/PrometheusMetrics';
 import type { UtilRepository } from '../utils/UtilRepository';
@@ -68,6 +69,7 @@ import { ProjectCompileLogService } from './ProjectCompileLogService/ProjectComp
 import { ProjectDbtSourcesService } from './ProjectDbtSourcesService';
 import { ProjectParametersService } from './ProjectParametersService';
 import { ProjectService } from './ProjectService/ProjectService';
+import { provisionTrainingProject } from './ProjectService/provisionTrainingProject';
 import { PromoteService } from './PromoteService/PromoteService';
 import { PromptService } from './PromptService/PromptService';
 import { PullRequestsService } from './PullRequestsService/PullRequestsService';
@@ -945,6 +947,40 @@ export class ServiceRepository
                         customDimensions: new Set(),
                         additionalMetrics: new Set(),
                     }),
+                    // Enable Learn (CS-257). Core seeds the space, charts,
+                    // dashboard, pins, comment and categories; EE overrides
+                    // this to add the data app, agent and research run.
+                    provisionTrainingProject: ({ user, projectService }) =>
+                        provisionTrainingProject({
+                            user,
+                            projectService,
+                            learnEnabled:
+                                this.context.lightdashConfig.learn.enabled,
+                            projectModel: this.models.getProjectModel(),
+                            onboardingModel: this.models.getOnboardingModel(),
+                            catalogService: this.getCatalogService(),
+                            analytics: this.context.lightdashAnalytics,
+                            seedTrainingContent: ({
+                                projectUuid,
+                                user: seedUser,
+                                content,
+                            }) =>
+                                seedPlaygroundContent({
+                                    projectUuid,
+                                    user: seedUser,
+                                    content,
+                                    publicSpace: true,
+                                    spaceModel: this.models.getSpaceModel(),
+                                    savedChartModel:
+                                        this.models.getSavedChartModel(),
+                                    dashboardModel:
+                                        this.models.getDashboardModel(),
+                                    pinnedListModel:
+                                        this.models.getPinnedListModel(),
+                                    commentModel: this.models.getCommentModel(),
+                                    tagsModel: this.models.getTagsModel(),
+                                }),
+                        }),
                 }),
         );
     }

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -233,6 +233,8 @@ export type {
     AgentSqlScope,
     ApiCreateTrainingPreviewResponse,
     ApiEnsurePlaygroundProjectResponse,
+    ApiEnableLearnResponse,
+    EnableLearnResults,
     ApiGetProjectGroupAccesses,
     ApiProjectResponse,
     EnsurePlaygroundProjectRequest,

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -768,6 +768,14 @@ export type HealthState = {
     preAggregates: {
         enabled: boolean;
     };
+    learn: {
+        /**
+         * Whether Learn (the training project and its walkthroughs) is
+         * switched on for this instance (`LIGHTDASH_LEARN_ENABLED`). Off by
+         * default; an org admin still has to enable it for their org.
+         */
+        enabled: boolean;
+    };
     dataApps: {
         /**
          * Origin where data-app preview iframes are served (e.g.,

--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -1258,6 +1258,17 @@ export type EnsurePlaygroundProjectResults = {
     created: boolean;
 };
 
+/** The training project an org admin enabled Learn with (CS-257). */
+export type EnableLearnResults = {
+    projectUuid: string;
+    created: boolean;
+};
+
+export type ApiEnableLearnResponse = {
+    status: 'ok';
+    results: EnableLearnResults;
+};
+
 export const playgroundProjectTriggers = [
     'invite_expert',
     'agent_onboarding_wait',

--- a/packages/frontend/src/features/learn/EnableLearnPanel.tsx
+++ b/packages/frontend/src/features/learn/EnableLearnPanel.tsx
@@ -1,0 +1,130 @@
+import { Box, Button, Text } from '@mantine/core';
+import { type FC } from 'react';
+import MantineIcon from '../../components/common/MantineIcon';
+import {
+    GROUP_DESCRIPTIONS,
+    GROUP_LABELS,
+    GROUP_ORDER,
+    type LearnModule,
+} from './catalogue';
+import { GROUP_ICONS, groupVars } from './groupVisuals';
+import styles from './Learn.module.css';
+
+type Props = {
+    /** Whether the viewer may enable Learn (an organization admin). */
+    canEnable: boolean;
+    enabling: boolean;
+    error: string | null;
+    onEnable: () => void;
+    /** The library that enabling unlocks, for the summary. */
+    catalogue: LearnModule[];
+};
+
+/**
+ * What the Learn page shows before the organization has a training
+ * project (CS-257): what enabling unlocks, a button for admins and a
+ * pointer to an admin for everyone else.
+ */
+export const EnableLearnPanel: FC<Props> = ({
+    canEnable,
+    enabling,
+    error,
+    onEnable,
+    catalogue,
+}) => {
+    const groups = GROUP_ORDER.filter((group) =>
+        catalogue.some((module) => module.group === group),
+    );
+
+    return (
+        <Box className={styles.enableShell} data-learn-enable-panel>
+            <Box className={styles.enableColumn}>
+                <Box>
+                    <span
+                        className={`${styles.overline} ${styles.overlineAccent}`}
+                    >
+                        Learn
+                    </span>
+                    <h1 className={styles.enableTitle}>
+                        Learn Lightdash by doing, on data nobody can break
+                    </h1>
+                    <p className={styles.enableLede}>
+                        Learn gives everyone in your organisation a sample
+                        project to practise on, with a guided walkthrough for
+                        each thing Lightdash can do. Every walkthrough runs in a
+                        fresh copy of that project and the copy is removed when
+                        it ends, so nothing here touches your real projects.
+                    </p>
+                </Box>
+
+                <Box className={styles.enableGrid}>
+                    <Box className={styles.enableGroups}>
+                        {groups.map((group) => {
+                            const Glyph = GROUP_ICONS[group];
+                            return (
+                                <Box
+                                    key={group}
+                                    className={styles.enableGroup}
+                                    style={groupVars(group)}
+                                >
+                                    <span className={styles.enableGroupIcon}>
+                                        <MantineIcon icon={Glyph} size={18} />
+                                    </span>
+                                    <Box>
+                                        <h3>{GROUP_LABELS[group]}</h3>
+                                        <p>{GROUP_DESCRIPTIONS[group]}</p>
+                                    </Box>
+                                </Box>
+                            );
+                        })}
+                    </Box>
+
+                    <Box component="aside" className={styles.enableCard}>
+                        <span className={styles.overline}>Not enabled yet</span>
+                        {canEnable ? (
+                            <>
+                                <h2>Enable Learn for your organisation</h2>
+                                <p>Enabling does three things:</p>
+                                <ul>
+                                    <li>
+                                        creates a project named Training (sample
+                                        data), on a small built-in dataset;
+                                    </li>
+                                    <li>
+                                        gives everyone the permissions to
+                                        practise there, and only there;
+                                    </li>
+                                    <li>makes you that project's admin.</li>
+                                </ul>
+                                <Button
+                                    color="indigo"
+                                    size="md"
+                                    mt={6}
+                                    loading={enabling}
+                                    onClick={onEnable}
+                                    data-learn-enable
+                                >
+                                    Enable Learn
+                                </Button>
+                            </>
+                        ) : (
+                            <>
+                                <h2>Ask an admin to enable Learn</h2>
+                                <p data-learn-ask-admin>
+                                    An organisation admin turns Learn on from
+                                    this page. Once they have, every walkthrough
+                                    here is yours to start.
+                                </p>
+                            </>
+                        )}
+                        {error && (
+                            <Text c="red" fz="sm" data-learn-enable-error>
+                                {error}
+                            </Text>
+                        )}
+                    </Box>
+                </Box>
+            </Box>
+        </Box>
+    );
+};

--- a/packages/frontend/src/features/learn/Learn.module.css
+++ b/packages/frontend/src/features/learn/Learn.module.css
@@ -1,9 +1,7 @@
 /* The library from learn.lightdash.com, brought in-app: the same shell,
    sidebar, home cards, toolbar and module cards, on this app's neutrals. */
-.shell {
-    display: grid;
-    grid-template-columns: 240px minmax(0, 1fr);
-    min-height: 100%;
+.shell,
+.enableShell {
     --lu-accent: #5e4cff;
     --lu-track: light-dark(#e9ecef, #343a46);
     --lu-done-fg: #2f9e44;
@@ -14,6 +12,133 @@
     --lu-ink: light-dark(#111418, #f1f3f5);
     --lu-secondary: light-dark(#495057, #ced4da);
     --lu-muted: light-dark(#868e96, #909aa6);
+}
+
+.shell {
+    display: grid;
+    grid-template-columns: 240px minmax(0, 1fr);
+    min-height: 100%;
+}
+
+/* The page before an org has enabled Learn (CS-257): one centred column. */
+.enableShell {
+    min-height: 100%;
+    padding: 56px 32px 64px;
+    display: flex;
+    justify-content: center;
+    color: var(--lu-ink);
+}
+
+.enableColumn {
+    width: 100%;
+    max-width: 880px;
+    display: flex;
+    flex-direction: column;
+    gap: 28px;
+}
+
+.enableTitle {
+    margin: 0;
+    font-size: 30px;
+    line-height: 1.15;
+    font-weight: 650;
+    letter-spacing: -0.02em;
+    text-wrap: balance;
+}
+
+.enableLede {
+    margin: 8px 0 0;
+    max-width: 62ch;
+    font-size: 15px;
+    line-height: 1.55;
+    color: var(--lu-secondary);
+}
+
+.enableGrid {
+    display: grid;
+    grid-template-columns: minmax(0, 1.4fr) minmax(280px, 0.8fr);
+    gap: 20px;
+    align-items: stretch;
+}
+
+@media (max-width: 860px) {
+    .enableGrid {
+        grid-template-columns: minmax(0, 1fr);
+    }
+}
+
+.enableGroups {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-auto-rows: 1fr;
+    gap: 10px;
+}
+
+.enableGroup {
+    display: flex;
+    gap: 12px;
+    align-items: flex-start;
+    padding: 12px 14px;
+    border: 1px solid var(--lu-border);
+    border-radius: 8px;
+    background: var(--lu-surface);
+}
+
+.enableGroupIcon {
+    flex: none;
+    width: 34px;
+    height: 34px;
+    display: grid;
+    place-items: center;
+    border-radius: 8px;
+    background: var(--mi-band);
+    color: var(--mi-fg);
+}
+
+.enableGroup h3 {
+    margin: 0;
+    font-size: 13px;
+    line-height: 1.3;
+    font-weight: 600;
+}
+
+.enableGroup p {
+    margin: 2px 0 0;
+    font-size: 12px;
+    line-height: 1.4;
+    color: var(--lu-muted);
+}
+
+.enableCard {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 20px;
+    border: 1px solid var(--lu-border);
+    border-radius: 10px;
+    background: var(--lu-surface);
+    box-shadow: 0 8px 24px rgba(17, 20, 24, 0.06);
+}
+
+.enableCard h2 {
+    margin: 0;
+    font-size: 17px;
+    line-height: 1.3;
+}
+
+.enableCard p {
+    margin: 0;
+    font-size: 13px;
+    line-height: 1.5;
+    color: var(--lu-secondary);
+}
+
+.enableCard ul {
+    margin: 0;
+    padding-left: 18px;
+    font-size: 13px;
+    line-height: 1.6;
+    color: var(--lu-secondary);
 }
 
 .sidebar {

--- a/packages/frontend/src/features/learn/LearnLink.tsx
+++ b/packages/frontend/src/features/learn/LearnLink.tsx
@@ -4,24 +4,24 @@ import { IconSchool } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { useNavigate } from 'react-router';
 import MantineIcon from '../../components/common/MantineIcon';
+import useHealth from '../../hooks/health/useHealth';
 import { useProjects } from '../../hooks/useProjects';
 
 /**
  * Navbar entry to the library, an icon beside notifications and help;
- * present once the org has a training project, and never on a preview (a
- * learner's training copy included): a library opened inside a copy would
- * start walkthroughs from the wrong place.
+ * present for everyone on an instance with Learn switched on, whether or
+ * not the org has enabled it yet (the page says how), and never on a
+ * preview (a learner's training copy included): a library opened inside a
+ * copy would start walkthroughs from the wrong place.
  */
 export const LearnLink: FC<{ projectUuid: string }> = ({ projectUuid }) => {
     const navigate = useNavigate();
+    const { data: health } = useHealth();
     const { data: projects } = useProjects();
-    const hasTrainingProject = projects?.some(
-        (project) => project.type === ProjectType.TRAINING,
-    );
     const current = projects?.find(
         (project) => project.projectUuid === projectUuid,
     );
-    if (!hasTrainingProject || current?.type === ProjectType.PREVIEW)
+    if (!health?.learn.enabled || current?.type === ProjectType.PREVIEW)
         return null;
     return (
         <Tooltip label="Learn" position="bottom" withinPortal>

--- a/packages/frontend/src/features/learn/LearnPage.tsx
+++ b/packages/frontend/src/features/learn/LearnPage.tsx
@@ -1,8 +1,5 @@
-import {
-    type ProjectMemberRole,
-    ProjectType,
-    ScopeGroup,
-} from '@lightdash/common';
+import { subject } from '@casl/ability';
+import { type ProjectMemberRole, ProjectType } from '@lightdash/common';
 import {
     Box,
     Button,
@@ -14,22 +11,14 @@ import {
     UnstyledButton,
 } from '@mantine/core';
 import {
-    IconBuilding,
-    IconChartHistogram,
-    IconCompass,
     IconChevronDown,
-    IconDatabase,
     IconHelpCircle,
     IconSearch,
-    IconSend,
-    IconSettings,
-    IconSparkles,
-    IconTelescope,
-    type Icon,
 } from '@tabler/icons-react';
 import { type FC, useEffect, useMemo, useRef, useState } from 'react';
-import { useNavigate, useSearchParams } from 'react-router';
+import { Navigate, useNavigate, useSearchParams } from 'react-router';
 import MantineIcon from '../../components/common/MantineIcon';
+import useHealth from '../../hooks/health/useHealth';
 import { useOptionalProjectRoute } from '../../hooks/useProjectRoute';
 import { useProjects } from '../../hooks/useProjects';
 import useApp from '../../providers/App/useApp';
@@ -39,7 +28,6 @@ import { useLearnAvailability } from './availability';
 import {
     buildLearnCatalogue,
     focusModules,
-    FOUNDATIONS,
     GROUP_DESCRIPTIONS,
     GROUP_LABELS,
     GROUP_ORDER,
@@ -51,33 +39,13 @@ import {
     type LearnGroup,
     type LearnModule,
 } from './catalogue';
+import { EnableLearnPanel } from './EnableLearnPanel';
+import { GROUP_ICONS, groupVars } from './groupVisuals';
 import styles from './Learn.module.css';
 import { useLearnProgress } from './progress';
 import { thumbnailFor } from './thumbnails';
+import { useEnableLearn } from './useEnableLearn';
 import { useStartWalkthrough } from './useStartWalkthrough';
-
-const GROUP_ICONS: Record<LearnGroup, Icon> = {
-    [FOUNDATIONS]: IconCompass,
-    [ScopeGroup.CONTENT]: IconChartHistogram,
-    [ScopeGroup.SHARING]: IconSend,
-    [ScopeGroup.DATA]: IconDatabase,
-    [ScopeGroup.AI]: IconSparkles,
-    [ScopeGroup.PROJECT_MANAGEMENT]: IconSettings,
-    [ScopeGroup.SPOTLIGHT]: IconTelescope,
-    [ScopeGroup.ORGANIZATION_MANAGEMENT]: IconBuilding,
-};
-
-/** The library's band and glyph colours per group, as on learn.lightdash.com. */
-const GROUP_COLOURS: Record<LearnGroup, { band: string; fg: string }> = {
-    [FOUNDATIONS]: { band: '#f0dbd1', fg: '#b06a4c' },
-    [ScopeGroup.CONTENT]: { band: '#dfe8e2', fg: '#4f7d5d' },
-    [ScopeGroup.SHARING]: { band: '#dfe8e2', fg: '#4f7d5d' },
-    [ScopeGroup.DATA]: { band: '#ece3d1', fg: '#93743a' },
-    [ScopeGroup.AI]: { band: '#e2ddf1', fg: '#6b5bb8' },
-    [ScopeGroup.PROJECT_MANAGEMENT]: { band: '#d9e6e4', fg: '#41756f' },
-    [ScopeGroup.SPOTLIGHT]: { band: '#ece3d1', fg: '#93743a' },
-    [ScopeGroup.ORGANIZATION_MANAGEMENT]: { band: '#dfe1e6', fg: '#5b6478' },
-};
 
 const greeting = () => {
     const hour = new Date().getHours();
@@ -85,12 +53,6 @@ const greeting = () => {
     if (hour < 18) return 'Good afternoon';
     return 'Good evening';
 };
-
-const groupVars = (group: LearnGroup) =>
-    ({
-        '--mi-band': GROUP_COLOURS[group].band,
-        '--mi-fg': GROUP_COLOURS[group].fg,
-    }) as React.CSSProperties;
 
 type CardState = 'soon' | 'ready' | 'started' | 'done';
 
@@ -207,10 +169,22 @@ const ModuleCard: FC<{
 const LearnPage: FC = () => {
     const navigate = useNavigate();
     const { user } = useApp();
+    const { data: health } = useHealth();
     const { data: projects } = useProjects();
     const trainingProject = projects?.find(
         (project) => project.type === ProjectType.TRAINING,
     );
+    // Before the org has enabled Learn (CS-257): admins get the button,
+    // everyone else a pointer to an admin.
+    const organizationUuid = user.data?.organizationUuid;
+    const canEnableLearn =
+        !!organizationUuid &&
+        (user.data?.ability.can(
+            'manage',
+            subject('Organization', { organizationUuid }),
+        ) ??
+            false);
+    const enableLearn = useEnableLearn();
     // The library is never shown inside a preview (a training copy): it
     // belongs to the shared training project, so a preview's /learn goes
     // there instead.
@@ -300,6 +274,32 @@ const LearnPage: FC = () => {
             .getElementById(`learn-group-${group}`)
             ?.scrollIntoView({ behavior: 'smooth', block: 'start' });
     };
+
+    // Learn switched off for the instance: the route falls through to the
+    // project's home.
+    if (health && !health.learn.enabled) {
+        return (
+            <Navigate
+                to={
+                    projectRoute
+                        ? `/projects/${projectRoute.project.projectUuid}/home`
+                        : '/projects'
+                }
+                replace
+            />
+        );
+    }
+    if (projects && !trainingProject) {
+        return (
+            <EnableLearnPanel
+                canEnable={canEnableLearn}
+                enabling={enableLearn.isLoading}
+                error={enableLearn.error?.error.message ?? null}
+                onEnable={() => enableLearn.mutate()}
+                catalogue={catalogue}
+            />
+        );
+    }
 
     return (
         <Box className={styles.shell}>

--- a/packages/frontend/src/features/learn/groupVisuals.ts
+++ b/packages/frontend/src/features/learn/groupVisuals.ts
@@ -1,0 +1,43 @@
+import { ScopeGroup } from '@lightdash/common';
+import {
+    IconBuilding,
+    IconChartHistogram,
+    IconCompass,
+    IconDatabase,
+    IconSend,
+    IconSettings,
+    IconSparkles,
+    IconTelescope,
+    type Icon,
+} from '@tabler/icons-react';
+import { type CSSProperties } from 'react';
+import { FOUNDATIONS, type LearnGroup } from './catalogue';
+
+export const GROUP_ICONS: Record<LearnGroup, Icon> = {
+    [FOUNDATIONS]: IconCompass,
+    [ScopeGroup.CONTENT]: IconChartHistogram,
+    [ScopeGroup.SHARING]: IconSend,
+    [ScopeGroup.DATA]: IconDatabase,
+    [ScopeGroup.AI]: IconSparkles,
+    [ScopeGroup.PROJECT_MANAGEMENT]: IconSettings,
+    [ScopeGroup.SPOTLIGHT]: IconTelescope,
+    [ScopeGroup.ORGANIZATION_MANAGEMENT]: IconBuilding,
+};
+
+/** The library's band and glyph colours per group, as on learn.lightdash.com. */
+const GROUP_COLOURS: Record<LearnGroup, { band: string; fg: string }> = {
+    [FOUNDATIONS]: { band: '#f0dbd1', fg: '#b06a4c' },
+    [ScopeGroup.CONTENT]: { band: '#dfe8e2', fg: '#4f7d5d' },
+    [ScopeGroup.SHARING]: { band: '#dfe8e2', fg: '#4f7d5d' },
+    [ScopeGroup.DATA]: { band: '#ece3d1', fg: '#93743a' },
+    [ScopeGroup.AI]: { band: '#e2ddf1', fg: '#6b5bb8' },
+    [ScopeGroup.PROJECT_MANAGEMENT]: { band: '#d9e6e4', fg: '#41756f' },
+    [ScopeGroup.SPOTLIGHT]: { band: '#ece3d1', fg: '#93743a' },
+    [ScopeGroup.ORGANIZATION_MANAGEMENT]: { band: '#dfe1e6', fg: '#5b6478' },
+};
+
+export const groupVars = (group: LearnGroup) =>
+    ({
+        '--mi-band': GROUP_COLOURS[group].band,
+        '--mi-fg': GROUP_COLOURS[group].fg,
+    }) as CSSProperties;

--- a/packages/frontend/src/features/learn/useEnableLearn.ts
+++ b/packages/frontend/src/features/learn/useEnableLearn.ts
@@ -1,0 +1,30 @@
+import { type ApiError, type EnableLearnResults } from '@lightdash/common';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { lightdashApi } from '../../api';
+
+const enableLearn = async () =>
+    lightdashApi<EnableLearnResults>({
+        url: `/org/training-project`,
+        method: 'POST',
+        body: undefined,
+    });
+
+/**
+ * Enable Learn for the organization (CS-257): creates the training project
+ * with the caller as its admin. The project list and the user's abilities
+ * change with it (the trainee layer applies once the project exists), so
+ * both are refetched before the library renders.
+ */
+export const useEnableLearn = () => {
+    const queryClient = useQueryClient();
+    return useMutation<EnableLearnResults, ApiError>(enableLearn, {
+        mutationKey: ['enable_learn'],
+        onSuccess: async () => {
+            await Promise.all([
+                queryClient.invalidateQueries(['projects']),
+                queryClient.invalidateQueries(['user']),
+                queryClient.invalidateQueries(['account']),
+            ]);
+        },
+    });
+};

--- a/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
+++ b/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
@@ -151,6 +151,9 @@ export default function mockHealthResponse(
         preAggregates: {
             enabled: false,
         },
+        learn: {
+            enabled: false,
+        },
         dataApps: {
             previewOrigin: null,
             sampleDataEnabled: true,

--- a/rainbow.toml
+++ b/rainbow.toml
@@ -27,6 +27,9 @@ max_memory = "16gb"                # headroom the migrate rung and the pnpm inst
 system = ["postgresql-16-pgvector", "python3-venv"]  # catalog migrations CREATE EXTENSION vector; the dbt venv
 build = [
   "pnpm formula:build && pnpm common-build && pnpm warehouses-build",
+  # The tsoa routes and swagger are committed only by the release workflow, so a
+  # branch that adds an endpoint 404s on it until they are regenerated here.
+  "pnpm -F backend generate-api",
   "python3 -m venv /usr/local/dbt1.12 && /usr/local/dbt1.12/bin/pip install -q 'dbt-core==1.12.0' 'dbt-postgres~=1.10.0' && ln -sf /usr/local/dbt1.12/bin/dbt /usr/local/bin/dbt1.12",
 ]
 
@@ -121,6 +124,11 @@ files = ["packages/backend/src/database/migrations/**"]
 run = "pnpm -F backend migrate"
 env = { LIGHTDASH_LICENSE_KEY = "dummy-build-key" }
 memory = "12gb"
+
+[[tier]]
+name = "api-routes"
+files = ["packages/backend/src/controllers/**", "packages/backend/src/ee/controllers/**"]
+run = "pnpm -F backend generate-api"   # tsx watch restarts on the regenerated routes.ts
 
 [[tier]]
 name = "app"

--- a/rainbow.toml
+++ b/rainbow.toml
@@ -73,6 +73,10 @@ EMAIL_SMTP_SENDER_EMAIL = "noreply@lightdash.local"
 # flag-management API (docs/preview-feature-flags.md). Okteto got this from
 # LIGHTDASH_MODE=pr; LIGHTDASH_MODE=development here, so set it outright.
 LIGHTDASH_PREVIEW_FEATURE_FLAGS_ENABLED = "true"
+# Learn is off by default everywhere (docs/learn/architecture.md); previews
+# exist to try unreleased work, so switch it on here and let an admin press
+# Enable Learn in the environment.
+LIGHTDASH_LEARN_ENABLED = "true"
 
 # Two seeds, in the order CONTRIBUTING gives them. First the warehouse the
 # seeded project points at: dbt loads examples/full-jaffle-shop-demo into the


### PR DESCRIPTION
## Description

Closes CS-257. Replaces the flag-and-auto-provision trigger from the CS-207 spec with an explicit step by a named admin.

* **Instance switch.** `LIGHTDASH_LEARN_ENABLED`, default **off**. When off: no Learn icon, `/learn` falls through to the project home, the enable and training-copy endpoints return 404, and the trainee permission layer is withheld even if a training project exists (switching an instance off also closes the sandbox). Exposed to the frontend on the health endpoint as `learn.enabled`.
* **Learn for everyone, once switched on.** The Learn icon renders for every signed-in user whether or not the org has a training project. Before one exists the page shows an explanation with **Enable Learn** for org admins and "Ask an admin to enable Learn" for everyone else.
* **Enabling** (`POST /api/v1/org/training-project`, org `manage:Organization`): under a per-organization advisory lock, creates the training project from the embedded bundle, caches its explores, seeds the content the walkthroughs use (public Training space, pins, comment, categories, and on EE the data app, agent and finished research run), indexes the catalog, and makes the caller the project's assigned admin (project creator plus an explicit admin membership row). Idempotent: a second call returns the existing project. If the explores or the membership cannot be written the project is removed. Events `training_project.provisioned|skipped|failed`.
* The training project gets no default AI agent: the seeded agent is the one the walkthroughs name.

## How to test

* `pnpm -F backend test -- provisionTrainingProject` (6 tests), plus HealthService and UserModel tests.
* Recorded flow `cs-207-enable-learn.mjs` (green): removes the org's training project, checks the viewer's and the admin's Learn page, enables, verifies the project, membership, idempotency, seeded content and the viewer's trainee scopes. On the resulting project the full walkthrough smoke is 28/28 and the library and Ask AI flows are green.
* Manual: with the variable unset nothing Learn-related is visible; set `LIGHTDASH_LEARN_ENABLED=true`, sign in as an org admin, open Learn, click Enable Learn.

## Security review (2026-09-07)

* A training project whose seeding fails is deleted and the error surfaces, rather than staying live half-seeded.
* With the stack's review fixes the shared training project is read-only for everyone; the trainee set applies in each learner's copy. The full walkthrough smoke is 29/29 on the hardened code.

## Preview environments (2026-09-07)

Two recipe changes so Learn can be tried on Rainbow: `LIGHTDASH_LEARN_ENABLED` is on in every preview (previews exist to exercise unreleased work, like the preview feature flags), and the build regenerates the tsoa routes, since routes.ts is committed only by the release workflow and a branch adding an endpoint answered 404 in its environment until then. Previews run Community Edition today (no licence in the platform store), so the Enterprise seeds and modules are absent there by design.

Stack: PR 7 of the Lightdash Uni 2 stack (after #28715). Architecture doc: `docs/learn/architecture.md` (in #28710).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PpC4h5RtPcbV5Bj7SeLYHf

