### PR TITLE
feat(bigquery): expose nested and repeated columns in the warehouse catalog

### DIFF
--- a/packages/cli/src/dbt/models.test.ts
+++ b/packages/cli/src/dbt/models.test.ts
@@ -1,6 +1,63 @@
-import { isDocBlock } from './models';
+import {
+    DimensionType,
+    setCatalogNestedColumnShape,
+    type WarehouseCatalog,
+} from '@lightdash/common';
+import { isDocBlock, isGeneratableColumn } from './models';
 
 describe('Models', () => {
+    describe('isGeneratableColumn', () => {
+        const ref = { database: 'db', schema: 'ds', table: 'sessions' };
+        const catalog: WarehouseCatalog = {
+            db: {
+                ds: {
+                    sessions: {
+                        visitId: DimensionType.NUMBER,
+                        totals: DimensionType.STRING,
+                        'totals.pageviews': DimensionType.NUMBER,
+                        hits: DimensionType.STRING,
+                        'hits.page': DimensionType.STRING,
+                        'hits.page.pagePath': DimensionType.STRING,
+                        tags: DimensionType.STRING,
+                    },
+                },
+            },
+        };
+        const shapes = {
+            totals: { repeated: false, record: true },
+            hits: { repeated: true, record: true },
+            'hits.page': { repeated: false, record: true },
+            tags: { repeated: true, record: false },
+        };
+        Object.entries(shapes).forEach(([path, shape]) =>
+            setCatalogNestedColumnShape(
+                catalog,
+                ref.database,
+                ref.schema,
+                ref.table,
+                path,
+                shape,
+            ),
+        );
+
+        test('keeps scalar columns and leaves under plain structs', () => {
+            expect(isGeneratableColumn(catalog, ref, 'visitId')).toBe(true);
+            expect(isGeneratableColumn(catalog, ref, 'totals.pageviews')).toBe(
+                true,
+            );
+        });
+        test('skips container nodes and repeated scalars', () => {
+            expect(isGeneratableColumn(catalog, ref, 'totals')).toBe(false);
+            expect(isGeneratableColumn(catalog, ref, 'hits')).toBe(false);
+            expect(isGeneratableColumn(catalog, ref, 'tags')).toBe(false);
+        });
+        test('skips leaves beneath a repeated node', () => {
+            expect(isGeneratableColumn(catalog, ref, 'hits.page')).toBe(false);
+            expect(
+                isGeneratableColumn(catalog, ref, 'hits.page.pagePath'),
+            ).toBe(false);
+        });
+    });
     describe('isDocBlock', () => {
         test('should match all doc block variations', () => {
             expect(isDocBlock("{{doc('user_id')}}")).toBe(true); // single quote

--- a/packages/cli/src/dbt/models.ts
+++ b/packages/cli/src/dbt/models.ts
@@ -3,9 +3,11 @@ import {
     DbtModelNode,
     DbtSchemaEditor,
     DimensionType,
+    getCatalogNestedColumnShape,
     ParseError,
     patchPathParts,
     SupportedDbtVersions,
+    type WarehouseCatalog,
 } from '@lightdash/common';
 import { WarehouseClient, WarehouseTableSchema } from '@lightdash/warehouses';
 import execa from 'execa';
@@ -30,12 +32,39 @@ type GetDatabaseTableForModelArgs = {
     warehouseClient: WarehouseClient;
     preserveColumnCase: boolean;
 };
+type TableRef = { database: string; schema: string; table: string };
+
+/**
+ * Only scalar leaves reachable through non-repeated structs can be queried as
+ * plain columns today, so generated YAML skips container nodes and anything
+ * inside a repeated node.
+ */
+export const isGeneratableColumn = (
+    catalog: WarehouseCatalog,
+    { database, schema, table }: TableRef,
+    columnPath: string,
+): boolean => {
+    const segments = columnPath.split('.');
+    return segments.every((_, index) => {
+        const prefix = segments.slice(0, index + 1).join('.');
+        const shape = getCatalogNestedColumnShape(
+            catalog,
+            database,
+            schema,
+            table,
+            prefix,
+        );
+        const isLeaf = index === segments.length - 1;
+        return isLeaf ? shape === undefined : shape?.repeated === false;
+    });
+};
+
 export const getWarehouseTableForModel = async ({
     model,
     warehouseClient,
     preserveColumnCase,
 }: GetDatabaseTableForModelArgs): Promise<WarehouseTableSchema> => {
-    const tableRef = {
+    const tableRef: TableRef = {
         database: model.database,
         schema: model.schema,
         table: model.alias || model.name,
@@ -57,6 +86,9 @@ export const getWarehouseTableForModel = async ({
     }
     return Object.entries(table).reduce<WarehouseTableSchema>(
         (accumulator, [key, value]) => {
+            if (!isGeneratableColumn(catalog, tableRef, key)) {
+                return accumulator;
+            }
             const columnName = preserveColumnCase ? key : key.toLowerCase();
             accumulator[columnName] = value;
             return accumulator;

--- a/packages/common/src/compiler/translator.mock.ts
+++ b/packages/common/src/compiler/translator.mock.ts
@@ -38,7 +38,7 @@ const ID_COLUMN_WITHOUT_METRICS: DbtModelColumn = {
     data_type: DimensionType.STRING,
 };
 
-const column: DbtModelColumn = {
+export const column: DbtModelColumn = {
     name: 'myColumnName',
     meta: {},
 };

--- a/packages/common/src/compiler/translator.test.ts
+++ b/packages/common/src/compiler/translator.test.ts
@@ -27,6 +27,7 @@ import {
     type AttachTypesDiagnostics,
 } from './translator';
 import {
+    column,
     expectedModelWithTimestampDomain,
     expectedModelWithType,
     LIGHTDASH_TABLE_SQL_WHERE,
@@ -109,6 +110,27 @@ describe('attachTypesToModels', () => {
         expect(attachTypesToModels([model], warehouseSchema, false)[0]).toEqual(
             expectedModelWithType,
         );
+    });
+    it('should resolve a dotted nested column from its dotted catalog entry', async () => {
+        const nestedModel = {
+            ...model,
+            columns: {
+                ...model.columns,
+                'myRecordColumn.id': {
+                    ...column,
+                    name: 'myRecordColumn.id',
+                },
+            },
+        };
+        const nestedCatalog = structuredClone(warehouseSchema);
+        nestedCatalog[model.database][model.schema][model.name][
+            'myRecordColumn.id'
+        ] = DimensionType.NUMBER;
+        expect(
+            attachTypesToModels([nestedModel], nestedCatalog, true)[0].columns[
+                'myRecordColumn.id'
+            ].data_type,
+        ).toEqual(DimensionType.NUMBER);
     });
     it('should return models with undefined type when is missing dataset or table or column', async () => {
         expect(attachTypesToModels([model], {}, false)[0]).toEqual(model);

--- a/packages/common/src/types/warehouse.ts
+++ b/packages/common/src/types/warehouse.ts
@@ -170,6 +170,83 @@ export const ensureCatalogTimestampDomainsKey = (
         catalogWithDomains[WAREHOUSE_TIMESTAMP_DOMAINS_KEY] ?? {};
 };
 
+/**
+ * Shape of a non-scalar column path: `repeated` for arrays, `record` for
+ * structs. Keys are dotted paths (`product.attributes`), so a nested node
+ * appears at every level it occurs. Scalar columns have no entry.
+ */
+export type WarehouseNestedColumnShape = {
+    repeated: boolean;
+    record: boolean;
+};
+
+const isPlainRecord = (value: unknown): value is Record<string, unknown> =>
+    typeof value === 'object' && value !== null && !Array.isArray(value);
+
+export const isWarehouseNestedColumnShape = (
+    value: unknown,
+): value is WarehouseNestedColumnShape =>
+    isPlainRecord(value) &&
+    typeof value.repeated === 'boolean' &&
+    typeof value.record === 'boolean';
+
+/**
+ * Sidecar of nested column shapes keyed database → schema → table → column
+ * path, stored under a reserved key next to the database keys like the
+ * timestamp domains. Its value shares the catalog's key space, so it is read
+ * back through runtime checks rather than a cast; a malformed sidecar from an
+ * older cache is ignored.
+ */
+export const WAREHOUSE_NESTED_COLUMNS_KEY = '__lightdashNestedColumns';
+
+const getNestedColumnsSidecar = (
+    catalog: WarehouseCatalog,
+): Record<string, unknown> | undefined => {
+    const sidecar: unknown = catalog[WAREHOUSE_NESTED_COLUMNS_KEY];
+    return isPlainRecord(sidecar) ? sidecar : undefined;
+};
+
+export const getCatalogNestedColumnShape = (
+    catalog: WarehouseCatalog,
+    database: string,
+    schema: string,
+    table: string,
+    columnPath: string,
+): WarehouseNestedColumnShape | undefined => {
+    const shape = [database, schema, table, columnPath].reduce<unknown>(
+        (node, key) => (isPlainRecord(node) ? node[key] : undefined),
+        getNestedColumnsSidecar(catalog),
+    );
+    return isWarehouseNestedColumnShape(shape) ? shape : undefined;
+};
+
+export const setCatalogNestedColumnShape = (
+    catalog: WarehouseCatalog,
+    database: string,
+    schema: string,
+    table: string,
+    columnPath: string,
+    shape: WarehouseNestedColumnShape | undefined,
+): void => {
+    if (shape === undefined) return;
+    const sidecar = getNestedColumnsSidecar(catalog) ?? {};
+    Object.assign(catalog, { [WAREHOUSE_NESTED_COLUMNS_KEY]: sidecar });
+    const ensureRecord = (
+        parent: Record<string, unknown>,
+        key: string,
+    ): Record<string, unknown> => {
+        const existing = parent[key];
+        if (isPlainRecord(existing)) return existing;
+        const created: Record<string, unknown> = {};
+        // eslint-disable-next-line no-param-reassign
+        parent[key] = created;
+        return created;
+    };
+    ensureRecord(ensureRecord(ensureRecord(sidecar, database), schema), table)[
+        columnPath
+    ] = shape;
+};
+
 export type WarehouseTablesCatalog = {
     [database: string]: {
         [schema: string]: {

--- a/packages/frontend/src/features/sqlRunner/utils/monaco.ts
+++ b/packages/frontend/src/features/sqlRunner/utils/monaco.ts
@@ -322,7 +322,15 @@ export const registerCustomCompletionProvider = (
 
                 // Then apply quote preference
                 if (!settings || settings?.quotePreference === 'always') {
-                    return `${quoteChar}${formattedName}${quoteChar}`;
+                    // Backtick warehouses expose nested columns as dotted
+                    // paths; quoting the whole path would name one identifier.
+                    const segments =
+                        quoteChar === '`'
+                            ? formattedName.split('.')
+                            : [formattedName];
+                    return segments
+                        .map((segment) => `${quoteChar}${segment}${quoteChar}`)
+                        .join('.');
                 }
 
                 return formattedName;

--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.mock.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.mock.ts
@@ -58,6 +58,28 @@ const metadata = {
                 name: 'myObjectColumn',
                 type: BigqueryFieldType.STRUCT,
             },
+            {
+                name: 'myRepeatedColumn',
+                type: BigqueryFieldType.STRING,
+                mode: 'REPEATED',
+            },
+            {
+                name: 'myRecordColumn',
+                type: BigqueryFieldType.RECORD,
+                mode: 'NULLABLE',
+                fields: [
+                    { name: 'id', type: BigqueryFieldType.INT64 },
+                    { name: 'createdAt', type: BigqueryFieldType.TIMESTAMP },
+                    {
+                        name: 'tags',
+                        type: BigqueryFieldType.RECORD,
+                        mode: 'REPEATED',
+                        fields: [
+                            { name: 'label', type: BigqueryFieldType.STRING },
+                        ],
+                    },
+                ],
+            },
         ],
     },
 };
@@ -99,6 +121,12 @@ export const rows: Record<string, AnyType>[] = [
         myBooleanColumn: false,
         myArrayColumn: ['1', '2', '3'],
         myObjectColumn: { test: '1', toFixed: () => '123' },
+        myRepeatedColumn: ['a', 'b'],
+        myRecordColumn: {
+            id: 7,
+            createdAt: new BigQueryTimestamp('1990-03-02T08:30:00.010Z'),
+            tags: [{ label: 'x' }, { label: 'y' }],
+        },
     },
 ];
 

--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.test.ts
@@ -8,10 +8,14 @@ import {
     BigqueryAuthenticationType,
     BigqueryTokenError,
     DimensionType,
+    getCatalogNestedColumnShape,
+    setCatalogNestedColumnShape,
+    setCatalogTimestampDomain,
     WarehouseConnectionError,
     WarehouseQueryError,
     type BigqueryProject,
     type CreateBigqueryCredentials,
+    type WarehouseNestedColumnShape,
 } from '@lightdash/common';
 import type { Mock, MockInstance } from 'vitest';
 import {
@@ -43,11 +47,19 @@ describe('BigqueryWarehouseClient', () => {
         expect(results.fields).toEqual({
             ...expectedFields,
             myBigNumberColumn: { type: 'number' },
+            myRepeatedColumn: { type: 'string' },
+            myRecordColumn: { type: 'string' },
         });
         expect(results.rows[0]).toEqual({
             ...expectedRow,
             myNumberColumn: 100.25,
             myBigNumberColumn: 200.5,
+            // BigQuery serialises nested values as JSON; other clients pass them through
+            myArrayColumn: '["1","2","3"]',
+            myObjectColumn: '{"test":"1"}',
+            myRepeatedColumn: '["a","b"]',
+            myRecordColumn:
+                '{"id":7,"createdAt":"1990-03-02T08:30:00.010Z","tags":[{"label":"x"},{"label":"y"}]}',
         });
         expect(warehouse.client.createQueryJob as Mock).toHaveBeenCalledTimes(
             1,
@@ -94,11 +106,74 @@ describe('BigqueryWarehouseClient', () => {
         const expectedCatalog = structuredClone(
             expectedWarehouseSchemaWithAwareTimestamp,
         );
-        expectedCatalog.myDatabase.mySchema.myTable.myBigNumberColumn =
-            DimensionType.NUMBER;
+        Object.assign(expectedCatalog.myDatabase.mySchema.myTable, {
+            myBigNumberColumn: DimensionType.NUMBER,
+            myRepeatedColumn: DimensionType.STRING,
+            myRecordColumn: DimensionType.STRING,
+            'myRecordColumn.id': DimensionType.NUMBER,
+            'myRecordColumn.createdAt': DimensionType.TIMESTAMP,
+            'myRecordColumn.tags': DimensionType.STRING,
+            'myRecordColumn.tags.label': DimensionType.STRING,
+        });
+        setCatalogTimestampDomain(
+            expectedCatalog,
+            'myDatabase',
+            'mySchema',
+            'myTable',
+            'myRecordColumn.createdAt',
+            'aware',
+        );
+        const nestedShapes: Record<string, WarehouseNestedColumnShape> = {
+            myObjectColumn: { repeated: false, record: true },
+            myRepeatedColumn: { repeated: true, record: false },
+            myRecordColumn: { repeated: false, record: true },
+            'myRecordColumn.tags': { repeated: true, record: true },
+        };
+        Object.entries(nestedShapes).forEach(([path, shape]) =>
+            setCatalogNestedColumnShape(
+                expectedCatalog,
+                'myDatabase',
+                'mySchema',
+                'myTable',
+                path,
+                shape,
+            ),
+        );
         expect(await warehouse.getCatalog(config)).toEqual(expectedCatalog);
         expect(getTableMock).toHaveBeenCalledTimes(1);
         expect(getTableResponse.getMetadata).toHaveBeenCalledTimes(1);
+    });
+    it('expect getFields to flatten nested columns with the same shapes as getCatalog', async () => {
+        Dataset.prototype.table = vi
+            .fn()
+            .mockImplementationOnce(() => getTableResponse);
+        const warehouse = new BigqueryWarehouseClient(credentials);
+        const fields = await warehouse.getFields(
+            'myTable',
+            'mySchema',
+            'myDatabase',
+        );
+        expect(fields.myDatabase.mySchema.myTable['myRecordColumn.id']).toBe(
+            DimensionType.NUMBER,
+        );
+        expect(
+            getCatalogNestedColumnShape(
+                fields,
+                'myDatabase',
+                'mySchema',
+                'myTable',
+                'myRecordColumn.tags',
+            ),
+        ).toEqual({ repeated: true, record: true });
+        expect(
+            getCatalogNestedColumnShape(
+                fields,
+                'myDatabase',
+                'mySchema',
+                'myTable',
+                'myStringColumn',
+            ),
+        ).toBeUndefined();
     });
 });
 

--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
@@ -29,6 +29,7 @@ import {
     PartitionType,
     sanitizeQueryTagKey,
     sanitizeQueryTagValue,
+    setCatalogNestedColumnShape,
     setCatalogTimestampDomain,
     SupportedDbtAdapter,
     TimeIntervalUnit,
@@ -37,6 +38,7 @@ import {
     WarehouseResults,
     WarehouseTypes,
     type TimestampDomain,
+    type WarehouseNestedColumnShape,
 } from '@lightdash/common';
 import { pipeline, Transform } from 'stream';
 import {
@@ -99,6 +101,43 @@ const isBigqueryDecimal = (value: unknown): value is BigqueryDecimal =>
     value.c.length > 0 &&
     value.c.every((digit) => typeof digit === 'number');
 
+const isBigqueryTemporal = (
+    cell: unknown,
+): cell is BigQueryDate | BigQueryTimestamp | BigQueryDatetime | BigQueryTime =>
+    cell instanceof BigQueryDate ||
+    cell instanceof BigQueryTimestamp ||
+    cell instanceof BigQueryDatetime ||
+    cell instanceof BigQueryTime;
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+    typeof value === 'object' &&
+    value !== null &&
+    Object.getPrototypeOf(value) === Object.prototype;
+
+// STRUCT and ARRAY values arrive as plain objects/arrays whose leaves are the
+// same SDK wrappers as top-level cells, so leaves are normalised before the
+// whole value is serialised.
+const normaliseNestedValue = (value: AnyType): AnyType => {
+    if (Array.isArray(value)) {
+        return value.map(normaliseNestedValue);
+    }
+    if (isBigqueryTemporal(value)) {
+        return value.value;
+    }
+    if (isBigqueryDecimal(value)) {
+        return Number(value.toFixed());
+    }
+    if (isPlainObject(value)) {
+        return Object.fromEntries(
+            Object.entries(value).map(([key, nested]) => [
+                key,
+                normaliseNestedValue(nested),
+            ]),
+        );
+    }
+    return value;
+};
+
 const parseCell = (cell: AnyType) => {
     if (
         cell === undefined ||
@@ -109,17 +148,16 @@ const parseCell = (cell: AnyType) => {
         return cell;
     }
 
-    if (
-        cell instanceof BigQueryDate ||
-        cell instanceof BigQueryTimestamp ||
-        cell instanceof BigQueryDatetime ||
-        cell instanceof BigQueryTime
-    ) {
+    if (isBigqueryTemporal(cell)) {
         return new Date(cell.value);
     }
 
     if (isBigqueryDecimal(cell)) {
         return Number(cell.toFixed());
+    }
+
+    if (Array.isArray(cell) || isPlainObject(cell)) {
+        return JSON.stringify(normaliseNestedValue(cell));
     }
 
     return `${cell}`;
@@ -166,7 +204,10 @@ type TableSchema = {
     fields: SchemaFields[];
 };
 
-type SchemaFields = Required<Pick<bigquery.ITableFieldSchema, 'name' | 'type'>>;
+type SchemaFields = Required<
+    Pick<bigquery.ITableFieldSchema, 'name' | 'type'>
+> &
+    Pick<bigquery.ITableFieldSchema, 'mode' | 'fields'>;
 
 const isSchemaFields = (
     rawSchemaFields: bigquery.ITableFieldSchema[],
@@ -175,6 +216,41 @@ const isSchemaFields = (
 
 const isTableSchema = (schema: bigquery.ITableSchema): schema is TableSchema =>
     !!schema && !!schema.fields && isSchemaFields(schema.fields);
+
+const BIGQUERY_REPEATED_MODE = 'REPEATED';
+
+const isRecordType = (type: string) =>
+    type === BigqueryFieldType.RECORD || type === BigqueryFieldType.STRUCT;
+
+type FlattenedSchemaField = {
+    path: string;
+    type: string;
+    shape: WarehouseNestedColumnShape | undefined;
+};
+
+/**
+ * Walks nested RECORD fields depth-first, emitting every node under its dotted
+ * path. A record node is kept alongside its children so the container column
+ * still resolves; the shape says whether it is a struct, an array, or both.
+ */
+const flattenSchemaFields = (
+    fields: bigquery.ITableFieldSchema[],
+    prefix = '',
+): FlattenedSchemaField[] =>
+    fields.flatMap((field) => {
+        if (!field.name || !field.type) return [];
+        const path = prefix ? `${prefix}.${field.name}` : field.name;
+        const repeated = field.mode === BIGQUERY_REPEATED_MODE;
+        const record = isRecordType(field.type);
+        const node: FlattenedSchemaField = {
+            path,
+            type: field.type,
+            shape: repeated || record ? { repeated, record } : undefined,
+        };
+        return record
+            ? [node, ...flattenSchemaFields(field.fields ?? [], path)]
+            : [node];
+    });
 
 const parseRow = (row: Record<string, AnyType>[]) =>
     Object.fromEntries(
@@ -610,18 +686,27 @@ export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryC
                 acc[database] = acc[database] || {};
                 acc[database][schema] = acc[database][schema] || {};
                 acc[database][schema][table] = {};
-                tableSchema.fields.forEach(({ name, type }) => {
-                    if (name === undefined) return;
-                    acc[database][schema][table][name] = mapFieldType(type);
-                    setCatalogTimestampDomain(
-                        acc,
-                        database,
-                        schema,
-                        table,
-                        name,
-                        getBigqueryTimestampDomain(type),
-                    );
-                });
+                flattenSchemaFields(tableSchema.fields).forEach(
+                    ({ path, type, shape }) => {
+                        acc[database][schema][table][path] = mapFieldType(type);
+                        setCatalogTimestampDomain(
+                            acc,
+                            database,
+                            schema,
+                            table,
+                            path,
+                            getBigqueryTimestampDomain(type),
+                        );
+                        setCatalogNestedColumnShape(
+                            acc,
+                            database,
+                            schema,
+                            table,
+                            path,
+                            shape,
+                        );
+                    },
+                );
             }
 
             return acc;
@@ -708,24 +793,37 @@ export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryC
         const dataset: Dataset = new Dataset(this.client, schema, {
             projectId: database,
         });
-        const schemas = await BigqueryWarehouseClient.getTableMetadata(
-            dataset,
-            tableName,
-        ).catch((e: unknown) => {
-            this.throwIfGoogleOauthTokenError(e);
-            throw e;
-        });
-        return this.parseWarehouseCatalog(
-            schemas[3].fields.map((column) => ({
-                table_catalog: schemas[0],
-                table_schema: schemas[1],
-                table_name: schemas[2],
-                column_name: column.name,
-                data_type: column.type,
+        const [tableCatalog, tableSchema, table, metadataSchema] =
+            await BigqueryWarehouseClient.getTableMetadata(
+                dataset,
+                tableName,
+            ).catch((e: unknown) => {
+                this.throwIfGoogleOauthTokenError(e);
+                throw e;
+            });
+        const flattenedFields = flattenSchemaFields(metadataSchema.fields);
+        const catalog = this.parseWarehouseCatalog(
+            flattenedFields.map(({ path, type }) => ({
+                table_catalog: tableCatalog,
+                table_schema: tableSchema,
+                table_name: table,
+                column_name: path,
+                data_type: type,
             })),
             mapFieldType,
             getBigqueryTimestampDomain,
         );
+        flattenedFields.forEach(({ path, shape }) =>
+            setCatalogNestedColumnShape(
+                catalog,
+                tableCatalog,
+                tableSchema,
+                table,
+                path,
+                shape,
+            ),
+        );
+        return catalog;
     }
 
     parseError(error: bigquery.IErrorProto, query: string = '') {


### PR DESCRIPTION
BigQuery RECORD and REPEATED columns were read one level deep, so a dbt column documented with a dotted path such as `customer.address.city` never matched the warehouse catalog: it compiled as a string whatever its real type, and on the cached-catalog path the miss forced a full warehouse catalog refetch on every compile. STRUCT and ARRAY cells in query results also came back as `[object Object]`, because BigQuery was the only adapter that stringified nested values instead of serialising them, which is why the JSON cell viewer never worked there. Every BigQuery project with nested columns is affected, and this is the groundwork for unnesting repeated columns in the PR above this one.

Two behaviours change for users. Dotted struct leaves now get their type from the catalog with nothing declared in YAML, and `lightdash generate` proposes those leaves while leaving repeated columns alone until they can be queried.

Relates: #4102
