### PR TITLE
feat(explores): unnest repeated BigQuery columns into virtual tables

### DIFF
--- a/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.ts
@@ -46,6 +46,7 @@ import {
     CachedWarehouse,
     DbtClient,
     ProjectAdapter,
+    type ExploreCompileOptions,
     type TrackingParams,
 } from '../types';
 
@@ -195,11 +196,13 @@ export class DbtBaseProjectAdapter implements ProjectAdapter {
         trackingParams?: TrackingParams,
         loadSources: boolean = false,
         allowPartialCompilation: boolean = true,
+        compileOptions?: ExploreCompileOptions,
     ): Promise<(Explore | ExploreError)[]> {
         const stream = await this.prepareExploreStream(
             trackingParams,
             loadSources,
             allowPartialCompilation,
+            compileOptions,
         );
         const explores: (Explore | ExploreError)[] = [];
         for await (const explore of stream) explores.push(explore);
@@ -210,7 +213,10 @@ export class DbtBaseProjectAdapter implements ProjectAdapter {
         trackingParams?: TrackingParams,
         loadSources: boolean = false,
         allowPartialCompilation: boolean = true,
+        compileOptions?: ExploreCompileOptions,
     ): Promise<AsyncIterable<Explore | ExploreError>> {
+        const unnestRepeatedColumns =
+            compileOptions?.unnestRepeatedColumns ?? false;
         Logger.debug('Install dependencies');
         // Install dependencies for dbt and fetch the manifest - may raise error meaning no explores compile
         if (this.dbtClient.installDeps !== undefined) {
@@ -352,6 +358,7 @@ export class DbtBaseProjectAdapter implements ProjectAdapter {
                     disableTimestampConversion,
                     allowPartialCompilation,
                     postProcessors,
+                    unnestRepeatedColumns,
                 },
             );
             return (async function* compiledExplores() {
@@ -414,6 +421,7 @@ export class DbtBaseProjectAdapter implements ProjectAdapter {
                         disableTimestampConversion,
                         allowPartialCompilation,
                         postProcessors,
+                        unnestRepeatedColumns,
                     },
                 );
                 return (async function* compiledExplores() {

--- a/packages/backend/src/projectAdapters/dbtGitProjectAdapter.test.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectAdapter.test.ts
@@ -119,7 +119,13 @@ describe('Git explore compilation', () => {
                     })();
                 });
 
-            const result = await adapter[method](undefined, false, true);
+            const compileOptions = { unnestRepeatedColumns: true };
+            const result = await adapter[method](
+                undefined,
+                false,
+                true,
+                compileOptions,
+            );
             const collected = [];
             for await (const item of result) collected.push(item);
 
@@ -128,6 +134,7 @@ describe('Git explore compilation', () => {
                 undefined,
                 false,
                 true,
+                compileOptions,
             );
             expect(refresh).toHaveBeenCalledTimes(1);
         },

--- a/packages/backend/src/projectAdapters/dbtGitProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectAdapter.ts
@@ -19,7 +19,12 @@ import simpleGit, {
 } from 'simple-git';
 import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
 import Logger from '../logging/logger';
-import { CachedWarehouse, ProjectAdapter, type TrackingParams } from '../types';
+import {
+    CachedWarehouse,
+    ProjectAdapter,
+    type ExploreCompileOptions,
+    type TrackingParams,
+} from '../types';
 import { DbtLocalCredentialsProjectAdapter } from './dbtLocalCredentialsProjectAdapter';
 
 export type DbtGitProjectAdapterArgs = {
@@ -236,12 +241,14 @@ export class DbtGitProjectAdapter
         trackingParams?: TrackingParams,
         loadSources?: boolean,
         allowPartialCompilation?: boolean,
+        compileOptions?: ExploreCompileOptions,
     ) {
         await this._refreshRepo();
         return super.prepareExploreStream(
             trackingParams,
             loadSources,
             allowPartialCompilation,
+            compileOptions,
         );
     }
 

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -334,7 +334,11 @@ import { projectAdapterFromConfig } from '../../projectAdapters/projectAdapter';
 import { compileMetricQuery } from '../../queryCompiler';
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
 import { traceSpan } from '../../tracing/tracing';
-import { CachedWarehouse, ProjectAdapter } from '../../types';
+import {
+    CachedWarehouse,
+    ProjectAdapter,
+    type ExploreCompileOptions,
+} from '../../types';
 import { runWorkerThread, wrapSentryTransaction } from '../../utils';
 import { buildCacheHash, getCacheUserUuid } from '../../utils/cacheUtils';
 import { metricQueryWithLimit as applyMetricQueryLimit } from '../../utils/csvLimitUtils';
@@ -3355,6 +3359,9 @@ export class ProjectService extends BaseService {
                                           trackingParams,
                                           false, // loadSources
                                           true, // allowPartialCompilation
+                                          await this.getExploreCompileOptions(
+                                              user,
+                                          ),
                                       );
                                   const compiledProjectConfig =
                                       await adapter.getLightdashProjectConfig(
@@ -4101,6 +4108,7 @@ export class ProjectService extends BaseService {
                                     trackingParams,
                                     false, // loadSources
                                     true, // allowPartialCompilation
+                                    await this.getExploreCompileOptions(user),
                                 );
                             timings.compileExplores.end = performance.now();
                             timings.getConfig.start = performance.now();
@@ -8660,8 +8668,9 @@ export class ProjectService extends BaseService {
             };
             const exploreStream = await adapter.prepareExploreStream(
                 trackingParams,
-                false,
-                true,
+                false, // loadSources
+                true, // allowPartialCompilation
+                await this.getExploreCompileOptions(user),
             );
             const onCompiled = (summary: ExploreCompilationSummary) => {
                 this.analytics.track({
@@ -12076,6 +12085,17 @@ export class ProjectService extends BaseService {
         });
     }
 
+    async getExploreCompileOptions(user: {
+        userUuid: string;
+        organizationUuid?: string;
+    }): Promise<ExploreCompileOptions> {
+        const { enabled } = await this.featureFlagModel.get({
+            featureFlagId: FeatureFlags.UnnestRepeatedColumns,
+            user,
+        });
+        return { unnestRepeatedColumns: enabled };
+    }
+
     async isTimezoneSupportEnabled(user: {
         userUuid: string;
         organizationUuid?: string;
@@ -12618,6 +12638,7 @@ export class ProjectService extends BaseService {
             {
                 disableTimestampConversion,
                 postProcessors: [preAggregatePostProcessor],
+                ...(await this.getExploreCompileOptions(user)),
             },
         );
         Logger.info(`Explore count: ${convertedExplores.length}`);

--- a/packages/backend/src/types.ts
+++ b/packages/backend/src/types.ts
@@ -15,6 +15,11 @@ export type TrackingParams = {
     jobUuid?: string;
 };
 
+/** Feature-flag driven compile behaviour, resolved by the caller per user. */
+export type ExploreCompileOptions = {
+    unnestRepeatedColumns: boolean;
+};
+
 export interface ProjectAdapter {
     /**
      * Compile all explores
@@ -27,12 +32,14 @@ export interface ProjectAdapter {
         trackingParams: TrackingParams | undefined,
         loadSources?: boolean,
         allowPartialCompilation?: boolean,
+        compileOptions?: ExploreCompileOptions,
     ): Promise<(Explore | ExploreError)[]>;
 
     prepareExploreStream(
         trackingParams: TrackingParams | undefined,
         loadSources?: boolean,
         allowPartialCompilation?: boolean,
+        compileOptions?: ExploreCompileOptions,
     ): Promise<AsyncIterable<Explore | ExploreError>>;
 
     getDbtPackages(): Promise<DbtPackages | undefined>;

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -33,6 +33,7 @@ import {
 } from './MetricQueryBuilder';
 import {
     bigqueryClientMock,
+    emptyTable,
     EXPLORE,
     EXPLORE_NESTED_AGG_NAME_COLLISION,
     EXPLORE_WITH_AVERAGE_DISTINCT,
@@ -2013,6 +2014,103 @@ LIMIT 10`;
             expect(result.query).toContain(
                 'LEFT OUTER JOIN orders AS "orders"',
             );
+        });
+
+        test('Should render an unnested table with the alias its FROM item already carries', () => {
+            const explore: Explore = {
+                targetDatabase: SupportedDbtAdapter.BIGQUERY,
+                name: 'sessions',
+                label: 'Sessions',
+                baseTable: 'sessions',
+                tags: [],
+                tables: {
+                    sessions: {
+                        ...emptyTable('sessions'),
+                        primaryKey: ['id'],
+                        dimensions: {
+                            id: {
+                                type: DimensionType.NUMBER,
+                                name: 'id',
+                                label: 'Id',
+                                table: 'sessions',
+                                tableLabel: 'Sessions',
+                                fieldType: FieldType.DIMENSION,
+                                sql: '${TABLE}.id',
+                                compiledSql: '"sessions".id',
+                                tablesReferences: ['sessions'],
+                                hidden: false,
+                            },
+                        },
+                    },
+                    sessions__hits: {
+                        ...emptyTable('sessions__hits'),
+                        sqlTable:
+                            'UNNEST("sessions".hits) AS "sessions__hits" WITH OFFSET AS "sessions__hits__offset"',
+                        nestedFrom: {
+                            parentTable: 'sessions',
+                            columnPath: 'hits',
+                        },
+                        dimensions: {
+                            'page.pagePath': {
+                                type: DimensionType.STRING,
+                                name: 'page.pagePath',
+                                label: 'Page path',
+                                table: 'sessions__hits',
+                                tableLabel: 'Sessions: Hits',
+                                fieldType: FieldType.DIMENSION,
+                                sql: '${TABLE}.page.pagePath',
+                                compiledSql: '"sessions__hits".page.pagePath',
+                                tablesReferences: ['sessions__hits'],
+                                hidden: false,
+                            },
+                        },
+                    },
+                },
+                joinedTables: [
+                    {
+                        table: 'sessions__hits',
+                        sqlOn: 'TRUE',
+                        compiledSqlOn: 'TRUE',
+                        type: 'left',
+                        relationship: JoinRelationship.ONE_TO_MANY,
+                        tablesReferences: ['sessions'],
+                    },
+                ],
+            };
+            const result = buildQuery({
+                explore,
+                compiledMetricQuery: {
+                    exploreName: 'sessions',
+                    dimensions: [
+                        'sessions_id',
+                        'sessions__hits_page__pagePath',
+                    ],
+                    metrics: [],
+                    filters: {},
+                    sorts: [],
+                    limit: 10,
+                    tableCalculations: [],
+                    additionalMetrics: [],
+                    compiledTableCalculations: [],
+                    compiledAdditionalMetrics: [],
+                    compiledCustomDimensions: [],
+                },
+                warehouseSqlBuilder: warehouseClientMock,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+                timezone: QUERY_BUILDER_UTC_TIMEZONE,
+            });
+
+            expect(result.query).toContain(
+                'LEFT OUTER JOIN UNNEST("sessions".hits) AS "sessions__hits" WITH OFFSET AS "sessions__hits__offset"\n  ON TRUE',
+            );
+            expect(result.query).toContain(
+                '"sessions__hits".page.pagePath AS "sessions__hits_page__pagePath"',
+            );
+            expect(
+                result.warnings.some((w) =>
+                    w.message.includes('missing a primary key definition'),
+                ),
+            ).toBe(false);
         });
 
         test('Should throw when the referenced dimension table is aggregated in its own CTE', () => {

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -2574,6 +2574,11 @@ export class MetricQueryBuilder {
                     warehouseSqlBuilder,
                 );
 
+                // An unnested table's FROM item already carries its alias
+                // (and the offset alias that must follow it).
+                if (explore.tables[join.table].nestedFrom) {
+                    return `${joinType} ${joinTable}\n  ON ${parsedSqlOn}`;
+                }
                 return `${joinType} ${joinTable} AS ${fieldQuoteChar}${alias}${fieldQuoteChar}\n  ON ${parsedSqlOn}`;
             })
             .join('\n');

--- a/packages/backend/src/utils/QueryBuilder/utils.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/utils.test.ts
@@ -948,6 +948,51 @@ describe('applyLimitToSqlQuery', () => {
 });
 
 describe('findMetricInflationWarnings', () => {
+    it('does not ask unnested tables for a primary key but still flags parent metrics', () => {
+        const result = findMetricInflationWarnings({
+            tables: {
+                sessions: { primaryKey: ['id'] },
+                sessions__hits: {
+                    nestedFrom: { parentTable: 'sessions', columnPath: 'hits' },
+                },
+            },
+            possibleJoins: [
+                {
+                    table: 'sessions__hits',
+                    sqlOn: 'TRUE',
+                    compiledSqlOn: 'TRUE',
+                    tablesReferences: ['sessions'],
+                    relationship: JoinRelationship.ONE_TO_MANY,
+                },
+            ],
+            baseTable: 'sessions',
+            joinedTables: new Set(['sessions__hits']),
+            metrics: [
+                {
+                    name: 'total_pageviews',
+                    type: MetricType.SUM,
+                    table: 'sessions',
+                    label: 'Total pageviews',
+                },
+                {
+                    name: 'total_revenue',
+                    type: MetricType.SUM,
+                    table: 'sessions__hits',
+                    label: 'Total revenue',
+                },
+            ],
+        });
+
+        expect(
+            result.some((warning) =>
+                warning.message.includes('missing a primary key definition'),
+            ),
+        ).toBe(false);
+        expect(result.map((warning) => warning.fields)).toEqual([
+            ['sessions_total_pageviews'],
+        ]);
+    });
+
     it('should return no warnings when there are no metrics', () => {
         const result = findMetricInflationWarnings({
             tables: {

--- a/packages/backend/src/utils/QueryBuilder/utils.ts
+++ b/packages/backend/src/utils/QueryBuilder/utils.ts
@@ -1097,7 +1097,10 @@ export const findTablesWithMetricInflation = ({
         tablesWithMetricInflation.add(baseTable);
     } else {
         joinedTables.forEach((joinedTable) => {
-            if (!tables[joinedTable]?.primaryKey) {
+            if (
+                !tables[joinedTable]?.primaryKey &&
+                !tables[joinedTable]?.nestedFrom
+            ) {
                 // Warn the user about missing primary key so we can detect possible metric inflation
                 tablesWithoutPrimaryKey.add(joinedTable);
             }
@@ -1166,7 +1169,9 @@ export const findTablesWithMetricInflation = ({
 };
 
 type FindMetricInflationWarningsProps = {
-    tables: { [tableName: string]: Pick<CompiledTable, 'primaryKey'> };
+    tables: {
+        [tableName: string]: Pick<CompiledTable, 'primaryKey' | 'nestedFrom'>;
+    };
     possibleJoins: Explore['joinedTables']; // all joins metadata
     baseTable: Explore['baseTable']; // query table
     joinedTables: Set<string>; // query joined tables

--- a/packages/cli/src/handlers/compile.ts
+++ b/packages/cli/src/handlers/compile.ts
@@ -7,6 +7,7 @@ import {
     DbtModelNode,
     Explore,
     ExploreError,
+    FeatureFlags,
     getCompiledModels,
     getDbtManifestVersion,
     getErrorMessage,
@@ -21,6 +22,7 @@ import {
     preAggregatePostProcessor,
     QueryExecutionContext,
     WarehouseCatalog,
+    type FeatureFlag,
     type WarehouseClient,
 } from '@lightdash/common';
 import {
@@ -42,10 +44,28 @@ import { readAndLoadLightdashProjectConfig } from '../lightdash-config';
 import { loadLightdashModels } from '../lightdash/loader';
 import { detectProjectType } from '../lightdash/projectType';
 import * as styles from '../styles';
-import { lightdashRawApi } from './dbt/apiClient';
+import { lightdashApi, lightdashRawApi } from './dbt/apiClient';
 import { DbtCompileOptions, maybeCompileModelsAndJoins } from './dbt/compile';
 import { tryGetDbtVersion } from './dbt/getDbtVersion';
 import getWarehouseClient from './dbt/getWarehouseClient';
+
+// Compile-time behaviour the server gates behind a feature flag. Unreachable
+// servers and older ones that don't know the flag both mean "off".
+const getUnnestRepeatedColumns = async (): Promise<boolean> => {
+    try {
+        const flag = await lightdashApi<FeatureFlag>({
+            method: 'GET',
+            url: `/api/v2/feature-flag/${FeatureFlags.UnnestRepeatedColumns}`,
+            body: undefined,
+        });
+        return flag.enabled;
+    } catch (e) {
+        GlobalState.debug(
+            `> Could not read the ${FeatureFlags.UnnestRepeatedColumns} flag, compiling without it: ${getErrorMessage(e)}`,
+        );
+        return false;
+    }
+};
 
 export type CompileHandlerOptions = DbtCompileOptions & {
     projectDir: string;
@@ -748,6 +768,7 @@ export const compileProject = async (
                 disableTimestampConversion: options.disableTimestampConversion,
                 allowPartialCompilation,
                 postProcessors: [preAggregatePostProcessor],
+                unnestRepeatedColumns: await getUnnestRepeatedColumns(),
             },
         );
         const validatedExplores =

--- a/packages/common/src/compiler/exploreCompiler.test.ts
+++ b/packages/common/src/compiler/exploreCompiler.test.ts
@@ -622,6 +622,18 @@ describe('Parse dimension reference', () => {
             { refName: 'TABLE', refTable: 'table' },
         ]);
     });
+    test('should keep the first segment as the table and the rest as a nested field name', () => {
+        expect(
+            parseAllReferences('${orders.customer.address.city}', 'table'),
+        ).toStrictEqual([
+            { refName: 'customer.address.city', refTable: 'orders' },
+        ]);
+        // Two segments keep today's meaning: a nested field on the current
+        // table needs its table prefix.
+        expect(parseAllReferences('${customer.city}', 'orders')).toStrictEqual([
+            { refName: 'city', refTable: 'customer' },
+        ]);
+    });
     test('should parse unquoted TABLE column references', () => {
         expect(
             getTableColumnReferences(

--- a/packages/common/src/compiler/exploreCompiler.ts
+++ b/packages/common/src/compiler/exploreCompiler.ts
@@ -195,18 +195,14 @@ export const getParsedReference = (
     ref: string,
     currentTable: string,
 ): Reference => {
-    // Reference to another dimension
-    const split = ref.split('.');
-    if (split.length > 2) {
-        throw new CompileError(
-            `Model "${currentTable}" cannot resolve dimension reference: \${${ref}}`,
-            {},
-        );
+    // Reference to another dimension. The first segment is always the table
+    // when there is more than one, so a nested field on the current table is
+    // written with its table prefix: ${orders.customer.city}.
+    const [head, ...rest] = ref.split('.');
+    if (rest.length === 0) {
+        return { refTable: currentTable, refName: head };
     }
-    const refTable = split.length === 1 ? currentTable : split[0];
-    const refName = split.length === 1 ? split[0] : split[1];
-
-    return { refTable, refName };
+    return { refTable: head, refName: rest.join('.') };
 };
 
 /**
@@ -1753,6 +1749,13 @@ export class ExploreCompiler {
             },
             tables,
         );
+        // An unnested table's ON clause is TRUE; its dependency on the parent
+        // lives in the FROM item, so it is recorded here for join ordering
+        // and fan-out detection.
+        const nestedFrom = tables[join.table]?.nestedFrom;
+        if (nestedFrom) {
+            tablesReferences.add(nestedFrom.parentTable);
+        }
 
         // Extract parameter references from sqlOn
         const parameterReferences = getParameterReferences(sql);

--- a/packages/common/src/compiler/translator.test.ts
+++ b/packages/common/src/compiler/translator.test.ts
@@ -2,6 +2,8 @@ import { SupportedDbtAdapter, type DbtModelNode } from '../types/dbt';
 import {
     getExploreSplitCandidates,
     InlineErrorType,
+    isExploreError,
+    JoinRelationship,
     type Explore,
 } from '../types/explore';
 import {
@@ -13,6 +15,7 @@ import {
 import { DEFAULT_SPOTLIGHT_CONFIG } from '../types/lightdashProjectConfig';
 import { TimeFrames } from '../types/timeFrames';
 import {
+    setCatalogNestedColumnShape,
     WAREHOUSE_TIMESTAMP_DOMAINS_KEY,
     type WarehouseCatalog,
 } from '../types/warehouse';
@@ -27,7 +30,6 @@ import {
     type AttachTypesDiagnostics,
 } from './translator';
 import {
-    column,
     expectedModelWithTimestampDomain,
     expectedModelWithType,
     LIGHTDASH_TABLE_SQL_WHERE,
@@ -110,27 +112,6 @@ describe('attachTypesToModels', () => {
         expect(attachTypesToModels([model], warehouseSchema, false)[0]).toEqual(
             expectedModelWithType,
         );
-    });
-    it('should resolve a dotted nested column from its dotted catalog entry', async () => {
-        const nestedModel = {
-            ...model,
-            columns: {
-                ...model.columns,
-                'myRecordColumn.id': {
-                    ...column,
-                    name: 'myRecordColumn.id',
-                },
-            },
-        };
-        const nestedCatalog = structuredClone(warehouseSchema);
-        nestedCatalog[model.database][model.schema][model.name][
-            'myRecordColumn.id'
-        ] = DimensionType.NUMBER;
-        expect(
-            attachTypesToModels([nestedModel], nestedCatalog, true)[0].columns[
-                'myRecordColumn.id'
-            ].data_type,
-        ).toEqual(DimensionType.NUMBER);
     });
     it('should return models with undefined type when is missing dataset or table or column', async () => {
         expect(attachTypesToModels([model], {}, false)[0]).toEqual(model);
@@ -3267,5 +3248,285 @@ describe('convertExplores at scale', () => {
 
         const first = explores[0] as Explore;
         expect(Object.keys(first.tables)).toEqual(['m_0']);
+    });
+});
+
+describe('nested and repeated columns', () => {
+    const bigqueryClientMock = {
+        ...warehouseClientMock,
+        getAdapterType: () => SupportedDbtAdapter.BIGQUERY,
+        getFieldQuoteChar: () => '`',
+    };
+    const nestedColumn = (
+        name: string,
+        extra: Partial<DbtModelNode['columns'][string]> = {},
+    ) => ({ name, meta: {}, ...extra });
+    const gaSessions: DbtModelNode = {
+        ...model,
+        name: 'ga_sessions',
+        alias: 'ga_sessions',
+        unique_id: 'model.ga_sessions',
+        database: 'db',
+        schema: 'ds',
+        relation_name: '`db`.`ds`.`ga_sessions`',
+        meta: {},
+        columns: {
+            visitId: nestedColumn('visitId'),
+            'totals.pageviews': nestedColumn('totals.pageviews'),
+            hits: nestedColumn('hits', { description: 'One row per hit' }),
+            'customDimensions.index': nestedColumn('customDimensions.index'),
+            'customDimensions.value': nestedColumn('customDimensions.value'),
+            'hits.page.pagePath': nestedColumn('hits.page.pagePath'),
+            'hits.product.productSKU': nestedColumn('hits.product.productSKU'),
+            'hits.product.productRevenue': nestedColumn(
+                'hits.product.productRevenue',
+                {
+                    meta: {
+                        metrics: { total_revenue: { type: MetricType.SUM } },
+                    },
+                },
+            ),
+        },
+    };
+    const catalog: WarehouseCatalog = {
+        db: {
+            ds: {
+                ga_sessions: {
+                    visitId: DimensionType.NUMBER,
+                    totals: DimensionType.STRING,
+                    'totals.pageviews': DimensionType.NUMBER,
+                    customDimensions: DimensionType.STRING,
+                    'customDimensions.index': DimensionType.NUMBER,
+                    'customDimensions.value': DimensionType.STRING,
+                    hits: DimensionType.STRING,
+                    'hits.page': DimensionType.STRING,
+                    'hits.page.pagePath': DimensionType.STRING,
+                    'hits.product': DimensionType.STRING,
+                    'hits.product.productSKU': DimensionType.STRING,
+                    'hits.product.productRevenue': DimensionType.NUMBER,
+                },
+            },
+        },
+    };
+    Object.entries({
+        totals: { repeated: false, record: true },
+        customDimensions: { repeated: true, record: true },
+        hits: { repeated: true, record: true },
+        'hits.page': { repeated: false, record: true },
+        'hits.product': { repeated: true, record: true },
+    }).forEach(([path, shape]) =>
+        setCatalogNestedColumnShape(
+            catalog,
+            'db',
+            'ds',
+            'ga_sessions',
+            path,
+            shape,
+        ),
+    );
+    const typedModels = attachTypesToModels([gaSessions], catalog, true);
+
+    const compile = async (
+        models: DbtModelNode[],
+        unnestRepeatedColumns: boolean,
+    ) => {
+        const explores = await convertExplores(
+            models,
+            false,
+            SupportedDbtAdapter.BIGQUERY,
+            bigqueryClientMock,
+            { spotlight: DEFAULT_SPOTLIGHT_CONFIG },
+            { unnestRepeatedColumns },
+        );
+        const explore = explores.find((e) => e.name === 'ga_sessions');
+        if (!explore || isExploreError(explore)) {
+            throw new Error(JSON.stringify(explore));
+        }
+        return explore;
+    };
+
+    it('attaches the shape and repeated ancestors from the catalog', () => {
+        const { columns } = typedModels[0];
+        expect(columns.hits.nested_shape).toEqual({
+            repeated: true,
+            record: true,
+        });
+        expect(columns.hits.repeated_ancestors).toBeUndefined();
+        expect(columns['totals.pageviews'].repeated_ancestors).toBeUndefined();
+        expect(columns['hits.page.pagePath'].repeated_ancestors).toEqual([
+            'hits',
+        ]);
+        expect(columns['hits.product.productSKU'].repeated_ancestors).toEqual([
+            'hits',
+            'hits.product',
+        ]);
+    });
+
+    it("keeps today's dotted dimensions when unnesting is off", async () => {
+        const explore = await compile(typedModels, false);
+        expect(Object.keys(explore.tables)).toEqual(['ga_sessions']);
+        expect(
+            explore.tables.ga_sessions.dimensions['hits.product.productSKU']
+                .compiledSql,
+        ).toEqual('`ga_sessions`.hits.product.productSKU');
+    });
+
+    it('unnests each repeated node into a virtual table joined on TRUE', async () => {
+        const explore = await compile(typedModels, true);
+        expect(Object.keys(explore.tables).sort()).toEqual([
+            'ga_sessions',
+            'ga_sessions__customDimensions',
+            'ga_sessions__hits',
+            'ga_sessions__hits__product',
+        ]);
+
+        const base = explore.tables.ga_sessions;
+        expect(Object.keys(base.dimensions).sort()).toEqual([
+            'totals.pageviews',
+            'visitId',
+        ]);
+        expect(base.dimensions['totals.pageviews'].compiledSql).toEqual(
+            '`ga_sessions`.totals.pageviews',
+        );
+
+        const hits = explore.tables.ga_sessions__hits;
+        expect(hits.nestedFrom).toEqual({
+            parentTable: 'ga_sessions',
+            columnPath: 'hits',
+        });
+        expect(hits.sqlTable).toEqual(
+            'UNNEST(`ga_sessions`.hits) AS `ga_sessions__hits` WITH OFFSET AS `ga_sessions__hits__offset`',
+        );
+        expect(hits.label).toEqual('Ga sessions: Hits');
+        expect(hits.description).toEqual('One row per hit');
+        expect(hits.primaryKey).toBeUndefined();
+        expect(Object.keys(hits.dimensions).sort()).toEqual([
+            'offset',
+            'page.pagePath',
+        ]);
+        expect(hits.dimensions['page.pagePath']).toMatchObject({
+            table: 'ga_sessions__hits',
+            type: DimensionType.STRING,
+            compiledSql: '`ga_sessions__hits`.page.pagePath',
+        });
+        expect(hits.dimensions.offset).toMatchObject({
+            type: DimensionType.NUMBER,
+            compiledSql: '`ga_sessions__hits__offset`',
+        });
+
+        const product = explore.tables.ga_sessions__hits__product;
+        expect(product.nestedFrom).toEqual({
+            parentTable: 'ga_sessions__hits',
+            columnPath: 'hits.product',
+        });
+        expect(product.sqlTable).toEqual(
+            'UNNEST(`ga_sessions__hits`.product) AS `ga_sessions__hits__product` WITH OFFSET AS `ga_sessions__hits__product__offset`',
+        );
+        expect(product.label).toEqual('Ga sessions: Hits: Product');
+        expect(product.metrics.total_revenue).toMatchObject({
+            table: 'ga_sessions__hits__product',
+            compiledSql: 'SUM(`ga_sessions__hits__product`.productRevenue)',
+        });
+
+        expect(
+            explore.joinedTables.map(
+                ({
+                    table,
+                    type,
+                    relationship,
+                    compiledSqlOn,
+                    tablesReferences,
+                }) => ({
+                    table,
+                    type,
+                    relationship,
+                    compiledSqlOn,
+                    tablesReferences,
+                }),
+            ),
+        ).toEqual([
+            {
+                table: 'ga_sessions__customDimensions',
+                type: 'left',
+                relationship: JoinRelationship.ONE_TO_MANY,
+                compiledSqlOn: 'TRUE',
+                tablesReferences: ['ga_sessions'],
+            },
+            {
+                table: 'ga_sessions__hits',
+                type: 'left',
+                relationship: JoinRelationship.ONE_TO_MANY,
+                compiledSqlOn: 'TRUE',
+                tablesReferences: ['ga_sessions'],
+            },
+            {
+                table: 'ga_sessions__hits__product',
+                type: 'left',
+                relationship: JoinRelationship.ONE_TO_MANY,
+                compiledSqlOn: 'TRUE',
+                tablesReferences: ['ga_sessions__hits'],
+            },
+        ]);
+    });
+
+    it("adds a joined model's virtual tables after its own join", async () => {
+        const orders: DbtModelNode = {
+            ...model,
+            name: 'orders',
+            alias: 'orders',
+            unique_id: 'model.orders',
+            database: 'db',
+            schema: 'ds',
+            relation_name: '`db`.`ds`.`orders`',
+            columns: { id: nestedColumn('id') },
+            meta: {
+                joins: [
+                    {
+                        join: 'ga_sessions',
+                        sql_on: '${orders.id} = ${ga_sessions.visitId}',
+                    },
+                ],
+            },
+        };
+        const explores = await convertExplores(
+            [orders, ...typedModels],
+            false,
+            SupportedDbtAdapter.BIGQUERY,
+            bigqueryClientMock,
+            { spotlight: DEFAULT_SPOTLIGHT_CONFIG },
+            { unnestRepeatedColumns: true },
+        );
+        const explore = explores.find((e) => e.name === 'orders');
+        if (!explore || isExploreError(explore)) {
+            throw new Error(JSON.stringify(explore));
+        }
+        expect(explore.joinedTables.map(({ table }) => table)).toEqual([
+            'ga_sessions',
+            'ga_sessions__customDimensions',
+            'ga_sessions__hits',
+            'ga_sessions__hits__product',
+        ]);
+    });
+
+    it('fails the model when a virtual table name collides with a model', async () => {
+        const collidingModel: DbtModelNode = {
+            ...model,
+            name: 'ga_sessions__hits',
+            alias: 'ga_sessions__hits',
+            unique_id: 'model.ga_sessions__hits',
+            columns: { id: nestedColumn('id') },
+            meta: {},
+        };
+        const explores = await convertExplores(
+            [collidingModel, ...typedModels],
+            false,
+            SupportedDbtAdapter.BIGQUERY,
+            bigqueryClientMock,
+            { spotlight: DEFAULT_SPOTLIGHT_CONFIG },
+            { unnestRepeatedColumns: true },
+        );
+        const explore = explores.find((e) => e.name === 'ga_sessions');
+        expect(explore && isExploreError(explore)).toBe(true);
+        expect(JSON.stringify(explore)).toContain('already a model name');
     });
 });

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -22,11 +22,13 @@ import {
 import {
     CompileError,
     MissingCatalogEntryError,
+    NotSupportedError,
     ParseError,
 } from '../types/errors';
 import {
     InlineErrorType,
     isExploreError,
+    JoinRelationship,
     type Explore,
     type ExploreError,
     type InlineError,
@@ -51,9 +53,11 @@ import {
 import { OrderFieldsByStrategy, type FieldGroupType } from '../types/table';
 import { type TimeFrames } from '../types/timeFrames';
 import {
+    getCatalogNestedColumnShape,
     getCatalogTimestampDomain,
     WAREHOUSE_TIMESTAMP_DOMAINS_KEY,
     type WarehouseCatalog,
+    type WarehouseNestedColumnShape,
     type WarehouseSqlBuilder,
     type WarehouseTableSchema,
 } from '../types/warehouse';
@@ -652,6 +656,12 @@ function validateSets(
     return warnings;
 }
 
+const getColumnMeta = (column: DbtModelColumn): DbtColumnMetadata =>
+    merge({}, column.meta, column.config?.meta);
+
+const hasRepeatedAncestor = (column: DbtModelColumn): boolean =>
+    (column.repeated_ancestors?.length ?? 0) > 0;
+
 export const convertTable = (
     adapterType: SupportedDbtAdapter,
     model: DbtModelNode,
@@ -662,6 +672,7 @@ export const convertTable = (
     allowPartialCompilation?: boolean,
     additionalTimeIntervals?: ResolvedAdditionalTimeIntervals,
     granularityLabels?: Partial<Record<TimeFrames, string>>,
+    unnestRepeatedColumns?: boolean,
 ): Omit<Table, 'lineageGraph'> => {
     // Config block takes priority, then meta block
     const meta = merge({}, model.meta, model.config?.meta);
@@ -673,6 +684,17 @@ export const convertTable = (
         Record<string, Metric>,
     ] = Object.values(model.columns).reduce(
         ([prevDimensions, prevMetrics], column, index) => {
+            // Containers can't be selected as scalars and leaves under an
+            // array belong to the unnested table, unless custom SQL made
+            // the column scalar on purpose.
+            if (
+                unnestRepeatedColumns &&
+                !getColumnMeta(column).dimension?.sql &&
+                (column.nested_shape !== undefined ||
+                    hasRepeatedAncestor(column))
+            ) {
+                return [prevDimensions, prevMetrics];
+            }
             const dimension = convertDimension(
                 index,
                 adapterType,
@@ -1129,10 +1151,206 @@ export type ExplorePostProcessor = (
     },
 ) => (Explore | ExploreError)[];
 
+export const getNestedTableName = (modelName: string, columnPath: string) =>
+    `${modelName}__${columnPath.split('.').join('__')}`;
+
+const getOffsetColumnSql = (quoteChar: string, tableName: string) =>
+    `${quoteChar}${tableName}__offset${quoteChar}`;
+
+// The full FROM item, alias included, because the offset alias has to follow
+// the table alias and the join renderer only appends an ON clause.
+const getUnnestFromSql = (
+    adapterType: SupportedDbtAdapter,
+    quoteChar: string,
+    parentTable: string,
+    columnSegment: string,
+    tableName: string,
+): string => {
+    const q = quoteChar;
+    switch (adapterType) {
+        case SupportedDbtAdapter.BIGQUERY:
+            return `UNNEST(${q}${parentTable}${q}.${columnSegment}) AS ${q}${tableName}${q} WITH OFFSET AS ${q}${tableName}__offset${q}`;
+        default:
+            throw new NotSupportedError(
+                `Repeated column "${columnSegment}" can't be unnested on ${adapterType}. Unnesting repeated columns is only supported on BigQuery.`,
+            );
+    }
+};
+
+type ConvertNestedTablesArgs = {
+    adapterType: SupportedDbtAdapter;
+    model: DbtModelNode;
+    modelLabel: string;
+    reservedTableNames: Set<string>;
+    fieldQuoteChar: string;
+    spotlightConfig: LightdashProjectConfig['spotlight'];
+    startOfWeek?: WeekDay | null;
+    disableTimestampConversion?: boolean;
+    customGranularities?: Record<string, CustomGranularity>;
+    allowPartialCompilation?: boolean;
+    additionalTimeIntervals?: ResolvedAdditionalTimeIntervals;
+    granularityLabels?: Partial<Record<TimeFrames, string>>;
+};
+
+/**
+ * One virtual table per repeated node reached by a documented leaf. Each is
+ * a synthetic model run through convertTable, so leaves keep every column
+ * feature; its FROM item is the UNNEST of the parent's column and it is
+ * joined ON TRUE as one-to-many. Nodes are emitted outermost first so a
+ * child's join always follows its parent's.
+ */
+export const convertNestedTables = ({
+    adapterType,
+    model,
+    modelLabel,
+    reservedTableNames,
+    fieldQuoteChar,
+    spotlightConfig,
+    startOfWeek,
+    disableTimestampConversion,
+    customGranularities,
+    allowPartialCompilation,
+    additionalTimeIntervals,
+    granularityLabels,
+}: ConvertNestedTablesArgs): {
+    tables: Omit<Table, 'lineageGraph'>[];
+    joins: NonNullable<DbtModelNode['meta']['joins']>;
+} => {
+    const columns = Object.values(model.columns);
+    const isRoutedLeaf = (column: DbtModelColumn) =>
+        hasRepeatedAncestor(column) && !getColumnMeta(column).dimension?.sql;
+    const nodePaths = Array.from(
+        new Set(
+            columns
+                .filter(isRoutedLeaf)
+                .flatMap((column) => column.repeated_ancestors ?? []),
+        ),
+    ).sort(
+        (a, b) =>
+            a.split('.').length - b.split('.').length || a.localeCompare(b),
+    );
+
+    const labelsByPath = new Map<string, string>();
+    return nodePaths.reduce<{
+        tables: Omit<Table, 'lineageGraph'>[];
+        joins: NonNullable<DbtModelNode['meta']['joins']>;
+    }>(
+        (acc, nodePath) => {
+            const segments = nodePath.split('.');
+            const segment = segments[segments.length - 1];
+            const parentPath = segments.slice(0, -1).join('.');
+            const parentTable = parentPath
+                ? getNestedTableName(model.name, parentPath)
+                : model.name;
+            const parentLabel = labelsByPath.get(parentPath) ?? modelLabel;
+            const tableName = getNestedTableName(model.name, nodePath);
+            if (reservedTableNames.has(tableName)) {
+                throw new ParseError(
+                    `Repeated column "${nodePath}" in model "${model.name}" would be unnested as table "${tableName}", which is already a model name. Rename one of them.`,
+                );
+            }
+            const container = model.columns[nodePath];
+            const containerMeta = container
+                ? getColumnMeta(container)
+                : undefined;
+            const label =
+                containerMeta?.dimension?.label ??
+                `${parentLabel}: ${friendlyName(segment)}`;
+            labelsByPath.set(nodePath, label);
+
+            const leafColumns = columns
+                .filter(
+                    (column) =>
+                        isRoutedLeaf(column) &&
+                        column.repeated_ancestors?.[
+                            column.repeated_ancestors.length - 1
+                        ] === nodePath,
+                )
+                .map(
+                    ({
+                        repeated_ancestors: _ancestors,
+                        nested_shape: nestedShape,
+                        ...column
+                    }): DbtModelColumn => ({
+                        ...column,
+                        name: column.name.slice(nodePath.length + 1),
+                        ...(nestedShape ? { nested_shape: nestedShape } : {}),
+                    }),
+                );
+            const offsetColumn: DbtModelColumn = {
+                name: 'offset',
+                description: `Position of the element within ${nodePath}, starting at 0`,
+                data_type: DimensionType.NUMBER,
+                meta: {
+                    dimension: {
+                        type: DimensionType.NUMBER,
+                        sql: getOffsetColumnSql(fieldQuoteChar, tableName),
+                    },
+                },
+            };
+            const syntheticModel: DbtModelNode = {
+                ...model,
+                name: tableName,
+                alias: tableName,
+                unique_id: `${model.unique_id}.${nodePath}`,
+                description:
+                    container?.description ??
+                    `Elements of ${nodePath} in ${model.name}`,
+                relation_name: getUnnestFromSql(
+                    adapterType,
+                    fieldQuoteChar,
+                    parentTable,
+                    segment,
+                    tableName,
+                ),
+                columns: Object.fromEntries(
+                    [...leafColumns, offsetColumn].map((column) => [
+                        column.name,
+                        column,
+                    ]),
+                ),
+                meta: { label },
+                config: { ...model.config, meta: {} },
+            };
+            const table: Omit<Table, 'lineageGraph'> = {
+                ...convertTable(
+                    adapterType,
+                    syntheticModel,
+                    spotlightConfig,
+                    startOfWeek,
+                    disableTimestampConversion,
+                    customGranularities,
+                    allowPartialCompilation,
+                    additionalTimeIntervals,
+                    granularityLabels,
+                    true,
+                ),
+                nestedFrom: { parentTable, columnPath: nodePath },
+            };
+            return {
+                tables: [...acc.tables, table],
+                joins: [
+                    ...acc.joins,
+                    {
+                        join: tableName,
+                        sql_on: 'TRUE',
+                        type: 'left',
+                        relationship: JoinRelationship.ONE_TO_MANY,
+                        label,
+                        description: table.description,
+                    },
+                ],
+            };
+        },
+        { tables: [], joins: [] },
+    );
+};
+
 export type ConvertExploresOptions = {
     disableTimestampConversion?: boolean;
     allowPartialCompilation?: boolean;
     postProcessors?: ExplorePostProcessor[];
+    unnestRepeatedColumns?: boolean;
 };
 
 const MODELS_PER_EVENT_LOOP_YIELD = 200;
@@ -1160,6 +1378,7 @@ export async function* iterateExplores(
         disableTimestampConversion,
         allowPartialCompilation,
         postProcessors,
+        unnestRepeatedColumns = false,
     } = options ?? {};
     const resolvedNamesByUniqueId = qualifyManifestNames(
         models.map((model) => ({
@@ -1227,6 +1446,23 @@ export async function* iterateExplores(
         models.map((model) => [model.unique_id, model.name]),
     );
     const tableLineage = translateDbtModelsToTableLineage(resolvedModels);
+    const modelNames = new Set(resolvedModels.map((model) => model.name));
+    const nestedJoinsByModel = new Map<
+        string,
+        NonNullable<DbtModelNode['meta']['joins']>
+    >();
+    // A model's unnested tables join right after the model itself; an aliased
+    // join is skipped because the UNNEST references the parent by name.
+    const withNestedJoins = (
+        baseModelName: string,
+        joins: NonNullable<DbtModelNode['meta']['joins']>,
+    ): NonNullable<DbtModelNode['meta']['joins']> => [
+        ...(nestedJoinsByModel.get(baseModelName) ?? []),
+        ...joins.flatMap((join) => [
+            join,
+            ...(join.alias ? [] : (nestedJoinsByModel.get(join.join) ?? [])),
+        ]),
+    ];
     const additionalTimeIntervals = resolveAdditionalTimeIntervals(
         lightdashProjectConfig.defaults?.additional_time_intervals,
         lightdashProjectConfig.custom_granularities,
@@ -1263,6 +1499,7 @@ export async function* iterateExplores(
                 allowPartialCompilation,
                 additionalTimeIntervals,
                 granularityLabels,
+                unnestRepeatedColumns,
             );
 
             // add lineage
@@ -1278,7 +1515,30 @@ export async function* iterateExplores(
                 ...tableLineage[model.name],
             };
 
+            const nested = unnestRepeatedColumns
+                ? convertNestedTables({
+                      adapterType,
+                      model,
+                      modelLabel: table.label,
+                      reservedTableNames: modelNames,
+                      fieldQuoteChar: warehouseSqlBuilder.getFieldQuoteChar(),
+                      spotlightConfig: lightdashProjectConfig.spotlight,
+                      startOfWeek: warehouseSqlBuilder.getStartOfWeek(),
+                      disableTimestampConversion,
+                      customGranularities:
+                          lightdashProjectConfig.custom_granularities,
+                      allowPartialCompilation,
+                      additionalTimeIntervals,
+                      granularityLabels,
+                  })
+                : { tables: [], joins: [] };
+            if (nested.joins.length > 0) {
+                nestedJoinsByModel.set(model.name, nested.joins);
+            }
             tables.push(tableWithLineage);
+            nested.tables.forEach((nestedTable) =>
+                tables.push({ ...nestedTable, lineageGraph: {} }),
+            );
         } catch (e: unknown) {
             const exploreError: ExploreError = {
                 name: model.name,
@@ -1352,7 +1612,7 @@ export async function* iterateExplores(
                           ...(meta.groups && meta.groups.length > 0
                               ? { groups: meta.groups }
                               : {}),
-                          joins: meta?.joins || [],
+                          joins: withNestedJoins(model.name, meta?.joins || []),
                           description: meta.description,
                           caseSensitive: meta.case_sensitive,
                           tables: tableLookup,
@@ -1417,7 +1677,10 @@ export async function* iterateExplores(
                                     }
                                   : {}),
                               // Inherit joins from base model if not specified in explore config
-                              joins: exploreConfig.joins || meta?.joins || [],
+                              joins: withNestedJoins(
+                                  model.name,
+                                  exploreConfig.joins || meta?.joins || [],
+                              ),
                               description: exploreConfig.description,
                               caseSensitive: exploreConfig.case_sensitive,
                               tables: {
@@ -1717,7 +1980,12 @@ export const attachTypesToModels = (
         { database, schema, name, alias }: DbtModelNode,
         columnName: string,
     ):
-        | { type: DimensionType; timestampDomain: TimestampDomain | undefined }
+        | {
+              type: DimensionType;
+              timestampDomain: TimestampDomain | undefined;
+              nestedShape: WarehouseNestedColumnShape | undefined;
+              repeatedAncestors: string[];
+          }
         | undefined => {
         const tableName = alias || name;
         const hit = lookup(database, schema, tableName);
@@ -1734,6 +2002,19 @@ export const attachTypesToModels = (
                 } else {
                     exactLookups += 1;
                 }
+                const getShape = (columnPath: string) =>
+                    getCatalogNestedColumnShape(
+                        warehouseCatalog,
+                        hit.location.database,
+                        hit.location.schema,
+                        hit.location.table,
+                        columnPath,
+                    );
+                const segments = columnMatch.split('.');
+                const repeatedAncestors = segments
+                    .slice(0, -1)
+                    .map((_, index) => segments.slice(0, index + 1).join('.'))
+                    .filter((prefix) => getShape(prefix)?.repeated === true);
                 return {
                     type: hit.columns[columnMatch],
                     timestampDomain: getCatalogTimestampDomain(
@@ -1743,6 +2024,8 @@ export const attachTypesToModels = (
                         hit.location.table,
                         columnMatch,
                     ),
+                    nestedShape: getShape(columnMatch),
+                    repeatedAncestors,
                 };
             }
         }
@@ -1772,6 +2055,16 @@ export const attachTypesToModels = (
                         // wholesale, so the domain must ride separately.
                         ...(columnType?.timestampDomain
                             ? { timestamp_domain: columnType.timestampDomain }
+                            : {}),
+                        ...(columnType?.nestedShape
+                            ? { nested_shape: columnType.nestedShape }
+                            : {}),
+                        ...(columnType &&
+                        columnType.repeatedAncestors.length > 0
+                            ? {
+                                  repeated_ancestors:
+                                      columnType.repeatedAncestors,
+                              }
                             : {}),
                     },
                 ];

--- a/packages/common/src/types/dbt.ts
+++ b/packages/common/src/types/dbt.ts
@@ -34,6 +34,7 @@ import { type LightdashProjectConfig } from './lightdashProjectConfig';
 import { type PreAggregateSort } from './preAggregate';
 import { type OrderFieldsByStrategy, type TableBase } from './table';
 import { type DefaultTimeDimension, type TimeFrames } from './timeFrames';
+import { type WarehouseNestedColumnShape } from './warehouse';
 
 export enum SupportedDbtAdapter {
     BIGQUERY = 'bigquery',
@@ -86,6 +87,10 @@ export type DbtModelColumn = ColumnInfo & {
     /** Catalog-derived timestamp domain; sibling of data_type because
      *  attachTypesToModels overwrites data_type wholesale. */
     timestamp_domain?: TimestampDomain;
+    /** Catalog-derived shape when the column is a struct or an array. */
+    nested_shape?: WarehouseNestedColumnShape;
+    /** Dotted prefixes of the column path that are arrays, outermost first. */
+    repeated_ancestors?: string[];
     config?: {
         meta?: DbtColumnMetadata;
     };

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -61,6 +61,12 @@ export enum FeatureFlags {
     ChangeChartExplore = 'change-chart-explore',
 
     /**
+     * Compile repeated (array) warehouse columns as unnested virtual tables
+     * instead of leaving their leaves as unqueryable dotted dimensions.
+     */
+    UnnestRepeatedColumns = 'unnest-repeated-columns',
+
+    /**
      * Keep visited dashboard tabs mounted in the DOM (hidden) for instant
      * re-switching. Enabled by default; disabled per-org for orgs where
      * large dashboards spiked browser memory to 3 GB+ from accumulated

--- a/packages/common/src/types/table.ts
+++ b/packages/common/src/types/table.ts
@@ -35,6 +35,8 @@ export type TableBase = {
      */
     schema: string;
     sqlTable: string; // The sql identifier for the table
+    /** Set on tables unnested from a repeated column of `parentTable`; their grain is derived, so they carry no primary key. */
+    nestedFrom?: { parentTable: string; columnPath: string };
     primaryKey?: string[];
     orderFieldsBy?: OrderFieldsByStrategy;
     groupLabel?: string;


### PR DESCRIPTION
Leaves under a repeated BigQuery column compiled to a dotted dereference such as `` `t`.hits.page.pagePath ``, which BigQuery rejects because `hits` is an array, so the only way to use nested data in Lightdash was flattening it in dbt first. Behind the `unnest-repeated-columns` feature flag, each repeated node reached by a documented leaf now appears in the explore as a joined virtual table that is unnested on read. The grain follows the fields a user picks exactly as it does for any other join, parent metrics go through the existing fan-out handling, and non-repeated struct leaves keep their dotted dimension on the model. Nested fields can be referenced from metrics and other dimensions as `${table.a.b}`.

Deployed projects compile in the CLI, so the CLI reads the flag from the server and treats an unreachable or older server as off. BigQuery only for now: with the flag on, a model with repeated columns on another warehouse fails its compile with a message saying so.

Relates: #4102

<details><summary>Some screens</summary>

_Compiled SQL: LEFT OUTER JOIN UNNEST ... WITH OFFSET ... ON TRUE_
<img width="3600" height="1972" alt="image" src="https://github.com/user-attachments/assets/df2db5c6-74c1-4220-b6b7-90f7906a0170" />

_Query across two chained unnests with a deduplicated parent metric_
<img width="3600" height="1972" alt="image" src="https://github.com/user-attachments/assets/cec8ac28-03ed-4b0d-92fe-2dcb7cf0ce8f" />


</details> 
