### PR TITLE
fix(projects): reject SSH tunnel saves without a recognised public key

### DIFF
--- a/packages/backend/src/models/SshKeyPairModel.ts
+++ b/packages/backend/src/models/SshKeyPairModel.ts
@@ -31,12 +31,12 @@ export class SshKeyPairModel {
         };
     }
 
-    async get(publicKey: string): Promise<SshKeyPair> {
+    async find(publicKey: string): Promise<SshKeyPair | null> {
         const row = await this.database('ssh_key_pairs')
             .where({ public_key: publicKey })
             .first();
         if (row === undefined) {
-            throw new Error('Public SSH Key not recognised');
+            return null;
         }
         const privateKey = this.encryptionUtil.decrypt(row.private_key);
         return {

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -364,6 +364,7 @@ import { getFieldValuesMetricQuery } from './fieldValuesQueryBuilder';
 import { getAvailableParameterDefinitions } from './parameters';
 import { projectMergedManifest } from './projectMergedManifest';
 import { applyCurrentGithubInstallationId } from './resolveGithubInstallationId';
+import { resolveSshTunnelPrivateKey } from './resolveSshTunnelCredentials';
 
 const manifestWithCompilationSelection = (
     manifest: DbtManifest,
@@ -1547,14 +1548,12 @@ export class ProjectService extends BaseService {
                 args.warehouseConnection.type === WarehouseTypes.POSTGRES) &&
             args.warehouseConnection.useSshTunnel
         ) {
-            const publicKey = args.warehouseConnection.sshTunnelPublicKey || '';
-            const { privateKey } = await this.sshKeyPairModel.get(publicKey);
             return {
                 ...args,
-                warehouseConnection: {
-                    ...args.warehouseConnection,
-                    sshTunnelPrivateKey: privateKey,
-                },
+                warehouseConnection: await resolveSshTunnelPrivateKey(
+                    this.sshKeyPairModel,
+                    args.warehouseConnection,
+                ),
             };
         }
 

--- a/packages/backend/src/services/ProjectService/resolveSshTunnelCredentials.test.ts
+++ b/packages/backend/src/services/ProjectService/resolveSshTunnelCredentials.test.ts
@@ -1,0 +1,68 @@
+import { ParameterError, WarehouseTypes } from '@lightdash/common';
+import { describe, expect, it, vi } from 'vitest';
+import { type SshKeyPairModel } from '../../models/SshKeyPairModel';
+import {
+    resolveSshTunnelPrivateKey,
+    SSH_TUNNEL_KEY_MISSING_MESSAGE,
+    SSH_TUNNEL_KEY_UNKNOWN_MESSAGE,
+} from './resolveSshTunnelCredentials';
+
+const knownKey = 'ssh-rsa AAAA-known (generated_by_lightdash_at_2026-09-04)';
+
+const sshKeyPairModel = {
+    find: vi.fn(async (publicKey: string) =>
+        publicKey === knownKey ? { publicKey, privateKey: 'PRIVATE' } : null,
+    ),
+} as unknown as SshKeyPairModel;
+
+const credentials = {
+    type: WarehouseTypes.POSTGRES as const,
+    host: 'db.internal',
+    user: 'lightdash',
+    password: 'secret',
+    port: 5432,
+    dbname: 'analytics',
+    schema: 'public',
+    useSshTunnel: true,
+    sshTunnelHost: 'bastion.example.com',
+    sshTunnelPort: 22,
+    sshTunnelUser: 'ubuntu',
+};
+
+describe('resolveSshTunnelPrivateKey', () => {
+    it('attaches the private key when the public key is known', async () => {
+        const resolved = await resolveSshTunnelPrivateKey(sshKeyPairModel, {
+            ...credentials,
+            sshTunnelPublicKey: knownKey,
+        });
+        expect(resolved.sshTunnelPrivateKey).toBe('PRIVATE');
+        expect(resolved.sshTunnelPublicKey).toBe(knownKey);
+    });
+
+    it.each([
+        ['undefined', undefined],
+        ['empty', ''],
+        ['whitespace', '   '],
+    ])(
+        'rejects a %s public key with an actionable ParameterError',
+        async (_label, sshTunnelPublicKey) => {
+            await expect(
+                resolveSshTunnelPrivateKey(sshKeyPairModel, {
+                    ...credentials,
+                    sshTunnelPublicKey,
+                }),
+            ).rejects.toThrow(
+                new ParameterError(SSH_TUNNEL_KEY_MISSING_MESSAGE),
+            );
+        },
+    );
+
+    it('rejects a public key that is not in ssh_key_pairs with a ParameterError', async () => {
+        await expect(
+            resolveSshTunnelPrivateKey(sshKeyPairModel, {
+                ...credentials,
+                sshTunnelPublicKey: 'ssh-rsa AAAA-stale (generated elsewhere)',
+            }),
+        ).rejects.toThrow(new ParameterError(SSH_TUNNEL_KEY_UNKNOWN_MESSAGE));
+    });
+});

--- a/packages/backend/src/services/ProjectService/resolveSshTunnelCredentials.ts
+++ b/packages/backend/src/services/ProjectService/resolveSshTunnelCredentials.ts
@@ -1,0 +1,33 @@
+import {
+    ParameterError,
+    type CreatePostgresCredentials,
+    type CreateRedshiftCredentials,
+} from '@lightdash/common';
+import { type SshKeyPairModel } from '../../models/SshKeyPairModel';
+
+type SshTunnelCredentials =
+    | CreatePostgresCredentials
+    | CreateRedshiftCredentials;
+
+export const SSH_TUNNEL_KEY_MISSING_MESSAGE =
+    'SSH tunnel is enabled but no public key has been generated. Click "Generate public key", add the key to your SSH host, then save again.';
+
+export const SSH_TUNNEL_KEY_UNKNOWN_MESSAGE =
+    'The SSH public key on this connection is not recognised by Lightdash. Click "Regenerate key", add the new key to your SSH host, then save again.';
+
+export const resolveSshTunnelPrivateKey = async <
+    T extends SshTunnelCredentials,
+>(
+    sshKeyPairModel: SshKeyPairModel,
+    credentials: T,
+): Promise<T & { sshTunnelPrivateKey: string }> => {
+    const publicKey = credentials.sshTunnelPublicKey ?? '';
+    if (publicKey.trim() === '') {
+        throw new ParameterError(SSH_TUNNEL_KEY_MISSING_MESSAGE);
+    }
+    const keyPair = await sshKeyPairModel.find(publicKey);
+    if (keyPair === null) {
+        throw new ParameterError(SSH_TUNNEL_KEY_UNKNOWN_MESSAGE);
+    }
+    return { ...credentials, sshTunnelPrivateKey: keyPair.privateKey };
+};

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/PostgresForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/PostgresForm.tsx
@@ -354,30 +354,31 @@ const PostgresForm: FC<{
                                     )}
                                 />
 
-                                {sshTunnelPublicKey && (
-                                    <TextInput
-                                        name="warehouse.sshTunnelPublicKey"
-                                        {...form.getInputProps(
-                                            'warehouse.sshTunnelPublicKey',
-                                        )}
-                                        label="Generated SSH Public Key"
-                                        readOnly={true}
-                                        disabled={disabled}
-                                        rightSectionPointerEvents="all"
-                                        rightSection={
-                                            <>
-                                                <CopyActionIcon
-                                                    value={sshTunnelPublicKey}
-                                                    tooltipPosition="right"
-                                                    aria-label="Copy SSH tunnel public key"
-                                                    onMouseDown={(event) =>
-                                                        event.preventDefault()
-                                                    }
-                                                />
-                                            </>
-                                        }
-                                    />
-                                )}
+                                <TextInput
+                                    name="warehouse.sshTunnelPublicKey"
+                                    {...form.getInputProps(
+                                        'warehouse.sshTunnelPublicKey',
+                                    )}
+                                    value={sshTunnelPublicKey ?? ''}
+                                    label="Generated SSH Public Key"
+                                    description="Generate a key and add it to your SSH host before saving."
+                                    placeholder="No key generated yet"
+                                    readOnly={true}
+                                    disabled={disabled}
+                                    rightSectionPointerEvents="all"
+                                    rightSection={
+                                        sshTunnelPublicKey ? (
+                                            <CopyActionIcon
+                                                value={sshTunnelPublicKey}
+                                                tooltipPosition="right"
+                                                aria-label="Copy SSH tunnel public key"
+                                                onMouseDown={(event) =>
+                                                    event.preventDefault()
+                                                }
+                                            />
+                                        ) : undefined
+                                    }
+                                />
                                 <Button
                                     onClick={() => mutate()}
                                     loading={isLoading}

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/RedshiftForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/RedshiftForm.tsx
@@ -349,30 +349,31 @@ const RedshiftForm: FC<{
                                     )}
                                 />
 
-                                {sshTunnelPublicKey && (
-                                    <TextInput
-                                        name="warehouse.sshTunnelPublicKey"
-                                        {...form.getInputProps(
-                                            'warehouse.sshTunnelPublicKey',
-                                        )}
-                                        label="Generated SSH Public Key"
-                                        readOnly={true}
-                                        disabled={disabled}
-                                        rightSectionPointerEvents="all"
-                                        rightSection={
-                                            <>
-                                                <CopyActionIcon
-                                                    value={sshTunnelPublicKey}
-                                                    tooltipPosition="right"
-                                                    aria-label="Copy SSH tunnel public key"
-                                                    onMouseDown={(event) =>
-                                                        event.preventDefault()
-                                                    }
-                                                />
-                                            </>
-                                        }
-                                    />
-                                )}
+                                <TextInput
+                                    name="warehouse.sshTunnelPublicKey"
+                                    {...form.getInputProps(
+                                        'warehouse.sshTunnelPublicKey',
+                                    )}
+                                    value={sshTunnelPublicKey ?? ''}
+                                    label="Generated SSH Public Key"
+                                    description="Generate a key and add it to your SSH host before saving."
+                                    placeholder="No key generated yet"
+                                    readOnly={true}
+                                    disabled={disabled}
+                                    rightSectionPointerEvents="all"
+                                    rightSection={
+                                        sshTunnelPublicKey ? (
+                                            <CopyActionIcon
+                                                value={sshTunnelPublicKey}
+                                                tooltipPosition="right"
+                                                aria-label="Copy SSH tunnel public key"
+                                                onMouseDown={(event) =>
+                                                    event.preventDefault()
+                                                }
+                                            />
+                                        ) : undefined
+                                    }
+                                />
                                 <Button
                                     onClick={() => mutate()}
                                     loading={isLoading}

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/validators.test.ts
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/validators.test.ts
@@ -1,0 +1,54 @@
+import { WarehouseTypes } from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import { type ProjectConnectionForm } from '../types';
+import { PostgresDefaultValues, RedshiftDefaultValues } from './defaultValues';
+import {
+    createWarehouseValueValidators,
+    SSH_TUNNEL_PUBLIC_KEY_REQUIRED_MESSAGE,
+    warehouseValueValidators,
+} from './validators';
+
+const formValues = (
+    warehouse: ProjectConnectionForm['warehouse'],
+): ProjectConnectionForm => ({ warehouse }) as unknown as ProjectConnectionForm;
+
+describe.each([
+    ['postgres', WarehouseTypes.POSTGRES, PostgresDefaultValues],
+    ['redshift', WarehouseTypes.REDSHIFT, RedshiftDefaultValues],
+] as const)('%s sshTunnelPublicKey validation', (_label, type, defaults) => {
+    const validators = [
+        ['update', warehouseValueValidators[type].sshTunnelPublicKey],
+        ['create', createWarehouseValueValidators[type].sshTunnelPublicKey],
+    ] as const;
+
+    it.each(validators)(
+        '%s form rejects an empty key when the tunnel is enabled',
+        (_form, validate) => {
+            const values = formValues({ ...defaults, useSshTunnel: true });
+            expect(validate('', values)).toBe(
+                SSH_TUNNEL_PUBLIC_KEY_REQUIRED_MESSAGE,
+            );
+            expect(validate('   ', values)).toBe(
+                SSH_TUNNEL_PUBLIC_KEY_REQUIRED_MESSAGE,
+            );
+        },
+    );
+
+    it.each(validators)(
+        '%s form accepts a generated key when the tunnel is enabled',
+        (_form, validate) => {
+            const values = formValues({ ...defaults, useSshTunnel: true });
+            expect(
+                validate('ssh-rsa AAAA (generated)', values),
+            ).toBeUndefined();
+        },
+    );
+
+    it.each(validators)(
+        '%s form ignores the key when the tunnel is disabled',
+        (_form, validate) => {
+            const values = formValues({ ...defaults, useSshTunnel: false });
+            expect(validate('', values)).toBeUndefined();
+        },
+    );
+});

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/validators.ts
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/validators.ts
@@ -15,7 +15,23 @@ import {
 } from '../../../utils/fieldValidators';
 import { type ProjectConnectionForm } from '../types';
 
-type Validator = (value: string) => string | undefined;
+type Validator = (
+    value: string,
+    values: ProjectConnectionForm,
+) => string | undefined;
+
+const sshTunnelEnabled = (values: ProjectConnectionForm) =>
+    (values.warehouse.type === WarehouseTypes.POSTGRES ||
+        values.warehouse.type === WarehouseTypes.REDSHIFT) &&
+    values.warehouse.useSshTunnel === true;
+
+export const SSH_TUNNEL_PUBLIC_KEY_REQUIRED_MESSAGE =
+    'SSH tunnel is enabled but no public key has been generated. Click "Generate public key" and add it to your SSH host before saving.';
+
+const sshTunnelPublicKeyValidator: Validator = (value, values) =>
+    sshTunnelEnabled(values) && (!value || value.trim() === '')
+        ? SSH_TUNNEL_PUBLIC_KEY_REQUIRED_MESSAGE
+        : undefined;
 
 export const warehouseValueValidators: Record<
     WarehouseTypes,
@@ -38,12 +54,14 @@ export const warehouseValueValidators: Record<
         host: hasNoWhiteSpaces('Host'),
         user: hasNoWhiteSpaces('User'),
         dbname: hasNoWhiteSpaces('Database name'),
+        sshTunnelPublicKey: sshTunnelPublicKeyValidator,
     },
     [WarehouseTypes.REDSHIFT]: {
         schema: hasNoWhiteSpaces('Schema'),
         host: hasNoWhiteSpaces('Host'),
         user: hasNoWhiteSpaces('User'),
         dbname: hasNoWhiteSpaces('Database name'),
+        sshTunnelPublicKey: sshTunnelPublicKeyValidator,
     },
     [WarehouseTypes.SNOWFLAKE]: {
         schema: hasNoWhiteSpaces('Schema'),
@@ -165,6 +183,7 @@ export const createWarehouseValueValidators: Record<
         user: required('User', hasNoWhiteSpaces),
         password: required('Password'),
         dbname: required('Database name', hasNoWhiteSpaces),
+        sshTunnelPublicKey: sshTunnelPublicKeyValidator,
     },
     [WarehouseTypes.REDSHIFT]: {
         schema: required('Schema', hasNoWhiteSpaces),
@@ -172,6 +191,7 @@ export const createWarehouseValueValidators: Record<
         user: required('User', hasNoWhiteSpaces),
         password: required('Password'),
         dbname: required('Database name', hasNoWhiteSpaces),
+        sshTunnelPublicKey: sshTunnelPublicKeyValidator,
     },
     [WarehouseTypes.SNOWFLAKE]: {
         schema: required('Schema', hasNoWhiteSpaces),


### PR DESCRIPTION
Closes https://github.com/lightdash/lightdash/issues/28618 (PROD-10932)

## Problem

Saving a Postgres or Redshift connection with **Use SSH tunnel** on, but without a public key Lightdash recognises, failed with a generic 500 ("Failed to update project / Something went wrong") and a Sentry event. The backend called `SshKeyPairModel.get(sshTunnelPublicKey || '')`, which threw a plain `Error` on a miss, so the user got no hint that the missing step was the key.

Two ways to hit it:

- No key generated at all (empty string).
- A key that is not in `ssh_key_pairs`. This is what the support thread shows: the key input was populated at submit time, but every save with the tunnel on died in `SshKeyPairModel.get`. A fresh key had been generated, but a full page reload happened before saving, which resets the form to the saved (stale) key.

## Fix

**Backend**

- `SshKeyPairModel.get` becomes `find` and returns `null` on a miss instead of throwing.
- New `resolveSshTunnelPrivateKey` helper (`services/ProjectService/resolveSshTunnelCredentials.ts`) does the lookup and throws a `ParameterError` (400) with an actionable message for both cases: "no public key has been generated, click Generate public key" and "key is not recognised, click Regenerate key". `ProjectService._resolveWarehouseClientCredentials` uses it for the Postgres and Redshift SSH path, which covers create, update, test connection and warehouse-credentials update.

**Frontend**

- `warehouse.sshTunnelPublicKey` is validated in both the create and update project forms for Postgres and Redshift: required when `useSshTunnel` is on, ignored otherwise.
- The "Generated SSH Public Key" field is always rendered inside the SSH section (empty state "No key generated yet", with a description), so the inline error has somewhere to show and the missing step is visible. The copy button only renders when a key exists.

## Proof

Local dev, Postgres seed project, `PATCH /api/v1/projects/:uuid` with `useSshTunnel: true`.

| Case | Before | After |
|---|---|---|
| Empty key | `500 UnexpectedServerError "Something went wrong."` | `400 ParameterError "SSH tunnel is enabled but no public key has been generated. Click \"Generate public key\", add the key to your SSH host, then save again."` |
| Key not in `ssh_key_pairs` | `500 UnexpectedServerError "Something went wrong."` | `400 ParameterError "The SSH public key on this connection is not recognised by Lightdash. Click \"Regenerate key\", add the new key to your SSH host, then save again."` |

UI (headless Playwright, toggle tunnel on, save without generating a key):

- Before: toast "Failed to update project / Something went wrong / Notify support", no inline error.
- After: form is blocked client-side, inline error under the key field plus a "Form errors" toast with the same message. No request is sent.

The known-key path is unchanged (`find` returns the pair and the private key is attached), covered by the new unit test.

<img width="1137" height="456" alt="image" src="https://github.com/user-attachments/assets/724c956c-f67c-4965-a779-45fb1bdddfb5" />
<img width="580" height="501" alt="image" src="https://github.com/user-attachments/assets/8c97cc5c-40e3-479d-91a6-e84aef4e930a" />


## Regression analysis

- The only behavioural change on the happy path is `get` → `find`; the resolved credentials object is identical.
- Non-SSH warehouses are untouched: the validator returns `undefined` unless `useSshTunnel` is `true` on a Postgres/Redshift form.
- Toggling the tunnel off with an empty key still saves, as before.
- Error status changes from 500 to 400 for the two failure cases only. Nothing depends on the 500.

## Tests

- `packages/backend/src/services/ProjectService/resolveSshTunnelCredentials.test.ts` (known key, undefined/empty/whitespace key, unknown key).
- `packages/frontend/src/components/ProjectConnection/WarehouseForms/validators.test.ts` (create and update validators for Postgres and Redshift, tunnel on and off).

## Not covered here

Why the customer's saved key was not in `ssh_key_pairs` is still open (see the investigation notes on the Linear ticket). This PR makes that state recoverable from the UI: the user now sees "not recognised, click Regenerate key" instead of a 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E25gtARWrvu12k5m25Vkor
