### PR TITLE
fix(frontend): resolve project slugs in useProjectUuid outside ProjectRoute

### DIFF
--- a/packages/frontend/src/components/DataAppVizRenderer/index.test.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.test.tsx
@@ -80,6 +80,9 @@ const mocks = vi.hoisted(() => ({
 vi.mock('react-router', () => ({
     useParams: () => ({ projectUuid: 'project-uuid' }),
 }));
+vi.mock('../../hooks/useProjectUuid', () => ({
+    useProjectUuid: () => 'project-uuid',
+}));
 vi.mock('../../ee/providers/Embed/useEmbed', () => ({
     default: () => ({ embedToken: mocks.embedToken.current }),
 }));

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/CustomVisConfig.test.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/CustomVisConfig.test.tsx
@@ -34,6 +34,9 @@ vi.mock('../../../../hooks/useServerOrClientFeatureFlag', () => ({
         data: { enabled: enabledFlags.has(featureFlag) },
     }),
 }));
+vi.mock('../../../../hooks/useProjectUuid', () => ({
+    useProjectUuid: () => 'project-1',
+}));
 vi.mock('../../../LightdashVisualization/useVisualizationContext', () => ({
     useVisualizationContext: vi.fn(),
 }));

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.test.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.test.tsx
@@ -116,6 +116,9 @@ vi.mock('../../../hooks/useServerOrClientFeatureFlag', () => ({
         isLoading: false,
     }),
 }));
+vi.mock('../../../hooks/useProjectUuid', () => ({
+    useProjectUuid: () => 'project-1',
+}));
 vi.mock('../../../features/chartTypes/hooks/useDataAppVisualization', () => ({
     useDataAppVisualization: vi.fn(),
 }));

--- a/packages/frontend/src/ee/features/agentOnboarding/AgentOnboardingStartPage.test.tsx
+++ b/packages/frontend/src/ee/features/agentOnboarding/AgentOnboardingStartPage.test.tsx
@@ -16,6 +16,10 @@ vi.mock('../../../hooks/useProject', () => ({
     useProject: () => ({ data: state.project, isInitialLoading: false }),
 }));
 
+vi.mock('../../../hooks/useProjectUuid', () => ({
+    useProjectUuid: () => 'project-uuid',
+}));
+
 vi.mock('../../../hooks/useServerOrClientFeatureFlag', () => ({
     useServerFeatureFlag: () => ({
         data: { enabled: state.isFlagEnabled },

--- a/packages/frontend/src/ee/pages/AiAgents/DeepResearchReportPage.test.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/DeepResearchReportPage.test.tsx
@@ -21,6 +21,10 @@ vi.mock('../../features/aiCopilot/hooks/useDeepResearch', () => ({
     useDeepResearchReport,
 }));
 
+vi.mock('../../../hooks/useProjectUuid', () => ({
+    useProjectUuid: () => 'project-1',
+}));
+
 vi.mock(
     '../../features/aiCopilot/components/DeepResearch/DeepResearchReport',
     () => ({

--- a/packages/frontend/src/features/mergeQuery/context/MergeContext.test.tsx
+++ b/packages/frontend/src/features/mergeQuery/context/MergeContext.test.tsx
@@ -29,6 +29,10 @@ vi.mock('react-router', () => ({
     useSearchParams: () => [searchParams, setSearchParams],
 }));
 
+vi.mock('../../../hooks/useProjectUuid', () => ({
+    useProjectUuid: () => 'project-uuid',
+}));
+
 vi.mock('../../../hooks/useQueryResults', () => ({
     useInfiniteQueryResults: () => ({
         data: undefined,

--- a/packages/frontend/src/hooks/useProjectUuid.test.tsx
+++ b/packages/frontend/src/hooks/useProjectUuid.test.tsx
@@ -1,0 +1,96 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const PROJECT_UUID = '0f1b2c3d-4e5f-4a6b-8c7d-9e0f1a2b3c4d';
+const OTHER_PROJECT_UUID = '1a2b3c4d-5e6f-4a7b-8c9d-0e1f2a3b4c5d';
+
+let routeProjectParam: string | undefined;
+vi.mock('react-router', () => ({
+    useParams: () => ({ projectUuid: routeProjectParam }),
+}));
+
+let projectRouteContext: { projectUuid: string } | null;
+vi.mock('./useProjectRoute', () => ({
+    useOptionalProjectRoute: () => projectRouteContext,
+}));
+
+let embedProjectUuid: string | undefined;
+vi.mock('../ee/providers/Embed/useEmbed', () => ({
+    default: () => ({ projectUuid: embedProjectUuid }),
+}));
+
+const useProjectsMock = vi.fn();
+vi.mock('./useProjects', () => ({
+    useProjects: (options: { enabled: boolean }) => useProjectsMock(options),
+}));
+
+import { useProjectUuid } from './useProjectUuid';
+
+describe('useProjectUuid', () => {
+    beforeEach(() => {
+        routeProjectParam = undefined;
+        projectRouteContext = null;
+        embedProjectUuid = undefined;
+        useProjectsMock.mockReset();
+        useProjectsMock.mockReturnValue({
+            data: [
+                { projectUuid: PROJECT_UUID, slug: 'my-project' },
+                { projectUuid: OTHER_PROJECT_UUID, slug: 'other-project' },
+            ],
+        });
+    });
+
+    it('prefers the uuid resolved by ProjectRoute', () => {
+        projectRouteContext = { projectUuid: PROJECT_UUID };
+        routeProjectParam = 'my-project';
+
+        const { result } = renderHook(() => useProjectUuid());
+
+        expect(result.current).toBe(PROJECT_UUID);
+        expect(useProjectsMock).toHaveBeenCalledWith({ enabled: false });
+    });
+
+    it('returns a uuid url param as is without fetching projects', () => {
+        routeProjectParam = PROJECT_UUID;
+
+        const { result } = renderHook(() => useProjectUuid());
+
+        expect(result.current).toBe(PROJECT_UUID);
+        expect(useProjectsMock).toHaveBeenCalledWith({ enabled: false });
+    });
+
+    it('resolves a slug url param outside ProjectRoute', () => {
+        routeProjectParam = 'other-project';
+
+        const { result } = renderHook(() => useProjectUuid());
+
+        expect(result.current).toBe(OTHER_PROJECT_UUID);
+        expect(useProjectsMock).toHaveBeenCalledWith({ enabled: true });
+    });
+
+    it('never returns the raw slug while projects are loading', () => {
+        routeProjectParam = 'other-project';
+        useProjectsMock.mockReturnValue({ data: undefined });
+
+        const { result } = renderHook(() => useProjectUuid());
+
+        expect(result.current).toBeUndefined();
+    });
+
+    it('returns undefined for a slug that does not match a project', () => {
+        routeProjectParam = 'unknown-project';
+
+        const { result } = renderHook(() => useProjectUuid());
+
+        expect(result.current).toBeUndefined();
+    });
+
+    it('falls back to the embed project uuid without a url param', () => {
+        embedProjectUuid = PROJECT_UUID;
+
+        const { result } = renderHook(() => useProjectUuid());
+
+        expect(result.current).toBe(PROJECT_UUID);
+        expect(useProjectsMock).toHaveBeenCalledWith({ enabled: false });
+    });
+});

--- a/packages/frontend/src/hooks/useProjectUuid.ts
+++ b/packages/frontend/src/hooks/useProjectUuid.ts
@@ -1,6 +1,8 @@
 import { useParams } from 'react-router';
+import { validate as isUuidString } from 'uuid';
 import useEmbed from '../ee/providers/Embed/useEmbed';
 import { useOptionalProjectRoute } from './useProjectRoute';
+import { useProjects } from './useProjects';
 
 /**
  * We have a couple ways to derive the projectUuid:
@@ -8,13 +10,28 @@ import { useOptionalProjectRoute } from './useProjectRoute';
  * - From the embed context when logging in via the Lightdash SDK or embed URL
  *
  * We prioritize the URL over the embed context to facilitate the most use-cases.
+ *
+ * In-app links use the project slug, so the URL segment is only a uuid when
+ * ProjectRoute has resolved it. Components mounted outside ProjectRoute (the
+ * AI launcher, full-page AI routes) resolve a slug here the same way.
  */
 export function useProjectUuid() {
     const projectRoute = useOptionalProjectRoute();
-    const { projectUuid: projectUuidFromParams } = useParams<{
+    const { projectUuid: projectIdentifierFromParams } = useParams<{
         projectUuid: string;
     }>();
     const { projectUuid: embedProjectUuid } = useEmbed();
+
+    const isParamSlug =
+        !projectRoute &&
+        !!projectIdentifierFromParams &&
+        !isUuidString(projectIdentifierFromParams);
+    const { data: projects } = useProjects({ enabled: isParamSlug });
+    const projectUuidFromParams = isParamSlug
+        ? projects?.find(
+              (project) => project.slug === projectIdentifierFromParams,
+          )?.projectUuid
+        : projectIdentifierFromParams;
 
     return (
         projectRoute?.projectUuid || projectUuidFromParams || embedProjectUuid

--- a/packages/frontend/src/pages/AppPreviewTest.capturedQueryCount.test.tsx
+++ b/packages/frontend/src/pages/AppPreviewTest.capturedQueryCount.test.tsx
@@ -68,6 +68,10 @@ vi.mock('../features/apps/hooks/useGetApp', () => ({
     }),
 }));
 
+vi.mock('../hooks/useProjectUuid', () => ({
+    useProjectUuid: () => 'project-uuid',
+}));
+
 vi.mock('../providers/Fullscreen/useNativeFullscreenToggle', () => ({
     default: () => ({
         enabled: false,

--- a/packages/frontend/src/pages/ChartTypeBuilder.test.tsx
+++ b/packages/frontend/src/pages/ChartTypeBuilder.test.tsx
@@ -30,6 +30,9 @@ import ChartTypeBuilder from './ChartTypeBuilder';
 vi.mock('../hooks/useServerOrClientFeatureFlag', () => ({
     useServerFeatureFlag: vi.fn(),
 }));
+vi.mock('../hooks/useProjectUuid', () => ({
+    useProjectUuid: () => 'p1',
+}));
 vi.mock('../features/apps/hooks/useCanCreateDataApp', () => ({
     useCanCreateDataApp: vi.fn(),
 }));

--- a/packages/frontend/src/pages/ChartTypeGallery.test.tsx
+++ b/packages/frontend/src/pages/ChartTypeGallery.test.tsx
@@ -19,6 +19,10 @@ vi.mock('../hooks/useServerOrClientFeatureFlag', () => ({
     useServerFeatureFlag: vi.fn(),
 }));
 
+vi.mock('../hooks/useProjectUuid', () => ({
+    useProjectUuid: () => 'project-1',
+}));
+
 vi.mock('../features/chartTypes/hooks/useDataAppVisualizations', () => ({
     useDataAppVisualizations: vi.fn(),
 }));

--- a/packages/frontend/src/pages/MinimalApp.captureMode.test.tsx
+++ b/packages/frontend/src/pages/MinimalApp.captureMode.test.tsx
@@ -32,6 +32,9 @@ vi.mock('react-router', () => ({
     useParams: () => ({ projectUuid: 'project-uuid', appUuid: 'app-uuid' }),
     useSearchParams: () => [mocks.searchParams, vi.fn()],
 }));
+vi.mock('../hooks/useProjectUuid', () => ({
+    useProjectUuid: () => 'project-uuid',
+}));
 
 vi.mock('../features/apps/AppIframePreview', () => ({
     default: mocks.iframePreview,

--- a/packages/frontend/src/pages/MinimalApp.captureReload.test.tsx
+++ b/packages/frontend/src/pages/MinimalApp.captureReload.test.tsx
@@ -22,6 +22,9 @@ vi.mock('react-router', () => ({
     useParams: () => ({ projectUuid: 'project-uuid', appUuid: 'app-uuid' }),
     useSearchParams: () => [mocks.searchParams, vi.fn()],
 }));
+vi.mock('../hooks/useProjectUuid', () => ({
+    useProjectUuid: () => 'project-uuid',
+}));
 
 vi.mock('../features/apps/AppIframePreview', () => ({
     default: mocks.iframePreview,

--- a/packages/frontend/src/pages/MinimalDashboard.tsx
+++ b/packages/frontend/src/pages/MinimalDashboard.tsx
@@ -642,7 +642,7 @@ const MinimalDashboard: FC = () => {
 };
 
 const MinimalDashboardRoute: FC = () => {
-    const projectIdentifier = useProjectUuid();
+    const { projectUuid: projectIdentifier } = useParams();
     const isProjectUuid = isUuidString(projectIdentifier ?? '');
     const projectsQuery = useProjects({
         enabled: !!projectIdentifier && !isProjectUuid,


### PR DESCRIPTION
## Problem

Since #27826, in-app links use the project slug in the URL (`/projects/<slug>/...`). `ProjectRoute` resolves the slug to a uuid and exposes it through context, and #27914 moved every consumer onto `useProjectUuid()` on the assumption that it always returns a uuid.

That assumption breaks for anything rendered outside `ProjectRoute`. `useProjectUuid()` falls back to the raw `:projectUuid` URL param when there is no route context, and React Router exposes child route params to ancestor layouts. The AI launcher is mounted at the app root in `App.tsx`, above the router's `ProjectRoute`, so when it is opened from a slug URL the chart renderer inside it (`AiVisualizationRenderer`, plus `AgentVisualizationMetricsAndDimensions`, `MemoryCitation`, `AgentChatUserBubble`) sends the slug to uuid-only endpoints:

```
GET /api/v1/projects/<slug>/explores/<explore>   → 500
GET /api/v1/projects/<slug>/colorPalette          → 500
```

The backend feeds the slug into `where project_uuid = $1`, Postgres rejects it with `invalid input syntax for type uuid`, and the user sees "Something went wrong" on the chart the agent just produced. The launcher's own thread and artifact requests use `useActiveProjectUuid()`, which validates the param, so only the chart requests fail.

The same fallback affects the full-page AI routes (`/projects/:projectUuid/ai-agents/*`), which are wrapped in `PrivateRoute` rather than `ProjectRoute`, if a user lands there via a slug URL.

Sentry shows this on the explore and colour palette endpoints across many instances on every release since 2.122.0.

## Sentry

- Issue: https://lightdash.sentry.io/issues/LIGHTDASH-BACKEND-CG4 (a catch-all group for `pg-protocol` database errors, so it mixes several causes; the events for this bug are the ones whose message ends in `invalid input syntax for type uuid: "<project-slug>"`).
- Events isolated to this bug, grouped by endpoint: https://lightdash.sentry.io/explore/discover/homepage/?dataset=errors&queryDataset=error-events&query=issue%3ALIGHTDASH-BACKEND-CG4+error.value%3A%22*invalid+input+syntax+for+type+uuid*%22&field=transaction&field=count%28%29&field=count_unique%28user.email%29&sort=-count%28%29&statsPeriod=14d&mode=aggregate&yAxis=count%28%29
- Over the last 14 days that query shows roughly 250 explore and 220 colour palette failures from about 40 users across many instances, all on releases 2.122.0 and later.

## Fix

`useProjectUuid()` now only trusts the URL param when it validates as a uuid. Otherwise it resolves the slug against the organisation's projects list, the same way `ProjectRoute` does, and returns `undefined` until that resolves so callers with `enabled: !!projectUuid` guards wait instead of firing a slug request. The projects query is only enabled when a slug actually needs resolving, so uuid URLs and pages under `ProjectRoute` make no extra request.

## Regression analysis

- Under `ProjectRoute`: unchanged, the context uuid wins and the projects query stays disabled.
- Uuid URL outside `ProjectRoute` (existing AI routes, minimal pages): unchanged, the param is returned as is.
- Embed: embed URLs carry uuids, so the slug branch never enables; the embed fallback order is unchanged.
- Slug URL outside `ProjectRoute`: previously returned the slug (the bug); now returns the resolved uuid, or `undefined` while loading / when no project matches.

## Testing

- New `useProjectUuid.test.tsx` covers the context, uuid param, slug param, loading, unmatched slug, and embed cases.
- `pnpm -F frontend test src/hooks/useProjectUuid.test.tsx`, lint, format and typecheck pass.

Relates: SPK-1206
Relates: GLITCH-689

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UBjVoAmfboFYiQucGPCtwD
