### PR TITLE
fix(frontend): replace the share redirect history entry so back returns to the dashboard

### DIFF
--- a/packages/frontend/src/pages/ShareRedirect.test.tsx
+++ b/packages/frontend/src/pages/ShareRedirect.test.tsx
@@ -1,0 +1,90 @@
+import { MantineProvider } from '@mantine/core';
+import { render, screen, waitFor } from '@testing-library/react';
+import { createMemoryRouter, RouterProvider } from 'react-router';
+
+const state = vi.hoisted(() => ({
+    useGetShare: vi.fn(),
+}));
+
+vi.mock('../hooks/useShare', () => ({
+    useGetShare: state.useGetShare,
+}));
+
+// eslint-disable-next-line import/first
+import ShareRedirect from './ShareRedirect';
+
+const DASHBOARD_PATH = '/projects/p1/dashboards/d1/view';
+const EXPLORER_PATH = '/projects/p1/tables/orders';
+
+const renderFromDashboard = () => {
+    const router = createMemoryRouter(
+        [
+            { path: DASHBOARD_PATH, element: <div>Dashboard page</div> },
+            { path: '/share/:shareNanoid', element: <ShareRedirect /> },
+            { path: EXPLORER_PATH, element: <div>Explorer page</div> },
+        ],
+        {
+            initialEntries: [DASHBOARD_PATH, '/share/abc123'],
+            initialIndex: 1,
+        },
+    );
+    render(
+        <MantineProvider>
+            <RouterProvider router={router} />
+        </MantineProvider>,
+    );
+    return router;
+};
+
+describe('ShareRedirect', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('replaces the share entry so one back step returns to the previous page', async () => {
+        state.useGetShare.mockReturnValue({
+            data: {
+                url: `${EXPLORER_PATH}?create_saved_chart_version=%7B%7D`,
+            },
+            error: null,
+        });
+
+        const router = renderFromDashboard();
+
+        await screen.findByText('Explorer page');
+        expect(router.state.location.pathname).toBe(EXPLORER_PATH);
+        expect(router.state.location.search).toBe(
+            '?create_saved_chart_version=%7B%7D',
+        );
+
+        await router.navigate(-1);
+
+        await waitFor(() =>
+            expect(router.state.location.pathname).toBe(DASHBOARD_PATH),
+        );
+        expect(await screen.findByText('Dashboard page')).toBeInTheDocument();
+    });
+
+    it('stays on the loading state until the share resolves', () => {
+        state.useGetShare.mockReturnValue({ data: undefined, error: null });
+
+        const router = renderFromDashboard();
+
+        expect(screen.getByText('Loading...')).toBeInTheDocument();
+        expect(router.state.location.pathname).toBe('/share/abc123');
+    });
+
+    it('shows an error state when the share link does not exist', () => {
+        state.useGetShare.mockReturnValue({
+            data: undefined,
+            error: { error: { statusCode: 404 } },
+        });
+
+        const router = renderFromDashboard();
+
+        expect(
+            screen.getByText('Shared link does not exist'),
+        ).toBeInTheDocument();
+        expect(router.state.location.pathname).toBe('/share/abc123');
+    });
+});

--- a/packages/frontend/src/pages/ShareRedirect.tsx
+++ b/packages/frontend/src/pages/ShareRedirect.tsx
@@ -12,7 +12,7 @@ const ShareRedirect: FC = () => {
 
     useEffect(() => {
         if (data && data.url) {
-            void navigate(data.url);
+            void navigate(data.url, { replace: true });
         }
     }, [data, navigate]);
 


### PR DESCRIPTION
Closes: #28622

### Description

"Explore from here" (from the View underlying data modal, chart pages, dashboard tile menus, the metrics catalog and AI charts) navigates to a short `/share/:nanoid` link so the long Explorer URL never hits URL length limits. The redirect page then navigated to the destination with a **push**, so the redirect stayed in browser history:

```
[dashboard, /share/abc, explorer]
```

Pressing back landed on `/share/abc`, which mounted again and pushed the Explorer back on top. The dashboard was unreachable through the back button.

`ShareRedirect` now navigates with `{ replace: true }`, so the redirect entry is replaced by the destination:

```
[dashboard, explorer]
```

One back press returns to the page that created the link. Same effect for the new-tab callers (back inside the new tab used to bounce too) and for pasted share links (back now goes to the referrer instead of re-entering the redirect).

A community contributor reached the same line in #28701 before it was auto-closed. This PR adds a behavioural test on top: a real memory router seeded with a dashboard entry, asserting the location after `navigate(-1)`. It fails on `main` and passes with the fix.

Proof of work with before/after recordings against the dev app: https://claude.ai/code/artifact/b85d5472-536c-4a04-b7d6-1e50a445a9d9

### Regression analysis

- The Explorer already uses `replace` for its own URL rewrites (consuming `create_saved_chart_version`, clearing the query), so the share hop was the only pushed intermediate entry. No other page depends on `/share/:nanoid` remaining in history.
- The alternative of skipping the short link for same-tab navigation was rejected: the hop exists because of URL length (#9038, #20178).
- Forward navigation still works and goes to the Explorer, not the redirect.
- Direct visits to a shared link resolve exactly as before; only the history entry changes.

### Verification

- Playwright against the running dev app on the seeded Jaffle dashboard, logging `history.length` and `location.pathname` from the page. Before: 2 → 4 entries, two back presses stay on the Explorer. After: 2 → 3 entries, one back press lands on the dashboard.
- `pnpm -F frontend test src/pages/ShareRedirect.test.tsx`: 3 passed (1 fails without the fix).
- oxlint, oxfmt and `pnpm -F frontend typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016bHBRVcEX8ULTB7CekbcJi
