### PR TITLE
feat(dashboard-filters): search fields from the picker input

### DIFF
--- a/packages/e2e/cypress/e2e/app/dashboard.cy.ts
+++ b/packages/e2e/cypress/e2e/app/dashboard.cy.ts
@@ -55,8 +55,7 @@ describe('Dashboard', () => {
         // Add filter
         cy.contains('Add filter').click();
 
-        cy.findByTestId('FilterConfiguration/FieldSelect').click();
-        cy.findByTestId('FilterConfiguration/FieldSelectSearch')
+        cy.findByTestId('FilterConfiguration/FieldSelect')
             .click()
             .type('payment');
         cy.wait(200);
@@ -194,8 +193,7 @@ describe('Dashboard', () => {
 
         // Add filter Payment method is credit_card and apply
         cy.contains('Add filter').click();
-        cy.findByTestId('FilterConfiguration/FieldSelect').click();
-        cy.findByTestId('FilterConfiguration/FieldSelectSearch')
+        cy.findByTestId('FilterConfiguration/FieldSelect')
             .click()
             .type('payment');
         cy.wait(200);
@@ -425,8 +423,7 @@ describe('Dashboard', () => {
         // Add filter
         cy.contains('Add filter').click();
 
-        cy.findByTestId('FilterConfiguration/FieldSelect').click();
-        cy.findByTestId('FilterConfiguration/FieldSelectSearch')
+        cy.findByTestId('FilterConfiguration/FieldSelect')
             .click()
             .type('payment');
         cy.wait(200);

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/FilterFieldSelect/index.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/FilterFieldSelect/index.tsx
@@ -50,6 +50,11 @@ const GROUP_HEADER_HEIGHT = 28;
 const SECTION_HEADER_HEIGHT = 30;
 const DROPDOWN_MAX_HEIGHT = 300;
 
+const getSelectedFieldLabel = (field: DashboardFilterableField) =>
+    isField(field)
+        ? `${field.tableLabel} ${field.label}`
+        : getItemLabelWithoutTableName(field);
+
 const FilterFieldSelect: FC<FilterFieldSelectProps> = ({
     fields,
     availableTileFilters,
@@ -63,12 +68,11 @@ const FilterFieldSelect: FC<FilterFieldSelectProps> = ({
     const getUiString = useUiStrings();
     const [search, setSearch] = useState('');
     const [debouncedSearch] = useDebouncedValue(search, 150);
-    const searchRef = useRef<HTMLInputElement>(null);
     const scrollRef = useRef<HTMLDivElement>(null);
 
     const combobox = useCombobox({
         onDropdownOpen: () => {
-            combobox.resetSelectedOption();
+            combobox.updateSelectedOptionIndex('active');
             popoverProps?.onOpen?.();
         },
         onDropdownClose: () => {
@@ -155,6 +159,8 @@ const FilterFieldSelect: FC<FilterFieldSelectProps> = ({
         combobox.closeDropdown();
     };
 
+    const selectedFieldId = selectedField ? getItemId(selectedField) : null;
+
     const renderVirtualItem = useCallback(
         (item: VirtualItem) => {
             switch (item.type) {
@@ -183,6 +189,7 @@ const FilterFieldSelect: FC<FilterFieldSelectProps> = ({
                     return (
                         <Combobox.Option
                             value={fieldId}
+                            active={fieldId === selectedFieldId}
                             className={`${styles.option} ${item.dimmed ? styles.dimmedOption : ''}`}
                         >
                             <Tooltip
@@ -213,9 +220,18 @@ const FilterFieldSelect: FC<FilterFieldSelectProps> = ({
                 }
             }
         },
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-        [],
+        [selectedFieldId],
     );
+
+    const isOpen = combobox.dropdownOpened;
+    const selectedLabel = selectedField
+        ? getSelectedFieldLabel(selectedField)
+        : null;
+
+    const placeholder = isOpen
+        ? (selectedLabel ??
+          getUiString('filters.config.searchFieldPlaceholder'))
+        : getUiString('filters.config.selectFilterPlaceholder');
 
     return (
         <div>
@@ -233,65 +249,32 @@ const FilterFieldSelect: FC<FilterFieldSelectProps> = ({
             >
                 <Combobox.Target>
                     <InputBase
-                        component="button"
-                        type="button"
                         radius="md"
                         size="xs"
-                        pointer
-                        onClick={() => combobox.toggleDropdown()}
+                        value={isOpen ? search : (selectedLabel ?? '')}
+                        placeholder={placeholder}
+                        onChange={(event) => {
+                            setSearch(event.currentTarget.value);
+                            combobox.openDropdown();
+                        }}
+                        onClick={() => combobox.openDropdown()}
+                        onBlur={() => combobox.closeDropdown()}
                         leftSection={
-                            selectedField ? (
+                            selectedField && !isOpen ? (
                                 <FieldIcon item={selectedField} />
-                            ) : undefined
+                            ) : (
+                                <MantineIcon icon={IconSearch} color="dimmed" />
+                            )
                         }
                         rightSection={<MantineIcon icon={IconSelector} />}
                         rightSectionPointerEvents="none"
-                        multiline={false}
+                        autoComplete="off"
+                        data-autofocus
                         data-testid="FilterConfiguration/FieldSelect"
-                    >
-                        {selectedField ? (
-                            <Text size="xs" truncate="end">
-                                {isField(selectedField)
-                                    ? `${selectedField.tableLabel} ${selectedField.label}`
-                                    : getItemLabelWithoutTableName(
-                                          selectedField,
-                                      )}
-                            </Text>
-                        ) : (
-                            <Text size="xs" truncate="end">
-                                {getUiString(
-                                    'filters.config.selectFilterPlaceholder',
-                                )}
-                            </Text>
-                        )}
-                    </InputBase>
+                    />
                 </Combobox.Target>
 
                 <Combobox.Dropdown p={0}>
-                    <Combobox.Search
-                        ref={searchRef}
-                        value={search}
-                        onChange={(event) =>
-                            setSearch(event.currentTarget.value)
-                        }
-                        placeholder={getUiString(
-                            'filters.config.searchFieldPlaceholder',
-                        )}
-                        size="xs"
-                        radius="md"
-                        leftSection={
-                            <MantineIcon icon={IconSearch} color="dimmed" />
-                        }
-                        data-testid="FilterConfiguration/FieldSelectSearch"
-                        styles={{
-                            input: {
-                                border: `1px solid var(--mantine-color-ldGray-1)`,
-                                borderRadius: 'var(--mantine-radius-sm)',
-                                margin: 2,
-                                width: 'calc(100% - 4px)',
-                            },
-                        }}
-                    />
                     <Combobox.Options>
                         {totalFields === 0 ? (
                             <Combobox.Empty>


### PR DESCRIPTION
## Summary

The field picker in the dashboard **Add filter** popover was a button that opened a list with a second search input inside it, so getting to the search took three clicks. It is now a single text input:

- The popover opens with the cursor already in the input (`data-autofocus` inside the popover's focus trap). Typing or `↓` opens the list, and typing narrows it.
- The picked field is shown in the input with its type icon. Clicking the input again clears the text and shows the current field as the placeholder so you can search for another one; tabbing or clicking away without a pick restores it.
- The list, virtualiser, sorting, table grouping, tab sections and description tooltips are unchanged. No new UI strings: the existing `filters.config.selectFilterPlaceholder` and `filters.config.searchFieldPlaceholder` keys are reused for the closed and open placeholders, so the embed `uiOverrides` contract is untouched.

The Cypress dashboard spec no longer clicks the removed inner search box and types straight into the field select.

## Regression analysis

The same scripted scenarios were run against the original component and this one in the local dev app (Jaffle dashboard):

| Scenario | Before | After |
| --- | --- | --- |
| Search results for "payment" | 8 fields, same order | same |
| Mouse pick from the list | field set, value editor opens | same |
| `Esc` while the list is open | list closes, popover stays | same |
| `Esc` with the list closed | popover closes | same |
| Click outside while the list is open | list closes, popover stays | same |
| `↓` from the focused control | opens the list | same |
| Type "order date month", `↓`, `Enter` | picks the first match | same |
| No matches | "No matching fields" | same |
| Focus when the popover opens | Filter Settings tab | the field input |
| Focus after a keyboard pick | lost to the page body | stays in the input |
| `Esc` right after a keyboard pick | nothing (focus was lost) | popover closes, like any closed picker |

The last row follows from keeping focus: the old control unmounted its search input on pick and stranded keyboard users on the body.

Preselecting the top match while typing was deliberately left out: it would make `↓` `Enter` pick the second result and change existing keyboard behaviour.

The click-outside guard in `AddFilterButton` still works because the new input reports open and close through the same `popoverProps` callbacks, and the list still renders inline (`withinPortal={false}`), so option clicks never register as outside clicks.

## Testing

- `packages/e2e` `dashboard.cy.ts` against the dev app with `CYPRESS_RETRIES=0`: 3 passing, 0 failing (6 pending are pre-existing skips).
- `FilterConfiguration/index.test.tsx` and `GuidedFilterSetupOverlay.test.tsx`: 18 passing.
- Frontend typecheck, oxlint and oxfmt clean.

Relates: PROD-5790

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ViuN6fUnUCWe3ZNP9MQFWp
