### PR TITLE
fix(explorer): tolerate saved filter groups with no items array

### DIFF
--- a/packages/common/src/utils/filters.test.ts
+++ b/packages/common/src/utils/filters.test.ts
@@ -129,6 +129,24 @@ describe('getFilterExpression', () => {
             items: [includedRule],
         });
     });
+
+    test('treats a persisted group without an items array as empty', () => {
+        // Stored chart JSON can carry a group with no `and`/`or` array
+        const persistedGroup = (json: string): FilterGroup => JSON.parse(json);
+        const metricRule = rule('metric');
+        const filters: Filters = {
+            dimensions: persistedGroup('{"id":"dimensions"}'),
+            metrics: {
+                id: 'metrics',
+                and: [metricRule, persistedGroup('{"id":"nested","or":null}')],
+            },
+        };
+
+        expect(getFilterExpression(filters)).toEqual({
+            operator: FilterGroupOperator.and,
+            items: [metricRule],
+        });
+    });
 });
 
 describe('addDashboardFiltersToMetricQuery', () => {

--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -99,13 +99,16 @@ const getFilterGroupExpression = (
         ? FilterGroupOperator.and
         : FilterGroupOperator.or;
     const groupItems = isAndFilterGroup(group) ? group.and : group.or;
-    const items = groupItems.flatMap<FilterRule | FilterExpression>((item) => {
-        if (isFilterGroup(item)) {
-            const expression = getFilterGroupExpression(item, includeRule);
-            return expression ? [expression] : [];
-        }
-        return includeRule(item) ? [item] : [];
-    });
+    // Persisted groups can lack their items array; treat them as empty
+    const items = (groupItems ?? []).flatMap<FilterRule | FilterExpression>(
+        (item) => {
+            if (isFilterGroup(item)) {
+                const expression = getFilterGroupExpression(item, includeRule);
+                return expression ? [expression] : [];
+            }
+            return includeRule(item) ? [item] : [];
+        },
+    );
 
     return items.length > 0 ? { operator, items } : undefined;
 };


### PR DESCRIPTION
## Description

Opening a saved chart crashed the explorer page with `TypeError: Cannot read properties of undefined (reading 'flatMap')` the moment the chart loaded, before any query ran.

The throw is in `getFilterGroupExpression` (`packages/common/src/utils/filters.ts`). It reads the group's `and` / `or` items array and calls `flatMap` on it with no guard. A persisted chart whose filter group has no items array (a bare `{ "id": "..." }`, or `"or": null`) therefore crashes the filters card on render. The sibling helper `getFilterRulesFromGroup` already treats a missing array as empty, so the two disagreed on the same stored input.

## Fix

Guard the items with `?? []`, mirroring `getFilterRulesFromGroup`. A malformed group now contributes no filters and the chart renders. The backend Google Sheets filter summary shares this helper and gets the same protection.

## Regression analysis

- The unguarded `flatMap` was introduced with the filter-expression builder for Google Sheets sync summaries (#27432), which the explorer filters card later adopted for its rule labels. Charts with a malformed group predate that and were readable before.
- The change only affects groups whose items array is missing. Well-formed groups take the same path as before.
- The new unit test reproduces the production TypeError without the guard and passes with it.

## Verification

- `pnpm -F common test src/utils/filters.test.ts` (1 file, all passing; the new case fails on main)
- `pnpm -F common typecheck`
- `pnpm -F common lint`

Sentry: LIGHTDASH-FRONTEND-5HK

Closes: #28725

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kbi7bhY98B43sA1qJ2N2wE