### PR TITLE
fix(direct-access): reduce shared content lookup overhead

### DIFF
--- a/packages/backend/src/models/AppAccessModel.ts
+++ b/packages/backend/src/models/AppAccessModel.ts
@@ -102,7 +102,10 @@ export class AppAccessModel {
                 `${OrganizationTableName}.organization_id`,
                 `${ProjectTableName}.organization_id`,
             )
-            .whereIn(`${AppUserAccessTableName}.app_uuid`, uniqueAppUuids)
+            .whereRaw('?? = ANY(?::uuid[])', [
+                `${AppUserAccessTableName}.app_uuid`,
+                uniqueAppUuids,
+            ])
             .where(`${AppUserAccessTableName}.user_uuid`, userUuid)
             .where(
                 `${OrganizationTableName}.organization_uuid`,
@@ -159,10 +162,10 @@ export class AppAccessModel {
                             );
                         },
                     )
-                    .whereIn(
+                    .whereRaw('?? = ANY(?::uuid[])', [
                         `${AppGroupAccessTableName}.app_uuid`,
                         uniqueAppUuids,
-                    )
+                    ])
                     .where(`${UserTableName}.user_uuid`, userUuid)
                     .where(
                         `${OrganizationTableName}.organization_uuid`,

--- a/packages/backend/src/models/DashboardAccessModel.ts
+++ b/packages/backend/src/models/DashboardAccessModel.ts
@@ -89,10 +89,10 @@ export class DashboardAccessModel {
                 `${OrganizationTableName}.organization_id`,
                 `${ProjectTableName}.organization_id`,
             )
-            .whereIn(
+            .whereRaw('?? = ANY(?::uuid[])', [
                 `${DashboardUserAccessTableName}.dashboard_uuid`,
                 uniqueDashboardUuids,
-            )
+            ])
             .where(`${DashboardUserAccessTableName}.user_uuid`, userUuid)
             .where(
                 `${OrganizationTableName}.organization_uuid`,
@@ -152,10 +152,10 @@ export class DashboardAccessModel {
                             );
                         },
                     )
-                    .whereIn(
+                    .whereRaw('?? = ANY(?::uuid[])', [
                         `${DashboardGroupAccessTableName}.dashboard_uuid`,
                         uniqueDashboardUuids,
-                    )
+                    ])
                     .where(`${UserTableName}.user_uuid`, userUuid)
                     .where(
                         `${OrganizationTableName}.organization_uuid`,

--- a/packages/backend/src/models/DirectAccessModels.test.ts
+++ b/packages/backend/src/models/DirectAccessModels.test.ts
@@ -1,6 +1,7 @@
 import { SpaceMemberRole } from '@lightdash/common';
 import knex, { type Knex } from 'knex';
 import { getTracker, MockClient, type Tracker } from 'knex-mock-client';
+import { randomUUID } from 'node:crypto';
 import { lightdashConfigMock } from '../config/lightdashConfig.mock';
 import { AppUserAccessTableName } from '../database/entities/appAccess';
 import { DashboardUserAccessTableName } from '../database/entities/dashboardAccess';
@@ -8,8 +9,48 @@ import { type UtilRepository } from '../utils/UtilRepository';
 import { AppAccessModel } from './AppAccessModel';
 import { DashboardAccessModel } from './DashboardAccessModel';
 import { ModelRepository } from './ModelRepository';
+import { SavedChartAccessModel } from './SavedChartAccessModel';
+import { SavedSqlAccessModel } from './SavedSqlAccessModel';
 
 const database = knex({ client: MockClient, dialect: 'pg' });
+
+describe.each([
+    ['dashboard', DashboardAccessModel],
+    ['chart', SavedChartAccessModel],
+    ['SQL chart', SavedSqlAccessModel],
+    ['app', AppAccessModel],
+] as const)('%s resource list bindings', (_name, AccessModel) => {
+    afterEach(() => {
+        getTracker().reset();
+    });
+
+    it('keeps the bind count constant as the grant set grows', async () => {
+        const tracker = getTracker();
+        tracker.on.select(() => true).response([]);
+        const model = new AccessModel(database);
+        const resourceUuids = Array.from({ length: 1000 }, () => randomUUID());
+        const userUuid = randomUUID();
+        const organizationUuid = randomUUID();
+
+        await model.getUserAccess(resourceUuids.slice(0, 1), userUuid, {
+            organizationUuid,
+        });
+        await model.getUserAccess(
+            [...resourceUuids, resourceUuids[0]],
+            userUuid,
+            {
+                organizationUuid,
+            },
+        );
+
+        const [small, large] = tracker.history.select;
+        expect(large.bindings).toHaveLength(small.bindings.length);
+        expect(large.bindings.filter(Array.isArray)).toEqual([
+            resourceUuids,
+            resourceUuids,
+        ]);
+    });
+});
 
 describe('dashboard direct access read model', () => {
     let tracker: Tracker;

--- a/packages/backend/src/models/SavedChartAccessModel.ts
+++ b/packages/backend/src/models/SavedChartAccessModel.ts
@@ -91,10 +91,10 @@ export class SavedChartAccessModel {
                 `${OrganizationTableName}.organization_id`,
                 `${ProjectTableName}.organization_id`,
             )
-            .whereIn(
+            .whereRaw('?? = ANY(?::uuid[])', [
                 `${SavedChartUserAccessTableName}.saved_chart_uuid`,
                 uniqueUuids,
-            )
+            ])
             .where(`${SavedChartUserAccessTableName}.user_uuid`, userUuid)
             .where(
                 `${OrganizationTableName}.organization_uuid`,
@@ -160,10 +160,10 @@ export class SavedChartAccessModel {
                             );
                         },
                     )
-                    .whereIn(
+                    .whereRaw('?? = ANY(?::uuid[])', [
                         `${SavedChartGroupAccessTableName}.saved_chart_uuid`,
                         uniqueUuids,
-                    )
+                    ])
                     .where(`${UserTableName}.user_uuid`, userUuid)
                     .where(
                         `${OrganizationTableName}.organization_uuid`,

--- a/packages/backend/src/models/SavedSqlAccessModel.ts
+++ b/packages/backend/src/models/SavedSqlAccessModel.ts
@@ -85,10 +85,10 @@ export class SavedSqlAccessModel {
                 `${OrganizationTableName}.organization_id`,
                 `${ProjectTableName}.organization_id`,
             )
-            .whereIn(
+            .whereRaw('?? = ANY(?::uuid[])', [
                 `${SavedSqlUserAccessTableName}.saved_sql_uuid`,
                 uniqueUuids,
-            )
+            ])
             .where(`${SavedSqlUserAccessTableName}.user_uuid`, userUuid)
             .where(
                 `${OrganizationTableName}.organization_uuid`,
@@ -154,10 +154,10 @@ export class SavedSqlAccessModel {
                             );
                         },
                     )
-                    .whereIn(
+                    .whereRaw('?? = ANY(?::uuid[])', [
                         `${SavedSqlGroupAccessTableName}.saved_sql_uuid`,
                         uniqueUuids,
-                    )
+                    ])
                     .where(`${UserTableName}.user_uuid`, userUuid)
                     .where(
                         `${OrganizationTableName}.organization_uuid`,

--- a/packages/backend/src/services/ContentService/ContentService.test.ts
+++ b/packages/backend/src/services/ContentService/ContentService.test.ts
@@ -2,10 +2,12 @@ import {
     ChartSourceType,
     ContentType,
     defineUserAbility,
+    DirectAccessResourceType,
     ForbiddenError,
     KnexPaginatedData,
     OrganizationMemberRole,
     ProjectMemberRole,
+    SpaceMemberRole,
     SummaryContent,
 } from '@lightdash/common';
 import type { DeletedContentItem, SessionUser } from '@lightdash/common';
@@ -65,11 +67,21 @@ const createService = ({
     spaceModel = {} as SpaceModel,
     spacePermissionService = {} as SpacePermissionService,
     sharedWithMeUuids = { dashboard: [], chart: [], sqlChart: [], app: [] },
+    sharedWithMeRoles = {
+        dashboard: { 'dashboard-1': [SpaceMemberRole.EDITOR] },
+        chart: {},
+        sqlChart: {},
+        app: {},
+    },
 }: {
     contentModel?: ContentModel;
     spaceModel?: SpaceModel;
     spacePermissionService?: SpacePermissionService;
     sharedWithMeUuids?: Record<string, string[]>;
+    sharedWithMeRoles?: Record<
+        DirectAccessResourceType,
+        Record<string, SpaceMemberRole[]>
+    >;
 } = {}) => {
     const projectModel = {
         getAllByOrganizationUuid: vi.fn().mockResolvedValue([
@@ -109,7 +121,13 @@ const createService = ({
         deleteDashboardValidations: vi.fn().mockResolvedValue(undefined),
     };
     const directAccessService = {
-        findSharedWithMeUuids: vi.fn().mockResolvedValue(sharedWithMeUuids),
+        findSharedWithMeAccess: vi.fn().mockResolvedValue({
+            uuidsByType: sharedWithMeUuids,
+            rolesByType: sharedWithMeRoles,
+        }),
+        findGrantedRoles: vi.fn().mockResolvedValue({
+            'dashboard-1': [SpaceMemberRole.EDITOR],
+        }),
     };
 
     return {
@@ -605,6 +623,133 @@ describe('ContentService.find sharedWithMe', () => {
         data: [],
     });
 
+    it('returns grant roles without fetching them again after pagination', async () => {
+        const dashboard = {
+            uuid: 'dashboard-1',
+            contentType: ContentType.DASHBOARD,
+        } as SummaryContent;
+        const findSummaryContents = vi.fn().mockResolvedValue({
+            ...(await emptyModelPage()),
+            data: [dashboard],
+        });
+        const deps = createService({
+            contentModel: { findSummaryContents } as unknown as ContentModel,
+            sharedWithMeUuids: {
+                dashboard: ['dashboard-1'],
+                chart: [],
+                sqlChart: [],
+                app: [],
+            },
+        });
+
+        const result = await deps.service.find(
+            createUser(),
+            { sharedWithMe: true },
+            {},
+            { page: 1, pageSize: 10 },
+        );
+
+        expect(result.data).toEqual([
+            { ...dashboard, directAccessRoles: [SpaceMemberRole.EDITOR] },
+        ]);
+        expect(
+            deps.directAccessService.findGrantedRoles,
+        ).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        [ContentType.DASHBOARD, undefined, DirectAccessResourceType.DASHBOARD],
+        [ContentType.DATA_APP, undefined, DirectAccessResourceType.APP],
+        [
+            ContentType.CHART,
+            ChartSourceType.DBT_EXPLORE,
+            DirectAccessResourceType.CHART,
+        ],
+        [
+            ContentType.CHART,
+            ChartSourceType.SQL,
+            DirectAccessResourceType.SQL_CHART,
+        ],
+    ] as const)(
+        'keeps roles scoped to %s (%s) when another type has the same UUID',
+        async (contentType, source, resourceType) => {
+            const item = {
+                uuid: 'same-uuid',
+                contentType,
+                source,
+            } as SummaryContent;
+            const deps = createService({
+                contentModel: {
+                    findSummaryContents: vi.fn().mockResolvedValue({
+                        ...(await emptyModelPage()),
+                        data: [item],
+                    }),
+                } as unknown as ContentModel,
+                sharedWithMeUuids: {
+                    dashboard: ['same-uuid'],
+                    chart: ['same-uuid'],
+                    sqlChart: ['same-uuid'],
+                    app: ['same-uuid'],
+                },
+                sharedWithMeRoles: {
+                    dashboard: { 'same-uuid': [SpaceMemberRole.ADMIN] },
+                    chart: { 'same-uuid': [SpaceMemberRole.ADMIN] },
+                    sqlChart: { 'same-uuid': [SpaceMemberRole.ADMIN] },
+                    app: { 'same-uuid': [SpaceMemberRole.ADMIN] },
+                    [resourceType]: { 'same-uuid': [SpaceMemberRole.VIEWER] },
+                },
+            });
+
+            const result = await deps.service.find(
+                createUser(),
+                { sharedWithMe: true, contentTypes: [contentType] },
+                {},
+                { page: 1, pageSize: 1 },
+            );
+            expect(result.data).toEqual([
+                { ...item, directAccessRoles: [SpaceMemberRole.VIEWER] },
+            ]);
+            expect(
+                deps.directAccessService.findGrantedRoles,
+            ).not.toHaveBeenCalled();
+        },
+    );
+
+    it('keeps an empty role list when a hydrated resource has no matching grant', async () => {
+        const dashboard = {
+            uuid: 'dashboard-1',
+            contentType: ContentType.DASHBOARD,
+            directAccessRoles: [],
+        };
+        const deps = createService({
+            contentModel: {
+                findSummaryContents: vi.fn().mockResolvedValue({
+                    ...(await emptyModelPage()),
+                    data: [dashboard],
+                }),
+            } as unknown as ContentModel,
+            sharedWithMeUuids: {
+                dashboard: ['dashboard-1'],
+                chart: [],
+                sqlChart: [],
+                app: [],
+            },
+            sharedWithMeRoles: {
+                dashboard: {},
+                chart: {},
+                sqlChart: {},
+                app: {},
+            },
+        });
+        const result = await deps.service.find(
+            createUser(),
+            { sharedWithMe: true },
+            {},
+            { page: 1, pageSize: 10 },
+        );
+        expect(result.data).toEqual([dashboard]);
+    });
+
     it('hydrates only granted uuids without space scoping', async () => {
         const findSummaryContents = vi.fn(emptyModelPage);
         const getAccessibleSpaceUuids = vi.fn();
@@ -631,7 +776,7 @@ describe('ContentService.find sharedWithMe', () => {
         );
 
         expect(
-            deps.directAccessService.findSharedWithMeUuids,
+            deps.directAccessService.findSharedWithMeAccess,
         ).toHaveBeenCalledWith({ userUuid, organizationUuid }, [projectUuid]);
         expect(getAccessibleSpaceUuids).not.toHaveBeenCalled();
         expect(findSummaryContents).toHaveBeenCalledWith(
@@ -724,7 +869,7 @@ describe('ContentService.find sharedWithMe', () => {
             ),
         ).resolves.toMatchObject({ data: [] });
         expect(
-            deps.directAccessService.findSharedWithMeUuids,
+            deps.directAccessService.findSharedWithMeAccess,
         ).not.toHaveBeenCalled();
     });
 });

--- a/packages/backend/src/services/ContentService/ContentService.ts
+++ b/packages/backend/src/services/ContentService/ContentService.ts
@@ -396,13 +396,14 @@ export class ContentService extends BaseService {
             return emptyPage;
         }
 
-        const granted = await this.directAccessService.findSharedWithMeUuids(
-            {
-                userUuid: user.userUuid,
-                organizationUuid: user.organizationUuid,
-            },
-            filters.projectUuids,
-        );
+        const { uuidsByType: granted, rolesByType } =
+            await this.directAccessService.findSharedWithMeAccess(
+                {
+                    userUuid: user.userUuid,
+                    organizationUuid: user.organizationUuid,
+                },
+                filters.projectUuids,
+            );
         const grantedUuids = [
             ...(contentTypes.includes(ContentType.DASHBOARD)
                 ? granted[DirectAccessResourceType.DASHBOARD]
@@ -444,14 +445,39 @@ export class ContentService extends BaseService {
             ...results,
             // Spaces are excluded from grantable content types above, so no
             // row needs the SpaceContent access enrichment.
-            data: await this.withDirectAccessRoles(
-                user,
-                results.data.filter(
+            data: results.data
+                .filter(
                     (item): item is Exclude<SummaryContent, SpaceContentBase> =>
                         item.contentType !== ContentType.SPACE,
-                ),
-            ),
+                )
+                .map((item) => ({
+                    ...item,
+                    directAccessRoles:
+                        rolesByType[
+                            ContentService.getDirectAccessResourceType(item)
+                        ][item.uuid] ?? [],
+                })),
         };
+    }
+
+    private static getDirectAccessResourceType(
+        item: Exclude<SummaryContent, SpaceContentBase>,
+    ): DirectAccessResourceType {
+        switch (item.contentType) {
+            case ContentType.DASHBOARD:
+                return DirectAccessResourceType.DASHBOARD;
+            case ContentType.DATA_APP:
+                return DirectAccessResourceType.APP;
+            case ContentType.CHART:
+                return item.source === ChartSourceType.SQL
+                    ? DirectAccessResourceType.SQL_CHART
+                    : DirectAccessResourceType.CHART;
+            default:
+                return assertUnreachable(
+                    item,
+                    'Unsupported direct access content type',
+                );
+        }
     }
 
     async bulkMove(

--- a/packages/backend/src/services/DirectAccess/DirectAccessService.test.ts
+++ b/packages/backend/src/services/DirectAccess/DirectAccessService.test.ts
@@ -443,8 +443,16 @@ describe('DirectAccessService.findSharedWithMeUuids', () => {
         grantReadModel.getUserAccess.mockResolvedValue({
             // 'dashboard-inert' dropped by the read model (lost membership);
             // 'dashboard-other' filtered out by project scope below.
-            'dashboard-live': { projectUuid: PROJECT_UUID },
-            'dashboard-other': { projectUuid: 'other-project-uuid' },
+            'dashboard-live': {
+                projectUuid: PROJECT_UUID,
+                userRole: SpaceMemberRole.EDITOR,
+                groupRoles: [SpaceMemberRole.VIEWER],
+            },
+            'dashboard-other': {
+                projectUuid: 'other-project-uuid',
+                userRole: SpaceMemberRole.ADMIN,
+                groupRoles: [],
+            },
         });
 
         await expect(
@@ -462,5 +470,101 @@ describe('DirectAccessService.findSharedWithMeUuids', () => {
         );
         // Types with no candidates skip validation entirely.
         expect(grantReadModel.getUserAccess).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('DirectAccessService.findSharedWithMeAccess', () => {
+    const requester = {
+        userUuid: USER_UUID,
+        organizationUuid: ORGANIZATION_UUID,
+    };
+
+    it.each(Object.values(DirectAccessResourceType))(
+        'retains user and group roles only for validated %s grants in allowed projects',
+        async (resourceType) => {
+            const { service, directAccessModel, grantReadModel } =
+                buildService();
+            directAccessModel.findCandidateResourceUuidsForUser.mockImplementation(
+                async (type: DirectAccessResourceType) =>
+                    type === resourceType
+                        ? ['live', 'group-only', 'inert', 'other-project']
+                        : [],
+            );
+            grantReadModel.getUserAccess.mockResolvedValue({
+                live: {
+                    projectUuid: PROJECT_UUID,
+                    userRole: SpaceMemberRole.EDITOR,
+                    groupRoles: [SpaceMemberRole.ADMIN, SpaceMemberRole.VIEWER],
+                },
+                'group-only': {
+                    projectUuid: PROJECT_UUID,
+                    userRole: null,
+                    groupRoles: [SpaceMemberRole.VIEWER],
+                },
+                'other-project': {
+                    projectUuid: 'other-project',
+                    userRole: SpaceMemberRole.ADMIN,
+                    groupRoles: [],
+                },
+            });
+
+            const access = await service.findSharedWithMeAccess(requester, [
+                PROJECT_UUID,
+            ]);
+
+            expect(access).toEqual({
+                uuidsByType: {
+                    dashboard: [],
+                    chart: [],
+                    sqlChart: [],
+                    app: [],
+                    [resourceType]: ['live', 'group-only'],
+                },
+                rolesByType: {
+                    dashboard: {},
+                    chart: {},
+                    sqlChart: {},
+                    app: {},
+                    [resourceType]: {
+                        live: [
+                            SpaceMemberRole.EDITOR,
+                            SpaceMemberRole.ADMIN,
+                            SpaceMemberRole.VIEWER,
+                        ],
+                        'group-only': [SpaceMemberRole.VIEWER],
+                    },
+                },
+            });
+            expect(grantReadModel.getUserAccess).toHaveBeenCalledTimes(1);
+        },
+    );
+
+    it('returns no identifiers or roles when disabled', async () => {
+        const { service, directAccessModel, grantReadModel } = buildService({
+            enabled: false,
+        });
+        await expect(
+            service.findSharedWithMeAccess(requester, [PROJECT_UUID]),
+        ).resolves.toEqual({
+            uuidsByType: { dashboard: [], chart: [], sqlChart: [], app: [] },
+            rolesByType: { dashboard: {}, chart: {}, sqlChart: {}, app: {} },
+        });
+        expect(
+            directAccessModel.findCandidateResourceUuidsForUser,
+        ).not.toHaveBeenCalled();
+        expect(grantReadModel.getUserAccess).not.toHaveBeenCalled();
+    });
+
+    it('propagates grant read failures', async () => {
+        const { service, directAccessModel, grantReadModel } = buildService();
+        directAccessModel.findCandidateResourceUuidsForUser.mockResolvedValue([
+            'resource',
+        ]);
+        grantReadModel.getUserAccess.mockRejectedValue(
+            new Error('Database unavailable'),
+        );
+        await expect(
+            service.findSharedWithMeAccess(requester, [PROJECT_UUID]),
+        ).rejects.toThrow('Database unavailable');
     });
 });

--- a/packages/backend/src/services/DirectAccess/DirectAccessService.ts
+++ b/packages/backend/src/services/DirectAccess/DirectAccessService.ts
@@ -43,6 +43,14 @@ type DirectAccessServiceArguments = {
 
 export type SharedWithMeUuids = Record<DirectAccessResourceType, UUID[]>;
 
+type SharedWithMeAccess = {
+    uuidsByType: SharedWithMeUuids;
+    rolesByType: Record<
+        DirectAccessResourceType,
+        Record<UUID, SpaceMemberRole[]>
+    >;
+};
+
 /**
  * One administration seam for direct access across every registered resource
  * type. Requests are feature-gated, resolved against the concrete resource,
@@ -159,23 +167,39 @@ export class DirectAccessService extends BaseService {
         );
     }
 
+    async findSharedWithMeUuids(
+        user: { userUuid: UUID; organizationUuid: UUID },
+        projectUuids: UUID[],
+    ): Promise<SharedWithMeUuids> {
+        const access = await this.findSharedWithMeAccess(user, projectUuids);
+        return access.uuidsByType;
+    }
+
     /**
-     * Resources of every type that are directly granted to the user or their
+     * Resources and roles of every type directly granted to the user or their
      * groups, deduplicated and restricted to the given projects. Candidates
      * from the grant tables are validated through each type's read model, so
      * inert grants (lost membership, inactive granted groups, deleted or
      * ineligible resources) never surface. Feature off means no results —
      * grant rows are preserved but stay invisible.
      */
-    async findSharedWithMeUuids(
+    async findSharedWithMeAccess(
         user: { userUuid: UUID; organizationUuid: UUID },
         projectUuids: UUID[],
-    ): Promise<SharedWithMeUuids> {
-        const empty: SharedWithMeUuids = {
-            [DirectAccessResourceType.DASHBOARD]: [],
-            [DirectAccessResourceType.CHART]: [],
-            [DirectAccessResourceType.SQL_CHART]: [],
-            [DirectAccessResourceType.APP]: [],
+    ): Promise<SharedWithMeAccess> {
+        const empty: SharedWithMeAccess = {
+            uuidsByType: {
+                [DirectAccessResourceType.DASHBOARD]: [],
+                [DirectAccessResourceType.CHART]: [],
+                [DirectAccessResourceType.SQL_CHART]: [],
+                [DirectAccessResourceType.APP]: [],
+            },
+            rolesByType: {
+                [DirectAccessResourceType.DASHBOARD]: {},
+                [DirectAccessResourceType.CHART]: {},
+                [DirectAccessResourceType.SQL_CHART]: {},
+                [DirectAccessResourceType.APP]: {},
+            },
         };
         if (projectUuids.length === 0) {
             return empty;
@@ -196,22 +220,39 @@ export class DirectAccessService extends BaseService {
                         user.userUuid,
                     );
                 if (candidates.length === 0) {
-                    return [resourceType, []] as const;
+                    return [resourceType, {}] as const;
                 }
                 const access = await this.getGrantReadModel(
                     resourceType,
                 ).getUserAccess(candidates, user.userUuid, {
                     organizationUuid: user.organizationUuid,
                 });
-                const uuids = Object.entries(access)
-                    .filter(([, grant]) =>
-                        allowedProjects.has(grant.projectUuid),
-                    )
-                    .map(([resourceUuid]) => resourceUuid);
-                return [resourceType, uuids] as const;
+                const roles = Object.fromEntries(
+                    Object.entries(access)
+                        .filter(([, grant]) =>
+                            allowedProjects.has(grant.projectUuid),
+                        )
+                        .map(([resourceUuid, grant]) => [
+                            resourceUuid,
+                            [
+                                ...(grant.userRole ? [grant.userRole] : []),
+                                ...grant.groupRoles,
+                            ],
+                        ]),
+                );
+                return [resourceType, roles] as const;
             }),
         );
-        return Object.fromEntries(entries) as SharedWithMeUuids;
+        return entries.reduce<SharedWithMeAccess>(
+            (result, [resourceType, roles]) => ({
+                uuidsByType: {
+                    ...result.uuidsByType,
+                    [resourceType]: Object.keys(roles),
+                },
+                rolesByType: { ...result.rolesByType, [resourceType]: roles },
+            }),
+            empty,
+        );
     }
 
     private static toAccessTarget(


### PR DESCRIPTION
Relates: https://linear.app/lightdash/issue/SPK-1542/direct-access-grant-lookups-100x-parameter-overhead-duplicate-fetch

## Summary

Reduce direct-access query overhead when browsing Shared with me. This covers the ticket's two product fixes; pool alerts are a separate cloud change.

## Root cause

Each grant lookup expands the resource UUID list twice, once for user grants and once for group grants. Shared with me then discards validated roles and fetches them again after pagination.

## Fix

Bind UUID arrays in all four grant readers and reuse validated roles within the request. Keep roles keyed by resource type so identical UUIDs in different tables cannot overwrite each other. UUID-only callers retain their existing contract.

```text
1,000 resource UUIDs per grant lookup
Before: 2,008 bindings → paginate → fetch roles again
After:     10 bindings → paginate → reuse roles
```

Local Postgres measurements did not reproduce the ticket's 100× latency difference; this change makes no such speedup claim. Membership predicates, feature gating, pagination and the full-grant materialization strategy remain unchanged.

## Test plan

- [x] Backend typecheck and lint.
- [x] 254 unit tests, including failing-before/passing-after binding-count and duplicate-fetch regressions, role collisions, missing roles and project filtering.
- [x] 74 existing grant-reader integration tests against local Postgres. A temporary setup supplies the seeded database instead of bootstrapping the unrelated full app; test bodies and SQL are unchanged.
- [x] API before/after with 1,000 synthetic grants: roles, total count, page sizes 1/25, second page, space-only and unmatched search. All fixtures removed.

### Risk assessment

- [ ] This is a high-risk change

No migrations or public API shape changes. Existing authorization predicates are preserved and exercised against Postgres.
