### PR TITLE
feat(merge): submit a merge through the query source DAG

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -1188,6 +1188,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     savedSqlModel: models.getSavedSqlModel(),
                     resultsStorageClient: clients.getResultsFileStorageClient(),
                     composeEngineClient: repository.getComposeEngineClient(),
+                    getQuerySourceService: () =>
+                        repository.getQuerySourceService(),
                     featureFlagModel: models.getFeatureFlagModel(),
                     projectParametersModel: models.getProjectParametersModel(),
                     organizationWarehouseCredentialsModel:

--- a/packages/backend/src/ee/services/ExternalSourceService/ExternalQuerySource.test.ts
+++ b/packages/backend/src/ee/services/ExternalSourceService/ExternalQuerySource.test.ts
@@ -22,6 +22,7 @@ const submitArgs = {
     userAttributeOverrides: {},
     invalidateCache: false,
     pivotConfiguration: null,
+    plan: null,
 };
 
 describe('ExternalQuerySource', () => {

--- a/packages/backend/src/ee/services/ExternalSourceService/ExternalQuerySource.test.ts
+++ b/packages/backend/src/ee/services/ExternalSourceService/ExternalQuerySource.test.ts
@@ -80,7 +80,7 @@ describe('ExternalQuerySource', () => {
             },
         });
 
-        expect(result).toEqual({ queryUuid: 'query-1' });
+        expect(result).toEqual({ queryUuid: 'query-1', cacheHit: false });
         expect(executeAsyncExternalSqlQuery).toHaveBeenCalledWith({
             account,
             projectUuid: 'project-1',

--- a/packages/backend/src/ee/services/ExternalSourceService/ExternalQuerySource.ts
+++ b/packages/backend/src/ee/services/ExternalSourceService/ExternalQuerySource.ts
@@ -135,7 +135,10 @@ export class ExternalQuerySource implements QuerySourceClient {
         parameters,
         invalidateCache,
         pivotConfiguration,
-    }: SubmitSourceQueryArgs): Promise<{ queryUuid: string }> {
+    }: SubmitSourceQueryArgs): Promise<{
+        queryUuid: string;
+        cacheHit: boolean;
+    }> {
         const sourceQuery = ExternalQuerySource.assertSourceQuery(query);
         if (pivotConfiguration !== null) {
             throw new ParameterError(
@@ -155,6 +158,7 @@ export class ExternalQuerySource implements QuerySourceClient {
                 invalidateCache,
             });
 
-        return { queryUuid: results.queryUuid };
+        // External SQL always runs on the engine; nothing is served from cache
+        return { queryUuid: results.queryUuid, cacheHit: false };
     }
 }

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -119,6 +119,8 @@ import {
     tablesConfiguration,
     validExplore,
 } from '../ProjectService/ProjectService.mock';
+import { QuerySourceRegistry } from '../QuerySourceService/QuerySourceRegistry';
+import { QuerySourceService } from '../QuerySourceService/QuerySourceService';
 import { SemanticLayerQuerySource } from '../QuerySourceService/sources/SemanticLayerQuerySource';
 import { SqlQuerySource } from '../QuerySourceService/sources/SqlQuerySource';
 import type { SubmitSourceQueryArgs } from '../QuerySourceService/types';
@@ -278,8 +280,23 @@ const userAttributesModel = {
 const getMockedAsyncQueryService = (
     lightdashConfig: LightdashConfig,
     overrides: Partial<AsyncQueryService> = {},
-) =>
-    new AsyncQueryService({
+) => {
+    // The registry is built over the service under test, so a merge's DAG
+    // nodes reach the same mocks a direct call would
+    let querySourceService: QuerySourceService | undefined;
+    const service: AsyncQueryService = new AsyncQueryService({
+        getQuerySourceService: () => {
+            querySourceService ??= new QuerySourceService({
+                projectModel: (service as AnyType).projectModel,
+                queryHistoryModel: service.queryHistoryModel,
+                featureFlagModel: (service as AnyType).featureFlagModel,
+                registry: QuerySourceRegistry.withBuiltInSources({
+                    asyncQueryService: service,
+                    projectService: service,
+                }),
+            });
+            return querySourceService;
+        },
         lightdashConfig,
         analytics: analyticsMock,
         contentDraftModel: {
@@ -440,6 +457,8 @@ const getMockedAsyncQueryService = (
         userOAuthGrantsModel:
             overrides.userOAuthGrantsModel ?? ({} as UserOAuthGrantsModel),
     });
+    return service;
+};
 
 const getJsonlStream = (rows: Record<string, unknown>[]) =>
     Readable.from(rows.map((row) => `${JSON.stringify(row)}\n`).join(''));
@@ -772,6 +791,10 @@ describe('AsyncQueryService', () => {
                 tableCalculations: [],
             } as unknown as MetricQuery;
 
+            const requestParameters = {
+                context: QueryExecutionContext.EXPLORE,
+                sql: 'SELECT * FROM orders',
+            };
             const submission = await service.executeAsyncDuckdbSourceQuery({
                 account: sessionAccount,
                 projectUuid,
@@ -786,12 +809,15 @@ describe('AsyncQueryService', () => {
                         originalColumns,
                         pivotConfiguration: undefined,
                         metricQuery,
+                        requestParameters,
                     },
                     engine: 'scopedToReferencedResults',
                     guard,
                 },
             });
-            await submission.settled;
+            await vi.waitFor(() =>
+                expect(runDuckdbQuery).toHaveBeenCalledTimes(1),
+            );
 
             expect(submission.queryUuid).toBe('join-uuid');
             const flagsRead = (
@@ -805,12 +831,12 @@ describe('AsyncQueryService', () => {
                     fields: fieldsMap,
                     originalColumns,
                     metricQuery,
+                    requestParameters,
                     usedParameters: { region: 'EU' },
                     pivotConfiguration: null,
                     compiledSql: 'SELECT * FROM orders',
                 }),
             );
-            expect(runDuckdbQuery).toHaveBeenCalledTimes(1);
             expect(runDuckdbQuery.mock.calls[0][0]).toMatchObject({
                 queryUuid: 'join-uuid',
                 columns: { mode: 'supplied', fieldsMap, originalColumns },
@@ -6556,6 +6582,25 @@ describe('executeAsyncMergeQuery on the compose engine', () => {
         } as unknown as WarehouseClient;
         const legByUuid = (queryUuid: string) =>
             legHistory(queryUuid, legRowCount);
+        const update = vi.fn();
+        let joinRan = false;
+        // The outcome reporter polls the join row: it lands in a terminal
+        // state only once the tail has either refused it or run the join
+        const mergeHistoryOnceSettled = async () => {
+            const errored = () =>
+                update.mock.calls.some(
+                    ([queryUuid, , patch]) =>
+                        queryUuid === 'merge-query-uuid' &&
+                        patch?.status === QueryHistoryStatus.ERROR,
+                );
+            await vi.waitFor(() => expect(errored() || joinRan).toBe(true));
+            return {
+                ...legHistory('merge-query-uuid', legRowCount),
+                status: errored()
+                    ? QueryHistoryStatus.ERROR
+                    : QueryHistoryStatus.READY,
+            };
+        };
         const service = getMockedAsyncQueryService(config, {
             featureFlagModel: composeFlags,
             composeEngineClient: new ComposeEngineClient({
@@ -6567,9 +6612,11 @@ describe('executeAsyncMergeQuery on the compose engine', () => {
                 get: vi.fn(async (queryUuid: string) => legByUuid(queryUuid)),
                 pollForQueryCompletion: vi.fn(
                     async ({ queryUuid }: { queryUuid: string }) =>
-                        legByUuid(queryUuid),
+                        queryUuid === 'merge-query-uuid'
+                            ? mergeHistoryOnceSettled()
+                            : legByUuid(queryUuid),
                 ),
-                update: vi.fn(),
+                update,
             } as unknown as QueryHistoryModel,
             resultsStorageClient: {
                 isEnabled: true,
@@ -6585,7 +6632,9 @@ describe('executeAsyncMergeQuery on the compose engine', () => {
         ).mockResolvedValue(fieldTypes);
         const runWarehouseQuery = vi
             .spyOn(service, 'runAsyncWarehouseQuery')
-            .mockResolvedValue(undefined);
+            .mockImplementation(async () => {
+                joinRan = true;
+            });
         const trackAccount = vi
             .spyOn(analyticsMock, 'trackAccount')
             .mockImplementation(() => {});
@@ -6595,7 +6644,7 @@ describe('executeAsyncMergeQuery on the compose engine', () => {
             runWarehouseQuery,
             trackAccount,
             create: service.queryHistoryModel.create as import('vitest').Mock,
-            update: service.queryHistoryModel.update as import('vitest').Mock,
+            update,
         };
     };
 
@@ -6674,9 +6723,22 @@ describe('executeAsyncMergeQuery on the compose engine', () => {
             mode: { type: 'interactive' },
         });
 
+    // The outcome reporter polls the join row, so a test that started a merge
+    // waits for its event or the event lands in the next test's spy
+    const drainMergeEvents = (
+        trackAccount: ReturnType<typeof buildService>['trackAccount'],
+        count: number,
+    ) =>
+        vi.waitFor(() => expect(mergeEvents(trackAccount)).toHaveLength(count));
+
     it('runs the join in supplied mode: no column probe, and the compile-time columns reach execution unchanged', async () => {
-        const { service, streamQuery, runWarehouseQuery, create } =
-            buildService({ config: lightdashConfigMock, legRowCount: 2 });
+        const {
+            service,
+            streamQuery,
+            runWarehouseQuery,
+            create,
+            trackAccount,
+        } = buildService({ config: lightdashConfigMock, legRowCount: 2 });
 
         const outcome = await execute(service);
         if (outcome.outcome !== 'started') {
@@ -6693,7 +6755,7 @@ describe('executeAsyncMergeQuery on the compose engine', () => {
                 typedColumns,
                 itemsMap,
                 usedParametersValues: {},
-                legQueryUuidBySourceId,
+                legReferenceBySourceId: legQueryUuidBySourceId,
             }),
         );
         expect(executed.originalColumns?.a_orders_count).toMatchObject({
@@ -6714,6 +6776,7 @@ describe('executeAsyncMergeQuery on the compose engine', () => {
         expect(executed.query).toContain(
             `read_json_auto('s3://results-bucket/${legQueryUuidBySourceId.b}.jsonl')`,
         );
+        await drainMergeEvents(trackAccount, 1);
     });
 
     it('tracks the merge once it is ready, with leg cache hits and the merged row count', async () => {
@@ -6793,10 +6856,11 @@ describe('executeAsyncMergeQuery on the compose engine', () => {
     });
 
     it('runs the join when every leg is under the row cap', async () => {
-        const { service, runWarehouseQuery, update } = buildService({
-            config: cappedConfig,
-            legRowCount: SOURCE_ROW_CAP - 1,
-        });
+        const { service, runWarehouseQuery, update, trackAccount } =
+            buildService({
+                config: cappedConfig,
+                legRowCount: SOURCE_ROW_CAP - 1,
+            });
 
         await execute(service);
 
@@ -6809,10 +6873,11 @@ describe('executeAsyncMergeQuery on the compose engine', () => {
             expect.objectContaining({ status: QueryHistoryStatus.ERROR }),
             expect.anything(),
         );
+        await drainMergeEvents(trackAccount, 1);
     });
 
     it("compiles every leg with the submission's user attribute overrides, a different query per override", async () => {
-        const { service, executeAsyncQuery, compiledLegs } =
+        const { service, executeAsyncQuery, compiledLegs, trackAccount } =
             buildServiceWithCompiledLegs();
         const submit = (region: string) =>
             service.executeAsyncMergeQuery({
@@ -6846,6 +6911,7 @@ describe('executeAsyncMergeQuery on the compose engine', () => {
             expect(euSql).not.toContain('base');
             expect(usSql).not.toContain('base');
         }
+        await drainMergeEvents(trackAccount, 2);
     });
 });
 

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -722,6 +722,113 @@ describe('AsyncQueryService', () => {
             expect(service.queryHistoryModel.create).not.toHaveBeenCalled();
         });
 
+        test('a supplied plan records its columns, runs on a scoped session and reads no flag', async () => {
+            const featureFlagModel = {
+                get: vi.fn(async () => ({ enabled: false })),
+            } as unknown as FeatureFlagModel;
+            const createExecutionWarehouseClient = vi.fn(
+                () => warehouseClientMock,
+            );
+            const service = getMockedAsyncQueryService(lightdashConfigMock, {
+                featureFlagModel,
+                composeEngineClient: {
+                    createExecutionWarehouseClient,
+                } as unknown as ComposeEngineClient,
+                queryHistoryModel: {
+                    create: vi.fn(async () => ({ queryUuid: 'join-uuid' })),
+                    get: vi.fn(async () => referencedQueryHistory),
+                } as unknown as QueryHistoryModel,
+            } as never);
+            const runDuckdbQuery = vi
+                .spyOn(service as AnyType, 'runDuckdbQuery')
+                .mockResolvedValue(undefined);
+            const guard = vi.fn(() => null);
+            const fieldsMap = {
+                a_orders_count: {
+                    fieldType: FieldType.METRIC,
+                    type: MetricType.COUNT,
+                    name: 'orders_count',
+                    label: 'Orders',
+                    table: 'a',
+                    tableLabel: 'Query A',
+                    sql: '',
+                    hidden: false,
+                },
+            } as ItemsMap;
+            const originalColumns: ResultColumns = {
+                a_orders_count: {
+                    reference: 'a_orders_count',
+                    type: DimensionType.NUMBER,
+                    label: 'Orders',
+                },
+            };
+            const metricQuery = {
+                exploreName: 'merge',
+                dimensions: [],
+                metrics: ['a_orders_count'],
+                filters: {},
+                sorts: [],
+                limit: 500,
+                tableCalculations: [],
+            } as unknown as MetricQuery;
+
+            const submission = await service.executeAsyncDuckdbSourceQuery({
+                account: sessionAccount,
+                projectUuid,
+                context: QueryExecutionContext.EXPLORE,
+                sql: 'SELECT * FROM orders',
+                references: { orders: referencedQueryHistory.queryUuid },
+                plan: {
+                    columns: {
+                        mode: 'supplied',
+                        fieldsMap,
+                        usedParameters: { region: 'EU' },
+                        originalColumns,
+                        pivotConfiguration: undefined,
+                        metricQuery,
+                    },
+                    engine: 'scopedToReferencedResults',
+                    guard,
+                },
+            });
+            await submission.settled;
+
+            expect(submission.queryUuid).toBe('join-uuid');
+            const flagsRead = (
+                featureFlagModel.get as import('vitest').Mock
+            ).mock.calls.map(([{ featureFlagId }]) => featureFlagId);
+            expect(flagsRead).not.toContain(FeatureFlags.ComposeSqlRunner);
+            expect(flagsRead).not.toContain(FeatureFlags.MultiSourceQuery);
+            expect(service.queryHistoryModel.create).toHaveBeenCalledWith(
+                sessionAccount,
+                expect.objectContaining({
+                    fields: fieldsMap,
+                    originalColumns,
+                    metricQuery,
+                    usedParameters: { region: 'EU' },
+                    pivotConfiguration: null,
+                    compiledSql: 'SELECT * FROM orders',
+                }),
+            );
+            expect(runDuckdbQuery).toHaveBeenCalledTimes(1);
+            expect(runDuckdbQuery.mock.calls[0][0]).toMatchObject({
+                queryUuid: 'join-uuid',
+                columns: { mode: 'supplied', fieldsMap, originalColumns },
+                engine: { kind: 'scopedToReferencedResults' },
+                references: {
+                    kind: 'queries',
+                    references: { orders: referencedQueryHistory.queryUuid },
+                    guard,
+                },
+            });
+            // The shared session is built for the dialect and to refuse a
+            // missing results storage up front; the run scopes its own
+            expect(createExecutionWarehouseClient).toHaveBeenCalledWith({
+                storage: 'results',
+                scope: null,
+            });
+        });
+
         test('reads external-source files on the pre-aggregate bucket session', async () => {
             const createExecutionWarehouseClient = vi.fn(
                 () => warehouseClientMock,
@@ -6758,6 +6865,7 @@ describe('query sources carry the execution context', () => {
         userAttributeOverrides: {},
         invalidateCache: false,
         pivotConfiguration: null,
+        plan: null,
     };
 
     const createSemanticLayerHarness = () => {

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -291,10 +291,13 @@ import {
     type DownloadAsyncQueryResultsArgs,
     type DuckdbQueryColumns,
     type DuckdbQueryEngine,
+    type DuckdbQueryPlan,
     type DuckdbQueryReferences,
+    type DuckdbSourceQuerySubmission,
     type ExecuteAsyncComposeSqlQueryArgs,
     type ExecuteAsyncDashboardChartQueryArgs,
     type ExecuteAsyncDashboardSqlChartArgs,
+    type ExecuteAsyncDuckdbSourceQueryArgs,
     type ExecuteAsyncExternalSqlQueryArgs,
     type ExecuteAsyncFieldValueSearchArgs,
     type ExecuteAsyncMergeQueryArgs,
@@ -7439,6 +7442,52 @@ export class AsyncQueryService extends ProjectService {
             throw new ForbiddenError();
         }
 
+        const { queryUuid } = await this.executeAsyncDuckdbSourceQuery({
+            account,
+            projectUuid,
+            sql,
+            context,
+            limit,
+            references,
+            parameters,
+            plan: {
+                columns: { mode: 'discover' },
+                engine: 'client',
+                guard: null,
+            },
+        });
+
+        return {
+            queryUuid,
+            cacheMetadata: { cacheHit: false },
+            parameterReferences: [],
+            usedParametersValues: {},
+            resolvedTimezone: null,
+        };
+    }
+
+    /**
+     * The execution tail every DuckDB query over other results shares,
+     * below any feature flag or ability gate: the caller has authorized the
+     * submission. The plan decides whether columns are probed or supplied
+     * and which engine session runs the statement; the statement itself is
+     * still checked for file access and its references for read access.
+     */
+    async executeAsyncDuckdbSourceQuery({
+        account,
+        projectUuid,
+        sql,
+        context,
+        limit,
+        references,
+        parameters,
+        plan,
+    }: ExecuteAsyncDuckdbSourceQueryArgs): Promise<DuckdbSourceQuerySubmission> {
+        assertIsAccountWithOrg(account);
+
+        const projectSummary = await this.projectModel.getSummary(projectUuid);
+        const { organizationUuid } = projectSummary;
+
         // Blocks read_parquet/read_json/... and file table paths in the raw
         // user SQL; the only file reads in the executed SQL are the reference
         // CTEs injected below after authorizing them.
@@ -7461,18 +7510,15 @@ export class AsyncQueryService extends ProjectService {
             });
         }
 
-        // Throws MissingConfigError when results storage is not configured
+        // Throws MissingConfigError when results storage is not configured:
+        // a query without an engine is refused here, never in the background.
+        // A scoped plan still needs the dialect, and its own session is
+        // built once the referenced result files are known.
         const warehouseClient =
             this.composeEngineClient.createExecutionWarehouseClient({
                 storage: 'results',
                 scope: null,
             });
-
-        const combinedParameters = await this.combineParameters(
-            projectUuid,
-            undefined,
-            parameters,
-        );
 
         const queryTags: RunQueryTags = {
             ...this.getUserQueryTags(account),
@@ -7484,28 +7530,23 @@ export class AsyncQueryService extends ProjectService {
 
         // The row is created before references are resolved so the queryUuid
         // returns immediately even when referenced queries are still running;
-        // compiled sql, fields and columns are filled in by the background
-        // phase once referenced results exist.
-        const placeholderComposer = new SqlQueryComposer({
-            userSql: sql,
-            columns: [],
-            warehouseClient,
-            pivotConfiguration: undefined,
+        // a discover plan has the background phase fill in compiled sql,
+        // fields and columns once referenced results exist.
+        const resolved = await this.resolveDuckdbQueryPlan({
+            plan,
+            projectUuid,
+            sql,
             limit,
-            parameters: combinedParameters,
-            dashboardFilters: undefined,
-            tileUuid: undefined,
-            dashboardSorts: undefined,
+            parameters,
+            warehouseClient,
         });
-
-        AsyncQueryService.throwIfMissingParameterValues(placeholderComposer);
 
         // Parameter values change the executed SQL without changing its text
         const cacheKey = QueryHistoryModel.getCacheKey(projectUuid, {
             sql: JSON.stringify({
                 sql,
                 references: normalizedReferences ?? null,
-                parameters: combinedParameters,
+                parameters: resolved.parameters,
             }),
             userUuid: null,
         });
@@ -7515,7 +7556,7 @@ export class AsyncQueryService extends ProjectService {
             limit,
             context,
             references,
-            parameters: combinedParameters,
+            parameters: resolved.parameters,
         };
 
         const queryCreatedAt = new Date();
@@ -7523,14 +7564,14 @@ export class AsyncQueryService extends ProjectService {
             projectUuid,
             organizationUuid,
             context,
-            fields: {},
+            fields: resolved.fields,
             compiledSql: sql,
             requestParameters,
-            usedParameters: placeholderComposer.getUsedParameters(),
-            metricQuery: placeholderComposer.getMetricQuery(),
+            usedParameters: resolved.usedParameters,
+            metricQuery: resolved.metricQuery,
             cacheKey,
-            pivotConfiguration: null,
-            originalColumns: {},
+            pivotConfiguration: resolved.pivotConfiguration,
+            originalColumns: resolved.originalColumns,
         });
         this.prometheusMetrics?.trackQueryStateTransition(
             'new',
@@ -7543,7 +7584,7 @@ export class AsyncQueryService extends ProjectService {
             organizationUuid,
         });
 
-        void this.runDuckdbQuery({
+        const settled = this.runDuckdbQuery({
             account,
             projectUuid,
             organizationUuid,
@@ -7556,33 +7597,102 @@ export class AsyncQueryService extends ProjectService {
             references: {
                 kind: 'queries',
                 references: normalizedReferences ?? {},
-                guard: null,
+                guard: plan.guard,
             },
-            columns: {
-                mode: 'discover',
-                limit,
-                parameters: combinedParameters,
-            },
+            columns: resolved.columns,
             storedCompiledSql: null,
-            engine: { kind: 'client', warehouseClient },
+            engine:
+                plan.engine === 'client'
+                    ? { kind: 'client', warehouseClient }
+                    : { kind: 'scopedToReferencedResults' },
             queryTags,
             queryCreatedAt,
             cacheKey,
             context,
         }).catch((e) => {
             this.logger.error(
-                `Async compose SQL query ${queryUuid} failed: ${getErrorMessage(
+                `Async DuckDB source query ${queryUuid} failed: ${getErrorMessage(
                     e,
                 )}`,
             );
         });
 
+        return { queryUuid, queryCreatedAt, settled };
+    }
+
+    /**
+     * What the history row and the run need from a plan. Discovered columns
+     * come from a placeholder composer over the raw SQL, which is also where
+     * a missing parameter value refuses before any row is written; supplied
+     * columns were fixed at compile time and are recorded as they are.
+     */
+    private async resolveDuckdbQueryPlan({
+        plan,
+        projectUuid,
+        sql,
+        limit,
+        parameters,
+        warehouseClient,
+    }: {
+        plan: DuckdbQueryPlan;
+        projectUuid: string;
+        sql: string;
+        limit: number | undefined;
+        parameters: ParametersValuesMap | undefined;
+        warehouseClient: WarehouseClient;
+    }): Promise<{
+        columns: DuckdbQueryColumns;
+        parameters: ParametersValuesMap;
+        fields: ItemsMap;
+        usedParameters: ParametersValuesMap;
+        metricQuery: MetricQuery;
+        pivotConfiguration: PivotConfiguration | null;
+        originalColumns: ResultColumns;
+    }> {
+        if (plan.columns.mode === 'supplied') {
+            const { metricQuery, ...columns } = plan.columns;
+            const usedParameters = columns.usedParameters ?? {};
+            return {
+                columns,
+                parameters: usedParameters,
+                fields: columns.fieldsMap,
+                usedParameters,
+                metricQuery,
+                pivotConfiguration: columns.pivotConfiguration ?? null,
+                originalColumns: columns.originalColumns,
+            };
+        }
+
+        const combinedParameters = await this.combineParameters(
+            projectUuid,
+            undefined,
+            parameters,
+        );
+        const placeholderComposer = new SqlQueryComposer({
+            userSql: sql,
+            columns: [],
+            warehouseClient,
+            pivotConfiguration: undefined,
+            limit,
+            parameters: combinedParameters,
+            dashboardFilters: undefined,
+            tileUuid: undefined,
+            dashboardSorts: undefined,
+        });
+        AsyncQueryService.throwIfMissingParameterValues(placeholderComposer);
+
         return {
-            queryUuid,
-            cacheMetadata: { cacheHit: false },
-            parameterReferences: [],
-            usedParametersValues: {},
-            resolvedTimezone: null,
+            columns: {
+                mode: 'discover',
+                limit,
+                parameters: combinedParameters,
+            },
+            parameters: combinedParameters,
+            fields: {},
+            usedParameters: placeholderComposer.getUsedParameters(),
+            metricQuery: placeholderComposer.getMetricQuery(),
+            pivotConfiguration: null,
+            originalColumns: {},
         };
     }
 

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -95,6 +95,7 @@ import {
     QueryExecutionContext,
     QueryHistoryListFilters,
     QueryHistoryStatus,
+    QuerySourceType,
     resolveQueryTimezone,
     ResultRow,
     ResultsExpiredError,
@@ -123,6 +124,7 @@ import {
     type CompiledCustomSqlDimension,
     type CompiledMetric,
     type CustomDimension,
+    type DuckdbSourceQuery,
     type ExecuteAsyncComposeMergeQueryRequestParams,
     type ExecuteAsyncComposeSqlQueryRequestParams,
     type ExecuteAsyncDashboardChartRequestParams,
@@ -245,6 +247,7 @@ import {
     getNextAndPreviousPage,
     validatePagination,
 } from '../ProjectService/resultsPagination';
+import type { QuerySourceService } from '../QuerySourceService/QuerySourceService';
 import { mergeDraftIntoChart } from '../SavedChartsService/chartDraftOverlay';
 import {
     exploreHasFilteredAttribute,
@@ -263,6 +266,7 @@ import {
 import {
     applyMergeExportLimit,
     buildComposeMergeOriginalColumns,
+    buildMergeLegNode,
     buildMergeRowCapGuard,
     getMergeResultSourceCutShortError,
     getMergeSourceLabels,
@@ -293,7 +297,6 @@ import {
     type DuckdbQueryEngine,
     type DuckdbQueryPlan,
     type DuckdbQueryReferences,
-    type DuckdbSourceQuerySubmission,
     type ExecuteAsyncComposeSqlQueryArgs,
     type ExecuteAsyncDashboardChartQueryArgs,
     type ExecuteAsyncDashboardSqlChartArgs,
@@ -439,6 +442,8 @@ type AsyncQueryServiceArguments = ProjectServiceArguments & {
     persistentDownloadFileService: PersistentDownloadFileService;
     organizationAccessService: OrganizationAccessService;
     composeEngineClient: ComposeEngineClient;
+    /** Lazy: the query source registry is built over this service. */
+    getQuerySourceService: () => QuerySourceService;
     preAggregateStrategy?: PreAggregateStrategy;
     /** EE resolver for external tables; absent in OSS. */
     externalSourceTableResolver?: (
@@ -574,6 +579,8 @@ export class AsyncQueryService extends ProjectService {
 
     private readonly composeEngineClient: ComposeEngineClient;
 
+    private readonly getQuerySourceService: () => QuerySourceService;
+
     protected readonly preAggregateStrategy: PreAggregateStrategy;
 
     private readonly externalSourceTableResolver: AsyncQueryServiceArguments['externalSourceTableResolver'];
@@ -594,6 +601,7 @@ export class AsyncQueryService extends ProjectService {
         this.persistentDownloadFileService = args.persistentDownloadFileService;
         this.organizationAccessService = args.organizationAccessService;
         this.composeEngineClient = args.composeEngineClient;
+        this.getQuerySourceService = args.getQuerySourceService;
         this.preAggregateStrategy =
             args.preAggregateStrategy ?? new NoOpPreAggregateStrategy();
         this.externalSourceTableResolver = args.externalSourceTableResolver;
@@ -7482,7 +7490,7 @@ export class AsyncQueryService extends ProjectService {
         references,
         parameters,
         plan,
-    }: ExecuteAsyncDuckdbSourceQueryArgs): Promise<DuckdbSourceQuerySubmission> {
+    }: ExecuteAsyncDuckdbSourceQueryArgs): Promise<{ queryUuid: string }> {
         assertIsAccountWithOrg(account);
 
         const projectSummary = await this.projectModel.getSummary(projectUuid);
@@ -7535,8 +7543,10 @@ export class AsyncQueryService extends ProjectService {
         const resolved = await this.resolveDuckdbQueryPlan({
             plan,
             projectUuid,
+            context,
             sql,
             limit,
+            references,
             parameters,
             warehouseClient,
         });
@@ -7551,14 +7561,6 @@ export class AsyncQueryService extends ProjectService {
             userUuid: null,
         });
 
-        const requestParameters: ExecuteAsyncComposeSqlQueryRequestParams = {
-            sql,
-            limit,
-            context,
-            references,
-            parameters: resolved.parameters,
-        };
-
         const queryCreatedAt = new Date();
         const { queryUuid } = await this.queryHistoryModel.create(account, {
             projectUuid,
@@ -7566,7 +7568,7 @@ export class AsyncQueryService extends ProjectService {
             context,
             fields: resolved.fields,
             compiledSql: sql,
-            requestParameters,
+            requestParameters: resolved.requestParameters,
             usedParameters: resolved.usedParameters,
             metricQuery: resolved.metricQuery,
             cacheKey,
@@ -7584,7 +7586,7 @@ export class AsyncQueryService extends ProjectService {
             organizationUuid,
         });
 
-        const settled = this.runDuckdbQuery({
+        void this.runDuckdbQuery({
             account,
             projectUuid,
             organizationUuid,
@@ -7617,7 +7619,7 @@ export class AsyncQueryService extends ProjectService {
             );
         });
 
-        return { queryUuid, queryCreatedAt, settled };
+        return { queryUuid };
     }
 
     /**
@@ -7629,15 +7631,19 @@ export class AsyncQueryService extends ProjectService {
     private async resolveDuckdbQueryPlan({
         plan,
         projectUuid,
+        context,
         sql,
         limit,
+        references,
         parameters,
         warehouseClient,
     }: {
         plan: DuckdbQueryPlan;
         projectUuid: string;
+        context: QueryExecutionContext;
         sql: string;
         limit: number | undefined;
+        references: ExecuteAsyncDuckdbSourceQueryArgs['references'];
         parameters: ParametersValuesMap | undefined;
         warehouseClient: WarehouseClient;
     }): Promise<{
@@ -7648,9 +7654,10 @@ export class AsyncQueryService extends ProjectService {
         metricQuery: MetricQuery;
         pivotConfiguration: PivotConfiguration | null;
         originalColumns: ResultColumns;
+        requestParameters: ExecuteAsyncQueryRequestParams;
     }> {
         if (plan.columns.mode === 'supplied') {
-            const { metricQuery, ...columns } = plan.columns;
+            const { metricQuery, requestParameters, ...columns } = plan.columns;
             const usedParameters = columns.usedParameters ?? {};
             return {
                 columns,
@@ -7660,6 +7667,7 @@ export class AsyncQueryService extends ProjectService {
                 metricQuery,
                 pivotConfiguration: columns.pivotConfiguration ?? null,
                 originalColumns: columns.originalColumns,
+                requestParameters,
             };
         }
 
@@ -7681,6 +7689,13 @@ export class AsyncQueryService extends ProjectService {
         });
         AsyncQueryService.throwIfMissingParameterValues(placeholderComposer);
 
+        const requestParameters: ExecuteAsyncComposeSqlQueryRequestParams = {
+            sql,
+            limit,
+            context,
+            references,
+            parameters: combinedParameters,
+        };
         return {
             columns: {
                 mode: 'discover',
@@ -7693,6 +7708,7 @@ export class AsyncQueryService extends ProjectService {
             metricQuery: placeholderComposer.getMetricQuery(),
             pivotConfiguration: null,
             originalColumns: {},
+            requestParameters,
         };
     }
 
@@ -8688,47 +8704,30 @@ export class AsyncQueryService extends ProjectService {
                 scope: null,
             });
 
-        const projectSummary = await this.projectModel.getSummary(projectUuid);
         const sourceRowCap = this.lightdashConfig.query.maxLimit;
 
-        // Metric sources run whole (the merged statement sorts and limits,
-        // and a side is never silently truncated below the source row cap);
-        // result sources are already materialized and join as they are —
-        // referencing them costs no warehouse query at all.
-        const legs = await Promise.all(
-            mergeQuery.sources.map(async (source) => {
-                if (isMergeResultSource(source)) {
-                    return {
-                        sourceId: source.id,
-                        queryUuid: source.queryUuid,
-                        cacheHit: null,
-                    };
-                }
-                const leg = await this.executeAsyncMetricQuery({
-                    account,
-                    projectUuid,
-                    context,
-                    invalidateCache,
-                    parameters,
-                    userAttributeOverrides,
-                    metricQuery: {
-                        ...source.metricQuery,
-                        sorts: [],
-                        limit: sourceRowCap,
-                    },
-                });
-                return {
-                    sourceId: source.id,
-                    queryUuid: leg.queryUuid,
-                    cacheHit: leg.cacheMetadata.cacheHit,
-                };
+        // Metric sources run whole as semantic-layer nodes (the merged
+        // statement sorts and limits, and a side is never silently truncated
+        // below the source row cap); result sources are already materialized
+        // and the join references them by queryUuid, costing no query at all
+        const metricSources = mergeQuery.sources.filter(isMergeMetricSource);
+        const legNodeIdBySourceId = Object.fromEntries(
+            metricSources.map((source, index) => [source.id, `leg_${index}`]),
+        );
+        const legNodes = metricSources.map((source) =>
+            buildMergeLegNode({
+                nodeId: legNodeIdBySourceId[source.id],
+                metricQuery: source.metricQuery,
+                sourceRowCap,
             }),
         );
-        const legQueryUuidBySourceId = Object.fromEntries(
-            legs.map(({ sourceId, queryUuid }) => [sourceId, queryUuid]),
-        );
-        const legCacheHits = legs.flatMap(({ cacheHit }) =>
-            cacheHit === null ? [] : [cacheHit],
+        const legReferenceBySourceId = Object.fromEntries(
+            mergeQuery.sources.map((source) => [
+                source.id,
+                isMergeResultSource(source)
+                    ? source.queryUuid
+                    : legNodeIdBySourceId[source.id],
+            ]),
         );
 
         const fieldTypes = await this.getMergeFieldTypesForQuery(
@@ -8775,19 +8774,12 @@ export class AsyncQueryService extends ProjectService {
         });
         const fieldsMap = composer.getFields();
 
-        // Merge table calculations carry user-authored SQL into the DuckDB
-        // statement, so the same file-access block as raw compose SQL applies
-        try {
-            DuckdbWarehouseClient.validateUserSqlFileAccess(sql);
-        } catch (e) {
-            throw new ParameterError(getErrorMessage(e));
-        }
-
+        // Each reference table binds to a leg node, or to an existing result
         const references = Object.fromEntries(
             Object.entries(referenceTableBySourceId).map(
                 ([sourceId, tableName]) => [
                     tableName,
-                    legQueryUuidBySourceId[sourceId],
+                    legReferenceBySourceId[sourceId],
                 ],
             ),
         );
@@ -8806,36 +8798,14 @@ export class AsyncQueryService extends ProjectService {
                     labelBySourceId[source.id],
                 ]),
         );
-        await this.authorizeQueryReferences({
-            account,
-            projectUuid,
-            organizationUuid,
-            references,
-        });
-
         const originalColumns: ResultColumns = buildComposeMergeOriginalColumns(
             {
                 typedColumns: compiledMerge.typedColumns,
                 itemsMap: compiledMerge.itemsMap,
                 usedParametersValues: compiledMerge.usedParametersValues,
-                legQueryUuidBySourceId,
+                legReferenceBySourceId,
             },
         );
-
-        const queryTags: RunQueryTags = {
-            ...this.getUserQueryTags(account),
-            ...AsyncQueryService.getSchedulerQueryTags(),
-            organization_uuid: organizationUuid,
-            project_uuid: projectUuid,
-            query_context: context,
-        };
-
-        // Keyed to the user: legs compile under per-user attributes, so the
-        // merged result is per-user too
-        const cacheKey = QueryHistoryModel.getCacheKey(projectUuid, {
-            sql: JSON.stringify({ mergeSql: sql, references }),
-            userUuid: account.user.id,
-        });
 
         const requestParameters: ExecuteAsyncComposeMergeQueryRequestParams = {
             context,
@@ -8844,31 +8814,66 @@ export class AsyncQueryService extends ProjectService {
             parameters,
             pivotConfiguration,
         };
-
-        const queryCreatedAt = new Date();
-        const { queryUuid } = await this.queryHistoryModel.create(account, {
-            projectUuid,
-            organizationUuid,
-            context,
-            fields: fieldsMap,
-            compiledSql: sql,
-            requestParameters,
-            usedParameters: composer.getUsedParameters(),
-            metricQuery: composer.getMetricQuery(),
-            cacheKey,
-            pivotConfiguration: pivotConfiguration ?? null,
-            originalColumns,
-        });
-        this.prometheusMetrics?.trackQueryStateTransition(
-            'new',
-            QueryHistoryStatus.PENDING,
-            context,
+        const rowCap = observeRowCapRefusal(
+            buildMergeRowCapGuard({ legLabelByReferenceTable, sourceRowCap }),
         );
+        const joinNodeId = 'merge';
+        const joinNode: DuckdbSourceQuery = {
+            sourceType: QuerySourceType.DUCKDB,
+            nodeId: joinNodeId,
+            sql,
+            references,
+        };
+        const plan: DuckdbQueryPlan = {
+            columns: {
+                mode: 'supplied',
+                fieldsMap,
+                usedParameters: composer.getUsedParameters(),
+                originalColumns,
+                pivotConfiguration,
+                metricQuery: composer.getMetricQuery(),
+                requestParameters,
+            },
+            // A merge calculation is user SQL: it runs on a session that
+            // reaches only the leg files it joins
+            engine: 'scopedToReferencedResults',
+            guard: rowCap.guard,
+        };
 
-        const onboardingFlow = await this.getOnboardingFlow({
-            userUuid: account.user.id,
-            organizationUuid,
-        });
+        // The DAG submits the legs, then the join with its references
+        // rewritten to their queryUuids; the join waits for the legs itself
+        const submittedAt = new Date();
+        const { queries } = await traceSpan(
+            {
+                op: 'merge_query.execute',
+                name: 'merge_query.execute.compose',
+                attributes: {
+                    'lightdash.projectUuid': projectUuid,
+                    'lightdash.queryContext': context,
+                    'lightdash.joinType': mergeQuery.joinType,
+                },
+            },
+            () =>
+                this.getQuerySourceService().submitQueries({
+                    account,
+                    projectUuid,
+                    context,
+                    queries: [...legNodes, joinNode],
+                    parameters: parameters ?? {},
+                    userAttributeOverrides: userAttributeOverrides ?? {},
+                    invalidateCache: invalidateCache ?? false,
+                    plans: { [joinNodeId]: plan },
+                }),
+        );
+        const join = queries.find((query) => query.nodeId === joinNodeId);
+        if (!join) {
+            throw new UnexpectedServerError(
+                'The merge join node was not submitted',
+            );
+        }
+        const legCacheHits = queries
+            .filter((query) => query.nodeId !== joinNodeId)
+            .map((query) => query.cacheHit);
 
         const submission: MergeSubmission = {
             organizationUuid,
@@ -8876,73 +8881,23 @@ export class AsyncQueryService extends ProjectService {
             context,
             mergeQuery,
         };
-        const rowCap = observeRowCapRefusal(
-            buildMergeRowCapGuard({ legLabelByReferenceTable, sourceRowCap }),
-        );
-        void traceSpan(
-            {
-                op: 'merge_query.execute',
-                name: 'merge_query.execute.compose',
-                attributes: {
-                    'lightdash.queryUuid': queryUuid,
-                    'lightdash.projectUuid': projectUuid,
-                    'lightdash.queryContext': context,
-                    'lightdash.joinType': mergeQuery.joinType,
-                },
-            },
-            () =>
-                this.runDuckdbQuery({
-                    account,
-                    projectUuid,
-                    organizationUuid,
-                    isPreviewProject:
-                        projectSummary.type === ProjectType.PREVIEW ||
-                        projectSummary.provisioningSource === 'playground',
-                    onboardingFlow,
-                    queryUuid,
-                    sql,
-                    references: {
-                        kind: 'queries',
-                        references,
-                        guard: rowCap.guard,
-                    },
-                    columns: {
-                        mode: 'supplied',
-                        fieldsMap,
-                        usedParameters: composer.getUsedParameters(),
-                        originalColumns,
-                        pivotConfiguration,
-                    },
-                    storedCompiledSql: null,
-                    // A merge calculation is user SQL: it runs on a session
-                    // that reaches only the leg files it joins
-                    engine: { kind: 'scopedToReferencedResults' },
-                    queryTags,
-                    queryCreatedAt,
-                    cacheKey,
-                    context,
-                }),
-        )
-            .then(() =>
-                this.reportComposeMergeOutcome({
-                    account,
-                    submission,
-                    queryUuid,
-                    queryCreatedAt,
-                    legCacheHits,
-                    rowCapRefused: rowCap.wasRefused(),
-                }),
-            )
-            .catch((e) => {
-                this.logger.error(
-                    `Async compose merge query ${queryUuid} failed: ${getErrorMessage(
-                        e,
-                    )}`,
-                );
-            });
+        void this.reportComposeMergeOutcome({
+            account,
+            submission,
+            queryUuid: join.queryUuid,
+            submittedAt,
+            legCacheHits,
+            wasRowCapRefused: rowCap.wasRefused,
+        }).catch((e) => {
+            this.logger.error(
+                `Async compose merge query ${
+                    join.queryUuid
+                } outcome was not reported: ${getErrorMessage(e)}`,
+            );
+        });
 
         return {
-            queryUuid,
+            queryUuid: join.queryUuid,
             cacheMetadata: { cacheHit: false },
             metricQuery: composer.getMetricQuery(),
             fields: fieldsMap,
@@ -8953,29 +8908,39 @@ export class AsyncQueryService extends ProjectService {
         };
     }
 
-    /** Reads the terminal state the shared tail wrote, once the background run settled. */
+    /**
+     * Reads the join's terminal state once it lands in query history. Polling
+     * rather than awaiting the run keeps this correct wherever the join
+     * executes; the wait covers the legs' own wait plus the join.
+     */
     private async reportComposeMergeOutcome({
         account,
         submission,
         queryUuid,
-        queryCreatedAt,
+        submittedAt,
         legCacheHits,
-        rowCapRefused,
+        wasRowCapRefused,
     }: {
         account: Account;
         submission: MergeSubmission;
         queryUuid: string;
-        queryCreatedAt: Date;
+        submittedAt: Date;
         legCacheHits: boolean[];
-        rowCapRefused: boolean;
+        wasRowCapRefused: () => boolean;
     }): Promise<void> {
-        const history = await this.queryHistoryModel.get(
+        const history = await this.queryHistoryModel.pollForQueryCompletion({
             queryUuid,
-            submission.projectUuid,
             account,
-        );
-        const outcome = resolveComposeMergeOutcome({ history, rowCapRefused });
-        const durationMs = Date.now() - queryCreatedAt.getTime();
+            projectUuid: submission.projectUuid,
+            throwOnCancelled: false,
+            throwOnError: false,
+            timeoutMs: 2 * AsyncQueryService.REFERENCE_WAIT_TIMEOUT_MS,
+        });
+        const outcome = resolveComposeMergeOutcome({
+            history,
+            rowCapRefused: wasRowCapRefused(),
+        });
+        const durationMs = Date.now() - submittedAt.getTime();
         switch (outcome.kind) {
             case 'refused_row_cap':
                 this.analytics.trackAccount(

--- a/packages/backend/src/services/AsyncQueryService/mergeQueryExecution.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/mergeQueryExecution.test.ts
@@ -165,7 +165,7 @@ describe('buildComposeMergeOriginalColumns', () => {
         typedColumns,
         itemsMap,
         usedParametersValues: {},
-        legQueryUuidBySourceId: { orders: 'orders-leg-uuid' },
+        legReferenceBySourceId: { orders: 'orders-leg-uuid' },
     });
 
     test('source-owned columns set provenance to the field in the leg query', () => {
@@ -203,7 +203,7 @@ describe('buildComposeMergeOriginalColumns', () => {
             typedColumns,
             itemsMap,
             usedParametersValues: {},
-            legQueryUuidBySourceId: {},
+            legReferenceBySourceId: {},
         });
         expect(withoutLeg.orders_count.provenance).toEqual({
             fieldId: 'orders_count',

--- a/packages/backend/src/services/AsyncQueryService/mergeQueryExecution.ts
+++ b/packages/backend/src/services/AsyncQueryService/mergeQueryExecution.ts
@@ -3,13 +3,46 @@ import {
     getResultColumnMetadataFromItem,
     isField,
     isMergeMetricSource,
+    QuerySourceType,
     type ItemsMap,
     type MergeQuery,
     type MergeTypedColumn,
+    type MetricQuery,
     type ParametersValuesMap,
     type ResultColumns,
+    type SemanticLayerSourceQuery,
 } from '@lightdash/common';
 import type { DuckdbQueryReferenceGuard } from './types';
+
+/**
+ * A merge leg as a DAG node: the source's metric query run whole, at the
+ * source row cap with no sorts, since the merged statement sorts and limits
+ * and a side must never be silently truncated below the cap.
+ */
+export const buildMergeLegNode = ({
+    nodeId,
+    metricQuery,
+    sourceRowCap,
+}: {
+    nodeId: string;
+    metricQuery: MetricQuery;
+    sourceRowCap: number;
+}): SemanticLayerSourceQuery => ({
+    sourceType: QuerySourceType.SEMANTIC_LAYER,
+    nodeId,
+    exploreName: metricQuery.exploreName,
+    dimensions: metricQuery.dimensions,
+    metrics: metricQuery.metrics,
+    filters: metricQuery.filters,
+    sorts: [],
+    limit: sourceRowCap,
+    tableCalculations: metricQuery.tableCalculations,
+    additionalMetrics: metricQuery.additionalMetrics,
+    customDimensions: metricQuery.customDimensions,
+    metricOverrides: metricQuery.metricOverrides,
+    dimensionOverrides: metricQuery.dimensionOverrides,
+    timezone: metricQuery.timezone,
+});
 
 /**
  * Builds the pre-pivot original columns of a compose-mode merge: display
@@ -19,17 +52,20 @@ import type { DuckdbQueryReferenceGuard } from './types';
  * can both expose `orders_status`, so a fieldId alone is ambiguous). Join
  * keys are shared by every source, so they keep the merged field's own
  * provenance; table calculations have none.
+ *
+ * A leg reference is its queryUuid, or the id of the DAG node that will
+ * produce it: a node id resolves to the queryUuid when the join submits.
  */
 export const buildComposeMergeOriginalColumns = ({
     typedColumns,
     itemsMap,
     usedParametersValues,
-    legQueryUuidBySourceId,
+    legReferenceBySourceId,
 }: {
     typedColumns: MergeTypedColumn[];
     itemsMap: ItemsMap;
     usedParametersValues: ParametersValuesMap;
-    legQueryUuidBySourceId: Record<string, string>;
+    legReferenceBySourceId: Record<string, string>;
 }): ResultColumns =>
     Object.fromEntries(
         typedColumns.map((column) => {
@@ -40,7 +76,7 @@ export const buildComposeMergeOriginalColumns = ({
             );
             if (column.origin.kind === 'source') {
                 const sourceQueryUuid =
-                    legQueryUuidBySourceId[column.origin.sourceId];
+                    legReferenceBySourceId[column.origin.sourceId];
                 if (sourceQueryUuid) {
                     metadata.provenance = {
                         fieldId: column.origin.sourceFieldId,

--- a/packages/backend/src/services/AsyncQueryService/types.ts
+++ b/packages/backend/src/services/AsyncQueryService/types.ts
@@ -295,6 +295,15 @@ export type RunAsyncPreAggregateQueryArgs = Omit<
     preAggregateExecution: PreAggregateExecutionEngine;
 };
 
+/** Known at compile time, so nothing is probed and nothing overwritten. */
+export type SuppliedDuckdbQueryColumns = {
+    mode: 'supplied';
+    fieldsMap: ItemsMap;
+    usedParameters: ParametersValuesMap | null;
+    originalColumns: ResultColumns;
+    pivotConfiguration: PivotConfiguration | undefined;
+};
+
 /** Where a DuckDB query's output columns come from. */
 export type DuckdbQueryColumns =
     | {
@@ -303,14 +312,7 @@ export type DuckdbQueryColumns =
           limit: number | undefined;
           parameters: ParametersValuesMap;
       }
-    | {
-          /** Known at compile time, so nothing is probed and nothing overwritten. */
-          mode: 'supplied';
-          fieldsMap: ItemsMap;
-          usedParameters: ParametersValuesMap | null;
-          originalColumns: ResultColumns;
-          pivotConfiguration: PivotConfiguration | undefined;
-      };
+    | SuppliedDuckdbQueryColumns;
 
 /**
  * Runs once every referenced query has completed and before anything
@@ -341,6 +343,35 @@ export type DuckdbQueryEngine =
           /** An isolated results session whose credentials reach only the bound result files. */
           kind: 'scopedToReferencedResults';
       };
+
+/**
+ * How a DuckDB source query executes, decided by whoever built it. A public
+ * submission discovers its columns on the shared results session; an
+ * internal caller such as a merge supplies its compile-time columns, a
+ * session scoped to the results it reads, and a guard over those results.
+ */
+export type DuckdbQueryPlan = {
+    columns:
+        | { mode: 'discover' }
+        | (SuppliedDuckdbQueryColumns & { metricQuery: MetricQuery });
+    engine: DuckdbQueryEngine['kind'];
+    guard: DuckdbQueryReferenceGuard | null;
+};
+
+export type ExecuteAsyncDuckdbSourceQueryArgs = CommonAsyncQueryArgs & {
+    sql: string;
+    limit?: number;
+    /** Table name -> queryUuid of a previous async query to expose as that table. */
+    references?: Record<string, UUID>;
+    plan: DuckdbQueryPlan;
+};
+
+export type DuckdbSourceQuerySubmission = {
+    queryUuid: string;
+    queryCreatedAt: Date;
+    /** Resolves once the background execution has settled; never rejects. */
+    settled: Promise<void>;
+};
 
 /** A query's references, bound: the CTEs to attach and the result files they read. */
 export type BoundDuckdbQueryReferences = {

--- a/packages/backend/src/services/AsyncQueryService/types.ts
+++ b/packages/backend/src/services/AsyncQueryService/types.ts
@@ -15,6 +15,7 @@ import {
     type DashboardFilters,
     type DateZoom,
     type DownloadAsyncQueryResultsPayload,
+    type ExecuteAsyncQueryRequestParams,
     type ExternalSourceTableReference,
     type Filters,
     type ItemsMap,
@@ -349,11 +350,19 @@ export type DuckdbQueryEngine =
  * submission discovers its columns on the shared results session; an
  * internal caller such as a merge supplies its compile-time columns, a
  * session scoped to the results it reads, and a guard over those results.
+ *
+ * Supplied columns are recorded on the history row as they are, with the
+ * request that produced them. A supplied column's provenance may name a
+ * node of the same submission instead of a queryUuid; it resolves to that
+ * node's query at submit time, the way a table reference does.
  */
 export type DuckdbQueryPlan = {
     columns:
         | { mode: 'discover' }
-        | (SuppliedDuckdbQueryColumns & { metricQuery: MetricQuery });
+        | (SuppliedDuckdbQueryColumns & {
+              metricQuery: MetricQuery;
+              requestParameters: ExecuteAsyncQueryRequestParams;
+          });
     engine: DuckdbQueryEngine['kind'];
     guard: DuckdbQueryReferenceGuard | null;
 };
@@ -364,13 +373,6 @@ export type ExecuteAsyncDuckdbSourceQueryArgs = CommonAsyncQueryArgs & {
     /** Table name -> queryUuid of a previous async query to expose as that table. */
     references?: Record<string, UUID>;
     plan: DuckdbQueryPlan;
-};
-
-export type DuckdbSourceQuerySubmission = {
-    queryUuid: string;
-    queryCreatedAt: Date;
-    /** Resolves once the background execution has settled; never rejects. */
-    settled: Promise<void>;
 };
 
 /** A query's references, bound: the CTEs to attach and the result files they read. */

--- a/packages/backend/src/services/QuerySourceService/QuerySourceService.test.ts
+++ b/packages/backend/src/services/QuerySourceService/QuerySourceService.test.ts
@@ -1,4 +1,5 @@
 import {
+    DimensionType,
     ForbiddenError,
     ParameterError,
     QueryExecutionContext,
@@ -43,6 +44,7 @@ const createFakeSource = (
         .fn()
         .mockImplementation(async ({ query }: { query: SourceQuery }) => ({
             queryUuid: `${query.nodeId ?? sourceType}-query-uuid`,
+            cacheHit: false,
         })),
 ): QuerySourceClient & { submitQuery: Mock } => ({
     definition: { sourceType, label: sourceType, description: 'fake source' },
@@ -611,14 +613,14 @@ describe('composer pipelines return the standard results interface', () => {
         const asyncQueryService = {
             executeAsyncMetricQuery: vi.fn().mockResolvedValue({
                 queryUuid: 'metric-query-uuid',
+                cacheMetadata: { cacheHit: true },
             }),
             executeAsyncComposeSqlQuery: vi.fn().mockResolvedValue({
                 queryUuid: 'compose-query-uuid',
+                cacheMetadata: { cacheHit: false },
             }),
             executeAsyncDuckdbSourceQuery: vi.fn().mockResolvedValue({
                 queryUuid: 'planned-query-uuid',
-                queryCreatedAt: new Date(),
-                settled: Promise.resolve(),
             }),
         };
         const registry = new QuerySourceRegistry();
@@ -766,6 +768,11 @@ describe('composer pipelines return the standard results interface', () => {
         expect(
             result.queries.find((q) => q.nodeId === 'joined')?.queryUuid,
         ).toEqual('planned-query-uuid');
+        // The leg's cache hit is reported; a DuckDB run never is one
+        expect(result.queries.map((q) => [q.nodeId, q.cacheHit])).toEqual([
+            ['orders', true],
+            ['joined', false],
+        ]);
         expect(
             asyncQueryService.executeAsyncComposeSqlQuery,
         ).not.toHaveBeenCalled();
@@ -777,6 +784,74 @@ describe('composer pipelines return the standard results interface', () => {
                 plan,
             }),
         );
+    });
+
+    it("resolves a supplied column's provenance from a node id to that node's queryUuid", async () => {
+        const { registry, asyncQueryService } = createRealSources();
+        const { service } = createService(registry);
+        const column = (sourceQueryUuid: string) => ({
+            reference: 'orders_total_revenue',
+            type: DimensionType.NUMBER,
+            provenance: { fieldId: 'orders_total_revenue', sourceQueryUuid },
+        });
+        const plan: DuckdbQueryPlan = {
+            columns: {
+                mode: 'supplied',
+                fieldsMap: {},
+                usedParameters: null,
+                originalColumns: { orders_total_revenue: column('orders') },
+                pivotConfiguration: undefined,
+                metricQuery: {
+                    exploreName: 'merge',
+                    dimensions: [],
+                    metrics: ['orders_total_revenue'],
+                    filters: {},
+                    sorts: [],
+                    limit: 500,
+                    tableCalculations: [],
+                },
+                requestParameters: {
+                    context: QueryExecutionContext.EXPLORE,
+                    sql: 'SELECT * FROM orders',
+                },
+            },
+            engine: 'scopedToReferencedResults',
+            guard: null,
+        };
+
+        await service.submitQueries({
+            ...executionContext,
+            account,
+            projectUuid,
+            context: QueryExecutionContext.EXPLORE,
+            queries: [
+                {
+                    sourceType: QuerySourceType.SEMANTIC_LAYER,
+                    nodeId: 'orders',
+                    exploreName: 'orders',
+                    dimensions: [],
+                    metrics: ['orders_total_revenue'],
+                },
+                {
+                    sourceType: QuerySourceType.DUCKDB,
+                    nodeId: 'joined',
+                    sql: 'SELECT * FROM orders',
+                    references: ['orders'],
+                },
+            ],
+            plans: { joined: plan },
+        });
+
+        const submitted = (
+            asyncQueryService.executeAsyncDuckdbSourceQuery as Mock
+        ).mock.calls[0][0];
+        expect(submitted.plan.columns.originalColumns).toEqual({
+            orders_total_revenue: column('metric-query-uuid'),
+        });
+        // The caller's plan is not mutated
+        expect(
+            plan.columns.mode === 'supplied' && plan.columns.originalColumns,
+        ).toEqual({ orders_total_revenue: column('orders') });
     });
 
     it('hands a DuckDB node its parameters and cache control, and refuses a pivot on it', async () => {

--- a/packages/backend/src/services/QuerySourceService/QuerySourceService.test.ts
+++ b/packages/backend/src/services/QuerySourceService/QuerySourceService.test.ts
@@ -4,6 +4,7 @@ import {
     QueryExecutionContext,
     QueryHistoryStatus,
     QuerySourceType,
+    UnexpectedServerError,
     VizAggregationOptions,
     VizIndexType,
     type PivotConfiguration,
@@ -15,6 +16,7 @@ import type { FeatureFlagModel } from '../../models/FeatureFlagModel/FeatureFlag
 import type { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import type { QueryHistoryModel } from '../../models/QueryHistoryModel/QueryHistoryModel';
 import type { AsyncQueryService } from '../AsyncQueryService/AsyncQueryService';
+import type { DuckdbQueryPlan } from '../AsyncQueryService/types';
 import type { ProjectService } from '../ProjectService/ProjectService';
 import { QuerySourceRegistry } from './QuerySourceRegistry';
 import { QuerySourceService } from './QuerySourceService';
@@ -368,14 +370,17 @@ describe('QuerySourceService', () => {
                 expect.objectContaining({
                     ...sharedContext,
                     pivotConfiguration,
+                    plan: null,
                 }),
             );
             // The pivot belongs to the node that declared it; nodes without
-            // one get an explicit null, never the neighbour's pivot
+            // one get an explicit null, never the neighbour's pivot. A public
+            // submission never carries an execution plan
             expect(fakes.duckdbSource.submitQuery).toHaveBeenCalledWith(
                 expect.objectContaining({
                     ...sharedContext,
                     pivotConfiguration: null,
+                    plan: null,
                 }),
             );
         });
@@ -444,6 +449,7 @@ describe('QuerySourceService', () => {
                 userAttributeOverrides: {},
                 invalidateCache: false,
                 pivotConfiguration: null,
+                plan: null,
             };
             const { userAttributeOverrides, ...withoutOverrides } = args;
             // @ts-expect-error omitting the overrides is a compile error, not a silent default
@@ -470,6 +476,80 @@ describe('QuerySourceService', () => {
                     context: QueryExecutionContext.MULTI_SOURCE_QUERY,
                 }),
             ).rejects.toThrow('warehouse exploded');
+        });
+    });
+
+    describe('submitQueries', () => {
+        const joinPlan: DuckdbQueryPlan = {
+            columns: { mode: 'discover' },
+            engine: 'scopedToReferencedResults',
+            guard: null,
+        };
+        const legAndJoin: SourceQuery[] = [
+            {
+                nodeId: 'orders',
+                sourceType: QuerySourceType.SEMANTIC_LAYER,
+                exploreName: 'orders',
+                dimensions: ['orders_status'],
+                metrics: ['orders_total'],
+            },
+            {
+                nodeId: 'joined',
+                sourceType: QuerySourceType.DUCKDB,
+                sql: 'SELECT * FROM orders',
+                references: ['orders'],
+            },
+        ];
+
+        it('submits below the flag and ability gates and hands the named duckdb node its plan', async () => {
+            const fakes = createRegistryWithFakes();
+            const { service, mocks } = createService(fakes.registry);
+            mocks.featureFlagModel.get.mockResolvedValue({ enabled: false });
+
+            const results = await service.submitQueries({
+                ...executionContext,
+                account,
+                projectUuid,
+                queries: legAndJoin,
+                context: QueryExecutionContext.EXPLORE,
+                plans: { joined: joinPlan },
+            });
+
+            expect(results.queries.map((q) => q.nodeId)).toEqual([
+                'orders',
+                'joined',
+            ]);
+            expect(mocks.featureFlagModel.get).not.toHaveBeenCalled();
+            expect(mocks.projectModel.getSummary).not.toHaveBeenCalled();
+            expect(fakes.semanticLayerSource.submitQuery).toHaveBeenCalledWith(
+                expect.objectContaining({ plan: null }),
+            );
+            expect(fakes.duckdbSource.submitQuery).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    plan: joinPlan,
+                    resolvedReferences: { orders: 'orders-query-uuid' },
+                }),
+            );
+        });
+
+        it('refuses a plan that names anything but a duckdb node before submitting any node', async () => {
+            const fakes = createRegistryWithFakes();
+            const { service } = createService(fakes.registry);
+
+            await expect(
+                service.submitQueries({
+                    ...executionContext,
+                    account,
+                    projectUuid,
+                    queries: legAndJoin,
+                    context: QueryExecutionContext.EXPLORE,
+                    plans: { orders: joinPlan },
+                }),
+            ).rejects.toThrow(UnexpectedServerError);
+            expect(
+                fakes.semanticLayerSource.submitQuery,
+            ).not.toHaveBeenCalled();
+            expect(fakes.duckdbSource.submitQuery).not.toHaveBeenCalled();
         });
     });
 
@@ -534,6 +614,11 @@ describe('composer pipelines return the standard results interface', () => {
             }),
             executeAsyncComposeSqlQuery: vi.fn().mockResolvedValue({
                 queryUuid: 'compose-query-uuid',
+            }),
+            executeAsyncDuckdbSourceQuery: vi.fn().mockResolvedValue({
+                queryUuid: 'planned-query-uuid',
+                queryCreatedAt: new Date(),
+                settled: Promise.resolve(),
             }),
         };
         const registry = new QuerySourceRegistry();
@@ -642,6 +727,54 @@ describe('composer pipelines return the standard results interface', () => {
         ).toHaveBeenCalledWith(
             expect.objectContaining({
                 references: { orders: 'metric-query-uuid' },
+            }),
+        );
+    });
+
+    it('runs a planned DuckDB node on the execution tail, never the gated compose SQL path', async () => {
+        const { registry, asyncQueryService } = createRealSources();
+        const { service } = createService(registry);
+        const plan: DuckdbQueryPlan = {
+            columns: { mode: 'discover' },
+            engine: 'scopedToReferencedResults',
+            guard: null,
+        };
+
+        const result = await service.submitQueries({
+            ...executionContext,
+            account,
+            projectUuid,
+            context: QueryExecutionContext.EXPLORE,
+            queries: [
+                {
+                    sourceType: QuerySourceType.SEMANTIC_LAYER,
+                    nodeId: 'orders',
+                    exploreName: 'orders',
+                    dimensions: ['orders_status'],
+                    metrics: ['orders_total_revenue'],
+                },
+                {
+                    sourceType: QuerySourceType.DUCKDB,
+                    nodeId: 'joined',
+                    sql: 'SELECT * FROM orders',
+                    references: ['orders'],
+                },
+            ],
+            plans: { joined: plan },
+        });
+
+        expect(
+            result.queries.find((q) => q.nodeId === 'joined')?.queryUuid,
+        ).toEqual('planned-query-uuid');
+        expect(
+            asyncQueryService.executeAsyncComposeSqlQuery,
+        ).not.toHaveBeenCalled();
+        expect(
+            asyncQueryService.executeAsyncDuckdbSourceQuery,
+        ).toHaveBeenCalledWith(
+            expect.objectContaining({
+                references: { orders: 'metric-query-uuid' },
+                plan,
             }),
         );
     });

--- a/packages/backend/src/services/QuerySourceService/QuerySourceService.ts
+++ b/packages/backend/src/services/QuerySourceService/QuerySourceService.ts
@@ -4,19 +4,21 @@ import {
     FeatureFlags,
     ForbiddenError,
     ParameterError,
+    QuerySourceType,
+    UnexpectedServerError,
     type Account,
     type ApiExecuteSourceQueriesResults,
     type ApiGetSourceQueryStatusResults,
     type ApiListQuerySourcesResults,
     type ApiScanQuerySourceSchemaResults,
     type QueryExecutionContext,
-    type QuerySourceType,
     type SourceQuery,
     type SourceQuerySubmission,
 } from '@lightdash/common';
 import type { FeatureFlagModel } from '../../models/FeatureFlagModel/FeatureFlagModel';
 import type { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import type { QueryHistoryModel } from '../../models/QueryHistoryModel/QueryHistoryModel';
+import type { DuckdbQueryPlan } from '../AsyncQueryService/types';
 import { BaseService } from '../BaseService';
 import type { QuerySourceRegistry } from './QuerySourceRegistry';
 import type { QuerySourceClient, SourceQueryExecutionContext } from './types';
@@ -286,7 +288,42 @@ export class QuerySourceService extends BaseService {
         await this.throwIfMultiSourceQueryDisabled(account);
         await this.throwIfCannotRunQueries(account, projectUuid);
 
+        return this.submitQueries({
+            account,
+            projectUuid,
+            queries,
+            context,
+            parameters,
+            userAttributeOverrides,
+            invalidateCache,
+            plans: {},
+        });
+    }
+
+    /**
+     * The ungated submission: no feature flag, no ability check. For callers
+     * inside the server that have already authorized what they submit, such
+     * as a merge, and that may hand a duckdb node an execution plan by node
+     * id. The public endpoint never reaches this directly.
+     */
+    async submitQueries({
+        account,
+        projectUuid,
+        queries,
+        context,
+        parameters,
+        userAttributeOverrides,
+        invalidateCache,
+        plans,
+    }: SourceQueryExecutionContext & {
+        account: Account;
+        projectUuid: string;
+        queries: SourceQuery[];
+        context: QueryExecutionContext;
+        plans: Record<string, DuckdbQueryPlan>;
+    }): Promise<ApiExecuteSourceQueriesResults> {
         const ordered = this.validateQueries(queries);
+        QuerySourceService.assertPlansNameDuckdbNodes(ordered, plans);
 
         // nodeId -> queryUuid, grown as submissions happen so later queries'
         // node-id references resolve
@@ -304,6 +341,7 @@ export class QuerySourceService extends BaseService {
                 userAttributeOverrides,
                 invalidateCache,
                 pivotConfiguration: entry.query.pivotConfiguration ?? null,
+                plan: plans[entry.nodeId] ?? null,
             });
             resolvedReferences[entry.nodeId] = queryUuid;
             submissions.push({
@@ -314,6 +352,23 @@ export class QuerySourceService extends BaseService {
         }
 
         return { queries: submissions };
+    }
+
+    /** A plan on anything but a duckdb node is a caller bug, not a user error. */
+    private static assertPlansNameDuckdbNodes(
+        ordered: ValidatedQuery[],
+        plans: Record<string, DuckdbQueryPlan>,
+    ): void {
+        const sourceTypeByNodeId = new Map(
+            ordered.map((entry) => [entry.nodeId, entry.query.sourceType]),
+        );
+        Object.keys(plans).forEach((nodeId) => {
+            if (sourceTypeByNodeId.get(nodeId) !== QuerySourceType.DUCKDB) {
+                throw new UnexpectedServerError(
+                    `Execution plan for "${nodeId}" does not name a ${QuerySourceType.DUCKDB} node`,
+                );
+            }
+        });
     }
 
     /**

--- a/packages/backend/src/services/QuerySourceService/QuerySourceService.ts
+++ b/packages/backend/src/services/QuerySourceService/QuerySourceService.ts
@@ -21,7 +21,15 @@ import type { QueryHistoryModel } from '../../models/QueryHistoryModel/QueryHist
 import type { DuckdbQueryPlan } from '../AsyncQueryService/types';
 import { BaseService } from '../BaseService';
 import type { QuerySourceRegistry } from './QuerySourceRegistry';
-import type { QuerySourceClient, SourceQueryExecutionContext } from './types';
+import type {
+    QuerySourceClient,
+    SourceQueryExecutionContext,
+    SourceQuerySubmissionResult,
+} from './types';
+
+/** A submission as the server sees it: the public row plus what the run reported. */
+export type InternalSourceQuerySubmission = SourceQuerySubmission &
+    Pick<SourceQuerySubmissionResult, 'cacheHit'>;
 
 type QuerySourceServiceArguments = {
     projectModel: ProjectModel;
@@ -288,7 +296,7 @@ export class QuerySourceService extends BaseService {
         await this.throwIfMultiSourceQueryDisabled(account);
         await this.throwIfCannotRunQueries(account, projectUuid);
 
-        return this.submitQueries({
+        const submitted = await this.submitQueries({
             account,
             projectUuid,
             queries,
@@ -298,6 +306,15 @@ export class QuerySourceService extends BaseService {
             invalidateCache,
             plans: {},
         });
+        return {
+            queries: submitted.queries.map(
+                ({ nodeId, sourceType, queryUuid }) => ({
+                    nodeId,
+                    sourceType,
+                    queryUuid,
+                }),
+            ),
+        };
     }
 
     /**
@@ -321,17 +338,17 @@ export class QuerySourceService extends BaseService {
         queries: SourceQuery[];
         context: QueryExecutionContext;
         plans: Record<string, DuckdbQueryPlan>;
-    }): Promise<ApiExecuteSourceQueriesResults> {
+    }): Promise<{ queries: InternalSourceQuerySubmission[] }> {
         const ordered = this.validateQueries(queries);
         QuerySourceService.assertPlansNameDuckdbNodes(ordered, plans);
 
         // nodeId -> queryUuid, grown as submissions happen so later queries'
         // node-id references resolve
         const resolvedReferences: Record<string, string> = {};
-        const submissions: SourceQuerySubmission[] = [];
+        const submissions: InternalSourceQuerySubmission[] = [];
         for (const entry of ordered) {
             // eslint-disable-next-line no-await-in-loop -- dependency order: later submits need earlier queryUuids
-            const { queryUuid } = await entry.source.submitQuery({
+            const { queryUuid, cacheHit } = await entry.source.submitQuery({
                 account,
                 projectUuid,
                 context,
@@ -348,6 +365,7 @@ export class QuerySourceService extends BaseService {
                 nodeId: entry.nodeId,
                 sourceType: entry.query.sourceType,
                 queryUuid,
+                cacheHit,
             });
         }
 

--- a/packages/backend/src/services/QuerySourceService/sources/DuckdbQuerySource.ts
+++ b/packages/backend/src/services/QuerySourceService/sources/DuckdbQuerySource.ts
@@ -7,9 +7,11 @@ import {
     type SourceQuery,
 } from '@lightdash/common';
 import type { AsyncQueryService } from '../../AsyncQueryService/AsyncQueryService';
+import type { DuckdbQueryPlan } from '../../AsyncQueryService/types';
 import type {
     QuerySourceClient,
     ScanSchemaArgs,
+    SourceQuerySubmissionResult,
     SubmitSourceQueryArgs,
 } from '../types';
 
@@ -61,6 +63,37 @@ export class DuckdbQuerySource implements QuerySourceClient {
         return references;
     }
 
+    /** A supplied column's provenance may name a node; it resolves like a table reference. */
+    private static resolvePlanReferences(
+        plan: DuckdbQueryPlan,
+        resolvedReferences: Record<string, string>,
+    ): DuckdbQueryPlan {
+        if (plan.columns.mode !== 'supplied') return plan;
+        const originalColumns = Object.fromEntries(
+            Object.entries(plan.columns.originalColumns).map(
+                ([reference, column]) => {
+                    const sourceQueryUuid = column.provenance?.sourceQueryUuid;
+                    if (sourceQueryUuid === undefined) {
+                        return [reference, column];
+                    }
+                    return [
+                        reference,
+                        {
+                            ...column,
+                            provenance: {
+                                ...column.provenance,
+                                sourceQueryUuid:
+                                    resolvedReferences[sourceQueryUuid] ??
+                                    sourceQueryUuid,
+                            },
+                        },
+                    ];
+                },
+            ),
+        );
+        return { ...plan, columns: { ...plan.columns, originalColumns } };
+    }
+
     // eslint-disable-next-line class-methods-use-this
     async scanSchema(_args: ScanSchemaArgs): Promise<QuerySourceSchema> {
         return {
@@ -95,7 +128,7 @@ export class DuckdbQuerySource implements QuerySourceClient {
         invalidateCache,
         pivotConfiguration,
         plan,
-    }: SubmitSourceQueryArgs): Promise<{ queryUuid: string }> {
+    }: SubmitSourceQueryArgs): Promise<SourceQuerySubmissionResult> {
         const sourceQuery = DuckdbQuerySource.assertSourceQuery(query);
         if (pivotConfiguration !== null) {
             throw new ParameterError(
@@ -130,9 +163,13 @@ export class DuckdbQuerySource implements QuerySourceClient {
                 ? await this.asyncQueryService.executeAsyncComposeSqlQuery(args)
                 : await this.asyncQueryService.executeAsyncDuckdbSourceQuery({
                       ...args,
-                      plan,
+                      plan: DuckdbQuerySource.resolvePlanReferences(
+                          plan,
+                          resolvedReferences,
+                      ),
                   });
 
-        return { queryUuid };
+        // A DuckDB query always runs: its inputs may be cached, it is not
+        return { queryUuid, cacheHit: false };
     }
 }

--- a/packages/backend/src/services/QuerySourceService/sources/DuckdbQuerySource.ts
+++ b/packages/backend/src/services/QuerySourceService/sources/DuckdbQuerySource.ts
@@ -80,6 +80,10 @@ export class DuckdbQuerySource implements QuerySourceClient {
      * User attribute overrides have nothing to apply to here: referenced
      * results were produced under them and compose SQL carries no attribute
      * references. A pivot refuses until the join node owns the pivot stage.
+     *
+     * Without a plan the query takes the public compose SQL path, which
+     * carries its own flag and ability gates. With one it goes straight to
+     * the execution tail: the caller that built the plan owns authorization.
      */
     async submitQuery({
         account,
@@ -90,6 +94,7 @@ export class DuckdbQuerySource implements QuerySourceClient {
         parameters,
         invalidateCache,
         pivotConfiguration,
+        plan,
     }: SubmitSourceQueryArgs): Promise<{ queryUuid: string }> {
         const sourceQuery = DuckdbQuerySource.assertSourceQuery(query);
         if (pivotConfiguration !== null) {
@@ -110,18 +115,24 @@ export class DuckdbQuerySource implements QuerySourceClient {
               )
             : undefined;
 
-        const results =
-            await this.asyncQueryService.executeAsyncComposeSqlQuery({
-                account,
-                projectUuid,
-                sql: sourceQuery.sql,
-                limit: sourceQuery.limit,
-                references,
-                context,
-                parameters,
-                invalidateCache,
-            });
+        const args = {
+            account,
+            projectUuid,
+            sql: sourceQuery.sql,
+            limit: sourceQuery.limit,
+            references,
+            context,
+            parameters,
+            invalidateCache,
+        };
+        const { queryUuid } =
+            plan === null
+                ? await this.asyncQueryService.executeAsyncComposeSqlQuery(args)
+                : await this.asyncQueryService.executeAsyncDuckdbSourceQuery({
+                      ...args,
+                      plan,
+                  });
 
-        return { queryUuid: results.queryUuid };
+        return { queryUuid };
     }
 }

--- a/packages/backend/src/services/QuerySourceService/sources/SemanticLayerQuerySource.ts
+++ b/packages/backend/src/services/QuerySourceService/sources/SemanticLayerQuerySource.ts
@@ -138,7 +138,10 @@ export class SemanticLayerQuerySource implements QuerySourceClient {
         userAttributeOverrides,
         invalidateCache,
         pivotConfiguration,
-    }: SubmitSourceQueryArgs): Promise<{ queryUuid: string }> {
+    }: SubmitSourceQueryArgs): Promise<{
+        queryUuid: string;
+        cacheHit: boolean;
+    }> {
         const sourceQuery = SemanticLayerQuerySource.assertSourceQuery(query);
 
         // Only exploreName/dimensions/metrics are required on the wire; the
@@ -153,6 +156,8 @@ export class SemanticLayerQuerySource implements QuerySourceClient {
             tableCalculations: sourceQuery.tableCalculations ?? [],
             additionalMetrics: sourceQuery.additionalMetrics,
             customDimensions: sourceQuery.customDimensions,
+            metricOverrides: sourceQuery.metricOverrides,
+            dimensionOverrides: sourceQuery.dimensionOverrides,
             timezone: sourceQuery.timezone,
         };
 
@@ -167,6 +172,9 @@ export class SemanticLayerQuerySource implements QuerySourceClient {
             pivotConfiguration: pivotConfiguration ?? undefined,
         });
 
-        return { queryUuid: results.queryUuid };
+        return {
+            queryUuid: results.queryUuid,
+            cacheHit: results.cacheMetadata.cacheHit,
+        };
     }
 }

--- a/packages/backend/src/services/QuerySourceService/sources/SqlQuerySource.ts
+++ b/packages/backend/src/services/QuerySourceService/sources/SqlQuerySource.ts
@@ -103,7 +103,10 @@ export class SqlQuerySource implements QuerySourceClient {
         userAttributeOverrides,
         invalidateCache,
         pivotConfiguration,
-    }: SubmitSourceQueryArgs): Promise<{ queryUuid: string }> {
+    }: SubmitSourceQueryArgs): Promise<{
+        queryUuid: string;
+        cacheHit: boolean;
+    }> {
         const sourceQuery = SqlQuerySource.assertSourceQuery(query);
 
         const results = await this.asyncQueryService.executeAsyncSqlQuery({
@@ -118,6 +121,9 @@ export class SqlQuerySource implements QuerySourceClient {
             pivotConfiguration: pivotConfiguration ?? undefined,
         });
 
-        return { queryUuid: results.queryUuid };
+        return {
+            queryUuid: results.queryUuid,
+            cacheHit: results.cacheMetadata.cacheHit,
+        };
     }
 }

--- a/packages/backend/src/services/QuerySourceService/types.ts
+++ b/packages/backend/src/services/QuerySourceService/types.ts
@@ -8,6 +8,7 @@ import type {
     SourceQuery,
     UserAttributeValueMap,
 } from '@lightdash/common';
+import type { DuckdbQueryPlan } from '../AsyncQueryService/types';
 
 export type ScanSchemaArgs = {
     account: Account;
@@ -43,6 +44,12 @@ export type SubmitSourceQueryArgs = SourceQueryExecutionContext & {
     resolvedReferences: Record<string, string>;
     /** The node's own pivot, lifted off the query so every source reads one place. */
     pivotConfiguration: PivotConfiguration | null;
+    /**
+     * How a duckdb node executes. Null is the public plan: the gated compose
+     * SQL path, columns discovered, shared results session. Only internal
+     * submissions carry a plan; the public endpoint cannot express one.
+     */
+    plan: DuckdbQueryPlan | null;
 };
 
 /**

--- a/packages/backend/src/services/QuerySourceService/types.ts
+++ b/packages/backend/src/services/QuerySourceService/types.ts
@@ -64,11 +64,19 @@ export type SubmitSourceQueryArgs = SourceQueryExecutionContext & {
  * register with QuerySourceRegistry; how a source authenticates against its
  * backing system is an implementation detail behind this contract.
  */
+export type SourceQuerySubmissionResult = {
+    queryUuid: string;
+    /** Whether the submission was served from an earlier result rather than run. */
+    cacheHit: boolean;
+};
+
 export interface QuerySourceClient {
     definition: QuerySourceDefinition;
     /** Whether a query of this source may carry a pivotConfiguration. */
     supportsPivot: boolean;
     scanSchema(args: ScanSchemaArgs): Promise<QuerySourceSchema>;
     getQueryReferences(query: SourceQuery): string[];
-    submitQuery(args: SubmitSourceQueryArgs): Promise<{ queryUuid: string }>;
+    submitQuery(
+        args: SubmitSourceQueryArgs,
+    ): Promise<SourceQuerySubmissionResult>;
 }

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -1017,6 +1017,7 @@ export class ServiceRepository
                     resultsStorageClient:
                         this.clients.getResultsFileStorageClient(),
                     composeEngineClient: this.getComposeEngineClient(),
+                    getQuerySourceService: () => this.getQuerySourceService(),
                     featureFlagModel: this.models.getFeatureFlagModel(),
                     projectParametersModel:
                         this.models.getProjectParametersModel(),

--- a/packages/common/src/types/querySources.ts
+++ b/packages/common/src/types/querySources.ts
@@ -8,6 +8,8 @@ import {
 } from './field';
 import {
     type AdditionalMetric,
+    type DimensionOverrides,
+    type MetricOverrides,
     type MetricQueryRequest,
     type SortField,
 } from './metricQuery';
@@ -100,6 +102,10 @@ export type SemanticLayerSourceQuery = {
     additionalMetrics?: AdditionalMetric[];
     /** Ad-hoc dimensions not defined in the explore. */
     customDimensions?: CustomDimension[];
+    /** Formatting overrides for metrics in this query, keyed by field id. */
+    metricOverrides?: MetricOverrides;
+    /** Formatting overrides for dimensions in this query, keyed by field id. */
+    dimensionOverrides?: DimensionOverrides;
     /** IANA timezone for time dimension bucketing, e.g. "America/New_York". */
     timezone?: string;
     /**


### PR DESCRIPTION
## What changed

A merge now submits as a query source DAG: one `semanticLayer` node per metric source and one `duckdb` join node, handed to `QuerySourceService`. This is the first of three PRs for PROD-10901 and changes no contract: the `merge-on-compose` flag still routes, the warehouse merge still exists for flag-off orgs, and the public query-sources endpoint behaves as before.

```mermaid
flowchart LR
    P["POST /query-sources/queries"] --> E["executeSourceQueries<br/>multi-source flag + manage Explore"]
    M["submitAsyncMergeQuery<br/>(merge-on-compose on)"] --> S
    E -- "plans: {}" --> S["submitQueries<br/>no gates"]
    M -. "plans: { merge: plan }" .-> S
    S --> L0["leg_0<br/>semanticLayer"]
    S --> L1["leg_1<br/>semanticLayer"]
    S --> J["merge<br/>duckdb node"]
    L0 -- "result" --> J
    L1 -- "result" --> J
    J -- "plan = null" --> C["executeAsyncComposeSqlQuery<br/>compose-sql-runner flag + manage Explore"]
    J -- "plan set" --> T["executeAsyncDuckdbSourceQuery<br/>the tail: file access, references, history row"]
    C -- "discover plan" --> T
```

Two pieces make that possible:

- **An ungated DAG entry.** `QuerySourceService.submitQueries` is the same submission as `executeSourceQueries` without the multi-source flag and the `manage Explore` ability, for callers inside the server that have already authorized what they submit. It takes an execution plan per `duckdb` node. The public method is now the gates plus that call with no plans.
- **A DuckDB execution plan on the submit contract.** `SubmitSourceQueryArgs.plan` is a required `DuckdbQueryPlan | null`. Null is the public plan (gated compose SQL path, columns discovered, shared results session). A plan carries compile-time columns, the engine session kind and a reference guard, and sends the node straight to `AsyncQueryService.executeAsyncDuckdbSourceQuery`, the tail the compose SQL runner already had below its gates. The public request body cannot express a plan.

The merge builds two leg nodes (`buildMergeLegNode`: the metric query whole, at the source row cap, unsorted), references a result source by its own queryUuid with no node, and gives the join node a supplied plan with the compile's fields map, columns, metric query and request parameters, a session scoped to the leg files, and the row-cap guard. Provenance on a supplied column may name a leg node; the duckdb source resolves it to the leg's queryUuid at submit, the way it resolves a table reference, so the plan can be built before any leg has run.

Smaller changes riding along: `SemanticLayerSourceQuery` gains `metricOverrides` and `dimensionOverrides` so a leg round-trips its metric query; every query source reports whether its submission was a cache hit, so the merge event keeps its leg cache-hit count without widening the public DAG response; and the merge outcome reporter polls the join row instead of awaiting the in-process run, which keeps it correct once the join moves to the worker (PROD-10993).

## Regression analysis

- **Flag-off orgs**: untouched. The warehouse merge path is not modified here.
- **Flag-on orgs**: the legs are the same metric queries with the same limit and sorts, submitted through `SemanticLayerQuerySource` instead of directly; the join runs on the same tail with the same supplied columns and scoped session. Two behaviour changes: the join's results cache key no longer includes the user (the leg queryUuids in the key are already per-user rows), and leg cache hits come from each leg's own submission rather than the return value of a direct call.
- **Public query-sources endpoint**: every node gets `plan: null`, which is exactly the previous behaviour; a `plan` on anything but a duckdb node is refused before any node submits.
- **Service wiring**: `AsyncQueryService` takes a lazy `getQuerySourceService` in both editions, because the registry is built over the service itself.

## Verification

- Backend typecheck, lint and format clean; `AsyncQueryService.test.ts` 111 tests, query source, external source and merge helper suites 59 tests, all green.
- New unit cases: a planned duckdb node bypasses both gates and reaches the tail with its plan; a plan on a semantic-layer node is refused before any submission; a supplied plan writes the caller's fields, columns and metric query to the history row and never reads the compose SQL or multi-source flags; provenance named by node id resolves to the node's queryUuid without mutating the caller's plan.
- The merge parity suite (`packages/api-tests/tests/mergeQuery.test.ts`) ran 12 of 12 against an isolated instance on this branch with the flag on: value parity per join type, pivoted parity, saved merged chart, dashboard tile and result-source merge.

## References

Relates: PROD-10901

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEnsqumJBXz87BAyqXXKC7
