### PR TITLE
feat(merge): compile the join for the compose engine and delete the warehouse merge

### DIFF
--- a/packages/api-tests/tests/mergeQuery.test.ts
+++ b/packages/api-tests/tests/mergeQuery.test.ts
@@ -33,12 +33,11 @@ import { uniqueName } from '../helpers/test-isolation';
 
 // Two independent aggregations of the jaffle dataset, joined on the order
 // month. The payments explore joins orders, so both sides expose the same
-// month dimension. Two flags touch merges: `merge-queries` gates the Explorer
-// entry point only, and `merge-on-compose` runs each source as its own leg
-// and joins the results on the compose engine instead of in one warehouse
-// statement. Whichever path a warehouse takes, every merged value must equal
-// what its source query returns on its own; this suite is that bar, and a
-// warehouse going green here is the gate for changing how its merges run.
+// month dimension. One flag touches merges: `merge-queries` gates the
+// Explorer entry point only. A merge runs each source as its own leg on the
+// warehouse and joins the results on the compose engine; every merged value
+// must equal what its source query returns on its own, and this suite is
+// that bar for every credentialed warehouse.
 const ordersByMonth = {
     exploreName: 'orders',
     dimensions: ['orders_order_date_month'],
@@ -481,12 +480,9 @@ function registerMergeQueryTests(getContext: () => MergeTestContext) {
     }, 90_000);
 
     // Result sources: an existing query result referenced by queryUuid joins
-    // as the rows it already holds — nothing re-runs. Only the compose
-    // engine can join one, so environments without it must refuse with the
-    // compose_required contract instead of falling back to a warehouse
-    // statement that cannot exist. The same parity bar applies either way:
-    // merged values must equal what the referenced queries returned.
-    it('merges existing query results by queryUuid, or refuses without the compose engine', async () => {
+    // as the rows it already holds — nothing re-runs. The same parity bar
+    // applies: merged values must equal what the referenced queries returned.
+    it('merges existing query results by queryUuid', async () => {
         const startAndFetch = async (query: Record<string, unknown>) => {
             const started = await admin.post<Body<{ queryUuid: string }>>(
                 `/api/v2/projects/${projectUuid}/query/metric-query`,
@@ -527,11 +523,12 @@ function registerMergeQueryTests(getContext: () => MergeTestContext) {
             context: QueryExecutionContext.EXPLORE,
         });
         expect(runResp.status).toBe(200);
-        if (runResp.body.results.outcome === 'refused') {
-            expect(
-                runResp.body.results.errors.map((error) => error.kind),
-            ).toContain(MergeQueryErrorKind.COMPOSE_REQUIRED);
-            return;
+        if (runResp.body.results.outcome !== 'started') {
+            throw new Error(
+                `Expected the merge to start: ${JSON.stringify(
+                    runResp.body.results.errors,
+                )}`,
+            );
         }
 
         const results = await pollQueryResults(

--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -588,7 +588,8 @@ type ResultsCacheDeleteEvent = BaseTrack & {
     };
 };
 
-export type MergeEngine = 'compose' | 'warehouse';
+/** The one engine merges run on; kept as a property so the event shape holds. */
+export type MergeEngine = 'compose';
 export type MergeSourceKind = 'metric' | 'result';
 /** The row cap has no compile-time kind: a leg is known to have reached it only once it has run. */
 export type MergeRefusalKind = MergeQueryErrorKind | 'row_cap';
@@ -609,8 +610,7 @@ export type MergeQueryExecutedEvent = BaseTrack & {
     properties: MergeQueryShapeProperties & {
         queryId: string;
         engine: MergeEngine;
-        /** `ready` and `error` are terminal; `started` is a warehouse merge whose outcome is not tracked. */
-        status: 'started' | 'ready' | 'error';
+        status: 'ready' | 'error';
         /** Whether the merged result itself was served from cache. */
         cacheHit: boolean;
         /** Legs this merge ran; referenced results run nothing. */

--- a/packages/backend/src/controllers/v2/QueryController.ts
+++ b/packages/backend/src/controllers/v2/QueryController.ts
@@ -285,7 +285,7 @@ export class QueryController extends BaseController {
     }
 
     /**
-     * Validates and executes a merge on the compose engine as one asynchronous query request. Unlike Execute merge query, sources may reference existing query results by queryUuid; each referenced query is authorized with the same access checks as fetching its results. Requires the merge-on-compose feature flag.
+     * Validates and executes a merge on the compose engine as one asynchronous query request. Unlike Execute merge query, sources may reference existing query results by queryUuid; each referenced query is authorized with the same access checks as fetching its results.
      * @summary Execute compose merge query
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -92,6 +92,8 @@ import type { UserWarehouseCredentialsModel } from '../../models/UserWarehouseCr
 import type { WarehouseAvailableTablesModel } from '../../models/WarehouseAvailableTablesModel/WarehouseAvailableTablesModel';
 import type { SchedulerClient } from '../../scheduler/SchedulerClient';
 import type { EncryptionUtil } from '../../utils/EncryptionUtil/EncryptionUtil';
+import { buildComposeMergeSql } from '../../utils/QueryBuilder/composeMergeSql';
+import { applyMergeTerminalWrapper } from '../../utils/QueryBuilder/MergeQueryBuilder';
 import { warehouseClientMock } from '../../utils/QueryBuilder/MetricQueryBuilder.mock';
 import type { QueryComposer } from '../../utils/QueryBuilder/QueryComposer';
 import { AdminNotificationService } from '../AdminNotificationService/AdminNotificationService';
@@ -631,9 +633,7 @@ describe('AsyncQueryService', () => {
             get: vi.fn(
                 async ({ featureFlagId }: { featureFlagId: string }) => ({
                     id: featureFlagId,
-                    enabled:
-                        featureFlagId === FeatureFlags.ComposeSqlRunner ||
-                        featureFlagId === FeatureFlags.MergeOnCompose,
+                    enabled: featureFlagId === FeatureFlags.ComposeSqlRunner,
                 }),
             ),
         } as unknown as FeatureFlagModel;
@@ -909,7 +909,11 @@ describe('AsyncQueryService', () => {
             vi.spyOn(service, 'compileMergeQuery').mockResolvedValue({
                 coreSql: 'SELECT 1',
                 typedColumns: [],
-                terminalWrapper: null,
+                terminalWrapper: {
+                    orderBy: [],
+                    limit: null,
+                    sourceLimitExceededSql: null,
+                },
                 errors: [],
                 parameterReferences: [],
                 fieldOrigins: {},
@@ -917,7 +921,7 @@ describe('AsyncQueryService', () => {
                 fieldIdByColumn: {},
                 itemsMap: {},
                 usedParametersValues: {},
-                requiresCompose: false,
+                legs: [],
             } as never);
 
             await expect(
@@ -6378,13 +6382,6 @@ describe('executeAsyncMergeQuery on the compose engine', () => {
         a: '1a6f0f8c-2d3e-4f5a-8b9c-0d1e2f3a4b5c',
         b: '2b7a1a9d-3e4f-4a6b-9c0d-1e2f3a4b5c6d',
     };
-    const composeFlags = {
-        get: vi.fn(async ({ featureFlagId }: { featureFlagId: string }) => ({
-            id: featureFlagId,
-            enabled: featureFlagId === FeatureFlags.MergeOnCompose,
-        })),
-    } as unknown as FeatureFlagModel;
-
     const itemsMap = {
         merge_month: {
             fieldType: FieldType.DIMENSION,
@@ -6450,11 +6447,39 @@ describe('executeAsyncMergeQuery on the compose engine', () => {
         a: { orders_month: { type: DimensionType.DATE, timeInterval: null } },
         b: { payments_month: { type: DimensionType.DATE, timeInterval: null } },
     };
+    const fieldIdByColumn = {
+        month: 'merge_month',
+        c0_0: 'a_orders_count',
+        c1_0: 'b_payments_sum',
+    };
+    // The join core exactly as the compile emits it, so the run path is
+    // exercised on the real DuckDB statement over the reference tables
+    const joinSql = buildComposeMergeSql({
+        sources: [
+            { id: 'a', valueColumns: ['orders_count'] },
+            { id: 'b', valueColumns: ['payments_sum'] },
+        ],
+        joinKey: [
+            {
+                name: 'month',
+                fieldIdBySourceId: { a: 'orders_month', b: 'payments_month' },
+            },
+        ],
+        joinType: MergeJoinType.FULL,
+        tableCalculations: [],
+        fieldTypes,
+        outputAliasByColumn: fieldIdByColumn,
+        limit: 500,
+    });
     const compiledMerge = {
-        sql: null,
-        coreSql: null,
+        sql: applyMergeTerminalWrapper(
+            joinSql.coreSql,
+            joinSql.terminalWrapper,
+        ),
+        legs: [],
+        coreSql: joinSql.coreSql,
         typedColumns,
-        terminalWrapper: null,
+        terminalWrapper: joinSql.terminalWrapper,
         columns: {
             joinKeyColumns: ['month'],
             valueColumnBySourceColumn: {
@@ -6467,12 +6492,7 @@ describe('executeAsyncMergeQuery on the compose engine', () => {
         fieldOrigins: {},
         parameterReferences: [],
         usedParametersValues: {},
-        fieldIdByColumn: {
-            month: 'merge_month',
-            c0_0: 'a_orders_count',
-            c1_0: 'b_payments_sum',
-        },
-        requiresCompose: false,
+        fieldIdByColumn,
         errors: [],
     };
     const mergeQuery: MergeQuery = {
@@ -6602,7 +6622,6 @@ describe('executeAsyncMergeQuery on the compose engine', () => {
             };
         };
         const service = getMockedAsyncQueryService(config, {
-            featureFlagModel: composeFlags,
             composeEngineClient: new ComposeEngineClient({
                 lightdashConfig: config,
                 createDuckdbWarehouseClient: () => warehouseClient,
@@ -7359,7 +7378,13 @@ describe('executeAsyncMergeQuery over a result source', () => {
         });
 
         expect(compiled.errors).toEqual([]);
-        expect(compiled.requiresCompose).toBe(true);
+        // A result source contributes rows, never a leg statement
+        expect(compiled.legs).toEqual([
+            { sourceId: 'a', sql: null },
+            { sourceId: 'b', sql: null },
+        ]);
+        expect(compiled.coreSql).toContain('"merge_source_0"');
+        expect(compiled.coreSql).toContain('"merge_source_1"');
     });
 
     it('leaves a referenced result with no recorded row count alone', async () => {

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -813,6 +813,7 @@ describe('AsyncQueryService', () => {
                     },
                     engine: 'scopedToReferencedResults',
                     guard,
+                    referenceLabels: {},
                 },
             });
             await vi.waitFor(() =>
@@ -845,6 +846,7 @@ describe('AsyncQueryService', () => {
                     kind: 'queries',
                     references: { orders: referencedQueryHistory.queryUuid },
                     guard,
+                    labelByTable: {},
                 },
             });
             // The shared session is built for the dialect and to refuse a
@@ -6189,6 +6191,7 @@ describe('runDuckdbQuery', () => {
                     kind: 'queries',
                     references: { merge_source_0: 'leg-uuid' },
                     guard: null,
+                    labelByTable: {},
                 },
                 columns: {
                     mode: 'supplied',
@@ -6259,6 +6262,7 @@ describe('runDuckdbQuery', () => {
                         merge_source_1: 'leg-b',
                     },
                     guard: null,
+                    labelByTable: {},
                 },
                 columns: {
                     mode: 'supplied',
@@ -6316,6 +6320,36 @@ describe('runDuckdbQuery', () => {
         );
     });
 
+    it('a leg that fails names the source in the error, not the reference table', async () => {
+        const { run, runWarehouseQuery, pollForQueryCompletion, update } =
+            buildService();
+        pollForQueryCompletion.mockRejectedValueOnce(
+            new Error('permission denied for table orders'),
+        );
+
+        await run(
+            baseArgs({
+                references: {
+                    kind: 'queries',
+                    references: { merge_source_0: 'leg-uuid' },
+                    guard: null,
+                    labelByTable: { merge_source_0: 'Query A ("a")' },
+                },
+            }),
+        );
+
+        expect(runWarehouseQuery).not.toHaveBeenCalled();
+        expect(update).toHaveBeenCalledWith(
+            'duckdb-query-uuid',
+            projectUuid,
+            expect.objectContaining({
+                status: QueryHistoryStatus.ERROR,
+                error: 'Query A ("a") did not complete: permission denied for table orders',
+            }),
+            expect.anything(),
+        );
+    });
+
     it('a guard refusal lands as the query error before anything runs', async () => {
         const { streamQuery, warehouseClient } = probingClient({});
         const { run, runWarehouseQuery, update } = buildService();
@@ -6328,6 +6362,7 @@ describe('runDuckdbQuery', () => {
                     kind: 'queries',
                     references: { orders: 'leg-uuid' },
                     guard,
+                    labelByTable: {},
                 },
             }),
         );
@@ -6831,6 +6866,22 @@ describe('executeAsyncMergeQuery on the compose engine', () => {
                 joinExecutionTimeMs: 12,
             },
         });
+    });
+
+    it('refuses a join that reads files before any leg runs', async () => {
+        const { service, create } = buildService({
+            config: lightdashConfigMock,
+            legRowCount: 2,
+        });
+        vi.spyOn(service, 'compileMergeQuery').mockResolvedValue({
+            ...compiledMerge,
+            coreSql: "SELECT * FROM read_parquet('s3://bucket/secret.parquet')",
+        } as never);
+
+        await expect(execute(service)).rejects.toThrow(ParameterError);
+
+        expect(service.executeAsyncMetricQuery).not.toHaveBeenCalled();
+        expect(create).not.toHaveBeenCalled();
     });
 
     it('refuses before the join when a leg reached the row cap, naming the source', async () => {

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -70,7 +70,6 @@ import {
     isMergeMetricSource,
     isMergeResultSource,
     isMetric,
-    isMetricSourcedMergeQuery,
     isValidTimezone,
     isVizTableConfig,
     ItemsMap,
@@ -78,7 +77,6 @@ import {
     KnexPaginatedData,
     LightdashError,
     MergeQuery,
-    MergeQueryErrorKind,
     MetricQuery,
     MissingConfigError,
     normalizeIndexColumns,
@@ -130,7 +128,6 @@ import {
     type ExecuteAsyncDashboardChartRequestParams,
     type ExecuteAsyncExternalSqlQueryRequestParams,
     type ExecuteAsyncFieldValueSearchRequestParams,
-    type ExecuteAsyncMergeQueryRequestParams,
     type ExecuteAsyncMetricQueryRequestParams,
     type ExecuteAsyncQueryRequestParams,
     type ExecuteAsyncSavedChartRequestParams,
@@ -206,7 +203,7 @@ import {
     processFieldsForExport,
     streamJsonlData,
 } from '../../utils/FileDownloadUtils/FileDownloadUtils';
-import { buildComposeMergeSql } from '../../utils/QueryBuilder/composeMergeSql';
+import { composeMergeReferenceTable } from '../../utils/QueryBuilder/composeMergeSql';
 import { updateExploreWithDateZoom } from '../../utils/QueryBuilder/dateZoom';
 import { getSqlBuilderForExplore } from '../../utils/QueryBuilder/getSqlBuilderForExplore';
 import {
@@ -320,12 +317,14 @@ import {
     type UnboundedRerunFromQueryHistoryResult,
 } from './types';
 
+/** A compiled merge that can run: no errors, the join core and full metadata. */
 type RunnableCompiledMergeQuery = ApiCompiledMergeQueryResults & {
     coreSql: string;
-    typedColumns: NonNullable<ApiCompiledMergeQueryResults['typedColumns']>;
     terminalWrapper: NonNullable<
         ApiCompiledMergeQueryResults['terminalWrapper']
     >;
+    typedColumns: NonNullable<ApiCompiledMergeQueryResults['typedColumns']>;
+    columns: NonNullable<ApiCompiledMergeQueryResults['columns']>;
 };
 
 const isRunnableCompiledMergeQuery = (
@@ -333,23 +332,7 @@ const isRunnableCompiledMergeQuery = (
 ): compiled is RunnableCompiledMergeQuery =>
     compiled.errors.length === 0 &&
     compiled.coreSql !== null &&
-    compiled.typedColumns !== null &&
-    compiled.terminalWrapper !== null;
-
-/**
- * A compiled merge the compose engine can run: no errors and full metadata.
- * Unlike the warehouse-runnable narrowing it needs no statement — the
- * compose path builds its own join over the sources' materialized results.
- */
-type ComposableCompiledMergeQuery = ApiCompiledMergeQueryResults & {
-    typedColumns: NonNullable<ApiCompiledMergeQueryResults['typedColumns']>;
-    columns: NonNullable<ApiCompiledMergeQueryResults['columns']>;
-};
-
-const isComposableCompiledMergeQuery = (
-    compiled: ApiCompiledMergeQueryResults,
-): compiled is ComposableCompiledMergeQuery =>
-    compiled.errors.length === 0 &&
+    compiled.terminalWrapper !== null &&
     compiled.typedColumns !== null &&
     compiled.columns !== null;
 
@@ -360,15 +343,6 @@ type DuckdbQueryExecution = {
     usedParameters: ParametersValuesMap | null;
     originalColumns: ResultColumns;
     pivotConfiguration: PivotConfiguration | undefined;
-};
-
-type ExecuteCompiledAsyncMergeQueryArgs = Omit<
-    ExecuteAsyncMergeQueryArgs,
-    'mode' | 'chart'
-> & {
-    organizationUuid: string;
-    compiledMerge: RunnableCompiledMergeQuery;
-    pivotConfiguration?: PivotConfiguration;
 };
 
 type ExecuteMergeQueryInternalArgs = Omit<
@@ -8415,7 +8389,7 @@ export class AsyncQueryService extends ProjectService {
             parameters,
             userAttributeOverrides,
         });
-        if (!isComposableCompiledMergeQuery(compiledMerge)) {
+        if (!isRunnableCompiledMergeQuery(compiledMerge)) {
             return {
                 outcome: 'refused',
                 errors: compiledMerge.errors,
@@ -8443,7 +8417,7 @@ export class AsyncQueryService extends ProjectService {
             return undefined;
         })();
 
-        const composeQuery = await this.tryExecuteComposeMergeQuery({
+        const query = await this.submitMergeDag({
             account,
             projectUuid,
             organizationUuid,
@@ -8454,55 +8428,6 @@ export class AsyncQueryService extends ProjectService {
             userAttributeOverrides,
             pivotConfiguration,
             compiledMerge,
-        });
-        if (composeQuery !== null) {
-            return {
-                outcome: 'started',
-                query: composeQuery,
-                parameterReferences: compiledMerge.parameterReferences,
-                fieldOrigins: compiledMerge.fieldOrigins,
-            };
-        }
-
-        // Result sources and external source tables have no warehouse
-        // statement to fall back to
-        if (compiledMerge.requiresCompose) {
-            return {
-                outcome: 'refused',
-                errors: [
-                    {
-                        kind: MergeQueryErrorKind.COMPOSE_REQUIRED,
-                        sourceId: null,
-                        fieldIds: [],
-                        message:
-                            'This merge reads existing query results or external source tables, which need the compose engine. It is not enabled or not available on this instance.',
-                    },
-                ],
-                parameterReferences: compiledMerge.parameterReferences,
-                fieldOrigins: compiledMerge.fieldOrigins,
-            };
-        }
-
-        if (!isRunnableCompiledMergeQuery(compiledMerge)) {
-            return {
-                outcome: 'refused',
-                errors: compiledMerge.errors,
-                parameterReferences: compiledMerge.parameterReferences,
-                fieldOrigins: compiledMerge.fieldOrigins,
-            };
-        }
-
-        const query = await this.executeCompiledAsyncMergeQuery({
-            account,
-            projectUuid,
-            organizationUuid,
-            mergeQuery: effectiveMergeQuery,
-            context,
-            invalidateCache,
-            parameters,
-            pivotConfiguration,
-            compiledMerge,
-            userAttributeOverrides,
         });
 
         return {
@@ -8514,154 +8439,13 @@ export class AsyncQueryService extends ProjectService {
     }
 
     /**
-     * Runs a merge as one statement on the org's own warehouse.
-     *
-     * The compile is the merge: both sides become CTEs of one statement in
-     * the warehouse's dialect, and that statement runs through the ordinary
-     * async tail — query history, paging, formatting, pivoting, caching and
-     * downloads all behave as for any other query. Nothing materialises to
-     * S3 and nothing runs anywhere but the project warehouse.
+     * Submits a compiled merge as a query source DAG: one semantic-layer node
+     * per metric source, inheriting that query's access rules and result
+     * cache, and one duckdb node that joins the materialized results with
+     * the compile's join statement. Submission never blocks on the legs: the
+     * join waits for their results through the standard reference wait.
      */
-    private async executeCompiledAsyncMergeQuery({
-        account,
-        projectUuid,
-        mergeQuery,
-        context,
-        invalidateCache,
-        pivotConfiguration,
-        parameters,
-        organizationUuid,
-        compiledMerge,
-        userAttributeOverrides,
-    }: ExecuteCompiledAsyncMergeQueryArgs): Promise<ApiExecuteAsyncMetricQueryResults> {
-        // Only for composing SQL — quoting and the pivot stage need the
-        // dialect. The async runtime opens its own connection to execute.
-        const [warehouseCredentials, userAccessControls] = await Promise.all([
-            this.getWarehouseCredentials({
-                projectUuid,
-                userId: account.user.id,
-                isRegisteredUser: account.isRegisteredUser(),
-                isServiceAccount: account.isServiceAccount(),
-            }),
-            this.getUserAttributes({ account }),
-        ]);
-        const { warehouseClient, sshTunnel } = await this._getWarehouseClient(
-            projectUuid,
-            warehouseCredentials,
-        );
-
-        let composer: MergeQueryComposer;
-        try {
-            composer = new MergeQueryComposer({
-                coreSql: compiledMerge.coreSql,
-                terminalWrapper: compiledMerge.terminalWrapper,
-                itemsMap: compiledMerge.itemsMap,
-                typedColumns: compiledMerge.typedColumns,
-                columnOrder: Object.values(compiledMerge.fieldIdByColumn),
-                limit: mergeQuery.limit,
-                parameterReferences: compiledMerge.parameterReferences,
-                usedParametersValues: compiledMerge.usedParametersValues,
-                warehouseClient,
-                pivotConfiguration,
-            });
-        } finally {
-            await sshTunnel.disconnect();
-        }
-
-        const baseQueryTags: RunQueryTags = {
-            ...this.getUserQueryTags(account),
-            ...AsyncQueryService.getSchedulerQueryTags(),
-            organization_uuid: organizationUuid,
-            project_uuid: projectUuid,
-            query_context: context,
-        };
-        const queryTags = AsyncQueryService.addUserAttributeQueryTags(
-            baseQueryTags,
-            userAttributeOverrides
-                ? {
-                      ...userAccessControls,
-                      userAttributes: {
-                          ...userAccessControls.userAttributes,
-                          ...userAttributeOverrides,
-                      },
-                  }
-                : userAccessControls,
-        );
-        // Routing guarantees this: merges with result sources never reach
-        // the warehouse path (they require the compose engine)
-        if (!isMetricSourcedMergeQuery(mergeQuery)) {
-            throw new UnexpectedServerError(
-                'A merge with result sources cannot run as a warehouse statement',
-            );
-        }
-        const requestParameters: ExecuteAsyncMergeQueryRequestParams = {
-            context,
-            invalidateCache,
-            mergeQuery,
-            parameters,
-            pivotConfiguration,
-        };
-        const { queryUuid, cacheMetadata } = await this.executeAsyncQuery(
-            {
-                account,
-                projectUuid,
-                organizationUuid,
-                context,
-                queryTags,
-                invalidateCache,
-                queryComposer: composer,
-                warehouseCredentials,
-                routingTarget: 'warehouse',
-            },
-            requestParameters,
-        );
-        // The shared background tail has no merge hook, so this engine reports submission only
-        this.analytics.trackAccount(
-            account,
-            buildMergeExecutedEvent({
-                submission: {
-                    organizationUuid,
-                    projectUuid,
-                    context,
-                    mergeQuery,
-                },
-                queryId: queryUuid,
-                engine: 'warehouse',
-                status: 'started',
-                cacheHit: cacheMetadata.cacheHit,
-                legCacheHits: [],
-                rowCount: null,
-                durationMs: null,
-                joinExecutionTimeMs: null,
-            }),
-        );
-
-        return {
-            queryUuid,
-            cacheMetadata,
-            metricQuery: composer.getMetricQuery(),
-            fields: composer.getFields(),
-            warnings: composer.getWarnings(),
-            parameterReferences: composer.getParameterReferences(),
-            usedParametersValues: composer.getUsedParameters(),
-            resolvedTimezone: composer.getDisplayTimezone(),
-        };
-    }
-
-    /**
-     * Runs a merge as composition when the merge-on-compose flag is on and
-     * the compose engine is available; returns null to fall back to the
-     * single-statement warehouse merge otherwise.
-     *
-     * Each source executes as its own metric query — inheriting that query's
-     * access rules and the metric-query result cache — and the DuckDB
-     * compose engine joins the materialized results. The join is the same
-     * MergeQueryBuilder assembly as the warehouse statement, in the DuckDB
-     * dialect over reference tables, so join semantics are shared by
-     * construction. Submission never blocks on the legs: the background
-     * phase waits for their results through the standard reference wait.
-     */
-    private async tryExecuteComposeMergeQuery({
+    private async submitMergeDag({
         account,
         projectUuid,
         organizationUuid,
@@ -8682,18 +8466,9 @@ export class AsyncQueryService extends ProjectService {
         parameters: ParametersValuesMap | undefined;
         userAttributeOverrides: UserAttributeValueMap | undefined;
         pivotConfiguration: PivotConfiguration | undefined;
-        compiledMerge: ComposableCompiledMergeQuery;
-    }): Promise<ApiExecuteAsyncMetricQueryResults | null> {
+        compiledMerge: RunnableCompiledMergeQuery;
+    }): Promise<ApiExecuteAsyncMetricQueryResults> {
         assertIsAccountWithOrg(account);
-
-        const { enabled } = await this.featureFlagModel.get({
-            user: {
-                userUuid: account.user.id,
-                organizationUuid: account.organization.organizationUuid,
-            },
-            featureFlagId: FeatureFlags.MergeOnCompose,
-        });
-        if (!enabled) return null;
 
         // Throws MissingConfigError when results storage is not configured:
         // a merge without an engine is refused, never silently downgraded.
@@ -8730,36 +8505,19 @@ export class AsyncQueryService extends ProjectService {
             ]),
         );
 
-        const fieldTypes = await this.getMergeFieldTypesForQuery(
-            account,
-            projectUuid,
-            mergeQuery,
-        );
         const columnOrder = Object.values(compiledMerge.fieldIdByColumn);
-        const { coreSql, terminalWrapper, referenceTableBySourceId } =
-            buildComposeMergeSql({
-                sources: mergeQuery.sources.map((source) => ({
-                    id: source.id,
-                    valueColumns: Object.keys(
-                        compiledMerge.columns.valueColumnBySourceColumn[
-                            source.id
-                        ] ?? {},
-                    ),
-                })),
-                joinKey: mergeQuery.joinKey,
-                joinType: mergeQuery.joinType,
-                tableCalculations: mergeQuery.tableCalculations,
-                fieldTypes,
-                outputAliasByColumn: compiledMerge.fieldIdByColumn,
-                limit: Math.min(mergeQuery.limit, sourceRowCap),
-            });
+        const referenceTableBySourceId = Object.fromEntries(
+            mergeQuery.sources.map((source, index) => [
+                source.id,
+                composeMergeReferenceTable(index),
+            ]),
+        );
 
-        // The same composer as the warehouse merge, with the compose engine
-        // as the dialect: the pivot stage and terminal wrapper compile for
-        // DuckDB through the one shared seam
+        // The pivot stage and terminal wrapper compile for the compose
+        // engine over the compile's join core
         const composer = new MergeQueryComposer({
-            coreSql,
-            terminalWrapper,
+            coreSql: compiledMerge.coreSql,
+            terminalWrapper: compiledMerge.terminalWrapper,
             itemsMap: compiledMerge.itemsMap,
             typedColumns: compiledMerge.typedColumns,
             columnOrder,

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -7280,10 +7280,12 @@ export class AsyncQueryService extends ProjectService {
         account,
         projectUuid,
         references,
+        labelByTable,
     }: {
         account: Account;
         projectUuid: string;
         references: Record<string, string>;
+        labelByTable: Record<string, string>;
     }): Promise<Record<string, QueryHistory>> {
         const completed = await Promise.all(
             Object.entries(references).map(async ([tableName, queryUuid]) => {
@@ -7298,10 +7300,17 @@ export class AsyncQueryService extends ProjectService {
                         });
                     return [tableName, queryHistory] as const;
                 } catch (e) {
-                    throw new ParameterError(
-                        `Referenced query "${tableName}" (${queryUuid}) did not complete: ${getErrorMessage(
+                    // The message names what the user knows; the uuid goes to the log
+                    const label = labelByTable[tableName];
+                    this.logger.info(
+                        `Referenced query ${queryUuid} (${tableName}) did not complete: ${getErrorMessage(
                             e,
                         )}`,
+                    );
+                    throw new ParameterError(
+                        `${
+                            label ?? `Referenced query "${tableName}"`
+                        } did not complete: ${getErrorMessage(e)}`,
                     );
                 }
             }),
@@ -7436,6 +7445,7 @@ export class AsyncQueryService extends ProjectService {
                 columns: { mode: 'discover' },
                 engine: 'client',
                 guard: null,
+                referenceLabels: {},
             },
         });
 
@@ -7574,6 +7584,7 @@ export class AsyncQueryService extends ProjectService {
                 kind: 'queries',
                 references: normalizedReferences ?? {},
                 guard: plan.guard,
+                labelByTable: plan.referenceLabels,
             },
             columns: resolved.columns,
             storedCompiledSql: null,
@@ -8102,6 +8113,7 @@ export class AsyncQueryService extends ProjectService {
                     account,
                     projectUuid,
                     references: references.references,
+                    labelByTable: references.labelByTable,
                 });
                 const refusal = references.guard?.(completed) ?? null;
                 if (refusal !== null) throw new ParameterError(refusal);
@@ -8596,7 +8608,16 @@ export class AsyncQueryService extends ProjectService {
             // reaches only the leg files it joins
             engine: 'scopedToReferencedResults',
             guard: rowCap.guard,
+            referenceLabels: legLabelByReferenceTable,
         };
+
+        // A statement that reads files is refused before any leg runs; the
+        // join node checks it again when it submits
+        try {
+            DuckdbWarehouseClient.validateUserSqlFileAccess(sql);
+        } catch (e) {
+            throw new ParameterError(getErrorMessage(e));
+        }
 
         // The DAG submits the legs, then the join with its references
         // rewritten to their queryUuids; the join waits for the legs itself

--- a/packages/backend/src/services/AsyncQueryService/mergeQueryTelemetry.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/mergeQueryTelemetry.test.ts
@@ -97,30 +97,6 @@ describe('buildMergeExecutedEvent', () => {
             },
         });
     });
-
-    it('reports a warehouse merge with no legs and no outcome', () => {
-        const event = buildMergeExecutedEvent({
-            submission,
-            queryId: 'merge-query-uuid',
-            engine: 'warehouse',
-            status: 'started',
-            cacheHit: true,
-            legCacheHits: [],
-            rowCount: null,
-            durationMs: null,
-            joinExecutionTimeMs: null,
-        });
-
-        expect(event.properties).toMatchObject({
-            engine: 'warehouse',
-            status: 'started',
-            cacheHit: true,
-            legCount: 0,
-            legCacheHitCount: 0,
-            rowCount: null,
-            durationMs: null,
-        });
-    });
 });
 
 describe('buildMergeRefusedEvent', () => {

--- a/packages/backend/src/services/AsyncQueryService/types.ts
+++ b/packages/backend/src/services/AsyncQueryService/types.ts
@@ -335,6 +335,8 @@ export type DuckdbQueryReferences =
           kind: 'queries';
           references: Record<string, string>;
           guard: DuckdbQueryReferenceGuard | null;
+          /** What the user calls each referenced table, for messages that name one. */
+          labelByTable: Record<string, string>;
       };
 
 /** Which compose engine session executes a DuckDB query. */
@@ -365,6 +367,8 @@ export type DuckdbQueryPlan = {
           });
     engine: DuckdbQueryEngine['kind'];
     guard: DuckdbQueryReferenceGuard | null;
+    /** What the user calls each referenced table; empty when nothing names them. */
+    referenceLabels: Record<string, string>;
 };
 
 export type ExecuteAsyncDuckdbSourceQueryArgs = CommonAsyncQueryArgs & {

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -241,6 +241,7 @@ import {
     type ApiCreateProjectResults,
     type CreateDatabricksCredentials,
     type DataTimezonePreviewRequest,
+    type MergeCompiledLeg,
     type MergeItemEntry,
     type MergeTypedColumn,
     type Metric,
@@ -338,11 +339,8 @@ import { metricQueryWithLimit as applyMetricQueryLimit } from '../../utils/csvLi
 import { omitDbtEnvironment } from '../../utils/dbtProjectConfig';
 import { pickEmbedProject } from '../../utils/embedProject';
 import { EncryptionUtil } from '../../utils/EncryptionUtil/EncryptionUtil';
-import {
-    applyMergeTerminalWrapper,
-    getMergeJoinKeySqlOptions,
-    MergeQueryBuilder,
-} from '../../utils/QueryBuilder/MergeQueryBuilder';
+import { createComposeMergeQueryBuilder } from '../../utils/QueryBuilder/composeMergeSql';
+import { applyMergeTerminalWrapper } from '../../utils/QueryBuilder/MergeQueryBuilder';
 import { PivotQueryBuilder } from '../../utils/QueryBuilder/PivotQueryBuilder';
 import { QueryComposer } from '../../utils/QueryBuilder/QueryComposer';
 import { applyLimitToSqlQuery } from '../../utils/QueryBuilder/utils';
@@ -5874,16 +5872,6 @@ export class ProjectService extends BaseService {
                 };
             }),
         );
-        // Result sources have no warehouse statement, and external source
-        // explores have no warehouse relation — either forces the compose
-        // engine.
-        const requiresCompose =
-            mergeQuery.sources.some(isMergeResultSource) ||
-            maybeResolvedSources.some(
-                (source) =>
-                    source?.explore?.type === ExploreType.EXTERNAL_SOURCE,
-            );
-
         if (resolutionErrors.length > 0) {
             return {
                 sql: null,
@@ -5897,7 +5885,8 @@ export class ProjectService extends BaseService {
                 parameterReferences: [],
                 usedParametersValues: {},
                 fieldIdByColumn: {},
-                requiresCompose,
+                legs: [],
+                requiresCompose: false,
                 errors: resolutionErrors,
             };
         }
@@ -5963,7 +5952,8 @@ export class ProjectService extends BaseService {
                 parameterReferences: [],
                 usedParametersValues: {},
                 fieldIdByColumn: {},
-                requiresCompose,
+                legs: [],
+                requiresCompose: false,
                 errors,
             };
         }
@@ -5986,25 +5976,14 @@ export class ProjectService extends BaseService {
             });
         }
 
-        const warehouseCredentials =
-            await this.projectModel.getWarehouseCredentialsForProject(
-                projectUuid,
-            );
-        const warehouseSqlBuilder = warehouseSqlBuilderFromType(
-            warehouseCredentials.type,
-            warehouseCredentials.startOfWeek,
-        );
+        // Each leg runs whole: the merged statement sorts and limits, and a
+        // side is never silently truncated below the source row cap
+        const sourceRowCap = this.lightdashConfig.query.maxLimit;
 
         const sources = await Promise.all(
             mergeQuery.sources.map(async (source) => {
                 const resolvedMetricQuery =
                     resolvedMetricQueryBySourceId[source.id];
-                const joinKeyColumnByName = Object.fromEntries(
-                    mergeQuery.joinKey.map((part) => [
-                        part.name,
-                        part.fieldIdBySourceId[source.id],
-                    ]),
-                );
                 const valueColumns = [
                     ...resolvedMetricQuery.metrics,
                     ...resolvedMetricQuery.tableCalculations.map(
@@ -6016,13 +5995,11 @@ export class ProjectService extends BaseService {
                 );
 
                 // A result source is already materialized: it contributes
-                // columns and rows, never SQL — only the compose engine can
-                // join it, which `requiresCompose` reports.
+                // columns and rows, never SQL
                 if (isMergeResultSource(source)) {
                     return {
                         id: source.id,
-                        sql: '',
-                        joinKeyColumnByName,
+                        sql: null,
                         valueColumns,
                         missingParameters: [],
                         parameterReferences: [],
@@ -6034,24 +6011,20 @@ export class ProjectService extends BaseService {
                 // Each metric source compiles exactly as it would on its own,
                 // so a merged query inherits the same access rules, required
                 // filters and parameter handling as the query it was built
-                // from.
+                // from. This is the statement the leg runs: whole, at the
+                // source row cap, unsorted.
                 const compiled = await this.compileQuery({
                     account,
                     projectUuid,
                     exploreName: source.metricQuery.exploreName,
-                    body: { ...source.metricQuery, parameters },
+                    body: {
+                        ...source.metricQuery,
+                        sorts: [],
+                        limit: sourceRowCap,
+                        parameters,
+                    },
                     userAttributeOverrides,
-                    // A pre-aggregate compiles to a placeholder table name
-                    // that only the pre-aggregate execution path resolves.
-                    // A merge embeds this SQL as a CTE and runs it itself,
-                    // so routing here would emit a statement the warehouse
-                    // cannot parse.
                     usePreAggregateCache: false,
-                    // No per-side ORDER BY or LIMIT: a limited side would
-                    // join only its top-N rows — a silent truncation that
-                    // looks like real data. The merged statement sorts and
-                    // limits once for the whole result.
-                    asCteBody: true,
                 });
                 // The single-query path refuses to run with an unvalued
                 // parameter; the compile-for-embedding path only warns.
@@ -6063,7 +6036,6 @@ export class ProjectService extends BaseService {
                 return {
                     id: source.id,
                     sql: compiled.query,
-                    joinKeyColumnByName,
                     valueColumns,
                     missingParameters: Array.from(
                         compiled.missingParameterReferences,
@@ -6098,6 +6070,10 @@ export class ProjectService extends BaseService {
             {},
             ...sources.map((source) => source.usedParametersValues),
         );
+        const legs: MergeCompiledLeg[] = sources.map((source) => ({
+            sourceId: source.id,
+            sql: source.sql,
+        }));
         if (parameterErrors.length > 0) {
             return {
                 sql: null,
@@ -6111,41 +6087,26 @@ export class ProjectService extends BaseService {
                 parameterReferences,
                 usedParametersValues,
                 fieldIdByColumn: {},
-                requiresCompose,
+                legs: [],
+                requiresCompose: false,
                 errors: parameterErrors,
             };
         }
 
-        // A placeholder per key so null keys match each other rather than
-        // landing as two unmatched rows. Safe because the join also compares
-        // null-ness: a real value equal to the placeholder can never pair with
-        // a null.
-        const { nullPlaceholderByKeyName, stringJoinKeyNames } =
-            getMergeJoinKeySqlOptions(
-                mergeQuery.joinKey,
-                fieldTypes,
-                warehouseSqlBuilder,
-            );
-
-        const mergeQueryBuilder = new MergeQueryBuilder({
-            sources,
-            joinKeyNames: mergeQuery.joinKey.map((part) => part.name),
+        // The join, in the compose engine's dialect over the legs' results.
+        // Clamped like any other query: the merged statement is the one
+        // that actually returns rows, so the instance row cap applies to it
+        // rather than to the queries it was assembled from.
+        const { builder: mergeQueryBuilder } = createComposeMergeQueryBuilder({
+            sources: sources.map((source) => ({
+                id: source.id,
+                valueColumns: source.valueColumns,
+            })),
+            joinKey: mergeQuery.joinKey,
             joinType: mergeQuery.joinType,
-            warehouseSqlBuilder,
-            // Clamped like any other query: the merged statement is the one
-            // that actually returns rows, so the instance row cap applies to
-            // it rather than to the queries it was assembled from.
-            limit: Math.min(
-                mergeQuery.limit,
-                this.lightdashConfig.query.maxLimit,
-            ),
             tableCalculations: mergeQuery.tableCalculations,
-            nullPlaceholderByKeyName,
-            stringJoinKeyNames,
-            // Each query is bounded, but reaching the bound is reported rather
-            // than trimmed: a join over a trimmed side returns numbers that
-            // look complete and are not.
-            sourceRowCap: this.lightdashConfig.query.maxLimit,
+            fieldTypes,
+            limit: Math.min(mergeQuery.limit, sourceRowCap),
         });
 
         // Resolve calculation references against the columns the merge
@@ -6201,7 +6162,8 @@ export class ProjectService extends BaseService {
                 parameterReferences,
                 usedParametersValues,
                 fieldIdByColumn: {},
-                requiresCompose,
+                legs: [],
+                requiresCompose: false,
                 errors: referenceErrors,
             };
         }
@@ -6539,27 +6501,21 @@ export class ProjectService extends BaseService {
                 parameterReferences,
                 usedParametersValues,
                 fieldIdByColumn: {},
-                requiresCompose,
+                legs: [],
+                requiresCompose: false,
                 errors: typeErrors,
             };
         }
 
         // Named by field id, so results are keyed by the same ids the
-        // items map is keyed by and every lookup downstream resolves. A merge
-        // over result sources has no warehouse statement: the compose path
-        // builds its own join over the referenced results.
-        const coreSql = requiresCompose
-            ? null
-            : mergeQueryBuilder.toCoreSql(fieldIdByColumn);
-        const terminalWrapper = requiresCompose
-            ? null
-            : mergeQueryBuilder.buildTerminalWrapper(fieldIdByColumn);
+        // items map is keyed by and every lookup downstream resolves
+        const coreSql = mergeQueryBuilder.toCoreSql(fieldIdByColumn);
+        const terminalWrapper =
+            mergeQueryBuilder.buildTerminalWrapper(fieldIdByColumn);
 
         return {
-            sql:
-                coreSql !== null && terminalWrapper !== null
-                    ? applyMergeTerminalWrapper(coreSql, terminalWrapper)
-                    : null,
+            sql: applyMergeTerminalWrapper(coreSql, terminalWrapper),
+            legs,
             coreSql,
             typedColumns,
             terminalWrapper,
@@ -6572,7 +6528,7 @@ export class ProjectService extends BaseService {
             parameterReferences,
             usedParametersValues,
             fieldIdByColumn,
-            requiresCompose,
+            requiresCompose: false,
             errors: [],
         };
     }

--- a/packages/backend/src/services/QuerySourceService/QuerySourceService.test.ts
+++ b/packages/backend/src/services/QuerySourceService/QuerySourceService.test.ts
@@ -486,6 +486,7 @@ describe('QuerySourceService', () => {
             columns: { mode: 'discover' },
             engine: 'scopedToReferencedResults',
             guard: null,
+            referenceLabels: {},
         };
         const legAndJoin: SourceQuery[] = [
             {
@@ -740,6 +741,7 @@ describe('composer pipelines return the standard results interface', () => {
             columns: { mode: 'discover' },
             engine: 'scopedToReferencedResults',
             guard: null,
+            referenceLabels: {},
         };
 
         const result = await service.submitQueries({
@@ -817,6 +819,7 @@ describe('composer pipelines return the standard results interface', () => {
             },
             engine: 'scopedToReferencedResults',
             guard: null,
+            referenceLabels: {},
         };
 
         await service.submitQueries({

--- a/packages/backend/src/utils/QueryBuilder/composeMergeSql.ts
+++ b/packages/backend/src/utils/QueryBuilder/composeMergeSql.ts
@@ -21,46 +21,40 @@ export type ComposeMergeSql = {
     referenceTableBySourceId: Record<string, string>;
 };
 
-/** Table name a merge source's results are exposed under in the compose SQL. */
+/** Table name a merge source's results are exposed under in the join SQL. */
 export const composeMergeReferenceTable = (sourceIndex: number): string =>
     `merge_source_${sourceIndex}`;
 
-/**
- * The compose form of a merge: the same MergeQueryBuilder assembly as the
- * warehouse statement, but in the DuckDB dialect over reference tables —
- * each source is `SELECT * FROM merge_source_N`, bound at execution time to
- * that source's already-materialized results (a freshly-run leg or an
- * existing result referenced by queryUuid; the builder cannot tell and does
- * not care). The join semantics (coalesced keys, typed null placeholders,
- * string casts) are identical by construction because the builder and the
- * key-option derivation are shared; only the dialect and where the source
- * rows come from differ.
- *
- * No source row cap here: the sources are legs that already ran at the cap,
- * so a cap in this statement could never see past it. The run path reads
- * the legs' own row counts instead (getMergeRowCapError).
- */
-export const buildComposeMergeSql = (args: {
+type ComposeMergeArgs = {
     /** Sources in merge order; value columns in the compile's column order. */
     sources: Array<{ id: string; valueColumns: string[] }>;
     joinKey: MergeJoinKeyPart[];
     joinType: MergeJoinType;
     tableCalculations: MergeTableCalculation[];
     fieldTypes: MergeFieldTypes;
-    /** Output field-id alias per internal column, from the merge compile. */
-    outputAliasByColumn: Record<string, string>;
     /** Row cap for the merged result, already clamped to the instance limit. */
     limit: number;
-}): ComposeMergeSql => {
-    const {
-        sources,
-        joinKey,
-        joinType,
-        tableCalculations,
-        fieldTypes,
-        outputAliasByColumn,
-        limit,
-    } = args;
+};
+
+/**
+ * The join of a merge, in the DuckDB dialect over reference tables: each
+ * source is `SELECT * FROM merge_source_N`, bound at execution time to that
+ * source's already-materialized results (a freshly-run leg or an existing
+ * result referenced by queryUuid; the builder cannot tell and does not
+ * care).
+ *
+ * No source row cap here: the sources are legs that already ran at the cap,
+ * so a cap in this statement could never see past it. The run path reads
+ * the legs' own row counts instead (getMergeRowCapError).
+ */
+export const createComposeMergeQueryBuilder = (
+    args: ComposeMergeArgs,
+): {
+    builder: MergeQueryBuilder;
+    referenceTableBySourceId: Record<string, string>;
+} => {
+    const { sources, joinKey, joinType, tableCalculations, fieldTypes, limit } =
+        args;
     const warehouseSqlBuilder = warehouseSqlBuilderFromType(
         SupportedDbtAdapter.DUCKDB,
     );
@@ -101,6 +95,19 @@ export const buildComposeMergeSql = (args: {
         stringJoinKeyNames,
     });
 
+    return { builder, referenceTableBySourceId };
+};
+
+/** The join SQL in one call, for callers that already know their aliases. */
+export const buildComposeMergeSql = (
+    args: ComposeMergeArgs & {
+        /** Output field-id alias per internal column, from the merge compile. */
+        outputAliasByColumn: Record<string, string>;
+    },
+): ComposeMergeSql => {
+    const { outputAliasByColumn, ...builderArgs } = args;
+    const { builder, referenceTableBySourceId } =
+        createComposeMergeQueryBuilder(builderArgs);
     return {
         coreSql: builder.toCoreSql(outputAliasByColumn),
         terminalWrapper: builder.buildTerminalWrapper(outputAliasByColumn),

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -291,14 +291,6 @@ export enum FeatureFlags {
     QueryHistory = 'query-history',
 
     /**
-     * Run merges as composition: each source executes separately against
-     * the warehouse and the DuckDB compose engine joins the results. Falls
-     * back to the single-statement warehouse merge when the compose engine
-     * is unavailable or the merge needs a pivot. Off by default.
-     */
-    MergeOnCompose = 'merge-on-compose',
-
-    /**
      * Configurable retention for AI agent threads. Off by default; enabled
      * per-org on demand for enterprise customers.
      */

--- a/packages/common/src/types/mergeQuery.ts
+++ b/packages/common/src/types/mergeQuery.ts
@@ -31,11 +31,9 @@ export type MergeQueryMetricSource = {
 /**
  * One side of a merge: an existing query result, referenced by queryUuid and
  * joined as the rows it already holds — nothing re-runs. Its structure and
- * types resolve at compile time from the stored query metadata, and the join
- * executes on the compose engine (`requiresCompose` on the compiled merge),
- * so a merge with a result source is refused where that engine is
- * unavailable. Results are creator-scoped and expire; an expired reference
- * is re-submitted as a query, not refreshed by handle.
+ * types resolve at compile time from the stored query metadata. Results are
+ * creator-scoped and expire; an expired reference is re-submitted as a
+ * query, not refreshed by handle.
  */
 export type MergeQueryResultSource = {
     /** Stable id. Names the CTE, and the table its merged fields belong to. */
@@ -249,11 +247,6 @@ export enum MergeQueryErrorKind {
      * text — the same refusal the query makes when it runs on its own.
      */
     MISSING_PARAMETERS = 'missing_parameters',
-    /**
-     * The merge references existing query results, which only the compose
-     * engine can join — there is no warehouse statement to fall back to.
-     */
-    COMPOSE_REQUIRED = 'compose_required',
     /**
      * A referenced query result cannot back a merge source: not found, not
      * the caller's, not ready, or expired. The remedy is re-running the
@@ -551,16 +544,33 @@ export type MergeTerminalWrapper = {
 };
 
 /**
+ * One side of a merge as it runs: the statement its metric query compiles to,
+ * or null for a result source, whose rows already exist.
+ */
+export type MergeCompiledLeg = {
+    sourceId: string;
+    sql: string | null;
+};
+
+/**
  * What the compile endpoint returns. `sql` is null exactly when `errors` is
  * non-empty: a merge that would produce wrong numbers is reported, not run.
+ *
+ * A merge runs as a composition: each metric source runs on its own as a
+ * leg, and the join runs on the compose engine over the legs' results, which
+ * it reads as `merge_source_N` tables in source order. `legs` and `sql`
+ * together are the SQL that runs.
  */
 export type ApiCompiledMergeQueryResults = {
+    /** The join statement over the `merge_source_N` reference tables. */
     sql: string | null;
+    /** What each source runs on its own, in source order. Empty on an error. */
+    legs: MergeCompiledLeg[];
     /**
-     * The composable core: a self-contained single-statement SELECT with no
-     * ORDER BY, no LIMIT and no guard column — valid under `SELECT *`, so it
-     * can back a virtual view. `sql` is this core with the terminal wrapper
-     * attached.
+     * The composable core of the join: a self-contained single-statement
+     * SELECT with no ORDER BY, no LIMIT and no guard column — valid under
+     * `SELECT *`, so it can back a virtual view. `sql` is this core with the
+     * terminal wrapper attached.
      */
     coreSql: string | null;
     /** The core's columns, in the order the statement returns them. */
@@ -589,9 +599,10 @@ export type ApiCompiledMergeQueryResults = {
      */
     fieldIdByColumn: Record<string, FieldId>;
     /**
-     * The merge references existing query results, so it has no warehouse
-     * statement (`sql`/`coreSql` stay null without that being an error) and
-     * only the compose engine can run it.
+     * @deprecated Always false: every merge runs on the compose engine.
+     * Nothing reads it; it stays on the response until the legacy merge
+     * endpoints are retired, because removing a required response property
+     * is an API break.
      */
     requiresCompose: boolean;
     errors: MergeQueryError[];


### PR DESCRIPTION
## What changed

This is the switch. A merge compiles to what runs, and the warehouse merge is deleted. Second of three PRs for PROD-10901.

```mermaid
flowchart TB
    subgraph before ["Before: two engines behind one flag"]
        direction TB
        B0["compileMergeQuery<br/>emits a warehouse statement, every run"] --> B1{"merge-on-compose?"}
        B1 -- "yes" --> B2["legs + DuckDB join<br/>(statement discarded)"]
        B1 -- "no" --> B3["warehouse statement runs<br/>per-dialect join"]
        B1 -- "no, result source" --> B4["refused: compose_required"]
    end
    subgraph after ["After: one path"]
        direction TB
        A0["compileMergeQuery<br/>emits legs + the DuckDB join"] --> A1["submitMergeDag"]
        A1 --> A2["DAG: leg_0, leg_1 → merge"]
        A2 --> A3["SQL card shows legs + join"]
    end
    before ~~~ after
```

- **The compile emits the DuckDB join.** `compileMergeQuery` no longer builds a warehouse statement in the project's dialect only to discard it. It compiles each metric source to the statement its leg runs (whole, at the source row cap, unsorted) and builds the join in the DuckDB dialect over `merge_source_N` reference tables. The compile response gains `legs`, one entry per source with that source's statement or `null` for a result source, so `legs` and `sql` together are the SQL that runs.
- **The warehouse merge executor is gone**, with the `merge-on-compose` flag and its only read, the `compose_required` refusal kind, and the warehouse-runnable narrowing of a compiled merge. A merge runs behind `merge-queries` alone.
- **Telemetry** keeps its `engine` property with the single value `compose`, and the executed event's status is `ready` or `error`; the warehouse-only `started` value is gone.

`requiresCompose` stays on the compile response, always `false` and marked deprecated: the pinned OpenAPI check scores removing a required response property as a breaking change, so it leaves with the legacy merge endpoints in PROD-10904 rather than here.

## Regression analysis

- **Orgs with `merge-queries` but without `merge-on-compose`** move from one warehouse statement to legs plus a DuckDB join. The parity suite is the bar for that: merged values must equal what each source returns on its own, per join type, pivoted and unpivoted, through a saved chart and a dashboard tile.
- **Result-source merges** no longer have a refusal path for a missing engine: an instance without results storage is refused with a `MissingConfigError` naming the variables at submit, as it already was on the compose path.
- **The compile response** adds `legs` (additive) and stops setting `requiresCompose` to true (it was only true for result-source merges; the frontend never read it). The `compose_required` enum member is removed; the pinned oasdiff does not score a response enum value removal, and no frontend code reads it.
- **Per-source compile** now includes the leg's limit and no longer compiles as a CTE body. That statement is only reported in `legs`; the join reads the legs' materialized results, not this SQL.
- **Saved merged charts** are untouched: the saved schema is unchanged and only execution moves.

- **Results storage is now on the path of every merge, not only result-source merges.** The compose engine refuses to start without `results.s3`. That setting is always present on a running instance: config parsing already fails to boot without `S3_ENDPOINT`, `S3_BUCKET` and `S3_REGION`, and results storage defaults to that bucket. What can differ on a self-hosted image is the CA bundle the engine needs to read object storage over HTTPS; the runtime image installs it, and a missing one refuses the merge at submit with a message naming it rather than failing in the background.
- **Merged results are not served from the results cache on this path yet.** The warehouse merge went through the ordinary cache lookup, so a dashboard reload with merged tiles was a cache hit after the first load. The join's cache key includes the leg query uuids, which change on every leg cache hit, so nothing looks it up: the legs are served from cache, the join re-runs on their files each time, and a reload writes three history rows per merged tile instead of one. Restoring the lookup keyed on the legs' result files is the top of this chain (PROD-11011) and should land with it.
- **A leg that fails now names its source.** The join used to report `Referenced query "merge_source_0" (<uuid>) did not complete: …`; it reports `Query A ("a") did not complete: …`, with the uuid in the log.
- **A join that reads files is refused before any leg runs**, as it was when the merge was one statement, instead of after both legs were dispatched.
- **Not changed, and worth knowing:** cancelling a merge while its legs run does not cancel the legs, and the join still executes once they finish (PROD-11012); null ordering under a sorted LIMIT follows DuckDB's default rather than the warehouse's (PROD-11013). Both are pre-existing on the compose path and now apply to every merge.

## Verification

- Typecheck clean for backend, common, frontend and api-tests; lint and format clean.
- `AsyncQueryService.test.ts` and `ProjectService.test.ts`: 312 tests green with the compose-merge fixtures now built from the real DuckDB join; query source, merge builder, composer, fidelity, telemetry and controller suites: 102 green plus the fidelity suite's one expected failure.
- OpenAPI break check with CI's pinned oasdiff digest against main's spec: no breaking changes.
- The merge parity suite ran 12 of 12 against an isolated instance on this branch, with the api-test's former `compose_required` branch removed so it asserts parity unconditionally.

## References

Relates: PROD-10901

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEnsqumJBXz87BAyqXXKC7

