### PR TITLE
fix(organizations): track organization setup state instead of a blank name

### DIFF
--- a/packages/backend/src/database/entities/organizations.ts
+++ b/packages/backend/src/database/entities/organizations.ts
@@ -27,9 +27,13 @@ export type DbOrganization = {
     impersonation_enabled: boolean;
     ai_agent_memory_enabled: boolean | null;
     brand: DbOrganizationBrand | null;
+    is_setup_complete: boolean;
 };
 
-export type DbOrganizationIn = Pick<DbOrganization, 'organization_name'>;
+export type DbOrganizationIn = Pick<
+    DbOrganization,
+    'organization_name' | 'is_setup_complete'
+>;
 export type DbOrganizationUpdate = Partial<
     Pick<
         DbOrganization,
@@ -39,6 +43,7 @@ export type DbOrganizationUpdate = Partial<
         | 'impersonation_enabled'
         | 'ai_agent_memory_enabled'
         | 'brand'
+        | 'is_setup_complete'
     >
 >;
 

--- a/packages/backend/src/database/migrations/20260907120000_add_is_setup_complete_to_organizations.ts
+++ b/packages/backend/src/database/migrations/20260907120000_add_is_setup_complete_to_organizations.ts
@@ -1,0 +1,35 @@
+import { Knex } from 'knex';
+
+const OrganizationsTableName = 'organizations';
+const IsSetupCompleteColumnName = 'is_setup_complete';
+const DefaultOrganizationName = 'My organization';
+
+export const classification = {
+    kind: 'safe',
+    reason: 'Adds a defaulted boolean to the small organizations table and names the few blank organizations',
+} as const;
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw("SET LOCAL lock_timeout = '5s'");
+
+    await knex.schema.alterTable(OrganizationsTableName, (table) => {
+        table.boolean(IsSetupCompleteColumnName).notNullable().defaultTo(false);
+    });
+
+    await knex(OrganizationsTableName)
+        .whereNot('organization_name', '')
+        .update({ [IsSetupCompleteColumnName]: true });
+
+    // Blank names were the old "not set up yet" signal; the flag now carries it.
+    await knex(OrganizationsTableName)
+        .where('organization_name', '')
+        .update({ organization_name: DefaultOrganizationName });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw("SET LOCAL lock_timeout = '5s'");
+
+    await knex.schema.alterTable(OrganizationsTableName, (table) => {
+        table.dropColumn(IsSetupCompleteColumnName);
+    });
+}

--- a/packages/backend/src/database/seeds/development/01_initial_user.ts
+++ b/packages/backend/src/database/seeds/development/01_initial_user.ts
@@ -49,9 +49,11 @@ export async function seed(knex: Knex): Promise<void> {
     await knex('users').del();
     await knex('organizations').del();
 
-    const addOrganization = async (seedOrganization: DbOrganizationIn) => {
+    const addOrganization = async (
+        seedOrganization: Omit<DbOrganizationIn, 'is_setup_complete'>,
+    ) => {
         const [organization] = await knex('organizations')
-            .insert(seedOrganization)
+            .insert({ ...seedOrganization, is_setup_complete: true })
             .returning(['organization_id', 'organization_uuid']);
 
         if (organization === undefined) {

--- a/packages/backend/src/ee/models/ExternalSourceModel.integration.test.ts
+++ b/packages/backend/src/ee/models/ExternalSourceModel.integration.test.ts
@@ -41,7 +41,10 @@ describe('ExternalSourceModel lifecycle integration', () => {
     beforeEach(async () => {
         transaction = await getTestContext().db.transaction();
         const [organization] = await transaction('organizations')
-            .insert({ organization_name: 'External lifecycle test' })
+            .insert({
+                organization_name: 'External lifecycle test',
+                is_setup_complete: true,
+            })
             .returning(['organization_id', 'organization_uuid']);
         const [user] = await transaction('users')
             .insert({

--- a/packages/backend/src/models/OrganizationModel.ts
+++ b/packages/backend/src/models/OrganizationModel.ts
@@ -1,6 +1,5 @@
 import {
     CreateColorPalette,
-    CreateOrganization,
     NotFoundError,
     Organization,
     OrganizationBrand,
@@ -203,6 +202,7 @@ export class OrganizationModel {
                 ? data.default_project_uuid
                 : undefined,
             createdAt: data.created_at,
+            isSetupComplete: data.is_setup_complete,
         };
     }
 
@@ -275,10 +275,13 @@ export class OrganizationModel {
         );
     }
 
-    async create(data: CreateOrganization): Promise<Organization> {
+    async create(
+        data: Pick<Organization, 'name' | 'isSetupComplete'>,
+    ): Promise<Organization> {
         const [org] = await this.database(OrganizationTableName)
             .insert({
                 organization_name: data.name,
+                is_setup_complete: data.isSetupComplete,
             })
             .returning('*');
         // seed with default color palettes
@@ -300,17 +303,20 @@ export class OrganizationModel {
 
     async update(
         organizationUuid: string,
-        data: UpdateOrganization,
+        data: UpdateOrganization &
+            Partial<Pick<Organization, 'isSetupComplete'>>,
     ): Promise<Organization> {
         // Undefined values are ignored by .update (it DOES NOT set null)
         const updateData: {
             organization_name?: string;
             default_project_uuid?: string | null;
             color_palette_uuid?: string | null;
+            is_setup_complete?: boolean;
         } = {
             organization_name: data.name,
             default_project_uuid: data.defaultProjectUuid,
             color_palette_uuid: data.colorPaletteUuid,
+            is_setup_complete: data.isSetupComplete,
         };
 
         const [org] = await this.database(OrganizationTableName)

--- a/packages/backend/src/services/AdminNotificationService/AdminNotificationService.mock.ts
+++ b/packages/backend/src/services/AdminNotificationService/AdminNotificationService.mock.ts
@@ -21,6 +21,7 @@ export const mockOrganization: Organization = {
     needsProject: false,
     defaultProjectUuid: undefined,
     chartColors: [],
+    isSetupComplete: true,
 };
 
 export const mockTargetUser: LightdashUser = {

--- a/packages/backend/src/services/InstanceConfigurationService/InstanceConfigurationService.ts
+++ b/packages/backend/src/services/InstanceConfigurationService/InstanceConfigurationService.ts
@@ -153,6 +153,12 @@ export class InstanceConfigurationService extends BaseService {
                 );
             }
 
+            if (setup.organization.name.trim() === '') {
+                throw new ParameterError(
+                    'Initial setup: organization name must not be empty',
+                );
+            }
+
             // No organization and no projects, we can create a new one
             // using the initial setup config
             this.logger.debug(
@@ -161,6 +167,7 @@ export class InstanceConfigurationService extends BaseService {
 
             const { organizationUuid } = await this.organizationModel.create({
                 name: setup.organization.name,
+                isSetupComplete: true,
             });
 
             this.logger.info(

--- a/packages/backend/src/services/OrganizationService/OrganizationService.mock.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.mock.ts
@@ -36,6 +36,7 @@ export const user: SessionUser = {
 export const organization: Organization = {
     organizationUuid: 'organizationUuid',
     name: 'Lightdash',
+    isSetupComplete: true,
 };
 
 export const Config = {

--- a/packages/backend/src/services/OrganizationService/OrganizationService.test.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.test.ts
@@ -3,6 +3,7 @@ import {
     ForbiddenError,
     LightdashInstallType,
     OrganizationMemberRole,
+    ParameterError,
     type PossibleAbilities,
     type SessionUser,
 } from '@lightdash/common';
@@ -146,6 +147,28 @@ describe('organization service', () => {
         process.env = {
             LIGHTDASH_INSTALL_TYPE: LightdashInstallType.UNKNOWN,
         };
+    });
+
+    it('creates the organization pending setup by its creator', async () => {
+        await organizationService.createAndJoinOrg(
+            { ...user, organizationUuid: undefined },
+            { name: 'Organization' },
+        );
+
+        expect(organizationModel.create).toHaveBeenCalledExactlyOnceWith({
+            name: 'Organization',
+            isSetupComplete: false,
+        });
+    });
+
+    it('rejects a blank organization name', async () => {
+        await expect(
+            organizationService.createAndJoinOrg(
+                { ...user, organizationUuid: undefined },
+                { name: '   ' },
+            ),
+        ).rejects.toThrow(ParameterError);
+        expect(organizationModel.create).not.toHaveBeenCalled();
     });
 
     it('tracks the onboarding flow when creating an organization', async () => {

--- a/packages/backend/src/services/OrganizationService/OrganizationService.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.ts
@@ -245,7 +245,7 @@ export class OrganizationService extends BaseService {
         ) {
             throw new ForbiddenError();
         }
-        if (data.name) {
+        if (data.name !== undefined) {
             validateOrganizationNameOrThrow(data.name);
         }
         const org = await this.organizationModel.update(organizationUuid, data);
@@ -888,6 +888,7 @@ export class OrganizationService extends BaseService {
         user: SessionUser,
         data: CreateOrganization,
     ): Promise<void> {
+        validateOrganizationNameOrThrow(data.name);
         if (
             !this.lightdashConfig.allowMultiOrgs &&
             (await this.userModel.hasUsers()) &&
@@ -900,7 +901,12 @@ export class OrganizationService extends BaseService {
         if (isUserWithOrg(user)) {
             throw new ForbiddenError('User already has an organization');
         }
-        const org = await this.organizationModel.create(data);
+        // Self-serve organizations start with a placeholder name that the
+        // creator confirms in onboarding.
+        const org = await this.organizationModel.create({
+            name: data.name,
+            isSetupComplete: false,
+        });
         const { enabled: newOnboardingEnabled } =
             await this.featureFlagModel.get({
                 user,

--- a/packages/backend/src/services/UserService.mock.ts
+++ b/packages/backend/src/services/UserService.mock.ts
@@ -112,6 +112,7 @@ export const newUser: SessionUser = {
 export const organisation: Organization = {
     organizationUuid: 'organizationUuid',
     name: 'organizationName',
+    isSetupComplete: true,
 };
 
 export const userWithoutOrg: LightdashUser = {

--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -177,6 +177,7 @@ const emailClient = {
 
 const organizationModel = {
     get: vi.fn(async () => organisation),
+    update: vi.fn(async () => organisation),
     getAllowedOrgsForDomain: vi.fn(async () => []),
 };
 
@@ -590,6 +591,50 @@ describe('UserService', () => {
     });
 
     describe('completeUserSetup', () => {
+        test('names the organization and marks its setup complete', async () => {
+            const organizationAdmin: SessionUser = {
+                ...sessionUser,
+                ability: new Ability<PossibleAbilities>([
+                    { subject: 'Organization', action: ['update'] },
+                ]),
+            };
+
+            await userService.completeUserSetup(organizationAdmin, {
+                organizationName: 'Acme Analytics',
+                jobTitle: '',
+                howDidYouHearAboutUs: 'A podcast',
+                enableEmailDomainAccess: false,
+                isMarketingOptedIn: true,
+                isTrackingAnonymized: false,
+            });
+
+            expect(vi.mocked(organizationModel.update)).toHaveBeenCalledWith(
+                sessionUser.organizationUuid,
+                { name: 'Acme Analytics', isSetupComplete: true },
+            );
+        });
+
+        test('rejects a blank organization name', async () => {
+            const organizationAdmin: SessionUser = {
+                ...sessionUser,
+                ability: new Ability<PossibleAbilities>([
+                    { subject: 'Organization', action: ['update'] },
+                ]),
+            };
+
+            await expect(
+                userService.completeUserSetup(organizationAdmin, {
+                    organizationName: '   ',
+                    jobTitle: '',
+                    howDidYouHearAboutUs: 'A podcast',
+                    enableEmailDomainAccess: false,
+                    isMarketingOptedIn: true,
+                    isTrackingAnonymized: false,
+                }),
+            ).rejects.toThrow(ParameterError);
+            expect(organizationModel.update).not.toHaveBeenCalled();
+        });
+
         test('persists and tracks a trimmed answer', async () => {
             await userService.completeUserSetup(sessionUser, {
                 jobTitle: '',

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -1506,6 +1506,7 @@ export class UserService extends BaseService {
 
             await this.organizationModel.update(user.organizationUuid, {
                 name: organizationName,
+                isSetupComplete: true,
             });
             this.analytics.track({
                 userId: user.userUuid,

--- a/packages/common/src/types/organization.ts
+++ b/packages/common/src/types/organization.ts
@@ -37,6 +37,12 @@ export type Organization = {
      */
     needsProject?: boolean;
     /**
+     * Whether the person who created the organization has finished setting it
+     * up. Organizations created during signup carry a placeholder name until
+     * their creator confirms one in onboarding.
+     */
+    isSetupComplete: boolean;
+    /**
      * The project a user sees when they first log in to the organization
      */
     defaultProjectUuid?: string;
@@ -64,7 +70,7 @@ export type Organization = {
 export type CreateOrganization = Pick<Organization, 'name'>;
 
 export type UpdateOrganization = Partial<
-    Omit<Organization, 'organizationUuid' | 'needsProject'>
+    Omit<Organization, 'organizationUuid' | 'needsProject' | 'isSetupComplete'>
 >;
 
 export type ApiOrganization = {

--- a/packages/common/src/utils/organization.test.ts
+++ b/packages/common/src/utils/organization.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import {
+    DEFAULT_ORGANIZATION_NAME,
+    getDefaultOrganizationName,
+    inferOrganizationNameFromDomain,
+} from './organization';
+
+describe('inferOrganizationNameFromDomain', () => {
+    it('title-cases the first label of the domain', () => {
+        expect(inferOrganizationNameFromDomain('acme-analytics.co.uk')).toBe(
+            'Acme Analytics',
+        );
+        expect(inferOrganizationNameFromDomain('lightdash.com')).toBe(
+            'Lightdash',
+        );
+    });
+});
+
+describe('getDefaultOrganizationName', () => {
+    it('guesses from a company email domain', () => {
+        expect(getDefaultOrganizationName('demo@lightdash.com')).toBe(
+            'Lightdash',
+        );
+    });
+
+    it('falls back for personal email providers', () => {
+        expect(getDefaultOrganizationName('someone@gmail.com')).toBe(
+            DEFAULT_ORGANIZATION_NAME,
+        );
+    });
+
+    it('falls back when there is no email', () => {
+        expect(getDefaultOrganizationName(undefined)).toBe(
+            DEFAULT_ORGANIZATION_NAME,
+        );
+    });
+
+    it('falls back when the guess is not a valid organization name', () => {
+        expect(getDefaultOrganizationName('a@---.com')).toBe(
+            DEFAULT_ORGANIZATION_NAME,
+        );
+    });
+});

--- a/packages/common/src/utils/organization.ts
+++ b/packages/common/src/utils/organization.ts
@@ -1,5 +1,8 @@
 import { z } from 'zod';
 import { ParameterError } from '../types/errors';
+import { getEmailDomain, validateOrganizationEmailDomains } from './email';
+
+export const DEFAULT_ORGANIZATION_NAME = 'My organization';
 
 export const validateOrganizationName = (name: string) => {
     const trimmedName = name.trim();
@@ -26,4 +29,31 @@ export const validateOrganizationNameOrThrow = (name: string) => {
         }
         throw new ParameterError(parsedOrganizationName.error.message);
     }
+};
+
+/** "acme-analytics.com" becomes "Acme Analytics". */
+export const inferOrganizationNameFromDomain = (domain: string): string =>
+    (domain.split('.')[0] ?? '')
+        .split(/[-_]/)
+        .filter(Boolean)
+        .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+        .join(' ');
+
+/**
+ * Placeholder name for an organization created during signup, before its
+ * creator confirms one. Company email domains give a useful guess; personal
+ * ones fall back to a generic name.
+ */
+export const getDefaultOrganizationName = (
+    email: string | undefined,
+): string => {
+    if (!email) return DEFAULT_ORGANIZATION_NAME;
+    const domain = getEmailDomain(email);
+    if (validateOrganizationEmailDomains([domain])) {
+        return DEFAULT_ORGANIZATION_NAME;
+    }
+    const inferred = inferOrganizationNameFromDomain(domain);
+    return validateOrganizationName(inferred)
+        ? inferred
+        : DEFAULT_ORGANIZATION_NAME;
 };

--- a/packages/frontend/src/components/UserCompletionModal/UserCompletionModal.test.tsx
+++ b/packages/frontend/src/components/UserCompletionModal/UserCompletionModal.test.tsx
@@ -1,4 +1,4 @@
-import { LightdashMode } from '@lightdash/common';
+import { LightdashMode, type Organization } from '@lightdash/common';
 import { useQueryClient } from '@tanstack/react-query';
 import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -85,6 +85,24 @@ const renderModal = (mocks?: Parameters<typeof renderWithProviders>[1]) =>
         mocks,
     );
 
+type MockOrganization = Pick<Organization, 'name' | 'isSetupComplete'>;
+
+const pendingOrganization: MockOrganization = {
+    name: 'My organization',
+    isSetupComplete: false,
+};
+
+const namedOrganization: MockOrganization = {
+    name: 'test organization',
+    isSetupComplete: true,
+};
+
+const mockOrgApi = (organization: MockOrganization) =>
+    nock(BASE_API_URL)
+        .persist()
+        .get('/api/v1/org')
+        .reply(200, { status: 'ok', results: organization });
+
 describe('UserCompletionModal', () => {
     beforeEach(() => {
         mockFeatureFlag(false);
@@ -99,6 +117,7 @@ describe('UserCompletionModal', () => {
     });
 
     it("should render user completion modal if user's setup is not complete", async () => {
+        mockOrgApi(namedOrganization);
         renderModal({
             user: {
                 isSetupComplete: false,
@@ -112,7 +131,8 @@ describe('UserCompletionModal', () => {
         ).toBeInTheDocument();
     });
 
-    it('should not show organization name input if organization already has organization name', async () => {
+    it('should not show organization name input if the organization is already set up', async () => {
+        mockOrgApi(namedOrganization);
         renderModal({
             user: {
                 isSetupComplete: false,
@@ -130,11 +150,11 @@ describe('UserCompletionModal', () => {
         expect(nameInput).not.toBeInTheDocument();
     });
 
-    it('should show organization name input if organization does not have organization name', async () => {
+    it('should show organization name input, seeded with the placeholder, while the organization is pending setup', async () => {
+        mockOrgApi(pendingOrganization);
         renderModal({
             user: {
                 isSetupComplete: false,
-                organizationName: '',
             },
         });
 
@@ -146,14 +166,14 @@ describe('UserCompletionModal', () => {
 
         const nameInput =
             await screen.findByPlaceholderText('Enter company name');
-        expect(nameInput).toBeInTheDocument();
+        expect(nameInput).toHaveValue('My organization');
     });
 
     it("should not show email domain checkbox if user's email provider is from common email providers", async () => {
+        mockOrgApi(pendingOrganization);
         renderModal({
             user: {
                 isSetupComplete: false,
-                organizationName: '',
                 email: 'demo@gmail.com',
             },
         });
@@ -171,10 +191,10 @@ describe('UserCompletionModal', () => {
     });
 
     it('should show email domain checkbox if user is using custom email provider', async () => {
+        mockOrgApi(pendingOrganization);
         renderModal({
             user: {
                 isSetupComplete: false,
-                organizationName: '',
                 email: 'demo@lightdash.com',
             },
         });
@@ -192,10 +212,10 @@ describe('UserCompletionModal', () => {
     });
 
     it("should not show anonymize tracking checkbox if organization's mode is cloud beta", async () => {
+        mockOrgApi(pendingOrganization);
         renderModal({
             user: {
                 isSetupComplete: false,
-                organizationName: '',
             },
             health: {
                 mode: LightdashMode.CLOUD_BETA,
@@ -215,10 +235,10 @@ describe('UserCompletionModal', () => {
     });
 
     it('should show anonymize tracking checkbox if organization is not cloud beta', async () => {
+        mockOrgApi(pendingOrganization);
         renderModal({
             user: {
                 isSetupComplete: false,
-                organizationName: '',
             },
             health: {
                 mode: LightdashMode.DEFAULT,
@@ -240,10 +260,11 @@ describe('UserCompletionModal', () => {
     it("should submit user's completion with correct data", async () => {
         const user = userEvent.setup();
 
+        mockOrgApi(pendingOrganization);
+
         renderModal({
             user: {
                 isSetupComplete: false,
-                organizationName: '',
                 email: 'demo@lightdash.com',
             },
             health: {
@@ -261,6 +282,7 @@ describe('UserCompletionModal', () => {
         const nameInput =
             await screen.findByPlaceholderText('Enter company name');
         expect(nameInput).toBeInTheDocument();
+        await user.clear(nameInput);
         await user.type(nameInput, 'test organization');
 
         // select role
@@ -323,8 +345,10 @@ describe('UserCompletionModal', () => {
         await waitFor(() => expect(scope.isDone()).toBe(true));
     });
 
-    it("should not submit organization name and email domain if user's organization already has organization name", async () => {
+    it('should not submit organization name and email domain when the organization is already set up', async () => {
         const user = userEvent.setup();
+
+        mockOrgApi(namedOrganization);
 
         renderModal({
             user: {
@@ -385,10 +409,10 @@ describe('UserCompletionModal', () => {
     });
 
     it('should render the how did you hear about us input for the org creator', async () => {
+        mockOrgApi(pendingOrganization);
         renderModal({
             user: {
                 isSetupComplete: false,
-                organizationName: '',
             },
         });
 
@@ -401,6 +425,7 @@ describe('UserCompletionModal', () => {
     });
 
     it('should not render the how did you hear about us input for invited members', async () => {
+        mockOrgApi(namedOrganization);
         renderModal({
             user: {
                 isSetupComplete: false,
@@ -419,10 +444,11 @@ describe('UserCompletionModal', () => {
     it('should submit the trimmed how did you hear about us answer', async () => {
         const user = userEvent.setup();
 
+        mockOrgApi(pendingOrganization);
+
         renderModal({
             user: {
                 isSetupComplete: false,
-                organizationName: '',
             },
         });
 
@@ -432,6 +458,7 @@ describe('UserCompletionModal', () => {
 
         const nameInput =
             await screen.findByPlaceholderText('Enter company name');
+        await user.clear(nameInput);
         await user.type(nameInput, 'test organization');
 
         const roleSelect =
@@ -466,10 +493,11 @@ describe('UserCompletionModal', () => {
     it('should not submit completion request when referral field is empty', async () => {
         const user = userEvent.setup();
 
+        mockOrgApi(pendingOrganization);
+
         renderModal({
             user: {
                 isSetupComplete: false,
-                organizationName: '',
             },
         });
 
@@ -479,6 +507,7 @@ describe('UserCompletionModal', () => {
 
         const nameInput =
             await screen.findByPlaceholderText('Enter company name');
+        await user.clear(nameInput);
         await user.type(nameInput, 'test organization');
 
         const roleSelect =

--- a/packages/frontend/src/components/UserCompletionModal/UserCompletionModal.tsx
+++ b/packages/frontend/src/components/UserCompletionModal/UserCompletionModal.tsx
@@ -5,6 +5,7 @@ import {
     LightdashMode,
     validateOrganizationEmailDomains,
     type CompleteUserArgs,
+    type Organization,
 } from '@lightdash/common';
 import { Button, Checkbox, Select, Stack, TextInput } from '@mantine/core';
 import { useForm } from '@mantine/form';
@@ -13,16 +14,22 @@ import { useIsMutating } from '@tanstack/react-query';
 import { zod4Resolver as zodResolver } from 'mantine-form-zod-resolver';
 import { type FC, useEffect, useMemo, useState } from 'react';
 import { Navigate, useLocation } from 'react-router';
+import { useOrganization } from '../../hooks/organization/useOrganization';
 import { useUserCompleteMutation } from '../../hooks/user/useUserCompleteMutation';
 import { useServerFeatureFlag } from '../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../providers/App/useApp';
 import MantineModal from '../common/MantineModal';
 import { jobTitles } from './jobTitles';
 
-const UserCompletionModal: FC = () => {
+type UserCompletionFormProps = {
+    organization: Organization;
+};
+
+const UserCompletionForm: FC<UserCompletionFormProps> = ({ organization }) => {
     const { health, user } = useApp();
 
-    const canEnterOrganizationName = user.data?.organizationName === '';
+    // Only the creator of a not-yet-set-up organization gets to name it.
+    const canEnterOrganizationName = !organization.isSetupComplete;
 
     const validate = useMemo(
         () =>
@@ -42,7 +49,7 @@ const UserCompletionModal: FC = () => {
 
     const form = useForm<CompleteUserArgs>({
         initialValues: {
-            organizationName: '',
+            organizationName: canEnterOrganizationName ? organization.name : '',
             jobTitle: '',
             howDidYouHearAboutUs: '',
             enableEmailDomainAccess: false,
@@ -61,11 +68,11 @@ const UserCompletionModal: FC = () => {
             ? data.howDidYouHearAboutUs?.trim() || undefined
             : undefined;
         const payload = { ...data, howDidYouHearAboutUs };
-        if (user.data?.organizationName) {
+        if (canEnterOrganizationName) {
+            mutate(payload);
+        } else {
             const { organizationName, ...rest } = payload;
             mutate(rest);
-        } else {
-            mutate(payload);
         }
     });
 
@@ -82,10 +89,11 @@ const UserCompletionModal: FC = () => {
     const canEnableEmailDomainAccess =
         canEnterOrganizationName && isValidOrganizationDomain;
 
-    useEffect(() => {
-        if (!user.data) return;
-        setFieldValue('organizationName', user.data.organizationName);
-    }, [setFieldValue, user.data]);
+    const canSubmit =
+        !!form.values.jobTitle &&
+        (!canEnterOrganizationName ||
+            (!!form.values.organizationName &&
+                !!form.values.howDidYouHearAboutUs?.trim()));
 
     useEffect(() => {
         if (!canEnableEmailDomainAccess) return;
@@ -115,14 +123,7 @@ const UserCompletionModal: FC = () => {
                     type="submit"
                     form="complete_user"
                     loading={isLoading}
-                    disabled={
-                        !(
-                            form.values.organizationName &&
-                            form.values.jobTitle &&
-                            (!canEnterOrganizationName ||
-                                form.values.howDidYouHearAboutUs?.trim())
-                        )
-                    }
+                    disabled={!canSubmit}
                 >
                     Next
                 </Button>
@@ -205,6 +206,19 @@ const UserCompletionModal: FC = () => {
             </form>
         </MantineModal>
     );
+};
+
+const UserCompletionModal: FC = () => {
+    const { user } = useApp();
+    const organization = useOrganization({
+        enabled: !!user.data && !user.data.isSetupComplete,
+    });
+
+    if (!user.data || user.data.isSetupComplete || !organization.data) {
+        return null;
+    }
+
+    return <UserCompletionForm organization={organization.data} />;
 };
 
 const UserCompletionModalWithUser = () => {

--- a/packages/frontend/src/pages/JoinOrganization.tsx
+++ b/packages/frontend/src/pages/JoinOrganization.tsx
@@ -1,4 +1,4 @@
-import { getEmailDomain } from '@lightdash/common';
+import { getDefaultOrganizationName, getEmailDomain } from '@lightdash/common';
 import {
     Anchor,
     Avatar,
@@ -43,6 +43,9 @@ const JoinOrganizationPage: FC = () => {
         isSuccess: hasJoinedOrg,
     } = useJoinOrganizationMutation();
     const emailDomain = user.data?.email ? getEmailDomain(user.data.email) : '';
+    const defaultOrganizationName = getDefaultOrganizationName(
+        user.data?.email,
+    );
 
     // Read by both the effect that fires the auto-create and the guard that
     // holds the page while it is on its way. Derived once: two copies of this
@@ -53,9 +56,15 @@ const JoinOrganizationPage: FC = () => {
 
     useEffect(() => {
         if (shouldAutoCreateOrg && !isCreatingOrg && !isLoadingAllowedOrgs) {
-            createOrg({ name: '' });
+            createOrg({ name: defaultOrganizationName });
         }
-    }, [shouldAutoCreateOrg, createOrg, isCreatingOrg, isLoadingAllowedOrgs]);
+    }, [
+        shouldAutoCreateOrg,
+        createOrg,
+        isCreatingOrg,
+        isLoadingAllowedOrgs,
+        defaultOrganizationName,
+    ]);
 
     useEffect(() => {
         if ((hasCreatedOrg || hasJoinedOrg) && !createOrgError) {
@@ -156,7 +165,7 @@ const JoinOrganizationPage: FC = () => {
                 <Anchor
                     className={disabled ? styles.disabledAnchor : undefined}
                     component="button"
-                    onClick={() => createOrg({ name: '' })}
+                    onClick={() => createOrg({ name: defaultOrganizationName })}
                     ta="center"
                     size="sm"
                 >

--- a/packages/frontend/src/pages/OrganizationSetup.test.tsx
+++ b/packages/frontend/src/pages/OrganizationSetup.test.tsx
@@ -1,4 +1,4 @@
-import { LightdashMode } from '@lightdash/common';
+import { LightdashMode, type Organization } from '@lightdash/common';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
@@ -34,12 +34,27 @@ const renderSetupPage = (
         mocks,
     );
 
-const mockOrgApi = (name: string, { optional = false } = {}) => {
+type MockOrganization = Pick<Organization, 'name' | 'isSetupComplete'>;
+
+const pendingOrganization: MockOrganization = {
+    name: 'My organization',
+    isSetupComplete: false,
+};
+
+const namedOrganization: MockOrganization = {
+    name: 'test organization',
+    isSetupComplete: true,
+};
+
+const mockOrgApi = (
+    organization: MockOrganization,
+    { optional = false } = {},
+) => {
     const interceptor = nock(BASE_API_URL).get('/api/v1/org');
     if (optional) {
         interceptor.optionally();
     }
-    return interceptor.reply(200, { status: 'ok', results: { name } });
+    return interceptor.reply(200, { status: 'ok', results: organization });
 };
 
 const selectRole = async (user: ReturnType<typeof userEvent.setup>) => {
@@ -60,7 +75,7 @@ describe('OrganizationSetup', () => {
     it('does not ask invited members how they heard about us', async () => {
         const user = userEvent.setup();
 
-        mockOrgApi('test organization');
+        mockOrgApi(namedOrganization);
         renderSetupPage({
             user: {
                 isSetupComplete: false,
@@ -110,7 +125,7 @@ describe('OrganizationSetup', () => {
     it('submits the trimmed referral answer when a user creating an organization answers it', async () => {
         const user = userEvent.setup();
 
-        mockOrgApi('');
+        mockOrgApi(pendingOrganization);
         renderSetupPage({
             user: {
                 isSetupComplete: false,
@@ -123,6 +138,7 @@ describe('OrganizationSetup', () => {
         });
 
         const nameInput = await screen.findByPlaceholderText('Acme Analytics');
+        expect(nameInput).toHaveValue('My organization');
         await user.clear(nameInput);
         await user.type(nameInput, 'test organization');
         await user.click(
@@ -158,10 +174,10 @@ describe('OrganizationSetup', () => {
         await waitFor(() => expect(brandScope.isDone()).toBe(true));
     });
 
-    it('skips the workspace step when the organization is already named', async () => {
+    it('skips the workspace step when the organization is already set up', async () => {
         const user = userEvent.setup();
 
-        mockOrgApi('test organization');
+        mockOrgApi(namedOrganization);
         renderSetupPage({
             user: {
                 isSetupComplete: false,
@@ -204,7 +220,7 @@ describe('OrganizationSetup', () => {
     it('does not submit when referral field is empty', async () => {
         const user = userEvent.setup();
 
-        mockOrgApi('');
+        mockOrgApi(pendingOrganization);
         renderSetupPage({
             user: {
                 isSetupComplete: false,
@@ -262,7 +278,7 @@ describe('OrganizationSetup', () => {
     });
 
     it('redirects to the redirect target when setup is already complete', async () => {
-        mockOrgApi('test organization', { optional: true });
+        mockOrgApi(namedOrganization, { optional: true });
         renderSetupPage(
             {
                 user: {
@@ -277,7 +293,7 @@ describe('OrganizationSetup', () => {
     });
 
     it('falls back to home when the redirect target is the setup page itself', async () => {
-        mockOrgApi('test organization', { optional: true });
+        mockOrgApi(namedOrganization, { optional: true });
         renderSetupPage(
             {
                 user: {

--- a/packages/frontend/src/pages/OrganizationSetup.tsx
+++ b/packages/frontend/src/pages/OrganizationSetup.tsx
@@ -5,6 +5,7 @@ import {
     LightdashMode,
     validateOrganizationEmailDomains,
     type HealthState,
+    type Organization,
     type OrganizationBrandColor,
     type OrganizationBrandLogo,
 } from '@lightdash/common';
@@ -80,13 +81,6 @@ const pickTileLogo = (logos: OrganizationBrandLogo[]): string | null => {
     return dark?.url ?? neutral?.url ?? logos[0]?.url ?? null;
 };
 
-const inferOrganizationName = (domain: string): string =>
-    (domain.split('.')[0] ?? '')
-        .split(/[-_]/)
-        .filter(Boolean)
-        .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-        .join(' ');
-
 const buildBrandColors = (
     selectedColor: string,
     brandColors: OrganizationBrandColor[],
@@ -116,18 +110,18 @@ type OrganizationSetupFormValues = {
 type OrganizationSetupContentProps = {
     user: UserWithAbility;
     health: HealthState;
-    organizationHasName: boolean;
+    organization: Organization;
     completeMutation: ReturnType<typeof useUserCompleteMutation>;
 };
 
 const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
     user,
     health,
-    organizationHasName,
+    organization,
     completeMutation,
 }) => {
-    const canEnterOrganizationName =
-        user.organizationName === '' && !organizationHasName;
+    // Only the creator of a not-yet-set-up organization gets the workspace step.
+    const canEnterOrganizationName = !organization.isSetupComplete;
     const emailDomain = user.email ? getEmailDomain(user.email) : '';
     const isCompanyDomain =
         !!user.email && !validateOrganizationEmailDomains([emailDomain]);
@@ -136,10 +130,7 @@ const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
 
     const form = useForm<OrganizationSetupFormValues>({
         initialValues: {
-            organizationName:
-                canEnterOrganizationName && isCompanyDomain
-                    ? inferOrganizationName(emailDomain)
-                    : '',
+            organizationName: canEnterOrganizationName ? organization.name : '',
             jobTitle: '',
             howDidYouHearAboutUs: '',
             enableEmailDomainAccess: canEnableEmailDomainAccess,
@@ -591,7 +582,7 @@ const OrganizationSetup: FC = () => {
         return <Navigate to="/" />;
     }
 
-    if (organization.isInitialLoading) {
+    if (organization.isInitialLoading || !organization.data) {
         return <PageSpinner />;
     }
 
@@ -600,7 +591,7 @@ const OrganizationSetup: FC = () => {
             key={user.data.userUuid}
             user={user.data}
             health={health.data}
-            organizationHasName={!!organization.data?.name}
+            organization={organization.data}
             completeMutation={completeMutation}
         />
     );


### PR DESCRIPTION
## Problem

Self-serve signup auto-created the organization with an empty name, and both onboarding surfaces (the legacy completion modal and the organization setup page) used `organizationName === ''` as the signal "this user created the org and still has to name it". Anyone who reached the app past that step with the blank name left behind (grandfathered setups, abandoned onboarding) had an organization with no name, which broke name-dependent flows such as the delete confirmation form.

## Change

Treat "the creator has not finished setting the organization up" as real state instead of inferring it from a blank name.

- **Schema**: `organizations.is_setup_complete boolean not null default false`. The migration marks every organization that already has a name as complete, and gives the blank ones the placeholder `My organization`. `down` drops the column only; names are never rewritten back to blank.
- **Backend**: `createAndJoinOrg` validates the name and creates the organization pending setup. `completeUserSetup` with an organization name marks it complete. Instance-config organizations are created complete. `updateOrg` now validates `name: ''` too (it previously skipped validation on a falsy name). The initial-setup config fails loudly on a blank organization name.
- **API**: `Organization` gains `isSetupComplete` on `GET /org`. It is excluded from the `PATCH /org` body.
- **Frontend**: the join page auto-creates with a placeholder derived from the signup email domain (`acme-analytics.com` becomes `Acme Analytics`, personal providers fall back to `My organization`). Both onboarding surfaces read `organization.isSetupComplete` to decide whether to show the naming step, and seed the field with the placeholder so the creator confirms or edits it.

## Flows

```mermaid
flowchart TD
    subgraph create["Organization creation"]
        signup["Self-serve signup<br/>join page auto-creates"] -->|"name = placeholder<br/>is_setup_complete = false"| pending["Organization pending setup"]
        config["Instance config<br/>LD_SETUP_ORGANIZATION_NAME"] -->|"name = configured<br/>is_setup_complete = true"| complete["Organization set up"]
        blank["POST /org with blank name"] -->|"ParameterError"| rejected["Rejected"]
    end

    subgraph onboarding["User onboarding (modal or setup page)"]
        pending --> creator["Creator sees the naming step<br/>field seeded with the placeholder"]
        creator -->|"completeUserSetup(organizationName)<br/>name = confirmed<br/>is_setup_complete = true"| complete
        complete --> invitee["Invited member<br/>no naming step, no referral question"]
        invitee -->|"completeUserSetup()"| done["User setup complete"]
        creator -->|"completeUserSetup(organizationName)"| done
    end

    subgraph migration["Migration on existing rows"]
        named["organization_name <> ''"] -->|"is_setup_complete = true"| complete
        empty["organization_name = ''"] -->|"name = My organization<br/>is_setup_complete = false"| pending
    end

    subgraph rollback["Rollback"]
        down["down(): drop column only"] --> keep["Placeholder names stay<br/>old code shows no naming step<br/>creator renames in settings"]
    end
```

## Regression analysis

- **Rolling deploy**: the migration runs before new pods serve. Old pods never read the new column, so nothing they do breaks. The column default is `false`, so an organization created by an old pod during the window is pending and gets the naming step from the new code. An old pod that completes a user's setup during the window names the org but does not flip the flag; the flag then flips the next time an admin who has not finished their own setup confirms the name. That state is harmless.
- **Rollback**: dropping the column is a full schema reversal. Organizations created while the column existed keep their placeholder name, so old code will not show them the naming step. Their creator can rename in settings. The migration deliberately does not try to restore blank names.
- **Legacy blank organizations**: renamed to `My organization` and left pending. Their admins already completed user setup, so nothing prompts them; they can rename in settings. The delete confirmation now works for them without special-casing.
- **Invited members**: unchanged. They join an organization that is already complete and do not see the naming step or the referral question.
- **Submit gating in the legacy modal** previously depended on the invitee's org name being copied into the form. It now depends only on the fields the invitee is asked for.
- **PATCH /org** with `name: ''` used to write the blank name; it is now rejected. The pinned oasdiff (CI digest) reports no breaking changes.

## Verification

- `pnpm -F common test src/utils/organization.test.ts`, `pnpm -F backend test` on OrganizationService, UserService and InstanceConfigurationService, `pnpm -F frontend test` on UserCompletionModal, OrganizationSetup and PrivateRoute: all green.
- Typecheck and lint for common, backend, frontend.
- Migration exercised on a scratch database: up, down, insert `Jaffle Shop` and `''` on the old schema, up again yields `Jaffle Shop / true` and `My organization / false`; down again keeps the names and drops the column.
- `pnpm generate-api` run locally to validate the type change; generated files not committed.

Closes: PROD-10317
Closes: #27633

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VLXUfh4yY4EFXh6hdmmf5d
