### PR TITLE
fix(compose): run compose SQL on a session scoped to the results it references

### DIFF
--- a/docs/multi-source-queries.md
+++ b/docs/multi-source-queries.md
@@ -90,6 +90,10 @@ The reference wait lives in `AsyncQueryService.runDuckdbQuery` (the
 background phase of `executeAsyncComposeSqlQuery`): references are validated
 and authorized at submit time with the exact access checks of fetching results
 by uuid, then resolved to S3-backed CTEs once the referenced queries complete.
+The statement then runs on an isolated DuckDB session whose storage
+credentials reach exactly those result files, so user SQL cannot read the
+rest of the results bucket; a duckdb query that references nothing is refused
+at submit, since it would have nothing to run on.
 One caveat inherited by design: when compose queries move to NATS workers, a
 waiting query occupies a worker slot; dependency-ordered submission keeps
 queue order aligned with dependency order, and a dedicated consumer is the

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -724,6 +724,82 @@ describe('AsyncQueryService', () => {
         test('refuses a compose SQL query naming the missing results storage', async () => {
             const service = getMockedAsyncQueryService(withoutResultsStorage, {
                 featureFlagModel: composeFlags,
+                queryHistoryModel: {
+                    create: vi.fn(),
+                    get: vi.fn(async () => referencedQueryHistory),
+                } as unknown as QueryHistoryModel,
+            } as never);
+
+            await expect(
+                service.executeAsyncComposeSqlQuery({
+                    account: sessionAccount,
+                    projectUuid,
+                    context: QueryExecutionContext.SQL_RUNNER,
+                    sql: 'SELECT one FROM orders',
+                    references: { orders: referencedQueryHistory.queryUuid },
+                }),
+            ).rejects.toThrow(
+                new MissingConfigError(
+                    'The compose engine needs results storage to read referenced query results. Set S3_ENDPOINT, S3_BUCKET and S3_REGION, or the RESULTS_S3_* overrides.',
+                ),
+            );
+            expect(service.queryHistoryModel.create).not.toHaveBeenCalled();
+        });
+
+        test('a compose SQL query runs on a session scoped to exactly the results it references', async () => {
+            const createExecutionWarehouseClient = vi.fn(
+                () => warehouseClientMock,
+            );
+            const service = getMockedAsyncQueryService(lightdashConfigMock, {
+                featureFlagModel: composeFlags,
+                composeEngineClient: {
+                    createExecutionWarehouseClient,
+                } as unknown as ComposeEngineClient,
+                queryHistoryModel: {
+                    create: vi.fn(async () => ({ queryUuid: 'queryUuid' })),
+                    get: vi.fn(async () => referencedQueryHistory),
+                    pollForQueryCompletion: vi.fn(
+                        async () => referencedQueryHistory,
+                    ),
+                    update: vi.fn(),
+                } as unknown as QueryHistoryModel,
+                resultsStorageClient: {
+                    isEnabled: true,
+                    configuration: { bucket: 'mock_bucket' },
+                } as unknown as S3ResultsFileStorageClient,
+            } as never);
+            const runAsyncWarehouseSpy = vi
+                .spyOn(service, 'runAsyncWarehouseQuery')
+                .mockResolvedValue(undefined);
+
+            await service.executeAsyncComposeSqlQuery({
+                account: sessionAccount,
+                projectUuid,
+                context: QueryExecutionContext.SQL_RUNNER,
+                sql: 'SELECT one FROM orders',
+                references: { orders: referencedQueryHistory.queryUuid },
+            });
+            await vi.waitFor(() =>
+                expect(runAsyncWarehouseSpy).toHaveBeenCalledTimes(1),
+            );
+
+            // The shared session is built once, for the dialect and to refuse
+            // a missing results storage up front; the run gets its own,
+            // scoped to the one file the query reads
+            expect(createExecutionWarehouseClient.mock.calls).toEqual([
+                [{ storage: 'results', scope: null }],
+                [
+                    {
+                        storage: 'results',
+                        scope: ['s3://mock_bucket/referenced-results.jsonl'],
+                    },
+                ],
+            ]);
+        });
+
+        test('refuses a compose SQL query that references no results before writing a row', async () => {
+            const service = getMockedAsyncQueryService(lightdashConfigMock, {
+                featureFlagModel: composeFlags,
             } as never);
 
             await expect(
@@ -734,9 +810,7 @@ describe('AsyncQueryService', () => {
                     sql: 'SELECT 1 AS one',
                 }),
             ).rejects.toThrow(
-                new MissingConfigError(
-                    'The compose engine needs results storage to read referenced query results. Set S3_ENDPOINT, S3_BUCKET and S3_REGION, or the RESULTS_S3_* overrides.',
-                ),
+                'A compose SQL query must reference at least one query result',
             );
             expect(service.queryHistoryModel.create).not.toHaveBeenCalled();
         });
@@ -7274,6 +7348,21 @@ describe('query sources carry the execution context', () => {
 
     test('a compose SQL submit with a missing parameter refuses synchronously and creates no query history row', async () => {
         const service = createComposeEngineService();
+        const referencedQueryUuid = '0b7c9c62-4b6e-4b1a-9c3e-4f6a0c8d2e11';
+        (
+            service.queryHistoryModel.get as import('vitest').Mock
+        ).mockResolvedValue({
+            queryUuid: referencedQueryUuid,
+            projectUuid,
+            organizationUuid: projectSummary.organizationUuid,
+            createdByUserUuid: sessionAccount.user.id,
+            context: QueryExecutionContext.EXPLORE,
+            status: QueryHistoryStatus.READY,
+            resultsFileName: 'referenced-results.jsonl',
+            resultsExpiresAt: null,
+            columns: {},
+            metricQuery: { exploreName: 'orders' },
+        });
 
         await expect(
             service.executeAsyncComposeSqlQuery({
@@ -7281,9 +7370,10 @@ describe('query sources carry the execution context', () => {
                 projectUuid,
                 context: QueryExecutionContext.MULTI_SOURCE_QUERY,
                 sql: 'SELECT * FROM t WHERE region = ${ld.parameters.region}',
+                references: { t: referencedQueryUuid },
                 parameters: {},
             }),
-        ).rejects.toThrow(ParameterError);
+        ).rejects.toThrow('region');
         expect(service.queryHistoryModel.create).not.toHaveBeenCalled();
     });
 

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -7420,6 +7420,15 @@ export class AsyncQueryService extends ProjectService {
             throw new ForbiddenError();
         }
 
+        // User SQL runs on a session whose credentials reach only the results
+        // it references, so a query that references nothing has nothing to
+        // run on: it is refused rather than given the whole bucket
+        if (references === undefined || Object.keys(references).length === 0) {
+            throw new ParameterError(
+                'A compose SQL query must reference at least one query result. Run SQL against the warehouse in the SQL runner instead.',
+            );
+        }
+
         const { queryUuid } = await this.executeAsyncDuckdbSourceQuery({
             account,
             projectUuid,
@@ -7430,7 +7439,7 @@ export class AsyncQueryService extends ProjectService {
             parameters,
             plan: {
                 columns: { mode: 'discover' },
-                engine: 'client',
+                engine: 'scopedToReferencedResults',
                 guard: null,
                 referenceLabels: {},
             },

--- a/packages/backend/src/services/QuerySourceService/sources/DuckdbQuerySource.ts
+++ b/packages/backend/src/services/QuerySourceService/sources/DuckdbQuerySource.ts
@@ -30,7 +30,7 @@ export class DuckdbQuerySource implements QuerySourceClient {
         sourceType: QuerySourceType.DUCKDB,
         label: 'DuckDB compose',
         description:
-            'DuckDB SQL over other query results. References expose results as named tables: an array of node ids (each a table named by its node id) or a {tableName: nodeIdOrQueryUuid} map. A referenced result keeps the column names of the query that produced it — field ids for semanticLayer queries, SELECT output names for sql queries. References to still-running queries are waited on.',
+            'DuckDB SQL over other query results. References expose results as named tables: an array of node ids (each a table named by its node id) or a {tableName: nodeIdOrQueryUuid} map. A referenced result keeps the column names of the query that produced it — field ids for semanticLayer queries, SELECT output names for sql queries. References to still-running queries are waited on. At least one reference is required: the query runs on a session that can reach only the results it references.',
     };
 
     readonly supportsPivot = false;

--- a/packages/common/src/types/querySources.ts
+++ b/packages/common/src/types/querySources.ts
@@ -153,7 +153,9 @@ export type DuckdbSourceQuery = {
      * table named by its node id — ["orders", "revenue"] lets the SQL run
      * SELECT * FROM orders JOIN revenue. Map form for aliasing or existing
      * results: {tableName: nodeIdOrQueryUuid}, e.g. {"o": "orders", "prev":
-     * "<queryUuid>"}.
+     * "<queryUuid>"}. Required at execution: the query runs on a session
+     * that can reach only these results, so one that references nothing is
+     * refused.
      */
     references?:
         | QueryNodeId[]


### PR DESCRIPTION
## What changed

The compose SQL runner ran user SQL on the shared results session, with credentials for the whole results bucket. A merge's join has run on an isolated session scoped to exactly the leg files it binds since PROD-10899. This applies the same mechanism to compose SQL: references are bound first, then the statement runs on a session whose storage credentials reach exactly those result files.

```mermaid
flowchart LR
    Q["POST compose SQL<br/>references: { orders: queryUuid }"] --> A["authorize references<br/>same checks as fetching results"]
    A --> B["bind references<br/>wait, then result file URIs"]
    B --> S["isolated DuckDB session<br/>secret scoped to those URIs"]
    S --> R["run the statement"]
    Q0["POST compose SQL<br/>no references"] --> X["refused at submit:<br/>nothing to run on"]
```

The decision the ticket left open, a compose SQL query with no references, is settled as a refusal: the query would have nothing to run on, and giving it the shared session would be exactly the credential exposure this closes. The refusal happens before any history row is written and names the SQL runner as the place for warehouse SQL. The node type's TSDoc, the duckdb source's description and `docs/multi-source-queries.md` say so.

One call-site change on the tail this PR's parent introduced: the plan's engine becomes `scopedToReferencedResults`, and the run resolves its own session once the references are bound. The shared session is still built once at submit, for the SQL dialect and so a missing results storage is refused synchronously.

## Regression analysis

- **Compose SQL queries with references**: same results, same columns discovered the same way; the only difference is which S3 secret the session carries. The column probe also runs on the scoped session, since it uses the resolved engine.
- **Compose SQL queries without references**: previously ran on the shared session; now refused with a message naming the remedy. The AI composer tool emits duckdb nodes over upstream results, so a node with no references was never a working shape there.
- **Cost**: each compose SQL run now pays for an isolated session, as merges already do.
- **Merges**: untouched; they already ran scoped.

## Verification

- Backend and common typecheck, lint and format clean; `AsyncQueryService.test.ts` and `QuerySourceService.test.ts`: 137 tests green.
- New cases: a compose SQL query's session is built with a scope of exactly the referenced result file, after the one shared session for the dialect; a compose SQL query with no references is refused before a history row is written. The existing missing-storage and missing-parameter cases now reference a result so they still exercise what they name.

## References

Closes: PROD-10970

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEnsqumJBXz87BAyqXXKC7
