### PR TITLE
fix: log why a process died before it exits

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -5,6 +5,7 @@ import { lightdashConfig } from './config/lightdashConfig';
 import { getEnterpriseAppArguments } from './ee';
 import knexConfig from './knexfile';
 import Logger from './logging/logger';
+import { installProcessExitLogging } from './logging/processExit';
 import { getProcessTimezoneWarning } from './utils/processTimezone';
 
 // trigger BE tests
@@ -12,9 +13,7 @@ import { getProcessTimezoneWarning } from './utils/processTimezone';
 // Winston (handleExceptions/handleRejections in winston.ts) owns structured logging
 // for both events. Logger uses exitOnError: false so rejections are tolerated.
 // We still want uncaught exceptions to terminate — process state may be corrupt.
-process.on('uncaughtException', () => {
-    process.exit(1);
-});
+installProcessExitLogging();
 
 (async () => {
     try {

--- a/packages/backend/src/logging/processExit.test.ts
+++ b/packages/backend/src/logging/processExit.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+    createSignalHandler,
+    createUncaughtExceptionHandler,
+    formatUncaughtExceptionLine,
+    SIGNAL_PREFIX,
+    UNCAUGHT_EXCEPTION_PREFIX,
+    type ProcessExitWriters,
+} from './processExit';
+
+const createWriters = () => {
+    const calls: string[] = [];
+    const writers: ProcessExitWriters = {
+        write: vi.fn((line: string) => {
+            calls.push(`write:${line}`);
+        }),
+        exit: vi.fn((code: number) => {
+            calls.push(`exit:${code}`);
+        }),
+    };
+    return { writers, calls };
+};
+
+describe('processExit', () => {
+    it('writes the exception line before it calls exit', () => {
+        const { writers, calls } = createWriters();
+
+        createUncaughtExceptionHandler(writers)(new Error('boom'));
+
+        expect(calls).toHaveLength(2);
+        expect(calls[0]).toContain(
+            `${UNCAUGHT_EXCEPTION_PREFIX} name=Error message=boom stack=`,
+        );
+        expect(calls[1]).toBe('exit:1');
+    });
+
+    it('writes the name, the message and the stack on one line', () => {
+        const error = new TypeError('two words');
+        error.stack = 'TypeError: two words\n    at frameOne\n    at frameTwo';
+
+        const line = formatUncaughtExceptionLine(error);
+
+        expect(line).toBe(
+            `${UNCAUGHT_EXCEPTION_PREFIX} name=TypeError message=two words stack=TypeError: two words\\n    at frameOne\\n    at frameTwo\n`,
+        );
+        expect(line.trimEnd()).not.toContain('\n');
+    });
+
+    it('describes a thrown value that is not an error', () => {
+        const { writers } = createWriters();
+
+        createUncaughtExceptionHandler(writers)('a plain string');
+
+        expect(writers.write).toHaveBeenCalledWith(
+            `${UNCAUGHT_EXCEPTION_PREFIX} name=string message=a plain string stack=<no stack>\n`,
+        );
+        expect(writers.exit).toHaveBeenCalledWith(1);
+    });
+
+    it('names the signal and leaves the exit to the graceful handler', () => {
+        const { writers } = createWriters();
+
+        createSignalHandler(writers, 'SIGTERM')();
+        createSignalHandler(writers, 'SIGINT')();
+
+        expect(writers.write).toHaveBeenNthCalledWith(
+            1,
+            `${SIGNAL_PREFIX} signal=SIGTERM\n`,
+        );
+        expect(writers.write).toHaveBeenNthCalledWith(
+            2,
+            `${SIGNAL_PREFIX} signal=SIGINT\n`,
+        );
+        expect(writers.exit).not.toHaveBeenCalled();
+    });
+});

--- a/packages/backend/src/logging/processExit.ts
+++ b/packages/backend/src/logging/processExit.ts
@@ -1,0 +1,95 @@
+import fs from 'fs';
+
+export const UNCAUGHT_EXCEPTION_PREFIX = 'lightdash.process.uncaughtException';
+export const SIGNAL_PREFIX = 'lightdash.process.signal';
+export const UNCAUGHT_EXCEPTION_EXIT_CODE = 1;
+
+export type LoggedSignal = 'SIGTERM' | 'SIGINT';
+
+export const LOGGED_SIGNALS: LoggedSignal[] = ['SIGTERM', 'SIGINT'];
+
+export type ProcessExitWriters = {
+    write: (line: string) => void;
+    exit: (code: number) => void;
+};
+
+const writeToStderrSync = (line: string) => {
+    fs.writeSync(2, line);
+};
+
+const exitProcess = (code: number) => {
+    process.exit(code);
+};
+
+const defaultWriters: ProcessExitWriters = {
+    write: writeToStderrSync,
+    exit: exitProcess,
+};
+
+const toSingleLine = (value: string): string => value.replace(/\r?\n/g, '\\n');
+
+type DescribedError = {
+    name: string;
+    message: string;
+    stack: string;
+};
+
+const describeError = (error: unknown): DescribedError => {
+    if (error instanceof Error) {
+        return {
+            name: error.name,
+            message: error.message,
+            stack: error.stack ?? '<no stack>',
+        };
+    }
+    try {
+        return {
+            name: typeof error,
+            message: String(error),
+            stack: '<no stack>',
+        };
+    } catch {
+        return {
+            name: typeof error,
+            message: '<unprintable>',
+            stack: '<no stack>',
+        };
+    }
+};
+
+export const formatUncaughtExceptionLine = (error: unknown): string => {
+    const { name, message, stack } = describeError(error);
+    return `${UNCAUGHT_EXCEPTION_PREFIX} name=${toSingleLine(
+        name,
+    )} message=${toSingleLine(message)} stack=${toSingleLine(stack)}\n`;
+};
+
+export const formatSignalLine = (signal: LoggedSignal): string =>
+    `${SIGNAL_PREFIX} signal=${signal}\n`;
+
+export const createUncaughtExceptionHandler =
+    (writers: ProcessExitWriters) =>
+    (error: unknown): void => {
+        writers.write(formatUncaughtExceptionLine(error));
+        writers.exit(UNCAUGHT_EXCEPTION_EXIT_CODE);
+    };
+
+export const createSignalHandler =
+    (writers: ProcessExitWriters, signal: LoggedSignal) => (): void => {
+        writers.write(formatSignalLine(signal));
+    };
+
+/**
+ * Writes the reason a process died to stderr synchronously, before any exit.
+ * Winston writes asynchronously to a pipe, so its line is lost when the
+ * process exits first. Signal handlers only log: the entry points already
+ * shut down gracefully on SIGTERM and SIGINT and own the exit.
+ */
+export const installProcessExitLogging = (
+    writers: ProcessExitWriters = defaultWriters,
+): void => {
+    process.on('uncaughtException', createUncaughtExceptionHandler(writers));
+    LOGGED_SIGNALS.forEach((signal) => {
+        process.on(signal, createSignalHandler(writers, signal));
+    });
+};

--- a/packages/backend/src/scheduler.ts
+++ b/packages/backend/src/scheduler.ts
@@ -3,15 +3,14 @@ import { lightdashConfig } from './config/lightdashConfig';
 import { getEnterpriseAppArguments } from './ee';
 import knexConfig from './knexfile';
 import Logger from './logging/logger';
+import { installProcessExitLogging } from './logging/processExit';
 import SchedulerApp from './SchedulerApp';
 import { getProcessTimezoneWarning } from './utils/processTimezone';
 
 // Winston (handleExceptions/handleRejections in winston.ts) owns structured logging
 // for both events. Logger uses exitOnError: false so rejections are tolerated.
 // We still want uncaught exceptions to terminate — process state may be corrupt.
-process.on('uncaughtException', () => {
-    process.exit(1);
-});
+installProcessExitLogging();
 
 (async () => {
     if (process.env.CI !== 'true') {


### PR DESCRIPTION
Linear: SPK-1926

## What breaks

The API entry point and the scheduler entry point exit on `uncaughtException` without writing anything:

```ts
process.on('uncaughtException', () => {
    process.exit(1);
});
```

Winston owns the structured log line, but it writes asynchronously to a pipe. `process.exit` runs before that write drains. So a dead pod's log ends with `stream closed: EOF` and no error. That is indistinguishable from a heap abort or a probe kill. A large self-hosted project spent three days on that ambiguity.

## What this changes

`packages/backend/src/logging/processExit.ts` installs the handlers. Each one writes to stderr with `fs.writeSync(2, ...)`, which returns only after the bytes leave the process.

| Event | Line | Exit |
|---|---|---|
| `uncaughtException` | `lightdash.process.uncaughtException name=<> message=<> stack=<>` | 1 |
| `SIGTERM` | `lightdash.process.signal signal=SIGTERM` | left to the graceful handler |
| `SIGINT` | `lightdash.process.signal signal=SIGINT` | left to the graceful handler |

The stack keeps its frames but the newlines become `\n`, so one event is one grep-able line.

Winston's handlers stay as they are.

## What the entry points already do on those signals

Checked before touching the exit path:

- `packages/backend/src/index.ts` registers `onExit` for `SIGUSR2`, `SIGINT`, `SIGTERM`, `SIGHUP` and `SIGABRT`. It calls `app.stop()`, then `process.exit()`.
- `packages/backend/src/SchedulerApp.ts` passes the same five signals to `createTerminus`, which runs the shutdown hooks and exits.

Both already own `SIGTERM` and `SIGINT`. So the new signal handlers only write the line. They do not exit, and the conventional codes 143 and 130 stay out of this change. Node calls listeners in registration order and `installProcessExitLogging()` runs at module load, so the line is written before the graceful handler starts.

## Before and after

Same fault in both runs: an uncaught `Error` with an async Winston-style handler registered alongside.

Before, the tail of stderr:

```
```

Nothing. The process is gone.

After:

```
lightdash.process.uncaughtException name=Error message=pool connection terminated unexpectedly stack=Error: pool connection terminated unexpectedly\n    at Timeout._onTimeout (...)\n    at listOnTimeout (node:internal/timers:605:17)\n    at process.processTimers (node:internal/timers:541:7)
```

A `SIGTERM` now leaves a trace ahead of the graceful shutdown:

```
lightdash.process.signal signal=SIGTERM
graceful: shutting down
```

## Result

The last line of a dead pod's log now says which of three things happened: an uncaught exception with its stack, a signal with its name, or nothing at all, which means a V8 abort or a kernel kill.

## Tests

`packages/backend/src/logging/processExit.test.ts` drives the handlers with injected `write` and `exit` functions. It asserts the exception line is written before `exit` is called, that the line holds the name, the message and the stack on one line, that a thrown non-error is still described, and that each signal line names its signal and calls no exit.

```
pnpm -F backend test src/logging/processExit.test.ts    4 passed
pnpm -F backend typecheck                               clean
pnpm -F backend linter <touched paths>                  clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A54wuTG4kUGoXqXPw6KFTB