### PR TITLE
feat(merge): pivot a merge on the join node

### DIFF
--- a/docs/merge-queries/architecture.md
+++ b/docs/merge-queries/architecture.md
@@ -27,10 +27,13 @@ is a dumb executor and must not become the place refusals are decided.
 
 Submission (`AsyncQueryService.submitMergeDag`) turns the compile into nodes:
 one `semanticLayer` node per metric source (`buildMergeLegNode`), and one
-`duckdb` node holding the join SQL, whose references map each
-`merge_source_N` to a leg node or, for a result source, straight to that
-result's queryUuid. The join node carries an execution plan: the compile's
-fields map, columns and metric query so nothing is probed, a session scoped to
+`duckdb` node holding the join core and the merge's pivot, whose references
+map each `merge_source_N` to a leg node or, for a result source, straight to
+that result's queryUuid. The join node carries an execution plan: a composer
+factory over the core (`MergeQueryComposer`, built by the node for the
+engine's dialect and the node's own pivot, so the pivot stage and the
+terminal wrapper are composed where the node runs and nothing upstream knows
+the merge is pivoted), the columns with their provenance, a session scoped to
 the leg files it reads, and the row-cap guard. Provenance on a supplied column
 may name a leg node; the duckdb source resolves it to the leg's queryUuid at
 submit, the way it resolves a table reference. The join's queryUuid is what

--- a/docs/multi-source-queries.md
+++ b/docs/multi-source-queries.md
@@ -45,7 +45,7 @@ There is deliberately no server-side pipeline executor, no pipeline tables and
 no new queue infrastructure. Submitting many queries at once validates them
 (unique node ids, resolvable references, no cycles) and submits every query
 immediately in dependency order, rewriting node-id references to the real
-queryUuids as each fire-and-forget submit returns. The dependency *wait*
+queryUuids as each fire-and-forget submit returns. The dependency _wait_
 happens inside the referencing query: a `duckdb` query's background execution
 blocks (via `QueryHistoryModel.pollForQueryCompletion`, bounded by a 15-minute
 timeout) until every referenced result exists, and fails with the upstream
@@ -74,8 +74,9 @@ than referencing expired results.
   execution context it is handed: `semanticLayer` and `sql` nodes apply all
   of it; `duckdb` and `external` nodes resolve parameters, never serve from a
   cache (so invalidation is trivially honoured), have no attribute-scoped SQL
-  to apply overrides to, and refuse a pivot until the join node owns the
-  pivot stage.
+  to apply overrides to, and refuse a pivot on a public submission, since raw
+  SQL has no fields to pivot on. A `duckdb` node submitted with an execution
+  plan (a merge's join) pivots through the plan's composer.
 - `QuerySourceRegistry.ts` — sources register by `sourceType`; the service
   resolves and lists them. Commercial/self-hosted extensions register
   additional sources at construction time (`ServiceRepository`).
@@ -100,12 +101,12 @@ All endpoints require the `multi-source-query` feature flag (on by default in
 preview environments) and live under
 `/api/v2/projects/{projectUuid}/query-sources`:
 
-| Endpoint | Purpose |
-| --- | --- |
-| `GET /` | List registered sources |
-| `GET /{sourceType}/schema` | Scan one source's schema into the standard `{tables: [{reference, columns: [{reference, type}]}]}` shape |
-| `POST /queries` | Submit 1..n source queries → immediate `{nodeId, queryUuid}` per query. Optional `parameters` and `invalidateCache` apply to every query; a query may carry its own `pivotConfiguration` |
-| `GET /queries/status?queryUuids=...` | Batch status poll (standard async query lifecycle) |
+| Endpoint                             | Purpose                                                                                                                                                                                  |
+| ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GET /`                              | List registered sources                                                                                                                                                                  |
+| `GET /{sourceType}/schema`           | Scan one source's schema into the standard `{tables: [{reference, columns: [{reference, type}]}]}` shape                                                                                 |
+| `POST /queries`                      | Submit 1..n source queries → immediate `{nodeId, queryUuid}` per query. Optional `parameters` and `invalidateCache` apply to every query; a query may carry its own `pivotConfiguration` |
+| `GET /queries/status?queryUuids=...` | Batch status poll (standard async query lifecycle)                                                                                                                                       |
 
 Individual results are fetched with the existing
 `GET /api/v2/projects/{projectUuid}/query/{queryUuid}` endpoint. Statuses are
@@ -117,21 +118,21 @@ Example body — two parallel sources merged by DuckDB:
 
 ```json
 {
-    "queries": [
-        { "nodeId": "orders", "sourceType": "sql", "sql": "SELECT ..." },
-        {
-            "nodeId": "revenue",
-            "sourceType": "semanticLayer",
-            "exploreName": "payments",
-            "dimensions": ["payments_order_id"],
-            "metrics": ["payments_total_revenue"]
-        },
-        {
-            "sourceType": "duckdb",
-            "sql": "SELECT * FROM orders JOIN revenue ON orders.order_id = revenue.payments_order_id",
-            "references": ["orders", "revenue"]
-        }
-    ]
+  "queries": [
+    { "nodeId": "orders", "sourceType": "sql", "sql": "SELECT ..." },
+    {
+      "nodeId": "revenue",
+      "sourceType": "semanticLayer",
+      "exploreName": "payments",
+      "dimensions": ["payments_order_id"],
+      "metrics": ["payments_total_revenue"]
+    },
+    {
+      "sourceType": "duckdb",
+      "sql": "SELECT * FROM orders JOIN revenue ON orders.order_id = revenue.payments_order_id",
+      "references": ["orders", "revenue"]
+    }
+  ]
 }
 ```
 

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -741,6 +741,87 @@ describe('AsyncQueryService', () => {
             expect(service.queryHistoryModel.create).not.toHaveBeenCalled();
         });
 
+        test("a supplied plan composes the node's own pivot stage and records the pivot on the row", async () => {
+            const service = getMockedAsyncQueryService(lightdashConfigMock, {
+                composeEngineClient: {
+                    createExecutionWarehouseClient: vi.fn(
+                        () => warehouseClientMock,
+                    ),
+                } as unknown as ComposeEngineClient,
+                queryHistoryModel: {
+                    create: vi.fn(async () => ({ queryUuid: 'join-uuid' })),
+                    get: vi.fn(async () => referencedQueryHistory),
+                } as unknown as QueryHistoryModel,
+            } as never);
+            const runDuckdbQuery = vi
+                .spyOn(service as AnyType, 'runDuckdbQuery')
+                .mockResolvedValue(undefined);
+            const pivotConfiguration: PivotConfiguration = {
+                indexColumn: {
+                    reference: 'merge_month',
+                    type: VizIndexType.TIME,
+                },
+                valuesColumns: [
+                    {
+                        reference: 'a_orders_count',
+                        aggregation: VizAggregationOptions.SUM,
+                    },
+                ],
+                groupByColumns: undefined,
+                sortBy: undefined,
+            };
+            const compose = vi.fn(
+                () =>
+                    ({
+                        getSql: () => 'SELECT pivoted FROM orders',
+                        getFields: () => ({}),
+                        getUsedParameters: () => ({}),
+                        getMetricQuery: () => ({ exploreName: 'merge' }),
+                    }) as unknown as QueryComposer,
+            );
+
+            await service.executeAsyncDuckdbSourceQuery({
+                account: sessionAccount,
+                projectUuid,
+                context: QueryExecutionContext.EXPLORE,
+                sql: 'SELECT * FROM orders',
+                references: { orders: referencedQueryHistory.queryUuid },
+                pivotConfiguration,
+                plan: {
+                    columns: {
+                        mode: 'supplied',
+                        compose,
+                        originalColumns: {},
+                        requestParameters: {
+                            context: QueryExecutionContext.EXPLORE,
+                            sql: 'SELECT * FROM orders',
+                        },
+                    },
+                    engine: 'scopedToReferencedResults',
+                    guard: null,
+                },
+            });
+            await vi.waitFor(() =>
+                expect(runDuckdbQuery).toHaveBeenCalledTimes(1),
+            );
+
+            expect(compose).toHaveBeenCalledWith({
+                warehouseClient: warehouseClientMock,
+                pivotConfiguration,
+            });
+            expect(service.queryHistoryModel.create).toHaveBeenCalledWith(
+                sessionAccount,
+                expect.objectContaining({
+                    pivotConfiguration,
+                    compiledSql: 'SELECT pivoted FROM orders',
+                }),
+            );
+            expect(runDuckdbQuery.mock.calls[0][0]).toMatchObject({
+                sql: 'SELECT pivoted FROM orders',
+                columns: { mode: 'supplied', pivotConfiguration },
+            });
+        });
+
         test('a supplied plan records its columns, runs on a scoped session and reads no flag', async () => {
             const featureFlagModel = {
                 get: vi.fn(async () => ({ enabled: false })),
@@ -795,6 +876,14 @@ describe('AsyncQueryService', () => {
                 context: QueryExecutionContext.EXPLORE,
                 sql: 'SELECT * FROM orders',
             };
+            // The plan's composer owns the statement, fields and pivot stage
+            const composer = {
+                getSql: vi.fn(() => 'SELECT * FROM orders ORDER BY 1'),
+                getFields: () => fieldsMap,
+                getUsedParameters: () => ({ region: 'EU' }),
+                getMetricQuery: () => metricQuery,
+            } as unknown as QueryComposer;
+            const compose = vi.fn(() => composer);
             const submission = await service.executeAsyncDuckdbSourceQuery({
                 account: sessionAccount,
                 projectUuid,
@@ -804,11 +893,8 @@ describe('AsyncQueryService', () => {
                 plan: {
                     columns: {
                         mode: 'supplied',
-                        fieldsMap,
-                        usedParameters: { region: 'EU' },
+                        compose,
                         originalColumns,
-                        pivotConfiguration: undefined,
-                        metricQuery,
                         requestParameters,
                     },
                     engine: 'scopedToReferencedResults',
@@ -821,6 +907,13 @@ describe('AsyncQueryService', () => {
             );
 
             expect(submission.queryUuid).toBe('join-uuid');
+            expect(compose).toHaveBeenCalledWith({
+                warehouseClient: warehouseClientMock,
+                pivotConfiguration: undefined,
+            });
+            expect(composer.getSql).toHaveBeenCalledWith({
+                columnLimit: lightdashConfigMock.pivotTable.maxColumnLimit,
+            });
             const flagsRead = (
                 featureFlagModel.get as import('vitest').Mock
             ).mock.calls.map(([{ featureFlagId }]) => featureFlagId);
@@ -835,11 +928,12 @@ describe('AsyncQueryService', () => {
                     requestParameters,
                     usedParameters: { region: 'EU' },
                     pivotConfiguration: null,
-                    compiledSql: 'SELECT * FROM orders',
+                    compiledSql: 'SELECT * FROM orders ORDER BY 1',
                 }),
             );
             expect(runDuckdbQuery.mock.calls[0][0]).toMatchObject({
                 queryUuid: 'join-uuid',
+                sql: 'SELECT * FROM orders ORDER BY 1',
                 columns: { mode: 'supplied', fieldsMap, originalColumns },
                 engine: { kind: 'scopedToReferencedResults' },
                 references: {
@@ -6819,7 +6913,7 @@ describe('executeAsyncMergeQuery on the compose engine', () => {
         expect(executed.originalColumns).toBe(
             create.mock.calls[0][1].originalColumns,
         );
-        expect(executed.fieldsMap).toBe(outcome.query.fields);
+        expect(executed.fieldsMap).toEqual(outcome.query.fields);
         expect(executed.query).toContain(
             `read_json_auto('s3://results-bucket/${legQueryUuidBySourceId.a}.jsonl')`,
         );

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -799,6 +799,7 @@ describe('AsyncQueryService', () => {
                     },
                     engine: 'scopedToReferencedResults',
                     guard: null,
+                    referenceLabels: {},
                 },
             });
             await vi.waitFor(() =>

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -6875,6 +6875,43 @@ describe('executeAsyncMergeQuery on the compose engine', () => {
     ) =>
         vi.waitFor(() => expect(mergeEvents(trackAccount)).toHaveLength(count));
 
+    it('refuses a pivot the composer rejects before any leg runs', async () => {
+        const { service, create } = buildService({
+            config: lightdashConfigMock,
+            legRowCount: 2,
+        });
+
+        await expect(
+            // The v1 route hands over a pivot the caller derived itself
+            service.executeLegacyAsyncMergeQuery({
+                account: sessionAccount,
+                projectUuid,
+                mergeQuery,
+                context: QueryExecutionContext.EXPLORE,
+                mode: { type: 'interactive' },
+                // A group column that is also the index column is refused by
+                // the pivot builder
+                pivotConfiguration: {
+                    indexColumn: {
+                        reference: 'merge_month',
+                        type: VizIndexType.TIME,
+                    },
+                    valuesColumns: [
+                        {
+                            reference: 'a_orders_count',
+                            aggregation: VizAggregationOptions.SUM,
+                        },
+                    ],
+                    groupByColumns: [{ reference: 'merge_month' }],
+                    sortBy: undefined,
+                },
+            }),
+        ).rejects.toThrow(ParameterError);
+
+        expect(service.executeAsyncMetricQuery).not.toHaveBeenCalled();
+        expect(create).not.toHaveBeenCalled();
+    });
+
     it('runs the join in supplied mode: no column probe, and the compile-time columns reach execution unchanged', async () => {
         const {
             service,

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -7459,6 +7459,7 @@ export class AsyncQueryService extends ProjectService {
         limit,
         references,
         parameters,
+        pivotConfiguration,
         plan,
     }: ExecuteAsyncDuckdbSourceQueryArgs): Promise<{ queryUuid: string }> {
         assertIsAccountWithOrg(account);
@@ -7518,13 +7519,14 @@ export class AsyncQueryService extends ProjectService {
             limit,
             references,
             parameters,
+            pivotConfiguration,
             warehouseClient,
         });
 
         // Parameter values change the executed SQL without changing its text
         const cacheKey = QueryHistoryModel.getCacheKey(projectUuid, {
             sql: JSON.stringify({
-                sql,
+                sql: resolved.sql,
                 references: normalizedReferences ?? null,
                 parameters: resolved.parameters,
             }),
@@ -7537,7 +7539,7 @@ export class AsyncQueryService extends ProjectService {
             organizationUuid,
             context,
             fields: resolved.fields,
-            compiledSql: sql,
+            compiledSql: resolved.sql,
             requestParameters: resolved.requestParameters,
             usedParameters: resolved.usedParameters,
             metricQuery: resolved.metricQuery,
@@ -7565,7 +7567,7 @@ export class AsyncQueryService extends ProjectService {
                 projectSummary.provisioningSource === 'playground',
             onboardingFlow,
             queryUuid,
-            sql,
+            sql: resolved.sql,
             references: {
                 kind: 'queries',
                 references: normalizedReferences ?? {},
@@ -7596,8 +7598,10 @@ export class AsyncQueryService extends ProjectService {
     /**
      * What the history row and the run need from a plan. Discovered columns
      * come from a placeholder composer over the raw SQL, which is also where
-     * a missing parameter value refuses before any row is written; supplied
-     * columns were fixed at compile time and are recorded as they are.
+     * a missing parameter value refuses before any row is written. Supplied
+     * columns come from the composer the plan builds, with the node's own
+     * pivot stage composed on it, so the statement that runs is the
+     * composer's and the column limit refuses here, before any row exists.
      */
     private async resolveDuckdbQueryPlan({
         plan,
@@ -7607,6 +7611,7 @@ export class AsyncQueryService extends ProjectService {
         limit,
         references,
         parameters,
+        pivotConfiguration,
         warehouseClient,
     }: {
         plan: DuckdbQueryPlan;
@@ -7616,8 +7621,11 @@ export class AsyncQueryService extends ProjectService {
         limit: number | undefined;
         references: ExecuteAsyncDuckdbSourceQueryArgs['references'];
         parameters: ParametersValuesMap | undefined;
+        pivotConfiguration: PivotConfiguration | undefined;
         warehouseClient: WarehouseClient;
     }): Promise<{
+        /** The statement that runs: composed for a supplied plan, raw otherwise. */
+        sql: string;
         columns: DuckdbQueryColumns;
         parameters: ParametersValuesMap;
         fields: ItemsMap;
@@ -7628,17 +7636,30 @@ export class AsyncQueryService extends ProjectService {
         requestParameters: ExecuteAsyncQueryRequestParams;
     }> {
         if (plan.columns.mode === 'supplied') {
-            const { metricQuery, requestParameters, ...columns } = plan.columns;
-            const usedParameters = columns.usedParameters ?? {};
+            const composer = plan.columns.compose({
+                warehouseClient,
+                pivotConfiguration,
+            });
+            const fieldsMap = composer.getFields();
+            const usedParameters = composer.getUsedParameters();
             return {
-                columns,
+                sql: composer.getSql({
+                    columnLimit: this.lightdashConfig.pivotTable.maxColumnLimit,
+                }),
+                columns: {
+                    mode: 'supplied',
+                    fieldsMap,
+                    usedParameters,
+                    originalColumns: plan.columns.originalColumns,
+                    pivotConfiguration,
+                },
                 parameters: usedParameters,
-                fields: columns.fieldsMap,
+                fields: fieldsMap,
                 usedParameters,
-                metricQuery,
-                pivotConfiguration: columns.pivotConfiguration ?? null,
-                originalColumns: columns.originalColumns,
-                requestParameters,
+                metricQuery: composer.getMetricQuery(),
+                pivotConfiguration: pivotConfiguration ?? null,
+                originalColumns: plan.columns.originalColumns,
+                requestParameters: plan.columns.requestParameters,
             };
         }
 
@@ -7668,6 +7689,7 @@ export class AsyncQueryService extends ProjectService {
             parameters: combinedParameters,
         };
         return {
+            sql,
             columns: {
                 mode: 'discover',
                 limit,
@@ -8468,15 +8490,6 @@ export class AsyncQueryService extends ProjectService {
     }): Promise<ApiExecuteAsyncMetricQueryResults> {
         assertIsAccountWithOrg(account);
 
-        // Throws MissingConfigError when results storage is not configured:
-        // a merge without an engine is refused, never silently downgraded.
-        // Dialect only: execution runs on a session scoped to the leg files
-        const warehouseClient =
-            this.composeEngineClient.createExecutionWarehouseClient({
-                storage: 'results',
-                scope: null,
-            });
-
         const sourceRowCap = this.lightdashConfig.query.maxLimit;
 
         // Metric sources run whole as semantic-layer nodes (the merged
@@ -8510,25 +8523,6 @@ export class AsyncQueryService extends ProjectService {
                 composeMergeReferenceTable(index),
             ]),
         );
-
-        // The pivot stage and terminal wrapper compile for the compose
-        // engine over the compile's join core
-        const composer = new MergeQueryComposer({
-            coreSql: compiledMerge.coreSql,
-            terminalWrapper: compiledMerge.terminalWrapper,
-            itemsMap: compiledMerge.itemsMap,
-            typedColumns: compiledMerge.typedColumns,
-            columnOrder,
-            limit: mergeQuery.limit,
-            parameterReferences: compiledMerge.parameterReferences,
-            usedParametersValues: compiledMerge.usedParametersValues,
-            warehouseClient,
-            pivotConfiguration,
-        });
-        const sql = composer.getSql({
-            columnLimit: this.lightdashConfig.pivotTable.maxColumnLimit,
-        });
-        const fieldsMap = composer.getFields();
 
         // Each reference table binds to a leg node, or to an existing result
         const references = Object.fromEntries(
@@ -8573,21 +8567,35 @@ export class AsyncQueryService extends ProjectService {
         const rowCap = observeRowCapRefusal(
             buildMergeRowCapGuard({ legLabelByReferenceTable, sourceRowCap }),
         );
+        // The join node carries the compile's core and its own pivot; the
+        // node composes the pivot stage and terminal wrapper for the engine,
+        // so nothing here knows whether the merge is pivoted
         const joinNodeId = 'merge';
         const joinNode: DuckdbSourceQuery = {
             sourceType: QuerySourceType.DUCKDB,
             nodeId: joinNodeId,
-            sql,
+            sql: compiledMerge.coreSql,
             references,
+            pivotConfiguration,
         };
         const plan: DuckdbQueryPlan = {
             columns: {
                 mode: 'supplied',
-                fieldsMap,
-                usedParameters: composer.getUsedParameters(),
+                compose: ({ warehouseClient, pivotConfiguration: pivot }) =>
+                    new MergeQueryComposer({
+                        coreSql: compiledMerge.coreSql,
+                        terminalWrapper: compiledMerge.terminalWrapper,
+                        itemsMap: compiledMerge.itemsMap,
+                        typedColumns: compiledMerge.typedColumns,
+                        columnOrder,
+                        limit: mergeQuery.limit,
+                        parameterReferences: compiledMerge.parameterReferences,
+                        usedParametersValues:
+                            compiledMerge.usedParametersValues,
+                        warehouseClient,
+                        pivotConfiguration: pivot,
+                    }),
                 originalColumns,
-                pivotConfiguration,
-                metricQuery: composer.getMetricQuery(),
                 requestParameters,
             },
             // A merge calculation is user SQL: it runs on a session that
@@ -8661,15 +8669,21 @@ export class AsyncQueryService extends ProjectService {
             );
         });
 
+        // The merged result's identity comes from the compile; the node's
+        // composer carries the same items map and parameters
         return {
             queryUuid: join.queryUuid,
             cacheMetadata: { cacheHit: false },
-            metricQuery: composer.getMetricQuery(),
-            fields: fieldsMap,
-            warnings: composer.getWarnings(),
-            parameterReferences: composer.getParameterReferences(),
-            usedParametersValues: composer.getUsedParameters(),
-            resolvedTimezone: composer.getDisplayTimezone(),
+            metricQuery: buildMergeResultMetricQuery({
+                itemsMap: compiledMerge.itemsMap,
+                columnOrder,
+                limit: mergeQuery.limit,
+            }),
+            fields: compiledMerge.itemsMap,
+            warnings: [],
+            parameterReferences: compiledMerge.parameterReferences,
+            usedParametersValues: compiledMerge.usedParametersValues,
+            resolvedTimezone: null,
         };
     }
 

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -292,6 +292,7 @@ import {
     type DuckdbQueryColumns,
     type DuckdbQueryEngine,
     type DuckdbQueryPlan,
+    type DuckdbQueryPlanComposer,
     type DuckdbQueryReferences,
     type ExecuteAsyncComposeSqlQueryArgs,
     type ExecuteAsyncDashboardChartQueryArgs,
@@ -7522,6 +7523,13 @@ export class AsyncQueryService extends ProjectService {
             pivotConfiguration,
             warehouseClient,
         });
+        // The statement that runs is the composed one, so it is checked too:
+        // a plan's composer must not be able to reach a file the raw SQL could not
+        try {
+            DuckdbWarehouseClient.validateUserSqlFileAccess(resolved.sql);
+        } catch (e) {
+            throw new ParameterError(getErrorMessage(e));
+        }
 
         // Parameter values change the executed SQL without changing its text
         const cacheKey = QueryHistoryModel.getCacheKey(projectUuid, {
@@ -8578,23 +8586,38 @@ export class AsyncQueryService extends ProjectService {
             references,
             pivotConfiguration,
         };
+        const compose: DuckdbQueryPlanComposer = ({
+            warehouseClient,
+            pivotConfiguration: pivot,
+        }) =>
+            new MergeQueryComposer({
+                coreSql: compiledMerge.coreSql,
+                terminalWrapper: compiledMerge.terminalWrapper,
+                itemsMap: compiledMerge.itemsMap,
+                typedColumns: compiledMerge.typedColumns,
+                columnOrder,
+                limit: mergeQuery.limit,
+                parameterReferences: compiledMerge.parameterReferences,
+                usedParametersValues: compiledMerge.usedParametersValues,
+                warehouseClient,
+                pivotConfiguration: pivot,
+            });
+        // A pivot the composer refuses fails here, before any leg runs; the
+        // join node composes again with the same inputs when it executes
+        compose({
+            warehouseClient:
+                this.composeEngineClient.createExecutionWarehouseClient({
+                    storage: 'results',
+                    scope: null,
+                }),
+            pivotConfiguration,
+        }).getSql({
+            columnLimit: this.lightdashConfig.pivotTable.maxColumnLimit,
+        });
         const plan: DuckdbQueryPlan = {
             columns: {
                 mode: 'supplied',
-                compose: ({ warehouseClient, pivotConfiguration: pivot }) =>
-                    new MergeQueryComposer({
-                        coreSql: compiledMerge.coreSql,
-                        terminalWrapper: compiledMerge.terminalWrapper,
-                        itemsMap: compiledMerge.itemsMap,
-                        typedColumns: compiledMerge.typedColumns,
-                        columnOrder,
-                        limit: mergeQuery.limit,
-                        parameterReferences: compiledMerge.parameterReferences,
-                        usedParametersValues:
-                            compiledMerge.usedParametersValues,
-                        warehouseClient,
-                        pivotConfiguration: pivot,
-                    }),
+                compose,
                 originalColumns,
                 requestParameters,
             },

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -8631,7 +8631,9 @@ export class AsyncQueryService extends ProjectService {
         // A statement that reads files is refused before any leg runs; the
         // join node checks it again when it submits
         try {
-            DuckdbWarehouseClient.validateUserSqlFileAccess(sql);
+            DuckdbWarehouseClient.validateUserSqlFileAccess(
+                compiledMerge.coreSql,
+            );
         } catch (e) {
             throw new ParameterError(getErrorMessage(e));
         }

--- a/packages/backend/src/services/AsyncQueryService/types.ts
+++ b/packages/backend/src/services/AsyncQueryService/types.ts
@@ -36,7 +36,10 @@ import {
 } from '@lightdash/common';
 import type { OnboardingFlow } from '../../analytics/LightdashAnalytics';
 import type { DbProjectParameter } from '../../database/entities/projectParameters';
-import type { TotalConfiguration } from '../../utils/QueryBuilder/QueryComposer';
+import type {
+    QueryComposer,
+    TotalConfiguration,
+} from '../../utils/QueryBuilder/QueryComposer';
 
 export type CommonAsyncQueryArgs = {
     account: Account;
@@ -353,18 +356,27 @@ export type DuckdbQueryEngine =
  * internal caller such as a merge supplies its compile-time columns, a
  * session scoped to the results it reads, and a guard over those results.
  *
- * Supplied columns are recorded on the history row as they are, with the
- * request that produced them. A supplied column's provenance may name a
- * node of the same submission instead of a queryUuid; it resolves to that
- * node's query at submit time, the way a table reference does.
+ * Supplied columns come from a composer the node builds over its own SQL,
+ * for the engine's dialect and with the node's own pivot, so the pivot stage
+ * belongs to the node and nothing upstream of it needs to know. The
+ * composer's fields, metric query and parameters are recorded on the history
+ * row as they are, with the request that produced them. A supplied column's
+ * provenance may name a node of the same submission instead of a queryUuid;
+ * it resolves to that node's query at submit time, the way a table
+ * reference does.
  */
 export type DuckdbQueryPlan = {
     columns:
         | { mode: 'discover' }
-        | (SuppliedDuckdbQueryColumns & {
-              metricQuery: MetricQuery;
+        | {
+              mode: 'supplied';
+              compose: (args: {
+                  warehouseClient: WarehouseClient;
+                  pivotConfiguration: PivotConfiguration | undefined;
+              }) => QueryComposer;
+              originalColumns: ResultColumns;
               requestParameters: ExecuteAsyncQueryRequestParams;
-          });
+          };
     engine: DuckdbQueryEngine['kind'];
     guard: DuckdbQueryReferenceGuard | null;
     /** What the user calls each referenced table; empty when nothing names them. */
@@ -376,6 +388,8 @@ export type ExecuteAsyncDuckdbSourceQueryArgs = CommonAsyncQueryArgs & {
     limit?: number;
     /** Table name -> queryUuid of a previous async query to expose as that table. */
     references?: Record<string, UUID>;
+    /** The node's own pivot stage; only a supplied plan can compose it. */
+    pivotConfiguration?: PivotConfiguration;
     plan: DuckdbQueryPlan;
 };
 

--- a/packages/backend/src/services/AsyncQueryService/types.ts
+++ b/packages/backend/src/services/AsyncQueryService/types.ts
@@ -365,15 +365,17 @@ export type DuckdbQueryEngine =
  * it resolves to that node's query at submit time, the way a table
  * reference does.
  */
+export type DuckdbQueryPlanComposer = (args: {
+    warehouseClient: WarehouseClient;
+    pivotConfiguration: PivotConfiguration | undefined;
+}) => QueryComposer;
+
 export type DuckdbQueryPlan = {
     columns:
         | { mode: 'discover' }
         | {
               mode: 'supplied';
-              compose: (args: {
-                  warehouseClient: WarehouseClient;
-                  pivotConfiguration: PivotConfiguration | undefined;
-              }) => QueryComposer;
+              compose: DuckdbQueryPlanComposer;
               originalColumns: ResultColumns;
               requestParameters: ExecuteAsyncQueryRequestParams;
           };

--- a/packages/backend/src/services/QuerySourceService/QuerySourceService.test.ts
+++ b/packages/backend/src/services/QuerySourceService/QuerySourceService.test.ts
@@ -16,6 +16,7 @@ import { buildAccount } from '../../auth/account/account.mock';
 import type { FeatureFlagModel } from '../../models/FeatureFlagModel/FeatureFlagModel';
 import type { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import type { QueryHistoryModel } from '../../models/QueryHistoryModel/QueryHistoryModel';
+import type { QueryComposer } from '../../utils/QueryBuilder/QueryComposer';
 import type { AsyncQueryService } from '../AsyncQueryService/AsyncQueryService';
 import type { DuckdbQueryPlan } from '../AsyncQueryService/types';
 import type { ProjectService } from '../ProjectService/ProjectService';
@@ -788,6 +789,67 @@ describe('composer pipelines return the standard results interface', () => {
         );
     });
 
+    it('hands a planned DuckDB node its pivot for the plan to compose, while a public one still refuses it', async () => {
+        const { registry, asyncQueryService } = createRealSources();
+        const { service } = createService(registry);
+        const pivotConfiguration: PivotConfiguration = {
+            indexColumn: {
+                reference: 'orders_status',
+                type: VizIndexType.CATEGORY,
+            },
+            valuesColumns: [
+                {
+                    reference: 'orders_total_revenue',
+                    aggregation: VizAggregationOptions.SUM,
+                },
+            ],
+            groupByColumns: undefined,
+            sortBy: undefined,
+        };
+        const joinNode: SourceQuery = {
+            sourceType: QuerySourceType.DUCKDB,
+            nodeId: 'joined',
+            sql: 'SELECT * FROM orders',
+            references: { orders: '123e4567-e89b-12d3-a456-426614174000' },
+            pivotConfiguration,
+        };
+        const plan: DuckdbQueryPlan = {
+            columns: {
+                mode: 'supplied',
+                compose: () => ({}) as unknown as QueryComposer,
+                originalColumns: {},
+                requestParameters: {
+                    context: QueryExecutionContext.EXPLORE,
+                    sql: 'SELECT * FROM orders',
+                },
+            },
+            engine: 'scopedToReferencedResults',
+            guard: null,
+        };
+
+        await service.submitQueries({
+            ...executionContext,
+            account,
+            projectUuid,
+            context: QueryExecutionContext.EXPLORE,
+            queries: [joinNode],
+            plans: { joined: plan },
+        });
+        expect(
+            asyncQueryService.executeAsyncDuckdbSourceQuery,
+        ).toHaveBeenCalledWith(expect.objectContaining({ pivotConfiguration }));
+
+        await expect(
+            service.executeSourceQueries({
+                ...executionContext,
+                account,
+                projectUuid,
+                context: QueryExecutionContext.MULTI_SOURCE_QUERY,
+                queries: [joinNode],
+            }),
+        ).rejects.toThrow(ParameterError);
+    });
+
     it("resolves a supplied column's provenance from a node id to that node's queryUuid", async () => {
         const { registry, asyncQueryService } = createRealSources();
         const { service } = createService(registry);
@@ -799,19 +861,8 @@ describe('composer pipelines return the standard results interface', () => {
         const plan: DuckdbQueryPlan = {
             columns: {
                 mode: 'supplied',
-                fieldsMap: {},
-                usedParameters: null,
+                compose: () => ({}) as unknown as QueryComposer,
                 originalColumns: { orders_total_revenue: column('orders') },
-                pivotConfiguration: undefined,
-                metricQuery: {
-                    exploreName: 'merge',
-                    dimensions: [],
-                    metrics: ['orders_total_revenue'],
-                    filters: {},
-                    sorts: [],
-                    limit: 500,
-                    tableCalculations: [],
-                },
                 requestParameters: {
                     context: QueryExecutionContext.EXPLORE,
                     sql: 'SELECT * FROM orders',

--- a/packages/backend/src/services/QuerySourceService/QuerySourceService.test.ts
+++ b/packages/backend/src/services/QuerySourceService/QuerySourceService.test.ts
@@ -825,6 +825,7 @@ describe('composer pipelines return the standard results interface', () => {
             },
             engine: 'scopedToReferencedResults',
             guard: null,
+            referenceLabels: {},
         };
 
         await service.submitQueries({

--- a/packages/backend/src/services/QuerySourceService/QuerySourceService.ts
+++ b/packages/backend/src/services/QuerySourceService/QuerySourceService.ts
@@ -156,7 +156,10 @@ export class QuerySourceService extends BaseService {
      * known source types, references either naming a query in the submission
      * or holding a queryUuid of an existing result, and no cycles.
      */
-    private validateQueries(queries: SourceQuery[]): ValidatedQuery[] {
+    private validateQueries(
+        queries: SourceQuery[],
+        plans: Record<string, DuckdbQueryPlan>,
+    ): ValidatedQuery[] {
         if (queries.length === 0) {
             throw new ParameterError('Submit at least one query');
         }
@@ -199,10 +202,12 @@ export class QuerySourceService extends BaseService {
             const source = this.registry.get(query.sourceType);
             // Refused here, before any node is submitted: a refusal inside
             // the submit loop would leave upstream nodes running with no
-            // queryUuid handed back to poll or cancel
+            // queryUuid handed back to poll or cancel. A node with an
+            // execution plan pivots through the plan's composer
             if (
                 query.pivotConfiguration !== undefined &&
-                !source.supportsPivot
+                !source.supportsPivot &&
+                plans[nodeId] === undefined
             ) {
                 throw new ParameterError(
                     `Query "${nodeId}" carries a pivotConfiguration, which ${query.sourceType} queries do not support yet`,
@@ -339,7 +344,7 @@ export class QuerySourceService extends BaseService {
         context: QueryExecutionContext;
         plans: Record<string, DuckdbQueryPlan>;
     }): Promise<{ queries: InternalSourceQuerySubmission[] }> {
-        const ordered = this.validateQueries(queries);
+        const ordered = this.validateQueries(queries, plans);
         QuerySourceService.assertPlansNameDuckdbNodes(ordered, plans);
 
         // nodeId -> queryUuid, grown as submissions happen so later queries'

--- a/packages/backend/src/services/QuerySourceService/sources/DuckdbQuerySource.ts
+++ b/packages/backend/src/services/QuerySourceService/sources/DuckdbQuerySource.ts
@@ -112,11 +112,13 @@ export class DuckdbQuerySource implements QuerySourceClient {
     /**
      * User attribute overrides have nothing to apply to here: referenced
      * results were produced under them and compose SQL carries no attribute
-     * references. A pivot refuses until the join node owns the pivot stage.
+     * references.
      *
      * Without a plan the query takes the public compose SQL path, which
-     * carries its own flag and ability gates. With one it goes straight to
-     * the execution tail: the caller that built the plan owns authorization.
+     * carries its own flag and ability gates and cannot pivot: raw SQL has no
+     * fields to pivot on. With a plan it goes straight to the execution
+     * tail, where the plan's composer owns the pivot stage; the caller that
+     * built the plan owns authorization.
      */
     async submitQuery({
         account,
@@ -130,7 +132,7 @@ export class DuckdbQuerySource implements QuerySourceClient {
         plan,
     }: SubmitSourceQueryArgs): Promise<SourceQuerySubmissionResult> {
         const sourceQuery = DuckdbQuerySource.assertSourceQuery(query);
-        if (pivotConfiguration !== null) {
+        if (pivotConfiguration !== null && plan === null) {
             throw new ParameterError(
                 `${QuerySourceType.DUCKDB} queries do not support pivotConfiguration yet`,
             );
@@ -163,6 +165,7 @@ export class DuckdbQuerySource implements QuerySourceClient {
                 ? await this.asyncQueryService.executeAsyncComposeSqlQuery(args)
                 : await this.asyncQueryService.executeAsyncDuckdbSourceQuery({
                       ...args,
+                      pivotConfiguration: pivotConfiguration ?? undefined,
                       plan: DuckdbQuerySource.resolvePlanReferences(
                           plan,
                           resolvedReferences,

--- a/packages/common/src/types/querySources.ts
+++ b/packages/common/src/types/querySources.ts
@@ -159,9 +159,10 @@ export type DuckdbSourceQuery = {
         | QueryNodeId[]
         | Record<QuerySourceTableName, QueryResultReference>;
     /**
-     * Pivots this node's result the way a pivoted chart does. Honoured by
-     * semanticLayer and sql nodes; duckdb and external nodes refuse it until
-     * the join node owns the pivot stage.
+     * Pivots this node's result the way a pivoted chart does. Refused on
+     * this endpoint: raw SQL has no fields to pivot on. A duckdb node
+     * submitted inside the server with an execution plan, such as a merge's
+     * join, pivots through that plan.
      */
     pivotConfiguration?: PivotConfiguration;
 };


### PR DESCRIPTION
## What changed

The pivot stage of a merge moves onto the join node. Stacks on #28732 (PROD-10901).

```mermaid
flowchart LR
    C["compileMergeQuery<br/>join core + items map"] --> M["submitMergeDag<br/>nodes + plan, no SQL built"]
    M --> N["duckdb join node<br/>sql: core, pivotConfiguration"]
    N --> P["plan.compose({ dialect, pivot })<br/>MergeQueryComposer"]
    P --> S["statement, fields, metric query<br/>composed once before submit, again on the node"]
    S --> R["runDuckdbQuery<br/>scoped session, row-cap guard"]
```

Until now the merge submission built a `MergeQueryComposer` itself, applied the pivot and the terminal wrapper, and handed the node finished SQL plus precomputed columns. The DAG had no concept of a pivot, so a pivoted merge was a special case the merge path owned.

- **A supplied plan carries a composer factory, not columns.** `DuckdbQueryPlan.columns` in supplied mode is `compose({ warehouseClient, pivotConfiguration }) => QueryComposer` plus the columns' provenance and the request to record. The tail calls it with the engine's dialect and the node's own `pivotConfiguration`, then takes the statement, fields, metric query and parameters from the composer. The merge composes once more before it submits the DAG, so a pivot the pivot builder refuses (a group column that is also an index column) fails before any leg runs, as it did before this change; the column limit itself is a filter in the pivot SQL, not a refusal. The statement a plan composes is also checked for file access, not only the raw SQL.
- **The join node carries the compile's core and the pivot.** `submitMergeDag` no longer builds SQL or a session for the dialect; it hands the node `coreSql`, the pivot derived from the chart, and a factory that builds `MergeQueryComposer` over the compile's items map, typed columns and terminal wrapper. The merge response's metric query, fields and parameters come straight from the compile.
- **The DAG allows a pivot on a node that has a plan.** Validation refuses a `pivotConfiguration` on a duckdb node only when no plan exists for it, and `DuckdbQuerySource` refuses it only on the public path. Raw SQL has no fields to pivot on; a plan's composer does.

## Regression analysis

- **Pivoted merges** run the same statement as before: the same `MergeQueryComposer` over the same core, terminal wrapper, items map and pivot configuration, built one step later in the same request. The live parity suite ran against this branch, including the pivoted cases and pivot details.
- **Unpivoted merges** are unchanged in SQL; the composer is built with `pivotConfiguration: undefined` as before.
- **The merge response** used to read `warnings`, `parameterReferences`, `usedParametersValues` and `resolvedTimezone` off the composer. Those were always the compile's values, an empty list and null; they now come from the compile directly.
- **Public duckdb nodes** still refuse a pivot with the same message.
- **Fields identity**: the join row's `fields` are the composer's, which for a merge is the compile's items map; the unit test that asserted object identity with the response now asserts equality.

## Verification

- Backend typecheck, lint and format clean; `AsyncQueryService.test.ts` 112 tests, query source, DuckDB join and composer suites 43 tests, all green.
- New cases: a supplied plan composes the node's own pivot and records it on the row and the run; the DAG hands a planned duckdb node its pivot while the public endpoint still refuses one; a pivot the builder rejects is refused before any leg or history row exists.
- The merge parity suite ran against an isolated instance on this branch: 12 of 12, including pivoted value parity per join type with pivot details and the saved pivoted chart.

## References

Closes: PROD-10902

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEnsqumJBXz87BAyqXXKC7

