### PR TITLE
feat(dashboard): delete registry custom metrics with an impact preview

### DIFF
--- a/packages/backend/src/controllers/dashboardController.ts
+++ b/packages/backend/src/controllers/dashboardController.ts
@@ -149,6 +149,51 @@ export class DashboardController extends BaseController {
     }
 
     /**
+     * Remove a custom metric from the dashboard registry. Charts keep their
+     * local snapshots — the metric just stops being offered to new charts.
+     * With `dryRun` it only reports the charts still using it.
+     * @summary Delete dashboard custom metric
+     * @param dashboardUuidOrSlug uuid or slug for the dashboard
+     * @param metricTable table of the registry metric to remove
+     * @param metricName name of the registry metric to remove
+     * @param dryRun report affected charts without writing
+     * @param projectUuid project to resolve a slug in, required when the slug exists in multiple projects (e.g. preview projects)
+     * @param req express request
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Delete('/custom-metrics/{metricTable}/{metricName}')
+    @OperationId('deleteDashboardCustomMetric')
+    async deleteDashboardCustomMetric(
+        @Path() dashboardUuidOrSlug: UuidOrSlug,
+        @Path() metricTable: string,
+        @Path() metricName: string,
+        @Request() req: express.Request,
+        @Query() dryRun?: boolean,
+        @Query() projectUuid?: UUID,
+    ): Promise<ApiUpdateDashboardCustomMetricResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getDashboardService()
+                .deleteCustomMetric(
+                    toSessionUser(req.account),
+                    dashboardUuidOrSlug,
+                    metricTable,
+                    metricName,
+                    dryRun ?? false,
+                    { projectUuid },
+                ),
+        };
+    }
+
+    /**
      * Get dashboard version history
      * @summary Get dashboard history
      * @param dashboardUuidOrSlug uuid or slug for the dashboard

--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -1876,13 +1876,13 @@ export class DashboardModel {
      * given custom metric — the only charts a registry edit may rewrite.
      * Single query so the write-through doesn't fan out over every chart.
      */
-    async getDashboardOwnedChartUuidsUsingMetric(
+    async getDashboardOwnedChartsUsingMetric(
         dashboardUuid: string,
         metricTable: string,
         metricName: string,
-    ): Promise<string[]> {
+    ): Promise<{ uuid: string; name: string }[]> {
         const { rows } = await this.database.raw<{
-            rows: { saved_query_uuid: string }[];
+            rows: { saved_query_uuid: string; name: string }[];
         }>(
             `
             WITH latest_versions AS (
@@ -1895,7 +1895,7 @@ export class DashboardModel {
                     AND sq.deleted_at IS NULL
                 ORDER BY v.saved_query_id, v.created_at DESC
             )
-            SELECT sq.saved_query_uuid
+            SELECT sq.saved_query_uuid, sq.name
             FROM latest_versions lv
             JOIN :chartsTable: sq ON sq.saved_query_id = lv.saved_query_id
             JOIN :metricsTable: m
@@ -1911,7 +1911,10 @@ export class DashboardModel {
                 metricTable,
             },
         );
-        return rows.map((row) => row.saved_query_uuid);
+        return rows.map((row) => ({
+            uuid: row.saved_query_uuid,
+            name: row.name,
+        }));
     }
 
     /**

--- a/packages/backend/src/services/DashboardService/DashboardService.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.test.ts
@@ -77,8 +77,8 @@ const dashboardModel = {
 
     getOrphanedCharts: vi.fn(async () => []),
 
-    getDashboardOwnedChartUuidsUsingMetric: vi.fn(
-        async (): Promise<string[]> => [],
+    getDashboardOwnedChartsUsingMetric: vi.fn(
+        async (): Promise<{ uuid: string; name: string }[]> => [],
     ),
 
     updateLatestVersionConfig: vi.fn(async () => undefined),
@@ -1724,8 +1724,8 @@ describe('DashboardService', () => {
             dashboardModel.getByIdOrSlug.mockResolvedValue(
                 dashboardWithRegistry as never,
             );
-            dashboardModel.getDashboardOwnedChartUuidsUsingMetric.mockResolvedValue(
-                [affectedChart.uuid],
+            dashboardModel.getDashboardOwnedChartsUsingMetric.mockResolvedValue(
+                [{ uuid: affectedChart.uuid, name: affectedChart.name }],
             );
             savedChartModel.get.mockResolvedValue(affectedChart as never);
         });
@@ -1777,6 +1777,55 @@ describe('DashboardService', () => {
                 dashboardModel.updateLatestVersionConfig,
             ).not.toHaveBeenCalled();
             expect(savedChartModel.createVersion).not.toHaveBeenCalled();
+        });
+
+        test('delete removes the entry without touching charts', async () => {
+            const result = await service.deleteCustomMetric(
+                user,
+                dashboardUuid,
+                registryMetric.table,
+                registryMetric.name,
+                false,
+            );
+
+            expect(result.customMetrics).toEqual([]);
+            expect(result.affectedCharts).toEqual([
+                { uuid: affectedChart.uuid, name: affectedChart.name },
+            ]);
+            expect(
+                dashboardModel.updateLatestVersionConfig,
+            ).toHaveBeenCalledWith(
+                dashboardUuid,
+                expect.objectContaining({ customMetrics: [] }),
+            );
+            expect(savedChartModel.createVersion).not.toHaveBeenCalled();
+        });
+
+        test('delete dryRun reports affected charts without writing', async () => {
+            const result = await service.deleteCustomMetric(
+                user,
+                dashboardUuid,
+                registryMetric.table,
+                registryMetric.name,
+                true,
+            );
+
+            expect(result.dryRun).toBe(true);
+            expect(
+                dashboardModel.updateLatestVersionConfig,
+            ).not.toHaveBeenCalled();
+        });
+
+        test('delete 404s for a metric not in the registry', async () => {
+            await expect(
+                service.deleteCustomMetric(
+                    user,
+                    dashboardUuid,
+                    'orders',
+                    'unknown_metric',
+                    false,
+                ),
+            ).rejects.toThrowError(NotFoundError);
         });
 
         test('blocks dashboards managed as code', async () => {

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -2365,12 +2365,12 @@ export class DashboardService
      * snapshot references it, atomically. `dryRun` reports the affected
      * charts without writing (the impact preview).
      */
-    async updateCustomMetric(
+    /** Auth + verified-content + content-as-code guards shared by registry mutations */
+    private async getRegistryMutationTarget(
         user: SessionUser,
         dashboardUuidOrSlug: UuidOrSlug,
-        payload: UpdateDashboardCustomMetric,
         options?: { projectUuid?: string },
-    ): Promise<DashboardCustomMetricUpdateResult> {
+    ): Promise<DashboardDAO> {
         const dashboard = await this.dashboardModel.getByIdOrSlug(
             dashboardUuidOrSlug,
             { projectUuid: options?.projectUuid },
@@ -2405,13 +2405,28 @@ export class DashboardService
             organizationUuid: dashboard.organizationUuid,
         });
 
-        // The write-through mutates published content and chart versions
+        // Registry mutations write published content and chart versions
         // directly, which the content-as-code draft lifecycle can't represent.
         if ((await this.resolveDraftBase(dashboard)) !== null) {
             throw new ParameterError(
                 'Shared metrics cannot be edited on a dashboard managed as code. Publish or discard its draft workflow first.',
             );
         }
+
+        return dashboard;
+    }
+
+    async updateCustomMetric(
+        user: SessionUser,
+        dashboardUuidOrSlug: UuidOrSlug,
+        payload: UpdateDashboardCustomMetric,
+        options?: { projectUuid?: string },
+    ): Promise<DashboardCustomMetricUpdateResult> {
+        const dashboard = await this.getRegistryMutationTarget(
+            user,
+            dashboardUuidOrSlug,
+            options,
+        );
 
         const { metric, dryRun = false } = payload;
         const registry = dashboard.config?.customMetrics ?? [];
@@ -2429,16 +2444,14 @@ export class DashboardService
 
         // One query finds the affected charts; full chart data is fetched
         // only for those, since each needs a rewritten version anyway.
-        const affectedChartUuids =
-            await this.dashboardModel.getDashboardOwnedChartUuidsUsingMetric(
+        const affectedCharts =
+            await this.dashboardModel.getDashboardOwnedChartsUsingMetric(
                 dashboard.uuid,
                 metric.table,
                 metric.name,
             );
         const affected = await Promise.all(
-            affectedChartUuids.map((chartUuid) =>
-                this.savedChartModel.get(chartUuid),
-            ),
+            affectedCharts.map((chart) => this.savedChartModel.get(chart.uuid)),
         );
 
         const updatedRegistry = [
@@ -2446,11 +2459,6 @@ export class DashboardService
             metric,
             ...registry.slice(existingIndex + 1),
         ];
-        const affectedCharts = affected.map((chart) => ({
-            uuid: chart.uuid,
-            name: chart.name,
-        }));
-
         if (!dryRun) {
             await this.savedChartModel.transaction(async (tx) => {
                 await this.dashboardModel.updateLatestVersionConfig(
@@ -2486,6 +2494,58 @@ export class DashboardService
                     ),
                 );
             });
+        }
+
+        return { customMetrics: updatedRegistry, affectedCharts, dryRun };
+    }
+
+    /**
+     * Removes a metric from the registry. Delete = un-share: charts keep
+     * their local snapshots untouched, the metric just stops being offered.
+     * `dryRun` reports the charts still using it (the impact preview).
+     */
+    async deleteCustomMetric(
+        user: SessionUser,
+        dashboardUuidOrSlug: UuidOrSlug,
+        metricTable: string,
+        metricName: string,
+        dryRun: boolean,
+        options?: { projectUuid?: string },
+    ): Promise<DashboardCustomMetricUpdateResult> {
+        const dashboard = await this.getRegistryMutationTarget(
+            user,
+            dashboardUuidOrSlug,
+            options,
+        );
+
+        const registry = dashboard.config?.customMetrics ?? [];
+        const metricId = getItemId({ table: metricTable, name: metricName });
+        const updatedRegistry = registry.filter(
+            (entry) => getItemId(entry) !== metricId,
+        );
+        if (updatedRegistry.length === registry.length) {
+            throw new NotFoundError(
+                `Custom metric "${metricName}" is not in this dashboard's registry`,
+            );
+        }
+
+        // Preview only needs names — the single lookup query carries them.
+        const affectedCharts =
+            await this.dashboardModel.getDashboardOwnedChartsUsingMetric(
+                dashboard.uuid,
+                metricTable,
+                metricName,
+            );
+
+        if (!dryRun) {
+            await this.dashboardModel.updateLatestVersionConfig(
+                dashboard.uuid,
+                {
+                    isDateZoomDisabled: false,
+                    ...dashboard.config,
+                    customMetrics: updatedRegistry,
+                },
+            );
         }
 
         return { customMetrics: updatedRegistry, affectedCharts, dryRun };

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartEditorModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartEditorModal.tsx
@@ -2,6 +2,7 @@ import {
     ChartType,
     mergeDashboardCustomMetrics,
     type AdditionalMetric,
+    type DashboardCustomMetricAffectedChart,
     type SavedChart,
 } from '@lightdash/common';
 import { IconChartBar } from '@tabler/icons-react';
@@ -13,6 +14,8 @@ import {
 } from '../../features/explorer/store';
 import { MergeProvider } from '../../features/mergeQuery/context/MergeContext';
 import { useDashboardCustomMetricSeed } from '../../hooks/dashboard/useDashboardCustomMetricSeed';
+import { useDeleteDashboardCustomMetric } from '../../hooks/dashboard/useUpdateDashboardCustomMetric';
+import useToaster from '../../hooks/toaster/useToaster';
 import { useExplore } from '../../hooks/useExplore';
 import { useExplorerQueryEffects } from '../../hooks/useExplorerQueryEffects';
 import { ExplorerSection } from '../../providers/Explorer/types';
@@ -20,6 +23,7 @@ import { ModalHostedContext } from '../../providers/Explorer/useIsModalHosted';
 import MantineModal from '../common/MantineModal';
 import Page from '../common/Page/Page';
 import Explorer from '../Explorer';
+import RegistryImpactPreviewModal from '../Explorer/CustomMetricModal/RegistryImpactPreviewModal';
 import ExploreSideBar from '../Explorer/ExploreSideBar';
 import PageSpinner from '../PageSpinner';
 
@@ -135,6 +139,7 @@ type Props = {
     editChart?: SavedChart;
     onChartSaved: (chart: SavedChart) => void;
     onRegistryMetricEdited: (metric: AdditionalMetric) => void;
+    onRegistryMetricDeleted: (metric: AdditionalMetric) => void;
     onClose: () => void;
 };
 
@@ -149,6 +154,7 @@ const DashboardChartEditorModal: FC<Props> = ({
     editChart,
     onChartSaved,
     onRegistryMetricEdited,
+    onRegistryMetricDeleted,
     onClose,
 }) => {
     const [pickedExploreId, setPickedExploreId] = useState<string>();
@@ -159,6 +165,70 @@ const DashboardChartEditorModal: FC<Props> = ({
         dashboardMetricIds,
         isLoading: isSeedLoading,
     } = useDashboardCustomMetricSeed(exploreId);
+
+    const { showToastSuccess, showToastError } = useToaster();
+    const deleteRegistryMetric = useDeleteDashboardCustomMetric(dashboardUuid);
+    const [registryDeletePreview, setRegistryDeletePreview] = useState<{
+        metric: AdditionalMetric;
+        affectedCharts: DashboardCustomMetricAffectedChart[];
+    } | null>(null);
+
+    const requestRegistryMetricDelete = useCallback(
+        (metric: AdditionalMetric) => {
+            // Dry-run feeds the impact preview before anything commits.
+            deleteRegistryMetric.mutate(
+                {
+                    metricTable: metric.table,
+                    metricName: metric.name,
+                    dryRun: true,
+                },
+                {
+                    onSuccess: (result) => {
+                        setRegistryDeletePreview({
+                            metric,
+                            affectedCharts: result.affectedCharts,
+                        });
+                    },
+                    onError: (error) => {
+                        showToastError({
+                            title: 'Failed to prepare metric removal',
+                            subtitle: error.error?.message,
+                        });
+                    },
+                },
+            );
+        },
+        [deleteRegistryMetric, showToastError],
+    );
+
+    const handleConfirmRegistryDelete = useCallback(() => {
+        if (!registryDeletePreview) return;
+        const { metric } = registryDeletePreview;
+        deleteRegistryMetric.mutate(
+            { metricTable: metric.table, metricName: metric.name },
+            {
+                onSuccess: () => {
+                    onRegistryMetricDeleted(metric);
+                    showToastSuccess({
+                        title: 'Custom metric removed from this dashboard',
+                    });
+                    setRegistryDeletePreview(null);
+                },
+                onError: (error) => {
+                    showToastError({
+                        title: 'Failed to remove custom metric',
+                        subtitle: error.error?.message,
+                    });
+                },
+            },
+        );
+    }, [
+        registryDeletePreview,
+        deleteRegistryMetric,
+        onRegistryMetricDeleted,
+        showToastSuccess,
+        showToastError,
+    ]);
 
     // Saving closes the modal via the host, bypassing handleClose — reset the
     // picked explore here too so the next New chart starts at the picker.
@@ -177,6 +247,7 @@ const DashboardChartEditorModal: FC<Props> = ({
             dashboard: { uuid: dashboardUuid, name: dashboardName },
             dashboardMetricIds,
             onRegistryMetricEdited,
+            requestRegistryMetricDelete,
         }),
         [
             handleChartSaved,
@@ -184,6 +255,7 @@ const DashboardChartEditorModal: FC<Props> = ({
             dashboardName,
             dashboardMetricIds,
             onRegistryMetricEdited,
+            requestRegistryMetricDelete,
         ],
     );
 
@@ -217,6 +289,19 @@ const DashboardChartEditorModal: FC<Props> = ({
                         onBackToTables={() => setPickedExploreId(undefined)}
                     />
                 )}
+                <RegistryImpactPreviewModal
+                    opened={registryDeletePreview !== null}
+                    variant="delete"
+                    metricLabel={
+                        registryDeletePreview?.metric.label ??
+                        registryDeletePreview?.metric.name ??
+                        ''
+                    }
+                    affectedCharts={registryDeletePreview?.affectedCharts ?? []}
+                    isSaving={deleteRegistryMetric.isLoading}
+                    onBack={() => setRegistryDeletePreview(null)}
+                    onConfirm={handleConfirmRegistryDelete}
+                />
             </ModalHostedContext.Provider>
         </MantineModal>
     );

--- a/packages/frontend/src/components/Explorer/CustomMetricModal/RegistryImpactPreviewModal.tsx
+++ b/packages/frontend/src/components/Explorer/CustomMetricModal/RegistryImpactPreviewModal.tsx
@@ -7,6 +7,7 @@ import MantineModal from '../../common/MantineModal';
 
 type Props = {
     opened: boolean;
+    variant?: 'update' | 'delete';
     metricLabel: string;
     affectedCharts: DashboardCustomMetricAffectedChart[];
     isSaving: boolean;
@@ -20,6 +21,7 @@ type Props = {
  */
 const RegistryImpactPreviewModal: FC<Props> = ({
     opened,
+    variant = 'update',
     metricLabel,
     affectedCharts,
     isSaving,
@@ -29,7 +31,11 @@ const RegistryImpactPreviewModal: FC<Props> = ({
     <MantineModal
         opened={opened}
         onClose={onBack}
-        title="Update metric in this dashboard"
+        title={
+            variant === 'delete'
+                ? 'Remove metric from this dashboard'
+                : 'Update metric in this dashboard'
+        }
         icon={IconShare2}
         cancelLabel={false}
         actions={
@@ -37,12 +43,18 @@ const RegistryImpactPreviewModal: FC<Props> = ({
                 <Button variant="default" onClick={onBack} disabled={isSaving}>
                     Back
                 </Button>
-                <Button onClick={onConfirm} loading={isSaving}>
-                    {affectedCharts.length > 0
-                        ? `Update metric and ${affectedCharts.length} chart${
-                              affectedCharts.length === 1 ? '' : 's'
-                          }`
-                        : 'Update metric'}
+                <Button
+                    color={variant === 'delete' ? 'red' : undefined}
+                    onClick={onConfirm}
+                    loading={isSaving}
+                >
+                    {variant === 'delete'
+                        ? 'Remove metric'
+                        : affectedCharts.length > 0
+                          ? `Update metric and ${affectedCharts.length} chart${
+                                affectedCharts.length === 1 ? '' : 's'
+                            }`
+                          : 'Update metric'}
                 </Button>
             </Group>
         }
@@ -57,7 +69,9 @@ const RegistryImpactPreviewModal: FC<Props> = ({
             {affectedCharts.length > 0 ? (
                 <>
                     <Text size="sm">
-                        These charts use it and will be updated:
+                        {variant === 'delete'
+                            ? 'These charts use it and keep their own copy:'
+                            : 'These charts use it and will be updated:'}
                     </Text>
                     <List spacing="xs" size="sm" center>
                         {affectedCharts.map((chart) => (
@@ -77,12 +91,15 @@ const RegistryImpactPreviewModal: FC<Props> = ({
                 </>
             ) : (
                 <Text size="sm" c="dimmed">
-                    No saved charts use it yet — only the shared definition
-                    changes.
+                    {variant === 'delete'
+                        ? 'No saved charts use it — only the shared definition is removed.'
+                        : 'No saved charts use it yet — only the shared definition changes.'}
                 </Text>
             )}
             <Text size="xs" c="dimmed">
-                Charts outside this dashboard are not affected.
+                {variant === 'delete'
+                    ? 'It will no longer be offered when building charts in this dashboard.'
+                    : 'Charts outside this dashboard are not affected.'}
             </Text>
         </Stack>
     </MantineModal>

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNodeActions.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNodeActions.tsx
@@ -42,6 +42,7 @@ import { useProjectUuid } from '../../../../../hooks/useProjectUuid';
 import { useCannotAuthorCustomSql } from '../../../../../hooks/user/useCannotAuthorCustomSql';
 import { useServerFeatureFlag } from '../../../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../../../providers/App/useApp';
+import { useRequestRegistryMetricDelete } from '../../../../../providers/Explorer/useIsModalHosted';
 import useTracking from '../../../../../providers/Tracking/useTracking';
 import { EventName } from '../../../../../types/Events';
 import MantineIcon from '../../../../common/MantineIcon';
@@ -90,6 +91,8 @@ const TreeSingleNodeActions: FC<Props> = ({
         }
         return isDimension(item) ? getCustomMetricType(item.type) : [];
     }, [item]);
+
+    const requestRegistryMetricDelete = useRequestRegistryMetricDelete();
 
     const { data: customGroupBinsFlag } = useServerFeatureFlag(
         FeatureFlags.CustomGroupBins,
@@ -204,6 +207,20 @@ const TreeSingleNodeActions: FC<Props> = ({
                         }}
                     >
                         Edit custom metric
+                    </Menu.Item>
+                ) : null}
+
+                {allowRegistryEdit && isAdditionalMetric(item) ? (
+                    <Menu.Item
+                        component="button"
+                        color="red"
+                        leftSection={<MantineIcon icon={IconTrash} />}
+                        onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+                            e.stopPropagation();
+                            requestRegistryMetricDelete?.(item);
+                        }}
+                    >
+                        Delete custom metric
                     </Menu.Item>
                 ) : null}
 

--- a/packages/frontend/src/hooks/dashboard/useUpdateDashboardCustomMetric.ts
+++ b/packages/frontend/src/hooks/dashboard/useUpdateDashboardCustomMetric.ts
@@ -29,3 +29,35 @@ export const useUpdateDashboardCustomMetric = (
         }
         return updateDashboardCustomMetric(dashboardUuid, payload);
     });
+
+type DeleteDashboardCustomMetricArgs = {
+    metricTable: string;
+    metricName: string;
+    dryRun?: boolean;
+};
+
+const deleteDashboardCustomMetric = (
+    dashboardUuid: string,
+    { metricTable, metricName, dryRun }: DeleteDashboardCustomMetricArgs,
+) =>
+    lightdashApi<DashboardCustomMetricUpdateResult>({
+        url: `/dashboards/${dashboardUuid}/custom-metrics/${encodeURIComponent(
+            metricTable,
+        )}/${encodeURIComponent(metricName)}?dryRun=${dryRun ? 'true' : 'false'}`,
+        method: 'DELETE',
+        body: undefined,
+    });
+
+export const useDeleteDashboardCustomMetric = (
+    dashboardUuid: string | undefined,
+) =>
+    useMutation<
+        DashboardCustomMetricUpdateResult,
+        ApiError,
+        DeleteDashboardCustomMetricArgs
+    >((args) => {
+        if (!dashboardUuid) {
+            throw new Error('Missing dashboard uuid');
+        }
+        return deleteDashboardCustomMetric(dashboardUuid, args);
+    });

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -852,6 +852,19 @@ const Dashboard: FC = () => {
         [setDashboardCustomMetrics, queryClient],
     );
 
+    const handleRegistryMetricDeleted = useCallback(
+        (metric: AdditionalMetric) => {
+            // Charts are untouched by deletion — only the registry changed.
+            setDashboardCustomMetrics((current) =>
+                current.filter(
+                    (entry) => getItemId(entry) !== getItemId(metric),
+                ),
+            );
+            void queryClient.invalidateQueries(['saved_dashboard_query']);
+        },
+        [setDashboardCustomMetrics, queryClient],
+    );
+
     const handleOpenNewChart = useCallback(() => {
         setIsNewChartOpen(true);
     }, []);
@@ -1210,6 +1223,9 @@ const Dashboard: FC = () => {
                             editChart={chartToEdit}
                             onChartSaved={handleChartEditorSaved}
                             onRegistryMetricEdited={handleRegistryMetricEdited}
+                            onRegistryMetricDeleted={
+                                handleRegistryMetricDeleted
+                            }
                             onClose={() => {
                                 setIsNewChartOpen(false);
                                 setChartToEdit(undefined);

--- a/packages/frontend/src/providers/Explorer/useIsModalHosted.ts
+++ b/packages/frontend/src/providers/Explorer/useIsModalHosted.ts
@@ -12,6 +12,10 @@ type ModalHostedValue = {
     dashboardMetricIds?: Set<string>;
     /** Syncs a write-through registry edit back into the host's staged state. */
     onRegistryMetricEdited?: (metric: AdditionalMetric) => void;
+    /** Syncs a registry deletion back into the host's staged state. */
+    onRegistryMetricDeleted?: (metric: AdditionalMetric) => void;
+    /** Opens the host-owned delete flow (impact preview + confirm). */
+    requestRegistryMetricDelete?: (metric: AdditionalMetric) => void;
 };
 
 export const ModalHostedContext = createContext<ModalHostedValue>({
@@ -35,3 +39,7 @@ export const useModalHostedDashboardMetricIds = (): Set<string> | undefined =>
 export const useModalHostedRegistryMetricEdited = ():
     | ((metric: AdditionalMetric) => void)
     | undefined => useContext(ModalHostedContext).onRegistryMetricEdited;
+
+export const useRequestRegistryMetricDelete = ():
+    | ((metric: AdditionalMetric) => void)
+    | undefined => useContext(ModalHostedContext).requestRegistryMetricDelete;


### PR DESCRIPTION
Closes: GLITCH-757

### Description:

The registry had no removal path — registry metrics had no delete action and `DashboardConfig.customMetrics` only ever grew. Anyone testing the workbook flow creates junk metrics and can't clean up.

**Semantics — delete = un-share, never rewrite.** The registry entry is removed and the metric stops being offered to new charts. Charts keep their local snapshots untouched (nothing can break), and their copies become editable chart-local metrics again. Because no chart is rewritten, deletion is always safe.

- `DELETE /dashboards/:uuidOrSlug/custom-metrics/:table/:name?dryRun=` — dry-run returns the affected-charts list for the preview. Same auth + verified-content + content-as-code-draft guards as the edit endpoint, extracted into a shared `getRegistryMutationTarget` helper.
- "Delete custom metric" restored on `=` registry metrics next to Edit (tree and selected section — the shared actions menu covers both).
- Impact preview (delete variant of the existing modal): "These charts use it and keep their own copy: …" → **Remove metric**. Back cancels with no writes.
- On confirm the host dashboard's staged registry drops the entry and the dashboard query cache is invalidated, so a later save can't resurrect it.
- 3 new service unit tests (delete without chart writes, dry-run no-write, 404) — 57/57 green.

Browser E2E pending — local dev stack was down at submit time; will verify and follow up.

### Risk assessment:

- [ ] This is a high-risk change

High-risk changes require approval from a reviewer other than the author before merging.
