### PR TITLE
fix: clarify explicit non-admin roadmap grants

### DIFF
--- a/docs/authentication-and-roles.md
+++ b/docs/authentication-and-roles.md
@@ -83,9 +83,14 @@ Two assignment surfaces:
    `project_memberships.role_uuid` to a custom role uuid. Used today by both
    human users and project-scoped automation.
 2. **Organization-level custom roles**. Set
-   `organization_memberships.role_uuid`. The same `roles` row can be assigned
-   either way — there's no project-vs-org distinction at the role level, only
-   at the assignment.
+   `organization_memberships.role_uuid`. Each custom role has a `level`
+   (`organization` or `project`) that controls its available scopes and
+   assignment level. The API rejects scopes or assignments at the wrong level.
+
+A membership can also hold additional custom roles alongside its system or
+primary custom role. Their permissions are additive. Use the role-set controls
+to retain the user's existing roles when adding a grant; a singular role
+assignment replaces the complete set.
 
 The custom-roles UI under **Settings → Custom roles** edits both surfaces
 through the same controllers (`CustomRolesController`, `OrganizationRolesController`).
@@ -250,34 +255,43 @@ deny tokens to a set of users. A project-level role cannot do it, by
 design. System organization roles are unaffected either way: their token
 access always comes from the deployment config.
 
-### What `BASE_ROLE_SCOPES` returns when you duplicate "Admin"
+### Role levels in the role builder
 
-When an operator clicks **Duplicate role** on a system role, the new
-custom role gets the union of project-level *and* org-level abilities
-that role grants — i.e. every scope a human admin (or editor / developer
-/ etc.) can effectively use across both layers. That's intentional and
-mirrors the user's expectation that "the role does what the system role
-does." The trade-off is the project-level no-op above: an admin clone
-assigned at the project level will still show org-management toggles
-ticked, but those toggles are dead at runtime in that context.
+The role builder filters permissions to the selected role level, and the API
+validates the same boundary. `view:Roadmap` is only available on organization
+roles. A project role cannot grant access to the organization roadmap, even
+if legacy data or a direct ability-builder call includes that scope.
 
-### Known UX gap (revisit)
+## Enabling the roadmap for a non-admin
 
-The role builder shows **all** scopes regardless of intended assignment
-level. An admin who toggles `manage:OrganizationMemberProfile` on a
-project-only role gets nothing — no error, no warning, just no effect.
-Possible future improvements (none implemented today):
+Roadmap access stays explicit: organization admins keep access, while other
+system roles do not receive it by default. To grant access without replacing
+the user's existing permissions:
 
-- Mark each scope's "applicable level" (`project | org | both`) and
-  filter the role-builder UI by intended assignment context.
-- Two distinct role flavors at the API level — "project role" vs
-  "org role" — each with its own scope catalog.
-- Inline hint in the role builder ("only effective at org assignment")
-  when an org-only scope is toggled.
+1. Confirm the deployment has an enterprise license and custom roles enabled
+   (`CUSTOM_ROLES_ENABLED=true` or the `custom-roles` flag). The organization
+   must also have the `OrganizationRoadmap` flag and a working Control Center
+   license-to-organization mapping. A role grant alone does not enable the
+   roadmap feature or provision its data.
+2. In **Settings → Roles**, create a user role at the **organization** level
+   containing **View Roadmap** (`view:Roadmap`, Organization Management).
+3. In the users table, add that organization role to the user's existing role
+   set, retaining their system role and any other custom roles. The role-set
+   API is `ReplaceOrganizationUserRoleSet`; submit the complete intended set.
+4. Verify the user sees **Settings → Roadmap** and
+   `GET /api/v1/org/roadmap` succeeds. Remove just the added role and verify
+   that the non-admin no longer sees the nav item and receives a 403.
 
-Each option trades simplicity (one shared role-builder UI) for
-discoverability. The current design preserves the simpler UX at the cost
-of the silent-no-op trap.
+On older releases with only a single-role assignment control, duplicate the
+user's current role at organization level, add View Roadmap, and assign that
+custom role. It replaces their system-role abilities, so verify the duplicate
+preserves their existing permissions. Do not use the single-role API to add a
+grant to a user with multiple roles: it replaces the entire set.
+
+Assigning a role at project level grants no roadmap access. The role builder
+explains this boundary and does not offer the organization-only scope there.
+Ability coverage is in `packages/common/src/authorization/roadmapAccess.test.ts`;
+it does not replace the configured-instance UI and endpoint verification above.
 
 ## Code references
 

--- a/packages/common/src/authorization/roadmapAccess.test.ts
+++ b/packages/common/src/authorization/roadmapAccess.test.ts
@@ -1,0 +1,207 @@
+import { subject } from '@casl/ability';
+import { OrganizationMemberRole } from '../types/organizationMemberProfile';
+import { ProjectMemberRole } from '../types/projectMemberRole';
+import { getUserAbilityBuilder } from './index';
+
+const ORG_UUID = 'roadmap-org-uuid';
+const PROJECT_UUID = 'roadmap-project-uuid';
+const USER_UUID = 'roadmap-user-uuid';
+const CUSTOM_ROLE_UUID = '44444444-4444-4444-a444-444444444444';
+
+const PERMISSIONS_CONFIG = {
+    pat: { enabled: false, allowedOrgRoles: [] },
+};
+
+const canViewRoadmap = ({
+    role = OrganizationMemberRole.MEMBER,
+    orgRoleUuid,
+    projectRoleUuid,
+    orgExtraRoleUuids = [],
+    projectExtraRoleUuids = [],
+    scopes = ['view:Roadmap'],
+    customRolesEnabled = true,
+    isEnterprise = true,
+}: {
+    role?: OrganizationMemberRole;
+    orgRoleUuid?: string;
+    projectRoleUuid?: string;
+    orgExtraRoleUuids?: string[];
+    projectExtraRoleUuids?: string[];
+    scopes?: string[];
+    customRolesEnabled?: boolean;
+    isEnterprise?: boolean;
+}): boolean => {
+    const { builder } = getUserAbilityBuilder({
+        user: {
+            role,
+            organizationUuid: ORG_UUID,
+            userUuid: USER_UUID,
+            roleUuid: orgRoleUuid,
+        },
+        orgExtraRoleUuids,
+        projectProfiles:
+            projectRoleUuid || projectExtraRoleUuids.length > 0
+                ? [
+                      {
+                          projectUuid: PROJECT_UUID,
+                          role: ProjectMemberRole.VIEWER,
+                          userUuid: USER_UUID,
+                          roleUuid: projectRoleUuid,
+                          extraRoleUuids: projectExtraRoleUuids,
+                      },
+                  ]
+                : [],
+        permissionsConfig: PERMISSIONS_CONFIG,
+        customRoleScopes: { [CUSTOM_ROLE_UUID]: scopes },
+        customRolesEnabled,
+        isEnterprise,
+    });
+
+    return builder
+        .build()
+        .can('view', subject('Roadmap', { organizationUuid: ORG_UUID }));
+};
+
+describe('Roadmap access', () => {
+    describe('System roles', () => {
+        it('grants the organization admin access', () => {
+            expect(canViewRoadmap({ role: OrganizationMemberRole.ADMIN })).toBe(
+                true,
+            );
+        });
+
+        it.each([
+            OrganizationMemberRole.MEMBER,
+            OrganizationMemberRole.VIEWER,
+            OrganizationMemberRole.INTERACTIVE_VIEWER,
+            OrganizationMemberRole.EDITOR,
+            OrganizationMemberRole.DEVELOPER,
+        ])('denies %s — access stays explicit-grant only', (role) => {
+            expect(canViewRoadmap({ role })).toBe(false);
+        });
+    });
+
+    describe('Organization-level custom role', () => {
+        it('grants a non-admin the roadmap when the role includes view:Roadmap', () => {
+            expect(
+                canViewRoadmap({
+                    role: OrganizationMemberRole.VIEWER,
+                    orgRoleUuid: CUSTOM_ROLE_UUID,
+                }),
+            ).toBe(true);
+        });
+
+        it('denies a non-admin when the role omits view:Roadmap', () => {
+            expect(
+                canViewRoadmap({
+                    role: OrganizationMemberRole.VIEWER,
+                    orgRoleUuid: CUSTOM_ROLE_UUID,
+                    scopes: ['view:Dashboard', 'view:Project'],
+                }),
+            ).toBe(false);
+        });
+
+        it('scopes the grant to the assigning organization', () => {
+            const { builder } = getUserAbilityBuilder({
+                user: {
+                    role: OrganizationMemberRole.VIEWER,
+                    organizationUuid: ORG_UUID,
+                    userUuid: USER_UUID,
+                    roleUuid: CUSTOM_ROLE_UUID,
+                },
+                projectProfiles: [],
+                permissionsConfig: PERMISSIONS_CONFIG,
+                customRoleScopes: { [CUSTOM_ROLE_UUID]: ['view:Roadmap'] },
+                customRolesEnabled: true,
+                isEnterprise: true,
+            });
+
+            expect(
+                builder.build().can(
+                    'view',
+                    subject('Roadmap', {
+                        organizationUuid: 'another-organization',
+                    }),
+                ),
+            ).toBe(false);
+        });
+
+        it('denies when custom roles are disabled — the assignment falls back to the system role', () => {
+            expect(
+                canViewRoadmap({
+                    role: OrganizationMemberRole.VIEWER,
+                    orgRoleUuid: CUSTOM_ROLE_UUID,
+                    customRolesEnabled: false,
+                }),
+            ).toBe(false);
+        });
+
+        it('denies without an enterprise license — view:Roadmap is an enterprise scope', () => {
+            expect(
+                canViewRoadmap({
+                    role: OrganizationMemberRole.VIEWER,
+                    orgRoleUuid: CUSTOM_ROLE_UUID,
+                    isEnterprise: false,
+                }),
+            ).toBe(false);
+        });
+
+        it('replaces the system role, so an admin assigned a role without view:Roadmap loses it', () => {
+            expect(
+                canViewRoadmap({
+                    role: OrganizationMemberRole.ADMIN,
+                    orgRoleUuid: CUSTOM_ROLE_UUID,
+                    scopes: ['view:Dashboard'],
+                }),
+            ).toBe(false);
+        });
+    });
+
+    describe('Additional organization role', () => {
+        it('grants access alongside a non-admin system role', () => {
+            expect(
+                canViewRoadmap({
+                    role: OrganizationMemberRole.VIEWER,
+                    orgExtraRoleUuids: [CUSTOM_ROLE_UUID],
+                }),
+            ).toBe(true);
+        });
+
+        it.each([
+            { customRolesEnabled: false },
+            { isEnterprise: false },
+            { scopes: ['view:Dashboard'] },
+            { orgExtraRoleUuids: [] },
+        ])(
+            'denies access when the explicit grant is unavailable: %j',
+            (overrides) => {
+                expect(
+                    canViewRoadmap({
+                        role: OrganizationMemberRole.VIEWER,
+                        orgExtraRoleUuids: [CUSTOM_ROLE_UUID],
+                        ...overrides,
+                    }),
+                ).toBe(false);
+            },
+        );
+    });
+
+    describe('Project-level assignment', () => {
+        it('grants nothing from an additional project role', () => {
+            expect(
+                canViewRoadmap({
+                    role: OrganizationMemberRole.VIEWER,
+                    projectExtraRoleUuids: [CUSTOM_ROLE_UUID],
+                }),
+            ).toBe(false);
+        });
+        it('grants nothing — view:Roadmap builds a projectUuid condition that never matches the org-keyed subject', () => {
+            expect(
+                canViewRoadmap({
+                    role: OrganizationMemberRole.VIEWER,
+                    projectRoleUuid: CUSTOM_ROLE_UUID,
+                }),
+            ).toBe(false);
+        });
+    });
+});

--- a/packages/frontend/src/ee/features/customRoles/components/ScopeSelector/ScopeSelector.tsx
+++ b/packages/frontend/src/ee/features/customRoles/components/ScopeSelector/ScopeSelector.tsx
@@ -536,6 +536,13 @@ export const ScopeSelector: FC<ScopeSelectorProps> = ({
                         </Button>
                     </Group>
                 </Group>
+                {level === 'project' && (
+                    <Text fz="xs" c="dimmed">
+                        Organization permissions, including View Roadmap, are
+                        available on organization roles. Assign an organization
+                        role to grant these permissions.
+                    </Text>
+                )}
             </Stack>
 
             {filteredScopes.length === 0 ? (


### PR DESCRIPTION
Relates: PROD-10995

### Description:

Non-admin users can receive `view:Roadmap` through an organization custom role, but the role builder does not explain why that permission is absent from project roles and the grant instructions lag behind role-set support. Add a short organization-level hint and document adding the grant while retaining a user's existing roles, with instructions for older single-role releases.

Add 19 focused ability cases covering explicit grants, system-role defaults, organization isolation, license/custom-role gates, grant removal, and project-level denial. Authorization rules and default access remain unchanged.

This current-main draft overlaps with #27022 and reuses its original grant-path tests, extending them for additional organization and project roles. Both drafts remain open for comparison; this PR does not close that PR or the tracking ticket.

### Validation:

- Passed: 19 focused roadmap ability tests, common typecheck, focused common lint, changed TypeScript/TSX formatting, and diff whitespace checks.
- Not run: full frontend build/typecheck or configured-instance UI/API verification. Before merge, verify nav and `GET /api/v1/org/roadmap` for a granted non-admin, grant removal, unchanged admin access, and the roadmap feature disabled.

### Risk assessment:

- [ ] This is a high-risk change

Low risk: the application change adds explanatory text; the remaining changes are permission regression tests and documentation. No scope, default grant, backend authorization, or data migration changes.
