### PR TITLE
fix(ai): declare Lightdash-managed keys from infrastructure, attribute data-app usage to the model the CLI ran, track delivery summaries

### DIFF
--- a/packages/backend/src/analytics/aiUsage.ts
+++ b/packages/backend/src/analytics/aiUsage.ts
@@ -33,7 +33,8 @@ export type AiCallFeature =
     | 'llm-judge'
     | 'data-app'
     | 'managed-agent'
-    | 'external-connection-config';
+    | 'external-connection-config'
+    | 'delivery-summary';
 
 /**
  * Whether the AI call ran on Lightdash's own (instance) provider key or the

--- a/packages/backend/src/config/aiConfigSchema.ts
+++ b/packages/backend/src/config/aiConfigSchema.ts
@@ -41,12 +41,15 @@ export const aiCopilotConfigSchema = z
         defaultProvider: z
             .enum(AI_PROVIDER_KEYS)
             .default(DEFAULT_DEFAULT_AI_PROVIDER),
-        // Providers whose instance-level API key belongs to the customer
-        // rather than Lightdash (e.g. a dedicated cloud deployment configured
-        // with the customer's own key). Only affects the `keyManagement`
-        // dimension on AI usage analytics; org BYO keys are tracked separately
-        // at config resolution.
-        selfManagedProviders: z.array(z.enum(AI_PROVIDER_KEYS)).default([]),
+        // Providers whose instance-level API key is Lightdash's own. Set by
+        // Lightdash infrastructure on Lightdash Cloud deployments; empty on
+        // self-hosted installs and on dedicated instances configured with a
+        // customer's key. Only affects the `keyManagement` dimension on AI
+        // usage analytics; org BYO keys are tracked separately at config
+        // resolution.
+        lightdashManagedProviders: z
+            .array(z.enum(AI_PROVIDER_KEYS))
+            .default([]),
         defaultEmbeddingModelProvider: z
             .enum(['openai', 'bedrock', 'azure'])
             .default(DEFAULT_DEFAULT_AI_PROVIDER),

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -298,7 +298,7 @@ export const lightdashConfigMock: LightdashConfig = {
             askAiButtonEnabled: false,
             embeddingEnabled: true,
             defaultProvider: 'openai',
-            selfManagedProviders: [],
+            lightdashManagedProviders: [],
             providers: {
                 openai: {
                     apiKey: 'mock_api_key',

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -10,6 +10,7 @@ import {
     WeekDay,
 } from '@lightdash/common';
 import { VERSION } from '../version';
+import { AI_PROVIDER_KEYS } from './aiConfigSchema';
 import {
     getFloatArrayFromEnvironmentVariable,
     getFloatFromEnvironmentVariable,
@@ -2319,5 +2320,33 @@ describe('APPS_CODING_AGENT', () => {
     test('throws on an unknown coding agent', () => {
         process.env.APPS_CODING_AGENT = 'cursor';
         expect(() => parseConfig()).toThrowError(ParseError);
+    });
+});
+
+describe('ai copilot key management config', () => {
+    it('treats every instance provider key as self-managed outside Lightdash Cloud', () => {
+        delete process.env.LIGHTDASH_CLOUD_INSTANCE;
+        process.env.AI_COPILOT_SELF_MANAGED_PROVIDERS = 'openai';
+
+        expect(parseConfig().ai.copilot.selfManagedProviders).toEqual([
+            ...AI_PROVIDER_KEYS,
+        ]);
+    });
+
+    it('treats instance keys as Lightdash-managed on Lightdash Cloud unless declared', () => {
+        process.env.LIGHTDASH_CLOUD_INSTANCE = 'cloud-instance';
+        delete process.env.AI_COPILOT_SELF_MANAGED_PROVIDERS;
+
+        expect(parseConfig().ai.copilot.selfManagedProviders).toEqual([]);
+    });
+
+    it('honours AI_COPILOT_SELF_MANAGED_PROVIDERS on Lightdash Cloud and drops unknown names', () => {
+        process.env.LIGHTDASH_CLOUD_INSTANCE = 'cloud-instance';
+        process.env.AI_COPILOT_SELF_MANAGED_PROVIDERS =
+            'anthropic,not-a-provider';
+
+        expect(parseConfig().ai.copilot.selfManagedProviders).toEqual([
+            'anthropic',
+        ]);
     });
 });

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -10,7 +10,6 @@ import {
     WeekDay,
 } from '@lightdash/common';
 import { VERSION } from '../version';
-import { AI_PROVIDER_KEYS } from './aiConfigSchema';
 import {
     getFloatArrayFromEnvironmentVariable,
     getFloatFromEnvironmentVariable,
@@ -2324,29 +2323,22 @@ describe('APPS_CODING_AGENT', () => {
 });
 
 describe('ai copilot key management config', () => {
-    it('treats every instance provider key as self-managed outside Lightdash Cloud', () => {
+    it('declares no Lightdash-managed providers by default, on or off Lightdash Cloud', () => {
+        delete process.env.AI_COPILOT_LIGHTDASH_MANAGED_PROVIDERS;
         delete process.env.LIGHTDASH_CLOUD_INSTANCE;
-        process.env.AI_COPILOT_SELF_MANAGED_PROVIDERS = 'openai';
+        expect(parseConfig().ai.copilot.lightdashManagedProviders).toEqual([]);
 
-        expect(parseConfig().ai.copilot.selfManagedProviders).toEqual([
-            ...AI_PROVIDER_KEYS,
-        ]);
+        process.env.LIGHTDASH_CLOUD_INSTANCE = 'cloud-instance';
+        expect(parseConfig().ai.copilot.lightdashManagedProviders).toEqual([]);
     });
 
-    it('treats instance keys as Lightdash-managed on Lightdash Cloud unless declared', () => {
-        process.env.LIGHTDASH_CLOUD_INSTANCE = 'cloud-instance';
-        delete process.env.AI_COPILOT_SELF_MANAGED_PROVIDERS;
+    it('reads AI_COPILOT_LIGHTDASH_MANAGED_PROVIDERS and drops unknown names', () => {
+        process.env.AI_COPILOT_LIGHTDASH_MANAGED_PROVIDERS =
+            'anthropic,openai,not-a-provider';
 
-        expect(parseConfig().ai.copilot.selfManagedProviders).toEqual([]);
-    });
-
-    it('honours AI_COPILOT_SELF_MANAGED_PROVIDERS on Lightdash Cloud and drops unknown names', () => {
-        process.env.LIGHTDASH_CLOUD_INSTANCE = 'cloud-instance';
-        process.env.AI_COPILOT_SELF_MANAGED_PROVIDERS =
-            'anthropic,not-a-provider';
-
-        expect(parseConfig().ai.copilot.selfManagedProviders).toEqual([
+        expect(parseConfig().ai.copilot.lightdashManagedProviders).toEqual([
             'anthropic',
+            'openai',
         ]);
     });
 });

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1261,34 +1261,25 @@ export const getAiConfig = () => ({
     defaultEmbeddingModelProvider:
         process.env.AI_DEFAULT_EMBEDDING_PROVIDER ||
         DEFAULT_DEFAULT_AI_PROVIDER,
-    // Which instance-level provider keys are the customer's rather than
-    // Lightdash's. Outside Lightdash Cloud (no LIGHTDASH_CLOUD_INSTANCE) every
-    // instance key is the customer's by construction, so all providers are
-    // self-managed and the env var is ignored. On a Lightdash Cloud instance
-    // the keys are Lightdash's unless AI_COPILOT_SELF_MANAGED_PROVIDERS names
-    // the providers whose key a customer handed us to install for them.
-    // Unknown names are dropped (with a log) rather than passed through so a
-    // typo can't fail schema validation and discard the whole parsed config.
-    selfManagedProviders:
-        process.env.LIGHTDASH_CLOUD_INSTANCE === undefined
-            ? [...AI_PROVIDER_KEYS]
-            : getArrayFromCommaSeparatedList(
-                  'AI_COPILOT_SELF_MANAGED_PROVIDERS',
-              ).filter(
-                  (provider): provider is (typeof AI_PROVIDER_KEYS)[number] => {
-                      if (
-                          (AI_PROVIDER_KEYS as readonly string[]).includes(
-                              provider,
-                          )
-                      ) {
-                          return true;
-                      }
-                      console.error(
-                          `Ignoring unknown provider "${provider}" in AI_COPILOT_SELF_MANAGED_PROVIDERS`,
-                      );
-                      return false;
-                  },
-              ),
+    // Which instance-level provider keys are Lightdash's. Set by Lightdash's
+    // own infrastructure on Lightdash Cloud deployments that run on Lightdash
+    // keys; never set by customers. Everything else — self-hosted installs,
+    // dedicated instances configured with a customer's key, org keys entered
+    // in the UI — is the customer's, so the default is "none". Only affects
+    // the `keyManagement` dimension on AI usage analytics. Unknown names are
+    // dropped (with a log) rather than passed through so a typo can't fail
+    // schema validation and discard the whole parsed config.
+    lightdashManagedProviders: getArrayFromCommaSeparatedList(
+        'AI_COPILOT_LIGHTDASH_MANAGED_PROVIDERS',
+    ).filter((provider): provider is (typeof AI_PROVIDER_KEYS)[number] => {
+        if ((AI_PROVIDER_KEYS as readonly string[]).includes(provider)) {
+            return true;
+        }
+        console.error(
+            `Ignoring unknown provider "${provider}" in AI_COPILOT_LIGHTDASH_MANAGED_PROVIDERS`,
+        );
+        return false;
+    }),
     providers: {
         azure: process.env.AZURE_AI_API_KEY
             ? {

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1261,19 +1261,34 @@ export const getAiConfig = () => ({
     defaultEmbeddingModelProvider:
         process.env.AI_DEFAULT_EMBEDDING_PROVIDER ||
         DEFAULT_DEFAULT_AI_PROVIDER,
+    // Which instance-level provider keys are the customer's rather than
+    // Lightdash's. Outside Lightdash Cloud (no LIGHTDASH_CLOUD_INSTANCE) every
+    // instance key is the customer's by construction, so all providers are
+    // self-managed and the env var is ignored. On a Lightdash Cloud instance
+    // the keys are Lightdash's unless AI_COPILOT_SELF_MANAGED_PROVIDERS names
+    // the providers whose key a customer handed us to install for them.
     // Unknown names are dropped (with a log) rather than passed through so a
     // typo can't fail schema validation and discard the whole parsed config.
-    selfManagedProviders: getArrayFromCommaSeparatedList(
-        'AI_COPILOT_SELF_MANAGED_PROVIDERS',
-    ).filter((provider): provider is (typeof AI_PROVIDER_KEYS)[number] => {
-        if ((AI_PROVIDER_KEYS as readonly string[]).includes(provider)) {
-            return true;
-        }
-        console.error(
-            `Ignoring unknown provider "${provider}" in AI_COPILOT_SELF_MANAGED_PROVIDERS`,
-        );
-        return false;
-    }),
+    selfManagedProviders:
+        process.env.LIGHTDASH_CLOUD_INSTANCE === undefined
+            ? [...AI_PROVIDER_KEYS]
+            : getArrayFromCommaSeparatedList(
+                  'AI_COPILOT_SELF_MANAGED_PROVIDERS',
+              ).filter(
+                  (provider): provider is (typeof AI_PROVIDER_KEYS)[number] => {
+                      if (
+                          (AI_PROVIDER_KEYS as readonly string[]).includes(
+                              provider,
+                          )
+                      ) {
+                          return true;
+                      }
+                      console.error(
+                          `Ignoring unknown provider "${provider}" in AI_COPILOT_SELF_MANAGED_PROVIDERS`,
+                      );
+                      return false;
+                  },
+              ),
     providers: {
         azure: process.env.AZURE_AI_API_KEY
             ? {

--- a/packages/backend/src/ee/services/AiRouterService/AiRouterService.ts
+++ b/packages/backend/src/ee/services/AiRouterService/AiRouterService.ts
@@ -196,7 +196,7 @@ export class AiRouterService extends BaseService {
             await this.orgAiCopilotConfigResolver.getCopilotConfig(
                 organizationUuid,
             );
-        const { model } = getModel(copilotConfig);
+        const { model, keyManagement } = getModel(copilotConfig);
         const brain = await selectAgent({
             model,
             candidates,
@@ -206,6 +206,7 @@ export class AiRouterService extends BaseService {
                 organizationUuid,
                 projectUuid,
                 userUuid: account.user.userUuid,
+                keyManagement,
             },
         });
 

--- a/packages/backend/src/ee/services/AiService/AiService.ts
+++ b/packages/backend/src/ee/services/AiService/AiService.ts
@@ -57,7 +57,10 @@ import {
 } from '../ai/models';
 import { getAnthropicModel } from '../ai/models/anthropic-claude';
 import { OrgAiCopilotConfigResolver } from '../ai/OrgAiCopilotConfigResolver';
-import { AiCallAttribution } from '../ai/utils/aiCallTelemetry';
+import {
+    AiCallAttribution,
+    getGeneratorTelemetry,
+} from '../ai/utils/aiCallTelemetry';
 import { DEFAULT_CUSTOM_VIZ_PROMPT } from './utils/prompts';
 import { getTotalTokenUsage } from './utils/tokens';
 
@@ -551,6 +554,11 @@ export class AiService extends BaseService {
             model: modelOptions.model,
             ...modelOptions.callOptions,
             providerOptions: modelOptions.providerOptions,
+            experimental_telemetry: getGeneratorTelemetry(
+                modelOptions,
+                'generateDeliverySummary',
+                'delivery-summary',
+            ),
             messages: [
                 {
                     role: 'system',

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.promoteApp.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.promoteApp.test.ts
@@ -356,7 +356,7 @@ async function buildScenario() {
             getClaudeCodeConfig: async () => ({
                 defaultProvider: 'anthropic',
                 providers: { anthropic: { apiKey: 'test-key' } },
-                selfManagedProviders: [],
+                lightdashManagedProviders: [],
                 byoProviders: [],
             }),
         } as never,

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -2124,37 +2124,71 @@ export class AppGenerateService extends BaseService {
         keyManagement: AiKeyManagement,
         usage: ClaudeGenerationUsage,
     ): void {
-        emitAiUsage(
-            getAiCallTelemetry({
-                functionId: 'appClaudeGeneration',
-                feature: 'data-app',
-                organizationUuid: payload.organizationUuid,
-                projectUuid: payload.projectUuid,
-                userUuid: payload.userUuid,
-                model,
-                provider,
-                keyManagement,
-                extra: {
-                    appUuid: payload.appUuid,
-                    appVersion: payload.version,
+        const emit = (
+            resolvedModel: string,
+            tokens: Pick<
+                ClaudeGenerationUsage,
+                | 'inputTokens'
+                | 'outputTokens'
+                | 'cacheReadInputTokens'
+                | 'cacheCreationInputTokens'
+            >,
+        ) =>
+            emitAiUsage(
+                getAiCallTelemetry({
+                    functionId: 'appClaudeGeneration',
+                    feature: 'data-app',
+                    organizationUuid: payload.organizationUuid,
+                    projectUuid: payload.projectUuid,
+                    userUuid: payload.userUuid,
+                    model: resolvedModel,
+                    provider,
+                    keyManagement,
+                    extra: {
+                        appUuid: payload.appUuid,
+                        appVersion: payload.version,
+                        codingAgentModel: model,
+                    },
+                }),
+                {
+                    // input_tokens is inclusive of cache reads and writes; the
+                    // warehouse derives the uncached share by subtraction.
+                    inputTokens:
+                        tokens.inputTokens +
+                        tokens.cacheReadInputTokens +
+                        tokens.cacheCreationInputTokens,
+                    outputTokens: tokens.outputTokens,
+                    cacheReadTokens: tokens.cacheReadInputTokens,
+                    cacheWriteTokens: tokens.cacheCreationInputTokens,
+                    reasoningTokens: null,
+                    totalTokens:
+                        tokens.inputTokens +
+                        tokens.cacheReadInputTokens +
+                        tokens.cacheCreationInputTokens +
+                        tokens.outputTokens,
                 },
-            }),
-            {
-                inputTokens:
-                    usage.inputTokens +
-                    usage.cacheReadInputTokens +
-                    usage.cacheCreationInputTokens,
-                outputTokens: usage.outputTokens,
-                cacheReadTokens: usage.cacheReadInputTokens,
-                cacheWriteTokens: usage.cacheCreationInputTokens,
-                reasoningTokens: null,
-                totalTokens:
-                    usage.inputTokens +
-                    usage.cacheReadInputTokens +
-                    usage.cacheCreationInputTokens +
-                    usage.outputTokens,
-            },
+            );
+
+        // The run is launched with a tier alias (`opus`, `sonnet`) that the
+        // CLI resolves to a concrete model, and subagents can run on another
+        // model again. Anthropic bills by the concrete model, so when the CLI
+        // reports the per-model split, emit one usage event per model it
+        // actually called; the alias is kept in `extra.codingAgentModel`.
+        const perModel = Object.entries(usage.modelUsage ?? {}).filter(
+            ([, tokens]) =>
+                tokens.inputTokens +
+                    tokens.outputTokens +
+                    tokens.cacheReadInputTokens +
+                    tokens.cacheCreationInputTokens >
+                0,
         );
+        if (perModel.length > 0) {
+            perModel.forEach(([resolvedModel, tokens]) =>
+                emit(resolvedModel, tokens),
+            );
+            return;
+        }
+        emit(model, usage);
     }
 
     /**

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -2255,11 +2255,18 @@ export class AppGenerateService extends BaseService {
                 generationUsage.numTurns > 0 ||
                 generationUsage.costUsd > 0)
         ) {
+            const claudeProvider = telemetry.claudeProvider ?? 'anthropic';
             AppGenerateService.emitDataAppAiUsage(
                 payload,
                 codingAgentModel,
-                telemetry.claudeProvider ?? 'anthropic',
-                telemetry.keyManagement ?? 'lightdash-managed',
+                claudeProvider,
+                // Fall back to the instance rule rather than assuming the key
+                // is Lightdash's: on self-hosted installs it never is.
+                telemetry.keyManagement ??
+                    resolveKeyManagement(
+                        this.lightdashConfig.ai.copilot,
+                        claudeProvider,
+                    ),
                 generationUsage,
             );
             await this.recordGenerationUsage(payload, generationUsage);

--- a/packages/backend/src/ee/services/AppGenerateService/ClaudeStreamProcessor.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/ClaudeStreamProcessor.test.ts
@@ -52,6 +52,63 @@ describe('ClaudeStreamProcessor result parsing', () => {
         });
     });
 
+    test('captures the per-model split from modelUsage under the concrete model ids', () => {
+        const processor = new ClaudeStreamProcessor();
+        processor.feedChunk(
+            resultLine({
+                modelUsage: {
+                    'claude-opus-4-8': {
+                        inputTokens: 900,
+                        outputTokens: 4_500,
+                        cacheReadInputTokens: 39_000,
+                        cacheCreationInputTokens: 1_800,
+                        webSearchRequests: 0,
+                        costUSD: 1.2,
+                        contextWindow: 1_000_000,
+                    },
+                    'claude-haiku-4-5-20251001': {
+                        inputTokens: 100,
+                        outputTokens: 500,
+                        cacheReadInputTokens: 1_000,
+                        cacheCreationInputTokens: 200,
+                    },
+                },
+            }),
+        );
+
+        expect(processor.lastUsage?.modelUsage).toEqual({
+            'claude-opus-4-8': {
+                inputTokens: 900,
+                outputTokens: 4_500,
+                cacheReadInputTokens: 39_000,
+                cacheCreationInputTokens: 1_800,
+            },
+            'claude-haiku-4-5-20251001': {
+                inputTokens: 100,
+                outputTokens: 500,
+                cacheReadInputTokens: 1_000,
+                cacheCreationInputTokens: 200,
+            },
+        });
+        // The run-level totals are unchanged by the split.
+        expect(processor.lastUsage?.inputTokens).toBe(1_000);
+        expect(processor.lastUsage?.outputTokens).toBe(5_000);
+    });
+
+    test('leaves modelUsage absent when the CLI does not report it', () => {
+        const processor = new ClaudeStreamProcessor();
+        processor.feedChunk(resultLine());
+
+        expect(processor.lastUsage).not.toHaveProperty('modelUsage');
+    });
+
+    test('leaves modelUsage absent when it is reported but empty', () => {
+        const processor = new ClaudeStreamProcessor();
+        processor.feedChunk(resultLine({ modelUsage: {} }));
+
+        expect(processor.lastUsage).not.toHaveProperty('modelUsage');
+    });
+
     test('defaults missing numeric fields to 0 and absent text to empty string', () => {
         const processor = new ClaudeStreamProcessor();
         const events = processor.feedChunk(
@@ -155,6 +212,59 @@ describe('ClaudeStreamProcessor turn timeline', () => {
 });
 
 describe('addClaudeUsage', () => {
+    test('sums the per-model split across runs and keeps models only one side saw', () => {
+        const a: ClaudeGenerationUsage = {
+            ...ZERO_CLAUDE_USAGE,
+            inputTokens: 10,
+            modelUsage: {
+                'claude-opus-4-8': {
+                    inputTokens: 10,
+                    outputTokens: 20,
+                    cacheReadInputTokens: 30,
+                    cacheCreationInputTokens: 40,
+                },
+            },
+        };
+        const b: ClaudeGenerationUsage = {
+            ...ZERO_CLAUDE_USAGE,
+            inputTokens: 1,
+            modelUsage: {
+                'claude-opus-4-8': {
+                    inputTokens: 1,
+                    outputTokens: 2,
+                    cacheReadInputTokens: 3,
+                    cacheCreationInputTokens: 4,
+                },
+                'claude-haiku-4-5-20251001': {
+                    inputTokens: 5,
+                    outputTokens: 6,
+                    cacheReadInputTokens: 7,
+                    cacheCreationInputTokens: 8,
+                },
+            },
+        };
+
+        expect(addClaudeUsage(a, b).modelUsage).toEqual({
+            'claude-opus-4-8': {
+                inputTokens: 11,
+                outputTokens: 22,
+                cacheReadInputTokens: 33,
+                cacheCreationInputTokens: 44,
+            },
+            'claude-haiku-4-5-20251001': {
+                inputTokens: 5,
+                outputTokens: 6,
+                cacheReadInputTokens: 7,
+                cacheCreationInputTokens: 8,
+            },
+        });
+        // A side without a split contributes nothing and does not add the key.
+        expect(
+            addClaudeUsage(ZERO_CLAUDE_USAGE, ZERO_CLAUDE_USAGE),
+        ).not.toHaveProperty('modelUsage');
+        expect(addClaudeUsage(a, null).modelUsage).toEqual(a.modelUsage);
+    });
+
     const usage = (n: number): ClaudeGenerationUsage => ({
         inputTokens: n,
         outputTokens: n,

--- a/packages/backend/src/ee/services/AppGenerateService/ClaudeStreamProcessor.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/ClaudeStreamProcessor.ts
@@ -15,6 +15,13 @@
  * needed to decompose `generateMs` into "too much output" vs "too many turns"
  * and to confirm prompt caching is landing (`cacheReadInputTokens > 0`).
  */
+export type ClaudeModelUsage = {
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadInputTokens: number;
+    cacheCreationInputTokens: number;
+};
+
 export type ClaudeGenerationUsage = {
     inputTokens: number;
     outputTokens: number;
@@ -23,6 +30,15 @@ export type ClaudeGenerationUsage = {
     numTurns: number;
     durationApiMs: number;
     costUsd: number;
+    /**
+     * Per-model split of the token counts, keyed by the concrete model id the
+     * CLI actually called (e.g. `claude-opus-4-8`), from the result event's
+     * `modelUsage`. The run is launched with a tier alias (`--model opus`)
+     * that the CLI resolves itself, and a run can fan out to a second model
+     * for subagents, so this is the only place the real model is known.
+     * Absent on CLI versions that don't report it.
+     */
+    modelUsage?: Record<string, ClaudeModelUsage>;
 };
 
 export const ZERO_CLAUDE_USAGE: ClaudeGenerationUsage = {
@@ -51,6 +67,34 @@ export const ZERO_CLAUDE_GENERATION_TELEMETRY: ClaudeGenerationTelemetry = {
     attemptCount: 0,
 };
 
+function addClaudeModelUsage(
+    a: Record<string, ClaudeModelUsage> | undefined,
+    b: Record<string, ClaudeModelUsage> | undefined,
+): Record<string, ClaudeModelUsage> | undefined {
+    if (!a && !b) return undefined;
+    const merged: Record<string, ClaudeModelUsage> = {};
+    for (const source of [a, b]) {
+        for (const [modelId, usage] of Object.entries(source ?? {})) {
+            const current = merged[modelId] ?? {
+                inputTokens: 0,
+                outputTokens: 0,
+                cacheReadInputTokens: 0,
+                cacheCreationInputTokens: 0,
+            };
+            merged[modelId] = {
+                inputTokens: current.inputTokens + usage.inputTokens,
+                outputTokens: current.outputTokens + usage.outputTokens,
+                cacheReadInputTokens:
+                    current.cacheReadInputTokens + usage.cacheReadInputTokens,
+                cacheCreationInputTokens:
+                    current.cacheCreationInputTokens +
+                    usage.cacheCreationInputTokens,
+            };
+        }
+    }
+    return merged;
+}
+
 /**
  * Sum two usage records field-by-field. One build can invoke `claude` several
  * times (main generation, build-fix re-runs, metadata), so the pipeline totals
@@ -61,6 +105,7 @@ export function addClaudeUsage(
     b: ClaudeGenerationUsage | null,
 ): ClaudeGenerationUsage {
     if (!b) return a;
+    const modelUsage = addClaudeModelUsage(a.modelUsage, b.modelUsage);
     return {
         inputTokens: a.inputTokens + b.inputTokens,
         outputTokens: a.outputTokens + b.outputTokens,
@@ -70,6 +115,7 @@ export function addClaudeUsage(
         numTurns: a.numTurns + b.numTurns,
         durationApiMs: a.durationApiMs + b.durationApiMs,
         costUsd: a.costUsd + b.costUsd,
+        ...(modelUsage ? { modelUsage } : {}),
     };
 }
 
@@ -244,6 +290,36 @@ function asFiniteNumber(value: unknown): number {
 }
 
 /**
+ * Parse the result event's `modelUsage` map (`{ [modelId]: { inputTokens,
+ * outputTokens, cacheReadInputTokens, cacheCreationInputTokens, ... } }`).
+ * Returns `undefined` when the CLI didn't report it or reported nothing usable,
+ * so callers fall back to the alias the run was launched with.
+ */
+function parseModelUsage(
+    raw: unknown,
+): Record<string, ClaudeModelUsage> | undefined {
+    if (!raw || typeof raw !== 'object') return undefined;
+    const parsed: Record<string, ClaudeModelUsage> = {};
+    Object.entries(raw as Record<string, unknown>).forEach(
+        ([modelId, value]) => {
+            if (!modelId || !value || typeof value !== 'object') return;
+            const fields = value as Record<string, unknown>;
+            parsed[modelId] = {
+                inputTokens: asFiniteNumber(fields.inputTokens),
+                outputTokens: asFiniteNumber(fields.outputTokens),
+                cacheReadInputTokens: asFiniteNumber(
+                    fields.cacheReadInputTokens,
+                ),
+                cacheCreationInputTokens: asFiniteNumber(
+                    fields.cacheCreationInputTokens,
+                ),
+            };
+        },
+    );
+    return Object.keys(parsed).length > 0 ? parsed : undefined;
+}
+
+/**
  * Parse a stream-json `result` event: the final response text plus the run's
  * usage summary (token counts, turn count, API time, cost). Returns
  * `undefined` for non-result lines. Missing numeric fields default to 0 —
@@ -265,6 +341,7 @@ function parseResult(line: string):
     }
     if (event.type !== 'result') return undefined;
     const usage = (event.usage ?? {}) as Record<string, unknown>;
+    const modelUsage = parseModelUsage(event.modelUsage);
     return {
         text: typeof event.result === 'string' ? event.result : null,
         // Populated only when the run was invoked with `--json-schema`; the CLI
@@ -281,6 +358,7 @@ function parseResult(line: string):
             numTurns: asFiniteNumber(event.num_turns),
             durationApiMs: asFiniteNumber(event.duration_api_ms),
             costUsd: asFiniteNumber(event.total_cost_usd),
+            ...(modelUsage ? { modelUsage } : {}),
         },
     };
 }

--- a/packages/backend/src/ee/services/ai/models/index.test.ts
+++ b/packages/backend/src/ee/services/ai/models/index.test.ts
@@ -177,8 +177,11 @@ describe('getModel', () => {
         expect(wrapLanguageModel).not.toHaveBeenCalled();
     });
 
-    it('stamps lightdash-managed when the resolved provider is not BYO', () => {
-        const { keyManagement } = getModel(copilotConfigWithStreaming(true));
+    it('stamps lightdash-managed when the resolved provider is declared Lightdash-managed and not BYO', () => {
+        const { keyManagement } = getModel({
+            ...copilotConfigWithStreaming(true),
+            lightdashManagedProviders: ['openai'],
+        });
         expect(keyManagement).toBe('lightdash-managed');
     });
 
@@ -193,6 +196,7 @@ describe('getModel', () => {
     it('stamps lightdash-managed when a different provider is BYO', () => {
         const { keyManagement } = getModel({
             ...copilotConfigWithStreaming(true),
+            lightdashManagedProviders: ['openai'],
             byoProviders: ['anthropic'],
         });
         expect(keyManagement).toBe('lightdash-managed');
@@ -357,20 +361,37 @@ describe('getModel', () => {
         expect(model.modelId).toBe('jp.anthropic.claude-opus-5');
     });
 
-    it('stamps self-managed when the resolved provider is instance self-managed', () => {
+    it('stamps lightdash-managed only when Lightdash infrastructure declared the provider', () => {
         const { keyManagement } = getModel({
             ...copilotConfigWithStreaming(true),
-            selfManagedProviders: ['openai'],
+            lightdashManagedProviders: ['openai'],
+        });
+        expect(keyManagement).toBe('lightdash-managed');
+    });
+
+    it('stamps self-managed when the resolved provider is not declared as Lightdash-managed', () => {
+        const { keyManagement } = getModel({
+            ...copilotConfigWithStreaming(true),
+            lightdashManagedProviders: ['anthropic'],
         });
         expect(keyManagement).toBe('self-managed');
     });
 
-    it('stamps lightdash-managed when a different provider is instance self-managed', () => {
+    it('stamps self-managed by default (self-hosted, or a dedicated instance on a customer key)', () => {
         const { keyManagement } = getModel({
             ...copilotConfigWithStreaming(true),
-            selfManagedProviders: ['anthropic'],
+            lightdashManagedProviders: [],
         });
-        expect(keyManagement).toBe('lightdash-managed');
+        expect(keyManagement).toBe('self-managed');
+    });
+
+    it('stamps self-managed for an org UI key even when the instance key is Lightdash-managed', () => {
+        const { keyManagement } = getModel({
+            ...copilotConfigWithStreaming(true),
+            lightdashManagedProviders: ['openai'],
+            byoProviders: ['openai'],
+        });
+        expect(keyManagement).toBe('self-managed');
     });
 
     it('wraps the model with simulateStreamingMiddleware when the provider does not support streaming', () => {

--- a/packages/backend/src/ee/services/ai/models/index.ts
+++ b/packages/backend/src/ee/services/ai/models/index.ts
@@ -37,26 +37,36 @@ export { MODEL_PRESETS };
 /**
  * Copilot config as consumed by the model builders. `byoProviders` is stamped
  * by the resolver (OrgAiCopilotConfigResolver) listing the providers whose
- * apiKey came from the org's own self-managed key; absent/empty for the
- * instance (Lightdash-managed) config. Optional so the raw instance config is
- * still a valid input (it resolves to Lightdash-managed). Instance-level
- * customer-owned keys are declared separately via
- * `selfManagedProviders` (AI_COPILOT_SELF_MANAGED_PROVIDERS) on the config
- * itself.
+ * apiKey came from the org's own key entered in the UI; absent/empty when the
+ * org falls through to the instance config. Whether an instance key is
+ * Lightdash's is declared by Lightdash infrastructure via
+ * `lightdashManagedProviders` (AI_COPILOT_LIGHTDASH_MANAGED_PROVIDERS); any
+ * key not declared there is the customer's.
  */
 export type CopilotConfigForModel = LightdashConfig['ai']['copilot'] & {
     byoProviders?: ByoAiProvider[];
 };
 
+/**
+ * Who pays for the key that serves a call. A key the org entered in the UI is
+ * always the customer's. An instance key is Lightdash's only when Lightdash
+ * infrastructure has declared the provider in `lightdashManagedProviders`;
+ * otherwise (self-hosted installs, dedicated instances running on a
+ * customer's key) it is the customer's. The default therefore errs towards
+ * self-managed: a missing declaration under-reports Lightdash's spend, which
+ * the console reconciliation catches, rather than silently billing customers'
+ * usage to Lightdash.
+ */
 export const resolveKeyManagement = (
     config: CopilotConfigForModel,
     provider: AiProvider,
 ): AiKeyManagement =>
-    (isByoAiProvider(provider) &&
-        (config.byoProviders ?? []).includes(provider)) ||
-    (config.selfManagedProviders ?? []).includes(provider)
-        ? 'self-managed'
-        : 'lightdash-managed';
+    !(
+        isByoAiProvider(provider) &&
+        (config.byoProviders ?? []).includes(provider)
+    ) && (config.lightdashManagedProviders ?? []).includes(provider)
+        ? 'lightdash-managed'
+        : 'self-managed';
 
 const withKeyManagement = <P extends AiProvider>(
     modelProperties: AiModel<P>,


### PR DESCRIPTION
Closes: —

### Description:

Follow-up to #28548. Reconciling `ai_usage` events against the Anthropic console **token** export (cloud key, per model, per token class) now matches to the token on clean days (2026-09-06: opus-5, opus-4-7, sonnet-5, sonnet-4-6, all four classes delta 0). What's left is producer-side. A prompt-level join showed every prompt already emits a usage event (1182/1180, 129/129, 105/103 prompts created vs prompts with usage on 09-04/05/06), so these are attribution errors and missing call sites, not lost prompts.

**1. Key origin was guessed, and guessed wrong for every self-hosted install.** `resolveKeyManagement` returned `lightdash-managed` for any provider the org hadn't keyed in the UI and the instance hadn't declared in `AI_COPILOT_SELF_MANAGED_PROVIDERS`. Self-hosted installs never set that var, so every call on a customer's own instance key was reported as running on Lightdash's key — 29 self-hosted orgs over the last 14 days (Octopus ×4, Doppel, Norm AI, doccla, Model ML, UpLearn, …), including orgs on Bedrock and Azure keys we don't have.

The party that knows whose key an instance runs on is whoever installed it, and on Lightdash Cloud that is Lightdash's own infra. So the declaration is inverted: `AI_COPILOT_SELF_MANAGED_PROVIDERS` is replaced by **`AI_COPILOT_LIGHTDASH_MANAGED_PROVIDERS`**, set only by Lightdash infrastructure (lightdash/lightdash-cloud derives it per deployment from the existing `aiSelfManagedProviders` declaration), and the default is self-managed everywhere:

| | result |
|---|---|
| org keyed the provider in the UI | self-managed (unchanged) |
| provider in `AI_COPILOT_LIGHTDASH_MANAGED_PROVIDERS` | lightdash-managed |
| anything else — self-hosted, dedicated instance on a customer key, undeclared | self-managed |

Nothing for self-hosters to configure. A missing declaration now under-reports Lightdash's spend, which the console reconciliation catches within a day, instead of silently attributing customers' usage to Lightdash's key. The data-app pipeline's usage fallback hardcoded `'lightdash-managed'` when a job carried no key origin; it now applies the same rule. `parseConfig` and `models/index` tests cover the branches.

**Rollout**: ship together with lightdash/lightdash-cloud (companion PR sets the env var on every cloud deployment). Until the infra change is live, cloud usage reports as self-managed — visible, and reversible.

**2. Data-app usage is logged under the tier alias the run was launched with (`opus`, `sonnet`), not the model that ran.** The `claude` CLI resolves the alias itself — to opus-4-8 in some sandbox templates and opus-5 in others — and can fan out to a second model for subagents. Anthropic bills by the concrete model, which is why `claude-opus-4-8` shows up on the cloud key with zero events (2.4M cache-read tokens on 09-04, 4.6M on 09-07). `ClaudeStreamProcessor` now parses the result event's `modelUsage` map, `addClaudeUsage` sums it across attempts, and `emitDataAppAiUsage` emits one usage event per concrete model (alias kept in `extra.codingAgentModel`). Falls back to the alias when the CLI doesn't report the split, so older templates are unchanged.

**3. `generateDeliverySummary` called `generateText` with no telemetry**, so scheduled-delivery summaries never reached `ai_usage`. Wired `getGeneratorTelemetry` with a new `'delivery-summary'` feature. This is the haiku shortfall (uncached + output short 1–3%/day, cache classes exact — a non-caching call site).

**4. `AiRouterService.selectAgent` didn't pass `keyManagement`**, so every `agent-selector` call landed in the null key bucket. Passed from `getModel`, same as `AiAgentService` already does.

Not addressed here: the bursty, uniform-across-all-classes shortfall on agent models (e.g. opus-4-7 -14…-26% on 09-05, exact on 09-06). Prompts aren't missing, so it's requests inside a prompt the telemetry span never finishes — mid-stream failures or aborts — which Anthropic bills for the partial. Tracked in GLITCH-758 (transport-level accounting).

Validation: `tsc --noEmit` clean for backend, `oxlint` clean and `oxfmt` applied on the changed files; `parseConfig.test.ts`, `models/index.test.ts`, `ClaudeStreamProcessor.test.ts`, `AppGenerateService.clarifyApp/promoteApp.test.ts`, `OrgAiCopilotConfigResolver.test.ts`, `aiUsage.test.ts` pass, with new cases for the declaration rule, the `modelUsage` parse, the absent/empty fallbacks, and the per-model merge.

### Risk assessment:

- [ ] This is a high-risk change

Telemetry only. `lightdashManagedProviders` steers nothing but the key-origin stamp (not read for routing). The per-model path changes how many `ai_usage` events a data-app generation emits (one per model instead of one per run); totals are unchanged and the warehouse sums per model. Nothing user-facing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tp8M68N7udfbPdgTtoRhrJ