### PR TITLE
perf(common): keep dbt manifest schemas out of the barrel

### DIFF
--- a/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.ts
@@ -23,7 +23,6 @@ import {
     isSupportedDbtAdapter,
     loadLightdashProjectConfig,
     loadProjectContextFile,
-    ManifestValidator,
     MissingCatalogEntryError,
     normaliseModelDatabase,
     NotFoundError,
@@ -34,6 +33,7 @@ import {
     type LightdashProjectConfig,
     type ProjectContextEntry,
 } from '@lightdash/common';
+import { ManifestValidator } from '@lightdash/common/dbt/validation';
 import { WarehouseClient } from '@lightdash/warehouses';
 import * as Sentry from '@sentry/node';
 import fs from 'fs/promises';

--- a/packages/backend/src/services/ProjectService/projectMergedManifest.test.ts
+++ b/packages/backend/src/services/ProjectService/projectMergedManifest.test.ts
@@ -4,10 +4,10 @@ import {
     DEFAULT_SPOTLIGHT_CONFIG,
     DimensionType,
     getModelsFromManifest,
-    ManifestValidator,
     SupportedDbtAdapter,
     type DbtManifest,
 } from '@lightdash/common';
+import { ManifestValidator } from '@lightdash/common/dbt/validation';
 import { warehouseClientMock } from '../../utils/QueryBuilder/MetricQueryBuilder.mock';
 import { projectMergedManifest } from './projectMergedManifest';
 

--- a/packages/cli/src/dbt/validation.test.ts
+++ b/packages/cli/src/dbt/validation.test.ts
@@ -1,9 +1,9 @@
 import {
     DbtManifestVersion,
     InlineErrorType,
-    ManifestValidator,
     type DbtRawModelNode,
 } from '@lightdash/common';
+import { ManifestValidator } from '@lightdash/common/dbt/validation';
 import { validateDbtModel } from './validation';
 
 const makeModel = (name: string): DbtRawModelNode =>

--- a/packages/cli/src/dbt/validation.ts
+++ b/packages/cli/src/dbt/validation.ts
@@ -5,11 +5,11 @@ import {
     friendlyName,
     InlineError,
     InlineErrorType,
-    ManifestValidator,
     normaliseModelDatabase,
     SupportedDbtAdapter,
     type DbtManifestVersion,
 } from '@lightdash/common';
+import { ManifestValidator } from '@lightdash/common/dbt/validation';
 import GlobalState from '../globalState';
 
 type DbtModelsGroupedByState = {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -12,6 +12,24 @@
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/esm/index.d.ts",
+      "require": "./dist/cjs/index.js",
+      "import": "./dist/esm/index.js",
+      "default": "./dist/esm/index.js"
+    },
+    "./dbt/validation": {
+      "types": "./dist/esm/dbt/validation.d.ts",
+      "require": "./dist/cjs/dbt/validation.js",
+      "import": "./dist/esm/dbt/validation.js",
+      "default": "./dist/esm/dbt/validation.js"
+    },
+    "./src": "./src/index.ts",
+    "./src/*": "./src/*",
+    "./dist/*": "./dist/*",
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "dev": "tsc --build --watch --preserveWatchOutput ./tsconfig.build.json",
     "build": "tsc --build ./tsconfig.build.json",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -28,7 +28,11 @@
       "default": "./dist/cjs/dbt/validation.js"
     },
     "./src": "./src/index.ts",
-    "./src/*": "./src/*",
+    "./src/*": [
+      "./src/*.ts",
+      "./src/*.tsx",
+      "./src/*"
+    ],
     "./dist/*": "./dist/*",
     "./package.json": "./package.json"
   },

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -15,15 +15,17 @@
   "exports": {
     ".": {
       "types": "./dist/esm/index.d.ts",
+      "module": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js",
-      "import": "./dist/esm/index.js",
-      "default": "./dist/esm/index.js"
+      "import": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
     },
     "./dbt/validation": {
       "types": "./dist/esm/dbt/validation.d.ts",
+      "module": "./dist/esm/dbt/validation.js",
       "require": "./dist/cjs/dbt/validation.js",
-      "import": "./dist/esm/dbt/validation.js",
-      "default": "./dist/esm/dbt/validation.js"
+      "import": "./dist/cjs/dbt/validation.js",
+      "default": "./dist/cjs/dbt/validation.js"
     },
     "./src": "./src/index.ts",
     "./src/*": "./src/*",

--- a/packages/common/src/index.barrel.test.ts
+++ b/packages/common/src/index.barrel.test.ts
@@ -1,0 +1,72 @@
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Guards the barrel's eager payload (#28697): `dbt/validation.ts` imports ~3.6 MB
+ * of dbt JSON schemas at module top level, and re-exporting it from `index.ts`
+ * made every frontend page — the signed-out login page included — load them.
+ * Only the backend and CLI validate manifests, via `@lightdash/common/dbt/validation`.
+ */
+const SRC = __dirname;
+const EXTENSIONS = ['.ts', '.tsx', '.json', '/index.ts', '/index.tsx'];
+
+const resolveSpecifier = (fromFile: string, specifier: string): string | null => {
+    const base = path.resolve(path.dirname(fromFile), specifier);
+    if (fs.existsSync(base) && fs.statSync(base).isFile()) return base;
+    for (const ext of EXTENSIONS) {
+        const candidate = `${base}${ext}`;
+        if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+            return candidate;
+        }
+    }
+    return null;
+};
+
+// Static `import ... from '...'`, `export ... from '...'` and bare `import '...'`.
+// Type-only forms are elided by the compiler, so they cost nothing at runtime.
+const STATIC_SPECIFIER =
+    /(?:^|\n)\s*(?:import|export)\s+(?!type\s)(?:[^;'"]*?\sfrom\s+)?['"](\.[^'"]*)['"]/g;
+
+const collectReachableModules = (entry: string): Set<string> => {
+    const seen = new Set<string>();
+    const queue = [entry];
+    while (queue.length > 0) {
+        const file = queue.pop()!;
+        if (seen.has(file)) continue;
+        seen.add(file);
+        if (file.endsWith('.json')) continue;
+
+        const source = fs.readFileSync(file, 'utf8');
+        for (const match of source.matchAll(STATIC_SPECIFIER)) {
+            const resolved = resolveSpecifier(file, match[1]!);
+            if (resolved !== null) queue.push(resolved);
+        }
+    }
+    return seen;
+};
+
+describe('@lightdash/common barrel eager payload (#28697)', () => {
+    const reachable = collectReachableModules(path.join(SRC, 'index.ts'));
+    const reachableJson = [...reachable].filter((f) => f.endsWith('.json'));
+
+    it('does not reach the dbt manifest schemas', () => {
+        const dbtSchemas = reachableJson
+            .filter((f) => f.includes(`${path.sep}dbt${path.sep}schemas${path.sep}`))
+            .map((f) => path.relative(SRC, f));
+
+        expect(dbtSchemas).toEqual([]);
+    });
+
+    it('does not reach dbt/validation', () => {
+        expect(reachable).not.toContain(path.join(SRC, 'dbt', 'validation.ts'));
+    });
+
+    it('keeps the eagerly imported JSON under budget', () => {
+        const totalBytes = reachableJson.reduce(
+            (total, file) => total + fs.statSync(file).size,
+            0,
+        );
+
+        expect(totalBytes).toBeLessThan(512 * 1024);
+    });
+});

--- a/packages/common/src/index.barrel.test.ts
+++ b/packages/common/src/index.barrel.test.ts
@@ -10,7 +10,10 @@ import path from 'path';
 const SRC = __dirname;
 const EXTENSIONS = ['.ts', '.tsx', '.json', '/index.ts', '/index.tsx'];
 
-const resolveSpecifier = (fromFile: string, specifier: string): string | null => {
+const resolveSpecifier = (
+    fromFile: string,
+    specifier: string,
+): string | null => {
     const base = path.resolve(path.dirname(fromFile), specifier);
     if (fs.existsSync(base) && fs.statSync(base).isFile()) return base;
     for (const ext of EXTENSIONS) {
@@ -32,14 +35,15 @@ const collectReachableModules = (entry: string): Set<string> => {
     const queue = [entry];
     while (queue.length > 0) {
         const file = queue.pop()!;
-        if (seen.has(file)) continue;
-        seen.add(file);
-        if (file.endsWith('.json')) continue;
-
-        const source = fs.readFileSync(file, 'utf8');
-        for (const match of source.matchAll(STATIC_SPECIFIER)) {
-            const resolved = resolveSpecifier(file, match[1]!);
-            if (resolved !== null) queue.push(resolved);
+        if (!seen.has(file)) {
+            seen.add(file);
+            if (!file.endsWith('.json')) {
+                const source = fs.readFileSync(file, 'utf8');
+                for (const match of source.matchAll(STATIC_SPECIFIER)) {
+                    const resolved = resolveSpecifier(file, match[1]!);
+                    if (resolved !== null) queue.push(resolved);
+                }
+            }
         }
     }
     return seen;
@@ -51,7 +55,9 @@ describe('@lightdash/common barrel eager payload (#28697)', () => {
 
     it('does not reach the dbt manifest schemas', () => {
         const dbtSchemas = reachableJson
-            .filter((f) => f.includes(`${path.sep}dbt${path.sep}schemas${path.sep}`))
+            .filter((f) =>
+                f.includes(`${path.sep}dbt${path.sep}schemas${path.sep}`),
+            )
             .map((f) => path.relative(SRC, f));
 
         expect(dbtSchemas).toEqual([]);

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -81,7 +81,8 @@ export { default as DbtSchemaEditor } from './dbt/DbtSchemaEditor/DbtSchemaEdito
 export * from './dbt/manifest';
 export * from './dbt/metricFlow';
 export * from './dbt/projectMergedManifest';
-export * from './dbt/validation';
+// './dbt/validation' is not re-exported: it eagerly imports ~3.6 MB of dbt JSON
+// schemas. Import it from '@lightdash/common/dbt/validation' instead.
 export * from './ee';
 export * from './preAggregates';
 export * from './pivot/derivePivotConfigFromChart';

--- a/packages/common/src/packageExports.test.ts
+++ b/packages/common/src/packageExports.test.ts
@@ -7,18 +7,18 @@ import path from 'path';
  * Node must land on `dist/cjs` through both `import` and `require`; bundlers
  * pick up `dist/esm` via the `module` condition, which Node ignores.
  */
-type ConditionalExport = Record<string, string>;
+type ExportTarget = string | string[] | Record<string, string>;
 
 const packageJson = JSON.parse(
     fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8'),
-) as { exports: Record<string, ConditionalExport | string> };
+) as { exports: Record<string, ExportTarget> };
+
+const conditionalEntries = Object.entries(packageJson.exports).filter(
+    (entry): entry is [string, Record<string, string>] =>
+        typeof entry[1] === 'object' && !Array.isArray(entry[1]),
+);
 
 describe('@lightdash/common exports map', () => {
-    const conditionalEntries = Object.entries(packageJson.exports).filter(
-        (entry): entry is [string, ConditionalExport] =>
-            typeof entry[1] === 'object',
-    );
-
     it('covers the entry points the workspace imports', () => {
         expect(Object.keys(packageJson.exports)).toEqual([
             '.',
@@ -56,4 +56,14 @@ describe('@lightdash/common exports map', () => {
             );
         },
     );
+
+    // Callers write `@lightdash/common/src/pivot/pivotQueryResults`; without the
+    // extension candidates the map resolves to a path that has no file.
+    it('resolves extensionless source subpaths', () => {
+        expect(packageJson.exports['./src/*']).toEqual([
+            './src/*.ts',
+            './src/*.tsx',
+            './src/*',
+        ]);
+    });
 });

--- a/packages/common/src/packageExports.test.ts
+++ b/packages/common/src/packageExports.test.ts
@@ -1,0 +1,59 @@
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * `dist/esm` is a bundler-only build: tsc emits extensionless relative
+ * specifiers and bare JSON imports, so Node's ESM loader cannot read it.
+ * Node must land on `dist/cjs` through both `import` and `require`; bundlers
+ * pick up `dist/esm` via the `module` condition, which Node ignores.
+ */
+type ConditionalExport = Record<string, string>;
+
+const packageJson = JSON.parse(
+    fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8'),
+) as { exports: Record<string, ConditionalExport | string> };
+
+describe('@lightdash/common exports map', () => {
+    const conditionalEntries = Object.entries(packageJson.exports).filter(
+        (entry): entry is [string, ConditionalExport] =>
+            typeof entry[1] === 'object',
+    );
+
+    it('covers the entry points the workspace imports', () => {
+        expect(Object.keys(packageJson.exports)).toEqual([
+            '.',
+            './dbt/validation',
+            './src',
+            './src/*',
+            './dist/*',
+            './package.json',
+        ]);
+    });
+
+    it.each(conditionalEntries)(
+        'sends Node to dist/cjs for "%s"',
+        (_, conditions) => {
+            expect(conditions.require).toMatch(/^\.\/dist\/cjs\//);
+            expect(conditions.import).toMatch(/^\.\/dist\/cjs\//);
+            expect(conditions.default).toMatch(/^\.\/dist\/cjs\//);
+        },
+    );
+
+    it.each(conditionalEntries)(
+        'sends bundlers to dist/esm for "%s"',
+        (_, conditions) => {
+            expect(conditions.module).toMatch(/^\.\/dist\/esm\//);
+            expect(conditions.types).toMatch(/^\.\/dist\/esm\/.*\.d\.ts$/);
+        },
+    );
+
+    it.each(conditionalEntries)(
+        'matches "module" before "import" for "%s"',
+        (_, conditions) => {
+            const order = Object.keys(conditions);
+            expect(order.indexOf('module')).toBeLessThan(
+                order.indexOf('import'),
+            );
+        },
+    );
+});


### PR DESCRIPTION
Closes: #28697

### Description:

`packages/common/src/index.ts` re-exported `./dbt/validation`, which imports 15 dbt JSON schemas at module top level. Every frontend page — the signed-out login page included — pulled 3.6 MB of schemas it never uses; only the backend and CLI validate manifests.

Adds an `exports` map to `@lightdash/common` with a `./dbt/validation` subpath, drops the barrel re-export, and moves the backend and CLI onto the subpath. Deep imports the workspace already relies on (`./src`, `./dist`, `./package.json`) are declared in the map so they keep resolving — the backend's oxlint rule bans `@lightdash/common/src` in runtime code, which is why the subpath rather than a deep source import.

Walking the barrel's static import graph, eagerly reachable JSON drops from **4,045,947 to 373,876 bytes** and the 15 dbt manifest schemas drop out entirely. `index.barrel.test.ts` guards that.

Two things an `exports` map changes that needed handling, each with a guard in `packageExports.test.ts`:

- `dist/esm` is a bundler-only build (tsc emits extensionless relative specifiers and bare JSON imports), so Node's ESM loader cannot read it. Before the map, Node fell back to `main` → `dist/cjs`. The map now sends `import`/`require`/`default` to `dist/cjs` and gives bundlers `dist/esm` through the `module` condition, which Node ignores.
- Exports targets get no extension substitution, so `./src/*` needs `.ts`/`.tsx` candidates ahead of the literal target for `@lightdash/common/src/pivot/pivotQueryResults` and friends to resolve.

Verified: common/warehouses/formula/query-sdk builds; frontend production build (bundle resolves common through `dist/esm`, contains no dbt schemas or `ManifestValidator`); backend, cli, common and frontend typecheck; full common suite (177 files, 4128 tests); the touched backend and cli tests; lint and format across common, backend and cli; and Node `import`/`require` of both the barrel and the new subpath.

Not in scope, still open on the issue: the `./ee` re-export and a `sideEffects` declaration.

### Risk assessment:

- [ ] This is a high-risk change

Backwards-compatible for every consumer in the workspace and covered by the checks above. It does remove `ManifestValidator` from the published `@lightdash/common` barrel and narrows arbitrary deep imports of the package, so it may warrant a release-safety declaration — flagging for the reviewer rather than declaring unilaterally, since a declaration holds self-hosted upgrades.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SMtPK3hd85oC2ZRpXZ95FC

---
_Generated by [Claude Code](https://claude.ai/code/session_01SMtPK3hd85oC2ZRpXZ95FC)_