### PR TITLE
fix(dashboard): exclude registry metrics shadowed by real explore fields

### DIFF
--- a/packages/common/src/utils/additionalMetrics.test.ts
+++ b/packages/common/src/utils/additionalMetrics.test.ts
@@ -383,6 +383,20 @@ describe('getCompatibleDashboardMetrics', () => {
         expect(result.map((m) => m.name)).toEqual(['custom_metric']);
     });
 
+    it('excludes metrics shadowed by a real explore field with the same id', () => {
+        const result = getCompatibleDashboardMetrics(
+            [
+                // Shadowed by the explore metric orders.total_amount
+                metric({ name: 'total_amount' }),
+                // Shadowed by the explore dimension orders.amount
+                metric({ name: 'amount' }),
+                metric({ name: 'not_shadowed' }),
+            ],
+            explore,
+        );
+        expect(result.map((m) => m.name)).toEqual(['not_shadowed']);
+    });
+
     it('requires every distinctKeys field to exist', () => {
         const result = getCompatibleDashboardMetrics(
             [

--- a/packages/common/src/utils/additionalMetrics.ts
+++ b/packages/common/src/utils/additionalMetrics.ts
@@ -143,6 +143,11 @@ const isMetricCompatibleWithExplore = (
 ): boolean => {
     const table = explore.tables[metric.table];
     if (!table) return false;
+    // Shadowed by a real field with the same id (e.g. after write-back was
+    // merged into dbt): offering it would duplicate the field id.
+    if (table.metrics[metric.name] || table.dimensions[metric.name]) {
+        return false;
+    }
     if (
         metric.baseDimensionName &&
         !table.dimensions[metric.baseDimensionName]


### PR DESCRIPTION
Closes: GLITCH-760
Relates: GLITCH-735

### Description:

If a dbt model gains a metric or dimension with the same `(table, name)` as a registry custom metric — exactly what the write-back → PR merge → dbt refresh path produces — seeding would offer a duplicate field id, and the ghost copy would be offered forever.

One guard in `getCompatibleDashboardMetrics`: a registry entry shadowed by a real field on its owning table is not offered (so it also loses the `=` badge surface). Charts already holding a snapshot are untouched per snapshot-wins. Partial mitigation of GLITCH-735 — compile-time registry reconciliation remains that ticket.

Unit tests cover shadowing by a metric, by a dimension, and the non-shadowed case (21/21).

### Risk assessment:

- [ ] This is a high-risk change

High-risk changes require approval from a reviewer other than the author before merging.