### PR TITLE
feat: attribute data app uninstall and fork events to registry source

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -1936,6 +1936,21 @@ export type DataAppDuplicatedEvent = BaseTrack & {
         appUuid: string;
         duplicatedFromAppUuid: string;
         duplicatedFromVersion: number;
+        // Non-null = fork of a registry-installed official chart type.
+        duplicatedFromRegistrySlug: string | null;
+    };
+};
+
+export type DataAppDeletedEvent = BaseTrack & {
+    event: 'data_app.deleted';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        appUuid: string;
+        softDelete: boolean;
+        // Non-null = uninstall of a registry-installed official chart type.
+        registrySlug: string | null;
     };
 };
 
@@ -2049,6 +2064,7 @@ export type DataAppEvent =
     | DataAppViewedEvent
     | DataAppVersionRestoredEvent
     | DataAppDuplicatedEvent
+    | DataAppDeletedEvent
     | DataAppPromotedEvent
     | DataAppDownloadedEvent
     | DataAppUploadedEvent

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -7932,6 +7932,7 @@ export class AppGenerateService extends BaseService {
                 appUuid: newAppUuid,
                 duplicatedFromAppUuid: sourceApp.app_id,
                 duplicatedFromVersion: sourceVersion.version,
+                duplicatedFromRegistrySlug: sourceApp.registry_slug,
             },
         });
 
@@ -9446,6 +9447,7 @@ export class AppGenerateService extends BaseService {
                 projectId: projectUuid,
                 appUuid,
                 softDelete: softDeleteEnabled,
+                registrySlug: app.registry_slug,
             },
         });
     }
@@ -9538,6 +9540,7 @@ export class AppGenerateService extends BaseService {
                 projectId: projectUuid,
                 appUuid,
                 softDelete: false,
+                registrySlug: app.registry_slug,
             },
         });
     }


### PR DESCRIPTION
Closes: [GLITCH-761](https://linear.app/lightdash/issue/GLITCH-761)

### Description:

Install/upgrade of registry chart types is already attributable (`data_app.registry_installed` carries `chartSlug`), but uninstall and fork fired generic events that couldn't be tied back to the source registry chart. This adds two purely additive event properties:

- `data_app.deleted` now carries `registrySlug: string | null` — non-null means the deleted app was a registry-installed official chart type. Both delete paths (soft/permanent via `deleteApp`, and `permanentDeleteApp`) are covered; the app row is already loaded at both call sites, so no extra query.
- `data_app.duplicated` now carries `duplicatedFromRegistrySlug: string | null` — non-null means the duplicate is a fork of an official chart type.

Also promotes `data_app.deleted` from an untyped event to a typed `DataAppDeletedEvent` in `LightdashAnalytics.ts`, so its payload is now compile-time checked like the rest of the data app events.

No event renames and no removed properties, so existing dashboards keep working. With this, installs, upgrades, uninstalls, and forks are all chartable per registry slug from events alone.

### Risk assessment:

- [ ] This is a high-risk change

High-risk changes require approval from a reviewer other than the author before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8sCUbSEj5R8babs36CnDN
