### PR TITLE
feat: add frontend funnel events for the chart type library

### DIFF
--- a/packages/frontend/src/features/chartTypes/components/ChartTypeDetailModal.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeDetailModal.tsx
@@ -6,12 +6,14 @@ import {
 } from '@lightdash/common';
 import { Box, Button, Group, SimpleGrid, Stack, Text } from '@mantine/core';
 import { IconFilePencil, IconGitFork, IconTrash } from '@tabler/icons-react';
-import { useState, type FC } from 'react';
+import { useEffect, useRef, useState, type FC } from 'react';
 import { Link } from 'react-router';
 import Callout from '../../../components/common/Callout';
 import MantineIcon from '../../../components/common/MantineIcon';
 import MantineModal from '../../../components/common/MantineModal';
 import { useTimeAgo } from '../../../hooks/useTimeAgo';
+import useTracking from '../../../providers/Tracking/useTracking';
+import { EventName } from '../../../types/Events';
 import { useAppVersionHistory } from '../../apps/hooks/useAppVersionHistory';
 import { useCanCreateDataApp } from '../../apps/hooks/useCanCreateDataApp';
 import { useCanEditDataApp } from '../../apps/hooks/useCanEditDataApp';
@@ -46,8 +48,25 @@ const ChartTypeDetailModal: FC<Props> = ({
     const isOfficial = isOfficialChartType(dataAppViz);
     const [isForkOpen, setIsForkOpen] = useState(false);
     const upgradeMutation = useInstallRegistryChartType();
+    const { track } = useTracking();
     const registryUpdate =
         registryEntry?.state === 'update_available' ? registryEntry : null;
+
+    const hasTrackedView = useRef(false);
+    const hasUpdate = registryUpdate !== null;
+    useEffect(() => {
+        if (hasTrackedView.current) return;
+        hasTrackedView.current = true;
+        track({
+            name: EventName.CHART_TYPE_DETAIL_VIEWED,
+            properties: {
+                projectUuid,
+                isOfficial,
+                registrySlug: dataAppViz.registrySlug,
+                hasUpdate,
+            },
+        });
+    }, [projectUuid, isOfficial, dataAppViz.registrySlug, hasUpdate, track]);
     const { latestReadyVersion, oldest, latest, hasOrigin } =
         useAppVersionHistory(projectUuid, dataAppViz.dataAppVizUuid);
 
@@ -103,7 +122,17 @@ const ChartTypeDetailModal: FC<Props> = ({
                             <Button
                                 variant="default"
                                 leftSection={<MantineIcon icon={IconGitFork} />}
-                                onClick={() => setIsForkOpen(true)}
+                                onClick={() => {
+                                    track({
+                                        name: EventName.CHART_TYPE_FORK_MODAL_OPENED,
+                                        properties: {
+                                            projectUuid,
+                                            registrySlug:
+                                                dataAppViz.registrySlug,
+                                        },
+                                    });
+                                    setIsForkOpen(true);
+                                }}
                             >
                                 Fork to customize
                             </Button>
@@ -155,12 +184,21 @@ const ChartTypeDetailModal: FC<Props> = ({
                                         size="xs"
                                         variant="default"
                                         loading={upgradeMutation.isLoading}
-                                        onClick={() =>
+                                        onClick={() => {
+                                            track({
+                                                name: EventName.CHART_TYPE_LIBRARY_INSTALL_CLICKED,
+                                                properties: {
+                                                    projectUuid,
+                                                    chartSlug:
+                                                        registryUpdate.slug,
+                                                    action: 'upgrade',
+                                                },
+                                            });
                                             upgradeMutation.mutate({
                                                 projectUuid,
                                                 chartSlug: registryUpdate.slug,
-                                            })
-                                        }
+                                            });
+                                        }}
                                     >
                                         Upgrade to v{registryUpdate.version}
                                     </Button>

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeLibraryDetailModal.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeLibraryDetailModal.tsx
@@ -20,6 +20,8 @@ import MantineModal from '../../../components/common/MantineModal';
 import { useTimeAgo } from '../../../hooks/useTimeAgo';
 import { Can } from '../../../providers/Ability';
 import useApp from '../../../providers/App/useApp';
+import useTracking from '../../../providers/Tracking/useTracking';
+import { EventName } from '../../../types/Events';
 import { useInstallRegistryChartType } from '../hooks/useInstallRegistryChartType';
 import { registryAssetUrl } from '../utils/registryAssetUrl';
 import ChartTypeBetaBadge from './ChartTypeBetaBadge';
@@ -40,8 +42,17 @@ const ChartTypeLibraryDetailModal: FC<Props> = ({
     const { user } = useApp();
     const publishedAgo = useTimeAgo(item.publishedAt);
     const installMutation = useInstallRegistryChartType();
+    const { track } = useTracking();
 
     const handleInstall = () => {
+        track({
+            name: EventName.CHART_TYPE_LIBRARY_INSTALL_CLICKED,
+            properties: {
+                projectUuid,
+                chartSlug: item.slug,
+                action: 'install',
+            },
+        });
         installMutation.mutate(
             { projectUuid, chartSlug: item.slug },
             { onSuccess: onClose },

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeLibrarySection.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeLibrarySection.tsx
@@ -1,8 +1,10 @@
 import { FeatureFlags } from '@lightdash/common';
 import { Group, Paper, SimpleGrid, Stack, Text } from '@mantine/core';
-import { useState, type FC } from 'react';
+import { useEffect, useMemo, useRef, useState, type FC } from 'react';
 import EmptyStateLoader from '../../../components/common/EmptyStateLoader';
 import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
+import useTracking from '../../../providers/Tracking/useTracking';
+import { EventName } from '../../../types/Events';
 import { useRegistryChartTypes } from '../hooks/useRegistryChartTypes';
 import ChartTypeLibraryCard from './ChartTypeLibraryCard';
 import ChartTypeLibraryDetailModal from './ChartTypeLibraryDetailModal';
@@ -26,6 +28,41 @@ const ChartTypeLibrarySection: FC<Props> = ({
     const flagEnabled = flagQuery.data?.enabled ?? false;
     const registryQuery = useRegistryChartTypes(projectUuid, flagEnabled);
     const [selectedSlug, setSelectedSlug] = useState<string | null>(null);
+    const { track } = useTracking();
+
+    const charts = useMemo(
+        () => registryQuery.data?.charts ?? [],
+        [registryQuery.data?.charts],
+    );
+    // Installed chart types (upgradable ones included) live in the installed
+    // tab only, where upgrades are offered; the library lists what there is
+    // to get — new or incompatible.
+    const visibleCharts = useMemo(
+        () =>
+            charts.filter(
+                (chart) =>
+                    chart.state === 'not_installed' ||
+                    chart.state === 'incompatible',
+            ),
+        [charts],
+    );
+    const registryEnabled = registryQuery.data?.registryEnabled === true;
+
+    const hasTrackedView = useRef(false);
+    useEffect(() => {
+        if (hasTrackedView.current || !flagEnabled || !registryEnabled) return;
+        hasTrackedView.current = true;
+        track({
+            name: EventName.CHART_TYPE_LIBRARY_VIEWED,
+            properties: { projectUuid, chartCount: visibleCharts.length },
+        });
+    }, [
+        flagEnabled,
+        registryEnabled,
+        visibleCharts.length,
+        projectUuid,
+        track,
+    ]);
 
     if (!flagEnabled) {
         return null;
@@ -35,14 +72,6 @@ const ChartTypeLibrarySection: FC<Props> = ({
         return null;
     }
 
-    const charts = registryQuery.data?.charts ?? [];
-    // Installed chart types (upgradable ones included) live in the installed
-    // tab only, where upgrades are offered; the library lists what there is
-    // to get — new or incompatible.
-    const visibleCharts = charts.filter(
-        (chart) =>
-            chart.state === 'not_installed' || chart.state === 'incompatible',
-    );
     const allInstalled = charts.length > 0 && visibleCharts.length === 0;
     const selected =
         visibleCharts.find((chart) => chart.slug === selectedSlug) ?? null;
@@ -95,7 +124,18 @@ const ChartTypeLibrarySection: FC<Props> = ({
                         <ChartTypeLibraryCard
                             key={chart.slug}
                             item={chart}
-                            onClick={() => setSelectedSlug(chart.slug)}
+                            onClick={() => {
+                                track({
+                                    name: EventName.CHART_TYPE_LIBRARY_CHART_CLICKED,
+                                    properties: {
+                                        projectUuid,
+                                        chartSlug: chart.slug,
+                                        channel: chart.channel ?? 'stable',
+                                        state: chart.state,
+                                    },
+                                });
+                                setSelectedSlug(chart.slug);
+                            }}
                         />
                     ))}
                 </SimpleGrid>

--- a/packages/frontend/src/features/chartTypes/components/ChartTypePreviewTableModal.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypePreviewTableModal.tsx
@@ -3,10 +3,14 @@ import { useState, type FC } from 'react';
 import { useNavigate } from 'react-router';
 import MantineModal from '../../../components/common/MantineModal';
 import { useExplores } from '../../../hooks/useExplores';
+import useTracking from '../../../providers/Tracking/useTracking';
+import { EventName } from '../../../types/Events';
 
 type Props = {
     projectUuid: string;
     dataAppVizUuid: string;
+    /** The chart type's registry slug, when it is a registry install */
+    registrySlug: string | null;
     onClose: () => void;
 };
 
@@ -19,9 +23,11 @@ type Props = {
 const ChartTypePreviewTableModal: FC<Props> = ({
     projectUuid,
     dataAppVizUuid,
+    registrySlug,
     onClose,
 }) => {
     const navigate = useNavigate();
+    const { track } = useTracking();
     const [tableName, setTableName] = useState<string | null>(null);
     const exploresQuery = useExplores(projectUuid, true);
     const options = (exploresQuery.data ?? [])
@@ -37,6 +43,10 @@ const ChartTypePreviewTableModal: FC<Props> = ({
             confirmDisabled={tableName === null}
             onConfirm={() => {
                 if (tableName === null) return;
+                track({
+                    name: EventName.CHART_TYPE_PREVIEW_IN_EXPLORER,
+                    properties: { projectUuid, registrySlug, tableName },
+                });
                 void navigate(
                     `/projects/${projectUuid}/tables/${tableName}?dataAppVizUuid=${dataAppVizUuid}&chartSidebar=configure`,
                 );

--- a/packages/frontend/src/pages/ChartTypeGallery.tsx
+++ b/packages/frontend/src/pages/ChartTypeGallery.tsx
@@ -92,6 +92,9 @@ const ChartTypeGallery = () => {
     const toDelete = dataAppVizs.find(
         (viz) => viz.dataAppVizUuid === deleteUuid,
     );
+    const toPreview = dataAppVizs.find(
+        (viz) => viz.dataAppVizUuid === previewUuid,
+    );
     // Unfiltered total, so the count holds steady while a search narrows the grid.
     const totalCount =
         !debouncedSearch && data?.pages[0]?.pagination
@@ -306,6 +309,7 @@ const ChartTypeGallery = () => {
                 <ChartTypePreviewTableModal
                     projectUuid={projectUuid}
                     dataAppVizUuid={previewUuid}
+                    registrySlug={toPreview?.registrySlug ?? null}
                     onClose={() => setPreviewUuid(null)}
                 />
             )}

--- a/packages/frontend/src/providers/Tracking/types.ts
+++ b/packages/frontend/src/providers/Tracking/types.ts
@@ -5,6 +5,7 @@ import {
     type DataAppTemplate,
     type HomepageRecommendedActionKey,
     type MapTileBackground,
+    type RegistryChartTypeState,
     type SearchItemType,
     type TableCalculationType,
     type TimeFrames,
@@ -939,6 +940,62 @@ type DashboardWorkbookEvent = {
     };
 };
 
+// Chart type library (registry) funnel. Payloads carry slugs and enums
+// only — never free-text names.
+type ChartTypeLibraryViewedEvent = {
+    name: EventName.CHART_TYPE_LIBRARY_VIEWED;
+    properties: {
+        projectUuid: string;
+        chartCount: number;
+    };
+};
+
+type ChartTypeLibraryChartClickedEvent = {
+    name: EventName.CHART_TYPE_LIBRARY_CHART_CLICKED;
+    properties: {
+        projectUuid: string;
+        chartSlug: string;
+        channel: 'stable' | 'beta';
+        state: RegistryChartTypeState;
+    };
+};
+
+type ChartTypeLibraryInstallClickedEvent = {
+    name: EventName.CHART_TYPE_LIBRARY_INSTALL_CLICKED;
+    properties: {
+        projectUuid: string;
+        chartSlug: string;
+        action: 'install' | 'upgrade';
+    };
+};
+
+type ChartTypeDetailViewedEvent = {
+    name: EventName.CHART_TYPE_DETAIL_VIEWED;
+    properties: {
+        projectUuid: string;
+        isOfficial: boolean;
+        registrySlug: string | null;
+        hasUpdate: boolean;
+    };
+};
+
+type ChartTypePreviewInExplorerEvent = {
+    name: EventName.CHART_TYPE_PREVIEW_IN_EXPLORER;
+    properties: {
+        projectUuid: string;
+        registrySlug: string | null;
+        tableName: string;
+    };
+};
+
+type ChartTypeForkModalOpenedEvent = {
+    name: EventName.CHART_TYPE_FORK_MODAL_OPENED;
+    properties: {
+        projectUuid: string;
+        registrySlug: string | null;
+    };
+};
+
 export type EventData =
     | GenericEvent
     | DashboardWorkbookEvent
@@ -1020,6 +1077,12 @@ export type EventData =
     | AiAgentSuggestionClickEvent
     | DataAppRecentSuggestionClickEvent
     | DataAppClarifyRoundResolvedEvent
+    | ChartTypeLibraryViewedEvent
+    | ChartTypeLibraryChartClickedEvent
+    | ChartTypeLibraryInstallClickedEvent
+    | ChartTypeDetailViewedEvent
+    | ChartTypePreviewInExplorerEvent
+    | ChartTypeForkModalOpenedEvent
     | ThemeToggledEvent
     | DashboardUiVersionToggledEvent
     | TableCalculationSaveEvent

--- a/packages/frontend/src/types/Events.ts
+++ b/packages/frontend/src/types/Events.ts
@@ -238,4 +238,12 @@ export enum EventName {
     AGENT_ONBOARDING_COMPLETION_TOAST_SHOWN = 'agent_onboarding_completion_toast.shown',
     AGENT_ONBOARDING_COMPLETION_TOAST_CLICKED = 'agent_onboarding_completion_toast.clicked',
     CREATE_PROJECT_COLUMNS_DEFINED_BUTTON_CLICKED = 'create_project_columns_defined_button.click',
+
+    // Chart type library (registry) funnel
+    CHART_TYPE_LIBRARY_VIEWED = 'chart_type_library.viewed',
+    CHART_TYPE_LIBRARY_CHART_CLICKED = 'chart_type_library.chart_clicked',
+    CHART_TYPE_LIBRARY_INSTALL_CLICKED = 'chart_type_library.install_clicked',
+    CHART_TYPE_DETAIL_VIEWED = 'chart_type.detail_viewed',
+    CHART_TYPE_PREVIEW_IN_EXPLORER = 'chart_type.preview_in_explorer',
+    CHART_TYPE_FORK_MODAL_OPENED = 'chart_type.fork_modal_opened',
 }


### PR DESCRIPTION
Closes: [GLITCH-762](https://linear.app/lightdash/issue/GLITCH-762)

### Description:

The chart type library frontend fired zero tracking events, so we could count conversions (backend install events) but not consideration — nobody could answer "how many people opened the library and bounced" or "which charts get looked at but never installed".

Adds six typed `track()` events (`useTracking` + `EventName`, following existing conventions):

- `chart_type_library.viewed` — library section shown (gallery `tab=chart-library`), once per mount, with the visible chart count. Fires only when the flag and registry are enabled.
- `chart_type_library.chart_clicked` — library card clicked (opens the detail modal): `chartSlug`, `channel`, `state`.
- `chart_type_library.install_clicked` — Install CTA in the library detail modal (`action: 'install'`) and Upgrade CTA in the installed-tab detail modal (`action: 'upgrade'`). Backend confirms success separately via `data_app.registry_installed`.
- `chart_type.detail_viewed` — installed-tab detail modal opened: `isOfficial`, `registrySlug | null`, `hasUpdate`.
- `chart_type.preview_in_explorer` — table confirmed in the preview picker: `registrySlug | null`, `tableName`. The picker gets a new required `registrySlug` prop from the gallery.
- `chart_type.fork_modal_opened` — fork intent, before the confirm: `registrySlug | null`. Pairs with the backend `data_app.duplicated` completion made attributable in #28751.

Funnel: library viewed → chart clicked → install clicked → `data_app.registry_installed` (backend). Payloads carry slugs and enums only — no free-text names.

### Risk assessment:

- [ ] This is a high-risk change

High-risk changes require approval from a reviewer other than the author before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8sCUbSEj5R8babs36CnDN
