### PR TITLE
feat(explores): warn when independent repeated columns are unnested together

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -21,7 +21,9 @@ import {
     VizIndexType,
     WeekDay,
     type CompiledDimension,
+    type CompiledExploreJoin,
     type CompiledMetric,
+    type CompiledTable,
     type MetricFilterRule,
     type TimestampDomain,
 } from '@lightdash/common';
@@ -2111,6 +2113,213 @@ LIMIT 10`;
                     w.message.includes('missing a primary key definition'),
                 ),
             ).toBe(false);
+        });
+
+        test('Should warn when two independent repeated columns are unnested together', () => {
+            const unnestedTable = (
+                tableName: string,
+                columnPath: string,
+                dimensionName: string,
+            ): CompiledTable => ({
+                ...emptyTable(tableName),
+                sqlTable: `UNNEST("sessions".${columnPath}) AS "${tableName}" WITH OFFSET AS "${tableName}__offset"`,
+                nestedFrom: { parentTable: 'sessions', columnPath },
+                dimensions: {
+                    [dimensionName]: {
+                        type: DimensionType.STRING,
+                        name: dimensionName,
+                        label: dimensionName,
+                        table: tableName,
+                        tableLabel: tableName,
+                        fieldType: FieldType.DIMENSION,
+                        sql: `\${TABLE}.${dimensionName}`,
+                        compiledSql: `"${tableName}".${dimensionName}`,
+                        tablesReferences: [tableName],
+                        hidden: false,
+                    },
+                },
+            });
+            const unnestJoin = (tableName: string): CompiledExploreJoin => ({
+                table: tableName,
+                sqlOn: 'TRUE',
+                compiledSqlOn: 'TRUE',
+                type: 'left',
+                relationship: JoinRelationship.ONE_TO_MANY,
+                tablesReferences: ['sessions'],
+            });
+            const explore: Explore = {
+                targetDatabase: SupportedDbtAdapter.BIGQUERY,
+                name: 'sessions',
+                label: 'Sessions',
+                baseTable: 'sessions',
+                tags: [],
+                tables: {
+                    sessions: {
+                        ...emptyTable('sessions'),
+                        primaryKey: ['id'],
+                    },
+                    sessions__hits: unnestedTable(
+                        'sessions__hits',
+                        'hits',
+                        'hitNumber',
+                    ),
+                    sessions__customDimensions: unnestedTable(
+                        'sessions__customDimensions',
+                        'customDimensions',
+                        'value',
+                    ),
+                },
+                joinedTables: [
+                    unnestJoin('sessions__hits'),
+                    unnestJoin('sessions__customDimensions'),
+                ],
+            };
+            const result = buildQuery({
+                explore,
+                compiledMetricQuery: {
+                    exploreName: 'sessions',
+                    dimensions: [
+                        'sessions__hits_hitNumber',
+                        'sessions__customDimensions_value',
+                    ],
+                    metrics: [],
+                    filters: {},
+                    sorts: [],
+                    limit: 10,
+                    tableCalculations: [],
+                    additionalMetrics: [],
+                    compiledTableCalculations: [],
+                    compiledAdditionalMetrics: [],
+                    compiledCustomDimensions: [],
+                },
+                warehouseSqlBuilder: warehouseClientMock,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+                timezone: QUERY_BUILDER_UTC_TIMEZONE,
+            });
+
+            const crossProductWarnings = result.warnings.filter((w) =>
+                w.message.includes('are unnested together'),
+            );
+            expect(crossProductWarnings).toHaveLength(1);
+            expect(crossProductWarnings[0].tables).toEqual([
+                'sessions__hits',
+                'sessions__customDimensions',
+            ]);
+            expect(
+                result.warnings.some((w) =>
+                    w.message.includes('missing a primary key definition'),
+                ),
+            ).toBe(false);
+        });
+
+        test('Should flag a metric on an unnested table as inflated by a deeper unnest without asking for a primary key', () => {
+            const explore: Explore = {
+                targetDatabase: SupportedDbtAdapter.BIGQUERY,
+                name: 'sessions',
+                label: 'Sessions',
+                baseTable: 'sessions',
+                tags: [],
+                tables: {
+                    sessions: {
+                        ...emptyTable('sessions'),
+                        primaryKey: ['id'],
+                    },
+                    sessions__hits: {
+                        ...emptyTable('sessions__hits'),
+                        sqlTable:
+                            'UNNEST("sessions".hits) AS "sessions__hits" WITH OFFSET AS "sessions__hits__offset"',
+                        nestedFrom: {
+                            parentTable: 'sessions',
+                            columnPath: 'hits',
+                        },
+                        metrics: {
+                            hit_count: {
+                                type: MetricType.COUNT,
+                                name: 'hit_count',
+                                label: 'Hit count',
+                                table: 'sessions__hits',
+                                tableLabel: 'Sessions: Hits',
+                                fieldType: FieldType.METRIC,
+                                sql: '${TABLE}.hitNumber',
+                                compiledSql:
+                                    'COUNT("sessions__hits".hitNumber)',
+                                tablesReferences: ['sessions__hits'],
+                                hidden: false,
+                            },
+                        },
+                    },
+                    sessions__hits__product: {
+                        ...emptyTable('sessions__hits__product'),
+                        sqlTable:
+                            'UNNEST("sessions__hits".product) AS "sessions__hits__product" WITH OFFSET AS "sessions__hits__product__offset"',
+                        nestedFrom: {
+                            parentTable: 'sessions__hits',
+                            columnPath: 'hits.product',
+                        },
+                        dimensions: {
+                            productSKU: {
+                                type: DimensionType.STRING,
+                                name: 'productSKU',
+                                label: 'Product SKU',
+                                table: 'sessions__hits__product',
+                                tableLabel: 'Sessions: Hits: Product',
+                                fieldType: FieldType.DIMENSION,
+                                sql: '${TABLE}.productSKU',
+                                compiledSql:
+                                    '"sessions__hits__product".productSKU',
+                                tablesReferences: ['sessions__hits__product'],
+                                hidden: false,
+                            },
+                        },
+                    },
+                },
+                joinedTables: [
+                    {
+                        table: 'sessions__hits',
+                        sqlOn: 'TRUE',
+                        compiledSqlOn: 'TRUE',
+                        type: 'left',
+                        relationship: JoinRelationship.ONE_TO_MANY,
+                        tablesReferences: ['sessions'],
+                    },
+                    {
+                        table: 'sessions__hits__product',
+                        sqlOn: 'TRUE',
+                        compiledSqlOn: 'TRUE',
+                        type: 'left',
+                        relationship: JoinRelationship.ONE_TO_MANY,
+                        tablesReferences: ['sessions__hits'],
+                    },
+                ],
+            };
+            const result = buildQuery({
+                explore,
+                compiledMetricQuery: {
+                    exploreName: 'sessions',
+                    dimensions: ['sessions__hits__product_productSKU'],
+                    metrics: ['sessions__hits_hit_count'],
+                    filters: {},
+                    sorts: [],
+                    limit: 10,
+                    tableCalculations: [],
+                    additionalMetrics: [],
+                    compiledTableCalculations: [],
+                    compiledAdditionalMetrics: [],
+                    compiledCustomDimensions: [],
+                },
+                warehouseSqlBuilder: warehouseClientMock,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+                timezone: QUERY_BUILDER_UTC_TIMEZONE,
+            });
+
+            expect(result.warnings.map((w) => w.message)).toEqual([
+                expect.stringContaining(
+                    'Metric **"Hit count"** could be inflated by another unnested repeated column',
+                ),
+            ]);
+            expect(result.warnings[0].fields).toEqual([
+                'sessions__hits_hit_count',
+            ]);
         });
 
         test('Should throw when the referenced dimension table is aggregated in its own CTE', () => {

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -97,6 +97,7 @@ import {
     findDateGrainTableCalcWarnings,
     findMetricInflationWarnings,
     findTablesWithMetricInflation,
+    findUnnestCrossProductWarnings,
     getCustomBinDimensionSql,
     getCustomSqlDimensionSql,
     getDimensionFromFilterTargetId,
@@ -2924,14 +2925,19 @@ export class MetricQueryBuilder {
             const metricsInCte: CompiledMetric[] = [];
 
             if (table?.primaryKey === undefined) {
-                // We can't handle deduplication if table doesn't have primary key
-                warnings.push({
-                    message: `Table **"${tableName}"** is missing a primary key definition. This can prevent data duplication in joins. [Read more](https://docs.lightdash.com/references/joins#sql-fanouts)`,
-                    tables: [tableName],
-                });
+                // Deduplication needs a primary key. An unnested table cannot
+                // declare one, so its metrics only get the inflation notice.
+                if (!table?.nestedFrom) {
+                    warnings.push({
+                        message: `Table **"${tableName}"** is missing a primary key definition. This can prevent data duplication in joins. [Read more](https://docs.lightdash.com/references/joins#sql-fanouts)`,
+                        tables: [tableName],
+                    });
+                }
                 metricsFromTable.forEach((metric) => {
                     warnings.push({
-                        message: `Metric **"${metric.label}"** could be inflated due to table missing primary key definition. [Read more](https://docs.lightdash.com/references/joins#sql-fanouts)`,
+                        message: table?.nestedFrom
+                            ? `Metric **"${metric.label}"** could be inflated by another unnested repeated column. [Read more](https://docs.lightdash.com/references/joins#sql-fanouts)`
+                            : `Metric **"${metric.label}"** could be inflated due to table missing primary key definition. [Read more](https://docs.lightdash.com/references/joins#sql-fanouts)`,
                         fields: [getItemId(metric)],
                         tables: [metric.table],
                     });
@@ -5458,6 +5464,12 @@ export class MetricQueryBuilder {
             // Log error but don't block code execution
             Logger.error('Error during date-grain table calc detection', e);
         }
+        warnings.push(
+            ...findUnnestCrossProductWarnings({
+                tables: explore.tables,
+                joinedTables: joins.tables,
+            }),
+        );
 
         // Deduplicated distinct CTE: build separate CTEs for distinct metrics (sum_distinct, average_distinct), joined on dimensions
         const ddMetricIds = this.getSelectedAndReferencedMetricIds().filter(

--- a/packages/backend/src/utils/QueryBuilder/utils.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/utils.test.ts
@@ -33,6 +33,7 @@ import {
     assertValidDimensionRequiredAttribute,
     findDateGrainTableCalcWarnings,
     findMetricInflationWarnings,
+    findUnnestCrossProductWarnings,
     getCustomBinDimensionSql,
     getCustomSqlDimensionSql,
     getJoinedTables,
@@ -1641,6 +1642,77 @@ describe('getJoinedTables', () => {
         const result = getJoinedTables(explore, ['orders', 'users']);
 
         expect(result).toContain('intermediary_table');
+    });
+});
+
+describe('findUnnestCrossProductWarnings', () => {
+    const tables = {
+        sessions: {},
+        sessions__hits: {
+            nestedFrom: { parentTable: 'sessions', columnPath: 'hits' },
+        },
+        sessions__hits__product: {
+            nestedFrom: {
+                parentTable: 'sessions__hits',
+                columnPath: 'hits.product',
+            },
+        },
+        sessions__hits__promotion: {
+            nestedFrom: {
+                parentTable: 'sessions__hits',
+                columnPath: 'hits.promotion',
+            },
+        },
+        sessions__customDimensions: {
+            nestedFrom: {
+                parentTable: 'sessions',
+                columnPath: 'customDimensions',
+            },
+        },
+        users: {},
+    };
+
+    it('does not warn for a single ancestry chain of unnests', () => {
+        expect(
+            findUnnestCrossProductWarnings({
+                tables,
+                joinedTables: new Set([
+                    'sessions__hits',
+                    'sessions__hits__product',
+                ]),
+            }),
+        ).toEqual([]);
+    });
+
+    it('does not warn when only regular joins are present', () => {
+        expect(
+            findUnnestCrossProductWarnings({
+                tables,
+                joinedTables: new Set(['users', 'sessions__hits']),
+            }),
+        ).toEqual([]);
+    });
+
+    it('warns once naming the independent unnests, not their shared ancestors', () => {
+        const result = findUnnestCrossProductWarnings({
+            tables,
+            joinedTables: new Set([
+                'sessions__hits',
+                'sessions__hits__product',
+                'sessions__hits__promotion',
+                'sessions__customDimensions',
+            ]),
+        });
+        expect(result).toHaveLength(1);
+        expect(result[0].tables).toEqual([
+            'sessions__hits__product',
+            'sessions__hits__promotion',
+            'sessions__customDimensions',
+        ]);
+        expect(result[0].message).toContain(
+            'Repeated columns **"sessions__hits__product"**, **"sessions__hits__promotion"** and **"sessions__customDimensions"** are unnested together',
+        );
+        expect(result[0].message).not.toContain('"sessions__hits"');
     });
 });
 

--- a/packages/backend/src/utils/QueryBuilder/utils.ts
+++ b/packages/backend/src/utils/QueryBuilder/utils.ts
@@ -1335,3 +1335,52 @@ export const findMetricInflationWarnings = ({
     });
     return warnings;
 };
+
+type FindUnnestCrossProductWarningsProps = {
+    tables: { [tableName: string]: Pick<CompiledTable, 'nestedFrom'> };
+    joinedTables: Set<string>;
+};
+
+const getUnnestAncestors = (
+    tables: FindUnnestCrossProductWarningsProps['tables'],
+    tableName: string,
+    visited: Set<string> = new Set(),
+): string[] => {
+    const parent = tables[tableName]?.nestedFrom?.parentTable;
+    if (parent === undefined || visited.has(parent)) {
+        return [];
+    }
+    return [parent, ...getUnnestAncestors(tables, parent, visited.add(parent))];
+};
+
+/**
+ * Unnested tables that are not on one ancestry chain pair every element of
+ * one array with every element of the other, so the row count multiplies.
+ */
+export const findUnnestCrossProductWarnings = ({
+    tables,
+    joinedTables,
+}: FindUnnestCrossProductWarningsProps): QueryWarning[] => {
+    const unnestedTables = Array.from(joinedTables).filter(
+        (tableName) => tables[tableName]?.nestedFrom !== undefined,
+    );
+    const ancestors = new Set(
+        unnestedTables.flatMap((tableName) =>
+            getUnnestAncestors(tables, tableName),
+        ),
+    );
+    const independentTables = unnestedTables.filter(
+        (tableName) => !ancestors.has(tableName),
+    );
+    if (independentTables.length < 2) {
+        return [];
+    }
+    const quoted = independentTables.map((tableName) => `**"${tableName}"**`);
+    const tableList = `${quoted.slice(0, -1).join(', ')} and ${quoted.at(-1)}`;
+    return [
+        {
+            message: `Repeated columns ${tableList} are unnested together, so each row pairs their elements and metrics can be inflated. [Read more](https://docs.lightdash.com/references/joins#sql-fanouts)`,
+            tables: independentTables,
+        },
+    ];
+};


### PR DESCRIPTION
Selecting leaves from two repeated columns that are not nested inside each other, such as `hits` and `customDimensions` on a GA session, unnests both arrays side by side. Every row then pairs one element of each array, so the row count is the product of the two array lengths and any metric on either side is inflated, with nothing in the UI saying so. The query looked like any other two-join query while the numbers were silently wrong.

The query now carries a warning that names the independent repeated columns being unnested together, shown once per query and only for the deepest tables involved, so a chain like `hits` into `hits.product` stays quiet. Along the way, the metrics CTE path stopped asking unnested tables for a primary key they can never declare, and instead tells the user which of their metrics is inflated by another unnested column.

Relates: #4102
