### PR TITLE
fix(frontend): make the invite activation page work on a phone

### DIFF
--- a/packages/frontend/src/AuthRoutes.tsx
+++ b/packages/frontend/src/AuthRoutes.tsx
@@ -1,5 +1,5 @@
 import { type RouteObject } from 'react-router';
-import { loadLazyRouteDefault } from './features/chunkErrorHandler';
+import { loadLazyRouteDefault } from './features/chunkErrorHandler/loadLazyRouteDefault';
 import { TrackPage } from './providers/Tracking/TrackingProvider';
 import { PageName } from './types/Events';
 

--- a/packages/frontend/src/AuthRoutes.tsx
+++ b/packages/frontend/src/AuthRoutes.tsx
@@ -1,0 +1,99 @@
+import { type RouteObject } from 'react-router';
+import { loadLazyRouteDefault } from './features/chunkErrorHandler';
+import { TrackPage } from './providers/Tracking/TrackingProvider';
+import { PageName } from './types/Events';
+
+const AUTH_ROUTES: RouteObject[] = [
+    {
+        path: '/auth/popup/:status',
+        lazy: async () => {
+            const AuthPopupResult = await loadLazyRouteDefault(
+                './pages/AuthPopupResult',
+                () => import('./pages/AuthPopupResult'),
+            );
+            return { Component: AuthPopupResult };
+        },
+    },
+    {
+        path: '/recover-password',
+        lazy: async () => {
+            const PasswordRecovery = await loadLazyRouteDefault(
+                './pages/PasswordRecovery',
+                () => import('./pages/PasswordRecovery'),
+            );
+            return {
+                Component: () => (
+                    <TrackPage name={PageName.PASSWORD_RECOVERY}>
+                        <PasswordRecovery />
+                    </TrackPage>
+                ),
+            };
+        },
+    },
+    {
+        path: '/reset-password/:code',
+        lazy: async () => {
+            const PasswordReset = await loadLazyRouteDefault(
+                './pages/PasswordReset',
+                () => import('./pages/PasswordReset'),
+            );
+            return {
+                Component: () => (
+                    <TrackPage name={PageName.PASSWORD_RESET}>
+                        <PasswordReset />
+                    </TrackPage>
+                ),
+            };
+        },
+    },
+    {
+        path: '/invite/:inviteCode',
+        lazy: async () => {
+            const Invite = await loadLazyRouteDefault(
+                './pages/Invite',
+                () => import('./pages/Invite'),
+            );
+            return {
+                Component: () => (
+                    <TrackPage name={PageName.SIGNUP}>
+                        <Invite />
+                    </TrackPage>
+                ),
+            };
+        },
+    },
+    {
+        path: '/verify-email',
+        lazy: async () => {
+            const VerifyEmailPage = await loadLazyRouteDefault(
+                './pages/VerifyEmail',
+                () => import('./pages/VerifyEmail'),
+            );
+            return {
+                Component: () => (
+                    <TrackPage name={PageName.VERIFY_EMAIL}>
+                        <VerifyEmailPage />
+                    </TrackPage>
+                ),
+            };
+        },
+    },
+    {
+        path: '/join-organization',
+        lazy: async () => {
+            const JoinOrganization = await loadLazyRouteDefault(
+                './pages/JoinOrganization',
+                () => import('./pages/JoinOrganization'),
+            );
+            return {
+                Component: () => (
+                    <TrackPage name={PageName.JOIN_ORGANIZATION}>
+                        <JoinOrganization />
+                    </TrackPage>
+                ),
+            };
+        },
+    },
+];
+
+export default AUTH_ROUTES;

--- a/packages/frontend/src/MobileRoutes.test.tsx
+++ b/packages/frontend/src/MobileRoutes.test.tsx
@@ -1,0 +1,64 @@
+import { MantineProvider } from '@mantine/core';
+import { render, screen } from '@testing-library/react';
+import { type ReactNode } from 'react';
+import { createMemoryRouter, RouterProvider } from 'react-router';
+import MobileRoutes from './MobileRoutes';
+
+vi.mock('./pages/Invite', () => ({
+    default: () => <div data-testid="invite-page" />,
+}));
+
+vi.mock('./pages/PasswordReset', () => ({
+    default: () => <div data-testid="password-reset-page" />,
+}));
+
+vi.mock('./pages/Register', () => ({
+    default: () => <div data-testid="register-page" />,
+}));
+
+vi.mock('./providers/Tracking/TrackingProvider', () => ({
+    TrackPage: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('./providers/Tracking/useTracking', () => ({
+    default: () => ({ track: vi.fn() }),
+}));
+
+const renderMobileRouteAt = (pathname: string) => {
+    const router = createMemoryRouter(MobileRoutes, {
+        initialEntries: [pathname],
+    });
+
+    return render(
+        <MantineProvider env="test">
+            <RouterProvider router={router} />
+        </MantineProvider>,
+    );
+};
+
+describe('MobileRoutes', () => {
+    it('renders the invite activation page', async () => {
+        renderMobileRouteAt('/invite/some-invite-code');
+
+        expect(await screen.findByTestId('invite-page')).toBeInTheDocument();
+    });
+
+    it('renders the password reset page', async () => {
+        renderMobileRouteAt('/reset-password/some-code');
+
+        expect(
+            await screen.findByTestId('password-reset-page'),
+        ).toBeInTheDocument();
+    });
+
+    it('keeps the desktop-only gate on routes a phone cannot use', async () => {
+        renderMobileRouteAt('/register');
+
+        expect(
+            await screen.findByText(
+                'This page is not available to view on mobile yet.',
+            ),
+        ).toBeInTheDocument();
+        expect(screen.queryByTestId('register-page')).not.toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/MobileRoutes.tsx
+++ b/packages/frontend/src/MobileRoutes.tsx
@@ -24,6 +24,7 @@ import {
     useParams,
     type RouteObject,
 } from 'react-router';
+import AUTH_ROUTES from './AuthRoutes';
 import AppRoute from './components/AppRoute';
 import MantineIcon from './components/common/MantineIcon';
 import RouterNavLink from './components/common/RouterNavLink';
@@ -198,11 +199,6 @@ export const MobileNavBar: FC = () => {
 
 const routesNotSupportedInMobile = [
     '/register',
-    '/recover-password',
-    '/reset-password/:code',
-    '/invite/:inviteCode',
-    '/verify-email',
-    '/join-organization',
     '/createProject/:method?',
     '/createProjectSettings/:projectUuid',
     '/get-started',
@@ -222,16 +218,7 @@ const FALLBACK_ROUTE: RouteObject = {
 };
 
 const PUBLIC_ROUTES: RouteObject[] = [
-    {
-        path: '/auth/popup/:status',
-        lazy: async () => {
-            const AuthPopupResult = await loadLazyRouteDefault(
-                './pages/AuthPopupResult',
-                () => import('./pages/AuthPopupResult'),
-            );
-            return { Component: AuthPopupResult };
-        },
-    },
+    ...AUTH_ROUTES,
     {
         path: '/login',
         lazy: async () => {

--- a/packages/frontend/src/Routes.tsx
+++ b/packages/frontend/src/Routes.tsx
@@ -1,6 +1,7 @@
 import { Stack } from '@mantine/core';
 import { type FC } from 'react';
 import { Navigate, Outlet, type RouteObject } from 'react-router';
+import AUTH_ROUTES from './AuthRoutes';
 import AppRoute from './components/AppRoute';
 import ProjectLayout from './components/common/ProjectLayout';
 import ForbiddenPanel from './components/ForbiddenPanel';
@@ -29,16 +30,7 @@ const NavBarLayout: FC = () => (
 );
 
 const PUBLIC_ROUTES: RouteObject[] = [
-    {
-        path: '/auth/popup/:status',
-        lazy: async () => {
-            const AuthPopupResult = await loadLazyRouteDefault(
-                './pages/AuthPopupResult',
-                () => import('./pages/AuthPopupResult'),
-            );
-            return { Component: AuthPopupResult };
-        },
-    },
+    ...AUTH_ROUTES,
     {
         path: '/register',
         lazy: async () => {
@@ -66,86 +58,6 @@ const PUBLIC_ROUTES: RouteObject[] = [
                 Component: () => (
                     <TrackPage name={PageName.LOGIN}>
                         <Login />
-                    </TrackPage>
-                ),
-            };
-        },
-    },
-    {
-        path: '/recover-password',
-        lazy: async () => {
-            const PasswordRecovery = await loadLazyRouteDefault(
-                './pages/PasswordRecovery',
-                () => import('./pages/PasswordRecovery'),
-            );
-            return {
-                Component: () => (
-                    <TrackPage name={PageName.PASSWORD_RECOVERY}>
-                        <PasswordRecovery />
-                    </TrackPage>
-                ),
-            };
-        },
-    },
-    {
-        path: '/reset-password/:code',
-        lazy: async () => {
-            const PasswordReset = await loadLazyRouteDefault(
-                './pages/PasswordReset',
-                () => import('./pages/PasswordReset'),
-            );
-            return {
-                Component: () => (
-                    <TrackPage name={PageName.PASSWORD_RESET}>
-                        <PasswordReset />
-                    </TrackPage>
-                ),
-            };
-        },
-    },
-    {
-        path: '/invite/:inviteCode',
-        lazy: async () => {
-            const Invite = await loadLazyRouteDefault(
-                './pages/Invite',
-                () => import('./pages/Invite'),
-            );
-            return {
-                Component: () => (
-                    <TrackPage name={PageName.SIGNUP}>
-                        <Invite />
-                    </TrackPage>
-                ),
-            };
-        },
-    },
-    {
-        path: '/verify-email',
-        lazy: async () => {
-            const VerifyEmailPage = await loadLazyRouteDefault(
-                './pages/VerifyEmail',
-                () => import('./pages/VerifyEmail'),
-            );
-            return {
-                Component: () => (
-                    <TrackPage name={PageName.VERIFY_EMAIL}>
-                        <VerifyEmailPage />
-                    </TrackPage>
-                ),
-            };
-        },
-    },
-    {
-        path: '/join-organization',
-        lazy: async () => {
-            const JoinOrganization = await loadLazyRouteDefault(
-                './pages/JoinOrganization',
-                () => import('./pages/JoinOrganization'),
-            );
-            return {
-                Component: () => (
-                    <TrackPage name={PageName.JOIN_ORGANIZATION}>
-                        <JoinOrganization />
                     </TrackPage>
                 ),
             };

--- a/packages/frontend/src/components/common/AuthLayout/AuthLayout.module.css
+++ b/packages/frontend/src/components/common/AuthLayout/AuthLayout.module.css
@@ -107,3 +107,24 @@
 .formSubtitle {
     color: var(--mantine-color-ldGray-6);
 }
+
+.legacyRoot {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    min-height: 100vh;
+    padding: var(--mantine-spacing-lg) var(--mantine-spacing-md);
+    background-color: var(--mantine-color-body);
+}
+
+.legacyContent {
+    width: 100%;
+    max-width: rem(400px);
+    margin-top: var(--mantine-spacing-4xl);
+}
+
+@media (max-width: $mantine-breakpoint-sm) {
+    .legacyContent {
+        margin-top: var(--mantine-spacing-md);
+    }
+}

--- a/packages/frontend/src/components/common/AuthLayout/AuthLayout.module.css
+++ b/packages/frontend/src/components/common/AuthLayout/AuthLayout.module.css
@@ -83,6 +83,7 @@
 .formPanel {
     display: flex;
     flex: 1;
+    min-width: 0;
     align-items: center;
     justify-content: center;
     padding: var(--mantine-spacing-xl);

--- a/packages/frontend/src/components/common/AuthLayout/index.tsx
+++ b/packages/frontend/src/components/common/AuthLayout/index.tsx
@@ -5,7 +5,6 @@ import LightdashLogo from '../../LightdashLogo/LightdashLogo';
 import PageSpinner from '../../PageSpinner';
 import { DocumentTitle } from '../DocumentTitle';
 import MantineIcon from '../MantineIcon';
-import Page from '../Page/Page';
 import classes from './AuthLayout.module.css';
 import LightdashMark from './LightdashMark';
 import { useAuthLayoutVariant } from './useAuthLayoutVariant';
@@ -49,26 +48,30 @@ const AuthLayout: FC<PropsWithChildren<Props>> = ({
 
     if (!isNewLayout) {
         return (
-            <Page title={pageTitle} withCenteredContent withNavbar={false}>
-                <Stack w={400} mt="4xl">
-                    <Box mx="auto" my="lg">
-                        <LightdashLogo />
-                    </Box>
-                    {withLegacyCard ? (
-                        <Card id={cardId} p="xl" radius="md">
-                            {legacyTitle && (
-                                <Title order={3} ta="center" mb="md">
-                                    {legacyTitle}
-                                </Title>
-                            )}
-                            {children}
-                        </Card>
-                    ) : (
-                        children
-                    )}
-                    {footer}
-                </Stack>
-            </Page>
+            <>
+                <DocumentTitle title={pageTitle} />
+
+                <Box className={classes.legacyRoot}>
+                    <Stack className={classes.legacyContent}>
+                        <Box mx="auto" my="lg">
+                            <LightdashLogo />
+                        </Box>
+                        {withLegacyCard ? (
+                            <Card id={cardId} p="xl" radius="md">
+                                {legacyTitle && (
+                                    <Title order={3} ta="center" mb="md">
+                                        {legacyTitle}
+                                    </Title>
+                                )}
+                                {children}
+                            </Card>
+                        ) : (
+                            children
+                        )}
+                        {footer}
+                    </Stack>
+                </Box>
+            </>
         );
     }
 

--- a/packages/frontend/src/pages/Invite.module.css
+++ b/packages/frontend/src/pages/Invite.module.css
@@ -1,0 +1,4 @@
+.oneClickLabel {
+    display: block;
+    text-overflow: ellipsis;
+}

--- a/packages/frontend/src/pages/Invite.tsx
+++ b/packages/frontend/src/pages/Invite.tsx
@@ -35,6 +35,7 @@ import {
 import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
 import useApp from '../providers/App/useApp';
 import useTracking from '../providers/Tracking/useTracking';
+import classes from './Invite.module.css';
 
 interface WelcomeCardProps {
     email: string | undefined;
@@ -161,7 +162,12 @@ const OneClickCard: FC<OneClickCardProps> = ({
                     ? 'One click and we’ll take you straight to connecting the data warehouse.'
                     : 'One click to join your team.'}
             </Text>
-            <Button fullWidth loading={isLoading} onClick={onActivate}>
+            <Button
+                fullWidth
+                loading={isLoading}
+                onClick={onActivate}
+                classNames={{ label: classes.oneClickLabel }}
+            >
                 Continue as {email}
             </Button>
         </Stack>


### PR DESCRIPTION
## What breaks

A person who opens a Lightdash invite link on a phone sees "This page is not available to view on mobile yet" and cannot activate the account. Every invited person who reads the invite email on a phone hits this. With the mobile apps it becomes the normal path.

`App.tsx` switches to `MobileRoutes.tsx` below 768px. `MobileRoutes.tsx` listed `/invite/:inviteCode` in `routesNotSupportedInMobile`, which points the route at the desktop-only gate.

Fixes SPK-1929

## Routes that now render on mobile

The public auth routes that both route tables share now live in one module, `AuthRoutes.tsx`, and both tables use it:

- `/invite/:inviteCode` — invite activation, the point of the ticket
- `/verify-email` — where a password signup lands straight after activation. Without it the new account is stranded on the gate
- `/join-organization` — where `PrivateRoute` sends a user with no organisation
- `/recover-password` and `/reset-password/:code` — password recovery
- `/auth/popup/:status` — unchanged, it was already in both tables

## Routes that still show the gate

`/register`, `/createProject/:method?`, `/createProjectSettings/:projectUuid`, `/get-started`, `/generalSettings/:tab?`, chart history, SQL runner, tables, user activity and the app pages. These need a desktop.

## Layout fixes the routing exposed

- The legacy auth layout rendered inside the app `Page` shell, which sets a 900px minimum content width, and used a fixed 400px column. Both scroll the page sideways on a phone. It now uses a fluid centred column.
- The one-click button holds the invited email address, which cannot wrap. It pushed the auth form panel wider than the screen. The panel can now shrink and the label truncates.

## Verified

At 375px in Chrome device emulation against a local dev instance:

- Invite page renders in both layout variants: the legacy card and the `new-onboarding` split layout
- `document.scrollWidth == clientWidth == 375` on the invite page, both variants, with and without SSO buttons, and with a 70-character email address
- SSO button and the password form both render and fit
- One-click activation end to end: tapped "Continue as …", account activated, landed on the mobile project home
- Password signup end to end: filled the form, submitted, landed on `/verify-email`, which renders
- `/recover-password`, `/reset-password/:code` and `/join-organization` render with no sideways scroll
- Desktop login at 1440px unchanged after the layout rework
- `pnpm -F frontend typecheck`, `src/MobileRoutes.test.tsx` (3 tests: invite renders, password reset renders, gate still applies to `/register`), oxlint on the touched files
- react-doctor on the touched files: no new diagnostics. `AuthRoutes.tsx` reports the same `no-multi-component-file` pattern every route table in the repo already has

## Not verified

- Not tested on a real phone, only Chrome device emulation
- The password reset happy path: `POST /user/password/reset` returns 500 in my dev environment, so `/reset-password/:code` was checked on its "no link found" state only
- `/join-organization` was checked as a signed-in user who already has an organisation, so it showed its own error state, not the join list

## Screenshots (375px)

| Before | After |
| --- | --- |
| ![before-invite-375](https://github.com/user-attachments/assets/902fd18f-1a7e-4dab-97bc-0f30e98ed418) | ![after-invite-sso-375](https://github.com/user-attachments/assets/735cef3f-0783-4527-bfb3-bf843bc5e541) |

Invite with SSO and password signup, before and after.

### One-click activation, new-onboarding layout

![after-invite-oneclick-375](https://github.com/user-attachments/assets/26cd38c6-bf02-4eed-b2bc-13fb83b8f1e0)

### Where a password signup lands next

![after-verify-email-375](https://github.com/user-attachments/assets/cbb29bde-1290-4890-b211-12bca7a5686c)

### Password recovery

![after-recover-password-375](https://github.com/user-attachments/assets/0fb03693-0b91-4ae2-a85a-c3b012dca60d)

### A long email address no longer widens the page

![check-longemail-ellipsis-375](https://github.com/user-attachments/assets/b9a6ccfb-f5ba-43c9-be54-8d25662e55a4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SgkU12Da3iCtCRFqZFZibx
