### PR TITLE
fix: remove duplicate js-yaml lockfile entries

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19061,7 +19061,7 @@ snapshots:
       globals: 13.24.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.2
       minimatch: 3.1.2
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -19075,7 +19075,7 @@ snapshots:
       globals: 13.24.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.2
       minimatch: 3.1.2
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -26360,7 +26360,7 @@ snapshots:
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       is-path-inside: 3.0.3
-      js-yaml: 4.3.0
+      js-yaml: 4.3.2
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
       lodash.merge: 4.6.2
@@ -26403,7 +26403,7 @@ snapshots:
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       is-path-inside: 3.0.3
-      js-yaml: 4.3.0
+      js-yaml: 4.3.2
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
       lodash.merge: 4.6.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11373,10 +11373,6 @@ packages:
     resolution: {integrity: sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==}
     hasBin: true
 
-  js-yaml@4.3.2:
-    resolution: {integrity: sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==}
-    hasBin: true
-
   jsbn@0.1.1:
     resolution: {integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==}
 
@@ -28246,10 +28242,6 @@ snapshots:
       argparse: 2.0.1
 
   js-yaml@4.3.0:
-    dependencies:
-      argparse: 2.0.1
-
-  js-yaml@4.3.2:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
## Summary

Regenerate `pnpm-lock.yaml` with pnpm install after #28486 introduced duplicate `js-yaml@4.3.2` mappings. These cause frozen installs on main to fail with `ERR_PNPM_BROKEN_LOCKFILE` before tests can run.

Restored the last valid lockfile from `86e7499abd`, keeping the current manifests, then ran `sfw pnpm install --lockfile-only --no-frozen-lockfile --ignore-scripts` with Node 24.18.0 / pnpm 11.20.0. No hand edits to the regenerated result. Starting from the malformed lockfile makes pnpm discard it and re-resolve the entire dependency tree, so using the valid predecessor preserves existing resolutions.

The generated result removes the duplicate mappings and updates four ESLint-related `js-yaml` references from 4.3.0 to 4.3.2. No manifest changes or unrelated package updates.

## Validation

- Reproduced the frozen-lockfile duplicate-key failure before the fix.
- `sfw pnpm install --frozen-lockfile --lockfile-only --ignore-scripts --offline` passes for all 16 workspace projects.
- Reviewed the generated diff: duplicate removal plus the four `js-yaml` reference updates only.
- `git diff --check` passes.

Relates: SPK-1924 (CI blocked by this regression)
Relates: #28486
