### PR TITLE
fix(deps): remove the duplicate js-yaml entry from pnpm-lock.yaml

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11373,10 +11373,6 @@ packages:
     resolution: {integrity: sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==}
     hasBin: true
 
-  js-yaml@4.3.2:
-    resolution: {integrity: sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==}
-    hasBin: true
-
   jsbn@0.1.1:
     resolution: {integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==}
 
@@ -28246,10 +28242,6 @@ snapshots:
       argparse: 2.0.1
 
   js-yaml@4.3.0:
-    dependencies:
-      argparse: 2.0.1
-
-  js-yaml@4.3.2:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
## What breaks

`pnpm` refuses to read `pnpm-lock.yaml` on `main`:

```
[ERR_PNPM_BROKEN_LOCKFILE] The lockfile at ".../pnpm-lock.yaml" is broken:
duplicated mapping key (11376:3)
```

Every install fails, so CI stops at the `Install packages` step and never reaches a build or a test. Anyone who runs `pnpm install` locally on a fresh checkout of main hits the same wall. It lands on every pull request as soon as its base picks up the broken commit, which makes it look like a per-PR failure rather than a main-side one.

Fixes SPK-1931

## Cause

Two js-yaml security bumps landed one after the other:

- #28488 upgraded 4.3.1 to 4.3.2 (`86e7499ab`)
- #28486 upgraded 4.3.0 to 4.3.2 (`23994eafb`)

Each dropped its own old entry and added a `js-yaml@4.3.2` entry. Neither conflicted with the other in git, so together they wrote the key twice in the `packages:` block (lines 11372 and 11376) and twice in the `snapshots:` block (lines 28252 and 28256).

The main run for `23994eafb`, the second of the two, is the first red one: https://github.com/lightdash/lightdash/actions/runs/34127011020. The run for `86e7499ab` one commit earlier is the last green one: https://github.com/lightdash/lightdash/actions/runs/34126962749.

Every main push since has failed the same way: `b5d7c8091`, `05173a614`, `fd0e94f0e`, `89cbf02c9`.

## The change

The duplicated blocks are byte-identical, so this removes the second of each pair. Eight deleted lines, nothing else.

**No package version changes.** Regenerating the lockfile from scratch was tried first and rejected: because pnpm cannot read the broken file it re-resolves everything from the registry, which moved real versions (`openai` 6.26.0 to 4.104.0, `ws`, `yaml`, `supports-color`, `@opentelemetry/semantic-conventions`) across ~12,000 lines. That is a different and much riskier change than fixing the duplicate.

## Verified

- `pnpm install --frozen-lockfile` succeeds and leaves the lockfile untouched
- `pnpm install --lockfile-only` afterwards reports `Already up to date` and rewrites nothing, so this file is byte-for-byte what pnpm itself would write
- The diff is only the eight deleted lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SgkU12Da3iCtCRFqZFZibx
