### PR TITLE
fix: prepare SDK automatically for Cloud Run sandbox images

### DIFF
--- a/sandboxes/data-apps/README.md
+++ b/sandboxes/data-apps/README.md
@@ -89,6 +89,37 @@ In CI, the release-driven jobs in `.github/workflows/post-release.yml` handle pu
 automatically — they tag each release as `lightdash-data-app:<version>` (and rolling
 `:latest`), rebuilding the image only when this folder or `packages/query-sdk/` changed.
 
+## Cloud Run gateway image
+
+Use the Node version in `.nvmrc` and pnpm version in the root `package.json`.
+Install repository dependencies with `sfw pnpm install --frozen-lockfile` from
+its root (`npm install -g sfw` installs the dependency firewall if needed).
+Docker with Buildx must be running.
+
+From the repository root:
+
+```bash
+# Build for local inspection
+./sandboxes/data-apps/build-cloud-run-image.sh lightdash-sandbox-gateway:local --load
+
+# Build and push to your authenticated registry
+./sandboxes/data-apps/build-cloud-run-image.sh \
+  <registry>/<project>/lightdash-sandbox-gateway:<lightdash-version> --push
+```
+
+The script builds and packs the SDK from the checkout on every invocation,
+includes the pinned ComputeSDK gateway, and cleans up its temporary build context.
+Additional arguments are passed to `docker buildx build`. Use a checkout matching
+both your deployed Lightdash version and the image tag. The script builds an
+image only; follow the [Cloud Run sandbox deployment instructions](https://docs.lightdash.com/self-host/customize-deployment/sandboxes#google-cloud-run-sandboxes-self-hosted-preview)
+to deploy and configure the service.
+
+E2B and local Docker builds use the same `pack-query-sdk.sh` helper, so old SDK
+archives are replaced when rebuilding after an upgrade.
+
+Run `bash sandboxes/data-apps/test-build-cloud-run-image.sh` from the repository
+root to check image assembly and failure handling without Docker or network access.
+
 ## Related
 
 - **GLITCH-270** — E2B sandbox that runs this scaffold in production

--- a/sandboxes/data-apps/build-cloud-run-image.sh
+++ b/sandboxes/data-apps/build-cloud-run-image.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Usage: ./build-cloud-run-image.sh <image-tag> [docker buildx build options...]
+set -euo pipefail
+
+if [ "$#" -eq 0 ]; then
+    echo "Usage: $0 <image-tag> [docker buildx build options...]" >&2
+    exit 1
+fi
+IMAGE="$1"
+shift
+cd "$(dirname "$0")"
+
+STAGE=$(mktemp -d)
+trap 'rm -rf "$STAGE"' EXIT
+
+bash ./pack-query-sdk.sh "$STAGE"
+cp -R template "$STAGE/"
+npm pack @computesdk/cloud-run@0.1.8 --ignore-scripts --pack-destination "$STAGE" >/dev/null
+tar -xzf "$STAGE/computesdk-cloud-run-0.1.8.tgz" \
+    -C "$STAGE" package/dist/gateway.mjs
+mv "$STAGE/package/dist/gateway.mjs" "$STAGE/gateway.mjs"
+
+sed 's|^RUN chown -R user:user /app|RUN useradd -m -s /bin/bash user \&\& chown -R user:user /app|' \
+    e2b.Dockerfile > "$STAGE/Dockerfile"
+cat >> "$STAGE/Dockerfile" <<'EOF'
+
+COPY gateway.mjs /gateway/gateway.mjs
+ENV NODE_ENV=production
+CMD ["node", "/gateway/gateway.mjs"]
+EOF
+
+docker buildx build --platform linux/amd64 -t "$IMAGE" "$@" "$STAGE"

--- a/sandboxes/data-apps/build-local-image.sh
+++ b/sandboxes/data-apps/build-local-image.sh
@@ -12,18 +12,7 @@ cd "$(dirname "$0")"
 
 IMAGE="${1:-lightdash-sandbox:local}"
 
-# Same prereq recipe as build-sandbox.ts, so this script works standalone.
-if [ ! -f lightdash-query-sdk.tgz ]; then
-    echo "lightdash-query-sdk.tgz missing — building and packing @lightdash/query-sdk ..."
-    pnpm -C ../../packages/query-sdk build
-    pnpm -C ../../packages/query-sdk pack --pack-destination "$(pwd)"
-    TARBALL="$(find . -maxdepth 1 -name 'lightdash-query-sdk-*.tgz' | head -1)"
-    if [ -z "$TARBALL" ]; then
-        echo "query-sdk pack produced no tarball" >&2
-        exit 1
-    fi
-    mv "$TARBALL" lightdash-query-sdk.tgz
-fi
+bash ./pack-query-sdk.sh
 
 # Derive a local Dockerfile that creates the `user` account before the chown.
 sed 's|^RUN chown -R user:user /app|RUN useradd -m -s /bin/bash user 2>/dev/null \|\| true \&\& chown -R user:user /app|' \

--- a/sandboxes/data-apps/build-sandbox.ts
+++ b/sandboxes/data-apps/build-sandbox.ts
@@ -13,7 +13,7 @@
  *   npx tsx build-sandbox.ts
  */
 import { Template } from 'e2b';
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 
@@ -27,23 +27,9 @@ if (fs.existsSync('.env')) {
     }
 }
 
-// Build and pack @lightdash/query-sdk so it can be installed in the sandbox
-console.log('Building @lightdash/query-sdk...');
-const sdkDir = path.resolve('../../packages/query-sdk');
-execSync(`pnpm -C ${sdkDir} build`, { stdio: 'inherit' });
-
-console.log('Packing @lightdash/query-sdk...');
-execSync(`pnpm -C ${sdkDir} pack --pack-destination ${process.cwd()}`, {
+execFileSync('bash', [path.resolve('pack-query-sdk.sh')], {
     stdio: 'inherit',
 });
-// Rename to a fixed name so the Dockerfile COPY is deterministic
-const tarballs = fs.readdirSync('.').filter((f) => f.startsWith('lightdash-query-sdk-') && f.endsWith('.tgz'));
-if (tarballs.length !== 1) {
-    console.error('Expected exactly one query-sdk tarball, found:', tarballs);
-    process.exit(1);
-}
-fs.renameSync(tarballs[0], 'lightdash-query-sdk.tgz');
-console.log('');
 
 const dockerfile = fs.readFileSync('e2b.Dockerfile', 'utf-8');
 
@@ -78,16 +64,12 @@ async function main() {
 
         const skipCache = process.argv.includes('--no-cache');
 
-        const info = await Template.buildInBackground(
-            template,
-            buildTarget,
-            {
-                cpuCount: 2,
-                memoryMB: 2048,
-                ...(extraTags.length ? { tags: extraTags } : {}),
-                ...(skipCache ? { skipCache: true } : {}),
-            },
-        );
+        const info = await Template.buildInBackground(template, buildTarget, {
+            cpuCount: 2,
+            memoryMB: 2048,
+            ...(extraTags.length ? { tags: extraTags } : {}),
+            ...(skipCache ? { skipCache: true } : {}),
+        });
 
         console.log(`Template: ${info.name}`);
         console.log(`Template ID: ${info.templateId}`);

--- a/sandboxes/data-apps/pack-query-sdk.sh
+++ b/sandboxes/data-apps/pack-query-sdk.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Build the checkout's SDK and pack it under the filename the images expect.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DESTINATION="${1:-$SCRIPT_DIR}"
+mkdir -p "$DESTINATION"
+DESTINATION="$(cd "$DESTINATION" && pwd)"
+PACK_DIR=$(mktemp -d)
+trap 'rm -rf "$PACK_DIR"' EXIT
+
+pnpm -C "$SCRIPT_DIR/../../packages/query-sdk" build
+pnpm -C "$SCRIPT_DIR/../../packages/query-sdk" pack --pack-destination "$PACK_DIR"
+
+shopt -s nullglob
+TARBALLS=("$PACK_DIR"/lightdash-query-sdk-*.tgz)
+if [ "${#TARBALLS[@]}" -ne 1 ]; then
+    echo "Expected exactly one query-sdk tarball, found ${#TARBALLS[@]}" >&2
+    exit 1
+fi
+mv "${TARBALLS[0]}" "$DESTINATION/lightdash-query-sdk.tgz"

--- a/sandboxes/data-apps/test-build-cloud-run-image.sh
+++ b/sandboxes/data-apps/test-build-cloud-run-image.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Exercise image assembly without Docker or registry access.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TEST_DIR=$(mktemp -d)
+trap 'rm -rf "$TEST_DIR"' EXIT
+export TEST_DIR
+mkdir -p "$TEST_DIR/bin" "$TEST_DIR/checkout with spaces" "$TEST_DIR/tmp"
+cp "$SCRIPT_DIR/"{build-cloud-run-image.sh,pack-query-sdk.sh,e2b.Dockerfile} "$TEST_DIR/checkout with spaces/"
+cp -R "$SCRIPT_DIR/template" "$TEST_DIR/checkout with spaces/"
+export TMPDIR="$TEST_DIR/tmp"
+export PATH="$TEST_DIR/bin:$PATH"
+
+cat > "$TEST_DIR/bin/pnpm" <<'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "$3" = build ]; then
+    exit "${BUILD_EXIT_CODE:-0}"
+fi
+[ "$3" = pack ]
+printf 'fresh sdk' > "$5/lightdash-query-sdk-1.0.0.tgz"
+MOCK
+cat > "$TEST_DIR/bin/npm" <<'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+[ "$1" = pack ]
+[ "$2" = @computesdk/cloud-run@0.1.8 ]
+[ "$3" = --ignore-scripts ]
+mkdir -p "$TEST_DIR/gateway/package/dist"
+printf 'gateway' > "$TEST_DIR/gateway/package/dist/gateway.mjs"
+tar -czf "$5/computesdk-cloud-run-0.1.8.tgz" -C "$TEST_DIR/gateway" package/dist/gateway.mjs
+MOCK
+cat > "$TEST_DIR/bin/docker" <<'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+[ "$1 $2 $3 $4 $5 $6 $7" = 'buildx build --platform linux/amd64 -t test:image --load' ]
+STAGE="$8"
+[ "$(cat "$STAGE/lightdash-query-sdk.tgz")" = 'fresh sdk' ]
+[ "$(cat "$STAGE/gateway.mjs")" = gateway ]
+[ -f "$STAGE/template/.npmrc" ]
+[ -d "$STAGE/template/.claude" ]
+rg -q '^RUN useradd .* && chown -R user:user /app$' "$STAGE/Dockerfile"
+rg -q '^CMD \["node", "/gateway/gateway.mjs"\]$' "$STAGE/Dockerfile"
+touch "$TEST_DIR/docker-called"
+MOCK
+chmod +x "$TEST_DIR/bin/"*
+
+# No pre-existing SDK archive; also exercise paths with spaces and cleanup.
+bash "$TEST_DIR/checkout with spaces/build-cloud-run-image.sh" test:image --load
+[ -f "$TEST_DIR/docker-called" ]
+[ -z "$(ls -A "$TMPDIR")" ]
+rm "$TEST_DIR/docker-called"
+
+# A failed SDK build must stop before Docker, even with an old archive present.
+printf stale > "$TEST_DIR/checkout with spaces/lightdash-query-sdk.tgz"
+if BUILD_EXIT_CODE=42 bash "$TEST_DIR/checkout with spaces/build-cloud-run-image.sh" test:image --load; then
+    echo 'Expected SDK build failure' >&2
+    exit 1
+fi
+[ ! -f "$TEST_DIR/docker-called" ]
+[ -z "$(ls -A "$TMPDIR")" ]
+
+# Repacking replaces an old archive rather than reusing it.
+bash "$TEST_DIR/checkout with spaces/pack-query-sdk.sh"
+[ "$(cat "$TEST_DIR/checkout with spaces/lightdash-query-sdk.tgz")" = 'fresh sdk' ]
+[ -z "$(ls -A "$TMPDIR")" ]
+echo 'Cloud Run image assembly tests passed'


### PR DESCRIPTION
### Description:

Cloud Run's documented image recipe copies `lightdash-query-sdk.tgz` from a fresh checkout without generating it, so image assembly fails before Docker can install the SDK. Add `build-cloud-run-image.sh` to build the checkout's SDK, stage the template and pinned ComputeSDK gateway (0.1.8), and invoke Docker Buildx for linux/amd64. It accepts an image tag and additional Buildx options such as `--load` or `--push`, preserves `/app` ownership, and cleans up temporary files.

Share SDK building and packaging across Cloud Run, E2B, and local Docker. Every invocation repacks the SDK in an isolated directory, replacing stale archives and avoiding ambiguous versioned tarballs. Document prerequisites and invocation in the scaffold README.

Validation:
- Real query-sdk build and packaging passed.
- Network-free image assembly regression checks passed: fresh checkout, paths with spaces, hidden template files, gateway version, Docker arguments, ownership, cleanup, early SDK failure, and stale archive replacement.
- Shell syntax, TypeScript formatting, diff checks, and commit hooks passed.
- Full linux/amd64 Docker image build passed. Inside the image, gateway syntax, SDK compiled files, /app ownership, and the starter app Vite production build passed.
- Cloud Run deployment not tested.

The public setup docs should be updated separately to use this script once available, with a build/pack workaround for older releases. This PR does not add CI or deploy a Cloud Run service.

### Risk assessment:

- [ ] This is a high-risk change

Build tooling only; no backend runtime changes. E2B and local Docker now rebuild the SDK on every image build instead of reusing an existing archive.
