### PR TITLE
test(backend): match the DuckDB strftime output from #28708

### DIFF
--- a/packages/backend/src/ee/preAggregates/buildPreAggregateExplore.test.ts
+++ b/packages/backend/src/ee/preAggregates/buildPreAggregateExplore.test.ts
@@ -492,7 +492,7 @@ describe('buildPreAggregateExplore', () => {
 
         expect(
             result.tables.orders.dimensions.order_date_month_name.compiledSql,
-        ).toBe("TO_CHAR(orders.orders_order_date_day, 'FMMonth')");
+        ).toBe("strftime(orders.orders_order_date_day, '%B')");
     });
 
     describe('external pre-aggregates', () => {


### PR DESCRIPTION
## What breaks

`Build & Test` fails on main and on every pull request that picks up the current base:

```
FAIL backend-unit-tests src/ee/preAggregates/buildPreAggregateExplore.test.ts
  > buildPreAggregateExplore > derives named time frames with the serving warehouse function

Expected: "TO_CHAR(orders.orders_order_date_day, 'FMMonth')"
Received: "strftime(orders.orders_order_date_day, '%B')"

Test Files  1 failed | 584 passed (585)
```

Everyone raising or merging a pull request sees a red Build & Test that has nothing to do with their change.

Fixes SPK-1932

## Cause

#28708 gave DuckDB its own time frame config instead of reusing the Postgres one, so `MONTH_NAME` compiles to `strftime(col, '%B')`. DuckDB has no `TO_CHAR`, which was the point of that fix.

It updated `packages/common/src/utils/timeFrames.test.ts` but not the backend test that asserts the same SQL through the pre-aggregate explore builder. `buildPreAggregateExplore.test.ts:495` still expected the Postgres output. That file was last touched by #27594, well before the change.

## The change

One assertion, updated to the SQL the serving warehouse now emits. It pins the same value the common test added in #28708:

```
[TimeFrames.MONTH_NAME, `strftime(${col}, '%B')`]
```

No production code touched.

## Verified

- `pnpm -F backend test src/ee/preAggregates/buildPreAggregateExplore.test.ts` — 39 passed, 1 file
- `pnpm -F backend typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SgkU12Da3iCtCRFqZFZibx
