### PR TITLE
feat(merge-queries): serve a DuckDB source query from the results cache by the files it reads

### DIFF
--- a/docs/merge-queries/architecture.md
+++ b/docs/merge-queries/architecture.md
@@ -53,6 +53,15 @@ than leaving it executing. A refusal by the guard is recorded
 on the row too, so the outcome reporter, which polls the join row rather than
 awaiting any run, tells a refusal from a failure wherever the join executed.
 
+The join is served from the results cache by the files it reads, not by the
+rows it referenced: a leg served from cache mints a new history row over the
+same result file, so the row uuids change on every run while the files do
+not. Once the references are bound, the run keys itself on the join's SQL,
+the referenced result files in reference-table order and its parameters,
+looks that key up, and either lands on the earlier run's results or runs and
+stores its own under that key. `invalidateCache` on the merge reaches the
+legs at submit and the join through its persisted spec.
+
 ### Why DuckDB
 
 - One join dialect instead of ten. `FULL OUTER JOIN` is the least portable

--- a/packages/backend/src/database/entities/queryHistory.ts
+++ b/packages/backend/src/database/entities/queryHistory.ts
@@ -86,6 +86,7 @@ export type DbQueryHistoryUpdate = Partial<
         | 'original_columns'
         | 'pre_aggregate_compiled_sql'
         | 'pre_aggregate_execution'
+        | 'cache_key'
         | 'pre_aggregate_fallback_reason'
         | 'processing_started_at'
         | 'duckdb_execution'

--- a/packages/backend/src/models/QueryHistoryModel/QueryHistoryModel.ts
+++ b/packages/backend/src/models/QueryHistoryModel/QueryHistoryModel.ts
@@ -439,6 +439,16 @@ export class QueryHistoryModel {
         return row?.duckdb_execution ?? null;
     }
 
+    /** Records that a DuckDB source query was served from another run's results. */
+    async markDuckdbCacheHit(queryUuid: string): Promise<void> {
+        await this.database.raw(
+            `UPDATE ${QueryHistoryTableName}
+             SET duckdb_execution = jsonb_set(COALESCE(duckdb_execution, '{}'::jsonb), '{cacheHit}', 'true'::jsonb)
+             WHERE query_uuid = ?`,
+            [queryUuid],
+        );
+    }
+
     /**
      * Marks a DuckDB source query as refused by its guard: the error status
      * and the refusal land in one statement, so whoever polls the row never

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -80,7 +80,7 @@ import type { ProjectDbtSourcesModel } from '../../models/ProjectDbtSourcesModel
 import type { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { projectUuid } from '../../models/ProjectModel/ProjectModel.mock';
 import { ProjectParametersModel } from '../../models/ProjectParametersModel';
-import type { QueryHistoryModel } from '../../models/QueryHistoryModel/QueryHistoryModel';
+import { QueryHistoryModel } from '../../models/QueryHistoryModel/QueryHistoryModel';
 import type { SavedChartModel } from '../../models/SavedChartModel';
 import type { SavedSqlModel } from '../../models/SavedSqlModel';
 import type { SpaceModel } from '../../models/SpaceModel';
@@ -324,6 +324,10 @@ const inMemoryDuckdbHistory = ({
         getDuckdbExecution: vi.fn(
             async (uuid: string) => specs.get(uuid) ?? null,
         ),
+        markDuckdbCacheHit: vi.fn(async (uuid: string) => {
+            const spec = specs.get(uuid);
+            if (spec) specs.set(uuid, { ...spec, cacheHit: true });
+        }),
         recordDuckdbRefusal: vi.fn(
             async (
                 uuid: string,
@@ -1093,6 +1097,8 @@ describe('AsyncQueryService', () => {
                 guard,
                 storedCompiledSql: null,
                 referenceLabels: {},
+                invalidateCache: false,
+                cacheHit: false,
                 refusal: null,
             });
             expect(
@@ -6309,9 +6315,11 @@ describe('runDuckdbQuery', () => {
         runDuckdbQuery: (args: RunDuckdbQueryArgs) => Promise<void>;
     };
 
-    const buildService = () => {
+    const buildService = (cached: CacheHitCacheResult | null = null) => {
         const pollForQueryCompletion = vi.fn(async () => legHistory(1));
         const recordDuckdbRefusal = vi.fn();
+        const markDuckdbCacheHit = vi.fn();
+        const findCachedResultsFile = vi.fn(async () => cached);
         const service = getMockedAsyncQueryService(lightdashConfigMock, {
             resultsStorageClient: {
                 isEnabled: true,
@@ -6321,7 +6329,9 @@ describe('runDuckdbQuery', () => {
                 update: vi.fn(),
                 pollForQueryCompletion,
                 recordDuckdbRefusal,
+                markDuckdbCacheHit,
             } as unknown as QueryHistoryModel,
+            cacheService: { findCachedResultsFile } as unknown as ICacheService,
         } as never);
         const runWarehouseQuery = vi
             .spyOn(service, 'runAsyncWarehouseQuery')
@@ -6332,8 +6342,34 @@ describe('runDuckdbQuery', () => {
             runWarehouseQuery,
             pollForQueryCompletion,
             recordDuckdbRefusal,
+            markDuckdbCacheHit,
+            findCachedResultsFile,
             update: service.queryHistoryModel.update as import('vitest').Mock,
         };
+    };
+
+    const fileKey = (files: string[]) =>
+        QueryHistoryModel.getCacheKey(projectUuid, {
+            sql: JSON.stringify({
+                sql: 'SELECT 1 AS one',
+                files,
+                parameters: {},
+            }),
+            userUuid: null,
+        });
+
+    const cachedResults: CacheHitCacheResult = {
+        cacheHit: true,
+        cacheKey: 'cached-key',
+        fileName: 'cached-results.jsonl',
+        createdAt: new Date('2026-09-07T10:00:00Z'),
+        updatedAt: new Date('2026-09-07T10:00:00Z'),
+        expiresAt: new Date('2026-09-08T10:00:00Z'),
+        totalRowCount: 26,
+        columns: { one: { reference: 'one', type: DimensionType.NUMBER } },
+        originalColumns: null,
+        pivotValuesColumns: null,
+        pivotTotalColumnCount: null,
     };
 
     const probingClient = (fields: Record<string, { type: DimensionType }>) => {
@@ -6365,6 +6401,7 @@ describe('runDuckdbQuery', () => {
             isRegisteredUser: true,
             isServiceAccount: false,
         },
+        invalidateCache: false,
         projectUuid,
         organizationUuid: projectSummary.organizationUuid,
         isPreviewProject: false,
@@ -6412,6 +6449,7 @@ describe('runDuckdbQuery', () => {
                 compiled_sql: executed.query,
                 fields: executed.fieldsMap,
                 original_columns: executed.originalColumns,
+                cache_key: 'cache-key',
             },
             expect.anything(),
         );
@@ -6495,6 +6533,8 @@ describe('runDuckdbQuery', () => {
                 compiled_sql: executed.query,
                 fields: fieldsMap,
                 original_columns: originalColumns,
+                // Keyed on the leg file it read, for the next run to find
+                cache_key: expect.any(String),
             },
             expect.anything(),
         );
@@ -6622,6 +6662,108 @@ describe('runDuckdbQuery', () => {
             }),
             expect.anything(),
         );
+    });
+
+    it('a run over the same result files is served from the earlier run without touching DuckDB', async () => {
+        const { streamQuery, warehouseClient } = probingClient({});
+        const {
+            run,
+            runWarehouseQuery,
+            findCachedResultsFile,
+            markDuckdbCacheHit,
+            update,
+        } = buildService(cachedResults);
+
+        await run(
+            baseArgs({
+                engine: { kind: 'client', warehouseClient },
+                references: {
+                    kind: 'queries',
+                    references: { orders: 'leg-uuid' },
+                    guard: null,
+                    labelByTable: {},
+                },
+            }),
+        );
+
+        // Keyed on the file the leg row points at, not the leg row itself
+        expect(findCachedResultsFile).toHaveBeenCalledWith(
+            projectUuid,
+            fileKey(['s3://results-bucket/leg-results.jsonl']),
+            expect.objectContaining({ userUuid: sessionAccount.user.id }),
+        );
+        expect(streamQuery).not.toHaveBeenCalled();
+        expect(runWarehouseQuery).not.toHaveBeenCalled();
+        expect(markDuckdbCacheHit).toHaveBeenCalledWith('duckdb-query-uuid');
+        expect(update).toHaveBeenCalledWith(
+            'duckdb-query-uuid',
+            projectUuid,
+            expect.objectContaining({
+                status: QueryHistoryStatus.READY,
+                cache_key: fileKey(['s3://results-bucket/leg-results.jsonl']),
+                results_file_name: 'cached-results.jsonl',
+                total_row_count: 26,
+                warehouse_execution_time_ms: 0,
+            }),
+            expect.anything(),
+        );
+    });
+
+    it('a run that finds nothing lands its results under the file-based key for the next one', async () => {
+        const { streamQuery, warehouseClient } = probingClient({
+            one: { type: DimensionType.NUMBER },
+        });
+        const { run, runWarehouseQuery, update } = buildService(null);
+
+        await run(
+            baseArgs({
+                engine: { kind: 'client', warehouseClient },
+                references: {
+                    kind: 'queries',
+                    references: { orders: 'leg-uuid' },
+                    guard: null,
+                    labelByTable: {},
+                },
+            }),
+        );
+
+        expect(streamQuery).toHaveBeenCalledTimes(1);
+        expect(update).toHaveBeenCalledWith(
+            'duckdb-query-uuid',
+            projectUuid,
+            expect.objectContaining({
+                cache_key: fileKey(['s3://results-bucket/leg-results.jsonl']),
+            }),
+            expect.anything(),
+        );
+        expect(runWarehouseQuery.mock.calls[0][0].cacheKey).toBe(
+            fileKey(['s3://results-bucket/leg-results.jsonl']),
+        );
+    });
+
+    it('invalidating the cache runs regardless of an earlier run over the same files', async () => {
+        const { streamQuery, warehouseClient } = probingClient({
+            one: { type: DimensionType.NUMBER },
+        });
+        const { run, runWarehouseQuery, findCachedResultsFile } =
+            buildService(cachedResults);
+
+        await run(
+            baseArgs({
+                invalidateCache: true,
+                engine: { kind: 'client', warehouseClient },
+                references: {
+                    kind: 'queries',
+                    references: { orders: 'leg-uuid' },
+                    guard: null,
+                    labelByTable: {},
+                },
+            }),
+        );
+
+        expect(findCachedResultsFile).not.toHaveBeenCalled();
+        expect(streamQuery).toHaveBeenCalledTimes(1);
+        expect(runWarehouseQuery).toHaveBeenCalledTimes(1);
     });
 
     it('a guard refusal lands as the query error and is recorded on the row before anything runs', async () => {
@@ -8050,6 +8192,8 @@ describe('DuckDB source queries on the worker', () => {
             guard,
             storedCompiledSql: null,
             referenceLabels: {},
+            invalidateCache: false,
+            cacheHit: false,
             refusal: null,
         });
 
@@ -8152,6 +8296,8 @@ describe('DuckDB source queries on the worker', () => {
             guard: null,
             storedCompiledSql: null,
             referenceLabels: {},
+            invalidateCache: false,
+            cacheHit: false,
             refusal: null,
         });
 
@@ -8243,6 +8389,8 @@ describe('DuckDB source queries on the worker', () => {
             guard: null,
             storedCompiledSql: null,
             referenceLabels: {},
+            invalidateCache: false,
+            cacheHit: false,
             refusal: null,
         };
         const { queueTimeoutMs } = lightdashConfigMock.natsWorker;

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -227,6 +227,7 @@ import { splitJsonlStream } from '../../utils/streamUtils';
 import { SubtotalsCalculator } from '../../utils/SubtotalsCalculator';
 import type { ICacheService } from '../CacheService/ICacheService';
 import { CreateCacheResult } from '../CacheService/types';
+import type { CacheHitCacheResult } from '../CacheService/types';
 import { CsvService } from '../CsvService/CsvService';
 import { ExcelService } from '../ExcelService/ExcelService';
 import { OrganizationAccessService } from '../OrganizationAccessService/OrganizationAccessService';
@@ -7479,6 +7480,7 @@ export class AsyncQueryService extends ProjectService {
         parameters,
         pivotConfiguration,
         plan,
+        invalidateCache,
     }: ExecuteAsyncDuckdbSourceQueryArgs): Promise<{ queryUuid: string }> {
         assertIsAccountWithOrg(account);
 
@@ -7594,6 +7596,8 @@ export class AsyncQueryService extends ProjectService {
             guard: plan.guard,
             storedCompiledSql: null,
             referenceLabels: plan.referenceLabels,
+            invalidateCache: invalidateCache ?? false,
+            cacheHit: false,
             refusal: null,
         });
 
@@ -7757,6 +7761,7 @@ export class AsyncQueryService extends ProjectService {
 
         return {
             actor,
+            invalidateCache: spec.invalidateCache,
             projectUuid: query.projectUuid,
             organizationUuid: query.organizationUuid,
             isPreviewProject: await this.isExcludedFromUsage(query.projectUuid),
@@ -8119,6 +8124,8 @@ export class AsyncQueryService extends ProjectService {
                 isRegisteredUser: account.isRegisteredUser(),
                 isServiceAccount: account.isServiceAccount(),
             },
+            // Bound references have no results to be served from
+            invalidateCache: true,
             projectUuid,
             organizationUuid,
             isPreviewProject:
@@ -8194,6 +8201,7 @@ export class AsyncQueryService extends ProjectService {
      */
     private async runDuckdbQuery({
         actor,
+        invalidateCache,
         projectUuid,
         organizationUuid,
         isPreviewProject,
@@ -8224,6 +8232,63 @@ export class AsyncQueryService extends ProjectService {
                 engine,
                 bound,
             );
+            // The results a query over other results depends on are the
+            // files it reads, not the rows it referenced: a leg served from
+            // cache mints a new row over the same file, so the file-based key
+            // is what a later run finds
+            const resultsKey =
+                references.kind === 'queries'
+                    ? QueryHistoryModel.getCacheKey(projectUuid, {
+                          sql: JSON.stringify({
+                              sql,
+                              files: bound.resultFileUris,
+                              parameters:
+                                  columns.mode === 'discover'
+                                      ? columns.parameters
+                                      : (columns.usedParameters ?? {}),
+                          }),
+                          userUuid: null,
+                      })
+                    : cacheKey;
+            if (references.kind === 'queries') {
+                const cached = invalidateCache
+                    ? null
+                    : ((await this.cacheService?.findCachedResultsFile(
+                          projectUuid,
+                          resultsKey,
+                          {
+                              userUuid: actor.userUuid,
+                              organizationUuid,
+                              organizationName: undefined,
+                          },
+                      )) ?? null);
+                this.prometheusMetrics?.incrementQueryCacheHit(
+                    cached !== null,
+                    context,
+                    false,
+                );
+                if (cached !== null) {
+                    await this.landDuckdbCacheHit({
+                        actor,
+                        account,
+                        projectUuid,
+                        organizationUuid,
+                        isPreviewProject,
+                        onboardingFlow,
+                        queryUuid,
+                        sql,
+                        columns,
+                        storedCompiledSql,
+                        resultsKey,
+                        cached,
+                        queryTags,
+                        queryCreatedAt,
+                        context,
+                        warehouseType: warehouseClient.credentials.type,
+                    });
+                    return;
+                }
+            }
             const resolvedSql = AsyncQueryService.wrapSqlWithReferenceCtes(
                 sql,
                 bound.referenceCtes,
@@ -8242,6 +8307,9 @@ export class AsyncQueryService extends ProjectService {
                     compiled_sql: storedCompiledSql ?? execution.query,
                     fields: execution.fieldsMap,
                     original_columns: execution.originalColumns,
+                    // The results land under the file-based key, so the next
+                    // run over the same files finds them
+                    cache_key: resultsKey,
                 },
                 account,
             );
@@ -8263,7 +8331,7 @@ export class AsyncQueryService extends ProjectService {
                 query: execution.query,
                 fieldsMap: execution.fieldsMap,
                 usedParameters: execution.usedParameters,
-                cacheKey,
+                cacheKey: resultsKey,
                 pivotConfiguration: execution.pivotConfiguration,
                 originalColumns: execution.originalColumns,
                 queryCreatedAt,
@@ -8297,6 +8365,113 @@ export class AsyncQueryService extends ProjectService {
                 account,
             );
         }
+    }
+
+    /** Lands a DuckDB source query on another run's results over the same files. */
+    private async landDuckdbCacheHit({
+        actor,
+        account,
+        projectUuid,
+        organizationUuid,
+        isPreviewProject,
+        onboardingFlow,
+        queryUuid,
+        sql,
+        columns,
+        storedCompiledSql,
+        resultsKey,
+        cached,
+        queryTags,
+        queryCreatedAt,
+        context,
+        warehouseType,
+    }: {
+        actor: QueryHistoryActor;
+        account: Pick<Account, 'isRegisteredUser'> & {
+            user: Pick<Account['user'], 'id'>;
+        };
+        projectUuid: string;
+        organizationUuid: string;
+        isPreviewProject: boolean;
+        onboardingFlow: RunDuckdbQueryArgs['onboardingFlow'];
+        queryUuid: string;
+        sql: string;
+        columns: DuckdbQueryColumns;
+        storedCompiledSql: string | null;
+        resultsKey: string;
+        cached: CacheHitCacheResult;
+        queryTags: RunQueryTags;
+        queryCreatedAt: Date;
+        context: QueryExecutionContext;
+        warehouseType: WarehouseTypes;
+    }): Promise<void> {
+        // The hit is on the spec before the row turns ready, so whoever polls
+        // the row reads them together
+        await this.queryHistoryModel.markDuckdbCacheHit(queryUuid);
+        await this.queryHistoryModel.update(
+            queryUuid,
+            projectUuid,
+            {
+                status: QueryHistoryStatus.READY,
+                error: null,
+                cache_key: resultsKey,
+                compiled_sql: storedCompiledSql ?? sql,
+                ...(columns.mode === 'supplied'
+                    ? { fields: columns.fieldsMap }
+                    : {}),
+                total_row_count: cached.totalRowCount,
+                columns: cached.columns,
+                original_columns:
+                    cached.originalColumns ??
+                    (columns.mode === 'supplied'
+                        ? columns.originalColumns
+                        : null),
+                results_file_name: cached.fileName,
+                results_created_at: cached.createdAt,
+                results_updated_at: cached.updatedAt,
+                results_expires_at: cached.expiresAt,
+                pivot_values_columns: cached.pivotValuesColumns,
+                pivot_total_column_count: cached.pivotTotalColumnCount,
+                warehouse_execution_time_ms: 0,
+            },
+            account,
+        );
+        this.prometheusMetrics?.trackQueryStateTransition(
+            QueryHistoryStatus.EXECUTING,
+            QueryHistoryStatus.READY,
+            context,
+        );
+        this.trackQueryTerminalStatus(
+            QueryHistoryStatus.READY,
+            queryCreatedAt,
+            context,
+        );
+        this.analytics.track({
+            ...(actor.isRegisteredUser
+                ? { userId: actor.userUuid }
+                : { anonymousId: 'embed' }),
+            event: 'query.completed',
+            properties: {
+                queryId: queryUuid,
+                organizationId: organizationUuid,
+                projectId: projectUuid,
+                isPreviewProject,
+                status: 'success',
+                context,
+                onboardingFlow,
+                exploreName: queryTags.explore_name ?? null,
+                chartId: queryTags.chart_uuid ?? null,
+                dashboardId: queryTags.dashboard_uuid ?? null,
+                cacheHit: true,
+                executionSource: 'pre_aggregate_duckdb',
+                warehouseType,
+                warehouseExecutionTimeMs: 0,
+                totalRowCount: cached.totalRowCount,
+                columnsCount: cached.columns
+                    ? Object.keys(cached.columns).length
+                    : null,
+            },
+        });
     }
 
     /**
@@ -8978,7 +9153,7 @@ export class AsyncQueryService extends ProjectService {
                         queryId: queryUuid,
                         engine: 'compose',
                         status: 'ready',
-                        cacheHit: false,
+                        cacheHit: spec?.cacheHit ?? false,
                         legCacheHits,
                         rowCount: outcome.rowCount,
                         durationMs,

--- a/packages/backend/src/services/AsyncQueryService/types.ts
+++ b/packages/backend/src/services/AsyncQueryService/types.ts
@@ -413,6 +413,8 @@ export type BoundDuckdbQueryReferences = {
 
 export type RunDuckdbQueryArgs = {
     actor: QueryHistoryActor;
+    /** Skip the lookup by result files and run regardless. */
+    invalidateCache: boolean;
     projectUuid: string;
     organizationUuid: string;
     isPreviewProject: boolean;

--- a/packages/backend/src/services/QuerySourceService/sources/DuckdbQuerySource.ts
+++ b/packages/backend/src/services/QuerySourceService/sources/DuckdbQuerySource.ts
@@ -172,7 +172,9 @@ export class DuckdbQuerySource implements QuerySourceClient {
                       ),
                   });
 
-        // A DuckDB query always runs: its inputs may be cached, it is not
+        // Whether the run is served from an earlier one over the same result
+        // files is known only once its references are bound, so submit
+        // cannot report it; the row and the merge event carry it
         return { queryUuid, cacheHit: false };
     }
 }

--- a/packages/common/src/types/queryHistory.ts
+++ b/packages/common/src/types/queryHistory.ts
@@ -108,5 +108,9 @@ export type DuckdbExecutionSpec = {
     storedCompiledSql: string | null;
     /** What the user calls each referenced table, for messages that name one. */
     referenceLabels: Record<string, string>;
+    /** The submitter asked for fresh results: no lookup by the result files. */
+    invalidateCache: boolean;
+    /** Set when the run was served from another run over the same result files. */
+    cacheHit: boolean;
     refusal: { kind: 'row_cap' } | null;
 };


### PR DESCRIPTION
Stacked on #28744 (PROD-10993). Top of the merge-as-composition chain. Restores what the review of #28731 found missing.

## What

A DuckDB source query, the merge join or a compose SQL query, is served from the results cache by the files it reads.

- The join's cache key used to include the leg query uuids. A leg served from cache mints a new history row over the same result file, so the uuids changed on every run and nothing ever looked the key up: a dashboard reload ran the join again over cached legs and wrote three history rows per merged tile instead of one.
- Once the references are bound, the run computes a key from its SQL, the referenced result files in reference-table order and its parameters. It looks that key up through the cache service; on a hit it lands the row as ready on the earlier run's file, columns and row count without opening DuckDB; on a miss it runs and stores its results under that key, so the next run over the same files finds them.
- `invalidateCache` on the merge reached the legs at submit and was dropped for the join. It is persisted on the join's execution spec and skips the lookup.
- The hit is recorded on the spec before the row turns ready, and the merge executed event reports it.

```mermaid
flowchart LR
    L0[leg row A] -- "results file a.jsonl" --> K
    L1[leg row B] -- "results file b.jsonl" --> K
    K["key = hash(join SQL, [a.jsonl, b.jsonl], parameters)"] --> C{results cache}
    C -- hit --> R[row ready on the earlier file, no DuckDB]
    C -- miss --> D[DuckDB join] --> S[results stored under key]
```

## Regression analysis

- **Dashboards with merged tiles**: a reload after the first load is a cache hit on the join as well as the legs, as it was on the warehouse merge. One history row per tile is written for the join, as before; the legs' rows are the same as any cached query.
- **Freshness**: the key is the files, so a leg that re-runs (its own cache expired or invalidated) produces a new file and a fresh join. A join cannot be served from results older than any leg it reads. The cache service's own TTL and expiry buffer apply unchanged.
- **Invalidate**: the merge's `invalidateCache` now bypasses the join lookup, which it could not before because the join never looked anything up.
- **Rows created before this change** carry a uuid-based key. They are never matched by a file-based key, so they are simply not served; nothing reads them wrongly.
- **Compose SQL** shares the tail and gains the same behaviour. External SQL, whose references are bound to private file URIs rather than result rows, does not participate.
- **Worker and in-process** run the same code; the lookup uses the row's actor, not a session, and the cache service's feature-flag check receives the user and organisation ids.
- **Submit response**: `cacheHit` on the merge submission stays `false`, since the hit is only known once the legs are bound. The row and the executed event carry the truth.
- **No API or schema change.** `cache_key` becomes updatable on the history row, which the run writes by primary key.

## Verification

- Backend typecheck, lint and format; `pnpm -F backend test:dev:nowatch`: 490 files, 8983 passed.
- New tests: a run over the same files is served from the earlier run without touching DuckDB; a run that finds nothing lands its results under the file-based key and hands that key to the executor; invalidating the cache skips the lookup.
- Live on an isolated instance: the merge parity suite run twice back to back; the second run's join rows land ready with a cache hit on the spec and zero DuckDB time.

Closes: PROD-11011

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEnsqumJBXz87BAyqXXKC7
