### PR TITLE
fix(sdk): follow the token prop when rotating embed tokens

### DIFF
--- a/packages/frontend/sdk/index.test.tsx
+++ b/packages/frontend/sdk/index.test.tsx
@@ -41,9 +41,19 @@ vi.mock('../src/components/MonacoEditor', () => ({
     useMonaco: () => null,
 }));
 
-vi.mock('../src/ee/pages/EmbedChart', () => ({
-    default: () => <div data-testid="embed-chart-view" />,
-}));
+vi.mock('../src/ee/pages/EmbedChart', async () => {
+    const { default: useEmbed } =
+        await import('../src/ee/providers/Embed/useEmbed');
+
+    return {
+        default: function MockEmbedChart() {
+            const { embedToken } = useEmbed();
+            return (
+                <div data-testid="embed-chart-view" data-token={embedToken} />
+            );
+        },
+    };
+});
 
 vi.mock('../src/ee/pages/EmbedExplore', () => ({
     default: ({
@@ -200,7 +210,21 @@ vi.mock('../src/pages/MetricsCatalog', async () => {
     };
 });
 
+vi.mock('../src/hooks/health/useHealth', () => ({
+    default: () => ({ data: undefined }),
+}));
+
 import { FilterOperator } from '@lightdash/common';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { lightdashApi } from '../src/api';
+import EmbedProvider from '../src/ee/providers/Embed/EmbedProvider';
+import { EMBED_KEY, type InMemoryEmbed } from '../src/ee/providers/Embed/types';
+import {
+    clearInMemoryStorage,
+    getFromInMemoryStorage,
+} from '../src/utils/inMemoryStorage';
 import {
     AiAgent,
     Chart,
@@ -676,5 +700,127 @@ describe('SDK API client', () => {
                 signal: undefined,
             },
         );
+    });
+});
+
+describe('SDK token rotation', () => {
+    const header = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9';
+    const payload =
+        'eyJjb250ZW50Ijp7InByb2plY3RVdWlkIjoidGVzdC1wcm9qZWN0LXV1aWQifX0';
+    const tokenA = `${header}.${payload}.signature-a`;
+    const tokenB = `${header}.${payload}.signature-b`;
+    const instanceUrl = 'http://localhost:3000';
+    const originalLocation = window.location;
+    const storedToken = () =>
+        getFromInMemoryStorage<InMemoryEmbed>(EMBED_KEY)?.token;
+
+    beforeEach(() => {
+        clearInMemoryStorage();
+        window.location = {
+            ...window.location,
+            pathname: '/test',
+            search: '',
+            hash: '',
+        };
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        window.location = originalLocation;
+    });
+
+    it('sends the rotated token on the next request without remounting', async () => {
+        const fetchMock = vi.fn().mockResolvedValue(
+            new Response(JSON.stringify({ status: 'ok', results: {} }), {
+                status: 200,
+            }),
+        );
+        vi.stubGlobal('fetch', fetchMock);
+
+        const { rerender, getByTestId } = render(
+            <Dashboard token={tokenA} instanceUrl={instanceUrl} filters={[]} />,
+        );
+        await waitFor(() => expect(storedToken()).toBe(tokenA));
+        const mountedDashboard = getByTestId('embed-dashboard');
+
+        rerender(
+            <Dashboard token={tokenB} instanceUrl={instanceUrl} filters={[]} />,
+        );
+        await waitFor(() => expect(storedToken()).toBe(tokenB));
+
+        expect(getByTestId('embed-dashboard')).toBe(mountedDashboard);
+
+        await lightdashApi({ url: '/anything', method: 'GET' });
+        const [, requestInit] = fetchMock.mock.calls[0];
+        expect(requestInit.headers['lightdash-embed-token']).toBe(tokenB);
+    });
+
+    it('ignores an older token promise that resolves after a newer one', async () => {
+        let resolveTokenA: (token: string) => void = () => {};
+        const slowTokenA = new Promise<string>((resolve) => {
+            resolveTokenA = resolve;
+        });
+
+        const { rerender, getByTestId } = render(
+            <Chart token={slowTokenA} instanceUrl={instanceUrl} id="chart" />,
+        );
+        rerender(
+            <Chart
+                token={Promise.resolve(tokenB)}
+                instanceUrl={instanceUrl}
+                id="chart"
+            />,
+        );
+        await waitFor(() =>
+            expect(getByTestId('embed-chart-view').dataset.token).toBe(tokenB),
+        );
+
+        await act(async () => {
+            resolveTokenA(tokenA);
+            await slowTokenA;
+        });
+
+        expect(getByTestId('embed-chart-view').dataset.token).toBe(tokenB);
+        expect(storedToken()).toBe(tokenB);
+    });
+
+    const renderProvider = (
+        queryClient: QueryClient,
+        embedToken: string | undefined,
+    ) => (
+        <QueryClientProvider client={queryClient}>
+            <MemoryRouter>
+                <EmbedProvider embedToken={embedToken} projectUuid="p1">
+                    <div />
+                </EmbedProvider>
+            </MemoryRouter>
+        </QueryClientProvider>
+    );
+
+    it('refetches the account when the token changes, not on mount', async () => {
+        const queryClient = new QueryClient();
+        const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
+
+        const { rerender } = render(renderProvider(queryClient, tokenA));
+        expect(invalidate).not.toHaveBeenCalled();
+
+        rerender(renderProvider(queryClient, tokenB));
+        await waitFor(() =>
+            expect(invalidate).toHaveBeenCalledWith({ queryKey: ['account'] }),
+        );
+        expect(invalidate).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps the direct-mode token after the hash is stripped from the URL', () => {
+        const queryClient = new QueryClient();
+        window.location = { ...window.location, hash: `#${tokenA}` };
+
+        const { rerender } = render(renderProvider(queryClient, undefined));
+        expect(storedToken()).toBe(tokenA);
+
+        window.location = { ...window.location, hash: '' };
+        rerender(renderProvider(queryClient, undefined));
+
+        expect(storedToken()).toBe(tokenA);
     });
 });

--- a/packages/frontend/sdk/index.tsx
+++ b/packages/frontend/sdk/index.tsx
@@ -149,17 +149,18 @@ const useEmbedTokenContext = (
     } | null>(null);
 
     useEffect(() => {
-        let isMounted = true;
+        // Flipped by cleanup on unmount and whenever the token prop changes,
+        // so an older token promise resolving late cannot overwrite a newer one.
+        let isCurrent = true;
 
         persistInstanceUrl(instanceUrl);
 
-        const resolveToken = async () =>
-            typeof tokenOrTokenPromise === 'string'
-                ? tokenOrTokenPromise
-                : tokenOrTokenPromise;
-
-        resolveToken()
+        Promise.resolve(tokenOrTokenPromise)
             .then((tokenToDecode) => {
+                if (!isCurrent) {
+                    return;
+                }
+
                 const { payload } = decodeJWT(tokenToDecode);
 
                 if (
@@ -167,12 +168,10 @@ const useEmbedTokenContext = (
                     'content' in payload &&
                     'projectUuid' in payload.content
                 ) {
-                    if (isMounted) {
-                        setTokenContext({
-                            token: tokenToDecode,
-                            projectUuid: payload.content.projectUuid,
-                        });
-                    }
+                    setTokenContext({
+                        token: tokenToDecode,
+                        projectUuid: payload.content.projectUuid,
+                    });
                 } else {
                     throw new Error('Error decoding token');
                 }
@@ -183,7 +182,7 @@ const useEmbedTokenContext = (
             });
 
         return () => {
-            isMounted = false;
+            isCurrent = false;
         };
     }, [instanceUrl, tokenOrTokenPromise]);
 
@@ -599,50 +598,21 @@ const Explore: FC<
     exploreId,
     savedChart,
 }) => {
-    const [token, setToken] = useState<string | null>(null);
-    const [projectUuid, setProjectUuid] = useState<string | null>(null);
+    const tokenContext = useEmbedTokenContext(instanceUrl, tokenOrTokenPromise);
 
-    const handleDecodeToken = (tokenToDecode: string) => {
-        const { payload } = decodeJWT(tokenToDecode);
-
-        if (
-            payload &&
-            'content' in payload &&
-            'projectUuid' in payload.content
-        ) {
-            setToken(tokenToDecode);
-            setProjectUuid(payload.content.projectUuid);
-        } else {
-            throw new Error('Error decoding token');
-        }
-    };
-
-    useEffect(() => {
-        persistInstanceUrl(instanceUrl);
-
-        if (typeof tokenOrTokenPromise === 'string') {
-            handleDecodeToken(tokenOrTokenPromise);
-        } else {
-            tokenOrTokenPromise
-                .then((tokenToDecode) => {
-                    handleDecodeToken(tokenToDecode);
-                })
-                .catch((error) => {
-                    console.error(error);
-                    throw new Error('Error retrieving token');
-                });
-        }
-    }, [instanceUrl, tokenOrTokenPromise]);
-
-    if (!token || !projectUuid) {
+    if (!tokenContext) {
         return null;
     }
 
     return (
-        <SdkProviders projectUuid={projectUuid} styles={styles} theme={theme}>
+        <SdkProviders
+            projectUuid={tokenContext.projectUuid}
+            styles={styles}
+            theme={theme}
+        >
             <EmbedProvider
-                embedToken={token}
-                projectUuid={projectUuid}
+                embedToken={tokenContext.token}
+                projectUuid={tokenContext.projectUuid}
                 filters={filters}
                 contentOverrides={contentOverrides}
                 uiOverrides={uiOverrides}
@@ -728,42 +698,9 @@ const Chart: FC<ChartProps> = ({
     id,
     isEditMode,
 }) => {
-    const [token, setToken] = useState<string | null>(null);
-    const [projectUuid, setProjectUuid] = useState<string | null>(null);
+    const tokenContext = useEmbedTokenContext(instanceUrl, tokenOrTokenPromise);
 
-    const handleDecodeToken = (tokenToDecode: string) => {
-        const { payload } = decodeJWT(tokenToDecode);
-
-        if (
-            payload &&
-            'content' in payload &&
-            'projectUuid' in payload.content
-        ) {
-            setToken(tokenToDecode);
-            setProjectUuid(payload.content.projectUuid);
-        } else {
-            throw new Error('Error decoding token');
-        }
-    };
-
-    useEffect(() => {
-        persistInstanceUrl(instanceUrl);
-
-        if (typeof tokenOrTokenPromise === 'string') {
-            handleDecodeToken(tokenOrTokenPromise);
-        } else {
-            tokenOrTokenPromise
-                .then((tokenToDecode) => {
-                    handleDecodeToken(tokenToDecode);
-                })
-                .catch((error) => {
-                    console.error(error);
-                    throw new Error('Error retrieving token');
-                });
-        }
-    }, [instanceUrl, tokenOrTokenPromise]);
-
-    if (!token || !projectUuid) {
+    if (!tokenContext) {
         return null;
     }
 
@@ -778,10 +715,14 @@ const Chart: FC<ChartProps> = ({
     };
 
     return (
-        <SdkProviders projectUuid={projectUuid} styles={styles} theme={theme}>
+        <SdkProviders
+            projectUuid={tokenContext.projectUuid}
+            styles={styles}
+            theme={theme}
+        >
             <EmbedProvider
-                embedToken={token}
-                projectUuid={projectUuid}
+                embedToken={tokenContext.token}
+                projectUuid={tokenContext.projectUuid}
                 contentOverrides={contentOverrides}
                 uiOverrides={uiOverrides}
                 savedQueryUuid={id}

--- a/packages/frontend/src/ee/providers/Embed/EmbedProvider.tsx
+++ b/packages/frontend/src/ee/providers/Embed/EmbedProvider.tsx
@@ -6,7 +6,15 @@ import {
     type UiStringKey,
     type UUID,
 } from '@lightdash/common';
-import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    type FC,
+} from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router';
 import { useAccount } from '../../../hooks/user/useAccount';
 import { useAbilityContext } from '../../../providers/Ability/useAbilityContext';
@@ -88,7 +96,22 @@ const EmbedProvider: FC<React.PropsWithChildren<Props>> = ({
     appUuid,
 }) => {
     const embedToken = encodedToken || window.location.hash.replace('#', '');
-    const [isInitialized, setIsInitialized] = useState(false);
+    const params = useParams();
+    const projectUuid = projectUuidFromProps || params.projectUuid;
+
+    // Synced during render, not in an effect: direct embeds strip the token hash
+    // on first render, and the empty prop that follows must not wipe the store.
+    const storedEmbed = getFromInMemoryStorage<InMemoryEmbed>(EMBED_KEY);
+    if (
+        embedToken &&
+        (storedEmbed?.token !== embedToken ||
+            storedEmbed?.projectUuid !== projectUuid)
+    ) {
+        setToInMemoryStorage(EMBED_KEY, {
+            projectUuid,
+            token: embedToken,
+        });
+    }
 
     // Parse theme params from URL once on mount (before hash is stripped)
     const [embedThemeParams] = useState(parseEmbedThemeParams);
@@ -101,10 +124,9 @@ const EmbedProvider: FC<React.PropsWithChildren<Props>> = ({
     const embed = getFromInMemoryStorage<InMemoryEmbed>(EMBED_KEY);
     const { data: account, isLoading } = useAccount();
     const ability = useAbilityContext();
-    const params = useParams();
     const navigate = useNavigate();
-    const projectUuid = projectUuidFromProps || params.projectUuid;
     const location = useLocation();
+    const queryClient = useQueryClient();
     const { dispatchEmbedEvent } = useEmbedEventEmitter();
     const mode: EmbedMode = encodedToken ? 'sdk' : 'direct';
     const tokenFromStorageOrProps = embedToken || embed?.token;
@@ -159,18 +181,16 @@ const EmbedProvider: FC<React.PropsWithChildren<Props>> = ({
         }
     }, [ability, account, isLoading]);
 
-    // There is method to this madness:
-    // When we get an embedded URL, the JWT token is added as a hash to the URL location.
-    // We immediately redirect somewhere else to a URL without the hash. Consequently, if we make
-    // this initialization in a useEffect, we will not have the hash token in the URL by the time
-    // the effect runs.
-    if (!isInitialized) {
-        setToInMemoryStorage(EMBED_KEY, {
-            projectUuid,
-            token: embedToken,
-        });
-        setIsInitialized(true);
-    }
+    // A rotated token can carry different claims, and the account query is not
+    // keyed on the token, so refetch it rather than serve stale abilities.
+    const lastSeenTokenRef = useRef(embedToken);
+    useEffect(() => {
+        if (!embedToken || lastSeenTokenRef.current === embedToken) {
+            return;
+        }
+        lastSeenTokenRef.current = embedToken;
+        void queryClient.invalidateQueries({ queryKey: ['account'] });
+    }, [embedToken, queryClient]);
 
     const value = useMemo(() => {
         return {

--- a/packages/sdk-test-app/src/examples/TokenRotationExamplePage.tsx
+++ b/packages/sdk-test-app/src/examples/TokenRotationExamplePage.tsx
@@ -1,0 +1,459 @@
+import Lightdash, { FilterOperator } from '@lightdash/sdk';
+import type { CSSProperties } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { ExampleLayout } from '../components/ExampleLayout';
+import { ExampleSelect } from '../components/ExampleSelect';
+import type { EmbedConfigState } from '../hooks/useEmbedConfig';
+import { getRepoSourceUrl } from '../lib/repo';
+import { monoFontFamily } from '../styles';
+import {
+    helperTextStyle,
+    sectionTitleStyle,
+} from './FiltersExamplePage.styles';
+
+type TokenRotationExamplePageProps = {
+    embedConfig: EmbedConfigState;
+};
+
+type TokenLabel = 'A' | 'B' | 'none' | 'other';
+
+type ObservedRequest = {
+    id: number;
+    path: string;
+    header: string | undefined;
+    status: number | 'failed';
+    at: string;
+};
+
+type RequestLogEntry = Omit<ObservedRequest, 'header'> & { token: TokenLabel };
+
+type RequestListener = (request: ObservedRequest) => void;
+
+const EMBED_TOKEN_HEADER = 'lightdash-embed-token';
+const MAX_LOG_ENTRIES = 9;
+
+const sourceUrl = getRepoSourceUrl(
+    'packages/sdk-test-app/src/examples/TokenRotationExamplePage.tsx',
+);
+
+const CUSTOMER_FIRST_NAME_OPTIONS = [
+    { value: '', label: 'All customers' },
+    { value: 'Barbara', label: 'Barbara' },
+    { value: 'David', label: 'David' },
+    { value: 'Diana', label: 'Diana' },
+    { value: 'Elizabeth', label: 'Elizabeth' },
+];
+
+const layoutStyle: CSSProperties = {
+    display: 'grid',
+    gridTemplateColumns: '380px minmax(0, 1fr)',
+    gap: '24px',
+    alignItems: 'start',
+};
+
+const columnStyle: CSSProperties = {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '16px',
+};
+
+const statusCardStyle: CSSProperties = {
+    border: '1px solid #e5e5e5',
+    borderRadius: '6px',
+    padding: '12px 14px',
+    backgroundColor: '#fafafa',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '4px',
+};
+
+const statusLabelStyle: CSSProperties = {
+    fontSize: '12px',
+    color: '#737373',
+};
+
+const statusValueStyle: CSSProperties = {
+    fontFamily: monoFontFamily,
+    fontSize: '22px',
+    lineHeight: 1.1,
+    color: '#171717',
+};
+
+const statusDetailStyle: CSSProperties = {
+    fontFamily: monoFontFamily,
+    fontSize: '12px',
+    color: '#525252',
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+};
+
+const buttonStyle: CSSProperties = {
+    fontSize: '13px',
+    fontWeight: 500,
+    padding: '10px 16px',
+    border: '1px solid #171717',
+    borderRadius: '6px',
+    backgroundColor: '#171717',
+    color: '#fff',
+    cursor: 'pointer',
+};
+
+const disabledButtonStyle: CSSProperties = {
+    ...buttonStyle,
+    backgroundColor: '#e5e5e5',
+    border: '1px solid #e5e5e5',
+    color: '#737373',
+    cursor: 'not-allowed',
+};
+
+const tokenInputStyle: CSSProperties = {
+    ...statusDetailStyle,
+    padding: '8px',
+    border: '1px solid #e5e5e5',
+    borderRadius: '4px',
+    backgroundColor: '#fff',
+};
+
+const tableStyle: CSSProperties = {
+    width: '100%',
+    borderCollapse: 'collapse',
+    fontFamily: monoFontFamily,
+    fontSize: '12px',
+};
+
+const cellStyle: CSSProperties = {
+    textAlign: 'left',
+    padding: '5px 6px',
+    borderBottom: '1px solid #e5e5e5',
+    whiteSpace: 'nowrap',
+};
+
+const dashboardStyle: CSSProperties = {
+    width: '100%',
+    height: '720px',
+    border: '1px solid #e5e5e5',
+    borderRadius: '8px',
+    backgroundColor: '#fafafa',
+    overflow: 'auto',
+};
+
+const decodeExpiry = (token: string | null): number | null => {
+    const payload = token?.split('.')[1];
+    if (!payload) return null;
+    try {
+        const normalized = payload.replace(/-/g, '+').replace(/_/g, '/');
+        const decoded = JSON.parse(atob(normalized)) as { exp?: number };
+        return typeof decoded.exp === 'number' ? decoded.exp * 1000 : null;
+    } catch {
+        return null;
+    }
+};
+
+const readHeader = (headers: HeadersInit | undefined): string | undefined => {
+    if (!headers) return undefined;
+    if (headers instanceof Headers) {
+        return headers.get(EMBED_TOKEN_HEADER) ?? undefined;
+    }
+    if (Array.isArray(headers)) {
+        return headers.find(
+            ([name]) => name.toLowerCase() === EMBED_TOKEN_HEADER,
+        )?.[1];
+    }
+    return headers[EMBED_TOKEN_HEADER];
+};
+
+const requestUrl = (input: RequestInfo | URL): string => {
+    if (typeof input === 'string') return input;
+    if (input instanceof URL) return input.toString();
+    return input.url;
+};
+
+const shortPath = (url: string) => {
+    try {
+        const { pathname } = new URL(url, window.location.origin);
+        return pathname
+            .replace(/^\/api\/v\d+/, '')
+            .replace(/[0-9a-f-]{36}/g, '…');
+    } catch {
+        return url;
+    }
+};
+
+// Installed once per page so the very first SDK requests are logged too.
+let requestListener: RequestListener | null = null;
+let observedOrigin: string | null = null;
+let nextRequestId = 1;
+let isFetchWrapped = false;
+
+const isInstanceRequest = (url: string) => {
+    try {
+        const parsed = new URL(url, window.location.origin);
+        return (
+            parsed.origin === observedOrigin &&
+            parsed.pathname.includes('/api/')
+        );
+    } catch {
+        return false;
+    }
+};
+
+const wrapFetch = () => {
+    if (isFetchWrapped) return;
+    isFetchWrapped = true;
+    const originalFetch = window.fetch;
+
+    window.fetch = async (input, init) => {
+        const url = requestUrl(input);
+        if (!requestListener || !isInstanceRequest(url)) {
+            return originalFetch(input, init);
+        }
+        const listener = requestListener;
+        const entry = {
+            id: nextRequestId++,
+            path: shortPath(url),
+            header: readHeader(init?.headers),
+            at: new Date().toLocaleTimeString(),
+        };
+        try {
+            const response = await originalFetch(input, init);
+            listener({ ...entry, status: response.status });
+            return response;
+        } catch (error) {
+            listener({ ...entry, status: 'failed' });
+            throw error;
+        }
+    };
+};
+
+const formatSeconds = (ms: number) => `${Math.max(0, Math.ceil(ms / 1000))}s`;
+
+export function TokenRotationExamplePage({
+    embedConfig,
+}: TokenRotationExamplePageProps) {
+    const query = useMemo(
+        () => new URLSearchParams(window.location.search),
+        [],
+    );
+    const instanceUrl =
+        embedConfig.instanceUrl ??
+        query.get('instanceUrl') ??
+        'http://localhost:3000/';
+    const tokenA = query.get('tokenA') ?? embedConfig.token;
+    const [tokenB, setTokenB] = useState(query.get('tokenB') ?? '');
+    const [activeToken, setActiveToken] = useState<'A' | 'B'>('A');
+    const [selectedCustomerFirstName, setSelectedCustomerFirstName] =
+        useState('');
+    const [requestLog, setRequestLog] = useState<RequestLogEntry[]>([]);
+    const [requestCount, setRequestCount] = useState(0);
+    const [now, setNow] = useState(() => Date.now());
+
+    const tokensRef = useRef({ tokenA, tokenB });
+    tokensRef.current = { tokenA, tokenB };
+
+    const recordRequest: RequestListener = ({ header, ...entry }) => {
+        const token: TokenLabel = !header
+            ? 'none'
+            : header === tokensRef.current.tokenA
+              ? 'A'
+              : header === tokensRef.current.tokenB
+                ? 'B'
+                : 'other';
+        setRequestLog((log) =>
+            [{ ...entry, token }, ...log].slice(0, MAX_LOG_ENTRIES),
+        );
+        setRequestCount((count) => count + 1);
+    };
+    const recordRequestRef = useRef(recordRequest);
+    recordRequestRef.current = recordRequest;
+
+    // Subscribe during the first render so child SDK requests are captured.
+    useState(() => {
+        wrapFetch();
+        observedOrigin = new URL(instanceUrl).origin;
+        requestListener = (request) => recordRequestRef.current(request);
+        return null;
+    });
+
+    useEffect(() => {
+        requestListener = (request) => recordRequestRef.current(request);
+        const timer = window.setInterval(() => setNow(Date.now()), 1000);
+        return () => {
+            window.clearInterval(timer);
+            requestListener = null;
+        };
+    }, []);
+
+    const currentToken = activeToken === 'A' ? tokenA : tokenB;
+    const expiryA = decodeExpiry(tokenA);
+    const expiryB = decodeExpiry(tokenB || null);
+    const lastRequest = requestLog[0];
+
+    const dashboardFilters = useMemo(
+        () =>
+            selectedCustomerFirstName
+                ? [
+                      {
+                          model: 'customers',
+                          field: 'first_name',
+                          operator: FilterOperator.EQUALS,
+                          value: [selectedCustomerFirstName],
+                      },
+                  ]
+                : [],
+        [selectedCustomerFirstName],
+    );
+
+    const describeExpiry = (expiry: number | null) => {
+        if (expiry === null) return 'no expiry';
+        return expiry > now
+            ? `expires in ${formatSeconds(expiry - now)}`
+            : `expired ${formatSeconds(now - expiry)} ago`;
+    };
+
+    return (
+        <ExampleLayout
+            embedConfig={embedConfig}
+            sourceUrl={sourceUrl}
+            title="Token rotation demo"
+            description={
+                <>
+                    Rotate the `token` prop from A to B while the same
+                    `Lightdash.Dashboard` stays mounted, then see which token
+                    each SDK request actually carries.
+                </>
+            }
+        >
+            {instanceUrl && tokenA ? (
+                <div style={layoutStyle} data-testid="token-rotation">
+                    <div style={columnStyle}>
+                        <div style={statusCardStyle}>
+                            <span style={statusLabelStyle}>
+                                Token in the prop
+                            </span>
+                            <span
+                                style={statusValueStyle}
+                                data-testid="prop-token"
+                            >
+                                {activeToken}
+                            </span>
+                            <span style={statusDetailStyle}>
+                                A {describeExpiry(expiryA)}
+                            </span>
+                            {tokenB ? (
+                                <span style={statusDetailStyle}>
+                                    B {describeExpiry(expiryB)}
+                                </span>
+                            ) : null}
+                        </div>
+                        <div style={statusCardStyle}>
+                            <span style={statusLabelStyle}>
+                                Last request header
+                            </span>
+                            <span
+                                style={statusValueStyle}
+                                data-testid="last-request-token"
+                            >
+                                {lastRequest?.token ?? '–'}
+                            </span>
+                            <span
+                                style={statusDetailStyle}
+                                data-testid="last-request-status"
+                            >
+                                {lastRequest
+                                    ? `${lastRequest.status} ${lastRequest.path}`
+                                    : 'no requests yet'}
+                            </span>
+                        </div>
+                        <div style={statusCardStyle}>
+                            <button
+                                type="button"
+                                data-testid="rotate-button"
+                                style={
+                                    tokenB && activeToken === 'A'
+                                        ? buttonStyle
+                                        : disabledButtonStyle
+                                }
+                                disabled={!tokenB || activeToken === 'B'}
+                                onClick={() => setActiveToken('B')}
+                            >
+                                {activeToken === 'B'
+                                    ? 'Rotated to token B'
+                                    : 'Rotate to token B'}
+                            </button>
+                            <input
+                                type="text"
+                                placeholder="Paste token B"
+                                value={tokenB}
+                                onChange={(event) =>
+                                    setTokenB(event.target.value.trim())
+                                }
+                                style={tokenInputStyle}
+                            />
+                        </div>
+                        <ExampleSelect
+                            label="Customer first name"
+                            value={selectedCustomerFirstName}
+                            onChange={setSelectedCustomerFirstName}
+                            options={CUSTOMER_FIRST_NAME_OPTIONS}
+                            helperText="Updates the filters prop, so the tiles query again. No remount, no key change."
+                        />
+                        <div>
+                            <h3 style={sectionTitleStyle}>Request log</h3>
+                            <table
+                                style={tableStyle}
+                                data-testid="request-log"
+                                data-request-count={requestCount}
+                            >
+                                <thead>
+                                    <tr>
+                                        <th style={cellStyle}>time</th>
+                                        <th style={cellStyle}>token</th>
+                                        <th style={cellStyle}>status</th>
+                                        <th style={cellStyle}>path</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {requestLog.map((entry) => (
+                                        <tr key={entry.id}>
+                                            <td style={cellStyle}>
+                                                {entry.at}
+                                            </td>
+                                            <td style={cellStyle}>
+                                                {entry.token}
+                                            </td>
+                                            <td style={cellStyle}>
+                                                {entry.status}
+                                            </td>
+                                            <td style={cellStyle}>
+                                                {entry.path}
+                                            </td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </table>
+                            {requestLog.length === 0 ? (
+                                <p style={helperTextStyle}>
+                                    SDK requests to /api/ will show up here.
+                                </p>
+                            ) : null}
+                        </div>
+                    </div>
+                    <div style={dashboardStyle} data-testid="dashboard-frame">
+                        <Lightdash.Dashboard
+                            instanceUrl={instanceUrl}
+                            token={currentToken ?? ''}
+                            filters={dashboardFilters}
+                            styles={{ backgroundColor: 'transparent' }}
+                        />
+                    </div>
+                </div>
+            ) : (
+                <p style={helperTextStyle}>
+                    Click Config to add an embed URL, or open this page with
+                    ?tokenA=…&tokenB=… in the query string.
+                </p>
+            )}
+        </ExampleLayout>
+    );
+}

--- a/packages/sdk-test-app/src/examples/examples.tsx
+++ b/packages/sdk-test-app/src/examples/examples.tsx
@@ -8,6 +8,7 @@ import { I18nExamplePage } from './I18nExamplePage';
 import { MetricsCatalogExamplePage } from './MetricsCatalogExamplePage';
 import { PaletteUuidExamplePage } from './PaletteUuidExamplePage';
 import { ThemeExamplePage } from './ThemeExamplePage';
+import { TokenRotationExamplePage } from './TokenRotationExamplePage';
 
 export type ExampleDefinition = {
     component: ComponentType<{ embedConfig: EmbedConfigState }>;
@@ -94,6 +95,16 @@ export const examples: ExampleDefinition[] = [
             'Switch the embedded dashboard between light and dark mode via the `theme` prop.',
         sourcePath: 'packages/sdk-test-app/src/examples/ThemeExamplePage.tsx',
         component: ThemeExamplePage,
+    },
+    {
+        slug: 'token-rotation',
+        path: '/examples/token-rotation',
+        title: 'Token rotation demo',
+        description:
+            'Swap the token prop at runtime and watch which token each SDK request carries, without remounting.',
+        sourcePath:
+            'packages/sdk-test-app/src/examples/TokenRotationExamplePage.tsx',
+        component: TokenRotationExamplePage,
     },
     // Future examples:
     // {


### PR DESCRIPTION
## Problem

Passing a new `token` prop to `Lightdash.Dashboard`, `Chart`, `Explore` or `MetricsCatalog` never reached the network layer. `EmbedProvider` wrote the token into the in-memory store once, behind an `isInitialized` flag, and both `lightdashApi` variants and `getResultsFromStream` build the `lightdash-embed-token` header from that store only. Hosts that mint short-lived JWTs and re-mint before expiry kept sending the first token until it expired, then every request failed with 403, while the host believed it had refreshed. The only workaround was a remount via `key`, which wipes dashboard filters, Explore state and chart edit mode.

The Data Apps bridge was unaffected because it reads the token from context and builds its own header.

## Fix

Three edits, all frontend, no API or backend change.

1. **`EmbedProvider` syncs the store whenever the token or project differs.** Still during render, not in an effect, because direct embeds strip the token hash on first render and an effect would run too late. The write is skipped when the prop is empty: after the hash is stripped the direct-mode value becomes `''`, and an unguarded compare-and-write would wipe the stored token and break every iframe embed.
2. **`EmbedProvider` invalidates `['account']` when the token changes**, skipping its first run. A rotated token can carry different `userAttributes` or `writeActions`, and the account query is not keyed on the token, so without this we would serve stale abilities.
3. **`Chart` and `Explore` use `useEmbedTokenContext`** instead of their own copies of the resolve-and-decode effect. The shared hook already discards a superseded promise through its cleanup flag; the copies did not, so an older token resolving late could overwrite a newer one.

Also adds a `Token rotation demo` page to `packages/sdk-test-app`. It keeps one `Lightdash.Dashboard` mounted, rotates the prop from token A to token B, and logs which token every SDK request carried, so the behaviour can be replayed by hand.

## Tests

Four new tests in `packages/frontend/sdk/index.test.tsx`. Three fail on `main`:

- sends the rotated token on the next request without remounting (asserts the same DOM node and the header of the next `lightdashApi` fetch)
- ignores an older token promise that resolves after a newer one (`Chart`)
- refetches the account when the token changes, not on mount
- keeps the direct-mode token after the hash is stripped from the URL (passes on `main` too; guards the sync against the iframe case above)

Verified in a browser against the local stack with the test app, token A minted with a 70s TTL: on `main` the header still carries A after rotation and tile queries 403 once A expires; on this branch the header carries B and the dashboard keeps working with its filters intact.

## Regression analysis

- **Direct iframe embeds**: behaviour unchanged, covered by the fourth test. The only difference is that a page opened with no token in the hash no longer writes an empty store entry, which only affects requests that would fail auth anyway. `EmbeddedApp` renders inside the app `ReactQueryProvider`, and `EmbedProvider` already used a react-query hook via the event emitter, so `useQueryClient` adds no new requirement.
- **Performance**: one extra `GET /user/account` per rotation, nothing else. The store sync is a Map lookup plus two string compares per `EmbedProvider` render, which already read the store on every render. No new renders, no dashboard query invalidation. Checked with a request probe: filter changes cost the same requests before and after rotation.
- **`Chart` and `Explore` with a string token**: the first render now lands one microtask later because the shared hook resolves through `Promise.resolve`. Not observable; existing tests pass.
- **`Dashboard`, `DashboardBuilder`, `MetricsCatalog`, `AiAgent`**: only a variable rename in the shared hook.
- **Known limitation, unchanged**: the store is a page-wide singleton, so two SDK components with different tokens on one page were already unsupported. With the sync they can now flip between tokens rather than stick to the last one mounted. Follow-up if anyone needs multi-embed.

## Follow-ups (not in this PR)

- `onTokenError` callback on the SDK components, so a rejected token promise reaches the host instead of ending as an unhandled rejection.
- Docs: the `token` prop may be updated at runtime; refresh before expiry; one SDK component per page.
- `AiAgent` puts the token in the iframe hash, so rotation reloads the iframe. Needs a `postMessage` path.

Closes: #20966

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ViMdr4Rno8U9KKisZns7kC
