### PR TITLE
test: expect DuckDB strftime for served pre-aggregate month name

### DIFF
--- a/packages/backend/src/ee/preAggregates/buildPreAggregateExplore.test.ts
+++ b/packages/backend/src/ee/preAggregates/buildPreAggregateExplore.test.ts
@@ -492,7 +492,7 @@ describe('buildPreAggregateExplore', () => {
 
         expect(
             result.tables.orders.dimensions.order_date_month_name.compiledSql,
-        ).toBe("TO_CHAR(orders.orders_order_date_day, 'FMMonth')");
+        ).toBe("strftime(orders.orders_order_date_day, '%B')");
     });
 
     describe('external pre-aggregates', () => {


### PR DESCRIPTION
Follow-up to #28708 (PROD-10975), which was merged before the backend unit-test failure it introduced was addressed.

`buildPreAggregateExplore` serves managed pre-aggregates via DuckDB. #28708 changed DuckDB named time frames to compile with `strftime` instead of Postgres `TO_CHAR`, so the test pinning the served month name to `TO_CHAR(..., 'FMMonth')` now fails on `main`.

This updates the expectation to `strftime(..., '%B')`. No product change.

Verified locally: `pnpm -F backend exec vitest run src/ee/preAggregates` → 140 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0147PnHU19FdRfGsqSRgktBZ