### PR TITLE
feat(cli): scaffold custom chart types with apps create --chart-type

### DIFF
--- a/packages/cli/src/handlers/apps/appsDownload.ts
+++ b/packages/cli/src/handlers/apps/appsDownload.ts
@@ -1,4 +1,5 @@
 import {
+    DATA_APP_VIZ_TEMPLATE,
     getErrorMessage,
     LightdashError,
     ParameterError,
@@ -436,6 +437,12 @@ export const downloadAppsToDir = async (args: {
                 buildStaticAuthoringFiles({
                     appName: code.manifest.name,
                     sdkVersion: cliVersion,
+                    // Downloaded chart types get the viz authoring docs, not
+                    // the app SDK skills a viz must not use.
+                    flavor:
+                        code.manifest.template === DATA_APP_VIZ_TEMPLATE
+                            ? 'chart-type'
+                            : 'app',
                 }),
             );
             // Server-provided deps override the scaffold's

--- a/packages/cli/src/handlers/apps/authoring/chart-type/AGENTS.md.tmpl
+++ b/packages/cli/src/handlers/apps/authoring/chart-type/AGENTS.md.tmpl
@@ -1,0 +1,22 @@
+# Working on this Lightdash custom chart type
+
+This folder is a **custom chart type** (a reusable visualization, the `data_app_viz` template) — ONE chart component that receives its data and settings from Lightdash, not a data app. It runs no query, owns no explore, and must not fetch anything itself.
+
+The contract lives in `.claude/skills/reusable-visualization` — read it before editing: the `useVizContext()` hook, the field/option declaration, resolved series colours, and pivoted results.
+
+The one difference from that skill here: the declaration is not emitted as structured output. It lives in this folder's `lightdash-app.yml` under `vizSchema`, and **must stay in lockstep with the component** — every key `src/App.jsx` reads from `fieldMapping` or `options` is declared there, and everything declared there is read. When you change what the component reads, update `vizSchema` in the same edit.
+
+Edit only `src/`. Root config files are read-only reference — the server rebuilds against a trusted template.
+
+## The loop
+
+1. Edit `src/` (and `vizSchema` in `lightdash-app.yml` when the declaration changes).
+2. `lightdash apps validate --build` — Cloud-parity Vite build; a failure is a validation error with the Vite output.
+3. `lightdash upload --chart-types <slug>` — the server rebuilds; the chart type then appears in the explorer's chart type picker for that project.
+4. Verify in Lightdash: open any explore, run a query, pick this chart type, and map its fields.
+
+There is no local preview for a chart type: `useVizContext()` waits for the Lightdash host, so the component renders nothing standalone (`lightdash apps preview` and `npm run dev` show a blank page). Upload and verify in the explorer instead.
+
+Build with the template's preinstalled dependency set (see `package.json` — React, Recharts, d3, and more). Do not add npm packages or vendor library source into `src/`; chart types published to the official registry must stay template-deps-only.
+
+`.npmrc` sets `ignore-scripts=true` — never remove it or run installs with scripts enabled.

--- a/packages/cli/src/handlers/apps/authoring/chart-type/App.jsx
+++ b/packages/cli/src/handlers/apps/authoring/chart-type/App.jsx
@@ -1,0 +1,95 @@
+import {
+    getFormatted,
+    getRaw,
+    resolveValueColor,
+    useVizContext,
+} from '@lightdash/query-sdk';
+import {
+    Bar,
+    BarChart,
+    Cell,
+    LabelList,
+    ResponsiveContainer,
+    Tooltip,
+    XAxis,
+    YAxis,
+} from 'recharts';
+
+// Starter custom chart type: a bar chart wired to the host the way every viz
+// must be. It runs no query — Lightdash runs the query and pushes rows plus a
+// mapping from the field names declared in lightdash-app.yml's vizSchema to
+// the query's columns. Everything read here (`category`/`value` fields,
+// `showLabels`/`maxBars` options) is declared there; keep the two in lockstep
+// (see .claude/skills/reusable-visualization).
+function App() {
+    const context = useVizContext();
+    const { fieldMapping, rows, options, ready } = context;
+    if (!ready) {
+        return <div style={{ height: '100vh' }} />;
+    }
+
+    const catField = fieldMapping.category;
+    const valField = fieldMapping.value;
+    if (!catField || !valField) {
+        return (
+            <div
+                style={{
+                    height: '100vh',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                }}
+            >
+                Map the Category and Value fields to see the chart.
+            </div>
+        );
+    }
+
+    const { showLabels, maxBars } = options;
+    const fallbackColors = ['#7162FF', '#1A1B1E'];
+    const data = rows.slice(0, maxBars).map((row) => ({
+        label: getFormatted(row, catField),
+        category: getRaw(row, catField),
+        value: Number(getRaw(row, valField) ?? 0),
+    }));
+
+    return (
+        // The root fills the viewport, so ResponsiveContainer has a height to
+        // measure.
+        <div style={{ height: '100vh' }}>
+            <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={data}>
+                    <XAxis
+                        dataKey="label"
+                        tickFormatter={(v) =>
+                            v.length > 12 ? `${v.slice(0, 11)}…` : v
+                        }
+                    />
+                    <YAxis tickFormatter={(v) => v.toLocaleString()} />
+                    <Tooltip />
+                    <Bar dataKey="value">
+                        {data.map((d, i) => (
+                            <Cell
+                                key={`${d.label}-${i}`}
+                                fill={
+                                    resolveValueColor(
+                                        context,
+                                        catField,
+                                        d.category,
+                                        i,
+                                    ) ??
+                                    fallbackColors[i % fallbackColors.length]
+                                }
+                            />
+                        ))}
+                        {showLabels && (
+                            <LabelList dataKey="value" position="top" />
+                        )}
+                    </Bar>
+                </BarChart>
+            </ResponsiveContainer>
+        </div>
+    );
+}
+
+export default App;

--- a/packages/cli/src/handlers/apps/authoring/chart-type/README.md.tmpl
+++ b/packages/cli/src/handlers/apps/authoring/chart-type/README.md.tmpl
@@ -1,0 +1,19 @@
+# {{APP_NAME}} — Lightdash custom chart type (local copy)
+
+Created or downloaded with the Lightdash CLI. This is a **custom chart type** (a reusable visualization): one chart component that Lightdash hands data and settings to. It runs no query of its own — the same component is reused across many different queries.
+
+## Edit → validate → upload
+1. Edit files under `src/`. The component's contract with Lightdash — the fields it maps and the config options viewers can change — is declared in `lightdash-app.yml` under `vizSchema` and must match what `src/App.jsx` reads (see `.claude/skills/reusable-visualization`).
+2. Run `lightdash apps validate` to check the source and manifest; `lightdash apps validate --build` adds the Cloud-parity Vite production build.
+3. `lightdash upload --chart-types <slug>` (the `slug` from `lightdash-app.yml`) — Lightdash rebuilds and serves it.
+4. Open any explore in Lightdash, run a query, and pick this chart type in the chart type picker to see it against real data.
+
+There is no standalone preview: the component waits for the Lightdash host's data, so `npm run dev` shows a blank page. Upload and verify in the explorer.
+
+## What's read-only
+Root config (`vite.config.js`, `tsconfig.json`, etc.) is read-only reference — the server rebuilds against a trusted template. Build within the template's fixed dependency set (see `package.json`); chart types published to the official registry must stay template-deps-only.
+
+`.npmrc` sets `ignore-scripts=true` so dependencies' lifecycle scripts never run on your machine. Keep it; explicit commands such as `npm run build` still work.
+
+## Publishing to the official registry
+Once it works in your instance, a chart type can be proposed for the official chart registry (`lightdash/lightdash-gallery`): copy this folder under that repo's `charts/<slug>/`, run `node scripts/prepare-chart.mjs charts/<slug>` there (it prunes the local scaffold and shapes the folder for the registry), add real screenshots, and open a PR — see that repo's README.

--- a/packages/cli/src/handlers/apps/createApp.test.ts
+++ b/packages/cli/src/handlers/apps/createApp.test.ts
@@ -12,6 +12,7 @@ import { selectProject } from '../selectProject';
 import { readBundleFromDir } from './appCodeFiles';
 import {
     buildLocalAppManifest,
+    CHART_TYPE_STARTER_VIZ_SCHEMA,
     createAppHandler,
     resolveLocalAppSlug,
 } from './createApp';
@@ -74,6 +75,19 @@ describe('resolveLocalAppSlug', () => {
 });
 
 describe('buildLocalAppManifest', () => {
+    it('marks chart types as data_app_viz with the starter vizSchema', () => {
+        const manifest = buildLocalAppManifest({
+            name: 'Radial Gauge',
+            description: '',
+            projectUuid: PROJECT_UUID,
+            slug: 'radial-gauge',
+            now: new Date('2026-01-01T00:00:00.000Z'),
+            chartType: true,
+        });
+        expect(manifest.template).toBe('data_app_viz');
+        expect(manifest.vizSchema).toEqual(CHART_TYPE_STARTER_VIZ_SCHEMA);
+    });
+
     it('builds a slug-identified manifest without an app uuid', () => {
         const manifest = buildLocalAppManifest({
             name: 'Revenue Explorer',
@@ -229,7 +243,7 @@ describe('createAppHandler', () => {
             expect.objectContaining({
                 type: 'confirm',
                 name: 'confirmed',
-                message: 'Install these packages and create the app?',
+                message: 'Install these packages and create the data app?',
                 default: false,
             }),
         ]);
@@ -263,6 +277,78 @@ describe('createAppHandler', () => {
                 input: '\u001B[B\n',
             }),
         );
+    });
+
+    it('creates a custom chart type scaffold with the viz starter and no shadcn', async () => {
+        const root = await fs.mkdtemp(path.join(os.tmpdir(), 'ld-create-app-'));
+
+        await createAppHandler('Radial Gauge', {
+            description: 'A gauge with a needle',
+            path: root,
+            chartType: true,
+            verbose: false,
+        });
+
+        const appDir = path.join(root, 'apps', 'radial-gauge');
+        const bundle = await readBundleFromDir(appDir);
+        expect(bundle.manifest.template).toBe('data_app_viz');
+        expect(bundle.manifest.vizSchema).toEqual(
+            CHART_TYPE_STARTER_VIZ_SCHEMA,
+        );
+
+        const appSource = await fs.readFile(
+            path.join(appDir, 'src/App.jsx'),
+            'utf8',
+        );
+        expect(appSource).toContain('useVizContext');
+
+        // No shadcn generation: chart types ship no UI-kit source.
+        expect(execaMock).not.toHaveBeenCalledWith(
+            'npx',
+            expect.anything(),
+            expect.anything(),
+        );
+
+        // The viz contract skill ships; the app-only skills do not.
+        await expect(
+            fs.access(
+                path.join(
+                    appDir,
+                    '.claude/skills/reusable-visualization/SKILL.md',
+                ),
+            ),
+        ).resolves.toBeUndefined();
+        await expect(
+            fs.access(
+                path.join(appDir, '.claude/skills/lightdash-data-app/SKILL.md'),
+            ),
+        ).rejects.toThrow();
+        await expect(
+            fs.access(
+                path.join(
+                    appDir,
+                    '.claude/skills/developing-data-apps-locally/SKILL.md',
+                ),
+            ),
+        ).rejects.toThrow();
+
+        expect(
+            await fs.readFile(path.join(appDir, 'AGENTS.md'), 'utf8'),
+        ).toContain('custom chart type');
+        expect(
+            await fs.readFile(path.join(appDir, 'README.md'), 'utf8'),
+        ).toContain('Radial Gauge');
+
+        expect(GlobalState.log).toHaveBeenCalledWith(
+            expect.stringContaining('upload --chart-types radial-gauge'),
+        );
+        expect(LightdashAnalytics.track).toHaveBeenCalledWith({
+            event: 'command.executed',
+            properties: expect.objectContaining({
+                command: 'create-chart-type',
+                success: true,
+            }),
+        });
     });
 
     it('requires npm before requesting app context', async () => {

--- a/packages/cli/src/handlers/apps/createApp.ts
+++ b/packages/cli/src/handlers/apps/createApp.ts
@@ -1,11 +1,13 @@
 import {
     AuthorizationError,
+    DATA_APP_VIZ_TEMPLATE,
     generateSlug,
     isValidDataAppSlug,
     LightdashError,
     ParameterError,
     type DataAppContext,
     type DataAppManifest,
+    type DataAppVizSchema,
 } from '@lightdash/common';
 import execa from 'execa';
 import { promises as fs } from 'fs';
@@ -26,16 +28,51 @@ import {
 } from './appCodeFiles';
 import {
     buildStaticAuthoringFiles,
+    loadChartTypeStarterApp,
     loadVendoredStarterSource,
 } from './scaffolding';
 
 export type CreateAppHandlerOptions = {
     assumeYes?: boolean;
+    chartType?: boolean;
     description?: string;
     path?: string;
     project?: string;
     slug?: string;
     verbose: boolean;
+};
+
+// Declaration matching the starter component in authoring/chart-type/App.jsx —
+// the two must stay in lockstep (every key the component reads from
+// fieldMapping/options is declared here, and everything declared is read).
+export const CHART_TYPE_STARTER_VIZ_SCHEMA: DataAppVizSchema = {
+    fields: [
+        {
+            name: 'category',
+            label: 'Category',
+            type: 'dimension',
+            required: true,
+        },
+        { name: 'value', label: 'Value', type: 'metric', required: true },
+    ],
+    configOptions: [
+        {
+            type: 'boolean',
+            name: 'showLabels',
+            label: 'Show value labels',
+            group: 'Labels',
+            default: true,
+        },
+        {
+            type: 'number',
+            name: 'maxBars',
+            label: 'Max bars',
+            default: 10,
+            min: 1,
+            max: 50,
+        },
+    ],
+    colorPalette: {},
 };
 
 export const SHADCN_VERSION = '2.3.0';
@@ -87,6 +124,7 @@ export const buildLocalAppManifest = (args: {
     projectUuid: string;
     slug: string;
     now: Date;
+    chartType?: boolean;
 }): DataAppManifest => ({
     codeVersion: 1,
     projectUuid: args.projectUuid,
@@ -94,7 +132,10 @@ export const buildLocalAppManifest = (args: {
     version: 1,
     name: args.name,
     description: args.description,
-    template: null,
+    template: args.chartType ? DATA_APP_VIZ_TEMPLATE : null,
+    // vizSchema round-trips through upload — without it the uploaded chart
+    // type never appears in the explorer's chart type picker.
+    ...(args.chartType ? { vizSchema: CHART_TYPE_STARTER_VIZ_SCHEMA } : {}),
     downloadedAt: args.now.toISOString(),
     scaffoldingVersion: CLI_VERSION,
 });
@@ -148,13 +189,21 @@ const assertNpmAvailable = async (): Promise<void> => {
 
 const confirmLocalPackageTooling = async (
     assumeYes: boolean,
+    entityLabel: string,
+    withShadcn: boolean,
 ): Promise<void> => {
     GlobalState.log(
         styles.warning(
             [
                 '⚠ Local package installation',
-                `Creating a data app downloads third-party packages through npm into the new app folder and runs shadcn@${SHADCN_VERSION} to generate UI files.`,
-                'Dependency lifecycle scripts are disabled, but npm and shadcn will access the network and write files on this machine.',
+                `Creating a ${entityLabel} downloads third-party packages through npm into the new folder${
+                    withShadcn
+                        ? ` and runs shadcn@${SHADCN_VERSION} to generate UI files`
+                        : ''
+                }.`,
+                `Dependency lifecycle scripts are disabled, but ${
+                    withShadcn ? 'npm and shadcn' : 'npm'
+                } will access the network and write files on this machine.`,
                 'Only continue if you trust these package sources and are comfortable running this tooling locally.',
             ].join('\n'),
         ),
@@ -163,7 +212,7 @@ const confirmLocalPackageTooling = async (
     if (assumeYes) return;
     if (GlobalState.isNonInteractive()) {
         throw new ParameterError(
-            'Creating a data app requires approval to download and install npm packages. Rerun with --assume-yes to approve in non-interactive mode.',
+            `Creating a ${entityLabel} requires approval to download and install npm packages. Rerun with --assume-yes to approve in non-interactive mode.`,
         );
     }
 
@@ -183,13 +232,19 @@ const confirmLocalPackageTooling = async (
 const confirmDependencyInstall = async (
     directPackages: string[],
     assumeYes: boolean,
+    entityLabel: string,
+    withShadcn: boolean,
 ): Promise<void> => {
     GlobalState.log(
         [
-            'Creating this data app will install these direct npm packages:',
+            `Creating this ${entityLabel} will install these direct npm packages:`,
             ...directPackages.map((packageSpec) => `  - ${packageSpec}`),
-            `\nIt will also run shadcn@${SHADCN_VERSION} to generate:`,
-            `  ${SHADCN_COMPONENTS.join(', ')}`,
+            ...(withShadcn
+                ? [
+                      `\nIt will also run shadcn@${SHADCN_VERSION} to generate:`,
+                      `  ${SHADCN_COMPONENTS.join(', ')}`,
+                  ]
+                : []),
             "\nDependency lifecycle scripts will be disabled. React 19 peer dependencies will use npm's legacy-peer-deps mode.",
         ].join('\n'),
     );
@@ -197,7 +252,7 @@ const confirmDependencyInstall = async (
     if (assumeYes) return;
     if (GlobalState.isNonInteractive()) {
         throw new ParameterError(
-            'Creating a data app requires approval to install npm packages. Rerun with --assume-yes to approve in non-interactive mode.',
+            `Creating a ${entityLabel} requires approval to install npm packages. Rerun with --assume-yes to approve in non-interactive mode.`,
         );
     }
 
@@ -205,7 +260,7 @@ const confirmDependencyInstall = async (
         {
             type: 'confirm',
             name: 'confirmed',
-            message: 'Install these packages and create the app?',
+            message: `Install these packages and create the ${entityLabel}?`,
             default: false,
         },
     ]);
@@ -214,7 +269,10 @@ const confirmDependencyInstall = async (
     }
 };
 
-const installDependenciesAndShadcn = async (appDir: string): Promise<void> => {
+const installDependenciesAndShadcn = async (
+    appDir: string,
+    withShadcn: boolean,
+): Promise<void> => {
     const npmEnv = {
         ...process.env,
         npm_config_ignore_scripts: 'true',
@@ -239,6 +297,9 @@ const installDependenciesAndShadcn = async (appDir: string): Promise<void> => {
         ['install', '--include=dev', '--ignore-scripts', '--no-package-lock'],
         subprocessOptions,
     );
+    // Chart types are single chart components (recharts/d3/SVG) — the shadcn
+    // UI kit would only be dead weight shipped in their published source.
+    if (!withShadcn) return;
     await execa(
         'npx',
         ['--yes', `shadcn@${SHADCN_VERSION}`, 'init', '--defaults', '--force'],
@@ -265,6 +326,8 @@ export const createAppHandler = async (
     const startTime = Date.now();
     let success = false;
     GlobalState.setVerbose(options.verbose);
+    const isChartType = options.chartType ?? false;
+    const entityLabel = isChartType ? 'custom chart type' : 'data app';
 
     try {
         const slug = resolveLocalAppSlug(name, options.slug);
@@ -301,15 +364,22 @@ export const createAppHandler = async (
             body: undefined,
         });
 
-        await confirmLocalPackageTooling(options.assumeYes ?? false);
+        await confirmLocalPackageTooling(
+            options.assumeYes ?? false,
+            entityLabel,
+            !isChartType,
+        );
 
         const staticFiles = buildStaticAuthoringFiles({
             appName: name,
             sdkVersion: CLI_VERSION,
+            flavor: isChartType ? 'chart-type' : 'app',
         });
         await confirmDependencyInstall(
             parseDirectPackages(staticFiles),
             options.assumeYes ?? false,
+            entityLabel,
+            !isChartType,
         );
         const manifest = buildLocalAppManifest({
             name,
@@ -317,6 +387,7 @@ export const createAppHandler = async (
             projectUuid,
             slug,
             now: new Date(),
+            chartType: isChartType,
         });
         const appsDir = path.dirname(appDir);
         await fs.mkdir(appsDir, { recursive: true });
@@ -329,22 +400,31 @@ export const createAppHandler = async (
                 manifest,
                 files: loadVendoredStarterSource(),
             });
+            if (isChartType) {
+                // Swap the app placeholder for the viz starter matching the
+                // manifest's CHART_TYPE_STARTER_VIZ_SCHEMA declaration.
+                await writeFilesToDir(temporaryAppDir, [
+                    loadChartTypeStarterApp(),
+                ]);
+            }
             await writeFilesToDir(temporaryAppDir, staticFiles);
             await writeContextToDir(temporaryAppDir, context);
-            await installDependenciesAndShadcn(temporaryAppDir);
+            await installDependenciesAndShadcn(temporaryAppDir, !isChartType);
 
             // shadcn rewrites package versions and tailwind colors while it
             // generates source. Restore the reviewed template declarations so
             // the approval list stays exact and uploads do not mistake the
             // generated app for one with custom dependencies.
-            await writeFilesToDir(
-                temporaryAppDir,
-                staticFiles.filter(
-                    (file) =>
-                        file.path === 'package.json' ||
-                        file.path === 'tailwind.config.js',
-                ),
-            );
+            if (!isChartType) {
+                await writeFilesToDir(
+                    temporaryAppDir,
+                    staticFiles.filter(
+                        (file) =>
+                            file.path === 'package.json' ||
+                            file.path === 'tailwind.config.js',
+                    ),
+                );
+            }
             await fs.rename(temporaryAppDir, appDir);
         } catch (error) {
             await fs.rm(temporaryAppDir, { recursive: true, force: true });
@@ -352,17 +432,23 @@ export const createAppHandler = async (
         }
 
         GlobalState.log(
-            styles.success(`Created data app "${name}" at ${appDir}`),
+            styles.success(`Created ${entityLabel} "${name}" at ${appDir}`),
         );
         GlobalState.log(
-            `\nNext:\n  cd ${JSON.stringify(appDir)}\n  npm run build\n  lightdash upload --apps ${slug}`,
+            isChartType
+                ? `\nNext:\n  cd ${JSON.stringify(
+                      appDir,
+                  )}\n  lightdash apps validate --build\n  lightdash upload --chart-types ${slug}\n\nThen open any explore in Lightdash and pick "${name}" in the chart type picker.`
+                : `\nNext:\n  cd ${JSON.stringify(
+                      appDir,
+                  )}\n  npm run build\n  lightdash upload --apps ${slug}`,
         );
         success = true;
     } finally {
         await LightdashAnalytics.track({
             event: 'command.executed',
             properties: {
-                command: 'create-app',
+                command: isChartType ? 'create-chart-type' : 'create-app',
                 durationMs: Date.now() - startTime,
                 success,
             },

--- a/packages/cli/src/handlers/apps/scaffolding.ts
+++ b/packages/cli/src/handlers/apps/scaffolding.ts
@@ -140,14 +140,35 @@ export const loadVendoredStarterSource = (): DataAppCodeFile[] => {
 };
 
 /**
+ * The chart-type starter component: replaces the template's src/App.jsx when
+ * scaffolding a custom chart type (data_app_viz). The rest of the starter
+ * source (main.jsx already mounts VizContextProvider, lib/, css) is shared
+ * with data apps.
+ */
+export const loadChartTypeStarterApp = (): DataAppCodeFile => {
+    const { authoringDir } = resolveVendorDirs();
+    return {
+        path: 'src/App.jsx',
+        contentBase64: readFileSync(
+            path.join(authoringDir, 'chart-type', 'App.jsx'),
+        ).toString('base64'),
+    };
+};
+
+/** Which scaffold is being assembled: a data app or a custom chart type. */
+export type AuthoringFlavor = 'app' | 'chart-type';
+
+/**
  * Assembles static authoring files (configs, skills, templates) to deploy alongside a data app.
  */
 export const buildStaticAuthoringFiles = (args: {
     appName: string;
     sdkVersion: string;
+    flavor?: AuthoringFlavor;
 }): DataAppCodeFile[] => {
-    const { appName, sdkVersion } = args;
+    const { appName, sdkVersion, flavor = 'app' } = args;
     const { templateDir, authoringDir } = resolveVendorDirs();
+    const isChartType = flavor === 'chart-type';
 
     const files: DataAppCodeFile[] = [];
 
@@ -156,34 +177,47 @@ export const buildStaticAuthoringFiles = (args: {
         files.push(file);
     }
 
-    // 2. skill.md → .claude/skills/lightdash-data-app/SKILL.md
-    files.push({
-        path: '.claude/skills/lightdash-data-app/SKILL.md',
-        contentBase64: readFileSync(
-            path.join(templateDir, 'skill.md'),
-        ).toString('base64'),
-    });
+    // 2+3. App-only skills: a chart type must not query through the SDK, so
+    // the app-building skills would only mislead — the viz contract ships via
+    // the template's .claude/skills/reusable-visualization (step 1).
+    if (!isChartType) {
+        // skill.md → .claude/skills/lightdash-data-app/SKILL.md
+        files.push({
+            path: '.claude/skills/lightdash-data-app/SKILL.md',
+            contentBase64: readFileSync(
+                path.join(templateDir, 'skill.md'),
+            ).toString('base64'),
+        });
 
-    // 3. authoring/developing-data-apps-locally/SKILL.md
-    //    → .claude/skills/developing-data-apps-locally/SKILL.md
-    files.push({
-        path: '.claude/skills/developing-data-apps-locally/SKILL.md',
-        contentBase64: readFileSync(
-            path.join(authoringDir, 'developing-data-apps-locally', 'SKILL.md'),
-        ).toString('base64'),
-    });
+        // authoring/developing-data-apps-locally/SKILL.md
+        //    → .claude/skills/developing-data-apps-locally/SKILL.md
+        files.push({
+            path: '.claude/skills/developing-data-apps-locally/SKILL.md',
+            contentBase64: readFileSync(
+                path.join(
+                    authoringDir,
+                    'developing-data-apps-locally',
+                    'SKILL.md',
+                ),
+            ).toString('base64'),
+        });
+    }
+
+    const flavorDir = isChartType
+        ? path.join(authoringDir, 'chart-type')
+        : authoringDir;
 
     // 4. AGENTS.md.tmpl → AGENTS.md
     files.push({
         path: 'AGENTS.md',
         contentBase64: readFileSync(
-            path.join(authoringDir, 'AGENTS.md.tmpl'),
+            path.join(flavorDir, 'AGENTS.md.tmpl'),
         ).toString('base64'),
     });
 
     // 5. README.md.tmpl → README.md  (substitute {{APP_NAME}})
     const readme = readFileSync(
-        path.join(authoringDir, 'README.md.tmpl'),
+        path.join(flavorDir, 'README.md.tmpl'),
         'utf-8',
     ).replace(/\{\{APP_NAME\}\}/g, appName);
     files.push({

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1186,7 +1186,12 @@ const appsProgram = program
     .description('Work with data apps (enterprise)');
 appsProgram
     .command('create <name>')
-    .description('Creates a new data app locally')
+    .description('Creates a new data app or custom chart type locally')
+    .option(
+        '--chart-type',
+        'Create a custom chart type (a reusable visualization the explorer chart type picker offers) instead of a data app',
+        false,
+    )
     .option('--description <text>', 'Set the app description', '')
     .option('--slug <slug>', 'Override the app slug')
     .option(
@@ -1203,12 +1208,16 @@ appsProgram
     .option('--verbose', undefined, false)
     .addHelpText(
         'after',
-        `\n${styles.bold('Example:')}\n  ${styles.title(
+        `\n${styles.bold('Examples:')}\n  ${styles.title(
             '⚡',
         )}️lightdash ${styles.bold(
             'apps create "Revenue explorer"',
         )} ${styles.secondary(
             '-- creates ./lightdash/apps/revenue-explorer',
+        )}\n  ${styles.title('⚡')}️lightdash ${styles.bold(
+            'apps create "Radial gauge" --chart-type',
+        )} ${styles.secondary(
+            '-- creates a custom chart type at ./lightdash/apps/radial-gauge',
         )}\n`,
     )
     .action(createAppHandler);


### PR DESCRIPTION
Closes: —

### Description:

Local-first bootstrap for custom chart types, mirroring `lightdash apps create` for data apps:

```bash
lightdash apps create "Radial gauge" --chart-type
```

produces `./lightdash/apps/radial-gauge` that uploads for testing with `lightdash upload --chart-types radial-gauge` (existing flag, works unchanged) and is registry-shapeable by lightdash-gallery's `prepare-chart.mjs`.

**What differs from the data-app scaffold** (everything else — trusted template, npm install approvals, `.lightdash/context/`, `.npmrc ignore-scripts` — is shared):

- Manifest: `template: data_app_viz` plus a starter `vizSchema` (category/value fields, showLabels/maxBars options, palette declaration). vizSchema round-trips through upload — without it the chart type never appears in the explorer's picker.
- `src/App.jsx`: a viz starter wired through `useVizContext()` (adapted from the `reusable-visualization` skill's worked example) that reads exactly what the manifest declares. The shared `main.jsx` already mounts `VizContextProvider`, so the rest of the starter source is untouched.
- No shadcn init/add — chart types are single chart components; the UI kit would be dead weight shipped in published viz source. The install-approval prompts drop the shadcn wording accordingly.
- Authoring docs: chart-type `AGENTS.md`/`README.md` pointing at the `reusable-visualization` contract skill; the app-SDK skills (`lightdash-data-app`, `developing-data-apps-locally`) are *not* shipped, since a viz must not query through the SDK. `lightdash download --chart-types` now also gets this flavor instead of the misleading app docs.
- Next-steps output: `apps validate --build` → `upload --chart-types <slug>` → pick it in the explorer's chart type picker (there is no standalone preview — `useVizContext` waits for the host).

### Testing

`createApp` suite extended (16 passing): viz manifest + starter schema, App.jsx swap, no `npx` shadcn calls, skill selection, `--chart-types` next steps, `create-chart-type` analytics command. Starter verified with a real production Vite build against published `@lightdash/query-sdk` + recharts (assembled exactly as `apps validate --build` would).

### Risk assessment:

- [ ] This is a high-risk change

High-risk changes require approval from a reviewer other than the author before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8sCUbSEj5R8babs36CnDN
