### PR TITLE
feat(cli): ship a developing-chart-types-locally skill in the scaffold

### DIFF
--- a/packages/cli/src/handlers/apps/appsDownload.test.ts
+++ b/packages/cli/src/handlers/apps/appsDownload.test.ts
@@ -688,6 +688,46 @@ describe('downloadAppsToDir', () => {
         ).toBe(true);
     });
 
+    it('gives downloaded chart types the chart-type authoring flavor', async () => {
+        const appsDir = tmpDir();
+        const vizCode = codeFor('my-chart-type');
+        vizCode.manifest.template = 'data_app_viz';
+
+        const outcome = await downloadAppsToDir({
+            appRefs: ['my-chart-type'],
+            projectId: 'project-uuid',
+            appsDir,
+            takenFolders: new Set(),
+            cliVersion: '0.0.0-test',
+            fetchApp: async () => vizCode,
+        });
+
+        expect(outcome.successCount).toBe(1);
+        const skillsDir = path.join(appsDir, 'my-chart-type', '.claude/skills');
+        expect(
+            fs.existsSync(
+                path.join(skillsDir, 'developing-chart-types-locally/SKILL.md'),
+            ),
+        ).toBe(true);
+        // The app SDK skills would only mislead — a viz must not query.
+        expect(
+            fs.existsSync(path.join(skillsDir, 'lightdash-data-app/SKILL.md')),
+        ).toBe(false);
+        expect(
+            fs.existsSync(
+                path.join(skillsDir, 'developing-data-apps-locally/SKILL.md'),
+            ),
+        ).toBe(false);
+        expect(
+            fs
+                .readFileSync(
+                    path.join(appsDir, 'my-chart-type', 'AGENTS.md'),
+                    'utf8',
+                )
+                .toString(),
+        ).toContain('custom chart type');
+    });
+
     it('skips bundles the skipBundle guard rejects without writing them', async () => {
         const appsDir = tmpDir();
         const vizCode = codeFor('my-chart-type');

--- a/packages/cli/src/handlers/apps/authoring/chart-type/AGENTS.md.tmpl
+++ b/packages/cli/src/handlers/apps/authoring/chart-type/AGENTS.md.tmpl
@@ -2,7 +2,9 @@
 
 This folder is a **custom chart type** (a reusable visualization, the `data_app_viz` template) — ONE chart component that receives its data and settings from Lightdash, not a data app. It runs no query, owns no explore, and must not fetch anything itself.
 
-The contract lives in `.claude/skills/reusable-visualization` — read it before editing: the `useVizContext()` hook, the field/option declaration, resolved series colours, and pivoted results.
+Two skills in `.claude/skills/` describe how to edit it:
+- `reusable-visualization` — the contract: the `useVizContext()` hook, the field/option declaration, resolved series colours, pivoted results.
+- `developing-chart-types-locally` — the local workflow: the vizSchema lockstep rule, validate/upload/verify loop, and the path to the official registry.
 
 The one difference from that skill here: the declaration is not emitted as structured output. It lives in this folder's `lightdash-app.yml` under `vizSchema`, and **must stay in lockstep with the component** — every key `src/App.jsx` reads from `fieldMapping` or `options` is declared there, and everything declared there is read. When you change what the component reads, update `vizSchema` in the same edit.
 

--- a/packages/cli/src/handlers/apps/authoring/developing-chart-types-locally/SKILL.md
+++ b/packages/cli/src/handlers/apps/authoring/developing-chart-types-locally/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: developing-chart-types-locally
+description: Use when editing a locally created or downloaded Lightdash custom chart type (data_app_viz) — the vizSchema/component lockstep contract, the upload-and-verify loop, why there is no standalone preview, and how a chart type reaches the official registry.
+---
+
+# Developing Lightdash Custom Chart Types Locally
+
+You are editing a Lightdash **custom chart type** (a reusable visualization, the `data_app_viz` template) that was created or downloaded with the Lightdash CLI. It is ONE chart component that Lightdash hands data and settings to — not a data app.
+
+## The contract is the reusable-visualization skill
+
+Read `.claude/skills/reusable-visualization` before editing. It defines everything the component may do: `useVizContext()` is the only channel to the host (data, options, resolved colours), the component runs no query, owns no explore, and never fetches anything itself. App-level SDK APIs (query builder, `useLightdash`, filters, `externalFetch`) do not apply here and must not be introduced.
+
+## The declaration lives in lightdash-app.yml — keep it in lockstep
+
+In the in-product builder the declaration is emitted by the generation run; **locally it is the `vizSchema` block in this folder's `lightdash-app.yml`**, and upload round-trips it to the server (without it the chart type never appears in the explorer's chart type picker).
+
+The correspondence must be exact in both directions: every key the component reads from `fieldMapping` or `options` is declared in `vizSchema`, and everything declared there is read by the component. When an edit changes what the component reads — a new field, a renamed option, a removed control — update `vizSchema` in the same edit. A declared option nothing reads is a dead control; a read key nothing declares never receives a value.
+
+## The edit → validate → upload → verify loop
+
+1. Edit files under `src/` (and `vizSchema` when the declaration changes).
+2. `lightdash apps validate` checks source and manifest (including that `vizSchema` parses); `lightdash apps validate --build` adds the Cloud-parity Vite production build. A build failure is a validation error with the Vite output.
+3. `lightdash upload --chart-types <slug>` (the `slug` from `lightdash-app.yml`) — the server rebuilds and serves it.
+4. Verify in Lightdash: open any explore, run a query with at least the required fields' shapes (e.g. a dimension and a metric), pick this chart type in the chart type picker, and map its fields. Check every config option you declared actually changes the chart.
+
+**There is no standalone preview.** `useVizContext()` waits for the Lightdash host to push context, so outside Lightdash the component renders nothing: `npm run dev` and `lightdash apps preview` show a blank page. Do not build a mock harness or feed the hook fake data to work around this — upload and verify in the explorer instead.
+
+Saved charts already using this chart type may pin a version; unpinned charts move to the newly uploaded version right away. While iterating in a shared project, prefer verifying on a throwaway chart.
+
+## Dependencies: template-deps-only, strictly
+
+Build with the template's preinstalled set (see `package.json` — React, Recharts, d3 and friends). Do not add npm packages and do not vendor library source into `src/`. This is stricter than for data apps: the official chart registry rejects any dependency drift from its template, so a chart type that grows custom dependencies becomes unpublishable.
+
+Root config files (`vite.config.js`, `tsconfig.json`, ...) are read-only reference — the server rebuilds against a trusted template. `.npmrc` sets `ignore-scripts=true`; never remove it or run installs with scripts enabled.
+
+## Publishing to the official registry
+
+Once the chart type works in an instance, it can be proposed for the official chart registry (the `lightdash/lightdash-gallery` repo, served to every Lightdash deployment with the chart type library enabled):
+
+1. Copy this folder into that repo under `charts/<slug>/`.
+2. Run `node scripts/prepare-chart.mjs charts/<slug>` there — it prunes the local scaffold (these skills, configs, AGENTS/README), scrubs instance-side manifest fields, and shapes the folder for the registry. The folder name becomes the **permanent official registry slug**; pass `--slug <official-slug>` if the local slug isn't the identity that should ship.
+3. Add real screenshots from the in-product preview under `screenshots/` (the first is the gallery thumbnail) and fill in `registry.yml` (version, tags, changelog). New versions default to the beta channel; releasing to customers requires an explicit `channel: stable`.
+4. Open a PR there. On merge, publishing is automatic; published versions are immutable — any later change needs a version bump.
+
+Report the registry step as a suggestion to the user rather than doing it unprompted: publishing makes the chart type public.

--- a/packages/cli/src/handlers/apps/createApp.test.ts
+++ b/packages/cli/src/handlers/apps/createApp.test.ts
@@ -309,12 +309,21 @@ describe('createAppHandler', () => {
             expect.anything(),
         );
 
-        // The viz contract skill ships; the app-only skills do not.
+        // The viz contract + local workflow skills ship; the app-only skills
+        // do not.
         await expect(
             fs.access(
                 path.join(
                     appDir,
                     '.claude/skills/reusable-visualization/SKILL.md',
+                ),
+            ),
+        ).resolves.toBeUndefined();
+        await expect(
+            fs.access(
+                path.join(
+                    appDir,
+                    '.claude/skills/developing-chart-types-locally/SKILL.md',
                 ),
             ),
         ).resolves.toBeUndefined();

--- a/packages/cli/src/handlers/apps/scaffolding.ts
+++ b/packages/cli/src/handlers/apps/scaffolding.ts
@@ -177,9 +177,22 @@ export const buildStaticAuthoringFiles = (args: {
         files.push(file);
     }
 
-    // 2+3. App-only skills: a chart type must not query through the SDK, so
-    // the app-building skills would only mislead — the viz contract ships via
+    // 2+3. Flavor-specific skills. A chart type must not query through the
+    // SDK, so the app-building skills would only mislead — it gets the local
+    // chart-type workflow skill instead, with the viz contract shipping via
     // the template's .claude/skills/reusable-visualization (step 1).
+    if (isChartType) {
+        files.push({
+            path: '.claude/skills/developing-chart-types-locally/SKILL.md',
+            contentBase64: readFileSync(
+                path.join(
+                    authoringDir,
+                    'developing-chart-types-locally',
+                    'SKILL.md',
+                ),
+            ).toString('base64'),
+        });
+    }
     if (!isChartType) {
         // skill.md → .claude/skills/lightdash-data-app/SKILL.md
         files.push({


### PR DESCRIPTION
Closes: —

### Description:

Stacked on #28763. Adds the local-workflow skill for chart types, following the pattern of `developing-data-apps-locally`:

`.claude/skills/developing-chart-types-locally/SKILL.md` ships in every chart-type scaffold (create and download) and covers what the contract skill (`reusable-visualization`) deliberately doesn't — the *local* mechanics:

- **The lockstep rule**: in-product, the declaration is emitted by the generation run; locally it's the `vizSchema` block in `lightdash-app.yml`, and it must change in the same edit as the component whenever what it reads changes.
- **The loop**: edit → `apps validate --build` → `upload --chart-types <slug>` → verify in the explorer (map fields, exercise every declared option).
- **No standalone preview**, and explicitly: don't build a mock harness around `useVizContext` to fake one.
- **Strict template-deps-only** — stricter than apps, because the official registry rejects dependency drift.
- **The registry path**: gallery repo, `prepare-chart.mjs` (`--slug` for the permanent official slug), screenshots, beta-by-default channels — with a note to suggest publishing to the user rather than doing it unprompted.

`AGENTS.md.tmpl` for chart types now lists both skills.

**Downloads are covered too**: #28763 makes `lightdash download --chart-types` pick the chart-type flavor from the manifest template, and this skill ships as part of that flavor — a new `appsDownload` test pins that a downloaded `data_app_viz` bundle gets `developing-chart-types-locally` (and not the app SDK skills).

### Risk assessment:

- [ ] This is a high-risk change

High-risk changes require approval from a reviewer other than the author before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8sCUbSEj5R8babs36CnDN
