### PR TITLE
refactor(charts): centralize ECharts theme defaults

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -422,6 +422,7 @@ export * from './visualizations/helpers/seriesZOrder';
 export * from './visualizations/helpers/styles/axisStyles';
 export * from './visualizations/helpers/styles/barChartStyles';
 export * from './visualizations/helpers/styles/gridStyles';
+export { lightdashEchartsTheme } from './visualizations/helpers/styles/echartsTheme';
 export * from './visualizations/helpers/styles/legendStyles';
 export * from './visualizations/helpers/styles/pieChartStyles';
 export * from './visualizations/helpers/styles/referenceLineStyles';

--- a/packages/common/src/visualizations/helpers/styles/axisStyles.ts
+++ b/packages/common/src/visualizations/helpers/styles/axisStyles.ts
@@ -1,35 +1,38 @@
-import { AXIS_TITLE_COLOR, GRAY_4, GRAY_5, GRAY_7, WHITE } from './themeColors';
+import { lightdashEchartsTheme } from './echartsTheme';
+import { GRAY_4, GRAY_5, GRAY_7, WHITE } from './themeColors';
 
-export const DEFAULT_AXIS_LABEL_FONT_SIZE = 11.5;
-export const DEFAULT_AXIS_TITLE_FONT_SIZE = 12;
+export {
+    DEFAULT_AXIS_LABEL_FONT_SIZE,
+    DEFAULT_AXIS_TITLE_FONT_SIZE,
+} from './echartsTheme';
 
 /**
  * Get axis label styling (for values like "Jan", "Feb", "Mar")
  */
 export const getAxisLabelStyle = (fontSize?: number) => ({
-    color: GRAY_7,
-    fontWeight: '500',
-    fontSize: fontSize ?? DEFAULT_AXIS_LABEL_FONT_SIZE,
+    ...lightdashEchartsTheme.categoryAxis.axisLabel,
+    fontWeight: String(lightdashEchartsTheme.categoryAxis.axisLabel.fontWeight),
+    fontSize: fontSize ?? lightdashEchartsTheme.categoryAxis.axisLabel.fontSize,
 });
 
 /**
  * Get axis title styling (for titles like "Month", "Amount")
  */
 export const getAxisTitleStyle = (fontSize?: number) => ({
-    color: AXIS_TITLE_COLOR,
-    fontWeight: '500',
-    fontSize: fontSize ?? DEFAULT_AXIS_TITLE_FONT_SIZE,
+    ...lightdashEchartsTheme.categoryAxis.nameTextStyle,
+    fontWeight: String(
+        lightdashEchartsTheme.categoryAxis.nameTextStyle.fontWeight,
+    ),
+    fontSize:
+        fontSize ?? lightdashEchartsTheme.categoryAxis.nameTextStyle.fontSize,
 });
 
 /**
  * Get axis line styling (the main axis line)
  */
 export const getAxisLineStyle = () => ({
-    show: true,
-    lineStyle: {
-        color: GRAY_4,
-        type: 'solid' as const,
-    },
+    ...lightdashEchartsTheme.categoryAxis.axisLine,
+    lineStyle: { ...lightdashEchartsTheme.categoryAxis.axisLine.lineStyle },
 });
 
 /**

--- a/packages/common/src/visualizations/helpers/styles/echartsTheme.test.json
+++ b/packages/common/src/visualizations/helpers/styles/echartsTheme.test.json
@@ -1,0 +1,61 @@
+{
+    "axisLabel": {
+        "color": "var(--mantine-color-ldGray-7, #495057)",
+        "fontWeight": "500",
+        "fontSize": 11.5
+    },
+    "nameTextStyle": {
+        "color": "var(--mantine-color-gray-6, #868e96)",
+        "fontWeight": "500",
+        "fontSize": 12
+    },
+    "axisLine": {
+        "show": true,
+        "lineStyle": {
+            "color": "var(--mantine-color-ldGray-4, #ced4da)",
+            "type": "solid"
+        }
+    },
+    "tooltip": {
+        "padding": 8,
+        "borderColor": "var(--mantine-color-ldGray-3, #dee2e6)",
+        "borderWidth": 1,
+        "borderRadius": 8,
+        "backgroundColor": "var(--mantine-color-background-0, #FEFEFE)",
+        "renderMode": "html",
+        "confine": true,
+        "textStyle": {
+            "color": "var(--mantine-color-ldGray-7, #495057)",
+            "fontSize": 12
+        },
+        "extraCssText": "box-shadow: 0px 8px 8px 0px rgba(0, 0, 0, 0.08), 0px 0px 1px 0px rgba(0, 0, 0, 0.25);"
+    },
+    "legend": {
+        "itemWidth": 12,
+        "itemHeight": 12,
+        "itemGap": 16,
+        "icon": "roundRect",
+        "itemStyle": {
+            "borderRadius": 3,
+            "borderWidth": 0
+        },
+        "textStyle": {
+            "color": "var(--mantine-color-ldGray-7, #495057)",
+            "fontSize": 12,
+            "fontWeight": 500,
+            "padding": [0, 0, 0, 2]
+        },
+        "inactiveBorderWidth": 0,
+        "pageButtonItemGap": 16,
+        "pageButtonGap": 8,
+        "pageTextStyle": {
+            "color": "var(--mantine-color-ldGray-7, #495057)",
+            "fontSize": 12,
+            "fontWeight": 500
+        },
+        "pageIconColor": "var(--mantine-color-ldGray-7, #495057)",
+        "pageIconInactiveColor": "var(--mantine-color-ldGray-3, #dee2e6)",
+        "pageIconSize": 12
+    },
+    "font": "Inter, sans-serif"
+}

--- a/packages/common/src/visualizations/helpers/styles/echartsTheme.test.ts
+++ b/packages/common/src/visualizations/helpers/styles/echartsTheme.test.ts
@@ -1,0 +1,203 @@
+import { init, type EChartsOption } from 'echarts';
+import { describe, expect, it } from 'vitest';
+import {
+    getAxisLabelStyle,
+    getAxisLineStyle,
+    getAxisTitleStyle,
+} from './axisStyles';
+import { lightdashEchartsTheme } from './echartsTheme';
+import legacyStyles from './echartsTheme.test.json';
+import { getLegendStyle } from './legendStyles';
+import { getTooltipStyle } from './tooltipStyles';
+
+// Captured before moving option styles into the theme; independent of its defaults.
+const normalizeSvg = (svg: string) => {
+    const classNames = new Map<string, string>();
+    return svg.replace(/zr\d+/g, 'zr').replace(/zr-cls-\d+/g, (name) => {
+        if (!classNames.has(name))
+            classNames.set(name, `cls-${classNames.size}`);
+        return classNames.get(name)!;
+    });
+};
+
+const render = (option: EChartsOption, themed: boolean) => {
+    const chart = init(null, themed ? lightdashEchartsTheme : undefined, {
+        renderer: 'svg',
+        ssr: true,
+        width: 640,
+        height: 400,
+    });
+    try {
+        chart.setOption(option);
+        return normalizeSvg(chart.renderToSVGString());
+    } finally {
+        chart.dispose();
+    }
+};
+
+const baseOption = (themed: boolean): EChartsOption => ({
+    animation: false,
+    textStyle: { fontFamily: 'Arial' },
+    legend: {
+        ...(!themed ? legacyStyles.legend : {}),
+        itemWidth: 12,
+        itemHeight: 12,
+        icon: 'roundRect',
+        itemStyle: { borderRadius: 3, borderWidth: 0 },
+        type: 'scroll',
+        selected: { Previous: false },
+    },
+    tooltip: {
+        ...(!themed ? legacyStyles.tooltip : {}),
+        renderMode: 'html',
+        trigger: 'item',
+    },
+});
+
+const cartesianOption = (
+    themed: boolean,
+    type: 'category' | 'value' | 'time' | 'log',
+    customFont: boolean,
+): EChartsOption => {
+    const axisStyle = themed
+        ? {}
+        : {
+              axisLabel: legacyStyles.axisLabel,
+              nameTextStyle: legacyStyles.nameTextStyle,
+              axisLine: legacyStyles.axisLine,
+          };
+    const data =
+        type === 'time'
+            ? [
+                  [Date.UTC(2025, 0, 1), 10],
+                  [Date.UTC(2025, 1, 1), 20],
+                  [Date.UTC(2025, 2, 1), 15],
+              ]
+            : [
+                  [1, 10],
+                  [2, 20],
+                  [3, 15],
+              ];
+    return {
+        ...baseOption(themed),
+        useUTC: true,
+        xAxis: {
+            ...axisStyle,
+            type,
+            name: 'Date / category',
+            ...(type === 'category' ? { data: ['One', 'Two', 'Three'] } : {}),
+            ...(customFont
+                ? {
+                      axisLabel: { ...axisStyle.axisLabel, fontSize: 18 },
+                      nameTextStyle: {
+                          ...axisStyle.nameTextStyle,
+                          fontSize: 20,
+                      },
+                  }
+                : {}),
+        },
+        yAxis: { ...axisStyle, type: 'value', name: 'Amount' },
+        series: [
+            { name: 'Current', type: 'line', data },
+            { name: 'Previous', type: 'line', data },
+        ],
+    } as EChartsOption;
+};
+
+describe('Lightdash ECharts theme', () => {
+    it('preserves inline helpers used by other renderers', () => {
+        expect(getAxisLabelStyle()).toEqual(legacyStyles.axisLabel);
+        expect(getAxisTitleStyle()).toEqual(legacyStyles.nameTextStyle);
+        expect(getAxisLineStyle()).toEqual(legacyStyles.axisLine);
+        expect(getLegendStyle()).toEqual(legacyStyles.legend);
+        expect(getTooltipStyle({ appendToBody: false })).toEqual(
+            legacyStyles.tooltip,
+        );
+    });
+
+    it('keeps caller mutations isolated from the theme and other charts', () => {
+        const legend = getLegendStyle();
+        legend.textStyle.color = '#123456';
+        legend.textStyle.padding[3] = 100;
+        legend.pageTextStyle.color = '#654321';
+        const tooltip = getTooltipStyle();
+        tooltip.textStyle.color = '#abcdef';
+        expect(getLegendStyle()).toEqual(legacyStyles.legend);
+        expect(getTooltipStyle({ appendToBody: false })).toEqual(
+            legacyStyles.tooltip,
+        );
+    });
+
+    it.each(['category', 'value', 'time', 'log'] as const)(
+        'preserves the SVG output of inline styles on %s axes',
+        (axisType) => {
+            expect(render(cartesianOption(true, axisType, false), true)).toBe(
+                render(cartesianOption(false, axisType, false), false),
+            );
+        },
+    );
+
+    it('preserves per-axis font overrides', () => {
+        expect(render(cartesianOption(true, 'category', true), true)).toBe(
+            render(cartesianOption(false, 'category', true), false),
+        );
+    });
+
+    it.each(['pie', 'funnel'] as const)(
+        'preserves %s legends, selection, and series colors',
+        (type) => {
+            const option = (themed: boolean): EChartsOption => ({
+                ...baseOption(themed),
+                color: ['#2e65db', '#ef8235'],
+                series: [
+                    {
+                        type,
+                        data: [
+                            { name: 'Current', value: 80 },
+                            { name: 'Previous', value: 40 },
+                        ],
+                    },
+                ],
+            });
+            expect(render(option(true), true)).toBe(
+                render(option(false), false),
+            );
+        },
+    );
+
+    it('keeps tooltip overrides and defaults across option replacement', () => {
+        const chart = init(null, lightdashEchartsTheme, {
+            renderer: 'svg',
+            ssr: true,
+            width: 640,
+            height: 400,
+        });
+        try {
+            const option: EChartsOption = {
+                tooltip: {
+                    backgroundColor: '#123456',
+                    textStyle: { fontSize: 19 },
+                    appendToBody: false,
+                },
+                series: [{ type: 'pie', data: [{ name: 'One', value: 1 }] }],
+            };
+            chart.setOption(option);
+            chart.setOption(option, { notMerge: true });
+            expect(chart.getOption().tooltip).toMatchObject([
+                {
+                    backgroundColor: '#123456',
+                    borderRadius: 8,
+                    padding: 8,
+                    appendToBody: false,
+                    textStyle: {
+                        fontSize: 19,
+                        color: legacyStyles.tooltip.textStyle.color,
+                    },
+                },
+            ]);
+            expect(option.tooltip).not.toHaveProperty('borderRadius');
+        } finally {
+            chart.dispose();
+        }
+    });
+});

--- a/packages/common/src/visualizations/helpers/styles/echartsTheme.ts
+++ b/packages/common/src/visualizations/helpers/styles/echartsTheme.ts
@@ -1,0 +1,76 @@
+import {
+    type LegendComponentOption,
+    type TooltipComponentOption,
+    type XAXisComponentOption,
+} from 'echarts';
+import {
+    AXIS_TITLE_COLOR,
+    GRAY_3,
+    GRAY_4,
+    GRAY_7,
+    TOOLTIP_BACKGROUND,
+} from './themeColors';
+
+export const DEFAULT_AXIS_LABEL_FONT_SIZE = 11.5;
+export const DEFAULT_AXIS_TITLE_FONT_SIZE = 12;
+
+const axisTheme = {
+    axisLabel: {
+        color: GRAY_7,
+        fontWeight: 500,
+        fontSize: DEFAULT_AXIS_LABEL_FONT_SIZE,
+    },
+    nameTextStyle: {
+        color: AXIS_TITLE_COLOR,
+        fontWeight: 500,
+        fontSize: DEFAULT_AXIS_TITLE_FONT_SIZE,
+    },
+    axisLine: {
+        show: true,
+        lineStyle: { color: GRAY_4, type: 'solid' as const },
+    },
+} satisfies XAXisComponentOption;
+
+// CSS tokens retain live SVG theming. Canvas callers resolve them before init.
+export const lightdashEchartsTheme = {
+    categoryAxis: axisTheme,
+    valueAxis: axisTheme,
+    timeAxis: axisTheme,
+    logAxis: axisTheme,
+    legend: {
+        itemGap: 16,
+        textStyle: {
+            color: GRAY_7,
+            fontSize: 12,
+            fontWeight: 500,
+            padding: [0, 0, 0, 2],
+        },
+        inactiveBorderWidth: 0, // Remove border on inactive items to prevent visual size increase
+        // Navigation controls (for scrollable legends)
+        pageButtonItemGap: 16, // Space between left arrow, page text, and right arrow
+        pageButtonGap: 8, // Space between legend items and navigation controls
+        pageTextStyle: {
+            color: GRAY_7,
+            fontSize: 12,
+            fontWeight: 500,
+        },
+        pageIconColor: GRAY_7, // Active chevron color
+        pageIconInactiveColor: GRAY_3, // Inactive chevron color
+        pageIconSize: 12,
+    } satisfies LegendComponentOption,
+    tooltip: {
+        padding: 8,
+        borderColor: GRAY_3,
+        borderWidth: 1,
+        borderRadius: 8,
+        backgroundColor: TOOLTIP_BACKGROUND,
+        renderMode: 'html' as const,
+        confine: true,
+        textStyle: {
+            color: GRAY_7,
+            fontSize: 12,
+        },
+        extraCssText:
+            'box-shadow: 0px 8px 8px 0px rgba(0, 0, 0, 0.08), 0px 0px 1px 0px rgba(0, 0, 0, 0.25);',
+    } satisfies TooltipComponentOption,
+};

--- a/packages/common/src/visualizations/helpers/styles/legendStyles.ts
+++ b/packages/common/src/visualizations/helpers/styles/legendStyles.ts
@@ -1,4 +1,4 @@
-import { GRAY_3, GRAY_7 } from './themeColors';
+import { lightdashEchartsTheme } from './echartsTheme';
 
 type LegendIconType = 'line' | 'square';
 
@@ -6,10 +6,9 @@ type LegendIconType = 'line' | 'square';
 const lineSeriesLegendIcon =
     'path://M0,5 L5,5 L5,7 L0,7 Z M13,5 L18,5 L18,7 L13,7 Z M9,2 A4,4 0 1,1 9,10 A4,4 0 1,1 9,2 Z';
 
-export const getLegendStyle = (iconType: LegendIconType = 'square') => ({
+export const getLegendIconStyle = (iconType: LegendIconType = 'square') => ({
     itemWidth: iconType === 'line' ? 18 : 12,
     itemHeight: 12,
-    itemGap: 16,
     ...(iconType === 'line'
         ? {
               icon: lineSeriesLegendIcon,
@@ -18,22 +17,14 @@ export const getLegendStyle = (iconType: LegendIconType = 'square') => ({
               icon: 'roundRect',
               itemStyle: { borderRadius: 3, borderWidth: 0 },
           }),
+});
+
+export const getLegendStyle = (iconType: LegendIconType = 'square') => ({
+    ...lightdashEchartsTheme.legend,
     textStyle: {
-        color: GRAY_7,
-        fontSize: 12,
-        fontWeight: 500,
-        padding: [0, 0, 0, 2],
+        ...lightdashEchartsTheme.legend.textStyle,
+        padding: [...lightdashEchartsTheme.legend.textStyle.padding],
     },
-    inactiveBorderWidth: 0, // Remove border on inactive items to prevent visual size increase
-    // Navigation controls (for scrollable legends)
-    pageButtonItemGap: 16, // Space between left arrow, page text, and right arrow
-    pageButtonGap: 8, // Space between legend items and navigation controls
-    pageTextStyle: {
-        color: GRAY_7,
-        fontSize: 12,
-        fontWeight: 500,
-    },
-    pageIconColor: GRAY_7, // Active chevron color
-    pageIconInactiveColor: GRAY_3, // Inactive chevron color
-    pageIconSize: 12,
+    pageTextStyle: { ...lightdashEchartsTheme.legend.pageTextStyle },
+    ...getLegendIconStyle(iconType),
 });

--- a/packages/common/src/visualizations/helpers/styles/tooltipStyles.ts
+++ b/packages/common/src/visualizations/helpers/styles/tooltipStyles.ts
@@ -1,10 +1,5 @@
-import {
-    GRAY_0,
-    GRAY_1,
-    GRAY_3,
-    GRAY_7,
-    TOOLTIP_BACKGROUND,
-} from './themeColors';
+import { lightdashEchartsTheme } from './echartsTheme';
+import { GRAY_0, GRAY_1, GRAY_7 } from './themeColors';
 
 /**
  * Helper to convert style object to CSS string
@@ -27,19 +22,8 @@ export const getTooltipStyle = ({
 }: {
     appendToBody?: boolean;
 } = {}) => ({
-    padding: 8,
-    borderColor: GRAY_3,
-    borderWidth: 1,
-    borderRadius: 8,
-    backgroundColor: TOOLTIP_BACKGROUND,
-    renderMode: 'html' as const,
-    confine: true,
-    textStyle: {
-        color: GRAY_7,
-        fontSize: 12,
-    },
-    extraCssText:
-        'box-shadow: 0px 8px 8px 0px rgba(0, 0, 0, 0.08), 0px 0px 1px 0px rgba(0, 0, 0, 0.25);',
+    ...lightdashEchartsTheme.tooltip,
+    textStyle: { ...lightdashEchartsTheme.tooltip.textStyle },
     ...(appendToBody ? { appendToBody: true } : {}),
 });
 

--- a/packages/frontend/src/components/FunnelChart/index.tsx
+++ b/packages/frontend/src/components/FunnelChart/index.tsx
@@ -19,7 +19,7 @@ import { useLegendDoubleClickSelection } from '../../hooks/echarts/useLegendDoub
 import { useContextMenuPermissions } from '../../hooks/useContextMenuPermissions';
 import LoadingChart from '../common/LoadingChart';
 import SuboptimalState from '../common/SuboptimalState/SuboptimalState';
-import EChartsReact from '../EChartsReactWrapper';
+import EChartsReact from '../LightdashECharts';
 import { useVisualizationContext } from '../LightdashVisualization/useVisualizationContext';
 import FunnelChartContextMenu, {
     type FunnelChartContextMenuProps,

--- a/packages/frontend/src/components/LightdashECharts.tsx
+++ b/packages/frontend/src/components/LightdashECharts.tsx
@@ -1,0 +1,59 @@
+import { lightdashEchartsTheme } from '@lightdash/common';
+import { useMantineTheme } from '@mantine/core';
+import { forwardRef, useMemo } from 'react';
+import { resolveCssVariablesInOptions } from '../utils/resolveEchartsCssVariables';
+import { sanitizeEchartsFontFamily } from '../utils/sanitizeEchartsFontFamily';
+import EChartsReact, {
+    type EChartsReact as EChartsReactInstance,
+    type EChartsReactProps,
+} from './EChartsReactWrapper';
+
+// Opt in only the visualization renderers whose options use these defaults.
+const LightdashECharts = forwardRef<EChartsReactInstance, EChartsReactProps>(
+    ({ option, theme: themeOverride, ...props }, ref) => {
+        const mantineTheme = useMantineTheme();
+        const chartFont = sanitizeEchartsFontFamily(
+            mantineTheme.other.chartFont,
+        );
+        const theme = useMemo(
+            () =>
+                props.opts?.renderer === 'canvas'
+                    ? resolveCssVariablesInOptions(
+                          lightdashEchartsTheme,
+                          (variable) => {
+                              const color = variable.match(
+                                  /^--mantine-color-(.+)-(\d+)$/,
+                              );
+                              return color
+                                  ? (mantineTheme.colors[color[1]]?.[
+                                        Number(color[2])
+                                    ] ?? '')
+                                  : '';
+                          },
+                      )
+                    : lightdashEchartsTheme,
+            [props.opts?.renderer, mantineTheme],
+        );
+        // Apply font changes through setOption to retain the chart instance.
+        const themedOption = useMemo(
+            () => ({
+                ...option,
+                textStyle: { fontFamily: chartFont, ...option.textStyle },
+            }),
+            [option, chartFont],
+        );
+
+        return (
+            <EChartsReact
+                {...props}
+                ref={ref}
+                theme={themeOverride ?? theme}
+                option={themedOption}
+            />
+        );
+    },
+);
+
+LightdashECharts.displayName = 'LightdashECharts';
+
+export default LightdashECharts;

--- a/packages/frontend/src/components/SimpleChart/index.tsx
+++ b/packages/frontend/src/components/SimpleChart/index.tsx
@@ -16,9 +16,10 @@ import {
     useLegendDoubleClickSelection,
     type LegendSelection,
 } from '../../hooks/echarts/useLegendDoubleClickSelection';
+import { resolveCssVariablesInOptions } from '../../utils/resolveEchartsCssVariables';
 import LoadingChart from '../common/LoadingChart';
 import SuboptimalState from '../common/SuboptimalState/SuboptimalState';
-import EChartsReact from '../EChartsReactWrapper';
+import EChartsReact from '../LightdashECharts';
 import { isCartesianVisualizationConfig } from '../LightdashVisualization/types';
 import { useVisualizationContext } from '../LightdashVisualization/useVisualizationContext';
 
@@ -97,51 +98,6 @@ type SimpleChartProps = Omit<EChartsReactProps, 'option'> & {
  * canvas is used instead of SVG to avoid DOM bloat.
  */
 const CANVAS_RENDERER_THRESHOLD = 500;
-
-/**
- * CSS variable pattern: var(--some-variable, fallback)
- * Matches CSS var() with an optional fallback value.
- */
-const CSS_VAR_REGEX = /^var\((--[^,)]+)(?:,\s*(.+))?\)$/;
-
-/**
- * Resolve a single CSS variable string to its computed value.
- * Falls back to the embedded fallback value if the variable isn't set.
- */
-const resolveCssVariable = (value: string): string => {
-    const match = value.match(CSS_VAR_REGEX);
-    if (!match) return value;
-
-    const [, varName, fallback] = match;
-    const computed = getComputedStyle(
-        document.documentElement,
-    ).getPropertyValue(varName);
-    return computed.trim() || fallback?.trim() || value;
-};
-
-/**
- * Recursively walk an object and resolve any CSS variable strings.
- * Used when switching to canvas renderer, which can't resolve CSS variables.
- */
-const resolveCssVariablesInOptions = <T,>(obj: T): T => {
-    if (obj === null || obj === undefined) return obj;
-    if (typeof obj === 'string') {
-        return resolveCssVariable(obj) as unknown as T;
-    }
-    if (Array.isArray(obj)) {
-        return obj.map(resolveCssVariablesInOptions) as unknown as T;
-    }
-    if (typeof obj === 'object') {
-        const result: Record<string, unknown> = {};
-        for (const [key, value] of Object.entries(
-            obj as Record<string, unknown>,
-        )) {
-            result[key] = resolveCssVariablesInOptions(value);
-        }
-        return result as T;
-    }
-    return obj;
-};
 
 // How far past the plot area a pointer still counts as hovering the axis
 const AXIS_LABEL_HOVER_BAND_PX = 40;

--- a/packages/frontend/src/components/SimpleGauge/index.tsx
+++ b/packages/frontend/src/components/SimpleGauge/index.tsx
@@ -6,7 +6,7 @@ import { DEFAULT_ROW_HEIGHT } from '../../features/dashboardTabs/gridUtils';
 import useEchartsGaugeConfig from '../../hooks/echarts/useEchartsGaugeConfig';
 import LoadingChart from '../common/LoadingChart';
 import SuboptimalState from '../common/SuboptimalState/SuboptimalState';
-import EChartsReact from '../EChartsReactWrapper';
+import EChartsReact from '../LightdashECharts';
 import { useVisualizationContext } from '../LightdashVisualization/useVisualizationContext';
 
 const EmptyChart = () => (

--- a/packages/frontend/src/components/SimplePieChart/index.tsx
+++ b/packages/frontend/src/components/SimplePieChart/index.tsx
@@ -18,7 +18,7 @@ import { useLegendDoubleClickSelection } from '../../hooks/echarts/useLegendDoub
 import { useContextMenuPermissions } from '../../hooks/useContextMenuPermissions';
 import LoadingChart from '../common/LoadingChart';
 import SuboptimalState from '../common/SuboptimalState/SuboptimalState';
-import EChartsReact from '../EChartsReactWrapper';
+import EChartsReact from '../LightdashECharts';
 import { useVisualizationContext } from '../LightdashVisualization/useVisualizationContext';
 import PieChartContextMenu, {
     type PieChartContextMenuProps,

--- a/packages/frontend/src/components/SimpleSankey/index.tsx
+++ b/packages/frontend/src/components/SimpleSankey/index.tsx
@@ -5,7 +5,7 @@ import { memo, useEffect, useRef, type FC } from 'react';
 import useEchartsSankeyConfig from '../../hooks/echarts/useEchartsSankeyConfig';
 import LoadingChart from '../common/LoadingChart';
 import SuboptimalState from '../common/SuboptimalState/SuboptimalState';
-import EChartsReact from '../EChartsReactWrapper';
+import EChartsReact from '../LightdashECharts';
 import { useVisualizationContext } from '../LightdashVisualization/useVisualizationContext';
 
 const EmptyChart = () => (

--- a/packages/frontend/src/components/SimpleTreemap/index.tsx
+++ b/packages/frontend/src/components/SimpleTreemap/index.tsx
@@ -4,7 +4,7 @@ import { memo, useEffect, useRef, type FC } from 'react';
 import useEchartsTreemapConfig from '../../hooks/echarts/useEchartsTreemapConfig';
 import LoadingChart from '../common/LoadingChart';
 import SuboptimalState from '../common/SuboptimalState/SuboptimalState';
-import EChartsReact from '../EChartsReactWrapper';
+import EChartsReact from '../LightdashECharts';
 import { useVisualizationContext } from '../LightdashVisualization/useVisualizationContext';
 
 const EmptyChart = () => (

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -14,12 +14,9 @@ import {
     formatValueWithExpression,
     friendlyName,
     getCartesianAxisFormatterConfig as getAxisFormatterConfig,
-    getAxisLabelStyle,
-    getAxisLineStyle,
     getAxisName,
     getAxisPointerStyle,
     getAxisTickStyle,
-    getAxisTitleStyle,
     getBarBorderRadius,
     getBarChartGridStyle,
     getBarStyle,
@@ -38,7 +35,7 @@ import {
     getReadableColor,
     getReferenceLineStyle,
     getResultValueArray,
-    getTooltipStyle,
+    lightdashEchartsTheme,
     getValueLabelStyle,
     hasFormatting,
     hashFieldReference,
@@ -102,7 +99,6 @@ import {
     defaultGrid,
     legendTopSpacing,
 } from '../../components/VisualizationConfigs/ChartConfigPanel/Grid/constants';
-import { sanitizeEchartsFontFamily } from '../../utils/sanitizeEchartsFontFamily';
 import { sliceRows } from '../../utils/sliceRows';
 import { EMPTY_X_AXIS } from '../cartesianChartConfig/useCartesianChartConfig';
 import {
@@ -2198,6 +2194,10 @@ const getEchartAxes = ({
         validCartesianConfig?.eChartsConfig?.axisLabelFontSize;
     const axisTitleFontSize =
         validCartesianConfig?.eChartsConfig?.axisTitleFontSize;
+    const axisLabelFontOverride =
+        axisLabelFontSize !== undefined ? { fontSize: axisLabelFontSize } : {};
+    const axisTitleFontOverride =
+        axisTitleFontSize !== undefined ? { fontSize: axisTitleFontSize } : {};
 
     const bottomAxisFormatterConfig = getAxisFormatterConfig({
         axisItem: bottomAxisXField,
@@ -2245,7 +2245,7 @@ const getEchartAxes = ({
         showXAxis && bottomAxisFormatterConfig.axisLabel
             ? {
                   axisLabel: {
-                      ...getAxisLabelStyle(axisLabelFontSize),
+                      ...axisLabelFontOverride,
                       ...bottomAxisFormatterConfig.axisLabel,
                       ...(hasBottomBarValueLabels
                           ? { margin: BOTTOM_VALUE_LABEL_AXIS_MARGIN }
@@ -2270,7 +2270,7 @@ const getEchartAxes = ({
         showXAxis && topAxisFormatterConfig.axisLabel
             ? {
                   axisLabel: {
-                      ...getAxisLabelStyle(axisLabelFontSize),
+                      ...axisLabelFontOverride,
                       ...topAxisFormatterConfig.axisLabel,
                   },
               }
@@ -2298,7 +2298,7 @@ const getEchartAxes = ({
         showLeftYAxis && leftAxisFormatterConfig.axisLabel
             ? {
                   axisLabel: {
-                      ...getAxisLabelStyle(axisLabelFontSize),
+                      ...axisLabelFontOverride,
                       ...leftAxisFormatterConfig.axisLabel,
                       ...(hasLeftBarValueLabels
                           ? {
@@ -2326,7 +2326,7 @@ const getEchartAxes = ({
         showRightYAxis && rightAxisFormatterConfig.axisLabel
             ? {
                   axisLabel: {
-                      ...getAxisLabelStyle(axisLabelFontSize),
+                      ...axisLabelFontOverride,
                       ...rightAxisFormatterConfig.axisLabel,
                   },
               }
@@ -2555,7 +2555,7 @@ const getEchartAxes = ({
     const rightAxisLabelConfig =
         clampSecondaryAxisTo100 && !validCartesianConfig.layout.flipAxes
             ? {
-                  ...getAxisLabelStyle(axisLabelFontSize),
+                  ...axisLabelFontOverride,
                   ...((rightAxisConfigWithStyle.axisLabel as
                       | Record<string, unknown>
                       | undefined) ?? {}),
@@ -2565,7 +2565,7 @@ const getEchartAxes = ({
     const topAxisLabelConfig =
         clampSecondaryAxisTo100 && validCartesianConfig.layout.flipAxes
             ? {
-                  ...getAxisLabelStyle(axisLabelFontSize),
+                  ...axisLabelFontOverride,
                   ...((topAxisConfigWithStyle.axisLabel as
                       | Record<string, unknown>
                       | undefined) ?? {}),
@@ -2599,7 +2599,7 @@ const getEchartAxes = ({
                                       getItemLabelWithoutTableName(xAxisItem)
                                     : undefined),
                           nameLocation: 'center',
-                          nameTextStyle: getAxisTitleStyle(axisTitleFontSize),
+                          nameTextStyle: axisTitleFontOverride,
                       }
                     : {}),
                 ...bottomAxisConfigWithStyle,
@@ -2610,7 +2610,6 @@ const getEchartAxes = ({
                     : showGridX
                       ? gridStyle
                       : { show: false },
-                axisLine: getAxisLineStyle(),
                 inverse: !!xAxisConfiguration?.[0]?.inverse,
                 axisTick: {
                     ...getAxisTickStyle(
@@ -2651,7 +2650,7 @@ const getEchartAxes = ({
                                 })
                               : undefined,
                           nameLocation: 'center',
-                          nameTextStyle: getAxisTitleStyle(axisTitleFontSize),
+                          nameTextStyle: axisTitleFontOverride,
                       }
                     : {}),
                 min:
@@ -2683,7 +2682,6 @@ const getEchartAxes = ({
                 splitLine: isAxisTheSameForAllSeries
                     ? gridStyle
                     : { show: false },
-                axisLine: getAxisLineStyle(),
                 axisTick: getAxisTickStyle(
                     validCartesianConfig?.eChartsConfig?.showAxisTicks,
                 ),
@@ -2717,7 +2715,7 @@ const getEchartAxes = ({
                                 }),
                           nameLocation: 'center',
                           nameTextStyle: {
-                              ...getAxisTitleStyle(axisTitleFontSize),
+                              ...axisTitleFontOverride,
                               align: 'center',
                           },
                       }
@@ -2736,7 +2734,6 @@ const getEchartAxes = ({
                     : showGridY
                       ? gridStyle
                       : { show: false },
-                axisLine: getAxisLineStyle(),
                 inverse: !!yAxisConfiguration?.[0]?.inverse,
                 axisTick: {
                     ...getAxisTickStyle(
@@ -2770,7 +2767,7 @@ const getEchartAxes = ({
                           nameLocation: 'center',
                           nameRotate: -90,
                           nameTextStyle: {
-                              ...getAxisTitleStyle(axisTitleFontSize),
+                              ...axisTitleFontOverride,
                               align: 'center',
                           },
                       }
@@ -2806,7 +2803,6 @@ const getEchartAxes = ({
                 splitLine: isAxisTheSameForAllSeries
                     ? gridStyle
                     : { show: false },
-                axisLine: getAxisLineStyle(),
                 axisTick: getAxisTickStyle(
                     validCartesianConfig?.eChartsConfig?.showAxisTicks,
                 ),
@@ -4084,9 +4080,9 @@ const useEchartsCartesianConfig = (
             show: true,
             trigger: 'axis',
             enterable: true,
-            ...getTooltipStyle({ appendToBody: !isTouchDevice }),
+            appendToBody: !isTouchDevice,
             extraCssText: `overflow-y: auto; max-height:280px; ${
-                getTooltipStyle({ appendToBody: !isTouchDevice }).extraCssText
+                lightdashEchartsTheme.tooltip.extraCssText
             }`,
             axisPointer: getAxisPointerStyle(hasLineAreaScatterSeries),
             formatter: buildCartesianTooltipFormatter({
@@ -4354,6 +4350,7 @@ const useEchartsCartesianConfig = (
                 s.type === CartesianSeriesType.AREA,
         );
 
+        // Preserve the existing precedence over saved legend and overflow styles.
         const legendStyle = getLegendStyle(
             hasOnlyLineCharts ? 'line' : 'square',
         );
@@ -4518,9 +4515,6 @@ const useEchartsCartesianConfig = (
             },
             tooltip,
             grid: currentGrid,
-            textStyle: {
-                fontFamily: sanitizeEchartsFontFamily(theme?.other.chartFont),
-            },
             // We assign colors per series, so we specify an empty list here.
             color: [],
             ...(enableDataZoom && {
@@ -4559,7 +4553,6 @@ const useEchartsCartesianConfig = (
         dataToRender,
         tooltip,
         currentGrid,
-        theme?.other.chartFont,
         validCartesianConfig,
         timeAxisMode,
     ]);

--- a/packages/frontend/src/hooks/echarts/useEchartsFunnelConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsFunnelConfig.ts
@@ -8,9 +8,8 @@ import {
     FunnelChartLabelPosition,
     FunnelChartLegendPosition,
     getGranularityMapFromItems,
-    getLegendStyle,
+    getLegendIconStyle,
     getReadableTextColor,
-    getTooltipStyle,
     resolveGranularityInLabel,
     type Metric,
     type ResultRow,
@@ -23,7 +22,6 @@ import round from 'lodash/round';
 import { useMemo } from 'react';
 import { isFunnelVisualizationConfig } from '../../components/LightdashVisualization/types';
 import { useVisualizationContext } from '../../components/LightdashVisualization/useVisualizationContext';
-import { sanitizeEchartsFontFamily } from '../../utils/sanitizeEchartsFontFamily';
 import { useLegendDoubleClickTooltip } from './useLegendDoubleClickTooltip';
 
 /**
@@ -251,7 +249,7 @@ const useEchartsFunnelConfig = (
             validConfig: { showLegend, legendPosition },
         } = chartConfig;
 
-        const legendStyle = getLegendStyle('square');
+        const legendStyle = getLegendIconStyle('square');
 
         const legendConfig = {
             show: showLegend,
@@ -282,11 +280,8 @@ const useEchartsFunnelConfig = (
         if (!chartConfig || !funnelSeriesOptions || !seriesData) return;
 
         const baseOptions = {
-            textStyle: {
-                fontFamily: sanitizeEchartsFontFamily(theme?.other.chartFont),
-            },
             tooltip: {
-                ...getTooltipStyle({ appendToBody: !isTouchDevice }),
+                appendToBody: !isTouchDevice,
                 trigger: 'item' as const,
             },
             series: [funnelSeriesOptions],
@@ -303,7 +298,6 @@ const useEchartsFunnelConfig = (
         seriesData,
         isInDashboard,
         minimal,
-        theme,
         legendConfigWithTooltip,
         isTouchDevice,
     ]);

--- a/packages/frontend/src/hooks/echarts/useEchartsGaugeConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsGaugeConfig.ts
@@ -15,7 +15,6 @@ import toNumber from 'lodash/toNumber';
 import { useMemo } from 'react';
 import { isGaugeVisualizationConfig } from '../../components/LightdashVisualization/types';
 import { useVisualizationContext } from '../../components/LightdashVisualization/useVisualizationContext';
-import { sanitizeEchartsFontFamily } from '../../utils/sanitizeEchartsFontFamily';
 
 const EchartsGaugeType = 'gauge';
 
@@ -433,19 +432,10 @@ const useEchartsGaugeConfig = ({
         if (!chartConfig || !gaugeSeries) return;
 
         return {
-            textStyle: {
-                fontFamily: sanitizeEchartsFontFamily(theme?.other?.chartFont),
-            },
             series: gaugeSeries,
             animation: !(isInDashboard || minimal),
         };
-    }, [
-        chartConfig,
-        gaugeSeries,
-        isInDashboard,
-        minimal,
-        theme?.other?.chartFont,
-    ]);
+    }, [chartConfig, gaugeSeries, isInDashboard, minimal]);
 
     if (!itemsMap) return;
     if (!eChartsOption) return;

--- a/packages/frontend/src/hooks/echarts/useEchartsPieConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsPieConfig.ts
@@ -6,24 +6,21 @@ import {
     formatTooltipRow,
     formatTooltipValue,
     getGranularityMapFromItems,
-    getLegendStyle,
+    getLegendIconStyle,
     getPieExternalLabelStyle,
     getPieInternalLabelStyle,
     getPieLabelLineStyle,
     getPieSliceStyle,
-    getTooltipStyle,
     PieChartLegendLabelMaxLengthDefault,
     PieChartTooltipLabelMaxLength,
     resolveGranularityInLabel,
     type ResultRow,
     type ResultValue,
 } from '@lightdash/common';
-import { useMantineTheme } from '@mantine/core';
 import { type EChartsOption, type PieSeriesOption } from 'echarts';
 import { useMemo } from 'react';
 import { isPieVisualizationConfig } from '../../components/LightdashVisualization/types';
 import { useVisualizationContext } from '../../components/LightdashVisualization/useVisualizationContext';
-import { sanitizeEchartsFontFamily } from '../../utils/sanitizeEchartsFontFamily';
 import { useLegendDoubleClickTooltip } from './useLegendDoubleClickTooltip';
 export type PieSeriesDataPoint = NonNullable<
     PieSeriesOption['data']
@@ -47,8 +44,6 @@ const useEchartsPieConfig = (
         isTouchDevice,
         resolvedTimezone,
     } = useVisualizationContext();
-
-    const theme = useMantineTheme();
 
     const chartConfig = useMemo(() => {
         if (!isPieVisualizationConfig(visualizationConfig)) return;
@@ -241,14 +236,11 @@ const useEchartsPieConfig = (
         } = chartConfig;
 
         return {
-            textStyle: {
-                fontFamily: sanitizeEchartsFontFamily(theme?.other?.chartFont),
-            },
             legend: {
                 show: showLegend,
                 orient: legendPosition,
                 type: 'scroll',
-                ...getLegendStyle('square'),
+                ...getLegendIconStyle('square'),
                 formatter: (name: string) => {
                     return name.length >
                         (legendMaxItemLength ??
@@ -276,7 +268,7 @@ const useEchartsPieConfig = (
             },
             tooltip: {
                 trigger: 'item',
-                ...getTooltipStyle({ appendToBody: !isTouchDevice }),
+                appendToBody: !isTouchDevice,
             },
             series: [pieSeriesOption],
             animation: !(isInDashboard || minimal),
@@ -284,7 +276,6 @@ const useEchartsPieConfig = (
     }, [
         chartConfig,
         pieSeriesOption,
-        theme?.other?.chartFont,
         legendDoubleClickTooltip,
         selectedLegends,
         isInDashboard,

--- a/packages/frontend/src/hooks/echarts/useEchartsSankeyConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsSankeyConfig.ts
@@ -3,7 +3,6 @@ import {
     formatItemValue,
     formatTooltipRow,
     formatTooltipValue,
-    getTooltipStyle,
     type Metric,
     type TableCalculation,
 } from '@lightdash/common';
@@ -12,7 +11,6 @@ import { type EChartsOption, type SankeySeriesOption } from 'echarts';
 import { useCallback, useMemo } from 'react';
 import { isSankeyVisualizationConfig } from '../../components/LightdashVisualization/types';
 import { useVisualizationContext } from '../../components/LightdashVisualization/useVisualizationContext';
-import { sanitizeEchartsFontFamily } from '../../utils/sanitizeEchartsFontFamily';
 
 const useEchartsSankeyConfig = (isInDashboard?: boolean) => {
     const {
@@ -124,11 +122,8 @@ const useEchartsSankeyConfig = (isInDashboard?: boolean) => {
         }
 
         return {
-            textStyle: {
-                fontFamily: sanitizeEchartsFontFamily(theme?.other.chartFont),
-            },
             tooltip: {
-                ...getTooltipStyle({ appendToBody: !isTouchDevice }),
+                appendToBody: !isTouchDevice,
                 trigger: 'item' as const,
                 formatter: (params: any) => {
                     if (params.dataType === 'edge') {
@@ -171,7 +166,6 @@ const useEchartsSankeyConfig = (isInDashboard?: boolean) => {
         sankeySeriesOption,
         isInDashboard,
         minimal,
-        theme,
         isTouchDevice,
         visualizationConfig,
         parameters,

--- a/packages/frontend/src/hooks/echarts/useEchartsTreemapConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsTreemapConfig.ts
@@ -7,7 +7,6 @@ import {
     getItemLabelWithoutTableName,
     getReadableTextColor,
     getTooltipDivider,
-    getTooltipStyle,
     vizThemeColors,
 } from '@lightdash/common';
 import { useMantineTheme } from '@mantine/core';
@@ -15,7 +14,6 @@ import { type EChartsOption, type TreemapSeriesOption } from 'echarts';
 import { useMemo } from 'react';
 import { isTreemapVisualizationConfig } from '../../components/LightdashVisualization/types';
 import { useVisualizationContext } from '../../components/LightdashVisualization/useVisualizationContext';
-import { sanitizeEchartsFontFamily } from '../../utils/sanitizeEchartsFontFamily';
 
 const EchartsTreemapType = 'treemap';
 
@@ -206,11 +204,8 @@ const useEchartsTreemapConfig = (isInDashboard: boolean) => {
         if (!chartConfig || !treemapSeriesOption) return;
 
         return {
-            textStyle: {
-                fontFamily: sanitizeEchartsFontFamily(theme?.other?.chartFont),
-            },
             tooltip: {
-                ...getTooltipStyle({ appendToBody: !isTouchDevice }),
+                appendToBody: !isTouchDevice,
                 trigger: 'item' as const, //Even though this is the default, tooltips will not show up if this is not set.
             },
             series: [treemapSeriesOption],
@@ -221,7 +216,6 @@ const useEchartsTreemapConfig = (isInDashboard: boolean) => {
         treemapSeriesOption,
         isInDashboard,
         minimal,
-        theme?.other?.chartFont,
         isTouchDevice,
     ]);
     if (!itemsMap) return;

--- a/packages/frontend/src/utils/resolveEchartsCssVariables.test.ts
+++ b/packages/frontend/src/utils/resolveEchartsCssVariables.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { resolveCssVariablesInOptions } from './resolveEchartsCssVariables';
+
+describe('resolveCssVariablesInOptions', () => {
+    afterEach(() => {
+        document.documentElement.style.removeProperty('--chart-color');
+    });
+
+    it('resolves canvas colors from CSS while retaining fallbacks', () => {
+        document.documentElement.style.setProperty('--chart-color', '#123456');
+        expect(
+            resolveCssVariablesInOptions({
+                color: 'var(--chart-color, #ffffff)',
+                borderColor: 'var(--missing-color, #abcdef)',
+            }),
+        ).toEqual({ color: '#123456', borderColor: '#abcdef' });
+    });
+
+    it('resolves a supplied theme without waiting for the DOM stylesheet', () => {
+        document.documentElement.style.setProperty('--chart-color', '#123456');
+        expect(
+            resolveCssVariablesInOptions(
+                { color: 'var(--chart-color, #ffffff)' },
+                () => '#eeeeee',
+            ),
+        ).toEqual({ color: '#eeeeee' });
+    });
+
+    it('preserves formatters and input options when resolving nested arrays', () => {
+        const formatter = (value: number) => `${value}%`;
+        const options = {
+            series: [
+                {
+                    data: [0, null, 10],
+                    label: {
+                        formatter,
+                        color: 'var(--missing-color, #abcdef)',
+                    },
+                },
+            ],
+        };
+        const resolved = resolveCssVariablesInOptions(options);
+        expect(resolved.series[0].label.color).toBe('#abcdef');
+        expect(resolved.series[0].label.formatter).toBe(formatter);
+        expect(resolved.series[0].data).toEqual([0, null, 10]);
+        expect(options.series[0].label.color).toBe(
+            'var(--missing-color, #abcdef)',
+        );
+    });
+});

--- a/packages/frontend/src/utils/resolveEchartsCssVariables.ts
+++ b/packages/frontend/src/utils/resolveEchartsCssVariables.ts
@@ -1,0 +1,42 @@
+const CSS_VAR_REGEX = /^var\((--[^,)]+)(?:,\s*(.+))?\)$/;
+
+const readCssVariable = (variable: string): string =>
+    getComputedStyle(document.documentElement).getPropertyValue(variable);
+
+const resolveCssVariable = (
+    value: string,
+    readVariable: (variable: string) => string,
+): string => {
+    const match = value.match(CSS_VAR_REGEX);
+    if (!match) return value;
+
+    const [, varName, fallback] = match;
+    const computed = readVariable(varName);
+    return computed.trim() || fallback?.trim() || value;
+};
+
+// Canvas needs literal colors. Preserve inputs and formatter functions when resolving.
+export const resolveCssVariablesInOptions = <T>(
+    obj: T,
+    readVariable: (variable: string) => string = readCssVariable,
+): T => {
+    if (obj === null || obj === undefined) return obj;
+    if (typeof obj === 'string') {
+        return resolveCssVariable(obj, readVariable) as unknown as T;
+    }
+    if (Array.isArray(obj)) {
+        return obj.map((value) =>
+            resolveCssVariablesInOptions(value, readVariable),
+        ) as unknown as T;
+    }
+    if (typeof obj === 'object') {
+        const result: Record<string, unknown> = {};
+        for (const [key, value] of Object.entries(
+            obj as Record<string, unknown>,
+        )) {
+            result[key] = resolveCssVariablesInOptions(value, readVariable);
+        }
+        return result as T;
+    }
+    return obj;
+};


### PR DESCRIPTION
### Description

Chart hooks repeatedly apply the same axis, legend, tooltip, and font styles. Centralize presentation defaults in `lightdashEchartsTheme` and apply them through a shared `LightdashECharts` wrapper for Cartesian, pie/donut, funnel, gauge, Sankey, and treemap visualizations.

Preserve existing appearance, custom fonts, conditional formatting, layout, and Cartesian legend override precedence. Existing style helpers remain compatible for other renderers. Canvas theme colors resolve from Mantine tokens; font changes retain the chart instance. ECharts remains on 5.6.0.

### Validation

- 179 tests passed: 164 Cartesian, 2 funnel, 10 theme rendering/compatibility, and 3 CSS-resolution tests.
- Frontend and common type checks, changed-file lint, and frontend unused-export checks passed.
- Saved line, bar, and pie charts in light/dark mode: all six chart-region comparisons are pixel-identical.
- Twelve renderer fixtures across light/dark and SVG/canvas: 48 combinations checked. Three matrices are pixel-identical; light SVG differs at five edge pixels by one color level. SVG geometry regression tests pass.
- Checked quoted custom fonts, live canvas theme switching, legend toggling, and SVG/PNG export generation. Before/after screenshots and original source are retained locally.

### Risk assessment

- [ ] This is a high-risk change

Low risk: reversible presentation refactor with visual comparisons and regression coverage. Theme inheritance is the main risk; the rollout is limited to the six existing visualization renderers, preserving other wrapper consumers and inline helper behavior.
