### PR TITLE
fix(frontend): include custom org roles in space share picker

### DIFF
--- a/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceAddUser.test.tsx
+++ b/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceAddUser.test.tsx
@@ -1,0 +1,140 @@
+import {
+    OrganizationMemberRole,
+    type OrganizationMemberProfile,
+    type Space,
+} from '@lightdash/common';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import { ShareSpaceAddUser } from './ShareSpaceAddUser';
+
+const organizationUsers: OrganizationMemberProfile[] = [];
+const organizationUsersData = { pages: [{ data: organizationUsers }] };
+const organizationGroupsData = { pages: [{ data: [] }] };
+const spaceAccessByUserUuid = new Map();
+
+vi.mock('../../../hooks/useOrganizationGroups', () => ({
+    useInfiniteOrganizationGroups: () => ({
+        data: organizationGroupsData,
+        fetchNextPage: vi.fn(),
+        hasNextPage: false,
+        isFetching: false,
+    }),
+}));
+
+vi.mock('../../../hooks/useOrganizationUsers', () => ({
+    useInfiniteOrganizationUsers: () => ({
+        data: organizationUsersData,
+        fetchNextPage: vi.fn(),
+        hasNextPage: false,
+        isFetching: false,
+    }),
+}));
+
+vi.mock('../../../hooks/useProjectAccess', () => ({
+    useProjectAccess: () => ({ data: [] }),
+}));
+
+vi.mock('../../../hooks/useSpaceAccess', () => ({
+    useSpaceAccessByUserUuids: () => ({
+        map: spaceAccessByUserUuid,
+        isLoading: false,
+        isError: false,
+    }),
+}));
+
+vi.mock('../../../hooks/useSpaces', () => ({
+    useAddGroupSpaceShareMutation: () => ({ mutateAsync: vi.fn() }),
+    useAddSpaceShareMutation: () => ({ mutateAsync: vi.fn() }),
+    useUpdateMutation: () => ({ mutateAsync: vi.fn() }),
+}));
+
+const makeOrganizationUser = (
+    userUuid: string,
+    email: string,
+    roleUuid: string | undefined,
+    hasMultipleRoles = false,
+): OrganizationMemberProfile => ({
+    userUuid,
+    userCreatedAt: new Date('2026-01-01'),
+    userUpdatedAt: new Date('2026-01-01'),
+    firstName: '',
+    lastName: '',
+    email,
+    organizationUuid: 'organization-uuid',
+    role: OrganizationMemberRole.MEMBER,
+    roleUuid,
+    hasMultipleRoles,
+    isActive: true,
+    avatarUrl: null,
+    avatarGradient: null,
+});
+
+const space: Space = {
+    organizationUuid: 'organization-uuid',
+    uuid: 'space-uuid',
+    name: 'Restricted space',
+    inheritsFromOrgOrProject: false,
+    queries: [],
+    projectUuid: 'project-uuid',
+    dashboards: [],
+    access: [],
+    groupsAccess: [],
+    pinnedListUuid: null,
+    pinnedListOrder: null,
+    slug: 'restricted-space',
+    childSpaces: [],
+    parentSpaceUuid: null,
+    inheritParentPermissions: false,
+    projectMemberAccessRole: null,
+    colorPaletteUuid: null,
+    path: 'restricted_space',
+};
+
+describe('ShareSpaceAddUser', () => {
+    beforeEach(() => {
+        organizationUsers.splice(
+            0,
+            organizationUsers.length,
+            makeOrganizationUser(
+                'custom-role-user',
+                'custom-role@example.com',
+                'custom-role-uuid',
+            ),
+            makeOrganizationUser(
+                'additional-custom-role-user',
+                'additional-custom-role@example.com',
+                undefined,
+                true,
+            ),
+            makeOrganizationUser(
+                'organization-member',
+                'member@example.com',
+                undefined,
+            ),
+        );
+    });
+
+    it('offers custom organization role users but not ineligible organization members', async () => {
+        renderWithProviders(
+            <ShareSpaceAddUser space={space} projectUuid="project-uuid" />,
+        );
+
+        await userEvent.click(
+            screen.getByPlaceholderText(
+                'Select groups or users to share this space with',
+            ),
+        );
+
+        expect(
+            await screen.findByText('custom-role@example.com'),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText('additional-custom-role@example.com'),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByText('member@example.com'),
+        ).not.toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceAddUser.tsx
+++ b/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceAddUser.tsx
@@ -160,7 +160,12 @@ export const ShareSpaceAddUser: FC<ShareSpaceAddUserProps> = ({
 
         const orgUserUuids =
             organizationUsers
-                ?.filter((user) => user.role !== OrganizationMemberRole.MEMBER)
+                ?.filter(
+                    (user) =>
+                        user.role !== OrganizationMemberRole.MEMBER ||
+                        user.roleUuid !== undefined ||
+                        user.hasMultipleRoles === true,
+                )
                 .map((user) => user.userUuid) ?? [];
 
         return [...new Set([...projectUserUuids, ...orgUserUuids])];


### PR DESCRIPTION
## What changed

- fix(frontend): include custom org roles in space share picker

## Verification

Visual proof captured at revision `39b29f5f4e`:
- Custom role assignment screenshot: https://dodo.lightdash.dev/evidence/8eebc5277dadde8089b0d8fba9f0ce722cd4e15aec5d2fc5daaa1350831c391f.png
- Space Share picker screenshot: https://dodo.lightdash.dev/evidence/26f555e221659b36ba8eb3680fe50a0ad48b5d0fd1fcaaf17434002eb86790b4.png
- Walkthrough video: https://dodo.lightdash.dev/evidence/e1861406f6cd1a16c3b170193d019510985b56fe77291bda1e58b56ef30554a7.mp4
- Walkthrough GIF: https://dodo.lightdash.dev/evidence/20170ec7020995b4f2ba6178d30a554c602346c59aaa50bf69c42d82bd26b1f5.gif

Screenshot observations confirmed the custom role assignment is visible and the Share picker dropdown contains the visible `Custom Role Viewer` result.

## Visual evidence

### Users & groups shows Custom Role Viewer assigned the organization-level “Project viewer (custom org role)” role.

![Lightdash development environment screenshot](https://dodo.lightdash.dev/evidence/8eebc5277dadde8089b0d8fba9f0ce722cd4e15aec5d2fc5daaa1350831c391f.png)

### The restricted-space Share picker returns Custom Role Viewer even though this user has no explicit project membership.

![Lightdash development environment screenshot](https://dodo.lightdash.dev/evidence/26f555e221659b36ba8eb3680fe50a0ad48b5d0fd1fcaaf17434002eb86790b4.png)

### Walkthrough from the custom organization role assignment to finding the same user in a restricted space’s Share picker.

![Lightdash development environment walkthrough](https://dodo.lightdash.dev/evidence/20170ec7020995b4f2ba6178d30a554c602346c59aaa50bf69c42d82bd26b1f5.gif)

[Open full walkthrough](https://dodo.lightdash.dev/evidence/e1861406f6cd1a16c3b170193d019510985b56fe77291bda1e58b56ef30554a7.mp4)

## Development environment

[Open the public Lightdash development environment](https://ld-runner-prod-10841-e7accc3702f6.exe.xyz) (anyone with the URL can access it)

Login: `demo@lightdash.com` / `demo_password!`

## References

Closes: [PROD-10841](https://linear.app/lightdash/issue/PROD-10841)

