### PR TITLE
feat(explores): unnest arrays of scalars into a virtual table with a value dimension

### DIFF
--- a/packages/cli/src/dbt/models.test.ts
+++ b/packages/cli/src/dbt/models.test.ts
@@ -46,10 +46,12 @@ describe('Models', () => {
                 true,
             );
         });
-        test('skips container nodes and repeated scalars', () => {
+        test('keeps an array of scalars, exposed through its container entry', () => {
+            expect(isGeneratableColumn(catalog, ref, 'tags')).toBe(true);
+        });
+        test('skips struct and repeated record containers', () => {
             expect(isGeneratableColumn(catalog, ref, 'totals')).toBe(false);
             expect(isGeneratableColumn(catalog, ref, 'hits')).toBe(false);
-            expect(isGeneratableColumn(catalog, ref, 'tags')).toBe(false);
         });
         test('skips leaves beneath a repeated node', () => {
             expect(isGeneratableColumn(catalog, ref, 'hits.page')).toBe(false);

--- a/packages/cli/src/dbt/models.ts
+++ b/packages/cli/src/dbt/models.ts
@@ -55,7 +55,14 @@ export const isGeneratableColumn = (
             prefix,
         );
         const isLeaf = index === segments.length - 1;
-        return isLeaf ? shape === undefined : shape?.repeated === false;
+        // An array of scalars is exposed through its container entry, so it
+        // is generated like a leaf; every other container and anything under
+        // an array is left for the user to document by hand.
+        const isScalarArray =
+            shape?.repeated === true && shape.record === false;
+        return isLeaf
+            ? shape === undefined || isScalarArray
+            : shape?.repeated === false;
     });
 };
 

--- a/packages/common/src/compiler/translator.test.ts
+++ b/packages/common/src/compiler/translator.test.ts
@@ -3304,6 +3304,8 @@ describe('nested and repeated columns', () => {
                     'hits.product': DimensionType.STRING,
                     'hits.product.productSKU': DimensionType.STRING,
                     'hits.product.productRevenue': DimensionType.NUMBER,
+                    tags: DimensionType.STRING,
+                    'hits.page.keywords': DimensionType.STRING,
                 },
             },
         },
@@ -3314,6 +3316,8 @@ describe('nested and repeated columns', () => {
         hits: { repeated: true, record: true },
         'hits.page': { repeated: false, record: true },
         'hits.product': { repeated: true, record: true },
+        tags: { repeated: true, record: false },
+        'hits.page.keywords': { repeated: true, record: false },
     }).forEach(([path, shape]) =>
         setCatalogNestedColumnShape(
             catalog,
@@ -3581,6 +3585,85 @@ describe('nested and repeated columns', () => {
             'SUM(`second_session__hits__product`.productRevenue)',
         );
         expect(explore.tables.ga_sessions__hits).toBeUndefined();
+    });
+
+    it('unnests an array of scalars into a virtual table with a value dimension', async () => {
+        const taggedSessions: DbtModelNode = {
+            ...gaSessions,
+            columns: {
+                visitId: nestedColumn('visitId'),
+                tags: nestedColumn('tags', {
+                    description: 'Session tags',
+                    meta: {
+                        dimension: { label: 'Tag list' },
+                        metrics: {
+                            last_tag: { type: MetricType.MAX },
+                        },
+                    },
+                }),
+                'hits.page.keywords': nestedColumn('hits.page.keywords'),
+            },
+        };
+        const explore = await compile(
+            attachTypesToModels([taggedSessions], catalog, true),
+            true,
+        );
+        expect(Object.keys(explore.tables).sort()).toEqual([
+            'ga_sessions',
+            'ga_sessions__hits',
+            'ga_sessions__hits__page__keywords',
+            'ga_sessions__tags',
+        ]);
+        expect(Object.keys(explore.tables.ga_sessions.dimensions)).toEqual([
+            'visitId',
+        ]);
+
+        const tags = explore.tables.ga_sessions__tags;
+        expect(tags.label).toEqual('Tag list');
+        expect(tags.description).toEqual('Session tags');
+        expect(tags.sqlTable).toEqual(
+            'UNNEST(`ga_sessions`.tags) AS `ga_sessions__tags` WITH OFFSET AS `ga_sessions__tags__offset`',
+        );
+        expect(Object.keys(tags.dimensions).sort()).toEqual([
+            'offset',
+            'value',
+        ]);
+        expect(tags.dimensions.value).toMatchObject({
+            type: DimensionType.STRING,
+            label: 'Value',
+            compiledSql: '`ga_sessions__tags`',
+        });
+        expect(tags.metrics.last_tag.compiledSql).toEqual(
+            'MAX(`ga_sessions__tags`)',
+        );
+
+        // An array below a struct inside a repeated record unnests from the
+        // repeated parent, with the struct path in the segment.
+        const keywords = explore.tables.ga_sessions__hits__page__keywords;
+        expect(keywords.nestedFrom).toEqual({
+            parentTable: 'ga_sessions__hits',
+            columnPath: 'hits.page.keywords',
+        });
+        expect(keywords.sqlTable).toEqual(
+            'UNNEST(`ga_sessions__hits`.page.keywords) AS `ga_sessions__hits__page__keywords` WITH OFFSET AS `ga_sessions__hits__page__keywords__offset`',
+        );
+        expect(keywords.label).toEqual('Ga sessions: Hits: Page: Keywords');
+        expect(keywords.dimensions.value.compiledSql).toEqual(
+            '`ga_sessions__hits__page__keywords`',
+        );
+        expect(
+            Object.keys(explore.tables.ga_sessions__hits.dimensions),
+        ).toEqual(['offset']);
+        expect(
+            explore.joinedTables.map(({ table, tablesReferences }) => [
+                table,
+                tablesReferences,
+            ]),
+        ).toEqual([
+            ['ga_sessions__hits', ['ga_sessions']],
+            ['ga_sessions__tags', ['ga_sessions']],
+            ['ga_sessions__hits__page__keywords', ['ga_sessions__hits']],
+        ]);
     });
 
     it('fails the model when a virtual table name collides with a model', async () => {

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -1187,11 +1187,40 @@ type NestedTableTemplate = {
     description: string | undefined;
 };
 
+const isRepeatedScalarColumn = (column: DbtModelColumn): boolean =>
+    column.nested_shape?.repeated === true &&
+    column.nested_shape.record === false &&
+    !getColumnMeta(column).dimension?.sql;
+
 /**
- * One template per repeated node reached by a documented leaf, outermost
- * first so a child's join always follows its parent's. Templates carry no
- * table names: the same model can be joined under several aliases, and the
- * UNNEST has to reference the parent by the name it has in that explore.
+ * An array of scalars has no leaves of its own: the element is the value, so
+ * the virtual table exposes it as a single `value` dimension whose SQL is the
+ * unnest alias itself. The container's dimension config (type, format...)
+ * applies to that element; its label names the table instead.
+ */
+const getScalarElementColumn = (container: DbtModelColumn): DbtModelColumn => {
+    const {
+        repeated_ancestors: _ancestors,
+        nested_shape: _shape,
+        config: _config,
+        ...column
+    } = container;
+    const { dimension, ...meta } = getColumnMeta(container);
+    const { label: _label, ...dimensionConfig } = dimension ?? {};
+    return {
+        ...column,
+        name: 'value',
+        description: container.description ?? `Element of ${container.name}`,
+        meta: { ...meta, dimension: { ...dimensionConfig, sql: '${TABLE}' } },
+    };
+};
+
+/**
+ * One template per repeated node: every array of records reached by a
+ * documented leaf, and every documented array of scalars. Outermost first so
+ * a child's join always follows its parent's. Templates carry no table
+ * names: the same model can be joined under several aliases, and the UNNEST
+ * has to reference the parent by the name it has in that explore.
  */
 export const getNestedTableTemplates = (
     model: DbtModelNode,
@@ -1200,41 +1229,59 @@ export const getNestedTableTemplates = (
     const isRoutedLeaf = (column: DbtModelColumn) =>
         hasRepeatedAncestor(column) && !getColumnMeta(column).dimension?.sql;
     const nodePaths = Array.from(
-        new Set(
-            columns
+        new Set([
+            ...columns
                 .filter(isRoutedLeaf)
                 .flatMap((column) => column.repeated_ancestors ?? []),
-        ),
+            ...columns
+                .filter(isRepeatedScalarColumn)
+                .flatMap((column) => [
+                    ...(column.repeated_ancestors ?? []),
+                    column.name,
+                ]),
+        ]),
     ).sort(
         (a, b) =>
             a.split('.').length - b.split('.').length || a.localeCompare(b),
     );
+    // A node can sit below a struct inside its repeated parent, so the
+    // parent is the deepest repeated prefix, not the previous path segment.
+    const getParentPath = (nodePath: string) =>
+        nodePaths
+            .filter((candidate) => nodePath.startsWith(`${candidate}.`))
+            .sort((a, b) => b.length - a.length)[0] ?? '';
     return nodePaths.map((nodePath) => {
-        const segments = nodePath.split('.');
+        const parentPath = getParentPath(nodePath);
         const container = model.columns[nodePath];
+        const leafColumns = columns
+            .filter(
+                (column) =>
+                    isRoutedLeaf(column) &&
+                    column.repeated_ancestors?.[
+                        column.repeated_ancestors.length - 1
+                    ] === nodePath,
+            )
+            .map(
+                ({
+                    repeated_ancestors: _ancestors,
+                    nested_shape: nestedShape,
+                    ...column
+                }): DbtModelColumn => ({
+                    ...column,
+                    name: column.name.slice(nodePath.length + 1),
+                    ...(nestedShape ? { nested_shape: nestedShape } : {}),
+                }),
+            );
         return {
             nodePath,
-            segment: segments[segments.length - 1],
-            parentPath: segments.slice(0, -1).join('.'),
-            columns: columns
-                .filter(
-                    (column) =>
-                        isRoutedLeaf(column) &&
-                        column.repeated_ancestors?.[
-                            column.repeated_ancestors.length - 1
-                        ] === nodePath,
-                )
-                .map(
-                    ({
-                        repeated_ancestors: _ancestors,
-                        nested_shape: nestedShape,
-                        ...column
-                    }): DbtModelColumn => ({
-                        ...column,
-                        name: column.name.slice(nodePath.length + 1),
-                        ...(nestedShape ? { nested_shape: nestedShape } : {}),
-                    }),
-                ),
+            segment: parentPath
+                ? nodePath.slice(parentPath.length + 1)
+                : nodePath,
+            parentPath,
+            columns:
+                container && isRepeatedScalarColumn(container)
+                    ? [getScalarElementColumn(container)]
+                    : leafColumns,
             label: container
                 ? getColumnMeta(container).dimension?.label
                 : undefined,
@@ -1305,9 +1352,10 @@ export const instantiateNestedTables = ({
             }
             const label =
                 template.label ??
-                `${labelsByPath.get(parentPath) ?? parentLabel}: ${friendlyName(
-                    segment,
-                )}`;
+                [
+                    labelsByPath.get(parentPath) ?? parentLabel,
+                    ...segment.split('.').map(friendlyName),
+                ].join(': ');
             labelsByPath.set(nodePath, label);
 
             const offsetColumn: DbtModelColumn = {


### PR DESCRIPTION
With the unnest-repeated-columns flag on, an array of scalars such as `tags ARRAY<STRING>` vanished from the explore. A virtual table was only synthesised for a repeated node that had a documented leaf beneath it, and a scalar array has none, so its container entry was skipped as a container and nothing replaced it. The most basic array shape was the one that did not work, and `lightdash generate` skipped the column too, so nothing told the user.

An array of scalars now becomes a virtual table with a `value` dimension for the element and the usual `offset`, typed from the catalog, with the container's dimension config and metrics applying to the element. Arrays that sit below a struct inside a repeated record now unnest from their repeated parent rather than from a table that does not exist, and `generate` writes the container entry so the array is exposed by default. Verified on the demo project with an `ARRAY<STRING>` column: one row per element, a `count_distinct` on the element, and the session count still deduplicated.

Relates: #4102
