### PR TITLE
fix: use slugs in chart type edit links

### DIFF
--- a/packages/backend/src/database/seeds/development/16_data_app_visualization.ts
+++ b/packages/backend/src/database/seeds/development/16_data_app_visualization.ts
@@ -31,43 +31,70 @@ const buildSourceTar = (): Promise<Buffer> =>
         p.finalize();
     });
 
+// The served bundle the builder/explorer preview iframes load. Without an
+// index.html under the version prefix the app-view route 404s, so every
+// fresh environment showed raw `{"status":"error"...}` JSON in the preview
+// pane, and the bundle-servable check reported the version unavailable.
+const SEED_INDEX_HTML = `<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>${SEED_DATA_APP_VIZ.name}</title>
+    </head>
+    <body style="font-family: sans-serif; display: flex; align-items: center; justify-content: center; height: 100vh; margin: 0; color: #6b7280;">
+        ${SEED_DATA_APP_VIZ.name} (static seed bundle)
+    </body>
+</html>
+`;
+
 /**
- * Stores the version's source archive so this seeded app matches production
- * invariants: a 'ready' version always has its source in object storage.
- * Without it, the CLI download of content referencing this custom chart
- * type fails with "Source not found".
+ * Stores the version's source archive and a minimal servable bundle so this
+ * seeded app matches production invariants: a 'ready' version always has
+ * its source in object storage (the CLI download of content referencing
+ * this custom chart type fails with "Source not found" without it) and an
+ * index.html the app-view route can serve.
  */
-const uploadSourceTar = async (): Promise<void> => {
+const uploadVersionArtifacts = async (): Promise<void> => {
     const s3Config = lightdashConfig.appRuntime.s3; // pragma: allowlist secret (product-name false positive)
     if (!s3Config) {
         console.warn(
-            'Skipping seed data app source upload: app runtime S3 is not configured',
+            'Skipping seed data app artifact upload: app runtime S3 is not configured',
         );
         return;
     }
     const client = createS3ClientFromConfig(s3Config);
     const sourceTar = await buildSourceTar();
-    const putSourceTar = () =>
-        client.send(
+    const prefix = versionPrefix(
+        SEED_DATA_APP_VIZ.appUuid,
+        SEED_DATA_APP_VIZ.version,
+    );
+    const putArtifacts = async () => {
+        await client.send(
             new PutObjectCommand({
                 Bucket: s3Config.bucket,
-                Key: `${versionPrefix(
-                    SEED_DATA_APP_VIZ.appUuid,
-                    SEED_DATA_APP_VIZ.version,
-                )}source.tar`,
+                Key: `${prefix}source.tar`,
                 Body: sourceTar,
                 ContentType: 'application/x-tar',
             }),
         );
+        await client.send(
+            new PutObjectCommand({
+                Bucket: s3Config.bucket,
+                Key: `${prefix}index.html`,
+                Body: SEED_INDEX_HTML,
+                ContentType: 'text/html',
+            }),
+        );
+    };
     try {
-        await putSourceTar();
+        await putArtifacts();
     } catch (error) {
         // Local MinIO may not have the apps bucket yet
         if (error instanceof Error && error.name === 'NoSuchBucket') {
             await client.send(
                 new CreateBucketCommand({ Bucket: s3Config.bucket }),
             );
-            await putSourceTar();
+            await putArtifacts();
             return;
         }
         throw error;
@@ -113,7 +140,7 @@ export async function seed(knex: Knex): Promise<void> {
         { forceSlug: true },
     );
 
-    await uploadSourceTar();
+    await uploadVersionArtifacts();
 
     await new SavedChartModel({
         database: knex,

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
@@ -38,6 +38,7 @@ const vizSchema: DataAppVizSchema = {
 
 const makeDataAppVizRow = (overrides: Record<string, unknown> = {}) => ({
     app_id: 'data-app-viz-1',
+    slug: 'radial-gauge',
     name: 'Radial gauge',
     description: 'A radial gauge renderer',
     project_uuid: 'project-1',
@@ -222,6 +223,7 @@ describe('AppGenerateService data app vizs', () => {
             data: [
                 {
                     dataAppVizUuid: 'data-app-viz-1',
+                    slug: 'radial-gauge',
                     name: 'Radial gauge',
                     description: 'A radial gauge renderer',
                     projectUuid: 'project-1',

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -8585,6 +8585,7 @@ export class AppGenerateService extends BaseService {
     ): DataAppViz {
         return {
             dataAppVizUuid: app.app_id,
+            slug: app.slug,
             name: app.name,
             description: app.description,
             projectUuid: app.project_uuid,

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -1113,6 +1113,7 @@ export const getEffectiveOptionValues = (
 // copy. `schema` is null until a version generates one.
 export type DataAppViz = {
     dataAppVizUuid: string;
+    slug: string;
     name: string;
     description: string;
     projectUuid: string;

--- a/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.test.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.test.tsx
@@ -29,6 +29,7 @@ const { mocks } = vi.hoisted(() => ({
 
 const projectChartType = {
     dataAppVizUuid: 'project-chart-type',
+    slug: 'event-pulse',
     name: 'Event pulse',
     description: 'Reusable ranked bars',
     projectUuid: 'project-uuid',

--- a/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoring.test.tsx
+++ b/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoring.test.tsx
@@ -139,6 +139,7 @@ const rows = [{ orders_status: { value: { raw: 'new', formatted: 'New' } } }];
 
 const dataAppViz = {
     dataAppVizUuid: 'viz-1',
+    slug: 'grouped-bars',
     name: 'Grouped bars',
     description: '',
     projectUuid: 'project-1',

--- a/packages/frontend/src/components/Explorer/VisualizationCardOptions/useChartTypeOptions.test.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCardOptions/useChartTypeOptions.test.tsx
@@ -20,6 +20,7 @@ vi.mock('../../LightdashVisualization/useVisualizationContext', () => ({
 
 const projectChartType = {
     dataAppVizUuid: 'project-chart-type',
+    slug: 'event-pulse',
     name: 'Event pulse',
     description: 'Reusable ranked bars',
     projectUuid: 'project-uuid',

--- a/packages/frontend/src/components/VisualizationConfigs/CustomChartType/CustomChartTypePicker.test.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/CustomChartType/CustomChartTypePicker.test.tsx
@@ -14,6 +14,7 @@ const mockedUseDataAppVisualizations = vi.mocked(useDataAppVisualizations);
 
 const makeDataAppViz = (overrides: Partial<DataAppViz>): DataAppViz => ({
     dataAppVizUuid: 'data-app-viz-1',
+    slug: 'radial-gauge',
     name: 'Radial gauge',
     description: '',
     projectUuid: 'project-1',

--- a/packages/frontend/src/components/VisualizationConfigs/CustomChartType/useSelectProjectChartType.test.ts
+++ b/packages/frontend/src/components/VisualizationConfigs/CustomChartType/useSelectProjectChartType.test.ts
@@ -65,6 +65,7 @@ const itemsMap = {
 
 const dataAppViz = {
     dataAppVizUuid: 'viz-uuid',
+    slug: 'grouped-bars',
     name: 'Grouped bars',
     description: 'Groups a metric by a series dimension',
     projectUuid: 'project-uuid',

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeDetailModal.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeDetailModal.tsx
@@ -142,7 +142,7 @@ const ChartTypeDetailModal: FC<Props> = ({
                             component={Link}
                             to={chartTypeBuilderPath(
                                 projectUuid,
-                                dataAppViz.dataAppVizUuid,
+                                dataAppViz.slug,
                             )}
                             variant="default"
                             leftSection={<MantineIcon icon={IconFilePencil} />}

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeGalleryCard.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeGalleryCard.tsx
@@ -113,7 +113,7 @@ const ChartTypeGalleryCard: FC<Props> = ({
                                       component={Link}
                                       to={chartTypeBuilderPath(
                                           dataAppViz.projectUuid,
-                                          dataAppViz.dataAppVizUuid,
+                                          dataAppViz.slug,
                                       )}
                                       aria-label={`Edit ${displayName}`}
                                       onClick={(e) => e.stopPropagation()}

--- a/packages/frontend/src/features/chartTypes/utils/chartTypeBuilderPath.ts
+++ b/packages/frontend/src/features/chartTypes/utils/chartTypeBuilderPath.ts
@@ -1,4 +1,4 @@
 export const chartTypeBuilderPath = (
     projectUuid: string,
-    dataAppVizUuid: string | null = null,
-) => `/projects/${projectUuid}/chart-types/${dataAppVizUuid ?? 'new'}`;
+    dataAppVizUuidOrSlug: string | null = null,
+) => `/projects/${projectUuid}/chart-types/${dataAppVizUuidOrSlug ?? 'new'}`;

--- a/packages/frontend/src/pages/ChartTypeBuilder.test.tsx
+++ b/packages/frontend/src/pages/ChartTypeBuilder.test.tsx
@@ -318,6 +318,15 @@ describe('ChartTypeBuilder', () => {
         expect(screen.getByText('Chart type not found')).toBeInTheDocument();
     });
 
+    it('resolves an edit route by slug', () => {
+        setApp(appMeta());
+
+        renderBuilder('/projects/p1/chart-types/stream-graph');
+
+        expect(useGetApp).toHaveBeenCalledWith('p1', 'stream-graph');
+        expect(screen.getByText('Stream graph')).toBeInTheDocument();
+    });
+
     it('hands non-viz apps to the app builder', () => {
         setApp(appMeta({ template: 'dashboard' as AppMeta['template'] }));
         renderBuilder(

--- a/packages/frontend/src/pages/ChartTypeGallery.test.tsx
+++ b/packages/frontend/src/pages/ChartTypeGallery.test.tsx
@@ -67,6 +67,7 @@ const mockedUseDataAppVisualizations = vi.mocked(useDataAppVisualizations);
 
 const makeDataAppViz = (overrides: Partial<DataAppViz>): DataAppViz => ({
     dataAppVizUuid: 'data-app-viz-1',
+    slug: 'radial-gauge',
     name: 'Radial gauge',
     description: 'A gauge for KPI progress',
     projectUuid: 'project-1',
@@ -250,7 +251,7 @@ describe('ChartTypeGallery', () => {
             screen.getByRole('link', { name: 'Edit' }).closest('a'),
         ).toHaveAttribute(
             'href',
-            '/projects/project-1/chart-types/data-app-viz-1',
+            '/projects/project-1/chart-types/radial-gauge',
         );
         expect(screen.getByText('v3')).toBeInTheDocument();
         // Typed field breakdown, matching the library modal.
@@ -351,7 +352,7 @@ describe('ChartTypeGallery', () => {
             screen.getByLabelText('Edit Radial gauge').closest('a'),
         ).toHaveAttribute(
             'href',
-            '/projects/project-1/chart-types/data-app-viz-1',
+            '/projects/project-1/chart-types/radial-gauge',
         );
 
         fireEvent.click(screen.getByLabelText('Actions for Radial gauge'));


### PR DESCRIPTION
## Summary
- expose the persisted app slug on chart type gallery list items
- use chart type slugs for edit links in gallery cards and the detail modal
- verify the existing builder route resolves slug identifiers

## Tests
- pnpm -F frontend test src/pages/ChartTypeGallery.test.tsx src/pages/ChartTypeBuilder.test.tsx
- pnpm -F backend test src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
- pnpm -F common typecheck
- pnpm -F frontend typecheck
- pnpm -F backend typecheck