### PR TITLE
fix(direct-access): enforce current API authority

### DIFF
--- a/packages/backend/src/models/SavedChartModel.ownership.integration.test.ts
+++ b/packages/backend/src/models/SavedChartModel.ownership.integration.test.ts
@@ -1,0 +1,259 @@
+import {
+    ChartType,
+    ConflictError,
+    SEED_ORG_1_ADMIN,
+    SEED_PROJECT,
+} from '@lightdash/common';
+import { type Knex } from 'knex';
+import { randomUUID } from 'node:crypto';
+import { lightdashConfigMock } from '../config/lightdashConfig.mock';
+import { DashboardsTableName } from '../database/entities/dashboards';
+import { ProjectTableName } from '../database/entities/projects';
+import {
+    SavedChartsTableName,
+    SavedChartVersionsTableName,
+} from '../database/entities/savedCharts';
+import { SpaceTableName } from '../database/entities/spaces';
+import { getTestContext } from '../vitest.setup.integration';
+import { createSavedChart, SavedChartModel } from './SavedChartModel';
+
+type Owner = 'dashboard' | 'space';
+type Destination = Owner | 'otherDashboard' | 'otherSpace';
+
+describe('SavedChartModel ownership preconditions', () => {
+    let database: Knex;
+    let transaction: Knex.Transaction;
+    let model: SavedChartModel;
+    let space: { space_id: number; space_uuid: string };
+    let otherSpace: { space_id: number; space_uuid: string };
+    let dashboardUuid: string;
+    let otherDashboardUuid: string;
+
+    beforeAll(() => {
+        database = getTestContext().db;
+    });
+
+    beforeEach(async () => {
+        transaction = await database.transaction();
+        model = new SavedChartModel({
+            database: transaction,
+            lightdashConfig: lightdashConfigMock,
+        });
+        const seedSpace = await transaction(SpaceTableName)
+            .innerJoin(
+                ProjectTableName,
+                `${ProjectTableName}.project_id`,
+                `${SpaceTableName}.project_id`,
+            )
+            .where(
+                `${ProjectTableName}.project_uuid`,
+                SEED_PROJECT.project_uuid,
+            )
+            .whereNull(`${SpaceTableName}.deleted_at`)
+            .select(
+                `${SpaceTableName}.space_id`,
+                `${SpaceTableName}.space_uuid`,
+                `${SpaceTableName}.project_id`,
+                `${SpaceTableName}.created_by_user_id`,
+            )
+            .first();
+        if (!seedSpace) {
+            throw new Error('Seed project space not found');
+        }
+        space = seedSpace;
+        const spaceSlug = `ownership-${randomUUID()}`;
+        [otherSpace] = await transaction(SpaceTableName)
+            .insert({
+                name: 'Other ownership test space',
+                project_id: seedSpace.project_id,
+                created_by_user_id: seedSpace.created_by_user_id,
+                slug: spaceSlug,
+                path: spaceSlug.replaceAll('-', '_'),
+                parent_space_uuid: null,
+                inherit_parent_permissions: false,
+                is_default_user_space: false,
+            })
+            .returning(['space_id', 'space_uuid']);
+        const dashboards = await transaction(DashboardsTableName)
+            .insert(
+                ['Initial', 'Other'].map((name) => ({
+                    project_uuid: SEED_PROJECT.project_uuid,
+                    name: `${name} ownership test dashboard`,
+                    description: undefined,
+                    space_id: space.space_id,
+                    slug: `ownership-${randomUUID()}`,
+                })),
+            )
+            .returning('dashboard_uuid');
+        dashboardUuid = dashboards[0].dashboard_uuid;
+        otherDashboardUuid = dashboards[1].dashboard_uuid;
+    });
+
+    afterEach(async () => {
+        await transaction.rollback();
+    });
+
+    const createChart = async (owner: Owner) => {
+        const uuid = await createSavedChart(
+            transaction,
+            SEED_PROJECT.project_uuid,
+            SEED_ORG_1_ADMIN.user_uuid,
+            {
+                name: 'Original chart name',
+                description: 'Original description',
+                tableName: 'orders',
+                metricQuery: {
+                    exploreName: 'orders',
+                    dimensions: [],
+                    metrics: [],
+                    filters: {},
+                    sorts: [],
+                    limit: 100,
+                    tableCalculations: [],
+                },
+                chartConfig: { type: ChartType.TABLE, config: {} },
+                tableConfig: { columnOrder: [] },
+                updatedByUser: {
+                    userUuid: SEED_ORG_1_ADMIN.user_uuid,
+                    firstName: SEED_ORG_1_ADMIN.first_name,
+                    lastName: SEED_ORG_1_ADMIN.last_name,
+                },
+                slug: `ownership-chart-${randomUUID()}`,
+                ...(owner === 'dashboard'
+                    ? { dashboardUuid, spaceUuid: null }
+                    : { spaceUuid: space.space_uuid, dashboardUuid: null }),
+            },
+        );
+        return model.get(uuid);
+    };
+
+    const changeOwner = async (chartUuid: string, destination: Destination) => {
+        const owners = {
+            dashboard: { dashboard_uuid: dashboardUuid, space_id: null },
+            otherDashboard: {
+                dashboard_uuid: otherDashboardUuid,
+                space_id: null,
+            },
+            space: { dashboard_uuid: null, space_id: space.space_id },
+            otherSpace: { dashboard_uuid: null, space_id: otherSpace.space_id },
+        };
+        await transaction(SavedChartsTableName)
+            .where('saved_query_uuid', chartUuid)
+            .update(owners[destination]);
+    };
+
+    it.each<Owner>(['dashboard', 'space'])(
+        'updates metadata and creates a version when the %s owner is unchanged',
+        async (owner) => {
+            const chart = await createChart(owner);
+            const expectedLocation = {
+                projectUuid: chart.projectUuid,
+                dashboardUuid: chart.dashboardUuid,
+                spaceUuid: chart.spaceUuid,
+            };
+            await model.update(
+                chart.uuid,
+                { name: 'Allowed update' },
+                expectedLocation,
+            );
+            const updated = await model.createVersion(
+                chart.uuid,
+                { ...chart, metricQuery: { ...chart.metricQuery, limit: 101 } },
+                undefined,
+                transaction,
+                expectedLocation,
+            );
+            expect(updated.name).toBe('Allowed update');
+            expect(updated.metricQuery.limit).toBe(101);
+            const versions = await transaction(
+                SavedChartVersionsTableName,
+            ).whereIn(
+                'saved_query_id',
+                transaction(SavedChartsTableName)
+                    .select('saved_query_id')
+                    .where('saved_query_uuid', chart.uuid),
+            );
+            expect(versions).toHaveLength(2);
+        },
+    );
+
+    describe.each<{
+        name: string;
+        owner: Owner;
+        destination: Destination;
+    }>([
+        {
+            name: 'dashboard changes',
+            owner: 'dashboard',
+            destination: 'otherDashboard',
+        },
+        {
+            name: 'dashboard becomes space-owned',
+            owner: 'dashboard',
+            destination: 'space',
+        },
+        {
+            name: 'space becomes dashboard-owned',
+            owner: 'space',
+            destination: 'dashboard',
+        },
+        { name: 'space changes', owner: 'space', destination: 'otherSpace' },
+    ])('$name', ({ owner, destination }) => {
+        it.each(['metadata', 'version'] as const)(
+            'rejects the stale %s write without changing the chart or versions',
+            async (operation) => {
+                const chart = await createChart(owner);
+                const expectedLocation = {
+                    projectUuid: chart.projectUuid,
+                    dashboardUuid: chart.dashboardUuid,
+                    spaceUuid: chart.spaceUuid,
+                };
+                await changeOwner(chart.uuid, destination);
+                const before = await transaction(SavedChartsTableName)
+                    .where('saved_query_uuid', chart.uuid)
+                    .first();
+                if (!before) {
+                    throw new Error('Ownership fixture chart not found');
+                }
+                const versionsBefore = await transaction(
+                    SavedChartVersionsTableName,
+                ).where('saved_query_id', before.saved_query_id);
+                const write =
+                    operation === 'metadata'
+                        ? model.update(
+                              chart.uuid,
+                              {
+                                  name: 'Rejected update',
+                                  description: 'Rejected description',
+                              },
+                              expectedLocation,
+                          )
+                        : model.createVersion(
+                              chart.uuid,
+                              {
+                                  ...chart,
+                                  metricQuery: {
+                                      ...chart.metricQuery,
+                                      limit: 999,
+                                  },
+                              },
+                              undefined,
+                              transaction,
+                              expectedLocation,
+                          );
+                await expect(write).rejects.toThrowError(ConflictError);
+                expect(
+                    await transaction(SavedChartsTableName)
+                        .where('saved_query_uuid', chart.uuid)
+                        .first(),
+                ).toEqual(before);
+                expect(
+                    await transaction(SavedChartVersionsTableName).where(
+                        'saved_query_id',
+                        before.saved_query_id,
+                    ),
+                ).toEqual(versionsBefore);
+            },
+        );
+    });
+});

--- a/packages/backend/src/models/SavedChartModel.test.ts
+++ b/packages/backend/src/models/SavedChartModel.test.ts
@@ -775,6 +775,75 @@ describe('update', () => {
         tracker.reset();
     });
 
+    test('rejects an update when the authorized chart location no longer matches', async () => {
+        tracker.on
+            .select(SavedChartsTableName)
+            .responseOnce([{ project_uuid: 'project-uuid' }]);
+        tracker.on.update(SavedChartsTableName).responseOnce(0);
+        const getChart = vi
+            .spyOn(model, 'get')
+            .mockResolvedValue(chartSummary as never);
+
+        await expect(
+            model.update(
+                'chart-uuid',
+                { name: 'Changed name' },
+                {
+                    projectUuid: 'project-uuid',
+                    dashboardUuid: 'authorized-dashboard',
+                    spaceUuid: 'authorized-space',
+                },
+            ),
+        ).rejects.toThrow('Chart location changed');
+        expect(getChart).not.toHaveBeenCalled();
+    });
+
+    test('checks dashboard ownership in the update that acquires the row lock', async () => {
+        tracker.on
+            .select(SavedChartsTableName)
+            .responseOnce([{ project_uuid: 'project-uuid' }]);
+        tracker.on.update(SavedChartsTableName).responseOnce(1);
+        vi.spyOn(model, 'get').mockResolvedValue(chartSummary as never);
+
+        await model.update(
+            'chart-uuid',
+            { name: 'Changed name' },
+            {
+                projectUuid: 'project-uuid',
+                dashboardUuid: 'authorized-dashboard',
+                spaceUuid: 'authorized-space',
+            },
+        );
+
+        const [updateQuery] = tracker.history.update;
+        expect(updateQuery.sql).toMatch(/"dashboard_uuid" = \$\d+/);
+        expect(updateQuery.sql).toContain('"space_id" is null');
+        expect(updateQuery.bindings).toContain('authorized-dashboard');
+    });
+
+    test('checks the authorized space when updating a standalone chart', async () => {
+        tracker.on
+            .select(SavedChartsTableName)
+            .responseOnce([{ project_uuid: 'project-uuid' }]);
+        tracker.on.update(SavedChartsTableName).responseOnce(1);
+        vi.spyOn(model, 'get').mockResolvedValue(chartSummary as never);
+
+        await model.update(
+            'chart-uuid',
+            { name: 'Changed name' },
+            {
+                projectUuid: 'project-uuid',
+                dashboardUuid: null,
+                spaceUuid: 'authorized-space',
+            },
+        );
+
+        const [updateQuery] = tracker.history.update;
+        expect(updateQuery.sql).toContain('"dashboard_uuid" is null');
+        expect(updateQuery.sql).toContain('"space_id" = (select');
+        expect(updateQuery.bindings).toContain('authorized-space');
+    });
+
     test('preserves dashboard linkage on name-only updates while writing the resolved project', async () => {
         const chartUuid = '11111111-1111-4111-8111-111111111111';
         const projectUuid = '22222222-2222-4222-8222-222222222222';

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -151,6 +151,12 @@ const getSavedChartPivotConfig = (
     };
 };
 
+type SavedChartLocation = {
+    projectUuid: string;
+    dashboardUuid: string | null;
+    spaceUuid: string;
+};
+
 const createSavedChartVersionFields = async (
     trx: Knex,
     data: CreateDbSavedChartVersionField[],
@@ -1081,14 +1087,25 @@ export class SavedChartModel {
         data: CreateSavedChartVersion,
         user: SessionUser | undefined,
         tx?: Knex,
+        expectedLocation?: SavedChartLocation,
     ): Promise<SavedChartDAO> {
         const doWork = async (trx: Knex) => {
-            const [savedChart] = await trx(SavedChartsTableName)
-                .select(['saved_query_id'])
-                .where('saved_query_uuid', savedChartUuid)
-                .whereNull('deleted_at');
+            const chartQuery = this.getChartMutationQuery(
+                trx,
+                savedChartUuid,
+                expectedLocation,
+            ).select(['saved_query_id']);
+            if (expectedLocation) {
+                chartQuery.forUpdate();
+            }
+            const [savedChart] = await chartQuery;
 
             if (!savedChart) {
+                if (expectedLocation) {
+                    throw new ConflictError(
+                        'Chart location changed. Reload the chart and try again.',
+                    );
+                }
                 throw new NotFoundError('Saved chart not found');
             }
 
@@ -1119,10 +1136,37 @@ export class SavedChartModel {
         return this.get(savedChartUuid);
     }
 
+    private getChartMutationQuery(
+        database: Knex,
+        savedChartUuid: string,
+        expectedLocation?: SavedChartLocation,
+    ) {
+        const query = database(SavedChartsTableName)
+            .where('saved_query_uuid', savedChartUuid)
+            .whereNull('deleted_at');
+        if (!expectedLocation) {
+            return query;
+        }
+
+        query
+            .where('project_uuid', expectedLocation.projectUuid)
+            .where('dashboard_uuid', expectedLocation.dashboardUuid);
+        if (expectedLocation.dashboardUuid !== null) {
+            return query.whereNull('space_id');
+        }
+        return query.where(
+            'space_id',
+            database(SpaceTableName)
+                .select('space_id')
+                .where('space_uuid', expectedLocation.spaceUuid),
+        );
+    }
+
     private async updateChart(
         database: Knex,
         savedChartUuid: string,
         data: UpdateSavedChart,
+        expectedLocation?: SavedChartLocation,
     ): Promise<void> {
         const savedChart = await database(SavedChartsTableName)
             .select(`${SavedChartsTableName}.project_uuid`)
@@ -1154,24 +1198,36 @@ export class SavedChartModel {
             targetSpaceId = space.space_id;
         }
 
-        await database(SavedChartsTableName)
-            .update({
-                name: data.name,
-                description: data.description,
-                project_uuid: savedChart.project_uuid,
-                space_id: targetSpaceId,
-                dashboard_uuid: data.spaceUuid ? null : undefined, // remove dashboard_uuid when moving chart to space
-                color_palette_uuid: data.colorPaletteUuid,
-            })
-            .where('saved_query_uuid', savedChartUuid)
-            .whereNull('deleted_at');
+        const updatedRows = await this.getChartMutationQuery(
+            database,
+            savedChartUuid,
+            expectedLocation,
+        ).update({
+            name: data.name,
+            description: data.description,
+            project_uuid: savedChart.project_uuid,
+            space_id: targetSpaceId,
+            dashboard_uuid: data.spaceUuid ? null : undefined, // remove dashboard_uuid when moving chart to space
+            color_palette_uuid: data.colorPaletteUuid,
+        });
+        if (expectedLocation && updatedRows !== 1) {
+            throw new ConflictError(
+                'Chart location changed. Reload the chart and try again.',
+            );
+        }
     }
 
     async update(
         savedChartUuid: string,
         data: UpdateSavedChart,
+        expectedLocation?: SavedChartLocation,
     ): Promise<SavedChartDAO> {
-        await this.updateChart(this.database, savedChartUuid, data);
+        await this.updateChart(
+            this.database,
+            savedChartUuid,
+            data,
+            expectedLocation,
+        );
         return this.get(savedChartUuid);
     }
 

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -2,6 +2,7 @@ import { Ability } from '@casl/ability';
 import {
     Account,
     AnyType,
+    assertUnreachable,
     ChartType,
     CreateWarehouseCredentials,
     DimensionType,
@@ -4901,8 +4902,22 @@ describe('AsyncQueryService', () => {
         });
 
         it('threads the source dateZoom from request_parameters into the totals query', async () => {
-            const service = getMockedAsyncQueryService(lightdashConfigMock);
+            const service = getMockedAsyncQueryService(lightdashConfigMock, {
+                savedChartModel: {
+                    get: vi.fn().mockResolvedValue({
+                        uuid: 'chart-uuid',
+                        projectUuid,
+                        organizationUuid: projectSummary.organizationUuid,
+                        spaceUuid: 'space-uuid',
+                        dashboardUuid: 'dashboard-uuid',
+                    }),
+                },
+            } as never);
             const account = buildAccount();
+            account.user.ability = new Ability<PossibleAbilities>([
+                ...account.user.ability.rules,
+                { subject: 'SavedChart', action: 'view' },
+            ]);
 
             const dateZoom = {
                 granularity: 'MONTH',
@@ -5830,6 +5845,568 @@ describe('checkDashboardChartQueryPermissions', () => {
             },
         );
     });
+});
+
+describe('saved chart query result access', () => {
+    const buildFixture = (
+        accountOptions: Parameters<typeof buildAccount>[0] = {},
+    ) => {
+        const account = buildAccount(accountOptions);
+        account.user.ability = new Ability<PossibleAbilities>([
+            {
+                subject: 'Project',
+                action: 'view',
+            },
+            {
+                subject: 'SavedChart',
+                action: 'view',
+                conditions: {
+                    access: { $elemMatch: { userUuid: account.user.id } },
+                },
+            },
+            {
+                subject: 'SavedChart',
+                action: 'view',
+                conditions: { inheritsFromOrgOrProject: true },
+            },
+            { subject: 'UnderlyingData', action: 'view' },
+            { subject: 'Explore', action: 'manage' },
+        ]);
+        const history: QueryHistory = {
+            queryUuid: 'source-query-uuid',
+            projectUuid,
+            organizationUuid: projectSummary.organizationUuid,
+            context: QueryExecutionContext.CHART,
+            status: QueryHistoryStatus.READY,
+            requestParameters: { chartUuid: 'source-chart-uuid' },
+            metricQuery: metricQueryMock,
+            fields: validExplore.tables.a.dimensions,
+            columns: expectedColumns,
+            resultsFileName: 'results.jsonl',
+            resultsExpiresAt: new Date(Date.now() + 60_000),
+            totalRowCount: 1,
+            defaultPageSize: 10,
+            createdAt: new Date(),
+            createdBy: account.user.id,
+            createdByUserUuid: account.user.id,
+            createdByAccount: null,
+            createdByActorType: account.authentication.type,
+            warehouseQueryId: null,
+            warehouseQueryMetadata: null,
+            compiledSql: 'select 1',
+            usedParameters: null,
+            warehouseExecutionTimeMs: null,
+            error: null,
+            erroredAt: null,
+            cacheKey: 'cache-key',
+            pivotConfiguration: null,
+            pivotValuesColumns: null,
+            pivotTotalColumnCount: null,
+            resultsCreatedAt: new Date(),
+            resultsUpdatedAt: new Date(),
+            originalColumns: expectedColumns,
+            preAggregateCompiledSql: null,
+            preAggregateExecution: null,
+            preAggregateFallbackReason: null,
+            processingStartedAt: null,
+        };
+        const getChart = vi.fn().mockResolvedValue({
+            uuid: 'source-chart-uuid',
+            projectUuid,
+            organizationUuid: projectSummary.organizationUuid,
+            spaceUuid: 'current-space-uuid',
+            dashboardUuid: null,
+        });
+        const resolveAccess = vi.fn().mockResolvedValue({
+            organizationUuid: projectSummary.organizationUuid,
+            projectUuid,
+            inheritsFromOrgOrProject: false,
+            access: [],
+            admins: [],
+            directOnly: false,
+        });
+        const service = getMockedAsyncQueryService(lightdashConfigMock, {
+            savedChartModel: { get: getChart },
+            spacePermissionService: { resolveAccess },
+            featureFlagModel: {
+                get: vi.fn(async () => ({
+                    id: FeatureFlags.ComposeSqlRunner,
+                    enabled: true,
+                })),
+            },
+        } as never);
+        service.queryHistoryModel.get = vi.fn().mockResolvedValue(history);
+        service.exportsStorageClient = {
+            isEnabled: () => true,
+        } as FileStorageClient;
+        const exportFile = vi
+            .spyOn(
+                service as unknown as {
+                    downloadAsyncQueryResultsAsFormattedFile: () => Promise<{
+                        fileUrl: string;
+                        truncated: boolean;
+                    }>;
+                },
+                'downloadAsyncQueryResultsAsFormattedFile',
+            )
+            .mockResolvedValue({ fileUrl: 'export.csv', truncated: false });
+        return {
+            account,
+            service,
+            history,
+            getChart,
+            resolveAccess,
+            exportFile,
+        };
+    };
+
+    it('denies result reads after the source chart grant is revoked', async () => {
+        const { account, service } = buildFixture();
+        await expect(
+            service.getAsyncQueryResults({
+                account,
+                projectUuid,
+                queryUuid: 'source-query-uuid',
+            }),
+        ).rejects.toThrow(ForbiddenError);
+        expect(
+            service.resultsStorageClient.getDownloadStream,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('denies CSV generation after the source chart grant is revoked', async () => {
+        const { account, service, exportFile } = buildFixture();
+        await expect(
+            service.download({
+                account,
+                projectUuid,
+                queryUuid: 'source-query-uuid',
+                type: DownloadFileType.CSV,
+                accessMode:
+                    PersistentDownloadFileAccessMode.AUTHENTICATED_CREATOR,
+            }),
+        ).rejects.toThrow(ForbiddenError);
+        expect(exportFile).not.toHaveBeenCalled();
+        expect(
+            service.resultsStorageClient.getFirstLine,
+        ).not.toHaveBeenCalled();
+    });
+
+    const readOrDownload = (
+        service: AsyncQueryService,
+        account: Account,
+        operation: 'read' | 'download',
+    ) => {
+        const args = { account, projectUuid, queryUuid: 'source-query-uuid' };
+        return operation === 'read'
+            ? service.getAsyncQueryResults(args)
+            : service.download({
+                  ...args,
+                  type: DownloadFileType.CSV,
+                  accessMode:
+                      PersistentDownloadFileAccessMode.AUTHENTICATED_CREATOR,
+              });
+    };
+
+    describe.each(['read', 'download'] as const)('%s', (operation) => {
+        it.each(['direct', 'group', 'space', 'project'] as const)(
+            'allows remaining %s access after a direct grant is removed',
+            async (accessSource) => {
+                const { account, service, resolveAccess } = buildFixture();
+                resolveAccess.mockResolvedValue({
+                    inheritsFromOrgOrProject: accessSource === 'project',
+                    access:
+                        accessSource === 'project'
+                            ? []
+                            : [{ userUuid: account.user.id, role: 'viewer' }],
+                    directOnly: accessSource === 'direct',
+                });
+                await expect(
+                    readOrDownload(service, account, operation),
+                ).resolves.toBeDefined();
+            },
+        );
+
+        it('checks the current owning dashboard instead of the historical one', async () => {
+            const { account, service, history, getChart, resolveAccess } =
+                buildFixture();
+            history.requestParameters = {
+                chartUuid: 'source-chart-uuid',
+                dashboardUuid: 'old-dashboard-uuid',
+                tileUuid: 'tile-uuid',
+                dashboardFilters: {
+                    dimensions: [],
+                    metrics: [],
+                    tableCalculations: [],
+                },
+                dashboardSorts: [],
+            };
+            getChart.mockResolvedValue({
+                uuid: 'source-chart-uuid',
+                projectUuid,
+                organizationUuid: projectSummary.organizationUuid,
+                spaceUuid: 'current-space-uuid',
+                dashboardUuid: 'current-dashboard-uuid',
+            });
+            resolveAccess.mockImplementation(async (_userUuid, target) => ({
+                inheritsFromOrgOrProject: false,
+                access:
+                    target.dashboardUuid === 'old-dashboard-uuid'
+                        ? [{ userUuid: account.user.id, role: 'viewer' }]
+                        : [],
+            }));
+            await expect(
+                readOrDownload(service, account, operation),
+            ).rejects.toThrow(ForbiddenError);
+            expect(getChart).toHaveBeenCalledWith(
+                'source-chart-uuid',
+                undefined,
+                { projectUuid },
+            );
+        });
+
+        it('allows access through the current owning dashboard', async () => {
+            const { account, service, getChart, resolveAccess } =
+                buildFixture();
+            getChart.mockResolvedValue({
+                uuid: 'source-chart-uuid',
+                projectUuid,
+                organizationUuid: projectSummary.organizationUuid,
+                spaceUuid: 'current-space-uuid',
+                dashboardUuid: 'current-dashboard-uuid',
+            });
+            resolveAccess.mockImplementation(async (_userUuid, target) => ({
+                inheritsFromOrgOrProject: false,
+                access:
+                    target.dashboardUuid === 'current-dashboard-uuid'
+                        ? [{ userUuid: account.user.id, role: 'viewer' }]
+                        : [],
+            }));
+            await expect(
+                readOrDownload(service, account, operation),
+            ).resolves.toBeDefined();
+        });
+
+        it('denies results when the source chart has been deleted', async () => {
+            const { account, service, getChart } = buildFixture();
+            getChart.mockRejectedValue(new NotFoundError('Chart not found'));
+            await expect(
+                readOrDownload(service, account, operation),
+            ).rejects.toThrow(NotFoundError);
+        });
+
+        it('preserves inherited service-account access', async () => {
+            const { account, service, resolveAccess } = buildFixture({
+                accountType: 'service-account',
+            });
+            resolveAccess.mockResolvedValue({
+                inheritsFromOrgOrProject: true,
+                access: [],
+            });
+            await expect(
+                readOrDownload(service, account, operation),
+            ).resolves.toBeDefined();
+        });
+
+        it('preserves the existing JWT access contract', async () => {
+            const { account, service, getChart } = buildFixture({
+                accountType: 'jwt',
+                userType: 'anonymous',
+            });
+            await expect(
+                readOrDownload(service, account, operation),
+            ).resolves.toBeDefined();
+            expect(getChart).not.toHaveBeenCalled();
+        });
+
+        it.each(['metric', 'sql', 'legacySqlChart'] as const)(
+            'preserves %s queries without saved-chart identity',
+            async (queryType) => {
+                const { account, service, history, getChart } = buildFixture();
+                history.requestParameters =
+                    queryType === 'sql'
+                        ? { sql: 'select 1' }
+                        : { query: metricQueryMock };
+                history.context =
+                    queryType === 'legacySqlChart'
+                        ? QueryExecutionContext.SQL_CHART
+                        : QueryExecutionContext.EXPLORE;
+                await expect(
+                    readOrDownload(service, account, operation),
+                ).resolves.toBeDefined();
+                expect(getChart).not.toHaveBeenCalled();
+            },
+        );
+
+        it('retains query ownership checks before source access', async () => {
+            const { account, service, getChart } = buildFixture();
+            vi.mocked(service.queryHistoryModel.get).mockRejectedValue(
+                new NotFoundError('Query not found for account'),
+            );
+            await expect(
+                readOrDownload(service, account, operation),
+            ).rejects.toThrow(NotFoundError);
+            expect(getChart).not.toHaveBeenCalled();
+        });
+    });
+
+    it.each([
+        'history',
+        'raw',
+        'stream',
+        'rerun',
+        'totals',
+        'underlying',
+        'schedule',
+    ] as const)(
+        'denies revoked source access through %s',
+        async (operation) => {
+            const { account, service } = buildFixture();
+            const args = {
+                account,
+                projectUuid,
+                queryUuid: 'source-query-uuid',
+            };
+            const run = () => {
+                switch (operation) {
+                    case 'schedule':
+                        return service.scheduleDownloadAsyncQueryResults(args);
+                    case 'history':
+                        return service.getAsyncQueryHistory(args);
+                    case 'raw':
+                        return service.getRawAsyncQueryResults(args);
+                    case 'stream':
+                        return service.getResultsStream(args);
+                    case 'rerun':
+                        return service.executeAsyncUnboundedRerunFromQueryHistory(
+                            { ...args, context: QueryExecutionContext.CSV },
+                        );
+                    case 'totals':
+                        return service.executeAsyncCalculateTotalFromQueryHistory(
+                            { ...args, kind: 'grandTotal' },
+                        );
+                    case 'underlying':
+                        return service.executeAsyncUnderlyingDataQuery({
+                            account,
+                            projectUuid,
+                            underlyingDataSourceQueryUuid: args.queryUuid,
+                            filters: {},
+                            context: QueryExecutionContext.VIEW_UNDERLYING_DATA,
+                        });
+                    default:
+                        return assertUnreachable(
+                            operation,
+                            'Unknown query operation',
+                        );
+                }
+            };
+            await expect(run()).rejects.toThrow(ForbiddenError);
+        },
+    );
+    it('denies composing a reference to a revoked saved-chart result', async () => {
+        const { account, service, getChart } = buildFixture();
+        const references = { source: '11111111-1111-4111-8111-111111111111' };
+        await expect(
+            service.executeAsyncComposeSqlQuery({
+                account,
+                projectUuid,
+                context: QueryExecutionContext.SQL_RUNNER,
+                sql: 'select * from source',
+                references,
+            }),
+        ).rejects.toThrow("You don't have access to this chart");
+        expect(getChart).toHaveBeenCalled();
+    });
+
+    it('denies merge metadata for a revoked saved-chart result', async () => {
+        const { account, service } = buildFixture();
+        await expect(
+            service['getMergeResultSourceMetadata'](
+                account,
+                projectUuid,
+                'source-query-uuid',
+            ),
+        ).rejects.toThrow(ForbiddenError);
+    });
+    it.each(['totals', 'rerun', 'underlying'] as const)(
+        'retains source access when %s are prepared before revocation',
+        async (operation) => {
+            const { account, service, history, resolveAccess } = buildFixture();
+            resolveAccess.mockResolvedValue({
+                inheritsFromOrgOrProject: false,
+                access: [{ userUuid: account.user.id, role: 'viewer' }],
+            });
+            const execution = service as unknown as {
+                getExploreForMetricQueryExecution: () => Promise<unknown>;
+                getExploreWithUserAccessControls: () => Promise<unknown>;
+                prepareMetricQueryAsyncQueryArgs: () => Promise<QueryComposer>;
+                executeAsyncQuery: (
+                    args: unknown,
+                    parameters: ExecuteAsyncQueryRequestParams,
+                ) => Promise<{ queryUuid: string; cacheMetadata: {} }>;
+            };
+            vi.spyOn(
+                execution,
+                'getExploreForMetricQueryExecution',
+            ).mockResolvedValue({ explore: validExplore });
+            vi.spyOn(
+                execution,
+                'getExploreWithUserAccessControls',
+            ).mockResolvedValue({ explore: validExplore });
+            vi.spyOn(
+                execution,
+                'prepareMetricQueryAsyncQueryArgs',
+            ).mockResolvedValue(createQueryComposerMock());
+            const persist = vi
+                .spyOn(execution, 'executeAsyncQuery')
+                .mockImplementation(async (_args, requestParameters) => {
+                    vi.mocked(service.queryHistoryModel.get).mockImplementation(
+                        async (queryUuid) =>
+                            queryUuid === history.queryUuid
+                                ? history
+                                : {
+                                      ...history,
+                                      queryUuid: 'derived-query-uuid',
+                                      requestParameters,
+                                  },
+                    );
+                    return {
+                        queryUuid: 'derived-query-uuid',
+                        cacheMetadata: {},
+                    };
+                });
+            const args = { account, projectUuid, queryUuid: history.queryUuid };
+            const derive = async () => {
+                switch (operation) {
+                    case 'totals':
+                        return service.executeAsyncCalculateTotalFromQueryHistory(
+                            { ...args, kind: 'grandTotal' },
+                        );
+                    case 'rerun':
+                        return service.executeAsyncUnboundedRerunFromQueryHistory(
+                            { ...args, context: QueryExecutionContext.CSV },
+                        );
+                    case 'underlying':
+                        return service.executeAsyncUnderlyingDataQuery({
+                            account,
+                            projectUuid,
+                            underlyingDataSourceQueryUuid: history.queryUuid,
+                            filters: {},
+                            context: QueryExecutionContext.VIEW_UNDERLYING_DATA,
+                        });
+                    default:
+                        return assertUnreachable(
+                            operation,
+                            'Unknown derivation',
+                        );
+                }
+            };
+            const result = await derive();
+            expect(result).toMatchObject({ queryUuid: 'derived-query-uuid' });
+            expect(persist).toHaveBeenCalledTimes(1);
+            const persistedParameters = persist.mock.calls[0][1];
+            expect(persistedParameters).not.toHaveProperty('chartUuid');
+            if (operation === 'underlying') {
+                expect(persistedParameters).toMatchObject({
+                    underlyingDataSourceQueryUuid: history.queryUuid,
+                    filters: {},
+                });
+            } else {
+                expect(persistedParameters).toMatchObject({
+                    query: metricQueryMock,
+                });
+                expect(persistedParameters).not.toHaveProperty(
+                    'underlyingDataSourceQueryUuid',
+                );
+            }
+            resolveAccess.mockResolvedValue({
+                inheritsFromOrgOrProject: false,
+                access: [],
+            });
+            await expect(
+                service.getAsyncQueryResults({
+                    ...args,
+                    queryUuid: 'derived-query-uuid',
+                }),
+            ).rejects.toThrow(ForbiddenError);
+        },
+    );
+    it.each(['underlying', 'compose', 'merge'] as const)(
+        'rechecks the source of existing %s result references',
+        async (operation) => {
+            const { account, service, history, resolveAccess } = buildFixture();
+            const sourceUuid = history.queryUuid;
+            const getRequestParameters = (): ExecuteAsyncQueryRequestParams => {
+                switch (operation) {
+                    case 'underlying':
+                        return {
+                            underlyingDataSourceQueryUuid: sourceUuid,
+                            filters: {},
+                        };
+                    case 'compose':
+                        return {
+                            sql: 'select * from source',
+                            references: { source: sourceUuid },
+                        };
+                    case 'merge':
+                        return {
+                            mergeQuery: {
+                                sources: [
+                                    { id: 'source', queryUuid: sourceUuid },
+                                ],
+                                joinKey: [],
+                                joinType: MergeJoinType.INNER,
+                                tableCalculations: [],
+                                limit: 10,
+                            },
+                        };
+                    default:
+                        return assertUnreachable(
+                            operation,
+                            'Unknown derived source',
+                        );
+                }
+            };
+            const requestParameters = getRequestParameters();
+            vi.mocked(service.queryHistoryModel.get).mockImplementation(
+                async (queryUuid) =>
+                    queryUuid === sourceUuid
+                        ? history
+                        : {
+                              ...history,
+                              queryUuid: 'derived-query-uuid',
+                              requestParameters,
+                          },
+            );
+            resolveAccess.mockResolvedValue({
+                inheritsFromOrgOrProject: false,
+                access: [{ userUuid: account.user.id, role: 'viewer' }],
+            });
+            const args = {
+                account,
+                projectUuid,
+                queryUuid: 'derived-query-uuid',
+            };
+            await expect(
+                service.getAsyncQueryResults(args),
+            ).resolves.toBeDefined();
+            resolveAccess.mockResolvedValue({
+                inheritsFromOrgOrProject: false,
+                access: [],
+            });
+            await expect(service.getAsyncQueryResults(args)).rejects.toThrow(
+                ForbiddenError,
+            );
+            await expect(
+                service.download({
+                    ...args,
+                    type: DownloadFileType.CSV,
+                    accessMode:
+                        PersistentDownloadFileAccessMode.AUTHENTICATED_CREATOR,
+                }),
+            ).rejects.toThrow(ForbiddenError);
+        },
+    );
 });
 
 describe('getQueryHistoryList', () => {

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -1301,18 +1301,113 @@ export class AsyncQueryService extends ProjectService {
         };
     }
 
+    private static getQuerySourceParameters(
+        parameters: ExecuteAsyncQueryRequestParams | undefined,
+    ): { chartUuid?: string; references?: Record<string, string> } {
+        if (!parameters) {
+            return {};
+        }
+        if ('chartUuid' in parameters) {
+            return { chartUuid: parameters.chartUuid };
+        }
+        if ('underlyingDataSourceQueryUuid' in parameters) {
+            return {
+                references: {
+                    source: parameters.underlyingDataSourceQueryUuid,
+                },
+            };
+        }
+        if ('references' in parameters) {
+            return { references: parameters.references };
+        }
+        if ('mergeQuery' in parameters) {
+            return {
+                references: Object.fromEntries(
+                    parameters.mergeQuery.sources.flatMap((source) =>
+                        'queryUuid' in source
+                            ? [[source.id, source.queryUuid]]
+                            : [],
+                    ),
+                ),
+            };
+        }
+        return {};
+    }
+
+    private async assertSavedChartQuerySourceAccess(
+        account: Account,
+        projectUuid: string,
+        queryHistory: QueryHistory,
+        checkedQueries = new Set<string>(),
+    ): Promise<void> {
+        if (isJwtUser(account) || checkedQueries.has(queryHistory.queryUuid)) {
+            return;
+        }
+        checkedQueries.add(queryHistory.queryUuid);
+        const { chartUuid, references } =
+            AsyncQueryService.getQuerySourceParameters(
+                queryHistory.requestParameters,
+            );
+        if (!chartUuid) {
+            await Promise.all(
+                Object.values(references ?? {}).map(async (sourceQueryUuid) => {
+                    const source = await this.queryHistoryModel.get(
+                        sourceQueryUuid,
+                        projectUuid,
+                        account,
+                    );
+                    await this.assertSavedChartQuerySourceAccess(
+                        account,
+                        projectUuid,
+                        source,
+                        checkedQueries,
+                    );
+                }),
+            );
+            return;
+        }
+
+        const chart = await this.savedChartModel.get(chartUuid, undefined, {
+            projectUuid,
+        });
+        const context = await this.spacePermissionService.resolveAccess(
+            account.user.id,
+            {
+                type: 'chart',
+                chartUuid: chart.uuid,
+                dashboardUuid: chart.dashboardUuid,
+                spaceUuid: chart.spaceUuid,
+            },
+        );
+        const ability = this.createAuditedAbility(account);
+        if (
+            ability.cannot(
+                'view',
+                subject('SavedChart', {
+                    organizationUuid: chart.organizationUuid,
+                    projectUuid: chart.projectUuid,
+                    inheritsFromOrgOrProject: context.inheritsFromOrgOrProject,
+                    access: context.access,
+                    metadata: { savedChartUuid: chart.uuid },
+                }),
+            )
+        ) {
+            throw new ForbiddenError("You don't have access to this chart");
+        }
+    }
+
     /**
      * The access check for reading a query's results by uuid: the account
      * must be able to view the project, be the embed AI JWT creator of the
      * query, or be able to view the query's explore. Note the query history
      * row itself is already creator-scoped by QueryHistoryModel.get.
      */
-    private throwIfCannotReadQueryHistory(
+    private async throwIfCannotReadQueryHistory(
         account: Account,
         projectUuid: string,
         organizationUuid: string,
         queryHistory: QueryHistory,
-    ): void {
+    ): Promise<void> {
         const { queryUuid } = queryHistory;
         const auditedAbility = this.createAuditedAbility(account);
         const canViewProject = auditedAbility.can(
@@ -1349,6 +1444,12 @@ export class AsyncQueryService extends ProjectService {
         if (isForbidden) {
             throw new ForbiddenError();
         }
+
+        await this.assertSavedChartQuerySourceAccess(
+            account,
+            projectUuid,
+            queryHistory,
+        );
     }
 
     async getAsyncQueryResults({
@@ -1365,7 +1466,7 @@ export class AsyncQueryService extends ProjectService {
             this.queryHistoryModel.get(queryUuid, projectUuid, account),
         ]);
 
-        this.throwIfCannotReadQueryHistory(
+        await this.throwIfCannotReadQueryHistory(
             account,
             projectUuid,
             organizationUuid,
@@ -1591,15 +1692,20 @@ export class AsyncQueryService extends ProjectService {
             }),
         );
 
-        if (canViewProject) {
-            return this.queryHistoryModel.get(queryUuid, projectUuid, account);
-        }
-
         const queryHistory = await this.queryHistoryModel.get(
             queryUuid,
             projectUuid,
             account,
         );
+        await this.assertSavedChartQuerySourceAccess(
+            account,
+            projectUuid,
+            queryHistory,
+        );
+
+        if (canViewProject) {
+            return queryHistory;
+        }
 
         if (
             auditedAbility.cannot(
@@ -1653,6 +1759,11 @@ export class AsyncQueryService extends ProjectService {
             queryUuid,
             projectUuid,
             account,
+        );
+        await this.assertSavedChartQuerySourceAccess(
+            account,
+            projectUuid,
+            queryHistory,
         );
 
         const { status, resultsFileName } = queryHistory;
@@ -1768,6 +1879,17 @@ export class AsyncQueryService extends ProjectService {
         ) {
             throw new ForbiddenError();
         }
+
+        const queryHistory = await this.queryHistoryModel.get(
+            payload.queryUuid,
+            payload.projectUuid,
+            account,
+        );
+        await this.assertSavedChartQuerySourceAccess(
+            account,
+            payload.projectUuid,
+            queryHistory,
+        );
 
         const userUuid = account.user.id;
 
@@ -1959,6 +2081,11 @@ export class AsyncQueryService extends ProjectService {
             queryUuid,
             projectUuid,
             account,
+        );
+        await this.assertSavedChartQuerySourceAccess(
+            account,
+            projectUuid,
+            queryHistory,
         );
 
         const displayTimezone = queryHistory.metricQuery.timezone ?? null;
@@ -5122,6 +5249,7 @@ export class AsyncQueryService extends ProjectService {
             totalConfiguration,
         }: ExecuteAsyncMetricQueryArgs,
         organizationUuid: string,
+        sourceQueryHistory?: QueryHistory,
     ): Promise<ApiExecuteAsyncMetricQueryResults> {
         assertIsAccountWithOrg(account);
 
@@ -5246,7 +5374,15 @@ export class AsyncQueryService extends ProjectService {
                 queryComposer.getUserAccessControls(),
             );
 
+        const sourceParameters = AsyncQueryService.getQuerySourceParameters(
+            sourceQueryHistory?.requestParameters,
+        );
+        const references =
+            sourceQueryHistory && sourceParameters.chartUuid
+                ? { source: sourceQueryHistory.queryUuid }
+                : sourceParameters.references;
         const requestParameters: ExecuteAsyncMetricQueryRequestParams = {
+            ...(references ? { references } : {}),
             context,
             query: effectiveMetricQuery,
             parameters: combinedParameters,
@@ -5346,6 +5482,11 @@ export class AsyncQueryService extends ProjectService {
             this.queryHistoryModel.get(queryUuid, projectUuid, account),
             this.projectModel.getSummary(projectUuid),
         ]);
+        await this.assertSavedChartQuerySourceAccess(
+            account,
+            projectUuid,
+            source,
+        );
 
         const { csvCellsLimit, maxLimit } =
             await resolveOrganizationExportLimits(
@@ -5380,6 +5521,7 @@ export class AsyncQueryService extends ProjectService {
                     invalidateCache,
                 },
                 organizationUuid,
+                source,
             );
 
         return {
@@ -5412,13 +5554,16 @@ export class AsyncQueryService extends ProjectService {
     }): Promise<ApiExecuteAsyncMetricQueryResults> {
         assertIsAccountWithOrg(account);
 
-        // `get` enforces the query belongs to this project and was created by
-        // this account — that ownership authorizes the totals query, so we skip
-        // the explore-level CASL gate (which embed JWT callers can't pass).
+        // Preserve the embed JWT contract without requiring explore-level access.
         const [source, { organizationUuid }] = await Promise.all([
             this.queryHistoryModel.get(queryUuid, projectUuid, account),
             this.projectModel.getSummary(projectUuid),
         ]);
+        await this.assertSavedChartQuerySourceAccess(
+            account,
+            projectUuid,
+            source,
+        );
 
         // Reuse the source's parameter values so the totals query sees the
         // same parameter context as the original. The execution path
@@ -5446,6 +5591,7 @@ export class AsyncQueryService extends ProjectService {
                 invalidateCache,
             },
             organizationUuid,
+            source,
         );
     }
 
@@ -6860,12 +7006,17 @@ export class AsyncQueryService extends ProjectService {
             isServiceAccount: account.isServiceAccount(),
         });
 
-        const { metricQuery, fields: metricQueryFields } =
-            await this.queryHistoryModel.get(
-                underlyingDataSourceQueryUuid,
-                projectUuid,
-                account,
-            );
+        const source = await this.queryHistoryModel.get(
+            underlyingDataSourceQueryUuid,
+            projectUuid,
+            account,
+        );
+        await this.assertSavedChartQuerySourceAccess(
+            account,
+            projectUuid,
+            source,
+        );
+        const { metricQuery, fields: metricQueryFields } = source;
 
         const { exploreName } = metricQuery;
 
@@ -7273,7 +7424,7 @@ export class AsyncQueryService extends ProjectService {
                     account,
                 );
 
-                this.throwIfCannotReadQueryHistory(
+                await this.throwIfCannotReadQueryHistory(
                     account,
                     projectUuid,
                     organizationUuid,
@@ -8929,6 +9080,11 @@ export class AsyncQueryService extends ProjectService {
             queryUuid,
             projectUuid,
             account,
+        );
+        await this.assertSavedChartQuerySourceAccess(
+            account,
+            projectUuid,
+            queryHistory,
         );
         if (queryHistory.status !== QueryHistoryStatus.READY) {
             throw new ParameterError(

--- a/packages/backend/src/services/DirectAccess/DirectAccessService.test.ts
+++ b/packages/backend/src/services/DirectAccess/DirectAccessService.test.ts
@@ -1,9 +1,12 @@
+import { subject } from '@casl/ability';
 import {
     defineUserAbility,
     DirectAccessPrincipalType,
     DirectAccessResourceType,
     ForbiddenError,
+    getUserAbilityBuilder,
     OrganizationMemberRole,
+    ProjectMemberRole,
     SpaceMemberRole,
     type RegisteredAccount,
 } from '@lightdash/common';
@@ -30,6 +33,11 @@ const OTHER_USER_UUID = 'aaaaaaaa-0000-0000-0000-000000000007';
 const buildAccount = (
     role: OrganizationMemberRole,
     userUuid: string = USER_UUID,
+    abilityOptions: {
+        projectProfiles?: Parameters<typeof defineUserAbility>[1];
+        roleUuid?: string;
+        customRoleScopes?: Parameters<typeof defineUserAbility>[2];
+    } = {},
 ): RegisteredAccount =>
     ({
         authentication: { type: 'session' },
@@ -41,15 +49,21 @@ const buildAccount = (
             lastName: 'User',
             email: 'test@example.com',
             role,
-            ability: defineUserAbility(
-                {
+            ability: getUserAbilityBuilder({
+                user: {
                     role,
                     organizationUuid: ORGANIZATION_UUID,
                     userUuid,
-                    roleUuid: undefined,
+                    roleUuid: abilityOptions.roleUuid,
                 },
-                [],
-            ),
+                projectProfiles: abilityOptions.projectProfiles ?? [],
+                customRoleScopes: abilityOptions.customRoleScopes,
+                customRolesEnabled: true,
+                isEnterprise: true,
+                permissionsConfig: {
+                    pat: { enabled: false, allowedOrgRoles: [] },
+                },
+            }).builder.build(),
         },
         isAnonymousUser: () => false,
         isServiceAccount: () => false,
@@ -315,6 +329,208 @@ describe('DirectAccessService', () => {
                 APP_UUID,
             ),
         ).resolves.toEqual([]);
+    });
+
+    describe('personal app policy authority', () => {
+        it.each([SpaceMemberRole.VIEWER, SpaceMemberRole.EDITOR])(
+            'denies policy reads and writes to a noncreator with direct %s access',
+            async (role) => {
+                const { service, directAccessModel } = buildService({
+                    location: personalAppLocation,
+                    context: spaceContext([
+                        { userUuid: OTHER_USER_UUID, role },
+                    ]),
+                });
+                const account = buildAccount(
+                    OrganizationMemberRole.INTERACTIVE_VIEWER,
+                    OTHER_USER_UUID,
+                );
+                const resourceArgs = [
+                    account,
+                    PROJECT_UUID,
+                    DirectAccessResourceType.APP,
+                    APP_UUID,
+                ] as const;
+                const principal = {
+                    type: DirectAccessPrincipalType.USER,
+                    uuid: USER_UUID,
+                };
+
+                const { ability } = account.user;
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('DataApp', {
+                            ...spaceContext([
+                                { userUuid: OTHER_USER_UUID, role },
+                            ]),
+                            createdByUserUuid: USER_UUID,
+                        }),
+                    ),
+                ).toBe(role === SpaceMemberRole.EDITOR);
+
+                await expect
+                    .soft(service.listAssignments(...resourceArgs))
+                    .rejects.toThrowError(ForbiddenError);
+                await expect
+                    .soft(
+                        service.upsertAssignment(
+                            ...resourceArgs,
+                            principal,
+                            SpaceMemberRole.ADMIN,
+                        ),
+                    )
+                    .rejects.toThrowError(ForbiddenError);
+                await expect
+                    .soft(service.revokeAssignment(...resourceArgs, principal))
+                    .rejects.toThrowError(ForbiddenError);
+                await expect
+                    .soft(service.resetAssignments(...resourceArgs))
+                    .rejects.toThrowError(ForbiddenError);
+                await expect
+                    .soft(service.replacePolicy(...resourceArgs, []))
+                    .rejects.toThrowError(ForbiddenError);
+                expect
+                    .soft(directAccessModel.listAssignments)
+                    .not.toHaveBeenCalled();
+                expect
+                    .soft(directAccessModel.upsertAccess)
+                    .not.toHaveBeenCalled();
+                expect
+                    .soft(directAccessModel.revokeAccess)
+                    .not.toHaveBeenCalled();
+                expect
+                    .soft(directAccessModel.resetAccess)
+                    .not.toHaveBeenCalled();
+                expect
+                    .soft(directAccessModel.replacePolicy)
+                    .not.toHaveBeenCalled();
+            },
+        );
+
+        it.each([
+            {
+                name: 'direct Admin',
+                account: buildAccount(
+                    OrganizationMemberRole.INTERACTIVE_VIEWER,
+                    OTHER_USER_UUID,
+                ),
+                access: [
+                    { userUuid: OTHER_USER_UUID, role: SpaceMemberRole.ADMIN },
+                ],
+            },
+            {
+                name: 'creator',
+                account: buildAccount(
+                    OrganizationMemberRole.INTERACTIVE_VIEWER,
+                ),
+                access: [],
+            },
+            {
+                name: 'organization Admin',
+                account: buildAccount(
+                    OrganizationMemberRole.ADMIN,
+                    OTHER_USER_UUID,
+                ),
+                access: [],
+            },
+            {
+                name: 'custom role with explicit app management',
+                account: buildAccount(
+                    OrganizationMemberRole.MEMBER,
+                    OTHER_USER_UUID,
+                    {
+                        roleUuid: 'app-manager-role',
+                        customRoleScopes: {
+                            'app-manager-role': ['manage:DataApp'],
+                        },
+                    },
+                ),
+                access: [],
+            },
+            {
+                name: 'project Admin',
+                account: buildAccount(
+                    OrganizationMemberRole.MEMBER,
+                    OTHER_USER_UUID,
+                    {
+                        projectProfiles: [
+                            {
+                                projectUuid: PROJECT_UUID,
+                                userUuid: OTHER_USER_UUID,
+                                role: ProjectMemberRole.ADMIN,
+                                roleUuid: undefined,
+                            },
+                        ],
+                    },
+                ),
+                access: [],
+            },
+        ])(
+            'preserves policy reads and writes for the $name',
+            async ({ account, access }) => {
+                const { service, directAccessModel } = buildService({
+                    location: personalAppLocation,
+                    context: spaceContext(access),
+                });
+                await expect(
+                    service.listAssignments(
+                        account,
+                        PROJECT_UUID,
+                        DirectAccessResourceType.APP,
+                        APP_UUID,
+                    ),
+                ).resolves.toEqual([]);
+                await expect(
+                    service.upsertAssignment(
+                        account,
+                        PROJECT_UUID,
+                        DirectAccessResourceType.APP,
+                        APP_UUID,
+                        {
+                            type: DirectAccessPrincipalType.USER,
+                            uuid: USER_UUID,
+                        },
+                        SpaceMemberRole.VIEWER,
+                    ),
+                ).resolves.toBeUndefined();
+                expect(directAccessModel.upsertAccess).toHaveBeenCalledOnce();
+            },
+        );
+
+        it('does not let a direct Admin grant exceed custom-role capabilities', async () => {
+            const { service, directAccessModel } = buildService({
+                location: personalAppLocation,
+                context: spaceContext([
+                    { userUuid: OTHER_USER_UUID, role: SpaceMemberRole.ADMIN },
+                ]),
+            });
+            const account = buildAccount(
+                OrganizationMemberRole.MEMBER,
+                OTHER_USER_UUID,
+                {
+                    roleUuid: 'restricted-role',
+                    customRoleScopes: { 'restricted-role': ['view:Project'] },
+                },
+            );
+            await expect(
+                service.listAssignments(
+                    account,
+                    PROJECT_UUID,
+                    DirectAccessResourceType.APP,
+                    APP_UUID,
+                ),
+            ).rejects.toThrowError(ForbiddenError);
+            await expect(
+                service.resetAssignments(
+                    account,
+                    PROJECT_UUID,
+                    DirectAccessResourceType.APP,
+                    APP_UUID,
+                ),
+            ).rejects.toThrowError(ForbiddenError);
+            expect(directAccessModel.resetAccess).not.toHaveBeenCalled();
+        });
     });
 
     it('audits committed upserts and skips no-op revokes', async () => {

--- a/packages/backend/src/services/DirectAccess/DirectAccessService.ts
+++ b/packages/backend/src/services/DirectAccess/DirectAccessService.ts
@@ -5,10 +5,10 @@ import {
     DirectAccessResourceType,
     ForbiddenError,
     NotFoundError,
+    SpaceMemberRole,
     type DirectAccessAssignment,
     type DirectAccessPrincipalRef,
     type RegisteredAccount,
-    type SpaceMemberRole,
     type UUID,
 } from '@lightdash/common';
 import { createActorFromAccount } from '../../logging/caslAuditWrapper';
@@ -343,6 +343,10 @@ export class DirectAccessService extends BaseService {
                       'manage',
                       subject('DataApp', {
                           ...context,
+                          // App editing rights do not include policy management.
+                          access: context.access.filter(
+                              ({ role }) => role === SpaceMemberRole.ADMIN,
+                          ),
                           // A null creator can never match the self rule.
                           createdByUserUuid: location.createdByUserUuid ?? '',
                       }),

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.contentVerification.test.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.contentVerification.test.ts
@@ -1,6 +1,7 @@
 import { Ability } from '@casl/ability';
 import {
     ChartType,
+    ConflictError,
     ContentType,
     CustomDimensionType,
     DimensionType,
@@ -9,6 +10,7 @@ import {
     NotFoundError,
     OrganizationMemberRole,
     PossibleAbilities,
+    type CreateSavedChartVersion,
 } from '@lightdash/common';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
 import { fromSession } from '../../auth/account';
@@ -386,6 +388,48 @@ describe('SavedChartService - Content Verification', () => {
     });
 
     describe('Preserve verification on edit', () => {
+        it('rejects a version ownership conflict using the authorized snapshot without unverifying or emitting success', async () => {
+            savedChartModel.createVersion.mockRejectedValueOnce(
+                new ConflictError('Chart location changed'),
+            );
+            const version: CreateSavedChartVersion = {
+                tableName: 'test_table',
+                metricQuery: {
+                    exploreName: 'test',
+                    dimensions: [],
+                    metrics: [],
+                    filters: {},
+                    sorts: [],
+                    limit: 500,
+                    tableCalculations: [],
+                },
+                chartConfig: { type: ChartType.CARTESIAN },
+                tableConfig: { columnOrder: [] },
+            };
+
+            await expect(
+                service.createVersion(
+                    fromSession(adminUser, 'session-cookie'),
+                    savedChartData.uuid,
+                    { ...version, preserveVerification: false },
+                ),
+            ).rejects.toThrow(ConflictError);
+
+            expect(savedChartModel.createVersion).toHaveBeenCalledWith(
+                savedChartData.uuid,
+                version,
+                expect.objectContaining({ userUuid: adminUser.userUuid }),
+                undefined,
+                {
+                    projectUuid: savedChartData.projectUuid,
+                    dashboardUuid: null,
+                    spaceUuid: savedChartData.spaceUuid,
+                },
+            );
+            expect(contentVerificationModel.unverify).not.toHaveBeenCalled();
+            expect(analyticsMock.track).not.toHaveBeenCalled();
+        });
+
         it('should preserve chart verification when admin edits content via createVersion', async () => {
             const result = await service.createVersion(
                 fromSession(adminUser, 'session-cookie'),

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.grantWrites.test.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.grantWrites.test.ts
@@ -1,5 +1,6 @@
 import { Ability } from '@casl/ability';
 import {
+    ConflictError,
     OrganizationMemberRole,
     type PossibleAbilities,
     type SessionUser,
@@ -362,5 +363,70 @@ describe('SavedChartService direct-grant write parity', () => {
                 }),
             }),
         );
+    });
+
+    it('rolls back a chart version using the authorized ownership snapshot', async () => {
+        await service.rollback(
+            grantOnlyEditor,
+            ownedChart.uuid,
+            'version-uuid',
+        );
+        expect(savedChartModel.createVersion).toHaveBeenCalledWith(
+            ownedChart.uuid,
+            ownedChart,
+            grantOnlyEditor,
+            undefined,
+            {
+                projectUuid: ownedChart.projectUuid,
+                dashboardUuid: OWNING_DASHBOARD,
+                spaceUuid: PRIVATE_SPACE,
+            },
+        );
+    });
+
+    it('rejects a metadata ownership conflict using the authorized snapshot without emitting success', async () => {
+        savedChartModel.update.mockRejectedValueOnce(
+            new ConflictError('Chart location changed'),
+        );
+        const update = { name: 'Rejected rename' };
+
+        await expect(
+            service.update(grantOnlyEditor, ownedChart.uuid, update),
+        ).rejects.toThrow(ConflictError);
+
+        expect(savedChartModel.update).toHaveBeenCalledWith(
+            ownedChart.uuid,
+            update,
+            {
+                projectUuid: ownedChart.projectUuid,
+                dashboardUuid: OWNING_DASHBOARD,
+                spaceUuid: PRIVATE_SPACE,
+            },
+        );
+        expect(projectModel.getExploreFromCache).not.toHaveBeenCalled();
+        expect(analyticsMock.track).not.toHaveBeenCalled();
+    });
+
+    it('propagates a rollback ownership conflict without using the later owner or emitting success', async () => {
+        const movedChart = { ...ownedChart, dashboardUuid: 'other-dashboard' };
+        savedChartModel.get.mockResolvedValue(movedChart);
+        savedChartModel.createVersion.mockRejectedValueOnce(
+            new ConflictError('Chart location changed'),
+        );
+        await expect(
+            service.rollback(grantOnlyEditor, ownedChart.uuid, 'version-uuid'),
+        ).rejects.toThrow(ConflictError);
+        expect(savedChartModel.createVersion).toHaveBeenCalledWith(
+            ownedChart.uuid,
+            movedChart,
+            grantOnlyEditor,
+            undefined,
+            {
+                projectUuid: ownedChart.projectUuid,
+                dashboardUuid: OWNING_DASHBOARD,
+                spaceUuid: PRIVATE_SPACE,
+            },
+        );
+        expect(analyticsMock.track).not.toHaveBeenCalled();
     });
 });

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -1069,6 +1069,8 @@ export class SavedChartService
             savedChartUuid,
             chartVersion,
             user,
+            undefined,
+            { projectUuid, dashboardUuid: dashboardUuid ?? null, spaceUuid },
         );
 
         if (!verificationAfterUpdate) {
@@ -1293,6 +1295,7 @@ export class SavedChartService
         const savedChart = await this.savedChartModel.update(
             savedChartUuid,
             chartUpdate,
+            { projectUuid, dashboardUuid: dashboardUuid ?? null, spaceUuid },
         );
 
         if (!verificationAfterUpdate) {
@@ -2847,7 +2850,10 @@ export class SavedChartService
         chartUuid: string,
         versionUuid: string,
     ): Promise<void> {
-        const { grantAudit } = await this.checkUpdateAccess(user, chartUuid);
+        const { grantAudit, savedChart } = await this.checkUpdateAccess(
+            user,
+            chartUuid,
+        );
         const currentChartVersion = await this.savedChartModel.get(chartUuid);
         const chartVersion = await this.savedChartModel.get(
             chartUuid,
@@ -2857,6 +2863,12 @@ export class SavedChartService
             chartUuid,
             chartVersion,
             user,
+            undefined,
+            {
+                projectUuid: savedChart.projectUuid,
+                dashboardUuid: savedChart.dashboardUuid ?? null,
+                spaceUuid: savedChart.spaceUuid,
+            },
         );
         this.analytics.track({
             event: 'saved_chart_version.rollback',


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/SPK-1933

## What this fixes

Direct Access can authorize a personal-app policy change, a chart write, or a cached export using authority that does not cover the operation. This closes the three API findings from the Direct Access end-to-end review.

Before:
- Personal-app Editors can inspect and change direct assignments.
- A chart metadata/version write can use an ownership snapshot that changed before persistence.
- A revoked chart recipient can initiate an export from existing query history.

After:
- Personal-app policy checks use Admin access while preserving creator and legitimate inherited authority.
- Metadata updates, version saves, and rollback pass the authorized chart location into an atomic model precondition. A changed location returns a conflict.
- Result reads and export initiation recheck current access to identifiable source charts, including sources referenced by derived queries.

## How

```text
Policy request -> effective policy authority -> assignment write
Chart write    -> authorized location        -> matching row -> persist
Cached result  -> persisted source references -> current chart access -> export
```

Derived metric histories retain their original replay shape and use source-history references for authorization. Ownership checks cover direct chart persistence; content-as-code drafts and parent-dashboard relocation keep their existing behavior. Generic queries, embed JWTs, and legacy SQL histories without resource identity retain existing authorization. No migration or public API shape changes.

## Who's affected

- Direct personal-app Viewer/Editor: policy inspection and mutation are denied; permitted app editing remains available.
- Effective Admin, creator, and authorized inherited users: policy and content operations remain available.
- Chart editors: a chart location change during metadata/version persistence returns a conflict instead of applying a stale write.
- Revoked chart recipients: cached result reads and export generation are denied. Recipients with remaining inherited access can still export.
- Service accounts and custom roles: existing ability checks remain in force; role/capability controls have regression coverage.

## Test plan

- [x] Backend typecheck and full lint.
- [x] 258 backend tests across six affected suites.
- [x] 10 PostgreSQL integration cases: allowed writes and rejected ownership transitions with unchanged persisted rows/versions.
- [x] Failing-before/passing-after policy, ownership, derived-source, replay, and rollback regressions.
- [x] Fresh ld1 runtime: 16 policy assertions and seven owned-chart update/version/rollback assertions.
- [x] Revoked result reads and CSV generation return 403; direct and inherited authorized users each download a CSV containing five fixture rows.
- [x] Five review lenses; all blocker and should-fix findings resolved and re-reviewed.

The companion UI PR builds on this API layer. License-loss behavior, performance, and deferred worker/scheduled-delivery execution are outside this change.
