### PR TITLE
feat(analytics): track content-as-code drafts and write-back

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.test.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.test.ts
@@ -157,6 +157,77 @@ describe('LightdashAnalytics', () => {
         });
     });
 
+    describe('actor fallback', () => {
+        const analytics = new LightdashAnalytics({
+            lightdashConfig: {
+                ...lightdashConfigMock,
+                rudder: {
+                    writeKey: 'test-write-key',
+                    dataPlaneUrl: 'http://localhost',
+                },
+            },
+            writeKey: 'test-write-key',
+            dataPlaneUrl: 'http://localhost',
+            options: { enable: false },
+        });
+
+        let superTrackSpy: ReturnType<typeof vi.spyOn>;
+
+        beforeEach(() => {
+            superTrackSpy = vi
+                .spyOn(Analytics.prototype, 'track')
+                .mockImplementation(() => {});
+        });
+
+        afterEach(() => {
+            superTrackSpy.mockRestore();
+        });
+
+        it('sends an event with no actor under the instance anonymous id', () => {
+            const warn = vi
+                .spyOn(Logger, 'warn')
+                .mockImplementation(() => Logger);
+
+            analytics.track({
+                event: 'content_as_code.pulled_from_git',
+                properties: {
+                    projectId: 'project-uuid',
+                    chartsCount: 1,
+                    dashboardsCount: 0,
+                    failureCount: 0,
+                },
+            } as never);
+
+            expect(superTrackSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    anonymousId: LightdashAnalytics.anonymousId,
+                }),
+            );
+            expect(warn).toHaveBeenCalledTimes(1);
+            warn.mockRestore();
+        });
+
+        it('leaves an event with a userId untouched', () => {
+            analytics.track({
+                event: 'content_as_code.pulled_from_git',
+                userId: 'user-uuid',
+                properties: {
+                    projectId: 'project-uuid',
+                    chartsCount: 1,
+                    dashboardsCount: 0,
+                    failureCount: 0,
+                },
+            });
+
+            expect(superTrackSpy).toHaveBeenCalledWith(
+                expect.objectContaining({ userId: 'user-uuid' }),
+            );
+            expect(superTrackSpy).toHaveBeenCalledWith(
+                expect.not.objectContaining({ anonymousId: expect.anything() }),
+            );
+        });
+    });
+
     describe('user.deleted anonymization', () => {
         const analytics = new LightdashAnalytics({
             lightdashConfig: {

--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -3466,6 +3466,116 @@ export type DashboardOwnershipReassignedEvent = BaseTrack & {
     };
 };
 
+type ContentAsCodeContentType = 'chart' | 'dashboard';
+
+type ContentDraftProperties = {
+    projectId: string;
+    draftId: string;
+    contentType: ContentAsCodeContentType;
+    contentId: string;
+};
+
+export type ContentDraftSavedEvent = BaseTrack & {
+    event: 'content_draft.saved';
+    userId: string;
+    properties: ContentDraftProperties & {
+        draftedFieldCount: number;
+    };
+};
+
+export type ContentDraftWrittenBackEvent = BaseTrack & {
+    event: 'content_draft.written_back';
+    userId: string;
+    properties: ContentDraftProperties & {
+        writebackId: string;
+        prNumber: number | null;
+    };
+};
+
+export type ContentDraftDismissedEvent = BaseTrack &
+    ({ userId: string } | { anonymousId: string }) & {
+        event: 'content_draft.dismissed';
+        properties: ContentDraftProperties & {
+            reason: 'reviewer' | 'pull_request_closed';
+        };
+    };
+
+export type ContentDraftReopenedEvent = BaseTrack & {
+    event: 'content_draft.reopened';
+    userId: string;
+    properties: ContentDraftProperties;
+};
+
+export type ContentDraftRebasedEvent = BaseTrack & {
+    event: 'content_draft.rebased';
+    userId: string;
+    properties: ContentDraftProperties & {
+        conflictingFieldCount: number;
+        keptLatestCount: number;
+        keptDraftCount: number;
+    };
+};
+
+export type ContentAsCodeProposedEvent = BaseTrack & {
+    event: 'content_as_code.proposed';
+    userId: string;
+    properties: {
+        projectId: string;
+        contentType: ContentAsCodeContentType;
+        contentId: string;
+        addToGit: boolean;
+        writebackId: string;
+        prNumber: number | null;
+    };
+};
+
+export type ContentAsCodeWritebackFailedEvent = BaseTrack & {
+    event: 'content_as_code_writeback.failed';
+    userId: string;
+    properties: {
+        projectId: string;
+        contentType: ContentAsCodeContentType;
+        contentId: string;
+        isDraft: boolean;
+        error: string;
+    };
+};
+
+export type ContentAsCodeWritebackPullRequestEvent = BaseTrack & {
+    event:
+        | 'content_as_code_writeback.pull_request_merged'
+        | 'content_as_code_writeback.pull_request_closed';
+    anonymousId: string;
+    properties: {
+        projectId: string;
+        writebackId: string;
+        contentType: ContentAsCodeContentType;
+        prNumber: number;
+        hadDraft: boolean;
+    };
+};
+
+export type ContentAsCodePulledFromGitEvent = BaseTrack & {
+    event: 'content_as_code.pulled_from_git';
+    userId: string;
+    properties: {
+        projectId: string;
+        chartsCount: number;
+        dashboardsCount: number;
+        failureCount: number;
+    };
+};
+
+export type ContentAsCodeSettingsStampedEvent = BaseTrack & {
+    event: 'content_as_code.settings_stamped';
+    userId: string;
+    properties: {
+        projectId: string;
+        syncEnabled: boolean;
+        pathConfigured: boolean;
+    };
+};
+
 export type ImpersonationEvent = BaseTrack & {
     event: 'user.impersonation_started' | 'user.impersonation_stopped';
     properties: {
@@ -3741,6 +3851,16 @@ type TypedEvent =
     | ContentReviewNotificationSentEvent
     | SchedulerOwnershipReassignedEvent
     | DashboardOwnershipReassignedEvent
+    | ContentDraftSavedEvent
+    | ContentDraftWrittenBackEvent
+    | ContentDraftDismissedEvent
+    | ContentDraftReopenedEvent
+    | ContentDraftRebasedEvent
+    | ContentAsCodeProposedEvent
+    | ContentAsCodeWritebackFailedEvent
+    | ContentAsCodeWritebackPullRequestEvent
+    | ContentAsCodePulledFromGitEvent
+    | ContentAsCodeSettingsStampedEvent
     | ImpersonationEvent
     | PromptFetchedEvent
     | FeatureFlagCheckedAggregatedEvent
@@ -3820,6 +3940,17 @@ export class LightdashAnalytics extends Analytics {
         });
     }
 
+    // RudderStack asserts that every event carries a userId or anonymousId.
+    // A system event that forgot its actor lands under the instance id
+    // instead of throwing inside the request that emitted it.
+    private static ensureActor<T extends BaseTrack>(payload: T): T {
+        if (payload.userId || payload.anonymousId) return payload;
+        Logger.warn(
+            `Analytics event ${payload.event} has no userId or anonymousId; using the instance anonymous id`,
+        );
+        return { ...payload, anonymousId: LightdashAnalytics.anonymousId };
+    }
+
     track<T extends BaseTrack>(payload: TypedEvent | UntypedEvent<T>) {
         // Usage event stream fires regardless of Rudderstack/anonymization settings
         this.eventStreamSink?.handle(payload);
@@ -3844,7 +3975,7 @@ export class LightdashAnalytics extends Analytics {
             };
 
             super.track({
-                ...payload,
+                ...LightdashAnalytics.ensureActor(payload),
                 event: `${this.lightdashContext.app.name}.${payload.event}`,
                 context: { ...this.lightdashContext }, // NOTE: spread because rudderstack manipulates arg
                 properties: payload.properties.isTrackingAnonymized
@@ -3860,7 +3991,7 @@ export class LightdashAnalytics extends Analytics {
         }
         if (isUserVerifiedEvent(payload)) {
             super.track({
-                ...payload,
+                ...LightdashAnalytics.ensureActor(payload),
                 event: `${this.lightdashContext.app.name}.${payload.event}`,
                 context: { ...this.lightdashContext }, // NOTE: spread because rudderstack manipulates arg
                 properties: {
@@ -3881,7 +4012,7 @@ export class LightdashAnalytics extends Analytics {
             };
 
             super.track({
-                ...payload,
+                ...LightdashAnalytics.ensureActor(payload),
                 event: `${this.lightdashContext.app.name}.${payload.event}`,
                 context: { ...this.lightdashContext },
                 properties: payload.properties.isTrackingAnonymized
@@ -3897,7 +4028,7 @@ export class LightdashAnalytics extends Analytics {
         }
 
         super.track({
-            ...payload,
+            ...LightdashAnalytics.ensureActor(payload),
             event: `${this.lightdashContext.app.name}.${payload.event}`,
             context: { ...this.lightdashContext }, // NOTE: spread because rudderstack manipulates arg
         });

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -3507,6 +3507,15 @@ export class CoderService extends BaseService {
                     ? null
                     : normalizeContentAsCodePath(settings.path),
         });
+        this.analytics.track({
+            event: 'content_as_code.settings_stamped',
+            userId: user.userUuid,
+            properties: {
+                projectId: projectUuid,
+                syncEnabled: settings.sync,
+                pathConfigured: settings.path !== undefined,
+            },
+        });
     }
 
     // Stamped project settings keep snapshot recording consistent for callers

--- a/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.test.ts
+++ b/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.test.ts
@@ -9,6 +9,7 @@ import {
     type SessionUser,
 } from '@lightdash/common';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
 import {
     getFileContent,
     getPullRequest,
@@ -198,6 +199,7 @@ const buildService = (overrides: Overrides = {}) => {
     };
     const service = new ContentAsCodeWritebackService({
         lightdashConfig: { siteUrl: 'https://app.lightdash.dev' } as never,
+        analytics: analyticsMock,
         projectModel: {
             get: vi.fn().mockResolvedValue({
                 projectUuid: 'project-uuid',
@@ -280,12 +282,26 @@ describe('ContentAsCodeWritebackService', () => {
 
     it('dismisses an open draft without deleting it', async () => {
         const { service, contentDraftModel } = buildService();
+        const track = vi.spyOn(analyticsMock, 'track');
 
         await service.dismissDraft(user, 'project-uuid', 'draft-uuid');
 
         expect(contentDraftModel.update).toHaveBeenCalledWith('draft-uuid', {
             status: 'dismissed',
         });
+        expect(track).toHaveBeenCalledWith(
+            expect.objectContaining({
+                event: 'content_draft.dismissed',
+                userId: user.userUuid,
+                properties: {
+                    projectId: 'project-uuid',
+                    draftId: 'draft-uuid',
+                    contentType: 'dashboard',
+                    contentId: 'dashboard-uuid',
+                    reason: 'reviewer',
+                },
+            }),
+        );
     });
 
     it('lets the author reopen the same dismissed draft', async () => {
@@ -441,6 +457,7 @@ describe('ContentAsCodeWritebackService', () => {
             state: 'closed',
             merged: false,
         } as never);
+        const track = vi.spyOn(analyticsMock, 'track');
 
         await service.listDrafts(user, 'project-uuid', { refresh: true });
 
@@ -454,6 +471,25 @@ describe('ContentAsCodeWritebackService', () => {
         });
         expect(contentDraftModel.listByProject).toHaveBeenCalledWith(
             'project-uuid',
+        );
+        expect(track).toHaveBeenCalledWith(
+            expect.objectContaining({
+                event: 'content_as_code_writeback.pull_request_closed',
+                properties: expect.objectContaining({
+                    writebackId: 'row-uuid',
+                    prNumber: 5,
+                    hadDraft: true,
+                }),
+            }),
+        );
+        expect(track).toHaveBeenCalledWith(
+            expect.objectContaining({
+                event: 'content_draft.dismissed',
+                properties: expect.objectContaining({
+                    draftId: 'draft-uuid',
+                    reason: 'pull_request_closed',
+                }),
+            }),
         );
     });
 

--- a/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.ts
+++ b/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.ts
@@ -33,6 +33,7 @@ import {
 } from '@lightdash/common';
 import * as yaml from 'js-yaml';
 import pLimit from 'p-limit';
+import { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
 import * as GithubClient from '../../clients/github/Github';
 import * as GitlabClient from '../../clients/gitlab/Gitlab';
 import { LightdashConfig } from '../../config/parseConfig';
@@ -55,6 +56,7 @@ import { GitIntegrationService } from '../GitIntegrationService/GitIntegrationSe
 
 type ContentAsCodeWritebackServiceArguments = {
     lightdashConfig: LightdashConfig;
+    analytics: LightdashAnalytics;
     projectModel: ProjectModel;
     gitIntegrationService: GitIntegrationService;
     coderService: CoderService;
@@ -80,6 +82,7 @@ type RepoContentFile = {
     content: string;
 };
 
+const ANALYTICS_ERROR_MAX_LENGTH = 500;
 const WRITEBACK_BRANCH_PREFIX = 'lightdash/write-back';
 
 // The stored branch column is varchar(255); file-backed git hosts cap a ref
@@ -148,6 +151,8 @@ export class ContentAsCodeWritebackService extends BaseService {
 
     private readonly projectModel: ProjectModel;
 
+    private readonly analytics: LightdashAnalytics;
+
     private readonly gitIntegrationService: GitIntegrationService;
 
     private readonly coderService: CoderService;
@@ -171,6 +176,7 @@ export class ContentAsCodeWritebackService extends BaseService {
     constructor(args: ContentAsCodeWritebackServiceArguments) {
         super();
         this.lightdashConfig = args.lightdashConfig;
+        this.analytics = args.analytics;
         this.projectModel = args.projectModel;
         this.gitIntegrationService = args.gitIntegrationService;
         this.coderService = args.coderService;
@@ -180,6 +186,15 @@ export class ContentAsCodeWritebackService extends BaseService {
         this.contentAsCodeWritebackModel = args.contentAsCodeWritebackModel;
         this.contentDraftModel = args.contentDraftModel;
         this.userModel = args.userModel;
+    }
+
+    private static toWritebackContentType(
+        contentType: string,
+    ): WritebackContentType {
+        if (contentType !== 'chart' && contentType !== 'dashboard') {
+            throw new ParameterError('Unsupported draft content type');
+        }
+        return contentType;
     }
 
     // Identifies this instance in branch names so two instances editing the
@@ -299,7 +314,7 @@ export class ContentAsCodeWritebackService extends BaseService {
                 `Content "${slug}" is not managed as code; pass addToGit to deliberately add it to the repo`,
             );
         }
-        return this.writeContentToWritebackPr(user, {
+        const row = await this.writeContentToWritebackPr(user, {
             projectUuid,
             contentType,
             contentUuid,
@@ -307,6 +322,19 @@ export class ContentAsCodeWritebackService extends BaseService {
             contentDraftUuid: null,
             author: commitAuthorFromUser(user),
         });
+        this.analytics.track({
+            event: 'content_as_code.proposed',
+            userId: user.userUuid,
+            properties: {
+                projectId: projectUuid,
+                contentType,
+                contentId: contentUuid,
+                addToGit: options.addToGit === true,
+                writebackId: row.uuid,
+                prNumber: row.prNumber,
+            },
+        });
+        return row;
     }
 
     // Write-back visibility is a dev/admin surface (the sync panel), never
@@ -648,6 +676,16 @@ export class ContentAsCodeWritebackService extends BaseService {
             }
         }
         /* eslint-enable no-await-in-loop */
+        this.analytics.track({
+            event: 'content_as_code.pulled_from_git',
+            userId: user.userUuid,
+            properties: {
+                projectId: projectUuid,
+                chartsCount: summary.charts,
+                dashboardsCount: summary.dashboards,
+                failureCount: summary.failures.length,
+            },
+        });
         return summary;
     }
 
@@ -843,6 +881,18 @@ export class ContentAsCodeWritebackService extends BaseService {
             writtenBackPublished: published,
             writtenBackDraft: draftDoc,
         });
+        this.analytics.track({
+            event: 'content_draft.written_back',
+            userId: user.userUuid,
+            properties: {
+                projectId: projectUuid,
+                draftId: draft.uuid,
+                contentType,
+                contentId: draft.contentUuid,
+                writebackId: row.uuid,
+                prNumber: row.prNumber,
+            },
+        });
         return { ...draft, status: 'written_back', prUrl: row.prUrl };
     }
 
@@ -889,6 +939,20 @@ export class ContentAsCodeWritebackService extends BaseService {
         }
         await this.contentDraftModel.update(draft.uuid, {
             status: 'dismissed',
+        });
+        this.analytics.track({
+            event: 'content_draft.dismissed',
+            userId: user.userUuid,
+            properties: {
+                projectId: projectUuid,
+                draftId: draft.uuid,
+                contentType:
+                    ContentAsCodeWritebackService.toWritebackContentType(
+                        draft.contentType,
+                    ),
+                contentId: draft.contentUuid,
+                reason: 'reviewer',
+            },
         });
     }
 
@@ -1019,6 +1083,23 @@ export class ContentAsCodeWritebackService extends BaseService {
         });
         const updated = await this.contentDraftModel.get(draft.uuid);
         if (!updated) throw new ParameterError('Draft not found');
+        const conflictingFields = staleness?.conflictingFields ?? [];
+        const keptLatestCount = conflictingFields.filter(
+            (field) => resolutions[field] === 'latest',
+        ).length;
+        this.analytics.track({
+            event: 'content_draft.rebased',
+            userId: user.userUuid,
+            properties: {
+                projectId: projectUuid,
+                draftId: draft.uuid,
+                contentType: draft.contentType,
+                contentId: draft.contentUuid,
+                conflictingFieldCount: conflictingFields.length,
+                keptLatestCount,
+                keptDraftCount: conflictingFields.length - keptLatestCount,
+            },
+        });
         return updated;
     }
 
@@ -1051,6 +1132,19 @@ export class ContentAsCodeWritebackService extends BaseService {
             );
         }
         await this.contentDraftModel.update(draft.uuid, { status: 'open' });
+        this.analytics.track({
+            event: 'content_draft.reopened',
+            userId: user.userUuid,
+            properties: {
+                projectId: projectUuid,
+                draftId: draft.uuid,
+                contentType:
+                    ContentAsCodeWritebackService.toWritebackContentType(
+                        draft.contentType,
+                    ),
+                contentId: draft.contentUuid,
+            },
+        });
         return { ...draft, status: 'open' };
     }
 
@@ -1096,11 +1190,13 @@ export class ContentAsCodeWritebackService extends BaseService {
                             row.uuid,
                             { status: 'merged' },
                         );
+                        this.trackPullRequestOutcome(row, 'merged');
                     } else if (pr.state === 'closed') {
                         await this.contentAsCodeWritebackModel.update(
                             row.uuid,
                             { status: 'closed' },
                         );
+                        this.trackPullRequestOutcome(row, 'closed');
                         await this.releaseDraftOfClosedPullRequest(row);
                     }
                 } catch (error) {
@@ -1111,6 +1207,32 @@ export class ContentAsCodeWritebackService extends BaseService {
                 }
             }),
         );
+    }
+
+    // The outcome is decided on the provider by whoever reviewed the PR, so
+    // the row is attributed to the instance rather than the polling user
+    private trackPullRequestOutcome(
+        row: ContentAsCodeWriteback,
+        outcome: 'merged' | 'closed',
+    ): void {
+        if (row.prNumber === null) return;
+        this.analytics.track({
+            event:
+                outcome === 'merged'
+                    ? 'content_as_code_writeback.pull_request_merged'
+                    : 'content_as_code_writeback.pull_request_closed',
+            anonymousId: LightdashAnalytics.anonymousId,
+            properties: {
+                projectId: row.projectUuid,
+                writebackId: row.uuid,
+                contentType:
+                    ContentAsCodeWritebackService.toWritebackContentType(
+                        row.contentType,
+                    ),
+                prNumber: row.prNumber,
+                hadDraft: row.contentDraftUuid !== null,
+            },
+        });
     }
 
     // A PR closed without merging hands the change back to its author as a
@@ -1124,6 +1246,20 @@ export class ContentAsCodeWritebackService extends BaseService {
         await this.contentDraftModel.update(draft.uuid, {
             status: 'dismissed',
             prUrl: null,
+        });
+        this.analytics.track({
+            event: 'content_draft.dismissed',
+            anonymousId: LightdashAnalytics.anonymousId,
+            properties: {
+                projectId: draft.projectUuid,
+                draftId: draft.uuid,
+                contentType:
+                    ContentAsCodeWritebackService.toWritebackContentType(
+                        draft.contentType,
+                    ),
+                contentId: draft.contentUuid,
+                reason: 'pull_request_closed',
+            },
         });
         this.logger.info(
             `Draft ${draft.uuid} for ${row.slug} released after PR #${row.prNumber} was closed without merging`,
@@ -1210,6 +1346,17 @@ export class ContentAsCodeWritebackService extends BaseService {
             await this.contentAsCodeWritebackModel.update(row.uuid, {
                 status: 'error',
                 error: message,
+            });
+            this.analytics.track({
+                event: 'content_as_code_writeback.failed',
+                userId: user.userUuid,
+                properties: {
+                    projectId: projectUuid,
+                    contentType,
+                    contentId: target.contentUuid,
+                    isDraft: target.contentDraftUuid !== null,
+                    error: message.slice(0, ANALYTICS_ERROR_MAX_LENGTH),
+                },
             });
             throw error;
         }

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -1905,6 +1905,17 @@ export class DashboardService
             ),
             base,
         });
+        this.analytics.track({
+            event: 'content_draft.saved',
+            userId: user.userUuid,
+            properties: {
+                projectId: existingDashboardDao.projectUuid,
+                draftId: stored.uuid,
+                contentType: 'dashboard',
+                contentId: existingDashboardDao.uuid,
+                draftedFieldCount: Object.keys(stored.draft).length,
+            },
+        });
         const overlaid = DashboardService.mergeDraftIntoDashboard(
             existingDashboardDao,
             stored.draft,

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -788,6 +788,17 @@ export class SavedChartService
             draft: pruneUnchangedDraftFields(existingChart, draftFields),
             base,
         });
+        this.analytics.track({
+            event: 'content_draft.saved',
+            userId: user.userUuid,
+            properties: {
+                projectId: existingChart.projectUuid,
+                draftId: stored.uuid,
+                contentType: 'chart',
+                contentId: existingChart.uuid,
+                draftedFieldCount: Object.keys(stored.draft).length,
+            },
+        });
         const chartForOverlay =
             'metricQuery' in existingChart
                 ? existingChart

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -1364,6 +1364,7 @@ export class ServiceRepository
             () =>
                 new ContentAsCodeWritebackService({
                     lightdashConfig: this.context.lightdashConfig,
+                    analytics: this.context.lightdashAnalytics,
                     projectModel: this.models.getProjectModel(),
                     gitIntegrationService: this.getGitIntegrationService(),
                     coderService: this.getCoderService(),


### PR DESCRIPTION
## Why

An audit of the last three weeks of work found that the whole content-as-code draft and write-back loop shipped with no analytics. Saves held as drafts, proposals to git, write-back PRs, repo pulls and the settings stamp were all dark, so there is no way to see whether the feature is used or where it fails.

Part 1 of 6 of the analytics stack.

## What

New typed events, all on the backend:

| Event | Fired from | Properties |
|---|---|---|
| `content_draft.saved` | chart and dashboard draft store | draft id, content type and id, drafted field count |
| `content_draft.written_back` | `writeBackDraft` | write-back id, PR number |
| `content_draft.dismissed` | `dismissDraft` (reason `reviewer`) and PR closed unmerged (reason `pull_request_closed`, instance actor) | reason |
| `content_draft.reopened` | `reopenDraft` | |
| `content_draft.rebased` | `rebaseDraft` | conflicting, kept-latest and kept-draft counts |
| `content_as_code.proposed` | `propose` | `addToGit`, write-back id, PR number |
| `content_as_code_writeback.failed` | write-back error path | whether it was a draft, error message |
| `content_as_code_writeback.pull_request_merged` / `pull_request_closed` | PR state refresh | PR number, whether a draft was attached |
| `content_as_code.pulled_from_git` | `pullFromGit` | charts, dashboards, failures |
| `content_as_code.settings_stamped` | `stampContentAsCodeSettings` | sync enabled, path configured |

`ContentAsCodeWritebackService` now takes `analytics` as a dependency.

### Guard against actor-less events

The RudderStack node SDK asserts that every event carries a `userId` or an `anonymousId` and throws synchronously, so an event that forgot its actor would crash the request that emitted it. `LightdashAnalytics.track` now falls back to the instance anonymous id (with a warning log) when neither is set; two tests cover the fallback and the untouched path. The dismissed draft event type is a union that requires one of the two ids, and the write-back error string is capped at 500 characters. The PR outcome events use the anonymous instance id because the decision was made on the provider by whoever reviewed the PR, not by the user whose page refresh noticed it.

## Regression analysis

- Tracking calls are fire-and-forget and sit after the state change they describe, so a tracking failure cannot roll back or short-circuit a save, write-back or pull.
- Dismiss and reopen now narrow the draft content type through a helper that throws `ParameterError` for an unsupported type. Only `chart` and `dashboard` are ever written to the drafts table, so no existing draft hits that path.
- The write-back service tests construct the service with the analytics mock and assert the dismissed and PR-closed events; the existing 54 tests still pass.

## Testing

- `pnpm -F backend typecheck`
- `pnpm -F backend test src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.test.ts` (56 passed)
- `pnpm -F backend test src/analytics/LightdashAnalytics.test.ts` (10 passed)

No Linear ticket or GitHub issue exists for this work (confirmed with the author). Labelled `📈 analytics-events`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WCdz5wsrbqwS2huRnfnUyE
