### PR TITLE
feat(analytics): track the external source lifecycle

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -12,6 +12,8 @@ import {
     ContentReviewNotificationEvent,
     ContentType,
     DbtProjectType,
+    ExternalSourceScope,
+    ExternalSourceType,
     getRequestMethod,
     InviteLinkPurpose,
     LightdashInstallType,
@@ -3576,6 +3578,56 @@ export type ContentAsCodeSettingsStampedEvent = BaseTrack & {
     };
 };
 
+export type ExternalSourceProperties = {
+    organizationId: string;
+    projectId: string;
+    externalSourceId: string;
+    sourceType: ExternalSourceType;
+    scope: ExternalSourceScope;
+};
+
+export type ExternalSourceStagedEvent = BaseTrack & {
+    event: 'external_source.staged';
+    userId: string;
+    properties: ExternalSourceProperties & {
+        fileSizeBytes: number;
+        columnCount: number;
+    };
+};
+
+export type ExternalSourceLifecycleEvent = BaseTrack & {
+    event:
+        | 'external_source.created'
+        | 'external_source.refreshed'
+        | 'external_source.reconnected'
+        | 'external_source.replaced'
+        | 'external_source.renamed'
+        | 'external_source.deleted';
+    userId: string;
+    properties: ExternalSourceProperties;
+};
+
+export type ExternalSourceIngestCompletedEvent = BaseTrack & {
+    event: 'external_source.ingest_completed';
+    anonymousId: string;
+    properties: ExternalSourceProperties & {
+        rowCount: number;
+        totalBytes: number;
+        columnCount: number;
+        durationMs: number;
+    };
+};
+
+export type ExternalSourceIngestFailedEvent = BaseTrack & {
+    event: 'external_source.ingest_failed';
+    anonymousId: string;
+    properties: ExternalSourceProperties & {
+        durationMs: number;
+        timedOut: boolean;
+        error: string;
+    };
+};
+
 export type ImpersonationEvent = BaseTrack & {
     event: 'user.impersonation_started' | 'user.impersonation_stopped';
     properties: {
@@ -3861,6 +3913,10 @@ type TypedEvent =
     | ContentAsCodeWritebackPullRequestEvent
     | ContentAsCodePulledFromGitEvent
     | ContentAsCodeSettingsStampedEvent
+    | ExternalSourceStagedEvent
+    | ExternalSourceLifecycleEvent
+    | ExternalSourceIngestCompletedEvent
+    | ExternalSourceIngestFailedEvent
     | ImpersonationEvent
     | PromptFetchedEvent
     | FeatureFlagCheckedAggregatedEvent

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -491,6 +491,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
             externalSourceService: ({ context, models, clients }) =>
                 new ExternalSourceService({
                     lightdashConfig: context.lightdashConfig,
+                    analytics: context.lightdashAnalytics,
                     externalSourceModel:
                         models.getExternalSourceModel<ExternalSourceModel>(),
                     projectModel: models.getProjectModel(),

--- a/packages/backend/src/ee/services/ExternalSourceService/ExternalSourceService.ts
+++ b/packages/backend/src/ee/services/ExternalSourceService/ExternalSourceService.ts
@@ -35,6 +35,11 @@ import {
 import { stringify } from 'csv-stringify';
 import { once } from 'events';
 import { PassThrough, Readable } from 'stream';
+import {
+    LightdashAnalytics,
+    type ExternalSourceLifecycleEvent,
+    type ExternalSourceProperties,
+} from '../../../analytics/LightdashAnalytics';
 import { type GoogleDriveClient } from '../../../clients/Google/GoogleDriveClient';
 import { type S3ResultsFileStorageClient } from '../../../clients/ResultsFileStorageClients/S3ResultsFileStorageClient';
 import { type LightdashConfig } from '../../../config/parseConfig';
@@ -81,6 +86,7 @@ const ALLOWED_UPLOAD_CONTENT_TYPES = [
 
 type ExternalSourceServiceArguments = {
     lightdashConfig: LightdashConfig;
+    analytics: LightdashAnalytics;
     externalSourceModel: ExternalSourceModel;
     projectModel: ProjectModel;
     featureFlagModel: FeatureFlagModel;
@@ -103,6 +109,8 @@ type ExternalSourceUploadInput = {
 export class ExternalSourceService extends BaseService {
     private readonly lightdashConfig: LightdashConfig;
 
+    private readonly analytics: LightdashAnalytics;
+
     private readonly externalSourceModel: ExternalSourceModel;
 
     private readonly projectModel: ProjectModel;
@@ -123,6 +131,7 @@ export class ExternalSourceService extends BaseService {
     constructor(args: ExternalSourceServiceArguments) {
         super({ serviceName: 'ExternalSourceService' });
         this.lightdashConfig = args.lightdashConfig;
+        this.analytics = args.analytics;
         this.externalSourceModel = args.externalSourceModel;
         this.projectModel = args.projectModel;
         this.featureFlagModel = args.featureFlagModel;
@@ -130,6 +139,14 @@ export class ExternalSourceService extends BaseService {
         this.storageClient = args.storageClient;
         this.googleDriveClient = args.googleDriveClient;
         this.userOAuthGrantsModel = args.userOAuthGrantsModel;
+    }
+
+    private trackLifecycle(
+        event: ExternalSourceLifecycleEvent['event'],
+        userUuid: string,
+        properties: ExternalSourceLifecycleEvent['properties'],
+    ): void {
+        this.analytics.track({ event, userId: userUuid, properties });
     }
 
     private static rawKey(
@@ -438,6 +455,19 @@ export class ExternalSourceService extends BaseService {
                 `SELECT * FROM read_csv('${escapedUri}', normalize_names=true) LIMIT 5`,
                 {},
             );
+            this.analytics.track({
+                event: 'external_source.staged',
+                userId: userUuid,
+                properties: {
+                    organizationId: organizationUuid,
+                    projectId: projectUuid,
+                    externalSourceId: source.sourceUuid,
+                    sourceType: ExternalSourceType.CSV,
+                    scope,
+                    fileSizeBytes: input.contentLength,
+                    columnCount: Object.keys(inferredColumns).length,
+                },
+            });
             return {
                 sourceUuid: source.sourceUuid,
                 inferredColumns,
@@ -622,6 +652,13 @@ export class ExternalSourceService extends BaseService {
             tableUuid: table.tableUuid,
             targetVersion: table.version + 1,
         });
+        this.trackLifecycle('external_source.created', userUuid, {
+            organizationId: organizationUuid,
+            projectId: projectUuid,
+            externalSourceId: source.sourceUuid,
+            sourceType: ExternalSourceType.GOOGLE_SHEETS,
+            scope: externalSourceScope(source.scope),
+        });
         return this.externalSourceModel.getSource(
             projectUuid,
             source.sourceUuid,
@@ -670,6 +707,13 @@ export class ExternalSourceService extends BaseService {
             scope: externalSourceScope(source.scope),
             tableUuid: table.tableUuid,
             targetVersion: table.version + 1,
+        });
+        this.trackLifecycle('external_source.refreshed', userUuid, {
+            organizationId: organizationUuid,
+            projectId: projectUuid,
+            externalSourceId: sourceUuid,
+            sourceType: source.type,
+            scope: externalSourceScope(source.scope),
         });
         return this.externalSourceModel.getSource(projectUuid, sourceUuid);
     }
@@ -722,6 +766,13 @@ export class ExternalSourceService extends BaseService {
             scope: externalSourceScope(source.scope),
             tableUuid: table.tableUuid,
             targetVersion: table.version + 1,
+        });
+        this.trackLifecycle('external_source.reconnected', userUuid, {
+            organizationId: organizationUuid,
+            projectId: projectUuid,
+            externalSourceId: sourceUuid,
+            sourceType: source.type,
+            scope: externalSourceScope(source.scope),
         });
         return this.externalSourceModel.getSource(projectUuid, sourceUuid);
     }
@@ -801,6 +852,13 @@ export class ExternalSourceService extends BaseService {
                 table.version + 1,
             ),
         });
+        this.trackLifecycle('external_source.created', userUuid, {
+            organizationId: organizationUuid,
+            projectId: projectUuid,
+            externalSourceId: sourceUuid,
+            sourceType: source.type,
+            scope: externalSourceScope(source.scope),
+        });
 
         return this.externalSourceModel.getSource(projectUuid, sourceUuid);
     }
@@ -848,7 +906,10 @@ export class ExternalSourceService extends BaseService {
         sourceUuid: UUID,
         payload: UpdateExternalSourcePayload,
     ): Promise<ExternalSource> {
-        await this.assertAccess(account, projectUuid);
+        const { organizationUuid, userUuid } = await this.assertAccess(
+            account,
+            projectUuid,
+        );
         const label = payload.label.trim();
         if (label.length === 0) {
             throw new ParameterError('Give the table a name');
@@ -890,6 +951,13 @@ export class ExternalSourceService extends BaseService {
                 explore,
             );
         }
+        this.trackLifecycle('external_source.renamed', userUuid, {
+            organizationId: organizationUuid,
+            projectId: projectUuid,
+            externalSourceId: sourceUuid,
+            sourceType: source.type,
+            scope: externalSourceScope(source.scope),
+        });
         return this.externalSourceModel.getSource(projectUuid, sourceUuid);
     }
 
@@ -982,6 +1050,13 @@ export class ExternalSourceService extends BaseService {
             targetVersion: table.version + 1,
             rawObjectKey: rawKey,
         });
+        this.trackLifecycle('external_source.replaced', userUuid, {
+            organizationId: organizationUuid,
+            projectId: projectUuid,
+            externalSourceId: sourceUuid,
+            sourceType: source.type,
+            scope: externalSourceScope(source.scope),
+        });
         return this.externalSourceModel.getSource(projectUuid, sourceUuid);
     }
 
@@ -1029,7 +1104,10 @@ export class ExternalSourceService extends BaseService {
         projectUuid: UUID,
         sourceUuid: UUID,
     ): Promise<void> {
-        await this.assertAccess(account, projectUuid);
+        const { organizationUuid, userUuid } = await this.assertAccess(
+            account,
+            projectUuid,
+        );
         const { source, tables } =
             await this.externalSourceModel.getSourceRowsForIngest(
                 projectUuid,
@@ -1048,6 +1126,13 @@ export class ExternalSourceService extends BaseService {
             projectUuid,
             source.external_source_uuid,
         );
+        this.trackLifecycle('external_source.deleted', userUuid, {
+            organizationId: organizationUuid,
+            projectId: projectUuid,
+            externalSourceId: sourceUuid,
+            sourceType: source.type,
+            scope: externalSourceScope(source.scope),
+        });
     }
 
     async markIngestError(attemptUuid: UUID, error: unknown): Promise<void> {
@@ -1153,6 +1238,8 @@ export class ExternalSourceService extends BaseService {
         const projectUuid = claimed.project_uuid;
         const executionUuid = claimed.execution_uuid;
         if (!executionUuid) throw new Error('Ingest lease has no execution id');
+        const startedAt = Date.now();
+        let ingestProperties: ExternalSourceProperties | undefined;
         let parquetKey: string | undefined;
         try {
             const { source, tables } =
@@ -1160,6 +1247,13 @@ export class ExternalSourceService extends BaseService {
                     projectUuid,
                     sourceUuid,
                 );
+            ingestProperties = {
+                organizationId: claimed.organization_uuid,
+                projectId: projectUuid,
+                externalSourceId: sourceUuid,
+                sourceType: source.type,
+                scope: externalSourceScope(source.scope),
+            };
             const table = tables.find(
                 (candidate) =>
                     candidate.external_source_table_uuid ===
@@ -1368,7 +1462,33 @@ export class ExternalSourceService extends BaseService {
                 attemptUuid: payload.attemptUuid,
                 executionUuid,
             });
+            this.analytics.track({
+                event: 'external_source.ingest_completed',
+                anonymousId: LightdashAnalytics.anonymousId,
+                properties: {
+                    ...ingestProperties,
+                    rowCount,
+                    totalBytes,
+                    columnCount: Object.keys(columns).length,
+                    durationMs: Date.now() - startedAt,
+                },
+            });
         } catch (error) {
+            if (ingestProperties) {
+                this.analytics.track({
+                    event: 'external_source.ingest_failed',
+                    anonymousId: LightdashAnalytics.anonymousId,
+                    properties: {
+                        ...ingestProperties,
+                        durationMs: Date.now() - startedAt,
+                        timedOut: error instanceof TimeoutError,
+                        error: sanitizeDuckdbError(error).slice(
+                            0,
+                            ERROR_MESSAGE_MAX_LENGTH,
+                        ),
+                    },
+                });
+            }
             if (parquetKey) {
                 await this.externalSourceModel
                     .abandonObject(parquetKey, sanitizeDuckdbError(error))

--- a/packages/backend/src/ee/services/ExternalSourceService/externalSourceIngest.test.ts
+++ b/packages/backend/src/ee/services/ExternalSourceService/externalSourceIngest.test.ts
@@ -14,6 +14,7 @@ import { warehouseSqlBuilderFromType } from '@lightdash/warehouses';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { analyticsMock } from '../../../analytics/LightdashAnalytics.mock';
 import { lightdashConfigMock } from '../../../config/lightdashConfig.mock';
 import { duckdbTypeToDimensionType } from '../../../utils/duckdb/duckdbTypeToDimensionType';
 import {
@@ -197,6 +198,7 @@ describe('external source ingest capacity', () => {
         };
         const service = new ExternalSourceService({
             lightdashConfig: lightdashConfigMock,
+            analytics: analyticsMock,
             externalSourceModel,
             schedulerClient,
         } as never);
@@ -220,6 +222,7 @@ describe('external source ingest capacity', () => {
         };
         const service = new ExternalSourceService({
             lightdashConfig: lightdashConfigMock,
+            analytics: analyticsMock,
             externalSourceModel,
         } as never);
 


### PR DESCRIPTION
## Why

CSV uploads and Google Sheets sources had no analytics on the backend or the frontend. Only their queries were visible, through the `external_source_duckdb` query context. Adoption per source type, the staged-to-created funnel and ingest failures were all invisible.

Part 2 of 6 of the analytics stack.

## What

New typed events on `ExternalSourceService`:

| Event | Fired from | Extra properties |
|---|---|---|
| `external_source.staged` | `stageCsvUpload` after the file is readable | file size, inferred column count |
| `external_source.created` | `createCsvTable`, `createGoogleSheetsSource` | |
| `external_source.refreshed` / `reconnected` / `replaced` / `renamed` / `deleted` | the matching methods | |
| `external_source.ingest_completed` | `runIngest`, full pipeline path | rows, bytes, columns, duration |
| `external_source.ingest_failed` | `runIngest` catch | duration, timed out, sanitised error |

Every event carries organisation, project, source id, source type (`csv` or `google_sheets`) and scope (`catalog` or `attachment`), so AI agent attachments are separable from catalog sources without a separate event. Ingest events use the anonymous instance id because they run on the worker.

## Regression analysis

- The service gains an `analytics` constructor argument, wired in the EE service repository. The ingest test file passes the analytics mock.
- Ingest tracking is placed after `publishIngestAttempt` and inside the existing catch, so it cannot change the ingest outcome or the error rethrown to the worker.
- Ingest resumptions that return early (already at the target version, or republishing recorded columns) deliberately fire nothing; only a real pipeline run reports completed or failed.

## Testing

- `pnpm -F backend typecheck`
- `pnpm -F backend test src/ee/services/ExternalSourceService/externalSourceIngest.test.ts` (7 passed)

No Linear ticket or GitHub issue exists for this work (confirmed with the author). Labelled `📈 analytics-events`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WCdz5wsrbqwS2huRnfnUyE
