### PR TITLE
feat(analytics): track AI agent thread actions, model choice and response timing

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -2717,6 +2717,9 @@ export type AiAgentCreatedEvent = BaseTrack & {
         agentName: string;
         tagsCount: number;
         integrationsCount: number;
+        modelProvider: string | null;
+        modelName: string | null;
+        reasoningEnabled: boolean | null;
         autoProvisioned?: boolean;
     };
 };
@@ -2732,6 +2735,30 @@ export type AiAgentThreadDeletedEvent = BaseTrack & {
         threadId: string;
         memoriesDeleted: number;
         deletedVia: 'admin' | 'owner';
+    };
+};
+
+export type AiAgentThreadPinnedEvent = BaseTrack & {
+    event: 'ai_agent.thread_pinned';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        agentId: string;
+        threadId: string;
+        pinned: boolean;
+    };
+};
+
+export type AiAgentThreadRenamedEvent = BaseTrack & {
+    event: 'ai_agent.thread_renamed';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        agentId: string;
+        threadId: string;
+        titleLength: number;
     };
 };
 
@@ -2791,6 +2818,9 @@ export type AiAgentUpdatedEvent = BaseTrack & {
         agentName: string | undefined;
         tagsCount: number;
         integrationsCount: number;
+        modelProvider: string | null;
+        modelName: string | null;
+        reasoningEnabled: boolean | null;
     };
 };
 
@@ -2877,8 +2907,11 @@ export type AiAgentResponseStreamed = BaseTrack & {
         usageTokensCount: number;
         stepsCount: number;
         model: string;
+        modelProvider: string | null;
         finishReason: string;
         stepCapReached: boolean;
+        timeToFirstTokenMs: number | null;
+        durationMs: number;
     };
 };
 
@@ -3867,6 +3900,8 @@ type TypedEvent =
     | DeprecatedRouteCalled
     | AiAgentCreatedEvent
     | AiAgentThreadDeletedEvent
+    | AiAgentThreadPinnedEvent
+    | AiAgentThreadRenamedEvent
     | AiAgentThreadsRetentionCleanedEvent
     | AiAgentProvisioningFailedEvent
     | AiAgentGithubMcpConnectedEvent

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -1009,6 +1009,20 @@ export class AiAgentService extends BaseService {
 
     private readonly mobilePushNotificationService: AiAgentServiceDependencies['mobilePushNotificationService'];
 
+    private static getModelConfigAnalyticsProperties(
+        modelConfig: AiAgentModelConfig | null | undefined,
+    ): {
+        modelProvider: string | null;
+        modelName: string | null;
+        reasoningEnabled: boolean | null;
+    } {
+        return {
+            modelProvider: modelConfig?.modelProvider ?? null,
+            modelName: modelConfig?.modelName ?? null,
+            reasoningEnabled: modelConfig?.reasoning ?? null,
+        };
+    }
+
     private static getPinnedContextAnalyticsProperties(
         context: AiPromptContextInput | undefined,
     ): Pick<
@@ -3484,7 +3498,7 @@ export class AiAgentService extends BaseService {
             );
         }
 
-        return thread;
+        return { thread, agent, organizationUuid };
     }
 
     async updateAgentThreadTitle(
@@ -3505,7 +3519,7 @@ export class AiAgentService extends BaseService {
             );
         }
 
-        await this.getManagedThread(user, {
+        const { agent, organizationUuid } = await this.getManagedThread(user, {
             agentUuid,
             threadUuid,
             action: 'rename',
@@ -3514,6 +3528,17 @@ export class AiAgentService extends BaseService {
         await this.aiAgentModel.updateThreadTitle({
             threadUuid,
             title: trimmedTitle,
+        });
+        this.analytics.track({
+            event: 'ai_agent.thread_renamed',
+            userId: user.userUuid,
+            properties: {
+                organizationId: organizationUuid,
+                projectId: agent.projectUuid,
+                agentId: agentUuid,
+                threadId: threadUuid,
+                titleLength: trimmedTitle.length,
+            },
         });
     }
 
@@ -3525,13 +3550,24 @@ export class AiAgentService extends BaseService {
             pinned,
         }: { agentUuid: string; threadUuid: string; pinned: boolean },
     ): Promise<void> {
-        await this.getManagedThread(user, {
+        const { agent, organizationUuid } = await this.getManagedThread(user, {
             agentUuid,
             threadUuid,
             action: pinned ? 'pin' : 'unpin',
         });
 
         await this.aiAgentModel.setThreadPinned({ threadUuid, pinned });
+        this.analytics.track({
+            event: 'ai_agent.thread_pinned',
+            userId: user.userUuid,
+            properties: {
+                organizationId: organizationUuid,
+                projectId: agent.projectUuid,
+                agentId: agentUuid,
+                threadId: threadUuid,
+                pinned,
+            },
+        });
     }
 
     async deleteAgentThread(
@@ -4130,6 +4166,9 @@ export class AiAgentService extends BaseService {
                 agentName: agent.name,
                 tagsCount: agent.tags?.length ?? 0,
                 integrationsCount: agent.integrations?.length ?? 0,
+                ...AiAgentService.getModelConfigAnalyticsProperties(
+                    agent.modelConfig,
+                ),
                 ...(options?.autoProvisioned ? { autoProvisioned: true } : {}),
             },
         });
@@ -5765,6 +5804,9 @@ export class AiAgentService extends BaseService {
                 agentName: body.name,
                 tagsCount: updatedAgent.tags?.length ?? 0,
                 integrationsCount: updatedAgent.integrations?.length ?? 0,
+                ...AiAgentService.getModelConfigAnalyticsProperties(
+                    updatedAgent.modelConfig,
+                ),
             },
         });
 

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -2334,12 +2334,18 @@ export const streamAgentResponse = async ({
                         agentName: args.agentSettings.name,
                         usageTokensCount: totalUsage.totalTokens ?? 0,
                         stepsCount: steps.length,
-                        model:
+                        model: modelName,
+                        modelProvider:
                             typeof args.model === 'string'
-                                ? args.model
-                                : args.model.modelId,
+                                ? null
+                                : args.model.provider,
                         finishReason,
                         stepCapReached,
+                        timeToFirstTokenMs:
+                            firstChunkTime === null
+                                ? null
+                                : firstChunkTime - startTime,
+                        durationMs: Date.now() - startTime,
                     },
                 });
                 logger(

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
@@ -29,6 +29,8 @@ import { LightdashUserAvatar } from '../../../components/Avatar';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { getModelKey } from '../../../components/common/ModelSelector/utils';
 import { useProjectUuid } from '../../../hooks/useProjectUuid';
+import useTracking from '../../../providers/Tracking/useTracking';
+import { EventName } from '../../../types/Events';
 import { AiAgentNewThreadMcpConnections } from '../../features/aiCopilot/components/AiAgentNewThreadMcpConnections';
 import { BattleModeSetup } from '../../features/aiCopilot/components/Battle/BattleModeSetup';
 import { AgentChatInput } from '../../features/aiCopilot/components/ChatElements/AgentChatInput';
@@ -73,6 +75,7 @@ import styles from './AiAgentNewThreadPage.module.css';
 const AiAgentNewThreadPage: FC = () => {
     const { agentUuid } = useParams();
     const projectUuid = useProjectUuid();
+    const { track } = useTracking();
     const isEmbed = isEmbedAiAgentRoute();
     const [searchParams] = useSearchParams();
     const chartUuid = searchParams.get('chartUuid');
@@ -231,6 +234,21 @@ const AiAgentNewThreadPage: FC = () => {
                 optimisticContext,
             );
             if (isBattle && projectUuid) {
+                const modelB = getModelOptionByKey(
+                    battleModels,
+                    effectiveBattleModelBKey,
+                );
+                track({
+                    name: EventName.AI_AGENT_BATTLE_STARTED,
+                    properties: {
+                        projectId: projectUuid,
+                        aiAgentId: agentUuid,
+                        modelA: selectedModel
+                            ? getModelKey(selectedModel)
+                            : null,
+                        modelB: modelB ? getModelKey(modelB) : null,
+                    },
+                });
                 const shared = {
                     agentUuid,
                     prompt: message,
@@ -249,13 +267,7 @@ const AiAgentNewThreadPage: FC = () => {
                     }),
                     createBattleThread({
                         ...shared,
-                        modelConfig: getAiAgentModelConfig(
-                            getModelOptionByKey(
-                                battleModels,
-                                effectiveBattleModelBKey,
-                            ),
-                            false,
-                        ),
+                        modelConfig: getAiAgentModelConfig(modelB, false),
                     }),
                 ]).then(([threadA, threadB]) =>
                     navigate(
@@ -293,6 +305,7 @@ const AiAgentNewThreadPage: FC = () => {
             battleModels,
             effectiveBattleModelBKey,
             navigate,
+            track,
         ],
     );
 

--- a/packages/frontend/src/providers/Tracking/types.ts
+++ b/packages/frontend/src/providers/Tracking/types.ts
@@ -574,6 +574,16 @@ type AiAgentChatMinimizedEvent = {
     };
 };
 
+type AiAgentBattleStartedEvent = {
+    name: EventName.AI_AGENT_BATTLE_STARTED;
+    properties: {
+        projectId: string;
+        aiAgentId: string;
+        modelA: string | null;
+        modelB: string | null;
+    };
+};
+
 type AiDeepResearchReportEngagedEvent = {
     name: EventName.AI_DEEP_RESEARCH_REPORT_ENGAGED;
     properties: {
@@ -1016,6 +1026,7 @@ export type EventData =
     | AiAgentAskClickedEvent
     | AiAgentChatMinimizedEvent
     | AiDeepResearchReportEngagedEvent
+    | AiAgentBattleStartedEvent
     | AiAgentSuggestionImpressionEvent
     | AiAgentSuggestionClickEvent
     | DataAppRecentSuggestionClickEvent

--- a/packages/frontend/src/types/Events.ts
+++ b/packages/frontend/src/types/Events.ts
@@ -208,6 +208,7 @@ export enum EventName {
     AI_AGENT_SUGGESTION_IMPRESSION = 'ai_agent.suggestion_impression',
     AI_AGENT_SUGGESTION_CLICK = 'ai_agent.suggestion_click',
     AI_DEEP_RESEARCH_REPORT_ENGAGED = 'ai_deep_research.report_engaged',
+    AI_AGENT_BATTLE_STARTED = 'ai_agent_battle.started',
 
     // Theme
     THEME_TOGGLED = 'theme.toggled',


### PR DESCRIPTION
## Why

Three recent AI agent features left no trace: pinning and renaming threads, selectable OpenRouter models, and battle mode. The agent created and updated events carried no model at all, so provider adoption could not be measured.

Part 3 of 6 of the analytics stack.

## What

- New `ai_agent.thread_pinned` (with `pinned`) and `ai_agent.thread_renamed` (with `titleLength`) events. The private `getManagedThread` helper now returns the agent and organisation alongside the thread so the events can carry project and organisation ids.
- `ai_agent.created` and `ai_agent.updated` carry `modelProvider`, `modelName` and `reasoningEnabled` from the agent's model config.
- `ai_agent.response_streamed` carries `modelProvider`, `timeToFirstTokenMs` and `durationMs`, computed from the same timestamps that battle mode already persists as response timing.
- Frontend: `ai_agent_battle.started` fires when a battle pair of threads is created, with both model keys.

## Regression analysis

- `getManagedThread` has two callers (rename and pin), both updated in this PR.
- The response streamed properties are additive; the `model` value is unchanged and now reads the existing `modelName` variable.
- The battle page now resolves model B once and reuses it for both the event and the thread config, which is the same value it computed inline before.

## Testing

- `pnpm -F backend typecheck`, `pnpm -F frontend typecheck`
- `pnpm -F backend test src/ee/services/AiAgentService/AiAgentService.test.ts` (54 passed)

No Linear ticket or GitHub issue exists for this work (confirmed with the author). Labelled `📈 analytics-events`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WCdz5wsrbqwS2huRnfnUyE
