### PR TITLE
feat(analytics): track review settings and the similar content nudge

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -3080,6 +3080,31 @@ export type ContentReviewRequestEvent = BaseTrack & {
     };
 };
 
+export type ContentReviewSettingsUpdatedEvent = BaseTrack & {
+    event: 'content_review_settings.updated';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        routedTo: 'space_editors' | 'group';
+        verifyOnApproveDefault: boolean;
+        slackNotificationsEnabled: boolean;
+    };
+};
+
+export type ContentReviewSimilarContentFoundEvent = BaseTrack & {
+    event: 'content_review_request.similar_content_found';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        contentType: ContentReviewContentType;
+        contentId: string | null;
+        matchCount: number;
+        verifiedMatchCount: number;
+    };
+};
+
 export type AiAgentArtifactVersionVerifiedEvent = BaseTrack & {
     event: 'ai_agent.artifact_version_verified';
     userId: string;
@@ -3935,6 +3960,8 @@ type TypedEvent =
     | AiRouterMessageRoutedEvent
     | ContentVerificationEvent
     | ContentReviewRequestEvent
+    | ContentReviewSettingsUpdatedEvent
+    | ContentReviewSimilarContentFoundEvent
     | ContentReviewNotificationSentEvent
     | SchedulerOwnershipReassignedEvent
     | DashboardOwnershipReassignedEvent

--- a/packages/backend/src/ee/services/ContentReviewRequestService/ContentReviewRequestService.test.ts
+++ b/packages/backend/src/ee/services/ContentReviewRequestService/ContentReviewRequestService.test.ts
@@ -731,4 +731,42 @@ describe('ContentReviewRequestService', () => {
             expect(contentVerificationModel.verify).not.toHaveBeenCalled();
         });
     });
+
+    describe('settings', () => {
+        const admin = buildUser('admin-uuid', [
+            { subject: 'Project', action: 'manage' },
+        ]);
+
+        it('tracks how reviews are routed when settings change', async () => {
+            const {
+                service,
+                contentReviewSettingsModel,
+                groupsModel,
+                analytics,
+            } = buildService();
+            groupsModel.getGroup.mockResolvedValue({ organizationUuid: ORG });
+            contentReviewSettingsModel.upsert.mockResolvedValue({
+                projectUuid: PROJECT,
+                reviewerGroupUuid: 'group-uuid',
+                verifyOnApproveDefault: true,
+                slackChannelId: 'C123',
+            });
+
+            await service.updateSettings(admin, PROJECT, {
+                reviewerGroupUuid: 'group-uuid',
+            });
+
+            expect(analytics.track).toHaveBeenCalledWith({
+                event: 'content_review_settings.updated',
+                userId: 'admin-uuid',
+                properties: {
+                    organizationId: ORG,
+                    projectId: PROJECT,
+                    routedTo: 'group',
+                    verifyOnApproveDefault: true,
+                    slackNotificationsEnabled: true,
+                },
+            });
+        });
+    });
 });

--- a/packages/backend/src/ee/services/ContentReviewRequestService/ContentReviewRequestService.ts
+++ b/packages/backend/src/ee/services/ContentReviewRequestService/ContentReviewRequestService.ts
@@ -1145,7 +1145,7 @@ export class ContentReviewRequestService extends BaseService {
             excludeContentUuid: string | null;
         },
     ): Promise<ContentReviewSimilarContentItem[]> {
-        await this.getProjectContext(user, projectUuid);
+        const context = await this.getProjectContext(user, projectUuid);
         if (params.name.trim().length === 0) return [];
         const candidates =
             await this.contentReviewRequestModel.findSimilarByName({
@@ -1184,7 +1184,7 @@ export class ContentReviewRequestService extends BaseService {
                 },
             ),
         );
-        return visible
+        const results = visible
             .map((c) => {
                 const isVerified =
                     verifiedByType.get(c.contentType)?.has(c.uuid) ?? false;
@@ -1201,6 +1201,22 @@ export class ContentReviewRequestService extends BaseService {
             })
             .sort((a, b) => b.score - a.score)
             .slice(0, SIMILAR_RESULT_LIMIT);
+        if (results.length > 0) {
+            this.analytics.track({
+                event: 'content_review_request.similar_content_found',
+                userId: user.userUuid,
+                properties: {
+                    organizationId: context.organizationUuid,
+                    projectId: projectUuid,
+                    contentType: params.contentType,
+                    contentId: params.excludeContentUuid,
+                    matchCount: results.length,
+                    verifiedMatchCount: results.filter((r) => r.isVerified)
+                        .length,
+                },
+            });
+        }
+        return results;
     }
 
     private assertCanManageSettings(
@@ -1249,6 +1265,24 @@ export class ContentReviewRequestService extends BaseService {
                 throw new NotFoundError('Group not found');
             }
         }
-        return this.contentReviewSettingsModel.upsert(projectUuid, update);
+        const settings = await this.contentReviewSettingsModel.upsert(
+            projectUuid,
+            update,
+        );
+        this.analytics.track({
+            event: 'content_review_settings.updated',
+            userId: user.userUuid,
+            properties: {
+                organizationId: context.organizationUuid,
+                projectId: projectUuid,
+                routedTo:
+                    settings.reviewerGroupUuid === null
+                        ? 'space_editors'
+                        : 'group',
+                verifyOnApproveDefault: settings.verifyOnApproveDefault,
+                slackNotificationsEnabled: settings.slackChannelId !== null,
+            },
+        });
+        return settings;
     }
 }

--- a/packages/frontend/src/ee/features/contentReview/components/ContentReviewItemRow.tsx
+++ b/packages/frontend/src/ee/features/contentReview/components/ContentReviewItemRow.tsx
@@ -16,6 +16,7 @@ type Props = {
     name: string;
     meta?: string;
     href?: string;
+    onClick?: () => void;
     isVerified?: boolean;
     compact?: boolean;
 };
@@ -27,6 +28,7 @@ const ContentReviewItemRow: FC<Props> = ({
     name,
     meta,
     href,
+    onClick,
     isVerified = false,
     compact = false,
 }) => {
@@ -104,6 +106,7 @@ const ContentReviewItemRow: FC<Props> = ({
             c="inherit"
             underline="never"
             className={classes.link}
+            onClick={onClick}
         >
             {body}
         </Anchor>

--- a/packages/frontend/src/ee/features/contentReview/components/RequestReviewModal.tsx
+++ b/packages/frontend/src/ee/features/contentReview/components/RequestReviewModal.tsx
@@ -218,6 +218,8 @@ const RequestReviewModal: FC<Props> = ({
                         </Group>
                         <SimilarContentPanel
                             projectUuid={projectUuid}
+                            contentType={contentType}
+                            contentUuid={contentUuid}
                             items={similarContent}
                         />
                         <Textarea

--- a/packages/frontend/src/ee/features/contentReview/components/SimilarContentPanel.tsx
+++ b/packages/frontend/src/ee/features/contentReview/components/SimilarContentPanel.tsx
@@ -1,8 +1,13 @@
-import { type ContentReviewSimilarContentItem } from '@lightdash/common';
+import {
+    type ContentReviewContentType,
+    type ContentReviewSimilarContentItem,
+} from '@lightdash/common';
 import { Button, Group, Paper, Stack, Text } from '@mantine/core';
 import { IconAlertTriangle } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
 import MantineIcon from '../../../../components/common/MantineIcon';
+import useTracking from '../../../../providers/Tracking/useTracking';
+import { EventName } from '../../../../types/Events';
 import { getContentHref } from '../utils';
 import ContentReviewItemRow from './ContentReviewItemRow';
 import classes from './SimilarContentPanel.module.css';
@@ -11,11 +16,19 @@ const VISIBLE_ROWS = 3;
 
 type Props = {
     projectUuid: string;
+    contentType: ContentReviewContentType;
+    contentUuid: string;
     items: ContentReviewSimilarContentItem[];
 };
 
-const SimilarContentPanel: FC<Props> = ({ projectUuid, items }) => {
+const SimilarContentPanel: FC<Props> = ({
+    projectUuid,
+    contentType,
+    contentUuid,
+    items,
+}) => {
     const [showAll, setShowAll] = useState(false);
+    const { track } = useTracking();
     if (items.length === 0) return null;
     const hidden = Math.max(items.length - VISIBLE_ROWS, 0);
     const visible = showAll ? items : items.slice(0, VISIBLE_ROWS);
@@ -49,6 +62,18 @@ const SimilarContentPanel: FC<Props> = ({ projectUuid, items }) => {
                         )}
                         isVerified={item.isVerified}
                         compact
+                        onClick={() =>
+                            track({
+                                name: EventName.CONTENT_REVIEW_SIMILAR_CONTENT_CLICKED,
+                                properties: {
+                                    projectId: projectUuid,
+                                    contentType,
+                                    contentId: contentUuid,
+                                    similarContentId: item.contentUuid,
+                                    similarContentIsVerified: item.isVerified,
+                                },
+                            })
+                        }
                     />
                 ))}
                 {hidden > 0 && (

--- a/packages/frontend/src/providers/Tracking/types.ts
+++ b/packages/frontend/src/providers/Tracking/types.ts
@@ -1,6 +1,7 @@
 import {
     type AppVersionStatus,
     type AiDeepResearchTerminalStatus,
+    type ContentReviewContentType,
     type CustomFormatType,
     type DataAppTemplate,
     type HomepageRecommendedActionKey,
@@ -584,6 +585,17 @@ type AiAgentBattleStartedEvent = {
     };
 };
 
+type ContentReviewSimilarContentClickedEvent = {
+    name: EventName.CONTENT_REVIEW_SIMILAR_CONTENT_CLICKED;
+    properties: {
+        projectId: string;
+        contentType: ContentReviewContentType;
+        contentId: string;
+        similarContentId: string;
+        similarContentIsVerified: boolean;
+    };
+};
+
 type AiDeepResearchReportEngagedEvent = {
     name: EventName.AI_DEEP_RESEARCH_REPORT_ENGAGED;
     properties: {
@@ -1027,6 +1039,7 @@ export type EventData =
     | AiAgentChatMinimizedEvent
     | AiDeepResearchReportEngagedEvent
     | AiAgentBattleStartedEvent
+    | ContentReviewSimilarContentClickedEvent
     | AiAgentSuggestionImpressionEvent
     | AiAgentSuggestionClickEvent
     | DataAppRecentSuggestionClickEvent

--- a/packages/frontend/src/types/Events.ts
+++ b/packages/frontend/src/types/Events.ts
@@ -210,6 +210,9 @@ export enum EventName {
     AI_DEEP_RESEARCH_REPORT_ENGAGED = 'ai_deep_research.report_engaged',
     AI_AGENT_BATTLE_STARTED = 'ai_agent_battle.started',
 
+    // Content review
+    CONTENT_REVIEW_SIMILAR_CONTENT_CLICKED = 'content_review_similar_content.clicked',
+
     // Theme
     THEME_TOGGLED = 'theme.toggled',
 


### PR DESCRIPTION
## Why

The review request lifecycle (submitted, approved, rejected, cancelled) is tracked, but the two adoption signals around it were not: configuring who reviews, and whether the similar content nudge does its job.

Part 4 of 6 of the analytics stack.

## What

- `content_review_settings.updated` reports how reviews are routed (`space_editors` or `group`), the verify-on-approve default and whether Slack notifications are configured.
- `content_review_request.similar_content_found` fires when a lookup returns matches, with match and verified-match counts. The lookup runs once per modal open (the name is the content's own name, not typed input), so volume is bounded.
- Frontend `content_review_similar_content.clicked` fires when the requester opens one of the suggested items. `ContentReviewItemRow` gains an optional `onClick` and `SimilarContentPanel` takes the requesting content's type and id.

Together with the existing `similarContentShown` count on the submitted event this gives the full nudge funnel: found, clicked, submitted anyway.

## Regression analysis

- `updateSettings` now awaits the upsert into a local before returning it; the return value is unchanged.
- `findSimilarContent` builds the same result array and returns it; the event is emitted only when it is non-empty.
- The request review modal test and the service tests pass; a new service test covers the settings event.

## Testing

- `pnpm -F backend typecheck`, `pnpm -F frontend typecheck`
- `pnpm -F backend test src/ee/services/ContentReviewRequestService/ContentReviewRequestService.test.ts` (22 passed)
- `pnpm -F frontend test src/ee/features/contentReview/components/RequestReviewModal.test.tsx` (3 passed)

No Linear ticket or GitHub issue exists for this work (confirmed with the author). Labelled `📈 analytics-events`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WCdz5wsrbqwS2huRnfnUyE
