### PR TITLE
feat(analytics): track dashboard owner assignments

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -3686,6 +3686,18 @@ export type ExternalSourceIngestFailedEvent = BaseTrack & {
     };
 };
 
+export type DashboardOwnerAssignedEvent = BaseTrack & {
+    event: 'dashboard.owner_assigned';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        dashboardId: string;
+        ownerUserUuid: string | null;
+        previousOwnerUserUuid: string | null;
+    };
+};
+
 export type ImpersonationEvent = BaseTrack & {
     event: 'user.impersonation_started' | 'user.impersonation_stopped';
     properties: {
@@ -3965,6 +3977,7 @@ type TypedEvent =
     | ContentReviewNotificationSentEvent
     | SchedulerOwnershipReassignedEvent
     | DashboardOwnershipReassignedEvent
+    | DashboardOwnerAssignedEvent
     | ContentDraftSavedEvent
     | ContentDraftWrittenBackEvent
     | ContentDraftDismissedEvent

--- a/packages/backend/src/services/DashboardService/DashboardService.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.test.ts
@@ -870,6 +870,28 @@ describe('DashboardService', () => {
             }),
         );
     });
+    test('should report an owner assignment on top of the update', async () => {
+        (dashboardModel.update as import('vitest').Mock).mockResolvedValueOnce(
+            dashboard,
+        );
+
+        await service.update(user, dashboardUuid, {
+            ...updateDashboard,
+            ownerUserUuid: 'target-user-uuid',
+        });
+
+        expect(analyticsMock.track).toHaveBeenCalledTimes(2);
+        expect(analyticsMock.track).toHaveBeenCalledWith(
+            expect.objectContaining({
+                event: 'dashboard.owner_assigned',
+                properties: expect.objectContaining({
+                    dashboardId: dashboard.uuid,
+                    ownerUserUuid: 'target-user-uuid',
+                    previousOwnerUserUuid: null,
+                }),
+            }),
+        );
+    });
     test('should update dashboard details & version', async () => {
         const result = await service.update(
             user,

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -2154,6 +2154,25 @@ export class DashboardService
                 },
             );
 
+            const previousOwnerUserUuid =
+                existingDashboardDao.owner?.userUuid ?? null;
+            if (
+                dashboardFields.ownerUserUuid !== undefined &&
+                dashboardFields.ownerUserUuid !== previousOwnerUserUuid
+            ) {
+                this.analytics.track({
+                    event: 'dashboard.owner_assigned',
+                    userId: user.userUuid,
+                    properties: {
+                        organizationId: existingDashboardDao.organizationUuid,
+                        projectId: existingDashboardDao.projectUuid,
+                        dashboardId: existingDashboardDao.uuid,
+                        ownerUserUuid: dashboardFields.ownerUserUuid,
+                        previousOwnerUserUuid,
+                    },
+                });
+            }
+
             this.analytics.track({
                 event: 'dashboard.updated',
                 userId: user.userUuid,


### PR DESCRIPTION
## Why

Assigning or clearing a dashboard owner went through the generic `dashboard.updated` event with no owner property. Only the transfer on user deletion was visible, so owner adoption could not be measured.

Part 5 of 6 of the analytics stack.

## What

`dashboard.owner_assigned` fires from `DashboardService.update` whenever the request carries an `ownerUserUuid` that differs from the current owner, with `ownerUserUuid` (null when cleared) and `previousOwnerUserUuid`.

## Regression analysis

- The event is emitted next to the existing `dashboard.updated` event in the unversioned update branch, after the model write succeeds.
- Updates that do not touch the owner still emit exactly one event, which the existing test pins with `toHaveBeenCalledTimes(1)`. A new test covers the owner change and expects two.

## Testing

- `pnpm -F backend typecheck`
- `pnpm -F backend test src/services/DashboardService/DashboardService.test.ts` (58 passed)

No Linear ticket or GitHub issue exists for this work (confirmed with the author). Labelled `📈 analytics-events`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WCdz5wsrbqwS2huRnfnUyE
