### PR TITLE
feat(analytics): carry the verified filter on search events

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -1319,6 +1319,8 @@ type ProjectSearch = BaseTrack & {
         fieldsResultsCount: number;
         dashboardTabsResultsCount: number;
         source: 'omnibar' | 'ai_search_box';
+        verifiedOnly: boolean;
+        typeFilter: string | null;
     };
 };
 type DashboardUpdateMultiple = BaseTrack & {

--- a/packages/backend/src/services/SearchService/SearchService.ts
+++ b/packages/backend/src/services/SearchService/SearchService.ts
@@ -549,6 +549,8 @@ export class SearchService extends BaseService {
                 dashboardTabsResultsCount: filteredResults.dashboardTabs.length,
                 dataAppsResultsCount: filteredResults.dataApps.length,
                 source,
+                verifiedOnly: filters?.verifiedOnly === true,
+                typeFilter: filters?.type ?? null,
             },
         });
 

--- a/packages/frontend/src/features/omnibar/components/Omnibar.tsx
+++ b/packages/frontend/src/features/omnibar/components/Omnibar.tsx
@@ -176,6 +176,7 @@ const Omnibar: FC<Props> = ({ projectUuid }) => {
             name: EventName.GLOBAL_SEARCH_CLOSED,
             properties: {
                 action: 'default',
+                verifiedOnly: searchFilters?.verifiedOnly === true,
             },
         });
         setFocusedItemIndex(undefined);
@@ -190,6 +191,7 @@ const Omnibar: FC<Props> = ({ projectUuid }) => {
             properties: {
                 type: item.type,
                 id: getSearchResultId(item.item),
+                verifiedOnly: searchFilters?.verifiedOnly === true,
             },
         });
         // Settings pages always navigate in place, never a new tab.
@@ -208,6 +210,7 @@ const Omnibar: FC<Props> = ({ projectUuid }) => {
             name: EventName.GLOBAL_SEARCH_CLOSED,
             properties: {
                 action: 'result_click',
+                verifiedOnly: searchFilters?.verifiedOnly === true,
             },
         });
 

--- a/packages/frontend/src/providers/Tracking/types.ts
+++ b/packages/frontend/src/providers/Tracking/types.ts
@@ -220,6 +220,7 @@ export type SearchResultClickedEvent = {
     properties: {
         type: SearchItemType;
         id: string;
+        verifiedOnly: boolean;
     };
 };
 
@@ -234,6 +235,7 @@ export type GlobalSearchClosedEvent = {
     name: EventName.GLOBAL_SEARCH_CLOSED;
     properties: {
         action: 'result_click' | 'default';
+        verifiedOnly: boolean;
     };
 };
 


### PR DESCRIPTION
## Why

The omnibar Verified filter left no trace: the backend `project.search` event had no filter properties and the frontend open, close and result click events did not say whether the filter was on.

Part 6 of 6 of the analytics stack.

## What

- `project.search` carries `verifiedOnly` and `typeFilter`.
- `search_result.clicked` and `global_search.closed` carry `verifiedOnly`.

## Regression analysis

Additive properties only. The omnibar is the sole caller of the two frontend events, and the search service test passes unchanged.

## Testing

- `pnpm -F backend typecheck`, `pnpm -F frontend typecheck`
- `pnpm -F backend test src/services/SearchService/SearchService.test.ts` (4 passed)

No Linear ticket or GitHub issue exists for this work (confirmed with the author). Labelled `📈 analytics-events`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WCdz5wsrbqwS2huRnfnUyE
