### PR TITLE
fix(direct-access): refresh sharing controls and dialog focus

### DIFF
--- a/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoring.test.tsx
+++ b/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoring.test.tsx
@@ -570,7 +570,12 @@ describe('ExplorerChartTypeAuthoring', () => {
         document.body.appendChild(sidebarTitle);
         try {
             renderAuthoring();
-            expect(screen.getByRole('heading', { level: 2 })).toHaveFocus();
+            expect(
+                screen.getByRole('heading', {
+                    level: 2,
+                    name: 'Editing chart type · Grouped bars',
+                }),
+            ).toHaveFocus();
 
             await userEvent.click(
                 screen.getByRole('button', { name: 'Back to chart' }),

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/TitleBreadcrumbs.test.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/TitleBreadcrumbs.test.tsx
@@ -1,0 +1,81 @@
+import { type SpaceSummary } from '@lightdash/common';
+import { screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useSpaceSummaries } from '../../../hooks/useSpaces';
+import { renderWithProviders } from '../../../testing/testUtils';
+import { TitleBreadCrumbs } from './TitleBreadcrumbs';
+
+vi.mock('../../../hooks/useSpaces', () => ({ useSpaceSummaries: vi.fn() }));
+vi.mock('../../../hooks/useProjectRoute', () => ({
+    useOptionalProjectRoute: () => ({ projectUrlIdentifier: 'project-slug' }),
+}));
+
+const setSpaces = (spaces: SpaceSummary[], isError = false) => {
+    vi.mocked(useSpaceSummaries).mockReturnValue({
+        data: spaces,
+        isError,
+    } as ReturnType<typeof useSpaceSummaries>);
+};
+
+const renderBreadcrumb = (dashboard = false) =>
+    renderWithProviders(
+        <MemoryRouter>
+            <TitleBreadCrumbs
+                projectUuid="project-uuid"
+                spaceUuid="private-space"
+                spaceName="Private space"
+                {...(dashboard
+                    ? {
+                          dashboardUuid: 'dashboard-uuid',
+                          dashboardSlug: 'dashboard-slug',
+                          dashboardName: 'Dashboard',
+                      }
+                    : {})}
+            />
+        </MemoryRouter>,
+    );
+
+describe('TitleBreadCrumbs', () => {
+    beforeEach(() => {
+        setSpaces([]);
+    });
+
+    it('keeps an inaccessible parent name visible without a link', () => {
+        renderBreadcrumb();
+        expect(screen.getByText('Private space')).toBeInTheDocument();
+        expect(
+            screen.queryByRole('link', { name: 'Private space' }),
+        ).not.toBeInTheDocument();
+    });
+
+    it('links to an accessible parent using the project route identifier', () => {
+        setSpaces([{ uuid: 'private-space' } as SpaceSummary]);
+        renderBreadcrumb();
+        expect(
+            screen.getByRole('link', { name: 'Private space' }),
+        ).toHaveAttribute(
+            'href',
+            '/projects/project-slug/spaces/private-space',
+        );
+    });
+
+    it('does not trust cached spaces when the access query fails', () => {
+        setSpaces([{ uuid: 'private-space' } as SpaceSummary], true);
+        renderBreadcrumb();
+        expect(
+            screen.queryByRole('link', { name: 'Private space' }),
+        ).not.toBeInTheDocument();
+    });
+
+    it('preserves the owning dashboard link without linking the inaccessible space', () => {
+        renderBreadcrumb(true);
+        expect(screen.getByRole('link', { name: 'Dashboard' })).toHaveAttribute(
+            'href',
+            '/projects/project-slug/dashboards/dashboard-slug',
+        );
+        expect(
+            screen.queryByRole('link', { name: 'Private space' }),
+        ).not.toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/TitleBreadcrumbs.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/TitleBreadcrumbs.tsx
@@ -3,6 +3,7 @@ import { IconFolder } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { Link } from 'react-router';
 import { useOptionalProjectRoute } from '../../../hooks/useProjectRoute';
+import { useSpaceSummaries } from '../../../hooks/useSpaces';
 import MantineIcon from '../../common/MantineIcon';
 
 type Props = {
@@ -31,6 +32,10 @@ export const TitleBreadCrumbs: FC<Props> = ({
     dashboardName,
 }) => {
     const projectRoute = useOptionalProjectRoute();
+    const spacesQuery = useSpaceSummaries(projectUuid, true);
+    const canAccessSpace =
+        !spacesQuery.isError &&
+        spacesQuery.data?.some((space) => space.uuid === spaceUuid);
     const projectUrlIdentifier =
         projectRoute?.projectUrlIdentifier ?? projectUuid;
     const isChartWithinDashboard = !!(dashboardUuid && dashboardName);
@@ -61,23 +66,29 @@ export const TitleBreadCrumbs: FC<Props> = ({
                                         icon={IconFolder}
                                     />
                                 </ActionIcon>
-                            ) : (
+                            ) : canAccessSpace ? (
                                 <Anchor
                                     fw={500}
                                     fz="md"
                                     c="dimmed"
                                     component={Link}
                                     to={`/projects/${projectUrlIdentifier}/spaces/${spaceUuid}`}
-                                    style={{
-                                        maxWidth: `${MAX_WIDTH_TITLE_PX}px`,
-                                        whiteSpace: 'nowrap',
-                                        overflow: 'hidden',
-                                        textOverflow: 'ellipsis',
-                                        display: 'inline-block',
-                                    }}
+                                    truncate
+                                    maw={MAX_WIDTH_TITLE_PX}
+                                    display="inline-block"
                                 >
                                     {spaceName}
                                 </Anchor>
+                            ) : (
+                                <Text
+                                    fw={500}
+                                    fz="md"
+                                    c="dimmed"
+                                    truncate
+                                    maw={MAX_WIDTH_TITLE_PX}
+                                >
+                                    {spaceName}
+                                </Text>
                             )}
                         </Tooltip>
                     </Group>

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -846,6 +846,7 @@ const SavedChartsHeader: FC = () => {
                     {showChartActions && (
                         <Menu
                             position="bottom"
+                            returnFocus={!isDirectAccessModalOpen}
                             withArrow
                             width={200}
                             disabled={!unsavedChartVersion.tableName}

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -764,6 +764,7 @@ const DashboardHeader = memo(
                         {!isFullscreen && (
                             <Menu
                                 data-testid="dashboard-header-menu"
+                                returnFocus={!isDirectAccessModalOpen}
                                 position="bottom"
                                 withArrow
                                 disabled={

--- a/packages/frontend/src/components/common/MantineModal/index.test.tsx
+++ b/packages/frontend/src/components/common/MantineModal/index.test.tsx
@@ -1,0 +1,90 @@
+import { MantineProvider } from '@mantine/core';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import MantineModal, { type MantineModalProps } from './index';
+
+const renderModal = (props: Partial<MantineModalProps> = {}) => {
+    const onClose = vi.fn();
+    render(
+        <MantineProvider env="test">
+            <MantineModal
+                opened
+                title="Share dashboard"
+                onClose={onClose}
+                {...props}
+            />
+        </MantineProvider>,
+    );
+    return { onClose };
+};
+
+describe('MantineModal accessibility', () => {
+    it('names the dialog from its title and labels the close button', async () => {
+        const user = userEvent.setup();
+        const { onClose } = renderModal();
+        const dialog = screen.getByRole('dialog', { name: 'Share dashboard' });
+        await user.click(within(dialog).getByRole('button', { name: 'Close' }));
+        expect(onClose).toHaveBeenCalledOnce();
+    });
+
+    it('allows Escape to dismiss an ordinary dialog', async () => {
+        const user = userEvent.setup();
+        const { onClose } = renderModal();
+        await user.keyboard('{Escape}');
+        expect(onClose).toHaveBeenCalledOnce();
+    });
+
+    it('keeps a destructive confirmation open on Escape', async () => {
+        const user = userEvent.setup();
+        const onConfirm = vi.fn();
+        const { onClose } = renderModal({
+            variant: 'delete',
+            title: 'Remove access',
+            onConfirm,
+        });
+        const dialog = screen.getByRole('dialog', {
+            name: 'Remove access',
+        });
+        await user.keyboard('{Escape}');
+        expect(onClose).not.toHaveBeenCalled();
+        expect(onConfirm).not.toHaveBeenCalled();
+        await user.click(
+            within(dialog).getByRole('button', { name: 'Delete' }),
+        );
+        expect(onConfirm).toHaveBeenCalledOnce();
+    });
+
+    it('names the unsaved changes confirmation and preserves edits on cancellation', async () => {
+        const user = userEvent.setup();
+        const { onClose } = renderModal({ confirmBeforeClose: true });
+        await user.keyboard('{Escape}');
+        const confirmation = await screen.findByRole('dialog', {
+            name: 'Unsaved changes',
+        });
+        expect(
+            within(confirmation).getByRole('button', { name: 'Close' }),
+        ).toBeVisible();
+        await user.click(
+            within(confirmation).getByRole('button', { name: 'Keep editing' }),
+        );
+        expect(onClose).not.toHaveBeenCalled();
+        expect(
+            screen.getByRole('dialog', { name: 'Share dashboard' }),
+        ).toBeVisible();
+    });
+
+    it('discards edits only after explicit confirmation', async () => {
+        const user = userEvent.setup();
+        const { onClose } = renderModal({ confirmBeforeClose: true });
+        await user.keyboard('{Escape}');
+        const confirmation = await screen.findByRole('dialog', {
+            name: 'Unsaved changes',
+        });
+        await user.click(
+            within(confirmation).getByRole('button', {
+                name: 'Discard changes',
+            }),
+        );
+        expect(onClose).toHaveBeenCalledOnce();
+    });
+});

--- a/packages/frontend/src/components/common/MantineModal/index.tsx
+++ b/packages/frontend/src/components/common/MantineModal/index.tsx
@@ -363,9 +363,14 @@ const MantineModal: React.FC<MantineModalProps> = ({
                                 </Paper>
                             ) : null}
                             <Stack gap={2} miw={0}>
-                                <Text c="ldDark.9" fw={600} fz="md" lh="28px">
+                                <Modal.Title
+                                    c="ldDark.9"
+                                    fw={600}
+                                    fz="md"
+                                    lh="28px"
+                                >
                                     {title}
-                                </Text>
+                                </Modal.Title>
                                 {subtitle ? (
                                     <Text c="dimmed" fz="sm" lh="20px">
                                         {subtitle}
@@ -378,7 +383,9 @@ const MantineModal: React.FC<MantineModalProps> = ({
                                 {headerActions}
                             </Group>
                         ) : null}
-                        {withCloseButton && <Modal.CloseButton />}
+                        {withCloseButton && (
+                            <Modal.CloseButton aria-label="Close" />
+                        )}
                     </Modal.Header>
 
                     {renderBody()}
@@ -438,10 +445,15 @@ const MantineModal: React.FC<MantineModalProps> = ({
                             px="xl"
                             py="md"
                         >
-                            <Text c="ldDark.9" fw={600} fz="md" lh="28px">
+                            <Modal.Title
+                                c="ldDark.9"
+                                fw={600}
+                                fz="md"
+                                lh="28px"
+                            >
                                 Unsaved changes
-                            </Text>
-                            <Modal.CloseButton />
+                            </Modal.Title>
+                            <Modal.CloseButton aria-label="Close" />
                         </Modal.Header>
                         <Modal.Body p={0}>
                             <Stack gap="md" px="xl" py="md">

--- a/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
@@ -389,6 +389,7 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
             <Menu
                 disabled={disabled}
                 opened={isOpen}
+                returnFocus={!isManageAccessOpen}
                 position="bottom-start"
                 withArrow
                 arrowPosition="center"

--- a/packages/frontend/src/features/apps/components/AppHeaderActions.tsx
+++ b/packages/frontend/src/features/apps/components/AppHeaderActions.tsx
@@ -316,6 +316,7 @@ const AppHeaderActions: FC<Props> = ({
             )}
             <Menu
                 position="bottom-end"
+                returnFocus={!isDirectAccessModalOpen}
                 withArrow
                 arrowPosition="center"
                 onOpen={() => setMenuOpened(true)}

--- a/packages/frontend/src/features/directAccess/components/DirectAccessModal.module.css
+++ b/packages/frontend/src/features/directAccess/components/DirectAccessModal.module.css
@@ -1,0 +1,4 @@
+.content {
+    /* Prevent long names from expanding the ScrollArea's intrinsic minimum width. */
+    contain: inline-size;
+}

--- a/packages/frontend/src/features/directAccess/components/DirectAccessModal.test.tsx
+++ b/packages/frontend/src/features/directAccess/components/DirectAccessModal.test.tsx
@@ -107,22 +107,27 @@ const mockAssignmentsQuery = (
     } as unknown as ReturnType<typeof useDirectAccessAssignments>);
 };
 
+const modalElement = (
+    resourceType: DirectAccessResourceType = DirectAccessResourceType.DASHBOARD,
+) => (
+    <DirectAccessModal
+        opened
+        onClose={vi.fn()}
+        projectUuid={PROJECT_UUID}
+        resource={{
+            resourceType,
+            resourceUuid: 'resource-uuid',
+            name: 'Revenue dashboard',
+        }}
+    />
+);
+
 const renderModal = (
     resourceType: DirectAccessResourceType = DirectAccessResourceType.DASHBOARD,
 ) =>
-    renderWithProviders(
-        <DirectAccessModal
-            opened
-            onClose={vi.fn()}
-            projectUuid={PROJECT_UUID}
-            resource={{
-                resourceType,
-                resourceUuid: 'resource-uuid',
-                name: 'Revenue dashboard',
-            }}
-        />,
-        { user: { userUuid: SESSION_USER_UUID } },
-    );
+    renderWithProviders(modalElement(resourceType), {
+        user: { userUuid: SESSION_USER_UUID },
+    });
 
 describe('DirectAccessModal', () => {
     beforeEach(() => {
@@ -217,7 +222,7 @@ describe('DirectAccessModal', () => {
             ],
         });
         const user = userEvent.setup();
-        renderModal();
+        const { rerender } = renderModal();
 
         // wait for the session user to resolve so self-detection is active
         await screen.findByText('(you)');
@@ -234,6 +239,68 @@ describe('DirectAccessModal', () => {
             principalType: DirectAccessPrincipalType.USER,
             principalUuid: SESSION_USER_UUID,
         });
+
+        mockAssignmentsQuery({
+            isError: true,
+            error: {
+                status: 'error',
+                error: {
+                    name: 'ForbiddenError',
+                    statusCode: 403,
+                    message: 'Policy access removed',
+                    data: {},
+                },
+            },
+        });
+        rerender(modalElement());
+        expect(
+            screen.queryByRole('button', { name: 'Share' }),
+        ).not.toBeInTheDocument();
+        expect(
+            screen.queryByRole('button', { name: 'Remove all access' }),
+        ).not.toBeInTheDocument();
+        await user.click(screen.getByRole('button', { name: 'Retry' }));
+        mockAssignmentsQuery({ data: [] });
+        rerender(modalElement());
+        expect(
+            screen.getByRole('button', { name: 'Share' }),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByText('Could not load access'),
+        ).not.toBeInTheDocument();
+    });
+
+    it('removes pending reset confirmation actions when policy access is lost', async () => {
+        const user = userEvent.setup();
+        const { rerender } = renderModal();
+        await user.click(
+            screen.getByRole('button', { name: 'Remove all access' }),
+        );
+        expect(
+            screen.getByRole('button', { name: 'Remove' }),
+        ).toBeInTheDocument();
+        mockAssignmentsQuery({
+            isError: true,
+            error: {
+                status: 'error',
+                error: {
+                    name: 'ForbiddenError',
+                    statusCode: 403,
+                    message: 'Policy access removed',
+                    data: {},
+                },
+            },
+        });
+        rerender(modalElement());
+        await waitFor(() =>
+            expect(
+                screen.queryByRole('button', { name: 'Remove' }),
+            ).not.toBeInTheDocument(),
+        );
+        expect(
+            screen.getByRole('button', { name: 'Done' }),
+        ).toBeInTheDocument();
+        expect(resetMutate).not.toHaveBeenCalled();
     });
 
     it('asks for confirmation before removing all access', async () => {
@@ -312,7 +379,84 @@ describe('DirectAccessModal', () => {
         renderModal();
 
         expect(screen.queryByText('Vera Viewer')).not.toBeInTheDocument();
+        expect(
+            screen.queryByRole('button', { name: 'Share' }),
+        ).not.toBeInTheDocument();
     });
+
+    it('keeps focus in the dialog when a focused role disappears and Retry restores the policy', async () => {
+        const user = userEvent.setup();
+        const { rerender } = renderModal();
+        const roleInput = screen.getByRole('textbox', {
+            name: 'Role for Vera Viewer',
+        });
+        roleInput.focus();
+        expect(roleInput).toHaveFocus();
+
+        mockAssignmentsQuery({
+            isError: true,
+            error: {
+                status: 'error',
+                error: {
+                    name: 'ForbiddenError',
+                    statusCode: 403,
+                    message: 'Policy access removed',
+                    data: {},
+                },
+            },
+        });
+        rerender(modalElement());
+        const retry = screen.getByRole('button', { name: 'Retry' });
+        expect(retry).toHaveFocus();
+        expect(screen.getByRole('dialog')).toContainElement(
+            document.activeElement as HTMLElement,
+        );
+
+        await user.click(retry);
+        mockAssignmentsQuery();
+        rerender(modalElement());
+        const recipientInput = screen.getByRole('textbox', {
+            name: 'Select a user or group to share with',
+        });
+        expect(recipientInput).toHaveFocus();
+        expect(screen.getByRole('dialog')).toContainElement(
+            document.activeElement as HTMLElement,
+        );
+    });
+
+    it.each([403, 404, 500])(
+        'removes mutation controls when refreshing cached policy returns %s',
+        (statusCode) => {
+            mockAssignmentsQuery({
+                isError: true,
+                error: {
+                    status: 'error',
+                    error: {
+                        name: 'ForbiddenError',
+                        statusCode,
+                        message: 'Unable to read policy',
+                        data: {},
+                    },
+                },
+            });
+            renderModal();
+            expect(
+                screen.getByText('Could not load access'),
+            ).toBeInTheDocument();
+            expect(
+                screen.queryByRole('button', { name: 'Share' }),
+            ).not.toBeInTheDocument();
+            expect(
+                screen.queryByRole('button', { name: 'Remove all access' }),
+            ).not.toBeInTheDocument();
+            expect(
+                screen.queryByRole('textbox', { name: 'Role for Vera Viewer' }),
+            ).not.toBeInTheDocument();
+            expect(
+                screen.getByRole('button', { name: 'Retry' }),
+            ).toBeInTheDocument();
+        },
+    );
 
     it('shows the error state and retries', async () => {
         mockAssignmentsQuery({

--- a/packages/frontend/src/features/directAccess/components/DirectAccessModal.tsx
+++ b/packages/frontend/src/features/directAccess/components/DirectAccessModal.tsx
@@ -38,6 +38,7 @@ import {
     useRevokeDirectAccessAssignment,
     useUpsertDirectAccessAssignment,
 } from '../hooks/useDirectAccess';
+import classes from './DirectAccessModal.module.css';
 
 const ROLE_OPTIONS = [
     { value: SpaceMemberRole.VIEWER, label: 'Can view' },
@@ -89,7 +90,7 @@ const AssignmentRow: FC<AssignmentRowProps> = ({
 
     return (
         <Group gap="sm" justify="space-between" wrap="nowrap">
-            <Group gap="sm" wrap="nowrap" miw={0}>
+            <Group gap="sm" wrap="nowrap" miw={0} flex={1}>
                 {isUser ? (
                     <LightdashUserAvatar
                         size="sm"
@@ -109,7 +110,7 @@ const AssignmentRow: FC<AssignmentRowProps> = ({
                         <MantineIcon icon={IconUsers} />
                     </LightdashUserAvatar>
                 )}
-                <Stack gap={0} miw={0}>
+                <Stack gap={0} miw={0} flex={1}>
                     <Text fw={600} fz="sm" truncate>
                         {isUser ? userDisplayName(principal) : principal.name}
                         {isSelf ? (
@@ -131,7 +132,7 @@ const AssignmentRow: FC<AssignmentRowProps> = ({
                 </Stack>
             </Group>
 
-            <Group gap="xs" wrap="nowrap">
+            <Group gap="xs" wrap="nowrap" className="ld-shrink-0">
                 <Select
                     size="xs"
                     w={120}
@@ -240,8 +241,10 @@ const AddDirectAccess: FC<AddDirectAccessProps> = ({
         <Group gap="xs" wrap="nowrap" align="flex-end">
             <Select
                 flex={1}
+                miw={0}
                 size="xs"
                 label="Share with"
+                autoFocus
                 placeholder="Select users or groups to share with"
                 searchable
                 clearable
@@ -255,6 +258,7 @@ const AddDirectAccess: FC<AddDirectAccessProps> = ({
             <Select
                 size="xs"
                 w={120}
+                className="ld-shrink-0"
                 aria-label="Role for new assignment"
                 data={ROLE_OPTIONS}
                 value={selectedRole}
@@ -265,6 +269,7 @@ const AddDirectAccess: FC<AddDirectAccessProps> = ({
             />
             <Button
                 size="xs"
+                className="ld-shrink-0"
                 disabled={!selectedPrincipal || isMutating}
                 onClick={handleAdd}
             >
@@ -308,6 +313,10 @@ const DirectAccessModal: FC<DirectAccessModalProps> = ({
     const assignmentsQuery = useDirectAccessAssignments(projectUuid, ref, {
         enabled: opened && availability.isAvailable,
     });
+    const canManageAssignments =
+        availability.isAvailable &&
+        !assignmentsQuery.isInitialLoading &&
+        !assignmentsQuery.isError;
     const upsertMutation = useUpsertDirectAccessAssignment(projectUuid, ref);
     const revokeMutation = useRevokeDirectAccessAssignment(projectUuid, ref);
     const resetMutation = useResetDirectAccess(projectUuid, ref);
@@ -361,13 +370,15 @@ const DirectAccessModal: FC<DirectAccessModalProps> = ({
     return (
         <>
             <MantineModal
-                opened={opened && confirmation === null}
+                opened={
+                    opened && (confirmation === null || !canManageAssignments)
+                }
                 onClose={onClose}
                 title={`Share "${resource.name}"`}
                 icon={IconUsers}
                 size="lg"
                 leftActions={
-                    assignments.length > 0 ? (
+                    canManageAssignments && assignments.length > 0 ? (
                         <Button
                             variant="subtle"
                             color="red"
@@ -385,7 +396,7 @@ const DirectAccessModal: FC<DirectAccessModalProps> = ({
                     </Button>
                 }
             >
-                <Stack gap="md">
+                <Stack gap="md" className={classes.content}>
                     {isUnavailable ? (
                         <Callout variant="info" title="Sharing isn't available">
                             <Text fz="sm">
@@ -394,18 +405,20 @@ const DirectAccessModal: FC<DirectAccessModalProps> = ({
                             </Text>
                         </Callout>
                     ) : null}
-                    <AddDirectAccess
-                        projectUuid={projectUuid}
-                        assignedKeys={assignedKeys}
-                        isMutating={isMutating}
-                        onAdd={(principalType, uuid, role) =>
-                            upsertMutation.mutate({
-                                principalType,
-                                principalUuid: uuid,
-                                role,
-                            })
-                        }
-                    />
+                    {canManageAssignments && (
+                        <AddDirectAccess
+                            projectUuid={projectUuid}
+                            assignedKeys={assignedKeys}
+                            isMutating={isMutating}
+                            onAdd={(principalType, uuid, role) =>
+                                upsertMutation.mutate({
+                                    principalType,
+                                    principalUuid: uuid,
+                                    role,
+                                })
+                            }
+                        />
+                    )}
 
                     {assignmentsQuery.isInitialLoading ? (
                         <Center py="lg">
@@ -421,15 +434,18 @@ const DirectAccessModal: FC<DirectAccessModalProps> = ({
                                 <Button
                                     size="xs"
                                     variant="default"
-                                    onClick={() =>
-                                        void assignmentsQuery.refetch()
-                                    }
+                                    autoFocus
+                                    onClick={() => {
+                                        setConfirmation(null);
+                                        void assignmentsQuery.refetch();
+                                    }}
                                 >
                                     Retry
                                 </Button>
                             </Stack>
                         </Callout>
-                    ) : assignments.length === 0 ? (
+                    ) : !canManageAssignments ? null : assignments.length ===
+                      0 ? (
                         <Text fz="sm" c="dimmed" ta="center" py="md">
                             {resource.resourceType ===
                             DirectAccessResourceType.APP
@@ -468,7 +484,7 @@ const DirectAccessModal: FC<DirectAccessModalProps> = ({
             </MantineModal>
 
             <MantineModal
-                opened={confirmation !== null}
+                opened={opened && confirmation !== null && canManageAssignments}
                 onClose={() => setConfirmation(null)}
                 variant="delete"
                 size="sm"

--- a/packages/frontend/src/features/directAccess/hooks/useCanManageDirectAccess.test.tsx
+++ b/packages/frontend/src/features/directAccess/hooks/useCanManageDirectAccess.test.tsx
@@ -1,0 +1,64 @@
+import {
+    defineUserAbility,
+    OrganizationMemberRole,
+    SpaceMemberRole,
+} from '@lightdash/common';
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useCanManageDirectAccess } from './useCanManageDirectAccess';
+
+vi.mock('../../../hooks/useSpaces', () => ({
+    useSpaceSummaries: () => ({ data: [] }),
+}));
+vi.mock('../../../providers/App/useApp', () => ({
+    default: () => ({
+        user: { data: { userUuid: 'user', organizationUuid: 'org' } },
+    }),
+}));
+vi.mock('../../../providers/Ability/useAbilityContext', () => ({
+    useAbilityContext: () =>
+        defineUserAbility(
+            {
+                role: OrganizationMemberRole.INTERACTIVE_VIEWER,
+                organizationUuid: 'org',
+                userUuid: 'user',
+                roleUuid: undefined,
+            },
+            [],
+        ),
+}));
+
+describe('personal app sharing controls', () => {
+    it.each([
+        { role: SpaceMemberRole.VIEWER, expected: false },
+        { role: SpaceMemberRole.EDITOR, expected: false },
+        { role: SpaceMemberRole.ADMIN, expected: true },
+    ])(
+        'exposes policy management for direct $role: $expected',
+        ({ role, expected }) => {
+            const { result } = renderHook(() =>
+                useCanManageDirectAccess({
+                    projectUuid: 'project',
+                    spaceUuid: null,
+                    createdByUserUuid: 'creator',
+                    access: [],
+                    grantRoles: [role],
+                }),
+            );
+            expect(result.current).toBe(expected);
+        },
+    );
+
+    it('preserves creator authority without a direct grant', () => {
+        const { result } = renderHook(() =>
+            useCanManageDirectAccess({
+                projectUuid: 'project',
+                spaceUuid: null,
+                createdByUserUuid: 'user',
+                access: [],
+                grantRoles: [],
+            }),
+        );
+        expect(result.current).toBe(true);
+    });
+});

--- a/packages/frontend/src/features/directAccess/hooks/useCanManageDirectAccess.ts
+++ b/packages/frontend/src/features/directAccess/hooks/useCanManageDirectAccess.ts
@@ -1,5 +1,5 @@
 import { subject } from '@casl/ability';
-import { type SpaceMemberRole } from '@lightdash/common';
+import { SpaceMemberRole } from '@lightdash/common';
 import { useSpaceSummaries } from '../../../hooks/useSpaces';
 import { useAbilityContext } from '../../../providers/Ability/useAbilityContext';
 import useApp from '../../../providers/App/useApp';
@@ -65,7 +65,9 @@ export const useCanManageDirectAccess = ({
               subject('DataApp', {
                   organizationUuid,
                   projectUuid,
-                  access: resolvedAccess,
+                  access: resolvedAccess.filter(
+                      ({ role }) => role === SpaceMemberRole.ADMIN,
+                  ),
                   // A null creator can never match the self rule.
                   createdByUserUuid: createdByUserUuid ?? '',
               }),

--- a/packages/frontend/src/features/directAccess/hooks/useDirectAccess.test.tsx
+++ b/packages/frontend/src/features/directAccess/hooks/useDirectAccess.test.tsx
@@ -1,0 +1,273 @@
+import {
+    DirectAccessPrincipalType,
+    DirectAccessResourceType,
+    SpaceMemberRole,
+    type SqlChart,
+} from '@lightdash/common';
+import {
+    QueryClient,
+    QueryClientProvider,
+    useQuery,
+} from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { type PropsWithChildren } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { useSavedSqlChartResults } from '../../sqlRunner/hooks/useSavedSqlChartResults';
+import { fetchSavedSqlChart } from '../../sqlRunner/hooks/useSavedSqlCharts';
+import {
+    useRevokeDirectAccessAssignment,
+    useUpsertDirectAccessAssignment,
+} from './useDirectAccess';
+
+vi.mock('../api', () => ({
+    upsertDirectAccessAssignment: vi.fn().mockResolvedValue(undefined),
+    revokeDirectAccessAssignment: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../../sqlRunner/hooks/useSavedSqlCharts', () => ({
+    fetchSavedSqlChart: vi.fn(),
+}));
+vi.mock('../../../hooks/useQueryRetry', () => ({
+    useQueryRetryConfig: () => ({ retry: false }),
+}));
+vi.mock('../../../hooks/appearance/useProjectColorPalette', () => ({
+    useProjectColorPalette: () => ({ data: undefined }),
+}));
+vi.mock('../../queryRunner/sqlRunnerPivotQueries', () => ({
+    getSqlChartPivotChartData: () => new Promise(() => {}),
+}));
+vi.mock('../../../hooks/toaster/useToaster', () => ({
+    default: () => ({ showToastSuccess: vi.fn(), showToastApiError: vi.fn() }),
+}));
+
+describe('direct access resource permission refresh', () => {
+    it.each(['downgrade', 'revoke'] as const)(
+        'refreshes the actual SQL viewer after self-%s',
+        async (operation) => {
+            const chart = {
+                savedSqlUuid: 'resource-uuid',
+                space: {
+                    userAccess: {
+                        userUuid: 'current-user',
+                        role: SpaceMemberRole.ADMIN,
+                        hasDirectAccess: true,
+                        projectRole: undefined,
+                        inheritedRole: undefined,
+                        inheritedFrom: undefined,
+                    },
+                },
+            } as SqlChart;
+            vi.mocked(fetchSavedSqlChart).mockResolvedValue(chart);
+            const client = new QueryClient({
+                defaultOptions: {
+                    queries: { retry: false, staleTime: Infinity },
+                },
+            });
+            const wrapper = ({ children }: PropsWithChildren) => (
+                <QueryClientProvider client={client}>
+                    {children}
+                </QueryClientProvider>
+            );
+            const { result, unmount } = renderHook(
+                () => {
+                    const viewer = useSavedSqlChartResults({
+                        projectUuid: 'project',
+                        slug: 'sql-slug',
+                    });
+                    const target = {
+                        resourceType: DirectAccessResourceType.SQL_CHART,
+                        resourceUuid: 'resource-uuid',
+                    };
+                    const upsert = useUpsertDirectAccessAssignment(
+                        'project',
+                        target,
+                    );
+                    const revoke = useRevokeDirectAccessAssignment(
+                        'project',
+                        target,
+                    );
+                    return { viewer, upsert, revoke };
+                },
+                { wrapper },
+            );
+            await waitFor(() =>
+                expect(
+                    result.current.viewer.chartQuery.data?.space.userAccess
+                        ?.role,
+                ).toBe(SpaceMemberRole.ADMIN),
+            );
+            if (operation === 'downgrade') {
+                vi.mocked(fetchSavedSqlChart).mockResolvedValue({
+                    ...chart,
+                    space: {
+                        ...chart.space,
+                        userAccess: {
+                            userUuid: 'current-user',
+                            role: SpaceMemberRole.VIEWER,
+                            hasDirectAccess: true,
+                            projectRole: undefined,
+                            inheritedRole: undefined,
+                            inheritedFrom: undefined,
+                        },
+                    },
+                });
+            } else {
+                vi.mocked(fetchSavedSqlChart).mockRejectedValue({
+                    status: 'error',
+                    error: { statusCode: 403, message: 'Access removed' },
+                });
+            }
+            await act(async () => {
+                const principal = {
+                    principalType: DirectAccessPrincipalType.USER,
+                    principalUuid: 'current-user',
+                };
+                if (operation === 'downgrade') {
+                    await result.current.upsert.mutateAsync({
+                        ...principal,
+                        role: SpaceMemberRole.VIEWER,
+                    });
+                } else {
+                    await result.current.revoke.mutateAsync(principal);
+                }
+            });
+            await waitFor(() => {
+                if (operation === 'downgrade') {
+                    expect(
+                        result.current.viewer.chartQuery.data?.space.userAccess
+                            ?.role,
+                    ).toBe(SpaceMemberRole.VIEWER);
+                } else {
+                    expect(
+                        result.current.viewer.chartQuery.error?.error
+                            ?.statusCode,
+                    ).toBe(403);
+                }
+            });
+            unmount();
+            client.clear();
+        },
+    );
+    it.each([
+        {
+            resourceType: DirectAccessResourceType.CHART,
+            key: ['saved_query', 'chart-slug', 'project', false],
+            otherKey: ['saved_query', 'chart-slug', 'other-project', false],
+        },
+        {
+            resourceType: DirectAccessResourceType.DASHBOARD,
+            key: ['saved_dashboard_query', 'dashboard-slug', 'project', false],
+            otherKey: [
+                'saved_dashboard_query',
+                'dashboard-slug',
+                'other-project',
+                false,
+            ],
+        },
+        {
+            resourceType: DirectAccessResourceType.SQL_CHART,
+            key: [
+                'sqlRunner',
+                'savedSqlChart',
+                'project',
+                'sql-slug',
+                undefined,
+            ],
+            otherKey: [
+                'sqlRunner',
+                'savedSqlChart',
+                'other-project',
+                'sql-slug',
+                undefined,
+            ],
+        },
+        {
+            resourceType: DirectAccessResourceType.APP,
+            key: ['app', 'project', 'app-slug'],
+            otherKey: ['app', 'other-project', 'app-slug'],
+        },
+        {
+            resourceType: DirectAccessResourceType.SQL_CHART,
+            key: [
+                'savedSqlChart',
+                'sql-slug',
+                'registered',
+                undefined,
+                'project',
+            ],
+            otherKey: [
+                'savedSqlChart',
+                'sql-slug',
+                'registered',
+                undefined,
+                'other-project',
+            ],
+        },
+        {
+            resourceType: DirectAccessResourceType.SQL_CHART,
+            key: [
+                'savedSqlChart',
+                'sql-slug',
+                'registered',
+                undefined,
+                'project',
+            ],
+            otherKey: ['savedSqlChart', 'sql-slug', 'embed', 'tile', 'project'],
+        },
+    ])(
+        'refreshes $resourceType permissions for slug routes without refetching other projects',
+        async ({ resourceType, key, otherKey }) => {
+            const client = new QueryClient({
+                defaultOptions: {
+                    queries: { retry: false, staleTime: Infinity },
+                },
+            });
+            const fetchResource = vi
+                .fn()
+                .mockResolvedValue({ role: SpaceMemberRole.VIEWER });
+            const fetchOther = vi
+                .fn()
+                .mockResolvedValue({ role: SpaceMemberRole.ADMIN });
+            const wrapper = ({ children }: PropsWithChildren) => (
+                <QueryClientProvider client={client}>
+                    {children}
+                </QueryClientProvider>
+            );
+            const { result, unmount } = renderHook(
+                () => {
+                    const resource = useQuery({
+                        queryKey: key,
+                        queryFn: fetchResource,
+                        initialData: { role: SpaceMemberRole.ADMIN },
+                    });
+                    useQuery({
+                        queryKey: otherKey,
+                        queryFn: fetchOther,
+                        initialData: { role: SpaceMemberRole.ADMIN },
+                    });
+                    const mutation = useUpsertDirectAccessAssignment(
+                        'project',
+                        { resourceType, resourceUuid: 'resource-uuid' },
+                    );
+                    return { resource, mutation };
+                },
+                { wrapper },
+            );
+
+            await act(async () => {
+                await result.current.mutation.mutateAsync({
+                    principalType: DirectAccessPrincipalType.USER,
+                    principalUuid: 'current-user',
+                    role: SpaceMemberRole.VIEWER,
+                });
+            });
+            await waitFor(() =>
+                expect(result.current.resource.data.role).toBe(
+                    SpaceMemberRole.VIEWER,
+                ),
+            );
+            expect(fetchOther).not.toHaveBeenCalled();
+            unmount();
+            client.clear();
+        },
+    );
+});

--- a/packages/frontend/src/features/directAccess/hooks/useDirectAccess.ts
+++ b/packages/frontend/src/features/directAccess/hooks/useDirectAccess.ts
@@ -1,5 +1,6 @@
 import {
     CommercialFeatureFlags,
+    DirectAccessResourceType,
     type ApiError,
     type DirectAccessAssignment,
     type DirectAccessPrincipalType,
@@ -67,6 +68,36 @@ const useInvalidateAfterDirectAccessMutation = (
                 directAccessQueryKey(projectUuid, ref),
             ),
             queryClient.invalidateQueries(['favorites']),
+            queryClient.invalidateQueries({
+                predicate: ({ queryKey }) => {
+                    switch (ref.resourceType) {
+                        case DirectAccessResourceType.CHART:
+                            return (
+                                queryKey[0] === 'saved_query' &&
+                                queryKey[2] === projectUuid
+                            );
+                        case DirectAccessResourceType.DASHBOARD:
+                            return (
+                                queryKey[0] === 'saved_dashboard_query' &&
+                                queryKey[2] === projectUuid
+                            );
+                        case DirectAccessResourceType.SQL_CHART:
+                            return (
+                                (queryKey[0] === 'sqlRunner' &&
+                                    queryKey[1] === 'savedSqlChart' &&
+                                    queryKey[2] === projectUuid) ||
+                                (queryKey[0] === 'savedSqlChart' &&
+                                    queryKey[2] === 'registered' &&
+                                    queryKey[4] === projectUuid)
+                            );
+                        case DirectAccessResourceType.APP:
+                            return (
+                                queryKey[0] === 'app' &&
+                                queryKey[1] === projectUuid
+                            );
+                    }
+                },
+            }),
             invalidateContent(queryClient, projectUuid),
         ]);
     };

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderView.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderView.tsx
@@ -255,7 +255,12 @@ export const HeaderView: FC = () => {
                         {(canManageChart ||
                             canSyncWithGoogleSheets ||
                             contentReview.canRequest) && (
-                            <Menu position="bottom" withArrow width={200}>
+                            <Menu
+                                position="bottom"
+                                returnFocus={!isDirectAccessModalOpen}
+                                withArrow
+                                width={200}
+                            >
                                 <Menu.Target>
                                     <ActionIcon>
                                         <MantineIcon icon={IconDots} />

--- a/packages/frontend/src/features/sqlRunner/hooks/useSavedSqlChartResults.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useSavedSqlChartResults.tsx
@@ -113,6 +113,7 @@ export const useSavedSqlChartResults = (
             savedSqlUuid ?? slug,
             embedDashboard ? 'embed' : 'registered',
             embedDashboard ? args.tileUuid : undefined,
+            projectUuid,
         ],
         async () => {
             if (isEmbedDashboardArgs(args)) {
@@ -235,6 +236,7 @@ export const useSavedSqlChartResults = (
         {
             enabled:
                 !!chartQuery.data &&
+                !chartQuery.isError &&
                 !!projectUuid &&
                 (embedDashboard || !!savedSqlUuid || !!slug),
             ...retryConfig,
@@ -244,7 +246,11 @@ export const useSavedSqlChartResults = (
     // Get query uuid for download
     const getDownloadQueryUuid = useCallback(
         async (limit: number | null) => {
-            if (!chartResultsQuery.data || !chartQuery.data) {
+            if (
+                !chartResultsQuery.data ||
+                !chartQuery.data ||
+                chartQuery.isError
+            ) {
                 throw new Error('Chart results query or chart query not found');
             }
 
@@ -295,6 +301,7 @@ export const useSavedSqlChartResults = (
         [
             args,
             chartQuery.data,
+            chartQuery.isError,
             chartResultsQuery.data,
             context,
             projectUuid,

--- a/packages/frontend/src/pages/ViewSqlChart.test.tsx
+++ b/packages/frontend/src/pages/ViewSqlChart.test.tsx
@@ -1,0 +1,114 @@
+import { ChartKind } from '@lightdash/common';
+import { Button, MantineProvider } from '@mantine/core';
+import { render, screen } from '@testing-library/react';
+import { type PropsWithChildren, type ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { useSavedSqlChartResults } from '../features/sqlRunner/hooks/useSavedSqlChartResults';
+import ViewSqlChartPage from './ViewSqlChart';
+
+vi.mock('react-router', () => ({ useParams: () => ({ slug: 'sql-chart' }) }));
+vi.mock('react-redux', async (importOriginal) => ({
+    ...(await importOriginal<object>()),
+    Provider: ({ children }: PropsWithChildren) => children,
+}));
+vi.mock('../features/sqlRunner/store', () => ({ store: {} }));
+vi.mock('../features/sqlRunner/store/hooks', () => ({
+    useAppDispatch: () => vi.fn(),
+    useAppSelector: () => ({}),
+}));
+vi.mock('../features/sqlRunner/hooks/useSavedSqlChartResults', () => ({
+    useSavedSqlChartResults: vi.fn(),
+}));
+vi.mock('../hooks/useProjectUuid', () => ({ useProjectUuid: () => 'project' }));
+vi.mock('../features/parameters', () => ({
+    Parameters: () => null,
+    useParameters: () => ({ data: [] }),
+}));
+vi.mock('../components/common/Page/Page', () => ({
+    default: ({
+        children,
+        header,
+    }: PropsWithChildren<{ header: ReactNode }>) => (
+        <>
+            {header}
+            {children}
+        </>
+    ),
+}));
+vi.mock('../components/common/ErrorState', () => ({
+    default: () => 'Access removed',
+}));
+vi.mock('../features/sqlRunner/components/Header', () => ({
+    Header: () => <Button>Share</Button>,
+}));
+vi.mock(
+    '../features/sqlRunner/components/Download/ResultsDownloadButton',
+    () => ({ default: () => <Button>Download</Button> }),
+);
+vi.mock('../components/DataViz/visualizations/Table', () => ({
+    Table: () => 'Cached results',
+}));
+
+describe('SQL viewer access loss', () => {
+    it.each([403, 404])(
+        'removes header actions and cached downloads when a refetch returns %s',
+        (statusCode) => {
+            const cachedQuery = {
+                chartQuery: {
+                    data: {
+                        sql: 'select 1',
+                        config: { type: ChartKind.TABLE },
+                        name: 'Chart',
+                    },
+                    isLoading: false,
+                    error: null,
+                },
+                chartResultsQuery: {
+                    data: { chartUnderlyingData: { columns: [], rows: [] } },
+                    isLoading: false,
+                },
+                getDownloadQueryUuid: vi.fn(),
+            };
+            vi.mocked(useSavedSqlChartResults).mockReturnValue(
+                cachedQuery as unknown as ReturnType<
+                    typeof useSavedSqlChartResults
+                >,
+            );
+            const page = (
+                <MantineProvider>
+                    <ViewSqlChartPage />
+                </MantineProvider>
+            );
+            const { rerender } = render(page);
+            expect(
+                screen.getByRole('button', { name: 'Share' }),
+            ).toBeInTheDocument();
+            expect(
+                screen.getByRole('button', { name: 'Download' }),
+            ).toBeInTheDocument();
+
+            vi.mocked(useSavedSqlChartResults).mockReturnValue({
+                ...cachedQuery,
+                chartQuery: {
+                    ...cachedQuery.chartQuery,
+                    error: { error: { statusCode, message: 'Access removed' } },
+                },
+            } as unknown as ReturnType<typeof useSavedSqlChartResults>);
+            rerender(
+                <MantineProvider>
+                    <ViewSqlChartPage />
+                </MantineProvider>,
+            );
+            expect(screen.getByText('Access removed')).toBeInTheDocument();
+            expect(
+                screen.queryByRole('button', { name: 'Share' }),
+            ).not.toBeInTheDocument();
+            expect(
+                screen.queryByRole('button', { name: 'Download' }),
+            ).not.toBeInTheDocument();
+            expect(
+                screen.queryByText('Cached results'),
+            ).not.toBeInTheDocument();
+        },
+    );
+});

--- a/packages/frontend/src/pages/ViewSqlChart.tsx
+++ b/packages/frontend/src/pages/ViewSqlChart.tsx
@@ -104,19 +104,27 @@ const ViewSqlChart = () => {
 
     // TODO: remove state sync - this is because the <Header /> component depends on the Redux state
     useEffect(() => {
-        if (chartData) {
+        if (chartData && !chartError) {
             dispatch(setSavedChartData(chartData));
         }
         if (projectUuid) {
             dispatch(setProjectUuid(projectUuid));
         }
-    }, [dispatch, chartData, projectUuid]);
+    }, [dispatch, chartData, chartError, projectUuid]);
 
     const {
         data: projectParameters,
         isLoading: isProjectParametersLoading,
         isError: isProjectParametersError,
     } = useParameters(projectUuid, Array.from(parameterReferences ?? []));
+
+    if (chartError) {
+        return (
+            <Page title="SQL chart">
+                <ErrorState error={chartError.error} />
+            </Page>
+        );
+    }
 
     return (
         <Page
@@ -231,7 +239,6 @@ const ViewSqlChart = () => {
                         </Group>
                     </Box>
 
-                    {chartError && <ErrorState error={chartError.error} />}
                     {chartResultsError && (
                         <ErrorState error={chartResultsError.error} />
                     )}


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/SPK-1934

## Summary

PR 2 of 2 for the Direct Access end-to-end findings. Stacks on [#28769](https://github.com/lightdash/lightdash/pull/28769), which enforces current API authority for policy changes, chart writes, and exports ([SPK-1933](https://linear.app/lightdash/issue/SPK-1933)).

Sharing controls now follow current authority after a grant changes. Losing management access removes assignment controls, and losing SQL-chart access removes its cached header and results. Inaccessible parent spaces remain visible as text. Sharing dialogs receive accessible names and keep keyboard focus through opening, errors, recovery, and closing.

## Changes

- Gate assignment controls and confirmations on a usable policy response, with Retry for errors.
- Refresh project-scoped resource queries after grant mutations, including SQL viewer queries reached by UUID or slug.
- Match personal-app policy controls to effective Admin access and preserve accessible parent navigation.
- Coordinate menu/modal focus and label shared dialogs and Close controls.
- Keep long principal names from widening the sharing dialog; role and remove controls fit a 650px viewport in light and dark themes.

```text
Grant changes -> refresh resource + policy
  Still authorized -> current controls
  Policy denied    -> Retry receives focus; mutation controls disappear
  Resource denied  -> access error replaces cached SQL view
```

Before, permission errors left stale management controls and modal focus could remain behind the dialog. After, controls reflect current authority and keyboard focus stays on the active dialog, returning to its menu trigger when that trigger remains available.

## Test plan

- [x] Full frontend suite: 3,467 tests across 473 files, including chart-builder focus entry/return with accessible modal headings.

- [x] 48 frontend tests across eight affected suites, including failing-before/passing-after authority, invalidation, focus, and breadcrumb regressions.
- [x] Frontend typecheck and full lint.
- [x] 25 Chrome DevTools MCP scenarios on ld1: individual/group sharing, Viewer/Editor/Admin ceilings, self-downgrade/revoke, reset, inherited access, owned/dependent charts, apps, discovery, sorting/pagination, errors, feature flag, and accessibility.
- [x] Real warehouse results: five-row Explore/dashboard/app results and SQL value=1. UI Editor save confirmed persisted; downgrade prevented the subsequent write.
- [x] Keyboard Tab/Shift+Tab/Escape, confirmation cancellation, Retry recovery, and 180-character principal names at 650px in light/dark themes.
- [x] All five review lenses approved; SQL invalidation, focus recovery, and narrow layout fixes received focused re-review.

The API parent must land first. License behavior is excluded from this change. No migration or API schema changes.
