### PR TITLE
fix(content-as-code): upload succeeds when the target space was deleted

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -389,6 +389,8 @@ Slugs are unique per project and resource type for charts, dashboards, SQL Runne
 
 Use `generateUniqueSlugScopedToProject()` (`packages/backend/src/utils/SlugUtils.ts`) for normal creation. It derives the base with `generateSlug()`, probes exact indexed candidates, and appends `-1`, `-2`, and so on for conflicts. Explicit slugs used by content-as-code and promotion must be inserted exactly; same-project conflicts return an actionable conflict or resolve the intended active upsert, never overwrite another resource.
 
+Content-as-code upserts address content by exact slug, so a soft-deleted chart or dashboard that owns the slug is revived in place with the uploaded content instead of blocking the upload. Space paths are not database-constrained: one active space and any number of deleted spaces may share a path, and restoring a deleted space is rejected while an active space holds its path.
+
 UUIDs remain the canonical internal identity. Use them for foreign keys, durable relationships, and references without an explicit project scope. Slugs are appropriate for project-scoped URLs and portable content-as-code selectors.
 
 `getLtreePathFromSlug` is lossy: hyphens and underscores map to the same ltree label. Space hierarchy and access logic must use `parent_space_uuid`; path-based resolution must reject ambiguity rather than selecting an arbitrary row.

--- a/packages/backend/src/models/DashboardModel/DashboardModel.test.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.test.ts
@@ -404,26 +404,93 @@ describe('DashboardModel', () => {
         });
     });
 
-    test('rejects an exact slug owned by a deleted dashboard', async () => {
+    test('revives a deleted dashboard that owns an exact slug', async () => {
         tracker.on.select('pg_advisory_xact_lock').response({});
         tracker.on.select(DashboardsTableName).responseOnce([
             {
                 dashboard_uuid: 'deleted-dashboard-uuid',
                 deleted_at: new Date(),
+                deleted_by_user_uuid: 'deleter-user-uuid',
             },
         ]);
-
-        await expect(
-            model.create(
-                'spaceUuid',
-                { ...createDashboard, forceSlug: true },
-                user,
-                projectUuid,
-            ),
-        ).rejects.toThrow(
-            `Dashboard slug "${createDashboard.slug}" is already used by a deleted dashboard`,
+        tracker.on.select(SpaceTableName).responseOnce([spaceEntry]);
+        tracker.on.update(DashboardsTableName).responseOnce([
+            {
+                dashboard_id: dashboardEntry.dashboard_id,
+                dashboard_uuid: 'deleted-dashboard-uuid',
+            },
+        ]);
+        tracker.on.update(SavedChartsTableName).responseOnce(1);
+        tracker.on
+            .insert(DashboardVersionsTableName)
+            .responseOnce([dashboardVersionEntry]);
+        tracker.on
+            .insert(DashboardViewsTableName)
+            .responseOnce([dashboardViewEntry]);
+        tracker.on
+            .insert(DashboardTilesTableName)
+            .responseOnce([dashboardTileEntry]);
+        tracker.on.select(SavedChartsTableName).responseOnce([savedChartEntry]);
+        tracker.on.insert(DashboardTileChartTableName).responseOnce([]);
+        tracker.on.update(DashboardViewsTableName).responseOnce([]);
+        vi.spyOn(model, 'getByIdOrSlug').mockImplementationOnce(() =>
+            Promise.resolve(expectedDashboard),
         );
+
+        await model.create(
+            'spaceUuid',
+            { ...createDashboard, forceSlug: true },
+            user,
+            projectUuid,
+        );
+
+        expect(
+            tracker.history.insert.some((query) =>
+                query.sql.includes(`into "${DashboardsTableName}"`),
+            ),
+        ).toBe(false);
+        const revive = tracker.history.update.find((query) =>
+            query.sql.includes(`update "${DashboardsTableName}"`),
+        );
+        expect(revive?.sql).toContain('"deleted_at" = $');
+        expect(revive?.bindings).toEqual(
+            expect.arrayContaining([
+                createDashboard.name,
+                spaceEntry.space_id,
+                'deleted-dashboard-uuid',
+            ]),
+        );
+        const chartRevive = tracker.history.update.find((query) =>
+            query.sql.includes(`update "${SavedChartsTableName}"`),
+        );
+        expect(chartRevive?.bindings).toContain('deleter-user-uuid');
+        expect(tracker.history.insert[0].sql).toContain(
+            DashboardVersionsTableName,
+        );
+    });
+
+    test('reuses an active dashboard that owns an exact slug', async () => {
+        tracker.on.select('pg_advisory_xact_lock').response({});
+        tracker.on.select(DashboardsTableName).responseOnce([
+            {
+                dashboard_uuid: 'active-dashboard-uuid',
+                deleted_at: null,
+                deleted_by_user_uuid: null,
+            },
+        ]);
+        vi.spyOn(model, 'getByIdOrSlug').mockImplementationOnce(() =>
+            Promise.resolve(expectedDashboard),
+        );
+
+        await model.create(
+            'spaceUuid',
+            { ...createDashboard, forceSlug: true },
+            user,
+            projectUuid,
+        );
+
         expect(tracker.history.insert).toHaveLength(0);
+        expect(tracker.history.update).toHaveLength(0);
     });
 
     test('should update dashboard', async () => {

--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -1,6 +1,5 @@
 import {
     assertUnreachable,
-    ConflictError,
     ContentReviewContentType,
     ContentType,
     CreateDashboard,
@@ -148,6 +147,11 @@ export type GetChartTileQuery = Pick<
 type DashboardModelArguments = {
     database: Knex;
     contentVerificationModel?: ContentVerificationModel;
+};
+
+type DeletedDashboardSlugOwner = {
+    dashboard_uuid: string;
+    deleted_by_user_uuid: string | null;
 };
 
 export class DashboardModel {
@@ -1445,6 +1449,51 @@ export class DashboardModel {
         );
     }
 
+    // An exact slug owned by a deleted dashboard is the same content as code
+    // identity, so it comes back in the requested space with the new content.
+    private static async reviveDeletedDashboard(
+        trx: Knex.Transaction,
+        deletedDashboard: DeletedDashboardSlugOwner,
+        spaceId: number,
+        dashboard: CreateDashboard & { slug: string },
+        user: Pick<SessionUser, 'userUuid'>,
+    ): Promise<string> {
+        const [revived] = await trx(DashboardsTableName)
+            .update({
+                name: dashboard.name,
+                description: dashboard.description,
+                space_id: spaceId,
+                owner_user_uuid: dashboard.ownerUserUuid ?? null,
+                deleted_at: null,
+                deleted_by_user_uuid: null,
+            })
+            .where('dashboard_uuid', deletedDashboard.dashboard_uuid)
+            .returning(['dashboard_id', 'dashboard_uuid']);
+
+        // Dashboard charts cascade-deleted with it come back too
+        if (deletedDashboard.deleted_by_user_uuid) {
+            await trx(SavedChartsTableName)
+                .update({
+                    deleted_at: null,
+                    deleted_by_user_uuid: null,
+                })
+                .where('dashboard_uuid', deletedDashboard.dashboard_uuid)
+                .whereNull('space_id')
+                .where(
+                    'deleted_by_user_uuid',
+                    deletedDashboard.deleted_by_user_uuid,
+                );
+        }
+
+        await DashboardModel.createVersion(trx, revived.dashboard_id, {
+            ...dashboard,
+            tabs: dashboard.tabs || [],
+            updatedByUser: user,
+        });
+
+        return revived.dashboard_uuid;
+    }
+
     async create(
         spaceUuid: string,
         dashboard: CreateDashboard & { slug: string; forceSlug?: boolean },
@@ -1454,6 +1503,7 @@ export class DashboardModel {
         const dashboardId = await this.database.transaction(async (trx) => {
             await acquireProjectSlugLock(trx, projectUuid, dashboard.slug);
 
+            let deletedOwner: DeletedDashboardSlugOwner | undefined;
             if (dashboard.forceSlug) {
                 const existing = await trx(DashboardsTableName)
                     .where(`${DashboardsTableName}.project_uuid`, projectUuid)
@@ -1461,16 +1511,13 @@ export class DashboardModel {
                     .select(
                         `${DashboardsTableName}.dashboard_uuid`,
                         `${DashboardsTableName}.deleted_at`,
+                        `${DashboardsTableName}.deleted_by_user_uuid`,
                     )
                     .first();
-                if (existing?.deleted_at) {
-                    throw new ConflictError(
-                        `Dashboard slug "${dashboard.slug}" is already used by a deleted dashboard`,
-                    );
-                }
-                if (existing) {
+                if (existing && !existing.deleted_at) {
                     return existing.dashboard_uuid;
                 }
+                deletedOwner = existing;
             }
 
             const [space] = await trx(SpaceTableName)
@@ -1485,6 +1532,16 @@ export class DashboardModel {
                 .limit(1);
             if (!space) {
                 throw new NotFoundError('Space not found');
+            }
+
+            if (deletedOwner) {
+                return DashboardModel.reviveDeletedDashboard(
+                    trx,
+                    deletedOwner,
+                    space.space_id,
+                    dashboard,
+                    user,
+                );
             }
 
             const [newDashboard] = await trx(DashboardsTableName)

--- a/packages/backend/src/models/SavedChartModel.test.ts
+++ b/packages/backend/src/models/SavedChartModel.test.ts
@@ -238,30 +238,53 @@ describe('createSavedChart', () => {
         ).toBe(true);
     });
 
-    test('rejects a forced slug owned by a deleted chart', async () => {
+    test('revives a deleted chart that owns a forced slug', async () => {
         tracker.on.select(SavedChartsTableName).responseOnce([
             {
                 saved_query_uuid: 'deleted-chart-uuid',
                 deleted_at: new Date(),
             },
         ]);
+        tracker.on.select(SpaceTableName).responseOnce([{ space_id: 7 }]);
+        tracker.on
+            .update(SavedChartsTableName)
+            .responseOnce([
+                { saved_query_id: 11, saved_query_uuid: 'deleted-chart-uuid' },
+            ]);
+        tracker.on
+            .insert('saved_queries_versions')
+            .responseOnce([{ saved_queries_version_id: 13 }]);
 
-        await expect(
-            createSavedChart(
-                database,
-                '22222222-2222-4222-8222-222222222222',
-                '11111111-1111-4111-8111-111111111111',
-                {
-                    ...chartInput,
-                    spaceUuid: '33333333-3333-4333-8333-333333333333',
-                    dashboardUuid: null,
-                    forceSlug: true,
-                },
-            ),
-        ).rejects.toThrow(
-            'Chart slug "orders" is already used by a deleted chart',
+        const result = await createSavedChart(
+            database,
+            '22222222-2222-4222-8222-222222222222',
+            '11111111-1111-4111-8111-111111111111',
+            {
+                ...chartInput,
+                spaceUuid: '33333333-3333-4333-8333-333333333333',
+                dashboardUuid: null,
+                forceSlug: true,
+            },
         );
-        expect(tracker.history.insert).toHaveLength(0);
+
+        expect(result).toBe('deleted-chart-uuid');
+        expect(
+            tracker.history.insert.some((query) =>
+                query.sql.includes(`into "${SavedChartsTableName}"`),
+            ),
+        ).toBe(false);
+        const revive = tracker.history.update.find((query) =>
+            query.sql.includes(`update "${SavedChartsTableName}"`),
+        );
+        expect(revive?.sql).toContain('"deleted_at" = $');
+        expect(revive?.sql).not.toContain('"slug"');
+        expect(revive?.bindings).toEqual(
+            expect.arrayContaining([7, 'deleted-chart-uuid']),
+        );
+        const versionInsert = tracker.history.insert.find((query) =>
+            query.sql.includes('into "saved_queries_versions"'),
+        );
+        expect(versionInsert?.bindings).toContain(11);
     });
 
     test('preserves a long forced slug', async () => {

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -529,13 +529,17 @@ export const createSavedChart = async (
             return await db.transaction(async (trx) => {
                 await acquireProjectSlugLock(trx, projectUuid, slug);
 
+                let deletedOwnerUuid: string | undefined;
                 if (forceSlug) {
-                    const existingUuid = await resolveForcedChartSlug(
+                    const owner = await getSavedChartSlugOwner(
                         trx,
                         projectUuid,
                         slug,
                     );
-                    if (existingUuid) return existingUuid;
+                    if (owner && !owner.deleted_at) {
+                        return owner.saved_query_uuid;
+                    }
+                    deletedOwnerUuid = owner?.saved_query_uuid;
                 }
 
                 let chart: InsertChart;
@@ -607,9 +611,29 @@ export const createSavedChart = async (
                         space_id: space.space_id,
                     };
                 }
-                const [newSavedChart] = await trx(SavedChartsTableName)
-                    .insert(chart)
-                    .returning('*');
+                // An exact slug owned by a deleted chart is the same content
+                // as code identity, so it comes back where the upload puts it.
+                const [newSavedChart] = deletedOwnerUuid
+                    ? await trx(SavedChartsTableName)
+                          .update({
+                              name: chart.name,
+                              description: chart.description,
+                              last_version_chart_kind:
+                                  chart.last_version_chart_kind,
+                              last_version_updated_by_user_uuid:
+                                  chart.last_version_updated_by_user_uuid,
+                              last_version_updated_at: new Date(),
+                              color_palette_uuid: chart.color_palette_uuid,
+                              space_id: chart.space_id,
+                              dashboard_uuid: chart.dashboard_uuid,
+                              deleted_at: null,
+                              deleted_by_user_uuid: null,
+                          })
+                          .where('saved_query_uuid', deletedOwnerUuid)
+                          .returning('*')
+                    : await trx(SavedChartsTableName)
+                          .insert(chart)
+                          .returning('*');
                 await createSavedChartVersion(
                     trx,
                     newSavedChart.saved_query_id,

--- a/packages/backend/src/models/SpaceModel.test.ts
+++ b/packages/backend/src/models/SpaceModel.test.ts
@@ -1,4 +1,9 @@
-import { ParameterError, SpaceMemberRole } from '@lightdash/common';
+import {
+    ConflictError,
+    NotFoundError,
+    ParameterError,
+    SpaceMemberRole,
+} from '@lightdash/common';
 import knex from 'knex';
 import { getTracker, MockClient, Tracker } from 'knex-mock-client';
 import { EmailTableName } from '../database/entities/emails';
@@ -65,6 +70,108 @@ describe('SpaceModel project-scoped creation', () => {
 
         expect(space.uuid).toBe('existing-space-uuid');
         expect(tracker.history.insert).toHaveLength(0);
+    });
+
+    it('creates a new space when the CaC path only matches a deleted space', async () => {
+        tracker.on.select(ProjectTableName).responseOnce({ project_id: 1 });
+        tracker.on.select('pg_advisory_xact_lock').response({});
+        // No active space at the path; the deleted one still reserves the slug
+        tracker.on.select(SpaceTableName).responseOnce([]);
+        tracker.on.select(SpaceTableName).responseOnce([{ slug: 'churn' }]);
+        tracker.on.select(SpaceTableName).responseOnce([]);
+        tracker.on.insert(SpaceTableName).responseOnce([
+            {
+                organization_uuid: 'organization-uuid',
+                space_uuid: 'new-space-uuid',
+                name: 'Churn',
+                slug: 'churn-1',
+                path: 'commercial.churn',
+                parent_space_uuid: 'commercial-space-uuid',
+                inherit_parent_permissions: true,
+                project_member_access_role: null,
+                color_palette_uuid: null,
+                deleted_at: null,
+            },
+        ]);
+
+        const space = await model.createSpace(
+            {
+                name: 'Churn',
+                inheritParentPermissions: true,
+                parentSpaceUuid: 'commercial-space-uuid',
+            },
+            {
+                projectUuid: 'project-uuid',
+                userId: 1,
+                path: 'commercial.churn',
+            },
+        );
+
+        expect(space.uuid).toBe('new-space-uuid');
+        expect(space.slug).toBe('churn-1');
+        expect(space.path).toBe('commercial.churn');
+        expect(tracker.history.insert).toHaveLength(1);
+        expect(tracker.history.insert[0].bindings).toEqual(
+            expect.arrayContaining(['commercial.churn', 'churn-1']),
+        );
+        const pathLookup = tracker.history.select.find((query) =>
+            query.sql.includes('"path" = $'),
+        );
+        expect(pathLookup?.sql).toContain('"deleted_at" is null');
+    });
+});
+
+describe('SpaceModel restore', () => {
+    const database = knex({ client: MockClient, dialect: 'pg' });
+    const model = new SpaceModel({ database });
+    let tracker: Tracker;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    afterEach(() => {
+        tracker.reset();
+    });
+
+    const deletedSpaceRow = {
+        project_id: 1,
+        path: 'commercial.churn',
+        name: 'Churn',
+    };
+
+    it('restores a deleted space when no active space uses its path', async () => {
+        tracker.on.select(SpaceTableName).responseOnce([deletedSpaceRow]);
+        tracker.on.select(SpaceTableName).responseOnce([]);
+        tracker.on.update(SpaceTableName).responseOnce(1);
+
+        await model.restore('deleted-space-uuid');
+
+        expect(tracker.history.update).toHaveLength(1);
+        expect(tracker.history.update[0].bindings).toContain(
+            'deleted-space-uuid',
+        );
+    });
+
+    it('rejects restoring a space whose path is now used by an active space', async () => {
+        tracker.on.select(SpaceTableName).responseOnce([deletedSpaceRow]);
+        tracker.on
+            .select(SpaceTableName)
+            .responseOnce([{ name: 'Churn (as code)' }]);
+
+        await expect(model.restore('deleted-space-uuid')).rejects.toThrow(
+            ConflictError,
+        );
+        expect(tracker.history.update).toHaveLength(0);
+    });
+
+    it('throws NotFoundError when the space is not deleted', async () => {
+        tracker.on.select(SpaceTableName).responseOnce([]);
+
+        await expect(model.restore('active-space-uuid')).rejects.toThrow(
+            NotFoundError,
+        );
+        expect(tracker.history.update).toHaveLength(0);
     });
 });
 

--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -1996,7 +1996,8 @@ export class SpaceModel {
             )
             .whereRaw('?::ltree <@ path', [space.path])
             .andWhereNot('space_uuid', spaceUuid)
-            .andWhere(`${ProjectTableName}.project_uuid`, projectUuid);
+            .andWhere(`${ProjectTableName}.project_uuid`, projectUuid)
+            .whereNull(`${SpaceTableName}.deleted_at`);
 
         return ancestors.map((ancestor) => ancestor.space_uuid);
     }
@@ -2123,15 +2124,13 @@ export class SpaceModel {
             `space:${path ?? baseSlug}`,
         );
         if (path !== undefined) {
+            // Deleted spaces keep their path for restore but must not block
+            // new content at that location; restore() rejects the clash.
             const existing = await trx(SpaceTableName)
                 .where('project_id', project.project_id)
                 .where('path', path)
+                .whereNull('deleted_at')
                 .first();
-            if (existing?.deleted_at) {
-                throw new ConflictError(
-                    `Space path "${path}" is already used by a deleted space`,
-                );
-            }
             if (existing) {
                 return SpaceModel.convertCreatedSpace(existing, projectUuid);
             }
@@ -2186,17 +2185,35 @@ export class SpaceModel {
     }
 
     async restore(spaceUuid: string): Promise<void> {
-        const updateCount = await this.database(SpaceTableName)
-            .update({
-                deleted_at: null,
-                deleted_by_user_uuid: null,
-            })
-            .where('space_uuid', spaceUuid)
-            .whereNotNull('deleted_at');
+        await this.database.transaction(async (trx) => {
+            const deletedSpace = await trx(SpaceTableName)
+                .select('project_id', 'path', 'name')
+                .where('space_uuid', spaceUuid)
+                .whereNotNull('deleted_at')
+                .first();
+            if (!deletedSpace) {
+                throw new NotFoundError('Deleted space not found');
+            }
 
-        if (updateCount !== 1) {
-            throw new NotFoundError('Deleted space not found');
-        }
+            const activeSpaceAtPath = await trx(SpaceTableName)
+                .select('name')
+                .where('project_id', deletedSpace.project_id)
+                .where('path', deletedSpace.path)
+                .whereNull('deleted_at')
+                .first();
+            if (activeSpaceAtPath) {
+                throw new ConflictError(
+                    `Cannot restore space "${deletedSpace.name}" because the space "${activeSpaceAtPath.name}" now exists at the same location. Delete or move that space first.`,
+                );
+            }
+
+            await trx(SpaceTableName)
+                .update({
+                    deleted_at: null,
+                    deleted_by_user_uuid: null,
+                })
+                .where('space_uuid', spaceUuid);
+        });
     }
 
     async getDescendantSpaceUuids(spaceUuid: string): Promise<string[]> {


### PR DESCRIPTION
## Problem

`lightdash upload` fails with `Space path "<path>" is already used by a deleted space` when a dashboard or chart managed as code targets a space path that someone has since deleted in the UI (soft delete). The content was cascade-deleted with the space, so even with the space error gone the next attempt hits `Dashboard slug "<slug>" is already used by a deleted dashboard`. The upload can never recover without manual work on the deleted space.

## Root cause

#26393 consolidated slug allocation and made `SpaceModel.createSpace` treat a soft-deleted space at the requested path as a hard conflict. Before that, it inserted a new row: `spaces.path` has no unique constraint, only slugs do. The same change made forced-slug creates reject a deleted owner for charts and dashboards. Content as code addresses content by exact slug and path, so it cannot sidestep with a suffix the way the UI does.

## Fix

- `SpaceModel.createSpace` with an explicit path reuses only an active space at that path. A deleted space no longer blocks. The new space gets a fresh unique slug but the same path, which is the content-as-code identifier.
- `SpaceModel.restore` runs in a transaction and rejects with a 409 when an active space now holds the same path. Deleted spaces keep their path, so a restore stays safe when the path is free.
- Forced-slug creates (`DashboardModel.create`, `createSavedChart`) revive a soft-deleted owner of the exact slug in place: same uuid, moved into the requested space or dashboard, new version with the uploaded content. Dashboard-scoped charts cascade-deleted alongside come back, using the same rule as `DashboardModel.restore`.
- `getSpaceAncestors` ignores deleted spaces, so a deleted twin at the same path cannot appear as an ancestor during promotion.
- `CLAUDE.md` documents the new invariant next to the slug rules.

## Regression analysis

- UI-created spaces derive their path from an already unique slug, so they never reach the explicit-path branch. Only content as code and promotion pass explicit paths.
- Forced-slug create on an active owner is unchanged: returns the existing uuid without writing.
- Restore of a deleted space whose path is free is unchanged.
- Two ltree `<@` descendant queries remain path-based and can see a deleted twin: `includeDescendantCounts` in `SpaceContentConfiguration` (the Recently deleted row shows "Contains 1 space, 1 dashboard" for the deleted twin) and the `moveToSpace` path rewrite. Both already tolerate duplicate paths from the lossy slug to path conversion noted in `SpacePermissionModel`. Follow-up to move them to `parent_space_uuid` walks.

## Verification

- Live reproduction with the local CLI build against a worktree API with `SOFT_DELETE_ENABLED=true`: upload creates `commercial/churn` and the dashboard, the space is deleted in the UI, the upload fails on main with the reported error, and with this change the same upload reports `1 created` (dashboard revived with its uuid), a third run reports `1 updated`, and restoring the deleted space returns 409 in the API and as a toast in Recently deleted.
- Unit tests: `SpaceModel` (path creation and restore), `DashboardModel`, `SavedChartModel`. Backend typecheck and oxlint pass.

Closes: #28640

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HDVYrT3ZgWfNSnP3ewRNLn
