### PR TITLE
fix(ai): send the configured OpenRouter provider sort

### DIFF
--- a/packages/backend/src/ee/services/ai/models/openrouter.test.ts
+++ b/packages/backend/src/ee/services/ai/models/openrouter.test.ts
@@ -29,7 +29,14 @@ describe('getOpenRouterModel', () => {
         expect(routingBlock()).toEqual({
             data_collection: 'deny',
             require_parameters: true,
+            sort: 'latency',
         });
+    });
+
+    test('sends the configured provider sort', () => {
+        getOpenRouterModel({ ...baseConfig, sortOrder: 'throughput' });
+
+        expect(routingBlock()).toMatchObject({ sort: 'throughput' });
     });
 
     test('pins upstream providers with an `only` filter', () => {

--- a/packages/backend/src/ee/services/ai/models/openrouter.ts
+++ b/packages/backend/src/ee/services/ai/models/openrouter.ts
@@ -19,6 +19,10 @@ export const getOpenRouterModel = (
             provider: {
                 data_collection: 'deny',
                 require_parameters: true,
+                // Ranks the upstream pool by latency/throughput/price instead
+                // of OpenRouter's default price-weighted load balancing.
+                // Providers listed in `order` are still tried first.
+                sort: config.sortOrder,
                 ...(config.allowedProviders.length > 0
                     ? { only: config.allowedProviders }
                     : {}),


### PR DESCRIPTION
## Why

`OPENROUTER_SORT_ORDER` (schema default `latency`) was added in #28632 but `getOpenRouterModel` never put it in the request, so every OpenRouter call still used the router's default price-weighted load balancing. Investigating slow battle-mode turns on analytics showed the config was dead.

## What

- Send `provider.sort: config.sortOrder` alongside `order` / `only` in `openrouter.ts`.
- Test asserts the default `latency` sort is sent and that a configured `throughput` sort goes through.

## Behaviour change

Every OpenRouter deployment now sends `sort: latency` by default, which per the OpenRouter docs disables load balancing and tries providers by measured latency. Providers in `OPENROUTER_PROVIDER_ORDER` are still tried first. Set `OPENROUTER_SORT_ORDER=price` to get closest to the previous behaviour.

Ref: https://openrouter.ai/docs/features/provider-routing#provider-sorting

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VfxtAPa4jEUjecyn2PowgC