### PR TITLE
feat(ai): picker metadata for glm-5.3, qwen3.8-flash and gpt-oss-120b

### DIFF
--- a/packages/backend/src/ee/services/ai/models/presets.ts
+++ b/packages/backend/src/ee/services/ai/models/presets.ts
@@ -435,6 +435,30 @@ const OPENROUTER_MODEL_METADATA: Record<
         contextWindowTokens: 1_310_720,
         supportsReasoning: false,
     },
+    'z-ai/glm-5.3': {
+        displayName: 'GLM 5.3',
+        description:
+            'Large reasoning model for complex engineering and long-horizon agent tasks',
+        groupLabel: 'Z.ai',
+        contextWindowTokens: 1_310_720,
+        supportsReasoning: false,
+    },
+    'qwen/qwen3.8-flash': {
+        displayName: 'Qwen3.8 Flash',
+        description:
+            'Fast multimodal reasoning model for agentic workflows and chart analysis',
+        groupLabel: 'Qwen',
+        contextWindowTokens: 1_000_000,
+        supportsReasoning: false,
+    },
+    'openai/gpt-oss-120b': {
+        displayName: 'GPT-OSS 120B',
+        description:
+            'Open-weight MoE reasoning model; served by fast-inference upstreams',
+        groupLabel: 'OpenAI (open weights)',
+        contextWindowTokens: 131_072,
+        supportsReasoning: false,
+    },
 };
 
 export function openRouterPreset(modelName: string): ModelPreset<'openrouter'> {


### PR DESCRIPTION
## Why

OpenRouter models without an entry in `OPENROUTER_MODEL_METADATA` show up in the model picker as the raw slug with no description or context window. lightdash/lightdash-cloud#3721 adds three such models to the analytics roster.

## What

Adds display name, description, group and context window for:

- `z-ai/glm-5.3` (1,310,720 ctx)
- `qwen/qwen3.8-flash` (1,000,000 ctx)
- `openai/gpt-oss-120b` (131,072 ctx)

`supportsReasoning` stays `false` to match the existing OpenRouter entries. No behaviour change for instances that do not list these models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VfxtAPa4jEUjecyn2PowgC