### PR TITLE
fix: pass the parsed merged manifest to the adapter

### DIFF
--- a/packages/backend/src/projectAdapters/dbtManifestProjectAdapter.test.ts
+++ b/packages/backend/src/projectAdapters/dbtManifestProjectAdapter.test.ts
@@ -1,4 +1,5 @@
 import {
+    DbtError,
     DEFAULT_SPOTLIGHT_CONFIG,
     SupportedDbtVersions,
     type WarehouseClient,
@@ -135,7 +136,7 @@ describe('DbtManifestProjectAdapter', () => {
         },
     );
 
-    it('should throw error when manifest is invalid JSON', async () => {
+    it('throws the manifest validation error for malformed JSON', async () => {
         const invalidManifestAdapter = new DbtManifestProjectAdapter({
             warehouseClient: mockWarehouseClient,
             cachedWarehouse: {
@@ -146,9 +147,12 @@ describe('DbtManifestProjectAdapter', () => {
             manifest: 'invalid json',
         });
 
-        await expect(
-            invalidManifestAdapter.dbtClient.getDbtManifest(),
-        ).rejects.toThrow();
+        const result = invalidManifestAdapter.dbtClient.getDbtManifest();
+
+        await expect(result).rejects.toBeInstanceOf(DbtError);
+        await expect(result).rejects.toThrow(
+            'Cannot read response from dbt, manifest.json not valid',
+        );
     });
 
     it('should throw error when manifest is missing required fields', async () => {

--- a/packages/backend/src/projectAdapters/dbtManifestProjectAdapter.test.ts
+++ b/packages/backend/src/projectAdapters/dbtManifestProjectAdapter.test.ts
@@ -105,6 +105,36 @@ describe('DbtManifestProjectAdapter', () => {
         expect(manifestResult.selectedModelIds).toEqual([]);
     });
 
+    it.each([undefined, [], ['model.test.example']])(
+        'reuses the parsed manifest with selection %j',
+        async (selectedModelIds) => {
+            const { manifest } =
+                await mockProjectAdapter.dbtClient.getDbtManifest();
+            const adapter = new DbtManifestProjectAdapter({
+                warehouseClient: mockWarehouseClient,
+                cachedWarehouse: {
+                    warehouseCatalog: undefined,
+                    onWarehouseCatalogChange: vi.fn(),
+                },
+                dbtVersion: SupportedDbtVersions.V1_8,
+                parsedManifest: manifest,
+                selectedModelIds,
+                dbtProjectDir: '/tmp/dbt-project',
+            });
+
+            const result = await adapter.getDbtManifest();
+            const repeated = await adapter.getDbtManifest();
+
+            expect(result.manifest).toBe(manifest);
+            expect(repeated.manifest).toBe(manifest);
+            expect(result.selectedModelIds).toEqual(selectedModelIds);
+            expect(adapter.dbtProjectDir).toBe('/tmp/dbt-project');
+            if (selectedModelIds === undefined) {
+                expect(result).not.toHaveProperty('selectedModelIds');
+            }
+        },
+    );
+
     it('should throw error when manifest is invalid JSON', async () => {
         const invalidManifestAdapter = new DbtManifestProjectAdapter({
             warehouseClient: mockWarehouseClient,

--- a/packages/backend/src/projectAdapters/dbtManifestProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtManifestProjectAdapter.ts
@@ -1,5 +1,6 @@
 import {
     DbtError,
+    DbtManifest,
     DbtRpcGetManifestResults,
     isDbtRpcManifestResults,
     SupportedDbtVersions,
@@ -10,14 +11,18 @@ import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
 import { CachedWarehouse, DbtClient } from '../types';
 import { DbtBaseProjectAdapter } from './dbtBaseProjectAdapter';
 
+export type ManifestInput =
+    | { manifest: string; parsedManifest?: never }
+    | { parsedManifest: DbtManifest; manifest?: never };
+
 // Dummy dbt client that doesn't actually run dbt commands
 class ManifestDbtClient implements DbtClient {
-    private readonly manifest: string;
+    private readonly manifestInput: ManifestInput;
 
     private readonly selectedModelIds?: string[];
 
-    constructor(manifest: string, selectedModelIds?: string[]) {
-        this.manifest = manifest;
+    constructor(manifestInput: ManifestInput, selectedModelIds?: string[]) {
+        this.manifestInput = manifestInput;
         this.selectedModelIds = selectedModelIds;
     }
 
@@ -28,13 +33,17 @@ class ManifestDbtClient implements DbtClient {
 
     // eslint-disable-next-line class-methods-use-this
     async getDbtManifest(): Promise<DbtRpcGetManifestResults> {
-        if (!this.manifest) {
+        const { manifest, parsedManifest } = this.manifestInput;
+        if (!manifest && !parsedManifest) {
             throw new UnexpectedServerError(
                 'Missing manifest on manifest project adapter',
             );
         }
         const rawManifest = {
-            manifest: JSON.parse(this.manifest),
+            manifest:
+                parsedManifest !== undefined
+                    ? parsedManifest
+                    : JSON.parse(manifest),
             ...(this.selectedModelIds !== undefined
                 ? { selectedModelIds: this.selectedModelIds }
                 : {}),
@@ -59,12 +68,11 @@ class ManifestDbtClient implements DbtClient {
     }
 }
 
-type DbtManifestProjectAdapterArgs = {
+type DbtManifestProjectAdapterArgs = ManifestInput & {
     warehouseClient: WarehouseClient;
     cachedWarehouse: CachedWarehouse;
     dbtVersion: SupportedDbtVersions;
     analytics?: LightdashAnalytics;
-    manifest: string;
     // Optional dbt project dir to read lightdash.config.yml / project_context.yml
     // from. Used by the multiple-dbt-sources merge to point the merged manifest
     // adapter at the primary source's checkout so its project config is kept.
@@ -79,12 +87,13 @@ export class DbtManifestProjectAdapter extends DbtBaseProjectAdapter {
         dbtVersion,
         analytics,
         manifest,
+        parsedManifest,
         dbtProjectDir,
         selectedModelIds,
     }: DbtManifestProjectAdapterArgs) {
         // Create a dummy dbt client since we don't need it for manifest-based compilation
         const manifestDbtClient = new ManifestDbtClient(
-            manifest,
+            parsedManifest !== undefined ? { parsedManifest } : { manifest },
             selectedModelIds,
         );
 

--- a/packages/backend/src/projectAdapters/dbtManifestProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtManifestProjectAdapter.ts
@@ -39,11 +39,18 @@ class ManifestDbtClient implements DbtClient {
                 'Missing manifest on manifest project adapter',
             );
         }
+        let manifestValue: unknown = parsedManifest;
+        if (parsedManifest === undefined) {
+            try {
+                manifestValue = JSON.parse(manifest);
+            } catch {
+                throw new DbtError(
+                    'Cannot read response from dbt, manifest.json not valid',
+                );
+            }
+        }
         const rawManifest = {
-            manifest:
-                parsedManifest !== undefined
-                    ? parsedManifest
-                    : JSON.parse(manifest),
+            manifest: manifestValue,
             ...(this.selectedModelIds !== undefined
                 ? { selectedModelIds: this.selectedModelIds }
                 : {}),

--- a/packages/backend/src/projectAdapters/projectAdapter.ts
+++ b/packages/backend/src/projectAdapters/projectAdapter.ts
@@ -26,7 +26,7 @@ import { DbtNoneCredentialsProjectAdapter } from './dbtNoneCredentialsProjectAda
 
 export const projectAdapterFromConfig = async (
     config:
-        | DbtProjectConfig
+        | Exclude<DbtProjectConfig, DbtManifestProjectConfig>
         | (Omit<DbtManifestProjectConfig, 'manifest'> & ManifestInput),
     warehouseCredentials: CreateWarehouseCredentials,
     cachedWarehouse: CachedWarehouse,
@@ -73,8 +73,7 @@ export const projectAdapterFromConfig = async (
                 cachedWarehouse,
                 dbtVersion,
                 analytics,
-                ...('parsedManifest' in config &&
-                config.parsedManifest !== undefined
+                ...(config.parsedManifest !== undefined
                     ? { parsedManifest: config.parsedManifest }
                     : { manifest: config.manifest }),
                 dbtProjectDir: manifestOptions?.projectDir,

--- a/packages/backend/src/projectAdapters/projectAdapter.ts
+++ b/packages/backend/src/projectAdapters/projectAdapter.ts
@@ -1,5 +1,6 @@
 import {
     CreateWarehouseCredentials,
+    DbtManifestProjectConfig,
     DbtProjectConfig,
     DbtProjectType,
     DbtVersionOption,
@@ -17,11 +18,16 @@ import { DbtCloudIdeProjectAdapter } from './dbtCloudIdeProjectAdapter';
 import { DbtGithubProjectAdapter } from './dbtGithubProjectAdapter';
 import { DbtGitlabProjectAdapter } from './dbtGitlabProjectAdapter';
 import { DbtLocalCredentialsProjectAdapter } from './dbtLocalCredentialsProjectAdapter';
-import { DbtManifestProjectAdapter } from './dbtManifestProjectAdapter';
+import {
+    DbtManifestProjectAdapter,
+    ManifestInput,
+} from './dbtManifestProjectAdapter';
 import { DbtNoneCredentialsProjectAdapter } from './dbtNoneCredentialsProjectAdapter';
 
 export const projectAdapterFromConfig = async (
-    config: DbtProjectConfig,
+    config:
+        | DbtProjectConfig
+        | (Omit<DbtManifestProjectConfig, 'manifest'> & ManifestInput),
     warehouseCredentials: CreateWarehouseCredentials,
     cachedWarehouse: CachedWarehouse,
     dbtVersionOption: DbtVersionOption,
@@ -67,7 +73,10 @@ export const projectAdapterFromConfig = async (
                 cachedWarehouse,
                 dbtVersion,
                 analytics,
-                manifest: config.manifest,
+                ...('parsedManifest' in config &&
+                config.parsedManifest !== undefined
+                    ? { parsedManifest: config.parsedManifest }
+                    : { manifest: config.manifest }),
                 dbtProjectDir: manifestOptions?.projectDir,
                 selectedModelIds: manifestOptions?.selectedModelIds,
             });

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -5833,6 +5833,32 @@ describe('ProjectService.resolveCompileAdapter (MultiDbtSources regression firew
         expect(result).not.toHaveProperty('selectedModelIds');
     });
 
+    it('passes the staged merged manifest to the adapter by reference', async () => {
+        const primaryManifest = buildManifest([
+            {
+                uniqueId: 'model.pkg_a.orders',
+                name: 'orders',
+                packageName: 'pkg_a',
+            },
+        ]);
+        const sourceManifest = buildManifest([
+            {
+                uniqueId: 'model.pkg_b.customers',
+                name: 'customers',
+                packageName: 'pkg_b',
+            },
+        ]);
+        const { projectService, adapter: adapterPromise } =
+            buildMergedAdapterWithService(primaryManifest, sourceManifest);
+        const stageManifest = vi.spyOn(projectService, 'stageMergedManifest');
+
+        const { adapter } = await adapterPromise;
+        const result = await adapter.getDbtManifest();
+
+        expect(stageManifest).toHaveBeenCalledOnce();
+        expect(result.manifest).toBe(stageManifest.mock.calls[0][1]);
+    });
+
     it('preserves an empty selection when every selector matches nothing', async () => {
         const primaryManifest = buildManifest([
             {

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -5261,7 +5261,7 @@ export class ProjectService extends BaseService {
             adapter: await projectAdapterFromConfig(
                 {
                     type: DbtProjectType.MANIFEST,
-                    manifest: JSON.stringify(mergedManifest),
+                    parsedManifest: mergedManifest,
                     hideRefreshButton: true,
                 },
                 shared.warehouseCredentials,


### PR DESCRIPTION
Large compiles keep a JSON string of the merged manifest while the adapter parses a second copy. Pass the parsed manifest to the internal adapter. Keep the string input for existing callers.

Malformed JSON on the string path returns the same DbtError as an invalid manifest structure. A regression test checks the error type and message.

Linear: SPK-1922

## Result

Eight paired runs, two repetitions per arm, control and treatment alternated. Output fingerprints are identical within each arm, so the treatment saves the same explores.

| Arm | Node heap peak (MiB) | CPU (s) | Wall (s) | Unanswered probe (s) |
| --- | ---: | ---: | ---: | ---: |
| W control | 1954 / 1946 | 331.6 / 324.1 | 126.0 / 99.3 | 19.4 / 14.0 |
| W treatment | 1313 / 1332 | 308.5 / 307.2 | 100.4 / 99.5 | 14.0 / 14.1 |
| WJ control | 2713 / 2701 | 414.1 / 411.5 | 124.7 / 123.4 | 16.2 / 14.7 |
| WJ treatment | 2331 / 2327 | 393.6 / 387.9 | 124.8 / 128.5 | 13.8 / 13.3 |

The heap peak falls by about 630 MiB on W and about 380 MiB on WJ. CPU falls by about 5 percent on both arms. Wall time is unchanged within noise; the first W control ran under host contention from another agent's emulator, which explains its 126 s. Cgroup peaks are unchanged within noise.

## Measurements

Control: `c790d7bdb6d50d05251ffd4a8b23665ae5f1af77`. Treatment: `84f29e9f60277cdaa36cb04e9f85f2487346299b`. W uses the same 14-source fixture, an 8 GiB cgroup cap, and the default heap. WJ uses two joins, a 10 GiB cap, and `--max-old-space-size=8124`. Heap peaks are sampled. The external probe includes the trailing window. Repetitions alternate control and treatment within each arm.

Start: Mon Sep  7 18:38:52 UTC 2026; load 0.95 5.40 16.14 1/1963 7917; MemAvailable:   10542844 kB. Resident processes: java PID 30008: 80.1% CPU, 7329148 KiB RSS; java PID 30283: 12.4% CPU, 3511420 KiB RSS; claude PID 16534: 1.4% CPU, 515152 KiB RSS; claude PID 31868: 2.0% CPU, 443232 KiB RSS; claude PID 488: 1.9% CPU, 436256 KiB RSS; claude PID 4215: 1.8% CPU, 432552 KiB RSS; claude PID 9011: 1.5% CPU, 414392 KiB RSS; claude PID 21078: 1.2% CPU, 406088 KiB RSS; claude PID 8572: 1.5% CPU, 391860 KiB RSS; claude PID 7630: 1.4% CPU, 380860 KiB RSS; claude PID 20498: 1.4% CPU, 370004 KiB RSS; claude PID 8789: 1.5% CPU, 369268 KiB RSS.

End: Mon Sep  7 18:40:58 UTC 2026; load 10.67 7.12 15.37 2/2153 9871; MemAvailable:    5403032 kB. Resident processes: java PID 30008: 77.7% CPU, 7335768 KiB RSS; qemu-system-x86 PID 8554: 406% CPU, 5004588 KiB RSS; java PID 30283: 12.0% CPU, 3509048 KiB RSS; claude PID 16534: 1.4% CPU, 518884 KiB RSS; claude PID 31868: 2.0% CPU, 443140 KiB RSS; claude PID 18999: 2.0% CPU, 441368 KiB RSS; claude PID 488: 1.9% CPU, 439584 KiB RSS; claude PID 4215: 1.8% CPU, 439384 KiB RSS; claude PID 9011: 1.5% CPU, 414456 KiB RSS; claude PID 21078: 1.2% CPU, 399252 KiB RSS; claude PID 8572: 1.5% CPU, 377668 KiB RSS; claude PID 7630: 1.4% CPU, 371140 KiB RSS.

| Run | Wall (s) | CPU (s) | Node heap peak (MiB) | Cgroup peak (MiB) | Unanswered probe (s) | Trailing window (s) | Chunks | Explores | Fingerprint |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| `spk1922-c790-W-before-1` | 126.0 | 331.6 | 1954 | 3385 | 19.4 | 1.1 | 13 | 10006 | `0693f5008b4454a482b8160f0ee1a329eebd94bb37792b216e8d6b043ee8a55b` |

Start: Mon Sep  7 19:58:02 UTC 2026; load 4.50 3.44 4.27 8/2081 21197; MemAvailable:   12469096 kB. Resident processes: java PID 30008: 54.2% CPU, 4291012 KiB RSS; java PID 30283: 5.7% CPU, 3501676 KiB RSS; mempalace PID 19603: 102% CPU, 745992 KiB RSS; claude PID 16534: 1.4% CPU, 537168 KiB RSS; claude PID 488: 1.9% CPU, 465984 KiB RSS; claude PID 31868: 2.0% CPU, 465816 KiB RSS; claude PID 18999: 2.1% CPU, 457556 KiB RSS; claude PID 4215: 1.8% CPU, 455692 KiB RSS; claude PID 21078: 1.2% CPU, 440476 KiB RSS; claude PID 9011: 1.5% CPU, 432516 KiB RSS; claude PID 7630: 1.4% CPU, 407648 KiB RSS; claude PID 8572: 1.5% CPU, 403800 KiB RSS.

End: Mon Sep  7 19:59:43 UTC 2026; load 6.47 4.41 4.54 8/2175 22989; MemAvailable:   12263284 kB. Resident processes: java PID 30008: 53.9% CPU, 4315312 KiB RSS; java PID 30283: 5.7% CPU, 3529272 KiB RSS; mempalace PID 19603: 100% CPU, 746040 KiB RSS; claude PID 16534: 1.4% CPU, 534784 KiB RSS; claude PID 4215: 1.8% CPU, 471916 KiB RSS; claude PID 18999: 2.1% CPU, 467216 KiB RSS; claude PID 31868: 2.0% CPU, 467116 KiB RSS; claude PID 488: 1.9% CPU, 466164 KiB RSS; claude PID 21078: 1.2% CPU, 441016 KiB RSS; claude PID 9011: 1.5% CPU, 433356 KiB RSS; claude PID 7630: 1.4% CPU, 408256 KiB RSS; claude PID 8572: 1.5% CPU, 404956 KiB RSS.

| Run | Wall (s) | CPU (s) | Node heap peak (MiB) | Cgroup peak (MiB) | Unanswered probe (s) | Trailing window (s) | Chunks | Explores | Fingerprint |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| `spk1922-c790-W-after-1` | 100.4 | 308.5 | 1313 | 3467 | 14.0 | 1.0 | 13 | 10006 | `0693f5008b4454a482b8160f0ee1a329eebd94bb37792b216e8d6b043ee8a55b` |

Start: Mon Sep  7 21:04:15 UTC 2026; load 0.14 0.26 1.45 2/1961 30017; MemAvailable:   13192980 kB. Resident processes: java PID 30008: 42.8% CPU, 4606224 KiB RSS; java PID 30283: 3.9% CPU, 3528712 KiB RSS; claude PID 16534: 1.4% CPU, 547764 KiB RSS; claude PID 31868: 2.0% CPU, 454480 KiB RSS; claude PID 4215: 1.8% CPU, 453568 KiB RSS; claude PID 488: 1.9% CPU, 453496 KiB RSS; claude PID 9011: 1.5% CPU, 436000 KiB RSS; claude PID 21078: 1.2% CPU, 429680 KiB RSS; claude PID 18999: 2.1% CPU, 405204 KiB RSS; claude PID 8572: 1.5% CPU, 398844 KiB RSS; claude PID 7630: 1.4% CPU, 397064 KiB RSS; claude PID 13661: 1.6% CPU, 377892 KiB RSS.

End: Mon Sep  7 21:06:20 UTC 2026; load 2.95 1.51 1.78 4/1961 31270; MemAvailable:   12979028 kB. Resident processes: java PID 30008: 42.3% CPU, 4605868 KiB RSS; java PID 30283: 3.9% CPU, 3528392 KiB RSS; claude PID 16534: 1.4% CPU, 547368 KiB RSS; claude PID 31868: 2.0% CPU, 454432 KiB RSS; claude PID 4215: 1.8% CPU, 453556 KiB RSS; claude PID 488: 1.9% CPU, 452532 KiB RSS; claude PID 9011: 1.5% CPU, 435932 KiB RSS; claude PID 21078: 1.2% CPU, 429600 KiB RSS; claude PID 18999: 2.1% CPU, 405076 KiB RSS; claude PID 8572: 1.5% CPU, 398772 KiB RSS; claude PID 7630: 1.4% CPU, 396992 KiB RSS; claude PID 13661: 1.6% CPU, 377796 KiB RSS.

| Run | Wall (s) | CPU (s) | Node heap peak (MiB) | Cgroup peak (MiB) | Unanswered probe (s) | Trailing window (s) | Chunks | Explores | Fingerprint |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| `spk1922-c790-WJ-before-1` | 124.7 | 414.1 | 2713 | 4224 | 16.2 | 0.3 | 37 | 10006 | `c1f46391b8c12a82280cafe7c9e1297c89a80ba4c7ab3d836769287d2d42b4fc` |

Start: Mon Sep  7 21:08:37 UTC 2026; load 0.62 1.08 1.58 3/1961 31905; MemAvailable:   13191956 kB. Resident processes: java PID 30008: 41.9% CPU, 4605888 KiB RSS; java PID 30283: 3.9% CPU, 3528392 KiB RSS; claude PID 16534: 1.4% CPU, 547368 KiB RSS; claude PID 31868: 2.0% CPU, 454432 KiB RSS; claude PID 4215: 1.8% CPU, 453556 KiB RSS; claude PID 488: 1.9% CPU, 452548 KiB RSS; claude PID 9011: 1.5% CPU, 435932 KiB RSS; claude PID 21078: 1.2% CPU, 429600 KiB RSS; claude PID 18999: 2.1% CPU, 405100 KiB RSS; claude PID 8572: 1.5% CPU, 398772 KiB RSS; claude PID 7630: 1.4% CPU, 396996 KiB RSS; claude PID 13661: 1.6% CPU, 377860 KiB RSS.

End: Mon Sep  7 21:10:42 UTC 2026; load 2.97 1.98 1.86 1/1961 717; MemAvailable:   13112324 kB. Resident processes: java PID 30008: 41.5% CPU, 4605952 KiB RSS; java PID 30283: 3.8% CPU, 3528392 KiB RSS; claude PID 16534: 1.4% CPU, 547432 KiB RSS; claude PID 31868: 2.0% CPU, 454448 KiB RSS; claude PID 4215: 1.8% CPU, 453572 KiB RSS; claude PID 488: 1.9% CPU, 452552 KiB RSS; claude PID 9011: 1.5% CPU, 437020 KiB RSS; claude PID 21078: 1.2% CPU, 430652 KiB RSS; claude PID 18999: 2.1% CPU, 407712 KiB RSS; claude PID 7630: 1.4% CPU, 398500 KiB RSS; claude PID 8572: 1.5% CPU, 394656 KiB RSS; claude PID 13661: 1.6% CPU, 377880 KiB RSS.

| Run | Wall (s) | CPU (s) | Node heap peak (MiB) | Cgroup peak (MiB) | Unanswered probe (s) | Trailing window (s) | Chunks | Explores | Fingerprint |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| `spk1922-c790-WJ-after-1` | 124.8 | 393.6 | 2331 | 3800 | 13.8 | 1.0 | 37 | 10006 | `c1f46391b8c12a82280cafe7c9e1297c89a80ba4c7ab3d836769287d2d42b4fc` |

Start: Mon Sep  7 21:12:59 UTC 2026; load 1.35 1.73 1.79 1/1961 1380; MemAvailable:   13199132 kB. Resident processes: java PID 30008: 41.0% CPU, 4605952 KiB RSS; java PID 30283: 3.8% CPU, 3528392 KiB RSS; claude PID 16534: 1.4% CPU, 547436 KiB RSS; claude PID 488: 1.9% CPU, 458520 KiB RSS; claude PID 31868: 2.0% CPU, 454448 KiB RSS; claude PID 4215: 1.8% CPU, 453572 KiB RSS; claude PID 9011: 1.5% CPU, 433856 KiB RSS; claude PID 21078: 1.2% CPU, 430648 KiB RSS; claude PID 18999: 2.1% CPU, 405620 KiB RSS; claude PID 7630: 1.4% CPU, 398500 KiB RSS; claude PID 8572: 1.5% CPU, 394796 KiB RSS; claude PID 13661: 1.6% CPU, 377880 KiB RSS.

End: Mon Sep  7 21:14:39 UTC 2026; load 4.13 2.62 2.10 5/1963 2335; MemAvailable:   13014644 kB. Resident processes: java PID 30008: 40.7% CPU, 4605952 KiB RSS; java PID 30283: 3.7% CPU, 3528392 KiB RSS; claude PID 16534: 1.4% CPU, 547468 KiB RSS; claude PID 488: 1.9% CPU, 458520 KiB RSS; claude PID 31868: 2.0% CPU, 454504 KiB RSS; claude PID 4215: 1.8% CPU, 454456 KiB RSS; claude PID 9011: 1.5% CPU, 433860 KiB RSS; claude PID 21078: 1.2% CPU, 430648 KiB RSS; claude PID 18999: 2.1% CPU, 405744 KiB RSS; claude PID 7630: 1.4% CPU, 398500 KiB RSS; claude PID 8572: 1.5% CPU, 396316 KiB RSS; claude PID 13661: 1.6% CPU, 377880 KiB RSS.

| Run | Wall (s) | CPU (s) | Node heap peak (MiB) | Cgroup peak (MiB) | Unanswered probe (s) | Trailing window (s) | Chunks | Explores | Fingerprint |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| `spk1922-c790-W-before-2` | 99.3 | 324.1 | 1946 | 3494 | 14.0 | 0.9 | 13 | 10006 | `0693f5008b4454a482b8160f0ee1a329eebd94bb37792b216e8d6b043ee8a55b` |

Start: Mon Sep  7 21:16:56 UTC 2026; load 0.94 1.92 1.91 1/1960 2900; MemAvailable:   13213000 kB. Resident processes: java PID 30008: 40.3% CPU, 4605952 KiB RSS; java PID 30283: 3.7% CPU, 3528392 KiB RSS; claude PID 16534: 1.4% CPU, 547472 KiB RSS; claude PID 488: 1.9% CPU, 458520 KiB RSS; claude PID 31868: 2.0% CPU, 454520 KiB RSS; claude PID 4215: 1.8% CPU, 454484 KiB RSS; claude PID 9011: 1.5% CPU, 433856 KiB RSS; claude PID 21078: 1.2% CPU, 430652 KiB RSS; claude PID 18999: 2.1% CPU, 405748 KiB RSS; claude PID 8572: 1.5% CPU, 396180 KiB RSS; claude PID 7630: 1.4% CPU, 394520 KiB RSS; claude PID 13661: 1.6% CPU, 377880 KiB RSS.

End: Mon Sep  7 21:18:35 UTC 2026; load 3.84 2.77 2.22 1/1958 3872; MemAvailable:   13091524 kB. Resident processes: java PID 30008: 40.0% CPU, 4605952 KiB RSS; java PID 30283: 3.7% CPU, 3528392 KiB RSS; claude PID 16534: 1.4% CPU, 547472 KiB RSS; claude PID 488: 1.9% CPU, 458520 KiB RSS; claude PID 31868: 2.0% CPU, 454520 KiB RSS; claude PID 4215: 1.8% CPU, 451784 KiB RSS; claude PID 9011: 1.5% CPU, 433856 KiB RSS; claude PID 21078: 1.2% CPU, 430712 KiB RSS; claude PID 18999: 2.1% CPU, 405748 KiB RSS; claude PID 8572: 1.5% CPU, 396180 KiB RSS; claude PID 7630: 1.4% CPU, 394516 KiB RSS; claude PID 13661: 1.6% CPU, 377896 KiB RSS.

| Run | Wall (s) | CPU (s) | Node heap peak (MiB) | Cgroup peak (MiB) | Unanswered probe (s) | Trailing window (s) | Chunks | Explores | Fingerprint |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| `spk1922-c790-W-after-2` | 99.5 | 307.2 | 1332 | 3501 | 14.1 | 1.0 | 13 | 10006 | `0693f5008b4454a482b8160f0ee1a329eebd94bb37792b216e8d6b043ee8a55b` |

Start: Mon Sep  7 21:20:52 UTC 2026; load 0.94 1.95 1.99 4/1961 4576; MemAvailable:   13202000 kB. Resident processes: java PID 30008: 39.6% CPU, 4605952 KiB RSS; java PID 30283: 3.6% CPU, 3528392 KiB RSS; claude PID 16534: 1.4% CPU, 547560 KiB RSS; claude PID 488: 1.9% CPU, 459500 KiB RSS; claude PID 31868: 2.0% CPU, 455248 KiB RSS; claude PID 4215: 1.8% CPU, 452236 KiB RSS; claude PID 9011: 1.5% CPU, 434336 KiB RSS; claude PID 21078: 1.2% CPU, 431140 KiB RSS; claude PID 18999: 2.1% CPU, 406260 KiB RSS; claude PID 8572: 1.5% CPU, 396592 KiB RSS; claude PID 7630: 1.4% CPU, 395112 KiB RSS; claude PID 13661: 1.6% CPU, 378544 KiB RSS.

End: Mon Sep  7 21:22:55 UTC 2026; load 4.17 2.97 2.37 2/2061 6901; MemAvailable:   12973044 kB. Resident processes: java PID 30008: 39.2% CPU, 4605952 KiB RSS; java PID 30283: 3.6% CPU, 3528388 KiB RSS; claude PID 16534: 1.4% CPU, 546932 KiB RSS; claude PID 488: 1.9% CPU, 455400 KiB RSS; claude PID 31868: 2.0% CPU, 455252 KiB RSS; claude PID 4215: 1.8% CPU, 452236 KiB RSS; claude PID 9011: 1.5% CPU, 434316 KiB RSS; claude PID 21078: 1.2% CPU, 427596 KiB RSS; claude PID 18999: 2.1% CPU, 405100 KiB RSS; claude PID 8572: 1.5% CPU, 396588 KiB RSS; claude PID 7630: 1.4% CPU, 395064 KiB RSS; claude PID 13661: 1.6% CPU, 378540 KiB RSS.

| Run | Wall (s) | CPU (s) | Node heap peak (MiB) | Cgroup peak (MiB) | Unanswered probe (s) | Trailing window (s) | Chunks | Explores | Fingerprint |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| `spk1922-c790-WJ-before-2` | 123.4 | 411.5 | 2701 | 3763 | 14.7 | 1.1 | 37 | 10006 | `c1f46391b8c12a82280cafe7c9e1297c89a80ba4c7ab3d836769287d2d42b4fc` |

Start: Mon Sep  7 21:52:08 UTC 2026; load 1.15 3.07 3.11 7/2136 17160; MemAvailable:   12721416 kB. Resident processes: java PID 30008: 34.7% CPU, 4605912 KiB RSS; java PID 30283: 3.2% CPU, 3527300 KiB RSS; claude PID 16534: 1.4% CPU, 542340 KiB RSS; claude PID 488: 1.9% CPU, 478028 KiB RSS; claude PID 4215: 1.8% CPU, 461936 KiB RSS; claude PID 31868: 2.0% CPU, 456888 KiB RSS; claude PID 9011: 1.5% CPU, 440176 KiB RSS; claude PID 21078: 1.2% CPU, 428456 KiB RSS; claude PID 18999: 2.1% CPU, 405296 KiB RSS; claude PID 8572: 1.5% CPU, 401548 KiB RSS; claude PID 7630: 1.4% CPU, 393704 KiB RSS; claude PID 8789: 1.5% CPU, 377940 KiB RSS.

End: Mon Sep  7 21:54:16 UTC 2026; load 3.55 3.55 3.30 1/2109 18567; MemAvailable:   12554704 kB. Resident processes: java PID 30008: 34.4% CPU, 4605912 KiB RSS; java PID 30283: 3.2% CPU, 3527256 KiB RSS; claude PID 16534: 1.4% CPU, 542244 KiB RSS; claude PID 488: 1.9% CPU, 478028 KiB RSS; claude PID 4215: 1.8% CPU, 461864 KiB RSS; claude PID 31868: 2.0% CPU, 456888 KiB RSS; claude PID 9011: 1.5% CPU, 438236 KiB RSS; claude PID 21078: 1.2% CPU, 428456 KiB RSS; claude PID 18999: 2.1% CPU, 405296 KiB RSS; claude PID 8572: 1.5% CPU, 401552 KiB RSS; claude PID 7630: 1.4% CPU, 393708 KiB RSS; claude PID 8789: 1.5% CPU, 377940 KiB RSS.

| Run | Wall (s) | CPU (s) | Node heap peak (MiB) | Cgroup peak (MiB) | Unanswered probe (s) | Trailing window (s) | Chunks | Explores | Fingerprint |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| `spk1922-c790-WJ-after-2` | 128.5 | 387.9 | 2327 | 3825 | 13.3 | 1.0 | 37 | 10006 | `c1f46391b8c12a82280cafe7c9e1297c89a80ba4c7ab3d836769287d2d42b4fc` |

All planned runs complete. Content fingerprints match within each arm. This PR remains in draft for review. The tables retain the host state for each run.

W must save 13 chunks and 10,006 explores. WJ must save 37 chunks and 10,006 explores. Full fingerprints appear beside every completed run.

## Validation

The adapter input now excludes the duplicate public MANIFEST union member. It narrows directly on parsedManifest. No cast is needed. Backend typecheck and all ten adapter tests pass on head `84f29e9f60277cdaa36cb04e9f85f2487346299b`. [Build & Test passes on this exact head](https://github.com/lightdash/lightdash/actions/runs/34155516916/job/101846486031). The full local backend suite passes.

The full backend suite passes 588 files: 9,749 tests pass, one expected failure remains, and one test is skipped. Package lint and oxfmt pass on all changed files. Tests cover parsed-object identity, repeated reads, selection, and the service handoff.

## Not measured here

Code-read and unit tests cover the actual service handoff and adapter behavior. The scale rig replays the pipeline. It does not run ProjectService or persist the gzip manifest. Its save path uses a transaction per chunk. It does not prove product transaction behavior. Remote Git performance is not measured here.

The internal adapter accepts a parsed manifest as an alternative to its existing string input. The public configuration format stays the same.

Co-Authored-By: Codex GPT-6-Astra <noreply@openai.com>

