### PR TITLE
fix: save compiled explores in batches

### DIFF
--- a/packages/backend/src/database/entities/projects.ts
+++ b/packages/backend/src/database/entities/projects.ts
@@ -12,6 +12,7 @@ import { Knex } from 'knex';
 export const ProjectTableName = 'projects';
 export const CachedExploresTableName = 'cached_explores';
 export const CachedExploreTableName = 'cached_explore';
+export const CachedExploreStagingTableName = 'cached_explore_staging';
 export const CachedWarehouseTableName = 'cached_warehouse';
 
 export type DbProject = {
@@ -124,6 +125,11 @@ export type CachedExploreTable = Knex.CompositeTableType<
     DbCachedExplore,
     Omit<DbCachedExplore, 'cached_explore_uuid'>
 >;
+
+export type DbCachedExploreStaging = DbCachedExplore & {
+    save_uuid: string;
+    created_at: Date;
+};
 
 export type DbCachedWarehouse = {
     project_uuid: string;

--- a/packages/backend/src/database/migrations/20260907190000_create_cached_explore_staging.ts
+++ b/packages/backend/src/database/migrations/20260907190000_create_cached_explore_staging.ts
@@ -1,0 +1,41 @@
+import type { Knex } from 'knex';
+
+export const classification = {
+    kind: 'safe',
+    reason: 'Adds an isolated staging table for atomic cached explore replacement',
+} as const;
+
+const CachedExploreStagingTableName = 'cached_explore_staging';
+const ProjectsTableName = 'projects';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw("SET LOCAL lock_timeout = '5s'");
+    await knex.schema.createTable(CachedExploreStagingTableName, (table) => {
+        table
+            .uuid('cached_explore_uuid')
+            .primary()
+            .notNullable()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+        table.uuid('save_uuid').notNullable();
+        table
+            .uuid('project_uuid')
+            .notNullable()
+            .references('project_uuid')
+            .inTable(ProjectsTableName)
+            .onDelete('CASCADE')
+            .index();
+        table.text('name').notNullable();
+        table.specificType('table_names', 'TEXT[]').notNullable();
+        table.jsonb('explore').notNullable();
+        table
+            .timestamp('created_at', { useTz: true })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+        table.unique(['save_uuid', 'name', 'project_uuid']);
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw("SET LOCAL lock_timeout = '5s'");
+    await knex.schema.dropTable(CachedExploreStagingTableName);
+}

--- a/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
@@ -887,43 +887,172 @@ describe('ProjectModel', () => {
             }
         };
 
-        const mockCacheQueries = (
-            userManagedExplores: { explore: unknown }[] = [],
-        ) => {
+        const mockStagedCacheQueries = ({
+            getUserManagedExplores = () => [],
+            getLockedNames,
+            onLock,
+            stageError,
+            swapError,
+        }: {
+            getUserManagedExplores?: () => {
+                explore: { name: string; label?: string };
+            }[];
+            getLockedNames?: () => string[];
+            onLock?: () => void;
+            stageError?: Error;
+            swapError?: Error;
+        } = {}) => {
+            const stagedRows = new Map<
+                string,
+                {
+                    name: string;
+                    cached_explore_uuid: string;
+                    label?: string;
+                }
+            >();
+            const stageExplore = (explore: {
+                name: string;
+                label?: string;
+            }) => {
+                const existing = stagedRows.get(explore.name);
+                stagedRows.set(explore.name, {
+                    name: explore.name,
+                    cached_explore_uuid:
+                        existing?.cached_explore_uuid ??
+                        `${explore.name}-${explore.label}`,
+                    label: explore.label,
+                });
+            };
+            const stageInsert = tracker.on.insert(
+                ({ sql }) =>
+                    sql.includes('"cached_explore_staging"') &&
+                    sql.includes('values'),
+            );
+            if (stageError) {
+                stageInsert.simulateError(stageError);
+            } else {
+                stageInsert.response(({ bindings }) => {
+                    bindings
+                        .filter(
+                            (binding): binding is string =>
+                                typeof binding === 'string' &&
+                                binding.startsWith('{'),
+                        )
+                        .map(
+                            (binding) =>
+                                JSON.parse(binding) as {
+                                    name: string;
+                                    label?: string;
+                                },
+                        )
+                        .forEach(stageExplore);
+                    return [];
+                });
+            }
             tracker.on
                 .insert(({ sql }) => sql.includes('"cached_explores"'))
-                .response([]);
+                .response(() => {
+                    onLock?.();
+                    return [];
+                });
             tracker.on
                 .select(({ sql }) => sql.includes('"cached_explores"'))
                 .response([{}]);
             tracker.on
-                .select(({ sql }) => sql.includes('"cached_explore"'))
-                .response(userManagedExplores);
-            tracker.on
                 .delete(({ sql }) => sql.includes('"cached_explore"'))
                 .response([]);
             tracker.on
-                .insert(({ sql }) => sql.includes('"cached_explore"'))
-                .response(({ bindings }) => {
-                    const serialised = bindings.find(
-                        (binding): binding is string =>
-                            typeof binding === 'string' &&
-                            binding.startsWith('{'),
-                    );
-                    const saved = JSON.parse(serialised ?? '{}') as {
-                        label?: string;
-                        name: string;
-                    };
-                    return [
-                        {
-                            name: saved.name,
-                            cached_explore_uuid: `${saved.name}-${saved.label}`,
-                        },
-                    ];
+                .delete(({ sql }) => sql.includes('"cached_explore_staging"'))
+                .response([]);
+            tracker.on
+                .select(({ sql }) => sql.includes('"cached_explore_staging"'))
+                .response(() => {
+                    const names =
+                        getLockedNames?.() ?? Array.from(stagedRows.keys());
+                    return names.map((name) => ({ name }));
                 });
+            tracker.on
+                .any(
+                    ({ sql }) =>
+                        sql.startsWith('INSERT INTO') &&
+                        sql.includes('"cached_explore_staging"') &&
+                        sql.includes("explore->>'type'"),
+                )
+                .response(() => {
+                    const managedRows = getUserManagedExplores();
+                    managedRows.forEach(({ explore }) => stageExplore(explore));
+                    return {
+                        rows: managedRows.map(({ explore }) =>
+                            stagedRows.get(explore.name),
+                        ),
+                    };
+                });
+            const promotion = tracker.on.any(
+                ({ sql }) =>
+                    sql.startsWith('INSERT INTO "cached_explore"') &&
+                    sql.includes('SELECT cached_explore_uuid'),
+            );
+            if (swapError) {
+                promotion.simulateError(swapError);
+            } else {
+                promotion.response(() => ({
+                    rows: Array.from(stagedRows.values()),
+                }));
+            }
+            return { stagedRows };
         };
 
-        test('keeps managed explores, appends absent managed explores, and preserves UUID order', async () => {
+        test('fully consumes the generator before taking the transaction lock', async () => {
+            oneRowChunks();
+            let consumed = false;
+            mockStagedCacheQueries({
+                onLock: () => expect(consumed).toBe(true),
+            });
+            async function* observedStream() {
+                yield exploreWithMetricFilters;
+                consumed = true;
+            }
+
+            await model.saveExploreStreamToCache(projectUuid, observedStream());
+
+            expect(consumed).toBe(true);
+        });
+
+        test('locks the project before the exact staged name set and promotion', async () => {
+            oneRowChunks();
+            mockStagedCacheQueries();
+
+            await model.saveExploreStreamToCache(
+                projectUuid,
+                stream([exploreWithMetricFilters]),
+            );
+
+            const transactionQueries = tracker.history.transactions[0].queries;
+            const projectLockIndex = transactionQueries.findIndex(
+                ({ sql }) =>
+                    sql.includes('"cached_explores"') &&
+                    sql.includes('for update'),
+            );
+            const stagedLockIndex = transactionQueries.findIndex(
+                ({ sql }) =>
+                    sql.includes('"cached_explore_staging"') &&
+                    sql.includes('for update'),
+            );
+            const liveDeleteIndex = transactionQueries.findIndex(({ sql }) =>
+                sql.startsWith('delete from "cached_explore"'),
+            );
+            const promotionIndex = transactionQueries.findIndex(
+                ({ sql }) =>
+                    sql.startsWith('INSERT INTO "cached_explore"') &&
+                    sql.includes('SELECT cached_explore_uuid'),
+            );
+            expect(projectLockIndex).toBeGreaterThanOrEqual(0);
+            expect(stagedLockIndex).toBeGreaterThan(projectLockIndex);
+            expect(liveDeleteIndex).toBeGreaterThan(stagedLockIndex);
+            expect(promotionIndex).toBeGreaterThan(liveDeleteIndex);
+        });
+
+        test('keeps managed overrides, late managed writes, and result order', async () => {
             oneRowChunks();
             const managedOverride = {
                 ...exploreWithMetricFilters,
@@ -947,10 +1076,16 @@ describe('ProjectModel', () => {
                 name: 'incoming',
                 label: 'incoming',
             };
-            mockCacheQueries([
-                { explore: managedOverride },
-                { explore: managedAppend },
-            ]);
+            let userManagedExplores: { explore: typeof managedOverride }[] = [];
+            const { stagedRows } = mockStagedCacheQueries({
+                getUserManagedExplores: () => userManagedExplores,
+                onLock: () => {
+                    userManagedExplores = [
+                        { explore: managedOverride },
+                        { explore: managedAppend },
+                    ];
+                },
+            });
 
             await expect(
                 model.saveExploreStreamToCache(
@@ -959,51 +1094,70 @@ describe('ProjectModel', () => {
                 ),
             ).resolves.toEqual({
                 cachedExploreUuids: [
-                    'managed_override-managed',
+                    'managed_override-incoming',
                     'incoming-incoming',
                     'managed_append-append',
                 ],
             });
-
-            expect(tracker.history.insert).toEqual(
-                expect.arrayContaining([
-                    expect.objectContaining({
-                        bindings: expect.arrayContaining([
-                            JSON.stringify(managedOverride),
-                        ]),
-                    }),
-                    expect.objectContaining({
-                        bindings: expect.arrayContaining([
-                            JSON.stringify(managedAppend),
-                        ]),
-                    }),
-                ]),
-            );
+            expect(stagedRows.get('managed_override')?.label).toBe('managed');
         });
 
-        test('keeps the last duplicate across streamed batches', async () => {
-            oneRowChunks();
+        test('keeps the last duplicate within and across streamed batches while preserving first-name order', async () => {
+            vi.mocked(chunkAsyncRowsByBytesMock).mockImplementation(
+                async function* twoRowChunks(rows) {
+                    let pending: { row: AnyType; bytes: number }[] = [];
+                    for await (const row of rows) {
+                        pending.push(row);
+                        if (pending.length === 2) {
+                            yield {
+                                rows: pending.map((item) => item.row),
+                                bytes: pending.reduce(
+                                    (total, item) => total + item.bytes,
+                                    0,
+                                ),
+                            };
+                            pending = [];
+                        }
+                    }
+                    if (pending.length > 0) {
+                        yield {
+                            rows: pending.map((item) => item.row),
+                            bytes: pending.reduce(
+                                (total, item) => total + item.bytes,
+                                0,
+                            ),
+                        };
+                    }
+                },
+            );
             const first = {
                 ...exploreWithMetricFilters,
                 name: 'duplicate',
                 label: 'first',
             };
             const second = { ...first, label: 'second' };
-            mockCacheQueries();
+            const other = {
+                ...exploreWithMetricFilters,
+                name: 'other',
+                label: 'other',
+            };
+            const third = { ...first, label: 'third' };
+            const { stagedRows } = mockStagedCacheQueries();
 
             await expect(
                 model.saveExploreStreamToCache(
                     projectUuid,
-                    stream([first, second]),
+                    stream([first, second, other, third]),
                 ),
             ).resolves.toEqual({
-                cachedExploreUuids: ['duplicate-second'],
+                cachedExploreUuids: ['duplicate-second', 'other-other'],
             });
+            expect(stagedRows.get('duplicate')?.label).toBe('third');
         });
 
         test('rejects an empty stream', async () => {
             oneRowChunks();
-            mockCacheQueries();
+            mockStagedCacheQueries();
 
             await expect(
                 model.saveExploreStreamToCache(projectUuid, stream([])),
@@ -1012,7 +1166,7 @@ describe('ProjectModel', () => {
 
         test('propagates source stream failures', async () => {
             oneRowChunks();
-            mockCacheQueries();
+            mockStagedCacheQueries();
             async function* failingStream() {
                 yield exploreWithMetricFilters;
                 throw new Error('stream failed');
@@ -1021,6 +1175,81 @@ describe('ProjectModel', () => {
             await expect(
                 model.saveExploreStreamToCache(projectUuid, failingStream()),
             ).rejects.toThrow('stream failed');
+            expect(
+                tracker.history.delete.filter(({ sql }) =>
+                    sql.includes('"cached_explore"'),
+                ),
+            ).toHaveLength(0);
+            expect(
+                tracker.history.insert.some(({ sql }) =>
+                    sql.includes('"cached_explores"'),
+                ),
+            ).toBe(false);
+            expect(
+                tracker.history.all.some(({ sql }) =>
+                    sql.startsWith('delete from "cached_explore_staging"'),
+                ),
+            ).toBe(true);
+        });
+
+        test('propagates staging insert failures without entering the swap', async () => {
+            oneRowChunks();
+            mockStagedCacheQueries({
+                stageError: new Error('stage insert failed'),
+            });
+
+            await expect(
+                model.saveExploreStreamToCache(
+                    projectUuid,
+                    stream([exploreWithMetricFilters]),
+                ),
+            ).rejects.toThrow('stage insert failed');
+            expect(
+                tracker.history.delete.filter(({ sql }) =>
+                    sql.includes('"cached_explore"'),
+                ),
+            ).toHaveLength(0);
+            expect(
+                tracker.history.insert.some(({ sql }) =>
+                    sql.includes('"cached_explores"'),
+                ),
+            ).toBe(false);
+        });
+
+        test('propagates swap failures after deletion', async () => {
+            oneRowChunks();
+            mockStagedCacheQueries({
+                swapError: new Error('swap insert failed'),
+            });
+
+            await expect(
+                model.saveExploreStreamToCache(
+                    projectUuid,
+                    stream([exploreWithMetricFilters]),
+                ),
+            ).rejects.toThrow('swap insert failed');
+            expect(
+                tracker.history.delete.filter(({ sql }) =>
+                    sql.includes('"cached_explore"'),
+                ),
+            ).toHaveLength(1);
+        });
+
+        test('rejects a changed staged name set before deleting live rows', async () => {
+            oneRowChunks();
+            mockStagedCacheQueries({ getLockedNames: () => [] });
+
+            await expect(
+                model.saveExploreStreamToCache(
+                    projectUuid,
+                    stream([exploreWithMetricFilters]),
+                ),
+            ).rejects.toThrow('Cached explore staging name set mismatch');
+            expect(
+                tracker.history.delete.filter(({ sql }) =>
+                    sql.includes('"cached_explore"'),
+                ),
+            ).toHaveLength(0);
         });
     });
 

--- a/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
@@ -68,6 +68,15 @@ import {
     updateTableSelectionMock,
 } from './ProjectModel.mock';
 
+const { chunkAsyncRowsByBytesMock } = vi.hoisted(() => ({
+    chunkAsyncRowsByBytesMock: vi.fn(),
+}));
+
+vi.mock('../../utils/chunkRowsByBytes', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('../../utils/chunkRowsByBytes')>()),
+    chunkAsyncRowsByBytes: chunkAsyncRowsByBytesMock,
+}));
+
 function queryMatcher(
     tableName: string,
     params: AnyType[] = [],
@@ -858,6 +867,160 @@ describe('ProjectModel', () => {
             expect(tracker.history.select).toHaveLength(1);
             expect(tracker.history.delete).toHaveLength(1);
             expect(tracker.history.insert).toHaveLength(2);
+        });
+    });
+
+    describe('saveExploreStreamToCache', () => {
+        const oneRowChunks = () => {
+            vi.mocked(chunkAsyncRowsByBytesMock).mockImplementation(
+                async function* singleRowChunks(rows) {
+                    for await (const row of rows) {
+                        yield { rows: [row.row], bytes: row.bytes };
+                    }
+                },
+            );
+        };
+
+        const stream = async function* exploreStream<T>(items: T[]) {
+            for (const item of items) {
+                yield item;
+            }
+        };
+
+        const mockCacheQueries = (
+            userManagedExplores: { explore: unknown }[] = [],
+        ) => {
+            tracker.on
+                .insert(({ sql }) => sql.includes('"cached_explores"'))
+                .response([]);
+            tracker.on
+                .select(({ sql }) => sql.includes('"cached_explores"'))
+                .response([{}]);
+            tracker.on
+                .select(({ sql }) => sql.includes('"cached_explore"'))
+                .response(userManagedExplores);
+            tracker.on
+                .delete(({ sql }) => sql.includes('"cached_explore"'))
+                .response([]);
+            tracker.on
+                .insert(({ sql }) => sql.includes('"cached_explore"'))
+                .response(({ bindings }) => {
+                    const serialised = bindings.find(
+                        (binding): binding is string =>
+                            typeof binding === 'string' &&
+                            binding.startsWith('{'),
+                    );
+                    const saved = JSON.parse(serialised ?? '{}') as {
+                        label?: string;
+                        name: string;
+                    };
+                    return [
+                        {
+                            name: saved.name,
+                            cached_explore_uuid: `${saved.name}-${saved.label}`,
+                        },
+                    ];
+                });
+        };
+
+        test('keeps managed explores, appends absent managed explores, and preserves UUID order', async () => {
+            oneRowChunks();
+            const managedOverride = {
+                ...exploreWithMetricFilters,
+                name: 'managed_override',
+                label: 'managed',
+                type: ExploreType.VIRTUAL,
+            };
+            const managedAppend = {
+                ...exploreWithMetricFilters,
+                name: 'managed_append',
+                label: 'append',
+                type: ExploreType.VIRTUAL,
+            };
+            const incomingOverride = {
+                ...exploreWithMetricFilters,
+                name: 'managed_override',
+                label: 'incoming',
+            };
+            const incoming = {
+                ...exploreWithMetricFilters,
+                name: 'incoming',
+                label: 'incoming',
+            };
+            mockCacheQueries([
+                { explore: managedOverride },
+                { explore: managedAppend },
+            ]);
+
+            await expect(
+                model.saveExploreStreamToCache(
+                    projectUuid,
+                    stream([incomingOverride, incoming]),
+                ),
+            ).resolves.toEqual({
+                cachedExploreUuids: [
+                    'managed_override-managed',
+                    'incoming-incoming',
+                    'managed_append-append',
+                ],
+            });
+
+            expect(tracker.history.insert).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        bindings: expect.arrayContaining([
+                            JSON.stringify(managedOverride),
+                        ]),
+                    }),
+                    expect.objectContaining({
+                        bindings: expect.arrayContaining([
+                            JSON.stringify(managedAppend),
+                        ]),
+                    }),
+                ]),
+            );
+        });
+
+        test('keeps the last duplicate across streamed batches', async () => {
+            oneRowChunks();
+            const first = {
+                ...exploreWithMetricFilters,
+                name: 'duplicate',
+                label: 'first',
+            };
+            const second = { ...first, label: 'second' };
+            mockCacheQueries();
+
+            await expect(
+                model.saveExploreStreamToCache(
+                    projectUuid,
+                    stream([first, second]),
+                ),
+            ).resolves.toEqual({
+                cachedExploreUuids: ['duplicate-second'],
+            });
+        });
+
+        test('rejects an empty stream', async () => {
+            oneRowChunks();
+            mockCacheQueries();
+
+            await expect(
+                model.saveExploreStreamToCache(projectUuid, stream([])),
+            ).rejects.toThrow('No explores to save');
+        });
+
+        test('propagates source stream failures', async () => {
+            oneRowChunks();
+            mockCacheQueries();
+            async function* failingStream() {
+                yield exploreWithMetricFilters;
+                throw new Error('stream failed');
+            }
+
+            await expect(
+                model.saveExploreStreamToCache(projectUuid, failingStream()),
+            ).rejects.toThrow('stream failed');
         });
     });
 

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -168,7 +168,10 @@ import {
 import { ServiceAccountsTableName } from '../../ee/database/entities/serviceAccounts';
 import Logger from '../../logging/logger';
 import { wrapSentryTransaction, wrapSentryTransactionSync } from '../../utils';
-import { chunkRowsByBytes } from '../../utils/chunkRowsByBytes';
+import {
+    chunkAsyncRowsByBytes,
+    chunkRowsByBytes,
+} from '../../utils/chunkRowsByBytes';
 import {
     hasSameDbtCredentialDestination,
     hasSameWarehouseCredentialDestination,
@@ -2336,6 +2339,119 @@ export class ProjectModel {
                     return {
                         cachedExploreUuids: individualCachedExplores.map(
                             (explore) => explore.cached_explore_uuid,
+                        ),
+                    };
+                }),
+        );
+    }
+
+    async saveExploreStreamToCache(
+        projectUuid: string,
+        explores: AsyncIterable<Explore | ExploreError>,
+    ): Promise<{ cachedExploreUuids: string[] }> {
+        return wrapSentryTransaction(
+            'ProjectModel.saveExploresToCache',
+            {},
+            async () =>
+                this.database.transaction(async (trx) => {
+                    await ProjectModel.lockAndEnsureCachedExplores(
+                        trx,
+                        projectUuid,
+                    );
+                    const userManagedRows = await trx(CachedExploreTableName)
+                        .select<{ explore: Explore | ExploreError }[]>(
+                            'explore',
+                        )
+                        .where('project_uuid', projectUuid)
+                        .whereRaw("explore->>'type' = ANY(?)", [
+                            [...USER_MANAGED_EXPLORE_TYPES],
+                        ]);
+                    const userManagedExplores = new Map(
+                        userManagedRows.map(({ explore }) => [
+                            explore.name,
+                            explore,
+                        ]),
+                    );
+                    await trx(CachedExploreTableName)
+                        .where('project_uuid', projectUuid)
+                        .delete();
+
+                    let savedBytes = 0;
+                    const seenNames = new Set<string>();
+                    async function* resolvedExplores() {
+                        for await (const explore of explores) {
+                            seenNames.add(explore.name);
+                            yield (
+                                userManagedExplores.get(explore.name) ?? explore
+                            );
+                        }
+                        for (const [name, explore] of userManagedExplores) {
+                            if (!seenNames.has(name)) yield explore;
+                        }
+                    }
+                    async function* sizedRows() {
+                        for await (const explore of resolvedExplores()) {
+                            const serialised = JSON.stringify(explore);
+                            const bytes = Buffer.byteLength(serialised);
+                            savedBytes += bytes;
+                            yield {
+                                row: {
+                                    project_uuid: projectUuid,
+                                    name: explore.name,
+                                    table_names: Object.keys(
+                                        explore.tables || {},
+                                    ),
+                                    explore: serialised,
+                                },
+                                bytes,
+                            };
+                        }
+                    }
+
+                    const cachedExploreUuidsByName = new Map<string, string>();
+                    let chunkCount = 0;
+                    let largestChunkBytes = 0;
+                    for await (const { rows, bytes } of chunkAsyncRowsByBytes(
+                        sizedRows(),
+                    )) {
+                        const uniqueRows = Array.from(
+                            new Map(
+                                rows.map((row) => [row.name, row]),
+                            ).values(),
+                        );
+                        const saved = await trx<DbCachedExplore>(
+                            CachedExploreTableName,
+                        )
+                            .insert(uniqueRows)
+                            .onConflict(['name', 'project_uuid'])
+                            .merge(['table_names', 'explore'])
+                            .returning(['name', 'cached_explore_uuid']);
+                        for (const row of saved) {
+                            cachedExploreUuidsByName.set(
+                                row.name,
+                                row.cached_explore_uuid,
+                            );
+                        }
+                        chunkCount += 1;
+                        largestChunkBytes = Math.max(largestChunkBytes, bytes);
+                    }
+                    if (cachedExploreUuidsByName.size === 0) {
+                        throw new ParameterError('No explores to save');
+                    }
+                    Logger.info(
+                        `dbt.compile.saveExplores projectUuid=${projectUuid} explores=${cachedExploreUuidsByName.size} chunks=${chunkCount} largestChunkBytes=${largestChunkBytes}`,
+                        {
+                            event: 'dbt.compile.saveExplores',
+                            projectUuid,
+                            explores: cachedExploreUuidsByName.size,
+                            chunks: chunkCount,
+                            largestChunkBytes,
+                            savedBytes,
+                        },
+                    );
+                    return {
+                        cachedExploreUuids: Array.from(
+                            cachedExploreUuidsByName.values(),
                         ),
                     };
                 }),

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -119,12 +119,14 @@ import {
 import { ProjectMergedManifestsTable } from '../../database/entities/projectMergedManifests';
 import {
     CachedExploresTableName,
+    CachedExploreStagingTableName,
     CachedExploreTableName,
     CachedWarehouseTableName,
     DbCachedWarehouse,
     DbProject,
     ProjectTableName,
     type DbCachedExplore,
+    type DbCachedExploreStaging,
 } from '../../database/entities/projects';
 import { RolesTableName } from '../../database/entities/roles';
 import {
@@ -2352,50 +2354,25 @@ export class ProjectModel {
         return wrapSentryTransaction(
             'ProjectModel.saveExploresToCache',
             {},
-            async () =>
-                this.database.transaction(async (trx) => {
-                    await ProjectModel.lockAndEnsureCachedExplores(
-                        trx,
-                        projectUuid,
-                    );
-                    const userManagedRows = await trx(CachedExploreTableName)
-                        .select<{ explore: Explore | ExploreError }[]>(
-                            'explore',
-                        )
-                        .where('project_uuid', projectUuid)
-                        .whereRaw("explore->>'type' = ANY(?)", [
-                            [...USER_MANAGED_EXPLORE_TYPES],
-                        ]);
-                    const userManagedExplores = new Map(
-                        userManagedRows.map(({ explore }) => [
-                            explore.name,
-                            explore,
-                        ]),
-                    );
-                    await trx(CachedExploreTableName)
-                        .where('project_uuid', projectUuid)
-                        .delete();
-
+            async () => {
+                const saveUuid = uuidv4();
+                try {
+                    const stageStartedAt = performance.now();
                     let savedBytes = 0;
-                    const seenNames = new Set<string>();
-                    async function* resolvedExplores() {
+                    const stagedNames = new Set<string>();
+                    const stagedNameOrder: string[] = [];
+                    const sizedRows = async function* sizedRowsGenerator() {
                         for await (const explore of explores) {
-                            seenNames.add(explore.name);
-                            yield (
-                                userManagedExplores.get(explore.name) ?? explore
-                            );
-                        }
-                        for (const [name, explore] of userManagedExplores) {
-                            if (!seenNames.has(name)) yield explore;
-                        }
-                    }
-                    async function* sizedRows() {
-                        for await (const explore of resolvedExplores()) {
+                            if (!stagedNames.has(explore.name)) {
+                                stagedNames.add(explore.name);
+                                stagedNameOrder.push(explore.name);
+                            }
                             const serialised = JSON.stringify(explore);
                             const bytes = Buffer.byteLength(serialised);
                             savedBytes += bytes;
                             yield {
                                 row: {
+                                    save_uuid: saveUuid,
                                     project_uuid: projectUuid,
                                     name: explore.name,
                                     table_names: Object.keys(
@@ -2406,9 +2383,8 @@ export class ProjectModel {
                                 bytes,
                             };
                         }
-                    }
+                    };
 
-                    const cachedExploreUuidsByName = new Map<string, string>();
                     let chunkCount = 0;
                     let largestChunkBytes = 0;
                     for await (const { rows, bytes } of chunkAsyncRowsByBytes(
@@ -2419,27 +2395,121 @@ export class ProjectModel {
                                 rows.map((row) => [row.name, row]),
                             ).values(),
                         );
-                        const saved = await trx<DbCachedExplore>(
-                            CachedExploreTableName,
+                        await this.database<DbCachedExploreStaging>(
+                            CachedExploreStagingTableName,
                         )
                             .insert(uniqueRows)
-                            .onConflict(['name', 'project_uuid'])
-                            .merge(['table_names', 'explore'])
-                            .returning(['name', 'cached_explore_uuid']);
-                        for (const row of saved) {
-                            cachedExploreUuidsByName.set(
-                                row.name,
-                                row.cached_explore_uuid,
-                            );
-                        }
+                            .onConflict(['save_uuid', 'name', 'project_uuid'])
+                            .merge(['table_names', 'explore']);
                         chunkCount += 1;
                         largestChunkBytes = Math.max(largestChunkBytes, bytes);
                     }
-                    if (cachedExploreUuidsByName.size === 0) {
-                        throw new ParameterError('No explores to save');
+                    const stageDurationMs = Math.round(
+                        performance.now() - stageStartedAt,
+                    );
+
+                    const swapStartedAt = performance.now();
+                    const { promotedRows, managedNames } =
+                        await this.database.transaction(async (trx) => {
+                            await ProjectModel.lockAndEnsureCachedExplores(
+                                trx,
+                                projectUuid,
+                            );
+                            const managedResult = await trx.raw<{
+                                rows: {
+                                    name: string;
+                                    cached_explore_uuid: string;
+                                }[];
+                            }>(
+                                `INSERT INTO ?? (save_uuid, project_uuid, name, table_names, explore)
+                                 SELECT ?, project_uuid, name, table_names, explore
+                                 FROM ??
+                                 WHERE project_uuid = ?
+                                   AND explore->>'type' = ANY(?)
+                                 ON CONFLICT (save_uuid, name, project_uuid) DO UPDATE
+                                 SET table_names = EXCLUDED.table_names,
+                                     explore = EXCLUDED.explore
+                                 RETURNING name, cached_explore_uuid`,
+                                [
+                                    CachedExploreStagingTableName,
+                                    saveUuid,
+                                    CachedExploreTableName,
+                                    projectUuid,
+                                    [...USER_MANAGED_EXPLORE_TYPES],
+                                ],
+                            );
+                            const expectedNames = new Set(stagedNames);
+                            managedResult.rows.forEach(({ name }) =>
+                                expectedNames.add(name),
+                            );
+                            if (expectedNames.size === 0) {
+                                throw new ParameterError('No explores to save');
+                            }
+                            const lockedStagedRows = await trx(
+                                CachedExploreStagingTableName,
+                            )
+                                .select<{ name: string }[]>('name')
+                                .where({
+                                    save_uuid: saveUuid,
+                                    project_uuid: projectUuid,
+                                })
+                                .forUpdate();
+                            if (
+                                lockedStagedRows.length !==
+                                    expectedNames.size ||
+                                lockedStagedRows.some(
+                                    ({ name }) => !expectedNames.has(name),
+                                )
+                            ) {
+                                throw new UnexpectedServerError(
+                                    'Cached explore staging name set mismatch',
+                                );
+                            }
+                            await trx(CachedExploreTableName)
+                                .where('project_uuid', projectUuid)
+                                .delete();
+                            const promotedResult = await trx.raw<{
+                                rows: {
+                                    name: string;
+                                    cached_explore_uuid: string;
+                                }[];
+                            }>(
+                                `INSERT INTO ?? (cached_explore_uuid, project_uuid, name, table_names, explore)
+                                 SELECT cached_explore_uuid, project_uuid, name, table_names, explore
+                                 FROM ??
+                                 WHERE save_uuid = ? AND project_uuid = ?
+                                 RETURNING name, cached_explore_uuid`,
+                                [
+                                    CachedExploreTableName,
+                                    CachedExploreStagingTableName,
+                                    saveUuid,
+                                    projectUuid,
+                                ],
+                            );
+                            return {
+                                promotedRows: promotedResult.rows,
+                                managedNames: managedResult.rows.map(
+                                    ({ name }) => name,
+                                ),
+                            };
+                        });
+                    const swapDurationMs = Math.round(
+                        performance.now() - swapStartedAt,
+                    );
+                    const cachedExploreUuidsByName = new Map(
+                        promotedRows.map(
+                            ({
+                                name,
+                                cached_explore_uuid: cachedExploreUuid,
+                            }) => [name, cachedExploreUuid],
+                        ),
+                    );
+                    const resultNames = [...stagedNameOrder];
+                    for (const name of managedNames) {
+                        if (!stagedNames.has(name)) resultNames.push(name);
                     }
                     Logger.info(
-                        `dbt.compile.saveExplores projectUuid=${projectUuid} explores=${cachedExploreUuidsByName.size} chunks=${chunkCount} largestChunkBytes=${largestChunkBytes}`,
+                        `dbt.compile.saveExplores projectUuid=${projectUuid} explores=${cachedExploreUuidsByName.size} chunks=${chunkCount} largestChunkBytes=${largestChunkBytes} stageDurationMs=${stageDurationMs} swapDurationMs=${swapDurationMs}`,
                         {
                             event: 'dbt.compile.saveExplores',
                             projectUuid,
@@ -2447,14 +2517,70 @@ export class ProjectModel {
                             chunks: chunkCount,
                             largestChunkBytes,
                             savedBytes,
+                            stageDurationMs,
+                            swapDurationMs,
                         },
                     );
                     return {
-                        cachedExploreUuids: Array.from(
-                            cachedExploreUuidsByName.values(),
-                        ),
+                        cachedExploreUuids: resultNames.map((name) => {
+                            const cachedExploreUuid =
+                                cachedExploreUuidsByName.get(name);
+                            if (cachedExploreUuid === undefined) {
+                                throw new UnexpectedServerError(
+                                    `Missing cached explore UUID for ${name}`,
+                                );
+                            }
+                            return cachedExploreUuid;
+                        }),
                     };
-                }),
+                } finally {
+                    const cleanupErrors: Error[] = [];
+                    try {
+                        await this.database(CachedExploreStagingTableName)
+                            .where('save_uuid', saveUuid)
+                            .delete();
+                    } catch (error) {
+                        cleanupErrors.push(
+                            error instanceof Error
+                                ? error
+                                : new Error(String(error)),
+                        );
+                    }
+                    try {
+                        await this.database(CachedExploreStagingTableName)
+                            .whereIn(
+                                'save_uuid',
+                                this.database(CachedExploreStagingTableName)
+                                    .select('save_uuid')
+                                    .groupBy('save_uuid')
+                                    .havingRaw(
+                                        "max(created_at) < now() - interval '24 hours'",
+                                    )
+                                    .limit(100),
+                            )
+                            .delete();
+                    } catch (error) {
+                        cleanupErrors.push(
+                            error instanceof Error
+                                ? error
+                                : new Error(String(error)),
+                        );
+                    }
+                    if (cleanupErrors.length > 0) {
+                        Logger.error(
+                            `dbt.compile.saveExplores.cleanupFailed projectUuid=${projectUuid} saveUuid=${saveUuid} errors=${cleanupErrors.length}`,
+                            {
+                                event: 'dbt.compile.saveExplores.cleanupFailed',
+                                projectUuid,
+                                saveUuid,
+                                errors: cleanupErrors.map(
+                                    (error) => error.message,
+                                ),
+                            },
+                        );
+                    }
+                }
+            },
         );
     }
 

--- a/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.ts
@@ -3,7 +3,6 @@ import {
     applyMetricFlowMetricsToModels,
     attachTypesToModels,
     catalogHasTimestampDomains,
-    convertExplores,
     DbtManifestVersion,
     DbtModelNode,
     DbtPackages,
@@ -21,6 +20,7 @@ import {
     InlineError,
     InlineErrorType,
     isSupportedDbtAdapter,
+    iterateExplores,
     loadLightdashProjectConfig,
     loadProjectContextFile,
     MissingCatalogEntryError,
@@ -196,6 +196,21 @@ export class DbtBaseProjectAdapter implements ProjectAdapter {
         loadSources: boolean = false,
         allowPartialCompilation: boolean = true,
     ): Promise<(Explore | ExploreError)[]> {
+        const stream = await this.prepareExploreStream(
+            trackingParams,
+            loadSources,
+            allowPartialCompilation,
+        );
+        const explores: (Explore | ExploreError)[] = [];
+        for await (const explore of stream) explores.push(explore);
+        return explores;
+    }
+
+    public async prepareExploreStream(
+        trackingParams?: TrackingParams,
+        loadSources: boolean = false,
+        allowPartialCompilation: boolean = true,
+    ): Promise<AsyncIterable<Explore | ExploreError>> {
         Logger.debug('Install dependencies');
         // Install dependencies for dbt and fetch the manifest - may raise error meaning no explores compile
         if (this.dbtClient.installDeps !== undefined) {
@@ -327,7 +342,7 @@ export class DbtBaseProjectAdapter implements ProjectAdapter {
                 this.warehouseClient.credentials.disableTimestampConversion ===
                     true;
 
-            const lazyExplores = await convertExplores(
+            const lazyExplores = iterateExplores(
                 lazyTypedModels,
                 loadSources,
                 adapterType,
@@ -339,8 +354,11 @@ export class DbtBaseProjectAdapter implements ProjectAdapter {
                     postProcessors,
                 },
             );
-            Logger.info('Finished compiling explores');
-            return [...lazyExplores, ...failedExplores];
+            return (async function* compiledExplores() {
+                yield* lazyExplores;
+                yield* failedExplores;
+                Logger.info('Finished compiling explores');
+            })();
         } catch (e) {
             if (e instanceof MissingCatalogEntryError) {
                 Logger.info(
@@ -386,7 +404,7 @@ export class DbtBaseProjectAdapter implements ProjectAdapter {
                     this.warehouseClient.credentials
                         .disableTimestampConversion === true;
 
-                const explores = await convertExplores(
+                const explores = iterateExplores(
                     typedModels,
                     loadSources,
                     adapterType,
@@ -398,10 +416,13 @@ export class DbtBaseProjectAdapter implements ProjectAdapter {
                         postProcessors,
                     },
                 );
-                Logger.info(
-                    'Finished compiling explores after missing catalog error',
-                );
-                return [...explores, ...failedExplores];
+                return (async function* compiledExplores() {
+                    yield* explores;
+                    yield* failedExplores;
+                    Logger.info(
+                        'Finished compiling explores after missing catalog error',
+                    );
+                })();
             }
             throw e;
         }

--- a/packages/backend/src/projectAdapters/dbtGitProjectAdapter.test.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectAdapter.test.ts
@@ -3,9 +3,11 @@ import {
     NotFoundError,
     UnexpectedGitError,
     UnexpectedServerError,
+    type ExploreError,
 } from '@lightdash/common';
 import { GitError } from 'simple-git';
-import { gitErrorHandler } from './dbtGitProjectAdapter';
+import { DbtBaseProjectAdapter } from './dbtBaseProjectAdapter';
+import { DbtGitProjectAdapter, gitErrorHandler } from './dbtGitProjectAdapter';
 
 const TOKEN_URL =
     'https://lightdash:ghp_secret_token_123@github.com/org/repo.git';
@@ -85,4 +87,49 @@ describe('gitErrorHandler', () => {
             );
         }
     });
+});
+
+describe('Git explore compilation', () => {
+    afterEach(() => vi.restoreAllMocks());
+
+    it.each(['prepareExploreStream', 'compileAllExplores'] as const)(
+        '%s refreshes the checkout before preparing the compile',
+        async (method) => {
+            const adapter = Object.create(
+                DbtGitProjectAdapter.prototype,
+            ) as DbtGitProjectAdapter;
+            const refresh = vi.fn(async () => undefined);
+            Object.defineProperty(adapter, '_refreshRepo', { value: refresh });
+            const explore: ExploreError = {
+                name: 'orders',
+                label: 'Orders',
+                errors: [],
+            };
+            const prepare = vi
+                .mocked(
+                    vi.spyOn(
+                        DbtBaseProjectAdapter.prototype,
+                        'prepareExploreStream',
+                    ),
+                )
+                .mockImplementation(async () => {
+                    expect(refresh).toHaveBeenCalledTimes(1);
+                    return (async function* stream() {
+                        yield explore;
+                    })();
+                });
+
+            const result = await adapter[method](undefined, false, true);
+            const collected = [];
+            for await (const item of result) collected.push(item);
+
+            expect(collected).toEqual([explore]);
+            expect(prepare).toHaveBeenCalledExactlyOnceWith(
+                undefined,
+                false,
+                true,
+            );
+            expect(refresh).toHaveBeenCalledTimes(1);
+        },
+    );
 });

--- a/packages/backend/src/projectAdapters/dbtGitProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectAdapter.ts
@@ -232,13 +232,13 @@ export class DbtGitProjectAdapter
         );
     }
 
-    public async compileAllExplores(
+    public async prepareExploreStream(
         trackingParams?: TrackingParams,
         loadSources?: boolean,
         allowPartialCompilation?: boolean,
     ) {
         await this._refreshRepo();
-        return super.compileAllExplores(
+        return super.prepareExploreStream(
             trackingParams,
             loadSources,
             allowPartialCompilation,

--- a/packages/backend/src/projectAdapters/dbtNoneCredentialsProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtNoneCredentialsProjectAdapter.ts
@@ -45,6 +45,14 @@ export class DbtNoneCredentialsProjectAdapter implements ProjectAdapter {
         );
     }
 
+    public async prepareExploreStream(): Promise<
+        AsyncIterable<Explore | ExploreError>
+    > {
+        throw new ParameterError(
+            'Cannot compile explores as this project was created via CLI and has no dbt connection configured. Either configure a dbt connection in project settings or use the CLI to deploy explores.',
+        );
+    }
+
     // eslint-disable-next-line class-methods-use-this
     public async getDbtPackages(): Promise<DbtPackages | undefined> {
         Logger.debug(`Get dbt packages`);

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -44,7 +44,9 @@ import {
     type DbtManifest,
     type DownloadFile,
     type Explore,
+    type ExploreError,
     type Job,
+    type LightdashProjectConfig,
     type MergeQuery,
     type MergeQuerySource,
     type PossibleAbilities,
@@ -242,6 +244,14 @@ const projectModel = {
     getWarehouseFromCache: vi.fn(async () => undefined),
     saveWarehouseToCache: vi.fn(async () => undefined),
     saveExploresToCache: vi.fn(async () => ({ cachedExploreUuids: [] })),
+    saveExploreStreamToCache: vi.fn<ProjectModel['saveExploreStreamToCache']>(
+        async (_projectUuid, explores) => {
+            for await (const explore of explores) {
+                expect(explore.name).toBeDefined();
+            }
+            return { cachedExploreUuids: [] };
+        },
+    ),
     setTableGroups: vi.fn(async () => undefined),
     updateProjectDefaults: vi.fn(async () => undefined),
     updateDefaultUserSpaces: vi.fn(async () => undefined),
@@ -540,6 +550,18 @@ const viewerAccount = {
         ]),
     },
 } as typeof account;
+
+type RefreshForTest = <T>(
+    user: Pick<SessionUser, 'userUuid'>,
+    projectUuid: string,
+    requestMethod: RequestMethod,
+    jobUuid: string | undefined,
+    consume: (prepared: {
+        exploreStream: AsyncIterable<Explore | ExploreError>;
+        lightdashProjectConfig: LightdashProjectConfig;
+        projectContext: undefined;
+    }) => Promise<T>,
+) => Promise<T>;
 
 describe('ProjectService', () => {
     const { projectUuid } = defaultProject;
@@ -1868,23 +1890,20 @@ describe('ProjectService', () => {
         const callRefresh = () =>
             (
                 service as unknown as {
-                    refreshTablesAndProjectConfig: (
-                        user: { userUuid: string },
-                        projectUuid: string,
-                        requestMethod: RequestMethod,
-                    ) => Promise<{
-                        explores: unknown[];
-                        lightdashProjectConfig: {
-                            parameters?: Record<string, unknown>;
-                            table_groups?: Record<string, unknown>;
-                            defaults?: unknown;
-                        };
-                    }>;
+                    refreshTablesAndProjectConfig: RefreshForTest;
                 }
             ).refreshTablesAndProjectConfig(
                 { userUuid: user.userUuid },
                 previewProjectUuid,
                 RequestMethod.WEB_APP,
+                undefined,
+                async ({ exploreStream, lightdashProjectConfig }) => {
+                    const explores = [];
+                    for await (const explore of exploreStream) {
+                        explores.push(explore);
+                    }
+                    return { explores, lightdashProjectConfig };
+                },
             );
 
         test('reuses the upstream explores and config instead of compiling from dbt', async () => {
@@ -3611,29 +3630,38 @@ describe('ProjectService', () => {
 
             vi.spyOn(
                 service as unknown as {
-                    refreshTablesAndProjectConfig: () => Promise<unknown>;
+                    refreshTablesAndProjectConfig: RefreshForTest;
                 },
                 'refreshTablesAndProjectConfig',
-            ).mockResolvedValueOnce({
-                explores: [
-                    validExplore,
-                    {
-                        name: 'invalid_orders',
-                        label: 'Invalid orders',
-                        errors: [],
-                    },
-                ],
-                lightdashProjectConfig: {
-                    spotlight: {
-                        categories: {
-                            finance: { label: 'Finance', color: 'blue' },
+            ).mockImplementationOnce(
+                async (_user, _projectUuid, _method, _jobUuid, consume) =>
+                    consume({
+                        exploreStream: (async function* stream() {
+                            yield* [
+                                validExplore,
+                                {
+                                    name: 'invalid_orders',
+                                    label: 'Invalid orders',
+                                    errors: [],
+                                },
+                            ];
+                        })(),
+                        lightdashProjectConfig: {
+                            spotlight: {
+                                ...DEFAULT_SPOTLIGHT_CONFIG,
+                                categories: {
+                                    finance: {
+                                        label: 'Finance',
+                                        color: 'blue',
+                                    },
+                                },
+                            },
+                            parameters: {},
+                            table_groups: {},
                         },
-                    },
-                    parameters: {},
-                    table_groups: {},
-                },
-                projectContext: undefined,
-            });
+                        projectContext: undefined,
+                    }),
+            );
             (projectModel.getSummary as import('vitest').Mock)
                 .mockResolvedValueOnce({
                     ...projectSummary,
@@ -3696,19 +3724,27 @@ describe('ProjectService', () => {
             vi
                 .spyOn(
                     service as unknown as {
-                        refreshTablesAndProjectConfig: () => Promise<unknown>;
+                        refreshTablesAndProjectConfig: RefreshForTest;
                     },
                     'refreshTablesAndProjectConfig',
                 )
-                .mockResolvedValueOnce({
-                    explores: [validExplore],
-                    lightdashProjectConfig: {
-                        spotlight: { categories: {} },
-                        parameters: {},
-                        table_groups: {},
-                    },
-                    projectContext: undefined,
-                });
+                .mockImplementationOnce(
+                    async (_user, _projectUuid, _method, _jobUuid, consume) =>
+                        consume({
+                            exploreStream: (async function* stream() {
+                                yield validExplore;
+                            })(),
+                            lightdashProjectConfig: {
+                                spotlight: {
+                                    ...DEFAULT_SPOTLIGHT_CONFIG,
+                                    categories: {},
+                                },
+                                parameters: {},
+                                table_groups: {},
+                            },
+                            projectContext: undefined,
+                        }),
+                );
 
         test('runs the afterCompile step after compiling and before the job is done', async () => {
             const compileJobUuid = 'compile-job-uuid';
@@ -3872,12 +3908,14 @@ describe('ProjectService', () => {
                 errors: [],
             };
             const adapter = {
-                compileAllExplores: vi.fn(async () => [
-                    validExplore,
-                    invalidExplore,
-                ]),
+                prepareExploreStream: vi.fn(async () =>
+                    (async function* explores() {
+                        yield validExplore;
+                        yield invalidExplore;
+                    })(),
+                ),
                 getLightdashProjectConfig: vi.fn(async () => ({
-                    spotlight: { categories: {} },
+                    spotlight: { ...DEFAULT_SPOTLIGHT_CONFIG, categories: {} },
                     parameters: {},
                     table_groups: {},
                 })),
@@ -3913,10 +3951,9 @@ describe('ProjectService', () => {
                 },
                 'getProjectContextFromAdapter',
             ).mockResolvedValueOnce(undefined);
-            vi.spyOn(
-                service,
-                'saveExploresToCacheAndIndexCatalog',
-            ).mockResolvedValueOnce('catalog-job-1');
+            vi.mocked(schedulerClient.indexCatalog).mockResolvedValueOnce({
+                jobId: 'catalog-job-1',
+            });
 
             await service.testAndCompileProject(
                 {
@@ -3934,7 +3971,7 @@ describe('ProjectService', () => {
             expect(jobModel.update).toHaveBeenCalledWith(compileJobUuid, {
                 jobStatus: JobStatusType.DONE,
                 jobResults: {
-                    indexCatalogJobUuid: 'catalog-job-1',
+                    indexCatalogJobUuid: { jobId: 'catalog-job-1' },
                     errorCount: 1,
                     total: 2,
                 },
@@ -6452,7 +6489,16 @@ describe('ProjectService.resolveCompileAdapter (MultiDbtSources regression firew
             destroy: vi.fn(async () => undefined),
         } as unknown as ProjectAdapter;
         const mergedAdapter = {
-            compileAllExplores,
+            prepareExploreStream: vi.fn(
+                async (
+                    ...args: Parameters<ProjectAdapter['compileAllExplores']>
+                ) => {
+                    const explores = await compileAllExplores(...args);
+                    return (async function* stream() {
+                        yield* explores;
+                    })();
+                },
+            ),
             getDbtPackages: vi.fn(async () => ({})),
             getLightdashProjectConfig: vi.fn(async () => ({
                 spotlight: {},
@@ -6529,9 +6575,12 @@ describe('ProjectService.resolveCompileAdapter (MultiDbtSources regression firew
         let cacheCompleted = false;
         let persistedManifest: Buffer | undefined;
         const projectService = buildCompilationBoundaryService();
-        projectModel.saveExploresToCache
+        projectModel.saveExploreStreamToCache
             .mockReset()
-            .mockImplementationOnce(async () => {
+            .mockImplementationOnce(async (_projectUuid, explores) => {
+                for await (const explore of explores) {
+                    expect(explore.name).toBeDefined();
+                }
                 await Promise.resolve();
                 cacheCompleted = true;
                 return { cachedExploreUuids: [] };
@@ -6554,10 +6603,10 @@ describe('ProjectService.resolveCompileAdapter (MultiDbtSources regression firew
             'compile-job-uuid',
         );
 
-        expect(projectModel.saveExploresToCache).toHaveBeenCalledTimes(1);
+        expect(projectModel.saveExploreStreamToCache).toHaveBeenCalledTimes(1);
         expect(projectModel.upsertMergedManifest).toHaveBeenCalledTimes(1);
         expect(
-            vi.mocked(projectModel.saveExploresToCache).mock
+            vi.mocked(projectModel.saveExploreStreamToCache).mock
                 .invocationCallOrder[0],
         ).toBeLessThan(
             vi.mocked(projectModel.upsertMergedManifest).mock
@@ -6570,9 +6619,12 @@ describe('ProjectService.resolveCompileAdapter (MultiDbtSources regression firew
         let cacheCompleted = false;
         let persistedManifest: Buffer | undefined;
         const projectService = buildCompilationBoundaryService();
-        projectModel.saveExploresToCache
+        projectModel.saveExploreStreamToCache
             .mockReset()
-            .mockImplementationOnce(async () => {
+            .mockImplementationOnce(async (_projectUuid, explores) => {
+                for await (const explore of explores) {
+                    expect(explore.name).toBeDefined();
+                }
                 await Promise.resolve();
                 cacheCompleted = true;
                 return { cachedExploreUuids: [] };
@@ -6595,10 +6647,10 @@ describe('ProjectService.resolveCompileAdapter (MultiDbtSources regression firew
             'compile-job-uuid',
         );
 
-        expect(projectModel.saveExploresToCache).toHaveBeenCalledTimes(1);
+        expect(projectModel.saveExploreStreamToCache).toHaveBeenCalledTimes(1);
         expect(projectModel.upsertMergedManifest).toHaveBeenCalledTimes(1);
         expect(
-            vi.mocked(projectModel.saveExploresToCache).mock
+            vi.mocked(projectModel.saveExploreStreamToCache).mock
                 .invocationCallOrder[0],
         ).toBeLessThan(
             vi.mocked(projectModel.upsertMergedManifest).mock
@@ -6613,7 +6665,7 @@ describe('ProjectService.resolveCompileAdapter (MultiDbtSources regression firew
             (projectService as unknown as ProjectServiceInternals).logger,
             'warn',
         );
-        projectModel.saveExploresToCache
+        projectModel.saveExploreStreamToCache
             .mockReset()
             .mockResolvedValueOnce({ cachedExploreUuids: [] });
         projectModel.upsertMergedManifest.mockRejectedValueOnce(

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -26,7 +26,6 @@ import {
     buildDataTimezonePreviewSql,
     buildMergeItems,
     CacheMetadata,
-    calculateCompilationReport,
     calculateExploreWarningReport,
     ChartSourceType,
     ChartSummary,
@@ -100,7 +99,6 @@ import {
     getDimensions,
     getErrorMessage,
     getFieldFormatOverrideProps,
-    getFields,
     getIntrinsicUserAttributes,
     getItemId,
     getItemMap,
@@ -343,6 +341,7 @@ import { metricQueryWithLimit as applyMetricQueryLimit } from '../../utils/csvLi
 import { omitDbtEnvironment } from '../../utils/dbtProjectConfig';
 import { pickEmbedProject } from '../../utils/embedProject';
 import { EncryptionUtil } from '../../utils/EncryptionUtil/EncryptionUtil';
+import { ExploreCompilationSummary } from '../../utils/ExploreCompilationSummary';
 import { createComposeMergeQueryBuilder } from '../../utils/QueryBuilder/composeMergeSql';
 import { applyMergeTerminalWrapper } from '../../utils/QueryBuilder/MergeQueryBuilder';
 import { PivotQueryBuilder } from '../../utils/QueryBuilder/PivotQueryBuilder';
@@ -522,6 +521,25 @@ type ResolvedCompileAdapter = {
     adapter: ProjectAdapter;
     stagedMergedManifest?: Buffer;
 };
+type SaveCompiledExploresArgs = {
+    userUuid: string;
+    projectUuid: string;
+    compilationSource: CompilationSource;
+    jobUuid?: string | null;
+    requestMethod?: string | null;
+    projectConfigDefaults?: ProjectDefaults;
+    cliVersion?: string | null;
+    complete?: boolean;
+};
+
+type PreparedExploreStream = {
+    exploreStream: AsyncIterable<Explore | ExploreError>;
+    lightdashProjectConfig: LightdashProjectConfig;
+    projectContext: ProjectContextEntry[] | undefined;
+    stagedMergedManifest?: Buffer;
+    onCompiled?: (summary: ExploreCompilationSummary) => void;
+};
+
 export class ProjectService extends BaseService {
     static CREATE_PROJECT_JOB_ENQUEUE_GRACE_MS = 15 * 60 * 1000;
 
@@ -2458,21 +2476,64 @@ export class ProjectService extends BaseService {
         }
     }
 
-    async saveExploresToCacheAndIndexCatalog(args: {
-        userUuid: string;
-        projectUuid: string;
-        explores: (Explore | ExploreError)[];
-        compilationSource: CompilationSource;
-        jobUuid?: string | null;
-        requestMethod?: string | null;
-        projectConfigDefaults?: ProjectDefaults;
-        cliVersion?: string | null;
-        complete?: boolean;
-    }) {
+    async saveExploresToCacheAndIndexCatalog(
+        args: SaveCompiledExploresArgs & {
+            explores: (Explore | ExploreError)[];
+        },
+    ) {
+        const { explores, ...metadata } = args;
+        const result = await this.saveExploresAndIndexCatalog({
+            ...metadata,
+            saveExplores: async (summary) => {
+                const saved = await this.projectModel.saveExploresToCache(
+                    args.projectUuid,
+                    explores,
+                    args.complete,
+                );
+                explores.forEach((explore) => summary.add(explore));
+                return saved;
+            },
+        });
+        return result.indexCatalogJobUuid;
+    }
+
+    private async saveExploreStreamToCacheAndIndexCatalog(
+        args: Omit<SaveCompiledExploresArgs, 'complete'> & {
+            exploreStream: AsyncIterable<Explore | ExploreError>;
+            onCompiled?: (summary: ExploreCompilationSummary) => void;
+        },
+    ) {
+        const { exploreStream, onCompiled, ...metadata } = args;
+        return this.saveExploresAndIndexCatalog({
+            ...metadata,
+            complete: true,
+            saveExplores: async (summary) => {
+                async function* observedExplores() {
+                    for await (const explore of exploreStream) {
+                        summary.add(explore, onCompiled !== undefined);
+                        yield explore;
+                    }
+                    onCompiled?.(summary);
+                }
+                return this.projectModel.saveExploreStreamToCache(
+                    args.projectUuid,
+                    observedExplores(),
+                );
+            },
+        });
+    }
+
+    private async saveExploresAndIndexCatalog(
+        args: SaveCompiledExploresArgs & {
+            saveExplores: (
+                summary: ExploreCompilationSummary,
+            ) => Promise<{ cachedExploreUuids: string[] }>;
+        },
+    ) {
         const {
             userUuid,
             projectUuid,
-            explores,
+            saveExplores,
             compilationSource,
             jobUuid,
             requestMethod,
@@ -2480,6 +2541,7 @@ export class ProjectService extends BaseService {
             cliVersion,
             complete,
         } = args;
+        const summary = new ExploreCompilationSummary();
         const prevCatalogItemsWithTags =
             await this.catalogModel.getCatalogItemsWithTags(projectUuid, {
                 onlyTagged: true, // We only need the tagged catalog items
@@ -2510,12 +2572,7 @@ export class ProjectService extends BaseService {
             });
         }
 
-        const { cachedExploreUuids } =
-            await this.projectModel.saveExploresToCache(
-                projectUuid,
-                explores,
-                complete,
-            );
+        const { cachedExploreUuids } = await saveExplores(summary);
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
@@ -2528,7 +2585,7 @@ export class ProjectService extends BaseService {
         // "dashboard loaded with stale reference at T2".
         try {
             const NAME_SAMPLE_CAP = 50;
-            const newNames = explores.map((explore) => explore.name);
+            const newNames = summary.names;
             const previousNameSet = new Set(previousExploreNames ?? []);
             const newNameSet = new Set(newNames);
             const removed = complete
@@ -2571,7 +2628,7 @@ export class ProjectService extends BaseService {
             });
         }
 
-        const compilationReport = calculateCompilationReport({ explores });
+        const compilationReport = summary.report;
         const project = await this.projectModel.get(projectUuid);
 
         Logger.info('compile.case_sensitive_resolution', {
@@ -2580,21 +2637,9 @@ export class ProjectService extends BaseService {
             compilationSource,
             cliVersion: cliVersion ?? null,
             projectDefault: projectConfigDefaults?.case_sensitive ?? null,
-            exploreCount: explores.length,
-            exploresWithFlag: explores
-                .filter((e) => e.caseSensitive !== undefined)
-                .map((e) => ({ name: e.name, value: e.caseSensitive })),
-            dimensionsWithFlag: explores.flatMap((e) =>
-                Object.entries(e.tables ?? {}).flatMap(([t, tbl]) =>
-                    Object.values(tbl.dimensions ?? {})
-                        .filter((d) => d.caseSensitive !== undefined)
-                        .map((d) => ({
-                            table: t,
-                            name: d.name,
-                            value: d.caseSensitive,
-                        })),
-                ),
-            ),
+            exploreCount: summary.report.totalExploresCount,
+            exploresWithFlag: summary.caseSensitiveExplores,
+            dimensionsWithFlag: summary.caseSensitiveDimensions,
         });
 
         await this.projectCompileLogModel.insert({
@@ -2632,7 +2677,11 @@ export class ProjectService extends BaseService {
             });
         }
 
-        return indexCatalogJob;
+        return {
+            indexCatalogJobUuid: indexCatalogJob,
+            errorCount: summary.report.errorExploresCount,
+            total: summary.report.totalExploresCount,
+        };
     }
 
     async getProject(projectUuid: string, account: Account): Promise<Project> {
@@ -4046,8 +4095,8 @@ export class ProjectService extends BaseService {
                                 jobUuid: job.jobUuid,
                             };
                             timings.compileExplores.start = performance.now();
-                            const explores =
-                                await compileAdapter.compileAllExplores(
+                            const exploreStream =
+                                await compileAdapter.prepareExploreStream(
                                     trackingParams,
                                     false, // loadSources
                                     true, // allowPartialCompilation
@@ -4106,30 +4155,26 @@ export class ProjectService extends BaseService {
                             );
                             timings.parameters.end = performance.now();
                             timings.cacheExplores.start = performance.now();
-                            const indexCatalogJobUuid =
-                                await this.saveExploresToCacheAndIndexCatalog({
-                                    userUuid: user.userUuid,
-                                    projectUuid,
-                                    explores,
-                                    compilationSource,
-                                    jobUuid: job.jobUuid,
-                                    requestMethod: method,
-                                    projectConfigDefaults:
-                                        lightdashProjectConfig.defaults,
-                                    complete: true,
-                                });
+                            const result =
+                                await this.saveExploreStreamToCacheAndIndexCatalog(
+                                    {
+                                        userUuid: user.userUuid,
+                                        projectUuid,
+                                        exploreStream,
+                                        compilationSource,
+                                        jobUuid: job.jobUuid,
+                                        requestMethod: method,
+                                        projectConfigDefaults:
+                                            lightdashProjectConfig.defaults,
+                                    },
+                                );
                             await this.persistMergedManifest(
                                 projectUuid,
                                 stagedMergedManifest,
                             );
                             timings.cacheExplores.end = performance.now();
 
-                            return {
-                                indexCatalogJobUuid,
-                                errorCount:
-                                    explores.filter(isExploreError).length,
-                                total: explores.length,
-                            };
+                            return result;
                         } finally {
                             await compileAdapter.destroy();
                             await sshTunnel.disconnect();
@@ -8516,17 +8561,13 @@ export class ProjectService extends BaseService {
         );
     }
 
-    private async refreshTablesAndProjectConfig(
+    private async refreshTablesAndProjectConfig<T>(
         user: Pick<SessionUser, 'userUuid'>,
         projectUuid: string,
         requestMethod: RequestMethod,
-        jobUuid?: string,
-    ): Promise<{
-        explores: (Explore | ExploreError)[];
-        lightdashProjectConfig: LightdashProjectConfig;
-        projectContext: ProjectContextEntry[] | undefined;
-        stagedMergedManifest?: Buffer;
-    }> {
+        jobUuid: string | undefined,
+        consume: (prepared: PreparedExploreStream) => Promise<T>,
+    ): Promise<T> {
         // Checks that project exists
         const project = await this.projectModel.get(projectUuid);
 
@@ -8549,8 +8590,10 @@ export class ProjectService extends BaseService {
                 this.projectParametersModel.find(upstreamProjectUuid),
                 this.projectModel.getTableGroups(upstreamProjectUuid),
             ]);
-            return {
-                explores: Object.values(upstreamExplores),
+            return consume({
+                exploreStream: (async function* upstreamStream() {
+                    yield* Object.values(upstreamExplores);
+                })(),
                 lightdashProjectConfig: {
                     spotlight: DEFAULT_SPOTLIGHT_CONFIG,
                     parameters: Object.fromEntries(
@@ -8563,7 +8606,7 @@ export class ProjectService extends BaseService {
                     defaults: upstreamProject.projectDefaults,
                 },
                 projectContext: undefined,
-            };
+            });
         }
 
         // Force refresh adapter (refetch git repos, check for changed credentials, etc.)
@@ -8598,139 +8641,29 @@ export class ProjectService extends BaseService {
                 userUuid: user.userUuid,
                 jobUuid,
             };
-            const explores = await adapter.compileAllExplores(
+            const exploreStream = await adapter.prepareExploreStream(
                 trackingParams,
-                false, // loadSources
-                true, // allowPartialCompilation
+                false,
+                true,
             );
-            this.analytics.track({
-                event: 'project.compiled',
-                userId: user.userUuid,
-                properties: {
-                    requestMethod,
-                    projectId: projectUuid,
-                    projectName: project.name,
-                    projectType: project.dbtConnection.type,
-                    warehouseType: project.warehouseConnection?.type,
-                    modelsCount: explores.length,
-                    modelsWithErrorsCount:
-                        explores.filter(isExploreError).length,
-                    modelsWithGroupLabelCount: explores.filter(
-                        ({ groupLabel }) => !!groupLabel,
-                    ).length,
-                    metricsCount: explores.reduce<number>((acc, explore) => {
-                        if (!isExploreError(explore)) {
-                            return acc + getMetrics(explore).length;
-                        }
-                        return acc;
-                    }, 0),
-                    packagesCount: packages
-                        ? Object.keys(packages).length
-                        : undefined,
-                    roundCount: explores.reduce<number>((acc, explore) => {
-                        if (!isExploreError(explore)) {
-                            return (
-                                acc +
-                                getMetrics(explore).filter(
-                                    ({ round }) => round !== undefined,
-                                ).length +
-                                getDimensions(explore).filter(
-                                    ({ round }) => round !== undefined,
-                                ).length
-                            );
-                        }
-                        return acc;
-                    }, 0),
-                    urlsCount: explores.reduce<number>((acc, explore) => {
-                        if (!isExploreError(explore)) {
-                            return (
-                                acc +
-                                getFields(explore)
-                                    .map((field) => (field.urls || []).length)
-                                    .reduce((a, b) => a + b, 0)
-                            );
-                        }
-                        return acc;
-                    }, 0),
-                    formattedFieldsCount: explores.reduce<number>(
-                        (acc, explore) => {
-                            try {
-                                if (!isExploreError(explore)) {
-                                    const filteredExplore = {
-                                        ...explore,
-                                        tables: {
-                                            [explore.baseTable]:
-                                                explore.tables[
-                                                    explore.baseTable
-                                                ],
-                                        },
-                                    };
-
-                                    return (
-                                        acc +
-                                        getFields(filteredExplore).filter(
-                                            ({ format }) =>
-                                                format !== undefined,
-                                        ).length
-                                    );
-                                }
-                            } catch (e) {
-                                this.logger.error(
-                                    `Unable to reduce formattedFieldsCount. ${e}`,
-                                );
-                            }
-                            return acc;
-                        },
-                        0,
-                    ),
-                    modelsWithSqlFiltersCount: explores.reduce<number>(
-                        (acc, explore) => {
-                            if (
-                                explore.tables &&
-                                explore.baseTable &&
-                                explore.tables[explore.baseTable].sqlWhere !==
-                                    undefined
-                            )
-                                return acc + 1;
-                            return acc;
-                        },
-                        0,
-                    ),
-                    columnAccessFiltersCount: explores.reduce<number>(
-                        (acc, explore) => {
-                            if (!isExploreError(explore)) {
-                                return (
-                                    acc +
-                                    getDimensions(explore).filter(
-                                        ({ requiredAttributes }) =>
-                                            requiredAttributes !== undefined,
-                                    ).length
-                                );
-                            }
-                            return acc;
-                        },
-                        0,
-                    ),
-                    additionalDimensionsCount: explores.reduce<number>(
-                        (acc, explore) => {
-                            if (!isExploreError(explore)) {
-                                return (
-                                    acc +
-                                    Object.values(
-                                        explore.tables[explore.baseTable]
-                                            .dimensions,
-                                    ).filter(
-                                        (field) => field.isAdditionalDimension,
-                                    ).length
-                                );
-                            }
-                            return acc;
-                        },
-                        0,
-                    ),
-                    dbtSourceCount,
-                },
-            });
+            const onCompiled = (summary: ExploreCompilationSummary) => {
+                this.analytics.track({
+                    event: 'project.compiled',
+                    userId: user.userUuid,
+                    properties: {
+                        requestMethod,
+                        projectId: projectUuid,
+                        projectName: project.name,
+                        projectType: project.dbtConnection.type,
+                        warehouseType: project.warehouseConnection?.type,
+                        ...summary.analytics,
+                        packagesCount: packages
+                            ? Object.keys(packages).length
+                            : undefined,
+                        dbtSourceCount,
+                    },
+                });
+            };
 
             const lightdashProjectConfig =
                 await adapter.getLightdashProjectConfig(trackingParams);
@@ -8740,12 +8673,13 @@ export class ProjectService extends BaseService {
                 organizationUuid: project.organizationUuid,
             });
 
-            return {
-                explores,
+            return await consume({
+                exploreStream,
                 lightdashProjectConfig,
                 projectContext,
                 stagedMergedManifest,
-            };
+                onCompiled,
+            });
         } catch (e) {
             if (!(e instanceof LightdashError)) {
                 Sentry.captureException(e);
@@ -9159,83 +9093,83 @@ export class ProjectService extends BaseService {
                 const compileResult = await this.jobModel.tryJobStep(
                     job.jobUuid,
                     JobStepType.COMPILING,
-                    async () => {
-                        const {
-                            explores,
-                            lightdashProjectConfig,
-                            projectContext,
-                            stagedMergedManifest,
-                        } = await this.refreshTablesAndProjectConfig(
+                    async () =>
+                        this.refreshTablesAndProjectConfig(
                             user,
                             projectUuid,
                             requestMethod,
                             job.jobUuid,
-                        );
+                            async ({
+                                exploreStream,
+                                lightdashProjectConfig,
+                                projectContext,
+                                stagedMergedManifest,
+                                onCompiled,
+                            }) => {
+                                timings.yaml.start = performance.now();
+                                await this.replaceYamlTagsWithoutPermissionCheck(
+                                    user,
+                                    organizationUuid,
+                                    projectUuid,
+                                    // TODO: Create util to generate categories from lightdashProjectConfig - this is used as well in deploy.ts
+                                    Object.entries(
+                                        lightdashProjectConfig.spotlight
+                                            ?.categories || {},
+                                    ).map(([key, category]) => ({
+                                        yamlReference: key,
+                                        name: category.label,
+                                        color: category.color ?? 'gray',
+                                    })),
+                                );
+                                timings.yaml.end = performance.now();
+                                timings.parameters.start = performance.now();
+                                await this.replaceProjectParameters({
+                                    user,
+                                    projectUuid,
+                                    parameters:
+                                        lightdashProjectConfig.parameters,
+                                });
+                                await this.projectModel.setTableGroups(
+                                    projectUuid,
+                                    lightdashProjectConfig.table_groups,
+                                );
+                                // Mirrors CLI deploy semantics: only overwrite stored
+                                // defaults when the config file defines them
+                                if (lightdashProjectConfig.defaults) {
+                                    await this.projectModel.updateProjectDefaults(
+                                        projectUuid,
+                                        lightdashProjectConfig.defaults,
+                                    );
+                                }
+                                await this.replaceProjectContext(
+                                    projectUuid,
+                                    projectContext,
+                                );
+                                timings.parameters.end = performance.now();
+                                timings.cacheExplores.start = performance.now();
+                                const result =
+                                    await this.saveExploreStreamToCacheAndIndexCatalog(
+                                        {
+                                            userUuid: user.userUuid,
+                                            projectUuid,
+                                            exploreStream,
+                                            onCompiled,
+                                            compilationSource: 'refresh_dbt',
+                                            jobUuid: job.jobUuid,
+                                            requestMethod,
+                                            projectConfigDefaults:
+                                                lightdashProjectConfig.defaults,
+                                        },
+                                    );
+                                await this.persistMergedManifest(
+                                    projectUuid,
+                                    stagedMergedManifest,
+                                );
+                                timings.cacheExplores.end = performance.now();
 
-                        timings.yaml.start = performance.now();
-                        await this.replaceYamlTagsWithoutPermissionCheck(
-                            user,
-                            organizationUuid,
-                            projectUuid,
-                            // TODO: Create util to generate categories from lightdashProjectConfig - this is used as well in deploy.ts
-                            Object.entries(
-                                lightdashProjectConfig.spotlight?.categories ||
-                                    {},
-                            ).map(([key, category]) => ({
-                                yamlReference: key,
-                                name: category.label,
-                                color: category.color ?? 'gray',
-                            })),
-                        );
-                        timings.yaml.end = performance.now();
-                        timings.parameters.start = performance.now();
-                        await this.replaceProjectParameters({
-                            user,
-                            projectUuid,
-                            parameters: lightdashProjectConfig.parameters,
-                        });
-                        await this.projectModel.setTableGroups(
-                            projectUuid,
-                            lightdashProjectConfig.table_groups,
-                        );
-                        // Mirrors CLI deploy semantics: only overwrite stored
-                        // defaults when the config file defines them
-                        if (lightdashProjectConfig.defaults) {
-                            await this.projectModel.updateProjectDefaults(
-                                projectUuid,
-                                lightdashProjectConfig.defaults,
-                            );
-                        }
-                        await this.replaceProjectContext(
-                            projectUuid,
-                            projectContext,
-                        );
-                        timings.parameters.end = performance.now();
-                        timings.cacheExplores.start = performance.now();
-                        const indexCatalogJobUuid =
-                            await this.saveExploresToCacheAndIndexCatalog({
-                                userUuid: user.userUuid,
-                                projectUuid,
-                                explores,
-                                compilationSource: 'refresh_dbt',
-                                jobUuid: job.jobUuid,
-                                requestMethod,
-                                projectConfigDefaults:
-                                    lightdashProjectConfig.defaults,
-                                complete: true,
-                            });
-                        await this.persistMergedManifest(
-                            projectUuid,
-                            stagedMergedManifest,
-                        );
-                        timings.cacheExplores.end = performance.now();
-
-                        return {
-                            indexCatalogJobUuid,
-                            errorCount: explores.filter(isExploreError).length,
-                            total: explores.length,
-                        };
-                    },
+                                return result;
+                            },
+                        ),
                 );
 
                 if (afterCompile) {

--- a/packages/backend/src/types.ts
+++ b/packages/backend/src/types.ts
@@ -29,6 +29,12 @@ export interface ProjectAdapter {
         allowPartialCompilation?: boolean,
     ): Promise<(Explore | ExploreError)[]>;
 
+    prepareExploreStream(
+        trackingParams: TrackingParams | undefined,
+        loadSources?: boolean,
+        allowPartialCompilation?: boolean,
+    ): Promise<AsyncIterable<Explore | ExploreError>>;
+
     getDbtPackages(): Promise<DbtPackages | undefined>;
 
     /**

--- a/packages/backend/src/utils/ExploreCompilationSummary.test.ts
+++ b/packages/backend/src/utils/ExploreCompilationSummary.test.ts
@@ -181,4 +181,21 @@ describe('ExploreCompilationSummary', () => {
             { table: 'orders_override', name: 'order_id', value: true },
         ]);
     });
+
+    it('accepts an error explore whose base table is absent', () => {
+        const summary = new ExploreCompilationSummary();
+        const error = {
+            name: 'broken',
+            label: 'broken',
+            baseTable: 'missing',
+            tables: {
+                present: table('present', {}, {}),
+            },
+            errors: [{ type: 'METADATA_PARSE_ERROR', message: 'broken' }],
+        } as ExploreError;
+
+        expect(() => summary.add(error, true)).not.toThrow();
+        expect(summary.analytics.modelsWithSqlFiltersCount).toBe(0);
+        expect(summary.analytics.modelsWithErrorsCount).toBe(1);
+    });
 });

--- a/packages/backend/src/utils/ExploreCompilationSummary.test.ts
+++ b/packages/backend/src/utils/ExploreCompilationSummary.test.ts
@@ -1,0 +1,184 @@
+import {
+    calculateCompilationReport,
+    type Explore,
+    type ExploreError,
+} from '@lightdash/common';
+import * as compilationReport from '@lightdash/common';
+import { ExploreCompilationSummary } from './ExploreCompilationSummary';
+
+const table = (
+    name: string,
+    dimensions: Record<string, object>,
+    metrics: Record<string, object>,
+    sqlWhere?: string,
+) =>
+    ({
+        name,
+        dimensions,
+        metrics,
+        sqlWhere,
+    }) as Explore['tables'][string];
+
+const explore = (
+    name: string,
+    baseTable: string,
+    tables: Explore['tables'],
+    overrides: Partial<Explore> = {},
+) =>
+    ({
+        name,
+        label: name,
+        tags: [],
+        baseTable,
+        joinedTables: [],
+        tables,
+        targetDatabase: 'postgres',
+        ...overrides,
+    }) as Explore;
+
+describe('ExploreCompilationSummary', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('accumulates reports, analytics, and case-sensitive values in input order', () => {
+        const orders = explore(
+            'orders',
+            'orders',
+            {
+                orders: table(
+                    'orders',
+                    {
+                        order_id: {
+                            name: 'order_id',
+                            round: 2,
+                            urls: [{ url: 'https://example.com/one' }],
+                            format: '0,0',
+                            requiredAttributes: ['region'],
+                            caseSensitive: false,
+                        },
+                        order_override: {
+                            name: 'order_override',
+                            isAdditionalDimension: true,
+                            format: '0.0',
+                            caseSensitive: true,
+                        },
+                    },
+                    {
+                        order_count: {
+                            name: 'order_count',
+                            round: 0,
+                            urls: [
+                                { url: 'https://example.com/two' },
+                                { url: 'https://example.com/three' },
+                            ],
+                            format: '0',
+                        },
+                    },
+                    'status = 1',
+                ),
+                customers: table(
+                    'customers',
+                    {
+                        customer_id: {
+                            name: 'customer_id',
+                            round: 1,
+                            urls: [{ url: 'https://example.com/four' }],
+                            format: '0,0',
+                            caseSensitive: true,
+                        },
+                    },
+                    {
+                        customer_count: { name: 'customer_count' },
+                    },
+                ),
+            },
+            { groupLabel: 'Sales', caseSensitive: true },
+        );
+        const error = {
+            name: 'broken',
+            label: 'broken',
+            groupLabel: 'Errors',
+            baseTable: 'broken',
+            caseSensitive: false,
+            tables: {
+                broken: table(
+                    'broken',
+                    {
+                        broken_id: {
+                            name: 'broken_id',
+                            caseSensitive: false,
+                        },
+                    },
+                    {},
+                    'invalid = true',
+                ),
+            },
+            errors: [{ type: 'METADATA_PARSE_ERROR', message: 'broken' }],
+        } as ExploreError;
+        const duplicateOrders = explore(
+            'orders',
+            'orders_override',
+            {
+                orders_override: table(
+                    'orders_override',
+                    {
+                        order_id: {
+                            name: 'order_id',
+                            round: 3,
+                            urls: [{ url: 'https://example.com/five' }],
+                            format: '0.00',
+                            requiredAttributes: [],
+                            isAdditionalDimension: true,
+                            caseSensitive: true,
+                        },
+                    },
+                    {
+                        order_total: {
+                            name: 'order_total',
+                            urls: [{ url: 'https://example.com/six' }],
+                            format: '0.00',
+                        },
+                    },
+                ),
+            },
+            { caseSensitive: false },
+        );
+        const explores = [orders, error, duplicateOrders];
+        const expectedReport = calculateCompilationReport({ explores });
+        const calculateReport = vi.mocked(
+            vi.spyOn(compilationReport, 'calculateCompilationReport'),
+        );
+        const summary = new ExploreCompilationSummary();
+
+        explores.forEach((item) => summary.add(item, true));
+
+        expect(calculateReport).toHaveBeenCalledTimes(explores.length);
+        expect(summary.report).toEqual(expectedReport);
+        expect(summary.names).toEqual(['orders', 'broken', 'orders']);
+        expect(summary.analytics).toEqual({
+            modelsCount: 3,
+            modelsWithErrorsCount: 1,
+            modelsWithGroupLabelCount: 2,
+            metricsCount: 3,
+            roundCount: 4,
+            urlsCount: 6,
+            formattedFieldsCount: 5,
+            modelsWithSqlFiltersCount: 2,
+            columnAccessFiltersCount: 2,
+            additionalDimensionsCount: 2,
+        });
+        expect(summary.caseSensitiveExplores).toEqual([
+            { name: 'orders', value: true },
+            { name: 'broken', value: false },
+            { name: 'orders', value: false },
+        ]);
+        expect(summary.caseSensitiveDimensions).toEqual([
+            { table: 'orders', name: 'order_id', value: false },
+            { table: 'orders', name: 'order_override', value: true },
+            { table: 'customers', name: 'customer_id', value: true },
+            { table: 'broken', name: 'broken_id', value: false },
+            { table: 'orders_override', name: 'order_id', value: true },
+        ]);
+    });
+});

--- a/packages/backend/src/utils/ExploreCompilationSummary.ts
+++ b/packages/backend/src/utils/ExploreCompilationSummary.ts
@@ -105,9 +105,8 @@ export class ExploreCompilationSummary {
         );
 
         if (
-            explore.tables &&
             explore.baseTable &&
-            explore.tables[explore.baseTable].sqlWhere !== undefined
+            explore.tables?.[explore.baseTable]?.sqlWhere !== undefined
         ) {
             this.analytics.modelsWithSqlFiltersCount += 1;
         }
@@ -141,7 +140,7 @@ export class ExploreCompilationSummary {
             ({ requiredAttributes }) => requiredAttributes !== undefined,
         ).length;
         this.analytics.additionalDimensionsCount += Object.values(
-            explore.tables[explore.baseTable].dimensions,
+            explore.tables[explore.baseTable]?.dimensions ?? {},
         ).filter(({ isAdditionalDimension }) => isAdditionalDimension).length;
     }
 

--- a/packages/backend/src/utils/ExploreCompilationSummary.ts
+++ b/packages/backend/src/utils/ExploreCompilationSummary.ts
@@ -1,0 +1,159 @@
+import {
+    calculateCompilationReport,
+    getDimensions,
+    getFields,
+    getMetrics,
+    isExploreError,
+    type CompilationHistoryReport,
+    type Explore,
+    type ExploreError,
+} from '@lightdash/common';
+import Logger from '../logging/logger';
+
+export type ExploreCompilationAnalytics = {
+    modelsCount: number;
+    modelsWithErrorsCount: number;
+    modelsWithGroupLabelCount: number;
+    metricsCount: number;
+    roundCount: number;
+    urlsCount: number;
+    formattedFieldsCount: number;
+    modelsWithSqlFiltersCount: number;
+    columnAccessFiltersCount: number;
+    additionalDimensionsCount: number;
+};
+
+export class ExploreCompilationSummary {
+    public readonly names: string[] = [];
+
+    public readonly analytics: ExploreCompilationAnalytics = {
+        modelsCount: 0,
+        modelsWithErrorsCount: 0,
+        modelsWithGroupLabelCount: 0,
+        metricsCount: 0,
+        roundCount: 0,
+        urlsCount: 0,
+        formattedFieldsCount: 0,
+        modelsWithSqlFiltersCount: 0,
+        columnAccessFiltersCount: 0,
+        additionalDimensionsCount: 0,
+    };
+
+    public readonly caseSensitiveExplores: { name: string; value: boolean }[] =
+        [];
+
+    public readonly caseSensitiveDimensions: {
+        table: string;
+        name: string;
+        value: boolean;
+    }[] = [];
+
+    private totalExploresCount = 0;
+
+    private successfulExploresCount = 0;
+
+    private errorExploresCount = 0;
+
+    private reportMetricsCount = 0;
+
+    private dimensionsCount = 0;
+
+    private readonly exploresWithErrors: ExploreError[] = [];
+
+    private readonly baseTableNames: string[] = [];
+
+    public add(
+        explore: Explore | ExploreError,
+        collectAnalytics = false,
+    ): void {
+        this.names.push(explore.name);
+
+        const report = calculateCompilationReport({ explores: [explore] });
+        this.totalExploresCount += report.totalExploresCount;
+        this.successfulExploresCount += report.successfulExploresCount;
+        this.errorExploresCount += report.errorExploresCount;
+        this.reportMetricsCount += report.metricsCount;
+        this.dimensionsCount += report.dimensionsCount;
+        this.exploresWithErrors.push(...report.exploresWithErrors);
+        this.baseTableNames.push(...report.baseTableNames);
+
+        if (explore.caseSensitive !== undefined) {
+            this.caseSensitiveExplores.push({
+                name: explore.name,
+                value: explore.caseSensitive,
+            });
+        }
+
+        Object.entries(explore.tables ?? {}).forEach(([table, value]) => {
+            Object.values(value.dimensions ?? {}).forEach((dimension) => {
+                if (dimension.caseSensitive !== undefined) {
+                    this.caseSensitiveDimensions.push({
+                        table,
+                        name: dimension.name,
+                        value: dimension.caseSensitive,
+                    });
+                }
+            });
+        });
+
+        if (!collectAnalytics) return;
+
+        this.analytics.modelsCount += 1;
+        this.analytics.modelsWithErrorsCount += Number(isExploreError(explore));
+        this.analytics.modelsWithGroupLabelCount += Number(
+            Boolean(explore.groupLabel),
+        );
+
+        if (
+            explore.tables &&
+            explore.baseTable &&
+            explore.tables[explore.baseTable].sqlWhere !== undefined
+        ) {
+            this.analytics.modelsWithSqlFiltersCount += 1;
+        }
+
+        if (isExploreError(explore)) {
+            return;
+        }
+
+        const metrics = getMetrics(explore);
+        const dimensions = getDimensions(explore);
+        const fields = getFields(explore);
+        this.analytics.metricsCount += metrics.length;
+        this.analytics.roundCount +=
+            metrics.filter(({ round }) => round !== undefined).length +
+            dimensions.filter(({ round }) => round !== undefined).length;
+        this.analytics.urlsCount += fields.reduce(
+            (count, field) => count + (field.urls || []).length,
+            0,
+        );
+        try {
+            this.analytics.formattedFieldsCount += getFields({
+                ...explore,
+                tables: {
+                    [explore.baseTable]: explore.tables[explore.baseTable],
+                },
+            }).filter(({ format }) => format !== undefined).length;
+        } catch (error) {
+            Logger.error(`Unable to reduce formattedFieldsCount. ${error}`);
+        }
+        this.analytics.columnAccessFiltersCount += dimensions.filter(
+            ({ requiredAttributes }) => requiredAttributes !== undefined,
+        ).length;
+        this.analytics.additionalDimensionsCount += Object.values(
+            explore.tables[explore.baseTable].dimensions,
+        ).filter(({ isAdditionalDimension }) => isAdditionalDimension).length;
+    }
+
+    public get report(): CompilationHistoryReport {
+        return {
+            totalExploresCount: this.totalExploresCount,
+            successfulExploresCount: this.successfulExploresCount,
+            errorExploresCount: this.errorExploresCount,
+            metricsCount: this.reportMetricsCount,
+            dimensionsCount: this.dimensionsCount,
+            exploresWithErrors: this.exploresWithErrors,
+            baseTableNames: this.baseTableNames,
+        };
+    }
+}

--- a/packages/backend/src/utils/chunkRowsByBytes.test.ts
+++ b/packages/backend/src/utils/chunkRowsByBytes.test.ts
@@ -1,4 +1,5 @@
 import {
+    chunkAsyncRowsByBytes,
     chunkRowsByBytes,
     describeWholeSetOverflow,
     POSTGRES_JSONB_MAX_BYTES,
@@ -74,6 +75,50 @@ describe('chunkRowsByBytes', () => {
         expect(
             [...chunkRowsByBytes(sized(5, 5), 0, 0)].map((c) => c.rows),
         ).toEqual([['row0'], ['row1']]);
+    });
+});
+
+describe('chunkAsyncRowsByBytes', () => {
+    it('bounds chunks by bytes and rows while preserving row order', async () => {
+        async function* rows() {
+            yield { row: 'row0', bytes: 40 };
+            yield { row: 'row1', bytes: 40 };
+            yield { row: 'row2', bytes: 40 };
+            yield { row: 'row3', bytes: 40 };
+        }
+
+        const chunks = [];
+        for await (const chunk of chunkAsyncRowsByBytes(rows(), 100, 2)) {
+            chunks.push(chunk);
+        }
+
+        expect(chunks).toEqual([
+            { rows: ['row0', 'row1'], bytes: 80 },
+            { rows: ['row2', 'row3'], bytes: 80 },
+        ]);
+    });
+
+    it('leaves unconsumed rows unread and closes the source on cancellation', async () => {
+        let produced = 0;
+        let closed = false;
+        async function* rows() {
+            try {
+                for (let index = 0; index < 10; index += 1) {
+                    produced += 1;
+                    yield { row: `row${index}`, bytes: 10 };
+                }
+            } finally {
+                closed = true;
+            }
+        }
+
+        const chunks = chunkAsyncRowsByBytes(rows(), 20, 1000);
+
+        await chunks.next();
+        await chunks.return(undefined);
+
+        expect(produced).toBe(3);
+        expect(closed).toBe(true);
     });
 });
 

--- a/packages/backend/src/utils/chunkRowsByBytes.ts
+++ b/packages/backend/src/utils/chunkRowsByBytes.ts
@@ -49,6 +49,33 @@ export function* chunkRowsByBytes<R>(
     }
 }
 
+export async function* chunkAsyncRowsByBytes<R>(
+    rows: AsyncIterable<SizedRow<R>>,
+    maxBytes: number = DEFAULT_CHUNK_MAX_BYTES,
+    maxRows: number = DEFAULT_CHUNK_MAX_ROWS,
+): AsyncGenerator<{ rows: R[]; bytes: number }, void, undefined> {
+    const byteLimit = Math.max(1, maxBytes);
+    const rowLimit = Math.max(1, maxRows);
+    let current: R[] = [];
+    let currentBytes = 0;
+
+    for await (const { row, bytes } of rows) {
+        if (
+            current.length > 0 &&
+            (currentBytes + bytes > byteLimit || current.length >= rowLimit)
+        ) {
+            yield { rows: current, bytes: currentBytes };
+            current = [];
+            currentBytes = 0;
+        }
+        current.push(row);
+        currentBytes += bytes;
+    }
+    if (current.length > 0) {
+        yield { rows: current, bytes: currentBytes };
+    }
+}
+
 /**
  * Serialised size of an explore set as one JSON array, without holding the array as a string.
  * Each element is serialised and released; only the running total is kept.

--- a/packages/common/src/compiler/translator.test.ts
+++ b/packages/common/src/compiler/translator.test.ts
@@ -16,12 +16,14 @@ import {
     WAREHOUSE_TIMESTAMP_DOMAINS_KEY,
     type WarehouseCatalog,
 } from '../types/warehouse';
+import { ExploreCompiler } from './exploreCompiler';
 import { warehouseClientMock } from './exploreCompiler.mock';
 import { getExploreParameterDefinitions } from './parameters';
 import {
     attachTypesToModels,
     convertExplores,
     convertTable,
+    iterateExplores,
     type AttachTypesDiagnostics,
 } from './translator';
 import {
@@ -3003,6 +3005,126 @@ describe('granularity_labels overrides', () => {
             expect(dims.created_week.timeIntervalLabel).toBeUndefined();
             expect(explore.granularityLabels).toBeUndefined();
         }
+    });
+});
+
+describe('iterateExplores', () => {
+    const buildStreamingModel = (
+        name: string,
+        meta: DbtModelNode['meta'] = {},
+    ): DbtModelNode => ({
+        ...model,
+        unique_id: `model.pkg.${name}`,
+        name,
+        alias: name,
+        relation_name: `analytics.${name}`,
+        meta,
+    });
+
+    const iterate = (models: DbtModelNode[]) =>
+        iterateExplores(
+            models,
+            false,
+            SupportedDbtAdapter.POSTGRES,
+            warehouseClientMock,
+            { spotlight: DEFAULT_SPOTLIGHT_CONFIG },
+        );
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('pauses compilation until the next explore is consumed', async () => {
+        const compileExplore = vi.mocked(
+            vi.spyOn(ExploreCompiler.prototype, 'compileExplore'),
+        );
+        const iterator = iterate([
+            buildStreamingModel('first'),
+            buildStreamingModel('second'),
+        ]);
+
+        expect(compileExplore).not.toHaveBeenCalled();
+
+        await iterator.next();
+
+        expect(compileExplore).toHaveBeenCalledTimes(1);
+
+        await Promise.resolve();
+
+        expect(compileExplore).toHaveBeenCalledTimes(1);
+
+        await iterator.next();
+
+        expect(compileExplore).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not compile unconsumed models after cancellation', async () => {
+        const compileExplore = vi.mocked(
+            vi.spyOn(ExploreCompiler.prototype, 'compileExplore'),
+        );
+        const iterator = iterate([
+            buildStreamingModel('first'),
+            buildStreamingModel('second'),
+            buildStreamingModel('third'),
+        ]);
+
+        await iterator.next();
+        await iterator.return(undefined);
+
+        expect(compileExplore).toHaveBeenCalledTimes(1);
+    });
+
+    it('preserves joined, error, and extra explore output order and JSON', async () => {
+        const models = [
+            buildStreamingModel('orders', {
+                joins: [
+                    {
+                        join: 'customers',
+                        sql_on: '${orders.myColumnName} = ${customers.myColumnName}',
+                    },
+                ],
+                explores: {
+                    orders_extra: {},
+                },
+            }),
+            buildStreamingModel('customers'),
+            buildStreamingModel('broken', {
+                joins: [
+                    {
+                        join: 'missing',
+                        sql_on: '${broken.myColumnName} = ${missing.myColumnName}',
+                    },
+                ],
+            }),
+        ];
+
+        const expected = await convertExplores(
+            models,
+            false,
+            SupportedDbtAdapter.POSTGRES,
+            warehouseClientMock,
+            { spotlight: DEFAULT_SPOTLIGHT_CONFIG },
+        );
+        const actual: Awaited<ReturnType<typeof convertExplores>> = [];
+        for await (const explore of iterate(models)) {
+            actual.push(explore);
+        }
+
+        expect(actual.map(({ name }) => name)).toEqual([
+            'orders',
+            'orders_extra',
+            'customers',
+            'broken',
+        ]);
+        expect(actual[0]).toMatchObject({
+            name: 'orders',
+            tables: { customers: expect.anything() },
+        });
+        expect(actual[3]).toMatchObject({
+            name: 'broken',
+            errors: expect.any(Array),
+        });
+        expect(JSON.stringify(actual)).toBe(JSON.stringify(expected));
     });
 });
 

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -1148,14 +1148,14 @@ const yieldToEventLoop = (): Promise<void> =>
         }
     });
 
-export const convertExplores = async (
+export async function* iterateExplores(
     models: DbtModelNode[],
     loadSources: boolean,
     adapterType: SupportedDbtAdapter,
     warehouseSqlBuilder: WarehouseSqlBuilder,
     lightdashProjectConfig: LightdashProjectConfig,
     options?: ConvertExploresOptions,
-): Promise<(Explore | ExploreError)[]> => {
+): AsyncGenerator<Explore | ExploreError> {
     const {
         disableTimestampConversion,
         allowPartialCompilation,
@@ -1324,7 +1324,6 @@ export const convertExplores = async (
     const exploreCompiler = new ExploreCompiler(warehouseSqlBuilder, {
         allowPartialCompilation,
     });
-    const explores: (Explore | ExploreError)[] = [];
     // eslint-disable-next-line no-restricted-syntax
     for (const [modelIndex, model] of validModels.entries()) {
         // Config block takes priority, then meta block
@@ -1564,7 +1563,8 @@ export const convertExplores = async (
             return [...errors, ...processor(successes, postProcessorContext)];
         }, successfulExplores);
 
-        explores.push(...compileErrors, ...postProcessedExplores);
+        yield* compileErrors;
+        yield* postProcessedExplores;
 
         if ((modelIndex + 1) % MODELS_PER_EVENT_LOOP_YIELD === 0) {
             // eslint-disable-next-line no-await-in-loop
@@ -1572,7 +1572,29 @@ export const convertExplores = async (
         }
     }
 
-    return [...explores, ...exploreErrors];
+    yield* exploreErrors;
+}
+
+export const convertExplores = async (
+    models: DbtModelNode[],
+    loadSources: boolean,
+    adapterType: SupportedDbtAdapter,
+    warehouseSqlBuilder: WarehouseSqlBuilder,
+    lightdashProjectConfig: LightdashProjectConfig,
+    options?: ConvertExploresOptions,
+): Promise<(Explore | ExploreError)[]> => {
+    const explores: (Explore | ExploreError)[] = [];
+    for await (const explore of iterateExplores(
+        models,
+        loadSources,
+        adapterType,
+        warehouseSqlBuilder,
+        lightdashProjectConfig,
+        options,
+    )) {
+        explores.push(explore);
+    }
+    return explores;
 };
 
 export type AttachTypesDiagnostics = {


### PR DESCRIPTION
Large projects hold every compiled explore until the cache save ends. This change converts and saves explores in bounded batches.

The first stream implementation holds the project lock during conversion. This revision writes batches to a staging table before the transaction. One transaction then takes the project lock, copies current managed explores, checks and locks the staged rows, deletes the old cache, and promotes the staged rows with server-side SQL. It does not serialize the explores again during the swap.

A staging failure leaves the old cache untouched. A swap failure rolls back the replacement. Cleanup removes the save's staged rows. Each save also removes up to 100 abandoned save groups older than 24 hours. Fresh concurrent saves remain separate. The new table supports PgBouncer transaction pooling.

The refresh and Test & deploy paths use the stream. The job results keep the same fields and counts. Managed explores keep their name overrides. Duplicate names keep the last value and the first name position. A partial error explore can omit its base-table entry without breaking the compilation summary.

Linear: SPK-1936

## Result

Eight paired runs, two repetitions per arm, control and treatment alternated. Output fingerprints are identical within each arm, so the treatment saves the same explores.

| Arm | Node heap peak (MiB) | Cgroup peak (MiB) | CPU (s) | Wall (s) | Unanswered probe (s) |
| --- | ---: | ---: | ---: | ---: | ---: |
| W control | 1955 / 1963 | 3483 / 3576 | 338.9 / 350.5 | 109.1 / 114.5 | 13.6 / 20.6 |
| W treatment | 1717 / 1716 | 3591 / 3683 | 317.8 / 323.5 | 106.4 / 107.5 | 14.3 / 14.0 |
| WJ control | 2685 / 2684 | 4912 / 4778 | 421.3 / 409.1 | 136.1 / 148.0 | 14.8 / 14.7 |
| WJ treatment | 1810 / 1810 | 4468 / 4248 | 388.3 / 391.6 | 142.3 / 142.8 | 16.2 / 16.2 |

The heap peak falls by about 242 MiB on W and about 874 MiB on WJ. CPU falls by about 7 percent on W and 6 percent on WJ. Wall time is within noise. The cgroup peak falls on WJ and is within noise on W.

## Measurements

Control: `c790d7bdb6d50d05251ffd4a8b23665ae5f1af77`. Treatment: `5c92aa30c1b52bcf9bd9e447c2b7d077fe34690d`. W uses the same 14-source fixture, an 8 GiB cgroup cap, and the default heap. WJ uses two joins, a 10 GiB cap, and `--max-old-space-size=8124`. Heap peaks are sampled. The external probe includes the trailing window. Repetitions alternate control and treatment within each arm.

Start: Mon Sep  7 21:25:12 UTC 2026; load 1.39 2.18 2.15 2/2098 8846; MemAvailable:   12839120 kB. Resident processes: java PID 30008: 38.8% CPU, 4605952 KiB RSS; java PID 30283: 3.6% CPU, 3527756 KiB RSS; claude PID 16534: 1.4% CPU, 547040 KiB RSS; claude PID 488: 1.9% CPU, 455496 KiB RSS; claude PID 31868: 2.0% CPU, 455380 KiB RSS; claude PID 4215: 1.8% CPU, 452536 KiB RSS; claude PID 9011: 1.5% CPU, 443168 KiB RSS; claude PID 21078: 1.2% CPU, 428924 KiB RSS; claude PID 18999: 2.1% CPU, 410476 KiB RSS; claude PID 8572: 1.5% CPU, 396760 KiB RSS; claude PID 7630: 1.4% CPU, 396572 KiB RSS; claude PID 13661: 1.6% CPU, 378640 KiB RSS.

End: Mon Sep  7 21:27:02 UTC 2026; load 4.90 3.27 2.55 2/2155 10924; MemAvailable:   12677484 kB. Resident processes: java PID 30008: 38.5% CPU, 4605200 KiB RSS; java PID 30283: 3.6% CPU, 3527088 KiB RSS; claude PID 16534: 1.4% CPU, 542988 KiB RSS; claude PID 31868: 2.0% CPU, 454584 KiB RSS; claude PID 488: 1.9% CPU, 449764 KiB RSS; claude PID 4215: 1.8% CPU, 449724 KiB RSS; claude PID 9011: 1.5% CPU, 439288 KiB RSS; claude PID 21078: 1.2% CPU, 426848 KiB RSS; claude PID 18999: 2.1% CPU, 405004 KiB RSS; claude PID 7630: 1.4% CPU, 394848 KiB RSS; claude PID 8572: 1.5% CPU, 393036 KiB RSS; claude PID 8789: 1.5% CPU, 377768 KiB RSS.

| Run | Wall (s) | CPU (s) | Node heap peak (MiB) | Cgroup peak (MiB) | Unanswered probe (s) | Trailing window (s) | Chunks | Explores | Fingerprint |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| `spk1936-stage-c790-W-before-1` | 109.1 | 338.9 | 1955 | 3483 | 13.6 | 0.7 | 13 | 10006 | `0693f5008b4454a482b8160f0ee1a329eebd94bb37792b216e8d6b043ee8a55b` |

Transaction: 13910 ms. Project lock to commit: 13900 ms. Stage: None ms. Swap, including acquisition: None ms. Error count: 0. Persisted payload fingerprint: `aaf98e1c7743f423a44b64ba08dfc95537316f208ccec7d659297f47b45f97d2`. Returned-order fingerprint: `9e8be9036d11fd55400e65d6290195443570bb586e66940d80aca8e49078f633`.

Order fingerprint: `9e8be9036d11fd55400e65d6290195443570bb586e66940d80aca8e49078f633`.

Start: Mon Sep  7 21:29:18 UTC 2026; load 2.44 2.97 2.54 2/2166 15224; MemAvailable:   12768596 kB. Resident processes: java PID 30008: 38.1% CPU, 4605036 KiB RSS; java PID 30283: 3.5% CPU, 3526924 KiB RSS; claude PID 16534: 1.4% CPU, 543044 KiB RSS; claude PID 31868: 2.0% CPU, 455280 KiB RSS; claude PID 488: 1.9% CPU, 449764 KiB RSS; claude PID 4215: 1.8% CPU, 449624 KiB RSS; claude PID 9011: 1.5% CPU, 438828 KiB RSS; claude PID 21078: 1.2% CPU, 426584 KiB RSS; claude PID 18999: 2.1% CPU, 405008 KiB RSS; claude PID 7630: 1.4% CPU, 394684 KiB RSS; claude PID 8572: 1.5% CPU, 392348 KiB RSS; claude PID 8789: 1.5% CPU, 377788 KiB RSS.

End: Mon Sep  7 21:31:05 UTC 2026; load 3.51 3.43 2.77 1/2177 16729; MemAvailable:   12695988 kB. Resident processes: java PID 30008: 37.8% CPU, 4605312 KiB RSS; java PID 30283: 3.5% CPU, 3526932 KiB RSS; claude PID 16534: 1.4% CPU, 543048 KiB RSS; claude PID 4215: 1.8% CPU, 462484 KiB RSS; claude PID 31868: 2.0% CPU, 455320 KiB RSS; claude PID 488: 1.9% CPU, 449764 KiB RSS; claude PID 9011: 1.5% CPU, 438836 KiB RSS; claude PID 21078: 1.2% CPU, 426584 KiB RSS; claude PID 18999: 2.1% CPU, 405184 KiB RSS; claude PID 8572: 1.5% CPU, 404508 KiB RSS; claude PID 7630: 1.4% CPU, 394688 KiB RSS; claude PID 8789: 1.5% CPU, 377788 KiB RSS.

| Run | Wall (s) | CPU (s) | Node heap peak (MiB) | Cgroup peak (MiB) | Unanswered probe (s) | Trailing window (s) | Chunks | Explores | Fingerprint |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| `spk1936-stage-c790-W-after-1` | 106.4 | 317.8 | 1717 | 3591 | 14.3 | 0.9 | 13 | 10006 | `0693f5008b4454a482b8160f0ee1a329eebd94bb37792b216e8d6b043ee8a55b` |

Transaction: 2055 ms. Project lock to commit: 2051 ms. Stage: 19144 ms. Swap, including acquisition: 2056 ms. Error count: 0. Persisted payload fingerprint: `aaf98e1c7743f423a44b64ba08dfc95537316f208ccec7d659297f47b45f97d2`. Returned-order fingerprint: `9e8be9036d11fd55400e65d6290195443570bb586e66940d80aca8e49078f633`.

Order fingerprint: `9e8be9036d11fd55400e65d6290195443570bb586e66940d80aca8e49078f633`.

Start: Mon Sep  7 22:01:49 UTC 2026; load 1.85 2.61 2.91 3/2100 22789; MemAvailable:   15330472 kB. Resident processes: java PID 30008: 33.4% CPU, 4605832 KiB RSS; mempalace PID 19703: 100% CPU, 968124 KiB RSS; claude PID 16534: 1.4% CPU, 543000 KiB RSS; claude PID 488: 1.9% CPU, 478116 KiB RSS; claude PID 4215: 1.8% CPU, 462896 KiB RSS; claude PID 31868: 2.0% CPU, 457016 KiB RSS; claude PID 9011: 1.5% CPU, 439660 KiB RSS; claude PID 21078: 1.2% CPU, 429516 KiB RSS; claude PID 18999: 2.1% CPU, 405152 KiB RSS; claude PID 8572: 1.5% CPU, 402696 KiB RSS; claude PID 7630: 1.4% CPU, 395064 KiB RSS; claude PID 8789: 1.5% CPU, 377960 KiB RSS.

End: Mon Sep  7 22:04:05 UTC 2026; load 5.27 3.83 3.33 5/2094 24171; MemAvailable:   15228488 kB. Resident processes: java PID 30008: 33.1% CPU, 4605832 KiB RSS; mempalace PID 19703: 99.6% CPU, 993424 KiB RSS; claude PID 16534: 1.4% CPU, 542920 KiB RSS; claude PID 488: 1.9% CPU, 477424 KiB RSS; claude PID 4215: 1.8% CPU, 462868 KiB RSS; claude PID 31868: 2.0% CPU, 457020 KiB RSS; claude PID 9011: 1.5% CPU, 439548 KiB RSS; claude PID 21078: 1.2% CPU, 429480 KiB RSS; claude PID 18999: 2.1% CPU, 405156 KiB RSS; claude PID 8572: 1.5% CPU, 402696 KiB RSS; claude PID 7630: 1.4% CPU, 395048 KiB RSS; claude PID 8789: 1.5% CPU, 378100 KiB RSS.

| Run | Wall (s) | CPU (s) | Node heap peak (MiB) | Cgroup peak (MiB) | Unanswered probe (s) | Trailing window (s) | Chunks | Explores | Fingerprint |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| `spk1936-stage-c790-WJ-before-1` | 136.1 | 421.3 | 2685 | 4912 | 14.8 | 0.2 | 37 | 10006 | `c1f46391b8c12a82280cafe7c9e1297c89a80ba4c7ab3d836769287d2d42b4fc` |

Transaction: 37860 ms. Project lock to commit: 37853 ms. Stage: None ms. Swap, including acquisition: None ms. Error count: 0. Persisted payload fingerprint: `9ad4efb7afb6ac5d795bfc7747412fba5bd2aab124ce2379f66d300667af451a`. Returned-order fingerprint: `9e8be9036d11fd55400e65d6290195443570bb586e66940d80aca8e49078f633`.

Order fingerprint: `9e8be9036d11fd55400e65d6290195443570bb586e66940d80aca8e49078f633`.

Start: Mon Sep  7 22:06:22 UTC 2026; load 1.83 2.92 3.05 2/2088 24660; MemAvailable:   15331392 kB. Resident processes: java PID 30008: 32.9% CPU, 4605832 KiB RSS; mempalace PID 19703: 100% CPU, 997060 KiB RSS; claude PID 16534: 1.4% CPU, 542920 KiB RSS; claude PID 488: 1.9% CPU, 477424 KiB RSS; claude PID 4215: 1.8% CPU, 462868 KiB RSS; claude PID 31868: 2.0% CPU, 457036 KiB RSS; claude PID 9011: 1.5% CPU, 439552 KiB RSS; claude PID 21078: 1.2% CPU, 427120 KiB RSS; claude PID 18999: 2.1% CPU, 405776 KiB RSS; claude PID 8572: 1.5% CPU, 402740 KiB RSS; claude PID 7630: 1.4% CPU, 395052 KiB RSS; claude PID 8789: 1.5% CPU, 378116 KiB RSS.

End: Mon Sep  7 22:08:44 UTC 2026; load 4.29 3.77 3.37 3/2089 25899; MemAvailable:   15313712 kB. Resident processes: java PID 30008: 32.6% CPU, 4605832 KiB RSS; mempalace PID 19703: 100% CPU, 1001796 KiB RSS; claude PID 16534: 1.4% CPU, 544192 KiB RSS; claude PID 488: 1.9% CPU, 479540 KiB RSS; claude PID 31868: 2.0% CPU, 466004 KiB RSS; claude PID 4215: 1.8% CPU, 465964 KiB RSS; claude PID 9011: 1.5% CPU, 442680 KiB RSS; claude PID 21078: 1.2% CPU, 431464 KiB RSS; claude PID 18999: 2.1% CPU, 408396 KiB RSS; claude PID 8572: 1.5% CPU, 406236 KiB RSS; claude PID 7630: 1.4% CPU, 396964 KiB RSS; claude PID 13661: 1.6% CPU, 387264 KiB RSS.

| Run | Wall (s) | CPU (s) | Node heap peak (MiB) | Cgroup peak (MiB) | Unanswered probe (s) | Trailing window (s) | Chunks | Explores | Fingerprint |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| `spk1936-stage-c790-WJ-after-1` | 142.3 | 388.3 | 1810 | 4468 | 16.2 | 0.4 | 37 | 10006 | `c1f46391b8c12a82280cafe7c9e1297c89a80ba4c7ab3d836769287d2d42b4fc` |

Transaction: 5356 ms. Project lock to commit: 5352 ms. Stage: 45186 ms. Swap, including acquisition: 5358 ms. Error count: 0. Persisted payload fingerprint: `9ad4efb7afb6ac5d795bfc7747412fba5bd2aab124ce2379f66d300667af451a`. Returned-order fingerprint: `9e8be9036d11fd55400e65d6290195443570bb586e66940d80aca8e49078f633`.

Order fingerprint: `9e8be9036d11fd55400e65d6290195443570bb586e66940d80aca8e49078f633`.

Start: Mon Sep  7 21:33:37 UTC 2026; load 2.74 2.88 2.64 2/2174 22681; MemAvailable:   12701836 kB. Resident processes: java PID 30008: 37.4% CPU, 4605812 KiB RSS; java PID 30283: 3.5% CPU, 3526932 KiB RSS; claude PID 16534: 1.4% CPU, 543076 KiB RSS; claude PID 4215: 1.8% CPU, 462484 KiB RSS; claude PID 31868: 2.0% CPU, 455320 KiB RSS; claude PID 488: 1.9% CPU, 449764 KiB RSS; claude PID 9011: 1.5% CPU, 438836 KiB RSS; claude PID 21078: 1.2% CPU, 427048 KiB RSS; claude PID 18999: 2.1% CPU, 405172 KiB RSS; claude PID 8572: 1.5% CPU, 404508 KiB RSS; claude PID 7630: 1.4% CPU, 394688 KiB RSS; claude PID 8789: 1.5% CPU, 377788 KiB RSS.

End: Mon Sep  7 21:35:31 UTC 2026; load 4.33 3.59 2.94 1/2182 24212; MemAvailable:   12663304 kB. Resident processes: java PID 30008: 37.1% CPU, 4605812 KiB RSS; java PID 30283: 3.4% CPU, 3526932 KiB RSS; claude PID 16534: 1.4% CPU, 541448 KiB RSS; claude PID 4215: 1.8% CPU, 462536 KiB RSS; claude PID 31868: 2.0% CPU, 455336 KiB RSS; claude PID 488: 1.9% CPU, 449764 KiB RSS; claude PID 9011: 1.5% CPU, 438844 KiB RSS; claude PID 21078: 1.2% CPU, 426960 KiB RSS; claude PID 18999: 2.1% CPU, 405196 KiB RSS; claude PID 8572: 1.5% CPU, 404508 KiB RSS; claude PID 7630: 1.4% CPU, 394692 KiB RSS; claude PID 8789: 1.5% CPU, 377788 KiB RSS.

| Run | Wall (s) | CPU (s) | Node heap peak (MiB) | Cgroup peak (MiB) | Unanswered probe (s) | Trailing window (s) | Chunks | Explores | Fingerprint |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| `spk1936-stage-c790-W-before-2` | 114.5 | 350.5 | 1963 | 3576 | 20.6 | 0.6 | 13 | 10006 | `0693f5008b4454a482b8160f0ee1a329eebd94bb37792b216e8d6b043ee8a55b` |

Transaction: 13589 ms. Project lock to commit: 13583 ms. Stage: None ms. Swap, including acquisition: None ms. Error count: 0. Persisted payload fingerprint: `aaf98e1c7743f423a44b64ba08dfc95537316f208ccec7d659297f47b45f97d2`. Returned-order fingerprint: `9e8be9036d11fd55400e65d6290195443570bb586e66940d80aca8e49078f633`.

Order fingerprint: `9e8be9036d11fd55400e65d6290195443570bb586e66940d80aca8e49078f633`.

Start: Mon Sep  7 21:38:18 UTC 2026; load 1.49 2.49 2.62 2/2157 27952; MemAvailable:   12478020 kB. Resident processes: java PID 30008: 36.7% CPU, 4605812 KiB RSS; java PID 30283: 3.4% CPU, 3526932 KiB RSS; claude PID 16534: 1.4% CPU, 541448 KiB RSS; claude PID 4215: 1.8% CPU, 462536 KiB RSS; claude PID 31868: 2.0% CPU, 455344 KiB RSS; claude PID 488: 1.9% CPU, 449764 KiB RSS; claude PID 9011: 1.5% CPU, 438844 KiB RSS; claude PID 21078: 1.2% CPU, 426960 KiB RSS; claude PID 18999: 2.1% CPU, 405212 KiB RSS; claude PID 8572: 1.5% CPU, 404508 KiB RSS; claude PID 7630: 1.4% CPU, 394692 KiB RSS; claude PID 8789: 1.5% CPU, 377808 KiB RSS.

End: Mon Sep  7 21:40:06 UTC 2026; load 3.38 3.08 2.83 4/2158 29412; MemAvailable:   12388232 kB. Resident processes: java PID 30008: 36.4% CPU, 4605824 KiB RSS; java PID 30283: 3.4% CPU, 3527300 KiB RSS; claude PID 16534: 1.4% CPU, 542748 KiB RSS; claude PID 4215: 1.8% CPU, 462532 KiB RSS; claude PID 31868: 2.0% CPU, 455352 KiB RSS; claude PID 488: 1.9% CPU, 449764 KiB RSS; claude PID 9011: 1.5% CPU, 440100 KiB RSS; claude PID 21078: 1.2% CPU, 428376 KiB RSS; claude PID 18999: 2.1% CPU, 409868 KiB RSS; claude PID 8572: 1.5% CPU, 404516 KiB RSS; claude PID 7630: 1.4% CPU, 395952 KiB RSS; claude PID 8789: 1.5% CPU, 377816 KiB RSS.

| Run | Wall (s) | CPU (s) | Node heap peak (MiB) | Cgroup peak (MiB) | Unanswered probe (s) | Trailing window (s) | Chunks | Explores | Fingerprint |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| `spk1936-stage-c790-W-after-2` | 107.5 | 323.5 | 1716 | 3683 | 14.0 | 0.9 | 13 | 10006 | `0693f5008b4454a482b8160f0ee1a329eebd94bb37792b216e8d6b043ee8a55b` |

Transaction: 2158 ms. Project lock to commit: 2151 ms. Stage: 19010 ms. Swap, including acquisition: 2160 ms. Error count: 0. Persisted payload fingerprint: `aaf98e1c7743f423a44b64ba08dfc95537316f208ccec7d659297f47b45f97d2`. Returned-order fingerprint: `9e8be9036d11fd55400e65d6290195443570bb586e66940d80aca8e49078f633`.

Order fingerprint: `9e8be9036d11fd55400e65d6290195443570bb586e66940d80aca8e49078f633`.

Start: Mon Sep  7 22:11:01 UTC 2026; load 1.98 2.96 3.12 3/2087 26404; MemAvailable:   15368976 kB. Resident processes: java PID 30008: 32.3% CPU, 4605832 KiB RSS; mempalace PID 19703: 100% CPU, 1002048 KiB RSS; claude PID 16534: 1.4% CPU, 544208 KiB RSS; claude PID 31868: 2.0% CPU, 485428 KiB RSS; claude PID 488: 1.9% CPU, 479540 KiB RSS; claude PID 4215: 1.8% CPU, 465968 KiB RSS; claude PID 9011: 1.5% CPU, 441692 KiB RSS; claude PID 21078: 1.2% CPU, 433544 KiB RSS; claude PID 8572: 1.5% CPU, 406364 KiB RSS; claude PID 18999: 2.1% CPU, 406312 KiB RSS; claude PID 7630: 1.4% CPU, 398464 KiB RSS; claude PID 13661: 1.6% CPU, 387272 KiB RSS.

End: Mon Sep  7 22:13:29 UTC 2026; load 6.70 4.71 3.77 6/2099 27752; MemAvailable:   14562012 kB. Resident processes: java PID 30008: 32.0% CPU, 4605232 KiB RSS; mempalace PID 19703: 130% CPU, 1745896 KiB RSS; claude PID 16534: 1.4% CPU, 543148 KiB RSS; claude PID 31868: 2.0% CPU, 485808 KiB RSS; claude PID 488: 1.9% CPU, 472368 KiB RSS; claude PID 4215: 1.8% CPU, 465916 KiB RSS; claude PID 9011: 1.5% CPU, 441620 KiB RSS; claude PID 21078: 1.2% CPU, 433480 KiB RSS; claude PID 8572: 1.5% CPU, 403844 KiB RSS; claude PID 7630: 1.4% CPU, 398420 KiB RSS; claude PID 18999: 2.1% CPU, 395568 KiB RSS; claude PID 8789: 1.5% CPU, 389148 KiB RSS.

| Run | Wall (s) | CPU (s) | Node heap peak (MiB) | Cgroup peak (MiB) | Unanswered probe (s) | Trailing window (s) | Chunks | Explores | Fingerprint |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| `spk1936-stage-c790-WJ-before-2` | 148.0 | 409.1 | 2684 | 4778 | 14.7 | 1.0 | 37 | 10006 | `c1f46391b8c12a82280cafe7c9e1297c89a80ba4c7ab3d836769287d2d42b4fc` |

Transaction: 41347 ms. Project lock to commit: 41341 ms. Stage: None ms. Swap, including acquisition: None ms. Error count: 0. Persisted payload fingerprint: `9ad4efb7afb6ac5d795bfc7747412fba5bd2aab124ce2379f66d300667af451a`. Returned-order fingerprint: `9e8be9036d11fd55400e65d6290195443570bb586e66940d80aca8e49078f633`.

Order fingerprint: `9e8be9036d11fd55400e65d6290195443570bb586e66940d80aca8e49078f633`.

Start: Mon Sep  7 22:15:46 UTC 2026; load 2.82 3.90 3.60 7/2107 28566; MemAvailable:   14295800 kB. Resident processes: java PID 30008: 31.7% CPU, 4605564 KiB RSS; mempalace PID 19703: 133% CPU, 2058596 KiB RSS; claude PID 16534: 1.4% CPU, 543148 KiB RSS; claude PID 31868: 2.0% CPU, 487484 KiB RSS; claude PID 488: 1.9% CPU, 472368 KiB RSS; claude PID 4215: 1.8% CPU, 467936 KiB RSS; claude PID 9011: 1.5% CPU, 441628 KiB RSS; claude PID 21078: 1.2% CPU, 433528 KiB RSS; claude PID 8572: 1.5% CPU, 404912 KiB RSS; claude PID 7630: 1.4% CPU, 398432 KiB RSS; claude PID 18999: 2.1% CPU, 395572 KiB RSS; claude PID 8789: 1.5% CPU, 389148 KiB RSS.

End: Mon Sep  7 22:18:09 UTC 2026; load 4.66 4.54 3.90 10/2111 30926; MemAvailable:   15476636 kB. Resident processes: java PID 30008: 31.5% CPU, 4604068 KiB RSS; mempalace PID 29721: 100% CPU, 882212 KiB RSS; claude PID 16534: 1.4% CPU, 531756 KiB RSS; claude PID 31868: 2.0% CPU, 479016 KiB RSS; claude PID 488: 1.9% CPU, 464360 KiB RSS; claude PID 4215: 1.8% CPU, 459476 KiB RSS; claude PID 9011: 1.5% CPU, 432204 KiB RSS; claude PID 21078: 1.2% CPU, 427092 KiB RSS; claude PID 8572: 1.5% CPU, 396356 KiB RSS; claude PID 18999: 2.1% CPU, 395492 KiB RSS; claude PID 7630: 1.4% CPU, 390600 KiB RSS; claude PID 8789: 1.5% CPU, 383496 KiB RSS.

| Run | Wall (s) | CPU (s) | Node heap peak (MiB) | Cgroup peak (MiB) | Unanswered probe (s) | Trailing window (s) | Chunks | Explores | Fingerprint |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| `spk1936-stage-c790-WJ-after-2` | 142.8 | 391.6 | 1810 | 4248 | 16.2 | 0.2 | 37 | 10006 | `c1f46391b8c12a82280cafe7c9e1297c89a80ba4c7ab3d836769287d2d42b4fc` |

Transaction: 7098 ms. Project lock to commit: 7088 ms. Stage: 45443 ms. Swap, including acquisition: 7099 ms. Error count: 0. Persisted payload fingerprint: `9ad4efb7afb6ac5d795bfc7747412fba5bd2aab124ce2379f66d300667af451a`. Returned-order fingerprint: `9e8be9036d11fd55400e65d6290195443570bb586e66940d80aca8e49078f633`.

Order fingerprint: `9e8be9036d11fd55400e65d6290195443570bb586e66940d80aca8e49078f633`.

All planned runs complete. Content fingerprints match within each arm. This PR remains in draft for review. The tables retain the host state for each run.

W must save 13 chunks and 10,006 explores. WJ must save 37 chunks and 10,006 explores. Full fingerprints appear beside every completed run.

## Validation

Head: `5c92aa30c1b52bcf9bd9e447c2b7d077fe34690d`. [Build & Test passes on this exact head](https://github.com/lightdash/lightdash/actions/runs/34155795047/job/101847242399). [API E2E passes on this exact head](https://github.com/lightdash/lightdash/actions/runs/34155795047/job/101848316100). Backend typecheck passes. The full backend suite passes 589 files: 9,760 tests pass, one expected failure remains, and one test is skipped. Lint and oxfmt pass on all changed backend paths. The previous common suite passes 177 files: 4,151 tests pass and one test is skipped. Common code does not change in this revision.

The actual PostgreSQL check pauses conversion for 300 ms with an idle transaction timeout of 100 ms. The save succeeds. A concurrent managed-explore write completes during staging. The small-fixture transaction takes 11 ms from BEGIN to completed COMMIT. The project lock spans 7 ms through commit completion. The method logs 314 ms for staging and 11 ms for the swap, including acquisition. These values do not measure the scale fixture. Each completed W or WJ row includes the scale transaction and lock-to-commit durations.

The PostgreSQL check also verifies stage failure, rollback after live deletion, last-wins duplicates, returned order, concurrent save isolation, and stale cleanup. Cleanup waits 325 ms behind staged row locks while the swap promotes all 1,000 rows. Migration rollback removes the staging table.

## Not measured here

Code-read and named tests cover service disposal, compile analytics, job results and manifest publication order. The scale rig replays the pipeline. It does not run ProjectService or persist the gzip manifest. The revised rig calls the actual save methods. It records both transaction and project-lock durations.

Initial project creation keeps its compile-before-create array path. CLI uploads and upstream-cache preview copying keep their existing array inputs. Remote Git performance and production catalog indexing are not measured here.

Co-Authored-By: Codex GPT-6-Astra <noreply@openai.com>

