### PR TITLE
feat(training): label the training project as a playground and guard its deletion

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -4474,6 +4474,22 @@ export class ProjectService extends BaseService {
         }
 
         if (project.type === ProjectType.TRAINING) {
+            // Deleting the playground takes every learner's copy with it and
+            // switches Learn off for the org, so it is an org admin's call
+            // (the same permission Enable Learn needs), not a project
+            // admin's.
+            if (
+                auditedAbility.cannot(
+                    'manage',
+                    subject('Organization', {
+                        organizationUuid: project.organizationUuid,
+                    }),
+                )
+            ) {
+                throw new ForbiddenError(
+                    'Only an organization admin can delete the training playground',
+                );
+            }
             // The copies exist only as sandboxes of this project; without it
             // they would linger as ordinary previews until they expire.
             const copies = (

--- a/packages/frontend/src/components/NavBar/ProjectSwitcher.tsx
+++ b/packages/frontend/src/components/NavBar/ProjectSwitcher.tsx
@@ -1,9 +1,5 @@
 import { subject } from '@casl/ability';
-import {
-    assertUnreachable,
-    ProjectType,
-    type OrganizationProject,
-} from '@lightdash/common';
+import { ProjectType, type OrganizationProject } from '@lightdash/common';
 import {
     ActionIcon,
     Badge,
@@ -46,6 +42,7 @@ import MantineIcon from '../common/MantineIcon';
 import AppColorSchemeScope from './AppColorSchemeScope';
 import { CreatePreviewModal } from './CreatePreviewProjectModal';
 import classes from './ProjectSwitcher.module.css';
+import { isPlaygroundProject, splitSwitcherProjects } from './switcherProjects';
 
 const MENU_TEXT_PROPS = {
     c: 'ldGray.9',
@@ -69,6 +66,13 @@ const CurrentBadge: FC = () => (
         className={classes.badge}
     >
         current
+    </Badge>
+);
+
+/** The org's training playground, so nobody takes it for a real project. */
+const PlaygroundBadge: FC = () => (
+    <Badge color="grape" size="xs" className={classes.badge}>
+        Playground
     </Badge>
 );
 
@@ -180,6 +184,7 @@ const ProjectRow: FC<{
 
                 <Group gap="xs" wrap="nowrap">
                     {isActive && <CurrentBadge />}
+                    {isPlaygroundProject(item) && <PlaygroundBadge />}
                     {previewCount > 0 && (
                         <Box
                             component="span"
@@ -457,53 +462,26 @@ const ProjectSwitcher: FC<ProjectSwitcherProps> = ({ portalTarget }) => {
 
     const { baseProjects, previewsByUpstream, baseProjectsByUuid } =
         useMemo(() => {
-            const base = (projects ?? []).filter(
-                (p) =>
-                    p.type === ProjectType.DEFAULT ||
-                    p.type === ProjectType.TRAINING,
+            // Only show previews the user is allowed to access: org-level
+            // preview creators, or developers of the preview project itself.
+            const grouped = splitSwitcherProjects(
+                projects ?? [],
+                (preview) =>
+                    orgRoleCanCreatePreviews ||
+                    !!user.data?.ability.can(
+                        'create',
+                        subject('Project', {
+                            upstreamProjectUuid: preview.projectUuid,
+                            type: ProjectType.PREVIEW,
+                        }),
+                    ),
             );
-
-            // Only show previews the user is allowed to access. Visibility is
-            // unchanged from before: org-level preview creators, or developers
-            // of the preview project itself.
-            const visiblePreviews = (projects ?? []).filter((project) => {
-                switch (project.type) {
-                    case ProjectType.DEFAULT:
-                    case ProjectType.TRAINING:
-                        return false;
-                    case ProjectType.PREVIEW:
-                        return (
-                            orgRoleCanCreatePreviews ||
-                            !!user.data?.ability.can(
-                                'create',
-                                subject('Project', {
-                                    upstreamProjectUuid: project.projectUuid,
-                                    type: ProjectType.PREVIEW,
-                                }),
-                            )
-                        );
-                    default:
-                        return assertUnreachable(
-                            project.type,
-                            `Unknown project type: ${project.type}`,
-                        );
-                }
-            });
-
-            const byUpstream = new Map<string, OrganizationProject[]>();
-            visiblePreviews.forEach((preview) => {
-                if (!preview.upstreamProjectUuid) return;
-                const existing =
-                    byUpstream.get(preview.upstreamProjectUuid) ?? [];
-                existing.push(preview);
-                byUpstream.set(preview.upstreamProjectUuid, existing);
-            });
-
             return {
-                baseProjects: base,
-                previewsByUpstream: byUpstream,
+                ...grouped,
                 baseProjectsByUuid: new Map(
-                    base.map((p) => [p.projectUuid, p] as const),
+                    grouped.baseProjects.map(
+                        (p) => [p.projectUuid, p] as const,
+                    ),
                 ),
             };
         }, [projects, orgRoleCanCreatePreviews, user.data]);

--- a/packages/frontend/src/components/NavBar/switcherProjects.test.ts
+++ b/packages/frontend/src/components/NavBar/switcherProjects.test.ts
@@ -1,0 +1,69 @@
+import { ProjectType, type OrganizationProject } from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import { isPlaygroundProject, splitSwitcherProjects } from './switcherProjects';
+
+const project = (
+    overrides: Partial<OrganizationProject> & { projectUuid: string },
+): OrganizationProject =>
+    ({
+        name: overrides.projectUuid,
+        type: ProjectType.DEFAULT,
+        createdByUserUuid: null,
+        upstreamProjectUuid: null,
+        warehouseType: null,
+        requireUserCredentials: false,
+        expiresAt: null,
+        ...overrides,
+    }) as OrganizationProject;
+
+describe('project switcher grouping', () => {
+    const real = project({ projectUuid: 'real' });
+    const training = project({
+        projectUuid: 'training',
+        type: ProjectType.TRAINING,
+    });
+    const preview = project({
+        projectUuid: 'preview',
+        type: ProjectType.PREVIEW,
+        upstreamProjectUuid: 'real',
+    });
+    const copy = project({
+        projectUuid: 'copy',
+        type: ProjectType.PREVIEW,
+        upstreamProjectUuid: 'training',
+    });
+
+    it('lists the training playground beside the real projects', () => {
+        const { baseProjects } = splitSwitcherProjects(
+            [preview, training, real, copy],
+            () => true,
+        );
+        expect(baseProjects.map((p) => p.projectUuid)).toEqual([
+            'training',
+            'real',
+        ]);
+    });
+
+    it('hangs previews and learner copies off their upstream project', () => {
+        const { previewsByUpstream } = splitSwitcherProjects(
+            [real, training, preview, copy],
+            () => true,
+        );
+        expect(previewsByUpstream.get('real')).toEqual([preview]);
+        expect(previewsByUpstream.get('training')).toEqual([copy]);
+    });
+
+    it('drops previews the caller may not see', () => {
+        const { previewsByUpstream } = splitSwitcherProjects(
+            [real, preview],
+            () => false,
+        );
+        expect(previewsByUpstream.size).toBe(0);
+    });
+
+    it('marks only the training project as the playground', () => {
+        expect(isPlaygroundProject(training)).toBe(true);
+        expect(isPlaygroundProject(real)).toBe(false);
+        expect(isPlaygroundProject(copy)).toBe(false);
+    });
+});

--- a/packages/frontend/src/components/NavBar/switcherProjects.ts
+++ b/packages/frontend/src/components/NavBar/switcherProjects.ts
@@ -1,0 +1,46 @@
+import {
+    assertUnreachable,
+    ProjectType,
+    type OrganizationProject,
+} from '@lightdash/common';
+
+/**
+ * How the project switcher groups an org's projects: the base list is the
+ * real projects plus the org's training playground (learners land in the
+ * playground and its copies, and the switcher is how they get back), and
+ * previews hang off their upstream project when the caller may see them.
+ */
+export const splitSwitcherProjects = (
+    projects: OrganizationProject[],
+    canSeePreview: (preview: OrganizationProject) => boolean,
+) => {
+    const baseProjects = projects.filter((project) => {
+        switch (project.type) {
+            case ProjectType.DEFAULT:
+            case ProjectType.TRAINING:
+                return true;
+            case ProjectType.PREVIEW:
+                return false;
+            default:
+                return assertUnreachable(
+                    project.type,
+                    `Unknown project type: ${project.type}`,
+                );
+        }
+    });
+    const previewsByUpstream = new Map<string, OrganizationProject[]>();
+    projects.forEach((project) => {
+        if (project.type !== ProjectType.PREVIEW) return;
+        if (!project.upstreamProjectUuid || !canSeePreview(project)) return;
+        const existing =
+            previewsByUpstream.get(project.upstreamProjectUuid) ?? [];
+        existing.push(project);
+        previewsByUpstream.set(project.upstreamProjectUuid, existing);
+    });
+    return { baseProjects, previewsByUpstream };
+};
+
+/** The org's training playground: labelled so nobody takes it for real work. */
+export const isPlaygroundProject = (
+    project: Pick<OrganizationProject, 'type'>,
+) => project.type === ProjectType.TRAINING;

--- a/packages/frontend/src/components/UserSettings/DefaultProjectPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/DefaultProjectPanel/index.tsx
@@ -60,7 +60,13 @@ const DefaultProjectPanel: FC = () => {
                     key={form.values.defaultProjectUuid}
                     label="Project name"
                     data={projects
-                        .filter(({ type }) => type !== ProjectType.PREVIEW)
+                        // Neither previews nor the training playground can
+                        // be the org's landing project.
+                        .filter(
+                            ({ type }) =>
+                                type !== ProjectType.PREVIEW &&
+                                type !== ProjectType.TRAINING,
+                        )
                         .map((project) => ({
                             value: project.projectUuid,
                             label: project.name,

--- a/packages/frontend/src/components/UserSettings/DeleteProjectPanel/DeleteProjectModal.tsx
+++ b/packages/frontend/src/components/UserSettings/DeleteProjectPanel/DeleteProjectModal.tsx
@@ -1,3 +1,4 @@
+import { ProjectType } from '@lightdash/common';
 import { Text, TextInput, type ModalProps } from '@mantine/core';
 import { useState, type FC } from 'react';
 import { useDeleteActiveProjectMutation } from '../../../hooks/useActiveProject';
@@ -33,11 +34,15 @@ export const ProjectDeleteModal: FC<
         onClose();
     };
 
+    const isPlayground = project.type === ProjectType.TRAINING;
+
     return (
         <MantineModal
             opened={opened}
             onClose={handleOnClose}
-            title="Delete Project"
+            title={
+                isPlayground ? 'Delete training playground' : 'Delete Project'
+            }
             variant="delete"
             resourceType="project"
             resourceLabel={project.name}
@@ -48,6 +53,13 @@ export const ProjectDeleteModal: FC<
             }
             confirmLoading={isDeleting}
         >
+            {isPlayground && (
+                <Text fz="sm">
+                    This is the training playground Learn created for your
+                    organization. Deleting it removes every learner's copy with
+                    it, and Learn goes back to asking an admin to enable it.
+                </Text>
+            )}
             <Text fz="sm" c="dimmed">
                 Type the name of this project to confirm. This action is not
                 reversible.

--- a/packages/frontend/src/components/UserSettings/ProjectManagementPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/ProjectManagementPanel/index.tsx
@@ -1,6 +1,5 @@
 import { subject } from '@casl/ability';
 import {
-    assertUnreachable,
     ProjectType,
     WarehouseTypes,
     type OrganizationProject,
@@ -64,12 +63,10 @@ import {
 import { ProjectDeleteModal } from '../DeleteProjectPanel/DeleteProjectModal';
 import { ProjectDeleteInBulkModal } from '../DeleteProjectPanel/ProjectDeleteInBulkModal';
 import classes from './ProjectManagementPanel.module.css';
-
-enum ProjectTypeFilter {
-    ALL = 'all',
-    DEFAULT = 'default',
-    PREVIEW = 'preview',
-}
+import {
+    matchesProjectTypeFilter,
+    ProjectTypeFilter,
+} from './projectTypeFilter';
 
 const WAREHOUSE_LABELS: Record<WarehouseTypes, string> = {
     [WarehouseTypes.BIGQUERY]: 'BigQuery',
@@ -196,27 +193,45 @@ const ProjectManagementPanel: FC = () => {
         }));
     }, [projects]);
 
+    // Deleting the org's training playground takes every learner's copy
+    // with it, so it is offered to org admins only (the same permission
+    // Enable Learn needs); other projects follow the delete ability alone.
+    const canDeleteProject = useCallback(
+        (project: OrganizationProject) => {
+            if (!user.data) return false;
+            const canDelete = user.data.ability.can(
+                'delete',
+                subject('Project', {
+                    type: project.type,
+                    projectUuid: project.projectUuid,
+                    organizationUuid: user.data.organizationUuid,
+                    createdByUserUuid: project.createdByUserUuid,
+                }),
+            );
+            if (project.type !== ProjectType.TRAINING) return canDelete;
+            return (
+                canDelete &&
+                user.data.ability.can(
+                    'manage',
+                    subject('Organization', {
+                        organizationUuid: user.data.organizationUuid,
+                    }),
+                )
+            );
+        },
+        [user.data],
+    );
+
     const filteredProjects = useMemo(() => {
         return projects.filter((project) => {
             const matchesSearch =
                 !search ||
                 project.name.toLowerCase().includes(search.toLowerCase());
 
-            const matchesType = (() => {
-                switch (activeFilter) {
-                    case ProjectTypeFilter.DEFAULT:
-                        return project.type === ProjectType.DEFAULT;
-                    case ProjectTypeFilter.PREVIEW:
-                        return project.type === ProjectType.PREVIEW;
-                    case ProjectTypeFilter.ALL:
-                        return true;
-                    default:
-                        return assertUnreachable(
-                            activeFilter,
-                            `Unknown filter: ${activeFilter}`,
-                        );
-                }
-            })();
+            const matchesType = matchesProjectTypeFilter(
+                activeFilter,
+                project.type,
+            );
 
             const matchesWarehouse =
                 selectedWarehouses.length === 0 ||
@@ -293,15 +308,7 @@ const ProjectManagementPanel: FC = () => {
                     ) : null,
                 Cell: ({ row }) => {
                     const project = row.original;
-                    const canDelete = user.data?.ability.can(
-                        'delete',
-                        subject('Project', {
-                            type: project.type,
-                            projectUuid: project.projectUuid,
-                            organizationUuid: user.data?.organizationUuid,
-                            createdByUserUuid: project.createdByUserUuid,
-                        }),
-                    );
+                    const canDelete = canDeleteProject(project);
                     return (
                         <Center>
                             <Checkbox
@@ -345,6 +352,11 @@ const ProjectManagementPanel: FC = () => {
                             )}
                             {project.type === ProjectType.PREVIEW && (
                                 <Badge size="xs">Preview</Badge>
+                            )}
+                            {project.type === ProjectType.TRAINING && (
+                                <Badge size="xs" color="grape" flex="none">
+                                    Playground
+                                </Badge>
                             )}
                         </Group>
                     );
@@ -469,15 +481,7 @@ const ProjectManagementPanel: FC = () => {
                             projectUuid: project.projectUuid,
                         }),
                     );
-                    const canDelete = user.data?.ability.can(
-                        'delete',
-                        subject('Project', {
-                            type: project.type,
-                            projectUuid: project.projectUuid,
-                            organizationUuid: user.data?.organizationUuid,
-                            createdByUserUuid: project.createdByUserUuid,
-                        }),
-                    );
+                    const canDelete = canDeleteProject(project);
 
                     return (
                         <Menu
@@ -568,6 +572,7 @@ const ProjectManagementPanel: FC = () => {
             lastProjectUuid,
             selectedProjects,
             user.data?.ability,
+            canDeleteProject,
             user.data?.organizationUuid,
         ],
     );
@@ -695,6 +700,18 @@ const ProjectManagementPanel: FC = () => {
                                         <Box>
                                             <Text fz="xs" fw={500}>
                                                 Preview
+                                            </Text>
+                                        </Box>
+                                    </Tooltip>
+                                ),
+                            },
+                            {
+                                value: ProjectTypeFilter.TRAINING,
+                                label: (
+                                    <Tooltip label="Show only the training playground Learn created">
+                                        <Box>
+                                            <Text fz="xs" fw={500}>
+                                                Training
                                             </Text>
                                         </Box>
                                     </Tooltip>

--- a/packages/frontend/src/components/UserSettings/ProjectManagementPanel/projectTypeFilter.test.ts
+++ b/packages/frontend/src/components/UserSettings/ProjectManagementPanel/projectTypeFilter.test.ts
@@ -1,0 +1,52 @@
+import { ProjectType } from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import {
+    matchesProjectTypeFilter,
+    ProjectTypeFilter,
+} from './projectTypeFilter';
+
+describe('project management type filter', () => {
+    it('shows every type under All, the training playground included', () => {
+        Object.values(ProjectType).forEach((type) => {
+            expect(matchesProjectTypeFilter(ProjectTypeFilter.ALL, type)).toBe(
+                true,
+            );
+        });
+    });
+
+    it('shows only the training playground under Training', () => {
+        expect(
+            matchesProjectTypeFilter(
+                ProjectTypeFilter.TRAINING,
+                ProjectType.TRAINING,
+            ),
+        ).toBe(true);
+        expect(
+            matchesProjectTypeFilter(
+                ProjectTypeFilter.TRAINING,
+                ProjectType.DEFAULT,
+            ),
+        ).toBe(false);
+        expect(
+            matchesProjectTypeFilter(
+                ProjectTypeFilter.TRAINING,
+                ProjectType.PREVIEW,
+            ),
+        ).toBe(false);
+    });
+
+    it('keeps the training playground out of Projects and Preview', () => {
+        expect(
+            matchesProjectTypeFilter(
+                ProjectTypeFilter.DEFAULT,
+                ProjectType.TRAINING,
+            ),
+        ).toBe(false);
+        expect(
+            matchesProjectTypeFilter(
+                ProjectTypeFilter.PREVIEW,
+                ProjectType.TRAINING,
+            ),
+        ).toBe(false);
+    });
+});

--- a/packages/frontend/src/components/UserSettings/ProjectManagementPanel/projectTypeFilter.ts
+++ b/packages/frontend/src/components/UserSettings/ProjectManagementPanel/projectTypeFilter.ts
@@ -1,0 +1,27 @@
+import { assertUnreachable, ProjectType } from '@lightdash/common';
+
+/** The type filter above the project management list. */
+export enum ProjectTypeFilter {
+    ALL = 'all',
+    DEFAULT = 'default',
+    PREVIEW = 'preview',
+    TRAINING = 'training',
+}
+
+export const matchesProjectTypeFilter = (
+    filter: ProjectTypeFilter,
+    type: ProjectType,
+): boolean => {
+    switch (filter) {
+        case ProjectTypeFilter.DEFAULT:
+            return type === ProjectType.DEFAULT;
+        case ProjectTypeFilter.PREVIEW:
+            return type === ProjectType.PREVIEW;
+        case ProjectTypeFilter.TRAINING:
+            return type === ProjectType.TRAINING;
+        case ProjectTypeFilter.ALL:
+            return true;
+        default:
+            return assertUnreachable(filter, `Unknown filter: ${filter}`);
+    }
+};


### PR DESCRIPTION
Closes CS-261.

The org's training project (created by Enable Learn) looked like any other project. Now:

- **Playground badge** on the training project in the project switcher and in Organisation settings › All projects. Learner copies keep their "Training copy" name and no badge.
- **Training filter** in the project management type filter; All still shows it.
- **Default project picker** never lists a training project.
- **Deletion guard.** Delete on a training project is offered to org admins only (the same `manage:Organization` Enable Learn needs); the confirm names it as the training playground and warns that learners' copies go with it. The backend enforces the same rule in `ProjectService.delete`.

The switcher's grouping and the panel's type filter are lifted into small pure modules with unit tests covering the new type.

Verified on a local instance: badge in switcher and list, Training filter, admin delete confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WzrWdus5zqJBTK2ouC1q6m