### PR TITLE
refactor(learn): library on the product palette, ring glides to late controls, hook cleanups

### DIFF
--- a/packages/backend/src/services/ProjectService/provisionTrainingProject.ts
+++ b/packages/backend/src/services/ProjectService/provisionTrainingProject.ts
@@ -72,6 +72,13 @@ const describe = (error: unknown): string =>
  * The bundle is the playground's (same DuckDB dataset and explores); only
  * the project type, name and the seeded space differ. The training bundle
  * of CS-207 Slice 1 replaces it when it lands.
+ *
+ * Authorisation is the caller's: `ProjectService.enableLearn` checks
+ * `manage:Organization` before calling this, and it is the only route
+ * reachable by users. The service wiring and the dev provisioning script
+ * also call it, deliberately without a user check, for an org they already
+ * administer. The organisation guard here narrows the type; it is not the
+ * permission check.
  */
 export const provisionTrainingProject = async ({
     user,

--- a/packages/frontend/src/components/common/GuidedTour/GuidedTour.module.css
+++ b/packages/frontend/src/components/common/GuidedTour/GuidedTour.module.css
@@ -319,3 +319,15 @@
     );
     transform: scale(1.15);
 }
+
+/* The ring and card still move between controls, just without the glide,
+   and the beacon holds still rather than pulsing. */
+@media (prefers-reduced-motion: reduce) {
+    .spotlightGliding,
+    .cardGliding {
+        transition: none;
+    }
+    .spotlightBeacon::before {
+        animation: none;
+    }
+}

--- a/packages/frontend/src/components/common/GuidedTour/GuidedTour.tsx
+++ b/packages/frontend/src/components/common/GuidedTour/GuidedTour.tsx
@@ -523,10 +523,30 @@ export const GuidedTour: FC<GuidedTourProps> = ({
     // The position transition is on only for a moment after a move starts,
     // so scroll and resize still track instantly afterwards.
     const [gliding, setGliding] = useState(false);
-    const glideFor = (ms: number) => {
+    const glideFor = useCallback((ms: number) => {
         setGliding(true);
         window.setTimeout(() => setGliding(false), ms);
-    };
+    }, []);
+    // The ring effect below answers to the target rect alone: the beacon,
+    // card phase and step it reads are mirrored into refs so a change in
+    // any of them does not re-run it (a click's beacon must wait for the
+    // next control, not bounce open on the one just clicked).
+    const beaconRef = useRef(beacon);
+    useEffect(() => {
+        beaconRef.current = beacon;
+    }, [beacon]);
+    const cardPhaseRef = useRef(cardPhase);
+    useEffect(() => {
+        cardPhaseRef.current = cardPhase;
+    }, [cardPhase]);
+    const stepIndexRef = useRef(stepIndex);
+    useEffect(() => {
+        stepIndexRef.current = stepIndex;
+    }, [stepIndex]);
+    // The step the ring last glided for: Next moves the ring from the old
+    // control to the new one with the same glide a beacon uses, once, even
+    // when the new control takes a moment to appear.
+    const glidedForStepRef = useRef(initialStepIndex);
     // The control the ring has just arrived at may still settle (a navbar
     // button loading in, a dialog growing), so the pending card expansion
     // must survive rect changes and open at wherever the control ended up.
@@ -537,15 +557,17 @@ export const GuidedTour: FC<GuidedTourProps> = ({
             // The control went away under a read step (a tile removed):
             // the card centres, with its buttons, rather than staying
             // anchored to nothing.
-            if (!beacon && cardPhase === 'shown') setCardRect(null);
+            if (!beaconRef.current && cardPhaseRef.current === 'shown')
+                setCardRect(null);
             return;
         }
         latestRectRef.current = rect;
         setShownRect(rect);
-        if (beacon) {
+        if (beaconRef.current) {
             // the beacon travels to the new control and opens; the card
             // expands out of it once the ring has arrived
             setBeacon(false);
+            glidedForStepRef.current = stepIndexRef.current;
             glideFor(GLIDE_MS);
             expandTimeoutRef.current = window.setTimeout(() => {
                 expandTimeoutRef.current = null;
@@ -555,8 +577,12 @@ export const GuidedTour: FC<GuidedTourProps> = ({
             }, GLIDE_MS);
             return;
         }
-        if (cardPhase === 'shown') setCardRect(rect);
-    }, [rect]); // eslint-disable-line react-hooks/exhaustive-deps
+        if (glidedForStepRef.current !== stepIndexRef.current) {
+            glidedForStepRef.current = stepIndexRef.current;
+            glideFor(GLIDE_MS);
+        }
+        if (cardPhaseRef.current === 'shown') setCardRect(rect);
+    }, [rect, glideFor]);
     useEffect(
         () => () => {
             if (expandTimeoutRef.current !== null)
@@ -592,7 +618,7 @@ export const GuidedTour: FC<GuidedTourProps> = ({
         setShownStepIndex(stepIndex);
         glideFor(GLIDE_MS);
         return undefined;
-    }, [stepIndex]);
+    }, [stepIndex, glideFor]);
 
     // While the beacon waits for the next control it becomes the cursor:
     // the native pointer is hidden and the beacon follows the mouse, so the
@@ -624,7 +650,7 @@ export const GuidedTour: FC<GuidedTourProps> = ({
     useEffect(() => {
         if (wasBusyRef.current && !busy) glideFor(GLIDE_MS);
         wasBusyRef.current = busy;
-    }, [busy]); // eslint-disable-line react-hooks/exhaustive-deps
+    }, [busy, glideFor]);
 
     const isLast = stepIndex === steps.length - 1;
 

--- a/packages/frontend/src/features/learn/EnableLearnPanel.tsx
+++ b/packages/frontend/src/features/learn/EnableLearnPanel.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Text } from '@mantine/core';
+import { Box, Button, List, Text, Title } from '@mantine/core';
 import { type FC } from 'react';
 import MantineIcon from '../../components/common/MantineIcon';
 import {
@@ -40,21 +40,22 @@ export const EnableLearnPanel: FC<Props> = ({
         <Box className={styles.enableShell} data-learn-enable-panel>
             <Box className={styles.enableColumn}>
                 <Box>
-                    <span
+                    <Text
+                        component="span"
                         className={`${styles.overline} ${styles.overlineAccent}`}
                     >
                         Learn
-                    </span>
-                    <h1 className={styles.enableTitle}>
+                    </Text>
+                    <Title order={1} className={styles.enableTitle}>
                         Learn Lightdash by doing, on data nobody can break
-                    </h1>
-                    <p className={styles.enableLede}>
+                    </Title>
+                    <Text component="p" className={styles.enableLede}>
                         Learn gives everyone in your organisation a sample
                         project to practise on, with a guided walkthrough for
                         each thing Lightdash can do. Every walkthrough runs in a
                         fresh copy of that project and the copy is removed when
                         it ends, so nothing here touches your real projects.
-                    </p>
+                    </Text>
                 </Box>
 
                 <Box className={styles.enableGrid}>
@@ -67,12 +68,19 @@ export const EnableLearnPanel: FC<Props> = ({
                                     className={styles.enableGroup}
                                     style={groupVars(group)}
                                 >
-                                    <span className={styles.enableGroupIcon}>
+                                    <Box
+                                        component="span"
+                                        className={styles.enableGroupIcon}
+                                    >
                                         <MantineIcon icon={Glyph} size={18} />
-                                    </span>
+                                    </Box>
                                     <Box>
-                                        <h3>{GROUP_LABELS[group]}</h3>
-                                        <p>{GROUP_DESCRIPTIONS[group]}</p>
+                                        <Title order={3}>
+                                            {GROUP_LABELS[group]}
+                                        </Title>
+                                        <Text component="p">
+                                            {GROUP_DESCRIPTIONS[group]}
+                                        </Text>
                                     </Box>
                                 </Box>
                             );
@@ -80,22 +88,30 @@ export const EnableLearnPanel: FC<Props> = ({
                     </Box>
 
                     <Box component="aside" className={styles.enableCard}>
-                        <span className={styles.overline}>Not enabled yet</span>
+                        <Text component="span" className={styles.overline}>
+                            Not enabled yet
+                        </Text>
                         {canEnable ? (
                             <>
-                                <h2>Enable Learn for your organisation</h2>
-                                <p>Enabling does three things:</p>
-                                <ul>
-                                    <li>
+                                <Title order={2}>
+                                    Enable Learn for your organisation
+                                </Title>
+                                <Text component="p">
+                                    Enabling does three things:
+                                </Text>
+                                <List>
+                                    <List.Item>
                                         creates a project named Training (sample
                                         data), on a small built-in dataset;
-                                    </li>
-                                    <li>
+                                    </List.Item>
+                                    <List.Item>
                                         gives everyone the permissions to
                                         practise there, and only there;
-                                    </li>
-                                    <li>makes you that project's admin.</li>
-                                </ul>
+                                    </List.Item>
+                                    <List.Item>
+                                        makes you that project's admin.
+                                    </List.Item>
+                                </List>
                                 <Button
                                     color="indigo"
                                     size="md"
@@ -109,12 +125,14 @@ export const EnableLearnPanel: FC<Props> = ({
                             </>
                         ) : (
                             <>
-                                <h2>Ask an admin to enable Learn</h2>
-                                <p data-learn-ask-admin>
+                                <Title order={2}>
+                                    Ask an admin to enable Learn
+                                </Title>
+                                <Text component="p" data-learn-ask-admin>
                                     An organisation admin turns Learn on from
                                     this page. Once they have, every walkthrough
                                     here is yours to start.
-                                </p>
+                                </Text>
                             </>
                         )}
                         {error && (

--- a/packages/frontend/src/features/learn/Learn.module.css
+++ b/packages/frontend/src/features/learn/Learn.module.css
@@ -8,8 +8,10 @@
        the surface differ per scheme. */
     --lu-accent: var(--mantine-color-ldBrandViolet-6);
     --lu-track: var(--mantine-color-ldGray-2);
-    --lu-done-fg: light-dark(#2f9e44, #69db7c);
-    --lu-done-border: light-dark(#b7e4c0, #2b5e3a);
+    --lu-done-fg: light-dark(
+        var(--mantine-color-green-7),
+        var(--mantine-color-green-4)
+    );
     --lu-surface: var(--mantine-color-background-0);
     --lu-sunken: var(--mantine-color-ldGray-1);
     --lu-border: var(--mantine-color-ldGray-2);
@@ -409,7 +411,10 @@
     height: 38px;
     display: grid;
     place-items: center;
-    background: rgba(255, 255, 255, 0.55);
+    background: light-dark(
+        rgba(255, 255, 255, 0.55),
+        rgba(255, 255, 255, 0.08)
+    );
     color: var(--mi-fg);
     border-radius: 44% 56% 47% 53% / 53% 44% 56% 47%;
 }

--- a/packages/frontend/src/features/learn/Learn.module.css
+++ b/packages/frontend/src/features/learn/Learn.module.css
@@ -394,17 +394,6 @@
     background: var(--mi-band);
 }
 
-.band::before {
-    content: '';
-    position: absolute;
-    inset: 0;
-    pointer-events: none;
-    opacity: 0.16;
-    background-image: radial-gradient(var(--mi-fg) 1.2px, transparent 1.3px);
-    background-size: 12px 12px;
-    background-position: 6px 4px;
-}
-
 .blob {
     position: relative;
     width: 38px;

--- a/packages/frontend/src/features/learn/LearnPage.tsx
+++ b/packages/frontend/src/features/learn/LearnPage.tsx
@@ -17,7 +17,7 @@ import {
     IconCircleCheck,
 } from '@tabler/icons-react';
 import { type FC, useEffect, useMemo, useState } from 'react';
-import { Navigate, useNavigate } from 'react-router';
+import { Navigate } from 'react-router';
 import MantineIcon from '../../components/common/MantineIcon';
 import useHealth from '../../hooks/health/useHealth';
 import { useOptionalProjectRoute } from '../../hooks/useProjectRoute';
@@ -145,7 +145,6 @@ const ModuleCard: FC<{
  * the learner back here when it ends.
  */
 const LearnPage: FC = () => {
-    const navigate = useNavigate();
     const { user } = useApp();
     const { data: health } = useHealth();
     const { data: projects } = useProjects();
@@ -182,22 +181,22 @@ const LearnPage: FC = () => {
             rememberLearnOrigin(projectRoute.project.projectUuid);
         }
     }, [projectRoute]);
-    useEffect(() => {
+    // A preview's /learn has no library of its own (see above): it goes to
+    // the remembered project's, or the training project's.
+    const previewRedirect = (() => {
         if (
-            projectRoute?.project.type === ProjectType.PREVIEW &&
-            trainingProject
-        ) {
-            const origin = readLearnOrigin();
-            const returnProject =
-                origin &&
-                projects?.some((project) => project.projectUuid === origin)
-                    ? origin
-                    : trainingProject.projectUuid;
-            void navigate(`/projects/${returnProject}/learn`, {
-                replace: true,
-            });
-        }
-    }, [projectRoute?.project.type, trainingProject, projects, navigate]);
+            projectRoute?.project.type !== ProjectType.PREVIEW ||
+            !trainingProject
+        )
+            return null;
+        const origin = readLearnOrigin();
+        const returnProject =
+            origin &&
+            projects?.some((project) => project.projectUuid === origin)
+                ? origin
+                : trainingProject.projectUuid;
+        return `/projects/${returnProject}/learn`;
+    })();
 
     // Only modules this instance can run: a walkthrough clicks the real
     // product, so a feature the instance hides has nothing to click.
@@ -255,6 +254,7 @@ const LearnPage: FC = () => {
             ?.scrollIntoView({ behavior: 'smooth', block: 'start' });
     };
 
+    if (previewRedirect) return <Navigate to={previewRedirect} replace />;
     // Learn switched off for the instance: the route falls through to the
     // project's home.
     if (health && !health.learn.enabled) {

--- a/packages/frontend/src/features/learn/availability.ts
+++ b/packages/frontend/src/features/learn/availability.ts
@@ -1,5 +1,5 @@
 import { FeatureFlags } from '@lightdash/common';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useAiOrganizationSettings } from '../../ee/features/aiCopilot/hooks/useAiOrganizationSettings';
 import { useIsCopilotEnabled } from '../../ee/features/aiCopilot/hooks/useIsCopilotEnabled';
 import { useServerFeatureFlag } from '../../hooks/useServerOrClientFeatureFlag';
@@ -24,21 +24,23 @@ export const useLearnAvailability = () => {
     const copilot = useIsCopilotEnabled();
     const aiSettings = useAiOrganizationSettings();
     const isEnterprise = health.data?.license?.hasLicenseKey === true;
-    const open: Record<LearnGate, boolean> = {
-        enterprise: isEnterprise,
-        // Data apps are Enterprise as well as flagged: without a licence the
-        // app endpoints refuse and nothing seeds an app to practise on.
-        dataApps: isEnterprise && dataApps.data?.enabled === true,
-        aiAgents:
-            isEnterprise &&
-            copilot.isCopilotEnabled &&
-            aiSettings.data?.aiAgentsVisible === true,
-    };
-    const key = JSON.stringify(open);
+    const dataAppsOn = dataApps.data?.enabled === true;
+    const copilotOn = copilot.isCopilotEnabled;
+    const agentsVisible = aiSettings.data?.aiAgentsVisible === true;
+    const open = useMemo<Record<LearnGate, boolean>>(
+        () => ({
+            enterprise: isEnterprise,
+            // Data apps are Enterprise as well as flagged: without a licence
+            // the app endpoints refuse and nothing seeds an app to practise
+            // on.
+            dataApps: isEnterprise && dataAppsOn,
+            aiAgents: isEnterprise && copilotOn && agentsVisible,
+        }),
+        [isEnterprise, dataAppsOn, copilotOn, agentsVisible],
+    );
     const isOpen = useCallback(
         (module: LearnModule) => module.gate === null || open[module.gate],
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-        [key],
+        [open],
     );
     return { isOpen };
 };

--- a/packages/frontend/src/features/learn/groupVisuals.ts
+++ b/packages/frontend/src/features/learn/groupVisuals.ts
@@ -26,21 +26,33 @@ export const GROUP_ICONS: Record<LearnGroup, Icon> = {
     [ScopeGroup.ORGANIZATION_MANAGEMENT]: IconBuilding,
 };
 
-/** The library's band and glyph colours per group, as on learn.lightdash.com. */
-const GROUP_COLOURS: Record<LearnGroup, { band: string; fg: string }> = {
-    [FOUNDATIONS]: { band: '#f0dbd1', fg: '#b06a4c' },
-    [ScopeGroup.CONTENT]: { band: '#dfe8e2', fg: '#4f7d5d' },
-    [ScopeGroup.SHARING]: { band: '#dfe8e2', fg: '#4f7d5d' },
-    [ScopeGroup.EMBED]: { band: '#dfe1e6', fg: '#5b6478' },
-    [ScopeGroup.DATA]: { band: '#ece3d1', fg: '#93743a' },
-    [ScopeGroup.AI]: { band: '#e2ddf1', fg: '#6b5bb8' },
-    [ScopeGroup.PROJECT_MANAGEMENT]: { band: '#d9e6e4', fg: '#41756f' },
-    [ScopeGroup.SPOTLIGHT]: { band: '#ece3d1', fg: '#93743a' },
-    [ScopeGroup.ORGANIZATION_MANAGEMENT]: { band: '#dfe1e6', fg: '#5b6478' },
+/**
+ * Each group's hue, taken from the product's own colour ramps so the library
+ * sits on Lightdash's palette in both schemes: the band is the ramp's lightest
+ * tint on light and a deep mix of it on dark, the glyph a mid shade either way.
+ */
+const GROUP_HUES: Record<LearnGroup, string> = {
+    [FOUNDATIONS]: 'indigo',
+    [ScopeGroup.CONTENT]: 'teal',
+    [ScopeGroup.SHARING]: 'cyan',
+    [ScopeGroup.EMBED]: 'lime',
+    [ScopeGroup.DATA]: 'yellow',
+    [ScopeGroup.AI]: 'grape',
+    [ScopeGroup.PROJECT_MANAGEMENT]: 'blue',
+    [ScopeGroup.SPOTLIGHT]: 'orange',
+    [ScopeGroup.ORGANIZATION_MANAGEMENT]: 'gray',
 };
 
-export const groupVars = (group: LearnGroup) =>
-    ({
-        '--mi-band': GROUP_COLOURS[group].band,
-        '--mi-fg': GROUP_COLOURS[group].fg,
-    }) as CSSProperties;
+const hueVar = (hue: string, shade: number) =>
+    `var(--mantine-color-${hue}-${shade})`;
+
+export const groupVars = (group: LearnGroup) => {
+    const hue = GROUP_HUES[group];
+    return {
+        '--mi-band': `light-dark(${hueVar(hue, 0)}, color-mix(in srgb, ${hueVar(
+            hue,
+            9,
+        )} 28%, var(--mantine-color-background-0)))`,
+        '--mi-fg': `light-dark(${hueVar(hue, 7)}, ${hueVar(hue, 3)})`,
+    } as CSSProperties;
+};

--- a/packages/frontend/src/features/learn/progress.ts
+++ b/packages/frontend/src/features/learn/progress.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useSyncExternalStore } from 'react';
 
 /**
  * What the learner has done with walkthroughs, kept in the browser for now:
@@ -55,28 +55,35 @@ export const markScopeStarted = (scope: string) =>
         localStorage.setItem(LAST_KEY, scope);
     });
 
-export const useLearnProgress = () => {
-    const [state, setState] = useState(() => ({
-        completed: readList(COMPLETED_KEY),
-        started: readList(STARTED_KEY),
-        lastStarted: readLast(),
-    }));
-    const refresh = useCallback(
-        () =>
-            setState({
-                completed: readList(COMPLETED_KEY),
-                started: readList(STARTED_KEY),
-                lastStarted: readLast(),
-            }),
-        [],
-    );
-    useEffect(() => {
-        window.addEventListener(CHANGE_EVENT, refresh);
-        window.addEventListener('storage', refresh);
-        return () => {
-            window.removeEventListener(CHANGE_EVENT, refresh);
-            window.removeEventListener('storage', refresh);
-        };
-    }, [refresh]);
-    return state;
+type LearnProgress = {
+    completed: string[];
+    started: string[];
+    lastStarted: string | null;
 };
+
+// The store's snapshot must be the same object while nothing changed, so
+// it is rebuilt only when the stored text differs from the last read.
+let snapshot: LearnProgress | null = null;
+let snapshotKey = '';
+const readProgress = (): LearnProgress => {
+    const completed = readList(COMPLETED_KEY);
+    const started = readList(STARTED_KEY);
+    const lastStarted = readLast();
+    const key = JSON.stringify([completed, started, lastStarted]);
+    if (snapshot === null || key !== snapshotKey) {
+        snapshotKey = key;
+        snapshot = { completed, started, lastStarted };
+    }
+    return snapshot;
+};
+const subscribe = (onChange: () => void) => {
+    window.addEventListener(CHANGE_EVENT, onChange);
+    window.addEventListener('storage', onChange);
+    return () => {
+        window.removeEventListener(CHANGE_EVENT, onChange);
+        window.removeEventListener('storage', onChange);
+    };
+};
+
+export const useLearnProgress = (): LearnProgress =>
+    useSyncExternalStore(subscribe, readProgress, readProgress);


### PR DESCRIPTION
Closes CS-262.

**Visual**
- The library's group bands and glyphs take one hue per group from the product's own colour ramps (light tint on light, deep mix on dark) instead of a hand-picked pastel set; the done colour is the theme's green.
- The walkthrough ring glides to a step's control when it appears after a page change rather than jumping; glide and beacon pulse stop under `prefers-reduced-motion`.
- The ring and beacon stay indigo (already a product token). The Complete label stays, per #28788.

**Structural, from Graphite's review of Stack 1**
- `GuidedTour.tsx`: `glideFor` is stable and the ring, step and busy effects list their real dependencies; beacon, card phase and step index are mirrored into refs so a change in them does not re-run the ring effect (a click's beacon must wait for the next control).
- `availability.ts`: the gate map is memoised and `isOpen` depends on it directly.
- `progress.ts`: `useSyncExternalStore` with the change event as the subscription and a cached snapshot.
- `LearnPage.tsx`: a preview's `/learn` renders `<Navigate>` instead of navigating in an effect.
- `EnableLearnPanel.tsx`: Mantine `Title`, `Text`, `List`, `Box`.
- `provisionTrainingProject.ts`: documents that authorisation is the caller's (`enableLearn` checks `manage:Organization`); the org guard is type narrowing.

Verified on a local instance in light and dark: library palette, and the pinning walkthrough end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WzrWdus5zqJBTK2ouC1q6m