### PR TITLE
test(e2e): clear the suggested chart name before typing one

### DIFF
--- a/packages/e2e/cypress/e2e/app/dashboard.cy.ts
+++ b/packages/e2e/cypress/e2e/app/dashboard.cy.ts
@@ -180,9 +180,9 @@ describe('Dashboard', () => {
         cy.findByText('Payment method').click();
         cy.findByText('Unique payment count').click();
         cy.findByText('Save chart').click();
-        cy.findByTestId('ChartCreateModal/NameInput').type(
-            `What's the number of unique payments per payment method?`,
-        );
+        cy.findByTestId('ChartCreateModal/NameInput')
+            .clear()
+            .type(`What's the number of unique payments per payment method?`);
         cy.findByText('Save').click();
         cy.findByText(
             `Success! What's the number of unique payments per payment method? was added to Title`,
@@ -231,9 +231,9 @@ describe('Dashboard', () => {
         cy.findByText('Payment method').click();
         cy.findByText('Total revenue').click();
         cy.findByText('Save chart').click();
-        cy.findByTestId('ChartCreateModal/NameInput').type(
-            `What's the total revenue per payment method?`,
-        );
+        cy.findByTestId('ChartCreateModal/NameInput')
+            .clear()
+            .type(`What's the total revenue per payment method?`);
         cy.findByText('Save').click();
         cy.findByText(
             `Success! What's the total revenue per payment method? was added to Title`,
@@ -290,9 +290,9 @@ describe('Dashboard', () => {
         cy.findByText('Payment method').click();
         cy.findByText('Amount').click();
         cy.findByText('Save chart').click();
-        cy.findByTestId('ChartCreateModal/NameInput').type(
-            `Stg Payments (payment method x amount)?`,
-        );
+        cy.findByTestId('ChartCreateModal/NameInput')
+            .clear()
+            .type(`Stg Payments (payment method x amount)?`);
         cy.findByText('Save').click();
         cy.findByText(
             `Success! Stg Payments (payment method x amount)? was added to Title`,
@@ -369,9 +369,9 @@ describe('Dashboard', () => {
         cy.findByText('Payment method').click();
         cy.findByText('Unique payment count').click();
         cy.findByText('Save chart').click();
-        cy.findByTestId('ChartCreateModal/NameInput').type(
-            `What's the number of unique payments per payment method?`,
-        );
+        cy.findByTestId('ChartCreateModal/NameInput')
+            .clear()
+            .type(`What's the number of unique payments per payment method?`);
         cy.findByText('Save').click();
 
         cy.findByText('Save changes').click();

--- a/packages/e2e/cypress/e2e/app/explore.cy.ts
+++ b/packages/e2e/cypress/e2e/app/explore.cy.ts
@@ -64,7 +64,7 @@ describe('Explore', () => {
 
         cy.findByText('Save chart').click();
 
-        cy.findByTestId('ChartCreateModal/NameInput').type('My chart');
+        cy.findByTestId('ChartCreateModal/NameInput').clear().type('My chart');
         cy.contains('Next').click();
         cy.findByText('Save').click();
         cy.findByText('Success! Chart was saved.');

--- a/packages/e2e/cypress/e2e/app/pivotTables.cy.ts
+++ b/packages/e2e/cypress/e2e/app/pivotTables.cy.ts
@@ -59,9 +59,9 @@ describe('Pivot Tables', () => {
 
         // Save a pivot table
         cy.contains('Save chart').click();
-        cy.get('[data-testid="ChartCreateModal/NameInput"]').type(
-            'My Pivot Table Chart',
-        );
+        cy.get('[data-testid="ChartCreateModal/NameInput"]')
+            .clear()
+            .type('My Pivot Table Chart');
         cy.findByText('Next').click();
         cy.findByText('Save').click();
         cy.contains('Chart was saved');

--- a/packages/e2e/cypress/e2e/app/space.cy.ts
+++ b/packages/e2e/cypress/e2e/app/space.cy.ts
@@ -60,6 +60,7 @@ describe('Space', () => {
 
         cy.get('.mantine-Modal-body').find('button').should('be.disabled');
         cy.get('[data-testid="ChartCreateModal/NameInput"]')
+            .clear()
             .type(`Private chart ${timestamp}`)
             .should('have.value', `Private chart ${timestamp}`);
 


### PR DESCRIPTION
## Description

Since #28786 the save-chart dialog opens with a name built from the query ("<metrics> by <dimensions>") instead of an empty field. The E2E specs that name a chart through that dialog typed into it without clearing, so the typed name was appended to the suggestion and two of them fail on every PR since:

* `space.cy.ts`: "Another non-admin user cannot see private content" (expected `Private chart …`, got `Total order amount by StatusPrivate chart …`)
* `dashboard.cy.ts`: "Should create dashboard with saved chart + charts within dashboard + filters + tile targets" (the success toast names the chart)

This clears the field before typing in all seven places a spec uses `ChartCreateModal/NameInput` (`space`, `dashboard` x4, `explore`, `pivotTables`). No product change.

## How to test

E2E: App shards 1/5 and 5/5 go green on this PR; they were red on #28786 and #28790 with the two failures above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014noLpwSN7QMpCr3MTpkogM
