### PR TITLE
chore(rainbow): drop the generate-api build step; the api-routes tier covers it

### DIFF
--- a/rainbow.toml
+++ b/rainbow.toml
@@ -27,9 +27,6 @@ max_memory = "16gb"                # headroom the migrate rung and the pnpm inst
 system = ["postgresql-16-pgvector", "python3-venv"]  # catalog migrations CREATE EXTENSION vector; the dbt venv
 build = [
   "pnpm formula:build && pnpm common-build && pnpm warehouses-build",
-  # The tsoa routes and swagger are committed only by the release workflow, so a
-  # branch that adds an endpoint 404s on it until they are regenerated here.
-  "pnpm -F backend generate-api",
   "python3 -m venv /usr/local/dbt1.12 && /usr/local/dbt1.12/bin/pip install -q 'dbt-core==1.12.0' 'dbt-postgres~=1.10.0' && ln -sf /usr/local/dbt1.12/bin/dbt /usr/local/bin/dbt1.12",
 ]
 


### PR DESCRIPTION
## Description

Since #28716 added `pnpm -F backend generate-api` to the Rainbow base image build, every branch image has failed to build ("compile branch base image: image build failed … script exit 1"), so no PR has had a preview since. This branch removes only that step and its preview built in nine minutes, which settles the cause.

The step is redundant: the `api-routes` tier in the same recipe already regenerates the tsoa routes for any branch that touches a controller, which is the case the build step was added for. Main's committed routes match main's controllers closely enough for the base image.

## How to test

The Rainbow bot posts a preview link on this PR (it did, at `f1c360d4`); PRs based on main after this merges get previews again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014noLpwSN7QMpCr3MTpkogM
