### PR TITLE
fix: reject a warehouse location on the primary dbt source update

### DIFF
--- a/packages/backend/src/services/ProjectDbtSourcesService.test.ts
+++ b/packages/backend/src/services/ProjectDbtSourcesService.test.ts
@@ -443,6 +443,27 @@ describe('ProjectDbtSourcesService', () => {
             expect(projectDbtSourcesModel.getSource).not.toHaveBeenCalled();
         });
 
+        it('rejects a warehouse location on the primary source', async () => {
+            const service = getService();
+
+            await expect(
+                service.updateProjectDbtSource(
+                    adminAccount,
+                    projectUuid,
+                    primarySourceUuid,
+                    {
+                        name: 'core_analytics',
+                        warehouseLocation: {
+                            database: 'analytics',
+                            schema: 'core',
+                        },
+                    },
+                ),
+            ).rejects.toThrow(ParameterError);
+
+            expect(projectModel.updateDbtSourceName).not.toHaveBeenCalled();
+        });
+
         it('rejects the primary source name', async () => {
             projectDbtSourcesModel.getSource.mockResolvedValue({
                 projectDbtSourceUuid: sourceUuid,

--- a/packages/backend/src/services/ProjectDbtSourcesService.ts
+++ b/packages/backend/src/services/ProjectDbtSourcesService.ts
@@ -341,7 +341,11 @@ export class ProjectDbtSourcesService extends BaseService {
         const identity =
             await this.projectModel.getDbtSourceIdentity(projectUuid);
         if (projectDbtSourceUuid === identity.dbtSourceUuid) {
-            if (data.name === undefined || data.dbtConnection !== undefined) {
+            if (
+                data.name === undefined ||
+                data.dbtConnection !== undefined ||
+                data.warehouseLocation !== undefined
+            ) {
                 throw new ParameterError(
                     'Only the primary dbt source name can be updated here',
                 );


### PR DESCRIPTION
Primary dbt source PATCH requests can include a warehouse location. The service ignores the field and returns a successful response.

This change rejects warehouse locations on primary source updates. It keeps primary source updates limited to renames.

## Validation

- Added `rejects a warehouse location on the primary source` in `ProjectDbtSourcesService.test.ts`.
- Pass: `pnpm -F backend exec vitest run src/services/ProjectDbtSourcesService.test.ts`.
- Pass: `pnpm --filter backend run linter src/services/ProjectDbtSourcesService.ts src/services/ProjectDbtSourcesService.test.ts`.
- Pass: `pnpm -F backend exec oxfmt --check src/services/ProjectDbtSourcesService.ts src/services/ProjectDbtSourcesService.test.ts`.
- Fail: `pnpm -F backend typecheck`. The fresh worktree lacks built `@lightdash/common` and `@lightdash/warehouses` artifacts.

Linear: SPK-1955