### PR TITLE
feat(auth): link a managed mobile sign-in to the same-tenant web identity

### DIFF
--- a/docs/managed-sign-in.md
+++ b/docs/managed-sign-in.md
@@ -200,9 +200,9 @@ encrypted and the tenant id cannot be a SQL predicate
 ## User matching
 
 The exchange builds an OpenID user and calls
-`UserService.loginWithOpenId`, so browser sign-in and managed sign-in share one
-rule set. Just-in-time creation, allowed email domains and organisation
-membership follow the same rules.
+`UserService.loginWithOpenId`. Just-in-time creation, allowed email domains
+and organisation membership follow the browser sign-in rules. The exchange
+also passes an explicit option for same-tenant Azure identity linking.
 
 | Field | Value |
 |---|---|
@@ -213,23 +213,36 @@ membership follow the same rules.
 
 ### Identity linking
 
-Because `sub` is pairwise, the lookup by issuer and subject misses for anyone
-who already signed in through the browser. `loginWithOpenId` then finds the
-existing user by email and reaches its identity-collision guard
-(`packages/backend/src/services/UserService.ts:1307`).
+Entra assigns a different `sub` to each client registration. Browser sign-in
+stores that subject. Managed sign-in uses `oid`, so its first identity lookup
+can miss an existing web identity.
 
-That guard only links a new identity when OIDC linking is enabled, through
-`AUTH_ENABLE_OIDC_LINKING` or the per-organisation toggle
-(`UserService.ts:1023`). Linking is off by default.
+The exchange links the new identity to the existing user when all these
+conditions hold:
 
-**So on a default instance, the first managed sign-in fails for every user who
-has already signed in on the web**, with `user_not_allowed`. Browser sign-in
-never hits this branch, because it always uses the same registration. This is
-open as SPK-1909 Q8.
+- The validated token's `tid` matches the configured Azure tenant. A dedicated
+  instance uses its environment config. A shared instance resolves exactly
+  one enabled organisation from `tid`.
+- The token's email matches an existing Azure identity's email.
+- The stored identity has issuer type `azuread` and issuer
+  `https://login.microsoftonline.com/<tid>/v2.0` for that same tenant.
+- The matching identities belong to one active user with an organisation.
+  On shared instances, that organisation must be the resolved organisation.
 
-When linking is enabled, the mobile identity is added as a second
-`openid_identities` row against the same user. Later managed sign-ins match on
-issuer and subject and never reach the guard again.
+This rule does not require `AUTH_ENABLE_OIDC_LINKING` or the organisation's
+linking toggle. It applies only to the managed exchange. Browser sign-in and
+all other email-linking paths keep their existing toggle rules.
+
+The identity row has no tenant field. The check uses an exact tenant-specific
+issuer URL, as stored by the standard Azure browser strategy. It does not infer
+a tenant from an email domain or the current server config. Host-only issuers,
+`common` issuers and other issuer formats do not qualify for this exception.
+
+The row has no object-ID field either. Storing browser `oid` would need a
+migration, so browser identities keep their current shape.
+
+The mobile identity becomes a second `openid_identities` row for the same
+user. Later managed sign-ins match that row by issuer and subject.
 
 ## Error codes
 
@@ -243,7 +256,7 @@ one of these (`packages/common/src/types/managedSignIn.ts:45`).
 | `token_expired` | The token is outside its time window. | `exp` has passed, or `iat` is older than five minutes. |
 | `token_replayed` | The token was already exchanged. | A retry with the same token. |
 | `email_unverified` | The token carries no usable email. | The `email` claim is missing. |
-| `user_not_allowed` | Microsoft authenticated the person; Lightdash refused them. | Identity linking is off, the org refuses just-in-time creation, or the user's org does not match the tenant's org. |
+| `user_not_allowed` | Microsoft authenticated the person; Lightdash refused them. | No eligible identity link exists, the org refuses just-in-time creation, or the user's org does not match the tenant's org. |
 | `organisation_required` | The person signed in but belongs to no organisation. | Just-in-time creation made a user with no organisation. They need an invite, or an allowed email domain that joins them to one. |
 
 "Consent missing" and "policy not satisfied" never reach the server. They
@@ -290,20 +303,6 @@ platform's client id is set and the server can name a Microsoft tenant. A
 dedicated instance therefore needs the platform client id plus the existing
 `AUTH_AZURE_AD_OAUTH_TENANT_ID`. A shared instance needs the platform client id
 plus one organisation with an enabled Azure SSO config naming the tenant.
-
-### Rollout prerequisite: identity linking
-
-**On an instance that already has Microsoft users, turn on OIDC linking before
-you enable managed sign-in.** Set `AUTH_ENABLE_OIDC_LINKING=true`, or the
-per-organisation toggle.
-
-Without it, the first managed sign-in fails with `user_not_allowed` for every
-person who has already signed in through the browser. The mobile registration
-is a different Entra client, so its subject can never match the identity row
-browser sign-in stored, and the email path that would join them is off by
-default.
-
-A person who has never signed in on the web is unaffected.
 
 Neither variable replaces the web registration. Browser sign-in keeps using
 `AUTH_AZURE_AD_OAUTH_*` or the per-organisation config.
@@ -376,12 +375,8 @@ today is described above; these may change it.
 
 Q6, Q7, Q8 and Q9 are settled and built as described above: the server sends
 only non-reserved scopes, an organisation-less user is rejected with
-`organisation_required`, the linking prerequisite is documented rather than
-coded around, and the five-minute freshness rule stands.
-
-One follow-up remains open: treating the web and mobile registrations as one
-trust inside the exchange, so an existing web user does not need the linking
-prerequisite. See the rollout note above.
+`organisation_required`, the exchange links matching Azure identities from
+the same tenant, and the five-minute freshness rule stands.
 
 Related: registration shape and vocabulary on
 [SPK-1905](https://linear.app/lightdash/issue/SPK-1905), the security review on

--- a/packages/backend/src/services/OAuthService/managedSignIn/ManagedSignInService.test.ts
+++ b/packages/backend/src/services/OAuthService/managedSignIn/ManagedSignInService.test.ts
@@ -194,7 +194,7 @@ describe('ManagedSignInService', () => {
     });
 
     describe('happy path', () => {
-        it('signs the user in through the browser sign-in rules', async () => {
+        it('passes the validated dedicated tenant for managed identity linking', async () => {
             const { service, loginWithOpenId } =
                 createService(dedicatedConfig());
 
@@ -217,6 +217,12 @@ describe('ManagedSignInService', () => {
                 undefined,
                 undefined,
                 { ip: undefined, userAgent: undefined },
+                {
+                    managedAzureIdentityLink: {
+                        tenantId: TENANT_ID,
+                        organizationUuid: null,
+                    },
+                },
             );
         });
 
@@ -394,7 +400,8 @@ describe('ManagedSignInService', () => {
 
     describe('organization resolution', () => {
         it('rejects a tenant that is not the configured one', async () => {
-            const { service } = createService(dedicatedConfig());
+            const { service, loginWithOpenId } =
+                createService(dedicatedConfig());
 
             await expectRejection(
                 exchange(
@@ -405,13 +412,14 @@ describe('ManagedSignInService', () => {
                 ),
                 ManagedSignInError.TENANT_NOT_CONFIGURED,
             );
+            expect(vi.mocked(loginWithOpenId)).not.toHaveBeenCalled();
         });
 
         it('resolves the single organization that claims the tenant', async () => {
-            const { service, organizationSsoModel } = createService(
-                configWith(),
-                { azureMethods: [azureMethod(TENANT_ID)] },
-            );
+            const { service, organizationSsoModel, loginWithOpenId } =
+                createService(configWith(), {
+                    azureMethods: [azureMethod(TENANT_ID)],
+                });
 
             await expect(exchange(service, await signToken())).resolves.toEqual(
                 sessionUser,
@@ -419,6 +427,19 @@ describe('ManagedSignInService', () => {
             expect(
                 organizationSsoModel.findEnabledAzureAdMethodsByTenantId,
             ).toHaveBeenCalledWith(TENANT_ID);
+            expect(vi.mocked(loginWithOpenId)).toHaveBeenCalledWith(
+                expect.any(Object),
+                undefined,
+                undefined,
+                undefined,
+                { ip: undefined, userAgent: undefined },
+                {
+                    managedAzureIdentityLink: {
+                        tenantId: TENANT_ID,
+                        organizationUuid: ORGANIZATION_UUID,
+                    },
+                },
+            );
         });
 
         it('rejects a tenant no organization claims', async () => {

--- a/packages/backend/src/services/OAuthService/managedSignIn/ManagedSignInService.ts
+++ b/packages/backend/src/services/OAuthService/managedSignIn/ManagedSignInService.ts
@@ -216,6 +216,12 @@ export class ManagedSignInService {
                     undefined,
                     undefined,
                     { ip, userAgent },
+                    {
+                        managedAzureIdentityLink: {
+                            tenantId: claims.tid,
+                            organizationUuid: organizationUuid ?? null,
+                        },
+                    },
                 );
             } catch (error) {
                 throw new ManagedSignInRejection(

--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -3801,6 +3801,305 @@ describe('UserService', () => {
                 userModel.activateUser as import('vitest').Mock,
             ).toHaveBeenCalledTimes(0);
         });
+        describe('managed Azure identity linking', () => {
+            const tenantId = '11111111-2222-3333-4444-555555555555';
+            const issuer = `https://login.microsoftonline.com/${tenantId}/v2.0`;
+            const mobileUser = {
+                openId: {
+                    ...openIdUser.openId,
+                    issuer,
+                    issuerType: OpenIdIdentityIssuerType.AZUREAD,
+                    subject: 'mobile-object-id',
+                },
+            };
+            const webIdentity = {
+                ...openIdIdentity,
+                issuer,
+                issuerType: OpenIdIdentityIssuerType.AZUREAD,
+                subject: 'web-pairwise-subject',
+                email: mobileUser.openId.email,
+            };
+            const managedOptions = {
+                managedAzureIdentityLink: {
+                    tenantId,
+                    organizationUuid: sessionUser.organizationUuid!,
+                },
+            };
+            const configWithLinking = (enabled: boolean) => ({
+                ...lightdashConfigMock,
+                auth: {
+                    ...lightdashConfigMock.auth,
+                    enableOidcLinking: enabled,
+                    enableOidcToEmailLinking: false,
+                },
+            });
+
+            test.each([null, sessionUser.organizationUuid!])(
+                'links the same-tenant web identity with linking off and organisation %s',
+                async (organizationUuid) => {
+                    vi.mocked(
+                        openIdIdentityModel.findIdentitiesByEmail,
+                    ).mockResolvedValueOnce([webIdentity]);
+                    const service = createUserService(configWithLinking(false));
+
+                    await expect(
+                        service.loginWithOpenId(
+                            mobileUser,
+                            undefined,
+                            undefined,
+                            undefined,
+                            undefined,
+                            {
+                                managedAzureIdentityLink: {
+                                    tenantId,
+                                    organizationUuid,
+                                },
+                            },
+                        ),
+                    ).resolves.toEqual(sessionUser);
+
+                    expect(
+                        vi.mocked(openIdIdentityModel.findIdentitiesByEmail),
+                    ).toHaveBeenCalledWith(mobileUser.openId.email);
+                    expect(
+                        vi.mocked(openIdIdentityModel.createIdentity),
+                    ).toHaveBeenCalledExactlyOnceWith(
+                        expect.objectContaining({
+                            userId: sessionUser.userId,
+                            issuer,
+                            issuerType: OpenIdIdentityIssuerType.AZUREAD,
+                            subject: 'mobile-object-id',
+                            email: mobileUser.openId.email,
+                        }),
+                    );
+                    expect(
+                        vi.mocked(userModel.createUser),
+                    ).not.toHaveBeenCalled();
+                },
+            );
+
+            test.each([
+                [
+                    'another tenant',
+                    {
+                        ...webIdentity,
+                        issuer: 'https://login.microsoftonline.com/99999999-8888-7777-6666-555555555555/v2.0',
+                    },
+                ],
+                [
+                    'another provider',
+                    {
+                        ...webIdentity,
+                        issuerType: OpenIdIdentityIssuerType.GOOGLE,
+                    },
+                ],
+                [
+                    'an issuer without a tenant',
+                    {
+                        ...webIdentity,
+                        issuer: 'https://login.microsoftonline.com',
+                    },
+                ],
+                [
+                    'a common issuer',
+                    {
+                        ...webIdentity,
+                        issuer: 'https://login.microsoftonline.com/common/v2.0',
+                    },
+                ],
+                [
+                    'an issuer on another host',
+                    {
+                        ...webIdentity,
+                        issuer: `https://example.com/${tenantId}/v2.0`,
+                    },
+                ],
+                [
+                    'another email',
+                    { ...webIdentity, email: 'other@example.com' },
+                ],
+            ])(
+                'does not bypass linking for %s',
+                async (_description, identity) => {
+                    vi.mocked(
+                        openIdIdentityModel.findIdentitiesByEmail,
+                    ).mockResolvedValueOnce([identity]);
+                    const service = createUserService(configWithLinking(false));
+
+                    await expect(
+                        service.loginWithOpenId(
+                            mobileUser,
+                            undefined,
+                            undefined,
+                            undefined,
+                            undefined,
+                            managedOptions,
+                        ),
+                    ).rejects.toBeInstanceOf(ForbiddenError);
+                    expect(
+                        vi.mocked(openIdIdentityModel.createIdentity),
+                    ).not.toHaveBeenCalled();
+                },
+            );
+
+            test('does not bypass linking for a user outside the resolved organisation', async () => {
+                vi.mocked(
+                    openIdIdentityModel.findIdentitiesByEmail,
+                ).mockResolvedValueOnce([webIdentity]);
+                const service = createUserService(configWithLinking(false));
+
+                await expect(
+                    service.loginWithOpenId(
+                        mobileUser,
+                        undefined,
+                        undefined,
+                        undefined,
+                        undefined,
+                        {
+                            managedAzureIdentityLink: {
+                                tenantId,
+                                organizationUuid: 'another-organisation',
+                            },
+                        },
+                    ),
+                ).rejects.toBeInstanceOf(ForbiddenError);
+                expect(
+                    vi.mocked(openIdIdentityModel.createIdentity),
+                ).not.toHaveBeenCalled();
+            });
+
+            test.each([
+                [
+                    'another incoming provider',
+                    {
+                        ...mobileUser.openId,
+                        issuerType: OpenIdIdentityIssuerType.GOOGLE,
+                    },
+                ],
+                [
+                    'another incoming tenant',
+                    {
+                        ...mobileUser.openId,
+                        issuer: 'https://login.microsoftonline.com/99999999-8888-7777-6666-555555555555/v2.0',
+                    },
+                ],
+            ])(
+                'does not bypass linking for %s',
+                async (_description, incomingIdentity) => {
+                    vi.mocked(
+                        openIdIdentityModel.findIdentitiesByEmail,
+                    ).mockResolvedValueOnce([webIdentity]);
+                    const service = createUserService(configWithLinking(false));
+
+                    await expect(
+                        service.loginWithOpenId(
+                            { openId: incomingIdentity },
+                            undefined,
+                            undefined,
+                            undefined,
+                            undefined,
+                            managedOptions,
+                        ),
+                    ).rejects.toBeInstanceOf(ForbiddenError);
+                    expect(
+                        vi.mocked(openIdIdentityModel.createIdentity),
+                    ).not.toHaveBeenCalled();
+                },
+            );
+
+            test('does not link an ambiguous email shared by two users', async () => {
+                vi.mocked(
+                    openIdIdentityModel.findIdentitiesByEmail,
+                ).mockResolvedValueOnce([
+                    webIdentity,
+                    { ...webIdentity, userUuid: 'another-user' },
+                ]);
+                const service = createUserService(configWithLinking(false));
+
+                await expect(
+                    service.loginWithOpenId(
+                        mobileUser,
+                        undefined,
+                        undefined,
+                        undefined,
+                        undefined,
+                        managedOptions,
+                    ),
+                ).rejects.toBeInstanceOf(ForbiddenError);
+                expect(
+                    vi.mocked(openIdIdentityModel.createIdentity),
+                ).not.toHaveBeenCalled();
+            });
+
+            test('does not link a deactivated user', async () => {
+                vi.mocked(
+                    openIdIdentityModel.findIdentitiesByEmail,
+                ).mockResolvedValueOnce([webIdentity]);
+                vi.mocked(
+                    userModel.findSessionUserByUUID,
+                ).mockResolvedValueOnce({ ...sessionUser, isActive: false });
+                const service = createUserService(configWithLinking(false));
+
+                await expect(
+                    service.loginWithOpenId(
+                        mobileUser,
+                        undefined,
+                        undefined,
+                        undefined,
+                        undefined,
+                        managedOptions,
+                    ),
+                ).rejects.toBeInstanceOf(DeactivatedAccountError);
+                expect(
+                    vi.mocked(openIdIdentityModel.createIdentity),
+                ).not.toHaveBeenCalled();
+            });
+
+            test('keeps browser linking disabled without the exchange option', async () => {
+                vi.mocked(
+                    openIdIdentityModel.findIdentitiesByEmail,
+                ).mockResolvedValueOnce([webIdentity]);
+                const service = createUserService(configWithLinking(false));
+
+                await expect(
+                    service.loginWithOpenId(mobileUser, undefined, undefined),
+                ).rejects.toBeInstanceOf(ForbiddenError);
+                expect(
+                    vi.mocked(openIdIdentityModel.createIdentity),
+                ).not.toHaveBeenCalled();
+            });
+
+            test.each([undefined, managedOptions])(
+                'keeps enabled linking for another provider with options %j',
+                async (options) => {
+                    vi.mocked(
+                        openIdIdentityModel.findIdentitiesByEmail,
+                    ).mockResolvedValueOnce([
+                        {
+                            ...webIdentity,
+                            issuerType: OpenIdIdentityIssuerType.GOOGLE,
+                        },
+                    ]);
+                    const service = createUserService(configWithLinking(true));
+
+                    await expect(
+                        service.loginWithOpenId(
+                            mobileUser,
+                            undefined,
+                            undefined,
+                            undefined,
+                            undefined,
+                            options,
+                        ),
+                    ).resolves.toEqual(sessionUser);
+                    expect(
+                        vi.mocked(openIdIdentityModel.createIdentity),
+                    ).toHaveBeenCalledExactlyOnceWith(
+                        expect.objectContaining({ userId: sessionUser.userId }),
+                    );
+                },
+            );
+        });
         test('should link openid to an existing user that has the same verified email', async () => {
             const service = createUserService({
                 ...lightdashConfigMock,

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -28,6 +28,7 @@ import {
     getEmailDomain,
     getErrorMessage,
     getMicrosoftAuthority,
+    getMicrosoftIssuer,
     getUserAvatarUrl,
     hasInviteCode,
     hasProperty,
@@ -200,6 +201,10 @@ export type AuthAuditContext = {
 type LoginWithOpenIdOptions = {
     isLinkFlow?: boolean;
     emailVerified?: boolean;
+    managedAzureIdentityLink?: {
+        tenantId: string;
+        organizationUuid: string | null;
+    };
 };
 
 const emitAuthAuditEvent = ({
@@ -1213,11 +1218,35 @@ export class UserService extends BaseService {
                 const sessionUser = await this.userModel.findSessionUserByUUID(
                     identitiesUsers[0],
                 );
+                const managedAzureIdentityLink =
+                    options?.managedAzureIdentityLink;
+                const canLinkManagedAzureIdentity =
+                    managedAzureIdentityLink !== undefined &&
+                    openIdUser.openId.issuerType ===
+                        OpenIdIdentityIssuerType.AZUREAD &&
+                    openIdUser.openId.issuer ===
+                        getMicrosoftIssuer(managedAzureIdentityLink.tenantId) &&
+                    !!sessionUser.organizationUuid &&
+                    (managedAzureIdentityLink.organizationUuid === null ||
+                        sessionUser.organizationUuid ===
+                            managedAzureIdentityLink.organizationUuid) &&
+                    identities.some(
+                        (identity) =>
+                            identity.issuerType ===
+                                OpenIdIdentityIssuerType.AZUREAD &&
+                            identity.issuer === openIdUser.openId.issuer &&
+                            identity.email === openIdUser.openId.email,
+                    );
+
+                if (canLinkManagedAzureIdentity && !sessionUser.isActive) {
+                    throw new DeactivatedAccountError();
+                }
 
                 if (
-                    await this.isOidcLinkingEnabledForOrg(
+                    canLinkManagedAzureIdentity ||
+                    (await this.isOidcLinkingEnabledForOrg(
                         sessionUser.organizationUuid,
-                    )
+                    ))
                 ) {
                     this.logger.info(
                         `Linking new OpenID identity to existing user ${sessionUser.userUuid}`,


### PR DESCRIPTION
## What breaks

An existing web user can get `user_not_allowed` on the first managed mobile sign-in when OIDC linking is off. The web and mobile registrations use different identity subjects.

## Change

Pass a managed-exchange option from `ManagedSignInService` to `UserService.loginWithOpenId`. Link the new identity when its email matches one user's Azure identity and the stored issuer names the validated tenant. On shared instances, require the resolved organisation before linking. Keep browser sign-in and the existing linking toggles unchanged.

Use exact tenant-specific issuer equality because the identity row has no tenant field. Host-only and `common` issuers do not qualify. Skip browser `oid` storage because it needs a migration. Update the managed sign-in guide and remove the linking prerequisite.

Fixes SPK-1950

## Verification

- The two focused auth files pass: 240 tests.
- Backend typecheck and touched-path lint pass.
- API generation passes. Generated artifacts stay out of this PR, as required by the repository.
- The full backend run reports 585 passing files, five collection failures from a missing generated formula parser, and two catalog test timeouts. After building the parser, all six affected files pass in a sequential rerun: 1,049 tests.
