### PR TITLE
fix(auth): keep the most used tenant in the managed sign-in discovery cache

### DIFF
--- a/packages/backend/src/services/OAuthService/managedSignIn/ManagedSignInService.test.ts
+++ b/packages/backend/src/services/OAuthService/managedSignIn/ManagedSignInService.test.ts
@@ -646,6 +646,52 @@ describe('ManagedSignInService', () => {
         });
     });
 
+    describe('discovery cache eviction', () => {
+        const CACHE_MAX = 50;
+
+        const tenantAt = (index: number) =>
+            `${index.toString(16).padStart(8, '0')}-2222-3333-4444-555555555555`;
+
+        it('evicts the least recently used tenant, not the oldest', async () => {
+            const fetched: string[] = [];
+            const verifier = new MicrosoftTokenVerifier({
+                fetchOpenIdConfiguration: async (tenantId: string) => {
+                    fetched.push(tenantId);
+                    return {
+                        issuer: `https://login.microsoftonline.com/${tenantId}/v2.0`,
+                        jwks_uri: `https://login.microsoftonline.com/${tenantId}/discovery/v2.0/keys`,
+                    };
+                },
+                createKeySet: () => createLocalJWKSet({ keys: [publicJwk] }),
+            });
+            const warm = (token: string) =>
+                verifier.verify(token, [IOS_CLIENT_ID]).then(
+                    () => undefined,
+                    () => undefined,
+                );
+
+            const first = tenantAt(0);
+            const fillTokens = await Promise.all(
+                Array.from({ length: CACHE_MAX }, (_, index) =>
+                    signToken({ tid: tenantAt(index) }),
+                ),
+            );
+            await fillTokens.reduce(
+                (chain, token) => chain.then(() => warm(token)),
+                Promise.resolve(),
+            );
+
+            await warm(await signToken({ tid: first }));
+            const fetchesAfterTouch = fetched.length;
+
+            await warm(await signToken({ tid: tenantAt(CACHE_MAX) }));
+            expect(fetched.length).toEqual(fetchesAfterTouch + 1);
+
+            await warm(await signToken({ tid: first }));
+            expect(fetched.length).toEqual(fetchesAfterTouch + 1);
+        });
+    });
+
     describe('logging', () => {
         it('logs the rejection context and never the token', async () => {
             const warn = vi

--- a/packages/backend/src/services/OAuthService/managedSignIn/microsoftTokenVerifier.ts
+++ b/packages/backend/src/services/OAuthService/managedSignIn/microsoftTokenVerifier.ts
@@ -141,6 +141,8 @@ export class MicrosoftTokenVerifier {
     private async getDiscovery(tenantId: string): Promise<DiscoveryEntry> {
         const cached = this.discoveryCache.get(tenantId);
         if (cached && this.now() - cached.fetchedAt < DISCOVERY_TTL_MS) {
+            this.discoveryCache.delete(tenantId);
+            this.discoveryCache.set(tenantId, cached);
             return cached;
         }
 


### PR DESCRIPTION
## What breaks today

The managed sign-in verifier caches each Microsoft tenant's OpenID configuration and JWKS, capped at 50 tenants. A cache hit returned early without touching the entry's position in the map, so eviction dropped the tenant that was added first rather than the one used least.

On an instance with more than 50 tenants signing in, a busy tenant added early is dropped before a quiet tenant added late. Nobody sees an error. The cost is an extra discovery and JWKS fetch on that tenant's next sign-in, so a slower sign-in rather than a failed one.

Nobody notices today: a dedicated instance has one tenant, and the shared instance has far fewer than 50 with Microsoft SSO configured.

Fixes SPK-1958.

## The change

Two lines. On a cache hit, delete the key and set it again so the entry moves to the end of the insertion order. Eviction then takes the genuinely least recently used tenant.

## What is verified

One test, mutation-checked. It fills the cache to its cap, touches the oldest tenant, adds one more tenant to force an eviction, and then asserts the touched tenant is still cached by counting discovery fetches. Reverting the two lines fails that test and nothing else.

`pnpm -F backend typecheck` clean, linter clean on the touched path, 45 tests pass across the managed sign-in suite.

## Not a security fix

A made-up tenant id cannot push real tenants out of the cache. An entry is only inserted after a successful discovery fetch whose issuer matches the tenant, so an unreachable or invented GUID throws before it reaches the cache. This is correctness hygiene.

## Origin

Raised by the Graphite reviewer on #28694 and confirmed while reading the code. Out of scope for that pull request, which had already merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DqZs9QKtDEtPJ28Cqv7tw1