### PR TITLE
fix(frontend): truncate a long invited email on the invite page

### DIFF
--- a/packages/frontend/src/pages/Invite.module.css
+++ b/packages/frontend/src/pages/Invite.module.css
@@ -1,4 +1,7 @@
 .oneClickLabel {
     display: block;
+    min-width: 0;
+    overflow: hidden;
+    white-space: nowrap;
     text-overflow: ellipsis;
 }


### PR DESCRIPTION
## What breaks

`.oneClickLabel` in `packages/frontend/src/pages/Invite.module.css` sets `text-overflow: ellipsis` but never sets the two properties ellipsis needs to do anything: `overflow: hidden` and `white-space: nowrap`.

Today the label still truncates, because Mantine's own `.mantine-Button-label` base class supplies both. Measured on `main` at 360 px with a 40-character invited email, the label reports `overflow: hidden`, `white-space: nowrap`, `scrollWidth` 368 against `clientWidth` 286, and the ellipsis renders. So this is not a live break for anyone today.

It is a rule that only works by borrowing from a third-party base class that nothing in this repo pins. A Mantine upgrade that stops setting either property on the label makes the invited email overflow the button, and the person opening the invite on a phone is who sees it. The class already carries `display: block` for the same reason, so the intent to own this behaviour is there but incomplete.

Fixes SPK-1956

## Change

Declare all three properties on the class instead of inheriting two of them, and add `min-width: 0` so the label can shrink inside the flex button rather than forcing it wider:

```css
.oneClickLabel {
    display: block;
    min-width: 0;
    overflow: hidden;
    white-space: nowrap;
    text-overflow: ellipsis;
}
```

CSS only. No component or behaviour change.

## Verification

At 360 px in Chrome device emulation, invited email `charlotte.wainwright@northfields.example` (40 characters), against a local dev instance with the `new-onboarding` flag on so the one-click card renders:

| | Before | After |
| --- | --- | --- |
| Page `scrollWidth` / `clientWidth` | 360 / 360 | 360 / 360 |
| Label `scrollWidth` / `clientWidth` | 368 / 286 | 368 / 286 |
| Truncated with ellipsis | yes, via Mantine | yes, via this class |
| `min-width` on label | `auto` | `0px` |

Rendering is identical, which is the point: the properties now come from the rule that asks for the ellipsis. No horizontal scroll in either case.

`pnpm -F frontend typecheck` and oxlint on the touched paths both clean.

| Before | After |
| --- | --- |
| ![spk1956-before-360](https://github.com/user-attachments/assets/6747552f-22e3-4c9b-a7eb-75961c933e92) | ![spk1956-after-360](https://github.com/user-attachments/assets/2dc2d580-4b0e-4fc8-b2c5-175e8e1d5bfb) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SgkU12Da3iCtCRFqZFZibx
