### PR TITLE
fix(auth): record the managed sign-in audit event only after tokens are issued

### DIFF
--- a/packages/backend/src/services/OAuthService/managedSignIn/ManagedSignInService.test.ts
+++ b/packages/backend/src/services/OAuthService/managedSignIn/ManagedSignInService.test.ts
@@ -222,6 +222,7 @@ describe('ManagedSignInService', () => {
                         tenantId: TENANT_ID,
                         organizationUuid: null,
                     },
+                    deferSuccessAudit: true,
                 },
             );
         });
@@ -438,6 +439,7 @@ describe('ManagedSignInService', () => {
                         tenantId: TENANT_ID,
                         organizationUuid: ORGANIZATION_UUID,
                     },
+                    deferSuccessAudit: true,
                 },
             );
         });

--- a/packages/backend/src/services/OAuthService/managedSignIn/ManagedSignInService.ts
+++ b/packages/backend/src/services/OAuthService/managedSignIn/ManagedSignInService.ts
@@ -184,6 +184,17 @@ export class ManagedSignInService {
         );
     }
 
+    recordSignInAllowed(
+        user: SessionUser,
+        context: { ip?: string; userAgent?: string },
+    ): void {
+        this.getUserService().recordOpenIdLoginAllowed(
+            user,
+            OpenIdIdentityIssuerType.AZUREAD,
+            context,
+        );
+    }
+
     async exchangeIdToken({
         subjectToken,
         clientId,
@@ -221,6 +232,7 @@ export class ManagedSignInService {
                             tenantId: claims.tid,
                             organizationUuid: organizationUuid ?? null,
                         },
+                        deferSuccessAudit: true,
                     },
                 );
             } catch (error) {

--- a/packages/backend/src/services/OAuthService/managedSignIn/microsoftTokenExchangeGrantType.test.ts
+++ b/packages/backend/src/services/OAuthService/managedSignIn/microsoftTokenExchangeGrantType.test.ts
@@ -28,6 +28,7 @@ const createRequest = (body: Record<string, string>) =>
 
 const createGrant = ({
     exchangeIdToken = vi.fn(async () => sessionUser),
+    recordSignInAllowed = vi.fn(),
     saveToken = vi.fn(async (token, tokenClient, user) => ({
         ...token,
         client: tokenClient,
@@ -36,11 +37,13 @@ const createGrant = ({
     validateScope,
 }: {
     exchangeIdToken?: ManagedSignInService['exchangeIdToken'];
+    recordSignInAllowed?: ManagedSignInService['recordSignInAllowed'];
     saveToken?: OAuth2Server.AuthorizationCodeModel['saveToken'];
     validateScope?: OAuth2Server.AuthorizationCodeModel['validateScope'];
 } = {}) => {
     const managedSignInService = {
         exchangeIdToken,
+        recordSignInAllowed,
     } as unknown as ManagedSignInService;
     const GrantType = createMicrosoftTokenExchangeGrantType(
         () => managedSignInService,
@@ -54,7 +57,7 @@ const createGrant = ({
         refreshTokenLifetime: 7200,
         model,
     } as unknown as OAuth2Server.TokenOptions);
-    return { grant, exchangeIdToken, saveToken };
+    return { grant, exchangeIdToken, saveToken, recordSignInAllowed };
 };
 
 const validBody = {
@@ -84,6 +87,76 @@ describe('MicrosoftTokenExchangeGrantType', () => {
             client,
             sessionUser,
         );
+    });
+
+    it('records the allowed audit event only after the tokens are saved', async () => {
+        const order: string[] = [];
+        const { grant, recordSignInAllowed } = createGrant({
+            saveToken: vi.fn(async (token, tokenClient, user) => {
+                order.push('saveToken');
+                return { ...token, client: tokenClient, user };
+            }) as unknown as OAuth2Server.AuthorizationCodeModel['saveToken'],
+            recordSignInAllowed: vi.fn(() => {
+                order.push('audit');
+            }) as unknown as ManagedSignInService['recordSignInAllowed'],
+        });
+
+        await grant.handle(createRequest(validBody), client);
+
+        expect(order).toEqual(['saveToken', 'audit']);
+        expect(vi.mocked(recordSignInAllowed)).toHaveBeenCalledTimes(1);
+        expect(vi.mocked(recordSignInAllowed)).toHaveBeenCalledWith(
+            sessionUser,
+            { ip: undefined, userAgent: undefined },
+        );
+    });
+
+    it('records no allowed audit event when the exchange refuses', async () => {
+        const { grant, recordSignInAllowed } = createGrant({
+            exchangeIdToken: vi.fn(async () => {
+                throw new ManagedSignInRejection(
+                    ManagedSignInError.USER_NOT_ALLOWED,
+                    'user does not belong to the tenant organization',
+                );
+            }) as unknown as ManagedSignInService['exchangeIdToken'],
+        });
+
+        await expect(
+            grant.handle(createRequest(validBody), client),
+        ).rejects.toMatchObject({ name: 'invalid_grant' });
+        expect(vi.mocked(recordSignInAllowed)).not.toHaveBeenCalled();
+    });
+
+    it('records no allowed audit event when the token was replayed', async () => {
+        const { grant, recordSignInAllowed } = createGrant({
+            exchangeIdToken: vi.fn(async () => {
+                throw new ManagedSignInRejection(
+                    ManagedSignInError.TOKEN_REPLAYED,
+                    'token hash is already recorded',
+                );
+            }) as unknown as ManagedSignInService['exchangeIdToken'],
+        });
+
+        await expect(
+            grant.handle(createRequest(validBody), client),
+        ).rejects.toMatchObject({
+            name: 'invalid_grant',
+            message: ManagedSignInError.TOKEN_REPLAYED,
+        });
+        expect(vi.mocked(recordSignInAllowed)).not.toHaveBeenCalled();
+    });
+
+    it('records no allowed audit event when saving the token fails', async () => {
+        const { grant, recordSignInAllowed } = createGrant({
+            saveToken: vi.fn(
+                async () => undefined,
+            ) as unknown as OAuth2Server.AuthorizationCodeModel['saveToken'],
+        });
+
+        await expect(
+            grant.handle(createRequest(validBody), client),
+        ).rejects.toMatchObject({ name: 'invalid_grant' });
+        expect(vi.mocked(recordSignInAllowed)).not.toHaveBeenCalled();
     });
 
     it('rejects a missing subject token', async () => {

--- a/packages/backend/src/services/OAuthService/managedSignIn/microsoftTokenExchangeGrantType.ts
+++ b/packages/backend/src/services/OAuthService/managedSignIn/microsoftTokenExchangeGrantType.ts
@@ -1,4 +1,8 @@
-import { ID_TOKEN_TYPE, ManagedSignInError } from '@lightdash/common';
+import {
+    ID_TOKEN_TYPE,
+    ManagedSignInError,
+    type SessionUser,
+} from '@lightdash/common';
 import OAuth2Server from '@node-oauth/oauth2-server';
 import { ManagedSignInRejection } from './ManagedSignInRejection';
 import type { ManagedSignInService } from './ManagedSignInService';
@@ -34,13 +38,17 @@ export const createMicrosoftTokenExchangeGrantType = (
                 );
             }
 
-            let user: OAuth2Server.User;
+            const auditContext = {
+                ip: request.get('x-forwarded-for') ?? undefined,
+                userAgent: request.get('user-agent') ?? undefined,
+            };
+
+            let user: SessionUser;
             try {
                 user = await getManagedSignInService().exchangeIdToken({
                     subjectToken,
                     clientId: client.id,
-                    ip: request.get('x-forwarded-for') ?? undefined,
-                    userAgent: request.get('user-agent') ?? undefined,
+                    ...auditContext,
                 });
             } catch (error) {
                 throw new InvalidGrantError(
@@ -90,6 +98,9 @@ export const createMicrosoftTokenExchangeGrantType = (
             if (!saved) {
                 throw new InvalidGrantError(ManagedSignInError.TOKEN_INVALID);
             }
+
+            getManagedSignInService().recordSignInAllowed(user, auditContext);
+
             return saved;
         }
     };

--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -3693,6 +3693,49 @@ describe('UserService', () => {
     });
 
     describe('loginWithOpenId', () => {
+        const allowedLoginEvents = () =>
+            auditLogSpy.mock.calls.filter(
+                ([event]) =>
+                    (event as { action?: string; status?: string }).action ===
+                        'login' &&
+                    (event as { action?: string; status?: string }).status ===
+                        'allowed',
+            );
+
+        test('records the allowed audit event for browser sign-in', async () => {
+            userModel.findSessionUserByPrimaryEmail.mockResolvedValueOnce(
+                undefined,
+            );
+
+            await userService.loginWithOpenId(openIdUser, undefined, undefined);
+
+            expect(allowedLoginEvents()).toHaveLength(1);
+        });
+
+        test('defers the allowed audit event when the caller commits it', async () => {
+            userModel.findSessionUserByPrimaryEmail.mockResolvedValueOnce(
+                undefined,
+            );
+
+            const user = await userService.loginWithOpenId(
+                openIdUser,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                { deferSuccessAudit: true },
+            );
+
+            expect(allowedLoginEvents()).toHaveLength(0);
+
+            userService.recordOpenIdLoginAllowed(
+                user,
+                OpenIdIdentityIssuerType.AZUREAD,
+            );
+
+            expect(allowedLoginEvents()).toHaveLength(1);
+        });
+
         test('should throw error if provider not allowed', async () => {
             await expect(
                 userService.loginWithOpenId(

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -205,6 +205,7 @@ type LoginWithOpenIdOptions = {
         tenantId: string;
         organizationUuid: string | null;
     };
+    deferSuccessAudit?: boolean;
 };
 
 const emitAuthAuditEvent = ({
@@ -969,6 +970,22 @@ export class UserService extends BaseService {
         }
     }
 
+    recordOpenIdLoginAllowed(
+        user: SessionUser,
+        issuerType: OpenIdIdentityIssuerType,
+        context?: AuthAuditContext,
+    ) {
+        emitAuthAuditEvent({
+            actor: createActorFromUser(user),
+            action: 'login',
+            resourceType: 'Session',
+            status: 'allowed',
+            organizationUuid: user.organizationUuid,
+            metadata: { loginProvider: issuerType },
+            context,
+        });
+    }
+
     async loginWithOpenId(
         openIdUser: OpenIdUser,
         authenticatedUser: SessionUser | undefined,
@@ -993,15 +1010,13 @@ export class UserService extends BaseService {
                 refreshToken,
                 options,
             );
-            emitAuthAuditEvent({
-                actor: createActorFromUser(loggedInUser),
-                action: 'login',
-                resourceType: 'Session',
-                status: 'allowed',
-                organizationUuid: loggedInUser.organizationUuid,
-                metadata: { loginProvider: openIdUser.openId.issuerType },
-                context,
-            });
+            if (!options?.deferSuccessAudit) {
+                this.recordOpenIdLoginAllowed(
+                    loggedInUser,
+                    openIdUser.openId.issuerType,
+                    context,
+                );
+            }
             return loggedInUser;
         } catch (e) {
             emitAuthAuditEvent({


### PR DESCRIPTION
## What breaks

`UserService.loginWithOpenId` emits its `login` / `allowed` audit event as soon as the user is resolved. The managed sign-in exchange then applies two more checks — the cross-organisation refusal (`user_not_allowed`) and the single-use claim (`token_replayed`) — and the grant issues the tokens after that.

So a refused or replayed exchange left an "allowed" line in the durable audit log for a sign-in that never issued a token. Anyone reading the audit trail during an incident sees a successful login that did not happen.

This is the ordering point raised on SPK-1920 after the single-use claim moved last, and found again by the security review of #28798.

Fixes SPK-1964.

## Change

`loginWithOpenId` takes a `deferSuccessAudit` option. When set, it resolves the user and emits nothing; the caller records the event through a new `recordOpenIdLoginAllowed`. The denial event is unchanged and still emitted by `loginWithOpenId` itself.

The token-exchange grant calls the commit step **after `saveToken` succeeds**, not merely after the exchange returns. That is the stronger of the two options the ticket offered: it also covers a database failure while writing the tokens, which would otherwise leave an allowed event with no token.

Browser sign-in passes no option and keeps its current timing exactly.

## Verification

Six tests, mutation-checked.

Grant handler:
- the allowed event is recorded strictly after `saveToken`, asserted on call order, exactly once, with the request's audit context;
- no allowed event when the exchange refuses with `user_not_allowed`;
- no allowed event when the exchange refuses with `token_replayed`;
- no allowed event when `saveToken` fails.

`UserService`:
- browser sign-in still records exactly one allowed event;
- the deferred path records none until the caller commits, then exactly one.

Moving the emit back before issuance fails exactly two of these and nothing else.

`pnpm -F backend typecheck` clean, linter clean on the touched paths, full backend suite green at 592 files and 9848 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DqZs9QKtDEtPJ28Cqv7tw1
