### PR TITLE
fix(learn): add the embed scope group to the Learn library maps

### DIFF
--- a/packages/frontend/src/features/learn/catalogue.ts
+++ b/packages/frontend/src/features/learn/catalogue.ts
@@ -68,6 +68,7 @@ export const GROUP_ORDER: LearnGroup[] = [
     FOUNDATIONS,
     ScopeGroup.CONTENT,
     ScopeGroup.SHARING,
+    ScopeGroup.EMBED,
     ScopeGroup.DATA,
     ScopeGroup.AI,
     ScopeGroup.PROJECT_MANAGEMENT,
@@ -80,6 +81,7 @@ export const GROUP_DESCRIPTIONS: Record<LearnGroup, string> = {
     [FOUNDATIONS]: 'Become a knowledgeable Lightdash user',
     [ScopeGroup.CONTENT]: 'Create and maintain charts, dashboards, and spaces',
     [ScopeGroup.SHARING]: 'Send, schedule, and discuss trusted answers',
+    [ScopeGroup.EMBED]: 'Put charts and dashboards inside other products',
     [ScopeGroup.DATA]:
         'Shape, inspect, and extend the data available in Lightdash',
     [ScopeGroup.AI]: 'Ask better questions and manage AI-powered workflows',
@@ -93,6 +95,7 @@ export const GROUP_LABELS: Record<LearnGroup, string> = {
     [FOUNDATIONS]: 'Foundations',
     [ScopeGroup.CONTENT]: 'Content',
     [ScopeGroup.SHARING]: 'Sharing',
+    [ScopeGroup.EMBED]: 'Embedding',
     [ScopeGroup.DATA]: 'Data',
     [ScopeGroup.AI]: 'AI',
     [ScopeGroup.PROJECT_MANAGEMENT]: 'Project management',

--- a/packages/frontend/src/features/learn/groupVisuals.ts
+++ b/packages/frontend/src/features/learn/groupVisuals.ts
@@ -2,6 +2,7 @@ import { ScopeGroup } from '@lightdash/common';
 import {
     IconBuilding,
     IconChartHistogram,
+    IconCode,
     IconCompass,
     IconDatabase,
     IconSend,
@@ -17,6 +18,7 @@ export const GROUP_ICONS: Record<LearnGroup, Icon> = {
     [FOUNDATIONS]: IconCompass,
     [ScopeGroup.CONTENT]: IconChartHistogram,
     [ScopeGroup.SHARING]: IconSend,
+    [ScopeGroup.EMBED]: IconCode,
     [ScopeGroup.DATA]: IconDatabase,
     [ScopeGroup.AI]: IconSparkles,
     [ScopeGroup.PROJECT_MANAGEMENT]: IconSettings,
@@ -29,6 +31,7 @@ const GROUP_COLOURS: Record<LearnGroup, { band: string; fg: string }> = {
     [FOUNDATIONS]: { band: '#f0dbd1', fg: '#b06a4c' },
     [ScopeGroup.CONTENT]: { band: '#dfe8e2', fg: '#4f7d5d' },
     [ScopeGroup.SHARING]: { band: '#dfe8e2', fg: '#4f7d5d' },
+    [ScopeGroup.EMBED]: { band: '#dfe1e6', fg: '#5b6478' },
     [ScopeGroup.DATA]: { band: '#ece3d1', fg: '#93743a' },
     [ScopeGroup.AI]: { band: '#e2ddf1', fg: '#6b5bb8' },
     [ScopeGroup.PROJECT_MANAGEMENT]: { band: '#d9e6e4', fg: '#41756f' },


### PR DESCRIPTION
`main` does not typecheck: the frontend fails on the Learn library, so every open PR is red at "Build & Test". Two PRs crossed. #28749 added `EMBED` to the `ScopeGroup` enum, and the Learn library from #28715 derives its group type from that enum and keeps four `Record<LearnGroup, ...>` maps (labels, descriptions, icons, colours) that had no entry for it. Each PR was green on its own branch, and the release workflow does not run the frontend typecheck, so main stayed green while every PR check broke.

The embed group now has a label, a description, an icon and colours, and sits after Sharing in the group order. The Learn page only renders groups that have modules, so nothing changes visually until an embed scope becomes a trainee module.

Relates: #28749
Relates: #28715
