### PR TITLE
feat: reuse dbt Git checkouts and dependencies between compiles

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -122,6 +122,8 @@ export const lightdashConfigMock: LightdashConfig = {
     dbt: {
         environmentVariableAllowlist: [],
         sourceFetchConcurrency: undefined,
+        gitCacheMaxBytes: 2 * 1024 * 1024 * 1024,
+        gitCacheMaxAgeMs: 24 * 60 * 60 * 1000,
     },
     dashboard: {
         maxTilesPerTab: 50,

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -122,6 +122,7 @@ export const lightdashConfigMock: LightdashConfig = {
     dbt: {
         environmentVariableAllowlist: [],
         sourceFetchConcurrency: undefined,
+        gitCacheRoot: undefined,
         gitCacheMaxBytes: 2 * 1024 * 1024 * 1024,
         gitCacheMaxAgeMs: 24 * 60 * 60 * 1000,
     },

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -54,6 +54,23 @@ describe('usage events storage endpoint', () => {
     });
 });
 
+describe('dbt git cache config', () => {
+    it('uses conservative defaults', () => {
+        expect(parseConfig().dbt).toMatchObject({
+            gitCacheMaxBytes: 2 * 1024 * 1024 * 1024,
+            gitCacheMaxAgeMs: 24 * 60 * 60 * 1000,
+        });
+    });
+
+    it('reads byte and age overrides', () => {
+        process.env.DBT_GIT_CACHE_MAX_BYTES = '4096';
+        process.env.DBT_GIT_CACHE_MAX_AGE_MS = '60000';
+        expect(parseConfig().dbt).toMatchObject({
+            gitCacheMaxBytes: 4096,
+            gitCacheMaxAgeMs: 60_000,
+    });
+});
+
 describe('mobile login config', () => {
     it('is available by default', () => {
         expect(parseConfig().auth.mobileLogin).toEqual({ enabled: true });

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -55,6 +55,16 @@ describe('usage events storage endpoint', () => {
 });
 
 describe('dbt git cache config', () => {
+    it.each(['0', '-1'])('preserves the disabled byte limit %s', (limit) => {
+        process.env.DBT_GIT_CACHE_MAX_BYTES = limit;
+        expect(parseConfig().dbt.gitCacheMaxBytes).toBe(Number(limit));
+    });
+
+    it('reads an explicit cache root', () => {
+        process.env.DBT_GIT_CACHE_ROOT = '/var/cache/lightdash';
+        expect(parseConfig().dbt.gitCacheRoot).toBe('/var/cache/lightdash');
+    });
+
     it('uses conservative defaults', () => {
         expect(parseConfig().dbt).toMatchObject({
             gitCacheMaxBytes: 2 * 1024 * 1024 * 1024,

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -78,6 +78,7 @@ describe('dbt git cache config', () => {
         expect(parseConfig().dbt).toMatchObject({
             gitCacheMaxBytes: 4096,
             gitCacheMaxAgeMs: 60_000,
+        });
     });
 });
 

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1550,6 +1550,8 @@ export type LightdashConfig = {
     dbt: {
         environmentVariableAllowlist: string[];
         sourceFetchConcurrency: number | undefined;
+        gitCacheMaxBytes: number;
+        gitCacheMaxAgeMs: number;
     };
     database: {
         connectionUri: string | undefined;
@@ -3311,6 +3313,12 @@ export const parseConfig = (): LightdashConfig => {
             sourceFetchConcurrency: getIntegerFromEnvironmentVariable(
                 'DBT_SOURCE_FETCH_CONCURRENCY',
             ),
+            gitCacheMaxBytes:
+                getIntegerFromEnvironmentVariable('DBT_GIT_CACHE_MAX_BYTES') ??
+                2 * 1024 * 1024 * 1024,
+            gitCacheMaxAgeMs:
+                getIntegerFromEnvironmentVariable('DBT_GIT_CACHE_MAX_AGE_MS') ??
+                24 * 60 * 60 * 1000,
         },
         allowMultiOrgs: process.env.ALLOW_MULTIPLE_ORGS === 'true',
         maxPayloadSize: process.env.LIGHTDASH_MAX_PAYLOAD || '5mb',

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1552,6 +1552,7 @@ export type LightdashConfig = {
         sourceFetchConcurrency: number | undefined;
         gitCacheMaxBytes: number;
         gitCacheMaxAgeMs: number;
+        gitCacheRoot: string | undefined;
     };
     database: {
         connectionUri: string | undefined;
@@ -3316,6 +3317,7 @@ export const parseConfig = (): LightdashConfig => {
             gitCacheMaxBytes:
                 getIntegerFromEnvironmentVariable('DBT_GIT_CACHE_MAX_BYTES') ??
                 2 * 1024 * 1024 * 1024,
+            gitCacheRoot: process.env.DBT_GIT_CACHE_ROOT || undefined,
             gitCacheMaxAgeMs:
                 getIntegerFromEnvironmentVariable('DBT_GIT_CACHE_MAX_AGE_MS') ??
                 24 * 60 * 60 * 1000,

--- a/packages/backend/src/dbt/dbtCliClient.test.ts
+++ b/packages/backend/src/dbt/dbtCliClient.test.ts
@@ -63,7 +63,7 @@ const createSuccessfulExecaProcess = () =>
 const createFailedExecaProcess = () =>
     createExecaProcess(Promise.reject(cliMocks.error));
 
-const createPendingExecaProcess = (pid?: number) => {
+const createPendingExecaProcess = (pid?: number, cancelRejects = true) => {
     let resolve: (value: ExecaReturnValue) => void = () => undefined;
     let reject: (reason: unknown) => void = () => undefined;
     const result = new Promise<ExecaReturnValue>(
@@ -73,7 +73,9 @@ const createPendingExecaProcess = (pid?: number) => {
         },
     );
     const cancel = vi.fn(() => {
-        reject(Object.assign(new Error('cancelled'), { isCanceled: true }));
+        if (cancelRejects) {
+            reject(Object.assign(new Error('cancelled'), { isCanceled: true }));
+        }
     });
     const process = createExecaProcess(result, cancel, pid);
     return { process, cancel, resolve };
@@ -319,4 +321,48 @@ describe('DbtCliClient cancellation', () => {
 
         expect(pending.cancel).not.toHaveBeenCalled();
     });
+
+    it.each([
+        {
+            state: 'exited',
+            exitCode: 0,
+            signalCode: null,
+        },
+        {
+            state: 'signalled',
+            exitCode: null,
+            signalCode: 'SIGTERM' as NodeJS.Signals,
+        },
+    ])(
+        'does not kill the process group after a $state child is awaiting settlement',
+        async ({ exitCode, signalCode }) => {
+            const pending = createPendingExecaProcess(12345, false);
+            const processWithLifecycle = Object.defineProperties(
+                pending.process,
+                {
+                    exitCode: { configurable: true, value: exitCode },
+                    signalCode: { configurable: true, value: signalCode },
+                },
+            );
+            const kill = vi.spyOn(process, 'kill').mockReturnValue(true);
+            execaMock.mockReturnValueOnce(processWithLifecycle);
+            const controller = new AbortController();
+            const client = new DbtCliClient(cliArgs);
+            client.setAbortSignal(controller.signal);
+            try {
+                const command = client.installDeps();
+                await vi.waitFor(() =>
+                    expect(execaMock).toHaveBeenCalledTimes(1),
+                );
+                controller.abort();
+
+                expect(pending.cancel).toHaveBeenCalledTimes(1);
+                expect(kill).not.toHaveBeenCalled();
+                pending.resolve(successfulExecaResult());
+                await command;
+            } finally {
+                kill.mockRestore();
+            }
+        },
+    );
 });

--- a/packages/backend/src/dbt/dbtCliClient.test.ts
+++ b/packages/backend/src/dbt/dbtCliClient.test.ts
@@ -1,10 +1,11 @@
 import { DbtError, SupportedDbtVersions } from '@lightdash/common';
-import execa from 'execa';
+import { ChildProcess } from 'child_process';
+import execa, { type ExecaReturnValue } from 'execa';
 import * as fs from 'fs/promises';
 import { DbtCliClient } from './dbtCliClient';
 import {
     cliArgs as cliArgsWithoutVersion,
-    cliMockImplementation,
+    cliMocks,
     expectedCommandOptions,
     expectedDbtOptions,
     expectedPackages,
@@ -12,7 +13,71 @@ import {
     packagesYml,
 } from './dbtCliClient.mock';
 
-const execaMock = execa as unknown as import('vitest').Mock;
+type ExecaString = (
+    file: string,
+    args?: readonly string[],
+    options?: execa.Options,
+) => execa.ExecaChildProcess;
+
+const execaMock = vi.mocked(execa as ExecaString);
+
+function mockProcessKill(signal?: NodeJS.Signals | number): boolean;
+function mockProcessKill(signal?: string, options?: execa.KillOptions): void;
+function mockProcessKill(): boolean {
+    return true;
+}
+
+const successfulExecaResult = (): ExecaReturnValue => ({
+    command: 'dbt',
+    escapedCommand: 'dbt',
+    exitCode: 0,
+    stdout: '',
+    stderr: '',
+    failed: false,
+    timedOut: false,
+    killed: false,
+    isCanceled: false,
+    ...cliMocks.success,
+});
+
+const createExecaProcess = (
+    result: Promise<ExecaReturnValue>,
+    cancel: () => void = vi.fn(),
+    pid?: number,
+): execa.ExecaChildProcess => {
+    const child = Object.assign(new ChildProcess(), {
+        then: result.then.bind(result),
+        catch: result.catch.bind(result),
+        finally: result.finally.bind(result),
+        [Symbol.toStringTag]: 'Promise',
+        cancel,
+        kill: mockProcessKill,
+        pid,
+    });
+    return child;
+};
+
+const createSuccessfulExecaProcess = () =>
+    createExecaProcess(Promise.resolve(successfulExecaResult()));
+
+const createFailedExecaProcess = () =>
+    createExecaProcess(Promise.reject(cliMocks.error));
+
+const createPendingExecaProcess = (pid?: number) => {
+    let resolve: (value: ExecaReturnValue) => void = () => undefined;
+    let reject: (reason: unknown) => void = () => undefined;
+    const result = new Promise<ExecaReturnValue>(
+        (resolveResult, rejectResult) => {
+            resolve = resolveResult;
+            reject = rejectResult;
+        },
+    );
+    const cancel = vi.fn(() => {
+        reject(Object.assign(new Error('cancelled'), { isCanceled: true }));
+    });
+    const process = createExecaProcess(result, cancel, pid);
+    return { process, cancel, resolve };
+};
 
 vi.mock('fs/promises', () => ({
     readFile: vi.fn(),
@@ -35,7 +100,7 @@ Object.values(SupportedDbtVersions).map((dbtVersion) => {
             );
         });
         it('should install dependencies with success', async () => {
-            execaMock.mockImplementationOnce(cliMockImplementation.success);
+            execaMock.mockReturnValueOnce(createSuccessfulExecaProcess());
 
             const client = new DbtCliClient(cliArgs);
             const dbtExec = client.getDbtExec();
@@ -49,14 +114,14 @@ Object.values(SupportedDbtVersions).map((dbtVersion) => {
             );
         });
         it('should error on install dependencies', async () => {
-            execaMock.mockImplementationOnce(cliMockImplementation.error);
+            execaMock.mockReturnValueOnce(createFailedExecaProcess());
 
             const client = new DbtCliClient(cliArgs);
 
             await expect(client.installDeps()).rejects.toThrowError(DbtError);
         });
         it('should get manifest with success', async () => {
-            execaMock.mockImplementationOnce(cliMockImplementation.success);
+            execaMock.mockReturnValueOnce(createSuccessfulExecaProcess());
             vi.spyOn(fs, 'readFile').mockImplementationOnce(async () =>
                 JSON.stringify(manifestMock),
             );
@@ -118,7 +183,7 @@ describe('DbtCliClient environment', () => {
         vi.mocked(fs.mkdtemp).mockResolvedValue(
             '/tmp/dbt_target_test' as never,
         );
-        execaMock.mockImplementation(cliMockImplementation.success);
+        execaMock.mockImplementation(createSuccessfulExecaProcess);
     });
 
     afterEach(() => {
@@ -127,7 +192,7 @@ describe('DbtCliClient environment', () => {
 
     it('does not extend the backend environment', async () => {
         await new DbtCliClient(cliArgs).installDeps();
-        const [, , options] = execaMock.mock.calls[0];
+        const options = execaMock.mock.calls[0]?.[2];
 
         expect(options).toMatchObject({ extendEnv: false });
     });
@@ -137,8 +202,8 @@ describe('DbtCliClient environment', () => {
         vi.stubEnv('PATH', '/usr/local/bin');
 
         await new DbtCliClient(cliArgs).installDeps();
-        const [, , options] = execaMock.mock.calls[0];
-        const { env } = options as { env: Record<string, string> };
+        const options = execaMock.mock.calls[0]?.[2];
+        const env = options?.env ?? {};
 
         expect(env).not.toHaveProperty('LIGHTDASH_SECRET');
         expect(Object.values(env)).not.toContain('not-for-dbt');
@@ -152,9 +217,9 @@ describe('DbtCliClient environment', () => {
             ...cliArgs,
             environmentVariableAllowlist: ['UTILS_PII_SALT'],
         }).installDeps();
-        const [, , options] = execaMock.mock.calls[0];
+        const options = execaMock.mock.calls[0]?.[2];
 
-        expect((options as { env: Record<string, string> }).env).toMatchObject({
+        expect(options?.env).toMatchObject({
             UTILS_PII_SALT: 'machine-owned-salt',
         });
     });
@@ -164,8 +229,8 @@ describe('DbtCliClient environment', () => {
             ...cliArgs,
             gitConfigGlobalPath: '/tmp/lightdash-gitconfig',
         }).installDeps();
-        const [, , options] = execaMock.mock.calls[0];
-        const { env } = options as { env: Record<string, string> };
+        const options = execaMock.mock.calls[0]?.[2];
+        const env = options?.env ?? {};
 
         expect(env.GIT_CONFIG_GLOBAL).toEqual('/tmp/lightdash-gitconfig');
         expect(env.GIT_TERMINAL_PROMPT).toEqual('0');
@@ -173,7 +238,7 @@ describe('DbtCliClient environment', () => {
     });
 
     it('adds the GitHub App installation hint to dbt deps errors', async () => {
-        execaMock.mockImplementationOnce(cliMockImplementation.error);
+        execaMock.mockReturnValueOnce(createFailedExecaProcess());
 
         await expect(
             new DbtCliClient({
@@ -191,10 +256,67 @@ describe('DbtCliClient environment', () => {
             ...cliArgs,
             environment: { DBT_TARGET_PATH: '/tmp/attacker' },
         }).installDeps();
-        const [, , options] = execaMock.mock.calls[0];
+        const options = execaMock.mock.calls[0]?.[2];
 
-        expect((options as { env: Record<string, string> }).env).toMatchObject({
+        expect(options?.env).toMatchObject({
             DBT_TARGET_PATH: '/tmp/dbt_target_test',
         });
+    });
+});
+
+describe('DbtCliClient cancellation', () => {
+    const cliArgs = {
+        ...cliArgsWithoutVersion,
+        dbtVersion: SupportedDbtVersions.V1_10,
+    };
+
+    beforeEach(() => {
+        vi.resetAllMocks();
+        vi.mocked(fs.mkdtemp).mockResolvedValue(
+            '/tmp/dbt_target_test' as never,
+        );
+    });
+
+    it('cancels an active dbt process when its signal aborts', async () => {
+        const pending = createPendingExecaProcess(12345);
+        const kill = vi.spyOn(process, 'kill').mockReturnValue(true);
+        execaMock.mockReturnValueOnce(pending.process);
+        const controller = new AbortController();
+        const client = new DbtCliClient(cliArgs);
+        client.setAbortSignal(controller.signal);
+        try {
+            const command = client.installDeps();
+            const result = command.then(
+                () => undefined,
+                (error: unknown) => error,
+            );
+            await vi.waitFor(() => expect(execaMock).toHaveBeenCalledTimes(1));
+            controller.abort();
+
+            expect(await result).toMatchObject({ isCanceled: true });
+            expect(pending.cancel).toHaveBeenCalledTimes(1);
+            expect(kill).toHaveBeenCalledWith(-12345, 'SIGKILL');
+        } finally {
+            kill.mockRestore();
+        }
+    });
+
+    it('removes the abort listener after a dbt process completes', async () => {
+        const pending = createPendingExecaProcess();
+        execaMock.mockReturnValueOnce(pending.process);
+        const controller = new AbortController();
+        const client = new DbtCliClient(cliArgs);
+        client.setAbortSignal(controller.signal);
+
+        const command = client.installDeps();
+        await vi.waitFor(() => expect(execaMock).toHaveBeenCalledTimes(1));
+        pending.resolve({
+            all: '',
+            stdout: '',
+        } as ExecaReturnValue);
+        await command;
+        controller.abort();
+
+        expect(pending.cancel).not.toHaveBeenCalled();
     });
 });

--- a/packages/backend/src/dbt/dbtCliClient.ts
+++ b/packages/backend/src/dbt/dbtCliClient.ts
@@ -56,7 +56,14 @@ export const runAbortableProcess = async (
     );
     const abort = () => {
         child.cancel();
-        if (process.platform === 'win32' || child.pid === undefined) return;
+        if (
+            process.platform === 'win32' ||
+            child.pid === undefined ||
+            child.exitCode !== null ||
+            child.signalCode !== null
+        ) {
+            return;
+        }
         try {
             process.kill(-child.pid, 'SIGKILL');
         } catch (error) {

--- a/packages/backend/src/dbt/dbtCliClient.ts
+++ b/packages/backend/src/dbt/dbtCliClient.ts
@@ -40,6 +40,49 @@ type DbtCliArgs = {
     dbtDepsErrorHint?: string;
 };
 
+export const runAbortableProcess = async (
+    command: string,
+    args: readonly string[],
+    options: execa.Options,
+    signal: AbortSignal | undefined,
+): Promise<ExecaReturnValue> => {
+    signal?.throwIfAborted();
+    const child = execa(
+        command,
+        args,
+        signal && process.platform !== 'win32'
+            ? { ...options, detached: true }
+            : options,
+    );
+    const abort = () => {
+        child.cancel();
+        if (process.platform === 'win32' || child.pid === undefined) return;
+        try {
+            process.kill(-child.pid, 'SIGKILL');
+        } catch (error) {
+            if ((error as NodeJS.ErrnoException).code !== 'ESRCH') {
+                Logger.warn('Failed to terminate aborted process group', {
+                    error: {
+                        name:
+                            error instanceof Error
+                                ? error.name
+                                : 'UnknownError',
+                        message: getErrorMessage(error),
+                        code: (error as NodeJS.ErrnoException).code,
+                    },
+                });
+            }
+        }
+    };
+    signal?.addEventListener('abort', abort, { once: true });
+    if (signal?.aborted) abort();
+    try {
+        return await child;
+    } finally {
+        signal?.removeEventListener('abort', abort);
+    }
+};
+
 enum DbtCommands {
     DBT_1_4 = 'dbt',
     DBT_1_5 = 'dbt1.5',
@@ -75,6 +118,8 @@ export class DbtCliClient implements DbtClient {
 
     dbtDepsErrorHint?: string;
 
+    private abortSignal: AbortSignal | undefined;
+
     constructor({
         dbtProjectDirectory,
         dbtProfilesDirectory,
@@ -102,6 +147,14 @@ export class DbtCliClient implements DbtClient {
 
     getSelector(): string | undefined {
         return this.selector;
+    }
+
+    setAbortSignal(signal: AbortSignal | undefined): void {
+        this.abortSignal = signal;
+    }
+
+    private throwIfAborted(): void {
+        this.abortSignal?.throwIfAborted();
     }
 
     // Each client gets its own dbt target directory so that concurrent
@@ -176,8 +229,10 @@ export class DbtCliClient implements DbtClient {
         logs: DbtLog[];
         stdout: string;
     }> {
+        this.throwIfAborted();
         const dbtExec = this.getDbtExec();
         const targetPath = await this._getTargetDirectory();
+        this.throwIfAborted();
         const dbtArgs = [
             '--no-use-colors',
             '--log-format',
@@ -202,22 +257,28 @@ export class DbtCliClient implements DbtClient {
                     this.dbtVersion
                 }": ${dbtExec} ${dbtArgs.join(' ')}`,
             );
-            const dbtProcess = await execa(dbtExec, dbtArgs, {
-                all: true,
-                stdio: ['pipe', 'pipe', process.stderr],
-                extendEnv: false,
-                env: getDbtProcessEnvironment({
-                    processEnvironment: process.env,
-                    environmentVariableAllowlist:
-                        this.environmentVariableAllowlist,
-                    projectEnvironment: this.environment,
-                    targetPath,
-                    gitConfigGlobalPath: this.gitConfigGlobalPath,
-                }),
-            });
+            const { abortSignal } = this;
+            const result = await runAbortableProcess(
+                dbtExec,
+                dbtArgs,
+                {
+                    all: true,
+                    stdio: ['pipe', 'pipe', process.stderr],
+                    extendEnv: false,
+                    env: getDbtProcessEnvironment({
+                        processEnvironment: process.env,
+                        environmentVariableAllowlist:
+                            this.environmentVariableAllowlist,
+                        projectEnvironment: this.environment,
+                        targetPath,
+                        gitConfigGlobalPath: this.gitConfigGlobalPath,
+                    }),
+                },
+                abortSignal,
+            );
             return {
-                logs: DbtCliClient.parseDbtJsonLogs(dbtProcess.all),
-                stdout: dbtProcess.stdout,
+                logs: DbtCliClient.parseDbtJsonLogs(result.all),
+                stdout: result.stdout,
             };
         } catch (e) {
             Logger.error(

--- a/packages/backend/src/models/ProjectDbtSourcesModel.ts
+++ b/packages/backend/src/models/ProjectDbtSourcesModel.ts
@@ -172,6 +172,22 @@ export class ProjectDbtSourcesModel {
         return this.convertRow(row);
     }
 
+    async getSourceIdentityRows(projectDbtSourceUuids: string[]): Promise<
+        Array<{
+            projectUuid: string;
+            projectDbtSourceUuid: string;
+        }>
+    > {
+        if (projectDbtSourceUuids.length === 0) return [];
+        const rows = await this.database(ProjectDbtSourcesTableName)
+            .select('project_uuid', 'project_dbt_source_uuid')
+            .whereIn('project_dbt_source_uuid', projectDbtSourceUuids);
+        return rows.map((row) => ({
+            projectUuid: row.project_uuid,
+            projectDbtSourceUuid: row.project_dbt_source_uuid,
+        }));
+    }
+
     async createSource(
         projectUuid: string,
         data: CreateProjectDbtSource,

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -501,6 +501,22 @@ export class ProjectModel {
         };
     }
 
+    async getDbtSourceIdentityRows(projectUuids: string[]): Promise<
+        Array<{
+            projectUuid: string;
+            dbtSourceUuid: string | null;
+        }>
+    > {
+        if (projectUuids.length === 0) return [];
+        const rows = await this.database(ProjectTableName)
+            .select('project_uuid', 'dbt_source_uuid')
+            .whereIn('project_uuid', projectUuids);
+        return rows.map((row) => ({
+            projectUuid: row.project_uuid,
+            dbtSourceUuid: row.dbt_source_uuid,
+        }));
+    }
+
     async updateDbtSourceName(
         projectUuid: string,
         dbtSourceName: string,

--- a/packages/backend/src/projectAdapters/dbtAzureDevOpsProjectAdapter.test.ts
+++ b/packages/backend/src/projectAdapters/dbtAzureDevOpsProjectAdapter.test.ts
@@ -1,0 +1,43 @@
+import {
+    SupportedDbtVersions,
+    WarehouseTypes,
+    type CreateWarehouseCredentials,
+} from '@lightdash/common';
+import { warehouseClientMock } from '../utils/QueryBuilder/MetricQueryBuilder.mock';
+import { DbtAzureDevOpsProjectAdapter } from './dbtAzureDevOpsProjectAdapter';
+
+describe('DbtAzureDevOpsProjectAdapter', () => {
+    it('percent-encodes repository URL credentials', async () => {
+        const adapter = new DbtAzureDevOpsProjectAdapter({
+            warehouseClient: warehouseClientMock,
+            personalAccessToken: 'token/?#@:%',
+            organization: 'org',
+            project: 'project',
+            repository: 'repo',
+            branch: 'main',
+            projectDirectorySubPath: '/',
+            warehouseCredentials: {
+                type: WarehouseTypes.POSTGRES,
+                host: 'localhost',
+                port: 5432,
+                user: 'postgres',
+                password: 'password',
+                dbname: 'postgres',
+                schema: 'public',
+            } as CreateWarehouseCredentials,
+            targetName: undefined,
+            environment: undefined,
+            environmentVariableAllowlist: [],
+            cachedWarehouse: {
+                warehouseCatalog: {},
+                onWarehouseCatalogChange: vi.fn(),
+            },
+            dbtVersion: SupportedDbtVersions.V1_7,
+        });
+
+        expect(adapter.remoteRepositoryUrl).toBe(
+            'https://token%2F%3F%23%40%3A%25@dev.azure.com/org/project/_git/repo',
+        );
+        await adapter.destroy();
+    });
+});

--- a/packages/backend/src/projectAdapters/dbtAzureDevOpsProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtAzureDevOpsProjectAdapter.ts
@@ -6,7 +6,10 @@ import {
 import { WarehouseClient } from '@lightdash/warehouses';
 import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
 import { CachedWarehouse } from '../types';
-import { DbtGitProjectAdapter } from './dbtGitProjectAdapter';
+import {
+    DbtGitCacheContext,
+    DbtGitProjectAdapter,
+} from './dbtGitProjectAdapter';
 import { DbtGitCacheIdentity } from './dbtGitProjectCache';
 
 type Args = {
@@ -26,6 +29,7 @@ type Args = {
     selector?: string;
     analytics?: LightdashAnalytics;
     cacheIdentity?: DbtGitCacheIdentity;
+    cacheContext?: DbtGitCacheContext;
 };
 
 export class DbtAzureDevOpsProjectAdapter extends DbtGitProjectAdapter {
@@ -46,6 +50,7 @@ export class DbtAzureDevOpsProjectAdapter extends DbtGitProjectAdapter {
         dbtVersion,
         selector,
         cacheIdentity,
+        cacheContext,
     }: Args) {
         const remoteRepositoryUrl = `https://${encodeURIComponent(
             personalAccessToken,
@@ -65,6 +70,7 @@ export class DbtAzureDevOpsProjectAdapter extends DbtGitProjectAdapter {
             dbtVersion,
             selector,
             cacheIdentity,
+            cacheContext,
             credential: { token: personalAccessToken },
         });
     }

--- a/packages/backend/src/projectAdapters/dbtAzureDevOpsProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtAzureDevOpsProjectAdapter.ts
@@ -7,6 +7,7 @@ import { WarehouseClient } from '@lightdash/warehouses';
 import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
 import { CachedWarehouse } from '../types';
 import { DbtGitProjectAdapter } from './dbtGitProjectAdapter';
+import { DbtGitCacheIdentity } from './dbtGitProjectCache';
 
 type Args = {
     warehouseClient: WarehouseClient;
@@ -24,6 +25,7 @@ type Args = {
     dbtVersion: SupportedDbtVersions;
     selector?: string;
     analytics?: LightdashAnalytics;
+    cacheIdentity?: DbtGitCacheIdentity;
 };
 
 export class DbtAzureDevOpsProjectAdapter extends DbtGitProjectAdapter {
@@ -43,6 +45,7 @@ export class DbtAzureDevOpsProjectAdapter extends DbtGitProjectAdapter {
         cachedWarehouse,
         dbtVersion,
         selector,
+        cacheIdentity,
     }: Args) {
         const remoteRepositoryUrl = `https://${personalAccessToken}@dev.azure.com/${organization}/${project}/_git/${repository}`;
         super({
@@ -59,6 +62,7 @@ export class DbtAzureDevOpsProjectAdapter extends DbtGitProjectAdapter {
             cachedWarehouse,
             dbtVersion,
             selector,
+            cacheIdentity,
         });
     }
 }

--- a/packages/backend/src/projectAdapters/dbtAzureDevOpsProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtAzureDevOpsProjectAdapter.ts
@@ -47,7 +47,9 @@ export class DbtAzureDevOpsProjectAdapter extends DbtGitProjectAdapter {
         selector,
         cacheIdentity,
     }: Args) {
-        const remoteRepositoryUrl = `https://${personalAccessToken}@dev.azure.com/${organization}/${project}/_git/${repository}`;
+        const remoteRepositoryUrl = `https://${encodeURIComponent(
+            personalAccessToken,
+        )}@dev.azure.com/${organization}/${project}/_git/${repository}`;
         super({
             analytics,
             warehouseClient,
@@ -63,6 +65,7 @@ export class DbtAzureDevOpsProjectAdapter extends DbtGitProjectAdapter {
             dbtVersion,
             selector,
             cacheIdentity,
+            credential: { token: personalAccessToken },
         });
     }
 }

--- a/packages/backend/src/projectAdapters/dbtBitBucketProjectAdapter.test.ts
+++ b/packages/backend/src/projectAdapters/dbtBitBucketProjectAdapter.test.ts
@@ -1,0 +1,42 @@
+import {
+    SupportedDbtVersions,
+    WarehouseTypes,
+    type CreateWarehouseCredentials,
+} from '@lightdash/common';
+import { warehouseClientMock } from '../utils/QueryBuilder/MetricQueryBuilder.mock';
+import { DbtBitBucketProjectAdapter } from './dbtBitBucketProjectAdapter';
+
+describe('DbtBitBucketProjectAdapter', () => {
+    it('percent-encodes repository URL credentials', async () => {
+        const adapter = new DbtBitBucketProjectAdapter({
+            warehouseClient: warehouseClientMock,
+            username: 'user/?#@:%',
+            personalAccessToken: 'token/?#@:%',
+            repository: 'org/repo',
+            branch: 'main',
+            projectDirectorySubPath: '/',
+            warehouseCredentials: {
+                type: WarehouseTypes.POSTGRES,
+                host: 'localhost',
+                port: 5432,
+                user: 'postgres',
+                password: 'password',
+                dbname: 'postgres',
+                schema: 'public',
+            } as CreateWarehouseCredentials,
+            targetName: undefined,
+            environment: undefined,
+            environmentVariableAllowlist: [],
+            cachedWarehouse: {
+                warehouseCatalog: {},
+                onWarehouseCatalogChange: vi.fn(),
+            },
+            dbtVersion: SupportedDbtVersions.V1_7,
+        });
+
+        expect(adapter.remoteRepositoryUrl).toBe(
+            'https://user%2F%3F%23%40%3A%25:token%2F%3F%23%40%3A%25@bitbucket.org/org/repo.git',
+        );
+        await adapter.destroy();
+    });
+});

--- a/packages/backend/src/projectAdapters/dbtBitBucketProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtBitBucketProjectAdapter.ts
@@ -7,7 +7,10 @@ import { WarehouseClient } from '@lightdash/warehouses';
 import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
 import { CachedWarehouse } from '../types';
 import { DEFAULT_BITBUCKET_HOST_DOMAIN } from '../utils/credentialDestination';
-import { DbtGitProjectAdapter } from './dbtGitProjectAdapter';
+import {
+    DbtGitCacheContext,
+    DbtGitProjectAdapter,
+} from './dbtGitProjectAdapter';
 import { DbtGitCacheIdentity } from './dbtGitProjectCache';
 
 type Args = {
@@ -27,12 +30,14 @@ type Args = {
     selector?: string;
     analytics?: LightdashAnalytics;
     cacheIdentity?: DbtGitCacheIdentity;
+    cacheContext?: DbtGitCacheContext;
 };
 
 export class DbtBitBucketProjectAdapter extends DbtGitProjectAdapter {
     constructor({
         analytics,
         cacheIdentity,
+        cacheContext,
         warehouseClient,
         username,
         branch,
@@ -56,6 +61,7 @@ export class DbtBitBucketProjectAdapter extends DbtGitProjectAdapter {
         super({
             analytics,
             cacheIdentity,
+            cacheContext,
             warehouseClient,
             gitBranch: branch,
             remoteRepositoryUrl,

--- a/packages/backend/src/projectAdapters/dbtBitBucketProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtBitBucketProjectAdapter.ts
@@ -48,7 +48,9 @@ export class DbtBitBucketProjectAdapter extends DbtGitProjectAdapter {
         dbtVersion,
         selector,
     }: Args) {
-        const remoteRepositoryUrl = `https://${username}:${personalAccessToken}@${
+        const remoteRepositoryUrl = `https://${encodeURIComponent(
+            username,
+        )}:${encodeURIComponent(personalAccessToken)}@${
             hostDomain || DEFAULT_BITBUCKET_HOST_DOMAIN
         }/${repository}.git`;
         super({
@@ -66,6 +68,7 @@ export class DbtBitBucketProjectAdapter extends DbtGitProjectAdapter {
             cachedWarehouse,
             dbtVersion,
             selector,
+            credential: { token: personalAccessToken },
         });
     }
 }

--- a/packages/backend/src/projectAdapters/dbtBitBucketProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtBitBucketProjectAdapter.ts
@@ -8,6 +8,7 @@ import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
 import { CachedWarehouse } from '../types';
 import { DEFAULT_BITBUCKET_HOST_DOMAIN } from '../utils/credentialDestination';
 import { DbtGitProjectAdapter } from './dbtGitProjectAdapter';
+import { DbtGitCacheIdentity } from './dbtGitProjectCache';
 
 type Args = {
     warehouseClient: WarehouseClient;
@@ -25,11 +26,13 @@ type Args = {
     dbtVersion: SupportedDbtVersions;
     selector?: string;
     analytics?: LightdashAnalytics;
+    cacheIdentity?: DbtGitCacheIdentity;
 };
 
 export class DbtBitBucketProjectAdapter extends DbtGitProjectAdapter {
     constructor({
         analytics,
+        cacheIdentity,
         warehouseClient,
         username,
         branch,
@@ -50,6 +53,7 @@ export class DbtBitBucketProjectAdapter extends DbtGitProjectAdapter {
         }/${repository}.git`;
         super({
             analytics,
+            cacheIdentity,
             warehouseClient,
             gitBranch: branch,
             remoteRepositoryUrl,

--- a/packages/backend/src/projectAdapters/dbtGitProjectAdapter.test.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectAdapter.test.ts
@@ -23,6 +23,7 @@ import { DbtGitProjectAdapter } from './dbtGitProjectAdapter';
 import { gitErrorHandler } from './gitRepository';
 import { configureDbtGitProjectCache } from './dbtGitProjectCache';
 import { inspectDbtGitProject } from './dbtGitProjectInspection';
+import * as dbtGitVersion from './dbtGitVersion';
 
 const TOKEN_URL =
     'https://lightdash:ghp_secret_token_123@github.com/org/repo.git';
@@ -510,6 +511,34 @@ describe('DbtGitProjectAdapter cache', () => {
         await second.getDbtManifest();
         expect(second.getFetchMetrics().cloneMode).toBe('fresh');
         await second.destroy();
+    });
+
+    it('uses fresh clones when the installed Git version is unsupported', async () => {
+        const probe = vi
+            .spyOn(dbtGitVersion, 'getDbtGitVersionSupport')
+            .mockResolvedValue({
+                supported: false,
+                reason: 'git-version-unsupported',
+            });
+        try {
+            const { remote } = await createRemote({
+                'dbt_project.yml': 'name: test\n',
+            });
+            const first = createAdapter(remote);
+            await first.getDbtManifest();
+            expect(first.getCacheOutcome()).toMatchObject({
+                cloneMode: 'fresh',
+                missReason: 'git-version-unsupported',
+            });
+            await first.destroy();
+
+            const second = createAdapter(remote);
+            await second.getDbtManifest();
+            expect(second.getFetchMetrics().cloneMode).toBe('fresh');
+            await second.destroy();
+        } finally {
+            probe.mockRestore();
+        }
     });
 
     it('sanitizes malformed credential-bearing repository URLs', () => {

--- a/packages/backend/src/projectAdapters/dbtGitProjectAdapter.test.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectAdapter.test.ts
@@ -283,6 +283,7 @@ describe('DbtGitProjectAdapter cache', () => {
         gitConfigGlobalPath?: string,
         credential?: { token: string; installationId?: string },
         gitBranch = 'main',
+        projectDirectorySubPath = '.',
     ) =>
         new DbtGitProjectAdapter({
             warehouseClient: warehouseClientMock,
@@ -291,7 +292,7 @@ describe('DbtGitProjectAdapter cache', () => {
                 : pathToFileURL(remote).href,
             repository: 'test/repository',
             gitBranch,
-            projectDirectorySubPath: '.',
+            projectDirectorySubPath,
             warehouseCredentials: {
                 type: WarehouseTypes.POSTGRES,
                 host: 'localhost',
@@ -440,6 +441,140 @@ describe('DbtGitProjectAdapter cache', () => {
         await second.getDbtManifest();
         expect(second.getFetchMetrics().depsMode).toBe('reused');
         expect(installDeps).toHaveBeenCalledTimes(1);
+        await second.destroy();
+    });
+
+    it('keeps hooks and vars Jinja cacheable and invalidates on project config edits', async () => {
+        const { remote, source } = await createRemote({
+            'dbt_project.yml':
+                'name: test\non-run-end: "{{ first_hook() }}"\nvars:\n  start: "{{ env_var(\'START_DATE\') }}"\n',
+        });
+        const first = createAdapter(remote);
+        await first.getDbtManifest();
+        await first.destroy();
+        const second = createAdapter(remote);
+        await second.getDbtManifest();
+        expect(second.getFetchMetrics()).toMatchObject({
+            cloneMode: 'reused',
+            depsMode: 'reused',
+        });
+        await second.destroy();
+
+        await commitRemote(source, {
+            'dbt_project.yml':
+                'name: test\non-run-end: "{{ second_hook() }}"\nvars:\n  start: "{{ env_var(\'START_DATE\') }}"\n',
+        });
+        const third = createAdapter(remote);
+        await third.getDbtManifest();
+        expect(third.getFetchMetrics()).toMatchObject({
+            cloneMode: 'reused',
+            depsMode: 'fresh',
+        });
+        expect(installDeps).toHaveBeenCalledTimes(2);
+        await third.destroy();
+    });
+
+    it.each([
+        ['packages.yml', 'packages:\n  - local: "{{ env_var(\'LOCAL\') }}"\n'],
+        ['packages.yml', 'packages:\n  - nested:\n      path: ../package\n'],
+        [
+            'dependencies.yml',
+            'projects:\n  - name: package\n    config:\n      local: ../package\n',
+        ],
+    ])(
+        'declines retention for unsafe recursive dependency config in %s',
+        async (filename, content) => {
+            const { remote } = await createRemote({
+                'dbt_project.yml': 'name: test\n',
+                [filename]: content,
+            });
+            const first = createAdapter(remote);
+            await first.getDbtManifest();
+            await first.destroy();
+            const second = createAdapter(remote);
+            await second.getDbtManifest();
+
+            expect(second.getFetchMetrics()).toMatchObject({
+                cloneMode: 'fresh',
+                depsMode: 'fresh',
+            });
+            await second.destroy();
+        },
+    );
+
+    it('preserves packages and removes junk for literal metacharacter subpaths', async () => {
+        const projectSubPath =
+            ' leading /!/hash#/bracket[/question?/star*/ trailing ';
+        const { remote } = await createRemote({
+            [`${projectSubPath}/dbt_project.yml`]: 'name: test\n',
+            [`${projectSubPath}/packages.yml`]:
+                'packages:\n  - package: example/package\n',
+        });
+        installDeps.mockImplementation(
+            async function mockInstall(this: DbtCliClient) {
+                await fs.mkdir(
+                    path.join(this.dbtProjectDirectory, 'dbt_packages'),
+                );
+                await fs.writeFile(
+                    path.join(
+                        this.dbtProjectDirectory,
+                        'dbt_packages',
+                        'installed.sql',
+                    ),
+                    'select 1\n',
+                );
+                await fs.writeFile(
+                    path.join(this.dbtProjectDirectory, 'package-lock.yml'),
+                    'packages: []\n',
+                );
+            },
+        );
+        const first = createAdapter(
+            remote,
+            'source',
+            undefined,
+            undefined,
+            'main',
+            projectSubPath,
+        );
+        await first.getDbtManifest();
+        const retainedCheckout = first.localRepositoryDir;
+        await first.destroy();
+        await fs.writeFile(
+            path.join(retainedCheckout, projectSubPath, 'junk.sql'),
+            'select 2\n',
+        );
+        const second = createAdapter(
+            remote,
+            'source',
+            undefined,
+            undefined,
+            'main',
+            projectSubPath,
+        );
+        await second.getDbtManifest();
+
+        await expect(
+            fs.readFile(
+                path.join(
+                    second.localRepositoryDir,
+                    projectSubPath,
+                    'dbt_packages',
+                    'installed.sql',
+                ),
+                'utf8',
+            ),
+        ).resolves.toBe('select 1\n');
+        await expect(
+            fs.access(
+                path.join(
+                    second.localRepositoryDir,
+                    projectSubPath,
+                    'junk.sql',
+                ),
+            ),
+        ).rejects.toMatchObject({ code: 'ENOENT' });
+        expect(second.getFetchMetrics().depsMode).toBe('reused');
         await second.destroy();
     });
 
@@ -920,6 +1055,23 @@ describe('DbtGitProjectAdapter cache', () => {
             depsMode: 'fresh',
         });
         expect(installDeps).toHaveBeenCalledTimes(2);
+        await second.destroy();
+    });
+
+    it('declines retention for a glob package install path', async () => {
+        const { remote } = await createRemote({
+            'dbt_project.yml':
+                'name: test\npackages-install-path: "dbt*packages"\n',
+        });
+        const first = createAdapter(remote);
+        await first.getDbtManifest();
+        await first.destroy();
+        const second = createAdapter(remote);
+        await second.getDbtManifest();
+        expect(second.getFetchMetrics()).toMatchObject({
+            cloneMode: 'fresh',
+            depsMode: 'fresh',
+        });
         await second.destroy();
     });
 });

--- a/packages/backend/src/projectAdapters/dbtGitProjectAdapter.test.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectAdapter.test.ts
@@ -758,7 +758,29 @@ describe('DbtGitProjectAdapter cache', () => {
             'utf8',
         );
         expect(gitConfig).not.toMatch(/https?:\/\/[^\s/@]+:[^\s/@]*@/);
+        await expect(
+            fs.access(
+                path.join(second.localRepositoryDir, '.git', 'FETCH_HEAD'),
+            ),
+        ).rejects.toMatchObject({ code: 'ENOENT' });
         await second.destroy();
+    });
+
+    it('rejects option-like branches before running Git or dbt', async () => {
+        const { remote } = await createRemote({
+            'dbt_project.yml': 'name: test\n',
+        });
+
+        expect(() =>
+            createAdapter(
+                remote,
+                'source',
+                undefined,
+                undefined,
+                '--upload-pack=side-effect',
+            ),
+        ).toThrow(UnexpectedGitError);
+        expect(installDeps).not.toHaveBeenCalled();
     });
 
     it('fetches a retained checkout with the current credentials', async () => {

--- a/packages/backend/src/projectAdapters/dbtGitProjectAdapter.test.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectAdapter.test.ts
@@ -13,7 +13,7 @@ import * as fs from 'fs/promises';
 import { createServer, type Server } from 'http';
 import os from 'os';
 import path from 'path';
-import simpleGit, { GitError } from 'simple-git';
+import simpleGit from 'simple-git';
 import { pathToFileURL } from 'url';
 import { DbtCliClient } from '../dbt/dbtCliClient';
 import Logger from '../logging/logger';
@@ -68,23 +68,6 @@ describe('gitErrorHandler', () => {
             expect.unreachable();
         } catch (e) {
             expect(e).toBeInstanceOf(UnexpectedServerError);
-            expect((e as Error).message).not.toContain('ghp_secret_token_123');
-            expect((e as Error).message).toContain('//*****@github.com');
-        }
-    });
-
-    it('should strip credentials from stderr on the GitError branch', () => {
-        try {
-            gitErrorHandler(
-                new GitError(
-                    { commands: ['clone', TOKEN_URL] } as never,
-                    `Cloning into '/tmp/git_abc'...\nfatal: unable to access '${TOKEN_URL}/': server certificate verification failed\n`,
-                ),
-                'org/repo',
-            );
-            expect.unreachable();
-        } catch (e) {
-            expect(e).toBeInstanceOf(UnexpectedGitError);
             expect((e as Error).message).not.toContain('ghp_secret_token_123');
             expect((e as Error).message).toContain('//*****@github.com');
         }
@@ -266,6 +249,7 @@ describe('DbtGitProjectAdapter cache', () => {
             blocked?: boolean;
             closedRequests?: number;
             onBlocked?: () => void;
+            notFound?: boolean;
         },
     ) => {
         const authenticationState = authentication;
@@ -286,6 +270,11 @@ describe('DbtGitProjectAdapter cache', () => {
                         (authenticationState.closedRequests ?? 0) + 1;
                     authenticationState.blocked = false;
                 });
+                return;
+            }
+            if (authenticationState.notFound) {
+                response.writeHead(404, { 'Content-Type': 'text/plain' });
+                response.end('Repository not found.\n');
                 return;
             }
             const requestUrl = new URL(request.url ?? '/', 'http://localhost');
@@ -557,6 +546,86 @@ describe('DbtGitProjectAdapter cache', () => {
             await second.destroy();
         } finally {
             probe.mockRestore();
+        }
+    });
+
+    it('classifies a real Git authentication failure without exposing credentials', async () => {
+        const { remote } = await createRemote({
+            'dbt_project.yml': 'name: test\n',
+        });
+        const token = 'bad /?#@:% token';
+        const served = await serveRemote(path.dirname(remote), {
+            expected: `Basic ${Buffer.from('user:expected-token').toString(
+                'base64',
+            )}`,
+            received: [],
+        });
+        const url = new URL(served);
+        url.username = 'user';
+        url.password = token;
+        const adapter = createAdapter(
+            url.toString(),
+            'auth-failure',
+            undefined,
+            {
+                token,
+            },
+        );
+
+        try {
+            await adapter.getDbtManifest();
+            expect.unreachable();
+        } catch (error) {
+            expect(error).toBeInstanceOf(AuthorizationError);
+            expect((error as Error).message).toBe(
+                'Git credentials not recognized for this repository',
+            );
+            const serialized = JSON.stringify(error);
+            expect(serialized).not.toContain(token);
+            expect(serialized).not.toContain(encodeURIComponent(token));
+        } finally {
+            await adapter.destroy();
+        }
+    });
+
+    it('classifies a real missing Git repository without exposing credentials', async () => {
+        const { remote } = await createRemote({
+            'dbt_project.yml': 'name: test\n',
+        });
+        const token = 'missing /?#@:% token';
+        const authorization = `Basic ${Buffer.from(`user:${token}`).toString(
+            'base64',
+        )}`;
+        const served = await serveRemote(path.dirname(remote), {
+            expected: authorization,
+            received: [],
+            notFound: true,
+        });
+        const url = new URL(served);
+        url.username = 'user';
+        url.password = token;
+        const adapter = createAdapter(
+            url.toString(),
+            'missing-repository',
+            undefined,
+            {
+                token,
+            },
+        );
+
+        try {
+            await adapter.getDbtManifest();
+            expect.unreachable();
+        } catch (error) {
+            expect(error).toBeInstanceOf(NotFoundError);
+            expect((error as Error).message).toContain(
+                'Could not find git repository "test/repository"',
+            );
+            const serialized = JSON.stringify(error);
+            expect(serialized).not.toContain(token);
+            expect(serialized).not.toContain(encodeURIComponent(token));
+        } finally {
+            await adapter.destroy();
         }
     });
 

--- a/packages/backend/src/projectAdapters/dbtGitProjectAdapter.test.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectAdapter.test.ts
@@ -5,8 +5,8 @@ import {
     SupportedDbtVersions,
     UnexpectedGitError,
     UnexpectedServerError,
-    type ExploreError,
     WarehouseTypes,
+    type ExploreError,
 } from '@lightdash/common';
 import { spawn } from 'child_process';
 import * as fs from 'fs/promises';

--- a/packages/backend/src/projectAdapters/dbtGitProjectAdapter.test.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectAdapter.test.ts
@@ -21,7 +21,10 @@ import { warehouseClientMock } from '../utils/QueryBuilder/MetricQueryBuilder.mo
 import { DbtBaseProjectAdapter } from './dbtBaseProjectAdapter';
 import { DbtGitProjectAdapter } from './dbtGitProjectAdapter';
 import { gitErrorHandler } from './gitRepository';
-import { configureDbtGitProjectCache } from './dbtGitProjectCache';
+import {
+    configureDbtGitProjectCache,
+    type DbtGitCacheLease,
+} from './dbtGitProjectCache';
 import { inspectDbtGitProject } from './dbtGitProjectInspection';
 import * as dbtGitVersion from './dbtGitVersion';
 
@@ -257,16 +260,32 @@ describe('DbtGitProjectAdapter cache', () => {
 
     const serveRemote = async (
         root: string,
-        authentication: { expected: string; received: string[] },
+        authentication: {
+            expected: string;
+            received: string[];
+            blocked?: boolean;
+            closedRequests?: number;
+            onBlocked?: () => void;
+        },
     ) => {
+        const authenticationState = authentication;
         const server = createServer((request, response) => {
             const received = request.headers.authorization ?? '';
-            authentication.received.push(received);
-            if (received !== authentication.expected) {
+            authenticationState.received.push(received);
+            if (received !== authenticationState.expected) {
                 response.writeHead(401, {
                     'WWW-Authenticate': 'Basic realm="git"',
                 });
                 response.end();
+                return;
+            }
+            if (authenticationState.blocked) {
+                authenticationState.onBlocked?.();
+                response.once('close', () => {
+                    authenticationState.closedRequests =
+                        (authenticationState.closedRequests ?? 0) + 1;
+                    authenticationState.blocked = false;
+                });
                 return;
             }
             const requestUrl = new URL(request.url ?? '/', 'http://localhost');
@@ -880,6 +899,52 @@ describe('DbtGitProjectAdapter cache', () => {
         await second.destroy();
     });
 
+    it('retries from a fresh checkout when the lease aborts during dbt deps', async () => {
+        const { remote } = await createRemote({
+            'dbt_project.yml': 'name: test\n',
+        });
+        const first = createAdapter(remote);
+        await first.getDbtManifest();
+        const retainedCheckout = first.localRepositoryDir;
+        const retainedEntry = path.dirname(retainedCheckout);
+        await first.destroy();
+        await fs.rm(path.join(retainedEntry, 'deps.json'));
+
+        let notifyStarted: () => void = () => undefined;
+        const started = new Promise<void>((resolve) => {
+            notifyStarted = resolve;
+        });
+        let rejectDeps: (reason: unknown) => void = () => undefined;
+        installDeps.mockImplementationOnce(
+            () =>
+                new Promise<void>((_resolve, reject) => {
+                    rejectDeps = reject;
+                    notifyStarted();
+                }),
+        );
+        const second = createAdapter(remote);
+        const compile = second.getDbtManifest();
+        await started;
+        const lease = Reflect.get(second, 'cacheLease') as
+            | DbtGitCacheLease
+            | undefined;
+        expect(lease?.reused).toBe(true);
+        lease?.heartbeat?.invalidate('heartbeat-write-timeout');
+        rejectDeps(lease?.signal.reason);
+
+        await expect(compile).resolves.toBeDefined();
+        expect(second.localRepositoryDir).not.toBe(retainedCheckout);
+        expect(second.getCacheOutcome()).toMatchObject({
+            fallbackReason: 'lease-invalidated',
+            retainCheckout: false,
+        });
+        expect(installDeps).toHaveBeenCalledTimes(3);
+        await expect(
+            fs.access(path.join(retainedEntry, 'deps.json')),
+        ).rejects.toMatchObject({ code: 'ENOENT' });
+        await second.destroy();
+    }, 15_000);
+
     it('does not fail compilation when a successful deps marker cannot be written', async () => {
         const { remote } = await createRemote({
             'dbt_project.yml': 'name: test\n',
@@ -1001,6 +1066,60 @@ describe('DbtGitProjectAdapter cache', () => {
         expect(gitConfig).not.toContain('second');
         await second.destroy();
     });
+
+    it('aborts an active cached fetch when the lease is invalidated', async () => {
+        const { remote } = await createRemote({
+            'dbt_project.yml': 'name: test\n',
+        });
+        const authentication = {
+            expected: `Basic ${Buffer.from('user:token').toString('base64')}`,
+            received: [] as string[],
+            blocked: false,
+            closedRequests: 0,
+            onBlocked: undefined as (() => void) | undefined,
+        };
+        const cleanUrl = await serveRemote(
+            path.dirname(remote),
+            authentication,
+        );
+        const credentialedUrl = cleanUrl.replace('://', '://user:token@');
+        const first = createAdapter(credentialedUrl);
+        await first.getDbtManifest();
+        const retainedCheckout = first.localRepositoryDir;
+        await first.destroy();
+
+        authentication.received = [];
+        authentication.blocked = true;
+        let notifyBlocked: () => void = () => undefined;
+        const blockedRequest = new Promise<void>((resolve) => {
+            notifyBlocked = resolve;
+        });
+        authentication.onBlocked = notifyBlocked;
+        const second = createAdapter(credentialedUrl);
+        const compile = second.getDbtManifest();
+        await blockedRequest;
+        const lease = Reflect.get(second, 'cacheLease') as
+            | DbtGitCacheLease
+            | undefined;
+        expect(lease?.reused).toBe(true);
+        lease?.heartbeat?.invalidate('heartbeat-write-timeout');
+
+        await expect(compile).resolves.toBeDefined();
+        expect(authentication.closedRequests).toBeGreaterThan(0);
+        expect(second.localRepositoryDir).not.toBe(retainedCheckout);
+        expect(second.getCacheOutcome()).toMatchObject({
+            cloneMode: 'fresh',
+            fallbackReason: 'lease-invalidated',
+            retainCheckout: false,
+        });
+        expect(installDeps).toHaveBeenCalledTimes(2);
+        await second.destroy();
+
+        const third = createAdapter(credentialedUrl);
+        await third.getDbtManifest();
+        expect(third.getFetchMetrics().cloneMode).toBe('fresh');
+        await third.destroy();
+    }, 20_000);
 
     it('reuses checkout and dependencies when an installation token and credential store rotate', async () => {
         const { remote, source } = await createRemote({

--- a/packages/backend/src/projectAdapters/dbtGitProjectAdapter.test.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectAdapter.test.ts
@@ -281,6 +281,8 @@ describe('DbtGitProjectAdapter cache', () => {
         remote: string,
         sourceUuid = 'source',
         gitConfigGlobalPath?: string,
+        credential?: { token: string; installationId?: string },
+        gitBranch = 'main',
     ) =>
         new DbtGitProjectAdapter({
             warehouseClient: warehouseClientMock,
@@ -288,7 +290,7 @@ describe('DbtGitProjectAdapter cache', () => {
                 ? remote
                 : pathToFileURL(remote).href,
             repository: 'test/repository',
-            gitBranch: 'main',
+            gitBranch,
             projectDirectorySubPath: '.',
             warehouseCredentials: {
                 type: WarehouseTypes.POSTGRES,
@@ -308,6 +310,7 @@ describe('DbtGitProjectAdapter cache', () => {
             },
             dbtVersion: SupportedDbtVersions.V1_7,
             gitConfigGlobalPath,
+            credential,
             cacheIdentity: {
                 projectUuid: 'project',
                 sourceUuid,
@@ -667,6 +670,107 @@ describe('DbtGitProjectAdapter cache', () => {
         );
         expect(gitConfig).not.toContain('first');
         expect(gitConfig).not.toContain('second');
+        await second.destroy();
+    });
+
+    it('reuses checkout and dependencies when an installation token and credential store rotate', async () => {
+        const { remote, source } = await createRemote({
+            'dbt_project.yml': 'name: test\n',
+        });
+        const authentication = {
+            expected: `Basic ${Buffer.from('user:first').toString('base64')}`,
+            received: [] as string[],
+        };
+        const cleanUrl = await serveRemote(
+            path.dirname(remote),
+            authentication,
+        );
+        const credentialConfig = async (token: string) => {
+            const directory = await fs.mkdtemp(
+                path.join(os.tmpdir(), 'dbt-git-credentials-test-'),
+            );
+            temporaryDirectories.push(directory);
+            const configPath = path.join(directory, 'gitconfig');
+            const credentialsPath = path.join(directory, 'credentials');
+            await fs.writeFile(
+                configPath,
+                `[credential]\nhelper = store --file=${credentialsPath}\n`,
+            );
+            await fs.writeFile(
+                credentialsPath,
+                `https://user:${token}@example.com\n`,
+            );
+            return configPath;
+        };
+        const first = createAdapter(
+            cleanUrl.replace('://', '://user:first@'),
+            'source',
+            await credentialConfig('first'),
+            { token: 'first', installationId: 'installation' },
+        );
+        await first.getDbtManifest();
+        await first.destroy();
+        await commitRemote(source, {
+            'models/value.sql': 'select 2\n',
+        });
+        authentication.expected = `Basic ${Buffer.from('user:second').toString(
+            'base64',
+        )}`;
+        authentication.received = [];
+        const second = createAdapter(
+            cleanUrl.replace('://', '://user:second@'),
+            'source',
+            await credentialConfig('second'),
+            { token: 'second', installationId: 'installation' },
+        );
+        await second.getDbtManifest();
+
+        expect(second.getFetchMetrics()).toMatchObject({
+            cloneMode: 'reused',
+            depsMode: 'reused',
+        });
+        expect(installDeps).toHaveBeenCalledTimes(1);
+        expect(authentication.received).toContain(authentication.expected);
+        await second.destroy();
+    });
+
+    it('invalidates dependencies when a long-lived token rotates', async () => {
+        const { remote } = await createRemote({
+            'dbt_project.yml': 'name: test\n',
+        });
+        const authentication = {
+            expected: `Basic ${Buffer.from('user:first').toString('base64')}`,
+            received: [] as string[],
+        };
+        const cleanUrl = await serveRemote(
+            path.dirname(remote),
+            authentication,
+        );
+        const first = createAdapter(
+            cleanUrl.replace('://', '://user:first@'),
+            'source',
+            undefined,
+            { token: 'first' },
+        );
+        await first.getDbtManifest();
+        await first.destroy();
+        authentication.expected = `Basic ${Buffer.from('user:second').toString(
+            'base64',
+        )}`;
+        authentication.received = [];
+        const second = createAdapter(
+            cleanUrl.replace('://', '://user:second@'),
+            'source',
+            undefined,
+            { token: 'second' },
+        );
+        await second.getDbtManifest();
+
+        expect(second.getFetchMetrics()).toMatchObject({
+            cloneMode: 'reused',
+            depsMode: 'fresh',
+        });
+        expect(installDeps).toHaveBeenCalledTimes(2);
         await second.destroy();
     });
 

--- a/packages/backend/src/projectAdapters/dbtGitProjectAdapter.test.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectAdapter.test.ts
@@ -20,13 +20,13 @@ import Logger from '../logging/logger';
 import { warehouseClientMock } from '../utils/QueryBuilder/MetricQueryBuilder.mock';
 import { DbtBaseProjectAdapter } from './dbtBaseProjectAdapter';
 import { DbtGitProjectAdapter } from './dbtGitProjectAdapter';
-import { gitErrorHandler } from './gitRepository';
 import {
     configureDbtGitProjectCache,
     type DbtGitCacheLease,
 } from './dbtGitProjectCache';
 import { inspectDbtGitProject } from './dbtGitProjectInspection';
 import * as dbtGitVersion from './dbtGitVersion';
+import { gitErrorHandler } from './gitRepository';
 
 const TOKEN_URL =
     'https://lightdash:ghp_secret_token_123@github.com/org/repo.git';

--- a/packages/backend/src/projectAdapters/dbtGitProjectAdapter.test.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectAdapter.test.ts
@@ -1,6 +1,7 @@
 import {
     AuthorizationError,
     NotFoundError,
+    ProjectType,
     SupportedDbtVersions,
     UnexpectedGitError,
     UnexpectedServerError,
@@ -329,6 +330,7 @@ describe('DbtGitProjectAdapter cache', () => {
         credential?: { token: string; installationId?: string },
         gitBranch = 'main',
         projectDirectorySubPath = '.',
+        cacheContext?: { projectType?: ProjectType; jobUuid?: string },
     ) =>
         new DbtGitProjectAdapter({
             warehouseClient: warehouseClientMock,
@@ -362,6 +364,7 @@ describe('DbtGitProjectAdapter cache', () => {
                 sourceUuid,
                 sourceType: 'additional',
             },
+            cacheContext,
         });
 
     beforeEach(async () => {
@@ -464,6 +467,49 @@ describe('DbtGitProjectAdapter cache', () => {
         } finally {
             info.mockRestore();
         }
+    });
+
+    it('skips preview caching and attributes the cache outcome', async () => {
+        const { remote } = await createRemote({
+            'dbt_project.yml': 'name: test\n',
+        });
+        const cacheContext = {
+            projectType: ProjectType.PREVIEW,
+            jobUuid: 'job',
+        };
+        const first = createAdapter(
+            remote,
+            'source',
+            undefined,
+            undefined,
+            'main',
+            '.',
+            cacheContext,
+        );
+        await first.getDbtManifest();
+        expect(first.getCacheOutcome()).toMatchObject({
+            projectUuid: 'project',
+            sourceUuid: 'source',
+            sourceType: 'additional',
+            projectType: ProjectType.PREVIEW,
+            jobUuid: 'job',
+            missReason: 'preview-project',
+            cloneMode: 'fresh',
+        });
+        await first.destroy();
+
+        const second = createAdapter(
+            remote,
+            'source',
+            undefined,
+            undefined,
+            'main',
+            '.',
+            cacheContext,
+        );
+        await second.getDbtManifest();
+        expect(second.getFetchMetrics().cloneMode).toBe('fresh');
+        await second.destroy();
     });
 
     it('sanitizes malformed credential-bearing repository URLs', () => {

--- a/packages/backend/src/projectAdapters/dbtGitProjectAdapter.test.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectAdapter.test.ts
@@ -15,11 +15,13 @@ import path from 'path';
 import simpleGit, { GitError } from 'simple-git';
 import { pathToFileURL } from 'url';
 import { DbtCliClient } from '../dbt/dbtCliClient';
+import Logger from '../logging/logger';
 import { warehouseClientMock } from '../utils/QueryBuilder/MetricQueryBuilder.mock';
 import { DbtBaseProjectAdapter } from './dbtBaseProjectAdapter';
 import { DbtGitProjectAdapter } from './dbtGitProjectAdapter';
 import { gitErrorHandler } from './gitRepository';
 import { configureDbtGitProjectCache } from './dbtGitProjectCache';
+import { inspectDbtGitProject } from './dbtGitProjectInspection';
 
 const TOKEN_URL =
     'https://lightdash:ghp_secret_token_123@github.com/org/repo.git';
@@ -152,6 +154,49 @@ describe('Git explore compilation', () => {
         },
     );
 });
+describe('inspectDbtGitProject', () => {
+    it('finds nested credentials and accounts for every filesystem entry', async () => {
+        const root = await fs.mkdtemp(
+            path.join(os.tmpdir(), 'dbt-git-inspection-test-'),
+        );
+        const nested = path.join(root, 'dbt_packages', 'dependency');
+        const gitDirectory = path.join(nested, '.git');
+        const objectsDirectory = path.join(gitDirectory, 'objects');
+        const paths = [
+            root,
+            path.join(root, 'dbt_packages'),
+            nested,
+            gitDirectory,
+            objectsDirectory,
+            path.join(gitDirectory, 'config'),
+            path.join(objectsDirectory, 'object'),
+            path.join(root, 'model.sql'),
+        ];
+        try {
+            await fs.mkdir(objectsDirectory, { recursive: true });
+            await fs.writeFile(
+                path.join(gitDirectory, 'config'),
+                'url = https://user:secret@example.com/repo.git\n',
+            );
+            await fs.writeFile(path.join(objectsDirectory, 'object'), 'data');
+            await fs.writeFile(path.join(root, 'model.sql'), 'select 1\n');
+            const expectedSize = (
+                await Promise.all(paths.map((entry) => fs.lstat(entry)))
+            ).reduce((total, stat) => total + stat.size, 0);
+
+            const inspection = await inspectDbtGitProject(root);
+
+            expect(inspection).toMatchObject({
+                containsCredentials: true,
+                sizeBytes: expectedSize,
+            });
+            expect(inspection.durationMs).toBeGreaterThanOrEqual(0);
+        } finally {
+            await fs.rm(root, { recursive: true, force: true });
+        }
+    });
+});
+
 describe('DbtGitProjectAdapter cache', () => {
     const temporaryDirectories: string[] = [];
     const servers: Server[] = [];
@@ -384,6 +429,43 @@ describe('DbtGitProjectAdapter cache', () => {
         await second.destroy();
     });
 
+    it('reports one cache outcome with the actual inspection duration', async () => {
+        const cacheOutcomes: unknown[] = [];
+        const info = vi
+            .spyOn(Logger, 'info')
+            .mockImplementation((message: unknown, ...metadata: unknown[]) => {
+                if (message === 'dbt.git.cache.outcome') {
+                    cacheOutcomes.push(metadata[0]);
+                }
+                return Logger;
+            });
+        try {
+            const { remote } = await createRemote({
+                'dbt_project.yml': 'name: test\n',
+            });
+            const adapter = createAdapter(remote);
+            await adapter.getDbtManifest();
+            await adapter.destroy();
+
+            const outcome = adapter.getCacheOutcome();
+            expect(outcome).toMatchObject({
+                cloneMode: 'fresh',
+                depsMode: 'fresh',
+                missReason: 'cold',
+                retainCheckout: true,
+                eligible: true,
+                retained: true,
+            });
+            expect(outcome.inspectionDurationMs).toBeGreaterThanOrEqual(0);
+            expect(outcome.cleanupDurationMs).toBeGreaterThanOrEqual(
+                outcome.inspectionDurationMs,
+            );
+            expect(cacheOutcomes).toEqual([outcome]);
+        } finally {
+            info.mockRestore();
+        }
+    });
+
     it('sanitizes malformed credential-bearing repository URLs', () => {
         expect(() => createAdapter('https://user:secret@[invalid')).toThrow(
             UnexpectedGitError,
@@ -393,6 +475,21 @@ describe('DbtGitProjectAdapter cache', () => {
         } catch (error) {
             expect(JSON.stringify(error)).not.toContain('secret');
         }
+    });
+
+    it('disables the cache when supplied credentials do not match the URL split', async () => {
+        const adapter = createAdapter(
+            'https://abc/def@dev.azure.com/org/project/_git/repository',
+            'source',
+            undefined,
+            { token: 'abc/def' },
+        );
+
+        expect(adapter.getCacheOutcome().missReason).toBe(
+            'credential-url-mismatch',
+        );
+        expect(path.dirname(adapter.localRepositoryDir)).toBe(os.tmpdir());
+        await adapter.destroy();
     });
 
     it('invalidates deps reuse when an allowlisted value changes', async () => {
@@ -950,6 +1047,62 @@ describe('DbtGitProjectAdapter cache', () => {
         await second.destroy();
     });
 
+    it('sanitizes a credentialed cached refresh error before warning', async () => {
+        const { remote } = await createRemote({
+            'dbt_project.yml': 'name: test\n',
+        });
+        const authentication = {
+            expected: `Basic ${Buffer.from('user:secret-token').toString(
+                'base64',
+            )}`,
+            received: [] as string[],
+        };
+        const cleanUrl = await serveRemote(
+            path.dirname(remote),
+            authentication,
+        );
+        const credentialedUrl = cleanUrl.replace(
+            '://',
+            '://user:secret-token@',
+        );
+        const first = createAdapter(credentialedUrl, 'source', undefined, {
+            token: 'secret-token',
+        });
+        await first.getDbtManifest();
+        const retainedCheckout = first.localRepositoryDir;
+        await first.destroy();
+        await fs.rm(path.join(retainedCheckout, '.git'), {
+            recursive: true,
+            force: true,
+        });
+        const refreshWarnings: unknown[] = [];
+        const warn = vi
+            .spyOn(Logger, 'warn')
+            .mockImplementation((message: unknown, ...metadata: unknown[]) => {
+                if (
+                    message ===
+                    'Cached Git checkout refresh failed; using a fresh clone'
+                ) {
+                    refreshWarnings.push(metadata[0]);
+                }
+                return Logger;
+            });
+        try {
+            const second = createAdapter(credentialedUrl, 'source', undefined, {
+                token: 'secret-token',
+            });
+            await second.getDbtManifest();
+            expect(refreshWarnings).toHaveLength(1);
+            expect(JSON.stringify(refreshWarnings)).not.toContain(
+                'secret-token',
+            );
+            expect(JSON.stringify(refreshWarnings)).not.toContain('task');
+            await second.destroy();
+        } finally {
+            warn.mockRestore();
+        }
+    });
+
     it('falls back to a fresh clone when retained metadata is corrupt', async () => {
         const { remote } = await createRemote({
             'dbt_project.yml': 'name: test\n',
@@ -988,15 +1141,36 @@ describe('DbtGitProjectAdapter cache', () => {
     });
 
     it('propagates a failed fresh clone after cache fallback', async () => {
-        const missingRemote = path.join(
-            os.tmpdir(),
-            `missing-dbt-git-${Date.now()}.git`,
-        );
-        const adapter = createAdapter(missingRemote);
-        await expect(adapter.getDbtManifest()).rejects.toBeInstanceOf(
-            UnexpectedGitError,
-        );
-        await adapter.destroy();
+        const cacheOutcomes: unknown[] = [];
+        const info = vi
+            .spyOn(Logger, 'info')
+            .mockImplementation((message: unknown, ...metadata: unknown[]) => {
+                if (message === 'dbt.git.cache.outcome') {
+                    cacheOutcomes.push(metadata[0]);
+                }
+                return Logger;
+            });
+        try {
+            const missingRemote = path.join(
+                os.tmpdir(),
+                `missing-dbt-git-${Date.now()}.git`,
+            );
+            const adapter = createAdapter(missingRemote);
+            await expect(adapter.getDbtManifest()).rejects.toBeInstanceOf(
+                UnexpectedGitError,
+            );
+            await adapter.destroy();
+
+            expect(adapter.getCacheOutcome()).toMatchObject({
+                missReason: 'cold',
+                fallbackReason: 'cache-clone-failed',
+                eligible: null,
+                retained: false,
+            });
+            expect(cacheOutcomes).toHaveLength(1);
+        } finally {
+            info.mockRestore();
+        }
     });
 
     it('uses a fresh checkout while another adapter owns the cache lease', async () => {

--- a/packages/backend/src/projectAdapters/dbtGitProjectAdapter.test.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectAdapter.test.ts
@@ -1,14 +1,25 @@
 import {
     AuthorizationError,
     NotFoundError,
+    SupportedDbtVersions,
     UnexpectedGitError,
     UnexpectedServerError,
     type ExploreError,
+    WarehouseTypes,
 } from '@lightdash/common';
-import { GitError } from 'simple-git';
+import { spawn } from 'child_process';
+import * as fs from 'fs/promises';
+import { createServer, type Server } from 'http';
+import os from 'os';
+import path from 'path';
+import simpleGit, { GitError } from 'simple-git';
+import { pathToFileURL } from 'url';
+import { DbtCliClient } from '../dbt/dbtCliClient';
+import { warehouseClientMock } from '../utils/QueryBuilder/MetricQueryBuilder.mock';
 import { DbtBaseProjectAdapter } from './dbtBaseProjectAdapter';
 import { DbtGitProjectAdapter } from './dbtGitProjectAdapter';
 import { gitErrorHandler } from './gitRepository';
+import { configureDbtGitProjectCache } from './dbtGitProjectCache';
 
 const TOKEN_URL =
     'https://lightdash:ghp_secret_token_123@github.com/org/repo.git';
@@ -100,7 +111,7 @@ describe('Git explore compilation', () => {
                 DbtGitProjectAdapter.prototype,
             ) as DbtGitProjectAdapter;
             const refresh = vi.fn(async () => undefined);
-            Object.defineProperty(adapter, '_refreshRepo', { value: refresh });
+            Object.defineProperty(adapter, 'refreshRepo', { value: refresh });
             const explore: ExploreError = {
                 name: 'orders',
                 label: 'Orders',
@@ -140,4 +151,671 @@ describe('Git explore compilation', () => {
             expect(refresh).toHaveBeenCalledTimes(1);
         },
     );
+});
+describe('DbtGitProjectAdapter cache', () => {
+    const temporaryDirectories: string[] = [];
+    const servers: Server[] = [];
+    let installDeps: ReturnType<typeof vi.spyOn>;
+    let getDbtManifest: ReturnType<typeof vi.spyOn>;
+
+    const createRemote = async (files: Record<string, string>) => {
+        const root = await fs.mkdtemp(path.join(os.tmpdir(), 'dbt-git-test-'));
+        temporaryDirectories.push(root);
+        const remote = path.join(root, 'remote.git');
+        const source = path.join(root, 'source');
+        await fs.mkdir(remote);
+        await fs.mkdir(source);
+        await simpleGit(remote).init(true, {
+            '--bare': null,
+            '--initial-branch': 'main',
+        });
+        const git = simpleGit(source);
+        await git.init(false, { '--initial-branch': 'main' });
+        await git.cwd(source).addConfig('user.email', 'test@lightdash.com');
+        await git.cwd(source).addConfig('user.name', 'Lightdash Test');
+        await Promise.all(
+            Object.entries(files).map(async ([name, content]) => {
+                const filePath = path.join(source, name);
+                await fs.mkdir(path.dirname(filePath), { recursive: true });
+                await fs.writeFile(filePath, content);
+            }),
+        );
+        await git.cwd(source).add('.');
+        await git.cwd(source).commit('initial');
+        await git.cwd(source).addRemote('origin', remote);
+        await git.cwd(source).push('origin', 'main');
+        return { remote, source };
+    };
+
+    const commitRemote = async (
+        source: string,
+        files: Record<string, string | null>,
+    ) => {
+        await Promise.all(
+            Object.entries(files).map(async ([name, content]) => {
+                const filePath = path.join(source, name);
+                if (content === null) {
+                    await fs.rm(filePath, { force: true });
+                } else {
+                    await fs.mkdir(path.dirname(filePath), { recursive: true });
+                    await fs.writeFile(filePath, content);
+                }
+            }),
+        );
+        const git = simpleGit(source);
+        await git.add('.');
+        await git.commit('update');
+        await git.push('origin', 'main');
+    };
+
+    const serveRemote = async (
+        root: string,
+        authentication: { expected: string; received: string[] },
+    ) => {
+        const server = createServer((request, response) => {
+            const received = request.headers.authorization ?? '';
+            authentication.received.push(received);
+            if (received !== authentication.expected) {
+                response.writeHead(401, {
+                    'WWW-Authenticate': 'Basic realm="git"',
+                });
+                response.end();
+                return;
+            }
+            const requestUrl = new URL(request.url ?? '/', 'http://localhost');
+            const backend = spawn('git', ['http-backend'], {
+                env: {
+                    ...process.env,
+                    GIT_PROJECT_ROOT: root,
+                    GIT_HTTP_EXPORT_ALL: '1',
+                    PATH_INFO: requestUrl.pathname,
+                    QUERY_STRING: requestUrl.search.slice(1),
+                    REQUEST_METHOD: request.method ?? 'GET',
+                    CONTENT_TYPE: request.headers['content-type'] ?? '',
+                    CONTENT_LENGTH: request.headers['content-length'] ?? '0',
+                    REMOTE_ADDR: request.socket.remoteAddress ?? '',
+                },
+            });
+            const output: Buffer[] = [];
+            backend.stdout.on('data', (chunk: Buffer) => output.push(chunk));
+            backend.on('close', (code) => {
+                if (code !== 0) {
+                    response.writeHead(500);
+                    response.end();
+                    return;
+                }
+                const result = Buffer.concat(output);
+                const separator = result.indexOf('\r\n\r\n');
+                const headers = result.subarray(0, separator).toString('utf8');
+                const responseHeaders: Record<string, string> = {};
+                let status = 200;
+                for (const line of headers.split('\r\n')) {
+                    const colon = line.indexOf(':');
+                    if (colon !== -1) {
+                        const name = line.slice(0, colon);
+                        const value = line.slice(colon + 1).trim();
+                        if (name.toLowerCase() === 'status') {
+                            status = Number.parseInt(value, 10);
+                        } else {
+                            responseHeaders[name] = value;
+                        }
+                    }
+                }
+                response.writeHead(status, responseHeaders);
+                response.end(result.subarray(separator + 4));
+            });
+            request.pipe(backend.stdin);
+        });
+        await new Promise<void>((resolve) => {
+            server.listen(0, '127.0.0.1', resolve);
+        });
+        servers.push(server);
+        const address = server.address();
+        if (!address || typeof address === 'string') {
+            throw new Error('HTTP Git server has no TCP address');
+        }
+        return `http://127.0.0.1:${address.port}/remote.git`;
+    };
+
+    const createAdapter = (
+        remote: string,
+        sourceUuid = 'source',
+        gitConfigGlobalPath?: string,
+    ) =>
+        new DbtGitProjectAdapter({
+            warehouseClient: warehouseClientMock,
+            remoteRepositoryUrl: remote.includes('://')
+                ? remote
+                : pathToFileURL(remote).href,
+            repository: 'test/repository',
+            gitBranch: 'main',
+            projectDirectorySubPath: '.',
+            warehouseCredentials: {
+                type: WarehouseTypes.POSTGRES,
+                host: 'localhost',
+                port: 5432,
+                user: 'postgres',
+                password: 'password',
+                dbname: 'postgres',
+                schema: 'public',
+            },
+            targetName: undefined,
+            environment: undefined,
+            environmentVariableAllowlist: [],
+            cachedWarehouse: {
+                warehouseCatalog: {},
+                onWarehouseCatalogChange: vi.fn(),
+            },
+            dbtVersion: SupportedDbtVersions.V1_7,
+            gitConfigGlobalPath,
+            cacheIdentity: {
+                projectUuid: 'project',
+                sourceUuid,
+                sourceType: 'additional',
+            },
+        });
+
+    beforeEach(async () => {
+        const cacheRoot = await fs.mkdtemp(
+            path.join(os.tmpdir(), 'dbt-adapter-cache-test-'),
+        );
+        temporaryDirectories.push(cacheRoot);
+        configureDbtGitProjectCache({
+            root: cacheRoot,
+            maxBytes: 1024 * 1024,
+            maxAgeMs: 60_000,
+            livenessCheck: async (identities) =>
+                new Set(
+                    identities.map(
+                        ({ sourceType, projectUuid, sourceUuid }) =>
+                            `${sourceType}:${projectUuid}:${sourceUuid}`,
+                    ),
+                ),
+        });
+        installDeps = vi
+            .spyOn(DbtCliClient.prototype, 'installDeps')
+            .mockResolvedValue(undefined);
+        getDbtManifest = vi
+            .spyOn(DbtCliClient.prototype, 'getDbtManifest')
+            .mockResolvedValue({ manifest: { nodes: {} } } as never);
+    });
+
+    afterEach(async () => {
+        installDeps.mockRestore();
+        getDbtManifest.mockRestore();
+        delete process.env.DBT_CACHE_ALLOWLIST_TEST;
+        await Promise.all(
+            servers.splice(0).map(
+                (server) =>
+                    new Promise<void>((resolve, reject) => {
+                        server.close((error) =>
+                            error ? reject(error) : resolve(),
+                        );
+                    }),
+            ),
+        );
+        await Promise.all(
+            temporaryDirectories
+                .splice(0)
+                .map((directory) =>
+                    fs.rm(directory, { recursive: true, force: true }),
+                ),
+        );
+    });
+
+    it('reuses a checkout and a successful no-packages deps marker', async () => {
+        const { remote } = await createRemote({
+            'dbt_project.yml': 'name: test\n',
+        });
+        const first = createAdapter(remote);
+        await first.getDbtManifest();
+        await first.destroy();
+        const second = createAdapter(remote);
+        await second.getDbtManifest();
+        expect(second.getFetchMetrics()).toMatchObject({
+            cloneMode: 'reused',
+            depsMode: 'reused',
+        });
+        expect(installDeps).toHaveBeenCalledTimes(1);
+        await second.destroy();
+    });
+
+    it('sanitizes malformed credential-bearing repository URLs', () => {
+        expect(() => createAdapter('https://user:secret@[invalid')).toThrow(
+            UnexpectedGitError,
+        );
+        try {
+            createAdapter('https://user:secret@[invalid');
+        } catch (error) {
+            expect(JSON.stringify(error)).not.toContain('secret');
+        }
+    });
+
+    it('invalidates deps reuse when an allowlisted value changes', async () => {
+        const { remote } = await createRemote({
+            'dbt_project.yml': 'name: test\n',
+        });
+        process.env.DBT_CACHE_ALLOWLIST_TEST = 'first';
+        const first = createAdapter(remote);
+        (first.dbtClient as DbtCliClient).environmentVariableAllowlist = [
+            'DBT_CACHE_ALLOWLIST_TEST',
+        ];
+        await first.getDbtManifest();
+        await first.destroy();
+        process.env.DBT_CACHE_ALLOWLIST_TEST = 'second';
+        const second = createAdapter(remote);
+        (second.dbtClient as DbtCliClient).environmentVariableAllowlist = [
+            'DBT_CACHE_ALLOWLIST_TEST',
+        ];
+        await second.getDbtManifest();
+        expect(second.getFetchMetrics().depsMode).toBe('fresh');
+        expect(installDeps).toHaveBeenCalledTimes(2);
+        await second.destroy();
+    });
+
+    it('reuses populated packages after a successful install', async () => {
+        const { remote } = await createRemote({
+            'dbt_project.yml': 'name: test\n',
+            'packages.yml':
+                'packages:\n  - package: dbt-labs/dbt_utils\n    version: 1.0.0\n',
+        });
+        installDeps.mockImplementation(
+            async function mockInstall(this: DbtCliClient) {
+                await fs.mkdir(
+                    path.join(this.dbtProjectDirectory, 'dbt_packages'),
+                );
+                await fs.writeFile(
+                    path.join(this.dbtProjectDirectory, 'package-lock.yml'),
+                    'packages: []\n',
+                );
+            },
+        );
+        const first = createAdapter(remote);
+        await first.getDbtManifest();
+        await first.destroy();
+        const second = createAdapter(remote);
+        await second.getDbtManifest();
+        expect(second.getFetchMetrics().depsMode).toBe('reused');
+        expect(installDeps).toHaveBeenCalledTimes(1);
+        await second.destroy();
+    });
+
+    it('excludes temporary Git credential paths from dependency identity', async () => {
+        const { remote } = await createRemote({
+            'dbt_project.yml': 'name: test\n',
+            'packages.yml': 'packages:\n  - package: example/package\n',
+        });
+        installDeps.mockImplementation(
+            async function mockInstall(this: DbtCliClient) {
+                await fs.mkdir(
+                    path.join(this.dbtProjectDirectory, 'dbt_packages'),
+                );
+                await fs.writeFile(
+                    path.join(this.dbtProjectDirectory, 'package-lock.yml'),
+                    'packages: []\n',
+                );
+            },
+        );
+        const credentialConfig = async () => {
+            const directory = await fs.mkdtemp(
+                path.join(os.tmpdir(), 'dbt-git-credentials-test-'),
+            );
+            temporaryDirectories.push(directory);
+            const configPath = path.join(directory, 'gitconfig');
+            await fs.writeFile(
+                configPath,
+                `[credential]\nhelper = store --file=${path.join(
+                    directory,
+                    'credentials',
+                )}\n`,
+            );
+            await fs.writeFile(
+                path.join(directory, 'credentials'),
+                'https://user:same@example.com\n',
+            );
+            return configPath;
+        };
+        const first = createAdapter(remote, 'source', await credentialConfig());
+        await first.getDbtManifest();
+        await first.destroy();
+        const second = createAdapter(
+            remote,
+            'source',
+            await credentialConfig(),
+        );
+        await second.getDbtManifest();
+        expect(second.getFetchMetrics().depsMode).toBe('reused');
+        expect(installDeps).toHaveBeenCalledTimes(1);
+        await second.destroy();
+    });
+
+    it('cleans old package state when package inputs and install path change', async () => {
+        const { remote, source } = await createRemote({
+            'dbt_project.yml':
+                'name: test\npackages-install-path: packages_a\n',
+            'packages.yml': 'packages:\n  - package: dbt-labs/dbt_utils\n',
+            'package-lock.yml': 'packages:\n  - name: dbt_utils\n',
+        });
+        const observations: Array<{
+            oldPackages: boolean;
+            packageLock: boolean;
+        }> = [];
+        installDeps.mockImplementation(
+            async function mockInstall(this: DbtCliClient) {
+                observations.push({
+                    oldPackages: await fs
+                        .access(
+                            path.join(this.dbtProjectDirectory, 'packages_a'),
+                        )
+                        .then(() => true)
+                        .catch(() => false),
+                    packageLock: await fs
+                        .access(
+                            path.join(
+                                this.dbtProjectDirectory,
+                                'package-lock.yml',
+                            ),
+                        )
+                        .then(() => true)
+                        .catch(() => false),
+                });
+                if (observations.length === 1) {
+                    const packagesDirectory = path.join(
+                        this.dbtProjectDirectory,
+                        'packages_a',
+                    );
+                    await fs.mkdir(packagesDirectory);
+                    await simpleGit(packagesDirectory).init();
+                    await fs.writeFile(
+                        path.join(this.dbtProjectDirectory, 'package-lock.yml'),
+                        'packages:\n  - name: installed\n',
+                    );
+                }
+            },
+        );
+        const first = createAdapter(remote);
+        await first.getDbtManifest();
+        await first.destroy();
+        await commitRemote(source, {
+            'dbt_project.yml':
+                'name: test\npackages-install-path: packages_b\n',
+            'packages.yml': null,
+            'package-lock.yml': null,
+        });
+        const second = createAdapter(remote);
+        await second.getDbtManifest();
+        expect(second.getFetchMetrics()).toMatchObject({
+            cloneMode: 'reused',
+            depsMode: 'fresh',
+        });
+        expect(observations[1]).toEqual({
+            oldPackages: false,
+            packageLock: false,
+        });
+        await second.destroy();
+    });
+
+    it('does not publish a reusable marker after failed deps', async () => {
+        const { remote } = await createRemote({
+            'dbt_project.yml': 'name: test\n',
+        });
+        installDeps.mockRejectedValueOnce(new Error('deps failed'));
+        const first = createAdapter(remote);
+        await expect(first.getDbtManifest()).rejects.toThrow('deps failed');
+        await first.destroy();
+        const second = createAdapter(remote);
+        await second.getDbtManifest();
+        expect(second.getFetchMetrics().depsMode).toBe('fresh');
+        expect(installDeps).toHaveBeenCalledTimes(2);
+        await second.destroy();
+    });
+
+    it('does not fail compilation when a successful deps marker cannot be written', async () => {
+        const { remote } = await createRemote({
+            'dbt_project.yml': 'name: test\n',
+        });
+        installDeps.mockImplementationOnce(
+            async function mockInstall(this: DbtCliClient) {
+                await fs.mkdir(
+                    path.join(
+                        path.dirname(this.dbtProjectDirectory),
+                        'deps.json.tmp',
+                    ),
+                );
+            },
+        );
+        const first = createAdapter(remote);
+        await expect(first.getDbtManifest()).resolves.toBeDefined();
+        await first.destroy();
+        const second = createAdapter(remote);
+        await second.getDbtManifest();
+        expect(second.getFetchMetrics()).toMatchObject({
+            cloneMode: 'fresh',
+            depsMode: 'fresh',
+        });
+        await second.destroy();
+    });
+
+    it('fetches the current branch and keeps retained Git metadata credential-free', async () => {
+        const { remote, source } = await createRemote({
+            'dbt_project.yml': 'name: test\n',
+            'models/value.sql': 'select 1\n',
+        });
+        const first = createAdapter(remote);
+        await first.getDbtManifest();
+        await first.destroy();
+        await commitRemote(source, {
+            'models/value.sql': 'select 2\n',
+        });
+        const second = createAdapter(remote);
+        await second.getDbtManifest();
+        expect(
+            await fs.readFile(
+                path.join(second.localRepositoryDir, 'models/value.sql'),
+                'utf8',
+            ),
+        ).toBe('select 2\n');
+        const gitConfig = await fs.readFile(
+            path.join(second.localRepositoryDir, '.git/config'),
+            'utf8',
+        );
+        expect(gitConfig).not.toMatch(/https?:\/\/[^\s/@]+:[^\s/@]*@/);
+        await second.destroy();
+    });
+
+    it('fetches a retained checkout with the current credentials', async () => {
+        const { remote, source } = await createRemote({
+            'dbt_project.yml': 'name: test\n',
+            'models/value.sql': 'select 1\n',
+        });
+        const authentication = {
+            expected: `Basic ${Buffer.from('user:first').toString('base64')}`,
+            received: [] as string[],
+        };
+        const cleanUrl = await serveRemote(
+            path.dirname(remote),
+            authentication,
+        );
+        const first = createAdapter(cleanUrl.replace('://', '://user:first@'));
+        await first.getDbtManifest();
+        await first.destroy();
+        await commitRemote(source, {
+            'models/value.sql': 'select 2\n',
+        });
+        authentication.expected = `Basic ${Buffer.from('user:second').toString(
+            'base64',
+        )}`;
+        authentication.received = [];
+        const second = createAdapter(
+            cleanUrl.replace('://', '://user:second@'),
+        );
+        await second.getDbtManifest();
+        expect(second.getFetchMetrics().cloneMode).toBe('reused');
+        expect(
+            await fs.readFile(
+                path.join(second.localRepositoryDir, 'models/value.sql'),
+                'utf8',
+            ),
+        ).toBe('select 2\n');
+        expect(authentication.received).toContain(authentication.expected);
+        expect(authentication.received).not.toContain(
+            `Basic ${Buffer.from('user:first').toString('base64')}`,
+        );
+        const gitConfig = await fs.readFile(
+            path.join(second.localRepositoryDir, '.git/config'),
+            'utf8',
+        );
+        expect(gitConfig).not.toContain('first');
+        expect(gitConfig).not.toContain('second');
+        await second.destroy();
+    });
+
+    it('uses a new temporary clone when a retained checkout cannot reset', async () => {
+        const { remote } = await createRemote({
+            'dbt_project.yml': 'name: test\n',
+        });
+        const first = createAdapter(remote);
+        await first.getDbtManifest();
+        const retainedCheckout = first.localRepositoryDir;
+        await first.destroy();
+        await fs.rm(path.join(retainedCheckout, '.git'), {
+            recursive: true,
+            force: true,
+        });
+        const second = createAdapter(remote);
+        await second.getDbtManifest();
+        expect(second.getFetchMetrics().cloneMode).toBe('fresh');
+        expect(second.localRepositoryDir).not.toBe(retainedCheckout);
+        await second.destroy();
+    });
+
+    it('falls back to a fresh clone when retained metadata is corrupt', async () => {
+        const { remote } = await createRemote({
+            'dbt_project.yml': 'name: test\n',
+        });
+        const first = createAdapter(remote);
+        await first.getDbtManifest();
+        const entryDirectory = path.dirname(first.localRepositoryDir);
+        await first.destroy();
+        await fs.writeFile(path.join(entryDirectory, 'metadata.json'), '{}');
+        const second = createAdapter(remote);
+        await second.getDbtManifest();
+        expect(second.getFetchMetrics().cloneMode).toBe('fresh');
+        await second.destroy();
+    });
+
+    it('falls back to a temporary clone when the cache root is unusable', async () => {
+        const { remote } = await createRemote({
+            'dbt_project.yml': 'name: test\n',
+        });
+        const cacheRoot = await fs.mkdtemp(
+            path.join(os.tmpdir(), 'dbt-adapter-invalid-cache-test-'),
+        );
+        temporaryDirectories.push(cacheRoot);
+        await fs.chmod(cacheRoot, 0o755);
+        configureDbtGitProjectCache({
+            root: cacheRoot,
+            maxBytes: 1024 * 1024,
+            maxAgeMs: 60_000,
+            livenessCheck: async () => new Set(),
+        });
+        const adapter = createAdapter(remote);
+        await adapter.getDbtManifest();
+        expect(adapter.getFetchMetrics().cloneMode).toBe('fresh');
+        expect(path.dirname(adapter.localRepositoryDir)).toBe(os.tmpdir());
+        await adapter.destroy();
+    });
+
+    it('propagates a failed fresh clone after cache fallback', async () => {
+        const missingRemote = path.join(
+            os.tmpdir(),
+            `missing-dbt-git-${Date.now()}.git`,
+        );
+        const adapter = createAdapter(missingRemote);
+        await expect(adapter.getDbtManifest()).rejects.toBeInstanceOf(
+            UnexpectedGitError,
+        );
+        await adapter.destroy();
+    });
+
+    it('uses a fresh checkout while another adapter owns the cache lease', async () => {
+        const { remote } = await createRemote({
+            'dbt_project.yml': 'name: test\n',
+        });
+        const first = createAdapter(remote);
+        await first.getDbtManifest();
+        const second = createAdapter(remote);
+        await second.getDbtManifest();
+        expect(second.getFetchMetrics().cloneMode).toBe('fresh');
+        expect(second.localRepositoryDir).not.toBe(first.localRepositoryDir);
+        await first.destroy();
+        await second.destroy();
+        const third = createAdapter(remote);
+        await third.getDbtManifest();
+        expect(third.getFetchMetrics().cloneMode).toBe('reused');
+        await third.destroy();
+    });
+
+    it('releases the checkout lease when base cleanup fails', async () => {
+        const { remote } = await createRemote({
+            'dbt_project.yml': 'name: test\n',
+        });
+        const cleanup = vi
+            .spyOn(DbtCliClient.prototype, 'cleanup')
+            .mockRejectedValueOnce(new Error('cleanup failed'));
+        const first = createAdapter(remote);
+        await first.getDbtManifest();
+        await expect(first.destroy()).rejects.toThrow('cleanup failed');
+        cleanup.mockRestore();
+        const second = createAdapter(remote);
+        await second.getDbtManifest();
+        expect(second.getFetchMetrics().cloneMode).toBe('reused');
+        await second.destroy();
+    });
+
+    it('declines retention when dependency Git metadata contains credentials', async () => {
+        const { remote } = await createRemote({
+            'dbt_project.yml': 'name: test\n',
+            'packages.yml': 'packages:\n  - package: example/package\n',
+        });
+        installDeps.mockImplementation(
+            async function mockInstall(this: DbtCliClient) {
+                const gitDirectory = path.join(
+                    this.dbtProjectDirectory,
+                    'dbt_packages',
+                    'package',
+                    '.git',
+                );
+                await fs.mkdir(gitDirectory, { recursive: true });
+                await fs.writeFile(
+                    path.join(gitDirectory, 'config'),
+                    '[remote "origin"]\nurl = https://user:secret@example.com/repo.git\n',
+                );
+            },
+        );
+        const first = createAdapter(remote);
+        await first.getDbtManifest();
+        await first.destroy();
+        const second = createAdapter(remote);
+        await second.getDbtManifest();
+        expect(second.getFetchMetrics().cloneMode).toBe('fresh');
+        await second.destroy();
+    });
+
+    it('declines retention for an unsafe package install path', async () => {
+        const { remote } = await createRemote({
+            'dbt_project.yml': 'name: test\npackages-install-path: .\n',
+        });
+        const first = createAdapter(remote);
+        await first.getDbtManifest();
+        await first.destroy();
+        const second = createAdapter(remote);
+        await second.getDbtManifest();
+        expect(second.getFetchMetrics()).toMatchObject({
+            cloneMode: 'fresh',
+            depsMode: 'fresh',
+        });
+        expect(installDeps).toHaveBeenCalledTimes(2);
+        await second.destroy();
+    });
 });

--- a/packages/backend/src/projectAdapters/dbtGitProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectAdapter.ts
@@ -505,7 +505,7 @@ export class DbtGitProjectAdapter
         const previous = this.cacheLease;
         previous?.signal.removeEventListener('abort', this.onCacheLeaseAbort);
         this.cacheLease = lease;
-        (this.dbtClient as DbtCliClient).setAbortSignal(lease?.signal);
+        this.dbtClient.setAbortSignal?.(lease?.signal);
         lease?.signal.addEventListener('abort', this.onCacheLeaseAbort);
         if (lease?.signal.aborted || lease?.invalidated) {
             this.onCacheLeaseAbort();

--- a/packages/backend/src/projectAdapters/dbtGitProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectAdapter.ts
@@ -48,6 +48,10 @@ export type DbtGitProjectAdapterArgs = {
     gitConfigGlobalPath?: string;
     dbtDepsErrorHint?: string;
     cacheIdentity?: DbtGitCacheIdentity;
+    credential?: {
+        token: string;
+        installationId?: string;
+    };
 };
 
 export type DbtGitFetchMetrics = {
@@ -101,6 +105,13 @@ const withoutCredentials = (
     } catch (error) {
         return gitErrorHandler(error, repository);
     }
+};
+
+const decodedUrlCredentials = (remoteRepositoryUrl: string): string[] => {
+    const parsed = new URL(remoteRepositoryUrl);
+    return [parsed.username, parsed.password]
+        .filter((value) => value !== '')
+        .map((value) => decodeURIComponent(value));
 };
 
 const isContainedRelativePath = (value: string): boolean => {
@@ -324,6 +335,10 @@ export class DbtGitProjectAdapter
 
     private readonly cacheIdentity: DbtGitCacheIdentity | undefined;
 
+    private readonly credential:
+        | { token: string; installationId?: string }
+        | undefined;
+
     private readonly temporaryRepositoryDirectories = new Set<string>();
 
     private cacheLease: DbtGitCacheLease | undefined;
@@ -356,11 +371,35 @@ export class DbtGitProjectAdapter
         gitConfigGlobalPath,
         dbtDepsErrorHint,
         cacheIdentity,
+        credential,
     }: DbtGitProjectAdapterArgs) {
+        if (gitBranch.startsWith('-')) {
+            throw new UnexpectedGitError(
+                'Git branch names must not begin with an option prefix',
+            );
+        }
         const cleanRemoteRepositoryUrl = withoutCredentials(
             remoteRepositoryUrl,
             repository,
         );
+        let credentialMatchesUrl = true;
+        if (credential) {
+            try {
+                const urlCredentials =
+                    decodedUrlCredentials(remoteRepositoryUrl);
+                credentialMatchesUrl =
+                    credential.token === ''
+                        ? urlCredentials.length === 0
+                        : urlCredentials.includes(credential.token);
+            } catch {
+                credentialMatchesUrl = false;
+            }
+            if (!credentialMatchesUrl) {
+                Logger.warn(
+                    'Git credential URL validation failed; checkout cache disabled',
+                );
+            }
+        }
         const localRepositoryDir = fs.mkdtempSync(
             path.join(os.tmpdir(), 'git_'),
         );
@@ -386,11 +425,14 @@ export class DbtGitProjectAdapter
         this.localRepositoryDir = localRepositoryDir;
         this.temporaryRepositoryDirectories.add(localRepositoryDir);
         this.remoteRepositoryUrl = remoteRepositoryUrl;
+        this.credential = credential;
         this.cleanRemoteRepositoryUrl = cleanRemoteRepositoryUrl;
         this.branch = gitBranch;
         this.repository = repository;
         this.cacheIdentity =
-            cacheIdentity && isContainedRelativePath(projectDirectorySubPath)
+            credentialMatchesUrl &&
+            cacheIdentity &&
+            isContainedRelativePath(projectDirectorySubPath)
                 ? cacheIdentity
                 : undefined;
         const parsedRemote = new URL(this.cleanRemoteRepositoryUrl);
@@ -580,20 +622,48 @@ export class DbtGitProjectAdapter
             });
             delete effectiveEnvironment.DBT_TARGET_PATH;
             delete effectiveEnvironment.GIT_CONFIG_GLOBAL;
-            const credentialHash = createHash('sha256')
-                .update(this.remoteRepositoryUrl)
+            const parsedRemote = new URL(this.remoteRepositoryUrl);
+            const parsedUsername = parsedRemote.username
+                ? decodeURIComponent(parsedRemote.username)
+                : '';
+            const explicitCredentialIdentity = this.credential
+                ? {
+                      scheme: parsedRemote.protocol,
+                      host: parsedRemote.host,
+                      username:
+                          parsedUsername === this.credential.token
+                              ? ''
+                              : parsedUsername,
+                      installationId: this.credential.installationId ?? null,
+                      tokenHash:
+                          this.credential.token &&
+                          !this.credential.installationId
+                              ? createHash('sha256')
+                                    .update(this.credential.token)
+                                    .digest('hex')
+                              : null,
+                  }
+                : undefined;
+            const credentialHashBuilder = createHash('sha256')
                 .update(
-                    await directoryContentDigest(client.dbtProfilesDirectory),
+                    explicitCredentialIdentity
+                        ? JSON.stringify(explicitCredentialIdentity)
+                        : this.remoteRepositoryUrl,
                 )
                 .update(
+                    await directoryContentDigest(client.dbtProfilesDirectory),
+                );
+            if (!explicitCredentialIdentity) {
+                credentialHashBuilder.update(
                     client.gitConfigGlobalPath
                         ? await directoryContentDigest(
                               path.dirname(client.gitConfigGlobalPath),
                               true,
                           )
                         : '',
-                )
-                .digest('hex');
+                );
+            }
+            const credentialHash = credentialHashBuilder.digest('hex');
             const inputs = {
                 files: files.map((file, index) => ({
                     name: PACKAGE_CONFIG_FILES[index],

--- a/packages/backend/src/projectAdapters/dbtGitProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectAdapter.ts
@@ -33,6 +33,7 @@ import {
     releaseDbtGitProjectCache,
 } from './dbtGitProjectCache';
 import { inspectDbtGitProject } from './dbtGitProjectInspection';
+import * as dbtGitVersion from './dbtGitVersion';
 import { DbtLocalCredentialsProjectAdapter } from './dbtLocalCredentialsProjectAdapter';
 import { gitErrorHandler } from './gitRepository';
 
@@ -998,23 +999,29 @@ export class DbtGitProjectAdapter
             this.cacheIdentity &&
             this.cacheContext?.projectType !== ProjectType.PREVIEW
         ) {
-            try {
-                this.cacheLease = await acquireDbtGitProjectCache(
-                    this.cacheIdentity,
-                    this.repositoryIdentity,
-                    (reason) => {
-                        this.cacheOutcome.missReason = reason;
-                    },
-                );
-                if (this.cacheLease && !this.cacheLease.reused) {
-                    this.cacheOutcome.missReason = 'cold';
+            const gitVersionSupport =
+                await dbtGitVersion.getDbtGitVersionSupport();
+            if (!gitVersionSupport.supported) {
+                this.cacheOutcome.missReason = gitVersionSupport.reason;
+            } else {
+                try {
+                    this.cacheLease = await acquireDbtGitProjectCache(
+                        this.cacheIdentity,
+                        this.repositoryIdentity,
+                        (reason) => {
+                            this.cacheOutcome.missReason = reason;
+                        },
+                    );
+                    if (this.cacheLease && !this.cacheLease.reused) {
+                        this.cacheOutcome.missReason = 'cold';
+                    }
+                } catch (error) {
+                    this.cacheOutcome.missReason = 'acquire-error';
+                    this.warnSwallowedError(
+                        'Failed to acquire dbt Git checkout cache',
+                        error,
+                    );
                 }
-            } catch (error) {
-                this.cacheOutcome.missReason = 'acquire-error';
-                this.warnSwallowedError(
-                    'Failed to acquire dbt Git checkout cache',
-                    error,
-                );
             }
         }
         if (this.cacheLease) {

--- a/packages/backend/src/projectAdapters/dbtGitProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectAdapter.ts
@@ -2,6 +2,7 @@ import {
     CreateWarehouseCredentials,
     DbtProjectEnvironmentVariable,
     getErrorMessage,
+    ProjectType,
     SupportedDbtVersions,
     UnexpectedGitError,
 } from '@lightdash/common';
@@ -52,10 +53,16 @@ export type DbtGitProjectAdapterArgs = {
     gitConfigGlobalPath?: string;
     dbtDepsErrorHint?: string;
     cacheIdentity?: DbtGitCacheIdentity;
+    cacheContext?: DbtGitCacheContext;
     credential?: {
         token: string;
         installationId?: string;
     };
+};
+
+export type DbtGitCacheContext = {
+    projectType?: ProjectType;
+    jobUuid?: string;
 };
 
 export type DbtGitFetchMetrics = {
@@ -66,6 +73,11 @@ export type DbtGitFetchMetrics = {
 };
 
 export type DbtGitCacheOutcome = {
+    projectUuid: string | null;
+    sourceUuid: string | null;
+    sourceType: DbtGitCacheIdentity['sourceType'] | null;
+    projectType: ProjectType | null;
+    jobUuid: string | null;
     cloneMode: 'fresh' | 'reused';
     depsMode: 'fresh' | 'reused';
     missReason: string | null;
@@ -300,6 +312,8 @@ export class DbtGitProjectAdapter
 
     private readonly cacheIdentity: DbtGitCacheIdentity | undefined;
 
+    private readonly cacheContext: DbtGitCacheContext | undefined;
+
     private readonly credential:
         | { token: string; installationId?: string }
         | undefined;
@@ -317,6 +331,11 @@ export class DbtGitProjectAdapter
     private readonly sensitiveValues: string[];
 
     private cacheOutcome: DbtGitCacheOutcome = {
+        projectUuid: null,
+        sourceUuid: null,
+        sourceType: null,
+        projectType: null,
+        jobUuid: null,
         cloneMode: 'fresh',
         depsMode: 'fresh',
         missReason: null,
@@ -356,6 +375,7 @@ export class DbtGitProjectAdapter
         gitConfigGlobalPath,
         dbtDepsErrorHint,
         cacheIdentity,
+        cacheContext,
         credential,
     }: DbtGitProjectAdapterArgs) {
         assertValidGitBranch(gitBranch);
@@ -425,7 +445,15 @@ export class DbtGitProjectAdapter
             isContainedRelativePath(projectDirectorySubPath)
                 ? cacheIdentity
                 : undefined;
-        if (!credentialMatchesUrl) {
+        this.cacheContext = cacheContext;
+        this.cacheOutcome.projectUuid = cacheIdentity?.projectUuid ?? null;
+        this.cacheOutcome.sourceUuid = cacheIdentity?.sourceUuid ?? null;
+        this.cacheOutcome.sourceType = cacheIdentity?.sourceType ?? null;
+        this.cacheOutcome.projectType = cacheContext?.projectType ?? null;
+        this.cacheOutcome.jobUuid = cacheContext?.jobUuid ?? null;
+        if (cacheContext?.projectType === ProjectType.PREVIEW) {
+            this.cacheOutcome.missReason = 'preview-project';
+        } else if (!credentialMatchesUrl) {
             this.cacheOutcome.missReason = 'credential-url-mismatch';
         } else if (!cacheIdentity) {
             this.cacheOutcome.missReason = 'cache-identity-unavailable';
@@ -966,7 +994,10 @@ export class DbtGitProjectAdapter
         if (this.refreshed) return;
         this.refreshAttempted = true;
         const initialDirectory = this.localRepositoryDir;
-        if (this.cacheIdentity) {
+        if (
+            this.cacheIdentity &&
+            this.cacheContext?.projectType !== ProjectType.PREVIEW
+        ) {
             try {
                 this.cacheLease = await acquireDbtGitProjectCache(
                     this.cacheIdentity,

--- a/packages/backend/src/projectAdapters/dbtGitProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectAdapter.ts
@@ -2,6 +2,7 @@ import {
     CreateWarehouseCredentials,
     DbtProjectEnvironmentVariable,
     SupportedDbtVersions,
+    UnexpectedGitError,
 } from '@lightdash/common';
 import { WarehouseClient } from '@lightdash/warehouses';
 import { createHash } from 'crypto';
@@ -77,6 +78,7 @@ type DependencyMarker = {
 };
 
 const DEPENDENCY_MARKER_VERSION = 1;
+const CACHE_FETCH_REF = 'refs/lightdash/cache';
 const PACKAGE_CONFIG_FILES = [
     'packages.yml',
     'dependencies.yml',
@@ -84,6 +86,13 @@ const PACKAGE_CONFIG_FILES = [
     'dbt_project.yml',
 ] as const;
 
+export const assertValidGitBranch = (branch: string): void => {
+    if (branch.startsWith('-')) {
+        throw new UnexpectedGitError(
+            'Git branch names must not begin with an option prefix',
+        );
+    }
+};
 const withoutCredentials = (
     remoteRepositoryUrl: string,
     repository: string,
@@ -382,11 +391,7 @@ export class DbtGitProjectAdapter
         cacheIdentity,
         credential,
     }: DbtGitProjectAdapterArgs) {
-        if (gitBranch.startsWith('-')) {
-            throw new UnexpectedGitError(
-                'Git branch names must not begin with an option prefix',
-            );
-        }
+        assertValidGitBranch(gitBranch);
         const cleanRemoteRepositoryUrl = withoutCredentials(
             remoteRepositoryUrl,
             repository,
@@ -855,21 +860,26 @@ export class DbtGitProjectAdapter
 
     private async reuseCheckout() {
         const startedAt = Date.now();
-        await this.git()
-            .cwd(this.localRepositoryDir)
-            .fetch(this.cleanRemoteRepositoryUrl, this.branch, {
-                '--depth': 1,
-                '--no-tags': null,
-                '--progress': null,
-            });
-        await this.git()
-            .cwd(this.localRepositoryDir)
-            .reset(['--hard', 'FETCH_HEAD']);
-        await this.cleanReusedCheckout();
         await fspromises.rm(
             path.join(this.localRepositoryDir, '.git', 'FETCH_HEAD'),
             { force: true },
         );
+        await this.git()
+            .cwd(this.localRepositoryDir)
+            .fetch(
+                this.cleanRemoteRepositoryUrl,
+                `+${this.branch}:${CACHE_FETCH_REF}`,
+                {
+                    '--depth': 1,
+                    '--no-tags': null,
+                    '--no-write-fetch-head': null,
+                    '--progress': null,
+                },
+            );
+        await this.git()
+            .cwd(this.localRepositoryDir)
+            .reset(['--hard', CACHE_FETCH_REF]);
+        await this.cleanReusedCheckout();
         await fspromises.rm(
             path.join(this.localRepositoryDir, '.git', 'logs'),
             { recursive: true, force: true },

--- a/packages/backend/src/projectAdapters/dbtGitProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectAdapter.ts
@@ -155,6 +155,15 @@ const containsUnsafeDependency = (value: unknown): boolean => {
     );
 };
 
+const literalGitCleanExclusion = (
+    relativePath: string,
+    directory: boolean,
+): string => {
+    const normalizedPath = relativePath.split(path.sep).join('/');
+    const escapedPath = normalizedPath.replace(/[\\*?[\]!# ]/g, '\\$&');
+    return `/${escapedPath}${directory ? '/' : ''}`;
+};
+
 const FILESYSTEM_BATCH_SIZE = 32;
 
 const directorySize = async (directory: string): Promise<number> => {
@@ -537,8 +546,7 @@ export class DbtGitProjectAdapter
                 : null;
             if (
                 containsUnsafeDependency(parsedPackages) ||
-                containsUnsafeDependency(parsedDependencies) ||
-                containsUnsafeDependency(parsedProject)
+                containsUnsafeDependency(parsedDependencies)
             ) {
                 throw new Error('Dynamic or local package configuration');
             }
@@ -555,7 +563,8 @@ export class DbtGitProjectAdapter
                 installPath === '.' ||
                 !isContainedRelativePath(installPath) ||
                 installPath.includes('{{') ||
-                installPath.includes('{%')
+                installPath.includes('{%') ||
+                /[*?[\]]/.test(installPath)
             ) {
                 throw new Error('Unsafe package install path');
             }
@@ -791,13 +800,22 @@ export class DbtGitProjectAdapter
         const exclusions =
             marker?.inputHash === layout.inputHash
                 ? [
-                      path.relative(
-                          this.localRepositoryDir,
-                          layout.installDirectory,
+                      literalGitCleanExclusion(
+                          path.relative(
+                              this.localRepositoryDir,
+                              layout.installDirectory,
+                          ),
+                          true,
                       ),
-                      path.relative(
-                          this.localRepositoryDir,
-                          path.join(this.dbtProjectDir!, 'package-lock.yml'),
+                      literalGitCleanExclusion(
+                          path.relative(
+                              this.localRepositoryDir,
+                              path.join(
+                                  this.dbtProjectDir!,
+                                  'package-lock.yml',
+                              ),
+                          ),
+                          false,
                       ),
                   ]
                 : [];

--- a/packages/backend/src/projectAdapters/dbtGitProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectAdapter.ts
@@ -2,14 +2,18 @@ import {
     CreateWarehouseCredentials,
     DbtProjectEnvironmentVariable,
     SupportedDbtVersions,
-    UnexpectedServerError,
 } from '@lightdash/common';
 import { WarehouseClient } from '@lightdash/warehouses';
+import { createHash } from 'crypto';
 import fs from 'fs';
-import * as fspromises from 'fs-extra';
+import * as fspromises from 'fs/promises';
+import * as yaml from 'js-yaml';
+import os from 'os';
 import * as path from 'path';
-import simpleGit, { SimpleGit, SimpleGitProgressEvent } from 'simple-git';
+import simpleGit, { SimpleGitProgressEvent } from 'simple-git';
 import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
+import { DbtCliClient } from '../dbt/dbtCliClient';
+import { getDbtProcessEnvironment } from '../dbt/dbtProcessEnvironment';
 import Logger from '../logging/logger';
 import {
     CachedWarehouse,
@@ -17,8 +21,15 @@ import {
     type ExploreCompileOptions,
     type TrackingParams,
 } from '../types';
+import {
+    acquireDbtGitProjectCache,
+    DbtGitCacheIdentity,
+    DbtGitCacheLease,
+    invalidateOwnedDbtGitCacheLease,
+    releaseDbtGitProjectCache,
+} from './dbtGitProjectCache';
 import { DbtLocalCredentialsProjectAdapter } from './dbtLocalCredentialsProjectAdapter';
-import { GitRepository } from './gitRepository';
+import { gitErrorHandler } from './gitRepository';
 
 export type DbtGitProjectAdapterArgs = {
     warehouseClient: WarehouseClient;
@@ -36,8 +47,263 @@ export type DbtGitProjectAdapterArgs = {
     analytics?: LightdashAnalytics;
     gitConfigGlobalPath?: string;
     dbtDepsErrorHint?: string;
+    cacheIdentity?: DbtGitCacheIdentity;
 };
 
+export type DbtGitFetchMetrics = {
+    cloneMode: 'fresh' | 'reused';
+    depsMode: 'fresh' | 'reused';
+    cloneDurationMs: number;
+    depsDurationMs: number;
+};
+
+type DependencyLayout = {
+    eligible: boolean;
+    installDirectory: string;
+    hasDeclaredPackages: boolean;
+    hash: string;
+    inputHash: string;
+};
+
+type DependencyMarker = {
+    version: number;
+    hash: string;
+    hasDeclaredPackages: boolean;
+    inputHash: string;
+};
+
+const DEPENDENCY_MARKER_VERSION = 1;
+const PACKAGE_CONFIG_FILES = [
+    'packages.yml',
+    'dependencies.yml',
+    'package-lock.yml',
+    'dbt_project.yml',
+] as const;
+
+const withoutCredentials = (
+    remoteRepositoryUrl: string,
+    repository: string,
+): string => {
+    try {
+        const parsed = new URL(remoteRepositoryUrl);
+        if (
+            !['http:', 'https:', 'file:'].includes(parsed.protocol) ||
+            parsed.search ||
+            parsed.hash ||
+            (parsed.protocol === 'file:' &&
+                (parsed.username || parsed.password))
+        ) {
+            throw new Error('Unsupported Git repository protocol');
+        }
+        parsed.username = '';
+        parsed.password = '';
+        return parsed.href;
+    } catch (error) {
+        return gitErrorHandler(error, repository);
+    }
+};
+
+const isContainedRelativePath = (value: string): boolean => {
+    if (path.isAbsolute(value)) return false;
+    const resolved = path.resolve('/cache-root', value || '.');
+    return resolved === '/cache-root' || resolved.startsWith('/cache-root/');
+};
+
+const readRegularFile = async (
+    filePath: string,
+): Promise<{ safe: boolean; content: string | null }> => {
+    try {
+        const stat = await fspromises.lstat(filePath);
+        if (!stat.isFile() || stat.isSymbolicLink()) {
+            return { safe: false, content: null };
+        }
+        return {
+            safe: true,
+            content: await fspromises.readFile(filePath, 'utf8'),
+        };
+    } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+            return { safe: true, content: null };
+        }
+        return { safe: false, content: null };
+    }
+};
+
+const containsUnsafeDependency = (value: unknown): boolean => {
+    if (Array.isArray(value)) return value.some(containsUnsafeDependency);
+    if (value && typeof value === 'object') {
+        return Object.entries(value as Record<string, unknown>).some(
+            ([key, child]) =>
+                ['local', 'path'].includes(key.toLowerCase()) ||
+                containsUnsafeDependency(child),
+        );
+    }
+    return (
+        typeof value === 'string' &&
+        (value.includes('{{') || value.includes('{%'))
+    );
+};
+
+const FILESYSTEM_BATCH_SIZE = 32;
+
+const directorySize = async (directory: string): Promise<number> => {
+    let total = 0;
+    const pending = [directory];
+    const processBatch = async (): Promise<void> => {
+        const batch = pending.splice(0, FILESYSTEM_BATCH_SIZE);
+        if (batch.length === 0) return;
+        const results = await Promise.all(
+            batch.map(async (candidate) => {
+                const stat = await fspromises.lstat(candidate);
+                const children =
+                    stat.isDirectory() && !stat.isSymbolicLink()
+                        ? await fspromises.readdir(candidate)
+                        : [];
+                return { candidate, children, size: stat.size };
+            }),
+        );
+        results.forEach(({ candidate, children, size }) => {
+            total += size;
+            pending.push(
+                ...children.map((child) => path.join(candidate, child)),
+            );
+        });
+        await processBatch();
+    };
+    await processBatch();
+    return total;
+};
+
+const gitMetadataContainsCredentials = async (
+    root: string,
+): Promise<boolean> => {
+    const found: string[] = [];
+    const pending = [{ directory: root, gitMetadata: false }];
+    const scanBatch = async (): Promise<void> => {
+        const batch = pending.splice(0, FILESYSTEM_BATCH_SIZE);
+        if (batch.length === 0) return;
+        const results = await Promise.all(
+            batch.map(async (item) => ({
+                ...item,
+                entries: await fspromises.readdir(item.directory, {
+                    withFileTypes: true,
+                }),
+            })),
+        );
+        results.forEach(({ directory, entries, gitMetadata }) => {
+            entries.forEach((entry) => {
+                const candidate = path.join(directory, entry.name);
+                if (gitMetadata) {
+                    if (entry.name !== 'objects' && entry.name !== 'index') {
+                        if (entry.isDirectory()) {
+                            pending.push({
+                                directory: candidate,
+                                gitMetadata: true,
+                            });
+                        } else if (entry.isFile()) {
+                            found.push(candidate);
+                        } else {
+                            throw new Error('Unsupported Git metadata');
+                        }
+                    }
+                } else if (entry.name === '.git') {
+                    if (entry.isDirectory() && !entry.isSymbolicLink()) {
+                        pending.push({
+                            directory: candidate,
+                            gitMetadata: true,
+                        });
+                    } else {
+                        throw new Error('Git indirection is not cacheable');
+                    }
+                } else if (entry.isDirectory() && !entry.isSymbolicLink()) {
+                    pending.push({
+                        directory: candidate,
+                        gitMetadata: false,
+                    });
+                }
+            });
+        });
+        await scanBatch();
+    };
+    await scanBatch();
+    const remaining = [...found];
+    const inspectBatch = async (): Promise<boolean> => {
+        const batch = remaining.splice(0, FILESYSTEM_BATCH_SIZE);
+        if (batch.length === 0) return false;
+        const matches = await Promise.all(
+            batch.map(async (file) => {
+                const stat = await fspromises.lstat(file);
+                if (stat.size > 1024 * 1024) return true;
+                const content = await fspromises.readFile(file, 'utf8');
+                return /https?:\/\/[^\s/@]+(?::[^\s/@]*)?@/i.test(content);
+            }),
+        );
+        return matches.some(Boolean) || inspectBatch();
+    };
+    return inspectBatch();
+};
+
+const directoryContentDigest = async (
+    directory: string,
+    normalizeDirectoryPath = false,
+): Promise<string> => {
+    const hash = createHash('sha256');
+    const pending = [directory];
+    const files: Array<{ path?: string; relative: string }> = [];
+    const scanBatch = async (): Promise<void> => {
+        const batch = pending.splice(0, FILESYSTEM_BATCH_SIZE);
+        if (batch.length === 0) return;
+        const results = await Promise.all(
+            batch.map(async (current) => ({
+                current,
+                entries: await fspromises.readdir(current, {
+                    withFileTypes: true,
+                }),
+            })),
+        );
+        results.forEach(({ current, entries }) => {
+            entries.forEach((entry) => {
+                const candidate = path.join(current, entry.name);
+                const relative = path.relative(directory, candidate);
+                if (entry.isDirectory()) {
+                    pending.push(candidate);
+                } else if (entry.isFile()) {
+                    files.push({ path: candidate, relative });
+                } else {
+                    files.push({ relative: `${relative}:unsupported` });
+                }
+            });
+        });
+        await scanBatch();
+    };
+    await scanBatch();
+    files.sort((left, right) => left.relative.localeCompare(right.relative));
+    const digestBatch = async (offset: number): Promise<void> => {
+        const batch = files.slice(offset, offset + FILESYSTEM_BATCH_SIZE);
+        if (batch.length === 0) return;
+        const contents = await Promise.all(
+            batch.map(({ path: filePath }) =>
+                filePath ? fspromises.readFile(filePath) : undefined,
+            ),
+        );
+        batch.forEach(({ relative }, index) => {
+            hash.update(relative);
+            if (contents[index]) {
+                hash.update(
+                    normalizeDirectoryPath
+                        ? contents[index]!.toString('utf8').replaceAll(
+                              directory,
+                              '__temporary_directory__',
+                          )
+                        : contents[index]!,
+                );
+            }
+        });
+        await digestBatch(offset + FILESYSTEM_BATCH_SIZE);
+    };
+    await digestBatch(0);
+    return hash.digest('hex');
+};
 export class DbtGitProjectAdapter
     extends DbtLocalCredentialsProjectAdapter
     implements ProjectAdapter
@@ -52,7 +318,26 @@ export class DbtGitProjectAdapter
 
     branch: string;
 
-    git: SimpleGit;
+    private readonly cleanRemoteRepositoryUrl: string;
+
+    private readonly repositoryIdentity: string;
+
+    private readonly cacheIdentity: DbtGitCacheIdentity | undefined;
+
+    private readonly temporaryRepositoryDirectories = new Set<string>();
+
+    private cacheLease: DbtGitCacheLease | undefined;
+
+    private refreshed = false;
+
+    private retainCheckout = true;
+
+    private fetchMetrics: DbtGitFetchMetrics = {
+        cloneMode: 'fresh',
+        depsMode: 'fresh',
+        cloneDurationMs: 0,
+        depsDurationMs: 0,
+    };
 
     constructor({
         warehouseClient,
@@ -70,8 +355,15 @@ export class DbtGitProjectAdapter
         analytics,
         gitConfigGlobalPath,
         dbtDepsErrorHint,
+        cacheIdentity,
     }: DbtGitProjectAdapterArgs) {
-        const localRepositoryDir = fs.mkdtempSync('/tmp/git_');
+        const cleanRemoteRepositoryUrl = withoutCredentials(
+            remoteRepositoryUrl,
+            repository,
+        );
+        const localRepositoryDir = fs.mkdtempSync(
+            path.join(os.tmpdir(), 'git_'),
+        );
         const projectDir = path.join(
             localRepositoryDir,
             projectDirectorySubPath,
@@ -92,46 +384,524 @@ export class DbtGitProjectAdapter
         });
         this.projectDirectorySubPath = projectDirectorySubPath;
         this.localRepositoryDir = localRepositoryDir;
+        this.temporaryRepositoryDirectories.add(localRepositoryDir);
         this.remoteRepositoryUrl = remoteRepositoryUrl;
+        this.cleanRemoteRepositoryUrl = cleanRemoteRepositoryUrl;
         this.branch = gitBranch;
         this.repository = repository;
-        this.git = simpleGit({
+        this.cacheIdentity =
+            cacheIdentity && isContainedRelativePath(projectDirectorySubPath)
+                ? cacheIdentity
+                : undefined;
+        const parsedRemote = new URL(this.cleanRemoteRepositoryUrl);
+        this.repositoryIdentity = JSON.stringify({
+            authority: parsedRemote.host,
+            path: parsedRemote.pathname,
+            branch: gitBranch,
+            projectSubPath: path.normalize(projectDirectorySubPath || '.'),
+        });
+        const installDeps = this.dbtClient.installDeps?.bind(this.dbtClient);
+        if (installDeps) {
+            this.dbtClient.installDeps = () =>
+                this.installDepsWithCache(installDeps);
+        }
+    }
+
+    getFetchMetrics(): DbtGitFetchMetrics {
+        return { ...this.fetchMetrics };
+    }
+
+    private git() {
+        const authenticationEnvironment =
+            this.remoteRepositoryUrl === this.cleanRemoteRepositoryUrl
+                ? { GIT_CONFIG_COUNT: '0' }
+                : {
+                      GIT_CONFIG_COUNT: '1',
+                      GIT_CONFIG_KEY_0: `url.${this.remoteRepositoryUrl}.insteadOf`,
+                      GIT_CONFIG_VALUE_0: this.cleanRemoteRepositoryUrl,
+                  };
+        return simpleGit({
+            unsafe: { allowUnsafeConfigEnvCount: true },
             progress({ method, stage, progress }: SimpleGitProgressEvent) {
                 Logger.debug(
                     `git.${method} ${stage} stage ${progress}% complete`,
                 );
             },
+        }).env({
+            GIT_TERMINAL_PROMPT: '0',
+            ...authenticationEnvironment,
         });
     }
 
-    async destroy(): Promise<void> {
-        Logger.debug(`Destroy git project adapter`);
-        await this._destroyLocal();
-        await super.destroy();
+    private setRepositoryDirectory(directory: string) {
+        this.localRepositoryDir = directory;
+        this.dbtProjectDir = path.join(directory, this.projectDirectorySubPath);
+        (this.dbtClient as DbtCliClient).dbtProjectDirectory =
+            this.dbtProjectDir;
     }
 
-    private async _destroyLocal() {
+    private async removeTemporaryRepositoryDirectory(directory: string) {
+        await fspromises.rm(directory, {
+            recursive: true,
+            force: true,
+        });
+        this.temporaryRepositoryDirectories.delete(directory);
+    }
+
+    private async dependencyLayout(): Promise<DependencyLayout> {
+        if (!this.dbtProjectDir) {
+            return {
+                eligible: false,
+                installDirectory: '',
+                hasDeclaredPackages: false,
+                hash: '',
+                inputHash: '',
+            };
+        }
         try {
-            Logger.debug(`Destroy ${this.localRepositoryDir}`);
-            await fspromises.rm(this.localRepositoryDir, {
-                recursive: true,
-                force: true,
-            });
-        } catch (e) {
-            throw new UnexpectedServerError(
-                `Unexpected error while removing local git directory: ${e}`,
+            const repositoryRealPath = await fspromises.realpath(
+                this.localRepositoryDir,
             );
+            const projectRealPath = await fspromises.realpath(
+                this.dbtProjectDir,
+            );
+            const relativeProject = path.relative(
+                repositoryRealPath,
+                projectRealPath,
+            );
+            if (
+                relativeProject.startsWith('..') ||
+                path.isAbsolute(relativeProject)
+            ) {
+                throw new Error('Project path escapes checkout');
+            }
+            const files = await Promise.all(
+                PACKAGE_CONFIG_FILES.map((name) =>
+                    readRegularFile(path.join(projectRealPath, name)),
+                ),
+            );
+            if (files.some((file) => !file.safe)) {
+                throw new Error('Unsafe package configuration path');
+            }
+            const [packagesFile, dependenciesFile, , projectFile] = files;
+            const parsedPackages = packagesFile.content
+                ? yaml.load(packagesFile.content)
+                : null;
+            const parsedDependencies = dependenciesFile.content
+                ? yaml.load(dependenciesFile.content)
+                : null;
+            const parsedProject = projectFile.content
+                ? yaml.load(projectFile.content)
+                : null;
+            if (
+                containsUnsafeDependency(parsedPackages) ||
+                containsUnsafeDependency(parsedDependencies) ||
+                containsUnsafeDependency(parsedProject)
+            ) {
+                throw new Error('Dynamic or local package configuration');
+            }
+            const configuredInstallPath =
+                parsedProject && typeof parsedProject === 'object'
+                    ? (parsedProject as Record<string, unknown>)[
+                          'packages-install-path'
+                      ]
+                    : undefined;
+            const installPath = configuredInstallPath ?? 'dbt_packages';
+            if (
+                typeof installPath !== 'string' ||
+                installPath.trim() === '' ||
+                installPath === '.' ||
+                !isContainedRelativePath(installPath) ||
+                installPath.includes('{{') ||
+                installPath.includes('{%')
+            ) {
+                throw new Error('Unsafe package install path');
+            }
+            const installDirectory = path.resolve(projectRealPath, installPath);
+            const relativeInstall = path.relative(
+                projectRealPath,
+                installDirectory,
+            );
+            if (
+                relativeInstall === '' ||
+                relativeInstall.startsWith('..') ||
+                path.isAbsolute(relativeInstall)
+            ) {
+                throw new Error('Package path escapes project');
+            }
+            const installStat = await fspromises
+                .lstat(installDirectory)
+                .catch((error) => {
+                    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+                        return undefined;
+                    }
+                    throw error;
+                });
+            if (
+                installStat &&
+                (!installStat.isDirectory() || installStat.isSymbolicLink())
+            ) {
+                throw new Error('Unsafe package install directory');
+            }
+            if (installStat) {
+                const realInstall = await fspromises.realpath(installDirectory);
+                const realInstallRelative = path.relative(
+                    projectRealPath,
+                    realInstall,
+                );
+                if (
+                    realInstallRelative === '' ||
+                    realInstallRelative.startsWith('..') ||
+                    path.isAbsolute(realInstallRelative)
+                ) {
+                    throw new Error(
+                        'Package install directory escapes project',
+                    );
+                }
+            }
+            const hasDeclaredPackages = [
+                parsedPackages,
+                parsedDependencies,
+            ].some(
+                (value) =>
+                    value !== null &&
+                    value !== undefined &&
+                    (typeof value !== 'object' ||
+                        Object.keys(value as object).length > 0),
+            );
+            const client = this.dbtClient as DbtCliClient;
+            const effectiveEnvironment = getDbtProcessEnvironment({
+                processEnvironment: process.env,
+                environmentVariableAllowlist:
+                    client.environmentVariableAllowlist,
+                projectEnvironment: client.environment,
+                targetPath: '__excluded_target_path__',
+                gitConfigGlobalPath: client.gitConfigGlobalPath,
+            });
+            delete effectiveEnvironment.DBT_TARGET_PATH;
+            delete effectiveEnvironment.GIT_CONFIG_GLOBAL;
+            const credentialHash = createHash('sha256')
+                .update(this.remoteRepositoryUrl)
+                .update(
+                    await directoryContentDigest(client.dbtProfilesDirectory),
+                )
+                .update(
+                    client.gitConfigGlobalPath
+                        ? await directoryContentDigest(
+                              path.dirname(client.gitConfigGlobalPath),
+                              true,
+                          )
+                        : '',
+                )
+                .digest('hex');
+            const inputs = {
+                files: files.map((file, index) => ({
+                    name: PACKAGE_CONFIG_FILES[index],
+                    content: file.content,
+                })),
+                dbtVersion: client.dbtVersion,
+                target: client.target ?? null,
+                profileName: client.profileName ?? null,
+                installPath,
+                environment: Object.entries(effectiveEnvironment).sort(
+                    ([left], [right]) => left.localeCompare(right),
+                ),
+                credentialHash,
+            };
+            const hash = createHash('sha256')
+                .update(JSON.stringify(inputs))
+                .digest('hex');
+            const inputHash = createHash('sha256')
+                .update(
+                    JSON.stringify({
+                        ...inputs,
+                        files: inputs.files.filter(
+                            ({ name }) => name !== 'package-lock.yml',
+                        ),
+                    }),
+                )
+                .digest('hex');
+            return {
+                eligible: true,
+                installDirectory,
+                hasDeclaredPackages,
+                hash,
+                inputHash,
+            };
+        } catch {
+            return {
+                eligible: false,
+                installDirectory: '',
+                hasDeclaredPackages: false,
+                hash: '',
+                inputHash: '',
+            };
         }
     }
 
-    private async _refreshRepo() {
-        await new GitRepository(
-            this.git,
-            this.localRepositoryDir,
-            this.remoteRepositoryUrl,
-            this.repository,
-            this.branch,
-        ).refresh();
+    private async installDepsWithCache(installDeps: () => Promise<void>) {
+        const startedAt = Date.now();
+        const before = await this.dependencyLayout();
+        if (this.cacheLease?.reused && before.eligible) {
+            const marker = await fspromises
+                .readFile(this.cacheLease.depsMarkerPath, 'utf8')
+                .then((value) => JSON.parse(value) as DependencyMarker)
+                .catch(() => undefined);
+            const packageDirectoryExists = before.hasDeclaredPackages
+                ? await fspromises
+                      .lstat(before.installDirectory)
+                      .then(
+                          (stat) =>
+                              stat.isDirectory() && !stat.isSymbolicLink(),
+                      )
+                      .catch(() => false)
+                : true;
+            if (
+                marker?.version === DEPENDENCY_MARKER_VERSION &&
+                marker.hash === before.hash &&
+                marker.inputHash === before.inputHash &&
+                marker.hasDeclaredPackages === before.hasDeclaredPackages &&
+                packageDirectoryExists
+            ) {
+                this.fetchMetrics.depsMode = 'reused';
+                this.fetchMetrics.depsDurationMs = Date.now() - startedAt;
+                return;
+            }
+        }
+        if (this.cacheLease) {
+            await fspromises
+                .rm(this.cacheLease.depsMarkerPath, { force: true })
+                .catch(() => {
+                    this.retainCheckout = false;
+                });
+        }
+        try {
+            await installDeps();
+        } finally {
+            this.fetchMetrics.depsDurationMs = Date.now() - startedAt;
+        }
+        this.fetchMetrics.depsMode = 'fresh';
+        const after = await this.dependencyLayout();
+        if (this.cacheLease && after.eligible) {
+            try {
+                const temporaryPath = `${this.cacheLease.depsMarkerPath}.tmp`;
+                await fspromises.writeFile(
+                    temporaryPath,
+                    JSON.stringify({
+                        version: DEPENDENCY_MARKER_VERSION,
+                        hash: after.hash,
+                        hasDeclaredPackages: after.hasDeclaredPackages,
+                        inputHash: after.inputHash,
+                    } satisfies DependencyMarker),
+                    { mode: 0o600 },
+                );
+                await fspromises.rename(
+                    temporaryPath,
+                    this.cacheLease.depsMarkerPath,
+                );
+            } catch {
+                this.retainCheckout = false;
+            }
+        } else if (!after.eligible) {
+            this.retainCheckout = false;
+        }
+    }
+
+    private async cleanReusedCheckout() {
+        const layout = await this.dependencyLayout();
+        if (!layout.eligible) {
+            throw new Error('Unsafe cached dependency layout');
+        }
+        const marker = this.cacheLease
+            ? await fspromises
+                  .readFile(this.cacheLease.depsMarkerPath, 'utf8')
+                  .then((value) => JSON.parse(value) as DependencyMarker)
+                  .catch(() => undefined)
+            : undefined;
+        const exclusions =
+            marker?.inputHash === layout.inputHash
+                ? [
+                      path.relative(
+                          this.localRepositoryDir,
+                          layout.installDirectory,
+                      ),
+                      path.relative(
+                          this.localRepositoryDir,
+                          path.join(this.dbtProjectDir!, 'package-lock.yml'),
+                      ),
+                  ]
+                : [];
+        await this.git()
+            .cwd(this.localRepositoryDir)
+            .raw([
+                'clean',
+                '-ffdx',
+                ...exclusions.flatMap((value) => ['-e', value]),
+            ]);
+    }
+
+    private async cloneFresh() {
+        const startedAt = Date.now();
+        try {
+            await this.git().clone(
+                this.cleanRemoteRepositoryUrl,
+                this.localRepositoryDir,
+                {
+                    '--single-branch': null,
+                    '--depth': 1,
+                    '--branch': this.branch,
+                    '--no-tags': null,
+                    '--progress': null,
+                },
+            );
+            await this.git()
+                .cwd(this.localRepositoryDir)
+                .remote(['set-url', 'origin', this.cleanRemoteRepositoryUrl]);
+            this.fetchMetrics.cloneMode = 'fresh';
+        } catch (error) {
+            gitErrorHandler(error, this.repository);
+        } finally {
+            this.fetchMetrics.cloneDurationMs = Date.now() - startedAt;
+        }
+    }
+
+    private async reuseCheckout() {
+        const startedAt = Date.now();
+        await this.git()
+            .cwd(this.localRepositoryDir)
+            .fetch(this.cleanRemoteRepositoryUrl, this.branch, {
+                '--depth': 1,
+                '--no-tags': null,
+                '--progress': null,
+            });
+        await this.git()
+            .cwd(this.localRepositoryDir)
+            .reset(['--hard', 'FETCH_HEAD']);
+        await this.cleanReusedCheckout();
+        await fspromises.rm(
+            path.join(this.localRepositoryDir, '.git', 'FETCH_HEAD'),
+            { force: true },
+        );
+        await fspromises.rm(
+            path.join(this.localRepositoryDir, '.git', 'logs'),
+            { recursive: true, force: true },
+        );
+        this.fetchMetrics.cloneMode = 'reused';
+        this.fetchMetrics.cloneDurationMs = Date.now() - startedAt;
+    }
+
+    private async useFreshAfterCacheFailure() {
+        if (this.cacheLease) {
+            await invalidateOwnedDbtGitCacheLease(this.cacheLease).catch(
+                () => undefined,
+            );
+            this.cacheLease = undefined;
+        }
+        const temporaryDirectory = await fspromises.mkdtemp(
+            path.join(os.tmpdir(), 'git_'),
+        );
+        this.temporaryRepositoryDirectories.add(temporaryDirectory);
+        this.setRepositoryDirectory(temporaryDirectory);
+        await this.cloneFresh();
+        this.refreshed = true;
+    }
+
+    private async refreshRepo() {
+        if (this.refreshed) return;
+        const initialDirectory = this.localRepositoryDir;
+        if (this.cacheIdentity) {
+            this.cacheLease = await acquireDbtGitProjectCache(
+                this.cacheIdentity,
+                this.repositoryIdentity,
+            ).catch(() => undefined);
+        }
+        if (this.cacheLease) {
+            await this.removeTemporaryRepositoryDirectory(
+                initialDirectory,
+            ).catch(() => undefined);
+            this.setRepositoryDirectory(this.cacheLease.checkoutDirectory);
+            if (this.cacheLease.reused) {
+                try {
+                    await this.reuseCheckout();
+                    this.refreshed = true;
+                    return;
+                } catch {
+                    Logger.debug(
+                        'Cached git checkout refresh failed; using a fresh clone',
+                    );
+                    await this.useFreshAfterCacheFailure();
+                    return;
+                }
+            }
+            try {
+                await this.cloneFresh();
+                this.refreshed = true;
+                return;
+            } catch {
+                Logger.debug(
+                    'Cached git checkout clone failed; using a fresh clone',
+                );
+                await this.useFreshAfterCacheFailure();
+                return;
+            }
+        }
+        await this.cloneFresh();
+        this.refreshed = true;
+    }
+
+    private async containsRetainedCredentials(): Promise<boolean> {
+        return gitMetadataContainsCredentials(this.localRepositoryDir);
+    }
+
+    async destroy(): Promise<void> {
+        Logger.debug('Destroy git project adapter');
+        let cleanupError: unknown;
+        try {
+            await super.destroy();
+        } catch (error) {
+            cleanupError = error;
+        } finally {
+            if (this.cacheLease) {
+                try {
+                    if (
+                        !this.retainCheckout ||
+                        (await this.containsRetainedCredentials().catch(
+                            () => true,
+                        ))
+                    ) {
+                        await invalidateOwnedDbtGitCacheLease(this.cacheLease);
+                    } else {
+                        const sizeBytes = await directorySize(
+                            this.cacheLease.entryDirectory,
+                        );
+                        await releaseDbtGitProjectCache(
+                            this.cacheLease,
+                            sizeBytes,
+                        );
+                    }
+                } catch (error) {
+                    await invalidateOwnedDbtGitCacheLease(
+                        this.cacheLease,
+                    ).catch(() => undefined);
+                    Logger.warn('Failed to retain dbt git checkout cache', {
+                        error,
+                    });
+                }
+                this.cacheLease = undefined;
+            } else {
+                await this.removeTemporaryRepositoryDirectory(
+                    this.localRepositoryDir,
+                ).catch(() => undefined);
+            }
+            await Promise.all(
+                [...this.temporaryRepositoryDirectories].map((directory) =>
+                    this.removeTemporaryRepositoryDirectory(directory).catch(
+                        () => undefined,
+                    ),
+                ),
+            );
+        }
+        if (cleanupError) throw cleanupError;
     }
 
     public async prepareExploreStream(
@@ -140,7 +910,7 @@ export class DbtGitProjectAdapter
         allowPartialCompilation?: boolean,
         compileOptions?: ExploreCompileOptions,
     ) {
-        await this._refreshRepo();
+        await this.refreshRepo();
         return super.prepareExploreStream(
             trackingParams,
             loadSources,
@@ -150,12 +920,12 @@ export class DbtGitProjectAdapter
     }
 
     public async test() {
-        await this._refreshRepo();
+        await this.refreshRepo();
         await super.test();
     }
 
     public async getDbtManifest() {
-        await this._refreshRepo();
+        await this.refreshRepo();
         return super.getDbtManifest();
     }
 }

--- a/packages/backend/src/projectAdapters/dbtGitProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectAdapter.ts
@@ -14,9 +14,8 @@ import * as yaml from 'js-yaml';
 import os from 'os';
 import * as path from 'path';
 import { performance } from 'perf_hooks';
-import simpleGit, { SimpleGitProgressEvent } from 'simple-git';
 import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
-import { DbtCliClient } from '../dbt/dbtCliClient';
+import { DbtCliClient, runAbortableProcess } from '../dbt/dbtCliClient';
 import { getDbtProcessEnvironment } from '../dbt/dbtProcessEnvironment';
 import Logger from '../logging/logger';
 import {
@@ -494,7 +493,57 @@ export class DbtGitProjectAdapter
         });
     }
 
-    private git() {
+    private readonly onCacheLeaseAbort = () => {
+        this.retainCheckout = false;
+        this.cacheOutcome.fallbackReason ??= 'lease-invalidated';
+        this.cacheOutcome.retentionReason ??= 'lease-invalidated';
+    };
+
+    private replaceCacheLease(
+        lease: DbtGitCacheLease | undefined,
+    ): DbtGitCacheLease | undefined {
+        const previous = this.cacheLease;
+        previous?.signal.removeEventListener('abort', this.onCacheLeaseAbort);
+        this.cacheLease = lease;
+        (this.dbtClient as DbtCliClient).setAbortSignal(lease?.signal);
+        lease?.signal.addEventListener('abort', this.onCacheLeaseAbort);
+        if (lease?.signal.aborted || lease?.invalidated) {
+            this.onCacheLeaseAbort();
+        }
+        return previous;
+    }
+
+    private assertCacheLeaseActive(): void {
+        const lease = this.cacheLease;
+        if (!lease) return;
+        lease.signal.throwIfAborted();
+        if (lease.invalidated) {
+            throw new Error('Dbt Git cache lease was invalidated');
+        }
+    }
+
+    private cacheLeaseRequiresRecovery(): boolean {
+        return Boolean(
+            this.cacheLease &&
+            (this.cacheLease.signal.aborted || this.cacheLease.invalidated),
+        );
+    }
+
+    private async withCacheRecovery<T>(
+        operation: () => Promise<T>,
+    ): Promise<T> {
+        await this.refreshRepo();
+        try {
+            this.assertCacheLeaseActive();
+            return await operation();
+        } catch (error) {
+            if (!this.cacheLeaseRequiresRecovery()) throw error;
+            await this.useFreshAfterCacheFailure();
+            return operation();
+        }
+    }
+
+    private git(args: readonly string[], cwd?: string) {
         const authenticationEnvironment =
             this.remoteRepositoryUrl === this.cleanRemoteRepositoryUrl
                 ? { GIT_CONFIG_COUNT: '0' }
@@ -503,17 +552,21 @@ export class DbtGitProjectAdapter
                       GIT_CONFIG_KEY_0: `url.${this.remoteRepositoryUrl}.insteadOf`,
                       GIT_CONFIG_VALUE_0: this.cleanRemoteRepositoryUrl,
                   };
-        return simpleGit({
-            unsafe: { allowUnsafeConfigEnvCount: true },
-            progress({ method, stage, progress }: SimpleGitProgressEvent) {
-                Logger.debug(
-                    `git.${method} ${stage} stage ${progress}% complete`,
-                );
+        return runAbortableProcess(
+            'git',
+            args,
+            {
+                all: true,
+                cwd,
+                extendEnv: false,
+                env: {
+                    GIT_TERMINAL_PROMPT: '0',
+                    ...authenticationEnvironment,
+                },
+                stdio: ['ignore', 'pipe', 'pipe'],
             },
-        }).env({
-            GIT_TERMINAL_PROMPT: '0',
-            ...authenticationEnvironment,
-        });
+            this.cacheLease?.signal,
+        );
     }
 
     private setRepositoryDirectory(directory: string) {
@@ -532,6 +585,7 @@ export class DbtGitProjectAdapter
     }
 
     private async dependencyLayout(): Promise<DependencyLayout> {
+        this.assertCacheLeaseActive();
         if (!this.dbtProjectDir) {
             this.cacheOutcome.eligible = false;
             this.cacheOutcome.eligibilityReason = 'project-directory-missing';
@@ -734,6 +788,7 @@ export class DbtGitProjectAdapter
                     }),
                 )
                 .digest('hex');
+            this.assertCacheLeaseActive();
             this.cacheOutcome.eligible = true;
             this.cacheOutcome.eligibilityReason = null;
             return {
@@ -744,6 +799,12 @@ export class DbtGitProjectAdapter
                 inputHash,
             };
         } catch (error) {
+            if (
+                this.cacheLease?.signal.aborted ||
+                this.cacheLease?.invalidated
+            ) {
+                this.assertCacheLeaseActive();
+            }
             this.cacheOutcome.eligible = false;
             this.cacheOutcome.eligibilityReason = sanitizedError(
                 error,
@@ -764,8 +825,10 @@ export class DbtGitProjectAdapter
     }
 
     private async installDepsWithCache(installDeps: () => Promise<void>) {
+        this.assertCacheLeaseActive();
         const startedAt = Date.now();
         const before = await this.dependencyLayout();
+        this.assertCacheLeaseActive();
         if (this.cacheLease?.reused && before.eligible) {
             const marker = await this.readDependencyMarker();
             const packageDirectoryExists = before.hasDeclaredPackages
@@ -785,6 +848,7 @@ export class DbtGitProjectAdapter
                           return false;
                       })
                 : true;
+            this.assertCacheLeaseActive();
             if (
                 marker?.version === DEPENDENCY_MARKER_VERSION &&
                 marker.hash === before.hash &&
@@ -798,6 +862,7 @@ export class DbtGitProjectAdapter
             }
         }
         if (this.cacheLease) {
+            this.assertCacheLeaseActive();
             await fspromises
                 .rm(this.cacheLease.depsMarkerPath, { force: true })
                 .catch((error) => {
@@ -807,17 +872,22 @@ export class DbtGitProjectAdapter
                         error,
                     );
                 });
+            this.assertCacheLeaseActive();
         }
         try {
+            this.assertCacheLeaseActive();
             await installDeps();
         } finally {
             this.fetchMetrics.depsDurationMs = Date.now() - startedAt;
         }
+        this.assertCacheLeaseActive();
         this.fetchMetrics.depsMode = 'fresh';
         const after = await this.dependencyLayout();
+        this.assertCacheLeaseActive();
         if (this.cacheLease && after.eligible) {
             try {
                 const temporaryPath = `${this.cacheLease.depsMarkerPath}.tmp`;
+                this.assertCacheLeaseActive();
                 await fspromises.writeFile(
                     temporaryPath,
                     JSON.stringify({
@@ -826,14 +896,22 @@ export class DbtGitProjectAdapter
                         hasDeclaredPackages: after.hasDeclaredPackages,
                         inputHash: after.inputHash,
                     } satisfies DependencyMarker),
-                    { mode: 0o600 },
+                    { mode: 0o600, signal: this.cacheLease.signal },
                 );
+                this.assertCacheLeaseActive();
                 await fspromises.rename(
                     temporaryPath,
                     this.cacheLease.depsMarkerPath,
                 );
+                this.assertCacheLeaseActive();
             } catch (error) {
                 this.retainCheckout = false;
+                if (
+                    this.cacheLease?.signal.aborted ||
+                    this.cacheLease?.invalidated
+                ) {
+                    this.assertCacheLeaseActive();
+                }
                 this.warnSwallowedError(
                     'Failed to write dbt dependency cache marker',
                     error,
@@ -848,14 +926,23 @@ export class DbtGitProjectAdapter
         DependencyMarker | undefined
     > {
         if (!this.cacheLease) return undefined;
+        this.assertCacheLeaseActive();
         try {
-            return JSON.parse(
+            const marker = JSON.parse(
                 await fspromises.readFile(
                     this.cacheLease.depsMarkerPath,
                     'utf8',
                 ),
             ) as DependencyMarker;
+            this.assertCacheLeaseActive();
+            return marker;
         } catch (error) {
+            if (
+                this.cacheLease?.signal.aborted ||
+                this.cacheLease?.invalidated
+            ) {
+                this.assertCacheLeaseActive();
+            }
             if (!isMissingFileError(error)) {
                 this.warnSwallowedError(
                     'Failed to read dbt dependency cache marker',
@@ -867,6 +954,7 @@ export class DbtGitProjectAdapter
     }
 
     private async cleanReusedCheckout() {
+        this.assertCacheLeaseActive();
         const layout = await this.dependencyLayout();
         if (!layout.eligible) {
             throw new Error('Unsafe cached dependency layout');
@@ -894,33 +982,35 @@ export class DbtGitProjectAdapter
                       ),
                   ]
                 : [];
-        await this.git()
-            .cwd(this.localRepositoryDir)
-            .raw([
-                'clean',
-                '-ffdx',
-                ...exclusions.flatMap((value) => ['-e', value]),
-            ]);
+        await this.git(
+            ['clean', '-ffdx', ...exclusions.flatMap((value) => ['-e', value])],
+            this.localRepositoryDir,
+        );
+        this.assertCacheLeaseActive();
     }
 
     private async cloneFresh() {
         const startedAt = Date.now();
         let cloned = false;
         try {
-            await this.git().clone(
+            await this.git([
+                'clone',
+                '--single-branch',
+                '--depth',
+                '1',
+                `--branch=${this.branch}`,
+                '--no-tags',
+                '--progress',
+                '--',
                 this.cleanRemoteRepositoryUrl,
                 this.localRepositoryDir,
-                {
-                    '--single-branch': null,
-                    '--depth': 1,
-                    '--branch': this.branch,
-                    '--no-tags': null,
-                    '--progress': null,
-                },
+            ]);
+            this.assertCacheLeaseActive();
+            await this.git(
+                ['remote', 'set-url', 'origin', this.cleanRemoteRepositoryUrl],
+                this.localRepositoryDir,
             );
-            await this.git()
-                .cwd(this.localRepositoryDir)
-                .remote(['set-url', 'origin', this.cleanRemoteRepositoryUrl]);
+            this.assertCacheLeaseActive();
             this.fetchMetrics.cloneMode = 'fresh';
             cloned = true;
         } catch (error) {
@@ -937,30 +1027,39 @@ export class DbtGitProjectAdapter
 
     private async reuseCheckout() {
         const startedAt = Date.now();
+        this.assertCacheLeaseActive();
         await fspromises.rm(
             path.join(this.localRepositoryDir, '.git', 'FETCH_HEAD'),
             { force: true },
         );
-        await this.git()
-            .cwd(this.localRepositoryDir)
-            .fetch(
+        this.assertCacheLeaseActive();
+        await this.git(
+            [
+                'fetch',
+                '--depth',
+                '1',
+                '--no-tags',
+                '--no-write-fetch-head',
+                '--progress',
+                '--',
                 this.cleanRemoteRepositoryUrl,
                 `+${this.branch}:${CACHE_FETCH_REF}`,
-                {
-                    '--depth': 1,
-                    '--no-tags': null,
-                    '--no-write-fetch-head': null,
-                    '--progress': null,
-                },
-            );
-        await this.git()
-            .cwd(this.localRepositoryDir)
-            .reset(['--hard', CACHE_FETCH_REF]);
+            ],
+            this.localRepositoryDir,
+        );
+        this.assertCacheLeaseActive();
+        await this.git(
+            ['reset', '--hard', CACHE_FETCH_REF],
+            this.localRepositoryDir,
+        );
+        this.assertCacheLeaseActive();
         await this.cleanReusedCheckout();
+        this.assertCacheLeaseActive();
         await fspromises.rm(
             path.join(this.localRepositoryDir, '.git', 'logs'),
             { recursive: true, force: true },
         );
+        this.assertCacheLeaseActive();
         this.fetchMetrics.cloneMode = 'reused';
         this.fetchMetrics.cloneDurationMs = Date.now() - startedAt;
         Logger.info(
@@ -969,8 +1068,14 @@ export class DbtGitProjectAdapter
     }
 
     private async useFreshAfterCacheFailure() {
-        if (this.cacheLease) {
-            const lease = this.cacheLease;
+        const lease = this.cacheLease;
+        const temporaryDirectory = await fspromises.mkdtemp(
+            path.join(os.tmpdir(), 'git_'),
+        );
+        this.temporaryRepositoryDirectories.add(temporaryDirectory);
+        this.setRepositoryDirectory(temporaryDirectory);
+        this.replaceCacheLease(undefined);
+        if (lease) {
             await invalidateOwnedDbtGitCacheLease(lease).catch((error) => {
                 this.warnSwallowedError(
                     'Failed to invalidate dbt Git cache checkout',
@@ -980,13 +1085,7 @@ export class DbtGitProjectAdapter
             this.cacheOutcome.retained = lease.retained ?? false;
             this.cacheOutcome.retentionReason =
                 lease.retentionReason ?? 'invalidated';
-            this.cacheLease = undefined;
         }
-        const temporaryDirectory = await fspromises.mkdtemp(
-            path.join(os.tmpdir(), 'git_'),
-        );
-        this.temporaryRepositoryDirectories.add(temporaryDirectory);
-        this.setRepositoryDirectory(temporaryDirectory);
         await this.cloneFresh();
         this.refreshed = true;
     }
@@ -1005,13 +1104,14 @@ export class DbtGitProjectAdapter
                 this.cacheOutcome.missReason = gitVersionSupport.reason;
             } else {
                 try {
-                    this.cacheLease = await acquireDbtGitProjectCache(
+                    const lease = await acquireDbtGitProjectCache(
                         this.cacheIdentity,
                         this.repositoryIdentity,
                         (reason) => {
                             this.cacheOutcome.missReason = reason;
                         },
                     );
+                    this.replaceCacheLease(lease);
                     if (this.cacheLease && !this.cacheLease.reused) {
                         this.cacheOutcome.missReason = 'cold';
                     }
@@ -1040,6 +1140,10 @@ export class DbtGitProjectAdapter
                     this.refreshed = true;
                     return;
                 } catch (error) {
+                    if (this.cacheLeaseRequiresRecovery()) {
+                        await this.useFreshAfterCacheFailure();
+                        return;
+                    }
                     this.cacheOutcome.fallbackReason = 'refresh-failed';
                     this.warnSwallowedError(
                         'Cached Git checkout refresh failed; using a fresh clone',
@@ -1054,6 +1158,10 @@ export class DbtGitProjectAdapter
                 this.refreshed = true;
                 return;
             } catch (error) {
+                if (this.cacheLeaseRequiresRecovery()) {
+                    await this.useFreshAfterCacheFailure();
+                    return;
+                }
                 this.cacheOutcome.fallbackReason = 'cache-clone-failed';
                 this.warnSwallowedError(
                     'Cached Git checkout clone failed; using a fresh clone',
@@ -1079,7 +1187,16 @@ export class DbtGitProjectAdapter
             if (this.cacheLease) {
                 const lease = this.cacheLease;
                 try {
-                    if (!this.retainCheckout) {
+                    if (
+                        lease.invalidated ||
+                        lease.signal.aborted ||
+                        !this.retainCheckout
+                    ) {
+                        if (lease.invalidated || lease.signal.aborted) {
+                            this.retainCheckout = false;
+                            this.cacheOutcome.retentionReason ??=
+                                'lease-invalidated';
+                        }
                         await invalidateOwnedDbtGitCacheLease(lease);
                     } else {
                         let inspection:
@@ -1133,7 +1250,7 @@ export class DbtGitProjectAdapter
                         error,
                     );
                 }
-                this.cacheLease = undefined;
+                this.replaceCacheLease(undefined);
             } else {
                 await this.removeTemporaryRepositoryDirectory(
                     this.localRepositoryDir,
@@ -1172,22 +1289,21 @@ export class DbtGitProjectAdapter
         allowPartialCompilation?: boolean,
         compileOptions?: ExploreCompileOptions,
     ) {
-        await this.refreshRepo();
-        return super.prepareExploreStream(
-            trackingParams,
-            loadSources,
-            allowPartialCompilation,
-            compileOptions,
+        return this.withCacheRecovery(() =>
+            super.prepareExploreStream(
+                trackingParams,
+                loadSources,
+                allowPartialCompilation,
+                compileOptions,
+            ),
         );
     }
 
     public async test() {
-        await this.refreshRepo();
-        await super.test();
+        await this.withCacheRecovery(() => super.test());
     }
 
     public async getDbtManifest() {
-        await this.refreshRepo();
-        return super.getDbtManifest();
+        return this.withCacheRecovery(() => super.getDbtManifest());
     }
 }

--- a/packages/backend/src/projectAdapters/dbtGitProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectAdapter.ts
@@ -1,6 +1,7 @@
 import {
     CreateWarehouseCredentials,
     DbtProjectEnvironmentVariable,
+    getErrorMessage,
     SupportedDbtVersions,
     UnexpectedGitError,
 } from '@lightdash/common';
@@ -11,6 +12,7 @@ import * as fspromises from 'fs/promises';
 import * as yaml from 'js-yaml';
 import os from 'os';
 import * as path from 'path';
+import { performance } from 'perf_hooks';
 import simpleGit, { SimpleGitProgressEvent } from 'simple-git';
 import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
 import { DbtCliClient } from '../dbt/dbtCliClient';
@@ -29,6 +31,7 @@ import {
     invalidateOwnedDbtGitCacheLease,
     releaseDbtGitProjectCache,
 } from './dbtGitProjectCache';
+import { inspectDbtGitProject } from './dbtGitProjectInspection';
 import { DbtLocalCredentialsProjectAdapter } from './dbtLocalCredentialsProjectAdapter';
 import { gitErrorHandler } from './gitRepository';
 
@@ -62,6 +65,20 @@ export type DbtGitFetchMetrics = {
     depsDurationMs: number;
 };
 
+export type DbtGitCacheOutcome = {
+    cloneMode: 'fresh' | 'reused';
+    depsMode: 'fresh' | 'reused';
+    missReason: string | null;
+    fallbackReason: string | null;
+    retainCheckout: boolean;
+    eligible: boolean | null;
+    eligibilityReason: string | null;
+    inspectionDurationMs: number;
+    cleanupDurationMs: number;
+    retained: boolean | null;
+    retentionReason: string | null;
+};
+
 type DependencyLayout = {
     eligible: boolean;
     installDirectory: string;
@@ -85,6 +102,33 @@ const PACKAGE_CONFIG_FILES = [
     'package-lock.yml',
     'dbt_project.yml',
 ] as const;
+
+const stripTokensFromUrls = (raw: string) => {
+    const pattern = /\/\/(.*)@/g;
+    return raw.replace(pattern, '//*****@');
+};
+
+const sanitizedError = (error: unknown, sensitiveValues: string[]) => {
+    const source =
+        error instanceof Error ? error.message : getErrorMessage(error);
+    const message = sensitiveValues
+        .filter(Boolean)
+        .flatMap((value) => [value, encodeURIComponent(value)])
+        .reduce(
+            (result, value) => result.replaceAll(value, '*****'),
+            stripTokensFromUrls(source),
+        );
+    return {
+        name: error instanceof Error ? error.name : 'UnknownError',
+        message,
+        ...((error as NodeJS.ErrnoException | undefined)?.code
+            ? { code: (error as NodeJS.ErrnoException).code }
+            : {}),
+    };
+};
+
+const isMissingFileError = (error: unknown): boolean =>
+    (error as NodeJS.ErrnoException).code === 'ENOENT';
 
 export const assertValidGitBranch = (branch: string): void => {
     if (branch.startsWith('-')) {
@@ -142,10 +186,10 @@ const readRegularFile = async (
             content: await fspromises.readFile(filePath, 'utf8'),
         };
     } catch (error) {
-        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        if (isMissingFileError(error)) {
             return { safe: true, content: null };
         }
-        return { safe: false, content: null };
+        throw error;
     }
 };
 
@@ -174,103 +218,6 @@ const literalGitCleanExclusion = (
 };
 
 const FILESYSTEM_BATCH_SIZE = 32;
-
-const directorySize = async (directory: string): Promise<number> => {
-    let total = 0;
-    const pending = [directory];
-    const processBatch = async (): Promise<void> => {
-        const batch = pending.splice(0, FILESYSTEM_BATCH_SIZE);
-        if (batch.length === 0) return;
-        const results = await Promise.all(
-            batch.map(async (candidate) => {
-                const stat = await fspromises.lstat(candidate);
-                const children =
-                    stat.isDirectory() && !stat.isSymbolicLink()
-                        ? await fspromises.readdir(candidate)
-                        : [];
-                return { candidate, children, size: stat.size };
-            }),
-        );
-        results.forEach(({ candidate, children, size }) => {
-            total += size;
-            pending.push(
-                ...children.map((child) => path.join(candidate, child)),
-            );
-        });
-        await processBatch();
-    };
-    await processBatch();
-    return total;
-};
-
-const gitMetadataContainsCredentials = async (
-    root: string,
-): Promise<boolean> => {
-    const found: string[] = [];
-    const pending = [{ directory: root, gitMetadata: false }];
-    const scanBatch = async (): Promise<void> => {
-        const batch = pending.splice(0, FILESYSTEM_BATCH_SIZE);
-        if (batch.length === 0) return;
-        const results = await Promise.all(
-            batch.map(async (item) => ({
-                ...item,
-                entries: await fspromises.readdir(item.directory, {
-                    withFileTypes: true,
-                }),
-            })),
-        );
-        results.forEach(({ directory, entries, gitMetadata }) => {
-            entries.forEach((entry) => {
-                const candidate = path.join(directory, entry.name);
-                if (gitMetadata) {
-                    if (entry.name !== 'objects' && entry.name !== 'index') {
-                        if (entry.isDirectory()) {
-                            pending.push({
-                                directory: candidate,
-                                gitMetadata: true,
-                            });
-                        } else if (entry.isFile()) {
-                            found.push(candidate);
-                        } else {
-                            throw new Error('Unsupported Git metadata');
-                        }
-                    }
-                } else if (entry.name === '.git') {
-                    if (entry.isDirectory() && !entry.isSymbolicLink()) {
-                        pending.push({
-                            directory: candidate,
-                            gitMetadata: true,
-                        });
-                    } else {
-                        throw new Error('Git indirection is not cacheable');
-                    }
-                } else if (entry.isDirectory() && !entry.isSymbolicLink()) {
-                    pending.push({
-                        directory: candidate,
-                        gitMetadata: false,
-                    });
-                }
-            });
-        });
-        await scanBatch();
-    };
-    await scanBatch();
-    const remaining = [...found];
-    const inspectBatch = async (): Promise<boolean> => {
-        const batch = remaining.splice(0, FILESYSTEM_BATCH_SIZE);
-        if (batch.length === 0) return false;
-        const matches = await Promise.all(
-            batch.map(async (file) => {
-                const stat = await fspromises.lstat(file);
-                if (stat.size > 1024 * 1024) return true;
-                const content = await fspromises.readFile(file, 'utf8');
-                return /https?:\/\/[^\s/@]+(?::[^\s/@]*)?@/i.test(content);
-            }),
-        );
-        return matches.some(Boolean) || inspectBatch();
-    };
-    return inspectBatch();
-};
 
 const directoryContentDigest = async (
     directory: string,
@@ -363,7 +310,27 @@ export class DbtGitProjectAdapter
 
     private refreshed = false;
 
+    private refreshAttempted = false;
+
     private retainCheckout = true;
+
+    private readonly sensitiveValues: string[];
+
+    private cacheOutcome: DbtGitCacheOutcome = {
+        cloneMode: 'fresh',
+        depsMode: 'fresh',
+        missReason: null,
+        fallbackReason: null,
+        retainCheckout: true,
+        eligible: null,
+        eligibilityReason: null,
+        inspectionDurationMs: 0,
+        cleanupDurationMs: 0,
+        retained: null,
+        retentionReason: null,
+    };
+
+    private cacheOutcomeLogged = false;
 
     private fetchMetrics: DbtGitFetchMetrics = {
         cloneMode: 'fresh',
@@ -440,6 +407,15 @@ export class DbtGitProjectAdapter
         this.temporaryRepositoryDirectories.add(localRepositoryDir);
         this.remoteRepositoryUrl = remoteRepositoryUrl;
         this.credential = credential;
+        this.sensitiveValues = credential
+            ? [credential.token]
+            : (() => {
+                  try {
+                      return decodedUrlCredentials(remoteRepositoryUrl);
+                  } catch {
+                      return [];
+                  }
+              })();
         this.cleanRemoteRepositoryUrl = cleanRemoteRepositoryUrl;
         this.branch = gitBranch;
         this.repository = repository;
@@ -449,6 +425,13 @@ export class DbtGitProjectAdapter
             isContainedRelativePath(projectDirectorySubPath)
                 ? cacheIdentity
                 : undefined;
+        if (!credentialMatchesUrl) {
+            this.cacheOutcome.missReason = 'credential-url-mismatch';
+        } else if (!cacheIdentity) {
+            this.cacheOutcome.missReason = 'cache-identity-unavailable';
+        } else if (!isContainedRelativePath(projectDirectorySubPath)) {
+            this.cacheOutcome.missReason = 'project-subpath-ineligible';
+        }
         const parsedRemote = new URL(this.cleanRemoteRepositoryUrl);
         this.repositoryIdentity = JSON.stringify({
             authority: parsedRemote.host,
@@ -465,6 +448,21 @@ export class DbtGitProjectAdapter
 
     getFetchMetrics(): DbtGitFetchMetrics {
         return { ...this.fetchMetrics };
+    }
+
+    getCacheOutcome(): DbtGitCacheOutcome {
+        return {
+            ...this.cacheOutcome,
+            cloneMode: this.fetchMetrics.cloneMode,
+            depsMode: this.fetchMetrics.depsMode,
+            retainCheckout: this.retainCheckout,
+        };
+    }
+
+    private warnSwallowedError(message: string, error: unknown) {
+        Logger.warn(message, {
+            error: sanitizedError(error, this.sensitiveValues),
+        });
     }
 
     private git() {
@@ -506,6 +504,8 @@ export class DbtGitProjectAdapter
 
     private async dependencyLayout(): Promise<DependencyLayout> {
         if (!this.dbtProjectDir) {
+            this.cacheOutcome.eligible = false;
+            this.cacheOutcome.eligibilityReason = 'project-directory-missing';
             return {
                 eligible: false,
                 installDirectory: '',
@@ -705,6 +705,8 @@ export class DbtGitProjectAdapter
                     }),
                 )
                 .digest('hex');
+            this.cacheOutcome.eligible = true;
+            this.cacheOutcome.eligibilityReason = null;
             return {
                 eligible: true,
                 installDirectory,
@@ -712,7 +714,16 @@ export class DbtGitProjectAdapter
                 hash,
                 inputHash,
             };
-        } catch {
+        } catch (error) {
+            this.cacheOutcome.eligible = false;
+            this.cacheOutcome.eligibilityReason = sanitizedError(
+                error,
+                this.sensitiveValues,
+            ).message;
+            this.warnSwallowedError(
+                'Dbt Git dependency layout is not cacheable',
+                error,
+            );
             return {
                 eligible: false,
                 installDirectory: '',
@@ -727,10 +738,7 @@ export class DbtGitProjectAdapter
         const startedAt = Date.now();
         const before = await this.dependencyLayout();
         if (this.cacheLease?.reused && before.eligible) {
-            const marker = await fspromises
-                .readFile(this.cacheLease.depsMarkerPath, 'utf8')
-                .then((value) => JSON.parse(value) as DependencyMarker)
-                .catch(() => undefined);
+            const marker = await this.readDependencyMarker();
             const packageDirectoryExists = before.hasDeclaredPackages
                 ? await fspromises
                       .lstat(before.installDirectory)
@@ -738,7 +746,15 @@ export class DbtGitProjectAdapter
                           (stat) =>
                               stat.isDirectory() && !stat.isSymbolicLink(),
                       )
-                      .catch(() => false)
+                      .catch((error) => {
+                          if (!isMissingFileError(error)) {
+                              this.warnSwallowedError(
+                                  'Failed to inspect cached dbt package directory',
+                                  error,
+                              );
+                          }
+                          return false;
+                      })
                 : true;
             if (
                 marker?.version === DEPENDENCY_MARKER_VERSION &&
@@ -755,8 +771,12 @@ export class DbtGitProjectAdapter
         if (this.cacheLease) {
             await fspromises
                 .rm(this.cacheLease.depsMarkerPath, { force: true })
-                .catch(() => {
+                .catch((error) => {
                     this.retainCheckout = false;
+                    this.warnSwallowedError(
+                        'Failed to remove dbt dependency cache marker',
+                        error,
+                    );
                 });
         }
         try {
@@ -783,11 +803,37 @@ export class DbtGitProjectAdapter
                     temporaryPath,
                     this.cacheLease.depsMarkerPath,
                 );
-            } catch {
+            } catch (error) {
                 this.retainCheckout = false;
+                this.warnSwallowedError(
+                    'Failed to write dbt dependency cache marker',
+                    error,
+                );
             }
         } else if (!after.eligible) {
             this.retainCheckout = false;
+        }
+    }
+
+    private async readDependencyMarker(): Promise<
+        DependencyMarker | undefined
+    > {
+        if (!this.cacheLease) return undefined;
+        try {
+            return JSON.parse(
+                await fspromises.readFile(
+                    this.cacheLease.depsMarkerPath,
+                    'utf8',
+                ),
+            ) as DependencyMarker;
+        } catch (error) {
+            if (!isMissingFileError(error)) {
+                this.warnSwallowedError(
+                    'Failed to read dbt dependency cache marker',
+                    error,
+                );
+            }
+            return undefined;
         }
     }
 
@@ -796,12 +842,7 @@ export class DbtGitProjectAdapter
         if (!layout.eligible) {
             throw new Error('Unsafe cached dependency layout');
         }
-        const marker = this.cacheLease
-            ? await fspromises
-                  .readFile(this.cacheLease.depsMarkerPath, 'utf8')
-                  .then((value) => JSON.parse(value) as DependencyMarker)
-                  .catch(() => undefined)
-            : undefined;
+        const marker = await this.readDependencyMarker();
         const exclusions =
             marker?.inputHash === layout.inputHash
                 ? [
@@ -835,6 +876,7 @@ export class DbtGitProjectAdapter
 
     private async cloneFresh() {
         const startedAt = Date.now();
+        let cloned = false;
         try {
             await this.git().clone(
                 this.cleanRemoteRepositoryUrl,
@@ -851,10 +893,16 @@ export class DbtGitProjectAdapter
                 .cwd(this.localRepositoryDir)
                 .remote(['set-url', 'origin', this.cleanRemoteRepositoryUrl]);
             this.fetchMetrics.cloneMode = 'fresh';
+            cloned = true;
         } catch (error) {
             gitErrorHandler(error, this.repository);
         } finally {
             this.fetchMetrics.cloneDurationMs = Date.now() - startedAt;
+            if (cloned) {
+                Logger.info(
+                    `Git clone completed in ${this.fetchMetrics.cloneDurationMs}ms`,
+                );
+            }
         }
     }
 
@@ -886,13 +934,23 @@ export class DbtGitProjectAdapter
         );
         this.fetchMetrics.cloneMode = 'reused';
         this.fetchMetrics.cloneDurationMs = Date.now() - startedAt;
+        Logger.info(
+            `Git fetch completed in ${this.fetchMetrics.cloneDurationMs}ms`,
+        );
     }
 
     private async useFreshAfterCacheFailure() {
         if (this.cacheLease) {
-            await invalidateOwnedDbtGitCacheLease(this.cacheLease).catch(
-                () => undefined,
-            );
+            const lease = this.cacheLease;
+            await invalidateOwnedDbtGitCacheLease(lease).catch((error) => {
+                this.warnSwallowedError(
+                    'Failed to invalidate dbt Git cache checkout',
+                    error,
+                );
+            });
+            this.cacheOutcome.retained = lease.retained ?? false;
+            this.cacheOutcome.retentionReason =
+                lease.retentionReason ?? 'invalidated';
             this.cacheLease = undefined;
         }
         const temporaryDirectory = await fspromises.mkdtemp(
@@ -906,26 +964,48 @@ export class DbtGitProjectAdapter
 
     private async refreshRepo() {
         if (this.refreshed) return;
+        this.refreshAttempted = true;
         const initialDirectory = this.localRepositoryDir;
         if (this.cacheIdentity) {
-            this.cacheLease = await acquireDbtGitProjectCache(
-                this.cacheIdentity,
-                this.repositoryIdentity,
-            ).catch(() => undefined);
+            try {
+                this.cacheLease = await acquireDbtGitProjectCache(
+                    this.cacheIdentity,
+                    this.repositoryIdentity,
+                    (reason) => {
+                        this.cacheOutcome.missReason = reason;
+                    },
+                );
+                if (this.cacheLease && !this.cacheLease.reused) {
+                    this.cacheOutcome.missReason = 'cold';
+                }
+            } catch (error) {
+                this.cacheOutcome.missReason = 'acquire-error';
+                this.warnSwallowedError(
+                    'Failed to acquire dbt Git checkout cache',
+                    error,
+                );
+            }
         }
         if (this.cacheLease) {
             await this.removeTemporaryRepositoryDirectory(
                 initialDirectory,
-            ).catch(() => undefined);
+            ).catch((error) => {
+                this.warnSwallowedError(
+                    'Failed to remove temporary dbt Git checkout',
+                    error,
+                );
+            });
             this.setRepositoryDirectory(this.cacheLease.checkoutDirectory);
             if (this.cacheLease.reused) {
                 try {
                     await this.reuseCheckout();
                     this.refreshed = true;
                     return;
-                } catch {
-                    Logger.debug(
-                        'Cached git checkout refresh failed; using a fresh clone',
+                } catch (error) {
+                    this.cacheOutcome.fallbackReason = 'refresh-failed';
+                    this.warnSwallowedError(
+                        'Cached Git checkout refresh failed; using a fresh clone',
+                        error,
                     );
                     await this.useFreshAfterCacheFailure();
                     return;
@@ -935,9 +1015,11 @@ export class DbtGitProjectAdapter
                 await this.cloneFresh();
                 this.refreshed = true;
                 return;
-            } catch {
-                Logger.debug(
-                    'Cached git checkout clone failed; using a fresh clone',
+            } catch (error) {
+                this.cacheOutcome.fallbackReason = 'cache-clone-failed';
+                this.warnSwallowedError(
+                    'Cached Git checkout clone failed; using a fresh clone',
+                    error,
                 );
                 await this.useFreshAfterCacheFailure();
                 return;
@@ -947,11 +1029,8 @@ export class DbtGitProjectAdapter
         this.refreshed = true;
     }
 
-    private async containsRetainedCredentials(): Promise<boolean> {
-        return gitMetadataContainsCredentials(this.localRepositoryDir);
-    }
-
     async destroy(): Promise<void> {
+        const cleanupStartedAt = performance.now();
         Logger.debug('Destroy git project adapter');
         let cleanupError: unknown;
         try {
@@ -960,44 +1039,91 @@ export class DbtGitProjectAdapter
             cleanupError = error;
         } finally {
             if (this.cacheLease) {
+                const lease = this.cacheLease;
                 try {
-                    if (
-                        !this.retainCheckout ||
-                        (await this.containsRetainedCredentials().catch(
-                            () => true,
-                        ))
-                    ) {
-                        await invalidateOwnedDbtGitCacheLease(this.cacheLease);
+                    if (!this.retainCheckout) {
+                        await invalidateOwnedDbtGitCacheLease(lease);
                     } else {
-                        const sizeBytes = await directorySize(
-                            this.cacheLease.entryDirectory,
-                        );
-                        await releaseDbtGitProjectCache(
-                            this.cacheLease,
-                            sizeBytes,
-                        );
+                        let inspection:
+                            | Awaited<ReturnType<typeof inspectDbtGitProject>>
+                            | undefined;
+                        try {
+                            inspection = await inspectDbtGitProject(
+                                lease.entryDirectory,
+                            );
+                            this.cacheOutcome.inspectionDurationMs =
+                                inspection.durationMs;
+                        } catch (error) {
+                            this.cacheOutcome.retentionReason =
+                                'inspection-failed';
+                            this.warnSwallowedError(
+                                'Failed to inspect dbt Git checkout cache',
+                                error,
+                            );
+                        }
+                        if (!inspection || inspection.containsCredentials) {
+                            this.retainCheckout = false;
+                            if (inspection?.containsCredentials) {
+                                this.cacheOutcome.retentionReason =
+                                    'credential-metadata';
+                            }
+                            await invalidateOwnedDbtGitCacheLease(lease);
+                        } else {
+                            await releaseDbtGitProjectCache(
+                                lease,
+                                inspection.sizeBytes,
+                            );
+                        }
                     }
+                    this.cacheOutcome.retained = lease.retained ?? false;
+                    this.cacheOutcome.retentionReason ??=
+                        lease.retentionReason ?? null;
                 } catch (error) {
-                    await invalidateOwnedDbtGitCacheLease(
-                        this.cacheLease,
-                    ).catch(() => undefined);
-                    Logger.warn('Failed to retain dbt git checkout cache', {
+                    await invalidateOwnedDbtGitCacheLease(lease).catch(
+                        (invalidationError) => {
+                            this.warnSwallowedError(
+                                'Failed to invalidate unretained dbt Git checkout cache',
+                                invalidationError,
+                            );
+                        },
+                    );
+                    this.cacheOutcome.retained = false;
+                    this.cacheOutcome.retentionReason ??=
+                        lease.retentionReason ?? 'retention-error';
+                    this.warnSwallowedError(
+                        'Failed to retain dbt Git checkout cache',
                         error,
-                    });
+                    );
                 }
                 this.cacheLease = undefined;
             } else {
                 await this.removeTemporaryRepositoryDirectory(
                     this.localRepositoryDir,
-                ).catch(() => undefined);
+                ).catch((error) => {
+                    this.warnSwallowedError(
+                        'Failed to remove temporary dbt Git checkout',
+                        error,
+                    );
+                });
             }
             await Promise.all(
                 [...this.temporaryRepositoryDirectories].map((directory) =>
                     this.removeTemporaryRepositoryDirectory(directory).catch(
-                        () => undefined,
+                        (error) => {
+                            this.warnSwallowedError(
+                                'Failed to remove temporary dbt Git checkout',
+                                error,
+                            );
+                        },
                     ),
                 ),
             );
+            this.cacheOutcome.cleanupDurationMs =
+                performance.now() - cleanupStartedAt;
+            if (this.refreshAttempted && !this.cacheOutcomeLogged) {
+                Logger.info('dbt.git.cache.outcome', this.getCacheOutcome());
+                this.cacheOutcomeLogged = true;
+            }
         }
         if (cleanupError) throw cleanupError;
     }

--- a/packages/backend/src/projectAdapters/dbtGitProjectCache.test.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectCache.test.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
+import Logger from '../logging/logger';
 import {
     acquireDbtGitProjectCache,
     configureDbtGitProjectCache,
@@ -22,6 +23,12 @@ vi.mock('fs/promises', async (importOriginal) => {
         rm: vi.fn(actual.rm),
     };
 });
+
+vi.mock('../logging/logger', () => ({
+    default: {
+        warn: vi.fn(),
+    },
+}));
 
 const roots: string[] = [];
 
@@ -62,6 +69,7 @@ const staleOwner = (overrides: Record<string, unknown> = {}) => ({
 });
 
 afterEach(async () => {
+    vi.clearAllMocks();
     await Promise.all(
         roots
             .splice(0)
@@ -638,6 +646,119 @@ describe('dbt git project cache', () => {
             acquireDbtGitProjectCache(identity(1), 'repository'),
         ).resolves.toBeUndefined();
         expect(await entryDirectories(root)).toHaveLength(128);
+    });
+
+    it('reclaims an interrupted tombstone with a missing marker after the grace period', async () => {
+        const root = await configure();
+        const lease = await acquireDbtGitProjectCache(
+            identity(1),
+            'repository',
+        );
+        await fs.mkdir(lease!.checkoutDirectory);
+        await releaseDbtGitProjectCache(lease!, 100);
+        const tombstone = path.join(
+            root,
+            `.tombstone-${lease!.key}-00000000-0000-4000-8000-000000000001`,
+        );
+        await fs.rename(lease!.entryDirectory, tombstone);
+        await fs.rm(path.join(tombstone, '.lightdash-cache-entry.json'));
+        const stale = new Date(Date.now() - 6 * 60_000);
+        await fs.utimes(tombstone, stale, stale);
+
+        await maintainDbtGitProjectCache();
+
+        expect(await tombstoneDirectories(root)).toHaveLength(0);
+        const replacement = await acquireDbtGitProjectCache(
+            identity(1),
+            'repository',
+        );
+        await fs.mkdir(replacement!.checkoutDirectory);
+        await releaseDbtGitProjectCache(replacement!, 100);
+        const reused = await acquireDbtGitProjectCache(
+            identity(1),
+            'repository',
+        );
+        expect(reused?.reused).toBe(true);
+        await releaseDbtGitProjectCache(reused!, 100);
+    });
+
+    it('reclaims a metadata-less crashed acquisition after the grace period', async () => {
+        const root = await configure();
+        const seed = await acquireDbtGitProjectCache(identity(1), 'repository');
+        const key = seed!.key;
+        await invalidateOwnedDbtGitCacheLease(seed!);
+        const entryDirectory = path.join(root, key);
+        await fs.mkdir(entryDirectory, { mode: 0o700 });
+        const marker = path.join(entryDirectory, '.lightdash-cache-entry.json');
+        await fs.writeFile(marker, JSON.stringify({ version: 1, key }), {
+            mode: 0o600,
+        });
+        const stale = new Date(Date.now() - 6 * 60_000);
+        await fs.utimes(marker, stale, stale);
+
+        await maintainDbtGitProjectCache();
+
+        expect(await entryDirectories(root)).toHaveLength(0);
+    });
+
+    it('reclaims orphaned root marker writes only after the grace period', async () => {
+        const root = await configure();
+        const temporaryPath = path.join(
+            root,
+            '.lightdash-dbt-git-cache.json.00000000-0000-4000-8000-000000000001.tmp',
+        );
+        await fs.writeFile(temporaryPath, '{}', { mode: 0o600 });
+
+        await maintainDbtGitProjectCache();
+        await expect(fs.access(temporaryPath)).resolves.toBeUndefined();
+
+        const stale = new Date(Date.now() - 6 * 60_000);
+        await fs.utimes(temporaryPath, stale, stale);
+        await maintainDbtGitProjectCache();
+        await expect(fs.access(temporaryPath)).rejects.toThrow();
+    });
+
+    it('protects an active unowned entry during abandoned object cleanup', async () => {
+        const root = await configure();
+        const lease = await acquireDbtGitProjectCache(
+            identity(1),
+            'repository',
+        );
+        await fs.mkdir(lease!.checkoutDirectory);
+        const marker = path.join(
+            lease!.entryDirectory,
+            '.lightdash-cache-entry.json',
+        );
+        await fs.rm(marker);
+        const stale = new Date(Date.now() - 6 * 60_000);
+        await fs.utimes(lease!.entryDirectory, stale, stale);
+
+        await maintainDbtGitProjectCache();
+
+        await expect(fs.access(lease!.entryDirectory)).resolves.toBeUndefined();
+        await fs.writeFile(
+            marker,
+            JSON.stringify({ version: 1, key: lease!.key }),
+            { mode: 0o600 },
+        );
+        await releaseDbtGitProjectCache(lease!, 100);
+    });
+
+    it('warns with a reason when corrupt root state declines retention', async () => {
+        const root = await configure();
+        const lease = await acquireDbtGitProjectCache(
+            identity(1),
+            'repository',
+        );
+        await fs.mkdir(lease!.checkoutDirectory);
+        await fs.mkdir(path.join(root, '0'.repeat(64)), { mode: 0o700 });
+
+        await releaseDbtGitProjectCache(lease!, 100);
+
+        expect(vi.mocked(Logger.warn)).toHaveBeenCalledWith(
+            'Declined dbt git cache retention',
+            { reason: 'corrupt-root-entry' },
+        );
     });
 
     it('removes missing identities and retains entries on liveness errors', async () => {

--- a/packages/backend/src/projectAdapters/dbtGitProjectCache.test.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectCache.test.ts
@@ -1728,6 +1728,9 @@ describe('dbt git project cache', () => {
 
             expect(onMiss).toHaveBeenCalledWith('disabled');
             await expect(fs.access(root)).rejects.toThrow();
+            await maintainDbtGitProjectCache();
+            await invalidateDbtGitProjectCacheSource('project', 'source-1');
+            await expect(fs.access(root)).rejects.toThrow();
         },
     );
 

--- a/packages/backend/src/projectAdapters/dbtGitProjectCache.test.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectCache.test.ts
@@ -1416,6 +1416,74 @@ describe('dbt git project cache', () => {
         expect(await entryDirectories(root)).toHaveLength(0);
     });
 
+    it('protects a metadata-less entry with an unreadable lease owner', async () => {
+        const root = await configure();
+        const seed = await acquireDbtGitProjectCache(identity(1), 'repository');
+        const { key } = seed!;
+        await invalidateOwnedDbtGitCacheLease(seed!);
+        const entryDirectory = path.join(root, key);
+        const markerPath = path.join(
+            entryDirectory,
+            '.lightdash-cache-entry.json',
+        );
+        const ownerPath = path.join(entryDirectory, 'lease', 'owner.json');
+        await fs.mkdir(path.dirname(ownerPath), {
+            recursive: true,
+            mode: 0o700,
+        });
+        await fs.writeFile(markerPath, JSON.stringify({ version: 1, key }), {
+            mode: 0o600,
+        });
+        await fs.writeFile(ownerPath, JSON.stringify(staleOwner()));
+        const stale = new Date(Date.now() - 6 * 60_000);
+        await fs.utimes(markerPath, stale, stale);
+        const actualFs =
+            await vi.importActual<typeof import('fs/promises')>('fs/promises');
+        const readFile = vi.mocked(fs.readFile);
+        const error = new Error('permission denied') as NodeJS.ErrnoException;
+        error.code = 'EACCES';
+        readFile.mockImplementation(async (...args) => {
+            if (args[0] === ownerPath) throw error;
+            return actualFs.readFile(...args);
+        });
+        try {
+            await maintainDbtGitProjectCache();
+
+            await expect(fs.access(entryDirectory)).resolves.toBeUndefined();
+            expect(vi.mocked(Logger.warn)).toHaveBeenCalledWith(
+                'Failed to read dbt git cache lease owner',
+                { error },
+            );
+        } finally {
+            readFile.mockImplementation(actualFs.readFile);
+        }
+    });
+
+    it('protects a metadata-less entry with an owner-less lease directory', async () => {
+        const root = await configure();
+        const seed = await acquireDbtGitProjectCache(identity(1), 'repository');
+        const { key } = seed!;
+        await invalidateOwnedDbtGitCacheLease(seed!);
+        const entryDirectory = path.join(root, key);
+        const markerPath = path.join(
+            entryDirectory,
+            '.lightdash-cache-entry.json',
+        );
+        await fs.mkdir(path.join(entryDirectory, 'lease'), {
+            recursive: true,
+            mode: 0o700,
+        });
+        await fs.writeFile(markerPath, JSON.stringify({ version: 1, key }), {
+            mode: 0o600,
+        });
+        const stale = new Date(Date.now() - 6 * 60_000);
+        await fs.utimes(markerPath, stale, stale);
+
+        await maintainDbtGitProjectCache();
+
+        await expect(fs.access(entryDirectory)).resolves.toBeUndefined();
+    });
+
     it('reclaims orphaned root marker writes only after the grace period', async () => {
         const root = await configure();
         const temporaryPath = path.join(
@@ -1431,6 +1499,44 @@ describe('dbt git project cache', () => {
         await fs.utimes(temporaryPath, stale, stale);
         await maintainDbtGitProjectCache();
         await expect(fs.access(temporaryPath)).rejects.toThrow();
+    });
+
+    it('drains reserved cleanup when a debris reservation fails', async () => {
+        const root = await configure();
+        const seed = await acquireDbtGitProjectCache(identity(1), 'repository');
+        const { key } = seed!;
+        await invalidateOwnedDbtGitCacheLease(seed!);
+        const abandonedPath = path.join(root, key);
+        await fs.mkdir(abandonedPath, { mode: 0o700 });
+        const temporaryPath = path.join(
+            root,
+            '.lightdash-dbt-git-cache.json.00000000-0000-4000-8000-000000000001.tmp',
+        );
+        await fs.writeFile(temporaryPath, '{}', { mode: 0o600 });
+        const stale = new Date(Date.now() - 6 * 60_000);
+        await fs.utimes(abandonedPath, stale, stale);
+        await fs.utimes(temporaryPath, stale, stale);
+        const actualFs =
+            await vi.importActual<typeof import('fs/promises')>('fs/promises');
+        const rename = vi.mocked(fs.rename);
+        const error = new Error('rename failed') as NodeJS.ErrnoException;
+        error.code = 'EACCES';
+        rename.mockImplementation(async (oldPath, newPath) => {
+            if (oldPath === temporaryPath) throw error;
+            return actualFs.rename(oldPath, newPath);
+        });
+        try {
+            await maintainDbtGitProjectCache();
+
+            await expect(fs.access(abandonedPath)).rejects.toThrow();
+            await expect(fs.access(temporaryPath)).resolves.toBeUndefined();
+            expect(vi.mocked(Logger.warn)).toHaveBeenCalledWith(
+                'Failed to reserve dbt git cache root debris cleanup',
+                { error },
+            );
+        } finally {
+            rename.mockImplementation(actualFs.rename);
+        }
     });
 
     it('protects an active unowned entry during abandoned object cleanup', async () => {
@@ -1472,7 +1578,10 @@ describe('dbt git project cache', () => {
 
         expect(vi.mocked(Logger.warn)).toHaveBeenCalledWith(
             'Declined dbt git cache retention',
-            { reason: 'corrupt-root-entry' },
+            {
+                reason: 'corrupt-root-entry',
+                paths: [path.join(root, '0'.repeat(64))],
+            },
         );
     });
 

--- a/packages/backend/src/projectAdapters/dbtGitProjectCache.test.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectCache.test.ts
@@ -423,9 +423,9 @@ describe('dbt git project cache', () => {
             if (
                 pauseHeartbeat &&
                 typeof newPath === 'string' &&
-                newPath.endsWith('/lease/owner.json') &&
+                path.basename(newPath).startsWith('.heartbeat-') &&
                 typeof oldPath === 'string' &&
-                oldPath.includes('/lease/owner.json.')
+                path.basename(oldPath).startsWith('.heartbeat-')
             ) {
                 pauseHeartbeat = false;
                 startHeartbeat();
@@ -444,6 +444,8 @@ describe('dbt git project cache', () => {
             expect(released).toBe(false);
             finishHeartbeat();
             await release;
+            expect(lease?.invalidated).toBe(false);
+            expect(lease?.signal.aborted).toBe(false);
             const replacement = await acquireDbtGitProjectCache(
                 identity(1),
                 'repository',
@@ -461,6 +463,160 @@ describe('dbt git project cache', () => {
         } finally {
             finishHeartbeat();
             rename.mockImplementation(actualFs.rename);
+        }
+    });
+
+    it('aborts an invalidated lease after heartbeat ownership loss', async () => {
+        await configure();
+        const lease = await acquireDbtGitProjectCache(
+            identity(1),
+            'repository',
+        );
+        expect(lease?.signal.aborted).toBe(false);
+        await fs.mkdir(lease!.checkoutDirectory);
+        const ownerPath = path.join(
+            lease!.entryDirectory,
+            'lease',
+            'owner.json',
+        );
+        const currentOwner = JSON.parse(await fs.readFile(ownerPath, 'utf8'));
+        const replacementOwner = staleOwner({
+            leaseId: '00000000-0000-4000-8000-000000000002',
+            pid: process.pid,
+            processStartTime: currentOwner.processStartTime,
+            heartbeatAt: Date.now(),
+        });
+        await fs.writeFile(ownerPath, JSON.stringify(replacementOwner));
+
+        lease!.heartbeat?.schedule();
+
+        await expect.poll(() => lease!.signal.aborted).toBe(true);
+        expect(lease?.invalidated).toBe(true);
+        await releaseDbtGitProjectCache(lease!, 100);
+        expect(JSON.parse(await fs.readFile(ownerPath, 'utf8'))).toEqual(
+            replacementOwner,
+        );
+    });
+
+    it('times out a heartbeat write without overwriting a replacement owner', async () => {
+        await configure();
+        const lease = await acquireDbtGitProjectCache(
+            identity(1),
+            'repository',
+        );
+        await fs.mkdir(lease!.checkoutDirectory);
+        const actualFs =
+            await vi.importActual<typeof import('fs/promises')>('fs/promises');
+        const rename = vi.mocked(fs.rename);
+        let startHeartbeat: () => void = () => undefined;
+        let finishHeartbeat: () => void = () => undefined;
+        const heartbeatStarted = new Promise<void>((resolve) => {
+            startHeartbeat = resolve;
+        });
+        const heartbeatFinished = new Promise<void>((resolve) => {
+            finishHeartbeat = resolve;
+        });
+        rename.mockImplementation(async (oldPath, newPath) => {
+            if (
+                typeof newPath === 'string' &&
+                path.basename(newPath).startsWith('.heartbeat-')
+            ) {
+                startHeartbeat();
+                await heartbeatFinished;
+            }
+            return actualFs.rename(oldPath, newPath);
+        });
+        vi.useFakeTimers();
+        try {
+            lease!.heartbeat?.schedule();
+            await heartbeatStarted;
+            const ownerPath = path.join(
+                lease!.entryDirectory,
+                'lease',
+                'owner.json',
+            );
+            const currentOwner = JSON.parse(
+                await actualFs.readFile(ownerPath, 'utf8'),
+            );
+            const replacementOwner = staleOwner({
+                leaseId: '00000000-0000-4000-8000-000000000002',
+                pid: process.pid,
+                processStartTime: currentOwner.processStartTime,
+                heartbeatAt: Date.now(),
+            });
+            await actualFs.writeFile(
+                ownerPath,
+                JSON.stringify(replacementOwner),
+            );
+
+            await vi.advanceTimersByTimeAsync(30_001);
+
+            expect(lease?.invalidated).toBe(true);
+            expect(lease?.signal.aborted).toBe(true);
+            await expect(
+                releaseDbtGitProjectCache(lease!, 100),
+            ).resolves.toBeUndefined();
+            finishHeartbeat();
+            await vi.advanceTimersByTimeAsync(0);
+            expect(
+                JSON.parse(await actualFs.readFile(ownerPath, 'utf8')),
+            ).toEqual(replacementOwner);
+        } finally {
+            finishHeartbeat();
+            vi.useRealTimers();
+            rename.mockImplementation(actualFs.rename);
+        }
+    });
+
+    it('times out a heartbeat owner read without blocking lease release', async () => {
+        await configure();
+        const lease = await acquireDbtGitProjectCache(
+            identity(1),
+            'repository',
+        );
+        await fs.mkdir(lease!.checkoutDirectory);
+        const ownerPath = path.join(
+            lease!.entryDirectory,
+            'lease',
+            'owner.json',
+        );
+        const actualFs =
+            await vi.importActual<typeof import('fs/promises')>('fs/promises');
+        const readFile = vi.mocked(fs.readFile);
+        let startRead: () => void = () => undefined;
+        let finishRead: () => void = () => undefined;
+        const readStarted = new Promise<void>((resolve) => {
+            startRead = resolve;
+        });
+        const readFinished = new Promise<void>((resolve) => {
+            finishRead = resolve;
+        });
+        let pauseRead = true;
+        readFile.mockImplementation(async (...args) => {
+            if (pauseRead && args[0] === ownerPath) {
+                pauseRead = false;
+                startRead();
+                await readFinished;
+            }
+            return actualFs.readFile(...args);
+        });
+        vi.useFakeTimers();
+        try {
+            lease!.heartbeat?.schedule();
+            await readStarted;
+
+            await vi.advanceTimersByTimeAsync(30_001);
+
+            expect(lease?.invalidated).toBe(true);
+            expect(lease?.signal.aborted).toBe(true);
+            await expect(
+                releaseDbtGitProjectCache(lease!, 100),
+            ).resolves.toBeUndefined();
+        } finally {
+            finishRead();
+            await vi.advanceTimersByTimeAsync(0);
+            vi.useRealTimers();
+            readFile.mockImplementation(actualFs.readFile);
         }
     });
 

--- a/packages/backend/src/projectAdapters/dbtGitProjectCache.test.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectCache.test.ts
@@ -673,7 +673,7 @@ describe('dbt git project cache', () => {
         await expect.poll(() => tombstoneDirectories(root)).toHaveLength(0);
     });
 
-    it('does not publish while eviction cleanup remains charged', async () => {
+    it('publishes only against its own charged eviction reservation', async () => {
         const root = await configure({ maxBytes: 150 });
         const first = await acquireDbtGitProjectCache(
             identity(1),
@@ -708,15 +708,10 @@ describe('dbt git project cache', () => {
             return actualFs.rm(target, options);
         });
         try {
-            let secondReleased = false;
-            const secondRelease = releaseDbtGitProjectCache(second!, 100).then(
-                () => {
-                    secondReleased = true;
-                },
-            );
+            const secondRelease = releaseDbtGitProjectCache(second!, 100);
             await cleanupStarted;
-            await Promise.resolve();
-            expect(secondReleased).toBe(false);
+            await secondRelease;
+            expect(second).toMatchObject({ retained: true });
             expect(await tombstoneDirectories(root)).toHaveLength(1);
 
             const third = await acquireDbtGitProjectCache(
@@ -725,6 +720,13 @@ describe('dbt git project cache', () => {
             );
             await fs.mkdir(third!.checkoutDirectory);
             await releaseDbtGitProjectCache(third!, 1);
+            expect(third).toMatchObject({
+                retained: false,
+                retentionReason: 'capacity-unavailable',
+            });
+            await expect(
+                fs.access(second!.entryDirectory),
+            ).resolves.toBeUndefined();
             const thirdAgain = await acquireDbtGitProjectCache(
                 identity(3),
                 'repository-3',
@@ -742,12 +744,13 @@ describe('dbt git project cache', () => {
             await releaseDbtGitProjectCache(secondAgain!, 100);
         } finally {
             finishCleanup();
+            await expect.poll(() => tombstoneDirectories(root)).toHaveLength(0);
             rm.mockImplementation(actualFs.rm);
         }
     });
 
-    it('does not extend the retention deadline after accounting consumes it', async () => {
-        await configure({ maxBytes: 150 });
+    it('reserves enough idle victim bytes before optimistic publication', async () => {
+        const root = await configure({ maxBytes: 250 });
         const first = await acquireDbtGitProjectCache(
             identity(1),
             'repository-1',
@@ -759,70 +762,101 @@ describe('dbt git project cache', () => {
             'repository-2',
         );
         await fs.mkdir(second!.checkoutDirectory);
+        await releaseDbtGitProjectCache(second!, 100);
+        const third = await acquireDbtGitProjectCache(
+            identity(3),
+            'repository-3',
+        );
+        await fs.mkdir(third!.checkoutDirectory);
         const actualFs =
             await vi.importActual<typeof import('fs/promises')>('fs/promises');
-        const readFile = vi.mocked(fs.readFile);
         const rm = vi.mocked(fs.rm);
-        const clock = { now: Date.now(), advanced: false };
-        const now = vi.spyOn(Date, 'now').mockImplementation(() => clock.now);
+        let cleanupCount = 0;
+        let startCleanup: () => void = () => undefined;
         let finishCleanup: () => void = () => undefined;
         const cleanupStarted = new Promise<void>((resolve) => {
-            rm.mockImplementation(async (target, options) => {
-                if (
-                    typeof target === 'string' &&
-                    path
-                        .basename(target)
-                        .startsWith(`.tombstone-${first!.key}-`)
-                ) {
-                    resolve();
-                    await new Promise<void>((finish) => {
-                        finishCleanup = finish;
-                    });
-                }
-                return actualFs.rm(target, options);
-            });
+            startCleanup = resolve;
         });
-        readFile.mockImplementation(
-            async (...args: Parameters<typeof fs.readFile>) => {
-                if (
-                    !clock.advanced &&
-                    typeof args[0] === 'string' &&
-                    args[0].endsWith('.lightdash-cache-entry.json')
-                ) {
-                    clock.advanced = true;
-                    clock.now += 4_950;
-                }
-                return actualFs.readFile(...args);
-            },
-        );
+        const cleanupFinished = new Promise<void>((resolve) => {
+            finishCleanup = resolve;
+        });
+        rm.mockImplementation(async (target, options) => {
+            if (
+                typeof target === 'string' &&
+                [first!.key, second!.key].some((key) =>
+                    path.basename(target).startsWith(`.tombstone-${key}-`),
+                )
+            ) {
+                cleanupCount += 1;
+                if (cleanupCount === 2) startCleanup();
+                await cleanupFinished;
+            }
+            return actualFs.rm(target, options);
+        });
         try {
-            let released = false;
-            const release = releaseDbtGitProjectCache(second!, 100).then(() => {
-                released = true;
-            });
+            const release = releaseDbtGitProjectCache(third!, 250);
             await cleanupStarted;
-            await new Promise<void>((resolve) => {
-                setTimeout(resolve, 100);
-            });
-            expect(released).toBe(true);
-            expect(second).toMatchObject({
-                retained: false,
-                retentionReason: 'cleanup-timeout',
-            });
-            finishCleanup();
+
             await release;
-            const replacement = await acquireDbtGitProjectCache(
-                identity(2),
-                'repository-2',
+            expect(third).toMatchObject({ retained: true });
+            expect(await tombstoneDirectories(root)).toHaveLength(2);
+            finishCleanup();
+            await expect.poll(() => tombstoneDirectories(root)).toHaveLength(0);
+            const reused = await acquireDbtGitProjectCache(
+                identity(3),
+                'repository-3',
             );
-            expect(replacement?.reused).toBe(false);
-            await invalidateOwnedDbtGitCacheLease(replacement!);
+            expect(reused?.reused).toBe(true);
+            await releaseDbtGitProjectCache(reused!, 250);
         } finally {
             finishCleanup();
-            now.mockRestore();
-            readFile.mockImplementation(actualFs.readFile);
             rm.mockImplementation(actualFs.rm);
         }
+    });
+
+    it('releases untouched victim leases after a multi-victim rename failure', async () => {
+        await configure({ maxBytes: 250 });
+        const first = await acquireDbtGitProjectCache(
+            identity(1),
+            'repository-1',
+        );
+        await fs.mkdir(first!.checkoutDirectory);
+        await releaseDbtGitProjectCache(first!, 100);
+        const second = await acquireDbtGitProjectCache(
+            identity(2),
+            'repository-2',
+        );
+        await fs.mkdir(second!.checkoutDirectory);
+        await releaseDbtGitProjectCache(second!, 100);
+        const third = await acquireDbtGitProjectCache(
+            identity(3),
+            'repository-3',
+        );
+        await fs.mkdir(third!.checkoutDirectory);
+        const actualFs =
+            await vi.importActual<typeof import('fs/promises')>('fs/promises');
+        const rename = vi.mocked(fs.rename);
+        const error = new Error('rename failed') as NodeJS.ErrnoException;
+        error.code = 'EACCES';
+        rename.mockImplementation(async (oldPath, newPath) => {
+            if (oldPath === first!.entryDirectory) throw error;
+            return actualFs.rename(oldPath, newPath);
+        });
+        try {
+            await expect(
+                releaseDbtGitProjectCache(third!, 250),
+            ).rejects.toThrow('rename failed');
+        } finally {
+            rename.mockImplementation(actualFs.rename);
+        }
+
+        const untouched = await acquireDbtGitProjectCache(
+            identity(2),
+            'repository-2',
+        );
+        expect(untouched?.reused).toBe(true);
+        await invalidateOwnedDbtGitCacheLease(untouched!);
+        await invalidateOwnedDbtGitCacheLease(third!);
     });
 
     it('allows only one contender to reclaim a stale entry lease', async () => {
@@ -1354,7 +1388,7 @@ describe('dbt git project cache', () => {
         }
     });
 
-    it('caps retention cleanup waits at the retention budget', async () => {
+    it('retains a fresh checkout when background victim cleanup fails', async () => {
         const root = await configure({ maxBytes: 150 });
         const first = await acquireDbtGitProjectCache(
             identity(1),
@@ -1370,41 +1404,32 @@ describe('dbt git project cache', () => {
         const actualFs =
             await vi.importActual<typeof import('fs/promises')>('fs/promises');
         const rm = vi.mocked(fs.rm);
-        const clock = { now: Date.now() };
-        const now = vi.spyOn(Date, 'now').mockImplementation(() => clock.now);
-        let startCleanup: () => void = () => undefined;
-        let finishCleanup: () => void = () => undefined;
-        const cleanupStarted = new Promise<void>((resolve) => {
-            startCleanup = resolve;
-        });
-        const cleanupFinished = new Promise<void>((resolve) => {
-            finishCleanup = resolve;
-        });
+        let failCleanup = true;
         rm.mockImplementation(async (target, options) => {
             if (
+                failCleanup &&
                 typeof target === 'string' &&
                 path.basename(target).startsWith(`.tombstone-${first!.key}-`)
             ) {
-                clock.now += 3_001;
-                startCleanup();
-                await cleanupFinished;
+                failCleanup = false;
+                throw new Error('cleanup failed');
             }
             return actualFs.rm(target, options);
         });
         try {
-            const release = releaseDbtGitProjectCache(second!, 100);
-            await cleanupStarted;
+            await releaseDbtGitProjectCache(second!, 100);
 
-            await release;
-            expect(second).toMatchObject({
-                retained: false,
-                retentionReason: 'cleanup-timeout',
-            });
-            finishCleanup();
+            expect(second).toMatchObject({ retained: true });
+            await expect.poll(() => tombstoneDirectories(root)).toHaveLength(1);
+            await maintainDbtGitProjectCache();
             await expect.poll(() => tombstoneDirectories(root)).toHaveLength(0);
+            const reused = await acquireDbtGitProjectCache(
+                identity(2),
+                'repository-2',
+            );
+            expect(reused?.reused).toBe(true);
+            await releaseDbtGitProjectCache(reused!, 100);
         } finally {
-            finishCleanup();
-            now.mockRestore();
             rm.mockImplementation(actualFs.rm);
         }
     });

--- a/packages/backend/src/projectAdapters/dbtGitProjectCache.test.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectCache.test.ts
@@ -12,12 +12,14 @@ import {
     releaseDbtGitProjectCache,
     resolveLiveDbtGitCacheIdentities,
     type DbtGitCacheIdentity,
+    type DbtGitCacheLease,
 } from './dbtGitProjectCache';
 
 vi.mock('fs/promises', async (importOriginal) => {
     const actual = await importOriginal<typeof import('fs/promises')>();
     return {
         ...actual,
+        access: vi.fn(actual.access),
         readFile: vi.fn(actual.readFile),
         rename: vi.fn(actual.rename),
         rm: vi.fn(actual.rm),
@@ -68,19 +70,20 @@ const staleOwner = (overrides: Record<string, unknown> = {}) => ({
     ...overrides,
 });
 
-const retainEntries = async (count: number) => {
-    const leases = [];
-    for (let index = 0; index < count; index += 1) {
-        const lease = await acquireDbtGitProjectCache(
-            identity(index),
-            `repository-${index}`,
-        );
-        await fs.mkdir(lease!.checkoutDirectory);
-        await releaseDbtGitProjectCache(lease!, 1);
-        leases.push(lease!);
-    }
-    return leases;
-};
+const retainEntries = async (count: number) =>
+    Array.from({ length: count }).reduce<Promise<DbtGitCacheLease[]>>(
+        async (pendingLeases, _, index) => {
+            const leases = await pendingLeases;
+            const lease = await acquireDbtGitProjectCache(
+                identity(index),
+                `repository-${index}`,
+            );
+            await fs.mkdir(lease!.checkoutDirectory);
+            await releaseDbtGitProjectCache(lease!, 1);
+            return [...leases, lease!];
+        },
+        Promise.resolve([]),
+    );
 
 afterEach(async () => {
     vi.clearAllMocks();
@@ -198,6 +201,71 @@ describe('dbt git project cache', () => {
         await invalidateDbtGitProjectCacheSource('project', 'source-1');
         await releaseDbtGitProjectCache(lease!, 100);
         expect(await entryDirectories(root)).toHaveLength(0);
+        expect(lease).toMatchObject({
+            retained: false,
+            retentionReason: 'invalidated',
+        });
+    });
+
+    it('reports successful and declined retention outcomes on leases', async () => {
+        await configure({ maxBytes: 100 });
+        const retained = await acquireDbtGitProjectCache(
+            identity(1),
+            'repository-1',
+        );
+        await fs.mkdir(retained!.checkoutDirectory);
+        await releaseDbtGitProjectCache(retained!, 100);
+        expect(retained).toMatchObject({ retained: true });
+        expect(retained?.retentionReason).toBeUndefined();
+
+        const declined = await acquireDbtGitProjectCache(
+            identity(2),
+            'repository-2',
+        );
+        await fs.mkdir(declined!.checkoutDirectory);
+        await releaseDbtGitProjectCache(declined!, 101);
+        expect(declined).toMatchObject({
+            retained: false,
+            retentionReason: 'entry-too-large',
+        });
+    });
+
+    it('reports a busy cache miss', async () => {
+        await configure();
+        const active = await acquireDbtGitProjectCache(
+            identity(1),
+            'repository',
+        );
+        const onMiss = vi.fn();
+
+        const contender = await acquireDbtGitProjectCache(
+            identity(1),
+            'repository',
+            onMiss,
+        );
+
+        expect(contender).toBeUndefined();
+        expect(onMiss).toHaveBeenCalledExactlyOnceWith('busy');
+        await invalidateOwnedDbtGitCacheLease(active!);
+    });
+
+    it('reports a corrupt cache miss', async () => {
+        const root = await configure();
+        const seed = await acquireDbtGitProjectCache(identity(1), 'repository');
+        const { entryDirectory } = seed!;
+        await invalidateOwnedDbtGitCacheLease(seed!);
+        await fs.mkdir(entryDirectory, { mode: 0o700 });
+        const onMiss = vi.fn();
+
+        const lease = await acquireDbtGitProjectCache(
+            identity(1),
+            'repository',
+            onMiss,
+        );
+
+        expect(lease).toBeUndefined();
+        expect(onMiss).toHaveBeenCalledWith('corrupt');
+        expect(await entryDirectories(root)).toHaveLength(1);
     });
 
     it('does not let an old release delete a reacquired generation', async () => {
@@ -788,10 +856,57 @@ describe('dbt git project cache', () => {
                 ),
             ),
         );
+        const onMiss = vi.fn();
         await expect(
-            acquireDbtGitProjectCache(identity(1), 'repository'),
+            acquireDbtGitProjectCache(identity(1), 'repository', onMiss),
         ).resolves.toBeUndefined();
+        expect(onMiss).toHaveBeenCalledWith('entry-cap');
         expect(await entryDirectories(root)).toHaveLength(128);
+    });
+
+    it('reports a reservation lock timeout', async () => {
+        const root = await configure();
+        const seed = await acquireDbtGitProjectCache(identity(0), 'seed');
+        await fs.mkdir(seed!.checkoutDirectory);
+        await releaseDbtGitProjectCache(seed!, 1);
+        const reservationLock = path.join(root, '.reservation-lock');
+        await fs.mkdir(reservationLock);
+        await fs.writeFile(
+            path.join(reservationLock, 'owner.json'),
+            JSON.stringify(
+                staleOwner({
+                    hostname: 'active-pod',
+                    heartbeatAt: Date.now(),
+                }),
+            ),
+        );
+        const onMiss = vi.fn();
+        const actualFs =
+            await vi.importActual<typeof import('fs/promises')>('fs/promises');
+        const readFile = vi.mocked(fs.readFile);
+        const clock = { now: Date.now(), advanced: false };
+        const now = vi.spyOn(Date, 'now').mockImplementation(() => clock.now);
+        readFile.mockImplementation(
+            async (...args: Parameters<typeof fs.readFile>) => {
+                if (
+                    !clock.advanced &&
+                    args[0] === path.join(reservationLock, 'owner.json')
+                ) {
+                    clock.advanced = true;
+                    clock.now += 6_000;
+                }
+                return actualFs.readFile(...args);
+            },
+        );
+        try {
+            await expect(
+                acquireDbtGitProjectCache(identity(1), 'repository', onMiss),
+            ).resolves.toBeUndefined();
+            expect(onMiss).toHaveBeenCalledWith('lock-timeout');
+        } finally {
+            now.mockRestore();
+            readFile.mockImplementation(actualFs.readFile);
+        }
     });
 
     it('evicts the least recently used retained entry on admission', async () => {
@@ -915,7 +1030,7 @@ describe('dbt git project cache', () => {
     it('reclaims a metadata-less crashed acquisition after the grace period', async () => {
         const root = await configure();
         const seed = await acquireDbtGitProjectCache(identity(1), 'repository');
-        const key = seed!.key;
+        const { key } = seed!;
         await invalidateOwnedDbtGitCacheLease(seed!);
         const entryDirectory = path.join(root, key);
         await fs.mkdir(entryDirectory, { mode: 0o700 });
@@ -1071,5 +1186,50 @@ describe('dbt git project cache', () => {
         await expect(
             acquireDbtGitProjectCache(identity(1), 'repository'),
         ).rejects.toThrow('cache root');
+    });
+
+    it.each([0, -1])(
+        'disables the cache without creating its root for maxBytes %s',
+        async (maxBytes) => {
+            const parent = await fs.mkdtemp(
+                path.join(os.tmpdir(), 'dbt-cache-disabled-test-'),
+            );
+            roots.push(parent);
+            const root = path.join(parent, 'cache');
+            configureDbtGitProjectCache({
+                root,
+                maxBytes,
+                maxAgeMs: 60_000,
+                livenessCheck: async () => new Set(),
+            });
+            const onMiss = vi.fn();
+
+            await expect(
+                acquireDbtGitProjectCache(identity(1), 'repository', onMiss),
+            ).resolves.toBeUndefined();
+
+            expect(onMiss).toHaveBeenCalledWith('disabled');
+            await expect(fs.access(root)).rejects.toThrow();
+        },
+    );
+
+    it('warns when a filesystem inspection error is swallowed', async () => {
+        await configure();
+        const lease = await acquireDbtGitProjectCache(
+            identity(1),
+            'repository',
+        );
+        await fs.mkdir(lease!.checkoutDirectory);
+        const access = vi.mocked(fs.access);
+        const error = new Error('permission denied') as NodeJS.ErrnoException;
+        error.code = 'EACCES';
+        access.mockRejectedValueOnce(error);
+
+        await releaseDbtGitProjectCache(lease!, 100);
+
+        expect(vi.mocked(Logger.warn)).toHaveBeenCalledWith(
+            'Failed to inspect dbt git cache path',
+            { error },
+        );
     });
 });

--- a/packages/backend/src/projectAdapters/dbtGitProjectCache.test.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectCache.test.ts
@@ -590,7 +590,7 @@ describe('dbt git project cache', () => {
         }
     });
 
-    it('uses an independent cleanup wait after the lock budget is consumed', async () => {
+    it('does not extend the retention deadline after accounting consumes it', async () => {
         await configure({ maxBytes: 150 });
         const first = await acquireDbtGitProjectCache(
             identity(1),
@@ -648,15 +648,19 @@ describe('dbt git project cache', () => {
             await new Promise<void>((resolve) => {
                 setTimeout(resolve, 100);
             });
-            expect(released).toBe(false);
+            expect(released).toBe(true);
+            expect(second).toMatchObject({
+                retained: false,
+                retentionReason: 'cleanup-timeout',
+            });
             finishCleanup();
             await release;
-            const reused = await acquireDbtGitProjectCache(
+            const replacement = await acquireDbtGitProjectCache(
                 identity(2),
                 'repository-2',
             );
-            expect(reused?.reused).toBe(true);
-            await releaseDbtGitProjectCache(reused!, 100);
+            expect(replacement?.reused).toBe(false);
+            await invalidateOwnedDbtGitCacheLease(replacement!);
         } finally {
             finishCleanup();
             now.mockRestore();
@@ -950,7 +954,7 @@ describe('dbt git project cache', () => {
         expect(await entryDirectories(root)).toHaveLength(128);
     });
 
-    it('reports a reservation lock timeout', async () => {
+    it('reports an admission timeout while waiting for the reservation lock', async () => {
         const root = await configure();
         const seed = await acquireDbtGitProjectCache(identity(0), 'seed');
         await fs.mkdir(seed!.checkoutDirectory);
@@ -979,7 +983,7 @@ describe('dbt git project cache', () => {
                     args[0] === path.join(reservationLock, 'owner.json')
                 ) {
                     clock.advanced = true;
-                    clock.now += 6_000;
+                    clock.now += 4_000;
                 }
                 return actualFs.readFile(...args);
             },
@@ -988,7 +992,7 @@ describe('dbt git project cache', () => {
             await expect(
                 acquireDbtGitProjectCache(identity(1), 'repository', onMiss),
             ).resolves.toBeUndefined();
-            expect(onMiss).toHaveBeenCalledWith('lock-timeout');
+            expect(onMiss).toHaveBeenCalledExactlyOnceWith('admission-timeout');
         } finally {
             now.mockRestore();
             readFile.mockImplementation(actualFs.readFile);
@@ -1077,6 +1081,130 @@ describe('dbt git project cache', () => {
         await expect(fs.access(leases[1].entryDirectory)).rejects.toThrow();
         await releaseDbtGitProjectCache(active!, 1);
         await invalidateOwnedDbtGitCacheLease(admitted!);
+    });
+
+    it('falls back after the admission cleanup budget without late publication', async () => {
+        const root = await configure();
+        const leases = await retainEntries(128);
+        const oldestMetadataPath = path.join(
+            leases[0].entryDirectory,
+            'metadata.json',
+        );
+        const oldestMetadata = JSON.parse(
+            await fs.readFile(oldestMetadataPath, 'utf8'),
+        );
+        await fs.writeFile(
+            oldestMetadataPath,
+            JSON.stringify({
+                ...oldestMetadata,
+                lastUsedAt: Date.now() - 30_000,
+            }),
+        );
+        const actualFs =
+            await vi.importActual<typeof import('fs/promises')>('fs/promises');
+        const rm = vi.mocked(fs.rm);
+        const clock = { now: Date.now() };
+        const now = vi.spyOn(Date, 'now').mockImplementation(() => clock.now);
+        let startCleanup: () => void = () => undefined;
+        let finishCleanup: () => void = () => undefined;
+        const cleanupStarted = new Promise<void>((resolve) => {
+            startCleanup = resolve;
+        });
+        const cleanupFinished = new Promise<void>((resolve) => {
+            finishCleanup = resolve;
+        });
+        rm.mockImplementation(async (target, options) => {
+            if (
+                typeof target === 'string' &&
+                path.basename(target).startsWith(`.tombstone-${leases[0].key}-`)
+            ) {
+                clock.now += 3_001;
+                startCleanup();
+                await cleanupFinished;
+            }
+            return actualFs.rm(target, options);
+        });
+        try {
+            const onMiss = vi.fn();
+            const admission = acquireDbtGitProjectCache(
+                identity(128),
+                'repository-128',
+                onMiss,
+            );
+            await cleanupStarted;
+
+            await expect(admission).resolves.toBeUndefined();
+            expect(onMiss).toHaveBeenCalledExactlyOnceWith('admission-timeout');
+            finishCleanup();
+            await expect.poll(() => tombstoneDirectories(root)).toHaveLength(0);
+            expect(await entryDirectories(root)).toHaveLength(127);
+
+            const retry = await acquireDbtGitProjectCache(
+                identity(128),
+                'repository-128',
+            );
+            expect(retry?.reused).toBe(false);
+            await invalidateOwnedDbtGitCacheLease(retry!);
+        } finally {
+            finishCleanup();
+            now.mockRestore();
+            rm.mockImplementation(actualFs.rm);
+        }
+    });
+
+    it('caps retention cleanup waits at the retention budget', async () => {
+        const root = await configure({ maxBytes: 150 });
+        const first = await acquireDbtGitProjectCache(
+            identity(1),
+            'repository-1',
+        );
+        await fs.mkdir(first!.checkoutDirectory);
+        await releaseDbtGitProjectCache(first!, 100);
+        const second = await acquireDbtGitProjectCache(
+            identity(2),
+            'repository-2',
+        );
+        await fs.mkdir(second!.checkoutDirectory);
+        const actualFs =
+            await vi.importActual<typeof import('fs/promises')>('fs/promises');
+        const rm = vi.mocked(fs.rm);
+        const clock = { now: Date.now() };
+        const now = vi.spyOn(Date, 'now').mockImplementation(() => clock.now);
+        let startCleanup: () => void = () => undefined;
+        let finishCleanup: () => void = () => undefined;
+        const cleanupStarted = new Promise<void>((resolve) => {
+            startCleanup = resolve;
+        });
+        const cleanupFinished = new Promise<void>((resolve) => {
+            finishCleanup = resolve;
+        });
+        rm.mockImplementation(async (target, options) => {
+            if (
+                typeof target === 'string' &&
+                path.basename(target).startsWith(`.tombstone-${first!.key}-`)
+            ) {
+                clock.now += 3_001;
+                startCleanup();
+                await cleanupFinished;
+            }
+            return actualFs.rm(target, options);
+        });
+        try {
+            const release = releaseDbtGitProjectCache(second!, 100);
+            await cleanupStarted;
+
+            await release;
+            expect(second).toMatchObject({
+                retained: false,
+                retentionReason: 'cleanup-timeout',
+            });
+            finishCleanup();
+            await expect.poll(() => tombstoneDirectories(root)).toHaveLength(0);
+        } finally {
+            finishCleanup();
+            now.mockRestore();
+            rm.mockImplementation(actualFs.rm);
+        }
     });
 
     it('reclaims an interrupted tombstone with a missing marker after the grace period', async () => {

--- a/packages/backend/src/projectAdapters/dbtGitProjectCache.test.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectCache.test.ts
@@ -68,6 +68,20 @@ const staleOwner = (overrides: Record<string, unknown> = {}) => ({
     ...overrides,
 });
 
+const retainEntries = async (count: number) => {
+    const leases = [];
+    for (let index = 0; index < count; index += 1) {
+        const lease = await acquireDbtGitProjectCache(
+            identity(index),
+            `repository-${index}`,
+        );
+        await fs.mkdir(lease!.checkoutDirectory);
+        await releaseDbtGitProjectCache(lease!, 1);
+        leases.push(lease!);
+    }
+    return leases;
+};
+
 afterEach(async () => {
     vi.clearAllMocks();
     await Promise.all(
@@ -460,6 +474,81 @@ describe('dbt git project cache', () => {
         }
     });
 
+    it('uses an independent cleanup wait after the lock budget is consumed', async () => {
+        await configure({ maxBytes: 150 });
+        const first = await acquireDbtGitProjectCache(
+            identity(1),
+            'repository-1',
+        );
+        await fs.mkdir(first!.checkoutDirectory);
+        await releaseDbtGitProjectCache(first!, 100);
+        const second = await acquireDbtGitProjectCache(
+            identity(2),
+            'repository-2',
+        );
+        await fs.mkdir(second!.checkoutDirectory);
+        const actualFs =
+            await vi.importActual<typeof import('fs/promises')>('fs/promises');
+        const readFile = vi.mocked(fs.readFile);
+        const rm = vi.mocked(fs.rm);
+        const clock = { now: Date.now(), advanced: false };
+        const now = vi.spyOn(Date, 'now').mockImplementation(() => clock.now);
+        let finishCleanup: () => void = () => undefined;
+        const cleanupStarted = new Promise<void>((resolve) => {
+            rm.mockImplementation(async (target, options) => {
+                if (
+                    typeof target === 'string' &&
+                    path
+                        .basename(target)
+                        .startsWith(`.tombstone-${first!.key}-`)
+                ) {
+                    resolve();
+                    await new Promise<void>((finish) => {
+                        finishCleanup = finish;
+                    });
+                }
+                return actualFs.rm(target, options);
+            });
+        });
+        readFile.mockImplementation(
+            async (...args: Parameters<typeof fs.readFile>) => {
+                if (
+                    !clock.advanced &&
+                    typeof args[0] === 'string' &&
+                    args[0].endsWith('.lightdash-cache-entry.json')
+                ) {
+                    clock.advanced = true;
+                    clock.now += 4_950;
+                }
+                return actualFs.readFile(...args);
+            },
+        );
+        try {
+            let released = false;
+            const release = releaseDbtGitProjectCache(second!, 100).then(() => {
+                released = true;
+            });
+            await cleanupStarted;
+            await new Promise<void>((resolve) => {
+                setTimeout(resolve, 100);
+            });
+            expect(released).toBe(false);
+            finishCleanup();
+            await release;
+            const reused = await acquireDbtGitProjectCache(
+                identity(2),
+                'repository-2',
+            );
+            expect(reused?.reused).toBe(true);
+            await releaseDbtGitProjectCache(reused!, 100);
+        } finally {
+            finishCleanup();
+            now.mockRestore();
+            readFile.mockImplementation(actualFs.readFile);
+            rm.mockImplementation(actualFs.rm);
+        }
+    });
+
     it('allows only one contender to reclaim a stale entry lease', async () => {
         const root = await configure();
         const first = await acquireDbtGitProjectCache(
@@ -703,6 +792,90 @@ describe('dbt git project cache', () => {
             acquireDbtGitProjectCache(identity(1), 'repository'),
         ).resolves.toBeUndefined();
         expect(await entryDirectories(root)).toHaveLength(128);
+    });
+
+    it('evicts the least recently used retained entry on admission', async () => {
+        const root = await configure();
+        const leases = await retainEntries(128);
+        const oldestMetadataPath = path.join(
+            leases[0].entryDirectory,
+            'metadata.json',
+        );
+        const oldestMetadata = JSON.parse(
+            await fs.readFile(oldestMetadataPath, 'utf8'),
+        );
+        await fs.writeFile(
+            oldestMetadataPath,
+            JSON.stringify({
+                ...oldestMetadata,
+                lastUsedAt: Date.now() - 30_000,
+            }),
+        );
+
+        const admitted = await acquireDbtGitProjectCache(
+            identity(128),
+            'repository-128',
+        );
+
+        expect(admitted?.reused).toBe(false);
+        expect(await entryDirectories(root)).toHaveLength(128);
+        await expect(fs.access(leases[0].entryDirectory)).rejects.toThrow();
+        await expect(
+            fs.access(leases[1].entryDirectory),
+        ).resolves.toBeUndefined();
+        await invalidateOwnedDbtGitCacheLease(admitted!);
+    });
+
+    it('does not evict an active retained entry on admission', async () => {
+        const root = await configure();
+        const leases = await retainEntries(128);
+        const oldestMetadataPath = path.join(
+            leases[0].entryDirectory,
+            'metadata.json',
+        );
+        const secondMetadataPath = path.join(
+            leases[1].entryDirectory,
+            'metadata.json',
+        );
+        const oldestMetadata = JSON.parse(
+            await fs.readFile(oldestMetadataPath, 'utf8'),
+        );
+        const secondMetadata = JSON.parse(
+            await fs.readFile(secondMetadataPath, 'utf8'),
+        );
+        await fs.writeFile(
+            oldestMetadataPath,
+            JSON.stringify({
+                ...oldestMetadata,
+                lastUsedAt: Date.now() - 30_000,
+            }),
+        );
+        await fs.writeFile(
+            secondMetadataPath,
+            JSON.stringify({
+                ...secondMetadata,
+                lastUsedAt: Date.now() - 20_000,
+            }),
+        );
+        const active = await acquireDbtGitProjectCache(
+            identity(0),
+            'repository-0',
+        );
+
+        const admitted = await acquireDbtGitProjectCache(
+            identity(128),
+            'repository-128',
+        );
+
+        expect(active?.reused).toBe(true);
+        expect(admitted?.reused).toBe(false);
+        expect(await entryDirectories(root)).toHaveLength(128);
+        await expect(
+            fs.access(leases[0].entryDirectory),
+        ).resolves.toBeUndefined();
+        await expect(fs.access(leases[1].entryDirectory)).rejects.toThrow();
+        await releaseDbtGitProjectCache(active!, 1);
+        await invalidateOwnedDbtGitCacheLease(admitted!);
     });
 
     it('reclaims an interrupted tombstone with a missing marker after the grace period', async () => {

--- a/packages/backend/src/projectAdapters/dbtGitProjectCache.test.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectCache.test.ts
@@ -230,6 +230,54 @@ describe('dbt git project cache', () => {
         });
     });
 
+    it('declines retention after lease ownership changes', async () => {
+        await configure();
+        const lease = await acquireDbtGitProjectCache(
+            identity(1),
+            'repository',
+        );
+        await fs.mkdir(lease!.checkoutDirectory);
+        const currentOwner = JSON.parse(
+            await fs.readFile(
+                path.join(lease!.entryDirectory, 'lease', 'owner.json'),
+                'utf8',
+            ),
+        );
+        const replacementOwner = staleOwner({
+            leaseId: '00000000-0000-4000-8000-000000000002',
+            pid: process.pid,
+            processStartTime: currentOwner.processStartTime,
+            heartbeatAt: Date.now(),
+        });
+        await fs.writeFile(
+            path.join(lease!.entryDirectory, 'lease', 'owner.json'),
+            JSON.stringify(replacementOwner),
+        );
+
+        await releaseDbtGitProjectCache(lease!, 100);
+
+        expect(lease).toMatchObject({
+            retained: false,
+            retentionReason: 'lease-lost',
+        });
+        expect(
+            JSON.parse(
+                await fs.readFile(
+                    path.join(lease!.entryDirectory, 'metadata.json'),
+                    'utf8',
+                ),
+            ),
+        ).toMatchObject({ state: 'active' });
+        expect(
+            JSON.parse(
+                await fs.readFile(
+                    path.join(lease!.entryDirectory, 'lease', 'owner.json'),
+                    'utf8',
+                ),
+            ),
+        ).toEqual(replacementOwner);
+    });
+
     it('reports a busy cache miss', async () => {
         await configure();
         const active = await acquireDbtGitProjectCache(

--- a/packages/backend/src/projectAdapters/dbtGitProjectCache.test.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectCache.test.ts
@@ -1386,7 +1386,7 @@ describe('dbt git project cache', () => {
             now.mockRestore();
             rm.mockImplementation(actualFs.rm);
         }
-    });
+    }, 10_000);
 
     it('retains a fresh checkout when background victim cleanup fails', async () => {
         const root = await configure({ maxBytes: 150 });

--- a/packages/backend/src/projectAdapters/dbtGitProjectCache.test.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectCache.test.ts
@@ -1,0 +1,724 @@
+import * as fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import {
+    acquireDbtGitProjectCache,
+    configureDbtGitProjectCache,
+    dbtGitCacheIdentityKey,
+    invalidateDbtGitProjectCacheSource,
+    invalidateOwnedDbtGitCacheLease,
+    maintainDbtGitProjectCache,
+    releaseDbtGitProjectCache,
+    resolveLiveDbtGitCacheIdentities,
+    type DbtGitCacheIdentity,
+} from './dbtGitProjectCache';
+
+vi.mock('fs/promises', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('fs/promises')>();
+    return {
+        ...actual,
+        readFile: vi.fn(actual.readFile),
+        rename: vi.fn(actual.rename),
+        rm: vi.fn(actual.rm),
+    };
+});
+
+const roots: string[] = [];
+
+const identity = (index: number): DbtGitCacheIdentity => ({
+    projectUuid: 'project',
+    sourceUuid: `source-${index}`,
+    sourceType: 'additional',
+});
+
+const configure = async (
+    overrides: Partial<{ maxBytes: number; maxAgeMs: number }> = {},
+) => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'dbt-cache-test-'));
+    roots.push(root);
+    configureDbtGitProjectCache({
+        root,
+        maxBytes: overrides.maxBytes ?? 1024 * 1024,
+        maxAgeMs: overrides.maxAgeMs ?? 60_000,
+        livenessCheck: async (identities) =>
+            new Set(identities.map(dbtGitCacheIdentityKey)),
+    });
+    return root;
+};
+
+const entryDirectories = async (root: string) =>
+    (await fs.readdir(root)).filter((name) => /^[a-f0-9]{64}$/.test(name));
+
+const tombstoneDirectories = async (root: string) =>
+    (await fs.readdir(root)).filter((name) => name.startsWith('.tombstone-'));
+
+const staleOwner = (overrides: Record<string, unknown> = {}) => ({
+    leaseId: '00000000-0000-4000-8000-000000000001',
+    hostname: os.hostname(),
+    pid: 2147483647,
+    processStartTime: '1',
+    heartbeatAt: Date.now() - 10 * 60_000,
+    ...overrides,
+});
+
+afterEach(async () => {
+    await Promise.all(
+        roots
+            .splice(0)
+            .map((root) => fs.rm(root, { recursive: true, force: true })),
+    );
+});
+
+describe('dbt git project cache', () => {
+    it('uses exact primary and additional source membership semantics', () => {
+        const identities: DbtGitCacheIdentity[] = [
+            {
+                projectUuid: 'explicit-primary-project',
+                sourceUuid: 'explicit-primary-source',
+                sourceType: 'primary',
+            },
+            {
+                projectUuid: 'fallback-primary-project',
+                sourceUuid: 'fallback-primary-project',
+                sourceType: 'primary',
+            },
+            {
+                projectUuid: 'wrong-fallback-project',
+                sourceUuid: 'wrong-fallback-source',
+                sourceType: 'primary',
+            },
+            {
+                projectUuid: 'additional-project',
+                sourceUuid: 'additional-source',
+                sourceType: 'additional',
+            },
+            {
+                projectUuid: 'wrong-additional-project',
+                sourceUuid: 'additional-source',
+                sourceType: 'additional',
+            },
+        ];
+        const live = resolveLiveDbtGitCacheIdentities({
+            identities,
+            primaryRows: [
+                {
+                    projectUuid: 'explicit-primary-project',
+                    dbtSourceUuid: 'explicit-primary-source',
+                },
+                {
+                    projectUuid: 'fallback-primary-project',
+                    dbtSourceUuid: null,
+                },
+                {
+                    projectUuid: 'wrong-fallback-project',
+                    dbtSourceUuid: null,
+                },
+            ],
+            additionalRows: [
+                {
+                    projectUuid: 'additional-project',
+                    projectDbtSourceUuid: 'additional-source',
+                },
+            ],
+        });
+        expect(live).toEqual(
+            new Set(
+                identities
+                    .slice(0, 2)
+                    .concat(identities[3])
+                    .map(dbtGitCacheIdentityKey),
+            ),
+        );
+    });
+
+    it('retains simultaneous fitting checkouts for different sources', async () => {
+        await configure();
+        const leases = await Promise.all(
+            Array.from({ length: 14 }, async (_, index) => {
+                const lease = await acquireDbtGitProjectCache(
+                    identity(index),
+                    `repository-${index}`,
+                );
+                expect(lease).toBeDefined();
+                await fs.mkdir(lease!.checkoutDirectory);
+                await fs.writeFile(
+                    path.join(lease!.checkoutDirectory, 'dbt_project.yml'),
+                    'name: test\n',
+                );
+                return lease!;
+            }),
+        );
+        await Promise.all(
+            leases.map((lease) => releaseDbtGitProjectCache(lease, 100)),
+        );
+        const reused = await Promise.all(
+            Array.from({ length: 14 }, (_, index) =>
+                acquireDbtGitProjectCache(
+                    identity(index),
+                    `repository-${index}`,
+                ),
+            ),
+        );
+        expect(reused.every((lease) => lease?.reused)).toBe(true);
+        await Promise.all(
+            reused.map((lease) => releaseDbtGitProjectCache(lease!, 100)),
+        );
+    });
+
+    it('deletes an invalidated active entry on release', async () => {
+        const root = await configure();
+        const lease = await acquireDbtGitProjectCache(
+            identity(1),
+            'repository',
+        );
+        expect(lease).toBeDefined();
+        await fs.mkdir(lease!.checkoutDirectory);
+        await invalidateDbtGitProjectCacheSource('project', 'source-1');
+        await releaseDbtGitProjectCache(lease!, 100);
+        expect(await entryDirectories(root)).toHaveLength(0);
+    });
+
+    it('does not let an old release delete a reacquired generation', async () => {
+        const root = await configure();
+        const oldLease = await acquireDbtGitProjectCache(
+            identity(1),
+            'repository',
+        );
+        expect(oldLease).toBeDefined();
+        await invalidateOwnedDbtGitCacheLease(oldLease!);
+        const newLease = await acquireDbtGitProjectCache(
+            identity(1),
+            'repository',
+        );
+        expect(newLease).toBeDefined();
+        await fs.mkdir(newLease!.checkoutDirectory);
+        await releaseDbtGitProjectCache(oldLease!, 100);
+        expect(await entryDirectories(root)).toHaveLength(1);
+        await releaseDbtGitProjectCache(newLease!, 100);
+        const reused = await acquireDbtGitProjectCache(
+            identity(1),
+            'repository',
+        );
+        expect(reused?.reused).toBe(true);
+        await releaseDbtGitProjectCache(reused!, 100);
+    });
+
+    it('does not let paused tombstone cleanup delete a new generation', async () => {
+        const root = await configure();
+        const lease = await acquireDbtGitProjectCache(
+            identity(1),
+            'repository',
+        );
+        await fs.mkdir(lease!.checkoutDirectory);
+        const actualFs =
+            await vi.importActual<typeof import('fs/promises')>('fs/promises');
+        const rm = vi.mocked(fs.rm);
+        let startCleanup: () => void = () => undefined;
+        let finishCleanup: () => void = () => undefined;
+        const cleanupStarted = new Promise<void>((resolve) => {
+            startCleanup = resolve;
+        });
+        const cleanupFinished = new Promise<void>((resolve) => {
+            finishCleanup = resolve;
+        });
+        let paused = false;
+        rm.mockImplementation(async (target, options) => {
+            if (
+                !paused &&
+                typeof target === 'string' &&
+                path.basename(target).startsWith('.tombstone-')
+            ) {
+                paused = true;
+                startCleanup();
+                await cleanupFinished;
+            }
+            return actualFs.rm(target, options);
+        });
+        try {
+            await invalidateOwnedDbtGitCacheLease(lease!);
+            await cleanupStarted;
+            const replacement = await acquireDbtGitProjectCache(
+                identity(1),
+                'repository',
+            );
+            expect(replacement?.reused).toBe(false);
+            await fs.mkdir(replacement!.checkoutDirectory);
+            await fs.writeFile(
+                path.join(replacement!.checkoutDirectory, 'current'),
+                'current',
+            );
+            finishCleanup();
+            await expect.poll(() => tombstoneDirectories(root)).toHaveLength(0);
+            await expect(
+                fs.readFile(
+                    path.join(replacement!.checkoutDirectory, 'current'),
+                    'utf8',
+                ),
+            ).resolves.toBe('current');
+            await releaseDbtGitProjectCache(replacement!, 100);
+        } finally {
+            finishCleanup();
+            rm.mockImplementation(actualFs.rm);
+        }
+    });
+
+    it('drains an in-flight heartbeat before lease release and reacquire', async () => {
+        await configure();
+        const lease = await acquireDbtGitProjectCache(
+            identity(1),
+            'repository',
+        );
+        await fs.mkdir(lease!.checkoutDirectory);
+        const actualFs =
+            await vi.importActual<typeof import('fs/promises')>('fs/promises');
+        const rename = vi.mocked(fs.rename);
+        let startHeartbeat: () => void = () => undefined;
+        let finishHeartbeat: () => void = () => undefined;
+        const heartbeatStarted = new Promise<void>((resolve) => {
+            startHeartbeat = resolve;
+        });
+        const heartbeatFinished = new Promise<void>((resolve) => {
+            finishHeartbeat = resolve;
+        });
+        let pauseHeartbeat = true;
+        rename.mockImplementation(async (oldPath, newPath) => {
+            if (
+                pauseHeartbeat &&
+                typeof newPath === 'string' &&
+                newPath.endsWith('/lease/owner.json') &&
+                typeof oldPath === 'string' &&
+                oldPath.includes('/lease/owner.json.')
+            ) {
+                pauseHeartbeat = false;
+                startHeartbeat();
+                await heartbeatFinished;
+            }
+            return actualFs.rename(oldPath, newPath);
+        });
+        try {
+            lease!.heartbeat?.schedule();
+            await heartbeatStarted;
+            let released = false;
+            const release = releaseDbtGitProjectCache(lease!, 100).then(() => {
+                released = true;
+            });
+            await Promise.resolve();
+            expect(released).toBe(false);
+            finishHeartbeat();
+            await release;
+            const replacement = await acquireDbtGitProjectCache(
+                identity(1),
+                'repository',
+            );
+            expect(replacement?.reused).toBe(true);
+            const ownerPath = path.join(
+                replacement!.entryDirectory,
+                'lease',
+                'owner.json',
+            );
+            const ownerBefore = await fs.readFile(ownerPath, 'utf8');
+            await Promise.resolve();
+            expect(await fs.readFile(ownerPath, 'utf8')).toBe(ownerBefore);
+            await releaseDbtGitProjectCache(replacement!, 100);
+        } finally {
+            finishHeartbeat();
+            rename.mockImplementation(actualFs.rename);
+        }
+    });
+
+    it('counts a failed tombstone cleanup against retained capacity', async () => {
+        const root = await configure({ maxBytes: 1_000 });
+        const lease = await acquireDbtGitProjectCache(
+            identity(1),
+            'repository-1',
+        );
+        await fs.mkdir(lease!.checkoutDirectory);
+        const actualFs =
+            await vi.importActual<typeof import('fs/promises')>('fs/promises');
+        const rm = vi.mocked(fs.rm);
+        let failTombstone = true;
+        rm.mockImplementation(async (target, options) => {
+            if (
+                failTombstone &&
+                typeof target === 'string' &&
+                path.basename(target).startsWith('.tombstone-')
+            ) {
+                failTombstone = false;
+                throw new Error('cleanup failed');
+            }
+            return actualFs.rm(target, options);
+        });
+        try {
+            await invalidateOwnedDbtGitCacheLease(lease!);
+            await expect.poll(() => tombstoneDirectories(root)).toHaveLength(1);
+            await expect
+                .poll(async () => {
+                    const [tombstone] = await tombstoneDirectories(root);
+                    return fs
+                        .access(path.join(root, tombstone!, 'lease'))
+                        .then(() => true)
+                        .catch(() => false);
+                })
+                .toBe(false);
+            const candidate = await acquireDbtGitProjectCache(
+                identity(2),
+                'repository-2',
+            );
+            await fs.mkdir(candidate!.checkoutDirectory);
+            await releaseDbtGitProjectCache(candidate!, 100);
+            const next = await acquireDbtGitProjectCache(
+                identity(2),
+                'repository-2',
+            );
+            expect(next?.reused).toBe(false);
+            await invalidateOwnedDbtGitCacheLease(next!);
+        } finally {
+            rm.mockImplementation(actualFs.rm);
+        }
+        await maintainDbtGitProjectCache();
+        await expect.poll(() => tombstoneDirectories(root)).toHaveLength(0);
+    });
+
+    it('does not publish while eviction cleanup remains charged', async () => {
+        const root = await configure({ maxBytes: 150 });
+        const first = await acquireDbtGitProjectCache(
+            identity(1),
+            'repository-1',
+        );
+        await fs.mkdir(first!.checkoutDirectory);
+        await releaseDbtGitProjectCache(first!, 100);
+        const second = await acquireDbtGitProjectCache(
+            identity(2),
+            'repository-2',
+        );
+        await fs.mkdir(second!.checkoutDirectory);
+        const actualFs =
+            await vi.importActual<typeof import('fs/promises')>('fs/promises');
+        const rm = vi.mocked(fs.rm);
+        let startCleanup: () => void = () => undefined;
+        let finishCleanup: () => void = () => undefined;
+        const cleanupStarted = new Promise<void>((resolve) => {
+            startCleanup = resolve;
+        });
+        const cleanupFinished = new Promise<void>((resolve) => {
+            finishCleanup = resolve;
+        });
+        rm.mockImplementation(async (target, options) => {
+            if (
+                typeof target === 'string' &&
+                path.basename(target).startsWith(`.tombstone-${first!.key}-`)
+            ) {
+                startCleanup();
+                await cleanupFinished;
+            }
+            return actualFs.rm(target, options);
+        });
+        try {
+            let secondReleased = false;
+            const secondRelease = releaseDbtGitProjectCache(second!, 100).then(
+                () => {
+                    secondReleased = true;
+                },
+            );
+            await cleanupStarted;
+            await Promise.resolve();
+            expect(secondReleased).toBe(false);
+            expect(await tombstoneDirectories(root)).toHaveLength(1);
+
+            const third = await acquireDbtGitProjectCache(
+                identity(3),
+                'repository-3',
+            );
+            await fs.mkdir(third!.checkoutDirectory);
+            await releaseDbtGitProjectCache(third!, 1);
+            const thirdAgain = await acquireDbtGitProjectCache(
+                identity(3),
+                'repository-3',
+            );
+            expect(thirdAgain?.reused).toBe(false);
+            await invalidateOwnedDbtGitCacheLease(thirdAgain!);
+
+            finishCleanup();
+            await secondRelease;
+            const secondAgain = await acquireDbtGitProjectCache(
+                identity(2),
+                'repository-2',
+            );
+            expect(secondAgain?.reused).toBe(true);
+            await releaseDbtGitProjectCache(secondAgain!, 100);
+        } finally {
+            finishCleanup();
+            rm.mockImplementation(actualFs.rm);
+        }
+    });
+
+    it('allows only one contender to reclaim a stale entry lease', async () => {
+        const root = await configure();
+        const first = await acquireDbtGitProjectCache(
+            identity(1),
+            'repository',
+        );
+        expect(first).toBeDefined();
+        await fs.mkdir(first!.checkoutDirectory);
+        await releaseDbtGitProjectCache(first!, 100);
+        const [entry] = await entryDirectories(root);
+        const leaseDirectory = path.join(root, entry, 'lease');
+        await fs.mkdir(leaseDirectory);
+        await fs.writeFile(
+            path.join(leaseDirectory, 'owner.json'),
+            JSON.stringify(staleOwner()),
+        );
+        const contenders = await Promise.all([
+            acquireDbtGitProjectCache(identity(1), 'repository'),
+            acquireDbtGitProjectCache(identity(1), 'repository'),
+        ]);
+        expect(contenders.filter(Boolean)).toHaveLength(1);
+        await releaseDbtGitProjectCache(contenders.find(Boolean)!, 100);
+    });
+
+    it('serializes concurrent reclaim of a stale reservation lock', async () => {
+        const root = await configure();
+        const seed = await acquireDbtGitProjectCache(identity(0), 'seed');
+        await fs.mkdir(seed!.checkoutDirectory);
+        await releaseDbtGitProjectCache(seed!, 100);
+        const reservationLock = path.join(root, '.reservation-lock');
+        await fs.mkdir(reservationLock);
+        await fs.writeFile(
+            path.join(reservationLock, 'owner.json'),
+            JSON.stringify(staleOwner()),
+        );
+        const contenders = await Promise.all([
+            acquireDbtGitProjectCache(identity(1), 'repository-1'),
+            acquireDbtGitProjectCache(identity(2), 'repository-2'),
+        ]);
+        expect(contenders.every(Boolean)).toBe(true);
+        await Promise.all(
+            contenders.map((lease) => invalidateOwnedDbtGitCacheLease(lease!)),
+        );
+    });
+
+    it('protects a stale lease when an orphan reclaim claim exists', async () => {
+        const root = await configure();
+        const first = await acquireDbtGitProjectCache(
+            identity(1),
+            'repository',
+        );
+        await fs.mkdir(first!.checkoutDirectory);
+        await releaseDbtGitProjectCache(first!, 100);
+        const [entry] = await entryDirectories(root);
+        const leaseDirectory = path.join(root, entry, 'lease');
+        await fs.mkdir(leaseDirectory);
+        await fs.writeFile(
+            path.join(leaseDirectory, 'owner.json'),
+            JSON.stringify(staleOwner()),
+        );
+        await fs.writeFile(
+            path.join(leaseDirectory, '.reclaim.json'),
+            JSON.stringify({
+                claimId: '00000000-0000-4000-8000-000000000002',
+                claimant: staleOwner({
+                    leaseId: '00000000-0000-4000-8000-000000000002',
+                    pid: process.pid,
+                }),
+            }),
+        );
+        await expect(
+            acquireDbtGitProjectCache(identity(1), 'repository'),
+        ).resolves.toBeUndefined();
+        await expect(fs.access(leaseDirectory)).resolves.toBeUndefined();
+    });
+
+    it('does not reclaim a malformed lease owner', async () => {
+        const root = await configure();
+        const first = await acquireDbtGitProjectCache(
+            identity(1),
+            'repository',
+        );
+        await fs.mkdir(first!.checkoutDirectory);
+        await releaseDbtGitProjectCache(first!, 100);
+        const [entry] = await entryDirectories(root);
+        const leaseDirectory = path.join(root, entry, 'lease');
+        await fs.mkdir(leaseDirectory);
+        await fs.writeFile(
+            path.join(leaseDirectory, 'owner.json'),
+            JSON.stringify(staleOwner({ pid: 1.5, heartbeatAt: Infinity })),
+        );
+        await expect(
+            acquireDbtGitProjectCache(identity(1), 'repository'),
+        ).resolves.toBeUndefined();
+        await expect(fs.access(leaseDirectory)).resolves.toBeUndefined();
+    });
+
+    it('protects a lease when process identity cannot be read', async () => {
+        const root = await configure();
+        const first = await acquireDbtGitProjectCache(
+            identity(1),
+            'repository',
+        );
+        await fs.mkdir(first!.checkoutDirectory);
+        await releaseDbtGitProjectCache(first!, 100);
+        const [entry] = await entryDirectories(root);
+        const leaseDirectory = path.join(root, entry, 'lease');
+        await fs.mkdir(leaseDirectory);
+        await fs.writeFile(
+            path.join(leaseDirectory, 'owner.json'),
+            JSON.stringify(
+                staleOwner({
+                    pid: process.pid,
+                    processStartTime: '1',
+                }),
+            ),
+        );
+        const actualFs =
+            await vi.importActual<typeof import('fs/promises')>('fs/promises');
+        const readFile = vi.mocked(fs.readFile);
+        readFile.mockImplementation(
+            async (...args: Parameters<typeof fs.readFile>) => {
+                if (args[0] === `/proc/${process.pid}/stat`) {
+                    const error = new Error(
+                        'permission denied',
+                    ) as NodeJS.ErrnoException;
+                    error.code = 'EACCES';
+                    throw error;
+                }
+                return actualFs.readFile(...args);
+            },
+        );
+        try {
+            await expect(
+                acquireDbtGitProjectCache(identity(1), 'repository'),
+            ).resolves.toBeUndefined();
+            await expect(fs.access(leaseDirectory)).resolves.toBeUndefined();
+        } finally {
+            readFile.mockImplementation(actualFs.readFile);
+        }
+    });
+
+    it('evicts retained entries to fit the configured byte bound', async () => {
+        await configure({ maxBytes: 150 });
+        const first = await acquireDbtGitProjectCache(
+            identity(1),
+            'repository-1',
+        );
+        await fs.mkdir(first!.checkoutDirectory);
+        await releaseDbtGitProjectCache(first!, 100);
+        const second = await acquireDbtGitProjectCache(
+            identity(2),
+            'repository-2',
+        );
+        await fs.mkdir(second!.checkoutDirectory);
+        await releaseDbtGitProjectCache(second!, 100);
+        const reusedSecond = await acquireDbtGitProjectCache(
+            identity(2),
+            'repository-2',
+        );
+        expect(reusedSecond?.reused).toBe(true);
+        const recreatedFirst = await acquireDbtGitProjectCache(
+            identity(1),
+            'repository-1',
+        );
+        expect(recreatedFirst?.reused).toBe(false);
+        await invalidateOwnedDbtGitCacheLease(recreatedFirst!);
+        await releaseDbtGitProjectCache(reusedSecond!, 100);
+    });
+
+    it('counts every hash-shaped root entry before creating another', async () => {
+        const root = await configure();
+        const seed = await acquireDbtGitProjectCache(identity(0), 'seed');
+        await invalidateOwnedDbtGitCacheLease(seed!);
+        await Promise.all(
+            Array.from({ length: 128 }, (_, index) =>
+                fs.writeFile(
+                    path.join(root, index.toString(16).padStart(64, '0')),
+                    'unowned',
+                ),
+            ),
+        );
+        await expect(
+            acquireDbtGitProjectCache(identity(1), 'repository'),
+        ).resolves.toBeUndefined();
+        expect(await entryDirectories(root)).toHaveLength(128);
+    });
+
+    it('removes missing identities and retains entries on liveness errors', async () => {
+        const root = await configure();
+        const first = await acquireDbtGitProjectCache(
+            identity(1),
+            'repository',
+        );
+        await fs.mkdir(first!.checkoutDirectory);
+        await releaseDbtGitProjectCache(first!, 100);
+        configureDbtGitProjectCache({
+            root,
+            maxBytes: 1024,
+            maxAgeMs: 60_000,
+            livenessCheck: async () => {
+                throw new Error('database unavailable');
+            },
+        });
+        await maintainDbtGitProjectCache();
+        expect(await entryDirectories(root)).toHaveLength(1);
+        configureDbtGitProjectCache({
+            root,
+            maxBytes: 1024,
+            maxAgeMs: 60_000,
+            livenessCheck: async () => new Set(),
+        });
+        await maintainDbtGitProjectCache();
+        expect(await entryDirectories(root)).toHaveLength(0);
+    });
+
+    it('defers maintenance deletion until an active lease releases', async () => {
+        const root = await configure();
+        const lease = await acquireDbtGitProjectCache(
+            identity(1),
+            'repository',
+        );
+        await fs.mkdir(lease!.checkoutDirectory);
+        configureDbtGitProjectCache({
+            root,
+            maxBytes: 1024,
+            maxAgeMs: 60_000,
+            livenessCheck: async () => new Set(),
+        });
+        await maintainDbtGitProjectCache();
+        expect(await entryDirectories(root)).toHaveLength(1);
+        await releaseDbtGitProjectCache(lease!, 100);
+        expect(await entryDirectories(root)).toHaveLength(0);
+    });
+
+    it('rejects an expired entry when it is acquired', async () => {
+        const root = await configure({ maxAgeMs: 1 });
+        const first = await acquireDbtGitProjectCache(
+            identity(1),
+            'repository',
+        );
+        await fs.mkdir(first!.checkoutDirectory);
+        await releaseDbtGitProjectCache(first!, 100);
+        await new Promise<void>((resolve) => {
+            setTimeout(resolve, 5);
+        });
+        const next = await acquireDbtGitProjectCache(identity(1), 'repository');
+        expect(next?.reused).toBe(false);
+        await invalidateOwnedDbtGitCacheLease(next!);
+        expect(await entryDirectories(root)).toHaveLength(0);
+    });
+
+    it('refuses a symlinked cache root', async () => {
+        const target = await fs.mkdtemp(
+            path.join(os.tmpdir(), 'dbt-cache-target-'),
+        );
+        const link = `${target}-link`;
+        roots.push(target, link);
+        await fs.symlink(target, link);
+        configureDbtGitProjectCache({
+            root: link,
+            maxBytes: 1024,
+            maxAgeMs: 60_000,
+            livenessCheck: async () => new Set(),
+        });
+        await expect(
+            acquireDbtGitProjectCache(identity(1), 'repository'),
+        ).rejects.toThrow('cache root');
+    });
+});

--- a/packages/backend/src/projectAdapters/dbtGitProjectCache.test.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectCache.test.ts
@@ -1539,6 +1539,45 @@ describe('dbt git project cache', () => {
         }
     });
 
+    it('drains other reservations when an abandoned entry rename fails', async () => {
+        const root = await configure();
+        const seeds = await Promise.all([
+            acquireDbtGitProjectCache(identity(1), 'repository-1'),
+            acquireDbtGitProjectCache(identity(2), 'repository-2'),
+        ]);
+        await Promise.all(
+            seeds.map((seed) => invalidateOwnedDbtGitCacheLease(seed!)),
+        );
+        const failedPath = path.join(root, seeds[0]!.key);
+        const drainedPath = path.join(root, seeds[1]!.key);
+        await fs.mkdir(failedPath, { mode: 0o700 });
+        await fs.mkdir(drainedPath, { mode: 0o700 });
+        const stale = new Date(Date.now() - 6 * 60_000);
+        await fs.utimes(failedPath, stale, stale);
+        await fs.utimes(drainedPath, stale, stale);
+        const actualFs =
+            await vi.importActual<typeof import('fs/promises')>('fs/promises');
+        const rename = vi.mocked(fs.rename);
+        const error = new Error('rename failed') as NodeJS.ErrnoException;
+        error.code = 'EACCES';
+        rename.mockImplementation(async (oldPath, newPath) => {
+            if (oldPath === failedPath) throw error;
+            return actualFs.rename(oldPath, newPath);
+        });
+        try {
+            await maintainDbtGitProjectCache();
+
+            await expect(fs.access(failedPath)).resolves.toBeUndefined();
+            await expect(fs.access(drainedPath)).rejects.toThrow();
+            expect(vi.mocked(Logger.warn)).toHaveBeenCalledWith(
+                'Failed to reserve abandoned dbt git cache entry cleanup',
+                { error },
+            );
+        } finally {
+            rename.mockImplementation(actualFs.rename);
+        }
+    });
+
     it('protects an active unowned entry during abandoned object cleanup', async () => {
         const root = await configure();
         const lease = await acquireDbtGitProjectCache(

--- a/packages/backend/src/projectAdapters/dbtGitProjectCache.test.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectCache.test.ts
@@ -767,7 +767,7 @@ describe('dbt git project cache', () => {
         );
     });
 
-    it('protects a stale lease when an orphan reclaim claim exists', async () => {
+    it('protects a stale lease when a fresh orphan reclaim claim exists', async () => {
         const root = await configure();
         const first = await acquireDbtGitProjectCache(
             identity(1),
@@ -796,6 +796,44 @@ describe('dbt git project cache', () => {
             acquireDbtGitProjectCache(identity(1), 'repository'),
         ).resolves.toBeUndefined();
         await expect(fs.access(leaseDirectory)).resolves.toBeUndefined();
+    });
+
+    it('reclaims a stale lease after an orphan reclaim claim ages', async () => {
+        const root = await configure();
+        const first = await acquireDbtGitProjectCache(
+            identity(1),
+            'repository',
+        );
+        await fs.mkdir(first!.checkoutDirectory);
+        await releaseDbtGitProjectCache(first!, 100);
+        const [entry] = await entryDirectories(root);
+        const leaseDirectory = path.join(root, entry, 'lease');
+        await fs.mkdir(leaseDirectory);
+        await fs.writeFile(
+            path.join(leaseDirectory, 'owner.json'),
+            JSON.stringify(staleOwner()),
+        );
+        const claimPath = path.join(leaseDirectory, '.reclaim.json');
+        await fs.writeFile(
+            claimPath,
+            JSON.stringify({
+                claimId: '00000000-0000-4000-8000-000000000002',
+                claimant: staleOwner({
+                    leaseId: '00000000-0000-4000-8000-000000000002',
+                    heartbeatAt: Date.now() + 60 * 60_000,
+                }),
+            }),
+        );
+        const agedAt = new Date(Date.now() - 3 * 60_000);
+        await fs.utimes(claimPath, agedAt, agedAt);
+
+        const reclaimed = await acquireDbtGitProjectCache(
+            identity(1),
+            'repository',
+        );
+
+        expect(reclaimed?.reused).toBe(true);
+        await releaseDbtGitProjectCache(reclaimed!, 100);
     });
 
     it('does not reclaim a malformed lease owner', async () => {

--- a/packages/backend/src/projectAdapters/dbtGitProjectCache.test.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectCache.test.ts
@@ -984,6 +984,86 @@ describe('dbt git project cache', () => {
         }
     });
 
+    it('evicts the oldest of 256 future heartbeat observations', async () => {
+        const clock = { now: Date.now() };
+        const now = vi.spyOn(Date, 'now').mockImplementation(() => clock.now);
+        const maxAgeMs = 20 * 60_000;
+        const observeFutureHeartbeat = async (index: number) => {
+            const root = await configure({ maxAgeMs });
+            const cacheIdentity = identity(index);
+            const repositoryIdentity = `repository-${index}`;
+            const lease = await acquireDbtGitProjectCache(
+                cacheIdentity,
+                repositoryIdentity,
+            );
+            await fs.mkdir(lease!.checkoutDirectory);
+            await releaseDbtGitProjectCache(lease!, 100);
+            const leaseDirectory = path.join(lease!.entryDirectory, 'lease');
+            const owner = staleOwner({
+                leaseId: `00000000-0000-4000-8000-${String(index).padStart(12, '0')}`,
+                hostname: `clock-skewed-pod-${index}`,
+                heartbeatAt: clock.now - 11 * 60_000,
+            });
+            await fs.mkdir(leaseDirectory);
+            await fs.writeFile(
+                path.join(leaseDirectory, 'owner.json'),
+                JSON.stringify(owner),
+            );
+            await fs.writeFile(
+                path.join(leaseDirectory, `.heartbeat-${owner.leaseId}.json`),
+                JSON.stringify({
+                    ...owner,
+                    heartbeatAt: clock.now + 60 * 60_000,
+                }),
+            );
+            await expect(
+                acquireDbtGitProjectCache(cacheIdentity, repositoryIdentity),
+            ).resolves.toBeUndefined();
+            return { root, cacheIdentity, repositoryIdentity };
+        };
+        const selectFixture = (fixture: {
+            root: string;
+            cacheIdentity: DbtGitCacheIdentity;
+            repositoryIdentity: string;
+        }) => {
+            configureDbtGitProjectCache({
+                root: fixture.root,
+                maxBytes: 1024 * 1024,
+                maxAgeMs,
+                livenessCheck: async (identities) =>
+                    new Set(identities.map(dbtGitCacheIdentityKey)),
+            });
+        };
+        try {
+            const oldest = await observeFutureHeartbeat(1_000);
+            const newest = await Array.from({ length: 256 }).reduce<
+                Promise<Awaited<ReturnType<typeof observeFutureHeartbeat>>>
+            >(async (pending, _, index) => {
+                await pending;
+                return observeFutureHeartbeat(index + 2_000);
+            }, Promise.resolve(oldest));
+            clock.now += 11 * 60_000;
+
+            selectFixture(newest);
+            const reclaimedNewest = await acquireDbtGitProjectCache(
+                newest.cacheIdentity,
+                newest.repositoryIdentity,
+            );
+            expect(reclaimedNewest?.reused).toBe(true);
+            await releaseDbtGitProjectCache(reclaimedNewest!, 100);
+
+            selectFixture(oldest);
+            await expect(
+                acquireDbtGitProjectCache(
+                    oldest.cacheIdentity,
+                    oldest.repositoryIdentity,
+                ),
+            ).resolves.toBeUndefined();
+        } finally {
+            now.mockRestore();
+        }
+    }, 30_000);
+
     it('serializes concurrent reclaim of a stale reservation lock', async () => {
         const root = await configure();
         const seed = await acquireDbtGitProjectCache(identity(0), 'seed');

--- a/packages/backend/src/projectAdapters/dbtGitProjectCache.test.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectCache.test.ts
@@ -673,7 +673,7 @@ describe('dbt git project cache', () => {
         await expect.poll(() => tombstoneDirectories(root)).toHaveLength(0);
     });
 
-    it('publishes only against its own charged eviction reservation', async () => {
+    it('charges known tombstone bytes without reusing another publication reservation', async () => {
         const root = await configure({ maxBytes: 150 });
         const first = await acquireDbtGitProjectCache(
             identity(1),
@@ -721,18 +721,16 @@ describe('dbt git project cache', () => {
             await fs.mkdir(third!.checkoutDirectory);
             await releaseDbtGitProjectCache(third!, 1);
             expect(third).toMatchObject({
-                retained: false,
-                retentionReason: 'capacity-unavailable',
+                retained: true,
+                retentionReason: undefined,
             });
-            await expect(
-                fs.access(second!.entryDirectory),
-            ).resolves.toBeUndefined();
+            await expect(fs.access(second!.entryDirectory)).rejects.toThrow();
             const thirdAgain = await acquireDbtGitProjectCache(
                 identity(3),
                 'repository-3',
             );
-            expect(thirdAgain?.reused).toBe(false);
-            await invalidateOwnedDbtGitCacheLease(thirdAgain!);
+            expect(thirdAgain?.reused).toBe(true);
+            await releaseDbtGitProjectCache(thirdAgain!, 1);
 
             finishCleanup();
             await secondRelease;
@@ -740,8 +738,8 @@ describe('dbt git project cache', () => {
                 identity(2),
                 'repository-2',
             );
-            expect(secondAgain?.reused).toBe(true);
-            await releaseDbtGitProjectCache(secondAgain!, 100);
+            expect(secondAgain?.reused).toBe(false);
+            await invalidateOwnedDbtGitCacheLease(secondAgain!);
         } finally {
             finishCleanup();
             await expect.poll(() => tombstoneDirectories(root)).toHaveLength(0);
@@ -1168,6 +1166,93 @@ describe('dbt git project cache', () => {
         expect(recreatedFirst?.reused).toBe(false);
         await invalidateOwnedDbtGitCacheLease(recreatedFirst!);
         await releaseDbtGitProjectCache(reusedSecond!, 100);
+    });
+
+    it('declines retention when entry enumeration exhausts its deadline', async () => {
+        await configure();
+        const lease = await acquireDbtGitProjectCache(
+            identity(1),
+            'repository-1',
+        );
+        await fs.mkdir(lease!.checkoutDirectory);
+        const actualFs =
+            await vi.importActual<typeof import('fs/promises')>('fs/promises');
+        const readFile = vi.mocked(fs.readFile);
+        const clock = { now: Date.now() };
+        const now = vi.spyOn(Date, 'now').mockImplementation(() => clock.now);
+        let advanceClock = true;
+        readFile.mockImplementation(async (...args) => {
+            const result = await actualFs.readFile(...args);
+            if (
+                advanceClock &&
+                args[0] === path.join(lease!.entryDirectory, 'metadata.json')
+            ) {
+                advanceClock = false;
+                clock.now += 3_001;
+            }
+            return result;
+        });
+        try {
+            await releaseDbtGitProjectCache(lease!, 100);
+
+            expect(lease).toMatchObject({
+                retained: false,
+                retentionReason: 'publication-deadline',
+            });
+        } finally {
+            now.mockRestore();
+            readFile.mockImplementation(actualFs.readFile);
+        }
+    });
+
+    it('releases selected victims when leasing crosses the retention deadline', async () => {
+        await configure({ maxBytes: 150 });
+        const first = await acquireDbtGitProjectCache(
+            identity(1),
+            'repository-1',
+        );
+        await fs.mkdir(first!.checkoutDirectory);
+        await releaseDbtGitProjectCache(first!, 100);
+        const second = await acquireDbtGitProjectCache(
+            identity(2),
+            'repository-2',
+        );
+        await fs.mkdir(second!.checkoutDirectory);
+        const actualFs =
+            await vi.importActual<typeof import('fs/promises')>('fs/promises');
+        const rename = vi.mocked(fs.rename);
+        const clock = { now: Date.now() };
+        const now = vi.spyOn(Date, 'now').mockImplementation(() => clock.now);
+        const victimOwnerPath = path.join(
+            first!.entryDirectory,
+            'lease',
+            'owner.json',
+        );
+        let advanceClock = true;
+        rename.mockImplementation(async (source, destination) => {
+            await actualFs.rename(source, destination);
+            if (advanceClock && destination === victimOwnerPath) {
+                advanceClock = false;
+                clock.now += 3_001;
+            }
+        });
+        try {
+            await releaseDbtGitProjectCache(second!, 100);
+
+            expect(second).toMatchObject({
+                retained: false,
+                retentionReason: 'publication-deadline',
+            });
+            const firstAgain = await acquireDbtGitProjectCache(
+                identity(1),
+                'repository-1',
+            );
+            expect(firstAgain?.reused).toBe(true);
+            await releaseDbtGitProjectCache(firstAgain!, 100);
+        } finally {
+            now.mockRestore();
+            rename.mockImplementation(actualFs.rename);
+        }
     });
 
     it('counts every hash-shaped root entry before creating another', async () => {

--- a/packages/backend/src/projectAdapters/dbtGitProjectCache.test.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectCache.test.ts
@@ -484,6 +484,63 @@ describe('dbt git project cache', () => {
         await releaseDbtGitProjectCache(contenders.find(Boolean)!, 100);
     });
 
+    it('reclaims a foreign-host lease after five stale intervals', async () => {
+        const root = await configure();
+        const first = await acquireDbtGitProjectCache(
+            identity(1),
+            'repository',
+        );
+        await fs.mkdir(first!.checkoutDirectory);
+        await releaseDbtGitProjectCache(first!, 100);
+        const [entry] = await entryDirectories(root);
+        const leaseDirectory = path.join(root, entry, 'lease');
+        await fs.mkdir(leaseDirectory);
+        await fs.writeFile(
+            path.join(leaseDirectory, 'owner.json'),
+            JSON.stringify(
+                staleOwner({
+                    hostname: 'terminated-pod',
+                    heartbeatAt: Date.now() - 11 * 60_000,
+                }),
+            ),
+        );
+
+        const reclaimed = await acquireDbtGitProjectCache(
+            identity(1),
+            'repository',
+        );
+
+        expect(reclaimed?.reused).toBe(true);
+        await releaseDbtGitProjectCache(reclaimed!, 100);
+    });
+
+    it('protects a foreign-host lease within five stale intervals', async () => {
+        const root = await configure();
+        const first = await acquireDbtGitProjectCache(
+            identity(1),
+            'repository',
+        );
+        await fs.mkdir(first!.checkoutDirectory);
+        await releaseDbtGitProjectCache(first!, 100);
+        const [entry] = await entryDirectories(root);
+        const leaseDirectory = path.join(root, entry, 'lease');
+        await fs.mkdir(leaseDirectory);
+        await fs.writeFile(
+            path.join(leaseDirectory, 'owner.json'),
+            JSON.stringify(
+                staleOwner({
+                    hostname: 'active-pod',
+                    heartbeatAt: Date.now() - 9 * 60_000,
+                }),
+            ),
+        );
+
+        await expect(
+            acquireDbtGitProjectCache(identity(1), 'repository'),
+        ).resolves.toBeUndefined();
+        await expect(fs.access(leaseDirectory)).resolves.toBeUndefined();
+    });
+
     it('serializes concurrent reclaim of a stale reservation lock', async () => {
         const root = await configure();
         const seed = await acquireDbtGitProjectCache(identity(0), 'seed');

--- a/packages/backend/src/projectAdapters/dbtGitProjectCache.test.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectCache.test.ts
@@ -906,6 +906,52 @@ describe('dbt git project cache', () => {
         await expect(fs.access(leaseDirectory)).resolves.toBeUndefined();
     });
 
+    it('ages an unchanged future-dated foreign heartbeat from first observation', async () => {
+        const root = await configure({ maxAgeMs: 20 * 60_000 });
+        const first = await acquireDbtGitProjectCache(
+            identity(1),
+            'repository',
+        );
+        await fs.mkdir(first!.checkoutDirectory);
+        await releaseDbtGitProjectCache(first!, 100);
+        const [entry] = await entryDirectories(root);
+        const leaseDirectory = path.join(root, entry, 'lease');
+        const owner = staleOwner({
+            hostname: 'clock-skewed-pod',
+            heartbeatAt: Date.now() - 11 * 60_000,
+        });
+        await fs.mkdir(leaseDirectory);
+        await fs.writeFile(
+            path.join(leaseDirectory, 'owner.json'),
+            JSON.stringify(owner),
+        );
+        await fs.writeFile(
+            path.join(leaseDirectory, `.heartbeat-${owner.leaseId}.json`),
+            JSON.stringify({
+                ...owner,
+                heartbeatAt: Date.now() + 60 * 60_000,
+            }),
+        );
+        const clock = { now: Date.now() };
+        const now = vi.spyOn(Date, 'now').mockImplementation(() => clock.now);
+        try {
+            await expect(
+                acquireDbtGitProjectCache(identity(1), 'repository'),
+            ).resolves.toBeUndefined();
+
+            clock.now += 11 * 60_000;
+            const reclaimed = await acquireDbtGitProjectCache(
+                identity(1),
+                'repository',
+            );
+
+            expect(reclaimed?.reused).toBe(true);
+            await releaseDbtGitProjectCache(reclaimed!, 100);
+        } finally {
+            now.mockRestore();
+        }
+    });
+
     it('serializes concurrent reclaim of a stale reservation lock', async () => {
         const root = await configure();
         const seed = await acquireDbtGitProjectCache(identity(0), 'seed');

--- a/packages/backend/src/projectAdapters/dbtGitProjectCache.test.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectCache.test.ts
@@ -1255,6 +1255,52 @@ describe('dbt git project cache', () => {
         }
     });
 
+    it('does not publish after victim retirement crosses the retention deadline', async () => {
+        const root = await configure({ maxBytes: 150 });
+        const first = await acquireDbtGitProjectCache(
+            identity(1),
+            'repository-1',
+        );
+        await fs.mkdir(first!.checkoutDirectory);
+        await releaseDbtGitProjectCache(first!, 100);
+        const second = await acquireDbtGitProjectCache(
+            identity(2),
+            'repository-2',
+        );
+        await fs.mkdir(second!.checkoutDirectory);
+        const actualFs =
+            await vi.importActual<typeof import('fs/promises')>('fs/promises');
+        const readFile = vi.mocked(fs.readFile);
+        const clock = { now: Date.now() };
+        const now = vi.spyOn(Date, 'now').mockImplementation(() => clock.now);
+        const secondMetadataPath = path.join(
+            second!.entryDirectory,
+            'metadata.json',
+        );
+        let metadataReads = 0;
+        readFile.mockImplementation(async (...args) => {
+            const result = await actualFs.readFile(...args);
+            if (args[0] === secondMetadataPath) {
+                metadataReads += 1;
+                if (metadataReads === 2) clock.now += 3_001;
+            }
+            return result;
+        });
+        try {
+            await releaseDbtGitProjectCache(second!, 100);
+
+            expect(second).toMatchObject({
+                retained: false,
+                retentionReason: 'publication-deadline',
+            });
+            await expect.poll(() => tombstoneDirectories(root)).toHaveLength(0);
+            expect(await entryDirectories(root)).toHaveLength(0);
+        } finally {
+            now.mockRestore();
+            readFile.mockImplementation(actualFs.readFile);
+        }
+    });
+
     it('counts every hash-shaped root entry before creating another', async () => {
         const root = await configure();
         const seed = await acquireDbtGitProjectCache(identity(0), 'seed');

--- a/packages/backend/src/projectAdapters/dbtGitProjectCache.test.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectCache.test.ts
@@ -1299,6 +1299,59 @@ describe('dbt git project cache', () => {
         },
     );
 
+    it('expires retained entries and defers active entry deletion when disabled', async () => {
+        const root = await configure();
+        const retained = await acquireDbtGitProjectCache(
+            identity(1),
+            'repository-1',
+        );
+        await fs.mkdir(retained!.checkoutDirectory);
+        await releaseDbtGitProjectCache(retained!, 100);
+        const active = await acquireDbtGitProjectCache(
+            identity(2),
+            'repository-2',
+        );
+        await fs.mkdir(active!.checkoutDirectory);
+        configureDbtGitProjectCache({
+            root,
+            maxBytes: 0,
+            maxAgeMs: 60_000,
+            livenessCheck: async () => new Set(),
+        });
+
+        await maintainDbtGitProjectCache();
+
+        await expect(fs.access(retained!.entryDirectory)).rejects.toThrow();
+        await expect(
+            fs.access(active!.checkoutDirectory),
+        ).resolves.toBeUndefined();
+        await expect(
+            fs.access(path.join(active!.entryDirectory, 'pending-delete')),
+        ).resolves.toBeUndefined();
+        await releaseDbtGitProjectCache(active!, 100);
+        await expect(fs.access(active!.entryDirectory)).rejects.toThrow();
+    });
+
+    it('invalidates retained entries while disabled', async () => {
+        const root = await configure();
+        const retained = await acquireDbtGitProjectCache(
+            identity(1),
+            'repository',
+        );
+        await fs.mkdir(retained!.checkoutDirectory);
+        await releaseDbtGitProjectCache(retained!, 100);
+        configureDbtGitProjectCache({
+            root,
+            maxBytes: 0,
+            maxAgeMs: 60_000,
+            livenessCheck: async () => new Set(),
+        });
+
+        await invalidateDbtGitProjectCacheSource('project', 'source-1');
+
+        await expect(fs.access(retained!.entryDirectory)).rejects.toThrow();
+    });
+
     it('warns when a filesystem inspection error is swallowed', async () => {
         await configure();
         const lease = await acquireDbtGitProjectCache(

--- a/packages/backend/src/projectAdapters/dbtGitProjectCache.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectCache.ts
@@ -65,6 +65,11 @@ type LeaseOwner = {
     heartbeatAt: number;
 };
 
+type ReclaimClaim = {
+    claimId: string;
+    claimant: LeaseOwner;
+};
+
 type LeaseHeartbeat = {
     timer: NodeJS.Timeout;
     pending: Promise<void>;
@@ -206,6 +211,18 @@ const isLeaseOwner = (value: unknown): value is LeaseOwner => {
         typeof candidate.heartbeatAt === 'number' &&
         Number.isFinite(candidate.heartbeatAt) &&
         candidate.heartbeatAt >= 0
+    );
+};
+
+const isReclaimClaim = (value: unknown): value is ReclaimClaim => {
+    if (!value || typeof value !== 'object') return false;
+    const candidate = value as Partial<ReclaimClaim>;
+    return (
+        typeof candidate.claimId === 'string' &&
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+            candidate.claimId,
+        ) &&
+        isLeaseOwner(candidate.claimant)
     );
 };
 
@@ -504,6 +521,39 @@ const leaseOwnerIsProvablyStale = async (
     );
 };
 
+const removeAgedReclaimClaim = async (claimPath: string): Promise<boolean> => {
+    try {
+        const observedStat: Stats = await fs.lstat(claimPath);
+        const observed = await readJson(claimPath);
+        if (Date.now() - observedStat.mtimeMs <= LEASE_STALE_MS) return false;
+        const currentStat: Stats = await fs.lstat(claimPath);
+        const current = await readJson(claimPath);
+        if (
+            currentStat.dev !== observedStat.dev ||
+            currentStat.ino !== observedStat.ino ||
+            currentStat.mtimeMs !== observedStat.mtimeMs ||
+            currentStat.size !== observedStat.size ||
+            (isReclaimClaim(observed) &&
+                (!isReclaimClaim(current) ||
+                    current.claimId !== observed.claimId ||
+                    current.claimant.leaseId !== observed.claimant.leaseId ||
+                    current.claimant.heartbeatAt !==
+                        observed.claimant.heartbeatAt))
+        ) {
+            return false;
+        }
+        await fs.rm(claimPath, { force: true });
+        return true;
+    } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') return true;
+        warnSwallowedFilesystemError(
+            'Failed to inspect stale dbt git cache reclaim claim',
+            error,
+        );
+        return false;
+    }
+};
+
 const claimAndRemoveStaleLease = async (
     leaseDirectory: string,
 ): Promise<boolean> => {
@@ -516,25 +566,32 @@ const claimAndRemoveStaleLease = async (
     }
     const claimPath = path.join(leaseDirectory, RECLAIM_CLAIM);
     const claimId = randomUUID();
-    try {
-        await fs.writeFile(
-            claimPath,
-            JSON.stringify({
-                claimId,
-                claimant: await newLeaseOwner(claimId),
-            }),
-            {
+    const claim = JSON.stringify({
+        claimId,
+        claimant: await newLeaseOwner(claimId),
+    });
+    const tryClaim = async (): Promise<'claimed' | 'exists' | 'failed'> => {
+        try {
+            await fs.writeFile(claimPath, claim, {
                 flag: 'wx',
                 mode: 0o600,
-            },
-        );
-    } catch (error) {
-        warnSwallowedFilesystemError(
-            'Failed to claim stale dbt git cache lease',
-            error,
-        );
-        return false;
+            });
+            return 'claimed';
+        } catch (error) {
+            if ((error as NodeJS.ErrnoException).code === 'EEXIST')
+                return 'exists';
+            warnSwallowedFilesystemError(
+                'Failed to claim stale dbt git cache lease',
+                error,
+            );
+            return 'failed';
+        }
+    };
+    let claimResult = await tryClaim();
+    if (claimResult === 'exists' && (await removeAgedReclaimClaim(claimPath))) {
+        claimResult = await tryClaim();
     }
+    if (claimResult !== 'claimed') return false;
     try {
         const current = await readJson(path.join(leaseDirectory, LEASE_OWNER));
         if (
@@ -559,11 +616,11 @@ const claimAndRemoveStaleLease = async (
         );
         return false;
     } finally {
-        const claim = await readJson(claimPath);
+        const currentClaim = await readJson(claimPath);
         if (
-            claim &&
-            typeof claim === 'object' &&
-            (claim as { claimId?: unknown }).claimId === claimId
+            currentClaim &&
+            typeof currentClaim === 'object' &&
+            (currentClaim as { claimId?: unknown }).claimId === claimId
         ) {
             await fs.rm(claimPath, { force: true }).catch((error) => {
                 warnSwallowedFilesystemError(

--- a/packages/backend/src/projectAdapters/dbtGitProjectCache.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectCache.ts
@@ -11,6 +11,7 @@ export const DBT_GIT_CACHE_MAX_ENTRIES = 128;
 
 const CACHE_VERSION = 1;
 const LEASE_STALE_MS = 2 * 60 * 1000;
+const FOREIGN_HOST_LEASE_STALE_MS = 5 * LEASE_STALE_MS;
 const ROOT_MARKER = '.lightdash-dbt-git-cache.json';
 const ENTRY_MARKER = '.lightdash-cache-entry.json';
 const METADATA = 'metadata.json';
@@ -437,7 +438,9 @@ const newLeaseOwner = async (leaseId: string): Promise<LeaseOwner> => ({
 const leaseOwnerIsProvablyStale = async (
     value: LeaseOwner,
 ): Promise<boolean> => {
-    if (value.hostname !== os.hostname()) return false;
+    if (value.hostname !== os.hostname()) {
+        return Date.now() - value.heartbeatAt > FOREIGN_HOST_LEASE_STALE_MS;
+    }
     if (Date.now() - value.heartbeatAt <= LEASE_STALE_MS) return false;
     const actualStartTime = await processStartTime(value.pid);
     return (

--- a/packages/backend/src/projectAdapters/dbtGitProjectCache.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectCache.ts
@@ -1,0 +1,1144 @@
+import { createHash, randomUUID } from 'crypto';
+import * as fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import Logger from '../logging/logger';
+
+export const DBT_GIT_CACHE_DEFAULT_MAX_BYTES = 2 * 1024 * 1024 * 1024;
+export const DBT_GIT_CACHE_DEFAULT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+export const DBT_GIT_CACHE_MAINTENANCE_INTERVAL_MS = 15 * 60 * 1000;
+export const DBT_GIT_CACHE_MAX_ENTRIES = 128;
+
+const CACHE_VERSION = 1;
+const LEASE_STALE_MS = 2 * 60 * 1000;
+const ROOT_MARKER = '.lightdash-dbt-git-cache.json';
+const ENTRY_MARKER = '.lightdash-cache-entry.json';
+const METADATA = 'metadata.json';
+const LEASE_DIRECTORY = 'lease';
+const LEASE_OWNER = 'owner.json';
+const PENDING_DELETE = 'pending-delete';
+const CACHE_LOCK = '.reservation-lock';
+const RECLAIM_CLAIM = '.reclaim.json';
+const CACHE_LOCK_WAIT_MS = 5_000;
+const PUBLICATION_MAX_ATTEMPTS = DBT_GIT_CACHE_MAX_ENTRIES;
+
+export type DbtGitCacheIdentity = {
+    projectUuid: string;
+    sourceUuid: string;
+    sourceType: 'primary' | 'additional';
+};
+
+export type DbtGitCacheLivenessCheck = (
+    identities: DbtGitCacheIdentity[],
+) => Promise<Set<string>>;
+
+type CacheConfiguration = {
+    root: string;
+    maxBytes: number;
+    maxAgeMs: number;
+    livenessCheck?: DbtGitCacheLivenessCheck;
+};
+
+type EntryMetadata = {
+    version: number;
+    key: string;
+    identity: DbtGitCacheIdentity;
+    repositoryIdentity: string;
+    state: 'active' | 'retained';
+    sizeBytes: number;
+    lastUsedAt: number;
+};
+
+type LeaseOwner = {
+    leaseId: string;
+    hostname: string;
+    pid: number;
+    processStartTime: string | null;
+    heartbeatAt: number;
+};
+
+type LeaseHeartbeat = {
+    timer: NodeJS.Timeout;
+    pending: Promise<void>;
+    stopped: boolean;
+    schedule: () => void;
+};
+
+type DirectoryLease = {
+    leaseId: string;
+    directory: string;
+    heartbeat?: LeaseHeartbeat;
+};
+
+type TombstoneRetirement = {
+    cleanup: Promise<boolean>;
+};
+
+export type DbtGitCacheLease = {
+    key: string;
+    entryDirectory: string;
+    checkoutDirectory: string;
+    depsMarkerPath: string;
+    leaseId: string;
+    reused: boolean;
+    invalidated: boolean;
+    closed: boolean;
+    heartbeat?: LeaseHeartbeat;
+};
+
+type OwnedEntry = {
+    key: string;
+    entryDirectory: string;
+    kind: 'entry' | 'tombstone';
+    owned: boolean;
+    metadata?: EntryMetadata;
+};
+
+const activeLeases = new Map<string, DbtGitCacheLease>();
+let maintenanceTimer: NodeJS.Timeout | undefined;
+let configuration: CacheConfiguration = {
+    root: path.join(os.tmpdir(), 'lightdash-dbt-git-cache'),
+    maxBytes: DBT_GIT_CACHE_DEFAULT_MAX_BYTES,
+    maxAgeMs: DBT_GIT_CACHE_DEFAULT_MAX_AGE_MS,
+};
+
+export const dbtGitCacheIdentityKey = (identity: DbtGitCacheIdentity): string =>
+    `${identity.sourceType}:${identity.projectUuid}:${identity.sourceUuid}`;
+
+export const resolveLiveDbtGitCacheIdentities = (args: {
+    identities: DbtGitCacheIdentity[];
+    primaryRows: Array<{
+        projectUuid: string;
+        dbtSourceUuid: string | null;
+    }>;
+    additionalRows: Array<{
+        projectUuid: string;
+        projectDbtSourceUuid: string;
+    }>;
+}): Set<string> => {
+    const primaryRows = new Map(
+        args.primaryRows.map((project) => [project.projectUuid, project]),
+    );
+    const additionalRows = new Map(
+        args.additionalRows.map((source) => [
+            source.projectDbtSourceUuid,
+            source,
+        ]),
+    );
+    return new Set(
+        args.identities.flatMap((identity) => {
+            if (identity.sourceType === 'primary') {
+                const project = primaryRows.get(identity.projectUuid);
+                const live =
+                    project !== undefined &&
+                    (project.dbtSourceUuid === identity.sourceUuid ||
+                        (project.dbtSourceUuid === null &&
+                            project.projectUuid === identity.sourceUuid));
+                return live ? [dbtGitCacheIdentityKey(identity)] : [];
+            }
+            const source = additionalRows.get(identity.sourceUuid);
+            return source?.projectUuid === identity.projectUuid
+                ? [dbtGitCacheIdentityKey(identity)]
+                : [];
+        }),
+    );
+};
+
+const isIdentity = (value: unknown): value is DbtGitCacheIdentity => {
+    if (!value || typeof value !== 'object') return false;
+    const candidate = value as Partial<DbtGitCacheIdentity>;
+    return (
+        typeof candidate.projectUuid === 'string' &&
+        typeof candidate.sourceUuid === 'string' &&
+        (candidate.sourceType === 'primary' ||
+            candidate.sourceType === 'additional')
+    );
+};
+
+const isMetadata = (value: unknown): value is EntryMetadata => {
+    if (!value || typeof value !== 'object') return false;
+    const candidate = value as Partial<EntryMetadata>;
+    return (
+        candidate.version === CACHE_VERSION &&
+        typeof candidate.key === 'string' &&
+        isIdentity(candidate.identity) &&
+        typeof candidate.repositoryIdentity === 'string' &&
+        (candidate.state === 'active' || candidate.state === 'retained') &&
+        typeof candidate.sizeBytes === 'number' &&
+        Number.isFinite(candidate.sizeBytes) &&
+        candidate.sizeBytes >= 0 &&
+        typeof candidate.lastUsedAt === 'number' &&
+        Number.isFinite(candidate.lastUsedAt)
+    );
+};
+
+const isLeaseOwner = (value: unknown): value is LeaseOwner => {
+    if (!value || typeof value !== 'object') return false;
+    const candidate = value as Partial<LeaseOwner>;
+    return (
+        typeof candidate.leaseId === 'string' &&
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+            candidate.leaseId,
+        ) &&
+        typeof candidate.hostname === 'string' &&
+        candidate.hostname.length > 0 &&
+        typeof candidate.pid === 'number' &&
+        Number.isSafeInteger(candidate.pid) &&
+        candidate.pid > 0 &&
+        ((typeof candidate.processStartTime === 'string' &&
+            /^\d+$/.test(candidate.processStartTime)) ||
+            candidate.processStartTime === null) &&
+        typeof candidate.heartbeatAt === 'number' &&
+        Number.isFinite(candidate.heartbeatAt) &&
+        candidate.heartbeatAt >= 0
+    );
+};
+
+const keyFor = (
+    identity: DbtGitCacheIdentity,
+    repositoryIdentity: string,
+): string =>
+    createHash('sha256')
+        .update(JSON.stringify({ identity, repositoryIdentity }))
+        .digest('hex');
+
+const readJson = async (filePath: string): Promise<unknown> => {
+    try {
+        return JSON.parse(await fs.readFile(filePath, 'utf8'));
+    } catch {
+        return undefined;
+    }
+};
+
+const atomicWriteJson = async (filePath: string, value: unknown) => {
+    const temporaryPath = `${filePath}.${randomUUID()}.tmp`;
+    try {
+        await fs.writeFile(temporaryPath, JSON.stringify(value), {
+            mode: 0o600,
+        });
+        await fs.rename(temporaryPath, filePath);
+    } catch (error) {
+        await fs.rm(temporaryPath, { force: true }).catch(() => undefined);
+        throw error;
+    }
+};
+
+const isPrivateOwnedStat = (stat: Awaited<ReturnType<typeof fs.lstat>>) =>
+    Number(stat.uid) === process.getuid?.() && Number(stat.mode) % 0o100 === 0;
+
+const ensureRoot = async () => {
+    await fs.mkdir(configuration.root, { recursive: true, mode: 0o700 });
+    const stat = await fs.lstat(configuration.root);
+    if (
+        !stat.isDirectory() ||
+        stat.isSymbolicLink() ||
+        !isPrivateOwnedStat(stat)
+    ) {
+        throw new Error('Invalid dbt git cache root ownership');
+    }
+    const realRoot = await fs.realpath(configuration.root);
+    if (realRoot !== path.resolve(configuration.root)) {
+        throw new Error('Invalid dbt git cache root path');
+    }
+    const markerPath = path.join(configuration.root, ROOT_MARKER);
+    let markerStat: Awaited<ReturnType<typeof fs.lstat>>;
+    try {
+        markerStat = await fs.lstat(markerPath);
+    } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+        await atomicWriteJson(markerPath, { version: CACHE_VERSION });
+        markerStat = await fs.lstat(markerPath);
+    }
+    const marker = await readJson(markerPath);
+    if (
+        !markerStat.isFile() ||
+        markerStat.isSymbolicLink() ||
+        !isPrivateOwnedStat(markerStat) ||
+        !marker ||
+        typeof marker !== 'object' ||
+        (marker as { version?: unknown }).version !== CACHE_VERSION
+    ) {
+        throw new Error('Invalid dbt git cache root marker');
+    }
+};
+
+const isOwnedEntry = async (key: string, entryDirectory: string) => {
+    if (!/^[a-f0-9]{64}$/.test(key)) return false;
+    try {
+        const stat = await fs.lstat(entryDirectory);
+        if (
+            !stat.isDirectory() ||
+            stat.isSymbolicLink() ||
+            !isPrivateOwnedStat(stat)
+        ) {
+            return false;
+        }
+        const realRoot = await fs.realpath(configuration.root);
+        const realEntry = await fs.realpath(entryDirectory);
+        if (path.dirname(realEntry) !== realRoot) return false;
+        const markerPath = path.join(entryDirectory, ENTRY_MARKER);
+        const markerStat = await fs.lstat(markerPath);
+        if (
+            !markerStat.isFile() ||
+            markerStat.isSymbolicLink() ||
+            !isPrivateOwnedStat(markerStat)
+        ) {
+            return false;
+        }
+        const marker = await readJson(markerPath);
+        return (
+            !!marker &&
+            typeof marker === 'object' &&
+            (marker as { version?: unknown }).version === CACHE_VERSION &&
+            (marker as { key?: unknown }).key === key
+        );
+    } catch {
+        return false;
+    }
+};
+
+const listOwnedEntries = async (): Promise<OwnedEntry[]> => {
+    await ensureRoot();
+    const directoryEntries = await fs.readdir(configuration.root, {
+        withFileTypes: true,
+    });
+    type RootCandidate = {
+        entry: (typeof directoryEntries)[number];
+        key: string;
+        kind: 'entry' | 'tombstone';
+    };
+    const candidates = directoryEntries.flatMap((entry): RootCandidate[] => {
+        if (/^[a-f0-9]{64}$/.test(entry.name)) {
+            return [{ entry, key: entry.name, kind: 'entry' as const }];
+        }
+        const match = entry.name.match(
+            /^\.tombstone-([a-f0-9]{64})-[0-9a-f-]{36}$/,
+        );
+        return match
+            ? [{ entry, key: match[1], kind: 'tombstone' as const }]
+            : [];
+    });
+    const entries = await Promise.all(
+        candidates.map(async ({ entry, key, kind }): Promise<OwnedEntry> => {
+            const entryDirectory = path.join(configuration.root, entry.name);
+            const owned = await isOwnedEntry(key, entryDirectory);
+            if (!owned) {
+                return {
+                    key,
+                    entryDirectory,
+                    kind,
+                    owned: false,
+                };
+            }
+            const value = await readJson(path.join(entryDirectory, METADATA));
+            return {
+                key,
+                entryDirectory,
+                kind,
+                owned: true,
+                metadata: isMetadata(value) ? value : undefined,
+            };
+        }),
+    );
+    return entries;
+};
+
+const processStartTime = async (
+    pid: number,
+): Promise<
+    | { status: 'found'; value: string }
+    | { status: 'missing' }
+    | { status: 'unknown' }
+> => {
+    try {
+        const stat = await fs.readFile(`/proc/${pid}/stat`, 'utf8');
+        const value = stat.slice(stat.lastIndexOf(')') + 2).split(' ')[19];
+        return value ? { status: 'found', value } : { status: 'unknown' };
+    } catch (error) {
+        return (error as NodeJS.ErrnoException).code === 'ENOENT'
+            ? { status: 'missing' }
+            : { status: 'unknown' };
+    }
+};
+
+const newLeaseOwner = async (leaseId: string): Promise<LeaseOwner> => ({
+    leaseId,
+    hostname: os.hostname(),
+    pid: process.pid,
+    processStartTime: await processStartTime(process.pid).then((result) =>
+        result.status === 'found' ? result.value : null,
+    ),
+    heartbeatAt: Date.now(),
+});
+
+const leaseOwnerIsProvablyStale = async (
+    value: LeaseOwner,
+): Promise<boolean> => {
+    if (value.hostname !== os.hostname()) return false;
+    if (Date.now() - value.heartbeatAt <= LEASE_STALE_MS) return false;
+    const actualStartTime = await processStartTime(value.pid);
+    return (
+        actualStartTime.status === 'missing' ||
+        (actualStartTime.status === 'found' &&
+            value.processStartTime !== null &&
+            actualStartTime.value !== value.processStartTime)
+    );
+};
+
+const claimAndRemoveStaleLease = async (
+    leaseDirectory: string,
+): Promise<boolean> => {
+    const observed = await readJson(path.join(leaseDirectory, LEASE_OWNER));
+    if (
+        !isLeaseOwner(observed) ||
+        !(await leaseOwnerIsProvablyStale(observed))
+    ) {
+        return false;
+    }
+    const claimPath = path.join(leaseDirectory, RECLAIM_CLAIM);
+    const claimId = randomUUID();
+    try {
+        await fs.writeFile(
+            claimPath,
+            JSON.stringify({
+                claimId,
+                claimant: await newLeaseOwner(claimId),
+            }),
+            {
+                flag: 'wx',
+                mode: 0o600,
+            },
+        );
+    } catch {
+        return false;
+    }
+    try {
+        const current = await readJson(path.join(leaseDirectory, LEASE_OWNER));
+        if (
+            !isLeaseOwner(current) ||
+            current.leaseId !== observed.leaseId ||
+            current.hostname !== observed.hostname ||
+            current.pid !== observed.pid ||
+            current.processStartTime !== observed.processStartTime ||
+            current.heartbeatAt !== observed.heartbeatAt ||
+            !(await leaseOwnerIsProvablyStale(current))
+        ) {
+            return false;
+        }
+        const staleDirectory = `${leaseDirectory}.stale-${claimId}`;
+        await fs.rename(leaseDirectory, staleDirectory);
+        await fs.rm(staleDirectory, { recursive: true, force: true });
+        return true;
+    } catch {
+        return false;
+    } finally {
+        const claim = await readJson(claimPath);
+        if (
+            claim &&
+            typeof claim === 'object' &&
+            (claim as { claimId?: unknown }).claimId === claimId
+        ) {
+            await fs.rm(claimPath, { force: true }).catch(() => undefined);
+        }
+    }
+};
+
+const tryCreateDirectoryLease = async (
+    leaseDirectory: string,
+    withHeartbeat: boolean,
+): Promise<DirectoryLease | undefined> => {
+    const create = async (): Promise<boolean> => {
+        try {
+            await fs.mkdir(leaseDirectory, { mode: 0o700 });
+            return true;
+        } catch (error) {
+            if ((error as NodeJS.ErrnoException).code === 'EEXIST')
+                return false;
+            throw error;
+        }
+    };
+    if (!(await create())) {
+        if (!(await claimAndRemoveStaleLease(leaseDirectory))) return undefined;
+        if (!(await create())) return undefined;
+    }
+    const leaseId = randomUUID();
+    const ownerPath = path.join(leaseDirectory, LEASE_OWNER);
+    const writeHeartbeat = async () =>
+        atomicWriteJson(ownerPath, await newLeaseOwner(leaseId));
+    try {
+        await writeHeartbeat();
+    } catch (error) {
+        await fs.rm(leaseDirectory, { recursive: true, force: true });
+        throw error;
+    }
+    let heartbeat: LeaseHeartbeat | undefined;
+    if (withHeartbeat) {
+        const state = {
+            pending: Promise.resolve(),
+            stopped: false,
+            schedule: () => undefined,
+        } as Omit<LeaseHeartbeat, 'timer'>;
+        state.schedule = () => {
+            if (state.stopped) return;
+            state.pending = state.pending
+                .then(async () => {
+                    if (state.stopped) return;
+                    const current = await readJson(ownerPath);
+                    if (isLeaseOwner(current) && current.leaseId === leaseId) {
+                        await writeHeartbeat();
+                    }
+                })
+                .catch(() => undefined);
+        };
+        const timer = setInterval(state.schedule, 30_000);
+        timer.unref();
+        heartbeat = Object.assign(state, { timer });
+    }
+    return { leaseId, directory: leaseDirectory, heartbeat };
+};
+
+const stopHeartbeat = async (heartbeat: LeaseHeartbeat | undefined) => {
+    if (!heartbeat) return;
+    Object.assign(heartbeat, { stopped: true });
+    clearInterval(heartbeat.timer);
+    await heartbeat.pending.catch(() => undefined);
+};
+
+const releaseDirectoryLease = async (lease: DirectoryLease) => {
+    await stopHeartbeat(lease.heartbeat);
+    const value = await readJson(path.join(lease.directory, LEASE_OWNER));
+    if (isLeaseOwner(value) && value.leaseId === lease.leaseId) {
+        await fs.rm(lease.directory, { recursive: true, force: true });
+    }
+};
+
+const tryEntryLease = async (entryDirectory: string) =>
+    tryCreateDirectoryLease(path.join(entryDirectory, LEASE_DIRECTORY), true);
+
+const tryCacheLock = async () => {
+    await ensureRoot();
+    return tryCreateDirectoryLease(
+        path.join(configuration.root, CACHE_LOCK),
+        false,
+    );
+};
+
+const acquireCacheLock = async (
+    deadline = Date.now() + CACHE_LOCK_WAIT_MS,
+): Promise<DirectoryLease | undefined> => {
+    const attempt = async (): Promise<DirectoryLease | undefined> => {
+        if (Date.now() >= deadline) return undefined;
+        const lease = await tryCacheLock();
+        if (lease) return lease;
+        await new Promise<void>((resolve) => {
+            setTimeout(resolve, 25);
+        });
+        return attempt();
+    };
+    return attempt();
+};
+
+const leaseOwnsEntry = async (lease: DbtGitCacheLease): Promise<boolean> => {
+    const value = await readJson(
+        path.join(lease.entryDirectory, LEASE_DIRECTORY, LEASE_OWNER),
+    );
+    return isLeaseOwner(value) && value.leaseId === lease.leaseId;
+};
+
+const scheduleTombstoneCleanup = (
+    tombstoneDirectory: string,
+    lease: DirectoryLease,
+) =>
+    fs
+        .rm(tombstoneDirectory, { recursive: true, force: true })
+        .then(() => true)
+        .catch(async (error) => {
+            await releaseDirectoryLease(lease).catch(() => undefined);
+            Logger.warn('Failed to remove dbt git cache tombstone', { error });
+            return false;
+        });
+
+const waitForTombstoneCleanup = (cleanup: Promise<boolean>, deadline: number) =>
+    new Promise<boolean>((resolve) => {
+        let settled = false;
+        const timeout: { timer?: NodeJS.Timeout } = {};
+        const finish = (value: boolean) => {
+            if (settled) return;
+            settled = true;
+            if (timeout.timer) clearTimeout(timeout.timer);
+            resolve(value);
+        };
+        timeout.timer = setTimeout(
+            () => finish(false),
+            Math.max(0, deadline - Date.now()),
+        );
+        void cleanup.then(finish);
+    });
+
+const removeWhileLeased = async (
+    lease: DbtGitCacheLease,
+): Promise<TombstoneRetirement | undefined> => {
+    if (lease.closed) return undefined;
+    await stopHeartbeat(lease.heartbeat);
+    const active = activeLeases.get(lease.key);
+    if (active?.leaseId === lease.leaseId) {
+        activeLeases.delete(lease.key);
+    }
+    const ownsEntry = await leaseOwnsEntry(lease);
+    if (ownsEntry && (await isOwnedEntry(lease.key, lease.entryDirectory))) {
+        const tombstoneDirectory = path.join(
+            configuration.root,
+            `.tombstone-${lease.key}-${lease.leaseId}`,
+        );
+        try {
+            await fs.rename(lease.entryDirectory, tombstoneDirectory);
+        } catch (error) {
+            await releaseDirectoryLease({
+                leaseId: lease.leaseId,
+                directory: path.join(lease.entryDirectory, LEASE_DIRECTORY),
+                heartbeat: lease.heartbeat,
+            }).catch(() => undefined);
+            Object.assign(lease, { closed: true });
+            throw error;
+        }
+        Object.assign(lease, { closed: true });
+        return {
+            cleanup: scheduleTombstoneCleanup(tombstoneDirectory, {
+                leaseId: lease.leaseId,
+                directory: path.join(tombstoneDirectory, LEASE_DIRECTORY),
+                heartbeat: lease.heartbeat,
+            }),
+        };
+    }
+    if (ownsEntry) {
+        await releaseDirectoryLease({
+            leaseId: lease.leaseId,
+            directory: path.join(lease.entryDirectory, LEASE_DIRECTORY),
+            heartbeat: lease.heartbeat,
+        });
+    }
+    Object.assign(lease, { closed: true });
+    return undefined;
+};
+
+const removeTombstoneWhileLeased = async (
+    entry: OwnedEntry,
+    lease: DirectoryLease,
+): Promise<TombstoneRetirement | undefined> => {
+    await stopHeartbeat(lease.heartbeat);
+    const owner = await readJson(path.join(lease.directory, LEASE_OWNER));
+    if (
+        isLeaseOwner(owner) &&
+        owner.leaseId === lease.leaseId &&
+        (await isOwnedEntry(entry.key, entry.entryDirectory))
+    ) {
+        return {
+            cleanup: scheduleTombstoneCleanup(entry.entryDirectory, lease),
+        };
+    }
+    await releaseDirectoryLease(lease);
+    return undefined;
+};
+
+const toPublicLease = (
+    key: string,
+    entryDirectory: string,
+    lease: DirectoryLease,
+    reused: boolean,
+): DbtGitCacheLease => ({
+    key,
+    entryDirectory,
+    checkoutDirectory: path.join(entryDirectory, 'checkout'),
+    depsMarkerPath: path.join(entryDirectory, 'deps.json'),
+    leaseId: lease.leaseId,
+    heartbeat: lease.heartbeat,
+    reused,
+    invalidated: false,
+    closed: false,
+});
+
+const markPendingDelete = async (entryDirectory: string) => {
+    try {
+        await fs.writeFile(path.join(entryDirectory, PENDING_DELETE), '', {
+            flag: 'wx',
+            mode: 0o600,
+        });
+    } catch (error) {
+        if (
+            !['EEXIST', 'ENOENT'].includes(
+                (error as NodeJS.ErrnoException).code ?? '',
+            )
+        ) {
+            throw error;
+        }
+    }
+};
+
+const evictEntry = async (entry: OwnedEntry, deferIfLeased: boolean) => {
+    if (!entry.owned) return undefined;
+    const acquired = await tryEntryLease(entry.entryDirectory);
+    if (!acquired) {
+        if (deferIfLeased) await markPendingDelete(entry.entryDirectory);
+        return undefined;
+    }
+    if (entry.kind === 'tombstone') {
+        return removeTombstoneWhileLeased(entry, acquired);
+    }
+    return removeWhileLeased(
+        toPublicLease(entry.key, entry.entryDirectory, acquired, true),
+    );
+};
+
+const evictFirstAvailableEntry = async (
+    entries: OwnedEntry[],
+): Promise<TombstoneRetirement | undefined> => {
+    const [entry, ...remaining] = entries;
+    if (!entry) return undefined;
+    const retirement = await evictEntry(entry, false);
+    return retirement ?? evictFirstAvailableEntry(remaining);
+};
+
+export const acquireDbtGitProjectCache = async (
+    identity: DbtGitCacheIdentity,
+    repositoryIdentity: string,
+): Promise<DbtGitCacheLease | undefined> => {
+    await ensureRoot();
+    const key = keyFor(identity, repositoryIdentity);
+    const entryDirectory = path.join(configuration.root, key);
+    const existing = await isOwnedEntry(key, entryDirectory);
+    if (existing) {
+        const acquired = await tryEntryLease(entryDirectory);
+        if (!acquired) return undefined;
+        const lease = toPublicLease(key, entryDirectory, acquired, true);
+        try {
+            const value = await readJson(path.join(entryDirectory, METADATA));
+            const pending = await fs
+                .access(path.join(entryDirectory, PENDING_DELETE))
+                .then(() => true)
+                .catch(() => false);
+            if (
+                pending ||
+                !isMetadata(value) ||
+                value.key !== key ||
+                value.repositoryIdentity !== repositoryIdentity ||
+                dbtGitCacheIdentityKey(value.identity) !==
+                    dbtGitCacheIdentityKey(identity) ||
+                value.state !== 'retained' ||
+                Date.now() - value.lastUsedAt > configuration.maxAgeMs
+            ) {
+                await removeWhileLeased(lease);
+                return await acquireDbtGitProjectCache(
+                    identity,
+                    repositoryIdentity,
+                );
+            }
+            activeLeases.set(key, lease);
+            return lease;
+        } catch (error) {
+            await removeWhileLeased(lease).catch(() => undefined);
+            throw error;
+        }
+    }
+    const cacheLock = await acquireCacheLock();
+    if (!cacheLock) return undefined;
+    try {
+        const entries = await listOwnedEntries();
+        if (entries.length >= DBT_GIT_CACHE_MAX_ENTRIES) return undefined;
+        try {
+            await fs.mkdir(entryDirectory, { mode: 0o700 });
+        } catch (error) {
+            if ((error as NodeJS.ErrnoException).code === 'EEXIST')
+                return undefined;
+            throw error;
+        }
+        try {
+            await atomicWriteJson(path.join(entryDirectory, ENTRY_MARKER), {
+                version: CACHE_VERSION,
+                key,
+            });
+            await atomicWriteJson(path.join(entryDirectory, METADATA), {
+                version: CACHE_VERSION,
+                key,
+                identity,
+                repositoryIdentity,
+                state: 'active',
+                sizeBytes: 0,
+                lastUsedAt: Date.now(),
+            } satisfies EntryMetadata);
+            const acquired = await tryEntryLease(entryDirectory);
+            if (!acquired) {
+                await fs.rm(entryDirectory, { recursive: true, force: true });
+                return undefined;
+            }
+            const lease = toPublicLease(key, entryDirectory, acquired, false);
+            activeLeases.set(key, lease);
+            return lease;
+        } catch (error) {
+            await fs.rm(entryDirectory, { recursive: true, force: true });
+            throw error;
+        }
+    } finally {
+        await releaseDirectoryLease(cacheLock);
+    }
+};
+
+export const invalidateOwnedDbtGitCacheLease = async (
+    lease: DbtGitCacheLease,
+) => {
+    Object.assign(lease, { invalidated: true });
+    await removeWhileLeased(lease);
+};
+
+const retainDbtGitProjectCache = async (
+    lease: DbtGitCacheLease,
+    sizeBytes: number,
+    deadline: number,
+    attempt: number,
+): Promise<void> => {
+    if (Date.now() >= deadline || attempt >= PUBLICATION_MAX_ATTEMPTS) {
+        await removeWhileLeased(lease);
+        return;
+    }
+    const cacheLock = await acquireCacheLock(deadline);
+    if (!cacheLock) {
+        await removeWhileLeased(lease);
+        return;
+    }
+    let cleanup: Promise<boolean> | undefined;
+    let declineRetention = false;
+    try {
+        const entries = await listOwnedEntries();
+        const corrupt = entries.some(
+            (entry) =>
+                !entry.owned || (entry.kind === 'entry' && !entry.metadata),
+        );
+        if (corrupt || entries.length > DBT_GIT_CACHE_MAX_ENTRIES) {
+            declineRetention = true;
+        } else {
+            const others = entries.filter(
+                (entry) => entry.entryDirectory !== lease.entryDirectory,
+            );
+            const entryCapacityBytes = async (entry: OwnedEntry) => {
+                if (entry.kind === 'tombstone') return configuration.maxBytes;
+                if (!entry.metadata) return configuration.maxBytes;
+                if (entry.metadata.state === 'retained') {
+                    return entry.metadata.sizeBytes;
+                }
+                if (activeLeases.has(entry.key)) return 0;
+                const owner = await readJson(
+                    path.join(
+                        entry.entryDirectory,
+                        LEASE_DIRECTORY,
+                        LEASE_OWNER,
+                    ),
+                );
+                const actualStartTime = isLeaseOwner(owner)
+                    ? await processStartTime(owner.pid)
+                    : { status: 'unknown' as const };
+                if (
+                    isLeaseOwner(owner) &&
+                    owner.hostname === os.hostname() &&
+                    actualStartTime.status === 'found' &&
+                    actualStartTime.value === owner.processStartTime
+                ) {
+                    return 0;
+                }
+                return configuration.maxBytes;
+            };
+            const retainedBytes = (
+                await Promise.all(others.map(entryCapacityBytes))
+            ).reduce((total, entryBytes) => total + entryBytes, 0);
+            const retainedCount = others.filter(
+                (entry) =>
+                    entry.kind === 'tombstone' ||
+                    entry.metadata?.state === 'retained',
+            ).length;
+            if (
+                retainedBytes + sizeBytes > configuration.maxBytes ||
+                retainedCount + 1 > DBT_GIT_CACHE_MAX_ENTRIES
+            ) {
+                const candidates = others
+                    .filter(
+                        (entry) =>
+                            entry.kind === 'entry' &&
+                            entry.metadata?.state === 'retained',
+                    )
+                    .sort(
+                        (left, right) =>
+                            (left.metadata?.lastUsedAt ?? 0) -
+                            (right.metadata?.lastUsedAt ?? 0),
+                    );
+                cleanup = (await evictFirstAvailableEntry(candidates))?.cleanup;
+                declineRetention = cleanup === undefined;
+            } else {
+                const current = await readJson(
+                    path.join(lease.entryDirectory, METADATA),
+                );
+                const pendingAfterAccounting = await fs
+                    .access(path.join(lease.entryDirectory, PENDING_DELETE))
+                    .then(() => true)
+                    .catch(() => false);
+                if (
+                    lease.invalidated ||
+                    pendingAfterAccounting ||
+                    !isMetadata(current) ||
+                    current.key !== lease.key
+                ) {
+                    declineRetention = true;
+                } else {
+                    await atomicWriteJson(
+                        path.join(lease.entryDirectory, METADATA),
+                        {
+                            ...current,
+                            state: 'retained',
+                            sizeBytes,
+                            lastUsedAt: Date.now(),
+                        } satisfies EntryMetadata,
+                    );
+                    await releaseDirectoryLease({
+                        leaseId: lease.leaseId,
+                        directory: path.join(
+                            lease.entryDirectory,
+                            LEASE_DIRECTORY,
+                        ),
+                        heartbeat: lease.heartbeat,
+                    });
+                    if (
+                        activeLeases.get(lease.key)?.leaseId === lease.leaseId
+                    ) {
+                        activeLeases.delete(lease.key);
+                    }
+                    Object.assign(lease, { closed: true });
+                }
+            }
+        }
+    } finally {
+        await releaseDirectoryLease(cacheLock);
+    }
+    if (declineRetention) {
+        await removeWhileLeased(lease);
+        return;
+    }
+    if (cleanup) {
+        if (await waitForTombstoneCleanup(cleanup, deadline)) {
+            return retainDbtGitProjectCache(
+                lease,
+                sizeBytes,
+                deadline,
+                attempt + 1,
+            );
+        }
+        await removeWhileLeased(lease);
+    }
+};
+
+export const releaseDbtGitProjectCache = async (
+    lease: DbtGitCacheLease,
+    sizeBytes: number,
+) => {
+    if (lease.closed) return;
+    const pending = await fs
+        .access(path.join(lease.entryDirectory, PENDING_DELETE))
+        .then(() => true)
+        .catch(() => false);
+    if (lease.invalidated || pending || sizeBytes > configuration.maxBytes) {
+        await removeWhileLeased(lease);
+        return;
+    }
+    await retainDbtGitProjectCache(
+        lease,
+        sizeBytes,
+        Date.now() + CACHE_LOCK_WAIT_MS,
+        0,
+    );
+};
+
+const invalidateMatchingEntries = async (
+    predicate: (identity: DbtGitCacheIdentity) => boolean,
+) => {
+    const cacheLock = await acquireCacheLock();
+    if (!cacheLock) return;
+    try {
+        const entries = await listOwnedEntries();
+        await Promise.all(
+            entries.map(async (entry) => {
+                if (
+                    entry.kind !== 'entry' ||
+                    !entry.metadata ||
+                    !predicate(entry.metadata.identity)
+                ) {
+                    return;
+                }
+                const active = activeLeases.get(entry.key);
+                if (active) {
+                    active.invalidated = true;
+                    await markPendingDelete(entry.entryDirectory);
+                    return;
+                }
+                await evictEntry(entry, true);
+            }),
+        );
+    } finally {
+        await releaseDirectoryLease(cacheLock);
+    }
+};
+
+export const invalidateDbtGitProjectCacheProject = async (
+    projectUuid: string,
+) =>
+    invalidateMatchingEntries(
+        (identity) => identity.projectUuid === projectUuid,
+    );
+
+export const invalidateDbtGitProjectCacheSource = async (
+    projectUuid: string,
+    sourceUuid: string,
+) =>
+    invalidateMatchingEntries(
+        (identity) =>
+            identity.projectUuid === projectUuid &&
+            identity.sourceUuid === sourceUuid,
+    );
+
+export async function maintainDbtGitProjectCache() {
+    const entries = await listOwnedEntries();
+    const identities = entries.flatMap((entry) =>
+        entry.kind === 'entry' && entry.owned && entry.metadata
+            ? [entry.metadata.identity]
+            : [],
+    );
+    const checkedIdentities = new Set(identities.map(dbtGitCacheIdentityKey));
+    let live: Set<string> | undefined;
+    if (
+        configuration.livenessCheck &&
+        identities.length <= DBT_GIT_CACHE_MAX_ENTRIES
+    ) {
+        try {
+            live = await configuration.livenessCheck(identities);
+        } catch {
+            live = undefined;
+        }
+    }
+    const now = Date.now();
+    const candidates = await Promise.all(
+        entries.map(async (entry) => {
+            if (!entry.owned) return undefined;
+            if (entry.kind === 'tombstone') return entry;
+            if (entry.metadata) {
+                const identityKey = dbtGitCacheIdentityKey(
+                    entry.metadata.identity,
+                );
+                return now - entry.metadata.lastUsedAt >
+                    configuration.maxAgeMs ||
+                    (live !== undefined &&
+                        checkedIdentities.has(identityKey) &&
+                        !live.has(identityKey))
+                    ? entry
+                    : undefined;
+            }
+            const markerStat = await fs
+                .lstat(path.join(entry.entryDirectory, ENTRY_MARKER))
+                .catch(() => undefined);
+            return markerStat &&
+                now - markerStat.mtimeMs > configuration.maxAgeMs
+                ? entry
+                : undefined;
+        }),
+    ).then((values) => values.filter((entry): entry is OwnedEntry => !!entry));
+    const cacheLock = await acquireCacheLock();
+    if (!cacheLock) return;
+    try {
+        await Promise.all(
+            candidates.map(async (entry) => {
+                const acquired = await tryEntryLease(entry.entryDirectory);
+                if (!acquired) {
+                    if (
+                        entry.kind === 'entry' &&
+                        entry.metadata &&
+                        live !== undefined &&
+                        !live.has(
+                            dbtGitCacheIdentityKey(entry.metadata.identity),
+                        )
+                    ) {
+                        await markPendingDelete(entry.entryDirectory);
+                    }
+                    return;
+                }
+                if (entry.kind === 'tombstone') {
+                    await removeTombstoneWhileLeased(entry, acquired);
+                    return;
+                }
+                const lease = toPublicLease(
+                    entry.key,
+                    entry.entryDirectory,
+                    acquired,
+                    true,
+                );
+                const current = await readJson(
+                    path.join(entry.entryDirectory, METADATA),
+                );
+                const pending = await fs
+                    .access(path.join(entry.entryDirectory, PENDING_DELETE))
+                    .then(() => true)
+                    .catch(() => false);
+                let shouldDelete = pending;
+                if (isMetadata(current)) {
+                    const identityKey = dbtGitCacheIdentityKey(
+                        current.identity,
+                    );
+                    shouldDelete ||=
+                        now - current.lastUsedAt > configuration.maxAgeMs ||
+                        (live !== undefined &&
+                            checkedIdentities.has(identityKey) &&
+                            !live.has(identityKey));
+                } else {
+                    const markerStat = await fs
+                        .lstat(path.join(entry.entryDirectory, ENTRY_MARKER))
+                        .catch(() => undefined);
+                    shouldDelete ||=
+                        markerStat !== undefined &&
+                        now - markerStat.mtimeMs > configuration.maxAgeMs;
+                }
+                if (shouldDelete) {
+                    await removeWhileLeased(lease);
+                } else {
+                    await releaseDirectoryLease(acquired);
+                }
+            }),
+        );
+    } finally {
+        await releaseDirectoryLease(cacheLock);
+    }
+}
+
+export const configureDbtGitProjectCache = (args: {
+    maxBytes: number;
+    maxAgeMs: number;
+    livenessCheck: DbtGitCacheLivenessCheck;
+    root?: string;
+}) => {
+    configuration = {
+        root: args.root ?? configuration.root,
+        maxBytes:
+            Number.isSafeInteger(args.maxBytes) && args.maxBytes > 0
+                ? args.maxBytes
+                : DBT_GIT_CACHE_DEFAULT_MAX_BYTES,
+        maxAgeMs:
+            Number.isSafeInteger(args.maxAgeMs) && args.maxAgeMs > 0
+                ? args.maxAgeMs
+                : DBT_GIT_CACHE_DEFAULT_MAX_AGE_MS,
+        livenessCheck: args.livenessCheck,
+    };
+    if (!maintenanceTimer) {
+        maintenanceTimer = setInterval(() => {
+            void maintainDbtGitProjectCache().catch((error) => {
+                Logger.warn('Failed to maintain dbt git project cache', {
+                    error,
+                });
+            });
+        }, DBT_GIT_CACHE_MAINTENANCE_INTERVAL_MS);
+        maintenanceTimer.unref();
+    }
+};
+
+export const getDbtGitCacheConfigurationForTests = () => ({ ...configuration });

--- a/packages/backend/src/projectAdapters/dbtGitProjectCache.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectCache.ts
@@ -18,11 +18,13 @@ const ENTRY_MARKER = '.lightdash-cache-entry.json';
 const METADATA = 'metadata.json';
 const LEASE_DIRECTORY = 'lease';
 const LEASE_OWNER = 'owner.json';
+const LEASE_HEARTBEAT_PREFIX = '.heartbeat-';
 const PENDING_DELETE = 'pending-delete';
 const CACHE_LOCK = '.reservation-lock';
 const RECLAIM_CLAIM = '.reclaim.json';
 const CACHE_LOCK_WAIT_MS = 5_000;
 const ADMISSION_TOTAL_WAIT_MS = 3_000;
+const HEARTBEAT_WRITE_TIMEOUT_MS = 30_000;
 const TOMBSTONE_CLEANUP_WAIT_MS = 3_000;
 const RETENTION_TOTAL_WAIT_MS = 3_000;
 const PUBLICATION_MAX_ATTEMPTS = DBT_GIT_CACHE_MAX_ENTRIES;
@@ -75,6 +77,9 @@ type LeaseHeartbeat = {
     timer: NodeJS.Timeout;
     pending: Promise<void>;
     stopped: boolean;
+    abortController: AbortController;
+    invalidate: (reason: string) => void;
+    onInvalidated?: () => void;
     schedule: () => void;
 };
 
@@ -97,6 +102,7 @@ export type DbtGitCacheLease = {
     reused: boolean;
     invalidated: boolean;
     closed: boolean;
+    signal: AbortSignal;
     retained?: boolean;
     retentionReason?: string;
     heartbeat?: LeaseHeartbeat;
@@ -284,6 +290,61 @@ const atomicWriteJson = async (filePath: string, value: unknown) => {
         await fs.rm(temporaryPath, { force: true }).catch((cleanupError) => {
             warnSwallowedFilesystemError(
                 'Failed to remove dbt git cache temporary file',
+                cleanupError,
+            );
+        });
+        throw error;
+    }
+};
+
+const leaseHeartbeatPath = (leaseDirectory: string, leaseId: string) =>
+    path.join(leaseDirectory, `${LEASE_HEARTBEAT_PREFIX}${leaseId}.json`);
+
+const readLeaseOwner = async (leaseDirectory: string) => {
+    const owner = await readJson(path.join(leaseDirectory, LEASE_OWNER));
+    if (!isLeaseOwner(owner)) return owner;
+    const heartbeat = await readJson(
+        leaseHeartbeatPath(leaseDirectory, owner.leaseId),
+    );
+    if (
+        isLeaseOwner(heartbeat) &&
+        heartbeat.leaseId === owner.leaseId &&
+        heartbeat.hostname === owner.hostname &&
+        heartbeat.pid === owner.pid &&
+        heartbeat.processStartTime === owner.processStartTime &&
+        heartbeat.heartbeatAt >= owner.heartbeatAt
+    ) {
+        return heartbeat;
+    }
+    return owner;
+};
+
+const writeLeaseHeartbeat = async (
+    leaseDirectory: string,
+    owner: LeaseOwner,
+    shouldStop: () => boolean,
+): Promise<boolean> => {
+    const heartbeatPath = leaseHeartbeatPath(leaseDirectory, owner.leaseId);
+    const temporaryPath = `${heartbeatPath}.${randomUUID()}.tmp`;
+    try {
+        await fs.writeFile(temporaryPath, JSON.stringify(owner), {
+            mode: 0o600,
+        });
+        const current = await readJson(path.join(leaseDirectory, LEASE_OWNER));
+        if (
+            shouldStop() ||
+            !isLeaseOwner(current) ||
+            current.leaseId !== owner.leaseId
+        ) {
+            await fs.rm(temporaryPath, { force: true });
+            return false;
+        }
+        await fs.rename(temporaryPath, heartbeatPath);
+        return true;
+    } catch (error) {
+        await fs.rm(temporaryPath, { force: true }).catch((cleanupError) => {
+            warnSwallowedFilesystemError(
+                'Failed to remove dbt git cache heartbeat temporary file',
                 cleanupError,
             );
         });
@@ -558,7 +619,7 @@ const removeAgedReclaimClaim = async (claimPath: string): Promise<boolean> => {
 const claimAndRemoveStaleLease = async (
     leaseDirectory: string,
 ): Promise<boolean> => {
-    const observed = await readJson(path.join(leaseDirectory, LEASE_OWNER));
+    const observed = await readLeaseOwner(leaseDirectory);
     if (
         !isLeaseOwner(observed) ||
         !(await leaseOwnerIsProvablyStale(observed))
@@ -594,7 +655,7 @@ const claimAndRemoveStaleLease = async (
     }
     if (claimResult !== 'claimed') return false;
     try {
-        const current = await readJson(path.join(leaseDirectory, LEASE_OWNER));
+        const current = await readLeaseOwner(leaseDirectory);
         if (
             !isLeaseOwner(current) ||
             current.leaseId !== observed.leaseId ||
@@ -653,29 +714,104 @@ const tryCreateDirectoryLease = async (
     }
     const leaseId = randomUUID();
     const ownerPath = path.join(leaseDirectory, LEASE_OWNER);
-    const writeHeartbeat = async () =>
-        atomicWriteJson(ownerPath, await newLeaseOwner(leaseId));
+    const owner = await newLeaseOwner(leaseId);
     try {
-        await writeHeartbeat();
+        await atomicWriteJson(ownerPath, owner);
     } catch (error) {
         await fs.rm(leaseDirectory, { recursive: true, force: true });
         throw error;
     }
     let heartbeat: LeaseHeartbeat | undefined;
     if (withHeartbeat) {
+        const abortController = new AbortController();
         const state = {
             pending: Promise.resolve(),
             stopped: false,
+            abortController,
+            invalidate: (_reason: string) => undefined,
             schedule: () => undefined,
         } as Omit<LeaseHeartbeat, 'timer'>;
+        state.invalidate = (reason: string) => {
+            if (abortController.signal.aborted) return;
+            state.stopped = true;
+            clearInterval((state as LeaseHeartbeat).timer);
+            abortController.abort();
+            state.onInvalidated?.();
+            Logger.warn('Invalidated dbt git cache lease heartbeat', {
+                reason,
+            });
+        };
         state.schedule = () => {
             if (state.stopped) return;
             state.pending = state.pending
                 .then(async () => {
                     if (state.stopped) return;
-                    const current = await readJson(ownerPath);
-                    if (isLeaseOwner(current) && current.leaseId === leaseId) {
-                        await writeHeartbeat();
+                    const attempt = async (): Promise<
+                        'written' | 'ownership-lost'
+                    > => {
+                        const current = await readJson(ownerPath);
+                        if (
+                            !isLeaseOwner(current) ||
+                            current.leaseId !== leaseId
+                        ) {
+                            return 'ownership-lost';
+                        }
+                        const written = await writeLeaseHeartbeat(
+                            leaseDirectory,
+                            {
+                                ...owner,
+                                heartbeatAt: Date.now(),
+                            },
+                            () =>
+                                state.stopped || abortController.signal.aborted,
+                        );
+                        if (!written) return 'ownership-lost';
+                        const currentAfterWrite = await readJson(ownerPath);
+                        return isLeaseOwner(currentAfterWrite) &&
+                            currentAfterWrite.leaseId === leaseId
+                            ? 'written'
+                            : 'ownership-lost';
+                    };
+                    const attemptPromise = attempt();
+                    const result = await new Promise<
+                        'written' | 'ownership-lost' | 'timeout'
+                    >((resolve, reject) => {
+                        let settled = false;
+                        const timeout: { timer?: NodeJS.Timeout } = {};
+                        const finish = (
+                            value: 'written' | 'ownership-lost' | 'timeout',
+                        ) => {
+                            if (settled) return;
+                            settled = true;
+                            if (timeout.timer) clearTimeout(timeout.timer);
+                            resolve(value);
+                        };
+                        timeout.timer = setTimeout(
+                            () => finish('timeout'),
+                            HEARTBEAT_WRITE_TIMEOUT_MS,
+                        );
+                        timeout.timer.unref();
+                        void attemptPromise.then(finish).catch((error) => {
+                            if (settled) {
+                                warnSwallowedFilesystemError(
+                                    'Failed to finish timed out dbt git cache heartbeat',
+                                    error,
+                                );
+                                return;
+                            }
+                            settled = true;
+                            if (timeout.timer) clearTimeout(timeout.timer);
+                            reject(error);
+                        });
+                    });
+                    if (result === 'timeout') {
+                        if (!state.stopped) {
+                            state.invalidate('heartbeat-write-timeout');
+                        }
+                        return;
+                    }
+                    if (result === 'ownership-lost' && !state.stopped) {
+                        state.invalidate('lease-ownership-lost');
                     }
                 })
                 .catch((error) => {
@@ -683,6 +819,9 @@ const tryCreateDirectoryLease = async (
                         'Failed to update dbt git cache lease heartbeat',
                         error,
                     );
+                    if (!state.stopped) {
+                        state.invalidate('heartbeat-write-error');
+                    }
                 });
         };
         const timer = setInterval(state.schedule, 30_000);
@@ -706,7 +845,7 @@ const stopHeartbeat = async (heartbeat: LeaseHeartbeat | undefined) => {
 
 const releaseDirectoryLease = async (lease: DirectoryLease) => {
     await stopHeartbeat(lease.heartbeat);
-    const value = await readJson(path.join(lease.directory, LEASE_OWNER));
+    const value = await readLeaseOwner(lease.directory);
     if (isLeaseOwner(value) && value.leaseId === lease.leaseId) {
         await fs.rm(lease.directory, { recursive: true, force: true });
     }
@@ -739,8 +878,8 @@ const acquireCacheLock = async (
 };
 
 const leaseOwnsEntry = async (lease: DbtGitCacheLease): Promise<boolean> => {
-    const value = await readJson(
-        path.join(lease.entryDirectory, LEASE_DIRECTORY, LEASE_OWNER),
+    const value = await readLeaseOwner(
+        path.join(lease.entryDirectory, LEASE_DIRECTORY),
     );
     return isLeaseOwner(value) && value.leaseId === lease.leaseId;
 };
@@ -855,17 +994,29 @@ const toPublicLease = (
     entryDirectory: string,
     lease: DirectoryLease,
     reused: boolean,
-): DbtGitCacheLease => ({
-    key,
-    entryDirectory,
-    checkoutDirectory: path.join(entryDirectory, 'checkout'),
-    depsMarkerPath: path.join(entryDirectory, 'deps.json'),
-    leaseId: lease.leaseId,
-    heartbeat: lease.heartbeat,
-    reused,
-    invalidated: false,
-    closed: false,
-});
+): DbtGitCacheLease => {
+    const abortController =
+        lease.heartbeat?.abortController ?? new AbortController();
+    const publicLease: DbtGitCacheLease = {
+        key,
+        entryDirectory,
+        checkoutDirectory: path.join(entryDirectory, 'checkout'),
+        depsMarkerPath: path.join(entryDirectory, 'deps.json'),
+        leaseId: lease.leaseId,
+        heartbeat: lease.heartbeat,
+        reused,
+        invalidated: abortController.signal.aborted,
+        closed: false,
+        signal: abortController.signal,
+    };
+    const heartbeat = lease.heartbeat;
+    if (heartbeat) {
+        heartbeat.onInvalidated = () => {
+            publicLease.invalidated = true;
+        };
+    }
+    return publicLease;
+};
 
 const markPendingDelete = async (entryDirectory: string) => {
     try {
@@ -955,8 +1106,8 @@ const abandonedEntry = async (
     ) {
         return undefined;
     }
-    const owner = await readJson(
-        path.join(entry.entryDirectory, LEASE_DIRECTORY, LEASE_OWNER),
+    const owner = await readLeaseOwner(
+        path.join(entry.entryDirectory, LEASE_DIRECTORY),
     );
     if (isLeaseOwner(owner) && !(await leaseOwnerIsProvablyStale(owner))) {
         return undefined;
@@ -991,12 +1142,8 @@ const reserveAbandonedEntryCleanup = async (
     }
     const lease = await tryEntryLease(candidate.entry.entryDirectory);
     if (!lease) {
-        const owner = await readJson(
-            path.join(
-                candidate.entry.entryDirectory,
-                LEASE_DIRECTORY,
-                LEASE_OWNER,
-            ),
+        const owner = await readLeaseOwner(
+            path.join(candidate.entry.entryDirectory, LEASE_DIRECTORY),
         );
         if (isLeaseOwner(owner) && !(await leaseOwnerIsProvablyStale(owner))) {
             return undefined;
@@ -1329,12 +1476,8 @@ const retainDbtGitProjectCache = async (
                     return entry.metadata.sizeBytes;
                 }
                 if (activeLeases.has(entry.key)) return 0;
-                const owner = await readJson(
-                    path.join(
-                        entry.entryDirectory,
-                        LEASE_DIRECTORY,
-                        LEASE_OWNER,
-                    ),
+                const owner = await readLeaseOwner(
+                    path.join(entry.entryDirectory, LEASE_DIRECTORY),
                 );
                 const actualStartTime = isLeaseOwner(owner)
                     ? await processStartTime(owner.pid)

--- a/packages/backend/src/projectAdapters/dbtGitProjectCache.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectCache.ts
@@ -284,6 +284,16 @@ const pathExists = async (filePath: string) => {
     }
 };
 
+const cacheRootExists = async () => {
+    try {
+        await fs.lstat(configuration.root);
+        return true;
+    } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false;
+        throw error;
+    }
+};
+
 const atomicWriteJson = async (filePath: string, value: unknown) => {
     const temporaryPath = `${filePath}.${randomUUID()}.tmp`;
     try {
@@ -1705,6 +1715,7 @@ export const releaseDbtGitProjectCache = async (
 const invalidateMatchingEntries = async (
     predicate: (identity: DbtGitCacheIdentity) => boolean,
 ) => {
+    if (configuration.maxBytes <= 0 && !(await cacheRootExists())) return;
     const cacheLock = await acquireCacheLock();
     if (!cacheLock) return;
     try {
@@ -1751,6 +1762,7 @@ export const invalidateDbtGitProjectCacheSource = async (
 
 export async function maintainDbtGitProjectCache() {
     const disabled = configuration.maxBytes <= 0;
+    if (disabled && !(await cacheRootExists())) return;
     const entries = await listOwnedEntries();
     const rootDebris = await listRootDebris();
     const identities = entries.flatMap((entry) =>

--- a/packages/backend/src/projectAdapters/dbtGitProjectCache.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectCache.ts
@@ -1156,6 +1156,101 @@ const evictFirstAvailableEntry = async (
     return retirement ?? evictFirstAvailableEntry(remaining);
 };
 
+type RetentionVictim = {
+    entry: OwnedEntry;
+    lease: DirectoryLease;
+};
+
+const releaseRetentionVictims = async (victims: RetentionVictim[]) => {
+    await Promise.all(
+        victims.map(({ lease }) =>
+            releaseDirectoryLease(lease).catch((error) => {
+                warnSwallowedFilesystemError(
+                    'Failed to release dbt git cache retention victim lease',
+                    error,
+                );
+            }),
+        ),
+    );
+};
+
+const selectRetentionVictims = async (
+    entries: OwnedEntry[],
+    bytesNeeded: number,
+    countNeeded: number,
+    selected: RetentionVictim[] = [],
+): Promise<RetentionVictim[] | undefined> => {
+    if (bytesNeeded <= 0 && countNeeded <= 0) return selected;
+    const [entry, ...remaining] = entries;
+    if (!entry) {
+        await releaseRetentionVictims(selected);
+        return undefined;
+    }
+    let lease: DirectoryLease | undefined;
+    try {
+        lease = await tryEntryLease(entry.entryDirectory);
+    } catch (error) {
+        await releaseRetentionVictims(selected);
+        throw error;
+    }
+    if (!lease) {
+        return selectRetentionVictims(
+            remaining,
+            bytesNeeded,
+            countNeeded,
+            selected,
+        );
+    }
+    return selectRetentionVictims(
+        remaining,
+        bytesNeeded - (entry.metadata?.sizeBytes ?? 0),
+        countNeeded - 1,
+        [...selected, { entry, lease }],
+    );
+};
+
+const retireRetentionVictims = async (
+    victims: RetentionVictim[],
+): Promise<Promise<boolean>[] | undefined> => {
+    const [victim, ...remaining] = victims;
+    if (!victim) return [];
+    const retirement = await removeWhileLeased(
+        toPublicLease(
+            victim.entry.key,
+            victim.entry.entryDirectory,
+            victim.lease,
+            true,
+        ),
+    );
+    if (!retirement) {
+        await releaseRetentionVictims(remaining);
+        return undefined;
+    }
+    const remainingCleanups = await retireRetentionVictims(remaining);
+    return remainingCleanups
+        ? [retirement.cleanup, ...remainingCleanups]
+        : undefined;
+};
+
+const reserveRetentionVictims = async (
+    entries: OwnedEntry[],
+    bytesNeeded: number,
+    countNeeded: number,
+) => {
+    const victims = await selectRetentionVictims(
+        entries,
+        bytesNeeded,
+        countNeeded,
+    );
+    if (!victims) return undefined;
+    try {
+        return await retireRetentionVictims(victims);
+    } catch (error) {
+        await releaseRetentionVictims(victims);
+        throw error;
+    }
+};
+
 type AbandonedEntry = {
     entry: OwnedEntry;
     stat: Stats;
@@ -1558,15 +1653,9 @@ const retainDbtGitProjectCache = async (
     lease: DbtGitCacheLease,
     sizeBytes: number,
     totalDeadline: number,
-    attempt: number,
 ): Promise<void> => {
-    if (Date.now() >= totalDeadline || attempt >= PUBLICATION_MAX_ATTEMPTS) {
-        await declineDbtGitCacheRetention(
-            lease,
-            attempt >= PUBLICATION_MAX_ATTEMPTS
-                ? 'publication-attempt-limit'
-                : 'publication-deadline',
-        );
+    if (Date.now() >= totalDeadline) {
+        await declineDbtGitCacheRetention(lease, 'publication-deadline');
         return;
     }
     const cacheLock = await acquireCacheLock(
@@ -1576,7 +1665,7 @@ const retainDbtGitProjectCache = async (
         await declineDbtGitCacheRetention(lease, 'reservation-lock-timeout');
         return;
     }
-    let cleanup: Promise<boolean> | undefined;
+    let cleanup: Promise<boolean>[] = [];
     let declineRetention: string | undefined;
     let declineRetentionPaths: string[] | undefined;
     try {
@@ -1627,24 +1716,7 @@ const retainDbtGitProjectCache = async (
                     entry.kind === 'tombstone' ||
                     entry.metadata?.state === 'retained',
             ).length;
-            if (
-                retainedBytes + sizeBytes > configuration.maxBytes ||
-                retainedCount + 1 > DBT_GIT_CACHE_MAX_ENTRIES
-            ) {
-                const candidates = others
-                    .filter(
-                        (entry) =>
-                            entry.kind === 'entry' &&
-                            entry.metadata?.state === 'retained',
-                    )
-                    .sort(
-                        (left, right) =>
-                            (left.metadata?.lastUsedAt ?? 0) -
-                            (right.metadata?.lastUsedAt ?? 0),
-                    );
-                cleanup = (await evictFirstAvailableEntry(candidates))?.cleanup;
-                if (!cleanup) declineRetention = 'capacity-unavailable';
-            } else {
+            const publish = async () => {
                 const current = await readJson(
                     path.join(lease.entryDirectory, METADATA),
                 );
@@ -1668,35 +1740,59 @@ const retainDbtGitProjectCache = async (
                     } else {
                         declineRetention = 'invalid-metadata';
                     }
-                } else {
-                    await atomicWriteJson(
-                        path.join(lease.entryDirectory, METADATA),
-                        {
-                            ...current,
-                            state: 'retained',
-                            sizeBytes,
-                            lastUsedAt: Date.now(),
-                        } satisfies EntryMetadata,
-                    );
-                    await releaseDirectoryLease({
-                        leaseId: lease.leaseId,
-                        directory: path.join(
-                            lease.entryDirectory,
-                            LEASE_DIRECTORY,
-                        ),
-                        heartbeat: lease.heartbeat,
-                    });
-                    if (
-                        activeLeases.get(lease.key)?.leaseId === lease.leaseId
-                    ) {
-                        activeLeases.delete(lease.key);
-                    }
-                    Object.assign(lease, {
-                        closed: true,
-                        retained: true,
-                        retentionReason: undefined,
-                    });
+                    return;
                 }
+                await atomicWriteJson(
+                    path.join(lease.entryDirectory, METADATA),
+                    {
+                        ...current,
+                        state: 'retained',
+                        sizeBytes,
+                        lastUsedAt: Date.now(),
+                    } satisfies EntryMetadata,
+                );
+                await releaseDirectoryLease({
+                    leaseId: lease.leaseId,
+                    directory: path.join(lease.entryDirectory, LEASE_DIRECTORY),
+                    heartbeat: lease.heartbeat,
+                });
+                if (activeLeases.get(lease.key)?.leaseId === lease.leaseId) {
+                    activeLeases.delete(lease.key);
+                }
+                Object.assign(lease, {
+                    closed: true,
+                    retained: true,
+                    retentionReason: undefined,
+                });
+            };
+            if (
+                retainedBytes + sizeBytes > configuration.maxBytes ||
+                retainedCount + 1 > DBT_GIT_CACHE_MAX_ENTRIES
+            ) {
+                const candidates = others
+                    .filter(
+                        (entry) =>
+                            entry.kind === 'entry' &&
+                            entry.metadata?.state === 'retained',
+                    )
+                    .sort(
+                        (left, right) =>
+                            (left.metadata?.lastUsedAt ?? 0) -
+                            (right.metadata?.lastUsedAt ?? 0),
+                    );
+                const reserved = await reserveRetentionVictims(
+                    candidates,
+                    retainedBytes + sizeBytes - configuration.maxBytes,
+                    retainedCount + 1 - DBT_GIT_CACHE_MAX_ENTRIES,
+                );
+                if (!reserved) {
+                    declineRetention = 'capacity-unavailable';
+                } else {
+                    cleanup = reserved;
+                    await publish();
+                }
+            } else {
+                await publish();
             }
         }
     } finally {
@@ -1710,22 +1806,7 @@ const retainDbtGitProjectCache = async (
         );
         return;
     }
-    if (cleanup) {
-        if (
-            await waitForTombstoneCleanup(
-                cleanup,
-                Math.min(totalDeadline, Date.now() + TOMBSTONE_CLEANUP_WAIT_MS),
-            )
-        ) {
-            return retainDbtGitProjectCache(
-                lease,
-                sizeBytes,
-                totalDeadline,
-                attempt + 1,
-            );
-        }
-        await declineDbtGitCacheRetention(lease, 'cleanup-timeout');
-    }
+    void Promise.all(cleanup);
 };
 
 export const releaseDbtGitProjectCache = async (
@@ -1747,7 +1828,6 @@ export const releaseDbtGitProjectCache = async (
         lease,
         sizeBytes,
         Date.now() + RETENTION_TOTAL_WAIT_MS,
-        0,
     );
 };
 

--- a/packages/backend/src/projectAdapters/dbtGitProjectCache.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectCache.ts
@@ -1237,7 +1237,11 @@ const reserveAbandonedEntryCleanup = async (
                 );
             });
         }
-        throw error;
+        warnSwallowedFilesystemError(
+            'Failed to reserve abandoned dbt git cache entry cleanup',
+            error,
+        );
+        return undefined;
     }
     return {
         path: tombstonePath,

--- a/packages/backend/src/projectAdapters/dbtGitProjectCache.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectCache.ts
@@ -91,6 +91,8 @@ export type DbtGitCacheLease = {
     reused: boolean;
     invalidated: boolean;
     closed: boolean;
+    retained?: boolean;
+    retentionReason?: string;
     heartbeat?: LeaseHeartbeat;
 };
 
@@ -215,11 +217,41 @@ const keyFor = (
         .update(JSON.stringify({ identity, repositoryIdentity }))
         .digest('hex');
 
+const warnSwallowedFilesystemError = (message: string, error: unknown) => {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        Logger.warn(message, { error });
+    }
+};
+
 const readJson = async (filePath: string): Promise<unknown> => {
+    let contents: string;
     try {
-        return JSON.parse(await fs.readFile(filePath, 'utf8'));
-    } catch {
+        contents = await fs.readFile(filePath, 'utf8');
+    } catch (error) {
+        warnSwallowedFilesystemError(
+            'Failed to read dbt git cache JSON',
+            error,
+        );
         return undefined;
+    }
+    try {
+        return JSON.parse(contents);
+    } catch (error) {
+        Logger.warn('Failed to parse dbt git cache JSON', { error });
+        return undefined;
+    }
+};
+
+const pathExists = async (filePath: string) => {
+    try {
+        await fs.access(filePath);
+        return true;
+    } catch (error) {
+        warnSwallowedFilesystemError(
+            'Failed to inspect dbt git cache path',
+            error,
+        );
+        return false;
     }
 };
 
@@ -231,7 +263,12 @@ const atomicWriteJson = async (filePath: string, value: unknown) => {
         });
         await fs.rename(temporaryPath, filePath);
     } catch (error) {
-        await fs.rm(temporaryPath, { force: true }).catch(() => undefined);
+        await fs.rm(temporaryPath, { force: true }).catch((cleanupError) => {
+            warnSwallowedFilesystemError(
+                'Failed to remove dbt git cache temporary file',
+                cleanupError,
+            );
+        });
         throw error;
     }
 };
@@ -305,7 +342,11 @@ const isOwnedEntry = async (key: string, entryDirectory: string) => {
             (marker as { version?: unknown }).version === CACHE_VERSION &&
             (marker as { key?: unknown }).key === key
         );
-    } catch {
+    } catch (error) {
+        warnSwallowedFilesystemError(
+            'Failed to inspect dbt git cache entry',
+            error,
+        );
         return false;
     }
 };
@@ -370,9 +411,13 @@ const listRootDebris = async (): Promise<RootDebris[]> => {
                     : [],
             )
             .map(async (candidatePath) => {
-                const stat = await fs
-                    .lstat(candidatePath)
-                    .catch(() => undefined);
+                const stat = await fs.lstat(candidatePath).catch((error) => {
+                    warnSwallowedFilesystemError(
+                        'Failed to inspect dbt git cache root object',
+                        error,
+                    );
+                    return undefined;
+                });
                 return stat ? { path: candidatePath, stat } : undefined;
             }),
     ).then((values) =>
@@ -395,7 +440,13 @@ const isPrivateRootChild = async (
     ) {
         return false;
     }
-    const currentStat = await fs.lstat(candidatePath).catch(() => undefined);
+    const currentStat = await fs.lstat(candidatePath).catch((error) => {
+        warnSwallowedFilesystemError(
+            'Failed to verify dbt git cache root object',
+            error,
+        );
+        return undefined;
+    });
     return (
         currentStat !== undefined &&
         isSameFile(currentStat, expectedStat) &&
@@ -419,9 +470,11 @@ const processStartTime = async (
         const value = stat.slice(stat.lastIndexOf(')') + 2).split(' ')[19];
         return value ? { status: 'found', value } : { status: 'unknown' };
     } catch (error) {
-        return (error as NodeJS.ErrnoException).code === 'ENOENT'
-            ? { status: 'missing' }
-            : { status: 'unknown' };
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+            return { status: 'missing' };
+        }
+        Logger.warn('Failed to inspect dbt git cache lease process', { error });
+        return { status: 'unknown' };
     }
 };
 
@@ -475,7 +528,11 @@ const claimAndRemoveStaleLease = async (
                 mode: 0o600,
             },
         );
-    } catch {
+    } catch (error) {
+        warnSwallowedFilesystemError(
+            'Failed to claim stale dbt git cache lease',
+            error,
+        );
         return false;
     }
     try {
@@ -495,7 +552,11 @@ const claimAndRemoveStaleLease = async (
         await fs.rename(leaseDirectory, staleDirectory);
         await fs.rm(staleDirectory, { recursive: true, force: true });
         return true;
-    } catch {
+    } catch (error) {
+        warnSwallowedFilesystemError(
+            'Failed to remove stale dbt git cache lease',
+            error,
+        );
         return false;
     } finally {
         const claim = await readJson(claimPath);
@@ -504,7 +565,12 @@ const claimAndRemoveStaleLease = async (
             typeof claim === 'object' &&
             (claim as { claimId?: unknown }).claimId === claimId
         ) {
-            await fs.rm(claimPath, { force: true }).catch(() => undefined);
+            await fs.rm(claimPath, { force: true }).catch((error) => {
+                warnSwallowedFilesystemError(
+                    'Failed to remove dbt git cache reclaim claim',
+                    error,
+                );
+            });
         }
     }
 };
@@ -554,7 +620,12 @@ const tryCreateDirectoryLease = async (
                         await writeHeartbeat();
                     }
                 })
-                .catch(() => undefined);
+                .catch((error) => {
+                    warnSwallowedFilesystemError(
+                        'Failed to update dbt git cache lease heartbeat',
+                        error,
+                    );
+                });
         };
         const timer = setInterval(state.schedule, 30_000);
         timer.unref();
@@ -567,7 +638,12 @@ const stopHeartbeat = async (heartbeat: LeaseHeartbeat | undefined) => {
     if (!heartbeat) return;
     Object.assign(heartbeat, { stopped: true });
     clearInterval(heartbeat.timer);
-    await heartbeat.pending.catch(() => undefined);
+    await heartbeat.pending.catch((error) => {
+        warnSwallowedFilesystemError(
+            'Failed to drain dbt git cache lease heartbeat',
+            error,
+        );
+    });
 };
 
 const releaseDirectoryLease = async (lease: DirectoryLease) => {
@@ -619,7 +695,12 @@ const scheduleTombstoneCleanup = (
         .rm(tombstoneDirectory, { recursive: true, force: true })
         .then(() => true)
         .catch(async (error) => {
-            await releaseDirectoryLease(lease).catch(() => undefined);
+            await releaseDirectoryLease(lease).catch((releaseError) => {
+                warnSwallowedFilesystemError(
+                    'Failed to release dbt git cache tombstone lease',
+                    releaseError,
+                );
+            });
             Logger.warn('Failed to remove dbt git cache tombstone', { error });
             return false;
         });
@@ -663,7 +744,12 @@ const removeWhileLeased = async (
                 leaseId: lease.leaseId,
                 directory: path.join(lease.entryDirectory, LEASE_DIRECTORY),
                 heartbeat: lease.heartbeat,
-            }).catch(() => undefined);
+            }).catch((releaseError) => {
+                warnSwallowedFilesystemError(
+                    'Failed to release dbt git cache entry lease',
+                    releaseError,
+                );
+            });
             Object.assign(lease, { closed: true });
             throw error;
         }
@@ -781,7 +867,13 @@ const abandonedEntry = async (
     if (entry.owned && (entry.kind === 'tombstone' || entry.metadata)) {
         return undefined;
     }
-    const stat = await fs.lstat(entry.entryDirectory).catch(() => undefined);
+    const stat = await fs.lstat(entry.entryDirectory).catch((error) => {
+        warnSwallowedFilesystemError(
+            'Failed to inspect abandoned dbt git cache entry',
+            error,
+        );
+        return undefined;
+    });
     if (
         stat === undefined ||
         !(await isPrivateRootChild(entry.entryDirectory, stat, 'directory'))
@@ -791,7 +883,13 @@ const abandonedEntry = async (
     const ageStat = entry.owned
         ? await fs
               .lstat(path.join(entry.entryDirectory, ENTRY_MARKER))
-              .catch(() => undefined)
+              .catch((error) => {
+                  warnSwallowedFilesystemError(
+                      'Failed to inspect dbt git cache entry marker',
+                      error,
+                  );
+                  return undefined;
+              })
         : stat;
     if (
         ageStat === undefined ||
@@ -870,7 +968,14 @@ const reserveAbandonedEntryCleanup = async (
     try {
         await fs.rename(candidate.entry.entryDirectory, tombstonePath);
     } catch (error) {
-        if (lease) await releaseDirectoryLease(lease).catch(() => undefined);
+        if (lease) {
+            await releaseDirectoryLease(lease).catch((releaseError) => {
+                warnSwallowedFilesystemError(
+                    'Failed to release abandoned dbt git cache entry lease',
+                    releaseError,
+                );
+            });
+        }
         throw error;
     }
     return {
@@ -926,14 +1031,23 @@ const acquireNewDbtGitProjectCache = async (
     entryDirectory: string,
     totalDeadline: number,
     attempt: number,
+    onMiss: ((reason: string) => void) | undefined,
 ): Promise<DbtGitCacheLease | undefined> => {
     if (Date.now() >= totalDeadline || attempt >= PUBLICATION_MAX_ATTEMPTS) {
+        onMiss?.(
+            attempt >= PUBLICATION_MAX_ATTEMPTS
+                ? 'entry-cap'
+                : 'admission-timeout',
+        );
         return undefined;
     }
     const cacheLock = await acquireCacheLock(
         Math.min(totalDeadline, Date.now() + CACHE_LOCK_WAIT_MS),
     );
-    if (!cacheLock) return undefined;
+    if (!cacheLock) {
+        onMiss?.('lock-timeout');
+        return undefined;
+    }
     let cleanup: Promise<boolean> | undefined;
     try {
         const entries = await listOwnedEntries();
@@ -951,12 +1065,20 @@ const acquireNewDbtGitProjectCache = async (
                         (right.metadata?.lastUsedAt ?? 0),
                 );
             cleanup = (await evictFirstAvailableEntry(candidates))?.cleanup;
-            if (!cleanup) return undefined;
+            if (!cleanup) {
+                onMiss?.('entry-cap');
+                return undefined;
+            }
         } else {
             try {
                 await fs.mkdir(entryDirectory, { mode: 0o700 });
             } catch (error) {
                 if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+                    onMiss?.(
+                        (await isOwnedEntry(key, entryDirectory))
+                            ? 'busy'
+                            : 'corrupt',
+                    );
                     return undefined;
                 }
                 throw error;
@@ -981,6 +1103,7 @@ const acquireNewDbtGitProjectCache = async (
                         recursive: true,
                         force: true,
                     });
+                    onMiss?.('busy');
                     return undefined;
                 }
                 const lease = toPublicLease(
@@ -1013,29 +1136,38 @@ const acquireNewDbtGitProjectCache = async (
             entryDirectory,
             totalDeadline,
             attempt + 1,
+            onMiss,
         );
     }
+    onMiss?.('cleanup-timeout');
     return undefined;
 };
 
 export const acquireDbtGitProjectCache = async (
     identity: DbtGitCacheIdentity,
     repositoryIdentity: string,
+    onMiss?: (reason: string) => void,
 ): Promise<DbtGitCacheLease | undefined> => {
+    if (configuration.maxBytes <= 0) {
+        onMiss?.('disabled');
+        return undefined;
+    }
     await ensureRoot();
     const key = keyFor(identity, repositoryIdentity);
     const entryDirectory = path.join(configuration.root, key);
     const existing = await isOwnedEntry(key, entryDirectory);
     if (existing) {
         const acquired = await tryEntryLease(entryDirectory);
-        if (!acquired) return undefined;
+        if (!acquired) {
+            onMiss?.('busy');
+            return undefined;
+        }
         const lease = toPublicLease(key, entryDirectory, acquired, true);
         try {
             const value = await readJson(path.join(entryDirectory, METADATA));
-            const pending = await fs
-                .access(path.join(entryDirectory, PENDING_DELETE))
-                .then(() => true)
-                .catch(() => false);
+            const pending = await pathExists(
+                path.join(entryDirectory, PENDING_DELETE),
+            );
             if (
                 pending ||
                 !isMetadata(value) ||
@@ -1050,12 +1182,18 @@ export const acquireDbtGitProjectCache = async (
                 return await acquireDbtGitProjectCache(
                     identity,
                     repositoryIdentity,
+                    onMiss,
                 );
             }
             activeLeases.set(key, lease);
             return lease;
         } catch (error) {
-            await removeWhileLeased(lease).catch(() => undefined);
+            await removeWhileLeased(lease).catch((cleanupError) => {
+                warnSwallowedFilesystemError(
+                    'Failed to retire invalid dbt git cache entry',
+                    cleanupError,
+                );
+            });
             throw error;
         }
     }
@@ -1066,13 +1204,27 @@ export const acquireDbtGitProjectCache = async (
         entryDirectory,
         Date.now() + RETENTION_TOTAL_WAIT_MS,
         0,
+        onMiss,
     );
 };
 
 export const invalidateOwnedDbtGitCacheLease = async (
     lease: DbtGitCacheLease,
 ) => {
-    Object.assign(lease, { invalidated: true });
+    Object.assign(lease, {
+        invalidated: true,
+        retained: false,
+        retentionReason: 'invalidated',
+    });
+    await removeWhileLeased(lease);
+};
+
+const declineDbtGitCacheRetention = async (
+    lease: DbtGitCacheLease,
+    reason: string,
+) => {
+    Object.assign(lease, { retained: false, retentionReason: reason });
+    Logger.warn('Declined dbt git cache retention', { reason });
     await removeWhileLeased(lease);
 };
 
@@ -1083,23 +1235,19 @@ const retainDbtGitProjectCache = async (
     attempt: number,
 ): Promise<void> => {
     if (Date.now() >= totalDeadline || attempt >= PUBLICATION_MAX_ATTEMPTS) {
-        Logger.warn('Declined dbt git cache retention', {
-            reason:
-                attempt >= PUBLICATION_MAX_ATTEMPTS
-                    ? 'publication-attempt-limit'
-                    : 'publication-deadline',
-        });
-        await removeWhileLeased(lease);
+        await declineDbtGitCacheRetention(
+            lease,
+            attempt >= PUBLICATION_MAX_ATTEMPTS
+                ? 'publication-attempt-limit'
+                : 'publication-deadline',
+        );
         return;
     }
     const cacheLock = await acquireCacheLock(
         Math.min(totalDeadline, Date.now() + CACHE_LOCK_WAIT_MS),
     );
     if (!cacheLock) {
-        Logger.warn('Declined dbt git cache retention', {
-            reason: 'reservation-lock-timeout',
-        });
-        await removeWhileLeased(lease);
+        await declineDbtGitCacheRetention(lease, 'reservation-lock-timeout');
         return;
     }
     let cleanup: Promise<boolean> | undefined;
@@ -1172,21 +1320,22 @@ const retainDbtGitProjectCache = async (
                 const current = await readJson(
                     path.join(lease.entryDirectory, METADATA),
                 );
-                const pendingAfterAccounting = await fs
-                    .access(path.join(lease.entryDirectory, PENDING_DELETE))
-                    .then(() => true)
-                    .catch(() => false);
+                const pendingAfterAccounting = await pathExists(
+                    path.join(lease.entryDirectory, PENDING_DELETE),
+                );
                 if (
                     lease.invalidated ||
                     pendingAfterAccounting ||
                     !isMetadata(current) ||
                     current.key !== lease.key
                 ) {
-                    declineRetention = lease.invalidated
-                        ? 'invalidated'
-                        : pendingAfterAccounting
-                          ? 'pending-delete'
-                          : 'invalid-metadata';
+                    if (lease.invalidated) {
+                        declineRetention = 'invalidated';
+                    } else if (pendingAfterAccounting) {
+                        declineRetention = 'pending-delete';
+                    } else {
+                        declineRetention = 'invalid-metadata';
+                    }
                 } else {
                     await atomicWriteJson(
                         path.join(lease.entryDirectory, METADATA),
@@ -1210,7 +1359,11 @@ const retainDbtGitProjectCache = async (
                     ) {
                         activeLeases.delete(lease.key);
                     }
-                    Object.assign(lease, { closed: true });
+                    Object.assign(lease, {
+                        closed: true,
+                        retained: true,
+                        retentionReason: undefined,
+                    });
                 }
             }
         }
@@ -1218,10 +1371,7 @@ const retainDbtGitProjectCache = async (
         await releaseDirectoryLease(cacheLock);
     }
     if (declineRetention) {
-        Logger.warn('Declined dbt git cache retention', {
-            reason: declineRetention,
-        });
-        await removeWhileLeased(lease);
+        await declineDbtGitCacheRetention(lease, declineRetention);
         return;
     }
     if (cleanup) {
@@ -1238,10 +1388,7 @@ const retainDbtGitProjectCache = async (
                 attempt + 1,
             );
         }
-        Logger.warn('Declined dbt git cache retention', {
-            reason: 'cleanup-timeout',
-        });
-        await removeWhileLeased(lease);
+        await declineDbtGitCacheRetention(lease, 'cleanup-timeout');
     }
 };
 
@@ -1250,19 +1397,14 @@ export const releaseDbtGitProjectCache = async (
     sizeBytes: number,
 ) => {
     if (lease.closed) return;
-    const pending = await fs
-        .access(path.join(lease.entryDirectory, PENDING_DELETE))
-        .then(() => true)
-        .catch(() => false);
+    const pending = await pathExists(
+        path.join(lease.entryDirectory, PENDING_DELETE),
+    );
     if (lease.invalidated || pending || sizeBytes > configuration.maxBytes) {
-        Logger.warn('Declined dbt git cache retention', {
-            reason: lease.invalidated
-                ? 'invalidated'
-                : pending
-                  ? 'pending-delete'
-                  : 'entry-too-large',
-        });
-        await removeWhileLeased(lease);
+        let reason = 'entry-too-large';
+        if (lease.invalidated) reason = 'invalidated';
+        else if (pending) reason = 'pending-delete';
+        await declineDbtGitCacheRetention(lease, reason);
         return;
     }
     await retainDbtGitProjectCache(
@@ -1276,6 +1418,7 @@ export const releaseDbtGitProjectCache = async (
 const invalidateMatchingEntries = async (
     predicate: (identity: DbtGitCacheIdentity) => boolean,
 ) => {
+    if (configuration.maxBytes <= 0) return;
     const cacheLock = await acquireCacheLock();
     if (!cacheLock) return;
     try {
@@ -1321,6 +1464,7 @@ export const invalidateDbtGitProjectCacheSource = async (
     );
 
 export async function maintainDbtGitProjectCache() {
+    if (configuration.maxBytes <= 0) return;
     const entries = await listOwnedEntries();
     const rootDebris = await listRootDebris();
     const identities = entries.flatMap((entry) =>
@@ -1393,10 +1537,9 @@ export async function maintainDbtGitProjectCache() {
                 const current = await readJson(
                     path.join(entry.entryDirectory, METADATA),
                 );
-                const pending = await fs
-                    .access(path.join(entry.entryDirectory, PENDING_DELETE))
-                    .then(() => true)
-                    .catch(() => false);
+                const pending = await pathExists(
+                    path.join(entry.entryDirectory, PENDING_DELETE),
+                );
                 let shouldDelete = pending;
                 if (isMetadata(current)) {
                     const identityKey = dbtGitCacheIdentityKey(
@@ -1410,7 +1553,13 @@ export async function maintainDbtGitProjectCache() {
                 } else {
                     const markerStat = await fs
                         .lstat(path.join(entry.entryDirectory, ENTRY_MARKER))
-                        .catch(() => undefined);
+                        .catch((error) => {
+                            warnSwallowedFilesystemError(
+                                'Failed to inspect dbt git cache entry marker',
+                                error,
+                            );
+                            return undefined;
+                        });
                     shouldDelete ||=
                         markerStat !== undefined &&
                         now - markerStat.mtimeMs > configuration.maxAgeMs;
@@ -1422,14 +1571,22 @@ export async function maintainDbtGitProjectCache() {
                 }
             }),
         );
-        for (const entry of abandoned) {
-            const cleanup = await reserveAbandonedEntryCleanup(entry);
-            if (cleanup) reservedCleanup.push(cleanup);
-        }
-        for (const debris of rootDebris) {
-            const cleanup = await reserveRootDebrisCleanup(debris, now);
-            if (cleanup) reservedCleanup.push(cleanup);
-        }
+        const [abandonedCleanup, debrisCleanup] = await Promise.all([
+            Promise.all(abandoned.map(reserveAbandonedEntryCleanup)),
+            Promise.all(
+                rootDebris.map((debris) =>
+                    reserveRootDebrisCleanup(debris, now),
+                ),
+            ),
+        ]);
+        reservedCleanup.push(
+            ...abandonedCleanup.filter(
+                (cleanup): cleanup is ReservedCleanup => !!cleanup,
+            ),
+            ...debrisCleanup.filter(
+                (cleanup): cleanup is ReservedCleanup => !!cleanup,
+            ),
+        );
     } finally {
         await releaseDirectoryLease(cacheLock);
     }
@@ -1444,10 +1601,9 @@ export const configureDbtGitProjectCache = (args: {
 }) => {
     configuration = {
         root: args.root ?? configuration.root,
-        maxBytes:
-            Number.isSafeInteger(args.maxBytes) && args.maxBytes > 0
-                ? args.maxBytes
-                : DBT_GIT_CACHE_DEFAULT_MAX_BYTES,
+        maxBytes: Number.isSafeInteger(args.maxBytes)
+            ? args.maxBytes
+            : DBT_GIT_CACHE_DEFAULT_MAX_BYTES,
         maxAgeMs:
             Number.isSafeInteger(args.maxAgeMs) && args.maxAgeMs > 0
                 ? args.maxAgeMs

--- a/packages/backend/src/projectAdapters/dbtGitProjectCache.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectCache.ts
@@ -1323,16 +1323,20 @@ const retainDbtGitProjectCache = async (
                 const pendingAfterAccounting = await pathExists(
                     path.join(lease.entryDirectory, PENDING_DELETE),
                 );
+                const ownsLease = await leaseOwnsEntry(lease);
                 if (
                     lease.invalidated ||
                     pendingAfterAccounting ||
                     !isMetadata(current) ||
-                    current.key !== lease.key
+                    current.key !== lease.key ||
+                    !ownsLease
                 ) {
                     if (lease.invalidated) {
                         declineRetention = 'invalidated';
                     } else if (pendingAfterAccounting) {
                         declineRetention = 'pending-delete';
+                    } else if (!ownsLease) {
+                        declineRetention = 'lease-lost';
                     } else {
                         declineRetention = 'invalid-metadata';
                     }

--- a/packages/backend/src/projectAdapters/dbtGitProjectCache.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectCache.ts
@@ -1753,13 +1753,16 @@ const retainDbtGitProjectCache = async (
                 );
                 const ownsLease = await leaseOwnsEntry(lease);
                 if (
+                    Date.now() >= totalDeadline ||
                     lease.invalidated ||
                     pendingAfterAccounting ||
                     !isMetadata(current) ||
                     current.key !== lease.key ||
                     !ownsLease
                 ) {
-                    if (lease.invalidated) {
+                    if (Date.now() >= totalDeadline) {
+                        declineRetention = 'publication-deadline';
+                    } else if (lease.invalidated) {
                         declineRetention = 'invalidated';
                     } else if (pendingAfterAccounting) {
                         declineRetention = 'pending-delete';
@@ -1830,6 +1833,7 @@ const retainDbtGitProjectCache = async (
     } finally {
         await releaseDirectoryLease(cacheLock);
     }
+    void Promise.all(cleanup);
     if (declineRetention) {
         await declineDbtGitCacheRetention(
             lease,
@@ -1838,7 +1842,6 @@ const retainDbtGitProjectCache = async (
         );
         return;
     }
-    void Promise.all(cleanup);
 };
 
 export const releaseDbtGitProjectCache = async (

--- a/packages/backend/src/projectAdapters/dbtGitProjectCache.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectCache.ts
@@ -21,6 +21,10 @@ const CACHE_LOCK = '.reservation-lock';
 const RECLAIM_CLAIM = '.reclaim.json';
 const CACHE_LOCK_WAIT_MS = 5_000;
 const PUBLICATION_MAX_ATTEMPTS = DBT_GIT_CACHE_MAX_ENTRIES;
+const ABANDONED_ROOT_GRACE_MS = 5 * 60 * 1000;
+const ORPHAN_TEMPORARY_FILE =
+    /^\.lightdash-dbt-git-cache\.json\.[0-9a-f-]{36}\.tmp$/;
+const RETIRED_TEMPORARY_FILE = /^\.retired-[0-9a-f-]{36}\.tmp$/;
 
 export type DbtGitCacheIdentity = {
     projectUuid: string;
@@ -92,6 +96,11 @@ type OwnedEntry = {
     kind: 'entry' | 'tombstone';
     owned: boolean;
     metadata?: EntryMetadata;
+};
+
+type RootDebris = {
+    path: string;
+    stat: Awaited<ReturnType<typeof fs.lstat>>;
 };
 
 const activeLeases = new Map<string, DbtGitCacheLease>();
@@ -341,6 +350,60 @@ const listOwnedEntries = async (): Promise<OwnedEntry[]> => {
         }),
     );
     return entries;
+};
+
+const listRootDebris = async (): Promise<RootDebris[]> => {
+    await ensureRoot();
+    const entries = await fs.readdir(configuration.root, {
+        withFileTypes: true,
+    });
+    return Promise.all(
+        entries
+            .flatMap((entry) =>
+                ORPHAN_TEMPORARY_FILE.test(entry.name) ||
+                RETIRED_TEMPORARY_FILE.test(entry.name)
+                    ? [path.join(configuration.root, entry.name)]
+                    : [],
+            )
+            .map(async (candidatePath) => {
+                const stat = await fs
+                    .lstat(candidatePath)
+                    .catch(() => undefined);
+                return stat ? { path: candidatePath, stat } : undefined;
+            }),
+    ).then((values) =>
+        values.filter((value): value is RootDebris => value !== undefined),
+    );
+};
+
+const isSameFile = (
+    left: Awaited<ReturnType<typeof fs.lstat>>,
+    right: Awaited<ReturnType<typeof fs.lstat>>,
+) =>
+    Number(left.dev) === Number(right.dev) &&
+    Number(left.ino) === Number(right.ino);
+
+const isPrivateRootChild = async (
+    candidatePath: string,
+    expectedStat: Awaited<ReturnType<typeof fs.lstat>>,
+    kind: 'directory' | 'file',
+) => {
+    if (
+        path.dirname(path.resolve(candidatePath)) !==
+        path.resolve(configuration.root)
+    ) {
+        return false;
+    }
+    const currentStat = await fs.lstat(candidatePath).catch(() => undefined);
+    return (
+        currentStat !== undefined &&
+        isSameFile(currentStat, expectedStat) &&
+        !currentStat.isSymbolicLink() &&
+        isPrivateOwnedStat(currentStat) &&
+        (kind === 'directory'
+            ? currentStat.isDirectory()
+            : currentStat.isFile())
+    );
 };
 
 const processStartTime = async (
@@ -698,6 +761,161 @@ const evictFirstAvailableEntry = async (
     return retirement ?? evictFirstAvailableEntry(remaining);
 };
 
+type AbandonedEntry = {
+    entry: OwnedEntry;
+    stat: Awaited<ReturnType<typeof fs.lstat>>;
+};
+
+type ReservedCleanup = {
+    path: string;
+    lease?: DirectoryLease;
+};
+
+const abandonedEntry = async (
+    entry: OwnedEntry,
+    now: number,
+): Promise<AbandonedEntry | undefined> => {
+    if (entry.owned && (entry.kind === 'tombstone' || entry.metadata)) {
+        return undefined;
+    }
+    const stat = await fs.lstat(entry.entryDirectory).catch(() => undefined);
+    if (
+        stat === undefined ||
+        !(await isPrivateRootChild(entry.entryDirectory, stat, 'directory'))
+    ) {
+        return undefined;
+    }
+    const ageStat = entry.owned
+        ? await fs
+              .lstat(path.join(entry.entryDirectory, ENTRY_MARKER))
+              .catch(() => undefined)
+        : stat;
+    if (
+        ageStat === undefined ||
+        now - ageStat.mtimeMs <= ABANDONED_ROOT_GRACE_MS
+    ) {
+        return undefined;
+    }
+    const owner = await readJson(
+        path.join(entry.entryDirectory, LEASE_DIRECTORY, LEASE_OWNER),
+    );
+    if (isLeaseOwner(owner) && !(await leaseOwnerIsProvablyStale(owner))) {
+        return undefined;
+    }
+    return { entry, stat };
+};
+
+const reserveAbandonedEntryCleanup = async (
+    candidate: AbandonedEntry,
+): Promise<ReservedCleanup | undefined> => {
+    if (
+        !(await isPrivateRootChild(
+            candidate.entry.entryDirectory,
+            candidate.stat,
+            'directory',
+        ))
+    ) {
+        return undefined;
+    }
+    const owned = await isOwnedEntry(
+        candidate.entry.key,
+        candidate.entry.entryDirectory,
+    );
+    const metadata = owned
+        ? await readJson(path.join(candidate.entry.entryDirectory, METADATA))
+        : undefined;
+    if (
+        owned &&
+        (candidate.entry.kind === 'tombstone' || isMetadata(metadata))
+    ) {
+        return undefined;
+    }
+    const lease = await tryEntryLease(candidate.entry.entryDirectory);
+    if (!lease) {
+        const owner = await readJson(
+            path.join(
+                candidate.entry.entryDirectory,
+                LEASE_DIRECTORY,
+                LEASE_OWNER,
+            ),
+        );
+        if (isLeaseOwner(owner) && !(await leaseOwnerIsProvablyStale(owner))) {
+            return undefined;
+        }
+    } else {
+        await stopHeartbeat(lease.heartbeat);
+        const owner = await readJson(path.join(lease.directory, LEASE_OWNER));
+        if (!isLeaseOwner(owner) || owner.leaseId !== lease.leaseId) {
+            await releaseDirectoryLease(lease);
+            return undefined;
+        }
+    }
+    if (
+        !(await isPrivateRootChild(
+            candidate.entry.entryDirectory,
+            candidate.stat,
+            'directory',
+        ))
+    ) {
+        if (lease) await releaseDirectoryLease(lease);
+        return undefined;
+    }
+    const tombstonePath = path.join(
+        configuration.root,
+        `.tombstone-${candidate.entry.key}-${randomUUID()}`,
+    );
+    try {
+        await fs.rename(candidate.entry.entryDirectory, tombstonePath);
+    } catch (error) {
+        if (lease) await releaseDirectoryLease(lease).catch(() => undefined);
+        throw error;
+    }
+    return {
+        path: tombstonePath,
+        lease: lease
+            ? {
+                  ...lease,
+                  directory: path.join(tombstonePath, LEASE_DIRECTORY),
+              }
+            : undefined,
+    };
+};
+
+const reserveRootDebrisCleanup = async (
+    candidate: RootDebris,
+    now: number,
+): Promise<ReservedCleanup | undefined> => {
+    if (
+        now - candidate.stat.mtimeMs <= ABANDONED_ROOT_GRACE_MS ||
+        !(await isPrivateRootChild(candidate.path, candidate.stat, 'file'))
+    ) {
+        return undefined;
+    }
+    const retiredPath = path.join(
+        configuration.root,
+        `.retired-${randomUUID()}.tmp`,
+    );
+    await fs.rename(candidate.path, retiredPath);
+    return { path: retiredPath };
+};
+
+const cleanupReservedRootCandidate = async (cleanup: ReservedCleanup) => {
+    try {
+        await fs.rm(cleanup.path, { recursive: true, force: true });
+    } catch (error) {
+        if (cleanup.lease) {
+            await releaseDirectoryLease(cleanup.lease).catch((releaseError) => {
+                Logger.warn('Failed to release dbt git cache cleanup lease', {
+                    error: releaseError,
+                });
+            });
+        }
+        Logger.warn('Failed to remove abandoned dbt git cache object', {
+            error,
+        });
+    }
+};
+
 export const acquireDbtGitProjectCache = async (
     identity: DbtGitCacheIdentity,
     repositoryIdentity: string,
@@ -796,16 +1014,25 @@ const retainDbtGitProjectCache = async (
     attempt: number,
 ): Promise<void> => {
     if (Date.now() >= deadline || attempt >= PUBLICATION_MAX_ATTEMPTS) {
+        Logger.warn('Declined dbt git cache retention', {
+            reason:
+                attempt >= PUBLICATION_MAX_ATTEMPTS
+                    ? 'publication-attempt-limit'
+                    : 'publication-deadline',
+        });
         await removeWhileLeased(lease);
         return;
     }
     const cacheLock = await acquireCacheLock(deadline);
     if (!cacheLock) {
+        Logger.warn('Declined dbt git cache retention', {
+            reason: 'reservation-lock-timeout',
+        });
         await removeWhileLeased(lease);
         return;
     }
     let cleanup: Promise<boolean> | undefined;
-    let declineRetention = false;
+    let declineRetention: string | undefined;
     try {
         const entries = await listOwnedEntries();
         const corrupt = entries.some(
@@ -813,7 +1040,7 @@ const retainDbtGitProjectCache = async (
                 !entry.owned || (entry.kind === 'entry' && !entry.metadata),
         );
         if (corrupt || entries.length > DBT_GIT_CACHE_MAX_ENTRIES) {
-            declineRetention = true;
+            declineRetention = corrupt ? 'corrupt-root-entry' : 'entry-limit';
         } else {
             const others = entries.filter(
                 (entry) => entry.entryDirectory !== lease.entryDirectory,
@@ -869,7 +1096,7 @@ const retainDbtGitProjectCache = async (
                             (right.metadata?.lastUsedAt ?? 0),
                     );
                 cleanup = (await evictFirstAvailableEntry(candidates))?.cleanup;
-                declineRetention = cleanup === undefined;
+                if (!cleanup) declineRetention = 'capacity-unavailable';
             } else {
                 const current = await readJson(
                     path.join(lease.entryDirectory, METADATA),
@@ -884,7 +1111,11 @@ const retainDbtGitProjectCache = async (
                     !isMetadata(current) ||
                     current.key !== lease.key
                 ) {
-                    declineRetention = true;
+                    declineRetention = lease.invalidated
+                        ? 'invalidated'
+                        : pendingAfterAccounting
+                          ? 'pending-delete'
+                          : 'invalid-metadata';
                 } else {
                     await atomicWriteJson(
                         path.join(lease.entryDirectory, METADATA),
@@ -916,6 +1147,9 @@ const retainDbtGitProjectCache = async (
         await releaseDirectoryLease(cacheLock);
     }
     if (declineRetention) {
+        Logger.warn('Declined dbt git cache retention', {
+            reason: declineRetention,
+        });
         await removeWhileLeased(lease);
         return;
     }
@@ -928,6 +1162,9 @@ const retainDbtGitProjectCache = async (
                 attempt + 1,
             );
         }
+        Logger.warn('Declined dbt git cache retention', {
+            reason: 'cleanup-timeout',
+        });
         await removeWhileLeased(lease);
     }
 };
@@ -942,6 +1179,13 @@ export const releaseDbtGitProjectCache = async (
         .then(() => true)
         .catch(() => false);
     if (lease.invalidated || pending || sizeBytes > configuration.maxBytes) {
+        Logger.warn('Declined dbt git cache retention', {
+            reason: lease.invalidated
+                ? 'invalidated'
+                : pending
+                  ? 'pending-delete'
+                  : 'entry-too-large',
+        });
         await removeWhileLeased(lease);
         return;
     }
@@ -1002,6 +1246,7 @@ export const invalidateDbtGitProjectCacheSource = async (
 
 export async function maintainDbtGitProjectCache() {
     const entries = await listOwnedEntries();
+    const rootDebris = await listRootDebris();
     const identities = entries.flatMap((entry) =>
         entry.kind === 'entry' && entry.owned && entry.metadata
             ? [entry.metadata.identity]
@@ -1020,33 +1265,28 @@ export async function maintainDbtGitProjectCache() {
         }
     }
     const now = Date.now();
+    const abandoned = await Promise.all(
+        entries.map((entry) => abandonedEntry(entry, now)),
+    ).then((values) =>
+        values.filter((entry): entry is AbandonedEntry => !!entry),
+    );
     const candidates = await Promise.all(
         entries.map(async (entry) => {
             if (!entry.owned) return undefined;
             if (entry.kind === 'tombstone') return entry;
-            if (entry.metadata) {
-                const identityKey = dbtGitCacheIdentityKey(
-                    entry.metadata.identity,
-                );
-                return now - entry.metadata.lastUsedAt >
-                    configuration.maxAgeMs ||
-                    (live !== undefined &&
-                        checkedIdentities.has(identityKey) &&
-                        !live.has(identityKey))
-                    ? entry
-                    : undefined;
-            }
-            const markerStat = await fs
-                .lstat(path.join(entry.entryDirectory, ENTRY_MARKER))
-                .catch(() => undefined);
-            return markerStat &&
-                now - markerStat.mtimeMs > configuration.maxAgeMs
+            if (!entry.metadata) return undefined;
+            const identityKey = dbtGitCacheIdentityKey(entry.metadata.identity);
+            return now - entry.metadata.lastUsedAt > configuration.maxAgeMs ||
+                (live !== undefined &&
+                    checkedIdentities.has(identityKey) &&
+                    !live.has(identityKey))
                 ? entry
                 : undefined;
         }),
     ).then((values) => values.filter((entry): entry is OwnedEntry => !!entry));
     const cacheLock = await acquireCacheLock();
     if (!cacheLock) return;
+    const reservedCleanup: ReservedCleanup[] = [];
     try {
         await Promise.all(
             candidates.map(async (entry) => {
@@ -1106,9 +1346,18 @@ export async function maintainDbtGitProjectCache() {
                 }
             }),
         );
+        for (const entry of abandoned) {
+            const cleanup = await reserveAbandonedEntryCleanup(entry);
+            if (cleanup) reservedCleanup.push(cleanup);
+        }
+        for (const debris of rootDebris) {
+            const cleanup = await reserveRootDebrisCleanup(debris, now);
+            if (cleanup) reservedCleanup.push(cleanup);
+        }
     } finally {
         await releaseDirectoryLease(cacheLock);
     }
+    await Promise.all(reservedCleanup.map(cleanupReservedRootCandidate));
 }
 
 export const configureDbtGitProjectCache = (args: {

--- a/packages/backend/src/projectAdapters/dbtGitProjectCache.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectCache.ts
@@ -28,6 +28,7 @@ const HEARTBEAT_WRITE_TIMEOUT_MS = 30_000;
 const TOMBSTONE_CLEANUP_WAIT_MS = 3_000;
 const RETENTION_TOTAL_WAIT_MS = 3_000;
 const PUBLICATION_MAX_ATTEMPTS = DBT_GIT_CACHE_MAX_ENTRIES;
+const FUTURE_HEARTBEAT_OBSERVATION_LIMIT = DBT_GIT_CACHE_MAX_ENTRIES * 2;
 const ABANDONED_ROOT_GRACE_MS = 5 * 60 * 1000;
 const ORPHAN_TEMPORARY_FILE =
     /^\.lightdash-dbt-git-cache\.json\.[0-9a-f-]{36}\.tmp$/;
@@ -127,6 +128,10 @@ type RootDebris = {
 };
 
 const activeLeases = new Map<string, DbtGitCacheLease>();
+const futureHeartbeatObservations = new Map<
+    string,
+    { fingerprint: string; observedAt: number }
+>();
 let maintenanceTimer: NodeJS.Timeout | undefined;
 let configuration: CacheConfiguration = {
     root: path.join(os.tmpdir(), 'lightdash-dbt-git-cache'),
@@ -315,12 +320,39 @@ const atomicWriteJson = async (filePath: string, value: unknown) => {
 const leaseHeartbeatPath = (leaseDirectory: string, leaseId: string) =>
     path.join(leaseDirectory, `${LEASE_HEARTBEAT_PREFIX}${leaseId}.json`);
 
+const boundedHeartbeatAt = (
+    heartbeatPath: string,
+    heartbeat: LeaseOwner,
+    now: number,
+) => {
+    if (heartbeat.heartbeatAt <= now) {
+        futureHeartbeatObservations.delete(heartbeatPath);
+        return heartbeat.heartbeatAt;
+    }
+    const fingerprint = JSON.stringify(heartbeat);
+    const observed = futureHeartbeatObservations.get(heartbeatPath);
+    if (observed?.fingerprint === fingerprint) {
+        return Math.min(observed.observedAt, now);
+    }
+    if (
+        !observed &&
+        futureHeartbeatObservations.size >= FUTURE_HEARTBEAT_OBSERVATION_LIMIT
+    ) {
+        const oldestPath = futureHeartbeatObservations.keys().next().value;
+        if (oldestPath) futureHeartbeatObservations.delete(oldestPath);
+    }
+    futureHeartbeatObservations.set(heartbeatPath, {
+        fingerprint,
+        observedAt: now,
+    });
+    return now;
+};
+
 const readLeaseOwner = async (leaseDirectory: string) => {
     const owner = await readJson(path.join(leaseDirectory, LEASE_OWNER));
     if (!isLeaseOwner(owner)) return owner;
-    const heartbeat = await readJson(
-        leaseHeartbeatPath(leaseDirectory, owner.leaseId),
-    );
+    const heartbeatPath = leaseHeartbeatPath(leaseDirectory, owner.leaseId);
+    const heartbeat = await readJson(heartbeatPath);
     if (
         isLeaseOwner(heartbeat) &&
         heartbeat.leaseId === owner.leaseId &&
@@ -329,7 +361,14 @@ const readLeaseOwner = async (leaseDirectory: string) => {
         heartbeat.processStartTime === owner.processStartTime &&
         heartbeat.heartbeatAt >= owner.heartbeatAt
     ) {
-        return heartbeat;
+        return {
+            ...heartbeat,
+            heartbeatAt: boundedHeartbeatAt(
+                heartbeatPath,
+                heartbeat,
+                Date.now(),
+            ),
+        };
     }
     return owner;
 };

--- a/packages/backend/src/projectAdapters/dbtGitProjectCache.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectCache.ts
@@ -22,8 +22,9 @@ const PENDING_DELETE = 'pending-delete';
 const CACHE_LOCK = '.reservation-lock';
 const RECLAIM_CLAIM = '.reclaim.json';
 const CACHE_LOCK_WAIT_MS = 5_000;
-const TOMBSTONE_CLEANUP_WAIT_MS = 30_000;
-const RETENTION_TOTAL_WAIT_MS = 60_000;
+const ADMISSION_TOTAL_WAIT_MS = 3_000;
+const TOMBSTONE_CLEANUP_WAIT_MS = 3_000;
+const RETENTION_TOTAL_WAIT_MS = 3_000;
 const PUBLICATION_MAX_ATTEMPTS = DBT_GIT_CACHE_MAX_ENTRIES;
 const ABANDONED_ROOT_GRACE_MS = 5 * 60 * 1000;
 const ORPHAN_TEMPORARY_FILE =
@@ -1102,7 +1103,7 @@ const acquireNewDbtGitProjectCache = async (
         Math.min(totalDeadline, Date.now() + CACHE_LOCK_WAIT_MS),
     );
     if (!cacheLock) {
-        onMiss?.('lock-timeout');
+        onMiss?.('admission-timeout');
         return undefined;
     }
     let cleanup: Promise<boolean> | undefined;
@@ -1196,7 +1197,7 @@ const acquireNewDbtGitProjectCache = async (
             onMiss,
         );
     }
-    onMiss?.('cleanup-timeout');
+    onMiss?.('admission-timeout');
     return undefined;
 };
 
@@ -1259,7 +1260,7 @@ export const acquireDbtGitProjectCache = async (
         repositoryIdentity,
         key,
         entryDirectory,
-        Date.now() + RETENTION_TOTAL_WAIT_MS,
+        Date.now() + ADMISSION_TOTAL_WAIT_MS,
         0,
         onMiss,
     );

--- a/packages/backend/src/projectAdapters/dbtGitProjectCache.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectCache.ts
@@ -73,6 +73,11 @@ type ReclaimClaim = {
     claimant: LeaseOwner;
 };
 
+type LeaseOwnerState =
+    | { status: 'missing-directory' }
+    | { status: 'protected' }
+    | { status: 'owned'; owner: LeaseOwner };
+
 type LeaseHeartbeat = {
     timer: NodeJS.Timeout;
     pending: Promise<void>;
@@ -317,6 +322,50 @@ const readLeaseOwner = async (leaseDirectory: string) => {
         return heartbeat;
     }
     return owner;
+};
+
+const inspectLeaseOwner = async (
+    leaseDirectory: string,
+): Promise<LeaseOwnerState> => {
+    try {
+        const stat: Stats = await fs.lstat(leaseDirectory);
+        if (!stat.isDirectory() || stat.isSymbolicLink()) {
+            return { status: 'protected' };
+        }
+    } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+            return { status: 'missing-directory' };
+        }
+        warnSwallowedFilesystemError(
+            'Failed to inspect dbt git cache lease directory',
+            error,
+        );
+        return { status: 'protected' };
+    }
+    let contents: string;
+    try {
+        contents = await fs.readFile(
+            path.join(leaseDirectory, LEASE_OWNER),
+            'utf8',
+        );
+    } catch (error) {
+        warnSwallowedFilesystemError(
+            'Failed to read dbt git cache lease owner',
+            error,
+        );
+        return { status: 'protected' };
+    }
+    try {
+        const owner = JSON.parse(contents);
+        if (!isLeaseOwner(owner)) return { status: 'protected' };
+        const current = await readLeaseOwner(leaseDirectory);
+        return isLeaseOwner(current)
+            ? { status: 'owned', owner: current }
+            : { status: 'protected' };
+    } catch (error) {
+        Logger.warn('Failed to parse dbt git cache lease owner', { error });
+        return { status: 'protected' };
+    }
 };
 
 const writeLeaseHeartbeat = async (
@@ -995,21 +1044,20 @@ const toPublicLease = (
     lease: DirectoryLease,
     reused: boolean,
 ): DbtGitCacheLease => {
-    const abortController =
-        lease.heartbeat?.abortController ?? new AbortController();
+    const { heartbeat } = lease;
+    const abortController = heartbeat?.abortController ?? new AbortController();
     const publicLease: DbtGitCacheLease = {
         key,
         entryDirectory,
         checkoutDirectory: path.join(entryDirectory, 'checkout'),
         depsMarkerPath: path.join(entryDirectory, 'deps.json'),
         leaseId: lease.leaseId,
-        heartbeat: lease.heartbeat,
+        heartbeat,
         reused,
         invalidated: abortController.signal.aborted,
         closed: false,
         signal: abortController.signal,
     };
-    const heartbeat = lease.heartbeat;
     if (heartbeat) {
         heartbeat.onInvalidated = () => {
             publicLease.invalidated = true;
@@ -1106,10 +1154,14 @@ const abandonedEntry = async (
     ) {
         return undefined;
     }
-    const owner = await readLeaseOwner(
+    const ownerState = await inspectLeaseOwner(
         path.join(entry.entryDirectory, LEASE_DIRECTORY),
     );
-    if (isLeaseOwner(owner) && !(await leaseOwnerIsProvablyStale(owner))) {
+    if (
+        ownerState.status === 'protected' ||
+        (ownerState.status === 'owned' &&
+            !(await leaseOwnerIsProvablyStale(ownerState.owner)))
+    ) {
         return undefined;
     }
     return { entry, stat };
@@ -1142,10 +1194,14 @@ const reserveAbandonedEntryCleanup = async (
     }
     const lease = await tryEntryLease(candidate.entry.entryDirectory);
     if (!lease) {
-        const owner = await readLeaseOwner(
+        const ownerState = await inspectLeaseOwner(
             path.join(candidate.entry.entryDirectory, LEASE_DIRECTORY),
         );
-        if (isLeaseOwner(owner) && !(await leaseOwnerIsProvablyStale(owner))) {
+        if (
+            ownerState.status === 'protected' ||
+            (ownerState.status === 'owned' &&
+                !(await leaseOwnerIsProvablyStale(ownerState.owner)))
+        ) {
             return undefined;
         }
     } else {
@@ -1208,8 +1264,16 @@ const reserveRootDebrisCleanup = async (
         configuration.root,
         `.retired-${randomUUID()}.tmp`,
     );
-    await fs.rename(candidate.path, retiredPath);
-    return { path: retiredPath };
+    try {
+        await fs.rename(candidate.path, retiredPath);
+        return { path: retiredPath };
+    } catch (error) {
+        warnSwallowedFilesystemError(
+            'Failed to reserve dbt git cache root debris cleanup',
+            error,
+        );
+        return undefined;
+    }
 };
 
 const cleanupReservedRootCandidate = async (cleanup: ReservedCleanup) => {
@@ -1427,9 +1491,13 @@ export const invalidateOwnedDbtGitCacheLease = async (
 const declineDbtGitCacheRetention = async (
     lease: DbtGitCacheLease,
     reason: string,
+    paths?: string[],
 ) => {
     Object.assign(lease, { retained: false, retentionReason: reason });
-    Logger.warn('Declined dbt git cache retention', { reason });
+    Logger.warn(
+        'Declined dbt git cache retention',
+        paths ? { reason, paths } : { reason },
+    );
     await removeWhileLeased(lease);
 };
 
@@ -1457,14 +1525,20 @@ const retainDbtGitProjectCache = async (
     }
     let cleanup: Promise<boolean> | undefined;
     let declineRetention: string | undefined;
+    let declineRetentionPaths: string[] | undefined;
     try {
         const entries = await listOwnedEntries();
-        const corrupt = entries.some(
+        const corrupt = entries.filter(
             (entry) =>
                 !entry.owned || (entry.kind === 'entry' && !entry.metadata),
         );
-        if (corrupt || entries.length > DBT_GIT_CACHE_MAX_ENTRIES) {
-            declineRetention = corrupt ? 'corrupt-root-entry' : 'entry-limit';
+        if (corrupt.length > 0 || entries.length > DBT_GIT_CACHE_MAX_ENTRIES) {
+            declineRetention =
+                corrupt.length > 0 ? 'corrupt-root-entry' : 'entry-limit';
+            declineRetentionPaths =
+                corrupt.length > 0
+                    ? corrupt.map((entry) => entry.entryDirectory)
+                    : undefined;
         } else {
             const others = entries.filter(
                 (entry) => entry.entryDirectory !== lease.entryDirectory,
@@ -1576,7 +1650,11 @@ const retainDbtGitProjectCache = async (
         await releaseDirectoryLease(cacheLock);
     }
     if (declineRetention) {
-        await declineDbtGitCacheRetention(lease, declineRetention);
+        await declineDbtGitCacheRetention(
+            lease,
+            declineRetention,
+            declineRetentionPaths,
+        );
         return;
     }
     if (cleanup) {
@@ -1759,19 +1837,6 @@ export async function maintainDbtGitProjectCache() {
                         (live !== undefined &&
                             checkedIdentities.has(identityKey) &&
                             !live.has(identityKey));
-                } else {
-                    const markerStat = await fs
-                        .lstat(path.join(entry.entryDirectory, ENTRY_MARKER))
-                        .catch((error) => {
-                            warnSwallowedFilesystemError(
-                                'Failed to inspect dbt git cache entry marker',
-                                error,
-                            );
-                            return undefined;
-                        });
-                    shouldDelete ||=
-                        markerStat !== undefined &&
-                        now - markerStat.mtimeMs > configuration.maxAgeMs;
                 }
                 if (shouldDelete) {
                     await removeWhileLeased(lease);

--- a/packages/backend/src/projectAdapters/dbtGitProjectCache.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectCache.ts
@@ -1479,7 +1479,6 @@ export const releaseDbtGitProjectCache = async (
 const invalidateMatchingEntries = async (
     predicate: (identity: DbtGitCacheIdentity) => boolean,
 ) => {
-    if (configuration.maxBytes <= 0) return;
     const cacheLock = await acquireCacheLock();
     if (!cacheLock) return;
     try {
@@ -1525,7 +1524,7 @@ export const invalidateDbtGitProjectCacheSource = async (
     );
 
 export async function maintainDbtGitProjectCache() {
-    if (configuration.maxBytes <= 0) return;
+    const disabled = configuration.maxBytes <= 0;
     const entries = await listOwnedEntries();
     const rootDebris = await listRootDebris();
     const identities = entries.flatMap((entry) =>
@@ -1536,6 +1535,7 @@ export async function maintainDbtGitProjectCache() {
     const checkedIdentities = new Set(identities.map(dbtGitCacheIdentityKey));
     let live: Set<string> | undefined;
     if (
+        !disabled &&
         configuration.livenessCheck &&
         identities.length <= DBT_GIT_CACHE_MAX_ENTRIES
     ) {
@@ -1556,6 +1556,7 @@ export async function maintainDbtGitProjectCache() {
             if (!entry.owned) return undefined;
             if (entry.kind === 'tombstone') return entry;
             if (!entry.metadata) return undefined;
+            if (disabled) return entry;
             const identityKey = dbtGitCacheIdentityKey(entry.metadata.identity);
             return now - entry.metadata.lastUsedAt > configuration.maxAgeMs ||
                 (live !== undefined &&
@@ -1576,10 +1577,13 @@ export async function maintainDbtGitProjectCache() {
                     if (
                         entry.kind === 'entry' &&
                         entry.metadata &&
-                        live !== undefined &&
-                        !live.has(
-                            dbtGitCacheIdentityKey(entry.metadata.identity),
-                        )
+                        (disabled ||
+                            (live !== undefined &&
+                                !live.has(
+                                    dbtGitCacheIdentityKey(
+                                        entry.metadata.identity,
+                                    ),
+                                )))
                     ) {
                         await markPendingDelete(entry.entryDirectory);
                     }
@@ -1601,7 +1605,7 @@ export async function maintainDbtGitProjectCache() {
                 const pending = await pathExists(
                     path.join(entry.entryDirectory, PENDING_DELETE),
                 );
-                let shouldDelete = pending;
+                let shouldDelete = pending || disabled;
                 if (isMetadata(current)) {
                     const identityKey = dbtGitCacheIdentityKey(
                         current.identity,

--- a/packages/backend/src/projectAdapters/dbtGitProjectCache.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectCache.ts
@@ -1178,8 +1178,13 @@ const selectRetentionVictims = async (
     entries: OwnedEntry[],
     bytesNeeded: number,
     countNeeded: number,
+    deadline: number,
     selected: RetentionVictim[] = [],
-): Promise<RetentionVictim[] | undefined> => {
+): Promise<RetentionVictim[] | 'deadline' | undefined> => {
+    if (Date.now() >= deadline) {
+        await releaseRetentionVictims(selected);
+        return 'deadline';
+    }
     if (bytesNeeded <= 0 && countNeeded <= 0) return selected;
     const [entry, ...remaining] = entries;
     if (!entry) {
@@ -1193,11 +1198,18 @@ const selectRetentionVictims = async (
         await releaseRetentionVictims(selected);
         throw error;
     }
+    if (Date.now() >= deadline) {
+        await releaseRetentionVictims(
+            lease ? [...selected, { entry, lease }] : selected,
+        );
+        return 'deadline';
+    }
     if (!lease) {
         return selectRetentionVictims(
             remaining,
             bytesNeeded,
             countNeeded,
+            deadline,
             selected,
         );
     }
@@ -1205,6 +1217,7 @@ const selectRetentionVictims = async (
         remaining,
         bytesNeeded - (entry.metadata?.sizeBytes ?? 0),
         countNeeded - 1,
+        deadline,
         [...selected, { entry, lease }],
     );
 };
@@ -1236,13 +1249,15 @@ const reserveRetentionVictims = async (
     entries: OwnedEntry[],
     bytesNeeded: number,
     countNeeded: number,
+    deadline: number,
 ) => {
     const victims = await selectRetentionVictims(
         entries,
         bytesNeeded,
         countNeeded,
+        deadline,
     );
-    if (!victims) return undefined;
+    if (!victims || victims === 'deadline') return victims;
     try {
         return await retireRetentionVictims(victims);
     } catch (error) {
@@ -1670,23 +1685,33 @@ const retainDbtGitProjectCache = async (
     let declineRetentionPaths: string[] | undefined;
     try {
         const entries = await listOwnedEntries();
+        if (Date.now() >= totalDeadline) {
+            declineRetention = 'publication-deadline';
+        }
         const corrupt = entries.filter(
             (entry) =>
                 !entry.owned || (entry.kind === 'entry' && !entry.metadata),
         );
-        if (corrupt.length > 0 || entries.length > DBT_GIT_CACHE_MAX_ENTRIES) {
+        if (
+            !declineRetention &&
+            (corrupt.length > 0 || entries.length > DBT_GIT_CACHE_MAX_ENTRIES)
+        ) {
             declineRetention =
                 corrupt.length > 0 ? 'corrupt-root-entry' : 'entry-limit';
             declineRetentionPaths =
                 corrupt.length > 0
                     ? corrupt.map((entry) => entry.entryDirectory)
                     : undefined;
-        } else {
+        } else if (!declineRetention) {
             const others = entries.filter(
                 (entry) => entry.entryDirectory !== lease.entryDirectory,
             );
             const entryCapacityBytes = async (entry: OwnedEntry) => {
-                if (entry.kind === 'tombstone') return configuration.maxBytes;
+                if (entry.kind === 'tombstone') {
+                    return entry.metadata?.state === 'retained'
+                        ? entry.metadata.sizeBytes
+                        : configuration.maxBytes;
+                }
                 if (!entry.metadata) return configuration.maxBytes;
                 if (entry.metadata.state === 'retained') {
                     return entry.metadata.sizeBytes;
@@ -1711,6 +1736,9 @@ const retainDbtGitProjectCache = async (
             const retainedBytes = (
                 await Promise.all(others.map(entryCapacityBytes))
             ).reduce((total, entryBytes) => total + entryBytes, 0);
+            if (Date.now() >= totalDeadline) {
+                declineRetention = 'publication-deadline';
+            }
             const retainedCount = others.filter(
                 (entry) =>
                     entry.kind === 'tombstone' ||
@@ -1766,8 +1794,9 @@ const retainDbtGitProjectCache = async (
                 });
             };
             if (
-                retainedBytes + sizeBytes > configuration.maxBytes ||
-                retainedCount + 1 > DBT_GIT_CACHE_MAX_ENTRIES
+                !declineRetention &&
+                (retainedBytes + sizeBytes > configuration.maxBytes ||
+                    retainedCount + 1 > DBT_GIT_CACHE_MAX_ENTRIES)
             ) {
                 const candidates = others
                     .filter(
@@ -1784,14 +1813,17 @@ const retainDbtGitProjectCache = async (
                     candidates,
                     retainedBytes + sizeBytes - configuration.maxBytes,
                     retainedCount + 1 - DBT_GIT_CACHE_MAX_ENTRIES,
+                    totalDeadline,
                 );
-                if (!reserved) {
+                if (reserved === 'deadline') {
+                    declineRetention = 'publication-deadline';
+                } else if (!reserved) {
                     declineRetention = 'capacity-unavailable';
                 } else {
                     cleanup = reserved;
                     await publish();
                 }
-            } else {
+            } else if (!declineRetention) {
                 await publish();
             }
         }

--- a/packages/backend/src/projectAdapters/dbtGitProjectCache.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectCache.ts
@@ -1,4 +1,5 @@
 import { createHash, randomUUID } from 'crypto';
+import type { Stats } from 'fs';
 import * as fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
@@ -101,7 +102,7 @@ type OwnedEntry = {
 
 type RootDebris = {
     path: string;
-    stat: Awaited<ReturnType<typeof fs.lstat>>;
+    stat: Stats;
 };
 
 const activeLeases = new Map<string, DbtGitCacheLease>();
@@ -233,7 +234,7 @@ const atomicWriteJson = async (filePath: string, value: unknown) => {
     }
 };
 
-const isPrivateOwnedStat = (stat: Awaited<ReturnType<typeof fs.lstat>>) =>
+const isPrivateOwnedStat = (stat: Stats) =>
     Number(stat.uid) === process.getuid?.() && Number(stat.mode) % 0o100 === 0;
 
 const ensureRoot = async () => {
@@ -251,7 +252,7 @@ const ensureRoot = async () => {
         throw new Error('Invalid dbt git cache root path');
     }
     const markerPath = path.join(configuration.root, ROOT_MARKER);
-    let markerStat: Awaited<ReturnType<typeof fs.lstat>>;
+    let markerStat: Stats;
     try {
         markerStat = await fs.lstat(markerPath);
     } catch (error) {
@@ -377,16 +378,13 @@ const listRootDebris = async (): Promise<RootDebris[]> => {
     );
 };
 
-const isSameFile = (
-    left: Awaited<ReturnType<typeof fs.lstat>>,
-    right: Awaited<ReturnType<typeof fs.lstat>>,
-) =>
+const isSameFile = (left: Stats, right: Stats) =>
     Number(left.dev) === Number(right.dev) &&
     Number(left.ino) === Number(right.ino);
 
 const isPrivateRootChild = async (
     candidatePath: string,
-    expectedStat: Awaited<ReturnType<typeof fs.lstat>>,
+    expectedStat: Stats,
     kind: 'directory' | 'file',
 ) => {
     if (
@@ -766,7 +764,7 @@ const evictFirstAvailableEntry = async (
 
 type AbandonedEntry = {
     entry: OwnedEntry;
-    stat: Awaited<ReturnType<typeof fs.lstat>>;
+    stat: Stats;
 };
 
 type ReservedCleanup = {

--- a/packages/backend/src/projectAdapters/dbtGitProjectCache.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectCache.ts
@@ -22,6 +22,8 @@ const PENDING_DELETE = 'pending-delete';
 const CACHE_LOCK = '.reservation-lock';
 const RECLAIM_CLAIM = '.reclaim.json';
 const CACHE_LOCK_WAIT_MS = 5_000;
+const TOMBSTONE_CLEANUP_WAIT_MS = 30_000;
+const RETENTION_TOTAL_WAIT_MS = 60_000;
 const PUBLICATION_MAX_ATTEMPTS = DBT_GIT_CACHE_MAX_ENTRIES;
 const ABANDONED_ROOT_GRACE_MS = 5 * 60 * 1000;
 const ORPHAN_TEMPORARY_FILE =
@@ -917,6 +919,105 @@ const cleanupReservedRootCandidate = async (cleanup: ReservedCleanup) => {
     }
 };
 
+const acquireNewDbtGitProjectCache = async (
+    identity: DbtGitCacheIdentity,
+    repositoryIdentity: string,
+    key: string,
+    entryDirectory: string,
+    totalDeadline: number,
+    attempt: number,
+): Promise<DbtGitCacheLease | undefined> => {
+    if (Date.now() >= totalDeadline || attempt >= PUBLICATION_MAX_ATTEMPTS) {
+        return undefined;
+    }
+    const cacheLock = await acquireCacheLock(
+        Math.min(totalDeadline, Date.now() + CACHE_LOCK_WAIT_MS),
+    );
+    if (!cacheLock) return undefined;
+    let cleanup: Promise<boolean> | undefined;
+    try {
+        const entries = await listOwnedEntries();
+        if (entries.length >= DBT_GIT_CACHE_MAX_ENTRIES) {
+            const candidates = entries
+                .filter(
+                    (entry) =>
+                        entry.kind === 'entry' &&
+                        entry.owned &&
+                        entry.metadata?.state === 'retained',
+                )
+                .sort(
+                    (left, right) =>
+                        (left.metadata?.lastUsedAt ?? 0) -
+                        (right.metadata?.lastUsedAt ?? 0),
+                );
+            cleanup = (await evictFirstAvailableEntry(candidates))?.cleanup;
+            if (!cleanup) return undefined;
+        } else {
+            try {
+                await fs.mkdir(entryDirectory, { mode: 0o700 });
+            } catch (error) {
+                if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+                    return undefined;
+                }
+                throw error;
+            }
+            try {
+                await atomicWriteJson(path.join(entryDirectory, ENTRY_MARKER), {
+                    version: CACHE_VERSION,
+                    key,
+                });
+                await atomicWriteJson(path.join(entryDirectory, METADATA), {
+                    version: CACHE_VERSION,
+                    key,
+                    identity,
+                    repositoryIdentity,
+                    state: 'active',
+                    sizeBytes: 0,
+                    lastUsedAt: Date.now(),
+                } satisfies EntryMetadata);
+                const acquired = await tryEntryLease(entryDirectory);
+                if (!acquired) {
+                    await fs.rm(entryDirectory, {
+                        recursive: true,
+                        force: true,
+                    });
+                    return undefined;
+                }
+                const lease = toPublicLease(
+                    key,
+                    entryDirectory,
+                    acquired,
+                    false,
+                );
+                activeLeases.set(key, lease);
+                return lease;
+            } catch (error) {
+                await fs.rm(entryDirectory, { recursive: true, force: true });
+                throw error;
+            }
+        }
+    } finally {
+        await releaseDirectoryLease(cacheLock);
+    }
+    if (
+        cleanup &&
+        (await waitForTombstoneCleanup(
+            cleanup,
+            Math.min(totalDeadline, Date.now() + TOMBSTONE_CLEANUP_WAIT_MS),
+        ))
+    ) {
+        return acquireNewDbtGitProjectCache(
+            identity,
+            repositoryIdentity,
+            key,
+            entryDirectory,
+            totalDeadline,
+            attempt + 1,
+        );
+    }
+    return undefined;
+};
+
 export const acquireDbtGitProjectCache = async (
     identity: DbtGitCacheIdentity,
     repositoryIdentity: string,
@@ -958,47 +1059,14 @@ export const acquireDbtGitProjectCache = async (
             throw error;
         }
     }
-    const cacheLock = await acquireCacheLock();
-    if (!cacheLock) return undefined;
-    try {
-        const entries = await listOwnedEntries();
-        if (entries.length >= DBT_GIT_CACHE_MAX_ENTRIES) return undefined;
-        try {
-            await fs.mkdir(entryDirectory, { mode: 0o700 });
-        } catch (error) {
-            if ((error as NodeJS.ErrnoException).code === 'EEXIST')
-                return undefined;
-            throw error;
-        }
-        try {
-            await atomicWriteJson(path.join(entryDirectory, ENTRY_MARKER), {
-                version: CACHE_VERSION,
-                key,
-            });
-            await atomicWriteJson(path.join(entryDirectory, METADATA), {
-                version: CACHE_VERSION,
-                key,
-                identity,
-                repositoryIdentity,
-                state: 'active',
-                sizeBytes: 0,
-                lastUsedAt: Date.now(),
-            } satisfies EntryMetadata);
-            const acquired = await tryEntryLease(entryDirectory);
-            if (!acquired) {
-                await fs.rm(entryDirectory, { recursive: true, force: true });
-                return undefined;
-            }
-            const lease = toPublicLease(key, entryDirectory, acquired, false);
-            activeLeases.set(key, lease);
-            return lease;
-        } catch (error) {
-            await fs.rm(entryDirectory, { recursive: true, force: true });
-            throw error;
-        }
-    } finally {
-        await releaseDirectoryLease(cacheLock);
-    }
+    return acquireNewDbtGitProjectCache(
+        identity,
+        repositoryIdentity,
+        key,
+        entryDirectory,
+        Date.now() + RETENTION_TOTAL_WAIT_MS,
+        0,
+    );
 };
 
 export const invalidateOwnedDbtGitCacheLease = async (
@@ -1011,10 +1079,10 @@ export const invalidateOwnedDbtGitCacheLease = async (
 const retainDbtGitProjectCache = async (
     lease: DbtGitCacheLease,
     sizeBytes: number,
-    deadline: number,
+    totalDeadline: number,
     attempt: number,
 ): Promise<void> => {
-    if (Date.now() >= deadline || attempt >= PUBLICATION_MAX_ATTEMPTS) {
+    if (Date.now() >= totalDeadline || attempt >= PUBLICATION_MAX_ATTEMPTS) {
         Logger.warn('Declined dbt git cache retention', {
             reason:
                 attempt >= PUBLICATION_MAX_ATTEMPTS
@@ -1024,7 +1092,9 @@ const retainDbtGitProjectCache = async (
         await removeWhileLeased(lease);
         return;
     }
-    const cacheLock = await acquireCacheLock(deadline);
+    const cacheLock = await acquireCacheLock(
+        Math.min(totalDeadline, Date.now() + CACHE_LOCK_WAIT_MS),
+    );
     if (!cacheLock) {
         Logger.warn('Declined dbt git cache retention', {
             reason: 'reservation-lock-timeout',
@@ -1155,11 +1225,16 @@ const retainDbtGitProjectCache = async (
         return;
     }
     if (cleanup) {
-        if (await waitForTombstoneCleanup(cleanup, deadline)) {
+        if (
+            await waitForTombstoneCleanup(
+                cleanup,
+                Math.min(totalDeadline, Date.now() + TOMBSTONE_CLEANUP_WAIT_MS),
+            )
+        ) {
             return retainDbtGitProjectCache(
                 lease,
                 sizeBytes,
-                deadline,
+                totalDeadline,
                 attempt + 1,
             );
         }
@@ -1193,7 +1268,7 @@ export const releaseDbtGitProjectCache = async (
     await retainDbtGitProjectCache(
         lease,
         sizeBytes,
-        Date.now() + CACHE_LOCK_WAIT_MS,
+        Date.now() + RETENTION_TOTAL_WAIT_MS,
         0,
     );
 };

--- a/packages/backend/src/projectAdapters/dbtGitProjectInspection.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectInspection.ts
@@ -1,0 +1,112 @@
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { performance } from 'perf_hooks';
+
+const FILESYSTEM_BATCH_SIZE = 32;
+const MAX_GIT_METADATA_FILE_BYTES = 1024 * 1024;
+const CREDENTIAL_URL = /https?:\/\/[^\s/@]+(?::[^\s/@]*)?@/i;
+
+type InspectionMode = 'checkout' | 'git-metadata' | 'size-only';
+
+type PendingPath = {
+    path: string;
+    mode: InspectionMode;
+    gitRoot: boolean;
+};
+
+export type DbtGitProjectInspection = {
+    containsCredentials: boolean;
+    sizeBytes: number;
+    durationMs: number;
+};
+
+export const inspectDbtGitProject = async (
+    root: string,
+): Promise<DbtGitProjectInspection> => {
+    const startedAt = performance.now();
+    let containsCredentials = false;
+    let sizeBytes = 0;
+    const pending: PendingPath[] = [
+        { path: root, mode: 'checkout', gitRoot: false },
+    ];
+
+    const inspectBatch = async (): Promise<void> => {
+        const batch = pending.splice(0, FILESYSTEM_BATCH_SIZE);
+        if (batch.length === 0) return;
+        const results = await Promise.all(
+            batch.map(async (candidate) => {
+                const stat = await fs.lstat(candidate.path);
+                sizeBytes += stat.size;
+                if (candidate.gitRoot && !stat.isDirectory()) {
+                    throw new Error('Git indirection is not cacheable');
+                }
+                if (stat.isSymbolicLink()) {
+                    if (candidate.mode === 'git-metadata') {
+                        throw new Error('Unsupported Git metadata');
+                    }
+                    return [];
+                }
+                if (stat.isDirectory()) {
+                    const entries = await fs.readdir(candidate.path, {
+                        withFileTypes: true,
+                    });
+                    return entries.map((entry): PendingPath => {
+                        const childPath = path.join(candidate.path, entry.name);
+                        if (candidate.mode === 'size-only') {
+                            return {
+                                path: childPath,
+                                mode: 'size-only',
+                                gitRoot: false,
+                            };
+                        }
+                        if (candidate.mode === 'git-metadata') {
+                            return {
+                                path: childPath,
+                                mode:
+                                    entry.name === 'objects' ||
+                                    entry.name === 'index'
+                                        ? 'size-only'
+                                        : 'git-metadata',
+                                gitRoot: false,
+                            };
+                        }
+                        return {
+                            path: childPath,
+                            mode:
+                                entry.name === '.git'
+                                    ? 'git-metadata'
+                                    : 'checkout',
+                            gitRoot: entry.name === '.git',
+                        };
+                    });
+                }
+                if (candidate.mode === 'git-metadata') {
+                    if (!stat.isFile()) {
+                        throw new Error('Unsupported Git metadata');
+                    }
+                    if (stat.size > MAX_GIT_METADATA_FILE_BYTES) {
+                        containsCredentials = true;
+                    } else {
+                        const content = await fs.readFile(
+                            candidate.path,
+                            'utf8',
+                        );
+                        if (CREDENTIAL_URL.test(content)) {
+                            containsCredentials = true;
+                        }
+                    }
+                }
+                return [];
+            }),
+        );
+        for (const children of results) pending.push(...children);
+        await inspectBatch();
+    };
+    await inspectBatch();
+
+    return {
+        containsCredentials,
+        sizeBytes,
+        durationMs: performance.now() - startedAt,
+    };
+};

--- a/packages/backend/src/projectAdapters/dbtGitVersion.test.ts
+++ b/packages/backend/src/projectAdapters/dbtGitVersion.test.ts
@@ -1,0 +1,65 @@
+import type { VersionResult } from 'simple-git';
+import { createDbtGitVersionSupportProbe } from './dbtGitVersion';
+
+const version = (major: number, minor: number): VersionResult => ({
+    major,
+    minor,
+    patch: 0,
+    agent: 'git',
+    installed: true,
+});
+
+describe('dbtGitVersion', () => {
+    it('enables caching for the minimum supported Git version', async () => {
+        const getVersion = vi.fn().mockResolvedValue(version(2, 29));
+        const warn = vi.fn();
+        const probe = createDbtGitVersionSupportProbe({ getVersion, warn });
+
+        await expect(probe()).resolves.toEqual({
+            supported: true,
+            reason: null,
+        });
+        expect(warn).not.toHaveBeenCalled();
+    });
+
+    it('disables caching and warns for an older Git version', async () => {
+        const getVersion = vi.fn().mockResolvedValue(version(2, 28));
+        const warn = vi.fn();
+        const probe = createDbtGitVersionSupportProbe({ getVersion, warn });
+
+        await expect(probe()).resolves.toEqual({
+            supported: false,
+            reason: 'git-version-unsupported',
+        });
+        expect(warn).toHaveBeenCalledTimes(1);
+    });
+
+    it('disables caching and warns when the Git version probe fails', async () => {
+        const getVersion = vi.fn().mockRejectedValue(new Error('probe failed'));
+        const warn = vi.fn();
+        const probe = createDbtGitVersionSupportProbe({ getVersion, warn });
+
+        await expect(probe()).resolves.toEqual({
+            supported: false,
+            reason: 'git-version-probe-failed',
+        });
+        expect(warn).toHaveBeenCalledTimes(1);
+        expect(warn).toHaveBeenCalledWith(
+            'Dbt Git checkout cache disabled because the Git version probe failed',
+            {
+                error: { name: 'Error', message: 'probe failed' },
+            },
+        );
+    });
+
+    it('memoizes the first probe result and warning', async () => {
+        const getVersion = vi.fn().mockResolvedValue(version(1, 9));
+        const warn = vi.fn();
+        const probe = createDbtGitVersionSupportProbe({ getVersion, warn });
+
+        await Promise.all([probe(), probe(), probe()]);
+
+        expect(getVersion).toHaveBeenCalledTimes(1);
+        expect(warn).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/backend/src/projectAdapters/dbtGitVersion.test.ts
+++ b/packages/backend/src/projectAdapters/dbtGitVersion.test.ts
@@ -10,6 +10,10 @@ const version = (major: number, minor: number): VersionResult => ({
 });
 
 describe('dbtGitVersion', () => {
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
     it('enables caching for the minimum supported Git version', async () => {
         const getVersion = vi.fn().mockResolvedValue(version(2, 29));
         const warn = vi.fn();
@@ -61,5 +65,74 @@ describe('dbtGitVersion', () => {
 
         expect(getVersion).toHaveBeenCalledTimes(1);
         expect(warn).toHaveBeenCalledTimes(1);
+    });
+
+    it('times out a hung probe and retries after the cooldown', async () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(0);
+        let resolveFirst: ((result: VersionResult) => void) | undefined;
+        const firstProbe = new Promise<VersionResult>((resolve) => {
+            resolveFirst = resolve;
+        });
+        const getVersion = vi
+            .fn()
+            .mockImplementationOnce(() => firstProbe)
+            .mockResolvedValueOnce(version(2, 29));
+        const warn = vi.fn();
+        const probe = createDbtGitVersionSupportProbe({ getVersion, warn });
+
+        const timedOut = probe();
+        await vi.advanceTimersByTimeAsync(3_000);
+        await expect(timedOut).resolves.toEqual({
+            supported: false,
+            reason: 'git-version-probe-failed',
+        });
+        await expect(probe()).resolves.toEqual({
+            supported: false,
+            reason: 'git-version-probe-failed',
+        });
+        expect(getVersion).toHaveBeenCalledTimes(1);
+
+        await vi.advanceTimersByTimeAsync(29_999);
+        await expect(probe()).resolves.toEqual({
+            supported: false,
+            reason: 'git-version-probe-failed',
+        });
+        expect(getVersion).toHaveBeenCalledTimes(1);
+
+        await vi.advanceTimersByTimeAsync(1);
+        await expect(probe()).resolves.toEqual({
+            supported: true,
+            reason: null,
+        });
+        resolveFirst?.(version(1, 0));
+        await Promise.resolve();
+        await expect(probe()).resolves.toEqual({
+            supported: true,
+            reason: null,
+        });
+        expect(getVersion).toHaveBeenCalledTimes(2);
+        expect(warn).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries a failed probe after the cooldown', async () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(0);
+        const getVersion = vi
+            .fn()
+            .mockRejectedValueOnce(new Error('probe failed'))
+            .mockResolvedValueOnce(version(2, 29));
+        const probe = createDbtGitVersionSupportProbe({
+            getVersion,
+            warn: vi.fn(),
+        });
+
+        await expect(probe()).resolves.toMatchObject({ supported: false });
+        await vi.advanceTimersByTimeAsync(30_000);
+        await expect(probe()).resolves.toEqual({
+            supported: true,
+            reason: null,
+        });
+        expect(getVersion).toHaveBeenCalledTimes(2);
     });
 });

--- a/packages/backend/src/projectAdapters/dbtGitVersion.test.ts
+++ b/packages/backend/src/projectAdapters/dbtGitVersion.test.ts
@@ -115,24 +115,90 @@ describe('dbtGitVersion', () => {
         expect(warn).toHaveBeenCalledTimes(1);
     });
 
-    it('retries a failed probe after the cooldown', async () => {
+    it('suppresses repeated failure warnings before recovery', async () => {
         vi.useFakeTimers();
         vi.setSystemTime(0);
         const getVersion = vi
             .fn()
             .mockRejectedValueOnce(new Error('probe failed'))
+            .mockRejectedValueOnce(new Error('probe failed again'))
             .mockResolvedValueOnce(version(2, 29));
+        const warn = vi.fn();
         const probe = createDbtGitVersionSupportProbe({
             getVersion,
-            warn: vi.fn(),
+            warn,
         });
 
+        await expect(probe()).resolves.toMatchObject({ supported: false });
+        await vi.advanceTimersByTimeAsync(30_000);
         await expect(probe()).resolves.toMatchObject({ supported: false });
         await vi.advanceTimersByTimeAsync(30_000);
         await expect(probe()).resolves.toEqual({
             supported: true,
             reason: null,
         });
+        expect(getVersion).toHaveBeenCalledTimes(3);
+        expect(warn).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps a retry failure quiet after an initial timeout warning', async () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(0);
+        let resolveInitial: ((result: VersionResult) => void) | undefined;
+        const initialProbe = new Promise<VersionResult>((resolve) => {
+            resolveInitial = resolve;
+        });
+        const getVersion = vi
+            .fn()
+            .mockImplementationOnce(() => initialProbe)
+            .mockRejectedValueOnce(new Error('retry failed'));
+        const warn = vi.fn();
+        const probe = createDbtGitVersionSupportProbe({ getVersion, warn });
+
+        const timedOut = probe();
+        await vi.advanceTimersByTimeAsync(3_000);
+        await expect(timedOut).resolves.toMatchObject({ supported: false });
+        await vi.advanceTimersByTimeAsync(30_000);
+        await expect(probe()).resolves.toMatchObject({ supported: false });
+
         expect(getVersion).toHaveBeenCalledTimes(2);
+        expect(warn).toHaveBeenCalledTimes(1);
+        resolveInitial?.(version(2, 29));
+    });
+
+    it('logs an unsupported result separately after a probe failure', async () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(0);
+        const getVersion = vi
+            .fn()
+            .mockRejectedValueOnce(new Error('probe failed'))
+            .mockResolvedValueOnce(version(2, 28));
+        const warn = vi.fn();
+        const probe = createDbtGitVersionSupportProbe({ getVersion, warn });
+
+        await expect(probe()).resolves.toMatchObject({ supported: false });
+        await vi.advanceTimersByTimeAsync(30_000);
+        await expect(probe()).resolves.toEqual({
+            supported: false,
+            reason: 'git-version-unsupported',
+        });
+        await vi.advanceTimersByTimeAsync(30_000);
+        await expect(probe()).resolves.toEqual({
+            supported: false,
+            reason: 'git-version-unsupported',
+        });
+
+        expect(getVersion).toHaveBeenCalledTimes(2);
+        expect(warn).toHaveBeenCalledTimes(2);
+        expect(warn).toHaveBeenNthCalledWith(
+            1,
+            'Dbt Git checkout cache disabled because the Git version probe failed',
+            expect.anything(),
+        );
+        expect(warn).toHaveBeenNthCalledWith(
+            2,
+            'Dbt Git checkout cache disabled because Git 2.29 or newer is required',
+            { version: '2.28.0' },
+        );
     });
 });

--- a/packages/backend/src/projectAdapters/dbtGitVersion.ts
+++ b/packages/backend/src/projectAdapters/dbtGitVersion.ts
@@ -1,0 +1,63 @@
+import { getErrorMessage } from '@lightdash/common';
+import simpleGit, { type VersionResult } from 'simple-git';
+import Logger from '../logging/logger';
+
+export type DbtGitVersionSupport = {
+    supported: boolean;
+    reason: 'git-version-unsupported' | 'git-version-probe-failed' | null;
+};
+
+type DbtGitVersionSupportProbeDependencies = {
+    getVersion: () => Promise<VersionResult>;
+    warn: (message: string, metadata?: unknown) => unknown;
+};
+
+export const createDbtGitVersionSupportProbe = ({
+    getVersion = () => simpleGit().version(),
+    warn = (message, metadata) => Logger.warn(message, metadata),
+}: Partial<DbtGitVersionSupportProbeDependencies> = {}) => {
+    let result: Promise<DbtGitVersionSupport> | undefined;
+    return (): Promise<DbtGitVersionSupport> => {
+        result ??= Promise.resolve()
+            .then(getVersion)
+            .then<DbtGitVersionSupport>((gitVersion) => {
+                const supported =
+                    gitVersion.installed &&
+                    (gitVersion.major > 2 ||
+                        (gitVersion.major === 2 && gitVersion.minor >= 29));
+                if (!supported) {
+                    warn(
+                        'Dbt Git checkout cache disabled because Git 2.29 or newer is required',
+                        {
+                            version: `${gitVersion.major}.${gitVersion.minor}.${gitVersion.patch}`,
+                        },
+                    );
+                }
+                return {
+                    supported,
+                    reason: supported ? null : 'git-version-unsupported',
+                };
+            })
+            .catch<DbtGitVersionSupport>((error: unknown) => {
+                warn(
+                    'Dbt Git checkout cache disabled because the Git version probe failed',
+                    {
+                        error: {
+                            name:
+                                error instanceof Error
+                                    ? error.name
+                                    : 'UnknownError',
+                            message: getErrorMessage(error),
+                        },
+                    },
+                );
+                return {
+                    supported: false,
+                    reason: 'git-version-probe-failed',
+                };
+            });
+        return result;
+    };
+};
+
+export const getDbtGitVersionSupport = createDbtGitVersionSupportProbe();

--- a/packages/backend/src/projectAdapters/dbtGitVersion.ts
+++ b/packages/backend/src/projectAdapters/dbtGitVersion.ts
@@ -1,5 +1,6 @@
 import { getErrorMessage } from '@lightdash/common';
-import simpleGit, { type VersionResult } from 'simple-git';
+import type { VersionResult } from 'simple-git';
+import { runAbortableProcess } from '../dbt/dbtCliClient';
 import Logger from '../logging/logger';
 
 export type DbtGitVersionSupport = {
@@ -8,18 +9,67 @@ export type DbtGitVersionSupport = {
 };
 
 type DbtGitVersionSupportProbeDependencies = {
-    getVersion: () => Promise<VersionResult>;
+    getVersion: (signal: AbortSignal) => Promise<VersionResult>;
     warn: (message: string, metadata?: unknown) => unknown;
 };
 
+const probeTimeoutMs = 3_000;
+const failedProbeCooldownMs = 30_000;
+
+const getVersion = async (signal: AbortSignal): Promise<VersionResult> => {
+    const { stdout } = await runAbortableProcess(
+        'git',
+        ['--version'],
+        {},
+        signal,
+    );
+    const match = /(?:^|\s)(\d+)\.(\d+)(?:\.(\d+))?/.exec(stdout.toString());
+    if (!match) throw new Error('Could not parse Git version');
+    return {
+        major: Number(match[1]),
+        minor: Number(match[2]),
+        patch: Number(match[3] ?? 0),
+        agent: 'git',
+        installed: true,
+    };
+};
+
 export const createDbtGitVersionSupportProbe = ({
-    getVersion = () => simpleGit().version(),
+    getVersion: readVersion = getVersion,
     warn = (message, metadata) => Logger.warn(message, metadata),
 }: Partial<DbtGitVersionSupportProbeDependencies> = {}) => {
-    let result: Promise<DbtGitVersionSupport> | undefined;
+    let generation = 0;
+    let active: Promise<DbtGitVersionSupport> | undefined;
+    let cached:
+        | {
+              result: DbtGitVersionSupport;
+              retryAt: number | null;
+          }
+        | undefined;
+
     return (): Promise<DbtGitVersionSupport> => {
-        result ??= Promise.resolve()
-            .then(getVersion)
+        if (active) return active;
+        if (
+            cached &&
+            (cached.retryAt === null || Date.now() < cached.retryAt)
+        ) {
+            return Promise.resolve(cached.result);
+        }
+
+        generation += 1;
+        const attempt = generation;
+        const controller = new AbortController();
+        let timeout: NodeJS.Timeout | undefined;
+        const deadline = new Promise<never>((_, reject) => {
+            timeout = setTimeout(() => {
+                controller.abort();
+                reject(new Error('Git version probe timed out'));
+            }, probeTimeoutMs);
+        });
+        active = Promise.race([
+            Promise.resolve().then(() => readVersion(controller.signal)),
+            deadline,
+        ])
             .then<DbtGitVersionSupport>((gitVersion) => {
                 const supported =
                     gitVersion.installed &&
@@ -55,8 +105,24 @@ export const createDbtGitVersionSupportProbe = ({
                     supported: false,
                     reason: 'git-version-probe-failed',
                 };
+            })
+            .then((result) => {
+                if (attempt === generation) {
+                    cached = {
+                        result,
+                        retryAt:
+                            result.reason === 'git-version-probe-failed'
+                                ? Date.now() + failedProbeCooldownMs
+                                : null,
+                    };
+                    active = undefined;
+                }
+                return result;
+            })
+            .finally(() => {
+                if (timeout) clearTimeout(timeout);
             });
-        return result;
+        return active;
     };
 };
 

--- a/packages/backend/src/projectAdapters/dbtGitVersion.ts
+++ b/packages/backend/src/projectAdapters/dbtGitVersion.ts
@@ -40,6 +40,7 @@ export const createDbtGitVersionSupportProbe = ({
 }: Partial<DbtGitVersionSupportProbeDependencies> = {}) => {
     let generation = 0;
     let active: Promise<DbtGitVersionSupport> | undefined;
+    let probeFailureLogged = false;
     let cached:
         | {
               result: DbtGitVersionSupport;
@@ -71,6 +72,7 @@ export const createDbtGitVersionSupportProbe = ({
             deadline,
         ])
             .then<DbtGitVersionSupport>((gitVersion) => {
+                probeFailureLogged = false;
                 const supported =
                     gitVersion.installed &&
                     (gitVersion.major > 2 ||
@@ -89,18 +91,21 @@ export const createDbtGitVersionSupportProbe = ({
                 };
             })
             .catch<DbtGitVersionSupport>((error: unknown) => {
-                warn(
-                    'Dbt Git checkout cache disabled because the Git version probe failed',
-                    {
-                        error: {
-                            name:
-                                error instanceof Error
-                                    ? error.name
-                                    : 'UnknownError',
-                            message: getErrorMessage(error),
+                if (!probeFailureLogged) {
+                    probeFailureLogged = true;
+                    warn(
+                        'Dbt Git checkout cache disabled because the Git version probe failed',
+                        {
+                            error: {
+                                name:
+                                    error instanceof Error
+                                        ? error.name
+                                        : 'UnknownError',
+                                message: getErrorMessage(error),
+                            },
                         },
-                    },
-                );
+                    );
+                }
                 return {
                     supported: false,
                     reason: 'git-version-probe-failed',

--- a/packages/backend/src/projectAdapters/dbtGithubProjectAdapter.test.ts
+++ b/packages/backend/src/projectAdapters/dbtGithubProjectAdapter.test.ts
@@ -39,4 +39,38 @@ describe('DbtGithubProjectAdapter', () => {
 
         await adapter.destroy();
     });
+
+    it('percent-encodes repository URL credentials', async () => {
+        const token = 'ghp_token/?#@:%';
+        const adapter = new DbtGithubProjectAdapter({
+            warehouseClient: warehouseClientMock,
+            githubPersonalAccessToken: token,
+            githubRepository: 'org/repo',
+            githubBranch: 'main',
+            projectDirectorySubPath: '/',
+            warehouseCredentials: {
+                type: WarehouseTypes.POSTGRES,
+                host: 'localhost',
+                port: 5432,
+                user: 'postgres',
+                password: 'password',
+                dbname: 'postgres',
+                schema: 'public',
+            } as CreateWarehouseCredentials,
+            targetName: undefined,
+            environment: undefined,
+            environmentVariableAllowlist: [],
+            cachedWarehouse: {
+                warehouseCatalog: {},
+                onWarehouseCatalogChange: vi.fn(),
+            },
+            dbtVersion: SupportedDbtVersions.V1_7,
+        });
+
+        expect(adapter.remoteRepositoryUrl).toBe(
+            'https://lightdash:ghp_token%2F%3F%23%40%3A%25@github.com/org/repo.git',
+        );
+
+        await adapter.destroy();
+    });
 });

--- a/packages/backend/src/projectAdapters/dbtGithubProjectAdapter.test.ts
+++ b/packages/backend/src/projectAdapters/dbtGithubProjectAdapter.test.ts
@@ -3,10 +3,26 @@ import {
     WarehouseTypes,
     type CreateWarehouseCredentials,
 } from '@lightdash/common';
+import { createGithubGitCredentialFiles } from '../dbt/gitCredentials';
 import { warehouseClientMock } from '../utils/QueryBuilder/MetricQueryBuilder.mock';
 import { DbtGithubProjectAdapter } from './dbtGithubProjectAdapter';
 
+vi.mock('../dbt/gitCredentials', async (importOriginal) => {
+    const actual =
+        await importOriginal<typeof import('../dbt/gitCredentials')>();
+    return {
+        ...actual,
+        createGithubGitCredentialFiles: vi.fn(
+            actual.createGithubGitCredentialFiles,
+        ),
+    };
+});
+
 describe('DbtGithubProjectAdapter', () => {
+    beforeEach(() => {
+        vi.mocked(createGithubGitCredentialFiles).mockClear();
+    });
+
     it('uses a tokenless repository URL when no token is provided', async () => {
         const adapter = new DbtGithubProjectAdapter({
             warehouseClient: warehouseClientMock,
@@ -72,5 +88,36 @@ describe('DbtGithubProjectAdapter', () => {
         );
 
         await adapter.destroy();
+    });
+
+    it('rejects option-like branches before creating credential files', () => {
+        expect(
+            () =>
+                new DbtGithubProjectAdapter({
+                    warehouseClient: warehouseClientMock,
+                    githubPersonalAccessToken: 'ghp_token',
+                    githubRepository: 'org/repo',
+                    githubBranch: '--upload-pack=side-effect',
+                    projectDirectorySubPath: '/',
+                    warehouseCredentials: {
+                        type: WarehouseTypes.POSTGRES,
+                        host: 'localhost',
+                        port: 5432,
+                        user: 'postgres',
+                        password: 'password',
+                        dbname: 'postgres',
+                        schema: 'public',
+                    } as CreateWarehouseCredentials,
+                    targetName: undefined,
+                    environment: undefined,
+                    environmentVariableAllowlist: [],
+                    cachedWarehouse: {
+                        warehouseCatalog: {},
+                        onWarehouseCatalogChange: vi.fn(),
+                    },
+                    dbtVersion: SupportedDbtVersions.V1_7,
+                }),
+        ).toThrow('Git branch names must not begin with an option prefix');
+        expect(createGithubGitCredentialFiles).not.toHaveBeenCalled();
     });
 });

--- a/packages/backend/src/projectAdapters/dbtGithubProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtGithubProjectAdapter.ts
@@ -13,7 +13,10 @@ import {
 } from '../dbt/gitCredentials';
 import { CachedWarehouse } from '../types';
 import { DEFAULT_GITHUB_HOST_DOMAIN } from '../utils/credentialDestination';
-import { DbtGitProjectAdapter } from './dbtGitProjectAdapter';
+import {
+    assertValidGitBranch,
+    DbtGitProjectAdapter,
+} from './dbtGitProjectAdapter';
 import { DbtGitCacheIdentity } from './dbtGitProjectCache';
 
 type DbtGithubProjectAdapterArgs = {
@@ -60,6 +63,7 @@ export class DbtGithubProjectAdapter extends DbtGitProjectAdapter {
         if (!isValid) {
             throw new Error(error);
         }
+        assertValidGitBranch(githubBranch);
 
         const githubHost = hostDomain || DEFAULT_GITHUB_HOST_DOMAIN;
         const gitCredentialFiles = createGithubGitCredentialFiles({

--- a/packages/backend/src/projectAdapters/dbtGithubProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtGithubProjectAdapter.ts
@@ -67,7 +67,9 @@ export class DbtGithubProjectAdapter extends DbtGitProjectAdapter {
             token: githubPersonalAccessToken,
         });
         const remoteRepositoryUrl = githubPersonalAccessToken
-            ? `https://lightdash:${githubPersonalAccessToken}@${githubHost}/${githubRepository}.git`
+            ? `https://lightdash:${encodeURIComponent(
+                  githubPersonalAccessToken,
+              )}@${githubHost}/${githubRepository}.git`
             : `https://${githubHost}/${githubRepository}.git`;
         super({
             warehouseClient,
@@ -88,6 +90,10 @@ export class DbtGithubProjectAdapter extends DbtGitProjectAdapter {
                 ? 'If a dependency is a private GitHub repository, ensure it is included in the same GitHub App installation as this project.'
                 : undefined,
             cacheIdentity,
+            credential: {
+                token: githubPersonalAccessToken,
+                installationId: githubInstallationId,
+            },
         });
         this.gitCredentialFiles = gitCredentialFiles;
     }

--- a/packages/backend/src/projectAdapters/dbtGithubProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtGithubProjectAdapter.ts
@@ -15,6 +15,7 @@ import { CachedWarehouse } from '../types';
 import { DEFAULT_GITHUB_HOST_DOMAIN } from '../utils/credentialDestination';
 import {
     assertValidGitBranch,
+    DbtGitCacheContext,
     DbtGitProjectAdapter,
 } from './dbtGitProjectAdapter';
 import { DbtGitCacheIdentity } from './dbtGitProjectCache';
@@ -36,6 +37,7 @@ type DbtGithubProjectAdapterArgs = {
     selector?: string;
     analytics?: LightdashAnalytics;
     cacheIdentity?: DbtGitCacheIdentity;
+    cacheContext?: DbtGitCacheContext;
 };
 
 export class DbtGithubProjectAdapter extends DbtGitProjectAdapter {
@@ -58,6 +60,7 @@ export class DbtGithubProjectAdapter extends DbtGitProjectAdapter {
         selector,
         analytics,
         cacheIdentity,
+        cacheContext,
     }: DbtGithubProjectAdapterArgs) {
         const [isValid, error] = validateGithubToken(githubPersonalAccessToken);
         if (!isValid) {
@@ -94,6 +97,7 @@ export class DbtGithubProjectAdapter extends DbtGitProjectAdapter {
                 ? 'If a dependency is a private GitHub repository, ensure it is included in the same GitHub App installation as this project.'
                 : undefined,
             cacheIdentity,
+            cacheContext,
             credential: {
                 token: githubPersonalAccessToken,
                 installationId: githubInstallationId,

--- a/packages/backend/src/projectAdapters/dbtGithubProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtGithubProjectAdapter.ts
@@ -14,6 +14,7 @@ import {
 import { CachedWarehouse } from '../types';
 import { DEFAULT_GITHUB_HOST_DOMAIN } from '../utils/credentialDestination';
 import { DbtGitProjectAdapter } from './dbtGitProjectAdapter';
+import { DbtGitCacheIdentity } from './dbtGitProjectCache';
 
 type DbtGithubProjectAdapterArgs = {
     warehouseClient: WarehouseClient;
@@ -31,6 +32,7 @@ type DbtGithubProjectAdapterArgs = {
     dbtVersion: SupportedDbtVersions;
     selector?: string;
     analytics?: LightdashAnalytics;
+    cacheIdentity?: DbtGitCacheIdentity;
 };
 
 export class DbtGithubProjectAdapter extends DbtGitProjectAdapter {
@@ -52,6 +54,7 @@ export class DbtGithubProjectAdapter extends DbtGitProjectAdapter {
         dbtVersion,
         selector,
         analytics,
+        cacheIdentity,
     }: DbtGithubProjectAdapterArgs) {
         const [isValid, error] = validateGithubToken(githubPersonalAccessToken);
         if (!isValid) {
@@ -84,6 +87,7 @@ export class DbtGithubProjectAdapter extends DbtGitProjectAdapter {
             dbtDepsErrorHint: githubInstallationId
                 ? 'If a dependency is a private GitHub repository, ensure it is included in the same GitHub App installation as this project.'
                 : undefined,
+            cacheIdentity,
         });
         this.gitCredentialFiles = gitCredentialFiles;
     }

--- a/packages/backend/src/projectAdapters/dbtGitlabProjectAdapter.test.ts
+++ b/packages/backend/src/projectAdapters/dbtGitlabProjectAdapter.test.ts
@@ -1,0 +1,41 @@
+import {
+    SupportedDbtVersions,
+    WarehouseTypes,
+    type CreateWarehouseCredentials,
+} from '@lightdash/common';
+import { warehouseClientMock } from '../utils/QueryBuilder/MetricQueryBuilder.mock';
+import { DbtGitlabProjectAdapter } from './dbtGitlabProjectAdapter';
+
+describe('DbtGitlabProjectAdapter', () => {
+    it('percent-encodes repository URL credentials', async () => {
+        const adapter = new DbtGitlabProjectAdapter({
+            warehouseClient: warehouseClientMock,
+            gitlabPersonalAccessToken: 'token/?#@:%',
+            gitlabRepository: 'org/repo',
+            gitlabBranch: 'main',
+            projectDirectorySubPath: '/',
+            warehouseCredentials: {
+                type: WarehouseTypes.POSTGRES,
+                host: 'localhost',
+                port: 5432,
+                user: 'postgres',
+                password: 'password',
+                dbname: 'postgres',
+                schema: 'public',
+            } as CreateWarehouseCredentials,
+            targetName: undefined,
+            environment: undefined,
+            environmentVariableAllowlist: [],
+            cachedWarehouse: {
+                warehouseCatalog: {},
+                onWarehouseCatalogChange: vi.fn(),
+            },
+            dbtVersion: SupportedDbtVersions.V1_7,
+        });
+
+        expect(adapter.remoteRepositoryUrl).toBe(
+            'https://lightdash:token%2F%3F%23%40%3A%25@gitlab.com/org/repo.git',
+        );
+        await adapter.destroy();
+    });
+});

--- a/packages/backend/src/projectAdapters/dbtGitlabProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtGitlabProjectAdapter.ts
@@ -46,9 +46,9 @@ export class DbtGitlabProjectAdapter extends DbtGitProjectAdapter {
         analytics,
         cacheIdentity,
     }: DbtGitlabProjectAdapterArgs) {
-        const remoteRepositoryUrl = `https://lightdash:${gitlabPersonalAccessToken}@${
-            hostDomain || DEFAULT_GITLAB_HOST_DOMAIN
-        }/${gitlabRepository}.git`;
+        const remoteRepositoryUrl = `https://lightdash:${encodeURIComponent(
+            gitlabPersonalAccessToken,
+        )}@${hostDomain || DEFAULT_GITLAB_HOST_DOMAIN}/${gitlabRepository}.git`;
         super({
             warehouseClient,
             gitBranch: gitlabBranch,
@@ -64,6 +64,7 @@ export class DbtGitlabProjectAdapter extends DbtGitProjectAdapter {
             selector,
             analytics,
             cacheIdentity,
+            credential: { token: gitlabPersonalAccessToken },
         });
     }
 }

--- a/packages/backend/src/projectAdapters/dbtGitlabProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtGitlabProjectAdapter.ts
@@ -7,7 +7,10 @@ import { WarehouseClient } from '@lightdash/warehouses';
 import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
 import { CachedWarehouse } from '../types';
 import { DEFAULT_GITLAB_HOST_DOMAIN } from '../utils/credentialDestination';
-import { DbtGitProjectAdapter } from './dbtGitProjectAdapter';
+import {
+    DbtGitCacheContext,
+    DbtGitProjectAdapter,
+} from './dbtGitProjectAdapter';
 import { DbtGitCacheIdentity } from './dbtGitProjectCache';
 
 type DbtGitlabProjectAdapterArgs = {
@@ -26,6 +29,7 @@ type DbtGitlabProjectAdapterArgs = {
     selector?: string;
     analytics?: LightdashAnalytics;
     cacheIdentity?: DbtGitCacheIdentity;
+    cacheContext?: DbtGitCacheContext;
 };
 
 export class DbtGitlabProjectAdapter extends DbtGitProjectAdapter {
@@ -45,6 +49,7 @@ export class DbtGitlabProjectAdapter extends DbtGitProjectAdapter {
         selector,
         analytics,
         cacheIdentity,
+        cacheContext,
     }: DbtGitlabProjectAdapterArgs) {
         const remoteRepositoryUrl = `https://lightdash:${encodeURIComponent(
             gitlabPersonalAccessToken,
@@ -64,6 +69,7 @@ export class DbtGitlabProjectAdapter extends DbtGitProjectAdapter {
             selector,
             analytics,
             cacheIdentity,
+            cacheContext,
             credential: { token: gitlabPersonalAccessToken },
         });
     }

--- a/packages/backend/src/projectAdapters/dbtGitlabProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtGitlabProjectAdapter.ts
@@ -8,6 +8,7 @@ import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
 import { CachedWarehouse } from '../types';
 import { DEFAULT_GITLAB_HOST_DOMAIN } from '../utils/credentialDestination';
 import { DbtGitProjectAdapter } from './dbtGitProjectAdapter';
+import { DbtGitCacheIdentity } from './dbtGitProjectCache';
 
 type DbtGitlabProjectAdapterArgs = {
     warehouseClient: WarehouseClient;
@@ -24,6 +25,7 @@ type DbtGitlabProjectAdapterArgs = {
     dbtVersion: SupportedDbtVersions;
     selector?: string;
     analytics?: LightdashAnalytics;
+    cacheIdentity?: DbtGitCacheIdentity;
 };
 
 export class DbtGitlabProjectAdapter extends DbtGitProjectAdapter {
@@ -42,6 +44,7 @@ export class DbtGitlabProjectAdapter extends DbtGitProjectAdapter {
         dbtVersion,
         selector,
         analytics,
+        cacheIdentity,
     }: DbtGitlabProjectAdapterArgs) {
         const remoteRepositoryUrl = `https://lightdash:${gitlabPersonalAccessToken}@${
             hostDomain || DEFAULT_GITLAB_HOST_DOMAIN
@@ -60,6 +63,7 @@ export class DbtGitlabProjectAdapter extends DbtGitProjectAdapter {
             dbtVersion,
             selector,
             analytics,
+            cacheIdentity,
         });
     }
 }

--- a/packages/backend/src/projectAdapters/projectAdapter.ts
+++ b/packages/backend/src/projectAdapters/projectAdapter.ts
@@ -17,6 +17,7 @@ import { DbtBitBucketProjectAdapter } from './dbtBitBucketProjectAdapter';
 import { DbtCloudIdeProjectAdapter } from './dbtCloudIdeProjectAdapter';
 import { DbtGithubProjectAdapter } from './dbtGithubProjectAdapter';
 import { DbtGitlabProjectAdapter } from './dbtGitlabProjectAdapter';
+import { DbtGitCacheIdentity } from './dbtGitProjectCache';
 import { DbtLocalCredentialsProjectAdapter } from './dbtLocalCredentialsProjectAdapter';
 import {
     DbtManifestProjectAdapter,
@@ -37,6 +38,7 @@ export const projectAdapterFromConfig = async (
     // MANIFEST-only: project dir for Lightdash config and selected model ids.
     // Ignored by every other adapter type.
     manifestOptions?: { projectDir?: string; selectedModelIds?: string[] },
+    cacheIdentity?: DbtGitCacheIdentity,
 ): Promise<ProjectAdapter> => {
     Logger.debug(
         `Initialize warehouse client of type ${warehouseCredentials.type}`,
@@ -142,6 +144,7 @@ export const projectAdapterFromConfig = async (
                 dbtVersion,
 
                 selector: config.selector,
+                cacheIdentity,
             });
         case DbtProjectType.GITLAB:
             return new DbtGitlabProjectAdapter({
@@ -160,6 +163,7 @@ export const projectAdapterFromConfig = async (
                 dbtVersion,
 
                 selector: config.selector,
+                cacheIdentity,
             });
         case DbtProjectType.BITBUCKET:
             if (config.semanticLayer === 'lightdash') {
@@ -191,6 +195,7 @@ export const projectAdapterFromConfig = async (
                 dbtVersion,
 
                 selector: config.selector,
+                cacheIdentity,
             });
         case DbtProjectType.AZURE_DEVOPS:
             return new DbtAzureDevOpsProjectAdapter({
@@ -210,6 +215,7 @@ export const projectAdapterFromConfig = async (
                 dbtVersion,
 
                 selector: config.selector,
+                cacheIdentity,
             });
         default:
             const never: never = config;

--- a/packages/backend/src/projectAdapters/projectAdapter.ts
+++ b/packages/backend/src/projectAdapters/projectAdapter.ts
@@ -17,6 +17,7 @@ import { DbtBitBucketProjectAdapter } from './dbtBitBucketProjectAdapter';
 import { DbtCloudIdeProjectAdapter } from './dbtCloudIdeProjectAdapter';
 import { DbtGithubProjectAdapter } from './dbtGithubProjectAdapter';
 import { DbtGitlabProjectAdapter } from './dbtGitlabProjectAdapter';
+import { DbtGitCacheContext } from './dbtGitProjectAdapter';
 import { DbtGitCacheIdentity } from './dbtGitProjectCache';
 import { DbtLocalCredentialsProjectAdapter } from './dbtLocalCredentialsProjectAdapter';
 import {
@@ -39,6 +40,7 @@ export const projectAdapterFromConfig = async (
     // Ignored by every other adapter type.
     manifestOptions?: { projectDir?: string; selectedModelIds?: string[] },
     cacheIdentity?: DbtGitCacheIdentity,
+    cacheContext?: DbtGitCacheContext,
 ): Promise<ProjectAdapter> => {
     Logger.debug(
         `Initialize warehouse client of type ${warehouseCredentials.type}`,
@@ -145,6 +147,7 @@ export const projectAdapterFromConfig = async (
 
                 selector: config.selector,
                 cacheIdentity,
+                cacheContext,
             });
         case DbtProjectType.GITLAB:
             return new DbtGitlabProjectAdapter({
@@ -164,6 +167,7 @@ export const projectAdapterFromConfig = async (
 
                 selector: config.selector,
                 cacheIdentity,
+                cacheContext,
             });
         case DbtProjectType.BITBUCKET:
             if (config.semanticLayer === 'lightdash') {
@@ -196,6 +200,7 @@ export const projectAdapterFromConfig = async (
 
                 selector: config.selector,
                 cacheIdentity,
+                cacheContext,
             });
         case DbtProjectType.AZURE_DEVOPS:
             return new DbtAzureDevOpsProjectAdapter({
@@ -216,6 +221,7 @@ export const projectAdapterFromConfig = async (
 
                 selector: config.selector,
                 cacheIdentity,
+                cacheContext,
             });
         default:
             const never: never = config;

--- a/packages/backend/src/services/ProjectDbtSourcesService.test.ts
+++ b/packages/backend/src/services/ProjectDbtSourcesService.test.ts
@@ -12,7 +12,12 @@ import {
 } from '@lightdash/common';
 import { fromSession } from '../auth/account/account';
 import { buildAccount, defaultSessionUser } from '../auth/account/account.mock';
+import { invalidateDbtGitProjectCacheSource } from '../projectAdapters/dbtGitProjectCache';
 import { ProjectDbtSourcesService } from './ProjectDbtSourcesService';
+
+vi.mock('../projectAdapters/dbtGitProjectCache', () => ({
+    invalidateDbtGitProjectCacheSource: vi.fn(async () => undefined),
+}));
 
 const projectUuid = '11111111-1111-4111-8111-111111111111';
 const otherProjectUuid = '99999999-9999-4999-8999-999999999999';
@@ -781,6 +786,9 @@ describe('ProjectDbtSourcesService', () => {
             ).rejects.toThrow(ForbiddenError);
 
             expect(projectDbtSourcesModel.deleteSource).not.toHaveBeenCalled();
+            expect(
+                vi.mocked(invalidateDbtGitProjectCacheSource),
+            ).not.toHaveBeenCalled();
         });
 
         it('deletes a source belonging to the project', async () => {
@@ -799,6 +807,60 @@ describe('ProjectDbtSourcesService', () => {
             expect(projectDbtSourcesModel.deleteSource).toHaveBeenCalledWith(
                 sourceUuid,
             );
+            expect(
+                vi.mocked(invalidateDbtGitProjectCacheSource),
+            ).toHaveBeenCalledWith(projectUuid, sourceUuid);
+            expect(
+                vi.mocked(projectDbtSourcesModel.deleteSource).mock
+                    .invocationCallOrder[0],
+            ).toBeLessThan(
+                vi.mocked(invalidateDbtGitProjectCacheSource).mock
+                    .invocationCallOrder[0],
+            );
+        });
+
+        it('keeps the cached checkout when the database delete fails', async () => {
+            vi.mocked(projectDbtSourcesModel.getSource).mockResolvedValue({
+                projectDbtSourceUuid: sourceUuid,
+                projectUuid,
+            });
+            vi.mocked(
+                projectDbtSourcesModel.deleteSource,
+            ).mockRejectedValueOnce(new Error('delete failed'));
+
+            await expect(
+                getService().deleteProjectDbtSource(
+                    adminAccount,
+                    projectUuid,
+                    sourceUuid,
+                ),
+            ).rejects.toThrow('delete failed');
+
+            expect(
+                vi.mocked(invalidateDbtGitProjectCacheSource),
+            ).not.toHaveBeenCalled();
+        });
+
+        it('keeps a successful source delete successful when local cache cleanup fails', async () => {
+            vi.mocked(projectDbtSourcesModel.getSource).mockResolvedValue({
+                projectDbtSourceUuid: sourceUuid,
+                projectUuid,
+            });
+            vi.mocked(invalidateDbtGitProjectCacheSource).mockRejectedValueOnce(
+                new Error('cache unavailable'),
+            );
+
+            await expect(
+                getService().deleteProjectDbtSource(
+                    adminAccount,
+                    projectUuid,
+                    sourceUuid,
+                ),
+            ).resolves.toBeUndefined();
+
+            expect(
+                vi.mocked(projectDbtSourcesModel.deleteSource),
+            ).toHaveBeenCalledWith(sourceUuid);
         });
     });
 });

--- a/packages/backend/src/services/ProjectDbtSourcesService.ts
+++ b/packages/backend/src/services/ProjectDbtSourcesService.ts
@@ -26,6 +26,7 @@ import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
 import { LightdashConfig } from '../config/parseConfig';
 import { ProjectDbtSourcesModel } from '../models/ProjectDbtSourcesModel';
 import { ProjectModel } from '../models/ProjectModel/ProjectModel';
+import { invalidateDbtGitProjectCacheSource } from '../projectAdapters/dbtGitProjectCache';
 import { omitDbtEnvironment } from '../utils/dbtProjectConfig';
 import { BaseService } from './BaseService';
 
@@ -450,6 +451,10 @@ export class ProjectDbtSourcesService extends BaseService {
         const sources =
             await this.projectDbtSourcesModel.getSources(projectUuid);
         await this.projectDbtSourcesModel.deleteSource(projectDbtSourceUuid);
+        await invalidateDbtGitProjectCacheSource(
+            projectUuid,
+            projectDbtSourceUuid,
+        ).catch(() => undefined);
         this.analytics.track({
             event: 'dbt_source_removed',
             userId: account.user?.id,

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -97,6 +97,11 @@ import { UserOAuthGrantsModel } from '../../models/UserOAuthGrantsModel';
 import { UserWarehouseCredentialsModel } from '../../models/UserWarehouseCredentials/UserWarehouseCredentialsModel';
 import { WarehouseAvailableTablesModel } from '../../models/WarehouseAvailableTablesModel/WarehouseAvailableTablesModel';
 import { DbtBaseProjectAdapter } from '../../projectAdapters/dbtBaseProjectAdapter';
+import {
+    configureDbtGitProjectCache,
+    invalidateDbtGitProjectCacheProject,
+    type DbtGitCacheIdentity,
+} from '../../projectAdapters/dbtGitProjectCache';
 import * as projectAdapterModule from '../../projectAdapters/projectAdapter';
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
 import type { ProjectAdapter } from '../../types';
@@ -208,6 +213,14 @@ vi.mock('@lightdash/warehouses', async (importOriginal) => ({
     warehouseClientFromCredentials: vi.fn(() => warehouseClientMock),
 }));
 
+vi.mock('../../projectAdapters/dbtGitProjectCache', async (importOriginal) => ({
+    ...(await importOriginal<
+        typeof import('../../projectAdapters/dbtGitProjectCache')
+    >()),
+    configureDbtGitProjectCache: vi.fn(),
+    invalidateDbtGitProjectCacheProject: vi.fn(async () => undefined),
+}));
+
 const projectModel = {
     runInAnalyticsProvisioningLock: vi.fn(
         async (_org: string, callback: () => Promise<unknown>) => callback(),
@@ -220,6 +233,9 @@ const projectModel = {
         dbtSourceUuid: 'primary-source-uuid',
         dbtSourceName: 'dbt_project',
     })),
+    getDbtSourceIdentityRows: vi.fn<ProjectModel['getDbtSourceIdentityRows']>(
+        async () => [],
+    ),
     getTablesConfiguration: vi.fn(async () => tablesConfiguration),
     updateTablesConfiguration: vi.fn(),
     getExploreFromCache: vi.fn(async () => validExplore),
@@ -886,6 +902,127 @@ describe('ProjectService', () => {
             expect(
                 localAnalytics.assertLocalAnalyticsProjectEnabled,
             ).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('Git cache identity liveness', () => {
+        const getSourceIdentityRows =
+            vi.fn<ProjectDbtSourcesModel['getSourceIdentityRows']>();
+
+        const getLivenessCheck = () => {
+            getMockedProjectService(lightdashConfigMock, {
+                projectDbtSourcesModel: {
+                    getSourceIdentityRows,
+                } as unknown as ProjectDbtSourcesModel,
+            });
+            const configured = vi
+                .mocked(configureDbtGitProjectCache)
+                .mock.calls.at(-1)?.[0];
+            if (!configured) throw new Error('Git cache is not configured');
+            return configured.livenessCheck;
+        };
+
+        it('requires the exact primary identity or the null-identity fallback and the exact additional project pair', async () => {
+            vi.mocked(
+                projectModel.getDbtSourceIdentityRows,
+            ).mockResolvedValueOnce([
+                { projectUuid: 'current', dbtSourceUuid: 'primary-current' },
+                { projectUuid: 'legacy', dbtSourceUuid: null },
+                { projectUuid: 'changed', dbtSourceUuid: 'primary-new' },
+            ]);
+            vi.mocked(getSourceIdentityRows).mockResolvedValueOnce([
+                {
+                    projectUuid: 'current',
+                    projectDbtSourceUuid: 'additional-current',
+                },
+                {
+                    projectUuid: 'other',
+                    projectDbtSourceUuid: 'additional-moved',
+                },
+            ]);
+            const identities: DbtGitCacheIdentity[] = [
+                {
+                    projectUuid: 'current',
+                    sourceUuid: 'primary-current',
+                    sourceType: 'primary',
+                },
+                {
+                    projectUuid: 'legacy',
+                    sourceUuid: 'legacy',
+                    sourceType: 'primary',
+                },
+                {
+                    projectUuid: 'changed',
+                    sourceUuid: 'changed',
+                    sourceType: 'primary',
+                },
+                {
+                    projectUuid: 'missing',
+                    sourceUuid: 'primary-missing',
+                    sourceType: 'primary',
+                },
+                {
+                    projectUuid: 'current',
+                    sourceUuid: 'additional-current',
+                    sourceType: 'additional',
+                },
+                {
+                    projectUuid: 'current',
+                    sourceUuid: 'additional-moved',
+                    sourceType: 'additional',
+                },
+                {
+                    projectUuid: 'current',
+                    sourceUuid: 'additional-missing',
+                    sourceType: 'additional',
+                },
+            ];
+
+            const live = await getLivenessCheck()([
+                ...identities,
+                identities[0],
+                identities[4],
+            ]);
+
+            expect(live).toEqual(
+                new Set([
+                    'primary:current:primary-current',
+                    'primary:legacy:legacy',
+                    'additional:current:additional-current',
+                ]),
+            );
+            expect(
+                vi.mocked(projectModel.getDbtSourceIdentityRows),
+            ).toHaveBeenCalledExactlyOnceWith([
+                'current',
+                'legacy',
+                'changed',
+                'missing',
+            ]);
+            expect(
+                vi.mocked(getSourceIdentityRows),
+            ).toHaveBeenCalledExactlyOnceWith([
+                'additional-current',
+                'additional-moved',
+                'additional-missing',
+            ]);
+        });
+
+        it('rejects an uncertain lookup instead of returning a partial live set', async () => {
+            vi.mocked(
+                projectModel.getDbtSourceIdentityRows,
+            ).mockRejectedValueOnce(new Error('database unavailable'));
+            vi.mocked(getSourceIdentityRows).mockResolvedValueOnce([]);
+
+            await expect(
+                getLivenessCheck()([
+                    {
+                        projectUuid: 'current',
+                        sourceUuid: 'primary-current',
+                        sourceType: 'primary',
+                    },
+                ]),
+            ).rejects.toThrow('database unavailable');
         });
     });
 
@@ -2423,6 +2560,56 @@ describe('ProjectService', () => {
         expect(onboardingModel.update.mock.invocationCallOrder[0]).toBeLessThan(
             projectModel.delete.mock.invocationCallOrder[0],
         );
+        expect(
+            vi.mocked(invalidateDbtGitProjectCacheProject),
+        ).toHaveBeenCalledWith(projectUuid);
+        expect(projectModel.delete.mock.invocationCallOrder[0]).toBeLessThan(
+            vi.mocked(invalidateDbtGitProjectCacheProject).mock
+                .invocationCallOrder[0],
+        );
+    });
+
+    test('keeps the Git cache when the project delete fails', async () => {
+        vi.mocked(projectModel.delete).mockRejectedValueOnce(
+            new Error('delete failed'),
+        );
+        const deletingUser = {
+            ...user,
+            ability: new Ability<PossibleAbilities>([
+                { subject: 'Project', action: 'delete' },
+            ]),
+        };
+
+        await expect(service.delete(projectUuid, deletingUser)).rejects.toThrow(
+            'delete failed',
+        );
+
+        expect(
+            vi.mocked(invalidateDbtGitProjectCacheProject),
+        ).not.toHaveBeenCalled();
+    });
+
+    test('keeps a successful project delete successful when local cache cleanup fails', async () => {
+        vi.mocked(invalidateDbtGitProjectCacheProject).mockRejectedValueOnce(
+            new Error('cache unavailable'),
+        );
+        const deletingUser = {
+            ...user,
+            ability: new Ability<PossibleAbilities>([
+                { subject: 'Project', action: 'delete' },
+            ]),
+        };
+
+        await expect(
+            service.delete(projectUuid, deletingUser),
+        ).resolves.toBeUndefined();
+
+        expect(vi.mocked(projectModel.delete)).toHaveBeenCalledWith(
+            projectUuid,
+        );
+        expect(
+            vi.mocked(invalidateDbtGitProjectCacheProject),
+        ).toHaveBeenCalledWith(projectUuid);
     });
 
     describe('refreshTablesAndProjectConfig for a CLI/NONE preview', () => {
@@ -6843,6 +7030,11 @@ describe('ProjectService.resolveCompileAdapter (MultiDbtSources regression firew
             expect.objectContaining({
                 warehouseCredentials: primary.warehouseCredentials,
             }),
+            {
+                projectUuid: 'project-uuid',
+                sourceUuid: 'source-b-uuid',
+                sourceType: 'additional',
+            },
         );
     });
 
@@ -6851,16 +7043,29 @@ describe('ProjectService.resolveCompileAdapter (MultiDbtSources regression firew
             lightdashConfigMock,
         ) as unknown as ProjectServiceInternals;
         vi.mocked(warehouseClientFromCredentials).mockClear();
+        const factory = vi.spyOn(
+            projectAdapterModule,
+            'projectAdapterFromConfig',
+        );
+        const cacheIdentity = {
+            projectUuid: 'project-uuid',
+            sourceUuid: 'source-b-uuid',
+            sourceType: 'additional',
+        } as const;
 
         await projectService.buildSourceAdapter(
             { type: DbtProjectType.NONE },
             { database: null, schema: 'source_schema' },
             'org-uuid',
             primary,
+            cacheIdentity,
         );
 
         expect(warehouseClientFromCredentials).toHaveBeenCalledWith(
             expect.objectContaining({ schema: 'source_schema' }),
+        );
+        expect(vi.mocked(factory).mock.calls.at(-1)?.[7]).toEqual(
+            cacheIdentity,
         );
     });
 

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -6399,6 +6399,8 @@ type ResolveCompileAdapterArgs = {
 };
 
 type BuildMergedManifestAdapterArgs = {
+    projectType?: ProjectType;
+    jobUuid?: string;
     projectUuid: string;
     organizationUuid: string | undefined;
     primary: ResolveCompileAdapterArgs['primary'];
@@ -7026,6 +7028,8 @@ describe('ProjectService.resolveCompileAdapter (MultiDbtSources regression firew
         await projectService.buildMergedManifestAdapter({
             projectUuid: 'project-uuid',
             organizationUuid: 'org-uuid',
+            projectType: ProjectType.PREVIEW,
+            jobUuid: 'compile-job-uuid',
             primary: {
                 ...primary,
                 adapter: buildAdapterWithManifest(
@@ -7054,6 +7058,7 @@ describe('ProjectService.resolveCompileAdapter (MultiDbtSources regression firew
                 sourceUuid: 'source-b-uuid',
                 sourceType: 'additional',
             },
+            { projectType: ProjectType.PREVIEW, jobUuid: 'compile-job-uuid' },
         );
     });
 
@@ -7072,12 +7077,18 @@ describe('ProjectService.resolveCompileAdapter (MultiDbtSources regression firew
             sourceType: 'additional',
         } as const;
 
+        const cacheContext = {
+            projectType: ProjectType.PREVIEW,
+            jobUuid: 'compile-job-uuid',
+        };
+
         await projectService.buildSourceAdapter(
             { type: DbtProjectType.NONE },
             { database: null, schema: 'source_schema' },
             'org-uuid',
             primary,
             cacheIdentity,
+            cacheContext,
         );
 
         expect(warehouseClientFromCredentials).toHaveBeenCalledWith(
@@ -7086,6 +7097,7 @@ describe('ProjectService.resolveCompileAdapter (MultiDbtSources regression firew
         expect(vi.mocked(factory).mock.calls.at(-1)?.[7]).toEqual(
             cacheIdentity,
         );
+        expect(vi.mocked(factory).mock.calls.at(-1)?.[8]).toEqual(cacheContext);
     });
 
     it('BC-7: stages the projected merged manifest without publishing it during adapter construction', async () => {
@@ -7429,6 +7441,50 @@ describe('ProjectService.resolveCompileAdapter (MultiDbtSources regression firew
             projectDbtSourcesModel,
         });
     };
+
+    it.each(['compileProject', 'testAndCompileProject'] as const)(
+        '%s passes preview type and job identity to each source adapter',
+        async (method) => {
+            const projectService = buildCompilationBoundaryService();
+            const storedProject = await projectModel.getWithSensitiveFields();
+            const previewProject = {
+                ...storedProject,
+                type: ProjectType.PREVIEW,
+            };
+            vi.mocked(projectModel.getWithSensitiveFields).mockResolvedValue(
+                previewProject,
+            );
+            vi.mocked(projectModel.get).mockResolvedValue(previewProject);
+            const factory = vi.mocked(
+                projectAdapterModule.projectAdapterFromConfig,
+            );
+
+            await projectService[method](
+                compileUser,
+                'projectUuid',
+                RequestMethod.WEB_APP,
+                'preview-compile-job-uuid',
+            );
+
+            expect(
+                factory.mock.calls.slice(0, 2).map((args) => args[8]),
+            ).toEqual([
+                {
+                    projectType: ProjectType.PREVIEW,
+                    jobUuid: 'preview-compile-job-uuid',
+                },
+                {
+                    projectType: ProjectType.PREVIEW,
+                    jobUuid: 'preview-compile-job-uuid',
+                },
+            ]);
+            expect(
+                factory.mock.calls
+                    .slice(0, 2)
+                    .map((args) => args[7]?.sourceType),
+            ).toEqual(['primary', 'additional']);
+        },
+    );
 
     it('BC-7: distinguishes manifest staging failures from persistence failures', async () => {
         const projectService = buildCompilationBoundaryService();

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -906,6 +906,25 @@ describe('ProjectService', () => {
     });
 
     describe('Git cache identity liveness', () => {
+        it('passes the cache root and disabled limit to the cache', () => {
+            getMockedProjectService({
+                ...lightdashConfigMock,
+                dbt: {
+                    ...lightdashConfigMock.dbt,
+                    gitCacheRoot: '/var/cache/lightdash',
+                    gitCacheMaxBytes: 0,
+                },
+            });
+            expect(
+                vi.mocked(configureDbtGitProjectCache),
+            ).toHaveBeenLastCalledWith(
+                expect.objectContaining({
+                    root: '/var/cache/lightdash',
+                    maxBytes: 0,
+                }),
+            );
+        });
+
         const getSourceIdentityRows =
             vi.fn<ProjectDbtSourcesModel['getSourceIdentityRows']>();
 

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -781,6 +781,7 @@ export class ProjectService extends BaseService {
         this.provisionPlaygroundProject = provisionPlaygroundProject;
         this.provisionTrainingProject = provisionTrainingProject;
         configureDbtGitProjectCache({
+            root: lightdashConfig.dbt.gitCacheRoot,
             maxBytes: lightdashConfig.dbt.gitCacheMaxBytes,
             maxAgeMs: lightdashConfig.dbt.gitCacheMaxAgeMs,
             livenessCheck: async (identities) => {

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -337,6 +337,11 @@ import { UserOAuthGrantsModel } from '../../models/UserOAuthGrantsModel';
 import { UserWarehouseCredentialsModel } from '../../models/UserWarehouseCredentials/UserWarehouseCredentialsModel';
 import { WarehouseAvailableTablesModel } from '../../models/WarehouseAvailableTablesModel/WarehouseAvailableTablesModel';
 import { DbtBaseProjectAdapter } from '../../projectAdapters/dbtBaseProjectAdapter';
+import {
+    configureDbtGitProjectCache,
+    invalidateDbtGitProjectCacheProject,
+    resolveLiveDbtGitCacheIdentities,
+} from '../../projectAdapters/dbtGitProjectCache';
 import { projectAdapterFromConfig } from '../../projectAdapters/projectAdapter';
 import { compileMetricQuery } from '../../queryCompiler';
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
@@ -775,6 +780,41 @@ export class ProjectService extends BaseService {
         this.onProjectCreated = onProjectCreated;
         this.provisionPlaygroundProject = provisionPlaygroundProject;
         this.provisionTrainingProject = provisionTrainingProject;
+        configureDbtGitProjectCache({
+            maxBytes: lightdashConfig.dbt.gitCacheMaxBytes,
+            maxAgeMs: lightdashConfig.dbt.gitCacheMaxAgeMs,
+            livenessCheck: async (identities) => {
+                const primaryProjectUuids = [
+                    ...new Set(
+                        identities
+                            .filter(
+                                ({ sourceType }) => sourceType === 'primary',
+                            )
+                            .map(({ projectUuid }) => projectUuid),
+                    ),
+                ];
+                const additionalSourceUuids = [
+                    ...new Set(
+                        identities
+                            .filter(
+                                ({ sourceType }) => sourceType === 'additional',
+                            )
+                            .map(({ sourceUuid }) => sourceUuid),
+                    ),
+                ];
+                const [projects, sources] = await Promise.all([
+                    projectModel.getDbtSourceIdentityRows(primaryProjectUuids),
+                    projectDbtSourcesModel.getSourceIdentityRows(
+                        additionalSourceUuids,
+                    ),
+                ]);
+                return resolveLiveDbtGitCacheIdentities({
+                    identities,
+                    primaryRows: projects,
+                    additionalRows: sources,
+                });
+            },
+        });
     }
 
     /**
@@ -4231,6 +4271,8 @@ export class ProjectService extends BaseService {
             await this.jobModel.update(job.jobUuid, {
                 jobStatus: JobStatusType.RUNNING,
             });
+            const { dbtSourceUuid: primaryDbtSourceUuid } =
+                await this.projectModel.getDbtSourceIdentity(projectUuid);
             timings.testAdapter.start = performance.now();
             const {
                 adapter: primaryAdapter,
@@ -4247,6 +4289,11 @@ export class ProjectService extends BaseService {
                         user,
                         'project_update',
                         method,
+                        {
+                            projectUuid,
+                            sourceUuid: primaryDbtSourceUuid,
+                            sourceType: 'primary',
+                        },
                     ),
             );
             timings.testAdapter.end = performance.now();
@@ -4487,6 +4534,11 @@ export class ProjectService extends BaseService {
         user: Pick<SessionUser, 'userUuid' | 'organizationUuid'>,
         context: 'project_create' | 'project_update',
         method: RequestMethod,
+        cacheIdentity?: {
+            projectUuid: string;
+            sourceUuid: string;
+            sourceType: 'primary';
+        },
     ): Promise<{
         adapter: ProjectAdapter;
         sshTunnel: SshTunnel<CreateWarehouseCredentials>;
@@ -4520,6 +4572,8 @@ export class ProjectService extends BaseService {
                 dbtVersionOption,
                 this.lightdashConfig.dbt.environmentVariableAllowlist,
                 this.analytics,
+                undefined,
+                cacheIdentity,
             );
             await adapter.test();
             this.analytics.track({
@@ -4873,6 +4927,9 @@ export class ProjectService extends BaseService {
         } else {
             await this.projectModel.delete(projectUuid);
         }
+        await invalidateDbtGitProjectCacheProject(projectUuid).catch(
+            () => undefined,
+        );
 
         this.analytics.track({
             event: 'project.deleted',
@@ -4890,7 +4947,10 @@ export class ProjectService extends BaseService {
 
         const results = await Promise.allSettled(
             expiredProjects.map(({ projectUuid }) =>
-                this.projectModel.delete(projectUuid).then(() => {
+                this.projectModel.delete(projectUuid).then(async () => {
+                    await invalidateDbtGitProjectCacheProject(
+                        projectUuid,
+                    ).catch(() => undefined);
                     this.logger.info(
                         `Deleted expired preview project: ${projectUuid}`,
                     );
@@ -5094,6 +5154,8 @@ export class ProjectService extends BaseService {
         };
         const dbtVersionOption =
             project.dbtVersion || DefaultSupportedDbtVersion;
+        const { dbtSourceUuid } =
+            await this.projectModel.getDbtSourceIdentity(projectUuid);
         const adapter = await projectAdapterFromConfig(
             dbtConnection,
             sshTunnel.overrideCredentials,
@@ -5101,6 +5163,12 @@ export class ProjectService extends BaseService {
             dbtVersionOption,
             this.lightdashConfig.dbt.environmentVariableAllowlist,
             this.analytics,
+            undefined,
+            {
+                projectUuid,
+                sourceUuid: dbtSourceUuid,
+                sourceType: 'primary',
+            },
         );
         return {
             adapter,
@@ -5128,6 +5196,11 @@ export class ProjectService extends BaseService {
             cachedWarehouse: CachedWarehouse;
             dbtVersionOption: DbtVersionOption;
         },
+        cacheIdentity: {
+            projectUuid: string;
+            sourceUuid: string;
+            sourceType: 'additional';
+        },
     ): Promise<ProjectAdapter> {
         const resolvedConnection =
             await this.resolveDbtConnectionInstallationId(
@@ -5144,6 +5217,8 @@ export class ProjectService extends BaseService {
             shared.dbtVersionOption,
             this.lightdashConfig.dbt.environmentVariableAllowlist,
             this.analytics,
+            undefined,
+            cacheIdentity,
         );
     }
 
@@ -5306,6 +5381,7 @@ export class ProjectService extends BaseService {
         // The primary git adapter is only read for its manifest here; the merged
         // MANIFEST adapter is what compiles, so destroy the primary clone in finally.
         manifestFetchAdapters.push(primary.adapter);
+        const primaryStartedAt = Date.now();
         const [
             {
                 manifest: rawPrimaryManifest,
@@ -5316,6 +5392,30 @@ export class ProjectService extends BaseService {
             primary.adapter.getDbtManifest(),
             this.projectModel.getDbtSourceIdentity(projectUuid),
         ]);
+        const primaryDurationMs = Date.now() - primaryStartedAt;
+        const primaryModelCount = Object.values(
+            rawPrimaryManifest.nodes,
+        ).filter((node) => node.resource_type === 'model').length;
+        const primaryFetchMetrics = primary.adapter.getFetchMetrics?.();
+        const primaryFetchMetricsMessage = primaryFetchMetrics
+            ? ` cloneMode=${primaryFetchMetrics.cloneMode} depsMode=${primaryFetchMetrics.depsMode} cloneDurationMs=${primaryFetchMetrics.cloneDurationMs} depsDurationMs=${primaryFetchMetrics.depsDurationMs}`
+            : '';
+        this.logger.info(
+            `dbt.compile.sourceFetched projectUuid=${projectUuid} sourceName=${identity.dbtSourceName} durationMs=${primaryDurationMs} models=${primaryModelCount}${primaryFetchMetricsMessage}`,
+            {
+                event: 'dbt.compile.sourceFetched',
+                projectUuid,
+                jobUuid: jobUuid ?? null,
+                sourceName: identity.dbtSourceName,
+                durationMs: primaryDurationMs,
+                modelCount: primaryModelCount,
+                selectedModelCount: primarySelectedModelIds?.length ?? null,
+                cloneMode: primaryFetchMetrics?.cloneMode ?? null,
+                depsMode: primaryFetchMetrics?.depsMode ?? null,
+                cloneDurationMs: primaryFetchMetrics?.cloneDurationMs ?? null,
+                depsDurationMs: primaryFetchMetrics?.depsDurationMs ?? null,
+            },
+        );
         const selectedPrimaryManifest = manifestWithCompilationSelection(
             rawPrimaryManifest,
             primarySelectedModelIds,
@@ -5415,6 +5515,11 @@ export class ProjectService extends BaseService {
                         source.warehouseLocation,
                         organizationUuid,
                         shared,
+                        {
+                            projectUuid,
+                            sourceUuid: source.projectDbtSourceUuid,
+                            sourceType: 'additional',
+                        },
                     );
                 } catch (e) {
                     throw new ParameterError(
@@ -5457,8 +5562,12 @@ export class ProjectService extends BaseService {
                     const sourceModelCount = Object.values(
                         manifest.nodes,
                     ).filter((node) => node.resource_type === 'model').length;
+                    const fetchMetrics = sourceAdapter.getFetchMetrics?.();
+                    const fetchMetricsMessage = fetchMetrics
+                        ? ` cloneMode=${fetchMetrics.cloneMode} depsMode=${fetchMetrics.depsMode} cloneDurationMs=${fetchMetrics.cloneDurationMs} depsDurationMs=${fetchMetrics.depsDurationMs}`
+                        : '';
                     this.logger.info(
-                        `dbt.compile.sourceFetched projectUuid=${projectUuid} sourceName=${source.name} durationMs=${sourceDurationMs} models=${sourceModelCount}`,
+                        `dbt.compile.sourceFetched projectUuid=${projectUuid} sourceName=${source.name} durationMs=${sourceDurationMs} models=${sourceModelCount}${fetchMetricsMessage}`,
                         {
                             event: 'dbt.compile.sourceFetched',
                             projectUuid,
@@ -5468,6 +5577,12 @@ export class ProjectService extends BaseService {
                             modelCount: sourceModelCount,
                             selectedModelCount:
                                 sourceSelectedModelIds?.length ?? null,
+                            cloneMode: fetchMetrics?.cloneMode ?? null,
+                            depsMode: fetchMetrics?.depsMode ?? null,
+                            cloneDurationMs:
+                                fetchMetrics?.cloneDurationMs ?? null,
+                            depsDurationMs:
+                                fetchMetrics?.depsDurationMs ?? null,
                         },
                     );
                     return {
@@ -11377,6 +11492,9 @@ export class ProjectService extends BaseService {
 
         try {
             await this.projectModel.delete(previewProject.project.projectUuid);
+            await invalidateDbtGitProjectCacheProject(
+                previewProject.project.projectUuid,
+            ).catch(() => undefined);
         } catch (e) {
             Sentry.captureException(e);
             this.logger.error(
@@ -11689,6 +11807,9 @@ export class ProjectService extends BaseService {
             );
         }
         await this.projectModel.delete(copyProjectUuid);
+        await invalidateDbtGitProjectCacheProject(copyProjectUuid).catch(
+            () => undefined,
+        );
     }
 
     /*

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -337,6 +337,7 @@ import { UserOAuthGrantsModel } from '../../models/UserOAuthGrantsModel';
 import { UserWarehouseCredentialsModel } from '../../models/UserWarehouseCredentials/UserWarehouseCredentialsModel';
 import { WarehouseAvailableTablesModel } from '../../models/WarehouseAvailableTablesModel/WarehouseAvailableTablesModel';
 import { DbtBaseProjectAdapter } from '../../projectAdapters/dbtBaseProjectAdapter';
+import { DbtGitCacheContext } from '../../projectAdapters/dbtGitProjectAdapter';
 import {
     configureDbtGitProjectCache,
     invalidateDbtGitProjectCacheProject,
@@ -3529,6 +3530,8 @@ export class ProjectService extends BaseService {
                         user,
                         'project_create',
                         method,
+                        undefined,
+                        { projectType: createProject.type, jobUuid },
                     ),
             );
 
@@ -4295,6 +4298,7 @@ export class ProjectService extends BaseService {
                             sourceUuid: primaryDbtSourceUuid,
                             sourceType: 'primary',
                         },
+                        { projectType: updatedProject.type, jobUuid },
                     ),
             );
             timings.testAdapter.end = performance.now();
@@ -4316,6 +4320,8 @@ export class ProjectService extends BaseService {
                                     projectUuid,
                                     organizationUuid: user.organizationUuid,
                                     userUuid: user.userUuid,
+                                    jobUuid,
+                                    projectType: updatedProject.type,
                                     primary: {
                                         adapter: primaryAdapter,
                                         warehouseCredentials,
@@ -4540,6 +4546,7 @@ export class ProjectService extends BaseService {
             sourceUuid: string;
             sourceType: 'primary';
         },
+        cacheContext?: DbtGitCacheContext,
     ): Promise<{
         adapter: ProjectAdapter;
         sshTunnel: SshTunnel<CreateWarehouseCredentials>;
@@ -4575,6 +4582,7 @@ export class ProjectService extends BaseService {
                 this.analytics,
                 undefined,
                 cacheIdentity,
+                cacheContext,
             );
             await adapter.test();
             this.analytics.track({
@@ -4974,6 +4982,7 @@ export class ProjectService extends BaseService {
     private async buildAdapter(
         projectUuid: string,
         user: Pick<SessionUser, 'userUuid' | 'organizationUuid'>,
+        jobUuid?: string,
     ): Promise<{
         sshTunnel: SshTunnel<CreateWarehouseCredentials>;
         adapter: ProjectAdapter;
@@ -5170,6 +5179,7 @@ export class ProjectService extends BaseService {
                 sourceUuid: dbtSourceUuid,
                 sourceType: 'primary',
             },
+            { projectType: project.type, jobUuid },
         );
         return {
             adapter,
@@ -5202,6 +5212,7 @@ export class ProjectService extends BaseService {
             sourceUuid: string;
             sourceType: 'additional';
         },
+        cacheContext?: DbtGitCacheContext,
     ): Promise<ProjectAdapter> {
         const resolvedConnection =
             await this.resolveDbtConnectionInstallationId(
@@ -5220,6 +5231,7 @@ export class ProjectService extends BaseService {
             this.analytics,
             undefined,
             cacheIdentity,
+            cacheContext,
         );
     }
 
@@ -5360,10 +5372,12 @@ export class ProjectService extends BaseService {
         sources,
         manifestFetchAdapters,
         jobUuid,
+        projectType,
     }: {
         projectUuid: string;
         organizationUuid: string | undefined;
         jobUuid?: string;
+        projectType?: ProjectType;
         primary: {
             adapter: ProjectAdapter;
             warehouseCredentials: CreateWarehouseCredentials;
@@ -5521,6 +5535,7 @@ export class ProjectService extends BaseService {
                             sourceUuid: source.projectDbtSourceUuid,
                             sourceType: 'additional',
                         },
+                        { projectType, jobUuid },
                     );
                 } catch (e) {
                     throw new ParameterError(
@@ -5778,11 +5793,13 @@ export class ProjectService extends BaseService {
         manifestFetchAdapters,
         onDbtSourceCount,
         jobUuid,
+        projectType,
     }: {
         projectUuid: string;
         organizationUuid: string | undefined;
         userUuid: string;
         jobUuid?: string;
+        projectType?: ProjectType;
         primary: {
             adapter: ProjectAdapter;
             warehouseCredentials: CreateWarehouseCredentials;
@@ -5817,6 +5834,7 @@ export class ProjectService extends BaseService {
             sources,
             manifestFetchAdapters,
             jobUuid,
+            projectType,
         });
     }
 
@@ -9046,7 +9064,7 @@ export class ProjectService extends BaseService {
 
         // Force refresh adapter (refetch git repos, check for changed credentials, etc.)
         // Might want to cache parts of this in future if slow
-        const buildResult = await this.buildAdapter(projectUuid, user);
+        const buildResult = await this.buildAdapter(projectUuid, user, jobUuid);
         const { sshTunnel } = buildResult;
         let { adapter } = buildResult;
         // Adapters built only to read a source's manifest (git clones); destroyed in finally.
@@ -9064,6 +9082,8 @@ export class ProjectService extends BaseService {
                     organizationUuid: project.organizationUuid,
                     userUuid: user.userUuid,
                     primary: buildResult,
+                    jobUuid,
+                    projectType: project.type,
                     manifestFetchAdapters,
                     onDbtSourceCount: (count) => {
                         dbtSourceCount = count;

--- a/packages/backend/src/types.ts
+++ b/packages/backend/src/types.ts
@@ -81,6 +81,8 @@ export interface ProjectAdapter {
 export interface DbtClient {
     installDeps?(): Promise<void>;
 
+    setAbortSignal?(signal: AbortSignal | undefined): void;
+
     getDbtManifest(): Promise<DbtRpcGetManifestResults>;
 
     getDbtPackages?(): Promise<DbtPackages | undefined>;

--- a/packages/backend/src/types.ts
+++ b/packages/backend/src/types.ts
@@ -61,6 +61,13 @@ export interface ProjectAdapter {
 
     getProjectContext(): Promise<ProjectContextEntry[]>;
 
+    getFetchMetrics?(): {
+        cloneMode: 'fresh' | 'reused';
+        depsMode: 'fresh' | 'reused';
+        cloneDurationMs: number;
+        depsDurationMs: number;
+    };
+
     /**
      * Local dbt project directory this adapter reads `lightdash.config.yml` and
      * `lightdash.project_context.yml` from. Undefined for adapters with no


### PR DESCRIPTION
Each compile clones every Git source and runs dbt dependencies again. This change retains eligible checkouts and package results between compiles. A reused checkout fetches with the current credentials and resets to the fetched commit. A cache failure uses a new temporary clone. A failed fresh clone still fails the compile.

Each cache key includes the project, source, repository, branch and project path. An exclusive lease protects the checkout. A concurrent compile uses a fresh checkout when the entry is busy. Cleanup retires an owned entry before it removes its files. A heartbeat write that exceeds thirty seconds surrenders the lease. It cancels the owned Git and dbt process groups, including remote helpers. The adapter retries once in a fresh directory. This recovery replays the whole operation after a late lease loss. Side effects from the first attempt can repeat. This replay is deliberate. A failed fresh retry fails the compile. A surrendered holder does not publish dependency success or retain the checkout.

Dependency reuse requires matching package files, lock file, dbt version, target and effective environment. Failed dependency installs do not publish a success marker. Unsafe paths and unsupported package layouts use the fresh path.

The cache retains up to 2 GiB in TMPDIR by default. This limits retained data. Active checkouts can use extra disk space. Set DBT_GIT_CACHE_MAX_BYTES to zero or a negative value to disable reuse. Maintenance still expires retained entries. A disabled cache does not create a missing root during maintenance or invalidation. It marks active entries for deletion on release. Set DBT_GIT_CACHE_ROOT to choose the cache directory. DBT_GIT_CACHE_MAX_AGE_MS sets the inactivity limit. Entries expire after one day of inactivity by default. Each process checks project and source membership every 15 minutes. A missing identity removes an inactive entry. Active entries are removed on release. An uncertain owner or database lookup preserves the entry. Such entries still count against capacity.

The source-fetch logs include clone and dependency modes and durations. The public output, explore order and job results keep the same shape. No database migration is added.

Abandoned cache entries and orphan root writes become cleanup targets after a five-minute grace period. Foreign-host leases expire after ten minutes without a heartbeat. Future-dated heartbeat values are clamped to their first local observation. Repeated reads of unchanged future data keep that same ceiling. This permits short stalls and bounds retention after a pod dies. Admission evicts an idle retained entry when the entry limit is full. Admission and retention lock acquisition each have a three-second wait budget. Admission falls back to a fresh clone on timeout. Retention reserves enough idle victims before it publishes a fresh checkout. It does not await recursive victim deletion. Each pending deletion stays charged to other retention attempts. A known size uses the recorded bytes. An unknown size uses the full retention budget. Each publication reserves its own additional space. Maintenance retries a failed deletion. A slow deletion does not discard the fresh checkout. Existing filesystem work and heartbeat draining are not a hard three-second wall limit for destroy. Preview projects always use a fresh clone. They do not evict retained production entries.

Dependency identity uses the GitHub installation ID when the provider token is temporary. It hashes long-lived tokens. Project hooks and variables can use Jinja. Dependency files keep the stricter checks. Literal Git clean exclusions preserve package paths. A fetch updates a private ref without writing FETCH_HEAD. Branch validation runs before credential files are created. A process caches successful Git version probes. Versions below 2.29 disable the cache and log a warning. A probe times out after three seconds and cancels its Git child. Failed and timed-out probes disable reuse for thirty seconds. The next compile can then retry the probe. Consecutive failed probes produce one warning until a result is read.

One outcome log records each attempted source refresh after cleanup. It includes project UUID, source UUID, source type and job UUID. It includes eligibility, retention and miss or fallback reasons. Error logs redact credential values. Cleanup combines size accounting and Git metadata inspection in one traversal.

An interrupted checkout is repaired by fetch, reset and clean before reuse. A dependency marker must match the current inputs and installed content. An interrupted dependency install does not publish a marker. These checks recover incomplete work. They do not provide distributed filesystem fencing. An event-loop pause, host clock skew or a storage operation that outlives cancellation remains a deployment limitation.

Linear: SPK-1937

## Measurements

Current rebased code head: `fcda9e5412979bd9b2ff57af9dbc2faa14eb17fc`. The branch rebases onto main `196d5d97b7c408a132851d275faa863b9c0b8614` after all requested measurements are recorded. The eight local runs measure pre-rebase head `9d3bd964519929daa3b0b6b0e6629444c2506717`. The round 5 diagnostic and network tables measure pre-rebase head `e1805efc1901b27776beaaba4a2bba58e31a82dc`. The rebased head passes the full backend battery and Git/dbt smokes. It has no new scale measurement. The tables retain their measured heads.

### Round 3 measurement review, 2026-09-08

All eight watcher-owned runs complete at 00:10:37 UTC. Treatment is 9d3bd964519929daa3b0b6b0e6629444c2506717. Control is its unchanged parent tree at fe768c1e436ea1c971d34acbdf28b1078f28b1ed. The parent rechecks raw results, current source/helper hashes against recorded hashes, all 14 source hashes and remote commits, fixture equality, caps, heap flags, two-minute preflights, output fingerprints, cache modes and external probes including trailing windows. All checks pass. No OOM, cgroup ceiling hit or swap peak occurs. The review and 72 evidence hashes are saved in spk1937-round3-measurement-review.json.

Each row covers both compiles. Cgroup peaks are kernel whole-process peaks. CPU includes the measured cgroup's children. Each compile returns 10,006 explores and zero errors. W saves 13 chunks per compile; WJ saves 37. Full per-compile tables and start/end resident-process snapshots remain below in the PR draft and in the rig report. The table repeats host context beside each resource result.

| Arm/run | Wall s | CPU s | Heap MiB | Cgroup MiB | Unanswered s | Trailing s | Host load 1/5/15 min, start → end; other processes |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| W-before-1 | 250.7 | 689.0 | 1985 | 3788 | 13.9 | 1.2 | 5.49/8.06/7.63 → 8.52/8.90/8.14; indexer present throughout; other agent processes resident |
| W-after-1 | 217.1 | 681.4 | 1985 | 4211 | 14.2 | 0.7 | 1.53/4.99/6.73 → 2.98/4.36/6.14; indexer present at start, absent at end; other agent processes resident |
| WJ-before-1 | 280.3 | 836.8 | 2706 | 6650 | 16.3 | 0.4 | 0.55/2.05/4.73 → 3.63/3.18/4.52; no indexer in start/end snapshots; other agent processes resident |
| WJ-after-1 | 287.9 | 816.5 | 2842 | 6742 | 22.2 | 0.9 | 0.23/1.53/3.50 → 4.56/3.35/3.77; no indexer in start/end snapshots; other agent processes resident |
| W-before-2 | 208.2 | 662.8 | 1982 | 4036 | 13.4 | 1.2 | 0.38/1.79/3.03 → 4.50/3.41/3.44; no indexer in start/end snapshots; other agent processes resident |
| W-after-2 | 205.8 | 655.3 | 1999 | 4195 | 13.9 | 0.5 | 0.30/1.62/2.68 → 3.01/2.66/2.90; no indexer in start/end snapshots; other agent processes resident |
| WJ-before-2 | 278.8 | 817.8 | 2706 | 6634 | 13.9 | 0.4 | 0.21/1.20/2.23 → 5.31/3.49/2.92; indexer absent at start, present at end; other agent processes resident |
| WJ-after-2 | 279.8 | 813.3 | 2738 | 6770 | 19.2 | 0.6 | 1.24/2.24/2.54 → 4.92/4.45/3.46; indexer present throughout; other agent processes resident |

Content fingerprint W: `0693f5008b4454a482b8160f0ee1a329eebd94bb37792b216e8d6b043ee8a55b`.

Content fingerprint WJ: `c1f46391b8c12a82280cafe7c9e1297c89a80ba4c7ab3d836769287d2d42b4fc`.

Order fingerprint for all 16 compiles: `9e8be9036d11fd55400e65d6290195443570bb586e66940d80aca8e49078f633`.

All treatment cold compiles use 14 fresh clones and 14 fresh dependency runs. All treatment warm compiles reuse all 14 checkouts and dependency results. Controls stay fresh. Retained entries stay below the default 2 GiB retention bound.

The performance result is mixed. W repetition 1 overlaps an indexer that exits during treatment. Its larger wall reduction cannot isolate the cache effect. W repetition 2 has no indexer in either endpoint snapshot. Its warm compile changes from 101.9 s wall / 335.0 s CPU to 97.3 s / 317.6 s. Its warm source fetch changes from 56.1 s to 50.1 s. This is one less-contended comparison, not a general speed estimate.

WJ warm source fetch changes from 52.9 s to 50.7 s in repetition 1 and 55.0 s to 53.6 s in repetition 2. Warm compile wall changes from 134.2 s to 137.4 s, then from 137.6 s to 134.7 s. Whole-pair wall increases in both WJ repetitions. Whole-pair CPU decreases in all four comparisons. Kernel cgroup peaks increase in all four comparisons. These runs do not establish a memory reduction or a consistent end-to-end wall improvement.

WJ treatment cold health gaps rise from 16.3 s to 22.2 s and from 13.9 s to 19.2 s. Warm WJ gaps remain 13.2 s. Raw probe intervals place the longest gaps across catalog fetch completion, type attachment and conversion start in every run. They do not overlap Git fetching or adapter destruction. This identifies the observed interval, not the cause of the longer treatment gaps. The result does not establish a liveness fix. No causal regression diagnosis is claimed from two repetitions.

Local file remotes do not measure network clone latency. The fixtures have no declared packages and measure only skipped no-package dependency startup. Downloaded-package reuse time remains unmeasured here. Service wiring, production storage behavior and multi-pod removal timing retain the stated code-read limits. The separate credential-rotation smoke passes. Historical S11 cost stays explicitly tied to 05f5b17cb8.

No further scale run is owed for this round. The pre-PR handoff is complete with mixed performance evidence. No product code changes or repeated test battery are needed for this documentation update. That round-3 checkpoint remains historical. Later branch and verification states are recorded in the round 5 sections. The local PR stays unpublished for the orchestrator's PR gate. No ready or merge action occurs.

Control parent: `fe768c1e436ea1c971d34acbdf28b1078f28b1ed`. Treatment: `9d3bd964519929daa3b0b6b0e6629444c2506717`. The frozen control archive has the same full source tree as the parent. Both variants use the same 14 local Git remotes. Each run includes one cold compile and one warm compile. W uses an 8 GiB cap and the default heap. WJ uses a 10 GiB cap and `--max-old-space-size=8124`. Repetitions alternate control and treatment. Each run requires cap plus 2 GiB available for two minutes and 6 GiB free disk.

Start: Mon Sep  7 23:07:04 UTC 2026; load 5.49 8.06 7.63 15/2043 2350; MemAvailable:   19047820 kB.

End: Mon Sep  7 23:11:15 UTC 2026; load 8.52 8.90 8.14 7/2024 4613; MemAvailable:   18509848 kB.

| Run scope | Wall (s) | CPU (s) | Node heap peak (MiB) | Cgroup peak (MiB) | Unanswered probe (s) | Trailing window (s) |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| `spk1937-git-W-before-1` whole pair | 250.7 | 689.0 | 1985 | 3788 | 13.9 | 1.2 |

The kernel peak and external trailing window cover both compiles. The next table uses sampled cgroup peaks and probe gaps clipped to each compile. It does not reset the kernel peak.

| Compile | Wall (s) | CPU (s) | Node heap peak (MiB) | Sampled cgroup peak (MiB) | Unanswered within compile (s) | Chunks | Explores | Fingerprint |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| cold | 124.3 | 340.8 | 1962 | 3613 | 13.9 | 13 | 10006 | `0693f5008b4454a482b8160f0ee1a329eebd94bb37792b216e8d6b043ee8a55b` |
| warm | 123.7 | 344.6 | 1985 | 3785 | 13.2 | 13 | 10006 | `0693f5008b4454a482b8160f0ee1a329eebd94bb37792b216e8d6b043ee8a55b` |

Compile 1: all 14 clone modes are fresh. All 14 deps modes are fresh. Source fetch takes 74.9 s. The cache retains 0 entries and 0 bytes. Error count is 0. Order fingerprint: `9e8be9036d11fd55400e65d6290195443570bb586e66940d80aca8e49078f633`.

Compile 2: all 14 clone modes are fresh. All 14 deps modes are fresh. Source fetch takes 75.8 s. The cache retains 0 entries and 0 bytes. Error count is 0. Order fingerprint: `9e8be9036d11fd55400e65d6290195443570bb586e66940d80aca8e49078f633`.

Start: Mon Sep  7 23:15:31 UTC 2026; load 1.53 4.99 6.73 2/2009 5553; MemAvailable:   14159636 kB.

End: Mon Sep  7 23:19:08 UTC 2026; load 2.98 4.36 6.14 1/1979 7533; MemAvailable:   20497496 kB.

| Run scope | Wall (s) | CPU (s) | Node heap peak (MiB) | Cgroup peak (MiB) | Unanswered probe (s) | Trailing window (s) |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| `spk1937-git-W-after-1` whole pair | 217.1 | 681.4 | 1985 | 4211 | 14.2 | 0.7 |

The kernel peak and external trailing window cover both compiles. The next table uses sampled cgroup peaks and probe gaps clipped to each compile. It does not reset the kernel peak.

| Compile | Wall (s) | CPU (s) | Node heap peak (MiB) | Sampled cgroup peak (MiB) | Unanswered within compile (s) | Chunks | Explores | Fingerprint |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| cold | 106.3 | 340.9 | 1957 | 3674 | 14.0 | 13 | 10006 | `0693f5008b4454a482b8160f0ee1a329eebd94bb37792b216e8d6b043ee8a55b` |
| warm | 108.2 | 336.7 | 1985 | 4210 | 14.2 | 13 | 10006 | `0693f5008b4454a482b8160f0ee1a329eebd94bb37792b216e8d6b043ee8a55b` |

Compile 1: all 14 clone modes are fresh. All 14 deps modes are fresh. Source fetch takes 57.8 s. The cache retains 14 entries and 173578293 bytes. Error count is 0. Order fingerprint: `9e8be9036d11fd55400e65d6290195443570bb586e66940d80aca8e49078f633`.

Compile 2: all 14 clone modes are reused. All 14 deps modes are reused. Source fetch takes 50.9 s. The cache retains 14 entries and 173269897 bytes. Error count is 0. Order fingerprint: `9e8be9036d11fd55400e65d6290195443570bb586e66940d80aca8e49078f633`.

Start: Mon Sep  7 23:23:23 UTC 2026; load 0.55 2.05 4.73 2/1974 8471; MemAvailable:   20901356 kB.

End: Mon Sep  7 23:28:04 UTC 2026; load 3.63 3.18 4.52 3/1962 11252; MemAvailable:   20296872 kB.

| Run scope | Wall (s) | CPU (s) | Node heap peak (MiB) | Cgroup peak (MiB) | Unanswered probe (s) | Trailing window (s) |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| `spk1937-git-WJ-before-1` whole pair | 280.3 | 836.8 | 2706 | 6650 | 16.3 | 0.4 |

The kernel peak and external trailing window cover both compiles. The next table uses sampled cgroup peaks and probe gaps clipped to each compile. It does not reset the kernel peak.

| Compile | Wall (s) | CPU (s) | Node heap peak (MiB) | Sampled cgroup peak (MiB) | Unanswered within compile (s) | Chunks | Explores | Fingerprint |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| cold | 143.3 | 423.4 | 2706 | 4476 | 16.3 | 37 | 10006 | `c1f46391b8c12a82280cafe7c9e1297c89a80ba4c7ab3d836769287d2d42b4fc` |
| warm | 134.2 | 409.5 | 2670 | 6646 | 13.2 | 37 | 10006 | `c1f46391b8c12a82280cafe7c9e1297c89a80ba4c7ab3d836769287d2d42b4fc` |

Compile 1: all 14 clone modes are fresh. All 14 deps modes are fresh. Source fetch takes 54.3 s. The cache retains 0 entries and 0 bytes. Error count is 0. Order fingerprint: `9e8be9036d11fd55400e65d6290195443570bb586e66940d80aca8e49078f633`.

Compile 2: all 14 clone modes are fresh. All 14 deps modes are fresh. Source fetch takes 52.9 s. The cache retains 0 entries and 0 bytes. Error count is 0. Order fingerprint: `9e8be9036d11fd55400e65d6290195443570bb586e66940d80aca8e49078f633`.

Start: Mon Sep  7 23:32:19 UTC 2026; load 0.23 1.53 3.50 2/1962 12145; MemAvailable:   20903652 kB.

End: Mon Sep  7 23:37:07 UTC 2026; load 4.56 3.35 3.77 1/1963 14510; MemAvailable:   20445120 kB.

| Run scope | Wall (s) | CPU (s) | Node heap peak (MiB) | Cgroup peak (MiB) | Unanswered probe (s) | Trailing window (s) |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| `spk1937-git-WJ-after-1` whole pair | 287.9 | 816.5 | 2842 | 6742 | 22.2 | 0.9 |

The kernel peak and external trailing window cover both compiles. The next table uses sampled cgroup peaks and probe gaps clipped to each compile. It does not reset the kernel peak.

| Compile | Wall (s) | CPU (s) | Node heap peak (MiB) | Sampled cgroup peak (MiB) | Unanswered within compile (s) | Chunks | Explores | Fingerprint |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| cold | 147.7 | 428.6 | 2740 | 4464 | 22.2 | 37 | 10006 | `c1f46391b8c12a82280cafe7c9e1297c89a80ba4c7ab3d836769287d2d42b4fc` |
| warm | 137.4 | 384.0 | 2842 | 6740 | 13.2 | 37 | 10006 | `c1f46391b8c12a82280cafe7c9e1297c89a80ba4c7ab3d836769287d2d42b4fc` |

Compile 1: all 14 clone modes are fresh. All 14 deps modes are fresh. Source fetch takes 54.1 s. The cache retains 14 entries and 178008678 bytes. Error count is 0. Order fingerprint: `9e8be9036d11fd55400e65d6290195443570bb586e66940d80aca8e49078f633`.

Compile 2: all 14 clone modes are reused. All 14 deps modes are reused. Source fetch takes 50.7 s. The cache retains 14 entries and 177700079 bytes. Error count is 0. Order fingerprint: `9e8be9036d11fd55400e65d6290195443570bb586e66940d80aca8e49078f633`.

Start: Mon Sep  7 23:41:22 UTC 2026; load 0.38 1.79 3.03 1/1962 15451; MemAvailable:   20900396 kB.

End: Mon Sep  7 23:44:51 UTC 2026; load 4.50 3.41 3.44 1/1966 17620; MemAvailable:   20496928 kB.

| Run scope | Wall (s) | CPU (s) | Node heap peak (MiB) | Cgroup peak (MiB) | Unanswered probe (s) | Trailing window (s) |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| `spk1937-git-W-before-2` whole pair | 208.2 | 662.8 | 1982 | 4036 | 13.4 | 1.2 |

The kernel peak and external trailing window cover both compiles. The next table uses sampled cgroup peaks and probe gaps clipped to each compile. It does not reset the kernel peak.

| Compile | Wall (s) | CPU (s) | Node heap peak (MiB) | Sampled cgroup peak (MiB) | Unanswered within compile (s) | Chunks | Explores | Fingerprint |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| cold | 103.7 | 324.1 | 1968 | 3711 | 13.4 | 13 | 10006 | `0693f5008b4454a482b8160f0ee1a329eebd94bb37792b216e8d6b043ee8a55b` |
| warm | 101.9 | 335.0 | 1982 | 4033 | 13.2 | 13 | 10006 | `0693f5008b4454a482b8160f0ee1a329eebd94bb37792b216e8d6b043ee8a55b` |

Compile 1: all 14 clone modes are fresh. All 14 deps modes are fresh. Source fetch takes 55.7 s. The cache retains 0 entries and 0 bytes. Error count is 0. Order fingerprint: `9e8be9036d11fd55400e65d6290195443570bb586e66940d80aca8e49078f633`.

Compile 2: all 14 clone modes are fresh. All 14 deps modes are fresh. Source fetch takes 56.1 s. The cache retains 0 entries and 0 bytes. Error count is 0. Order fingerprint: `9e8be9036d11fd55400e65d6290195443570bb586e66940d80aca8e49078f633`.

Start: Mon Sep  7 23:49:06 UTC 2026; load 0.30 1.62 2.68 2/1963 18550; MemAvailable:   20893476 kB.

End: Mon Sep  7 23:52:32 UTC 2026; load 3.01 2.66 2.90 2/1962 20515; MemAvailable:   20354796 kB.

| Run scope | Wall (s) | CPU (s) | Node heap peak (MiB) | Cgroup peak (MiB) | Unanswered probe (s) | Trailing window (s) |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| `spk1937-git-W-after-2` whole pair | 205.8 | 655.3 | 1999 | 4195 | 13.9 | 0.5 |

The kernel peak and external trailing window cover both compiles. The next table uses sampled cgroup peaks and probe gaps clipped to each compile. It does not reset the kernel peak.

| Compile | Wall (s) | CPU (s) | Node heap peak (MiB) | Sampled cgroup peak (MiB) | Unanswered within compile (s) | Chunks | Explores | Fingerprint |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| cold | 105.8 | 333.9 | 1981 | 3748 | 13.9 | 13 | 10006 | `0693f5008b4454a482b8160f0ee1a329eebd94bb37792b216e8d6b043ee8a55b` |
| warm | 97.3 | 317.6 | 1999 | 4195 | 13.5 | 13 | 10006 | `0693f5008b4454a482b8160f0ee1a329eebd94bb37792b216e8d6b043ee8a55b` |

Compile 1: all 14 clone modes are fresh. All 14 deps modes are fresh. Source fetch takes 56.3 s. The cache retains 14 entries and 173588575 bytes. Error count is 0. Order fingerprint: `9e8be9036d11fd55400e65d6290195443570bb586e66940d80aca8e49078f633`.

Compile 2: all 14 clone modes are reused. All 14 deps modes are reused. Source fetch takes 50.1 s. The cache retains 14 entries and 173280092 bytes. Error count is 0. Order fingerprint: `9e8be9036d11fd55400e65d6290195443570bb586e66940d80aca8e49078f633`.

Start: Mon Sep  7 23:56:47 UTC 2026; load 0.21 1.20 2.23 2/1963 21622; MemAvailable:   20900408 kB.

End: Tue Sep  8 00:01:26 UTC 2026; load 5.31 3.49 2.92 3/2053 25091; MemAvailable:   19329736 kB.

| Run scope | Wall (s) | CPU (s) | Node heap peak (MiB) | Cgroup peak (MiB) | Unanswered probe (s) | Trailing window (s) |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| `spk1937-git-WJ-before-2` whole pair | 278.8 | 817.8 | 2706 | 6634 | 13.9 | 0.4 |

The kernel peak and external trailing window cover both compiles. The next table uses sampled cgroup peaks and probe gaps clipped to each compile. It does not reset the kernel peak.

| Compile | Wall (s) | CPU (s) | Node heap peak (MiB) | Sampled cgroup peak (MiB) | Unanswered within compile (s) | Chunks | Explores | Fingerprint |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| cold | 138.4 | 407.1 | 2706 | 4465 | 13.9 | 37 | 10006 | `c1f46391b8c12a82280cafe7c9e1297c89a80ba4c7ab3d836769287d2d42b4fc` |
| warm | 137.6 | 406.7 | 2702 | 6621 | 13.2 | 37 | 10006 | `c1f46391b8c12a82280cafe7c9e1297c89a80ba4c7ab3d836769287d2d42b4fc` |

Compile 1: all 14 clone modes are fresh. All 14 deps modes are fresh. Source fetch takes 52.3 s. The cache retains 0 entries and 0 bytes. Error count is 0. Order fingerprint: `9e8be9036d11fd55400e65d6290195443570bb586e66940d80aca8e49078f633`.

Compile 2: all 14 clone modes are fresh. All 14 deps modes are fresh. Source fetch takes 55.0 s. The cache retains 0 entries and 0 bytes. Error count is 0. Order fingerprint: `9e8be9036d11fd55400e65d6290195443570bb586e66940d80aca8e49078f633`.

Start: Tue Sep  8 00:05:42 UTC 2026; load 1.24 2.24 2.54 5/2046 27635; MemAvailable:   19724248 kB.

End: Tue Sep  8 00:10:21 UTC 2026; load 4.92 4.45 3.46 3/2052 30381; MemAvailable:   19040112 kB.

| Run scope | Wall (s) | CPU (s) | Node heap peak (MiB) | Cgroup peak (MiB) | Unanswered probe (s) | Trailing window (s) |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| `spk1937-git-WJ-after-2` whole pair | 279.8 | 813.3 | 2738 | 6770 | 19.2 | 0.6 |

The kernel peak and external trailing window cover both compiles. The next table uses sampled cgroup peaks and probe gaps clipped to each compile. It does not reset the kernel peak.

| Compile | Wall (s) | CPU (s) | Node heap peak (MiB) | Sampled cgroup peak (MiB) | Unanswered within compile (s) | Chunks | Explores | Fingerprint |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| cold | 142.3 | 424.3 | 2738 | 4000 | 19.2 | 37 | 10006 | `c1f46391b8c12a82280cafe7c9e1297c89a80ba4c7ab3d836769287d2d42b4fc` |
| warm | 134.7 | 385.0 | 2670 | 6761 | 13.2 | 37 | 10006 | `c1f46391b8c12a82280cafe7c9e1297c89a80ba4c7ab3d836769287d2d42b4fc` |

Compile 1: all 14 clone modes are fresh. All 14 deps modes are fresh. Source fetch takes 57.2 s. The cache retains 14 entries and 178008718 bytes. Error count is 0. Order fingerprint: `9e8be9036d11fd55400e65d6290195443570bb586e66940d80aca8e49078f633`.

Compile 2: all 14 clone modes are reused. All 14 deps modes are reused. Source fetch takes 53.6 s. The cache retains 14 entries and 177700157 bytes. Error count is 0. Order fingerprint: `9e8be9036d11fd55400e65d6290195443570bb586e66940d80aca8e49078f633`.

All eight runs pass the count, order, content and cache-mode checks. Local remotes do not measure network clone time. The fixtures measure no-package deps startup only.

## Historical round 4 validation

The round 4 validation head is b6270ce93fbb0c044ef342d10ad831ef5197aed8. The full backend battery runs once and passes. The suite passes 593 files and 9,861 tests. One test is an expected failure. One test is skipped. The test command takes 215.51 s. Typecheck, package lint and oxfmt pass on all nine paths changed in round 4.

The actual Git/dbt smoke passes control, treatment and credential-rotation arms. Control uses a fresh checkout twice. Treatment uses fresh clone and dependencies first, then reuses both. The credential arm rotates the installation token and credential store. The server accepts the new token. The second compile reports depsMode=reused. FETCH_HEAD checks and all owned cleanup pass.

The separate abort smoke runs one named test against a real authenticated HTTP Git remote. It blocks an active cached fetch. Lease invalidation closes the request. The same operation recovers from a fresh checkout. Exactly one test file and one test pass.

Named cache tests prove that a slow or failed victim deletion preserves the fresh checkout. They cover multiple victims and lease cleanup after rename failure. Version tests cover timeout, cooldown, retry and late results. Real Git failures produce the expected user messages without credentials. Child lifecycle tests prevent group kill after exit or signal termination.

These round 4 checks remain historical. The current verification and measurement heads are recorded in the round 5 sections. The eight earlier scale runs measure 9d3bd964519929daa3b0b6b0e6629444c2506717. They are historical evidence. They do not measure the final head. This draft remains local for the orchestrator to publish.

### Private S11 inspection-cost measurement

This cost is measured at 05f5b17cb8f7f6f38c763995371ce1b9707a8efc, before the round 3 fixes. It is not a measurement of the round 3 head.

One cold W source pass measures 236.125 ms in the combined inspection across 14 retained checkouts. Total adapter destruction takes 502.035 ms. Git/dbt source setup takes 249.880 s. Sources run serially. This is a summed inspection cost. It does not measure parallel cleanup wall time or a before/after full compile. The pass returns 10,006 models. It does not merge, convert or save explores.

Host load changes from 0.96/2.56/2.97 to 3.34/3.00/3.05. Java and other agent processes remain resident. An indexing process appears during the run and uses one CPU core. This is not a quiet-host result.

| Scope | Wall (s) | CPU (s) | Sampled Node heap peak (MiB) | Kernel cgroup peak (MiB) | Unanswered probe (s) | Trailing window (s) |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Serial cold W source pass | 253.099 | 256.338 | 452.6 | 1721.2 | 1.104 | 0.594 |

The watcher checks 10 GiB available memory for two minutes and 6 GiB free disk. The process uses the W 8 GiB cap and the default heap. No OOM occurs. This result does not replace the eight full scale runs.

## Not measured here

The eight local file-remote runs do not measure network clone latency or package downloads. The round 5 network runs measure one pinned public package through scoped shaping. They do not measure provider outages, private upstream authentication, or production repository payloads. Focused tests and Git/dbt smokes exercise credential rotation.

The rig calls the actual Git adapter and dbt client. It uses the established common compile and chunk-save replay. It does not run ProjectService, publish a merged manifest, emit analytics or validate job envelopes. The rig pools all 14 fetches. The service fetches the primary before its additional-source pool. Service wiring, deletion, ownership and fallback have named tests and code-read review.

Whole-pair kernel memory peak and probe windows are not warm-only measurements. Per-compile cgroup peaks are sampled from the process series. Production disk behavior and multi-pod removal timing remain code-read.

### Final pre-measurement fix batch

Head: `e1805efc1901b27776beaaba4a2bba58e31a82dc`. The cache file passes 55 named tests. The Git version file passes 8 named tests. Backend typecheck, touched-path lint and oxfmt pass. This small batch follows the requested named-test loop. At this pre-measurement checkpoint, the full backend battery and Git/dbt smokes remain historical at b6270ce93f. The round 5 measurements below record this pre-rebase head. The final rebase validation appears at the end.

## Round 5 diagnostic results

Treatment: `e1805efc1901b27776beaaba4a2bba58e31a82dc`. Control: `fe768c1e436ea1c971d34acbdf28b1078f28b1ed`, through the tree-identical frozen archive. Both use the same old WJ fixtures, 10 GiB cgroup cap, heap 8124 MiB, preload instrumentation and V8 CPU profiler. These are two targeted diagnostic runs, not replacements for the eight uninstrumented runs at `9d3bd96451`.

The historical treatment-only increase does not reproduce. The cold catalog takes 14.217 s in treatment and 18.585 s in control. The catalog returns 254,098 column rows for 10,006 requested tables. Synchronous mapping after query completion takes 12.492 s and 17.184 s. The existing mapping scans `requests.find` for each returned column. CPU samples concentrate in that reduction and its callback. This identifies the blocking work in these runs. It does not prove the cause of the historical additional four to five seconds. The direction reverses on the shared host.

| Cold catalog interval | Treatment s | Control s |
| --- | ---: | ---: |
| Query and buffered rows | 1.693 | 1.358 |
| Mapping after query | 12.492 | 17.184 |
| Observed GC overlap | 0.112 | 0.094 |

These rows contain elapsed time, not memory measurements. Host snapshots and full process metrics follow. Instrumentation adds overhead; the profiles sample wall-clock occupancy and cannot separate CPU descheduling from application execution. No product change follows from this diagnosis.

### spk1937-round5-diag-WJ-after-1

Source commit: `e1805efc1901b27776beaaba4a2bba58e31a82dc`.

host: Tue Sep  8 07:43:20 UTC 2026; load 4.72 4.15 4.25 13/2090 18679; MemAvailable:   18519912 kB. Other resident processes: mempalace PID 22618: 134% CPU, 2125244 KiB RSS; claude PID 16534: 1.4% CPU, 555976 KiB RSS; claude PID 31868: 2.0% CPU, 483620 KiB RSS; claude PID 488: 1.9% CPU, 480436 KiB RSS; claude PID 4215: 1.7% CPU, 466856 KiB RSS; claude PID 9011: 1.5% CPU, 446588 KiB RSS; claude PID 21078: 1.2% CPU, 439128 KiB RSS; claude PID 8789: 1.5% CPU, 406360 KiB RSS.

host-end: Tue Sep  8 07:48:40 UTC 2026; load 12.47 8.75 6.21 6/2113 22927; MemAvailable:   18051696 kB. Other resident processes: mempalace PID 22618: 175% CPU, 2142916 KiB RSS; claude PID 16534: 1.4% CPU, 551248 KiB RSS; claude PID 488: 1.9% CPU, 473912 KiB RSS; claude PID 31868: 2.0% CPU, 469504 KiB RSS; claude PID 4215: 1.7% CPU, 453280 KiB RSS; claude PID 9011: 1.5% CPU, 440016 KiB RSS; claude PID 21078: 1.2% CPU, 430904 KiB RSS; claude PID 7630: 1.4% CPU, 396976 KiB RSS.

| Scope | Wall s | CPU s | Node heap peak MiB | Kernel cgroup peak MiB | Longest unanswered s | Trailing s |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Whole process, cold + warm | 320.8 | 819.0 | 2753 | 6772 | 14.6 | 1.1 |

The same host snapshot applies to the next table. Per-compile cgroup peaks are sampled, not reset kernel peaks. Probe gaps are clipped to each compile; the whole-process row includes the trailing window.

| Compile | Wall s | CPU s | Node heap peak MiB | Sampled cgroup peak MiB | Unanswered s | Source fetch s | Chunks | Explores |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| cold | 156.2 | 418.9 | 2753 | 4553 | 14.6 | 83.7 | 37 | 10006 |
| warm | 160.8 | 395.4 | 2711 | 6759 | 13.5 | 80.3 | 37 | 10006 |

Both compiles return 14 sources, zero errors, and fingerprint `c1f46391b8c12a82280cafe7c9e1297c89a80ba4c7ab3d836769287d2d42b4fc`. Order fingerprint: `9e8be9036d11fd55400e65d6290195443570bb586e66940d80aca8e49078f633`. No cgroup ceiling event or OOM occurs.

cold: all clone modes `fresh`; all dependency modes `fresh`; retained entries 14.

warm: all clone modes `reused`; all dependency modes `reused`; retained entries 14.

### spk1937-round5-diag-WJ-before-1

Source commit: `fe768c1e436ea1c971d34acbdf28b1078f28b1ed`.

host: Tue Sep  8 07:50:42 UTC 2026; load 6.20 7.59 6.10 7/2147 24465; MemAvailable:   18452920 kB. Other resident processes: mempalace PID 22618: 188% CPU, 2152728 KiB RSS; claude PID 16534: 1.4% CPU, 551308 KiB RSS; claude PID 488: 1.9% CPU, 473912 KiB RSS; claude PID 31868: 2.0% CPU, 469504 KiB RSS; claude PID 4215: 1.7% CPU, 453728 KiB RSS; claude PID 9011: 1.5% CPU, 440508 KiB RSS; claude PID 21078: 1.2% CPU, 431088 KiB RSS; claude PID 7630: 1.4% CPU, 402196 KiB RSS.

host-end: Tue Sep  8 07:55:56 UTC 2026; load 11.06 9.94 7.59 8/2182 27963; MemAvailable:   16416436 kB. Other resident processes: mempalace PID 22618: 212% CPU, 2188808 KiB RSS; MainThread PID 27801: 40.7% CPU, 968472 KiB RSS; MainThread PID 27769: 37.1% CPU, 923292 KiB RSS; claude PID 16534: 1.4% CPU, 547920 KiB RSS; claude PID 488: 1.9% CPU, 474164 KiB RSS; claude PID 31868: 2.0% CPU, 468224 KiB RSS; claude PID 4215: 1.7% CPU, 458756 KiB RSS; claude PID 9011: 1.5% CPU, 440428 KiB RSS.

| Scope | Wall s | CPU s | Node heap peak MiB | Kernel cgroup peak MiB | Longest unanswered s | Trailing s |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Whole process, cold + warm | 313.9 | 836.9 | 2778 | 6619 | 19.2 | 0.6 |

The same host snapshot applies to the next table. Per-compile cgroup peaks are sampled, not reset kernel peaks. Probe gaps are clipped to each compile; the whole-process row includes the trailing window.

| Compile | Wall s | CPU s | Node heap peak MiB | Sampled cgroup peak MiB | Unanswered s | Source fetch s | Chunks | Explores |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| cold | 156.7 | 420.7 | 2778 | 4551 | 19.2 | 81.5 | 37 | 10006 |
| warm | 154.0 | 411.8 | 2736 | 6611 | 13.2 | 81.2 | 37 | 10006 |

Both compiles return 14 sources, zero errors, and fingerprint `c1f46391b8c12a82280cafe7c9e1297c89a80ba4c7ab3d836769287d2d42b4fc`. Order fingerprint: `9e8be9036d11fd55400e65d6290195443570bb586e66940d80aca8e49078f633`. No cgroup ceiling event or OOM occurs.

cold: all clone modes `fresh`; all dependency modes `fresh`; retained entries 0.

warm: all clone modes `fresh`; all dependency modes `fresh`; retained entries 0.

### Diagnosis review before network execution

Both profile clocks cover their complete catalog window (sample-time/window ratios 1.000012 and 1.000015). Neither trace drops critical events. No Git/dbt child lifetime or output-drain boundary overlaps either cold catalog window. Treatment records 50 asynchronous lease heartbeat filesystem operations there, with summed operation duration 57.24 ms and maximum 7.744 ms; these sums overlap and are not CPU time. No checkout inspection bucket overlaps the window. Cache inspection occurs after save. These observations rule out a direct multi-second inspection or child-drain block in the observed windows. They do not rule out earlier allocation or optimization effects in the historical runs.

Treatment drops 1,954 cache-detail events over the whole run when its separate detail budget fills. Checkout aggregate buckets and critical events do not drop. That limits whole-run detailed filesystem reconstruction. GC pauses total 112 ms in treatment and 94 ms in control, so observed GC does not explain a multi-second difference. Source-entry heap is similar in the historical runs. The remaining historical explanation is unresolved: JIT/optimization state, scheduling contention, or another earlier allocation effect could alter the same synchronous mapping path. No second instrumented repetition or quiet-host comparison is available.

Decision: proceed to the requested network pair without product edits. The existing per-column linear request lookup is pre-existing code. It is not changed within this cache ticket. Keep the earlier mixed local verdict.

## Round 5 network measurements

Measurement head: `e1805efc1901b27776beaaba4a2bba58e31a82dc`. Control: `fe768c1e436ea1c971d34acbdf28b1078f28b1ed`, through its tree-identical frozen archive. These measurements precede the requested rebase. The eight earlier local runs remain tied to `9d3bd964519929daa3b0b6b0e6629444c2506717`.

### Shape and proof

The private Smart HTTP server adds 40 ms before forwarding each request and 40 ms before returning response headers. This adds about 80 ms of round-trip delay. One shared FIFO pacer caps request and response bodies together at 50,000,000 bits/s. It writes at most 16 KiB per slice. It serves the same 14 compact source remotes to control and treatment. It forwards package Git requests to live GitHub. It does not serve a package mirror.

Each fixture adds only `packages.yml`. It pins the canonical `https://github.com/dbt-labs/dbt-utils.git` URL at commit `423277393abcd0f3827e30bdbe5c896bfa833239`. All 28 derived source refs, trees, one-path diffs and lineage checks pass. The new fixture pair is `0a5839ead32006c0e7bf2f053417f5db11768a0ef0e3ac7ca88e29c072a441b5`.

The self-check measures 46.52 Mbit/s for two concurrent 4 MiB transfers. Shaped ping takes 84.53 ms median. Unshaped ping takes 1.37 ms median. The added median delay is 83.16 ms. The same transport helper and settings serve every measured run. No global Git or network setting changes.

The independent evidence check passes all eight compiles and all 112 source package proofs. Each installed package has 234 tracked files and 277,853 bytes. The tracked byte-and-mode hash is `59b2dca6eca12fb49700375d72d1662b35d7899b9b77c02fe7613c4a94146435`. Every proof checks the declaration, lock pin, installed Git HEAD and canonical origin. Raw transport byte ranges reconcile with each compile's reported counts.

Each cold compile and each control warm compile makes 280 live package requests and receives about 6.80 MB of package response bytes. Both treatment warm compiles reuse all 14 checkouts and all 14 dependency sets. They make zero additional package requests and receive zero package bytes. Source update requests still occur. All fingerprints, order hashes, explore counts and error counts remain identical.

Each owned server exits normally. Its port refuses connections. Its cgroup is empty and removed. Loopback qdisc remains byte-identical. The transport runs in its own 512 MiB cgroup outside the application cgroup. Its CPU and memory are reported separately below.

### Verdict

The W warm compile falls from 144.3 to 137.8 seconds. Source fetch falls from 91.4 to 87.0 seconds. Warm CPU falls from 361.2 to 326.5 seconds. Cold wall time is nearly unchanged at 139.6 and 139.4 seconds. This repetition shows a modest W wall-time gain and a clear removal of package traffic.

The WJ warm compile falls from 300.1 to 132.6 seconds. Source fetch falls from 173.1 to 53.6 seconds. Warm CPU falls from 420.7 to 385.8 seconds. This large wall-time delta is confounded. Other Node workers run outside the control cgroup during its warm compile. Mid-run host load reaches 20.35. The treatment snapshot shows load 5.50. Control cold also takes 188.1 seconds while treatment cold takes 145.2 seconds, although both download packages. The full WJ wall-time gain cannot be assigned to reuse.

Warm CPU drops by about 35 seconds in both arms. Package reuse is directly verified. The wall-time estimate remains limited to one repetition per arm on a shared host. The combined evidence does not establish a general memory or health improvement. The eight earlier local tables keep their mixed verdict. These compact source repositories do not reproduce the clone payload or absolute clone time of a large self-hosted project.

The package-content verifier runs after save on both variants. Its measured time appears below. A 50 ms transport-log settling check follows source fetch. Source-fetch timing excludes that check. These checks add measurement work to both sides.

### spk1937-round5-net-W-before-1

Source commit: `fe768c1e436ea1c971d34acbdf28b1078f28b1ed`.

host: Tue Sep  8 08:00:24 UTC 2026; load 4.74 6.90 6.90 9/2170 30774; MemAvailable:   18222060 kB. Other resident processes: mempalace PID 22618: 228% CPU, 2311788 KiB RSS; claude PID 16534: 1.4% CPU, 547972 KiB RSS; claude PID 488: 1.9% CPU, 474444 KiB RSS; claude PID 31868: 2.0% CPU, 468288 KiB RSS; claude PID 4215: 1.7% CPU, 458912 KiB RSS; claude PID 9011: 1.5% CPU, 440476 KiB RSS; claude PID 21078: 1.2% CPU, 434608 KiB RSS; claude PID 7630: 1.4% CPU, 406076 KiB RSS.

host-end: Tue Sep  8 08:05:11 UTC 2026; load 8.25 8.08 7.44 7/2113 3967; MemAvailable:   18230860 kB. Other resident processes: mempalace PID 22618: 243% CPU, 2333116 KiB RSS; claude PID 16534: 1.4% CPU, 547972 KiB RSS; claude PID 488: 1.9% CPU, 474444 KiB RSS; claude PID 31868: 2.0% CPU, 468304 KiB RSS; claude PID 4215: 1.7% CPU, 458912 KiB RSS; claude PID 9011: 1.5% CPU, 444512 KiB RSS; claude PID 21078: 1.2% CPU, 434636 KiB RSS; claude PID 7630: 1.4% CPU, 406088 KiB RSS.

| Scope | Wall s | CPU s | Node heap peak MiB | Kernel cgroup peak MiB | Longest unanswered s | Trailing s |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Whole process, cold + warm | 286.6 | 716.3 | 1985 | 3581 | 14.4 | 0.3 |

The same host snapshot applies to the next table. Per-compile cgroup peaks are sampled, not reset kernel peaks. Probe gaps are clipped to each compile; the whole-process row includes the trailing window.

| Compile | Wall s | CPU s | Node heap peak MiB | Sampled cgroup peak MiB | Unanswered s | Source fetch s | Chunks | Explores |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| cold | 139.6 | 351.5 | 1961 | 3461 | 14.4 | 87.5 | 13 | 10006 |
| warm | 144.3 | 361.2 | 1985 | 3577 | 13.8 | 91.4 | 13 | 10006 |

Both compiles return 14 sources, zero errors, and fingerprint `0693f5008b4454a482b8160f0ee1a329eebd94bb37792b216e8d6b043ee8a55b`. Order fingerprint: `9e8be9036d11fd55400e65d6290195443570bb586e66940d80aca8e49078f633`. No cgroup ceiling event or OOM occurs.

cold: all clone modes `fresh`; all dependency modes `fresh`; retained entries 0.

warm: all clone modes `fresh`; all dependency modes `fresh`; retained entries 0.

| Compile | Live package requests | Live package response bytes | Package verification s |
| --- | ---: | ---: | ---: |
| cold | 280 | 6800888 | 0.327 |
| warm | 280 | 6800888 | 0.229 |

The owned transport runs outside the application cgroup on the same host. Its wall time includes the 120-second application preflight.

| Scope | Wall s | CPU s | Kernel cgroup peak MiB |
| --- | ---: | ---: | ---: |
| Transport | 407.274 | 3.375 | 33.582 |

The owned server exits normally. Its port refuses connections. Loopback qdisc remains byte-identical. No transport cgroup OOM or ceiling event occurs.

### spk1937-round5-net-W-after-1

Source commit: `e1805efc1901b27776beaaba4a2bba58e31a82dc`.

host: Tue Sep  8 08:07:12 UTC 2026; load 5.23 6.85 7.05 7/2108 4682; MemAvailable:   18337548 kB. Other resident processes: mempalace PID 22618: 247% CPU, 2303972 KiB RSS; claude PID 16534: 1.4% CPU, 547972 KiB RSS; claude PID 488: 1.9% CPU, 474444 KiB RSS; claude PID 31868: 2.0% CPU, 468320 KiB RSS; claude PID 4215: 1.7% CPU, 458920 KiB RSS; claude PID 9011: 1.5% CPU, 444512 KiB RSS; claude PID 21078: 1.2% CPU, 434648 KiB RSS; claude PID 7630: 1.4% CPU, 407352 KiB RSS.

host-end: Tue Sep  8 08:11:52 UTC 2026; load 12.60 9.41 8.03 8/2219 10202; MemAvailable:   17276556 kB. Other resident processes: mempalace PID 22618: 257% CPU, 2341308 KiB RSS; claude PID 16534: 1.4% CPU, 548008 KiB RSS; claude PID 488: 1.9% CPU, 474432 KiB RSS; claude PID 31868: 2.0% CPU, 468216 KiB RSS; claude PID 4215: 1.7% CPU, 459964 KiB RSS; claude PID 9011: 1.5% CPU, 444512 KiB RSS; claude PID 21078: 1.2% CPU, 436840 KiB RSS; claude PID 7630: 1.4% CPU, 407344 KiB RSS.

| Scope | Wall s | CPU s | Node heap peak MiB | Kernel cgroup peak MiB | Longest unanswered s | Trailing s |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Whole process, cold + warm | 280.1 | 685.4 | 2012 | 3797 | 14.5 | 1.1 |

The same host snapshot applies to the next table. Per-compile cgroup peaks are sampled, not reset kernel peaks. Probe gaps are clipped to each compile; the whole-process row includes the trailing window.

| Compile | Wall s | CPU s | Node heap peak MiB | Sampled cgroup peak MiB | Unanswered s | Source fetch s | Chunks | Explores |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| cold | 139.4 | 355.0 | 1981 | 3579 | 14.5 | 86.8 | 13 | 10006 |
| warm | 137.8 | 326.5 | 2012 | 3795 | 13.9 | 87.0 | 13 | 10006 |

Both compiles return 14 sources, zero errors, and fingerprint `0693f5008b4454a482b8160f0ee1a329eebd94bb37792b216e8d6b043ee8a55b`. Order fingerprint: `9e8be9036d11fd55400e65d6290195443570bb586e66940d80aca8e49078f633`. No cgroup ceiling event or OOM occurs.

cold: all clone modes `fresh`; all dependency modes `fresh`; retained entries 14.

warm: all clone modes `reused`; all dependency modes `reused`; retained entries 14.

| Compile | Live package requests | Live package response bytes | Package verification s |
| --- | ---: | ---: | ---: |
| cold | 280 | 6800853 | 0.259 |
| warm | 0 | 0 | 0.321 |

The owned transport runs outside the application cgroup on the same host. Its wall time includes the 120-second application preflight.

| Scope | Wall s | CPU s | Kernel cgroup peak MiB |
| --- | ---: | ---: | ---: |
| Transport | 400.804 | 2.247 | 30.059 |

The owned server exits normally. Its port refuses connections. Loopback qdisc remains byte-identical. No transport cgroup OOM or ceiling event occurs.

### spk1937-round5-net-WJ-before-1

Source commit: `fe768c1e436ea1c971d34acbdf28b1078f28b1ed`.

host: Tue Sep  8 08:13:53 UTC 2026; load 5.36 7.81 7.62 5/2224 12017; MemAvailable:   17781592 kB. Other resident processes: mempalace PID 22618: 261% CPU, 2345180 KiB RSS; claude PID 16534: 1.4% CPU, 548008 KiB RSS; claude PID 488: 1.9% CPU, 474448 KiB RSS; claude PID 31868: 2.0% CPU, 468216 KiB RSS; claude PID 4215: 1.7% CPU, 459964 KiB RSS; claude PID 9011: 1.5% CPU, 444512 KiB RSS; claude PID 21078: 1.2% CPU, 436848 KiB RSS; claude PID 7630: 1.4% CPU, 407356 KiB RSS.

host-end: Tue Sep  8 08:22:04 UTC 2026; load 17.29 14.67 10.83 14/2222 25636; MemAvailable:   16750912 kB. Other resident processes: mempalace PID 22618: 269% CPU, 2370832 KiB RSS; MainThread PID 17734: 13.2% CPU, 582960 KiB RSS; claude PID 16534: 1.4% CPU, 544612 KiB RSS; claude PID 31868: 2.0% CPU, 464056 KiB RSS; claude PID 488: 1.9% CPU, 460960 KiB RSS; claude PID 4215: 1.7% CPU, 456132 KiB RSS; claude PID 9011: 1.5% CPU, 444228 KiB RSS; claude PID 21078: 1.2% CPU, 435776 KiB RSS.

Additional mid-run host snapshot: 2026-09-08T08:19:56.194091+00:00; load 20.35 13.48 9.93 12/2247 22542. CPU-active processes: 22618 mempalace        268 2365624; 22499 MainThread      86.2 342564; 22464 MainThread      77.7 474872; 22507 MainThread      76.2 300820; 22515 MainThread      73.3 214552; 22542 python3         50.0 12560; 12027 MainThread      42.9 3490152. Columns are PID, command, CPU percent, RSS KiB. The control has a separate process-group snapshot that records other Node workers outside its application cgroup.

| Scope | Wall s | CPU s | Node heap peak MiB | Kernel cgroup peak MiB | Longest unanswered s | Trailing s |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Whole process, cold + warm | 491.1 | 851.8 | 3153 | 6942 | 17.3 | 0.9 |

The same host snapshot applies to the next table. Per-compile cgroup peaks are sampled, not reset kernel peaks. Probe gaps are clipped to each compile; the whole-process row includes the trailing window.

| Compile | Wall s | CPU s | Node heap peak MiB | Sampled cgroup peak MiB | Unanswered s | Source fetch s | Chunks | Explores |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| cold | 188.1 | 427.5 | 3153 | 4638 | 14.3 | 101.5 | 37 | 10006 |
| warm | 300.1 | 420.7 | 2653 | 6929 | 17.3 | 173.1 | 37 | 10006 |

Both compiles return 14 sources, zero errors, and fingerprint `c1f46391b8c12a82280cafe7c9e1297c89a80ba4c7ab3d836769287d2d42b4fc`. Order fingerprint: `9e8be9036d11fd55400e65d6290195443570bb586e66940d80aca8e49078f633`. No cgroup ceiling event or OOM occurs.

cold: all clone modes `fresh`; all dependency modes `fresh`; retained entries 0.

warm: all clone modes `fresh`; all dependency modes `fresh`; retained entries 0.

| Compile | Live package requests | Live package response bytes | Package verification s |
| --- | ---: | ---: | ---: |
| cold | 280 | 6801018 | 0.269 |
| warm | 280 | 6800938 | 1.115 |

The owned transport runs outside the application cgroup on the same host. Its wall time includes the 120-second application preflight.

| Scope | Wall s | CPU s | Kernel cgroup peak MiB |
| --- | ---: | ---: | ---: |
| Transport | 611.780 | 3.239 | 34.137 |

The owned server exits normally. Its port refuses connections. Loopback qdisc remains byte-identical. No transport cgroup OOM or ceiling event occurs.

### spk1937-round5-net-WJ-after-1

Source commit: `e1805efc1901b27776beaaba4a2bba58e31a82dc`.

host: Tue Sep  8 08:28:29 UTC 2026; load 3.17 7.63 9.08 3/2188 30477; MemAvailable:   16862876 kB. Other resident processes: mempalace PID 22618: 270% CPU, 3504672 KiB RSS; claude PID 16534: 1.4% CPU, 539188 KiB RSS; claude PID 31868: 2.0% CPU, 464180 KiB RSS; claude PID 488: 1.9% CPU, 461948 KiB RSS; claude PID 4215: 1.7% CPU, 461084 KiB RSS; claude PID 9011: 1.5% CPU, 444240 KiB RSS; claude PID 21078: 1.2% CPU, 437104 KiB RSS; claude PID 7630: 1.4% CPU, 407452 KiB RSS.

host-end: Tue Sep  8 08:33:10 UTC 2026; load 3.97 6.39 8.24 1/2101 1936; MemAvailable:   19919612 kB. Other resident processes: claude PID 16534: 1.4% CPU, 529436 KiB RSS; claude PID 31868: 2.0% CPU, 454332 KiB RSS; claude PID 4215: 1.7% CPU, 445524 KiB RSS; claude PID 488: 1.9% CPU, 444028 KiB RSS; claude PID 9011: 1.5% CPU, 441192 KiB RSS; claude PID 21078: 1.2% CPU, 423632 KiB RSS; claude PID 7630: 1.4% CPU, 392400 KiB RSS; claude PID 8572: 1.5% CPU, 385984 KiB RSS.

Additional mid-run host snapshot: 2026-09-08T08:30:36.072330+00:00; load 5.50 7.23 8.76 3/2190 32722. CPU-active processes: 22618 mempalace        265 7529432; 30488 MainThread      89.9 3264084; 32722 python3         60.0 12532; 32549 postgres        57.6 288300; 32721 bash            14.2  3468; 30497 python3         13.3 10032; 18999 claude           2.1 392940. Columns are PID, command, CPU percent, RSS KiB. The control has a separate process-group snapshot that records other Node workers outside its application cgroup.

| Scope | Wall s | CPU s | Node heap peak MiB | Kernel cgroup peak MiB | Longest unanswered s | Trailing s |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Whole process, cold + warm | 280.8 | 810.7 | 2735 | 6824 | 16.2 | 1.0 |

The same host snapshot applies to the next table. Per-compile cgroup peaks are sampled, not reset kernel peaks. Probe gaps are clipped to each compile; the whole-process row includes the trailing window.

| Compile | Wall s | CPU s | Node heap peak MiB | Sampled cgroup peak MiB | Unanswered s | Source fetch s | Chunks | Explores |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| cold | 145.2 | 420.9 | 2735 | 3753 | 16.2 | 61.5 | 37 | 10006 |
| warm | 132.6 | 385.8 | 2676 | 6820 | 13.2 | 53.6 | 37 | 10006 |

Both compiles return 14 sources, zero errors, and fingerprint `c1f46391b8c12a82280cafe7c9e1297c89a80ba4c7ab3d836769287d2d42b4fc`. Order fingerprint: `9e8be9036d11fd55400e65d6290195443570bb586e66940d80aca8e49078f633`. No cgroup ceiling event or OOM occurs.

cold: all clone modes `fresh`; all dependency modes `fresh`; retained entries 14.

warm: all clone modes `reused`; all dependency modes `reused`; retained entries 14.

| Compile | Live package requests | Live package response bytes | Package verification s |
| --- | ---: | ---: | ---: |
| cold | 280 | 6800868 | 0.240 |
| warm | 0 | 0 | 0.287 |

The owned transport runs outside the application cgroup on the same host. Its wall time includes the 120-second application preflight.

| Scope | Wall s | CPU s | Kernel cgroup peak MiB |
| --- | ---: | ---: | ---: |
| Transport | 401.440 | 2.255 | 35.668 |

The owned server exits normally. Its port refuses connections. Loopback qdisc remains byte-identical. No transport cgroup OOM or ceiling event occurs.

# Round 5 storage events

The WJ treatment launch first aborts with `ABORT_NETWORK_DISK_AVAILABLE` before it creates a server, application process, cgroup, or run directory. The original outer launch log and aborted queue state are preserved. This is a rejected preflight, not a measured repetition.

The completed W treatment cache scratch is archived in `archived-round5-network-W-scratch.tar.gz`. All 14,627 files pass byte checks. A /proc cwd and file-descriptor sweep finds no live user before removal. `round5-network-W-scratch-archive-result.json` records the archive hash. Its source metadata and raw measurement results remain unchanged.

Two inactive compiled snapshots for the completed earlier measurements are archived under `archived-completed-builds/`: `c790.tar.gz` (commit c790d7bdb6d50d05251ffd4a8b23665ae5f1af77; 8,339 verified files) and `spk1936.tar.gz` (commit 215463d4b60be25e54787b08ff59a74738ecd5c4; 8,171 verified files). Their original paths are `builds/c790` and `builds/spk1936`. Restore the corresponding archive under `builds` before replaying those historical helpers. `round5-earlier-builds-archive-plan.json` and `round5-earlier-builds-archive-result.json` record the dry run, ownership checks and archive hashes. The earlier memory watcher already reports complete.

The active `builds/base1938` control, current treatment source, all fixtures, historical helpers and raw evidence are preserved. No other agent process is stopped. The one missing WJ treatment then repeats and passes the unchanged 120-second memory and disk gate. The rejection does not produce a second cold/warm measurement.

After all network evidence is recorded, the completed WJ treatment scratch is also archived in `archived-round5-network-WJ-scratch.tar.gz`. All 14,627 files pass byte checks. No live cwd or file descriptor uses it. `round5-network-WJ-scratch-archive-result.json` records the archive hash. This restores disk space for rebase verification. Raw results and fixture metadata remain unchanged.

## Rebase and final validation

Current head: `fcda9e5412979bd9b2ff57af9dbc2faa14eb17fc`. Main base: `196d5d97b7c408a132851d275faa863b9c0b8614`. The branch pushes with an exact force-with-lease against `e1805efc1901b27776beaaba4a2bba58e31a82dc`. The remote head matches the verified local head. The working tree is clean.

Two files need conflict resolution. `dbtGitProjectAdapter.test.ts` keeps main's streamed and collected compilation tests and the branch's cache tests. It uses the branch's refresh seam. `dbtGitProjectAdapter.ts` wraps `prepareExploreStream` in cache recovery. The base collector calls this method. Both paths refresh once. Main's parsed-manifest handoff and staged batch save apply without conflicts and remain intact. The final follow-up sorts imports only. No schema or output contract changes during resolution.

The full backend battery runs once on this head. Typecheck passes. The full test script passes 597 files and 9,989 tests. One test has an expected failure. One test is skipped. The backend package linter and oxfmt check pass on all 28 touched paths. The changed common package is built before verification.

Real Git/dbt cold, warm and rotating-token smokes pass. The warm treatment reuses the checkout and dependencies. The rotating-token smoke proves that the second request uses the new token and still reuses dependencies. Each smoke uses a 2 GiB cgroup cap and the unchanged resource preconditions. The owned resources are cleaned up. A separate real blocked authenticated HTTP fetch test passes. Lease loss closes the blocked request and the operation recovers through a fresh checkout.

The Git verification gate and rebase gate now pin this head. The completed watcher stays paused. The historical network measurement gate remains unchanged so its recorded hash stays valid. No further measurement is queued. This draft remains unpublished for the orchestrator's review.

The eight local tables remain tied to pre-rebase `9d3bd964519929daa3b0b6b0e6629444c2506717`. The diagnostic and network tables remain tied to pre-rebase `e1805efc1901b27776beaaba4a2bba58e31a82dc`. These results do not measure the rebased head. The mixed verdict remains: package reuse is proven; the W wall-time gain is modest; the WJ wall-time gain is confounded; no general memory or health benefit is established.

Evidence: `spk1937-round5-rebase-final-verification.json`, `round5-rebase-git-rig-smoke-fcda9e541297.log`, `spk1937-round5-rebase-abort-smoke-verification.json`, `round5-rebase-report.md`, and `spk1937-round5-rebase-ready.json`.

Co-Authored-By: Codex GPT-6-Astra <noreply@openai.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)




## Review status

Four adversarial review rounds ran on this branch before the rebase, each followed by a fix round and a verification pass. The verification of the rebased head fcda9e5412 found it mergeable. A second rebase onto main at 1c4cf265da was verified line by line: nothing lost or duplicated, and the new compileOptions parameter is forwarded through the git adapter override, pinned by main's own test. A security scan of the original head ran; the two findings inside this branch are fixed. A re-scan of the fixed head is scheduled when scan quota resets.

The eight local measurement tables are tied to head 9d3bd96451 and the network-shaped tables to head e1805efc19. Neither measures a rebased head; the rebases changed no cache code.

