### PR TITLE
fix(merge-queries): run DuckDB jobs on the pre-aggregate worker, in-process when no worker takes them

### DIFF
--- a/packages/backend/src/clients/NatsClient.ts
+++ b/packages/backend/src/clients/NatsClient.ts
@@ -4,6 +4,7 @@ import {
     AckPolicy,
     connect,
     DebugEvents,
+    ErrorCode,
     Events,
     nanos,
     NatsError,
@@ -19,6 +20,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { type LightdashConfig } from '../config/parseConfig';
 import Logger from '../logging/logger';
 import {
+    getDuckdbQuerySubject,
     STREAM_CONFIGS,
     type AsyncQueryJobPayload,
     type AsyncQueryNatsEnvelope,
@@ -29,6 +31,20 @@ import { getTraceHeaders, traceSpan } from '../tracing/tracing';
 const ACK_WAIT_MS = 30_000;
 
 type EnqueueResult = Promise<{ jobId: string }>;
+
+/**
+ * JetStream answered the publish with "no responders": no stream on this
+ * server takes the subject, so no worker will ever run the job.
+ */
+export class NatsNoRespondersError extends Error {
+    readonly subject: string;
+
+    constructor(subject: string) {
+        super(`No NATS stream takes subject "${subject}"`);
+        this.name = 'NatsNoRespondersError';
+        this.subject = subject;
+    }
+}
 
 export interface INatsClient {
     enqueueWarehouseQuery(payload: AsyncQueryJobPayload): EnqueueResult;
@@ -213,7 +229,7 @@ export class NatsClient implements INatsClient {
     async enqueueDuckdbQuery(
         payload: AsyncQueryJobPayload,
     ): Promise<{ jobId: string }> {
-        return this.enqueue(STREAM_CONFIGS.duckdb.subjects.query, payload);
+        return this.enqueue(getDuckdbQuerySubject(), payload);
     }
 
     async enqueuePreAggregateQuery(
@@ -374,6 +390,12 @@ export class NatsClient implements INatsClient {
                             error,
                         )}`,
                     );
+                    if (
+                        error instanceof NatsError &&
+                        error.code === ErrorCode.NoResponders
+                    ) {
+                        throw new NatsNoRespondersError(subject);
+                    }
                     throw error;
                 }
             },

--- a/packages/backend/src/nats/NatsWorker.test.ts
+++ b/packages/backend/src/nats/NatsWorker.test.ts
@@ -1,0 +1,89 @@
+import { StringCodec, type JsMsg } from 'nats';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type NatsClient } from '../clients/NatsClient';
+import { type QueryHistoryModel } from '../models/QueryHistoryModel/QueryHistoryModel';
+import { type AsyncQueryService } from '../services/AsyncQueryService/AsyncQueryService';
+import { registerPreAggregateStream, STREAM_CONFIGS } from './natsConfig';
+import { NatsWorker } from './NatsWorker';
+
+const codec = StringCodec();
+
+const jobMessage = (subject: string): JsMsg =>
+    ({
+        subject,
+        data: codec.encode(
+            JSON.stringify({
+                jobId: 'job-1',
+                payload: { queryUuid: 'query-1' },
+            }),
+        ),
+        ack: vi.fn(),
+        nak: vi.fn(),
+        term: vi.fn(),
+        working: vi.fn(),
+    }) as unknown as JsMsg;
+
+describe('NatsWorker subject dispatch', () => {
+    const asyncQueryService = {
+        runAsyncWarehouseQueryFromHistory: vi.fn(async () => true),
+        runAsyncDuckdbQueryFromHistory: vi.fn(async () => true),
+        runAsyncPreAggregateQueryFromHistory: vi.fn(async () => true),
+    };
+    const queryHistoryModel = {
+        getByQueryUuid: vi.fn(async () => undefined),
+    };
+
+    const buildWorker = () =>
+        new NatsWorker({
+            natsClient: {} as NatsClient,
+            asyncQueryService:
+                asyncQueryService as unknown as AsyncQueryService,
+            queryHistoryModel:
+                queryHistoryModel as unknown as QueryHistoryModel,
+            streams: [],
+            workerConcurrency: 1,
+        });
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        registerPreAggregateStream();
+    });
+
+    it('runs a DuckDB job published on the dedicated DuckDB stream', async () => {
+        const message = jobMessage(STREAM_CONFIGS.duckdb.subjects.query);
+
+        await buildWorker().handleMessage(message, 'worker-1');
+
+        expect(
+            asyncQueryService.runAsyncDuckdbQueryFromHistory,
+        ).toHaveBeenCalledWith('query-1', 'worker-1', undefined);
+        expect(message.ack).toHaveBeenCalled();
+    });
+
+    it('runs a DuckDB job that rode the pre-aggregate stream', async () => {
+        const message = jobMessage(
+            STREAM_CONFIGS['pre-aggregate'].subjects.duckdb,
+        );
+
+        await buildWorker().handleMessage(message, 'worker-1');
+
+        expect(
+            asyncQueryService.runAsyncDuckdbQueryFromHistory,
+        ).toHaveBeenCalledWith('query-1', 'worker-1', undefined);
+        expect(
+            asyncQueryService.runAsyncPreAggregateQueryFromHistory,
+        ).not.toHaveBeenCalled();
+        expect(message.ack).toHaveBeenCalled();
+    });
+
+    it('terminates a job on a subject it does not know', async () => {
+        const message = jobMessage('pre_aggregate.unknown.jobs');
+
+        await buildWorker().handleMessage(message, 'worker-1');
+
+        expect(
+            asyncQueryService.runAsyncDuckdbQueryFromHistory,
+        ).not.toHaveBeenCalled();
+        expect(message.term).toHaveBeenCalled();
+    });
+});

--- a/packages/backend/src/nats/NatsWorker.ts
+++ b/packages/backend/src/nats/NatsWorker.ts
@@ -173,7 +173,11 @@ export class NatsWorker {
                 );
         }
 
-        if (subject === STREAM_CONFIGS.duckdb.subjects.query) {
+        const preAgg = STREAM_CONFIGS['pre-aggregate'];
+        if (
+            subject === STREAM_CONFIGS.duckdb.subjects.query ||
+            (preAgg && subject === preAgg.subjects.duckdb)
+        ) {
             return (queryUuid, worker, queryTags) =>
                 this.asyncQueryService.runAsyncDuckdbQueryFromHistory(
                     queryUuid,
@@ -182,7 +186,6 @@ export class NatsWorker {
                 );
         }
 
-        const preAgg = STREAM_CONFIGS['pre-aggregate'];
         if (preAgg && subject === preAgg.subjects.query) {
             return (queryUuid, worker, queryTags) =>
                 this.asyncQueryService.runAsyncPreAggregateQueryFromHistory(

--- a/packages/backend/src/nats/natsConfig.test.ts
+++ b/packages/backend/src/nats/natsConfig.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import {
+    getDuckdbQuerySubject,
+    registerPreAggregateStream,
+    STREAM_CONFIGS,
+} from './natsConfig';
+
+describe('getDuckdbQuerySubject', () => {
+    it('publishes to the dedicated DuckDB stream without a pre-aggregate stream', () => {
+        expect(STREAM_CONFIGS['pre-aggregate']).toBeUndefined();
+        expect(getDuckdbQuerySubject()).toBe('duckdb.query.jobs');
+    });
+
+    it('rides the pre-aggregate stream once it is registered', () => {
+        registerPreAggregateStream();
+
+        expect(getDuckdbQuerySubject()).toBe('pre_aggregate.duckdb.jobs');
+        // The subject is on the stream, so its worker's consumer filter takes it
+        expect(
+            Object.values(STREAM_CONFIGS['pre-aggregate'].subjects),
+        ).toContain('pre_aggregate.duckdb.jobs');
+    });
+});

--- a/packages/backend/src/nats/natsConfig.ts
+++ b/packages/backend/src/nats/natsConfig.ts
@@ -46,9 +46,10 @@ const OSS_STREAM_CONFIGS: Record<'warehouse' | 'duckdb', StreamConfig> = {
     },
     /**
      * DuckDB source queries over other results: merges and compose SQL. Its
-     * own stream and durable, so a worker from before it existed never
-     * receives a job it would terminate, and a join waiting on its legs does
-     * not hold a warehouse slot.
+     * own stream and durable, so a join waiting on its legs does not hold a
+     * warehouse slot. Only a worker started with `--stream duckdb` creates
+     * it; where the pre-aggregate stream is registered the jobs ride that
+     * stream instead, since its worker already runs DuckDB.
      */
     duckdb: {
         streamName: 'DUCKDB_QUERY_JOBS',
@@ -65,6 +66,7 @@ const PRE_AGGREGATE_STREAM_CONFIG: StreamConfig = {
     subjects: {
         query: 'pre_aggregate.query.jobs',
         materialization: 'pre_aggregate.materialization.jobs',
+        duckdb: 'pre_aggregate.duckdb.jobs',
     },
     durableName: 'worker-pre-aggregate',
 };
@@ -82,6 +84,16 @@ export const NATS_WORKER_STREAMS = natsWorkerStreamSchema.options;
  */
 export const getRegisteredStreams = (): NatsWorkerStream[] =>
     NATS_WORKER_STREAMS.filter((s) => STREAM_CONFIGS[s] !== undefined);
+
+/**
+ * The subject a DuckDB source query is published on. The pre-aggregate
+ * worker is the one deployed with DuckDB sized in, so when its stream is
+ * registered the jobs go there; the dedicated stream is for a worker
+ * started with `--stream duckdb`.
+ */
+export const getDuckdbQuerySubject = (): string =>
+    STREAM_CONFIGS['pre-aggregate']?.subjects.duckdb ??
+    STREAM_CONFIGS.duckdb.subjects.query;
 
 /**
  * Register an additional NATS stream configuration (used by EE).

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -56,7 +56,10 @@ import { defaultJwtToken } from '../../auth/account/account.mock';
 import type { S3CacheClient } from '../../clients/Aws/S3CacheClient';
 import EmailClient from '../../clients/EmailClient/EmailClient';
 import type { FileStorageClient } from '../../clients/FileStorage/FileStorageClient';
-import type { INatsClient } from '../../clients/NatsClient';
+import {
+    NatsNoRespondersError,
+    type INatsClient,
+} from '../../clients/NatsClient';
 import type { S3ResultsFileStorageClient } from '../../clients/ResultsFileStorageClients/S3ResultsFileStorageClient';
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
 import type { LightdashConfig } from '../../config/parseConfig';
@@ -8722,6 +8725,39 @@ describe('DuckDB source queries on the worker', () => {
             sessionAccount,
         );
         expect(runDuckdbQuery).not.toHaveBeenCalled();
+    });
+
+    it('a hand-off no stream takes runs the query in this process instead', async () => {
+        const { service, runDuckdbQuery } = buildWorkerService({
+            ...lightdashConfigMock,
+            natsWorker: { ...lightdashConfigMock.natsWorker, enabled: true },
+        });
+        (
+            service.natsClient.enqueueDuckdbQuery as import('vitest').Mock
+        ).mockRejectedValueOnce(
+            new NatsNoRespondersError('pre_aggregate.duckdb.jobs'),
+        );
+
+        await service.executeAsyncDuckdbSourceQuery({
+            account: sessionAccount,
+            projectUuid,
+            context: QueryExecutionContext.EXPLORE,
+            sql: 'SELECT * FROM merge_source_0',
+            references: { merge_source_0: referencedQueryHistory.queryUuid },
+            plan: suppliedPlan(),
+        });
+
+        const model = service.queryHistoryModel as unknown as ReturnType<
+            typeof inMemoryDuckdbHistory
+        >;
+        expect(model.updateStatusToError).not.toHaveBeenCalled();
+        expect(model.updateStatusToQueued).not.toHaveBeenCalled();
+        await vi.waitFor(() => {
+            expect(model.updateStatusToExecuting).toHaveBeenCalledWith(
+                'join-uuid',
+            );
+            expect(runDuckdbQuery).toHaveBeenCalledTimes(1);
+        });
     });
 
     it('the worker rebuilds a queued run from the row and its spec alone', async () => {

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -166,7 +166,10 @@ import {
 } from '../../analytics/LightdashAnalytics';
 import { transformAndExportResults } from '../../clients/Aws/transformAndExportResults';
 import { type FileStorageClient } from '../../clients/FileStorage/FileStorageClient';
-import type { INatsClient } from '../../clients/NatsClient';
+import {
+    NatsNoRespondersError,
+    type INatsClient,
+} from '../../clients/NatsClient';
 import { createLocalParquetUploadStream } from '../../clients/ResultsFileStorageClients/LocalParquetUploadStream';
 import { S3ResultsFileStorageClient } from '../../clients/ResultsFileStorageClients/S3ResultsFileStorageClient';
 import { type DbExternalSourceTable } from '../../database/entities/externalSources';
@@ -7762,23 +7765,35 @@ export class AsyncQueryService extends ProjectService {
                 context,
             });
         } else {
-            void this.runAsyncDuckdbQueryFromHistory(
-                queryUuid,
-                'main-loop',
-                queryTags,
-            ).catch((e) => {
-                this.logger.error(
-                    `Async DuckDB source query ${queryUuid} failed: ${getErrorMessage(
-                        e,
-                    )}`,
-                );
-            });
+            this.runDuckdbQueryInProcess(queryUuid, queryTags);
         }
 
         return { queryUuid };
     }
 
-    /** Hands a DuckDB source query to the worker, as a warehouse query is. */
+    /** Runs a submitted DuckDB source query on this process, as a worker would. */
+    private runDuckdbQueryInProcess(
+        queryUuid: string,
+        queryTags: RunQueryTags,
+    ): void {
+        void this.runAsyncDuckdbQueryFromHistory(
+            queryUuid,
+            'main-loop',
+            queryTags,
+        ).catch((e) => {
+            this.logger.error(
+                `Async DuckDB source query ${queryUuid} failed: ${getErrorMessage(
+                    e,
+                )}`,
+            );
+        });
+    }
+
+    /**
+     * Hands a DuckDB source query to the worker, as a warehouse query is. A
+     * deployment whose workers do not take the subject yet runs it here
+     * instead, so a merge never waits on a worker that will not come.
+     */
     private async enqueueDuckdbQuery({
         queryUuid,
         projectUuid,
@@ -7809,6 +7824,13 @@ export class AsyncQueryService extends ProjectService {
                 context,
             );
         } catch (e) {
+            if (e instanceof NatsNoRespondersError) {
+                this.logger.warn(
+                    `No NATS worker takes DuckDB source query ${queryUuid} on ${e.subject}; running it in this process`,
+                );
+                this.runDuckdbQueryInProcess(queryUuid, queryTags);
+                return;
+            }
             const errorMessage = getErrorMessage(e);
             this.logger.error(
                 `Failed to enqueue DuckDB source query ${queryUuid} on NATS`,


### PR DESCRIPTION
## What

A DuckDB source query (a merge join, a compose SQL query) is handed to the NATS worker on a subject a deployed worker actually consumes, and runs in the API process when no stream takes it.

- `pre_aggregate.duckdb.jobs` is a new subject on the existing `PRE_AGGREGATE_QUERY_JOBS` stream. Where the pre-aggregate stream is registered (any licensed instance), `enqueueDuckdbQuery` publishes there; otherwise it keeps publishing to the dedicated `DUCKDB_QUERY_JOBS` stream. `getDuckdbQuerySubject()` in `natsConfig.ts` is the one place that decides.
- The worker dispatches the new subject to `runAsyncDuckdbQueryFromHistory`, the same entry the dedicated stream uses.
- `NatsClient.enqueue` turns JetStream's no-responders reply into a typed `NatsNoRespondersError`. On that error alone, `AsyncQueryService.enqueueDuckdbQuery` runs the query in-process (the path a NATS-less instance already takes) instead of marking the row errored. Every other publish failure still errors the row as before.

## Why

Since 2.144.0 (#28744) every merge on a NATS-enabled deployment fails at hand-off with `Failed to enqueue DuckDB query: 503`. The dedicated `DUCKDB_QUERY_JOBS` stream is only created by a worker started with `--stream duckdb`. The chart starts workers with explicit `--stream warehouse` and `--stream pre-aggregate`, so no worker ever created it, and JetStream answers each publish with no responders (nats error code 503). The previous PR's rolling-deploy note assumed the default stream list, which deployed workers do not use.

The pre-aggregate worker is the pod already deployed with DuckDB sized in (`PRE_AGGREGATE_DUCKDB_QUERY_MEMORY_LIMIT`, which the compose engine borrows as its budget), so riding its stream needs no chart or deployment change. A dedicated DuckDB worker and its chart entry can follow later without undoing this: `getDuckdbQuerySubject()` is the only switch.

## Regression analysis

- **Licensed deployment with a pre-aggregate worker** (the reported case): the first pre-aggregate worker on this release updates the stream's subjects and its consumer's `filter_subjects` on startup (both mutable), so it starts taking DuckDB jobs. Rows go pending, queued, executing, ready as any worker query does.
- **Licensed deployment with NATS but no pre-aggregate worker**: the pre-aggregate stream is registered but was never created. The publish gets no responders, and the query now runs in-process, which is the behaviour before 2.144.0 and the behaviour every NATS-less instance has today. Before this PR these rows errored.
- **Unlicensed deployment with NATS**: unchanged, publishes to `DUCKDB_QUERY_JOBS`. With a worker on the default stream list that stream exists and the job runs there; with explicit `--stream` workers it falls back in-process instead of erroring.
- **NATS off**: unchanged. The in-process call is the same code, moved into `runDuckdbQueryInProcess`.
- **Rolling deploy of the pre-aggregate worker**: old worker pods share the durable, so once a new pod widens the consumer filter, an old pod can pull a `pre_aggregate.duckdb.jobs` message, find no handler and terminate it. The row is then claimed by nobody and expires on the queue timeout. This is a window of one rollout and only affects merges submitted during it. The dedicated stream avoided this, but was never created in practice.
- **Other publish failures** (connection down, timeout): still error the row with the enqueue failure. Only the no-responders code takes the fallback, so a transient outage does not silently move DuckDB load onto the API pod.
- **Pre-aggregate and materialization jobs**: untouched. The new subject is additive on the stream and the dispatcher checks it before the existing subjects.
- **API surface**: no controller or response type changes. No migration.

## Verification

- `pnpm -F backend typecheck`, oxlint and oxfmt on every changed file.
- `AsyncQueryService.test.ts`: 171 passed, including a new case where a no-responders hand-off runs the query in-process and never errors or queues the row.
- New `natsConfig.test.ts`: subject selection before and after the pre-aggregate stream is registered.
- New `NatsWorker.test.ts`: a job on the pre-aggregate DuckDB subject dispatches to the DuckDB runner, the dedicated subject still does, and an unknown subject is terminated.

Closes: PROD-11037
Relates: PROD-10993

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XgVMz6627KTXQRALSLTrhM
