### PR TITLE
chore(upgrade-automation): add title_scope input for scoped pin commit titles

### DIFF
--- a/examples/upgrade-automation/README.md
+++ b/examples/upgrade-automation/README.md
@@ -35,6 +35,7 @@ The plan action creates the pin commit through the GitHub API, so GitHub verifie
 | --- | --- | --- |
 | `instance_url` | `LIGHTDASH_INSTANCE_URL` | Public base URL of the deployment to verify. |
 | `bump_target` | `LIGHTDASH_BUMP_TARGET` | Relative YAML or JSON file plus a dot-separated scalar path, written as `file#path.to.version`. YAML must use block mappings, keep the scalar on the same line as its key, and not duplicate the target path. Its scalar must be unquoted, single-quoted, or JSON-compatible double-quoted. |
+| `title_scope` | `LIGHTDASH_TITLE_SCOPE` | Optional conventional-commit scope for the pin commit and pull request title. `analytics` produces `chore(analytics): upgrade Lightdash to VERSION`. Use it when one repository pins several instances so the squashed history says which one moved. Empty keeps `chore: upgrade Lightdash to VERSION`. |
 | `tag_suffix` | `LIGHTDASH_TAG_SUFFIX` | Optional suffix appended to a public version when writing the image tag. The suffix is removed before comparisons and calls to `upgrade-check`. |
 | `registry_check` | `LIGHTDASH_REGISTRY_CHECK` | Optional OCI image repository, without a tag. The action runs `docker manifest inspect repository:version+suffix`; authenticate to a private registry earlier in the job. An unavailable tag exits without opening or updating a pull request and is retried by the next trigger. |
 | `verify_window` | `LIGHTDASH_VERIFY_WINDOW` | Post-deploy verification budget. Accepts seconds or an `s`, `m`, or `h` suffix and defaults to `20m`. |

--- a/examples/upgrade-automation/plan/action.yml
+++ b/examples/upgrade-automation/plan/action.yml
@@ -8,6 +8,10 @@ inputs:
     description: Prefix used for upgrade branch names
     required: false
     default: lightdash-upgrade
+  title_scope:
+    description: Optional conventional-commit scope for the pin commit and pull request title, for example the instance name when one repository pins several instances. Empty keeps the title as chore: upgrade Lightdash to VERSION
+    required: false
+    default: ''
   tag_suffix:
     description: Suffix appended to the public release version for the deployed image tag
     required: false
@@ -66,6 +70,7 @@ runs:
       env:
         BUMP_TARGET: ${{ inputs.bump_target }}
         BRANCH_PREFIX: ${{ inputs.branch_prefix }}
+        TITLE_SCOPE: ${{ inputs.title_scope }}
         TAG_SUFFIX: ${{ inputs.tag_suffix }}
         REGISTRY_CHECK: ${{ inputs.registry_check }}
         SAFETY_GATE: ${{ inputs.safety_gate }}

--- a/examples/upgrade-automation/scripts/plan.sh
+++ b/examples/upgrade-automation/scripts/plan.sh
@@ -439,6 +439,15 @@ if [[ ! "$branch_prefix" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
     echo "branch_prefix must match ^[A-Za-z0-9][A-Za-z0-9._-]*$" >&2
     exit 1
 fi
+title_scope=${TITLE_SCOPE:-}
+if [[ -n "$title_scope" && ! "$title_scope" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+    echo "title_scope must be empty or match ^[A-Za-z0-9][A-Za-z0-9._-]*$" >&2
+    exit 1
+fi
+title_prefix=chore
+if [[ -n "$title_scope" ]]; then
+    title_prefix="chore($title_scope)"
+fi
 safety_gate=${SAFETY_GATE:-true}
 if [[ "$safety_gate" != "true" && "$safety_gate" != "false" ]]; then
     echo "safety_gate must be true or false" >&2
@@ -715,7 +724,7 @@ if [[ "${bump_filename#.}" == *.* && -n "$bump_extension" ]]; then
     mv "$head_file" "$head_file.$bump_extension"
     head_file="$head_file.$bump_extension"
 fi
-commit_message="chore: upgrade Lightdash to $mapped_version"
+commit_message="$title_prefix: upgrade Lightdash to $mapped_version"
 commit_response=
 committed=false
 skip_commit=false
@@ -827,7 +836,7 @@ elif [[ "$(jq -r '.safe' <<<"$selected_json")" != "true" ]]; then
     plain_reason='This target is the required stop identified by the gate. Landing on the stop satisfies the staged upgrade path before a later release can be selected.'
 fi
 
-pr_title="chore: upgrade Lightdash to $mapped_version"
+pr_title="$title_prefix: upgrade Lightdash to $mapped_version"
 hold_explanation=
 if [[ "$selected_green" != "true" ]]; then
     pr_title="HOLD: $pr_title"

--- a/examples/upgrade-automation/scripts/plan.test.sh
+++ b/examples/upgrade-automation/scripts/plan.test.sh
@@ -275,6 +275,61 @@ printf 'plan custom branch prefix test passed\n'
 printf 'image:\n  tag: 1.0.0\n' >"$test_dir/values.yml"
 : >"$test_dir/gh.log"
 : >"$test_dir/gate.log"
+rm -f "$test_dir/pr-title" "$test_dir/graphql-input"
+
+set +e
+output=$(PATH="$test_dir/bin:$PATH" \
+    TEST_SCENARIO_DIR="$test_dir" \
+    RUNNER_TEMP="$test_dir/runner-temp" \
+    GITHUB_REPOSITORY=example/upgrade-test \
+    BUMP_TARGET=values.yml#image.tag \
+    TITLE_SCOPE=staging \
+    FREEZE_LABEL=upgrade-freeze \
+    GH_TOKEN=test-token \
+    "${BASH:-bash}" "$root/examples/upgrade-automation/scripts/plan.sh" 2>&1)
+status=$?
+set -e
+
+if [[ $status -ne 0 ]]; then
+    printf 'expected a title scope to plan successfully, got status %s:\n%s\n' "$status" "$output" >&2
+    exit 1
+fi
+
+if [[ "$(cat "$test_dir/pr-title")" != 'HOLD: chore(staging): upgrade Lightdash to 1.0.1' ]]; then
+    printf 'expected the title scope in the pull request title, got: %s\n' "$(cat "$test_dir/pr-title")" >&2
+    exit 1
+fi
+
+if [[ "$(jq -r '.variables.input.message.headline' "$test_dir/graphql-input")" != 'chore(staging): upgrade Lightdash to 1.0.1' ]]; then
+    printf 'expected the title scope in the pin commit message, graphql input was:\n%s\n' "$(cat "$test_dir/graphql-input")" >&2
+    exit 1
+fi
+
+printf 'plan title scope test passed\n'
+
+set +e
+output=$(PATH="$test_dir/bin:$PATH" \
+    TEST_SCENARIO_DIR="$test_dir" \
+    RUNNER_TEMP="$test_dir/runner-temp" \
+    GITHUB_REPOSITORY=example/upgrade-test \
+    BUMP_TARGET=values.yml#image.tag \
+    TITLE_SCOPE='bad scope' \
+    FREEZE_LABEL=upgrade-freeze \
+    GH_TOKEN=test-token \
+    "${BASH:-bash}" "$root/examples/upgrade-automation/scripts/plan.sh" 2>&1)
+status=$?
+set -e
+
+if [[ $status -eq 0 ]] || [[ "$output" != *'title_scope must be empty or match'* ]]; then
+    printf 'expected an invalid title scope to fail, got status %s:\n%s\n' "$status" "$output" >&2
+    exit 1
+fi
+
+printf 'plan invalid title scope test passed\n'
+
+printf 'image:\n  tag: 1.0.0\n' >"$test_dir/values.yml"
+: >"$test_dir/gh.log"
+: >"$test_dir/gate.log"
 : >"$test_dir/npm.log"
 rm -f "$test_dir/pr-body"
 

--- a/examples/upgrade-automation/template-workflow.yml
+++ b/examples/upgrade-automation/template-workflow.yml
@@ -32,6 +32,7 @@ concurrency:
 env:
   LIGHTDASH_INSTANCE_URL: https://lightdash.example.com
   LIGHTDASH_BUMP_TARGET: deploy/values.yml#lightdash.image.tag
+  LIGHTDASH_TITLE_SCOPE: ''
   LIGHTDASH_TAG_SUFFIX: ''
   LIGHTDASH_REGISTRY_CHECK: ''
   LIGHTDASH_VERIFY_WINDOW: 20m
@@ -79,6 +80,7 @@ jobs:
       - uses: lightdash/lightdash/examples/upgrade-automation/plan@REPLACE_WITH_LIGHTDASH_COMMIT_SHA
         with:
           bump_target: ${{ env.LIGHTDASH_BUMP_TARGET }}
+          title_scope: ${{ env.LIGHTDASH_TITLE_SCOPE }}
           tag_suffix: ${{ env.LIGHTDASH_TAG_SUFFIX }}
           registry_check: ${{ env.LIGHTDASH_REGISTRY_CHECK }}
           auto_merge: ${{ env.LIGHTDASH_AUTO_MERGE }}
@@ -111,6 +113,7 @@ jobs:
         with:
           instance_url: ${{ env.LIGHTDASH_INSTANCE_URL }}
           bump_target: ${{ env.LIGHTDASH_BUMP_TARGET }}
+          title_scope: ${{ env.LIGHTDASH_TITLE_SCOPE }}
           tag_suffix: ${{ env.LIGHTDASH_TAG_SUFFIX }}
           verify_window: ${{ env.LIGHTDASH_VERIFY_WINDOW }}
           escalation: ${{ secrets.LIGHTDASH_UPGRADE_SLACK_WEBHOOK }}


### PR DESCRIPTION
## Why

`lightdash-cloud` runs the upgrade automation twice against one `customer-versions.yaml`, once for `overrides.analytics` and once for `overrides.staging`. Both pin PRs are titled `chore: upgrade Lightdash to VERSION`, and because they squash-merge, `main` ends up with identical commit subjects for different instances. Today's history shows the problem:

- `#3745` bumped only analytics
- `#3746` bumped only staging, six minutes later, with the same message

When analytics is frozen or held and staging moves alone, the log reads as if the whole fleet moved.

## What

- New optional `title_scope` input on the plan action. `analytics` produces `chore(analytics): upgrade Lightdash to VERSION` for both the pin commit headline and the PR title. Empty keeps the current title, so existing consumers see no change.
- Validated with the same character class as `branch_prefix`.
- Documented in the README inputs table and wired into `template-workflow.yml` as `LIGHTDASH_TITLE_SCOPE`.
- Two new tests in `plan.test.sh`: scope appears in both the GraphQL commit headline and the `pr create` title, and an invalid scope fails fast.

Nothing parses the title back (verify matches PRs by branch prefix), so this is safe for existing flows.

## Test plan

- [x] `common.test.sh`, `verify.test.sh`, `plan.test.sh` pass locally with bash 5
- [ ] Follow-up in `lightdash-cloud` bumps the action SHA and sets `title_scope: analytics` / `title_scope: staging`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KPM8jKe1sVfAVjYDndNwLw
