### PR TITLE
feat(learn): the library in the homepage's shape, with role views, group tabs and a Filter menu

### DIFF
--- a/packages/frontend/src/features/learn/Learn.module.css
+++ b/packages/frontend/src/features/learn/Learn.module.css
@@ -177,42 +177,6 @@
     color: var(--lu-ink);
 }
 
-.stats {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-    font-size: 12px;
-    color: var(--lu-muted);
-}
-
-.stat {
-    display: inline-flex;
-    align-items: center;
-    gap: 5px;
-    padding: 2px 8px;
-    border-radius: 999px;
-    font: inherit;
-    font-size: 12px;
-    color: var(--lu-muted);
-    background: transparent;
-    border: 1px solid transparent;
-}
-
-.stat b {
-    font-weight: 600;
-    color: var(--lu-secondary);
-}
-
-.statButton {
-    cursor: pointer;
-}
-
-.statButton:hover {
-    background: var(--lu-surface);
-    border-color: var(--lu-border);
-    color: var(--lu-ink);
-}
-
 /* Titled sections as on the homepage: a small icon, the title, and for a
    group its description alongside. */
 .section {
@@ -303,13 +267,143 @@
     color: var(--lu-muted);
 }
 
-/* The filters sit between Continue and the groups they narrow. */
-.filters {
+/* The library's header row, Linear's way: a title on the left, the Filter
+   and Display icon buttons on the right; chosen filters as removable chips
+   on the line beneath. */
+.libraryBar {
     display: flex;
-    flex-direction: column;
     align-items: center;
-    gap: 10px;
-    padding-top: 6px;
+    gap: 6px;
+    padding-top: 10px;
+}
+
+/* The roles as views, Linear's way: one pill per role, the chosen one
+   filled; the library is the modules that role can practise. */
+.views {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    margin-right: auto;
+}
+
+.view {
+    padding: 5px 12px;
+    border-radius: 999px;
+    font: inherit;
+    font-size: 12.5px;
+    color: var(--lu-muted);
+    background: transparent;
+    cursor: pointer;
+    transition:
+        background 120ms ease,
+        color 120ms ease;
+}
+
+.view:hover {
+    background: var(--lu-sunken);
+    color: var(--lu-ink);
+}
+
+.viewOn {
+    background: var(--lu-sunken);
+    color: var(--lu-ink);
+    font-weight: 600;
+    box-shadow: 0 0 0 1px var(--lu-border) inset;
+}
+
+.libraryCount {
+    font-size: 12px;
+    color: var(--lu-muted);
+    margin-right: 6px;
+}
+
+.iconButton {
+    position: relative;
+    width: 30px;
+    height: 26px;
+    display: inline-grid;
+    place-items: center;
+    border: 1px solid var(--lu-border);
+    border-radius: 6px;
+    background: var(--lu-surface);
+    color: var(--lu-muted);
+    cursor: pointer;
+}
+
+.iconButton:hover {
+    color: var(--lu-ink);
+}
+
+.iconButtonOn {
+    color: var(--lu-ink);
+    border-color: var(--lu-secondary);
+}
+
+.iconBadge {
+    position: absolute;
+    top: -6px;
+    right: -6px;
+    min-width: 15px;
+    height: 15px;
+    padding: 0 4px;
+    border-radius: 999px;
+    background: var(--lu-accent);
+    color: #fff;
+    font-size: 10px;
+    font-weight: 600;
+    line-height: 15px;
+    text-align: center;
+}
+
+.filterChips {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 6px;
+    margin-top: -8px;
+}
+
+.filterChip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 3px 4px 3px 9px;
+    border: 1px solid var(--lu-border);
+    border-radius: 6px;
+    background: var(--lu-surface);
+    color: var(--lu-ink);
+    font-size: 12px;
+}
+
+.filterChipKey {
+    color: var(--lu-muted);
+}
+
+.filterChipRemove {
+    display: inline-grid;
+    place-items: center;
+    width: 18px;
+    height: 18px;
+    border-radius: 4px;
+    color: var(--lu-muted);
+    cursor: pointer;
+}
+
+.filterChipRemove:hover {
+    background: var(--lu-sunken);
+    color: var(--lu-ink);
+}
+
+.filterClear {
+    font: inherit;
+    font-size: 12px;
+    color: var(--lu-muted);
+    padding: 3px 6px;
+    cursor: pointer;
+}
+
+.filterClear:hover {
+    color: var(--lu-ink);
 }
 
 .focusCard {
@@ -356,69 +450,12 @@
     scroll-margin-top: 80px;
 }
 
-/* The groups as quiet pills under the search, as the homepage's: nothing
-   but text until hovered or chosen, the group's colour as a swatch. All,
-   then one per group, a hairline, then the two view toggles. */
-.chips {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    gap: 4px;
-}
-
-.chip {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    padding: 4px 10px;
-    border: 1px solid transparent;
-    border-radius: 999px;
-    background: transparent;
-    color: var(--lu-muted);
-    font: inherit;
-    font-size: 12px;
-    line-height: 1.3;
-    cursor: pointer;
-    transition:
-        background 120ms ease,
-        border-color 120ms ease,
-        color 120ms ease;
-}
-
-.chip:hover {
-    background: var(--lu-surface);
-    border-color: var(--lu-border);
-    color: var(--lu-ink);
-}
-
-.chipOn {
-    background: var(--lu-surface);
-    border-color: var(--lu-border);
-    color: var(--lu-ink);
-    font-weight: 500;
-}
-
 .chipSwatch {
     width: 8px;
     height: 8px;
     border-radius: 3px;
     background: var(--mi-fg);
     flex: none;
-}
-
-/* The two view toggles sit at the end of the row as chips of their own,
-   past a hairline, so filters and toggles read as one set of controls. */
-.chipRule {
-    width: 1px;
-    height: 18px;
-    margin: 0 4px;
-    background: var(--lu-border);
-    align-self: center;
-}
-
-.chipHelp {
-    display: inline-flex;
-    color: var(--lu-muted);
 }
 
 .grid {

--- a/packages/frontend/src/features/learn/Learn.module.css
+++ b/packages/frontend/src/features/learn/Learn.module.css
@@ -21,8 +21,6 @@
 }
 
 .shell {
-    display: grid;
-    grid-template-columns: 240px minmax(0, 1fr);
     min-height: 100%;
 }
 
@@ -146,61 +144,6 @@
     font-size: 13px;
     line-height: 1.6;
     color: var(--lu-secondary);
-}
-
-.sidebar {
-    border-right: 1px solid var(--lu-border);
-    background: var(--lu-sunken);
-    padding: 24px 18px;
-}
-
-.sidebarInner {
-    position: sticky;
-    top: 76px;
-}
-
-.sidebarTitle {
-    margin: 0 0 12px;
-    font-size: 13px;
-    font-weight: 600;
-    color: var(--lu-muted);
-}
-
-.nav {
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
-}
-
-.navItem {
-    display: flex;
-    align-items: center;
-    gap: 9px;
-    text-align: left;
-    background: transparent;
-    border: 0;
-    border-radius: 8px;
-    color: var(--lu-secondary);
-    padding: 6px 10px;
-    font: inherit;
-    font-size: 13px;
-    cursor: pointer;
-}
-
-.navItem:hover {
-    background: var(--lu-surface);
-}
-
-.navItemActive {
-    background: var(--lu-surface);
-    color: var(--lu-ink);
-    font-weight: 600;
-    box-shadow: 0 1px 2px rgba(16, 16, 20, 0.06);
-}
-
-.navIcon {
-    display: inline-flex;
-    color: var(--mi-fg);
 }
 
 .main {
@@ -330,6 +273,53 @@
     gap: 16px;
     font-size: 13px;
     color: var(--lu-secondary);
+}
+
+/* The groups as filter chips under the search: All, then one per group with
+   the group's colour as a swatch. One chip at a time; All is the way back. */
+.chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-top: -4px;
+}
+
+.chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    padding: 4px 11px;
+    border: 1px solid var(--lu-border);
+    border-radius: 999px;
+    background: var(--lu-surface);
+    color: var(--lu-secondary);
+    font: inherit;
+    font-size: 12.5px;
+    line-height: 1.3;
+    cursor: pointer;
+    transition:
+        border-color 120ms ease,
+        color 120ms ease;
+}
+
+.chip:hover {
+    border-color: var(--lu-muted);
+    color: var(--lu-ink);
+}
+
+.chipOn {
+    border-color: var(--lu-accent);
+    color: var(--lu-ink);
+    font-weight: 600;
+    box-shadow: 0 0 0 1px var(--lu-accent) inset;
+}
+
+.chipSwatch {
+    width: 8px;
+    height: 8px;
+    border-radius: 3px;
+    background: var(--mi-fg);
+    flex: none;
 }
 
 .group {
@@ -504,28 +494,6 @@
 }
 
 @media (max-width: 900px) {
-    .shell {
-        grid-template-columns: minmax(0, 1fr);
-    }
-    .sidebar {
-        border-right: 0;
-        border-bottom: 1px solid var(--lu-border);
-        padding: 10px 16px;
-    }
-    .sidebarInner {
-        position: static;
-    }
-    .sidebarTitle {
-        display: none;
-    }
-    .nav {
-        flex-direction: row;
-        overflow-x: auto;
-    }
-    .navItem {
-        flex: none;
-        white-space: nowrap;
-    }
     .focusGrid {
         grid-template-columns: minmax(0, 1fr);
     }

--- a/packages/frontend/src/features/learn/Learn.module.css
+++ b/packages/frontend/src/features/learn/Learn.module.css
@@ -147,70 +147,148 @@
 }
 
 .main {
+    max-width: 1040px;
+    margin: 0 auto;
     min-width: 0;
     display: flex;
     flex-direction: column;
-    gap: 16px;
-    padding: 24px 28px 48px;
+    gap: 22px;
+    padding: 36px 24px 56px;
 }
 
+/* The head in the homepage's shape: a centred greeting over a wide search,
+   the groups as quiet pills beneath, and the role and count as a small
+   line under those. */
 .homeHead {
     display: flex;
+    flex-direction: column;
     align-items: center;
     gap: 14px;
-    flex-wrap: wrap;
 }
 
 .greeting {
     margin: 0;
-    font-size: 22px;
+    font-size: 28px;
     line-height: 1.2;
     font-weight: 600;
     letter-spacing: -0.02em;
+    text-align: center;
+    text-wrap: balance;
+    color: var(--lu-ink);
 }
 
 .stats {
     display: inline-flex;
-    align-items: stretch;
-    margin-left: auto;
-    border: 1px solid var(--lu-border);
-    border-radius: 8px;
-    background: var(--lu-surface);
+    align-items: center;
+    gap: 4px;
+    font-size: 12px;
+    color: var(--lu-muted);
 }
 
 .stat {
     display: inline-flex;
     align-items: center;
-    gap: 6px;
-    padding: 0 10px;
-    min-height: 32px;
+    gap: 5px;
+    padding: 2px 8px;
+    border-radius: 999px;
     font: inherit;
     font-size: 12px;
     color: var(--lu-muted);
     background: transparent;
-    border: 0;
-    border-right: 1px solid var(--lu-border);
-    white-space: nowrap;
-    cursor: default;
+    border: 1px solid transparent;
 }
 
 .stat b {
     font-weight: 600;
-    color: var(--lu-ink);
+    color: var(--lu-secondary);
 }
 
 .statButton {
     cursor: pointer;
 }
 
-.stats > :last-child {
-    border-right: 0;
+.statButton:hover {
+    background: var(--lu-surface);
+    border-color: var(--lu-border);
+    color: var(--lu-ink);
 }
 
-.focusGrid {
+/* Titled sections as on the homepage: a small icon, the title, and for a
+   group its description alongside. */
+.section {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.sectionTitle {
+    margin: 0;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--lu-ink);
+}
+
+.sectionDesc {
+    font-weight: 400;
+    color: var(--lu-muted);
+    margin-left: 4px;
+}
+
+.rows {
     display: grid;
-    grid-template-columns: minmax(0, 1.3fr) minmax(300px, 0.7fr);
-    gap: 16px;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 10px;
+}
+
+.row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 14px;
+    background: var(--lu-surface);
+    border: 1px solid var(--lu-border);
+    border-radius: 8px;
+    min-width: 0;
+}
+
+.rowTile {
+    width: 36px;
+    height: 36px;
+    flex: none;
+    display: grid;
+    place-items: center;
+    border-radius: 8px;
+    background: var(--mi-band);
+    color: var(--mi-fg);
+}
+
+.rowText {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    min-width: 0;
+}
+
+.rowText b {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--lu-ink);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.rowText small {
+    font-size: 12px;
+    color: var(--lu-muted);
+}
+
+.rowAction {
+    margin-left: auto;
+    flex: none;
 }
 
 .focusCard {
@@ -248,70 +326,55 @@
     line-height: 1.45;
 }
 
-.focusAction {
-    align-self: flex-start;
-    margin-top: auto;
-}
-
-.toolbar {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 14px;
-    flex-wrap: wrap;
-}
-
 .search {
-    flex: 1;
-    min-width: 220px;
-    max-width: 640px;
+    width: 100%;
+    max-width: 720px;
 }
 
-.toggles {
-    display: inline-flex;
-    align-items: center;
-    gap: 16px;
-    font-size: 13px;
-    color: var(--lu-secondary);
+.group {
+    scroll-margin-top: 80px;
 }
 
-/* The groups as filter chips under the search: All, then one per group with
-   the group's colour as a swatch. One chip at a time; All is the way back. */
+/* The groups as quiet pills under the search, as the homepage's: nothing
+   but text until hovered or chosen, the group's colour as a swatch. All,
+   then one per group, a hairline, then the two view toggles. */
 .chips {
     display: flex;
     flex-wrap: wrap;
-    gap: 6px;
-    margin-top: -4px;
+    justify-content: center;
+    gap: 4px;
 }
 
 .chip {
     display: inline-flex;
     align-items: center;
-    gap: 7px;
-    padding: 4px 11px;
-    border: 1px solid var(--lu-border);
+    gap: 6px;
+    padding: 4px 10px;
+    border: 1px solid transparent;
     border-radius: 999px;
-    background: var(--lu-surface);
-    color: var(--lu-secondary);
+    background: transparent;
+    color: var(--lu-muted);
     font: inherit;
-    font-size: 12.5px;
+    font-size: 12px;
     line-height: 1.3;
     cursor: pointer;
     transition:
+        background 120ms ease,
         border-color 120ms ease,
         color 120ms ease;
 }
 
 .chip:hover {
-    border-color: var(--lu-muted);
+    background: var(--lu-surface);
+    border-color: var(--lu-border);
     color: var(--lu-ink);
 }
 
 .chipOn {
-    border-color: var(--lu-accent);
+    background: var(--lu-surface);
+    border-color: var(--lu-border);
     color: var(--lu-ink);
-    font-weight: 600;
-    box-shadow: 0 0 0 1px var(--lu-accent) inset;
+    font-weight: 500;
 }
 
 .chipSwatch {
@@ -322,23 +385,18 @@
     flex: none;
 }
 
-.group {
-    margin: 6px 0 10px;
-    scroll-margin-top: 80px;
+/* The two view toggles sit at the end of the row as chips of their own,
+   past a hairline, so filters and toggles read as one set of controls. */
+.chipRule {
+    width: 1px;
+    height: 18px;
+    margin: 0 4px;
+    background: var(--lu-border);
+    align-self: center;
 }
 
-.groupTitle {
-    margin: 0;
-    font-size: 14px;
-    line-height: 1.35;
-    font-weight: 600;
-    color: var(--lu-ink);
-}
-
-.groupDesc {
-    margin: 2px 0 12px;
-    font-size: 12px;
-    line-height: 1.45;
+.chipHelp {
+    display: inline-flex;
     color: var(--lu-muted);
 }
 
@@ -491,10 +549,4 @@
 /* The completion page: the library's tokens and cards without its sidebar. */
 .overlineDone {
     color: var(--lu-done-fg);
-}
-
-@media (max-width: 900px) {
-    .focusGrid {
-        grid-template-columns: minmax(0, 1fr);
-    }
 }

--- a/packages/frontend/src/features/learn/Learn.module.css
+++ b/packages/frontend/src/features/learn/Learn.module.css
@@ -274,7 +274,7 @@
     display: flex;
     align-items: center;
     gap: 6px;
-    padding-top: 10px;
+    padding-top: 6px;
 }
 
 /* The roles as views, Linear's way: one pill per role, the chosen one
@@ -339,71 +339,46 @@
     border-color: var(--lu-secondary);
 }
 
-.iconBadge {
-    position: absolute;
-    top: -6px;
-    right: -6px;
-    min-width: 15px;
-    height: 15px;
-    padding: 0 4px;
-    border-radius: 999px;
-    background: var(--lu-accent);
-    color: #fff;
-    font-size: 10px;
-    font-weight: 600;
-    line-height: 15px;
-    text-align: center;
+/* Under the views, the groups as quiet tabs (All first) on the grid's
+   edge, the Filter button at the row's end. */
+.tabBar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: -10px;
+    padding-bottom: 8px;
+    border-bottom: 1px solid var(--lu-border);
 }
 
-.filterChips {
+.tabs {
     display: flex;
     flex-wrap: wrap;
-    align-items: center;
-    gap: 6px;
-    margin-top: -8px;
+    gap: 2px 12px;
+    margin-right: auto;
 }
 
-.filterChip {
+.tab {
     display: inline-flex;
     align-items: center;
     gap: 6px;
-    padding: 3px 4px 3px 9px;
-    border: 1px solid var(--lu-border);
-    border-radius: 6px;
-    background: var(--lu-surface);
-    color: var(--lu-ink);
-    font-size: 12px;
-}
-
-.filterChipKey {
-    color: var(--lu-muted);
-}
-
-.filterChipRemove {
-    display: inline-grid;
-    place-items: center;
-    width: 18px;
-    height: 18px;
-    border-radius: 4px;
-    color: var(--lu-muted);
-    cursor: pointer;
-}
-
-.filterChipRemove:hover {
-    background: var(--lu-sunken);
-    color: var(--lu-ink);
-}
-
-.filterClear {
+    padding: 4px 2px;
     font: inherit;
-    font-size: 12px;
+    font-size: 12.5px;
     color: var(--lu-muted);
-    padding: 3px 6px;
+    background: transparent;
     cursor: pointer;
+    border-bottom: 2px solid transparent;
+    transition: color 120ms ease;
 }
 
-.filterClear:hover {
+.tab:hover {
     color: var(--lu-ink);
+}
+
+.tabOn {
+    color: var(--lu-ink);
+    font-weight: 600;
+    border-bottom-color: var(--lu-accent);
 }
 
 .focusCard {

--- a/packages/frontend/src/features/learn/Learn.module.css
+++ b/packages/frontend/src/features/learn/Learn.module.css
@@ -153,7 +153,7 @@
     display: flex;
     flex-direction: column;
     gap: 22px;
-    padding: 36px 24px 56px;
+    padding: 72px 24px 56px;
 }
 
 /* The head in the homepage's shape: a centred greeting over a wide search,
@@ -205,8 +205,7 @@
    walkthrough named and described, its length and one action. */
 .upNext {
     width: 100%;
-    max-width: 720px;
-    margin: 0 auto;
+    margin-top: 10px;
 }
 
 .hero {

--- a/packages/frontend/src/features/learn/Learn.module.css
+++ b/packages/frontend/src/features/learn/Learn.module.css
@@ -237,12 +237,12 @@
     margin-left: 4px;
 }
 
-/* The two Continue cards as heroes: the group's colour as a tile, the
+/* The Up next card as a hero: the group's colour as a tile, the
    walkthrough named and described, its length and one action. */
-.heroGrid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-    gap: 14px;
+.upNext {
+    width: 100%;
+    max-width: 720px;
+    margin: 0 auto;
 }
 
 .hero {

--- a/packages/frontend/src/features/learn/Learn.module.css
+++ b/packages/frontend/src/features/learn/Learn.module.css
@@ -237,58 +237,79 @@
     margin-left: 4px;
 }
 
-.rows {
+/* The two Continue cards as heroes: the group's colour as a tile, the
+   walkthrough named and described, its length and one action. */
+.heroGrid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-    gap: 10px;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 14px;
 }
 
-.row {
+.hero {
     display: flex;
-    align-items: center;
-    gap: 12px;
-    padding: 10px 14px;
+    gap: 16px;
+    padding: 18px 20px;
     background: var(--lu-surface);
     border: 1px solid var(--lu-border);
-    border-radius: 8px;
+    border-radius: 10px;
     min-width: 0;
 }
 
-.rowTile {
-    width: 36px;
-    height: 36px;
+.heroTile {
+    width: 44px;
+    height: 44px;
     flex: none;
     display: grid;
     place-items: center;
-    border-radius: 8px;
+    border-radius: 10px;
     background: var(--mi-band);
     color: var(--mi-fg);
 }
 
-.rowText {
+.heroBody {
     display: flex;
     flex-direction: column;
-    gap: 1px;
+    gap: 6px;
     min-width: 0;
+    flex: 1;
 }
 
-.rowText b {
-    font-size: 13px;
+.heroBody h3 {
+    margin: 0;
+    font-size: 17px;
+    line-height: 1.25;
     font-weight: 600;
     color: var(--lu-ink);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
 }
 
-.rowText small {
+.heroBody p {
+    margin: 0;
+    font-size: 13px;
+    line-height: 1.45;
+    color: var(--lu-muted);
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+.heroFoot {
+    margin-top: 6px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
     font-size: 12px;
     color: var(--lu-muted);
 }
 
-.rowAction {
-    margin-left: auto;
-    flex: none;
+/* The filters sit between Continue and the groups they narrow. */
+.filters {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+    padding-top: 6px;
 }
 
 .focusCard {

--- a/packages/frontend/src/features/learn/LearnPage.tsx
+++ b/packages/frontend/src/features/learn/LearnPage.tsx
@@ -428,7 +428,6 @@ const LearnPage: FC = () => {
                                             ) : null
                                         }
                                         aria-checked={on}
-                                        role="menuitemcheckbox"
                                         data-learn-filter-group={group}
                                     >
                                         {GROUP_LABELS[group]}
@@ -448,7 +447,6 @@ const LearnPage: FC = () => {
                                     ) : null
                                 }
                                 aria-checked={showExtra}
-                                role="menuitemcheckbox"
                                 aria-label="Show extra modules"
                             >
                                 Extra modules
@@ -464,7 +462,6 @@ const LearnPage: FC = () => {
                                     ) : null
                                 }
                                 aria-checked={showSoon}
-                                role="menuitemcheckbox"
                                 aria-label="Coming soon"
                             >
                                 Coming soon

--- a/packages/frontend/src/features/learn/LearnPage.tsx
+++ b/packages/frontend/src/features/learn/LearnPage.tsx
@@ -212,7 +212,8 @@ const LearnPage: FC = () => {
     const [query, setQuery] = useState('');
     const [showExtra, setShowExtra] = useState(true);
     const [showSoon, setShowSoon] = useState(true);
-    const [activeGroup, setActiveGroup] = useState<LearnGroup | null>(null);
+    // One group, or every group: the chips beside the search.
+    const [groupFilter, setGroupFilter] = useState<LearnGroup | null>(null);
 
     const visible = useMemo(() => {
         const needle = query.trim().toLowerCase();
@@ -228,6 +229,12 @@ const LearnPage: FC = () => {
     const groups = GROUP_ORDER.filter((group) =>
         visible.some((module) => module.group === group),
     );
+    // A chip narrows the page to one group; the chips themselves always
+    // list every group with a match, so the way back is a click away.
+    const shownGroups =
+        groupFilter === null
+            ? groups
+            : groups.filter((group) => group === groupFilter);
     const available = catalogue.filter((m) => m.available);
     const doneCount = available.filter((m) =>
         completed.includes(m.scope),
@@ -247,12 +254,6 @@ const LearnPage: FC = () => {
     const { start, opening } = useStartWalkthrough(
         trainingProject?.projectUuid,
     );
-    const jumpTo = (group: LearnGroup) => {
-        setActiveGroup(group);
-        document
-            .getElementById(`learn-group-${group}`)
-            ?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    };
 
     if (previewRedirect) return <Navigate to={previewRedirect} replace />;
     // Learn switched off for the instance: the route falls through to the
@@ -283,45 +284,6 @@ const LearnPage: FC = () => {
 
     return (
         <Box className={styles.shell}>
-            <Box component="aside" className={styles.sidebar}>
-                <Box className={styles.sidebarInner}>
-                    <h2 className={styles.sidebarTitle}>Library</h2>
-                    <Box
-                        component="nav"
-                        className={styles.nav}
-                        aria-label="Library"
-                    >
-                        {groups.map((group) => {
-                            const Glyph = GROUP_ICONS[group];
-                            return (
-                                <UnstyledButton
-                                    key={group}
-                                    type="button"
-                                    className={`${styles.navItem} ${
-                                        activeGroup === group
-                                            ? styles.navItemActive
-                                            : ''
-                                    }`}
-                                    aria-current={
-                                        activeGroup === group
-                                            ? 'true'
-                                            : undefined
-                                    }
-                                    onClick={() => jumpTo(group)}
-                                >
-                                    <span
-                                        className={styles.navIcon}
-                                        style={groupVars(group)}
-                                    >
-                                        <MantineIcon icon={Glyph} size={15} />
-                                    </span>
-                                    {GROUP_LABELS[group]}
-                                </UnstyledButton>
-                            );
-                        })}
-                    </Box>
-                </Box>
-            </Box>
             <Box className={styles.main}>
                 <Box className={styles.homeHead}>
                     <h1 className={styles.greeting}>{greeting()}</h1>
@@ -482,12 +444,48 @@ const LearnPage: FC = () => {
                         />
                     </Group>
                 </Box>
+                <Box
+                    component="nav"
+                    className={styles.chips}
+                    aria-label="Library groups"
+                >
+                    <UnstyledButton
+                        type="button"
+                        className={`${styles.chip} ${
+                            groupFilter === null ? styles.chipOn : ''
+                        }`}
+                        aria-pressed={groupFilter === null}
+                        onClick={() => setGroupFilter(null)}
+                    >
+                        All
+                    </UnstyledButton>
+                    {groups.map((group) => (
+                        <UnstyledButton
+                            key={group}
+                            type="button"
+                            className={`${styles.chip} ${
+                                groupFilter === group ? styles.chipOn : ''
+                            }`}
+                            style={groupVars(group)}
+                            aria-pressed={groupFilter === group}
+                            data-learn-chip={group}
+                            onClick={() =>
+                                setGroupFilter(
+                                    groupFilter === group ? null : group,
+                                )
+                            }
+                        >
+                            <span className={styles.chipSwatch} aria-hidden />
+                            {GROUP_LABELS[group]}
+                        </UnstyledButton>
+                    ))}
+                </Box>
                 {groups.length === 0 && (
                     <Box className={styles.empty}>
                         No modules match this search.
                     </Box>
                 )}
-                {groups.map((group) => (
+                {shownGroups.map((group) => (
                     <Box
                         key={group}
                         component="section"

--- a/packages/frontend/src/features/learn/LearnPage.tsx
+++ b/packages/frontend/src/features/learn/LearnPage.tsx
@@ -11,7 +11,6 @@ import {
 import {
     IconCheck,
     IconFilter,
-    IconX,
     IconLayoutGrid,
     IconPlayerPlay,
     IconSearch,
@@ -207,14 +206,8 @@ const LearnPage: FC = () => {
     const [query, setQuery] = useState('');
     const [showExtra, setShowExtra] = useState(true);
     const [showSoon, setShowSoon] = useState(true);
-    // The groups chosen in the Filter menu; none chosen means every group.
-    const [selectedGroups, setSelectedGroups] = useState<LearnGroup[]>([]);
-    const toggleGroup = (group: LearnGroup) =>
-        setSelectedGroups((current) =>
-            current.includes(group)
-                ? current.filter((candidate) => candidate !== group)
-                : [...current, group],
-        );
+    // One group tab, or All.
+    const [groupFilter, setGroupFilter] = useState<LearnGroup | null>(null);
 
     const visible = useMemo(() => {
         const needle = query.trim().toLowerCase();
@@ -233,9 +226,9 @@ const LearnPage: FC = () => {
     // A chip narrows the page to one group; the chips themselves always
     // list every group with a match, so the way back is a click away.
     const shownGroups =
-        selectedGroups.length === 0
+        groupFilter === null
             ? groups
-            : groups.filter((group) => selectedGroups.includes(group));
+            : groups.filter((group) => group === groupFilter);
     const available = catalogue.filter((m) => m.available);
     const doneCount = available.filter((m) =>
         completed.includes(m.scope),
@@ -377,6 +370,43 @@ const LearnPage: FC = () => {
                     >
                         {doneCount} of {available.length} complete
                     </span>
+                </Box>
+                <Box className={styles.tabBar}>
+                    <Box
+                        component="nav"
+                        className={styles.tabs}
+                        aria-label="Library groups"
+                    >
+                        <UnstyledButton
+                            type="button"
+                            className={`${styles.tab} ${
+                                groupFilter === null ? styles.tabOn : ''
+                            }`}
+                            aria-pressed={groupFilter === null}
+                            onClick={() => setGroupFilter(null)}
+                        >
+                            All
+                        </UnstyledButton>
+                        {groups.map((group) => (
+                            <UnstyledButton
+                                key={group}
+                                type="button"
+                                className={`${styles.tab} ${
+                                    groupFilter === group ? styles.tabOn : ''
+                                }`}
+                                style={groupVars(group)}
+                                aria-pressed={groupFilter === group}
+                                data-learn-chip={group}
+                                onClick={() => setGroupFilter(group)}
+                            >
+                                <span
+                                    className={styles.chipSwatch}
+                                    aria-hidden
+                                />
+                                {GROUP_LABELS[group]}
+                            </UnstyledButton>
+                        ))}
+                    </Box>
                     <Menu
                         position="bottom-end"
                         withinPortal
@@ -387,7 +417,7 @@ const LearnPage: FC = () => {
                                 <UnstyledButton
                                     type="button"
                                     className={`${styles.iconButton} ${
-                                        selectedGroups.length > 0
+                                        !showExtra || !showSoon
                                             ? styles.iconButtonOn
                                             : ''
                                     }`}
@@ -396,45 +426,10 @@ const LearnPage: FC = () => {
                                     data-learn-filter
                                 >
                                     <MantineIcon icon={IconFilter} size={15} />
-                                    {selectedGroups.length > 0 && (
-                                        <span className={styles.iconBadge}>
-                                            {selectedGroups.length}
-                                        </span>
-                                    )}
                                 </UnstyledButton>
                             </Tooltip>
                         </Menu.Target>
                         <Menu.Dropdown>
-                            <Menu.Label>Group</Menu.Label>
-                            {groups.map((group) => {
-                                const on = selectedGroups.includes(group);
-                                return (
-                                    <Menu.Item
-                                        key={group}
-                                        onClick={() => toggleGroup(group)}
-                                        leftSection={
-                                            <span
-                                                className={styles.chipSwatch}
-                                                style={groupVars(group)}
-                                                aria-hidden
-                                            />
-                                        }
-                                        rightSection={
-                                            on ? (
-                                                <MantineIcon
-                                                    icon={IconCheck}
-                                                    size={13}
-                                                />
-                                            ) : null
-                                        }
-                                        aria-checked={on}
-                                        data-learn-filter-group={group}
-                                    >
-                                        {GROUP_LABELS[group]}
-                                    </Menu.Item>
-                                );
-                            })}
-                            <Menu.Divider />
                             <Menu.Label>Show</Menu.Label>
                             <Menu.Item
                                 onClick={() => setShowExtra(!showExtra)}
@@ -469,45 +464,6 @@ const LearnPage: FC = () => {
                         </Menu.Dropdown>
                     </Menu>
                 </Box>
-                {selectedGroups.length > 0 && (
-                    <Box
-                        className={styles.filterChips}
-                        aria-label="Active filters"
-                    >
-                        {selectedGroups.map((group) => (
-                            <span
-                                key={group}
-                                className={styles.filterChip}
-                                style={groupVars(group)}
-                                data-learn-chip={group}
-                            >
-                                <span className={styles.filterChipKey}>
-                                    Group is
-                                </span>
-                                <span
-                                    className={styles.chipSwatch}
-                                    aria-hidden
-                                />
-                                {GROUP_LABELS[group]}
-                                <UnstyledButton
-                                    type="button"
-                                    className={styles.filterChipRemove}
-                                    aria-label={`Remove ${GROUP_LABELS[group]} filter`}
-                                    onClick={() => toggleGroup(group)}
-                                >
-                                    <MantineIcon icon={IconX} size={12} />
-                                </UnstyledButton>
-                            </span>
-                        ))}
-                        <UnstyledButton
-                            type="button"
-                            className={styles.filterClear}
-                            onClick={() => setSelectedGroups([])}
-                        >
-                            Clear
-                        </UnstyledButton>
-                    </Box>
-                )}
                 {groups.length === 0 && (
                     <Box className={styles.empty}>
                         No modules match this search.

--- a/packages/frontend/src/features/learn/LearnPage.tsx
+++ b/packages/frontend/src/features/learn/LearnPage.tsx
@@ -3,22 +3,24 @@ import { type ProjectMemberRole, ProjectType } from '@lightdash/common';
 import {
     Box,
     Button,
-    Checkbox,
-    Group,
     Menu,
     TextInput,
     Tooltip,
     UnstyledButton,
 } from '@mantine/core';
 import {
+    IconCheck,
     IconChevronDown,
     IconHelpCircle,
+    IconLayoutGrid,
+    IconPlayerPlay,
     IconSearch,
     IconCircleCheck,
 } from '@tabler/icons-react';
 import { type FC, useEffect, useMemo, useState } from 'react';
 import { Navigate } from 'react-router';
 import MantineIcon from '../../components/common/MantineIcon';
+import { getGreeting } from '../../ee/features/homepageBuilder/greeting';
 import useHealth from '../../hooks/health/useHealth';
 import { useOptionalProjectRoute } from '../../hooks/useProjectRoute';
 import { useProjects } from '../../hooks/useProjects';
@@ -46,13 +48,6 @@ import { useLearnProgress } from './progress';
 import { thumbnailFor } from './thumbnails';
 import { useEnableLearn } from './useEnableLearn';
 import { useStartWalkthrough } from './useStartWalkthrough';
-
-const greeting = () => {
-    const hour = new Date().getHours();
-    if (hour < 12) return 'Good morning';
-    if (hour < 18) return 'Good afternoon';
-    return 'Good evening';
-};
 
 type CardState = 'soon' | 'ready' | 'started' | 'done';
 
@@ -285,10 +280,110 @@ const LearnPage: FC = () => {
     return (
         <Box className={styles.shell}>
             <Box className={styles.main}>
-                <Box className={styles.homeHead}>
-                    <h1 className={styles.greeting}>{greeting()}</h1>
+                <Box component="header" className={styles.homeHead}>
+                    <h1 className={styles.greeting}>
+                        {getGreeting(user.data?.firstName)}. What do you want to
+                        learn?
+                    </h1>
+                    <TextInput
+                        className={styles.search}
+                        size="md"
+                        radius="xl"
+                        placeholder="Search the library"
+                        aria-label="Search the library"
+                        leftSection={<MantineIcon icon={IconSearch} />}
+                        value={query}
+                        onChange={(event) =>
+                            setQuery(event.currentTarget.value)
+                        }
+                    />
+                    <Box
+                        component="nav"
+                        className={styles.chips}
+                        aria-label="Library groups"
+                    >
+                        <UnstyledButton
+                            type="button"
+                            className={`${styles.chip} ${
+                                groupFilter === null ? styles.chipOn : ''
+                            }`}
+                            aria-pressed={groupFilter === null}
+                            onClick={() => setGroupFilter(null)}
+                        >
+                            All
+                        </UnstyledButton>
+                        {groups.map((group) => (
+                            <UnstyledButton
+                                key={group}
+                                type="button"
+                                className={`${styles.chip} ${
+                                    groupFilter === group ? styles.chipOn : ''
+                                }`}
+                                style={groupVars(group)}
+                                aria-pressed={groupFilter === group}
+                                data-learn-chip={group}
+                                onClick={() =>
+                                    setGroupFilter(
+                                        groupFilter === group ? null : group,
+                                    )
+                                }
+                            >
+                                <span
+                                    className={styles.chipSwatch}
+                                    aria-hidden
+                                />
+                                {GROUP_LABELS[group]}
+                            </UnstyledButton>
+                        ))}
+                        <span className={styles.chipRule} aria-hidden />
+                        <UnstyledButton
+                            type="button"
+                            className={`${styles.chip} ${
+                                showExtra ? styles.chipOn : ''
+                            }`}
+                            role="switch"
+                            aria-checked={showExtra}
+                            aria-label="Show extra modules"
+                            onClick={() => setShowExtra(!showExtra)}
+                        >
+                            {showExtra && (
+                                <MantineIcon icon={IconCheck} size={12} />
+                            )}
+                            Extra modules
+                            <Tooltip
+                                label="Modules for roles above yours, with the role they need"
+                                withArrow
+                            >
+                                <span
+                                    className={styles.chipHelp}
+                                    role="img"
+                                    aria-label="Modules for roles above yours, with the role they need"
+                                >
+                                    <MantineIcon
+                                        icon={IconHelpCircle}
+                                        size={13}
+                                    />
+                                </span>
+                            </Tooltip>
+                        </UnstyledButton>
+                        <UnstyledButton
+                            type="button"
+                            className={`${styles.chip} ${
+                                showSoon ? styles.chipOn : ''
+                            }`}
+                            role="switch"
+                            aria-checked={showSoon}
+                            aria-label="Coming soon"
+                            onClick={() => setShowSoon(!showSoon)}
+                        >
+                            {showSoon && (
+                                <MantineIcon icon={IconCheck} size={12} />
+                            )}
+                            Coming soon
+                        </UnstyledButton>
+                    </Box>
                     <Box className={styles.stats} data-learn-role={role}>
-                        <Menu position="bottom-end" withinPortal>
+                        <Menu position="bottom" withinPortal>
                             <Menu.Target>
                                 <UnstyledButton
                                     type="button"
@@ -327,159 +422,83 @@ const LearnPage: FC = () => {
                         </span>
                     </Box>
                 </Box>
-                <Box className={styles.focusGrid}>
-                    {resume ? (
-                        <Box
-                            component="article"
-                            className={styles.focusCard}
-                            data-learn-resume={resume.scope}
-                        >
-                            <span
-                                className={`${styles.overline} ${styles.overlineAccent}`}
-                            >
-                                Resume
-                            </span>
-                            <h2>{resume.title}</h2>
-                            <p>{resume.blurb}</p>
-                            <Button
-                                className={styles.focusAction}
-                                variant="light"
-                                size="compact-md"
-                                loading={opening === resume.scope}
-                                onClick={() => start(resume.scope)}
-                            >
-                                Resume module
-                            </Button>
-                        </Box>
-                    ) : (
-                        <Box component="article" className={styles.focusCard}>
-                            <span
-                                className={`${styles.overline} ${styles.overlineAccent}`}
-                            >
-                                Resume
-                            </span>
-                            <h2>No module in progress</h2>
-                            <p>Start a module from the library below.</p>
-                        </Box>
-                    )}
-                    {recommended ? (
-                        <Box
-                            component="article"
-                            className={styles.focusCard}
-                            data-learn-recommended={recommended.scope}
-                        >
-                            <span className={styles.overline}>
-                                Recommended next
-                            </span>
-                            <h2>{recommended.title}</h2>
-                            <p>{recommended.blurb}</p>
-                            <Button
-                                className={styles.focusAction}
-                                variant="default"
-                                size="compact-md"
-                                loading={opening === recommended.scope}
-                                onClick={() => start(recommended.scope)}
-                            >
-                                Start
-                            </Button>
-                        </Box>
-                    ) : (
-                        <Box component="article" className={styles.focusCard}>
-                            <span className={styles.overline}>
-                                Recommendation
-                            </span>
-                            <h2>Nothing new for {ROLE_LABELS[role]}</h2>
-                            <p>
-                                Use Show extra modules when you want to go
-                                beyond your role.
-                            </p>
-                        </Box>
-                    )}
-                </Box>
-                <Box className={styles.toolbar}>
-                    <TextInput
-                        className={styles.search}
-                        size="sm"
-                        placeholder="Search the library"
-                        aria-label="Search the library"
-                        leftSection={<MantineIcon icon={IconSearch} />}
-                        value={query}
-                        onChange={(event) =>
-                            setQuery(event.currentTarget.value)
-                        }
-                    />
-                    <Group className={styles.toggles} gap="md">
-                        <Group gap={6} wrap="nowrap">
-                            <Checkbox
-                                size="xs"
-                                label="Show extra modules"
-                                checked={showExtra}
-                                onChange={(event) =>
-                                    setShowExtra(event.currentTarget.checked)
-                                }
-                            />
-                            <Tooltip
-                                label="Modules for roles above yours, with the role they need"
-                                withArrow
-                            >
-                                <span
-                                    role="img"
-                                    aria-label="Modules for roles above yours, with the role they need"
+                {(resume || recommended) && (
+                    <Box component="section" className={styles.section}>
+                        <h2 className={styles.sectionTitle}>
+                            <MantineIcon icon={IconPlayerPlay} size={14} />
+                            Continue
+                        </h2>
+                        <Box className={styles.rows}>
+                            {resume && (
+                                <Box
+                                    component="article"
+                                    className={styles.row}
+                                    data-learn-resume={resume.scope}
                                 >
-                                    <MantineIcon
-                                        icon={IconHelpCircle}
-                                        size={14}
-                                        color="dimmed"
-                                    />
-                                </span>
-                            </Tooltip>
-                        </Group>
-                        <Checkbox
-                            size="xs"
-                            label="Coming soon"
-                            checked={showSoon}
-                            onChange={(event) =>
-                                setShowSoon(event.currentTarget.checked)
-                            }
-                        />
-                    </Group>
-                </Box>
-                <Box
-                    component="nav"
-                    className={styles.chips}
-                    aria-label="Library groups"
-                >
-                    <UnstyledButton
-                        type="button"
-                        className={`${styles.chip} ${
-                            groupFilter === null ? styles.chipOn : ''
-                        }`}
-                        aria-pressed={groupFilter === null}
-                        onClick={() => setGroupFilter(null)}
-                    >
-                        All
-                    </UnstyledButton>
-                    {groups.map((group) => (
-                        <UnstyledButton
-                            key={group}
-                            type="button"
-                            className={`${styles.chip} ${
-                                groupFilter === group ? styles.chipOn : ''
-                            }`}
-                            style={groupVars(group)}
-                            aria-pressed={groupFilter === group}
-                            data-learn-chip={group}
-                            onClick={() =>
-                                setGroupFilter(
-                                    groupFilter === group ? null : group,
-                                )
-                            }
-                        >
-                            <span className={styles.chipSwatch} aria-hidden />
-                            {GROUP_LABELS[group]}
-                        </UnstyledButton>
-                    ))}
-                </Box>
+                                    <span
+                                        className={styles.rowTile}
+                                        style={groupVars(resume.group)}
+                                    >
+                                        <MantineIcon
+                                            icon={GROUP_ICONS[resume.group]}
+                                            size={16}
+                                        />
+                                    </span>
+                                    <span className={styles.rowText}>
+                                        <b>{resume.title}</b>
+                                        <small>
+                                            Resume · {resume.stepCount} steps
+                                        </small>
+                                    </span>
+                                    <Button
+                                        className={styles.rowAction}
+                                        variant="light"
+                                        size="compact-sm"
+                                        loading={opening === resume.scope}
+                                        onClick={() => start(resume.scope)}
+                                    >
+                                        Resume
+                                    </Button>
+                                </Box>
+                            )}
+                            {recommended && (
+                                <Box
+                                    component="article"
+                                    className={styles.row}
+                                    data-learn-recommended={recommended.scope}
+                                >
+                                    <span
+                                        className={styles.rowTile}
+                                        style={groupVars(recommended.group)}
+                                    >
+                                        <MantineIcon
+                                            icon={
+                                                GROUP_ICONS[recommended.group]
+                                            }
+                                            size={16}
+                                        />
+                                    </span>
+                                    <span className={styles.rowText}>
+                                        <b>{recommended.title}</b>
+                                        <small>
+                                            Recommended next ·{' '}
+                                            {recommended.stepCount} steps
+                                        </small>
+                                    </span>
+                                    <Button
+                                        className={styles.rowAction}
+                                        variant="default"
+                                        size="compact-sm"
+                                        loading={opening === recommended.scope}
+                                        onClick={() => start(recommended.scope)}
+                                    >
+                                        Start
+                                    </Button>
+                                </Box>
+                            )}
+                        </Box>
+                    </Box>
+                )}
                 {groups.length === 0 && (
                     <Box className={styles.empty}>
                         No modules match this search.
@@ -490,15 +509,16 @@ const LearnPage: FC = () => {
                         key={group}
                         component="section"
                         id={`learn-group-${group}`}
-                        className={styles.group}
+                        className={`${styles.group} ${styles.section}`}
                         data-learn-group={group}
                     >
-                        <h2 className={styles.groupTitle}>
+                        <h2 className={styles.sectionTitle}>
+                            <MantineIcon icon={IconLayoutGrid} size={14} />
                             {GROUP_LABELS[group]}
+                            <span className={styles.sectionDesc}>
+                                {GROUP_DESCRIPTIONS[group]}
+                            </span>
                         </h2>
-                        <p className={styles.groupDesc}>
-                            {GROUP_DESCRIPTIONS[group]}
-                        </p>
                         <Box className={styles.grid}>
                             {visible
                                 .filter((module) => module.group === group)

--- a/packages/frontend/src/features/learn/LearnPage.tsx
+++ b/packages/frontend/src/features/learn/LearnPage.tsx
@@ -10,8 +10,8 @@ import {
 } from '@mantine/core';
 import {
     IconCheck,
-    IconChevronDown,
-    IconHelpCircle,
+    IconFilter,
+    IconX,
     IconLayoutGrid,
     IconPlayerPlay,
     IconSearch,
@@ -207,8 +207,14 @@ const LearnPage: FC = () => {
     const [query, setQuery] = useState('');
     const [showExtra, setShowExtra] = useState(true);
     const [showSoon, setShowSoon] = useState(true);
-    // One group, or every group: the chips beside the search.
-    const [groupFilter, setGroupFilter] = useState<LearnGroup | null>(null);
+    // The groups chosen in the Filter menu; none chosen means every group.
+    const [selectedGroups, setSelectedGroups] = useState<LearnGroup[]>([]);
+    const toggleGroup = (group: LearnGroup) =>
+        setSelectedGroups((current) =>
+            current.includes(group)
+                ? current.filter((candidate) => candidate !== group)
+                : [...current, group],
+        );
 
     const visible = useMemo(() => {
         const needle = query.trim().toLowerCase();
@@ -227,9 +233,9 @@ const LearnPage: FC = () => {
     // A chip narrows the page to one group; the chips themselves always
     // list every group with a match, so the way back is a click away.
     const shownGroups =
-        groupFilter === null
+        selectedGroups.length === 0
             ? groups
-            : groups.filter((group) => group === groupFilter);
+            : groups.filter((group) => selectedGroups.includes(group));
     const available = catalogue.filter((m) => m.available);
     const doneCount = available.filter((m) =>
         completed.includes(m.scope),
@@ -344,132 +350,167 @@ const LearnPage: FC = () => {
                         </Box>
                     </Box>
                 )}
-                <Box className={styles.filters}>
+                <Box className={styles.libraryBar}>
                     <Box
                         component="nav"
-                        className={styles.chips}
-                        aria-label="Library groups"
+                        className={styles.views}
+                        aria-label="Viewing as"
+                        data-learn-role={role}
                     >
-                        <UnstyledButton
-                            type="button"
-                            className={`${styles.chip} ${
-                                groupFilter === null ? styles.chipOn : ''
-                            }`}
-                            aria-pressed={groupFilter === null}
-                            onClick={() => setGroupFilter(null)}
-                        >
-                            All
-                        </UnstyledButton>
-                        {groups.map((group) => (
+                        {ROLE_ORDER.map((candidate) => (
                             <UnstyledButton
-                                key={group}
+                                key={candidate}
                                 type="button"
-                                className={`${styles.chip} ${
-                                    groupFilter === group ? styles.chipOn : ''
+                                className={`${styles.view} ${
+                                    candidate === role ? styles.viewOn : ''
                                 }`}
-                                style={groupVars(group)}
-                                aria-pressed={groupFilter === group}
-                                data-learn-chip={group}
-                                onClick={() =>
-                                    setGroupFilter(
-                                        groupFilter === group ? null : group,
-                                    )
-                                }
+                                aria-pressed={candidate === role}
+                                onClick={() => setRole(candidate)}
                             >
+                                {ROLE_LABELS[candidate]}
+                            </UnstyledButton>
+                        ))}
+                    </Box>
+                    <span
+                        className={styles.libraryCount}
+                        data-learn-progress={`${doneCount}/${available.length}`}
+                    >
+                        {doneCount} of {available.length} complete
+                    </span>
+                    <Menu
+                        position="bottom-end"
+                        withinPortal
+                        closeOnItemClick={false}
+                    >
+                        <Menu.Target>
+                            <Tooltip label="Filter" withArrow>
+                                <UnstyledButton
+                                    type="button"
+                                    className={`${styles.iconButton} ${
+                                        selectedGroups.length > 0
+                                            ? styles.iconButtonOn
+                                            : ''
+                                    }`}
+                                    aria-label="Filter"
+                                    aria-haspopup="menu"
+                                    data-learn-filter
+                                >
+                                    <MantineIcon icon={IconFilter} size={15} />
+                                    {selectedGroups.length > 0 && (
+                                        <span className={styles.iconBadge}>
+                                            {selectedGroups.length}
+                                        </span>
+                                    )}
+                                </UnstyledButton>
+                            </Tooltip>
+                        </Menu.Target>
+                        <Menu.Dropdown>
+                            <Menu.Label>Group</Menu.Label>
+                            {groups.map((group) => {
+                                const on = selectedGroups.includes(group);
+                                return (
+                                    <Menu.Item
+                                        key={group}
+                                        onClick={() => toggleGroup(group)}
+                                        leftSection={
+                                            <span
+                                                className={styles.chipSwatch}
+                                                style={groupVars(group)}
+                                                aria-hidden
+                                            />
+                                        }
+                                        rightSection={
+                                            on ? (
+                                                <MantineIcon
+                                                    icon={IconCheck}
+                                                    size={13}
+                                                />
+                                            ) : null
+                                        }
+                                        aria-checked={on}
+                                        role="menuitemcheckbox"
+                                        data-learn-filter-group={group}
+                                    >
+                                        {GROUP_LABELS[group]}
+                                    </Menu.Item>
+                                );
+                            })}
+                            <Menu.Divider />
+                            <Menu.Label>Show</Menu.Label>
+                            <Menu.Item
+                                onClick={() => setShowExtra(!showExtra)}
+                                rightSection={
+                                    showExtra ? (
+                                        <MantineIcon
+                                            icon={IconCheck}
+                                            size={13}
+                                        />
+                                    ) : null
+                                }
+                                aria-checked={showExtra}
+                                role="menuitemcheckbox"
+                                aria-label="Show extra modules"
+                            >
+                                Extra modules
+                            </Menu.Item>
+                            <Menu.Item
+                                onClick={() => setShowSoon(!showSoon)}
+                                rightSection={
+                                    showSoon ? (
+                                        <MantineIcon
+                                            icon={IconCheck}
+                                            size={13}
+                                        />
+                                    ) : null
+                                }
+                                aria-checked={showSoon}
+                                role="menuitemcheckbox"
+                                aria-label="Coming soon"
+                            >
+                                Coming soon
+                            </Menu.Item>
+                        </Menu.Dropdown>
+                    </Menu>
+                </Box>
+                {selectedGroups.length > 0 && (
+                    <Box
+                        className={styles.filterChips}
+                        aria-label="Active filters"
+                    >
+                        {selectedGroups.map((group) => (
+                            <span
+                                key={group}
+                                className={styles.filterChip}
+                                style={groupVars(group)}
+                                data-learn-chip={group}
+                            >
+                                <span className={styles.filterChipKey}>
+                                    Group is
+                                </span>
                                 <span
                                     className={styles.chipSwatch}
                                     aria-hidden
                                 />
                                 {GROUP_LABELS[group]}
-                            </UnstyledButton>
-                        ))}
-                        <span className={styles.chipRule} aria-hidden />
-                        <UnstyledButton
-                            type="button"
-                            className={`${styles.chip} ${
-                                showExtra ? styles.chipOn : ''
-                            }`}
-                            role="switch"
-                            aria-checked={showExtra}
-                            aria-label="Show extra modules"
-                            onClick={() => setShowExtra(!showExtra)}
-                        >
-                            {showExtra && (
-                                <MantineIcon icon={IconCheck} size={12} />
-                            )}
-                            Extra modules
-                            <Tooltip
-                                label="Modules for roles above yours, with the role they need"
-                                withArrow
-                            >
-                                <span
-                                    className={styles.chipHelp}
-                                    role="img"
-                                    aria-label="Modules for roles above yours, with the role they need"
-                                >
-                                    <MantineIcon
-                                        icon={IconHelpCircle}
-                                        size={13}
-                                    />
-                                </span>
-                            </Tooltip>
-                        </UnstyledButton>
-                        <UnstyledButton
-                            type="button"
-                            className={`${styles.chip} ${
-                                showSoon ? styles.chipOn : ''
-                            }`}
-                            role="switch"
-                            aria-checked={showSoon}
-                            aria-label="Coming soon"
-                            onClick={() => setShowSoon(!showSoon)}
-                        >
-                            {showSoon && (
-                                <MantineIcon icon={IconCheck} size={12} />
-                            )}
-                            Coming soon
-                        </UnstyledButton>
-                    </Box>
-                    <Box className={styles.stats} data-learn-role={role}>
-                        <Menu position="bottom" withinPortal>
-                            <Menu.Target>
                                 <UnstyledButton
                                     type="button"
-                                    className={`${styles.stat} ${styles.statButton}`}
-                                    aria-haspopup="menu"
+                                    className={styles.filterChipRemove}
+                                    aria-label={`Remove ${GROUP_LABELS[group]} filter`}
+                                    onClick={() => toggleGroup(group)}
                                 >
-                                    Viewing as <b>{ROLE_LABELS[role]}</b>
-                                    <MantineIcon
-                                        icon={IconChevronDown}
-                                        size={14}
-                                    />
+                                    <MantineIcon icon={IconX} size={12} />
                                 </UnstyledButton>
-                            </Menu.Target>
-                            <Menu.Dropdown>
-                                {ROLE_ORDER.map((candidate) => (
-                                    <Menu.Item
-                                        key={candidate}
-                                        onClick={() => setRole(candidate)}
-                                        fw={
-                                            candidate === role ? 600 : undefined
-                                        }
-                                    >
-                                        {ROLE_LABELS[candidate]}
-                                    </Menu.Item>
-                                ))}
-                            </Menu.Dropdown>
-                        </Menu>
-                        <span
-                            className={styles.stat}
-                            data-learn-progress={`${doneCount}/${available.length}`}
+                            </span>
+                        ))}
+                        <UnstyledButton
+                            type="button"
+                            className={styles.filterClear}
+                            onClick={() => setSelectedGroups([])}
                         >
-                            Modules{' '}
-                            <b>
-                                {doneCount} of {available.length}
-                            </b>
-                        </span>
+                            Clear
+                        </UnstyledButton>
                     </Box>
-                </Box>
+                )}
                 {groups.length === 0 && (
                     <Box className={styles.empty}>
                         No modules match this search.

--- a/packages/frontend/src/features/learn/LearnPage.tsx
+++ b/packages/frontend/src/features/learn/LearnPage.tsx
@@ -297,6 +297,101 @@ const LearnPage: FC = () => {
                             setQuery(event.currentTarget.value)
                         }
                     />
+                </Box>
+                {(resume || recommended) && (
+                    <Box component="section" className={styles.section}>
+                        <h2 className={styles.sectionTitle}>
+                            <MantineIcon icon={IconPlayerPlay} size={14} />
+                            Continue
+                        </h2>
+                        <Box className={styles.heroGrid}>
+                            {resume && (
+                                <Box
+                                    component="article"
+                                    className={styles.hero}
+                                    style={groupVars(resume.group)}
+                                    data-learn-resume={resume.scope}
+                                >
+                                    <span className={styles.heroTile}>
+                                        <MantineIcon
+                                            icon={GROUP_ICONS[resume.group]}
+                                            size={20}
+                                        />
+                                    </span>
+                                    <Box className={styles.heroBody}>
+                                        <span
+                                            className={`${styles.overline} ${styles.overlineAccent}`}
+                                        >
+                                            Resume
+                                        </span>
+                                        <h3>{resume.title}</h3>
+                                        <p>{resume.blurb}</p>
+                                        <Box className={styles.heroFoot}>
+                                            <span>
+                                                {resume.stepCount} steps
+                                            </span>
+                                            <Button
+                                                variant="light"
+                                                size="compact-md"
+                                                loading={
+                                                    opening === resume.scope
+                                                }
+                                                onClick={() =>
+                                                    start(resume.scope)
+                                                }
+                                            >
+                                                Resume module
+                                            </Button>
+                                        </Box>
+                                    </Box>
+                                </Box>
+                            )}
+                            {recommended && (
+                                <Box
+                                    component="article"
+                                    className={styles.hero}
+                                    style={groupVars(recommended.group)}
+                                    data-learn-recommended={recommended.scope}
+                                >
+                                    <span className={styles.heroTile}>
+                                        <MantineIcon
+                                            icon={
+                                                GROUP_ICONS[recommended.group]
+                                            }
+                                            size={20}
+                                        />
+                                    </span>
+                                    <Box className={styles.heroBody}>
+                                        <span className={styles.overline}>
+                                            Recommended next
+                                        </span>
+                                        <h3>{recommended.title}</h3>
+                                        <p>{recommended.blurb}</p>
+                                        <Box className={styles.heroFoot}>
+                                            <span>
+                                                {recommended.stepCount} steps
+                                            </span>
+                                            <Button
+                                                variant="default"
+                                                size="compact-md"
+                                                loading={
+                                                    opening ===
+                                                    recommended.scope
+                                                }
+                                                onClick={() =>
+                                                    start(recommended.scope)
+                                                }
+                                            >
+                                                Start
+                                            </Button>
+                                        </Box>
+                                    </Box>
+                                </Box>
+                            )}
+                        </Box>
+                    </Box>
+                )}
+                <Box className={styles.filters}>
                     <Box
                         component="nav"
                         className={styles.chips}
@@ -422,83 +517,6 @@ const LearnPage: FC = () => {
                         </span>
                     </Box>
                 </Box>
-                {(resume || recommended) && (
-                    <Box component="section" className={styles.section}>
-                        <h2 className={styles.sectionTitle}>
-                            <MantineIcon icon={IconPlayerPlay} size={14} />
-                            Continue
-                        </h2>
-                        <Box className={styles.rows}>
-                            {resume && (
-                                <Box
-                                    component="article"
-                                    className={styles.row}
-                                    data-learn-resume={resume.scope}
-                                >
-                                    <span
-                                        className={styles.rowTile}
-                                        style={groupVars(resume.group)}
-                                    >
-                                        <MantineIcon
-                                            icon={GROUP_ICONS[resume.group]}
-                                            size={16}
-                                        />
-                                    </span>
-                                    <span className={styles.rowText}>
-                                        <b>{resume.title}</b>
-                                        <small>
-                                            Resume · {resume.stepCount} steps
-                                        </small>
-                                    </span>
-                                    <Button
-                                        className={styles.rowAction}
-                                        variant="light"
-                                        size="compact-sm"
-                                        loading={opening === resume.scope}
-                                        onClick={() => start(resume.scope)}
-                                    >
-                                        Resume
-                                    </Button>
-                                </Box>
-                            )}
-                            {recommended && (
-                                <Box
-                                    component="article"
-                                    className={styles.row}
-                                    data-learn-recommended={recommended.scope}
-                                >
-                                    <span
-                                        className={styles.rowTile}
-                                        style={groupVars(recommended.group)}
-                                    >
-                                        <MantineIcon
-                                            icon={
-                                                GROUP_ICONS[recommended.group]
-                                            }
-                                            size={16}
-                                        />
-                                    </span>
-                                    <span className={styles.rowText}>
-                                        <b>{recommended.title}</b>
-                                        <small>
-                                            Recommended next ·{' '}
-                                            {recommended.stepCount} steps
-                                        </small>
-                                    </span>
-                                    <Button
-                                        className={styles.rowAction}
-                                        variant="default"
-                                        size="compact-sm"
-                                        loading={opening === recommended.scope}
-                                        onClick={() => start(recommended.scope)}
-                                    >
-                                        Start
-                                    </Button>
-                                </Box>
-                            )}
-                        </Box>
-                    </Box>
-                )}
                 {groups.length === 0 && (
                     <Box className={styles.empty}>
                         No modules match this search.

--- a/packages/frontend/src/features/learn/LearnPage.tsx
+++ b/packages/frontend/src/features/learn/LearnPage.tsx
@@ -243,6 +243,9 @@ const LearnPage: FC = () => {
         completed,
         lastStarted,
     );
+    // One thing to do next: the recommendation, or whatever was last
+    // started if nothing is left to recommend.
+    const upNext = recommended ?? resume;
 
     // Start makes the learner's copy and goes straight into it; the
     // walkthrough brings them back to the library side when it ends.
@@ -288,7 +291,7 @@ const LearnPage: FC = () => {
                     <TextInput
                         className={styles.search}
                         size="md"
-                        radius="xl"
+                        radius="md"
                         placeholder="Search the library"
                         aria-label="Search the library"
                         leftSection={<MantineIcon icon={IconSearch} />}
@@ -298,96 +301,46 @@ const LearnPage: FC = () => {
                         }
                     />
                 </Box>
-                {(resume || recommended) && (
-                    <Box component="section" className={styles.section}>
+                {upNext && (
+                    <Box
+                        component="section"
+                        className={`${styles.section} ${styles.upNext}`}
+                    >
                         <h2 className={styles.sectionTitle}>
                             <MantineIcon icon={IconPlayerPlay} size={14} />
-                            Continue
+                            Up next
                         </h2>
-                        <Box className={styles.heroGrid}>
-                            {resume && (
-                                <Box
-                                    component="article"
-                                    className={styles.hero}
-                                    style={groupVars(resume.group)}
-                                    data-learn-resume={resume.scope}
-                                >
-                                    <span className={styles.heroTile}>
-                                        <MantineIcon
-                                            icon={GROUP_ICONS[resume.group]}
-                                            size={20}
-                                        />
-                                    </span>
-                                    <Box className={styles.heroBody}>
-                                        <span
-                                            className={`${styles.overline} ${styles.overlineAccent}`}
-                                        >
-                                            Resume
-                                        </span>
-                                        <h3>{resume.title}</h3>
-                                        <p>{resume.blurb}</p>
-                                        <Box className={styles.heroFoot}>
-                                            <span>
-                                                {resume.stepCount} steps
-                                            </span>
-                                            <Button
-                                                variant="light"
-                                                size="compact-md"
-                                                loading={
-                                                    opening === resume.scope
-                                                }
-                                                onClick={() =>
-                                                    start(resume.scope)
-                                                }
-                                            >
-                                                Resume module
-                                            </Button>
-                                        </Box>
-                                    </Box>
+                        <Box
+                            component="article"
+                            className={styles.hero}
+                            style={groupVars(upNext.group)}
+                            data-learn-recommended={upNext.scope}
+                        >
+                            <span className={styles.heroTile}>
+                                <MantineIcon
+                                    icon={GROUP_ICONS[upNext.group]}
+                                    size={20}
+                                />
+                            </span>
+                            <Box className={styles.heroBody}>
+                                <span className={styles.overline}>
+                                    {GROUP_LABELS[upNext.group]}
+                                </span>
+                                <h3>{upNext.title}</h3>
+                                <p>{upNext.blurb}</p>
+                                <Box className={styles.heroFoot}>
+                                    <span>{upNext.stepCount} steps</span>
+                                    <Button
+                                        variant="filled"
+                                        color="indigo"
+                                        size="compact-md"
+                                        loading={opening === upNext.scope}
+                                        onClick={() => start(upNext.scope)}
+                                    >
+                                        Start
+                                    </Button>
                                 </Box>
-                            )}
-                            {recommended && (
-                                <Box
-                                    component="article"
-                                    className={styles.hero}
-                                    style={groupVars(recommended.group)}
-                                    data-learn-recommended={recommended.scope}
-                                >
-                                    <span className={styles.heroTile}>
-                                        <MantineIcon
-                                            icon={
-                                                GROUP_ICONS[recommended.group]
-                                            }
-                                            size={20}
-                                        />
-                                    </span>
-                                    <Box className={styles.heroBody}>
-                                        <span className={styles.overline}>
-                                            Recommended next
-                                        </span>
-                                        <h3>{recommended.title}</h3>
-                                        <p>{recommended.blurb}</p>
-                                        <Box className={styles.heroFoot}>
-                                            <span>
-                                                {recommended.stepCount} steps
-                                            </span>
-                                            <Button
-                                                variant="default"
-                                                size="compact-md"
-                                                loading={
-                                                    opening ===
-                                                    recommended.scope
-                                                }
-                                                onClick={() =>
-                                                    start(recommended.scope)
-                                                }
-                                            >
-                                                Start
-                                            </Button>
-                                        </Box>
-                                    </Box>
-                                </Box>
-                            )}
+                            </Box>
                         </Box>
                     </Box>
                 )}


### PR DESCRIPTION
Stacked on #28793 (CS-262). Decisions with João and Josh, 2026-09-08.

The library page takes the homepage's shape:

- A centred greeting in the homepage's words (Good morning, Josh. What do you want to learn?) and the search as one line at the ask box's width.
- One **Up next** hero at the grid's width: the recommended module (the teaching order from #28815 once merged), with its group, blurb, length and Start. Resume goes: walkthroughs are not saved part way.
- A header row with the roles as **views** (pills, the learner's own role chosen by default) and the completed count.
- A second row with **All** and the group tabs on the grid's edge, and a **Filter** button at the end whose menu holds Extra modules and Coming soon.
- Titled group sections with the homepage's icon-and-title header; the page sits in the homepage's 1040px column. The sidebar is gone.

Verified on a local instance in light and dark; the library recorder flow covers the views, the group tabs, the Filter menu and the Up next hero.

Follow-on: CS-267 replaces the role pills with a picker and adds custom roles as views.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WzrWdus5zqJBTK2ouC1q6m