### PR TITLE
fix(upgrade-automation): quote the title_scope description so the manifest parses

### DIFF
--- a/.github/workflows/upgrade-automation-tests.yml
+++ b/.github/workflows/upgrade-automation-tests.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - run: bash examples/upgrade-automation/scripts/manifest.test.sh
       - run: bash examples/upgrade-automation/scripts/common.test.sh
       - run: bash examples/upgrade-automation/scripts/verify.test.sh
       - run: bash examples/upgrade-automation/scripts/plan.test.sh

--- a/examples/upgrade-automation/plan/action.yml
+++ b/examples/upgrade-automation/plan/action.yml
@@ -9,7 +9,7 @@ inputs:
     required: false
     default: lightdash-upgrade
   title_scope:
-    description: Optional conventional-commit scope for the pin commit and pull request title, for example the instance name when one repository pins several instances. Empty keeps the title as chore: upgrade Lightdash to VERSION
+    description: 'Optional conventional-commit scope for the pin commit and pull request title, for example the instance name when one repository pins several instances. Empty keeps the unscoped title.'
     required: false
     default: ''
   tag_suffix:

--- a/examples/upgrade-automation/scripts/manifest.test.sh
+++ b/examples/upgrade-automation/scripts/manifest.test.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+root=$(cd "$(dirname "$0")/../../.." && pwd)
+actions_dir="$root/examples/upgrade-automation"
+
+for manifest in "$actions_dir"/*/action.yml; do
+    if ! python3 -c "
+import sys, yaml
+path = sys.argv[1]
+try:
+    manifest = yaml.safe_load(open(path))
+except yaml.YAMLError as error:
+    print(f'{path} is not valid YAML: {error}', file=sys.stderr)
+    sys.exit(1)
+if not isinstance(manifest, dict):
+    print(f'{path} must parse to a mapping', file=sys.stderr)
+    sys.exit(1)
+declared = set((manifest.get('inputs') or {}).keys())
+used = set()
+for step in (manifest.get('runs') or {}).get('steps') or []:
+    for value in ((step.get('env') or {}).values()):
+        text = str(value)
+        for name in declared:
+            if 'inputs.' + name in text:
+                used.add(name)
+missing = sorted(name for name in declared if name not in used)
+if missing:
+    print(f'{path} declares inputs that no step consumes: {missing}', file=sys.stderr)
+    sys.exit(1)
+" "$manifest"; then
+        printf 'manifest test failed for %s\n' "$manifest" >&2
+        exit 1
+    fi
+    printf 'manifest %s parsed and wired\n' "${manifest#"$root/"}"
+done
+
+printf 'action manifest tests passed\n'


### PR DESCRIPTION
## Urgent: this unbreaks upgrade planning for every consumer

#28811 added a `title_scope` input whose description ended with a literal `chore: upgrade Lightdash to VERSION`. Unquoted, YAML reads that colon as a mapping key, so the plan action manifest no longer parses:

```
lightdash/lightdash/e1d46d5.../examples/upgrade-automation/plan/action.yml:
(Line: 12, Col: 200) - Mapping values are not allowed in this context.
##[error]Failed to load .../plan/action.yml
```

Every planning job now fails at `Set up job` before running a step. In `lightdash-cloud` the analytics run has been failing since the pin bumped, and staging fails on its next tick. `2.153.1` is out while both instances sit on `2.151.1`, so upgrades are blocked until this lands.

## What

- Quote the description and drop the colon from it.
- Add `scripts/manifest.test.sh`, which parses every action manifest and checks that each declared input is consumed by a step. CI runs it ahead of the other suites.

The new guard fails on exactly the manifest that broke and passes on the fix, so this class of breakage cannot merge again.

## Test plan

- [x] `manifest.test.sh` fails on the broken manifest, passes on the fixed one
- [x] `common.test.sh`, `verify.test.sh`, `plan.test.sh` all pass locally
- [ ] Follow-up bumps the `lightdash-cloud` pin to the squash commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KPM8jKe1sVfAVjYDndNwLw
