### PR TITLE
fix(ai-agent): stop paging Sentry for tool errors the model can recover from

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -3068,6 +3068,23 @@ export type AiAgentToolCallEvent = BaseTrack & {
     };
 };
 
+// A tool returned an error to the model. Most of these are the model's own
+// mistakes that it retries, so they are tracked here as a rate rather than
+// reported to Sentry.
+export type AiAgentToolCallFailedEvent = BaseTrack & {
+    event: 'ai_agent_tool_call_failed';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        aiAgentId: string;
+        agentName: string;
+        toolName: string;
+        threadId: string;
+        promptId: string;
+    };
+};
+
 export type ContentVerificationEvent = BaseTrack & {
     event: 'content_verification.created' | 'content_verification.deleted';
     userId: string;
@@ -3995,6 +4012,7 @@ type TypedEvent =
     | AiAgentEvalAppendedEvent
     | McpToolCallEvent
     | AiAgentToolCallEvent
+    | AiAgentToolCallFailedEvent
     | AiAgentArtifactVersionVerifiedEvent
     | AiAgentArtifactsRetrievedEvent
     | AiAgentFindContentCoverageEvent

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -210,6 +210,7 @@ import {
     AiAgentSuggestionSubmitEvent,
     AiAgentThreadsRetentionCleanedEvent,
     AiAgentToolCallEvent,
+    AiAgentToolCallFailedEvent,
     AiAgentUpdatedEvent,
     ContentVerificationEvent,
     LightdashAnalytics,
@@ -11845,6 +11846,7 @@ Use your existing tools to inspect them when relevant to the user's question (re
                 event:
                     | AiAgentResponseStreamed
                     | AiAgentToolCallEvent
+                    | AiAgentToolCallFailedEvent
                     | AiAgentFindContentCoverageEvent,
             ) => this.analytics.track(event),
 

--- a/packages/backend/src/ee/services/McpService/McpService.aiWritebackTasks.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.aiWritebackTasks.test.ts
@@ -21,6 +21,7 @@ const mockRegisterCapabilities = vi.fn();
 
 vi.mock('@sentry/node', () => ({
     captureException: vi.fn(),
+    addBreadcrumb: vi.fn(),
     getActiveSpan: () => undefined,
     isEnabled: () => false,
     wrapMcpServerWithSentry: (server: unknown) => server,

--- a/packages/backend/src/ee/services/McpService/McpService.listContent.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.listContent.test.ts
@@ -9,6 +9,7 @@ const mockRegisteredMcpTools = new Map<string, RegisteredToolCallback>();
 
 vi.mock('@sentry/node', () => ({
     captureException: vi.fn(),
+    addBreadcrumb: vi.fn(),
     getActiveSpan: () => undefined,
     isEnabled: () => false,
     startSpan: (_options: unknown, callback: CallableFunction) =>

--- a/packages/backend/src/ee/services/McpService/McpService.mcpAgentsEnabled.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.mcpAgentsEnabled.test.ts
@@ -9,6 +9,7 @@ const mockRegisteredMcpTools = new Map<string, RegisteredToolCallback>();
 
 vi.mock('@sentry/node', () => ({
     captureException: vi.fn(),
+    addBreadcrumb: vi.fn(),
     getActiveSpan: () => undefined,
     isEnabled: () => false,
     startSpanManual: (_options: unknown, callback: CallableFunction) =>

--- a/packages/backend/src/ee/services/McpService/McpService.queryPolling.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.queryPolling.test.ts
@@ -23,6 +23,7 @@ const mockRegisteredMcpToolInputSchemas = new Map<string, ZodRawShape>();
 
 vi.mock('@sentry/node', () => ({
     captureException: vi.fn(),
+    addBreadcrumb: vi.fn(),
     getActiveSpan: () => undefined,
     isEnabled: () => false,
     startSpanManual: (_options: unknown, callback: CallableFunction) =>

--- a/packages/backend/src/ee/services/McpService/McpService.routeAgent.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.routeAgent.test.ts
@@ -10,6 +10,7 @@ const mockRegisteredMcpTools = new Map<string, RegisteredToolCallback>();
 
 vi.mock('@sentry/node', () => ({
     captureException: vi.fn(),
+    addBreadcrumb: vi.fn(),
     getActiveSpan: () => undefined,
     isEnabled: () => false,
     startSpanManual: (_options: unknown, callback: CallableFunction) =>

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -110,6 +110,7 @@ import {
 } from '../utils/errorMessages';
 import { renderMemoryBlock } from '../utils/memoryBlock';
 import {
+    isErrorToolResult,
     isPendingToolResult,
     summarizeToolCall,
     summarizeToolResult,
@@ -486,6 +487,28 @@ export const normalizeToolOutput = (
     } catch {
         return { result: String(output) };
     }
+};
+
+const trackFailedToolResult = (
+    dependencies: Pick<AiAgentDependencies, 'trackEvent'>,
+    args: AiAgentArgs,
+    toolName: string,
+    output: unknown,
+) => {
+    if (!isErrorToolResult(output)) return;
+    dependencies.trackEvent({
+        event: 'ai_agent_tool_call_failed',
+        userId: args.userId,
+        properties: {
+            organizationId: args.organizationId,
+            projectId: args.agentSettings.projectUuid,
+            aiAgentId: args.agentSettings.uuid,
+            agentName: args.agentSettings.name,
+            toolName,
+            threadId: args.threadUuid,
+            promptId: args.promptUuid,
+        },
+    });
 };
 
 // Raw args of an invalid tool call: may be a parsed object or, when JSON
@@ -1786,6 +1809,12 @@ export const generateAgentResponse = async ({
                                     toolResult.toolCallId
                                 }) (RESULT: ${JSON.stringify(toolResult.output)})`,
                             );
+                            trackFailedToolResult(
+                                dependencies,
+                                args,
+                                toolResult.toolName,
+                                toolResult.output,
+                            );
                             const output = normalizeToolOutput(
                                 toolResult.output,
                             );
@@ -2162,6 +2191,12 @@ export const streamAgentResponse = async ({
                                     error,
                                 );
                             });
+                        trackFailedToolResult(
+                            dependencies,
+                            args,
+                            event.chunk.toolName,
+                            event.chunk.output,
+                        );
                         void dependencies
                             .storeToolResults([
                                 {

--- a/packages/backend/src/ee/services/ai/tools/exploreRepo.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/exploreRepo.test.ts
@@ -5,6 +5,8 @@ import { getExploreRepo } from './exploreRepo';
 
 vi.mock('@sentry/node', () => ({
     captureException: vi.fn(),
+    addBreadcrumb: vi.fn(),
+    getActiveSpan: vi.fn(),
 }));
 
 vi.mock('../../../../logging/logger', () => ({

--- a/packages/backend/src/ee/services/ai/tools/generateDataApp.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/generateDataApp.test.ts
@@ -4,6 +4,8 @@ import { getGenerateDataApp } from './generateDataApp';
 
 vi.mock('@sentry/node', () => ({
     captureException: vi.fn(),
+    addBreadcrumb: vi.fn(),
+    getActiveSpan: vi.fn(),
 }));
 
 vi.mock('../../../../logging/logger', () => ({

--- a/packages/backend/src/ee/services/ai/tools/generateDataApp.ts
+++ b/packages/backend/src/ee/services/ai/tools/generateDataApp.ts
@@ -1,7 +1,6 @@
 import {
     generateDataAppToolDefinition,
     getErrorMessage,
-    NotFoundError,
 } from '@lightdash/common';
 import { tool } from 'ai';
 import type { GenerateDataAppFn } from '../types/aiAgentDependencies';
@@ -43,8 +42,6 @@ export const getGenerateDataApp = ({ generateDataApp }: Dependencies) =>
                     result: toolErrorHandler(
                         error,
                         'Error starting the data app build. No app was created.',
-                        // An unknown slug is the agent's mistake, not an incident.
-                        { captureToSentry: !(error instanceof NotFoundError) },
                     ),
                     metadata: {
                         status: 'error' as const,

--- a/packages/backend/src/ee/services/ai/tools/iterateDataApp.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/iterateDataApp.test.ts
@@ -8,6 +8,8 @@ import { getIterateDataApp } from './iterateDataApp';
 
 vi.mock('@sentry/node', () => ({
     captureException: vi.fn(),
+    addBreadcrumb: vi.fn(),
+    getActiveSpan: vi.fn(),
 }));
 
 vi.mock('../../../../logging/logger', () => ({

--- a/packages/backend/src/ee/services/ai/tools/iterateDataApp.ts
+++ b/packages/backend/src/ee/services/ai/tools/iterateDataApp.ts
@@ -1,9 +1,6 @@
 import {
-    ForbiddenError,
     getErrorMessage,
     iterateDataAppToolDefinition,
-    NotFoundError,
-    ParameterError,
 } from '@lightdash/common';
 import { tool } from 'ai';
 import type { IterateDataAppFn } from '../types/aiAgentDependencies';
@@ -15,13 +12,6 @@ type Dependencies = {
 };
 
 const toolDefinition = iterateDataAppToolDefinition.for('agent');
-
-// The agent's mistakes and expected refusals, not incidents: an unknown slug,
-// a version already building, or missing manage permission on the app.
-const isExpectedIterateError = (error: unknown): boolean =>
-    error instanceof NotFoundError ||
-    error instanceof ParameterError ||
-    error instanceof ForbiddenError;
 
 export const getIterateDataApp = ({ iterateDataApp }: Dependencies) =>
     tool({
@@ -52,7 +42,6 @@ export const getIterateDataApp = ({ iterateDataApp }: Dependencies) =>
                     result: toolErrorHandler(
                         error,
                         'Error starting the data app build. No new version was created.',
-                        { captureToSentry: !isExpectedIterateError(error) },
                     ),
                     metadata: {
                         status: 'error' as const,

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -53,6 +53,7 @@ import {
     AiAgentFindContentCoverageEvent,
     AiAgentResponseStreamed,
     AiAgentToolCallEvent,
+    AiAgentToolCallFailedEvent,
 } from '../../../../analytics/LightdashAnalytics';
 import { PostSlackFile } from '../../../../clients/Slack/SlackClient';
 import type { DataAppRead } from '../../AiAgentToolsService/dataAppRead';
@@ -521,6 +522,7 @@ export type TrackEventFn = (
     event:
         | AiAgentResponseStreamed
         | AiAgentToolCallEvent
+        | AiAgentToolCallFailedEvent
         | AiAgentFindContentCoverageEvent,
 ) => void;
 

--- a/packages/backend/src/ee/services/ai/utils/toolErrorHandler.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/toolErrorHandler.test.ts
@@ -1,0 +1,100 @@
+import {
+    ForbiddenError,
+    MissingWarehouseCredentialsError,
+    NotFoundError,
+    UnexpectedServerError,
+    WarehouseConnectionError,
+    WarehouseQueryError,
+} from '@lightdash/common';
+import * as Sentry from '@sentry/node';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { isAgentRecoverableError, toolErrorHandler } from './toolErrorHandler';
+
+vi.mock('@sentry/node', () => ({
+    captureException: vi.fn(),
+    addBreadcrumb: vi.fn(),
+    getActiveSpan: vi.fn(),
+}));
+
+vi.mock('../../../../logging/logger', () => ({
+    __esModule: true,
+    default: { error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+const captureException = Sentry.captureException as import('vitest').Mock;
+
+describe('isAgentRecoverableError', () => {
+    it('treats 4xx LightdashErrors as the agent’s own mistake', () => {
+        expect(
+            isAgentRecoverableError(new WarehouseQueryError('bad sql')),
+        ).toBe(true);
+        expect(isAgentRecoverableError(new NotFoundError('no chart'))).toBe(
+            true,
+        );
+        expect(isAgentRecoverableError(new ForbiddenError())).toBe(true);
+    });
+
+    it('treats 5xx LightdashErrors and non-Lightdash errors as incidents', () => {
+        expect(isAgentRecoverableError(new UnexpectedServerError('boom'))).toBe(
+            false,
+        );
+        expect(isAgentRecoverableError(new Error('plain'))).toBe(false);
+        expect(isAgentRecoverableError('string')).toBe(false);
+    });
+
+    it('treats infrastructure failures as incidents even though they are 4xx', () => {
+        expect(
+            isAgentRecoverableError(new WarehouseConnectionError('down')),
+        ).toBe(false);
+        expect(
+            isAgentRecoverableError(
+                new MissingWarehouseCredentialsError('no credentials'),
+            ),
+        ).toBe(false);
+    });
+});
+
+describe('toolErrorHandler', () => {
+    beforeEach(() => {
+        captureException.mockClear();
+    });
+
+    it('hands the error back to the model as a retryable message', () => {
+        const result = toolErrorHandler(
+            new WarehouseQueryError('Conversion Error: bad cast'),
+            'Error running SQL query.',
+        );
+
+        expect(result).toContain('Error running SQL query.');
+        expect(result).toContain('Conversion Error: bad cast');
+        expect(result).toContain('Try again');
+    });
+
+    it('does not page Sentry for an error the model can recover from', () => {
+        toolErrorHandler(
+            new WarehouseQueryError('Conversion Error: bad cast'),
+            'Error running SQL query.',
+        );
+
+        expect(captureException).not.toHaveBeenCalled();
+    });
+
+    it('pages Sentry for an incident', () => {
+        const error = new WarehouseConnectionError('warehouse unreachable');
+
+        toolErrorHandler(error, 'Error running query.');
+
+        expect(captureException).toHaveBeenCalledWith(error);
+    });
+
+    it('lets a tool override the classification explicitly', () => {
+        const recoverable = new NotFoundError('no chart');
+        toolErrorHandler(recoverable, 'Error.', { captureToSentry: true });
+        expect(captureException).toHaveBeenCalledWith(recoverable);
+
+        captureException.mockClear();
+        const incident = new Error('plain');
+        toolErrorHandler(incident, 'Error.', { captureToSentry: false });
+        expect(captureException).not.toHaveBeenCalled();
+    });
+});

--- a/packages/backend/src/ee/services/ai/utils/toolErrorHandler.ts
+++ b/packages/backend/src/ee/services/ai/utils/toolErrorHandler.ts
@@ -1,16 +1,72 @@
-import { getErrorMessage } from '@lightdash/common';
+import {
+    BigqueryTokenError,
+    DatabricksTokenError,
+    getErrorMessage,
+    GoogleChatError,
+    LightdashError,
+    MissingWarehouseCredentialsError,
+    MsTeamsError,
+    RedshiftIamTokenError,
+    SlackError,
+    SlackFileUploadError,
+    SnowflakeTokenError,
+    SshTunnelError,
+    UnexpectedGoogleSheetsError,
+    WarehouseConnectionError,
+} from '@lightdash/common';
 import * as Sentry from '@sentry/node';
 import Logger from '../../../../logging/logger';
 import { serializeData } from './serializeData';
+
+// Reported as 4xx to API callers, but nothing the model can fix by rephrasing
+// its request: the warehouse or an integration is down or misconfigured.
+const infrastructureErrors = [
+    WarehouseConnectionError,
+    MissingWarehouseCredentialsError,
+    SshTunnelError,
+    SnowflakeTokenError,
+    DatabricksTokenError,
+    BigqueryTokenError,
+    RedshiftIamTokenError,
+    SlackError,
+    SlackFileUploadError,
+    MsTeamsError,
+    GoogleChatError,
+    UnexpectedGoogleSheetsError,
+];
+
+// Mirrors the HTTP error handler: a LightdashError below 500 is a request the
+// caller can fix (here, the model on its next attempt), so it is agent feedback
+// rather than an incident. Anything else is unexpected and should page.
+export const isAgentRecoverableError = (error: unknown): boolean =>
+    error instanceof LightdashError &&
+    error.statusCode < 500 &&
+    !infrastructureErrors.some((errorClass) => error instanceof errorClass);
+
+const errorName = (error: unknown): string =>
+    error instanceof Error ? error.name : 'UnknownError';
 
 export const toolErrorHandler = (
     error: unknown,
     message: string,
     options: { captureToSentry?: boolean } = {},
 ) => {
-    const { captureToSentry = true } = options;
+    const captureToSentry =
+        options.captureToSentry ?? !isAgentRecoverableError(error);
     if (captureToSentry) {
         Sentry.captureException(error);
+    } else {
+        // Keep the model's failed attempts visible on whatever incident fires
+        // later in the same turn, without making each attempt an issue.
+        Sentry.addBreadcrumb({
+            category: 'ai.tool',
+            level: 'warning',
+            message: `${errorName(error)}: ${getErrorMessage(error)}`,
+        });
+        Sentry.getActiveSpan()?.setAttributes({
+            'ai.tool.error.name': errorName(error),
+            'ai.tool.error.recoverable': true,
+        });
     }
 
     const errorMessage = `${message}

--- a/packages/backend/src/ee/services/ai/utils/toolSummaries.ts
+++ b/packages/backend/src/ee/services/ai/utils/toolSummaries.ts
@@ -89,12 +89,19 @@ export const summarizeToolCall = (toolName: string, input: AnyType) => {
     }
 };
 
-export const isPendingToolResult = (output: AnyType) =>
-    Boolean(output) &&
+const toolResultStatus = (output: AnyType): unknown =>
+    output &&
     typeof output === 'object' &&
-    typeof output.metadata === 'object' &&
-    Boolean(output.metadata) &&
-    output.metadata.status === 'pending';
+    output.metadata &&
+    typeof output.metadata === 'object'
+        ? output.metadata.status
+        : undefined;
+
+export const isPendingToolResult = (output: AnyType) =>
+    toolResultStatus(output) === 'pending';
+
+export const isErrorToolResult = (output: AnyType) =>
+    toolResultStatus(output) === 'error';
 
 export const summarizeToolResult = (toolName: string, output: AnyType) => {
     if (!output || typeof output !== 'object') return `Finished ${toolName}`;


### PR DESCRIPTION
Every AI tool reports its failures to Sentry, so agent-authored SQL that does not run, a wrong chart slug or an out-of-scope table all surface as high-priority backend issues, and Sentry's request context often pins them on an unrelated concurrent request from the same user. These are the model's own mistakes that it reads back and retries, not incidents, and they were drowning out the real ones. Agent tools now follow the same rule as the HTTP error handler for what counts as an incident, while still leaving a trace of each failed attempt and tracking failed tool calls in analytics so the rate stays visible.