### PR TITLE
feat(scheduler): upload CSV deliveries into the Slack thread

### DIFF
--- a/packages/backend/src/scheduler/SchedulerTask.test.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.test.ts
@@ -3467,6 +3467,220 @@ describe('app delivery target senders', () => {
         expect(blocks).toContain('Orders');
     });
 
+    describe('csv file attachments in the Slack thread', () => {
+        const sendToSlack = async (
+            scheduler: CreateSchedulerAndTargets,
+            page: PageData,
+        ) => {
+            const postMessage = vi.fn().mockResolvedValue({ ts: '111' });
+            const postFileToThread = vi.fn().mockResolvedValue(undefined);
+            const task = makeTaskWithDeps({
+                ...senderBaseDeps(),
+                slackClient: asDep<'slackClient'>({
+                    isEnabled: true,
+                    postMessage,
+                    postFileToThread,
+                }),
+            });
+            await (
+                task as unknown as {
+                    sendSlackNotification(
+                        jobId: string,
+                        notification: never,
+                    ): Promise<void>;
+                }
+            ).sendSlackNotification(
+                'job-1',
+                notificationOf(scheduler, page, { channel: 'C123' }),
+            );
+            return { postMessage, postFileToThread };
+        };
+
+        const attachingScheduler = (
+            overrides: Partial<CreateSchedulerAndTargets> = {},
+        ) =>
+            appScheduler({
+                options: {
+                    formatted: true,
+                    limit: 'table',
+                    asAttachment: true,
+                },
+                ...overrides,
+            });
+
+        beforeEach(() => {
+            vi.stubGlobal(
+                'fetch',
+                vi.fn(async (url: string) =>
+                    url.includes('missing')
+                        ? new Response('gone', { status: 404 })
+                        : new Response(`rows from ${url}`),
+                ),
+            );
+        });
+
+        afterEach(() => {
+            vi.unstubAllGlobals();
+        });
+
+        it('uploads every csv file into the thread of the delivery message', async () => {
+            const page = senderPage({
+                csvUrls: [
+                    {
+                        filename: 'csv-Revenue-2026-07-30.csv',
+                        path: 'https://files.example.com/revenue.csv?sig=1',
+                        localPath: 'https://files.example.com/revenue.csv',
+                        chartName: 'Revenue',
+                        truncated: false,
+                    },
+                    {
+                        filename: 'csv-Orders-2026-07-30.csv',
+                        path: 'https://files.example.com/orders.csv?sig=1',
+                        localPath: 'https://files.example.com/orders.csv',
+                        chartName: 'Orders',
+                        truncated: false,
+                    },
+                ],
+            });
+
+            const { postFileToThread } = await sendToSlack(
+                attachingScheduler(),
+                page,
+            );
+
+            expect(postFileToThread).toHaveBeenCalledTimes(2);
+            const [first, second] = postFileToThread.mock.calls.map(
+                (call) => call[0],
+            );
+            expect(first).toMatchObject({
+                organizationUuid: 'org-1',
+                channelId: 'C123',
+                threadTs: '111',
+                filename: 'csv-Revenue-2026-07-30.csv',
+                title: 'Revenue',
+                fileType: 'csv',
+            });
+            expect(first.file.toString()).toBe(
+                'rows from https://files.example.com/revenue.csv',
+            );
+            expect(second.filename).toBe('csv-Orders-2026-07-30.csv');
+        });
+
+        it('adds the csv extension to dashboard files that are named after their chart', async () => {
+            const page = senderPage({
+                csvUrls: [
+                    {
+                        filename: 'Revenue by method?',
+                        path: 'https://files.example.com/revenue.csv?sig=1',
+                        localPath: 'https://files.example.com/revenue.csv',
+                        chartName: 'Revenue by method?',
+                        truncated: false,
+                    },
+                ],
+            });
+
+            const { postFileToThread } = await sendToSlack(
+                attachingScheduler(),
+                page,
+            );
+
+            expect(postFileToThread.mock.calls[0][0]).toMatchObject({
+                filename: 'Revenue by method?.csv',
+                title: 'Revenue by method?',
+            });
+        });
+
+        it('uploads the chart csv with the chart name as the file title', async () => {
+            const page = senderPage({
+                pageType: LightdashPage.CHART,
+                details: { name: 'Revenue by method', description: '' },
+                csvUrls: undefined,
+                failures: undefined,
+                notices: undefined,
+                csvUrl: {
+                    filename: 'csv-Revenue-by-method-2026-07-30.csv',
+                    path: 'https://files.example.com/revenue.csv?sig=1',
+                    localPath: 'https://files.example.com/revenue.csv',
+                    truncated: false,
+                },
+            });
+
+            const { postFileToThread } = await sendToSlack(
+                attachingScheduler({
+                    appUuid: null,
+                    appName: null,
+                    savedChartUuid: 'chart-1',
+                }),
+                page,
+            );
+
+            expect(postFileToThread).toHaveBeenCalledTimes(1);
+            expect(postFileToThread.mock.calls[0][0]).toMatchObject({
+                threadTs: '111',
+                filename: 'csv-Revenue-by-method-2026-07-30.csv',
+                title: 'Revenue by method',
+            });
+        });
+
+        it('keeps the link-only message when the attachment option is off', async () => {
+            const { postMessage, postFileToThread } = await sendToSlack(
+                appScheduler(),
+                senderPage(),
+            );
+
+            expect(postMessage).toHaveBeenCalledTimes(1);
+            expect(postFileToThread).not.toHaveBeenCalled();
+        });
+
+        it('does not attach xlsx deliveries', async () => {
+            const { postFileToThread } = await sendToSlack(
+                attachingScheduler({ format: SchedulerFormat.XLSX }),
+                senderPage(),
+            );
+
+            expect(postFileToThread).not.toHaveBeenCalled();
+        });
+
+        it('skips empty results and carries on after a file that fails to download', async () => {
+            const page = senderPage({
+                csvUrls: [
+                    {
+                        filename: 'csv-Empty-2026-07-30.csv',
+                        path: '#no-results',
+                        localPath: '#no-results',
+                        chartName: 'Empty',
+                        truncated: false,
+                    },
+                    {
+                        filename: 'csv-Missing-2026-07-30.csv',
+                        path: 'https://files.example.com/missing.csv?sig=1',
+                        localPath: 'https://files.example.com/missing.csv',
+                        chartName: 'Missing',
+                        truncated: false,
+                    },
+                    {
+                        filename: 'csv-Orders-2026-07-30.csv',
+                        path: 'https://files.example.com/orders.csv?sig=1',
+                        localPath: 'https://files.example.com/orders.csv',
+                        chartName: 'Orders',
+                        truncated: false,
+                    },
+                ],
+            });
+
+            const { postMessage, postFileToThread } = await sendToSlack(
+                attachingScheduler(),
+                page,
+            );
+
+            expect(postMessage).toHaveBeenCalledTimes(1);
+            expect(postFileToThread).toHaveBeenCalledTimes(1);
+            expect(postFileToThread.mock.calls[0][0].filename).toBe(
+                'csv-Orders-2026-07-30.csv',
+            );
+        });
+    });
+
     it('sends an app csv delivery by email with its failures and notices', async () => {
         const sendDashboardCsvNotificationEmail = vi
             .fn()

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -227,6 +227,10 @@ export interface SchedulerAiAugmentationRunner {
     }): Promise<string | null>;
 }
 
+type SlackDeliveryFile = NonNullable<
+    NotificationPayloadBase['page']['csvUrls']
+>[number];
+
 export type SchedulerTaskArguments = {
     lightdashConfig: LightdashConfig;
     analytics: LightdashAnalytics;
@@ -626,6 +630,52 @@ export default class SchedulerTask {
         return isSchedulerCsvOptions(scheduler.options)
             ? scheduler.options
             : undefined;
+    }
+
+    // Sequential uploads (Slack rate-limits them); a failed file never fails the delivery.
+    private async postDeliveryFilesToSlackThread({
+        organizationUuid,
+        channel,
+        threadTs,
+        files,
+        fileType,
+    }: {
+        organizationUuid: string;
+        channel: string;
+        threadTs: string;
+        files: SlackDeliveryFile[];
+        fileType: SchedulerFormat.CSV;
+    }): Promise<void> {
+        await files.reduce<Promise<void>>(async (previous, file) => {
+            await previous;
+            if (file.path === '#no-results') return;
+            try {
+                const response = await fetch(file.localPath);
+                if (!response.ok) {
+                    throw new Error(
+                        `HTTP ${response.status} ${response.statusText}`,
+                    );
+                }
+                const extension = `.${fileType}`;
+                await this.slackClient.postFileToThread({
+                    organizationUuid,
+                    channelId: channel,
+                    threadTs,
+                    file: Buffer.from(await response.arrayBuffer()),
+                    title: file.chartName ?? file.filename,
+                    // Dashboard files are named after the chart; Slack needs the extension to preview them as a table
+                    filename: file.filename.endsWith(extension)
+                        ? file.filename
+                        : `${file.filename}${extension}`,
+                    fileType,
+                });
+            } catch (e) {
+                Logger.error(
+                    `Failed to attach delivery file "${file.filename}" to the Slack thread: ${getErrorMessage(e)}`,
+                    { fileUrl: file.localPath.split('?')[0] },
+                );
+            }
+        }, Promise.resolve());
     }
 
     protected async getChartOrDashboard(
@@ -2242,6 +2292,7 @@ export default class SchedulerTask {
                 });
             } else {
                 let blocks;
+                let deliveryFiles: SlackDeliveryFile[];
                 if (savedChartUuid) {
                     if (csvUrl === undefined) {
                         throw new Error('Missing CSV URL');
@@ -2254,6 +2305,7 @@ export default class SchedulerTask {
                                 ? csvUrl.path
                                 : undefined,
                     });
+                    deliveryFiles = [{ ...csvUrl, chartName: details.name }];
                 } else if (dashboardUuid || appUuid) {
                     if (csvUrls === undefined) {
                         throw new Error('Missing CSV URLS');
@@ -2264,15 +2316,30 @@ export default class SchedulerTask {
                         failures,
                         notices,
                     });
+                    deliveryFiles = csvUrls;
                 } else {
                     throw new Error('Not implemented');
                 }
-                await this.slackClient.postMessage({
+                const message = await this.slackClient.postMessage({
                     organizationUuid,
                     text: name,
                     channel,
                     blocks,
                 });
+                const csvOptions = SchedulerTask.getCsvOptions(scheduler);
+                if (
+                    message.ts &&
+                    format === SchedulerFormat.CSV &&
+                    csvOptions?.asAttachment
+                ) {
+                    await this.postDeliveryFilesToSlackThread({
+                        organizationUuid,
+                        channel,
+                        threadTs: message.ts,
+                        files: deliveryFiles,
+                        fileType: format,
+                    });
+                }
             }
             this.analytics.track({
                 event: 'scheduler_notification_job.completed',

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerDataFormatSection.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerDataFormatSection.tsx
@@ -31,7 +31,10 @@ import useHealth from '../../../../../hooks/health/useHealth';
 import { useProjectUuid } from '../../../../../hooks/useProjectUuid';
 import { CsvFormattingOptions } from '../../CsvFormattingOptions';
 import { Limit, Values } from '../../types';
-import { useSchedulerFormContext } from '../schedulerFormContext';
+import {
+    hasFileAttachmentTargets,
+    useSchedulerFormContext,
+} from '../schedulerFormContext';
 import { SchedulerFormFiltersTab } from '../SchedulerFormFiltersTab';
 import { SchedulerFormParametersTab } from '../SchedulerFormParametersTab';
 import classes from './SchedulerDeliveryModal.module.css';
@@ -267,20 +270,20 @@ export const SchedulerDataFormatSection: FC<Props> = ({
                     )}
                 {format === SchedulerFormat.CSV && (
                     <Tooltip
-                        label="You must have at least one email recipient to attach a file to emails"
+                        label="Add an email or Slack recipient to attach the file"
                         position="top-start"
-                        disabled={(form.values.emailTargets?.length || 0) > 0}
+                        disabled={hasFileAttachmentTargets(form.values)}
                     >
                         <Box display="flex" w="fit-content">
                             <Checkbox
                                 size="xs"
-                                label="Attach the file to emails"
+                                label="Attach the file to the delivery"
+                                description="Emails get it as an attachment, Slack channels get it in the message thread"
                                 {...form.getInputProps('options.asAttachment', {
                                     type: 'checkbox',
                                 })}
                                 disabled={
-                                    (form.values.emailTargets?.length || 0) ===
-                                    0
+                                    !hasFileAttachmentTargets(form.values)
                                 }
                             />
                         </Box>

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/schedulerFormContext.test.ts
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/schedulerFormContext.test.ts
@@ -1,4 +1,4 @@
-import { ThresholdOperator } from '@lightdash/common';
+import { SchedulerFormat, ThresholdOperator } from '@lightdash/common';
 import { describe, expect, test } from 'vitest';
 import {
     DEFAULT_VALUES,
@@ -7,6 +7,36 @@ import {
 } from './schedulerFormContext';
 
 describe('transformFormValues', () => {
+    test('keeps the csv attachment on when the only recipient is a Slack channel', () => {
+        const result = transformFormValues(
+            {
+                ...DEFAULT_VALUES,
+                format: SchedulerFormat.CSV,
+                options: { ...DEFAULT_VALUES.options, asAttachment: true },
+                emailTargets: [],
+                slackTargets: ['C123'],
+            },
+            'chart',
+        );
+
+        expect(result.options).toMatchObject({ asAttachment: true });
+    });
+
+    test('forces the csv attachment off when there is nobody to attach it for', () => {
+        const result = transformFormValues(
+            {
+                ...DEFAULT_VALUES,
+                format: SchedulerFormat.CSV,
+                options: { ...DEFAULT_VALUES.options, asAttachment: true },
+                emailTargets: [],
+                slackTargets: [],
+            },
+            'chart',
+        );
+
+        expect(result.options).toMatchObject({ asAttachment: false });
+    });
+
     test('omits blank threshold values from the API payload', () => {
         const result = transformFormValues(
             {

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/schedulerFormContext.ts
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/schedulerFormContext.ts
@@ -222,6 +222,12 @@ export const getFormValuesFromScheduler = (
     };
 };
 
+// Emails receive the file as an attachment, Slack channels get it in the message thread.
+export const hasFileAttachmentTargets = (
+    values: Pick<SchedulerFormValues, 'emailTargets' | 'slackTargets'>,
+): boolean =>
+    (values.emailTargets?.length || 0) + (values.slackTargets?.length || 0) > 0;
+
 export const transformFormValues = (
     values: SchedulerFormValues,
     resourceType: 'chart' | 'dashboard' | 'app' | undefined,
@@ -234,10 +240,9 @@ export const transformFormValues = (
                 values.options.limit === Limit.CUSTOM
                     ? values.options.customLimit
                     : values.options.limit,
-            // Only allow attachment for CSV format and if there are email targets
             asAttachment:
                 values.format === SchedulerFormat.CSV &&
-                (values.emailTargets?.length || 0) > 0
+                hasFileAttachmentTargets(values)
                     ? values.options.asAttachment
                     : false,
             exportPivotedData: values.options.exportPivotedData,


### PR DESCRIPTION
Closes PROD-8984 ([Linear](https://linear.app/lightdash/issue/PROD-8984/scheduled-deliveries-attach-all-exported-file-formats-in-slack)). This is the CSV half of the stack; XLSX follows in #28819. GitHub issue: #11857.

## What

Slack CSV deliveries only posted a signed download link, so Slack never showed the results. With the delivery's attachment option on, the scheduler now uploads each CSV into the thread of the delivery message and Slack renders it as a table in place.

- `sendSlackNotification`: after the CSV message posts, `postDeliveryFilesToSlackThread` uploads the chart's file, or one file per chart for dashboards and apps, into the message thread via the existing `postFileToThread`. Uploads run one at a time (Slack rate-limits file uploads). The `#no-results` sentinel is skipped. A file that fails to download or upload is logged and skipped, and never fails the delivery: the message with its download links has already been posted and is the fallback.
- Dashboard files are named after their chart with no extension, so Slack typed them as plain text. The upload appends `.csv` when missing, mirroring `EmailClient.createFileAttachment`.
- Form: the existing `asAttachment` option was forced off unless the delivery had an email recipient. It is now allowed with a Slack recipient too (`hasFileAttachmentTargets`), and the checkbox reads "Attach the file to the delivery" with a one-line description of what each destination gets. The preview panel already shows the `data.csv` chip for any destination.

Proof page with form stills, a recording of the flow on the branch, and the resulting Slack threads: https://claude.ai/code/artifact/cc151d3a-6be6-43c6-b12a-11dac67239c4

## Regression analysis

- Deliveries with the option off are byte-for-byte unchanged: the new branch is gated on `format === csv && options.asAttachment`, and a test pins that `postFileToThread` is not called.
- XLSX is explicitly not attached in this PR (test pins it), so no existing XLSX delivery changes.
- Email deliveries are untouched: `asAttachment` already flowed to the email client, and the transform still forces it off when there is no email or Slack recipient.
- Existing saved schedulers with `asAttachment: true` and a Slack target could not exist before (the form forced it off unless an email recipient was present, and in that case Slack targets would now also get the file). That is the intended behaviour of the option.
- No schema or API change. `SchedulerCsvOptions.asAttachment` already existed.

## Tests

- 6 new cases in `SchedulerTask.test.ts` (thread uploads for dashboards and charts, option off, XLSX untouched, no-results skip and failure isolation, extension normalisation). 124 pass.
- 2 new cases in `schedulerFormContext.test.ts` for the Slack-only recipient. 22 pass across the two form test files.
- Live: chart and dashboard CSV deliveries sent from an isolated instance on this branch, files inspected through the Slack API (typed `csv`, titled with the chart name, preview rendered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bd3Rg41LvPMWM5o1Z1L1rX
