### PR TITLE
feat: share native YAML compilation and preserve source paths

### DIFF
--- a/docs/native-git-projects.md
+++ b/docs/native-git-projects.md
@@ -1,0 +1,27 @@
+# Native Lightdash Git projects
+
+Native YAML and dbt share GitHub authentication, repository, branch and project
+subdirectory settings. The semantic format is a separate build choice: native
+Lightdash YAML does not use dbt profiles, targets, selectors, dependencies or a
+dbt installation. Existing connections default to dbt. GitLab support is deferred.
+
+`lightdash.config.yml` owns semantic configuration. The CLI uses its warehouse
+type to compile SQL; server builds use the project's existing warehouse
+connection. Connecting a repository to a CLI-created project must preserve its
+UUID, warehouse credentials and saved content.
+
+The shared Node loader uses `models/` when present, otherwise
+`lightdash/models/`, recursively accepting `.yml` and `.yaml` models with
+`type: model`, `model/v1beta` or `model/v1`. Files with other resource types are
+ignored. Invalid YAML, invalid models and duplicate model names fail loading
+instead of silently publishing an incomplete project.
+
+Loaded models retain paths relative to the project directory. The shared
+compiler carries those paths into compiled tables; Git operations prepend the
+configured project subdirectory exactly once to address repository files. A
+model named `orders` in `models/sales/daily.yaml` must write back to that file.
+
+Native models still compile through the existing internal model-node conversion
+and explore compiler. This preserves one semantic compiler without introducing
+a general source-adapter framework. The Node filesystem loader is a separate
+`@lightdash/common/lightdash/loader` entry point, outside the browser barrel.

--- a/packages/cli/src/handlers/compile.test.ts
+++ b/packages/cli/src/handlers/compile.test.ts
@@ -149,7 +149,7 @@ dimensions:
 
     test('should allow partial compilation by default and allow it to be disabled explicitly', async () => {
         vi.spyOn(lightdashLoader, 'loadLightdashModels').mockResolvedValue([
-            modelWithBrokenMetric,
+            { ...modelWithBrokenMetric, sourcePath: 'models/test_model.yml' },
         ]);
 
         const errorOutput: string[] = [];
@@ -192,6 +192,17 @@ dimensions:
                     'Compiled 1 explores, SUCCESS=0 ERRORS=1',
                 ),
             ]),
+        );
+    });
+
+    test('rejects malformed native YAML instead of compiling only the valid models', async () => {
+        await fs.writeFile(
+            path.join(tempDir, 'lightdash/models/broken.yml'),
+            'type: model\ndimensions: [',
+        );
+
+        await expect(compile(getCompileOptions(tempDir))).rejects.toThrow(
+            /broken.yml/,
         );
     });
 });

--- a/packages/cli/src/handlers/compile.ts
+++ b/packages/cli/src/handlers/compile.ts
@@ -1,8 +1,8 @@
 import {
     applyMetricFlowMetricsToModels,
     attachTypesToModels,
+    compileLightdashModels,
     convertExplores,
-    convertLightdashModelsToDbtModels,
     DbtManifest,
     DbtModelNode,
     Explore,
@@ -291,31 +291,18 @@ const getExploresFromLightdashYmlProject = async ({
         `> Using adapter type from lightdash.config.yml: ${adapterType}`,
     );
 
-    // Convert Lightdash models to DbtModelNode format
-    const validModels = convertLightdashModelsToDbtModels(lightdashModels);
-    if (validModels.length === 0) {
-        return null;
-    }
-
-    GlobalState.debug('> Skipping warehouse catalog (types in YAML)');
-
     const warehouseSqlBuilder = warehouseSqlBuilderFromType(
         adapterType,
         startOfWeek,
     );
-
-    const validExplores = await convertExplores(
-        validModels,
-        false,
-        warehouseSqlBuilder.getAdapterType(),
+    const validExplores = await compileLightdashModels({
+        models: lightdashModels,
         warehouseSqlBuilder,
         lightdashProjectConfig,
-        {
-            disableTimestampConversion,
-            allowPartialCompilation,
-            postProcessors: [preAggregatePostProcessor],
-        },
-    );
+        disableTimestampConversion,
+        allowPartialCompilation,
+        postProcessors: [preAggregatePostProcessor],
+    });
 
     return validExplores;
 };

--- a/packages/cli/src/handlers/compileProject.test.ts
+++ b/packages/cli/src/handlers/compileProject.test.ts
@@ -13,7 +13,11 @@ import path from 'path';
 import { getDbtContext } from '../dbt/context';
 import { loadCombineManifest, loadManifest } from '../dbt/manifest';
 import { validateDbtModel } from '../dbt/validation';
-import { loadLightdashModels } from '../lightdash/loader';
+import {
+    findLightdashModelFiles,
+    loadLightdashModels,
+} from '../lightdash/loader';
+import { CliProjectType, detectProjectType } from '../lightdash/projectType';
 import { compileProject, type CompileHandlerOptions } from './compile';
 import { lightdashRawApi } from './dbt/apiClient';
 import { maybeCompileModelsAndJoins } from './dbt/compile';
@@ -166,6 +170,67 @@ describe('compileProject completeness', () => {
         vi.restoreAllMocks();
         await fs.rm(tempDir, { recursive: true, force: true });
     });
+
+    test.each([false, true])(
+        'compiles dbt when ignored YAML is malformed, symlinked models: %s',
+        async (symlinkedModels) => {
+            const projectDir = path.join(tempDir, 'dbt-project');
+            const modelsDir = symlinkedModels
+                ? path.join(tempDir, 'shared-models')
+                : path.join(projectDir, 'models');
+            await fs.mkdir(projectDir);
+            await fs.mkdir(modelsDir);
+            if (symlinkedModels)
+                await fs.symlink(modelsDir, path.join(projectDir, 'models'));
+            await fs.writeFile(
+                path.join(projectDir, 'dbt_project.yml'),
+                'name: test_project\nversion: "1.0"\nconfig-version: 2\n',
+            );
+            await fs.writeFile(
+                path.join(projectDir, '.dbtignore'),
+                'models/archived.yml\n',
+            );
+            await fs.writeFile(
+                path.join(modelsDir, 'schema.yml'),
+                'version: 2\nmodels:\n  - name: orders\n',
+            );
+            await fs.writeFile(
+                path.join(modelsDir, 'archived.yml'),
+                'archived: [unfinished\n',
+            );
+            const loader = await vi.importActual<
+                typeof import('../lightdash/loader')
+            >('../lightdash/loader');
+            vi.mocked(findLightdashModelFiles).mockImplementationOnce(
+                loader.findLightdashModelFiles,
+            );
+            vi.mocked(loadLightdashModels).mockImplementationOnce(
+                loader.loadLightdashModels,
+            );
+            vi.mocked(loadManifest).mockResolvedValue(
+                manifest({
+                    'model.test.orders': dbtNode(
+                        'model.test.orders',
+                        'model',
+                        true,
+                    ),
+                }),
+            );
+            vi.mocked(maybeCompileModelsAndJoins).mockResolvedValue({
+                compiledModelIds: ['model.test.orders'],
+                originallySelectedModelIds: undefined,
+            });
+
+            await expect(
+                detectProjectType({ projectDir }),
+            ).resolves.toMatchObject({ type: CliProjectType.Dbt });
+            const result = await compileProject(compileOptions(projectDir));
+            expect(result.explores.map((explore) => explore.name)).toEqual([
+                'orders',
+            ]);
+            expect(maybeCompileModelsAndJoins).toHaveBeenCalled();
+        },
+    );
 
     test('reports an unselected model and seed manifest as complete', async () => {
         const projectManifest = manifest({

--- a/packages/cli/src/handlers/compileWarehouseColumnValidation.test.ts
+++ b/packages/cli/src/handlers/compileWarehouseColumnValidation.test.ts
@@ -617,7 +617,7 @@ describe('compile warehouse column validation', () => {
     describe('lightdash yml projects', () => {
         beforeEach(async () => {
             vi.mocked(loadLightdashModels).mockResolvedValue([
-                lightdashYmlModel,
+                { ...lightdashYmlModel, sourcePath: 'models/test_model.yml' },
             ]);
             await fs.writeFile(
                 path.join(tempDir, 'lightdash.config.yml'),

--- a/packages/cli/src/lightdash/loader.ts
+++ b/packages/cli/src/lightdash/loader.ts
@@ -1,53 +1,13 @@
-/**
- * Loader for Lightdash YAML model files
- */
-
-import { ParseError, type LightdashModel } from '@lightdash/common';
+import { type LightdashModelWithSource } from '@lightdash/common';
+import { loadLightdashModels as loadNativeLightdashModels } from '@lightdash/common/lightdash/loader';
 import * as fs from 'fs';
 import * as yaml from 'js-yaml';
 import * as path from 'path';
 import GlobalState from '../globalState';
 
-/**
- * Load a single Lightdash YAML model file
- */
-export async function loadLightdashModel(
-    filePath: string,
-): Promise<LightdashModel> {
-    try {
-        const fileContents = await fs.promises.readFile(filePath, 'utf8');
-        const parsed = yaml.load(fileContents) as LightdashModel;
+export { loadLightdashModel } from '@lightdash/common/lightdash/loader';
 
-        // Basic validation
-        if (!parsed.type || !parsed.name || !parsed.dimensions) {
-            throw new ParseError(
-                `Invalid Lightdash model in ${filePath}: must have type, name, and dimensions`,
-            );
-        }
-
-        if (!parsed.sql_from) {
-            throw new ParseError(
-                `Invalid Lightdash model in ${filePath}: must have sql_from`,
-            );
-        }
-
-        return parsed;
-    } catch (error) {
-        if (error instanceof ParseError) {
-            throw error;
-        }
-        throw new ParseError(
-            `Failed to load Lightdash model from ${filePath}: ${
-                error instanceof Error ? error.message : String(error)
-            }`,
-        );
-    }
-}
-
-/**
- * Check if a YAML file contains a Lightdash model definition
- * A valid model file must have a `type` field with value 'model', 'model/v1beta', or 'model/v1'
- */
+// Format detection must tolerate files that dbt may ignore or handle itself.
 async function isLightdashModelFile(filePath: string): Promise<boolean> {
     try {
         const fileContents = await fs.promises.readFile(filePath, 'utf8');
@@ -129,33 +89,9 @@ export async function findLightdashModelFiles(
     return modelFiles;
 }
 
-/**
- * Load all Lightdash YAML models from a project directory
- */
 export async function loadLightdashModels(
     projectDir: string,
-): Promise<LightdashModel[]> {
-    const modelFiles = await findLightdashModelFiles(projectDir);
-
-    GlobalState.debug(
-        `Found ${modelFiles.length} Lightdash model files in ${projectDir}`,
-    );
-
-    const models: LightdashModel[] = [];
-
-    for await (const filePath of modelFiles) {
-        try {
-            const model = await loadLightdashModel(filePath);
-            models.push(model);
-            GlobalState.debug(`Loaded Lightdash model: ${model.name}`);
-        } catch (error) {
-            console.error(
-                `Warning: Failed to load ${filePath}: ${
-                    error instanceof Error ? error.message : String(error)
-                }`,
-            );
-        }
-    }
-
-    return models;
+): Promise<LightdashModelWithSource[]> {
+    if ((await findLightdashModelFiles(projectDir)).length === 0) return [];
+    return loadNativeLightdashModels(projectDir);
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -27,6 +27,13 @@
       "import": "./dist/cjs/dbt/validation.js",
       "default": "./dist/cjs/dbt/validation.js"
     },
+    "./lightdash/loader": {
+      "types": "./dist/esm/lightdash/loader.d.ts",
+      "module": "./dist/esm/lightdash/loader.js",
+      "require": "./dist/cjs/lightdash/loader.js",
+      "import": "./dist/cjs/lightdash/loader.js",
+      "default": "./dist/cjs/lightdash/loader.js"
+    },
     "./src": "./src/index.ts",
     "./src/*": [
       "./src/*.ts",

--- a/packages/common/src/compiler/compileLightdashModels.ts
+++ b/packages/common/src/compiler/compileLightdashModels.ts
@@ -1,0 +1,28 @@
+import { type LightdashModelWithSource } from '../types/lightdashModel';
+import { type LightdashProjectConfig } from '../types/lightdashProjectConfig';
+import { type WarehouseSqlBuilder } from '../types/warehouse';
+import { convertLightdashModelToDbtModel } from './lightdashModelConverter';
+import { convertExplores, type ConvertExploresOptions } from './translator';
+
+export const compileLightdashModels = async ({
+    models,
+    warehouseSqlBuilder,
+    lightdashProjectConfig,
+    loadSources = false,
+    ...options
+}: {
+    models: LightdashModelWithSource[];
+    warehouseSqlBuilder: WarehouseSqlBuilder;
+    lightdashProjectConfig: LightdashProjectConfig;
+    loadSources?: boolean;
+} & ConvertExploresOptions) =>
+    convertExplores(
+        models.map((model) =>
+            convertLightdashModelToDbtModel(model, model.sourcePath),
+        ),
+        loadSources,
+        warehouseSqlBuilder.getAdapterType(),
+        warehouseSqlBuilder,
+        lightdashProjectConfig,
+        options,
+    );

--- a/packages/common/src/compiler/lightdashModelConverter.ts
+++ b/packages/common/src/compiler/lightdashModelConverter.ts
@@ -21,6 +21,7 @@ import {
  */
 export function convertLightdashModelToDbtModel(
     model: LightdashModel,
+    sourcePath?: string,
 ): DbtModelNode {
     // Generate a unique ID for this model
     const uniqueId = `model.lightdash.${model.name}`;
@@ -116,8 +117,8 @@ export function convertLightdashModelToDbtModel(
             meta: modelConfig,
         },
         tags: [],
-        path: `lightdash/models/${model.name}.yml`,
-        patch_path: `lightdash://${model.name}.yml`,
+        path: sourcePath ?? `lightdash/models/${model.name}.yml`,
+        patch_path: `lightdash://${sourcePath ?? `${model.name}.yml`}`,
         depends_on: {
             nodes: [],
             macros: [],
@@ -131,7 +132,7 @@ export function convertLightdashModelToDbtModel(
         raw_code: sqlFrom,
         language: 'sql' as const,
         package_name: 'lightdash',
-        original_file_path: `lightdash/models/${model.name}.yml`,
+        original_file_path: sourcePath ?? `lightdash/models/${model.name}.yml`,
         checksum: {
             name: 'sha256',
             checksum: '',

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1234,3 +1234,5 @@ export const SPACE_TREE_2: TreeCreateSpace[] = [
         ],
     },
 ] as const;
+
+export * from './compiler/compileLightdashModels';

--- a/packages/common/src/lightdash/loader.test.ts
+++ b/packages/common/src/lightdash/loader.test.ts
@@ -1,0 +1,84 @@
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { compileLightdashModels } from '../compiler/compileLightdashModels';
+import { warehouseClientMock } from '../compiler/exploreCompiler.mock';
+import { isExploreError } from '../types/explore';
+import { DEFAULT_SPOTLIGHT_CONFIG } from '../types/lightdashProjectConfig';
+import { loadLightdashModels } from './loader';
+
+const modelYaml = `type: model
+name: orders
+order_fields_by: label
+sql_from: public.orders
+dimensions:
+  - name: id
+    type: number
+    sql: id
+`;
+
+describe('native model loading and compilation', () => {
+    let projectDir: string;
+    beforeEach(async () => {
+        projectDir = await fs.mkdtemp(path.join(os.tmpdir(), 'native-models-'));
+    });
+    afterEach(async () => {
+        await fs.rm(projectDir, { recursive: true, force: true });
+    });
+    const writeModel = async (sourcePath: string, contents = modelYaml) => {
+        const filePath = path.join(projectDir, sourcePath);
+        await fs.mkdir(path.dirname(filePath), { recursive: true });
+        await fs.writeFile(filePath, contents);
+    };
+
+    it.each(['models/nested/sales.yaml', 'lightdash/models/nested/sales.yml'])(
+        'preserves the actual source path %s through explore compilation',
+        async (sourcePath) => {
+            await writeModel(sourcePath);
+            const models = await loadLightdashModels(projectDir);
+            const explores = await compileLightdashModels({
+                models,
+                warehouseSqlBuilder: warehouseClientMock,
+                lightdashProjectConfig: { spotlight: DEFAULT_SPOTLIGHT_CONFIG },
+                loadSources: true,
+            });
+            expect(explores).toHaveLength(1);
+            const explore = explores[0];
+            if (!explore || isExploreError(explore))
+                throw new Error('Expected compiled explore');
+            expect(explore.tables.orders.ymlPath).toBe(sourcePath);
+            expect(explore.tables.orders.orderFieldsBy).toBe('LABEL');
+            expect(explore.tables.orders.dimensions.id).toBeDefined();
+        },
+    );
+
+    it('prefers models/ over the legacy directory and ignores content YAML', async () => {
+        await writeModel('models/orders.yml');
+        await writeModel('models/space.yml', 'type: space\nname: My space\n');
+        await writeModel('lightdash/models/ignored.yml');
+        expect(
+            (await loadLightdashModels(projectDir)).map(
+                (model) => model.sourcePath,
+            ),
+        ).toEqual(['models/orders.yml']);
+    });
+
+    it.each(['type: model\nname: broken\n', 'type: model\ndimensions: ['])(
+        'rejects invalid YAML instead of deploying only the remaining models',
+        async (contents) => {
+            await writeModel('models/orders.yml');
+            await writeModel('models/broken.yml', contents);
+            await expect(loadLightdashModels(projectDir)).rejects.toThrow(
+                /broken.yml/,
+            );
+        },
+    );
+
+    it('rejects duplicate model names and identifies both source files', async () => {
+        await writeModel('models/a.yml');
+        await writeModel('models/nested/b.yml');
+        await expect(loadLightdashModels(projectDir)).rejects.toThrow(
+            'Duplicate Lightdash model "orders" in models/a.yml and models/nested/b.yml',
+        );
+    });
+});

--- a/packages/common/src/lightdash/loader.ts
+++ b/packages/common/src/lightdash/loader.ts
@@ -1,0 +1,111 @@
+import Ajv from 'ajv';
+import fs from 'fs/promises';
+import * as yaml from 'js-yaml';
+import path from 'path';
+import modelSchema from '../schemas/json/model-as-code-1.0.json';
+import { ParseError } from '../types/errors';
+import {
+    type LightdashModel,
+    type LightdashModelWithSource,
+} from '../types/lightdashModel';
+
+const ajv = new Ajv({ allErrors: true, strict: false });
+const validateModel = ajv.compile<LightdashModel>(modelSchema);
+const modelTypes = new Set(['model', 'model/v1beta', 'model/v1']);
+
+async function readYaml(filePath: string): Promise<unknown> {
+    try {
+        return yaml.load(await fs.readFile(filePath, 'utf8'));
+    } catch (error) {
+        throw new ParseError(
+            `Failed to read YAML from ${filePath}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+    }
+}
+
+export async function loadLightdashModel(
+    filePath: string,
+): Promise<LightdashModel> {
+    const parsed = await readYaml(filePath);
+    if (!validateModel(parsed)) {
+        throw new ParseError(
+            `Invalid Lightdash model in ${filePath}: ${ajv.errorsText(validateModel.errors)}`,
+        );
+    }
+    return parsed;
+}
+
+export async function findLightdashModelFiles(
+    projectDir: string,
+): Promise<string[]> {
+    const possibleDirs = [
+        path.join(projectDir, 'models'),
+        path.join(projectDir, 'lightdash', 'models'),
+    ];
+    let modelsDir: string | undefined;
+    for await (const dir of possibleDirs) {
+        try {
+            if ((await fs.stat(dir)).isDirectory()) {
+                modelsDir = dir;
+                break;
+            }
+        } catch (error) {
+            if (
+                !(
+                    error instanceof Error &&
+                    'code' in error &&
+                    error.code === 'ENOENT'
+                )
+            )
+                throw error;
+        }
+    }
+    if (!modelsDir) return [];
+
+    const files: string[] = [];
+    async function walk(dir: string): Promise<void> {
+        const entries = await fs.readdir(dir, { withFileTypes: true });
+        entries.sort((a, b) => a.name.localeCompare(b.name));
+        for await (const entry of entries) {
+            const filePath = path.join(dir, entry.name);
+            if (entry.isDirectory()) {
+                await walk(filePath);
+            } else if (entry.isFile() && /\.ya?ml$/.test(entry.name)) {
+                const parsed = await readYaml(filePath);
+                if (
+                    parsed &&
+                    typeof parsed === 'object' &&
+                    'type' in parsed &&
+                    typeof parsed.type === 'string' &&
+                    modelTypes.has(parsed.type)
+                )
+                    files.push(filePath);
+            }
+        }
+    }
+    await walk(modelsDir);
+    return files;
+}
+
+export async function loadLightdashModels(
+    projectDir: string,
+): Promise<LightdashModelWithSource[]> {
+    const files = await findLightdashModelFiles(projectDir);
+    const models: LightdashModelWithSource[] = [];
+    const names = new Map<string, string>();
+    for await (const filePath of files) {
+        const model = await loadLightdashModel(filePath);
+        const sourcePath = path
+            .relative(projectDir, filePath)
+            .split(path.sep)
+            .join('/');
+        const previousPath = names.get(model.name);
+        if (previousPath !== undefined)
+            throw new ParseError(
+                `Duplicate Lightdash model "${model.name}" in ${previousPath} and ${sourcePath}`,
+            );
+        names.set(model.name, sourcePath);
+        models.push({ ...model, sourcePath });
+    }
+    return models;
+}

--- a/packages/common/src/packageExports.test.ts
+++ b/packages/common/src/packageExports.test.ts
@@ -23,6 +23,7 @@ describe('@lightdash/common exports map', () => {
         expect(Object.keys(packageJson.exports)).toEqual([
             '.',
             './dbt/validation',
+            './lightdash/loader',
             './src',
             './src/*',
             './dist/*',

--- a/packages/common/src/schemas/json/model-as-code-1.0.json
+++ b/packages/common/src/schemas/json/model-as-code-1.0.json
@@ -49,7 +49,7 @@
                     "description": "Primary key column(s) for the model"
                 },
                 "order_fields_by": {
-                    "enum": ["INDEX", "LABEL"],
+                    "enum": ["INDEX", "LABEL", "index", "label"],
                     "description": "Strategy for ordering fields in the UI"
                 },
                 "group_label": {

--- a/packages/common/src/types/lightdashModel.ts
+++ b/packages/common/src/types/lightdashModel.ts
@@ -88,3 +88,8 @@ export type LightdashModel = Omit<
     explores?: Record<string, LightdashModelExplore>; // Override to use RequiredFilter
     dimensions: LightdashModelDimension[]; // Required: array of dimensions with types
 };
+
+export type LightdashModelWithSource = LightdashModel & {
+    /** Path relative to the project directory, retained for source editing. */
+    sourcePath: string;
+};


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-11032

### Description:

```diff
 Native YAML -> compile -> source file
- infer the YAML path from the model name
+ retain the actual nested .yml/.yaml path
```

- Share the native loader and compiler between CLI and future server builds. Preserve `models/` preference and legacy `lightdash/models/` support.
- Fail malformed/invalid native YAML and duplicate names instead of silently deploying a subset. Keep the filesystem loader outside the browser barrel.
- Preserve the previous CLI format detection for dbt, including ignored YAML and symlinked model directories. Strict native loading starts only after native models are detected.
- Document the Git connection/native build boundary. Stack 1/6; server builds, GitHub UI, metrics, dimensions and AI support follow.

Validation: 148 common tests and 39 CLI tests passed, covering original paths, invalid input, directory conventions and dbt compilation. Common/CLI typechecks, common lint, focused CLI lint and `git diff --check` passed. The actual demo repository also compiles successfully through the CLI (8 explores), including lowercase field ordering. Native GitHub end-to-end validation follows in the rest of the stack; no test data persisted by this slice.

Dbt regression validation: 42 CLI tests passed both at the full-stack tip and on this PR alone, including real format detection followed by dbt manifest compilation with malformed ignored YAML and symlinked models. Malformed native YAML still fails explicitly. Across the full stack, 580 focused backend/common/frontend/CLI tests and 12 isolated before/after comparison cases passed. Backend/CLI typechecks, focused lint/format, commit checks and `git diff --check` passed. These regression checks used mocked Git APIs; no new live Git or warehouse test was run.

Previous rebase validation at the full-stack tip (`6b15c2d017`, based on main `21e876fa94`): backend build, backend/frontend typechecks, common build, 183 query-history/service tests, MCP snapshot freshness and `git diff --check` passed. Upstream [#28851](https://github.com/lightdash/lightdash/pull/28851) reverted the change causing the `QueryHistory.errorName` errors; both those errors and the earlier Learn UI errors are resolved. All six feature patches are unchanged by this restack. The preceding restack also passed common/CLI typechecks and 468 focused feature tests. Remote CI is rerunning.

### Risk assessment:

- [ ] This is a high-risk change

Low risk: shared native compilation uses the existing explore compiler; dbt compilation is unchanged. Previously skipped malformed native files now fail explicitly to protect existing deployed content.
