### PR TITLE
feat(scheduler): upload XLSX deliveries into the Slack thread

### DIFF
--- a/packages/backend/src/scheduler/SchedulerTask.test.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.test.ts
@@ -3632,13 +3632,63 @@ describe('app delivery target senders', () => {
             expect(postFileToThread).not.toHaveBeenCalled();
         });
 
-        it('does not attach xlsx deliveries', async () => {
+        it('uploads xlsx files typed as xlsx', async () => {
+            const page = senderPage({
+                csvUrls: [
+                    {
+                        filename: 'Revenue',
+                        path: 'https://files.example.com/revenue.xlsx?sig=1',
+                        localPath: 'https://files.example.com/revenue.xlsx',
+                        chartName: 'Revenue',
+                        truncated: false,
+                    },
+                ],
+            });
+
             const { postFileToThread } = await sendToSlack(
                 attachingScheduler({ format: SchedulerFormat.XLSX }),
-                senderPage(),
+                page,
             );
 
-            expect(postFileToThread).not.toHaveBeenCalled();
+            expect(postFileToThread).toHaveBeenCalledTimes(1);
+            expect(postFileToThread.mock.calls[0][0]).toMatchObject({
+                filename: 'Revenue.xlsx',
+                title: 'Revenue',
+                fileType: 'xlsx',
+            });
+        });
+
+        it('uploads the single workbook when the dashboard xlsx layout is workbook', async () => {
+            const page = senderPage({
+                csvUrls: [
+                    {
+                        filename: 'Sales App',
+                        path: 'https://files.example.com/workbook.xlsx?sig=1',
+                        localPath: 'https://files.example.com/workbook.xlsx',
+                        truncated: false,
+                    },
+                ],
+            });
+
+            const { postFileToThread } = await sendToSlack(
+                attachingScheduler({
+                    format: SchedulerFormat.XLSX,
+                    options: {
+                        formatted: true,
+                        limit: 'table',
+                        asAttachment: true,
+                        xlsxFileLayout: 'workbook',
+                    },
+                }),
+                page,
+            );
+
+            expect(postFileToThread).toHaveBeenCalledTimes(1);
+            expect(postFileToThread.mock.calls[0][0]).toMatchObject({
+                filename: 'Sales App.xlsx',
+                title: 'Sales App',
+                fileType: 'xlsx',
+            });
         });
 
         it('skips empty results and carries on after a file that fails to download', async () => {

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -644,7 +644,7 @@ export default class SchedulerTask {
         channel: string;
         threadTs: string;
         files: SlackDeliveryFile[];
-        fileType: SchedulerFormat.CSV;
+        fileType: SchedulerFormat.CSV | SchedulerFormat.XLSX;
     }): Promise<void> {
         await files.reduce<Promise<void>>(async (previous, file) => {
             await previous;
@@ -663,7 +663,7 @@ export default class SchedulerTask {
                     threadTs,
                     file: Buffer.from(await response.arrayBuffer()),
                     title: file.chartName ?? file.filename,
-                    // Dashboard files are named after the chart; Slack needs the extension to preview them as a table
+                    // Dashboard files are named after the chart or workbook; Slack needs the extension to preview them
                     filename: file.filename.endsWith(extension)
                         ? file.filename
                         : `${file.filename}${extension}`,
@@ -2329,7 +2329,8 @@ export default class SchedulerTask {
                 const csvOptions = SchedulerTask.getCsvOptions(scheduler);
                 if (
                     message.ts &&
-                    format === SchedulerFormat.CSV &&
+                    (format === SchedulerFormat.CSV ||
+                        format === SchedulerFormat.XLSX) &&
                     csvOptions?.asAttachment
                 ) {
                     await this.postDeliveryFilesToSlackThread({

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerDataFormatSection.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerDataFormatSection.tsx
@@ -268,7 +268,8 @@ export const SchedulerDataFormatSection: FC<Props> = ({
                             })}
                         />
                     )}
-                {format === SchedulerFormat.CSV && (
+                {(format === SchedulerFormat.CSV ||
+                    format === SchedulerFormat.XLSX) && (
                     <Tooltip
                         label="Add an email or Slack recipient to attach the file"
                         position="top-start"

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerPreviewPanel.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerPreviewPanel.tsx
@@ -324,9 +324,12 @@ export const SchedulerPreviewPanel: FC<Props> = ({
                                     )}
                                 </Paper>
                             )}
-                            {format === SchedulerFormat.CSV &&
+                            {(format === SchedulerFormat.CSV ||
+                                format === SchedulerFormat.XLSX) &&
                                 form.values.options.asAttachment && (
-                                    <AttachmentChip filename="data.csv" />
+                                    <AttachmentChip
+                                        filename={`data.${format}`}
+                                    />
                                 )}
                             {format === SchedulerFormat.IMAGE &&
                                 form.values.options.withPdf && (

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/schedulerFormContext.test.ts
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/schedulerFormContext.test.ts
@@ -22,6 +22,21 @@ describe('transformFormValues', () => {
         expect(result.options).toMatchObject({ asAttachment: true });
     });
 
+    test('keeps the xlsx attachment on for a Slack recipient', () => {
+        const result = transformFormValues(
+            {
+                ...DEFAULT_VALUES,
+                format: SchedulerFormat.XLSX,
+                options: { ...DEFAULT_VALUES.options, asAttachment: true },
+                emailTargets: [],
+                slackTargets: ['C123'],
+            },
+            'chart',
+        );
+
+        expect(result.options).toMatchObject({ asAttachment: true });
+    });
+
     test('forces the csv attachment off when there is nobody to attach it for', () => {
         const result = transformFormValues(
             {

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/schedulerFormContext.ts
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/schedulerFormContext.ts
@@ -240,11 +240,9 @@ export const transformFormValues = (
                 values.options.limit === Limit.CUSTOM
                     ? values.options.customLimit
                     : values.options.limit,
-            asAttachment:
-                values.format === SchedulerFormat.CSV &&
-                hasFileAttachmentTargets(values)
-                    ? values.options.asAttachment
-                    : false,
+            asAttachment: hasFileAttachmentTargets(values)
+                ? values.options.asAttachment
+                : false,
             exportPivotedData: values.options.exportPivotedData,
             xlsxFileLayout:
                 values.format === SchedulerFormat.XLSX


### PR DESCRIPTION
Closes PROD-8984 ([Linear](https://linear.app/lightdash/issue/PROD-8984/scheduled-deliveries-attach-all-exported-file-formats-in-slack)). Second PR of the stack, on top of #28817 (CSV). GitHub issue: #11857.

## What

Extends the Slack thread upload from #28817 to XLSX deliveries.

- Backend: the upload gate accepts `xlsx` next to `csv`, the file is uploaded with `fileType: 'xlsx'`, and extension-less names get `.xlsx`. Dashboards with the single-workbook layout upload one workbook named after the dashboard; the per-chart layout uploads one file per chart, the same shape as CSV.
- Form: the "Attach the file to the delivery" checkbox now appears for XLSX as well as CSV, and the transform no longer forces the option off for XLSX. The preview chip shows `data.xlsx`.

## Regression analysis

- XLSX deliveries with the option off are unchanged (same gate as CSV, pinned by the existing option-off test).
- Email XLSX deliveries: `asAttachment` was previously impossible to set for XLSX because the form forced it off. The email client already handled XLSX attachments (`createFileAttachment` picks the spreadsheet content type), so enabling the option for XLSX also enables email XLSX attachments, which is the intended meaning of the option.
- No schema or API change.

## Tests

- Replaced the "XLSX is not attached" pin with two cases: per-chart XLSX upload typed `xlsx` with the extension added, and the single workbook upload for the `workbook` layout. 125 scheduler tests pass.
- Form: XLSX with a Slack-only recipient keeps the option on. 23 form tests pass.
- Live from the branch, files inspected through the Slack API: chart XLSX (`xlsx`, 6 KB), dashboard workbook (`Jaffle dashboard.xlsx`, 13 KB, title = dashboard name), dashboard per-chart (five `.xlsx` files titled with the chart names).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bd3Rg41LvPMWM5o1Z1L1rX
