### PR TITLE
feat: compile native GitHub projects without dbt on the server

### DIFF
--- a/docs/native-git-projects.md
+++ b/docs/native-git-projects.md
@@ -3,7 +3,9 @@
 Native YAML and dbt share GitHub authentication, repository, branch and project
 subdirectory settings. The semantic format is a separate build choice: native
 Lightdash YAML does not use dbt profiles, targets, selectors, dependencies or a
-dbt installation. Existing connections default to dbt. GitLab support is deferred.
+dbt installation. GitHub connections set `semanticLayer: lightdash` to select
+native builds; an omitted setting or `semanticLayer: dbt` keeps existing dbt
+behavior. GitLab support is deferred.
 
 `lightdash.config.yml` owns semantic configuration. The CLI uses its warehouse
 type to compile SQL; server builds use the project's existing warehouse

--- a/packages/backend/src/projectAdapters/dbtGitProjectAdapter.test.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectAdapter.test.ts
@@ -7,7 +7,8 @@ import {
 } from '@lightdash/common';
 import { GitError } from 'simple-git';
 import { DbtBaseProjectAdapter } from './dbtBaseProjectAdapter';
-import { DbtGitProjectAdapter, gitErrorHandler } from './dbtGitProjectAdapter';
+import { DbtGitProjectAdapter } from './dbtGitProjectAdapter';
+import { gitErrorHandler } from './gitRepository';
 
 const TOKEN_URL =
     'https://lightdash:ghp_secret_token_123@github.com/org/repo.git';

--- a/packages/backend/src/projectAdapters/dbtGitProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectAdapter.ts
@@ -1,22 +1,14 @@
 import {
-    AuthorizationError,
     CreateWarehouseCredentials,
     DbtProjectEnvironmentVariable,
-    getErrorMessage,
-    NotFoundError,
     SupportedDbtVersions,
-    UnexpectedGitError,
     UnexpectedServerError,
 } from '@lightdash/common';
 import { WarehouseClient } from '@lightdash/warehouses';
 import fs from 'fs';
 import * as fspromises from 'fs-extra';
 import * as path from 'path';
-import simpleGit, {
-    GitError,
-    SimpleGit,
-    SimpleGitProgressEvent,
-} from 'simple-git';
+import simpleGit, { SimpleGit, SimpleGitProgressEvent } from 'simple-git';
 import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
 import Logger from '../logging/logger';
 import {
@@ -26,6 +18,7 @@ import {
     type TrackingParams,
 } from '../types';
 import { DbtLocalCredentialsProjectAdapter } from './dbtLocalCredentialsProjectAdapter';
+import { GitRepository } from './gitRepository';
 
 export type DbtGitProjectAdapterArgs = {
     warehouseClient: WarehouseClient;
@@ -43,42 +36,6 @@ export type DbtGitProjectAdapterArgs = {
     analytics?: LightdashAnalytics;
     gitConfigGlobalPath?: string;
     dbtDepsErrorHint?: string;
-};
-
-const stripTokensFromUrls = (raw: string) => {
-    const pattern = /\/\/(.*)@/g;
-    return raw.replace(pattern, '//*****@');
-};
-
-export const gitErrorHandler = (e: unknown, repository: string) => {
-    if (!(e instanceof Error)) {
-        throw new UnexpectedServerError(
-            `Unexpected git error: ${stripTokensFromUrls(getErrorMessage(e))}`,
-        );
-    }
-    if (e.message.includes('Authentication failed')) {
-        throw new AuthorizationError(
-            'Git credentials not recognized for this repository',
-            { message: stripTokensFromUrls(e.message) },
-        );
-    }
-    if (e.message.includes('Repository not found')) {
-        throw new NotFoundError(
-            `Could not find git repository "${repository}". Check that your personal access token has access to the repository and that the repository name is correct.`,
-        );
-    }
-    if (e instanceof GitError) {
-        throw new UnexpectedGitError(
-            `Error while running "${
-                e.task?.commands[0]
-            }": ${stripTokensFromUrls(e.message)}`,
-        );
-    }
-    throw new UnexpectedGitError(
-        `Unexpected error while cloning git repository: ${stripTokensFromUrls(
-            e.message,
-        )}`,
-    );
 };
 
 export class DbtGitProjectAdapter
@@ -167,74 +124,14 @@ export class DbtGitProjectAdapter
         }
     }
 
-    private async _cleanLocal() {
-        try {
-            Logger.debug(`Clean ${this.localRepositoryDir}`);
-            await fspromises.emptyDir(this.localRepositoryDir);
-        } catch (e) {
-            throw new UnexpectedServerError(
-                `Unexpected error while cleaning local git directory: ${e}`,
-            );
-        }
-    }
-
-    private async _clone() {
-        try {
-            const defaultCloneOptions = {
-                '--single-branch': null,
-                '--depth': 1,
-                '--branch': this.branch,
-                '--no-tags': null,
-                '--progress': null,
-            };
-
-            const startTime = Date.now();
-            Logger.debug(`Git clone to ${this.localRepositoryDir}`);
-            await this.git
-                .env('GIT_TERMINAL_PROMPT', '0')
-                .clone(
-                    this.remoteRepositoryUrl,
-                    this.localRepositoryDir,
-                    defaultCloneOptions,
-                );
-            Logger.info(`Git clone completed in ${Date.now() - startTime}ms`);
-        } catch (e) {
-            gitErrorHandler(e, this.repository);
-        }
-    }
-
-    private async _pull() {
-        try {
-            const startTime = Date.now();
-            Logger.debug(`Git pull to ${this.localRepositoryDir}`);
-            await fspromises.access(this.localRepositoryDir);
-            await this.git
-                .env('GIT_TERMINAL_PROMPT', '0')
-                .cwd(this.localRepositoryDir)
-                .pull(this.remoteRepositoryUrl, this.branch, {
-                    '--ff-only': null,
-                    '--depth': 1,
-                    '--no-tags': null,
-                    '--progress': null,
-                });
-            Logger.info(`Git pull completed in ${Date.now() - startTime}ms`);
-        } catch (e) {
-            gitErrorHandler(e, this.repository);
-        }
-    }
-
     private async _refreshRepo() {
-        const startTime = Date.now();
-        try {
-            await this._pull();
-        } catch (e) {
-            Logger.debug(`Failed git pull ${e}`);
-            await this._cleanLocal();
-            await this._clone();
-        }
-        Logger.info(
-            `Git repo refresh completed in ${Date.now() - startTime}ms`,
-        );
+        await new GitRepository(
+            this.git,
+            this.localRepositoryDir,
+            this.remoteRepositoryUrl,
+            this.repository,
+            this.branch,
+        ).refresh();
     }
 
     public async prepareExploreStream(

--- a/packages/backend/src/projectAdapters/gitRepository.ts
+++ b/packages/backend/src/projectAdapters/gitRepository.ts
@@ -1,0 +1,125 @@
+import {
+    AuthorizationError,
+    getErrorMessage,
+    NotFoundError,
+    UnexpectedGitError,
+    UnexpectedServerError,
+} from '@lightdash/common';
+import * as fspromises from 'fs-extra';
+import { GitError, type SimpleGit } from 'simple-git';
+import Logger from '../logging/logger';
+
+const stripTokensFromUrls = (raw: string) => {
+    const pattern = /\/\/(.*)@/g;
+    return raw.replace(pattern, '//*****@');
+};
+
+export const gitErrorHandler = (e: unknown, repository: string) => {
+    if (!(e instanceof Error)) {
+        throw new UnexpectedServerError(
+            `Unexpected git error: ${stripTokensFromUrls(getErrorMessage(e))}`,
+        );
+    }
+    if (e.message.includes('Authentication failed')) {
+        throw new AuthorizationError(
+            'Git credentials not recognized for this repository',
+            { message: stripTokensFromUrls(e.message) },
+        );
+    }
+    if (e.message.includes('Repository not found')) {
+        throw new NotFoundError(
+            `Could not find git repository "${repository}". Check that your personal access token has access to the repository and that the repository name is correct.`,
+        );
+    }
+    if (e instanceof GitError) {
+        throw new UnexpectedGitError(
+            `Error while running "${
+                e.task?.commands[0]
+            }": ${stripTokensFromUrls(e.message)}`,
+        );
+    }
+    throw new UnexpectedGitError(
+        `Unexpected error while cloning git repository: ${stripTokensFromUrls(
+            e.message,
+        )}`,
+    );
+};
+
+export class GitRepository {
+    constructor(
+        private readonly git: SimpleGit,
+        private readonly localRepositoryDir: string,
+        private readonly remoteRepositoryUrl: string,
+        private readonly repository: string,
+        private readonly branch: string,
+    ) {}
+    private async _cleanLocal() {
+        try {
+            Logger.debug(`Clean ${this.localRepositoryDir}`);
+            await fspromises.emptyDir(this.localRepositoryDir);
+        } catch (e) {
+            throw new UnexpectedServerError(
+                `Unexpected error while cleaning local git directory: ${e}`,
+            );
+        }
+    }
+
+    private async _clone() {
+        try {
+            const defaultCloneOptions = {
+                '--single-branch': null,
+                '--depth': 1,
+                '--branch': this.branch,
+                '--no-tags': null,
+                '--progress': null,
+            };
+
+            const startTime = Date.now();
+            Logger.debug(`Git clone to ${this.localRepositoryDir}`);
+            await this.git
+                .env('GIT_TERMINAL_PROMPT', '0')
+                .clone(
+                    this.remoteRepositoryUrl,
+                    this.localRepositoryDir,
+                    defaultCloneOptions,
+                );
+            Logger.info(`Git clone completed in ${Date.now() - startTime}ms`);
+        } catch (e) {
+            gitErrorHandler(e, this.repository);
+        }
+    }
+
+    private async _pull() {
+        try {
+            const startTime = Date.now();
+            Logger.debug(`Git pull to ${this.localRepositoryDir}`);
+            await fspromises.access(this.localRepositoryDir);
+            await this.git
+                .env('GIT_TERMINAL_PROMPT', '0')
+                .cwd(this.localRepositoryDir)
+                .pull(this.remoteRepositoryUrl, this.branch, {
+                    '--ff-only': null,
+                    '--depth': 1,
+                    '--no-tags': null,
+                    '--progress': null,
+                });
+            Logger.info(`Git pull completed in ${Date.now() - startTime}ms`);
+        } catch (e) {
+            gitErrorHandler(e, this.repository);
+        }
+    }
+
+    public async refresh() {
+        const startTime = Date.now();
+        try {
+            await this._pull();
+        } catch (e) {
+            Logger.debug(`Failed git pull ${e}`);
+            await this._cleanLocal();
+            await this._clone();
+        }
+        Logger.info(
+            `Git repo refresh completed in ${Date.now() - startTime}ms`,
+        );
+    }
+}

--- a/packages/backend/src/projectAdapters/nativeGithubProjectAdapter.test.ts
+++ b/packages/backend/src/projectAdapters/nativeGithubProjectAdapter.test.ts
@@ -1,0 +1,154 @@
+import {
+    DbtProjectType,
+    SupportedDbtVersions,
+    WarehouseTypes,
+    type DbtGithubProjectConfig,
+} from '@lightdash/common';
+import fs from 'fs/promises';
+import path from 'path';
+import simpleGit from 'simple-git';
+import { getInstallationToken } from '../clients/github/Github';
+import { DbtCliClient } from '../dbt/dbtCliClient';
+import { warehouseClientMock } from '../utils/QueryBuilder/MetricQueryBuilder.mock';
+import { DbtGithubProjectAdapter } from './dbtGithubProjectAdapter';
+import { NativeGithubProjectAdapter } from './nativeGithubProjectAdapter';
+import { projectAdapterFromConfig } from './projectAdapter';
+
+vi.mock('simple-git');
+vi.mock('../clients/github/Github', () => ({ getInstallationToken: vi.fn() }));
+vi.mock('@lightdash/warehouses', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('@lightdash/warehouses')>()),
+    warehouseClientFromCredentials: vi.fn(() => warehouseClientMock),
+}));
+vi.mock('../dbt/dbtCliClient');
+
+const modelYaml = `type: model
+name: orders
+sql_from: public.orders
+dimensions:
+  - name: id
+    type: number
+    sql: id
+`;
+
+describe('native GitHub server compilation', () => {
+    const clone = vi.fn();
+    const pull = vi.fn();
+    const env = vi.fn();
+    const connection: DbtGithubProjectConfig = {
+        type: DbtProjectType.GITHUB,
+        semanticLayer: 'lightdash',
+        authorization_method: 'installation_id',
+        installation_id: '123',
+        repository: 'org/native',
+        branch: 'preview/change',
+        project_sub_path: 'analytics',
+    };
+    const createAdapter = (config = connection) =>
+        projectAdapterFromConfig(
+            config,
+            {
+                type: WarehouseTypes.POSTGRES,
+                host: 'localhost',
+                port: 5432,
+                user: 'postgres',
+                password: 'test',
+                dbname: 'postgres',
+                schema: 'public',
+            },
+            { warehouseCatalog: undefined, onWarehouseCatalogChange: vi.fn() },
+            SupportedDbtVersions.V1_10,
+            [],
+        );
+    const adapters: Awaited<ReturnType<typeof createAdapter>>[] = [];
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        const git = { clone, pull, env, cwd: vi.fn().mockReturnThis() };
+        env.mockReturnValue(git);
+        vi.mocked(simpleGit).mockReturnValue(
+            git as unknown as ReturnType<typeof simpleGit>,
+        );
+        pull.mockRejectedValue(new Error('No checkout yet'));
+        clone.mockImplementation(async (_url: string, directory: string) => {
+            const modelDir = path.join(directory, 'analytics/models/nested');
+            await fs.mkdir(modelDir, { recursive: true });
+            await fs.writeFile(path.join(modelDir, 'sales.yaml'), modelYaml);
+        });
+        vi.mocked(getInstallationToken).mockResolvedValue('ghs_test');
+    });
+    afterEach(async () => {
+        await Promise.all(
+            adapters.splice(0).map((adapter) => adapter.destroy()),
+        );
+    });
+
+    it('uses the installation, selected preview branch and subdirectory without dbt or catalog access', async () => {
+        const catalog = vi.spyOn(warehouseClientMock, 'getCatalog');
+        const adapter = await createAdapter();
+        adapters.push(adapter);
+        expect(adapter).toBeInstanceOf(NativeGithubProjectAdapter);
+        const explores = await adapter.compileAllExplores(undefined, true);
+        expect(getInstallationToken).toHaveBeenCalledWith('123');
+        expect(clone).toHaveBeenCalledWith(
+            'https://github.com/org/native.git',
+            expect.any(String),
+            expect.objectContaining({ '--branch': 'preview/change' }),
+        );
+        expect(explores).toEqual([
+            expect.objectContaining({
+                tables: expect.objectContaining({
+                    orders: expect.objectContaining({
+                        ymlPath: 'models/nested/sales.yaml',
+                    }),
+                }),
+            }),
+        ]);
+        expect(catalog).not.toHaveBeenCalled();
+        expect(DbtCliClient).not.toHaveBeenCalled();
+        expect(await fs.readdir(path.dirname(adapter.dbtProjectDir!))).toEqual([
+            'analytics',
+        ]);
+        expect(env).toHaveBeenCalledWith(
+            'GIT_CONFIG_GLOBAL',
+            expect.stringContaining('github_credentials_'),
+        );
+        catalog.mockRestore();
+    });
+
+    it.each([
+        'type: model\nname: broken\n',
+        `${modelYaml}metrics:\n  broken:\n    type: sum\n    sql: \${missing}\n`,
+    ])(
+        'fails before exposing a refresh stream when any native file is invalid',
+        async (invalidYaml) => {
+            const adapter = await createAdapter();
+            adapters.push(adapter);
+            await adapter.compileAllExplores(undefined);
+            pull.mockResolvedValue({});
+            await fs.writeFile(
+                path.join(adapter.dbtProjectDir!, 'models/broken.yml'),
+                invalidYaml.replace('name: orders', 'name: broken'),
+            );
+            await expect(
+                adapter.prepareExploreStream(undefined, false, true),
+            ).rejects.toThrow(/broken/);
+        },
+    );
+
+    it('keeps omitted format settings on the existing dbt adapter', async () => {
+        const adapter = await createAdapter({
+            ...connection,
+            semanticLayer: undefined,
+        });
+        adapters.push(adapter);
+        expect(adapter).toBeInstanceOf(DbtGithubProjectAdapter);
+    });
+
+    it('rejects a project subdirectory escaping the checkout before cloning', async () => {
+        await expect(
+            createAdapter({ ...connection, project_sub_path: '../outside' }),
+        ).rejects.toThrow('within the Git repository');
+        expect(clone).not.toHaveBeenCalled();
+    });
+});

--- a/packages/backend/src/projectAdapters/nativeGithubProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/nativeGithubProjectAdapter.ts
@@ -1,0 +1,207 @@
+import {
+    compileLightdashModels,
+    DEFAULT_SPOTLIGHT_CONFIG,
+    isExploreError,
+    loadLightdashProjectConfig,
+    loadProjectContextFile,
+    ParameterError,
+    ParseError,
+    validateGithubToken,
+    type Explore,
+    type LightdashProjectConfig,
+    type ProjectContextEntry,
+    type WarehouseClient,
+} from '@lightdash/common';
+import { loadLightdashModels } from '@lightdash/common/lightdash/loader';
+import fs from 'fs';
+import fsp from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import simpleGit from 'simple-git';
+import {
+    createGithubGitCredentialFiles,
+    type GitCredentialFiles,
+} from '../dbt/gitCredentials';
+import { preAggregatePostProcessor } from '../ee/preAggregates/postProcessor';
+import { type ProjectAdapter, type TrackingParams } from '../types';
+import { DEFAULT_GITHUB_HOST_DOMAIN } from '../utils/credentialDestination';
+import { GitRepository } from './gitRepository';
+
+export class NativeGithubProjectAdapter implements ProjectAdapter {
+    readonly dbtProjectDir: string;
+
+    private readonly localRepositoryDir: string;
+
+    private readonly credentials: GitCredentialFiles;
+
+    private readonly checkout: GitRepository;
+
+    private readonly warehouseClient: WarehouseClient;
+
+    constructor({
+        warehouseClient,
+        token,
+        repository,
+        branch,
+        projectSubPath,
+        hostDomain,
+    }: {
+        warehouseClient: WarehouseClient;
+        token: string;
+        repository: string;
+        branch: string;
+        projectSubPath: string;
+        hostDomain?: string;
+    }) {
+        const [valid, error] = validateGithubToken(token);
+        if (!valid) throw new ParameterError(error);
+        const subPath = projectSubPath.replace(/^\/+/, '');
+        if (subPath.split('/').includes('..') || subPath.includes('\\')) {
+            throw new ParameterError(
+                'Project subdirectory must stay within the Git repository',
+            );
+        }
+        const host = hostDomain || DEFAULT_GITHUB_HOST_DOMAIN;
+        this.credentials = createGithubGitCredentialFiles({ host, token });
+        this.localRepositoryDir = fs.mkdtempSync(
+            path.join(os.tmpdir(), 'native_git_'),
+        );
+        this.dbtProjectDir = path.join(this.localRepositoryDir, subPath);
+        this.warehouseClient = warehouseClient;
+        this.checkout = new GitRepository(
+            simpleGit({ unsafe: { allowUnsafeConfigPaths: true } }).env(
+                'GIT_CONFIG_GLOBAL',
+                this.credentials.configPath,
+            ),
+            this.localRepositoryDir,
+            `https://${host}/${repository}.git`,
+            repository,
+            branch,
+        );
+    }
+
+    private async assertWithinCheckout(filePath: string): Promise<void> {
+        const relativePath = path.relative(
+            await fsp.realpath(this.localRepositoryDir),
+            await fsp.realpath(filePath),
+        );
+        if (
+            relativePath === '..' ||
+            relativePath.startsWith(`..${path.sep}`) ||
+            path.isAbsolute(relativePath)
+        ) {
+            throw new ParameterError(
+                'Native project files must stay within the Git repository',
+            );
+        }
+    }
+
+    private async readConfigFile(name: string): Promise<string | null> {
+        const filePath = path.join(this.dbtProjectDir, name);
+        try {
+            await this.assertWithinCheckout(filePath);
+            return await fsp.readFile(filePath, 'utf8');
+        } catch (error) {
+            if (
+                error instanceof Error &&
+                'code' in error &&
+                error.code === 'ENOENT'
+            )
+                return null;
+            throw error;
+        }
+    }
+
+    async getLightdashProjectConfig(): Promise<LightdashProjectConfig> {
+        const contents = await this.readConfigFile('lightdash.config.yml');
+        return contents === null
+            ? { spotlight: DEFAULT_SPOTLIGHT_CONFIG }
+            : loadLightdashProjectConfig(contents);
+    }
+
+    async getProjectContext(): Promise<ProjectContextEntry[]> {
+        const contents = await this.readConfigFile(
+            'lightdash.project_context.yml',
+        );
+        return contents === null ? [] : loadProjectContextFile(contents);
+    }
+
+    async compileAllExplores(
+        _trackingParams?: TrackingParams,
+        loadSources = false,
+    ): Promise<Explore[]> {
+        await this.checkout.refresh();
+        await this.assertWithinCheckout(this.dbtProjectDir);
+        const models = await loadLightdashModels(this.dbtProjectDir);
+        if (models.length === 0) {
+            throw new ParseError(
+                'No native Lightdash models found. Add model YAML files under models/ or lightdash/models/ in the configured project subdirectory.',
+            );
+        }
+        const explores = await compileLightdashModels({
+            models,
+            warehouseSqlBuilder: this.warehouseClient,
+            lightdashProjectConfig: await this.getLightdashProjectConfig(),
+            loadSources,
+            allowPartialCompilation: false,
+            disableTimestampConversion:
+                this.warehouseClient.credentials.type === 'snowflake' &&
+                this.warehouseClient.credentials.disableTimestampConversion ===
+                    true,
+            postProcessors: [preAggregatePostProcessor],
+        });
+        const failures = explores.filter(isExploreError);
+        if (failures.length > 0) {
+            throw new ParseError(
+                `Native YAML compilation failed: ${failures.map((explore) => `${explore.name}: ${explore.errors.map((error) => error.message).join('; ')}`).join('\n')}`,
+            );
+        }
+        return explores.filter(
+            (explore): explore is Explore => !isExploreError(explore),
+        );
+    }
+
+    async prepareExploreStream(
+        trackingParams?: TrackingParams,
+        loadSources = false,
+    ): Promise<AsyncIterable<Explore>> {
+        const explores = await this.compileAllExplores(
+            trackingParams,
+            loadSources,
+        );
+        return (async function* stream() {
+            yield* explores;
+        })();
+    }
+
+    async test(): Promise<void> {
+        await this.compileAllExplores();
+        await this.warehouseClient.test();
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    async getDbtPackages(): Promise<undefined> {
+        return undefined;
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    async getDbtManifest(): Promise<never> {
+        throw new ParameterError(
+            'Native YAML projects cannot be combined with additional dbt sources.',
+        );
+    }
+
+    async destroy(): Promise<void> {
+        try {
+            await fsp.rm(this.localRepositoryDir, {
+                recursive: true,
+                force: true,
+            });
+        } finally {
+            await fsp.rm(this.credentials.directory, {
+                recursive: true,
+                force: true,
+            });
+        }
+    }
+}

--- a/packages/backend/src/projectAdapters/projectAdapter.ts
+++ b/packages/backend/src/projectAdapters/projectAdapter.ts
@@ -23,6 +23,7 @@ import {
     ManifestInput,
 } from './dbtManifestProjectAdapter';
 import { DbtNoneCredentialsProjectAdapter } from './dbtNoneCredentialsProjectAdapter';
+import { NativeGithubProjectAdapter } from './nativeGithubProjectAdapter';
 
 export const projectAdapterFromConfig = async (
     config:
@@ -109,6 +110,16 @@ export const projectAdapterFromConfig = async (
                 throw new ParameterError(
                     `Missing repository for GitHub project`,
                 );
+            }
+            if (config.semanticLayer === 'lightdash') {
+                return new NativeGithubProjectAdapter({
+                    warehouseClient,
+                    token: githubToken,
+                    repository: config.repository,
+                    branch: config.branch,
+                    projectSubPath: config.project_sub_path,
+                    hostDomain: config.host_domain,
+                });
             }
             return new DbtGithubProjectAdapter({
                 analytics,

--- a/packages/common/src/lightdash/loader.test.ts
+++ b/packages/common/src/lightdash/loader.test.ts
@@ -81,4 +81,16 @@ describe('native model loading and compilation', () => {
             'Duplicate Lightdash model "orders" in models/a.yml and models/nested/b.yml',
         );
     });
+    it('rejects a models directory symlink that leaves the project', async () => {
+        const nestedProject = path.join(projectDir, 'nested-project');
+        await writeModel('outside/orders.yml');
+        await fs.mkdir(nestedProject);
+        await fs.symlink(
+            path.join(projectDir, 'outside'),
+            path.join(nestedProject, 'models'),
+        );
+        await expect(loadLightdashModels(nestedProject)).rejects.toThrow(
+            'within the project directory',
+        );
+    });
 });

--- a/packages/common/src/lightdash/loader.ts
+++ b/packages/common/src/lightdash/loader.ts
@@ -62,6 +62,20 @@ export async function findLightdashModelFiles(
     }
     if (!modelsDir) return [];
 
+    const relativeModelsDir = path.relative(
+        await fs.realpath(projectDir),
+        await fs.realpath(modelsDir),
+    );
+    if (
+        relativeModelsDir === '..' ||
+        relativeModelsDir.startsWith(`..${path.sep}`) ||
+        path.isAbsolute(relativeModelsDir)
+    ) {
+        throw new ParseError(
+            'Native models directory must stay within the project directory',
+        );
+    }
+
     const files: string[] = [];
     async function walk(dir: string): Promise<void> {
         const entries = await fs.readdir(dir, { withFileTypes: true });

--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -1067,6 +1067,8 @@ export interface DbtCloudIDEProjectConfig extends DbtProjectConfigBase {
 
 export interface DbtGithubProjectConfig extends DbtProjectCompilerBase {
     type: DbtProjectType.GITHUB;
+    /** Omitted on existing connections, which continue to build with dbt. */
+    semanticLayer?: 'dbt' | 'lightdash';
     authorization_method: 'personal_access_token' | 'installation_id';
     personal_access_token?: string;
     installation_id?: string;


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-11031

### Description:

```diff
 GitHub project -> connection validation / refresh / preview
- always build with dbt
+ compile native YAML when the connection selects the Lightdash semantic format
```

- Reuse GitHub installation/PAT authentication, selected branch, project subdirectory and checkout behavior. Existing connections keep dbt behavior by default.
- Native builds use the existing warehouse connection and shared compiler, with no dbt profiles, commands or catalog fetch.
- Compile all native models before publishing a refresh stream. Invalid models fail the build; paths escaping the checkout are rejected and temporary credentials are cleaned up.
- Stack 2/6, based on #28818. The GitHub setup UI follows in the next PR.

Validation: 13 backend adapter tests and 7 common loader tests passed, covering native/dbt dispatch, installation credentials, preview branch selection, original paths, failed refresh and path containment. Common/backend typechecks, focused lint, API generation and `git diff --check` passed. The demo repo compiles through the CLI (8 explores). Full-stack E2E on localhost:3000: attached the existing CLI native project and retained its UUID/warehouse/content; created a new native project through the normal precompiled API; created a GitHub branch preview with copied content. Each compiled 8 explores. Malformed YAML made a preview refresh fail while its cached explore stayed identical; restored source and refreshed successfully. Demo project/preview data is persisted; no warehouse data was modified.

Latest rebase validation at the full-stack tip (`6b15c2d017`, based on main `21e876fa94`): backend build, backend/frontend typechecks, common build, 183 query-history/service tests, MCP snapshot freshness and `git diff --check` passed. Upstream [#28851](https://github.com/lightdash/lightdash/pull/28851) reverted the change causing the `QueryHistory.errorName` errors; both those errors and the earlier Learn UI errors are resolved. All six feature patches are unchanged by this restack. The preceding restack also passed common/CLI typechecks and 468 focused feature tests. Remote CI is rerunning.

### Risk assessment:

- [ ] This is a high-risk change

Low risk: native builds require an explicit format setting and reuse existing authorization. Existing dbt connections retain their adapter. Failed native compilation never exposes a replacement explore stream; API change is additive and requires no migration.
