### PR TITLE
feat: connect native Lightdash projects to GitHub in the UI

### DIFF
--- a/packages/backend/src/controllers/gitIntegrationController.test.ts
+++ b/packages/backend/src/controllers/gitIntegrationController.test.ts
@@ -1,0 +1,59 @@
+import { FeatureFlags } from '@lightdash/common';
+import type express from 'express';
+import { fromSession } from '../auth/account';
+import { user } from '../services/ProjectService/ProjectService.mock';
+import type { ServiceRepository } from '../services/ServiceRepository';
+import { GitIntegrationController } from './gitIntegrationController';
+
+vi.mock('../config/lightdashConfig', async () => {
+    const { lightdashConfigMock } =
+        await import('../config/lightdashConfig.mock');
+    return {
+        lightdashConfig: {
+            ...lightdashConfigMock,
+            editYamlInUi: { enabled: false },
+        },
+    };
+});
+
+it.each([false, true])(
+    'uses the resolved source editor flag for explore links: enabled=%s',
+    async (enabled) => {
+        const get = vi
+            .fn()
+            .mockResolvedValue({ id: FeatureFlags.EditYamlInUi, enabled });
+        const getFilePathForExplore = vi
+            .fn()
+            .mockResolvedValue({ filePath: 'models/nested/orders.yaml' });
+        const controller = new GitIntegrationController({
+            getFeatureFlagService: () => ({ get }),
+            getGitIntegrationService: () => ({ getFilePathForExplore }),
+        } as unknown as ServiceRepository);
+        const request = {
+            account: fromSession(
+                { ...user, organizationUuid: 'organizationUuid' },
+                'session-cookie',
+            ),
+        } as express.Request;
+        const result = controller.getFilePathForExplore(
+            'projectUuid',
+            'orders',
+            request,
+        );
+        if (enabled) {
+            await expect(result).resolves.toMatchObject({
+                results: { filePath: 'models/nested/orders.yaml' },
+            });
+            expect(getFilePathForExplore).toHaveBeenCalledWith(
+                expect.objectContaining({ userUuid: user.userUuid }),
+                'projectUuid',
+                'orders',
+            );
+        } else {
+            await expect(result).rejects.toThrow(
+                'Edit YAML in UI feature is not enabled',
+            );
+            expect(getFilePathForExplore).not.toHaveBeenCalled();
+        }
+    },
+);

--- a/packages/backend/src/controllers/gitIntegrationController.ts
+++ b/packages/backend/src/controllers/gitIntegrationController.ts
@@ -5,6 +5,7 @@ import {
     ApiGitFileContent,
     assertRegisteredAccount,
     CustomDimension,
+    FeatureFlags,
     ForbiddenError,
     PullRequestCreated,
     UUID,
@@ -27,7 +28,6 @@ import {
 } from '@tsoa/runtime';
 import express from 'express';
 import { toSessionUser } from '../auth/account';
-import { lightdashConfig } from '../config/lightdashConfig';
 import {
     allowApiKeyAuthentication,
     getDeprecatedRouteMiddleware,
@@ -211,7 +211,11 @@ export class GitIntegrationController extends BaseController {
         @Request() req: express.Request,
     ): Promise<{ status: 'ok'; results: ApiGitFileContent }> {
         assertRegisteredAccount(req.account);
-        if (!lightdashConfig.editYamlInUi.enabled) {
+        const flag = await this.services.getFeatureFlagService().get({
+            user: toSessionUser(req.account),
+            featureFlagId: FeatureFlags.EditYamlInUi,
+        });
+        if (!flag.enabled) {
             throw new ForbiddenError('Edit YAML in UI feature is not enabled');
         }
         this.setStatus(200);
@@ -245,7 +249,11 @@ export class GitIntegrationController extends BaseController {
         @Request() req: express.Request,
     ): Promise<{ status: 'ok'; results: { filePath: string } }> {
         assertRegisteredAccount(req.account);
-        if (!lightdashConfig.editYamlInUi.enabled) {
+        const flag = await this.services.getFeatureFlagService().get({
+            user: toSessionUser(req.account),
+            featureFlagId: FeatureFlags.EditYamlInUi,
+        });
+        if (!flag.enabled) {
             throw new ForbiddenError('Edit YAML in UI feature is not enabled');
         }
         this.setStatus(200);
@@ -293,7 +301,11 @@ export class GitIntegrationController extends BaseController {
         @Request() req: express.Request,
     ): Promise<{ status: 'ok'; results: PullRequestCreated }> {
         assertRegisteredAccount(req.account);
-        if (!lightdashConfig.editYamlInUi.enabled) {
+        const flag = await this.services.getFeatureFlagService().get({
+            user: toSessionUser(req.account),
+            featureFlagId: FeatureFlags.EditYamlInUi,
+        });
+        if (!flag.enabled) {
             throw new ForbiddenError('Edit YAML in UI feature is not enabled');
         }
         this.setStatus(200);

--- a/packages/backend/src/services/GitIntegrationService/GitIntegrationService.test.ts
+++ b/packages/backend/src/services/GitIntegrationService/GitIntegrationService.test.ts
@@ -90,6 +90,40 @@ describe('GitIntegrationService', () => {
         vi.clearAllMocks();
     });
 
+    it.each(['preview', 'create'] as const)(
+        'rejects native SQL Runner model %s before writing to Git',
+        async (action) => {
+            const project = await PROJECT_MODEL.get();
+            const nativeProject = {
+                ...project,
+                dbtConnection: {
+                    ...project.dbtConnection,
+                    semanticLayer: 'lightdash',
+                },
+            };
+            PROJECT_MODEL.get.mockResolvedValue(nativeProject);
+            try {
+                await expect(
+                    action === 'preview'
+                        ? service.writeBackPreview(user, 'projectUuid', 'model')
+                        : service.createPullRequestFromSql(
+                              user,
+                              'projectUuid',
+                              'model',
+                              'select 1',
+                              [],
+                          ),
+                ).rejects.toThrow(
+                    'SQL Runner model creation is only supported for dbt projects',
+                );
+                expect(createBranch).not.toHaveBeenCalled();
+                expect(updateFile).not.toHaveBeenCalled();
+            } finally {
+                PROJECT_MODEL.get.mockResolvedValue(project);
+            }
+        },
+    );
+
     describe('updateFile', () => {
         it('should update the file for custom metrics', async () => {
             await service.updateFile({

--- a/packages/backend/src/services/GitIntegrationService/GitIntegrationService.ts
+++ b/packages/backend/src/services/GitIntegrationService/GitIntegrationService.ts
@@ -1124,6 +1124,20 @@ ${sql}
         });
     }
 
+    private async assertSqlModelWritebackSupported(
+        projectUuid: string,
+    ): Promise<void> {
+        const { dbtConnection } = await this.projectModel.get(projectUuid);
+        if (
+            dbtConnection.type === DbtProjectType.GITHUB &&
+            dbtConnection.semanticLayer === 'lightdash'
+        ) {
+            throw new ParameterError(
+                'SQL Runner model creation is only supported for dbt projects.',
+            );
+        }
+    }
+
     async createPullRequestFromSql(
         user: SessionUser,
         projectUuid: string,
@@ -1133,6 +1147,7 @@ ${sql}
         quoteChar: `"` | `'` = '"',
     ): Promise<PullRequestCreated> {
         const gitProps = await this.getGitProps(user, projectUuid, quoteChar);
+        await this.assertSqlModelWritebackSupported(projectUuid);
         await GitIntegrationService.createBranch(gitProps);
 
         await GitIntegrationService.createSqlFile({
@@ -1226,6 +1241,7 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
         projectUuid: string,
         name: string,
     ): Promise<ApiGithubDbtWritePreview['results']> {
+        await this.assertSqlModelWritebackSupported(projectUuid);
         const { owner, repo, path, type, hostDomain } =
             await this.getProjectRepo(projectUuid);
 

--- a/packages/frontend/src/components/CompilationHistory/index.tsx
+++ b/packages/frontend/src/components/CompilationHistory/index.tsx
@@ -33,7 +33,7 @@ const CompilationHistory: FC<CompilationHistoryProps> = ({ projectUuid }) => {
 
             <SettingsPage
                 title="Compilation history"
-                description="Review recent dbt compilation runs for this project."
+                description="Review recent compilation runs for this project."
                 actions={
                     <Button
                         onClick={handleRefresh}

--- a/packages/frontend/src/components/CompilationHistory/types.ts
+++ b/packages/frontend/src/components/CompilationHistory/types.ts
@@ -6,7 +6,7 @@ export type CompilationSource =
 
 export const SOURCE_LABELS: Record<CompilationSource, string> = {
     cli_deploy: 'CLI Deploy',
-    refresh_dbt: 'Refresh dbt',
+    refresh_dbt: 'Refresh',
     create_project: 'Create Project',
     project_connection_form: 'Project connection form',
 };

--- a/packages/frontend/src/components/ProjectConnection/DbtForms/DbtNoneForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtForms/DbtNoneForm.tsx
@@ -14,41 +14,18 @@ const DbtNoneForm: FC<{ disabled: boolean }> = ({ disabled }) => {
                 icon={<MantineIcon icon={IconExclamationCircle} size="lg" />}
             >
                 <Text c="orange" fz="sm">
-                    This project was created from the CLI. If you want to keep
-                    Lightdash in sync with your dbt project, you need to either{' '}
+                    This project is deployed using the CLI. To refresh native
+                    YAML and edit source files in Lightdash, select GitHub above
+                    and choose Native Lightdash YAML. You can also deploy with{' '}
                     <Anchor
-                        href={
-                            'https://docs.lightdash.com/get-started/setup-lightdash/connect-project#2-import-a-dbt-project'
-                        }
-                        target="_blank"
-                        rel="noreferrer"
-                        fz="sm"
-                    >
-                        change your connection type
-                    </Anchor>
-                    , setup a{' '}
-                    <Anchor
-                        href={
-                            'https://docs.lightdash.com/guides/cli/how-to-use-lightdash-deploy#automatically-deploy-your-changes-to-lightdash-using-a-github-action'
-                        }
-                        target="_blank"
-                        rel="noreferrer"
-                        fz="sm"
-                    >
-                        GitHub action
-                    </Anchor>{' '}
-                    or, run{' '}
-                    <Anchor
-                        href={
-                            'https://docs.lightdash.com/guides/cli/how-to-use-lightdash-deploy#lightdash-deploy-syncs-the-changes-in-your-dbt-project-to-lightdash'
-                        }
+                        href="https://docs.lightdash.com/guides/cli/how-to-use-lightdash-deploy"
                         target="_blank"
                         rel="noreferrer"
                         fz="sm"
                     >
                         lightdash deploy
                     </Anchor>{' '}
-                    from your command line.
+                    or automate deployments with a GitHub action.
                 </Text>
             </Alert>
 
@@ -58,11 +35,11 @@ const DbtNoneForm: FC<{ disabled: boolean }> = ({ disabled }) => {
                 disabled={disabled}
                 {...form.getInputProps('dbt.hideRefreshButton')}
                 name="dbt.hideRefreshButton"
-                label="Hide refresh dbt button in the app"
+                label="Hide refresh button in the app"
                 description={
                     <Text fz="sm">
-                        This will hide the refresh dbt button from the explore
-                        page. Read more about your{' '}
+                        This will hide the refresh button from the explore page.
+                        Read more about your{' '}
                         <Anchor
                             href={
                                 'https://docs.lightdash.com/references/dbt-projects'

--- a/packages/frontend/src/components/ProjectConnection/DbtForms/GithubForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtForms/GithubForm.tsx
@@ -242,13 +242,15 @@ const GithubPersonalAccessTokenForm: FC<{ disabled: boolean }> = ({
 };
 
 const GithubForm: FC<{ disabled: boolean }> = ({ disabled }) => {
-    const { savedProject } = useProjectFormContext();
+    const { savedProject, isDbtSource } = useProjectFormContext();
     const form = useFormContext();
     const { data: githubConfig } = useGithubConfig();
 
     if (form.values.dbt.type !== DbtProjectType.GITHUB) {
         throw new Error('GithubForm can only be used for Github projects');
     }
+
+    const isNative = form.values.dbt.semanticLayer === 'lightdash';
 
     const formAuthorizationMethod = form.values.dbt?.authorization_method;
     const authorizationMethod: DbtGithubProjectConfig['authorization_method'] =
@@ -270,6 +272,39 @@ const GithubForm: FC<{ disabled: boolean }> = ({ disabled }) => {
     return (
         <>
             <Stack mt="xs">
+                {!isDbtSource && (
+                    <Select
+                        label="Semantic layer format"
+                        name="dbt.semanticLayer"
+                        value={form.values.dbt.semanticLayer ?? 'dbt'}
+                        allowDeselect={false}
+                        disabled={disabled}
+                        data={[
+                            { value: 'dbt', label: 'dbt' },
+                            {
+                                value: 'lightdash',
+                                label: 'Native Lightdash YAML',
+                            },
+                        ]}
+                        onChange={(value) => {
+                            if (value !== 'dbt' && value !== 'lightdash')
+                                return;
+                            if (form.values.dbt.type !== DbtProjectType.GITHUB)
+                                return;
+                            form.setFieldValue('dbt', {
+                                ...form.values.dbt,
+                                semanticLayer: value,
+                                ...(value === 'lightdash'
+                                    ? {
+                                          target: undefined,
+                                          selector: undefined,
+                                          environment: undefined,
+                                      }
+                                    : {}),
+                            });
+                        }}
+                    />
+                )}
                 <Group gap="sm">
                     <Select
                         allowDeselect={false}
@@ -324,7 +359,7 @@ const GithubForm: FC<{ disabled: boolean }> = ({ disabled }) => {
                     <GithubPersonalAccessTokenForm disabled={disabled} />
                 )}
 
-                <DbtVersionSelect disabled={disabled} />
+                {!isNative && <DbtVersionSelect disabled={disabled} />}
                 <TextInput
                     name="dbt.branch"
                     {...form.getInputProps('dbt.branch')}
@@ -351,21 +386,30 @@ const GithubForm: FC<{ disabled: boolean }> = ({ disabled }) => {
                     {...form.getInputProps('dbt.project_sub_path')}
                     label="Project directory path"
                     description={
-                        <>
-                            <p>
-                                Put <b>/</b> if your <b>dbt_project.yml</b> file
-                                is in the main folder of your repo (e.g.
-                                lightdash/lightdash-analytics/dbt_project.yml).
-                            </p>
-                            <p>
-                                Include the path to the sub-folder where your
-                                dbt project is if your dbt project is in a
-                                sub-folder in your repo. For example, if my
-                                project was in
-                                lightdash/lightdash-analytics/dbt/dbt_project.yml,
-                                I'd write <b>/dbt</b> in this field.
-                            </p>
-                        </>
+                        isNative ? (
+                            <Text size="sm">
+                                Use / for the repository root, or the
+                                subdirectory containing lightdash.config.yml and
+                                models/ (or lightdash/models/).
+                            </Text>
+                        ) : (
+                            <>
+                                <p>
+                                    Put <b>/</b> if your <b>dbt_project.yml</b>{' '}
+                                    file is in the main folder of your repo
+                                    (e.g.
+                                    lightdash/lightdash-analytics/dbt_project.yml).
+                                </p>
+                                <p>
+                                    Include the path to the sub-folder where
+                                    your dbt project is if your dbt project is
+                                    in a sub-folder in your repo. For example,
+                                    if my project was in
+                                    lightdash/lightdash-analytics/dbt/dbt_project.yml,
+                                    I'd write <b>/dbt</b> in this field.
+                                </p>
+                            </>
+                        )
                     }
                     required
                     disabled={disabled}

--- a/packages/frontend/src/components/ProjectConnection/DbtSettingsForm.test.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtSettingsForm.test.tsx
@@ -1,0 +1,127 @@
+import {
+    DbtProjectType,
+    DefaultSupportedDbtVersion,
+    WarehouseTypes,
+} from '@lightdash/common';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router';
+import { renderWithProviders } from '../../testing/testUtils';
+import { githubDefaultValues } from './DbtForms/defaultValues';
+import DbtSettingsForm from './DbtSettingsForm';
+import { FormProvider, useForm } from './formContext';
+import { ProjectFormProvider } from './ProjectFormProvider';
+
+vi.mock('../common/GithubIntegration/hooks/useGithubIntegration', () => ({
+    useGithubConfig: () => ({ data: { enabled: true, installationId: '123' } }),
+    useGitHubRepositories: () => ({ data: [{ fullName: 'org/native' }] }),
+}));
+
+const submit = vi.fn();
+const warehouse = {
+    type: WarehouseTypes.POSTGRES as const,
+    host: 'localhost',
+    port: 5432,
+    user: 'postgres',
+    password: 'test',
+    dbname: 'postgres',
+    schema: 'public',
+};
+
+const FormHarness = ({
+    disabled = false,
+    isDbtSource = false,
+}: {
+    disabled?: boolean;
+    isDbtSource?: boolean;
+}) => {
+    const form = useForm({
+        initialValues: {
+            name: 'Existing native project',
+            dbt: {
+                ...githubDefaultValues,
+                type: DbtProjectType.GITHUB,
+                repository: 'org/native',
+                branch: 'staging',
+                project_sub_path: '/analytics',
+                target: 'prod',
+                selector: 'tag:lightdash',
+            },
+            dbtVersion: DefaultSupportedDbtVersion,
+            warehouse,
+        },
+    });
+    return (
+        <MemoryRouter>
+            <ProjectFormProvider isDbtSource={isDbtSource}>
+                <FormProvider form={form}>
+                    <form onSubmit={form.onSubmit(submit)}>
+                        <DbtSettingsForm disabled={disabled} />
+                        <button type="submit">Submit</button>
+                    </form>
+                </FormProvider>
+            </ProjectFormProvider>
+        </MemoryRouter>
+    );
+};
+
+describe('native GitHub connection form', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('switches the build format while preserving Git and warehouse values and hiding dbt options', async () => {
+        const user = userEvent.setup();
+        renderWithProviders(<FormHarness />);
+        expect(screen.getByLabelText('Target name')).toBeInTheDocument();
+        await user.click(
+            screen.getByLabelText('Semantic layer format', {
+                selector: 'input',
+            }),
+        );
+        await user.click(
+            screen.getByRole('option', { name: 'Native Lightdash YAML' }),
+        );
+        expect(screen.queryByLabelText('Target name')).not.toBeInTheDocument();
+        expect(
+            screen.queryByText('dbt version', { exact: false }),
+        ).not.toBeInTheDocument();
+        expect(
+            screen.queryByText('Advanced configuration options'),
+        ).not.toBeInTheDocument();
+        expect(
+            screen.getByText(/containing lightdash.config.yml/),
+        ).toBeInTheDocument();
+        await user.click(screen.getByRole('button', { name: 'Submit' }));
+        expect(submit).toHaveBeenCalledWith(
+            expect.objectContaining({
+                warehouse,
+                dbt: expect.objectContaining({
+                    semanticLayer: 'lightdash',
+                    repository: 'org/native',
+                    branch: 'staging',
+                    project_sub_path: '/analytics',
+                    installation_id: '123',
+                    target: undefined,
+                    selector: undefined,
+                }),
+            }),
+            expect.anything(),
+        );
+    });
+
+    it('keeps the format disabled when connection editing is forbidden', () => {
+        renderWithProviders(<FormHarness disabled />);
+        expect(
+            screen.getByLabelText('Semantic layer format', {
+                selector: 'input',
+            }),
+        ).toBeDisabled();
+    });
+
+    it('keeps additional dbt sources restricted to dbt builds', () => {
+        renderWithProviders(<FormHarness isDbtSource />);
+        expect(
+            screen.queryByLabelText('Semantic layer format'),
+        ).not.toBeInTheDocument();
+        expect(screen.getByLabelText('Target name')).toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/components/ProjectConnection/DbtSettingsForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtSettingsForm.tsx
@@ -40,6 +40,10 @@ const DbtSettingsForm: FC<DbtSettingsFormProps> = ({
     const type: DbtProjectType =
         form.values.dbt.type ?? (defaultType || DbtProjectType.GITHUB);
 
+    const isNative =
+        form.values.dbt.type === DbtProjectType.GITHUB &&
+        form.values.dbt.semanticLayer === 'lightdash';
+
     const warehouseType: WarehouseTypes =
         form.values.warehouse?.type ??
         selectedWarehouse ??
@@ -163,7 +167,7 @@ const DbtSettingsForm: FC<DbtSettingsFormProps> = ({
 
                 <DbtForm disabled={disabled} />
 
-                {type !== DbtProjectType.NONE && (
+                {type !== DbtProjectType.NONE && !isNative && (
                     <>
                         <FormSection name="target">
                             <Stack mt="xs">

--- a/packages/frontend/src/components/ProjectConnection/ProjectForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectForm.tsx
@@ -1,7 +1,8 @@
-import { ProjectType, type DbtProjectType } from '@lightdash/common';
+import { ProjectType, DbtProjectType } from '@lightdash/common';
 import { TextInput, Flex, Stack, Text, Title, Avatar } from '@mantine/core';
 import { type FC } from 'react';
 import useApp from '../../providers/App/useApp';
+import LightdashLogo from '../../svgs/logo-icon.svg';
 import { SettingsGridCard } from '../common/Settings/SettingsCard';
 import DocumentationHelpButton from '../DocumentationHelpButton';
 import DbtSettingsForm from './DbtSettingsForm';
@@ -32,6 +33,9 @@ export const ProjectForm: FC<Props> = ({
     const form = useFormContext();
     const { savedProject } = useProjectFormContext();
     const warehouse = form.values.warehouse.type;
+    const isNative =
+        form.values.dbt.type === DbtProjectType.GITHUB &&
+        form.values.dbt.semanticLayer === 'lightdash';
 
     return (
         <Stack gap="xl">
@@ -78,7 +82,7 @@ export const ProjectForm: FC<Props> = ({
                         disabled={disabled}
                         isProjectUpdate={isProjectUpdate}
                     >
-                        {warehouseOnly &&
+                        {(warehouseOnly || isNative) &&
                             warehouse &&
                             !form.values
                                 .organizationWarehouseCredentialsUuid && (
@@ -95,10 +99,14 @@ export const ProjectForm: FC<Props> = ({
             {!warehouseOnly && (
                 <SettingsGridCard>
                     <div>
-                        <Avatar size="md" src={DbtLogo} alt="dbt icon" />
+                        <Avatar
+                            size="md"
+                            src={isNative ? LightdashLogo : DbtLogo}
+                            alt={isNative ? 'Lightdash icon' : 'dbt icon'}
+                        />
 
                         <Flex align="center" gap={2}>
-                            <Title order={5}>dbt connection</Title>
+                            <Title order={5}>Semantic layer connection</Title>
                             <DocumentationHelpButton
                                 href="https://docs.lightdash.com/get-started/setup-lightdash/connect-project"
                                 pos="relative"
@@ -116,9 +124,11 @@ export const ProjectForm: FC<Props> = ({
                 </SettingsGridCard>
             )}
 
-            {savedProject && savedProject.type !== ProjectType.PREVIEW && (
-                <DbtSourcesPanel projectUuid={savedProject.projectUuid} />
-            )}
+            {savedProject &&
+                savedProject.type !== ProjectType.PREVIEW &&
+                !isNative && (
+                    <DbtSourcesPanel projectUuid={savedProject.projectUuid} />
+                )}
         </Stack>
     );
 };

--- a/packages/frontend/src/components/RefreshDbtButton/index.tsx
+++ b/packages/frontend/src/components/RefreshDbtButton/index.tsx
@@ -52,6 +52,22 @@ const MODE_COPY: Record<
     },
 };
 
+const NATIVE_MODE_COPY: typeof MODE_COPY = {
+    dbt: {
+        ...MODE_COPY.dbt,
+        label: 'Refresh models',
+        description: 'Recompile explores from your native Lightdash YAML',
+        busy: 'Refreshing models',
+    },
+    'dbt-and-content': {
+        ...MODE_COPY['dbt-and-content'],
+        label: 'Refresh models and sync content',
+        busy: 'Refreshing models and content',
+        tooltip:
+            'Recompiles your native Lightdash models, then applies charts and dashboards as code from the repo.',
+    },
+};
+
 const loadStoredMode = (projectUuid: string): RefreshMode => {
     try {
         return localStorage.getItem(refreshModeStorageKey(projectUuid)) ===
@@ -145,17 +161,16 @@ const RefreshDbtButton: FC<{
                             leftSection={<MantineIcon icon={IconRefresh} />}
                             disabled
                         >
-                            Refresh dbt
+                            Refresh project
                         </Button>
                     </Box>
                 </Popover.Target>
                 <Popover.Dropdown>
                     <Text>
-                        You're still connected to a dbt project created from the
-                        CLI.
+                        This project is deployed using the CLI.
                         <br />
-                        To keep your Lightdash project in sync with your dbt
-                        project,
+                        To keep your Lightdash project in sync with your source
+                        files,
                         <br /> you need to either{' '}
                         <Anchor
                             href={
@@ -187,7 +202,7 @@ const RefreshDbtButton: FC<{
                         >
                             lightdash deploy
                         </Anchor>
-                        ) from your command line.
+                        from your command line.
                     </Text>
                 </Popover.Dropdown>
             </Popover>
@@ -224,15 +239,16 @@ const RefreshDbtButton: FC<{
         if (projectUuid) storeMode(projectUuid, nextMode);
     };
 
+    const modeCopy =
+        data?.dbtConnection.type === DbtProjectType.GITHUB &&
+        data.dbtConnection.semanticLayer === 'lightdash'
+            ? NATIVE_MODE_COPY
+            : MODE_COPY;
     const busy = isLoading;
-    const busyLabel = MODE_COPY[activeMode].busy;
+    const busyLabel = modeCopy[activeMode].busy;
 
     const refreshButton = (
-        <Tooltip
-            w={320}
-            position="bottom"
-            label={MODE_COPY[activeMode].tooltip}
-        >
+        <Tooltip w={320} position="bottom" label={modeCopy[activeMode].tooltip}>
             <Button
                 size="xs"
                 variant="default"
@@ -242,7 +258,7 @@ const RefreshDbtButton: FC<{
                 style={canSyncContent ? undefined : buttonStyles}
             >
                 {!busy
-                    ? (defaultTextOverride ?? MODE_COPY[activeMode].label)
+                    ? (defaultTextOverride ?? modeCopy[activeMode].label)
                     : (refreshingTextOverride ?? busyLabel)}
             </Button>
         </Tooltip>
@@ -287,10 +303,10 @@ const RefreshDbtButton: FC<{
                                                         : undefined
                                                 }
                                             >
-                                                {MODE_COPY[option].label}
+                                                {modeCopy[option].label}
                                             </Text>
                                             <Text fz="xs" c="dimmed">
-                                                {MODE_COPY[option].description}
+                                                {modeCopy[option].description}
                                             </Text>
                                         </Stack>
                                     </Menu.Item>

--- a/packages/frontend/src/components/Settings/ProjectSettings.tsx
+++ b/packages/frontend/src/components/Settings/ProjectSettings.tsx
@@ -152,7 +152,7 @@ const ProjectSettings: FC<{ externalSourcesEnabled: boolean }> = ({
                 element: (
                     <ProjectSettingsPage
                         title="Connection settings"
-                        description="Manage this project's warehouse and dbt connections."
+                        description="Manage this project's warehouse and semantic layer connections."
                     >
                         <UpdateProjectConnection projectUuid={projectUuid} />
                     </ProjectSettingsPage>

--- a/packages/frontend/src/features/sourceCodeEditor/components/CodeEditorPane/index.tsx
+++ b/packages/frontend/src/features/sourceCodeEditor/components/CodeEditorPane/index.tsx
@@ -1,4 +1,4 @@
-import { lightdashDbtYamlSchema } from '@lightdash/common';
+import { lightdashDbtYamlSchema, modelAsCodeSchema } from '@lightdash/common';
 import { Box, Loader, Stack, Text } from '@mantine/core';
 import { IconFileOff } from '@tabler/icons-react';
 import type { editor } from 'monaco-editor';
@@ -20,25 +20,42 @@ import { detectLanguage } from '../../utils/fileLanguageDetection';
 import styles from './CodeEditorPane.module.css';
 import EditorToolbar from './EditorToolbar';
 
-// Configure monaco-yaml with schema once at module level
-let yamlConfigured = false;
-const configureYamlSchema = (monaco: Monaco) => {
-    if (yamlConfigured) return;
-    yamlConfigured = true;
-
-    configureMonacoYaml(monaco, {
+let yamlConfiguration: ReturnType<typeof configureMonacoYaml> | undefined;
+const configureYamlSchema = (
+    monaco: Monaco,
+    semanticLayer: 'dbt' | 'lightdash',
+    filePath: string | null,
+) => {
+    const isNative = semanticLayer === 'lightdash';
+    const options = {
         enableSchemaRequest: false,
-        schemas: [
-            {
-                uri: 'https://schemas.lightdash.com/lightdash/lightdash-dbt-2.0.json',
-                fileMatch: ['*.yml', '*.yaml'],
-                schema: lightdashDbtYamlSchema as Record<string, unknown>,
-            },
-        ],
-    });
+        schemas:
+            isNative && !/(^|\/)models\//.test(filePath ?? '')
+                ? []
+                : [
+                      {
+                          uri: isNative
+                              ? 'https://schemas.lightdash.com/lightdash/model-as-code.json'
+                              : 'https://schemas.lightdash.com/lightdash/lightdash-dbt-2.0.json',
+                          fileMatch: ['*.yml', '*.yaml'],
+                          schema: (isNative
+                              ? modelAsCodeSchema
+                              : lightdashDbtYamlSchema) as Record<
+                              string,
+                              unknown
+                          >,
+                      },
+                  ],
+    };
+    if (yamlConfiguration) {
+        void yamlConfiguration.update(options);
+    } else {
+        yamlConfiguration = configureMonacoYaml(monaco, options);
+    }
 };
 
 type CodeEditorPaneProps = {
+    semanticLayer: 'dbt' | 'lightdash';
     filePath: string | null;
     content: string;
     isLoading: boolean;
@@ -52,6 +69,7 @@ type CodeEditorPaneProps = {
 };
 
 const CodeEditorPane: FC<CodeEditorPaneProps> = ({
+    semanticLayer,
     filePath,
     content,
     isLoading,
@@ -74,6 +92,11 @@ const CodeEditorPane: FC<CodeEditorPaneProps> = ({
 
     const isReadOnly = !canManage || isProtectedBranch;
 
+    useEffect(() => {
+        if (monacoRef.current)
+            configureYamlSchema(monacoRef.current, semanticLayer, filePath);
+    }, [semanticLayer, filePath]);
+
     // Update Monaco theme when color scheme changes
     useEffect(() => {
         if (monacoRef.current) {
@@ -82,22 +105,25 @@ const CodeEditorPane: FC<CodeEditorPaneProps> = ({
         }
     }, [monacoTheme]);
 
-    const handleBeforeMount: BeforeMount = useCallback((monaco) => {
-        // Define both light and dark themes
-        monaco.editor.defineTheme('lightdash-light', {
-            base: 'vs',
-            inherit: true,
-            ...getLightdashMonacoTheme('light'),
-        });
-        monaco.editor.defineTheme('lightdash-dark', {
-            base: 'vs-dark',
-            inherit: true,
-            ...getLightdashMonacoTheme('dark'),
-        });
+    const handleBeforeMount: BeforeMount = useCallback(
+        (monaco) => {
+            // Define both light and dark themes
+            monaco.editor.defineTheme('lightdash-light', {
+                base: 'vs',
+                inherit: true,
+                ...getLightdashMonacoTheme('light'),
+            });
+            monaco.editor.defineTheme('lightdash-dark', {
+                base: 'vs-dark',
+                inherit: true,
+                ...getLightdashMonacoTheme('dark'),
+            });
 
-        // Configure YAML schema validation
-        configureYamlSchema(monaco);
-    }, []);
+            // Configure YAML schema validation
+            configureYamlSchema(monaco, semanticLayer, filePath);
+        },
+        [semanticLayer, filePath],
+    );
 
     const handleEditorMount: OnMount = useCallback((editorInstance, monaco) => {
         editorRef.current = editorInstance;
@@ -164,6 +190,7 @@ const CodeEditorPane: FC<CodeEditorPaneProps> = ({
             ) : filePath ? (
                 <Box className={styles.editorContainer}>
                     <Editor
+                        path={filePath}
                         height="100%"
                         language={language}
                         value={content}

--- a/packages/frontend/src/features/sourceCodeEditor/components/SourceCodeEditorContent.tsx
+++ b/packages/frontend/src/features/sourceCodeEditor/components/SourceCodeEditorContent.tsx
@@ -1,5 +1,5 @@
 import { subject } from '@casl/ability';
-import { isGitProjectType } from '@lightdash/common';
+import { DbtProjectType, isGitProjectType } from '@lightdash/common';
 import { Box, Group } from '@mantine/core';
 import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
 import { useSearchParams } from 'react-router';
@@ -372,6 +372,13 @@ const SourceCodeEditorContent: FC = () => {
 
                 <Box flex={1}>
                     <CodeEditorPane
+                        semanticLayer={
+                            project?.dbtConnection.type ===
+                                DbtProjectType.GITHUB &&
+                            project.dbtConnection.semanticLayer === 'lightdash'
+                                ? 'lightdash'
+                                : 'dbt'
+                        }
                         filePath={currentFilePath}
                         content={editorContent}
                         isLoading={isLoadingFile && currentFilePath !== null}

--- a/packages/frontend/src/features/sourceCodeEditor/components/SourceCodeSidebar/index.tsx
+++ b/packages/frontend/src/features/sourceCodeEditor/components/SourceCodeSidebar/index.tsx
@@ -31,7 +31,7 @@ const SourceCodeSidebar: FC<SourceCodeSidebarProps> = ({
         <Stack gap="xs" className={styles.header}>
             <Title order={5}>Source Code</Title>
             <Text fz="xs" c="dimmed">
-                Browse and edit your dbt project files
+                Browse and edit your project files
             </Text>
             <BranchSelector
                 branches={branches}

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
@@ -104,6 +104,15 @@ export const HeaderCreate: FC = () => {
                 undefined,
             ];
         }
+        if (
+            project?.dbtConnection.type === DbtProjectType.GITHUB &&
+            project.dbtConnection.semanticLayer === 'lightdash'
+        ) {
+            return [
+                'SQL Runner model creation is only supported for dbt projects.',
+                undefined,
+            ];
+        }
         const hasGithubEnabled = gitIntegration?.enabled;
         const hasGitProject = [
             DbtProjectType.GITHUB,
@@ -142,7 +151,7 @@ export const HeaderCreate: FC = () => {
         gitIntegration?.enabled,
         health?.data?.hasGithub,
         health?.data?.siteUrl,
-        project?.dbtConnection.type,
+        project?.dbtConnection,
         project?.name,
         projectUuid,
     ]);

--- a/packages/frontend/src/hooks/useRefreshServer.test.ts
+++ b/packages/frontend/src/hooks/useRefreshServer.test.ts
@@ -28,7 +28,7 @@ describe('getJobCompletionToast', () => {
     test('keeps the successful sync message when every explore is valid', () => {
         expect(getJobCompletionToast(compileJob(0, 10))).toEqual({
             variant: 'success',
-            title: 'Successfully synced dbt project!',
+            title: 'Successfully synced project!',
         });
     });
 });

--- a/packages/frontend/src/hooks/useRefreshServer.ts
+++ b/packages/frontend/src/hooks/useRefreshServer.ts
@@ -46,13 +46,13 @@ export const jobStatusLabel = (status: JobStatusType, jobType?: JobType) => {
     }
     switch (status) {
         case JobStatusType.DONE:
-            return 'Successfully synced dbt project!';
+            return 'Successfully synced project!';
         case JobStatusType.STARTED:
             return 'Pending sync';
         case JobStatusType.ERROR:
-            return 'Error while syncing dbt project';
+            return 'Error while syncing project';
         case JobStatusType.RUNNING:
-            return 'Syncing dbt project';
+            return 'Syncing project';
         default:
             throw new Error('Unknown job status');
     }
@@ -162,7 +162,7 @@ export const useRefreshServer = () => {
         onSuccess: (data) => setActiveJobId(data.jobUuid),
         onError: ({ error }) =>
             showToastApiError({
-                title: 'Error syncing dbt project',
+                title: 'Error syncing project',
                 apiError: error,
             }),
     });


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-11033

### Description:

```diff
 Connect or edit a GitHub project
- configure a dbt build
+ choose dbt or Native Lightdash YAML using the same GitHub integration
```

- Attach an existing CLI native project in place, preserving its identity, warehouse configuration, and saved content. Native connections hide dbt-only settings and use native schema validation in the source editor. Source API gates now use the same resolved feature flag as the UI.
- Show the existing Lightdash logo for native YAML and the dbt logo for dbt in the same connection-header slot.
- Existing connection/source permissions and protected-branch editing rules still apply. Native SQL Runner model creation fails explicitly before creating a branch; metric, dimension, and AI write-back follow in separate stack entries.
- Stack: #28818 → #28820 → this PR.

Validation: 19 focused frontend tests and 15 GitIntegrationService tests plus 2 source-controller flag tests passed; backend typecheck, focused lint/format, and `git diff --check` passed.

On localhost:3000, attached the existing F1-native CLI project to `Spissable/lightdash-native-demo-1` through the installed GitHub integration. A missing branch failed visibly and skipped compilation. Switching to `main` compiled 8 explores, 44 metrics, and 181 dimensions, matching the previous CLI deployment. Verified unchanged project UUID/BigQuery settings and loaded existing dashboard and saved-chart query results. Connection settings were persisted; the existing form saves settings before compilation. After enabling the source-editor flag, verified the original native file loads with native schema validation and main is protected. Created a separate demo branch, saved a one-line comment, and opened [demo PR #3](https://github.com/Spissable/lightdash-native-demo-1/pull/3) entirely through the browser. The remote diff contains that single added line. The full-stack pass also created a new native project through the normal precompiled API (8 explores) and a branch preview with copied content. Viewer API checks denied source access, refresh and dimension write-back with 403. New-project wizard and Viewer browser interactions were not separately exercised.

Latest rebase validation at the full-stack tip (`6b15c2d017`, based on main `21e876fa94`): backend build, backend/frontend typechecks, common build, 183 query-history/service tests, MCP snapshot freshness and `git diff --check` passed. Upstream [#28851](https://github.com/lightdash/lightdash/pull/28851) reverted the change causing the `QueryHistory.errorName` errors; both those errors and the earlier Learn UI errors are resolved. All six feature patches are unchanged by this restack. The preceding restack also passed common/CLI typechecks and 468 focused feature tests. Remote CI is rerunning.

Logo validation: toggled between dbt and Native Lightdash YAML in the browser; confirmed the native logo in light and dark modes, restored light mode, and reloaded without saving connection settings. Focused lint/format, commit-hook unused-export check and `git diff --check` passed.

### Risk assessment:

- [ ] This is a high-risk change

Low risk: dbt remains the default, native is explicit, and existing authorization and credential flows are reused. No migration or warehouse data mutation. Failed compilation does not replace compiled explores.
