### PR TITLE
fix: use chart type slug after forking to customize

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.registryGuards.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.registryGuards.test.ts
@@ -95,7 +95,7 @@ function buildService(
         getVersion: vi.fn().mockResolvedValue(null),
         createVersion: vi.fn().mockResolvedValue({ version: 1 }),
         createWithVersion: vi.fn().mockResolvedValue({
-            app: { app_id: 'new-app-uuid' },
+            app: { app_id: 'new-app-uuid', slug: 'sankey-custom-2' },
             version: { version: 1 },
         }),
         updateApp: vi.fn().mockResolvedValue({
@@ -425,8 +425,19 @@ describe('duplicateApp fork lineage', () => {
             data_references: null,
         });
 
-        await service.duplicateApp(makeUser(), PROJECT_UUID, APP_UUID, {
-            name: 'Sankey (custom)',
+        const result = await service.duplicateApp(
+            makeUser(),
+            PROJECT_UUID,
+            APP_UUID,
+            {
+                name: 'Sankey (custom)',
+            },
+        );
+
+        expect(result).toEqual({
+            appUuid: expect.any(String),
+            slug: 'sankey-custom-2',
+            version: 1,
         });
 
         expect(appModel.createWithVersion).toHaveBeenCalledWith(

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -58,6 +58,7 @@ import {
     validateDataAppDependencies,
     type Account,
     type AnonymousAccount,
+    type ApiDuplicateAppResponse,
     type ApiOrganizationDesign,
     type AppBuildFromSourceJobPayload,
     type AppChartReference,
@@ -7843,7 +7844,7 @@ export class AppGenerateService extends BaseService {
         projectUuid: string,
         sourceAppUuid: string,
         options?: { name?: string },
-    ): Promise<GenerateAppResult> {
+    ): Promise<ApiDuplicateAppResponse['results']> {
         await this.assertDataAppsEnabled(user);
 
         const sourceApp = await this.appModel.getApp(
@@ -7916,9 +7917,10 @@ export class AppGenerateService extends BaseService {
         const duplicatePrompt = `Duplicate [${sourceDisplayName}](${sourcePreviewPath})`;
         const newAppName =
             options?.name?.trim() || `Duplicate of ${sourceDisplayName}`;
+        let newAppSlug: string;
 
         try {
-            await this.appModel.createWithVersion(
+            const { app } = await this.appModel.createWithVersion(
                 {
                     app_id: newAppUuid,
                     project_uuid: projectUuid,
@@ -7938,6 +7940,7 @@ export class AppGenerateService extends BaseService {
                 undefined,
                 sourceVersion.viz_schema ?? undefined,
             );
+            newAppSlug = app.slug;
             await this.persistVersionDataReferences(
                 newAppUuid,
                 newVersion,
@@ -7982,7 +7985,7 @@ export class AppGenerateService extends BaseService {
             `App ${newAppUuid}: duplicated from app ${sourceApp.app_id} v${sourceVersion.version} (user=${user.userUuid}, copied ${copiedKeys.length} S3 object(s))`,
         );
 
-        return { appUuid: newAppUuid, version: newVersion };
+        return { appUuid: newAppUuid, slug: newAppSlug, version: newVersion };
     }
 
     /**

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.vizSchemaCopy.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.vizSchemaCopy.test.ts
@@ -102,7 +102,7 @@ function buildService() {
         getLatestReadyVersion: vi.fn().mockResolvedValue(sourceVersion),
         getLatestVersion: vi.fn().mockResolvedValue({ version: 6 }),
         createWithVersion: vi.fn().mockResolvedValue({
-            app: { app_id: 'new-app-uuid' },
+            app: { app_id: 'new-app-uuid', slug: 'duplicated-chart-type' },
             version: { version: 1 },
         }),
         createVersion: vi.fn().mockResolvedValue({ version: 7 }),

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -556,6 +556,7 @@ export type ApiDuplicateAppRequest = {
 
 export type ApiDuplicateAppResponse = ApiSuccess<{
     appUuid: string;
+    slug: string;
     version: number;
 }>;
 

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeForkModal.test.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeForkModal.test.tsx
@@ -1,3 +1,4 @@
+import { type ApiDuplicateAppResponse } from '@lightdash/common';
 import { fireEvent, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '../../../testing/testUtils';
@@ -57,16 +58,20 @@ describe('ChartTypeForkModal', () => {
         );
     });
 
-    it('navigates to the builder for the new app on success', () => {
+    it('navigates to the builder using the forked app slug on success', () => {
         mockedDuplicate.mockImplementation((_params, options) =>
-            options?.onSuccess?.({ appUuid: 'viz-forked', version: 1 }),
+            options?.onSuccess?.({
+                appUuid: 'viz-forked',
+                slug: 'radial-gauge-custom-2',
+                version: 1,
+            } satisfies ApiDuplicateAppResponse['results']),
         );
         renderModal();
 
         fireEvent.click(screen.getByRole('button', { name: 'Fork' }));
 
         expect(mockedNavigate).toHaveBeenCalledWith(
-            '/projects/project-1/chart-types/viz-forked',
+            '/projects/project-1/chart-types/radial-gauge-custom-2',
         );
     });
 

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeForkModal.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeForkModal.tsx
@@ -49,7 +49,7 @@ const ChartTypeForkModal: FC<Props> = ({
                 onSuccess: (result) => {
                     showToastSuccess({ title: 'Chart type forked' });
                     void navigate(
-                        chartTypeBuilderPath(projectUuid, result.appUuid),
+                        chartTypeBuilderPath(projectUuid, result.slug),
                     );
                 },
             },

--- a/packages/frontend/src/features/chartTypes/utils/chartTypeBuilderPath.ts
+++ b/packages/frontend/src/features/chartTypes/utils/chartTypeBuilderPath.ts
@@ -1,4 +1,4 @@
 export const chartTypeBuilderPath = (
     projectUuid: string,
-    dataAppVizUuid: string | null = null,
-) => `/projects/${projectUuid}/chart-types/${dataAppVizUuid ?? 'new'}`;
+    dataAppVizUuidOrSlug: string | null = null,
+) => `/projects/${projectUuid}/chart-types/${dataAppVizUuidOrSlug ?? 'new'}`;

--- a/packages/frontend/src/pages/ChartTypeGallery.test.tsx
+++ b/packages/frontend/src/pages/ChartTypeGallery.test.tsx
@@ -137,6 +137,11 @@ const LocationSearch = () => {
     return <div data-testid="location-search">{search}</div>;
 };
 
+const LocationPathname = () => {
+    const { pathname } = useLocation();
+    return <div data-testid="location-pathname">{pathname}</div>;
+};
+
 const renderPage = (initialEntry = '/projects/project-1/gallery') =>
     renderWithProviders(
         <MemoryRouter initialEntries={[initialEntry]}>
@@ -153,6 +158,10 @@ const renderPage = (initialEntry = '/projects/project-1/gallery') =>
                 <Route
                     path="/projects/:projectUuid/home"
                     element={<div>home</div>}
+                />
+                <Route
+                    path="/projects/:projectUuid/chart-types/:slug"
+                    element={<LocationPathname />}
                 />
                 <Route
                     path="/projects/:projectUuid/tables/:tableId"
@@ -652,5 +661,44 @@ describe('ChartTypeGallery', () => {
             ).toBeInTheDocument();
             expect(screen.queryByText('Edit')).not.toBeInTheDocument();
         });
+
+        it.each(['card', 'detail modal'])(
+            'opens the forked chart type by its returned slug from the %s',
+            async (entryPoint) => {
+                vi.mocked(useDuplicateApp).mockReturnValue({
+                    mutate: vi.fn((_params, options) => {
+                        options.onSuccess({
+                            appUuid: 'forked-app-uuid',
+                            slug: 'radial-gauge-custom-2',
+                            version: 1,
+                        });
+                    }),
+                    isLoading: false,
+                } as unknown as ReturnType<typeof useDuplicateApp>);
+                setData([makeDataAppViz({ registrySlug: 'radial-gauge' })]);
+                renderPage();
+
+                if (entryPoint === 'card') {
+                    fireEvent.click(screen.getByLabelText('Fork Radial gauge'));
+                } else {
+                    fireEvent.click(screen.getByText('Radial gauge'));
+                    fireEvent.click(
+                        screen.getByRole('button', {
+                            name: /Fork to customize/,
+                        }),
+                    );
+                }
+
+                fireEvent.click(screen.getByRole('button', { name: 'Fork' }));
+
+                await waitFor(() =>
+                    expect(
+                        screen.getByTestId('location-pathname'),
+                    ).toHaveTextContent(
+                        '/projects/project-1/chart-types/radial-gauge-custom-2',
+                    ),
+                );
+            },
+        );
     });
 });


### PR DESCRIPTION
### Description:

Follow-up to #28768. “Fork to customize” still opened the chart type builder using the new chart type’s UUID. Return the saved slug from the duplicate API and use it for the redirect from both the gallery card and detail modal. Using the saved value also handles slugs suffixed to resolve name collisions.

### Validation:

- 39 focused tests passed: chart type gallery (23), registry guards and version metadata copy (16).
- Regression coverage verifies both fork entry points navigate using the returned slug and the service returns the saved slug.
- Frontend typecheck and targeted frontend/backend lint passed.
- API generation and its schema/snapshot hooks passed; generated API artifacts are excluded per repository policy.

### Risk assessment:

- [ ] This is a high-risk change

Low risk: an additive response field and a navigation change. The duplicate API retains its existing UUID and version fields.