### PR TITLE
feat: write custom metrics back to native Lightdash YAML

### DIFF
--- a/packages/backend/src/services/GitIntegrationService/GitIntegrationService.bitbucket.test.ts
+++ b/packages/backend/src/services/GitIntegrationService/GitIntegrationService.bitbucket.test.ts
@@ -153,6 +153,70 @@ beforeEach(() => {
 });
 
 describe('Bitbucket Explorer writeback', () => {
+    it.each(['customMetrics', 'customDimensions'] as const)(
+        'preserves both models and advances the parent commit for %s in a shared schema',
+        async (fieldType) => {
+            const { service } = setup();
+            let content = SCHEMA_YML;
+            let sha = 'base-sha';
+            let writes = 0;
+            vi.mocked(BitbucketClient.getFileContent).mockImplementation(
+                async () => ({ content, sha }),
+            );
+            vi.mocked(BitbucketClient.commitFiles).mockImplementation(
+                async (commit) => {
+                    expect(commit.expectedParent).toBe(sha);
+                    const change = commit.changes[0];
+                    if (!change || change.action !== 'upsert')
+                        throw new Error('Expected a schema update');
+                    content = change.content;
+                    writes += 1;
+                    sha = `sha-${writes}`;
+                },
+            );
+
+            await service.createPullRequest(
+                writebackUser,
+                'project',
+                "'",
+                fieldType === 'customMetrics'
+                    ? {
+                          type: fieldType,
+                          fields: [
+                              CUSTOM_METRIC,
+                              {
+                                  ...CUSTOM_METRIC,
+                                  name: 'new_metric_b',
+                                  table: 'table_b',
+                              },
+                          ],
+                      }
+                    : {
+                          type: fieldType,
+                          fields: [
+                              CUSTOM_DIMENSION,
+                              {
+                                  ...CUSTOM_DIMENSION,
+                                  id: 'amount_size_b',
+                                  table: 'table_b',
+                                  sql: '${table_b.dim_a}',
+                              },
+                          ],
+                      },
+            );
+
+            expect(writes).toBe(2);
+            expect(content).toContain(
+                fieldType === 'customMetrics' ? 'new_metric:' : 'amount_size:',
+            );
+            expect(content).toContain(
+                fieldType === 'customMetrics'
+                    ? 'new_metric_b:'
+                    : 'amount_size_b:',
+            );
+        },
+    );
+
     it.each([
         ['.', 'models/schema.yml'],
         ['/', 'models/schema.yml'],

--- a/packages/backend/src/services/GitIntegrationService/GitIntegrationService.mock.ts
+++ b/packages/backend/src/services/GitIntegrationService/GitIntegrationService.mock.ts
@@ -9,6 +9,11 @@ import {
 import { warehouseClientMock } from '../../utils/QueryBuilder/MetricQueryBuilder.mock';
 
 export const PROJECT_MODEL = {
+    getAllExploresFromCache: vi.fn().mockResolvedValue({
+        another_explore: {
+            tables: { table_a: { ymlPath: 'models/nested/original.yaml' } },
+        },
+    }),
     getExploreFromCache: vi.fn(() => ({ ymlPath: 'path/to/schema.yml' })),
     getWarehouseCredentialsForProject: vi.fn(() => ({})),
     getWarehouseClientFromCredentials: vi.fn(() => warehouseClientMock),

--- a/packages/backend/src/services/GitIntegrationService/GitIntegrationService.test.ts
+++ b/packages/backend/src/services/GitIntegrationService/GitIntegrationService.test.ts
@@ -20,6 +20,7 @@ import {
     getLastCommit,
     updateFile,
 } from '../../clients/github/Github';
+import * as GitlabClient from '../../clients/gitlab/Gitlab';
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
 import { GithubAppInstallationsModel } from '../../models/GithubAppInstallations/GithubAppInstallationsModel';
 import { ProjectDbtSourcesModel } from '../../models/ProjectDbtSourcesModel';
@@ -60,6 +61,19 @@ vi.mock('../../clients/github/Github.ts', () => ({
     })),
 }));
 
+vi.mock('../../clients/gitlab/Gitlab.ts', () => ({
+    createPullRequest: vi.fn(),
+    getFileContent: vi.fn(),
+    updateFile: vi.fn(),
+}));
+
+const updateFileResponse: Awaited<ReturnType<typeof updateFile>> = {
+    status: 200,
+    url: 'https://api.github.com/repos/owner/repo/contents/schema.yml',
+    headers: {},
+    data: { content: null, commit: {} },
+};
+
 describe('GitIntegrationService', () => {
     const service = new GitIntegrationService({
         lightdashConfig: lightdashConfigMock,
@@ -80,6 +94,8 @@ describe('GitIntegrationService', () => {
     });
 
     beforeEach(() => {
+        vi.mocked(updateFile).mockReset().mockResolvedValue(updateFileResponse);
+        vi.mocked(GitlabClient.updateFile).mockReset();
         vi.mocked(getFileContent).mockResolvedValue({
             content: SCHEMA_YML,
             sha: 'sha',
@@ -125,6 +141,88 @@ describe('GitIntegrationService', () => {
     );
 
     describe('updateFile', () => {
+        it.each([
+            { provider: DbtProjectType.GITHUB, fieldType: 'customMetrics' },
+            { provider: DbtProjectType.GITHUB, fieldType: 'customDimensions' },
+            { provider: DbtProjectType.GITLAB, fieldType: 'customMetrics' },
+            { provider: DbtProjectType.GITLAB, fieldType: 'customDimensions' },
+        ] as const)(
+            'preserves both models in a shared dbt schema for $provider $fieldType',
+            async ({ provider, fieldType }) => {
+                let content = SCHEMA_YML;
+                let sha = 'sha-0';
+                let writes = 0;
+                const read =
+                    provider === DbtProjectType.GITHUB
+                        ? getFileContent
+                        : GitlabClient.getFileContent;
+                const write =
+                    provider === DbtProjectType.GITHUB
+                        ? updateFile
+                        : GitlabClient.updateFile;
+                vi.mocked(read).mockImplementation(async () => ({
+                    content,
+                    sha,
+                }));
+                vi.mocked(write).mockImplementation(async (update) => {
+                    if (update.fileSha !== sha)
+                        throw new Error('File changed since it was read');
+                    content = update.content;
+                    writes += 1;
+                    sha = `sha-${writes}`;
+                    return updateFileResponse;
+                });
+
+                await service.updateFile({
+                    owner: 'owner',
+                    repo: 'repo',
+                    path: 'path',
+                    projectUuid: 'projectUuid',
+                    branch: 'branch',
+                    token: 'token',
+                    quoteChar: "'",
+                    mainBranch: 'main',
+                    type: provider,
+                    ...(fieldType === 'customMetrics'
+                        ? {
+                              fieldType,
+                              fields: [
+                                  CUSTOM_METRIC,
+                                  {
+                                      ...CUSTOM_METRIC,
+                                      name: 'new_metric_b',
+                                      table: 'table_b',
+                                  },
+                              ],
+                          }
+                        : {
+                              fieldType,
+                              fields: [
+                                  CUSTOM_DIMENSION,
+                                  {
+                                      ...CUSTOM_DIMENSION,
+                                      id: 'amount_size_b',
+                                      table: 'table_b',
+                                      sql: '${table_b.dim_a}',
+                                  },
+                              ],
+                          }),
+                });
+
+                expect(writes).toBe(2);
+                expect(content).toContain(
+                    fieldType === 'customMetrics'
+                        ? 'new_metric:'
+                        : 'amount_size:',
+                );
+                expect(content).toContain(
+                    fieldType === 'customMetrics'
+                        ? 'new_metric_b:'
+                        : 'amount_size_b:',
+                );
+            },
+        );
+
         it('should update the file for custom metrics', async () => {
             await service.updateFile({
                 owner: 'owner',
@@ -166,6 +264,110 @@ describe('GitIntegrationService', () => {
                 EXPECTED_SCHEMA_YML_WITH_CUSTOM_DIMENSION,
             );
         });
+    });
+
+    describe('native metric pull requests', () => {
+        const source = `# original native file
+type: model
+name: table_a
+sql_from: public.table_a
+dimensions:
+  - name: dim_a
+    type: number
+    sql: dim_a
+`;
+        it.each([false, true])(
+            'prepares native YAML against the configured branch, invalid metric: %s',
+            async (invalid) => {
+                const project = await PROJECT_MODEL.get();
+                const explores = await PROJECT_MODEL.getAllExploresFromCache();
+                const nativeProject = {
+                    ...project,
+                    dbtConnection: {
+                        ...project.dbtConnection,
+                        branch: 'release',
+                        semanticLayer: 'lightdash',
+                    },
+                };
+                PROJECT_MODEL.get.mockResolvedValue(nativeProject);
+                const nativeExplores = {
+                    another_explore: {
+                        tables: {
+                            table_a: {
+                                ymlPath: 'models/nested/original.yaml',
+                            },
+                            table_b: { ymlPath: 'models/table_b.yml' },
+                        },
+                    },
+                };
+                PROJECT_MODEL.getAllExploresFromCache.mockResolvedValue(
+                    nativeExplores,
+                );
+                vi.mocked(getFileContent).mockImplementation(async (file) => ({
+                    content: file.fileName.endsWith('table_b.yml')
+                        ? source.replace('name: table_a', 'name: table_b')
+                        : source,
+                    sha: 'original-sha',
+                }));
+                try {
+                    const request = service.createPullRequest(
+                        { ...user, organizationUuid: 'organizationUuid' },
+                        'projectUuid',
+                        "'",
+                        {
+                            type: 'customMetrics',
+                            fields: [
+                                CUSTOM_METRIC,
+                                ...(invalid
+                                    ? [
+                                          {
+                                              ...CUSTOM_METRIC,
+                                              name: 'unsupported',
+                                              table: 'table_b',
+                                              baseDimensionName: undefined,
+                                          },
+                                      ]
+                                    : []),
+                            ],
+                        },
+                    );
+                    if (invalid) {
+                        await expect(request).rejects.toThrow(
+                            'Only metrics based on a native dimension',
+                        );
+                        expect(createBranch).not.toHaveBeenCalled();
+                        expect(updateFile).not.toHaveBeenCalled();
+                        expect(createPullRequest).not.toHaveBeenCalled();
+                    } else {
+                        await expect(request).resolves.toMatchObject({
+                            prUrl: 'https://example.com/pull/1',
+                        });
+                        expect(getFileContent).toHaveBeenCalledWith(
+                            expect.objectContaining({
+                                branch: 'release',
+                                fileName: 'path/models/nested/original.yaml',
+                            }),
+                        );
+                        expect(updateFile).toHaveBeenCalledWith(
+                            expect.objectContaining({
+                                fileName: 'path/models/nested/original.yaml',
+                                fileSha: 'original-sha',
+                                content: expect.stringContaining('new_metric:'),
+                                branch: expect.stringMatching(/^lightdash-/),
+                            }),
+                        );
+                        expect(createPullRequest).toHaveBeenCalledWith(
+                            expect.objectContaining({ base: 'release' }),
+                        );
+                    }
+                } finally {
+                    PROJECT_MODEL.get.mockResolvedValue(project);
+                    PROJECT_MODEL.getAllExploresFromCache.mockResolvedValue(
+                        explores,
+                    );
+                }
+            },
+        );
     });
 
     describe('findOpenPullRequestForBranch', () => {

--- a/packages/backend/src/services/GitIntegrationService/GitIntegrationService.ts
+++ b/packages/backend/src/services/GitIntegrationService/GitIntegrationService.ts
@@ -19,7 +19,9 @@ import {
     GitFileOrDirectory,
     GitIntegrationConfiguration,
     isCustomBinDimension,
+    isExploreError,
     isUserWithOrg,
+    LightdashModelEditor,
     NotFoundError,
     ParameterError,
     ParseError,
@@ -83,11 +85,26 @@ type GitProps = {
     hostDomain?: string; // For GitLab or GitHub Enterprise
     type: DbtProjectType.GITHUB | DbtProjectType.GITLAB;
     dbtVersion?: SupportedDbtVersions;
+    semanticLayer?: 'dbt' | 'lightdash';
 };
 
 type ExploreGitProps =
     | GitProps
     | (Omit<GitProps, 'type'> & { type: DbtProjectType.BITBUCKET });
+
+type WriteBackFileArgs = ExploreGitProps &
+    (
+        | {
+              fieldType: 'customDimensions';
+              fields: CustomDimension[];
+          }
+        | {
+              fieldType: 'customMetrics';
+              fields: AdditionalMetric[];
+          }
+    ) & {
+        projectUuid: string;
+    };
 
 // Keep backward compatibility
 type GithubProps = GitProps;
@@ -363,18 +380,22 @@ Affected charts:
         type: ExploreGitProps['type'];
         hostDomain?: string;
     }) {
-        const explore = await this.projectModel.getExploreFromCache(
-            projectUuid,
-            table,
-        );
+        const project = await this.projectModel.get(projectUuid);
+        const isNative =
+            project.dbtConnection.type === DbtProjectType.GITHUB &&
+            project.dbtConnection.semanticLayer === 'lightdash';
+        const ymlPath = isNative
+            ? await this.getNativeModelPath(projectUuid, table)
+            : (await this.projectModel.getExploreFromCache(projectUuid, table))
+                  .ymlPath;
 
-        if (!explore.ymlPath)
+        if (!ymlPath)
             throw new ParameterError(
                 'Your project needs to be compiled before writing back custom fields. Please refresh your project to fix this issue.',
             );
 
         const fileName = GitIntegrationService.removeExtraSlashes(
-            `${path}/${explore.ymlPath}`,
+            `${path}/${ymlPath}`,
         );
 
         const getFileContent = {
@@ -392,8 +413,15 @@ Affected charts:
             hostDomain,
         });
 
-        // Get the dbt version from the project
-        const project = await this.projectModel.get(projectUuid);
+        // The native document uses its own schema, with no dbt envelope.
+        if (isNative) {
+            return {
+                yamlSchema: new LightdashModelEditor(fileContent, fileName),
+                fileName,
+                fileContent,
+                fileSha,
+            };
+        }
         const dbtVersion =
             project.dbtVersion === DbtVersionOptionLatest.LATEST
                 ? getLatestSupportDbtVersion()
@@ -412,21 +440,7 @@ Affected charts:
         return { yamlSchema, fileName, fileContent, fileSha };
     }
 
-    async updateFile(
-        args: ExploreGitProps &
-            (
-                | {
-                      fieldType: 'customDimensions';
-                      fields: CustomDimension[];
-                  }
-                | {
-                      fieldType: 'customMetrics';
-                      fields: AdditionalMetric[];
-                  }
-            ) & {
-                projectUuid: string;
-            },
-    ): Promise<void> {
+    private async *iterateFileUpdates(args: WriteBackFileArgs) {
         const {
             owner,
             repo,
@@ -468,12 +482,13 @@ Affected charts:
                     hostDomain,
                 });
 
-            if (!yamlSchema.hasModels()) {
-                throw new ParseError(`No models found in ${fileName}`);
-            }
-
             let updatedYml: string;
             if (fieldType === 'customDimensions') {
+                if (yamlSchema instanceof LightdashModelEditor) {
+                    throw new ParameterError(
+                        'Native custom dimension write-back is not supported yet',
+                    );
+                }
                 const warehouseCredentials =
                     await this.projectModel.getWarehouseCredentialsForProject(
                         projectUuid,
@@ -502,44 +517,99 @@ Affected charts:
 
             const message = `Updated file ${fileName} with ${fieldsForTable?.length} custom ${fieldsType} from table ${table}`;
 
-            if (gitType === DbtProjectType.BITBUCKET) {
+            yield {
+                type: gitType,
+                owner,
+                repo,
+                fileName,
+                content: updatedYml,
+                fileSha,
+                branch,
+                installationId,
+                token,
+                hostDomain,
+                message,
+            };
+        }
+    }
+
+    private async prepareFileUpdates(args: WriteBackFileArgs) {
+        const updates = [];
+        for await (const update of this.iterateFileUpdates(args)) {
+            updates.push(update);
+        }
+        return updates;
+    }
+
+    private static async updatePreparedFiles(
+        updates: Awaited<
+            ReturnType<GitIntegrationService['prepareFileUpdates']>
+        >,
+        branch: string,
+    ): Promise<void> {
+        for (const { type, ...update } of updates) {
+            if (type === DbtProjectType.BITBUCKET) {
                 await BitbucketClient.commitFiles({
-                    owner,
-                    repo,
-                    token,
+                    owner: update.owner,
+                    repo: update.repo,
+                    token: update.token,
                     branch,
-                    expectedParent: fileSha,
-                    message,
+                    expectedParent: update.fileSha,
+                    message: update.message,
                     changes: [
                         {
-                            path: fileName,
-                            content: updatedYml,
+                            path: update.fileName,
+                            content: update.content,
                             action: 'upsert',
                         },
                     ],
                 });
             } else {
                 const updateFile =
-                    gitType === DbtProjectType.GITHUB
+                    type === DbtProjectType.GITHUB
                         ? GithubClient.updateFile
                         : GitlabClient.updateFile;
-                await updateFile({
-                    owner,
-                    repo,
-                    fileName,
-                    content: updatedYml,
-                    fileSha,
-                    branch,
-                    installationId,
-                    token,
-                    hostDomain,
-                    message,
-                });
+                await updateFile({ ...update, branch });
             }
-            Logger.debug(
-                `Successfully updated file ${fileName} in ${owner}/${repo} (branch: ${branch})`,
+            Logger.debug('Successfully updated file', {
+                type,
+                owner: update.owner,
+                repo: update.repo,
+                fileName: update.fileName,
+                branch,
+            });
+        }
+    }
+
+    async updateFile(args: WriteBackFileArgs): Promise<void> {
+        // dbt models can share a YAML file; read each model after the previous write.
+        for await (const update of this.iterateFileUpdates(args)) {
+            await GitIntegrationService.updatePreparedFiles(
+                [update],
+                args.branch,
             );
         }
+    }
+
+    private async getNativeModelPath(
+        projectUuid: string,
+        table: string,
+    ): Promise<string> {
+        const explores =
+            await this.projectModel.getAllExploresFromCache(projectUuid);
+        const paths = new Set(
+            Object.values(explores).flatMap((explore) => {
+                if (isExploreError(explore)) return [];
+                const sourcePath = explore.tables[table]?.ymlPath;
+                return sourcePath ? [sourcePath] : [];
+            }),
+        );
+        if (paths.size !== 1) {
+            throw new ParameterError(
+                `Cannot determine the native source file for ${table}. Refresh the project before writing back.`,
+            );
+        }
+        return [...paths][0];
     }
 
     async getProjectRepo(projectUuid: string) {
@@ -566,6 +636,10 @@ Affected charts:
             branch,
             path,
             hostDomain,
+            semanticLayer:
+                connection.type === DbtProjectType.GITHUB
+                    ? connection.semanticLayer
+                    : undefined,
             type: project.dbtConnection.type as
                 | DbtProjectType.GITHUB
                 | DbtProjectType.GITLAB,
@@ -658,7 +732,8 @@ Affected charts:
         projectUuid: string,
         quoteChar: `"` | `'`,
     ) {
-        const { branch, path } = await this.getProjectRepo(projectUuid);
+        const { branch, path, semanticLayer } =
+            await this.getProjectRepo(projectUuid);
         const { owner, repo, hostDomain, type, token, installationId } =
             await this.getGitCredentials(user, projectUuid, {
                 preferUserToken: true,
@@ -688,6 +763,7 @@ Affected charts:
             installationId,
             quoteChar,
             dbtVersion,
+            semanticLayer,
         };
         return gitProps;
     }
@@ -831,6 +907,11 @@ Affected charts:
                 projectUuid,
                 table,
             });
+            if (yamlSchema instanceof LightdashModelEditor) {
+                throw new ParameterError(
+                    'Native custom dimension write-back is not supported yet',
+                );
+            }
             customDimensions
                 .filter((dimension) => dimension.table === table)
                 .forEach((dimension) => {
@@ -899,8 +980,31 @@ Affected charts:
             quoteChar,
         );
 
+        // Validate every native source document before creating a branch or writing files.
+        const nativeUpdates =
+            gitProps.semanticLayer === 'lightdash'
+                ? await this.prepareFileUpdates({
+                      ...gitProps,
+                      branch: gitProps.mainBranch,
+                      projectUuid,
+                      ...(args.type === 'customMetrics'
+                          ? {
+                                fieldType: 'customMetrics' as const,
+                                fields: args.fields,
+                            }
+                          : {
+                                fieldType: 'customDimensions' as const,
+                                fields: args.fields,
+                            }),
+                  })
+                : undefined;
         await GitIntegrationService.createBranch(gitProps);
-        if (args.type === 'customMetrics') {
+        if (nativeUpdates) {
+            await GitIntegrationService.updatePreparedFiles(
+                nativeUpdates,
+                gitProps.branch,
+            );
+        } else if (args.type === 'customMetrics') {
             await this.updateFile({
                 ...gitProps,
                 fieldType: 'customMetrics',
@@ -945,7 +1049,7 @@ Affected charts:
             } = await createPullRequest({
                 ...gitProps,
                 title: `Adds ${fieldsInfo}`,
-                body: `Created by Lightdash, this pull request adds ${fieldsInfo} to the dbt model.
+                body: `Created by Lightdash, this pull request adds ${fieldsInfo} to the ${gitProps.semanticLayer === 'lightdash' ? 'native Lightdash' : 'dbt'} model.
 Triggered by user ${user.firstName} ${user.lastName} (${user.email})
 
 ${replacementGuidance}`,

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1236,3 +1236,6 @@ export const SPACE_TREE_2: TreeCreateSpace[] = [
 ] as const;
 
 export * from './compiler/compileLightdashModels';
+
+export * from './lightdash/LightdashModelEditor';
+export * from './lightdash/convertCustomMetricToLightdash';

--- a/packages/common/src/lightdash/LightdashModelEditor.test.ts
+++ b/packages/common/src/lightdash/LightdashModelEditor.test.ts
@@ -1,0 +1,131 @@
+import { parse } from 'yaml';
+import { compileLightdashModels } from '../compiler/compileLightdashModels';
+import { warehouseClientMock } from '../compiler/exploreCompiler.mock';
+import { isExploreError } from '../types/explore';
+import { MetricType } from '../types/field';
+import { FilterOperator } from '../types/filter';
+import { DEFAULT_SPOTLIGHT_CONFIG } from '../types/lightdashProjectConfig';
+import { type AdditionalMetric } from '../types/metricQuery';
+import { LightdashModelEditor } from './LightdashModelEditor';
+
+const source = `# Keep this model comment
+type: model
+name: orders
+sql_from: public.orders
+metrics:
+  existing_count: # Keep this metric comment
+    type: count
+    sql: '1'
+dimensions:
+  - name: amount
+    type: number
+    sql: \${TABLE}.amount * 2 # Keep the original expression
+  - name: status
+    type: string
+    sql: \${TABLE}.status
+`;
+const metric: AdditionalMetric = {
+    name: 'paid_revenue',
+    label: 'Paid Revenue',
+    description: 'Revenue for paid orders',
+    table: 'orders',
+    baseDimensionName: 'amount',
+    sql: '${TABLE}.amount * 2',
+    type: MetricType.SUM,
+    filters: [
+        {
+            id: 'paid',
+            target: { fieldRef: 'orders.status' },
+            operator: FilterOperator.EQUALS,
+            values: ['paid'],
+        },
+    ],
+};
+
+describe('native model write-back', () => {
+    it('preserves existing YAML and compiles the metric with its SQL, filters and base dimension identity', async () => {
+        const output = new LightdashModelEditor(
+            source,
+            'models/nested/sales.yaml',
+        )
+            .addCustomMetrics([metric])
+            .toString();
+        expect(output.split('dimensions:')[0]).toBe(
+            source.split('dimensions:')[0],
+        );
+        expect(output).toContain('# Keep this model comment');
+        expect(output).toContain('# Keep this metric comment');
+        expect(output).toContain('# Keep the original expression');
+        const original = parse(source);
+        const updated = parse(output);
+        expect(updated.metrics).toEqual(original.metrics);
+        expect(updated.dimensions[1]).toEqual(original.dimensions[1]);
+        expect(updated).not.toHaveProperty('models');
+        const [explore] = await compileLightdashModels({
+            models: [{ ...updated, sourcePath: 'models/nested/sales.yaml' }],
+            warehouseSqlBuilder: warehouseClientMock,
+            lightdashProjectConfig: { spotlight: DEFAULT_SPOTLIGHT_CONFIG },
+        });
+        if (!explore || isExploreError(explore))
+            throw new Error('Expected compiled native explore');
+        expect(explore.tables.orders.metrics.paid_revenue).toMatchObject({
+            label: metric.label,
+            description: metric.description,
+            type: MetricType.SUM,
+            sql: metric.sql,
+            dimensionReference: 'orders_amount',
+            filters: [
+                expect.objectContaining({
+                    target: { fieldRef: 'status' },
+                    values: ['paid'],
+                }),
+            ],
+        });
+        expect(explore.ymlPath).toBe('models/nested/sales.yaml');
+    });
+
+    it.each([
+        { ...metric, name: 'existing_count' },
+        { ...metric, name: 'status' },
+        { ...metric, table: 'renamed_orders' },
+        { ...metric, baseDimensionName: 'missing' },
+        { ...metric, generationType: 'periodOverPeriod' as const },
+        { ...metric, baseDimensionName: undefined },
+    ])(
+        'rejects collisions, stale sources and unsupported metric definitions ($name)',
+        (field) => {
+            expect(() =>
+                new LightdashModelEditor(
+                    source,
+                    'models/orders.yml',
+                ).addCustomMetrics([field]),
+            ).toThrow();
+        },
+    );
+
+    it('rejects filters that the YAML serializer would otherwise drop', () => {
+        expect(() =>
+            new LightdashModelEditor(
+                source,
+                'models/orders.yml',
+            ).addCustomMetrics([
+                {
+                    ...metric,
+                    filters: [{ ...metric.filters![0], includeNull: true }],
+                },
+            ]),
+        ).toThrow('without changing its meaning');
+    });
+
+    it('rejects a second metric with the same name rather than overwriting the first', () => {
+        expect(() =>
+            new LightdashModelEditor(
+                source,
+                'models/orders.yml',
+            ).addCustomMetrics([
+                metric,
+                { ...metric, label: 'Different meaning' },
+            ]),
+        ).toThrow('already exists');
+    });
+});

--- a/packages/common/src/lightdash/LightdashModelEditor.ts
+++ b/packages/common/src/lightdash/LightdashModelEditor.ts
@@ -1,0 +1,121 @@
+import Ajv from 'ajv';
+import { Document, isMap, isSeq, parseDocument, type YAMLMap } from 'yaml';
+import modelSchema from '../schemas/json/model-as-code-1.0.json';
+import { ParameterError, ParseError } from '../types/errors';
+import { type LightdashModel } from '../types/lightdashModel';
+import { type AdditionalMetric } from '../types/metricQuery';
+import { convertCustomMetricToLightdash } from './convertCustomMetricToLightdash';
+
+const ajv = new Ajv({ allErrors: true, strict: false });
+const validate = ajv.compile<LightdashModel>(modelSchema);
+
+/** Edits the original native model document, preserving comments and unrelated nodes. */
+export class LightdashModelEditor {
+    private readonly doc: Document;
+
+    private readonly changedDimensions = new Set<YAMLMap>();
+
+    constructor(
+        private readonly contents: string,
+        private readonly filename: string,
+    ) {
+        this.doc = parseDocument(contents);
+        this.validate();
+    }
+
+    private validate(): LightdashModel {
+        const model: unknown = this.doc.toJS();
+        if (this.doc.errors.length > 0 || !validate(model)) {
+            throw new ParseError(
+                `Invalid Lightdash model in ${this.filename}: ${this.doc.errors.map((error) => error.message).join('; ') || ajv.errorsText(validate.errors)}`,
+            );
+        }
+        return model;
+    }
+
+    private assertModelName(name: string): void {
+        if (this.doc.get('name') !== name) {
+            throw new ParameterError(
+                `Model ${name} no longer matches ${this.filename}. Refresh the project before writing back.`,
+            );
+        }
+    }
+
+    private assertFieldDoesNotExist(name: string): void {
+        const model = this.validate();
+        const names = [
+            ...Object.keys(model.metrics ?? {}),
+            ...model.dimensions.flatMap((dimension) => [
+                dimension.name,
+                ...Object.keys(dimension.metrics ?? {}),
+                ...Object.keys(dimension.additional_dimensions ?? {}),
+            ]),
+        ];
+        if (
+            names.some(
+                (existing) => existing.toLowerCase() === name.toLowerCase(),
+            )
+        ) {
+            throw new ParameterError(
+                `Field ${name} already exists in ${this.filename}. Choose a different name to preserve the existing definition.`,
+            );
+        }
+    }
+
+    addCustomMetrics(metrics: AdditionalMetric[]): this {
+        metrics.forEach((metric) => {
+            this.assertModelName(metric.table);
+            this.assertFieldDoesNotExist(metric.name);
+            const definition = convertCustomMetricToLightdash(metric);
+            const dimensions = this.doc.get('dimensions');
+            const dimension = isSeq(dimensions)
+                ? dimensions.items.find(
+                      (item) =>
+                          isMap(item) &&
+                          item.get('name') === metric.baseDimensionName,
+                  )
+                : undefined;
+            if (!isMap(dimension)) {
+                throw new ParameterError(
+                    `Native dimension ${metric.baseDimensionName} not found in ${this.filename}. Refresh the project before writing back.`,
+                );
+            }
+            dimension.setIn(['metrics', metric.name], definition);
+            this.changedDimensions.add(dimension);
+        });
+        this.validate();
+        return this;
+    }
+
+    toString(options?: { quoteChar?: '"' | "'" }): string {
+        // Replace only changed dimension nodes. Serializing the whole document
+        // would reindent every list and reflow unrelated model SQL/descriptions.
+        let result = this.contents;
+        const nodes = [...this.changedDimensions].sort(
+            (a, b) => b.range![0] - a.range![0],
+        );
+        for (const node of nodes) {
+            const [start, , end] = node.range!;
+            const lineStart = this.contents.lastIndexOf('\n', start - 1) + 1;
+            const prefix = this.contents.slice(lineStart, start);
+            if (!/^ *-? *$/.test(prefix) || node.flow) {
+                throw new ParameterError(
+                    `Native write-back requires block-style dimensions in ${this.filename}. Expand flow-style YAML before writing back.`,
+                );
+            }
+            const clone = node.clone();
+            // A leading comment lies before range[0] and remains in the source.
+            clone.commentBefore = undefined;
+            const text = new Document(clone)
+                .toString({
+                    singleQuote: options?.quoteChar === "'" ? true : null,
+                    lineWidth: 0,
+                })
+                .trimEnd()
+                .split('\n')
+                .join(`\n${' '.repeat(prefix.length)}`);
+            result = `${result.slice(0, start) + text}\n${result.slice(end)}`;
+        }
+        return result;
+    }
+}

--- a/packages/common/src/lightdash/convertCustomMetricToLightdash.ts
+++ b/packages/common/src/lightdash/convertCustomMetricToLightdash.ts
@@ -1,0 +1,45 @@
+import { ParameterError } from '../types/errors';
+import { FilterOperator } from '../types/filter';
+import { type LightdashModelMetric } from '../types/lightdashModel';
+import { type AdditionalMetric } from '../types/metricQuery';
+import { convertCustomMetricToDbt } from '../utils/convertCustomMetricsToYaml';
+
+export const convertCustomMetricToLightdash = (
+    metric: AdditionalMetric,
+): LightdashModelMetric => {
+    if (
+        metric.generationType ||
+        !metric.baseDimensionName ||
+        !metric.sql.trim()
+    ) {
+        throw new ParameterError(
+            `Metric ${metric.name} cannot be written back to native YAML. Only metrics based on a native dimension are supported; generated period comparisons and metrics without a base dimension are not supported.`,
+        );
+    }
+    for (const filter of metric.filters ?? []) {
+        const noValues = [
+            FilterOperator.NULL,
+            FilterOperator.NOT_NULL,
+        ].includes(filter.operator);
+        const parts = filter.target.fieldRef.split('.');
+        if (
+            filter.includeNull ||
+            (!noValues && !filter.values?.length) ||
+            (!noValues &&
+                filter.operator !== FilterOperator.EQUALS &&
+                filter.values!.length !== 1) ||
+            (parts.length > 1 &&
+                (parts.length !== 2 || parts[0] !== metric.table))
+        ) {
+            throw new ParameterError(
+                `Filter ${filter.id} on metric ${metric.name} cannot be represented in native YAML without changing its meaning.`,
+            );
+        }
+    }
+    return {
+        ...convertCustomMetricToDbt(metric),
+        sql: metric.sql,
+        hidden: metric.hidden,
+        distinct_keys: metric.distinctKeys,
+    };
+};

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNodeActions.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNodeActions.tsx
@@ -276,7 +276,7 @@ const TreeSingleNodeActions: FC<Props> = ({
                                     );
                                 }}
                             >
-                                Write back to dbt
+                                Write back to project
                             </Menu.Item>
                         ) : null}
 
@@ -421,7 +421,7 @@ const TreeSingleNodeActions: FC<Props> = ({
                                                     );
                                                 }}
                                             >
-                                                Write back to dbt
+                                                Write back to project
                                             </Menu.Item>
                                         </Box>
                                     </Tooltip>

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/writeBack.test.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/writeBack.test.tsx
@@ -127,7 +127,7 @@ describe('custom bin write-back in Explorer trees', () => {
         const store = renderNodeActions(item);
 
         await user.click(
-            screen.getByRole('menuitem', { name: 'Write back to dbt' }),
+            screen.getByRole('menuitem', { name: 'Write back to project' }),
         );
 
         expect(store.getState().explorer.modals.writeBack.items).toEqual([
@@ -140,7 +140,7 @@ describe('custom bin write-back in Explorer trees', () => {
         renderNodeActions(makeBin(BinType.FIXED_WIDTH));
 
         expect(
-            screen.queryByRole('menuitem', { name: 'Write back to dbt' }),
+            screen.queryByRole('menuitem', { name: 'Write back to project' }),
         ).not.toBeInTheDocument();
     });
 
@@ -148,7 +148,7 @@ describe('custom bin write-back in Explorer trees', () => {
         const user = userEvent.setup();
         renderNodeActions(makeBin(BinType.FIXED_NUMBER));
         const action = screen.getByRole('menuitem', {
-            name: 'Write back to dbt',
+            name: 'Write back to project',
         });
 
         expect(action).toBeDisabled();

--- a/packages/frontend/src/components/Explorer/WriteBackModal/CreatedPullRequestModalContent.tsx
+++ b/packages/frontend/src/components/Explorer/WriteBackModal/CreatedPullRequestModalContent.tsx
@@ -14,7 +14,7 @@ export const CreatedPullRequestModalContent = ({
             size="auto"
             opened
             onClose={onClose}
-            title="Write back to dbt"
+            title="Write back to project"
             icon={IconGitBranch}
             actions={<Button onClick={onClose}>Close</Button>}
             modalRootProps={{
@@ -30,8 +30,8 @@ export const CreatedPullRequestModalContent = ({
                     was successfully created on git.
                 </Text>
                 <Text>
-                    Once it is merged, refresh your dbt connection to see your
-                    updated metrics and dimensions.
+                    Once it is merged, refresh your project to see your updated
+                    metrics and dimensions.
                 </Text>
             </Stack>
         </MantineModal>

--- a/packages/frontend/src/components/Explorer/WriteBackModal/hooks.ts
+++ b/packages/frontend/src/components/Explorer/WriteBackModal/hooks.ts
@@ -157,3 +157,11 @@ export const useSupportsCustomFieldWriteBack = (projectUuid: string) => {
         connection.type === DbtProjectType.GITLAB
     );
 };
+
+export const useIsNativeGitProject = (projectUuid: string) => {
+    const { data: project } = useProject(projectUuid);
+    return (
+        project?.dbtConnection.type === DbtProjectType.GITHUB &&
+        project.dbtConnection.semanticLayer === 'lightdash'
+    );
+};

--- a/packages/frontend/src/components/Explorer/WriteBackModal/index.test.tsx
+++ b/packages/frontend/src/components/Explorer/WriteBackModal/index.test.tsx
@@ -23,6 +23,7 @@ import { SingleItemModalContent, WriteBackModal } from './index';
 const project = vi.hoisted(() => ({
     type: 'github',
     host_domain: undefined as string | undefined,
+    semanticLayer: undefined as 'dbt' | 'lightdash' | undefined,
 }));
 vi.mock('../../../hooks/useProject', () => ({
     useProject: () => ({ data: { dbtConnection: project } }),
@@ -67,6 +68,7 @@ beforeEach(() => {
     vi.clearAllMocks();
     project.type = DbtProjectType.GITHUB;
     project.host_domain = undefined;
+    project.semanticLayer = undefined;
 });
 
 describe('custom field writeback modal', () => {
@@ -82,26 +84,31 @@ describe('custom field writeback modal', () => {
     });
 
     it.each([
-        [DbtProjectType.GITHUB, undefined, true],
-        [DbtProjectType.GITLAB, undefined, true],
-        [DbtProjectType.BITBUCKET, undefined, true],
-        [DbtProjectType.BITBUCKET, ' BITBUCKET.ORG. ', true],
-        [DbtProjectType.BITBUCKET, 'bitbucket.internal', false],
-        [DbtProjectType.BITBUCKET, 'bitbucket.org.evil.test', false],
-        [DbtProjectType.DBT, undefined, false],
-    ] as const)('allows %s on host %s: %s', (type, host, supported) => {
-        project.type = type;
-        project.host_domain = host;
-        renderModal();
-        const button = screen.getByRole('button', {
-            name: 'Open Pull Request',
-        });
-        if (supported) {
-            expect(button).toBeEnabled();
-        } else {
-            expect(button).toBeDisabled();
-        }
-    });
+        [DbtProjectType.GITHUB, undefined, true, undefined],
+        [DbtProjectType.GITHUB, undefined, true, 'lightdash'],
+        [DbtProjectType.GITLAB, undefined, true, undefined],
+        [DbtProjectType.BITBUCKET, undefined, true, undefined],
+        [DbtProjectType.BITBUCKET, ' BITBUCKET.ORG. ', true, undefined],
+        [DbtProjectType.BITBUCKET, 'bitbucket.internal', false, undefined],
+        [DbtProjectType.BITBUCKET, 'bitbucket.org.evil.test', false, undefined],
+        [DbtProjectType.DBT, undefined, false, undefined],
+    ] as const)(
+        'allows %s on host %s: %s',
+        (type, host, supported, semanticLayer) => {
+            project.type = type;
+            project.host_domain = host;
+            project.semanticLayer = semanticLayer;
+            renderModal();
+            const button = screen.getByRole('button', {
+                name: 'Open Pull Request',
+            });
+            if (supported) {
+                expect(button).toBeEnabled();
+            } else {
+                expect(button).toBeDisabled();
+            }
+        },
+    );
 
     it('does not enable Source Editor or ContentAsCode through the generic Git hook', () => {
         project.type = DbtProjectType.BITBUCKET;

--- a/packages/frontend/src/components/Explorer/WriteBackModal/index.tsx
+++ b/packages/frontend/src/components/Explorer/WriteBackModal/index.tsx
@@ -1,5 +1,6 @@
 import {
     capitalize,
+    convertCustomMetricToLightdash,
     getCustomDimensionWriteBackError,
     getErrorMessage,
     isCustomBinDimension,
@@ -36,6 +37,7 @@ import { CreatedPullRequestModalContent } from './CreatedPullRequestModalContent
 import {
     useCustomDimensionsWriteBackPreview,
     useSupportsCustomFieldWriteBack,
+    useIsNativeGitProject,
     useWriteBackCustomDimensions,
     useWriteBackCustomMetrics,
 } from './hooks';
@@ -110,6 +112,7 @@ export const SingleItemModalContent = ({
     const [showDiff, setShowDiff] = useState(true);
     const supportsCustomFieldWriteBack =
         useSupportsCustomFieldWriteBack(projectUuid);
+    const isNative = useIsNativeGitProject(projectUuid);
     const writeBackError = isCustomDimension(item)
         ? getCustomDimensionWriteBackError(item)
         : null;
@@ -127,12 +130,17 @@ export const SingleItemModalContent = ({
     const metricPreview = useMemo(() => {
         if (isCustomDimension(item)) return { code: '', error: null };
         try {
-            const { key, value } = convertToDbt(item);
+            const { key, value } = isNative
+                ? {
+                      key: item.name,
+                      value: convertCustomMetricToLightdash(item),
+                  }
+                : convertToDbt(item);
             return { code: yaml.dump({ [key]: value }), error: null };
         } catch (e) {
             return { code: '', error: parseError(e, type) };
         }
-    }, [item, type]);
+    }, [item, type, isNative]);
     const previewError =
         writeBackError ??
         (previewQuery.error
@@ -163,9 +171,9 @@ export const SingleItemModalContent = ({
             size="xl"
             opened={true}
             onClose={handleClose}
-            title="Write back to dbt"
+            title="Write back to project"
             icon={IconGitBranch}
-            description={`Convert this ${texts[type].name} into a ${texts[type].baseName} in your dbt project. This will create a new branch and open a pull request.`}
+            description={`Convert this ${texts[type].name} into a ${texts[type].baseName} in your project. This will create a new branch and open a pull request.`}
             actions={
                 <Tooltip
                     label={errorTooltipLabel}
@@ -198,8 +206,8 @@ export const SingleItemModalContent = ({
         >
             <Stack>
                 <Text fz="sm">
-                    Create a pull request in your dbt project's git repository
-                    for the following {texts[type].name}:
+                    Create a pull request in your project's git repository for
+                    the following {texts[type].name}:
                 </Text>
                 <List spacing="xs" pl="xs">
                     <List.Item fz="xs" ff="monospace">
@@ -274,6 +282,7 @@ const MultipleItemsModalContent = ({
 
     const supportsCustomFieldWriteBack =
         useSupportsCustomFieldWriteBack(projectUuid);
+    const isNative = useIsNativeGitProject(projectUuid);
 
     const [selectedItemIds, setSelectedItemIds] = useState<string[]>([]);
 
@@ -297,7 +306,12 @@ const MultipleItemsModalContent = ({
             const code = yaml.dump(
                 (selectedItems as AdditionalMetric[])
                     .map((item) => {
-                        const { key, value } = convertToDbt(item);
+                        const { key, value } = isNative
+                            ? {
+                                  key: item.name,
+                                  value: convertCustomMetricToLightdash(item),
+                              }
+                            : convertToDbt(item);
                         return { [key]: value };
                     })
                     .reduce((acc, curr) => ({ ...acc, ...curr }), {}),
@@ -306,7 +320,7 @@ const MultipleItemsModalContent = ({
         } catch (e) {
             return { code: '', error: parseError(e, type) };
         }
-    }, [selectedCustomDimensions.length, selectedItems, type]);
+    }, [selectedCustomDimensions.length, selectedItems, type, isNative]);
     const previewError = previewQuery.error
         ? getErrorMessage(previewQuery.error.error)
         : metricPreview.error;
@@ -343,9 +357,9 @@ const MultipleItemsModalContent = ({
             size="auto"
             opened={true}
             onClose={handleClose}
-            title="Write back to dbt"
+            title="Write back to project"
             icon={IconGitBranch}
-            description={`Create a pull request in your dbt project's git repository for the following ${texts[type].baseName}s`}
+            description={`Create a pull request in your project's git repository for the following ${texts[type].baseName}s`}
             actions={
                 <Tooltip
                     label={errorTooltipLabel}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentVisualizationMetricsAndDimensions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentVisualizationMetricsAndDimensions.tsx
@@ -153,7 +153,7 @@ const MetricDimensionItem: FC<{
                             <Tooltip
                                 openDelay={200}
                                 position="top"
-                                label="Write back to dbt"
+                                label="Write back to project"
                                 offset={5}
                             >
                                 <ActionIcon


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-11034

### Description:

```diff
 Custom metric -> Write back to project
- parse every source file as a dbt schema
+ add the metric to its original native dimension when the project uses Lightdash YAML
```

- Preserve comments, existing definitions, SQL, formatting, filters, and the base dimension identity used by saved-chart replacement. Rewrite only the affected dimension; unrelated YAML stays unchanged.
- Resolve original source paths from compiled tables, including joined models. Validate every native edit before creating the branch; collisions, stale model names, unsupported metric/filter forms, and malformed YAML fail explicitly.
- Reuse existing CustomFields permissions, GitHub credentials, configured PR base branch, and PR tracking. Native dimension write-back follows separately.
- Preserve sequential dbt read/edit/write ordering when multiple models share one schema YAML file, for both custom metrics and dimensions on GitHub and GitLab. Native files are all validated before branch creation or writes.
- Stack: #28818 → #28820 → #28822 → this PR.

Validation: 9 native editor/compiler tests, 17 GitIntegrationService tests, and 10 frontend write-back tests passed. Common/backend typechecks, common build, focused lint/format and `git diff --check` passed.

E2E on localhost:3000: unsupported metric returned 400; the installed GitHub integration created [demo PR #2](https://github.com/Spissable/lightdash-native-demo-1/pull/2) in the original `lightdash/models/fct_race_results.yml`. Reviewed its focused diff and compiled the actual branch through the CLI. Merged the demo PR, refreshed the existing project (8 explores, zero errors), then selected the new metric in the browser and queried BigQuery successfully (4,145). The test metric is persisted in the demo repo/project; no warehouse data was modified. An earlier formatting-only test PR was closed. GitLab native support is outside scope.

Dbt regression validation: 22 GitIntegrationService tests passed at the full-stack tip, and 21 passed on this PR alone. Coverage includes metrics/dimensions for two models sharing a schema file on GitHub/GitLab, plus an invalid second native file preventing all Git mutation. Across the full stack, 580 focused backend/common/frontend/CLI tests and 12 isolated before/after comparison cases passed. Backend/CLI typechecks, focused lint/format, commit checks and `git diff --check` passed. These regression checks used mocked Git APIs; no new live Git or warehouse test was run.

Previous rebase validation at the full-stack tip (`6b15c2d017`, based on main `21e876fa94`): backend build, backend/frontend typechecks, common build, 183 query-history/service tests, MCP snapshot freshness and `git diff --check` passed. Upstream [#28851](https://github.com/lightdash/lightdash/pull/28851) reverted the change causing the `QueryHistory.errorName` errors; both those errors and the earlier Learn UI errors are resolved. All six feature patches are unchanged by this restack. The preceding restack also passed common/CLI typechecks and 468 focused feature tests. Remote CI is rerunning.

### Risk assessment:

- [ ] This is a high-risk change

Low risk: native dispatch is explicit, writes use the existing permission/credential boundary, and existing fields are never overwritten. Native validation finishes before Git mutation; successful writes remain reviewable PRs. Existing dbt serialization is retained.
