### PR TITLE
feat: write custom dimensions back to native models

### DIFF
--- a/packages/backend/src/services/GitIntegrationService/GitIntegrationService.test.ts
+++ b/packages/backend/src/services/GitIntegrationService/GitIntegrationService.test.ts
@@ -370,6 +370,70 @@ dimensions:
         );
     });
 
+    it('previews and writes native SQL dimensions and bins into the original model', async () => {
+        const project = await PROJECT_MODEL.get();
+        const nativeProject = {
+            ...project,
+            dbtConnection: {
+                ...project.dbtConnection,
+                semanticLayer: 'lightdash',
+            },
+        };
+        PROJECT_MODEL.get.mockResolvedValue(nativeProject);
+        vi.mocked(getFileContent).mockResolvedValue({
+            content: `type: model
+name: table_a
+sql_from: public.table_a
+dimensions:
+  - name: dim_a
+    type: number
+    sql: \${TABLE}.dim_a * 2
+`,
+            sha: 'native-sha',
+        });
+        const dimensions = [
+            CUSTOM_DIMENSION,
+            {
+                id: 'amount_band',
+                name: 'Amount band',
+                table: 'table_a',
+                type: CustomDimensionType.BIN as const,
+                dimensionId: 'table_a_dim_a',
+                binType: BinType.FIXED_WIDTH as const,
+                binWidth: 10,
+            },
+        ];
+        try {
+            const preview = await service.previewCustomDimensions(
+                fromSession(
+                    { ...user, organizationUuid: 'organizationUuid' },
+                    'session-cookie',
+                ),
+                'projectUuid',
+                dimensions,
+                "'",
+            );
+            expect(preview.yaml).toContain('dimensions:');
+            expect(preview.yaml).toContain('name: amount_band');
+            expect(preview.yaml).toContain('${TABLE}.dim_a * 2');
+            expect(preview.yaml).not.toContain('additional_dimensions');
+            await service.createPullRequest(
+                { ...user, organizationUuid: 'organizationUuid' },
+                'projectUuid',
+                "'",
+                { type: 'customDimensions', fields: dimensions },
+            );
+            expect(updateFile).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    fileName: 'path/models/nested/original.yaml',
+                    content: expect.stringContaining('name: amount_band'),
+                }),
+            );
+        } finally {
+            PROJECT_MODEL.get.mockResolvedValue(project);
+        }
+    });
+
     describe('findOpenPullRequestForBranch', () => {
         it('returns the open PR the provider has for the branch', async () => {
             vi.mocked(findOpenPullRequestByHead).mockResolvedValueOnce({
@@ -529,7 +593,7 @@ models:
                     ],
                 }),
             ).rejects.toThrow(
-                'Fixed-number bins cannot be written back because they require a dbt model CTE',
+                'Fixed-number bins cannot be written back because their boundaries depend on query results',
             );
 
             expect(createBranch).not.toHaveBeenCalled();

--- a/packages/backend/src/services/GitIntegrationService/GitIntegrationService.ts
+++ b/packages/backend/src/services/GitIntegrationService/GitIntegrationService.ts
@@ -484,11 +484,6 @@ Affected charts:
 
             let updatedYml: string;
             if (fieldType === 'customDimensions') {
-                if (yamlSchema instanceof LightdashModelEditor) {
-                    throw new ParameterError(
-                        'Native custom dimension write-back is not supported yet',
-                    );
-                }
                 const warehouseCredentials =
                     await this.projectModel.getWarehouseCredentialsForProject(
                         projectUuid,
@@ -907,11 +902,6 @@ Affected charts:
                 projectUuid,
                 table,
             });
-            if (yamlSchema instanceof LightdashModelEditor) {
-                throw new ParameterError(
-                    'Native custom dimension write-back is not supported yet',
-                );
-            }
             customDimensions
                 .filter((dimension) => dimension.table === table)
                 .forEach((dimension) => {
@@ -924,7 +914,12 @@ Affected charts:
         }
 
         return {
-            yaml: yaml.dump(definitions, { quotingType: yamlQuoteChar }),
+            yaml: yaml.dump(
+                gitProps.semanticLayer === 'lightdash'
+                    ? { dimensions: Object.values(definitions) }
+                    : definitions,
+                { quotingType: yamlQuoteChar },
+            ),
         };
     }
 
@@ -1028,7 +1023,7 @@ Affected charts:
             args.type === 'customDimensions' &&
             args.fields.some(isCustomBinDimension);
         const replacementGuidance = containsCustomBins
-            ? '> ℹ️ **Existing saved charts keep their custom bin dimensions.** Lightdash does not automatically replace them with these YAML dimensions, so their current bin ordering remains unchanged. Use the new dimensions after refreshing the project, and define a separate numeric ordering dimension in dbt when bin order matters.'
+            ? '> ℹ️ **Existing saved charts keep their custom bin dimensions.** Lightdash does not automatically replace them with these YAML dimensions, so their current bin ordering remains unchanged. Use the new dimensions after refreshing the project, and define a separate numeric ordering dimension in your model when bin order matters.'
             : `> ⚠️ **Note: Do not change the \`label\` or \`id\` of your ${typeName}s in this pull request.** Your ${typeName}s _will not be replaced_ with YAML ${typeName}s if you change the \`label\` or \`id\` of the ${typeName}s in this pull request. Lightdash requires the IDs and labels to match 1:1 in order to replace custom ${typeName}s with YAML ${typeName}s.`;
         const eventProperties: WriteBackEvent['properties'] = {
             name: fieldsInfo,

--- a/packages/common/src/lightdash/LightdashModelEditor.test.ts
+++ b/packages/common/src/lightdash/LightdashModelEditor.test.ts
@@ -2,7 +2,14 @@ import { parse } from 'yaml';
 import { compileLightdashModels } from '../compiler/compileLightdashModels';
 import { warehouseClientMock } from '../compiler/exploreCompiler.mock';
 import { isExploreError } from '../types/explore';
-import { MetricType } from '../types/field';
+import {
+    BinType,
+    CustomDimensionType,
+    DimensionType,
+    GroupValueMatchType,
+    MetricType,
+    type CustomDimension,
+} from '../types/field';
 import { FilterOperator } from '../types/filter';
 import { DEFAULT_SPOTLIGHT_CONFIG } from '../types/lightdashProjectConfig';
 import { type AdditionalMetric } from '../types/metricQuery';
@@ -102,6 +109,118 @@ describe('native model write-back', () => {
             ).toThrow();
         },
     );
+
+    const customDimensions: CustomDimension[] = [
+        {
+            id: 'amount_times_ten',
+            name: 'Amount times ten',
+            table: 'orders',
+            type: CustomDimensionType.SQL,
+            dimensionType: DimensionType.NUMBER,
+            sql: '${orders.amount} * 10',
+        },
+        {
+            id: 'amount_band',
+            name: 'Amount band',
+            table: 'orders',
+            type: CustomDimensionType.BIN,
+            dimensionId: 'orders_amount',
+            binType: BinType.FIXED_WIDTH,
+            binWidth: 10,
+        },
+        {
+            id: 'amount_range',
+            name: 'Amount range',
+            table: 'orders',
+            type: CustomDimensionType.BIN,
+            dimensionId: 'orders_amount',
+            binType: BinType.CUSTOM_RANGE,
+            customRange: [
+                { from: undefined, to: 10 },
+                { from: 10, to: undefined },
+            ],
+        },
+        {
+            id: 'amount_group',
+            name: 'Amount group',
+            table: 'orders',
+            type: CustomDimensionType.BIN,
+            dimensionId: 'orders_amount',
+            binType: BinType.CUSTOM_GROUP,
+            customGroups: [
+                {
+                    name: 'Twenty',
+                    values: [
+                        { matchType: GroupValueMatchType.EXACT, value: '20' },
+                    ],
+                },
+            ],
+        },
+    ];
+
+    it.each(customDimensions)(
+        'appends and compiles native $id while preserving the original document',
+        async (dimension) => {
+            const output = new LightdashModelEditor(source, 'models/orders.yml')
+                .addCustomDimensions([dimension], warehouseClientMock)
+                .toString();
+            expect(output.startsWith(source)).toBe(true);
+            const model = parse(output);
+            const added = model.dimensions.at(-1);
+            expect(added.name).toBe(dimension.id);
+            expect(added.sql).toContain(
+                dimension.type === CustomDimensionType.SQL
+                    ? '${orders.amount}'
+                    : '${TABLE}.amount * 2',
+            );
+            expect(model).not.toHaveProperty('models');
+            const [explore] = await compileLightdashModels({
+                models: [{ ...model, sourcePath: 'models/orders.yml' }],
+                warehouseSqlBuilder: warehouseClientMock,
+                lightdashProjectConfig: { spotlight: DEFAULT_SPOTLIGHT_CONFIG },
+            });
+            if (!explore || isExploreError(explore))
+                throw new Error('Expected compiled native explore');
+            expect(
+                explore.tables.orders.dimensions[dimension.id].compiledSql,
+            ).toContain('amount');
+        },
+    );
+
+    it('keeps trailing model properties and comments when appending dimensions', () => {
+        const footer = '# Keep this root property\nprimary_key: amount\n';
+        const output = new LightdashModelEditor(
+            source + footer,
+            'models/orders.yml',
+        )
+            .addCustomDimensions([customDimensions[0]], warehouseClientMock)
+            .toString();
+        expect(output).toContain(footer);
+        expect(parse(output).primary_key).toBe('amount');
+        expect(parse(output).dimensions.at(-1).name).toBe('amount_times_ten');
+    });
+
+    it('rejects fixed-number bins instead of persisting query-dependent boundaries', () => {
+        expect(() =>
+            new LightdashModelEditor(
+                source,
+                'models/orders.yml',
+            ).addCustomDimensions(
+                [
+                    {
+                        id: 'unsupported',
+                        name: 'Unsupported',
+                        table: 'orders',
+                        type: CustomDimensionType.BIN,
+                        dimensionId: 'orders_amount',
+                        binType: BinType.FIXED_NUMBER,
+                        binNumber: 4,
+                    },
+                ],
+                warehouseClientMock,
+            ),
+        ).toThrow('Fixed-number bins cannot be written back');
+    });
 
     it('rejects filters that the YAML serializer would otherwise drop', () => {
         expect(() =>

--- a/packages/common/src/lightdash/LightdashModelEditor.ts
+++ b/packages/common/src/lightdash/LightdashModelEditor.ts
@@ -2,8 +2,22 @@ import Ajv from 'ajv';
 import { Document, isMap, isSeq, parseDocument, type YAMLMap } from 'yaml';
 import modelSchema from '../schemas/json/model-as-code-1.0.json';
 import { ParameterError, ParseError } from '../types/errors';
-import { type LightdashModel } from '../types/lightdashModel';
+import {
+    DimensionType,
+    friendlyName,
+    isCustomSqlDimension,
+    type CustomDimension,
+} from '../types/field';
+import {
+    type LightdashModel,
+    type LightdashModelDimension,
+} from '../types/lightdashModel';
 import { type AdditionalMetric } from '../types/metricQuery';
+import { type WarehouseSqlBuilder } from '../types/warehouse';
+import {
+    convertCustomBinDimensionToDbt,
+    getCustomDimensionWriteBackError,
+} from '../utils/convertCustomDimensionsToYaml';
 import { convertCustomMetricToLightdash } from './convertCustomMetricToLightdash';
 
 const ajv = new Ajv({ allErrors: true, strict: false });
@@ -14,6 +28,8 @@ export class LightdashModelEditor {
     private readonly doc: Document;
 
     private readonly changedDimensions = new Set<YAMLMap>();
+
+    private readonly newDimensions: LightdashModelDimension[] = [];
 
     constructor(
         private readonly contents: string,
@@ -87,14 +103,68 @@ export class LightdashModelEditor {
         return this;
     }
 
+    getCustomDimensionDefinition(
+        dimension: CustomDimension,
+        warehouseSqlBuilder: WarehouseSqlBuilder,
+    ): LightdashModelDimension {
+        this.assertModelName(dimension.table);
+        this.assertFieldDoesNotExist(dimension.id);
+        const error = getCustomDimensionWriteBackError(dimension);
+        if (error) throw new ParameterError(error);
+        if (isCustomSqlDimension(dimension)) {
+            return {
+                name: dimension.id,
+                label: friendlyName(dimension.name),
+                type: dimension.dimensionType,
+                sql: dimension.sql,
+            };
+        }
+        const model = this.validate();
+        const prefix = `${dimension.table}_`;
+        const baseName = dimension.dimensionId.startsWith(prefix)
+            ? dimension.dimensionId.slice(prefix.length)
+            : dimension.dimensionId;
+        const base = model.dimensions.find((item) => item.name === baseName);
+        if (!base) {
+            throw new ParameterError(
+                `Native dimension ${baseName} not found in ${this.filename}. Refresh the project before writing back.`,
+            );
+        }
+        const definition = convertCustomBinDimensionToDbt({
+            customDimension: dimension,
+            baseDimensionSql: base.sql,
+            warehouseSqlBuilder,
+        });
+        return {
+            ...definition,
+            name: dimension.id,
+            type: DimensionType.STRING,
+            sql: definition.sql!,
+        };
+    }
+
+    addCustomDimensions(
+        dimensions: CustomDimension[],
+        warehouseSqlBuilder: WarehouseSqlBuilder,
+    ): this {
+        dimensions.forEach((dimension) => {
+            const definition = this.getCustomDimensionDefinition(
+                dimension,
+                warehouseSqlBuilder,
+            );
+            this.doc.addIn(['dimensions'], definition);
+            this.newDimensions.push(definition);
+        });
+        this.validate();
+        return this;
+    }
+
     toString(options?: { quoteChar?: '"' | "'" }): string {
         // Replace only changed dimension nodes. Serializing the whole document
         // would reindent every list and reflow unrelated model SQL/descriptions.
         let result = this.contents;
-        const nodes = [...this.changedDimensions].sort(
-            (a, b) => b.range![0] - a.range![0],
-        );
-        for (const node of nodes) {
+        const changes: { start: number; end: number; text: string }[] = [];
+        for (const node of this.changedDimensions) {
             const [start, , end] = node.range!;
             const lineStart = this.contents.lastIndexOf('\n', start - 1) + 1;
             const prefix = this.contents.slice(lineStart, start);
@@ -114,7 +184,37 @@ export class LightdashModelEditor {
                 .trimEnd()
                 .split('\n')
                 .join(`\n${' '.repeat(prefix.length)}`);
-            result = `${result.slice(0, start) + text}\n${result.slice(end)}`;
+            changes.push({ start, end, text: `${text}\n` });
+        }
+        if (this.newDimensions.length > 0) {
+            const dimensions = this.doc.get('dimensions');
+            if (!isSeq(dimensions) || dimensions.flow || !dimensions.range) {
+                throw new ParameterError(
+                    `Native write-back requires block-style dimensions in ${this.filename}. Expand flow-style YAML before writing back.`,
+                );
+            }
+            const [start, end] = dimensions.range;
+            const lineStart = this.contents.lastIndexOf('\n', start - 1) + 1;
+            const indent = ' '.repeat(start - lineStart);
+            const text = new Document(this.newDimensions)
+                .toString({
+                    singleQuote: options?.quoteChar === "'" ? true : null,
+                    lineWidth: 0,
+                })
+                .trimEnd()
+                .split('\n')
+                .map((line) => indent + line)
+                .join('\n');
+            changes.push({
+                start: end,
+                end,
+                text: `${this.contents[end - 1] === '\n' ? '' : '\n'}${text}\n`,
+            });
+        }
+        for (const { start, end, text } of changes.sort(
+            (a, b) => b.start - a.start,
+        )) {
+            result = result.slice(0, start) + text + result.slice(end);
         }
         return result;
     }

--- a/packages/common/src/utils/convertCustomDimensionsToYaml.ts
+++ b/packages/common/src/utils/convertCustomDimensionsToYaml.ts
@@ -18,7 +18,7 @@ import {
 } from './customDimensions';
 
 export const FIXED_NUMBER_BIN_WRITE_BACK_ERROR =
-    'Fixed-number bins cannot be written back because they require a dbt model CTE. Use a fixed-width, custom-range, or custom-group bin instead.';
+    'Fixed-number bins cannot be written back because their boundaries depend on query results. Use a fixed-width, custom-range, or custom-group bin instead.';
 
 export const getCustomDimensionWriteBackError = (
     customDimension: CustomDimension,

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/writeBack.test.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/writeBack.test.tsx
@@ -155,7 +155,7 @@ describe('custom bin write-back in Explorer trees', () => {
         await user.hover(action.parentElement!);
         expect(
             await screen.findByText(
-                /Fixed-number bins cannot be written back because they require a dbt model CTE/,
+                /Fixed-number bins cannot be written back because their boundaries depend on query results/,
             ),
         ).toBeVisible();
     });

--- a/packages/frontend/src/components/Explorer/WriteBackModal/writeBackSupport.ts
+++ b/packages/frontend/src/components/Explorer/WriteBackModal/writeBackSupport.ts
@@ -1,7 +1,7 @@
 import { type CustomDimension } from '@lightdash/common';
 
 export const BIN_ORDERING_WRITE_BACK_WARNING =
-    'Existing saved charts will keep using this custom bin so their ordering is unchanged. After merging and refreshing your project, use the new dbt dimension in new charts and add a separate numeric ordering dimension in dbt when bin order matters.';
+    'Existing saved charts will keep using this custom bin so their ordering is unchanged. After merging and refreshing your project, use the new YAML dimension in new charts and add a separate numeric ordering dimension in your model when bin order matters.';
 
 export const getCustomDimensionsForWriteBack = (
     customDimensions: CustomDimension[] | undefined,


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-11035

### Description:

```diff
 Custom SQL dimension or supported bin -> Write back to project
- native YAML is treated as a dbt schema
+ append native dimensions to the original model file
```

- SQL dimensions and fixed-width, custom-range, and custom-group bins use the existing warehouse SQL builder and original base-dimension expression. Preview the actual native YAML before writing.
- Preserve existing source text, comments, unrelated definitions, configured PR base, permissions, and GitHub credentials. Reject collisions, stale fields, malformed YAML, and query-dependent fixed-number bins before creating a branch.
- Stack: #28818 → #28820 → #28822 → #28825 → this PR.

Validation: 15 native editor/compiler tests, 18 GitIntegrationService tests, and 10 frontend write-back tests passed. Common/backend typechecks, common build, focused lint/format, and `git diff --check` passed.

E2E on localhost:3000: the installed GitHub integration created [demo PR #4](https://github.com/Spissable/lightdash-native-demo-1/pull/4), adding eight lines to the original model file. Compiled its actual branch with the CLI, merged it, and refreshed eight explores with zero errors. The browser query grouped the persisted metric by both new dimensions: High/10–19 = 2,047; Low/0–9 = 1,173; High/20–29 = 925 (total 4,145). Viewer source access, refresh, and dimension write-back returned 403. Test dimensions remain in the demo repo/project; no warehouse data was modified. Custom-range/group bins have compiler coverage; live coverage uses fixed-width. GitLab is outside scope.

Latest rebase validation at the full-stack tip (`6b15c2d017`, based on main `21e876fa94`): backend build, backend/frontend typechecks, common build, 183 query-history/service tests, MCP snapshot freshness and `git diff --check` passed. Upstream [#28851](https://github.com/lightdash/lightdash/pull/28851) reverted the change causing the `QueryHistory.errorName` errors; both those errors and the earlier Learn UI errors are resolved. All six feature patches are unchanged by this restack. The preceding restack also passed common/CLI typechecks and 468 focused feature tests. Remote CI is rerunning.

### Risk assessment:

- [ ] This is a high-risk change

Low risk: native dispatch is explicit and existing dbt behavior remains covered. All native edits are validated before Git mutation, existing fields are never overwritten, and changes remain reviewable PRs.
