### PR TITLE
feat: support native Git projects in AI write-back and Reviews

### DIFF
--- a/docs/native-git-projects.md
+++ b/docs/native-git-projects.md
@@ -27,3 +27,16 @@ Native models still compile through the existing internal model-node conversion
 and explore compiler. This preserves one semantic compiler without introducing
 a general source-adapter framework. The Node filesystem loader is a separate
 `@lightdash/common/lightdash/loader` entry point, outside the browser barrel.
+
+Native AI write-back uses the existing sandbox, permission, conversation and PR
+lifecycle with native YAML instructions. It does not install dbt dependencies or
+prepare profiles. Before opening or updating a PR, the backend reads only native
+model/config/context YAML from the edited checkout and validates it with the
+shared compiler. A compile error prevents remote Git changes. This validation
+uses the connected warehouse dialect without sending warehouse credentials to
+the sandbox and does not depend on the sandbox's installed CLI version.
+
+Reviews semantic fixes follow the same path and retain the original model file
+paths. Project-context fixes retain the existing deterministic merge into
+`lightdash.project_context.yml` beside the project configuration. GitHub previews
+copy the connection format and compile the PR branch through the native adapter.

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -1829,7 +1829,7 @@ export class AiAgentAdminService extends BaseService {
                 );
             case 'unsupported_source_control':
                 throw new ParameterError(
-                    'Writeback requires a GitHub, GitLab or Bitbucket Cloud connected dbt project',
+                    'Writeback requires a GitHub, GitLab or Bitbucket Cloud connected project',
                 );
             case 'unsupported_root_cause':
             default:

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
@@ -1695,6 +1695,71 @@ describe('AiWritebackService.run (mocked end-to-end)', () => {
         expect(wrapperWrite[1]).toContain('-u ANTHROPIC_API_KEY');
     });
 
+    it.each([true, false])(
+        'validates native source before Git mutation (valid=%s)',
+        async (valid) => {
+            const sandbox = fakeSandbox(0, true);
+            fakeSandboxProvider.create.mockResolvedValue(sandbox);
+            const runCommand = sandbox.commands.run.getMockImplementation();
+            sandbox.commands.run.mockImplementation(
+                (command: string, options: AnyType) => {
+                    if (command.includes('.ld-native-snapshot.cjs'))
+                        return Promise.resolve({
+                            exitCode: 0,
+                            stdout: JSON.stringify({
+                                'lightdash/models/orders.yaml': `type: model\nname: orders\nsql_from: public.orders\ndimensions:\n  - name: amount\n    type: number\n    sql: ${valid ? '${TABLE}.amount' : '${orders.missing}'}\n`,
+                            }),
+                        });
+                    return runCommand(command, options);
+                },
+            );
+            const result = runService(
+                sandbox,
+                {},
+                {
+                    projectModel: {
+                        get: vi.fn().mockResolvedValue({
+                            organizationUuid: ORG,
+                            name: 'Native analytics',
+                            dbtConnection: {
+                                type: DbtProjectType.GITHUB,
+                                repository: 'acme/analytics',
+                                branch: 'release',
+                                project_sub_path: '/native',
+                                semanticLayer: 'lightdash',
+                            },
+                            warehouseConnection: {
+                                type: WarehouseTypes.POSTGRES,
+                            },
+                            dbtVersion: SupportedDbtVersions.V1_9,
+                        }),
+                    },
+                },
+            );
+            if (valid) {
+                await expect(result).resolves.toMatchObject({ prUrl: PR_7 });
+                expect(createPullRequest).toHaveBeenCalledTimes(1);
+            } else {
+                await expect(result).rejects.toThrow(/missing/);
+                expect(createPullRequest).not.toHaveBeenCalled();
+                expect(sandbox.git.createBranch).not.toHaveBeenCalled();
+            }
+            expect(
+                sandbox.commands.run.mock.calls
+                    .map(([command]: [string]) => command)
+                    .join('\n'),
+            ).not.toMatch(/dbt deps|profiles\.yml/);
+            expect(
+                sandbox.files.write.mock.calls.find(
+                    ([file]: [string]) => file === COMPILE_WRAPPER_PATH,
+                ),
+            ).toBeUndefined();
+            expect(sandbox.git.clone.mock.calls[0][1]).toMatchObject({
+                branch: 'release',
+            });
+        },
+    );
+
     // R13: the sandbox network lockdown is a security invariant. The egress
     // allowlist passed to the provider must stay [anthropic,github,gitlab] —
     // never widened to `*`. Under the SandboxProvider abstraction the implicit
@@ -3011,6 +3076,34 @@ describe('AiWritebackService.resolveWritableRepoTarget (fail-closed authz)', () 
 });
 
 describe('AiWritebackService.dbtWritebackConfig', () => {
+    it('uses native instructions and omits shell and profile access for native projects', async () => {
+        const service = buildService();
+        vi.spyOn(service as AnyType, 'gatherRepoContext').mockResolvedValue(
+            null,
+        );
+        const prepareProfiles = vi.spyOn(service as AnyType, 'prepareProfiles');
+        const turn = turnContext();
+        const setup = await (service as AnyType)
+            .dbtWritebackConfig()
+            .buildAgentSetup({
+                sandbox: {},
+                turn: {
+                    ...turn,
+                    gitConnection: {
+                        ...turn.gitConnection,
+                        provider: PullRequestProvider.GITHUB,
+                        semanticLayer: 'lightdash',
+                    },
+                },
+                repository: 'acme/analytics',
+            });
+        expect(prepareProfiles).not.toHaveBeenCalled();
+        expect(setup.systemPrompt).toContain('native Lightdash YAML');
+        expect(setup.systemPrompt).toContain('lightdash.project_context.yml');
+        expect(setup.allowedTools).not.toMatch(/Bash\(|ld-profiles/);
+        expect(setup.disallowedTools).toBe(GENERAL_DISALLOWED_TOOLS);
+    });
+
     it('returns gathered repository context through the agent setup', async () => {
         const service = buildService();
         const repoContext = {

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -101,6 +101,7 @@ import {
     GENERAL_SKILLS_DIR,
     GIT_TIMEOUT_MS,
     MAX_CONCURRENT_WORKSTREAM_TURNS_PER_THREAD,
+    NATIVE_ALLOWED_TOOLS,
     PR_DESCRIPTION_PATH,
     PR_TITLE_PATH,
     PROMPT_PATH,
@@ -123,13 +124,18 @@ import {
     WritebackRunAbortedError,
     WritebackThreadPrClosedError,
 } from './errors';
+import { validateNativeSandbox } from './nativeValidation';
 import { BitbucketProvider } from './providers/BitbucketProvider';
 import { GithubProvider } from './providers/GithubProvider';
 import { GitlabProvider } from './providers/GitlabProvider';
 import type { GitProvider } from './providers/GitProvider';
 import { buildGatherRepoContextScript } from './scripts';
 import { loadWarehouseSkills, warehouseTypeToSkillKey } from './skills';
-import { buildGeneralSystemPrompt, buildSystemPrompt } from './templates';
+import {
+    buildGeneralSystemPrompt,
+    buildNativeSystemPrompt,
+    buildSystemPrompt,
+} from './templates';
 import type {
     AdoptedPullRequest,
     AiWritebackRunArgs,
@@ -2359,7 +2365,10 @@ export class AiWritebackService extends BaseService {
                 adoptBranch:
                     adoptedPr?.headRef ??
                     (turn.gitConnection.provider ===
-                    PullRequestProvider.BITBUCKET
+                        PullRequestProvider.BITBUCKET ||
+                    (turn.gitConnection.provider ===
+                        PullRequestProvider.GITHUB &&
+                        turn.gitConnection.semanticLayer === 'lightdash')
                         ? turn.gitConnection.branch || null
                         : null),
                 setStage,
@@ -2436,6 +2445,22 @@ export class AiWritebackService extends BaseService {
                         ? `The coding agent exited with code ${agent.exitCode} before making any new changes. The pull request from an earlier turn (${crashPrUrl}) is unaffected.`
                         : `The coding agent exited with code ${agent.exitCode} and no pull request was created.`,
                 );
+            }
+
+            if (
+                hasChanges &&
+                turn.gitConnection.provider === PullRequestProvider.GITHUB &&
+                turn.gitConnection.semanticLayer === 'lightdash'
+            ) {
+                recordStep({
+                    kind: 'compile',
+                    label: 'Compiling native models',
+                });
+                await validateNativeSandbox({
+                    sandbox,
+                    projectSubPath: turn.gitConnection.projectSubPath,
+                    warehouseType: turn.warehouseType,
+                });
             }
 
             // Finalize claim: atomic arbitration with tasks/cancel before any
@@ -4236,6 +4261,13 @@ export class AiWritebackService extends BaseService {
             );
         }
 
+        await this.prepareWarehouseSkills(sandbox, turn);
+    }
+
+    private async prepareWarehouseSkills(
+        sandbox: SandboxHandle,
+        turn: TurnContext,
+    ): Promise<void> {
         // Push the warehouse skill files alongside the prompts. `shared.md`
         // always; the dialect file only when one exists for this warehouse.
         // The system prompt points the agent here before any `type:`/SQL edit.
@@ -4267,6 +4299,32 @@ export class AiWritebackService extends BaseService {
                     sandbox,
                     turn.gitConnection.projectSubPath,
                 );
+                if (
+                    turn.gitConnection.provider ===
+                        PullRequestProvider.GITHUB &&
+                    turn.gitConnection.semanticLayer === 'lightdash'
+                ) {
+                    return {
+                        systemPrompt: buildNativeSystemPrompt(
+                            turn.gitConnection.projectSubPath,
+                            {
+                                projectName: turn.projectName,
+                                repository,
+                                repoContext,
+                                warehouseType: turn.warehouseType,
+                                hasWarehouseSkill:
+                                    warehouseTypeToSkillKey(
+                                        turn.warehouseType,
+                                    ) !== null,
+                            },
+                        ),
+                        repoContext,
+                        allowedTools: NATIVE_ALLOWED_TOOLS,
+                        disallowedTools: GENERAL_DISALLOWED_TOOLS,
+                        addDirs: ['/tmp', SKILLS_DIR, CLAUDE_SKILLS_DIR],
+                        model: CLAUDE_MODEL,
+                    };
+                }
                 // Stage a credential-free profiles copy host-side so the agent
                 // doesn't burn turns discovering profiles.yml and hand-stripping
                 // Jinja (mkdir + cp + edit). Deterministic string work — no
@@ -4303,7 +4361,10 @@ export class AiWritebackService extends BaseService {
                 };
             },
             beforeAgentRun: (sandbox, turn) =>
-                this.prepareDbtAgentRun(sandbox, turn),
+                turn.gitConnection.provider === PullRequestProvider.GITHUB &&
+                turn.gitConnection.semanticLayer === 'lightdash'
+                    ? this.prepareWarehouseSkills(sandbox, turn)
+                    : this.prepareDbtAgentRun(sandbox, turn),
             afterAgentRun: (sandbox) => this.reportCompileTimings(sandbox),
         };
     }

--- a/packages/backend/src/ee/services/AiWritebackService/WritebackPreviewService.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/WritebackPreviewService.test.ts
@@ -121,41 +121,54 @@ describe('WritebackPreviewService.createPreviewForPullRequest', () => {
         expect(projectService.createPreview).not.toHaveBeenCalled();
     });
 
-    it('creates a preview and posts the preview URL for authorized users', async () => {
-        const githubClient = makeGithubClient();
-        const projectService = {
-            createPreview: vi.fn().mockResolvedValue({
-                projectUuid: 'preview-project-1',
+    it.each(['dbt', 'lightdash'])(
+        'creates a %s preview and posts its URL for authorized users',
+        async (semanticLayer) => {
+            const githubClient = makeGithubClient();
+            const projectService = {
+                createPreview: vi.fn().mockResolvedValue({
+                    projectUuid: 'preview-project-1',
+                    compileJobUuid: 'compile-job-1',
+                }),
+            };
+            const service = buildService({
+                githubClient,
+                projectService: projectService as AnyType,
+                projectModel: {
+                    get: vi.fn().mockResolvedValue({
+                        ...githubProject(),
+                        dbtConnection: {
+                            ...githubProject().dbtConnection,
+                            semanticLayer,
+                        },
+                    }),
+                } as AnyType,
+            });
+
+            const result = await service.createPreviewForPullRequest({
+                user: userWithSourceCodeAccess(true),
+                projectUuid: PROJECT,
+                prUrl: PR_URL,
+            });
+
+            expect(result).toEqual({
+                previewProjectUuid: 'preview-project-1',
+                previewUrl:
+                    'https://lightdash.example.com/projects/preview-project-1/home',
                 compileJobUuid: 'compile-job-1',
-            }),
-        };
-        const service = buildService({
-            githubClient,
-            projectService: projectService as AnyType,
-        });
-
-        const result = await service.createPreviewForPullRequest({
-            user: userWithSourceCodeAccess(true),
-            projectUuid: PROJECT,
-            prUrl: PR_URL,
-        });
-
-        expect(result).toEqual({
-            previewProjectUuid: 'preview-project-1',
-            previewUrl:
-                'https://lightdash.example.com/projects/preview-project-1/home',
-            compileJobUuid: 'compile-job-1',
-        });
-        expect(projectService.createPreview).toHaveBeenCalledWith(
-            expect.anything(),
-            PROJECT,
-            expect.objectContaining({
-                copyContent: true,
-                validateAfterCompile: true,
-            }),
-            expect.anything(),
-        );
-    });
+            });
+            expect(projectService.createPreview).toHaveBeenCalledWith(
+                expect.anything(),
+                PROJECT,
+                expect.objectContaining({
+                    copyContent: true,
+                    validateAfterCompile: true,
+                    dbtConnectionOverrides: { branch: 'feature/writeback' },
+                }),
+                expect.anything(),
+            );
+        },
+    );
 
     it('returns null when the PR URL repo does not match the project repo', async () => {
         const githubClient = makeGithubClient();

--- a/packages/backend/src/ee/services/AiWritebackService/constants.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/constants.ts
@@ -154,6 +154,14 @@ export const ALLOWED_TOOLS = [
     `Bash(${COMPILE_WRAPPER_PATH}:*)`,
 ].join(',');
 
+// Native compilation runs on the host with the shared compiler. The agent
+// needs neither shell execution nor access to temporary dbt profiles.
+export const NATIVE_ALLOWED_TOOLS = ALLOWED_TOOLS.split(',')
+    .filter(
+        (tool) => !tool.startsWith('Bash(') && !tool.includes(TMP_PROFILES_DIR),
+    )
+    .join(',');
+
 // Anthropic model used for the writeback agent. Pinned to a specific Sonnet
 // snapshot rather than the CLI default so runs stay deterministic across
 // Claude Code releases.

--- a/packages/backend/src/ee/services/AiWritebackService/nativeValidation.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/nativeValidation.ts
@@ -1,0 +1,139 @@
+import {
+    compileLightdashModels,
+    DEFAULT_SPOTLIGHT_CONFIG,
+    isExploreError,
+    loadLightdashProjectConfig,
+    loadProjectContextFile,
+    ParseError,
+    type WarehouseTypes,
+} from '@lightdash/common';
+import { loadLightdashModels } from '@lightdash/common/lightdash/loader';
+import { warehouseSqlBuilderFromType } from '@lightdash/warehouses';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { preAggregatePostProcessor } from '../../preAggregates/postProcessor';
+import type { SandboxHandle } from '../SandboxRuntime';
+import { CWD } from './constants';
+
+const SNAPSHOT_SCRIPT = '/home/user/.ld-native-snapshot.cjs';
+const MAX_BYTES = 10 * 1024 * 1024;
+const MAX_FILES = 10000;
+
+// Only native source is transferred, never credentials or arbitrary repo files.
+// Real paths are checked before reading, and no repository code is executed.
+export const buildNativeSnapshotScript = (projectSubPath: string): string => `
+const fs = require('fs');
+const path = require('path');
+const repo = fs.realpathSync(process.cwd());
+const root = fs.realpathSync(path.resolve(repo, ${JSON.stringify(projectSubPath)}));
+const within = (base, file) => {
+    const relative = path.relative(base, fs.realpathSync(file));
+    if (relative === '..' || relative.startsWith('../') || path.isAbsolute(relative))
+        throw new Error('Native source must stay inside the connected project');
+};
+within(repo, root);
+const files = {};
+let bytes = 0;
+const read = (file) => {
+    within(root, file);
+    bytes += fs.statSync(file).size;
+    if (bytes > ${MAX_BYTES} || Object.keys(files).length >= ${MAX_FILES})
+        throw new Error('Native source exceeds write-back validation limits');
+    files[path.relative(root, file)] = fs.readFileSync(file, 'utf8');
+};
+const walk = (dir) => {
+    within(root, dir);
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const file = path.join(dir, entry.name);
+        if (entry.isDirectory()) walk(file);
+        else if (entry.isFile() && /\\.ya?ml$/.test(entry.name)) read(file);
+    }
+};
+for (const dir of ['models', 'lightdash/models']) {
+    const file = path.join(root, dir);
+    if (fs.existsSync(file) && fs.statSync(file).isDirectory()) { walk(file); break; }
+}
+for (const name of ['lightdash.config.yml', 'lightdash.project_context.yml']) {
+    const file = path.join(root, name);
+    if (fs.existsSync(file)) read(file);
+}
+process.stdout.write(JSON.stringify(files));
+`;
+
+/** Validate the exact edited source with the server/CLI compiler before any PR mutation. */
+export async function validateNativeSandbox({
+    sandbox,
+    projectSubPath,
+    warehouseType,
+}: {
+    sandbox: SandboxHandle;
+    projectSubPath: string;
+    warehouseType: WarehouseTypes | null;
+}): Promise<void> {
+    if (!warehouseType)
+        throw new ParseError('Native write-back requires a warehouse type');
+    await sandbox.files.write(
+        SNAPSHOT_SCRIPT,
+        buildNativeSnapshotScript(projectSubPath),
+    );
+    const result = await sandbox.commands.run(`node ${SNAPSHOT_SCRIPT}`, {
+        cwd: CWD,
+        timeoutMs: 60000,
+    });
+    if (result.exitCode !== 0)
+        throw new ParseError('Could not read native source for validation');
+    if (Buffer.byteLength(result.stdout) > MAX_BYTES * 2)
+        throw new ParseError(
+            'Native source exceeds write-back validation limits',
+        );
+    const files: unknown = JSON.parse(result.stdout);
+    if (!files || typeof files !== 'object' || Array.isArray(files))
+        throw new ParseError('Invalid native source snapshot');
+    const directory = await fs.mkdtemp(
+        path.join(os.tmpdir(), 'native-writeback-'),
+    );
+    try {
+        for await (const [name, contents] of Object.entries(files)) {
+            if (
+                typeof contents !== 'string' ||
+                name.split('/').includes('..') ||
+                name.includes('\\') ||
+                !/^(?:(?:lightdash\/)?models\/.+\.ya?ml|lightdash\.(?:config|project_context)\.yml)$/.test(
+                    name,
+                )
+            )
+                throw new ParseError('Invalid native source path');
+            const target = path.join(directory, name);
+            await fs.mkdir(path.dirname(target), { recursive: true });
+            await fs.writeFile(target, contents);
+        }
+        const models = await loadLightdashModels(directory);
+        if (models.length === 0)
+            throw new ParseError('No native Lightdash models found');
+        const config =
+            'lightdash.config.yml' in files
+                ? await loadLightdashProjectConfig(
+                      String(files['lightdash.config.yml']),
+                  )
+                : { spotlight: DEFAULT_SPOTLIGHT_CONFIG };
+        if ('lightdash.project_context.yml' in files)
+            await loadProjectContextFile(
+                String(files['lightdash.project_context.yml']),
+            );
+        const explores = await compileLightdashModels({
+            models,
+            warehouseSqlBuilder: warehouseSqlBuilderFromType(warehouseType),
+            lightdashProjectConfig: config,
+            allowPartialCompilation: false,
+            postProcessors: [preAggregatePostProcessor],
+        });
+        const failures = explores.filter(isExploreError);
+        if (failures.length)
+            throw new ParseError(
+                `Native YAML compilation failed: ${failures.map((explore) => `${explore.name}: ${explore.errors.map((error) => error.message).join('; ')}`).join('\n')}`,
+            );
+    } finally {
+        await fs.rm(directory, { recursive: true, force: true });
+    }
+}

--- a/packages/backend/src/ee/services/AiWritebackService/providers/GithubProvider.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/providers/GithubProvider.ts
@@ -467,11 +467,14 @@ export class GithubProvider implements GitProvider {
         setStage: SetStage;
     }): Promise<LandedCommit> {
         setStage('commit');
-        const projectPaths = await resolveDbtProjectPaths(
-            sandbox,
-            connection.projectSubPath,
-            this.logger,
-        );
+        const projectPaths =
+            connection.semanticLayer === 'lightdash'
+                ? [connection.projectSubPath]
+                : await resolveDbtProjectPaths(
+                      sandbox,
+                      connection.projectSubPath,
+                      this.logger,
+                  );
         await stageChanges(sandbox, projectPaths, this.logger);
         const fileChanges = await collectFileChanges(sandbox);
         // Read the line stat while the change is still staged — the local commit

--- a/packages/backend/src/ee/services/AiWritebackService/scripts.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/scripts.test.ts
@@ -1,8 +1,15 @@
 import { execFileSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import {
+    mkdirSync,
+    mkdtempSync,
+    rmSync,
+    symlinkSync,
+    writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
+import { buildNativeSnapshotScript } from './nativeValidation';
 import { buildGatherRepoContextScript } from './scripts';
 
 describe('buildGatherRepoContextScript', () => {
@@ -13,6 +20,53 @@ describe('buildGatherRepoContextScript', () => {
             rmSync(directory, { recursive: true, force: true }),
         );
         temporaryDirectories.length = 0;
+    });
+
+    it('collects only native sources and config from a literal project subpath', () => {
+        const repository = mkdtempSync(join(tmpdir(), 'native-snapshot-'));
+        temporaryDirectories.push(repository);
+        const subpath = "native/team's $(ignored)";
+        const project = join(repository, subpath);
+        mkdirSync(join(project, 'lightdash/models/nested'), {
+            recursive: true,
+        });
+        writeFileSync(
+            join(project, 'lightdash/models/nested/orders.yaml'),
+            'native model',
+        );
+        writeFileSync(join(project, 'lightdash.config.yml'), 'native config');
+        writeFileSync(join(project, '.env'), 'must never leave sandbox');
+        const output = execFileSync(
+            process.execPath,
+            ['-e', buildNativeSnapshotScript(subpath)],
+            { cwd: repository, encoding: 'utf8' },
+        );
+        expect(JSON.parse(output)).toEqual({
+            'lightdash/models/nested/orders.yaml': 'native model',
+            'lightdash.config.yml': 'native config',
+        });
+    });
+
+    it('rejects a models directory escaping the connected project through a symlink', () => {
+        const repository = mkdtempSync(join(tmpdir(), 'native-snapshot-'));
+        temporaryDirectories.push(repository);
+        mkdirSync(join(repository, 'native'));
+        mkdirSync(join(repository, 'outside'));
+        writeFileSync(
+            join(repository, 'outside/private.yml'),
+            'must not be read',
+        );
+        symlinkSync(
+            join(repository, 'outside'),
+            join(repository, 'native/models'),
+        );
+        expect(() =>
+            execFileSync(
+                process.execPath,
+                ['-e', buildNativeSnapshotScript('native')],
+                { cwd: repository, stdio: 'pipe' },
+            ),
+        ).toThrow(/Native source must stay inside/);
     });
 
     it.each(['dbt/$(printf evaluated)', "dbt/team's models"])(

--- a/packages/backend/src/ee/services/AiWritebackService/templates.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/templates.ts
@@ -223,6 +223,59 @@ If you did not change any files, skip these steps entirely and do not emit the
 blocks.
 `.trim();
 
+export const buildNativeSystemPrompt = (
+    projectDir: string,
+    context: {
+        projectName: string;
+        repository: string;
+        repoContext: RepoContext | null;
+        warehouseType: WarehouseTypes | null;
+        hasWarehouseSkill: boolean;
+    },
+): string =>
+    `
+You are editing the native Lightdash YAML project "${context.projectName}" in ${context.repository}.
+The connected project directory is \`${projectDir}\`, relative to the cloned repository.
+Edit the original source files inside that directory. Preserve comments, unrelated definitions,
+and existing field identities. The host owns git: do not commit, push, or run git commands.
+
+This project uses native Lightdash models, not dbt schemas. Models are recursively loaded from
+\`models/\` if it exists, otherwise \`lightdash/models/\`, beneath the connected project directory.
+Each model file has a top-level \`type: model\` (also model/v1 or model/v1beta), \`name\`,
+\`sql_from\`, and a \`dimensions\` sequence. Edit the actual model file; never create a dbt
+\`models: [...]\` schema wrapper, \`meta\` wrapper, profiles, packages, or generated build output.
+Native dimensions have name, type and sql; metrics belong to the model's metrics mapping or
+the relevant dimension's metrics mapping. Reuse existing fields and native field references.
+Inspect the existing model syntax before editing joins, filters, metrics, or AI hints.
+
+Project-level knowledge and explore routing belong in \`lightdash.project_context.yml\` in
+the connected project directory. Preserve its existing schema and entries; inspect it before
+applying a Reviews context fix. Model-specific semantic fixes belong in the original model YAML.
+
+${buildWarehouseSkillGuidance(context.warehouseType, context.hasWarehouseSkill).replaceAll('`schema.yml`', 'native YAML')}
+Reuse existing dimensions and metrics in SQL. Avoid correlated subqueries; use existing joins
+or aggregated model expressions where appropriate.
+
+${context.repoContext ? `Connected project file ${context.repoContext.kind === 'full' ? 'listing' : 'directory summary'}:\n<repo_context>\n${context.repoContext.listing}\n</repo_context>` : 'Use Glob/Grep to locate the source files inside the connected project directory.'}
+
+The host validates the edited models, project configuration and project context with the shared
+native compiler before opening or updating a pull request. No warehouse credentials, dbt
+profiles, dependency installation, or sandbox CLI build are needed. Do not claim compilation
+passed yourself. Invalid native source fails the run before any remote branch or PR mutation.
+
+If you changed files, end your final reply with these metadata blocks, each tag on its own line:
+${PR_TITLE_OPEN}
+single-line PR title, plain text, max 72 characters
+${PR_TITLE_CLOSE}
+${PR_DESCRIPTION_OPEN}
+concise PR description in markdown
+${PR_DESCRIPTION_CLOSE}
+${PR_SUMMARY_OPEN}
+one or two sentences describing the user-visible outcome
+${PR_SUMMARY_CLOSE}
+If no files changed, omit these blocks.
+`.trim();
+
 // System prompt for the GENERAL coding agent (editRepo). Repo-generic: no dbt,
 // no warehouse skills, no compile step. The agent reads/edits files in the
 // cloned repo to satisfy the request and leaves the PR metadata on disk; the

--- a/packages/backend/src/ee/services/AiWritebackService/types.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/types.ts
@@ -39,6 +39,7 @@ export type GithubConnection = {
     projectSubPath: string;
     /** The project's configured branch, or '' to fall back to the repo default. */
     branch: string;
+    semanticLayer?: 'dbt' | 'lightdash';
 };
 
 export type GitlabConnection = {

--- a/packages/backend/src/ee/services/AiWritebackService/utils.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/utils.ts
@@ -83,6 +83,9 @@ export const parseGithubConnection = (
         repo,
         projectSubPath: normalizeProjectSubPath(connection.project_sub_path),
         branch: connection.branch?.trim() ?? '',
+        ...(connection.semanticLayer === 'lightdash'
+            ? { semanticLayer: 'lightdash' as const }
+            : {}),
     };
 };
 

--- a/packages/backend/src/ee/services/ProjectContextService/ProjectContextService.test.ts
+++ b/packages/backend/src/ee/services/ProjectContextService/ProjectContextService.test.ts
@@ -439,6 +439,74 @@ describe('ProjectContextService.writebackEntry', () => {
         expect(updated).not.toContain('content: old');
     });
 
+    test('bounds long context branch names without changing entry IDs or colliding on shared prefixes', async () => {
+        mockGetFileContent.mockRejectedValue(new NotFoundError('missing'));
+        const { service } = makeService({});
+        const entries = ['first', 'second'].map((suffix) => ({
+            ...judgeEntry,
+            content: `${'Native context definition '.repeat(16)}${suffix}`,
+            terms: [],
+        }));
+        for await (const entry of entries) {
+            const result = await service.writebackEntry({
+                user: userWithProjectContextAccess(),
+                projectUuid: PROJECT_UUID,
+                entry,
+                branchTimestamp: 1000,
+                sourceThread: null,
+            });
+            expect(result.entryId.length).toBeGreaterThan(255);
+            const commit = mockCreateSignedCommitOnBranch.mock.lastCall![0];
+            const written = Buffer.from(
+                commit.fileChanges.additions[0].contents,
+                'base64',
+            ).toString('utf8');
+            expect(written).toContain(`id: ${result.entryId}`);
+            expect(
+                Buffer.byteLength(`refs/heads/${commit.branch}`, 'utf8'),
+            ).toBeLessThanOrEqual(255);
+        }
+        expect(
+            new Set(mockCreateBranch.mock.calls.map(([args]) => args.branch))
+                .size,
+        ).toBe(2);
+    });
+
+    test('writes native project context beside config on the configured branch', async () => {
+        mockGetFileContent.mockRejectedValue(new NotFoundError('missing'));
+        const { service } = makeService({
+            project: {
+                ...githubProject,
+                dbtConnection: {
+                    ...githubProject.dbtConnection,
+                    semanticLayer: 'lightdash',
+                    branch: 'release',
+                    project_sub_path: '/native',
+                },
+            },
+        });
+        await service.writebackEntry({
+            user: userWithProjectContextAccess(),
+            projectUuid: PROJECT_UUID,
+            entry: judgeEntry,
+            branchTimestamp: 1000,
+            sourceThread: null,
+        });
+        expect(mockGetFileContent).toHaveBeenCalledWith(
+            expect.objectContaining({
+                fileName: 'native/lightdash.project_context.yml',
+                branch: 'release',
+            }),
+        );
+        expect(
+            mockCreateSignedCommitOnBranch.mock.calls[0][0].fileChanges
+                .additions[0].path,
+        ).toBe('native/lightdash.project_context.yml');
+        expect(mockCreatePullRequest).toHaveBeenCalledWith(
+            expect.objectContaining({ base: 'release' }),
+        );
+    });
+
     test('throws when the project has no GitHub access', async () => {
         const { service } = makeService({ installationId: undefined });
         await expect(

--- a/packages/backend/src/ee/services/ProjectContextService/ProjectContextService.ts
+++ b/packages/backend/src/ee/services/ProjectContextService/ProjectContextService.ts
@@ -12,6 +12,7 @@ import {
     type DbtProjectConfig,
     type SessionUser,
 } from '@lightdash/common';
+import { createHash } from 'crypto';
 import {
     createBranch,
     createPullRequest,
@@ -357,7 +358,14 @@ export class ProjectContextService extends BaseService {
             installationId,
             token,
         });
-        const headBranch = `lightdash-project-context/${entryId}-${args.branchTimestamp}`;
+        // Entry IDs may be derived from an entire context paragraph. Keep the
+        // GitHub ref below its 255-byte limit without changing the persisted ID
+        // or making entries with a shared long prefix target the same branch.
+        const branchEntryId =
+            Buffer.byteLength(entryId, 'utf8') > 160
+                ? createHash('sha256').update(entryId).digest('hex')
+                : entryId;
+        const headBranch = `lightdash-project-context/${branchEntryId}-${args.branchTimestamp}`;
         await createBranch({
             owner,
             repo,

--- a/packages/backend/src/ee/services/ai/reviewWriteback/buildReviewWritebackPrompt.test.ts
+++ b/packages/backend/src/ee/services/ai/reviewWriteback/buildReviewWritebackPrompt.test.ts
@@ -94,6 +94,28 @@ const expectPromptPlan = (plan: ReturnType<typeof planReviewWriteback>) => {
 };
 
 describe('planReviewWriteback', () => {
+    it('preserves original nested native model paths in semantic review fixes', () => {
+        const plan = expectPromptPlan(
+            planReviewWriteback(
+                baseItem(),
+                new Map([
+                    [
+                        'orders',
+                        {
+                            ymlPath: 'lightdash/models/nested/revenue.yaml',
+                            dbtSourceUuid: null,
+                        },
+                    ],
+                ]),
+            ),
+        );
+        expect(plan.promptText).toContain(
+            'yaml: lightdash/models/nested/revenue.yaml',
+        );
+        expect(plan.promptText).toContain('connected semantic layer YAML');
+        expect(plan.promptText).not.toContain('inspect the dbt project');
+    });
+
     it('builds a deterministic one-shot prompt for semantic_layer items', () => {
         const plan = expectPromptPlan(
             planReviewWriteback(

--- a/packages/backend/src/ee/services/ai/reviewWriteback/buildReviewWritebackPrompt.ts
+++ b/packages/backend/src/ee/services/ai/reviewWriteback/buildReviewWritebackPrompt.ts
@@ -130,14 +130,14 @@ const buildSemanticLayerWritebackPrompt = (
             .filter(isSemanticTargetRef)
             .map((ref) => `- ${formatSemanticTargetRef(ref, ymlPathByModel)}`);
         const sections = [
-            'You are improving the dbt/Lightdash semantic layer YAML to resolve a manually filed data issue. Make the smallest change that resolves it.',
+            'You are improving the connected semantic layer YAML to resolve a manually filed data issue. Make the smallest change that resolves it.',
             `Issue: ${item.title}`,
             item.description ? `Description: ${item.description}` : null,
             manualTargetLines.length > 0
                 ? `Related explore(s)/field(s):\n${manualTargetLines.join('\n')}`
                 : null,
-            'No source conversation is attached. Use the issue title and description as the source of truth, inspect the dbt project, and open a pull request if a semantic-layer change can resolve the ask.',
-            'Apply the change by updating field descriptions, ai_hint, or labels, or by adding a missing model, join, dimension, or metric as appropriate. Do not change SQL logic or unrelated fields. If the data needed to answer this is genuinely not present in the warehouse/dbt project and cannot be exposed by a semantic-layer edit, do not fabricate fields or invent data — open no pull request and report that upstream dbt modeling or ingestion is required.',
+            'No source conversation is attached. Use the issue title and description as the source of truth, inspect the connected project, and open a pull request if a semantic-layer change can resolve the ask.',
+            'Apply the change by updating field descriptions, ai_hint, or labels, or by adding a missing model, join, dimension, or metric as appropriate. Do not change SQL logic or unrelated fields. If the data needed to answer this is genuinely not present in the warehouse or connected project and cannot be exposed by a semantic-layer edit, do not fabricate fields or invent data — open no pull request and report that upstream modeling or ingestion is required.',
         ].filter((section): section is string => section !== null);
 
         return {
@@ -154,7 +154,7 @@ const buildSemanticLayerWritebackPrompt = (
     const recommendation = finding?.recommendation ?? null;
 
     const sections = [
-        'You are improving the dbt/Lightdash semantic layer YAML to fix a recurring issue surfaced by AI agent review. Make the smallest change that resolves it.',
+        'You are improving the connected semantic layer YAML to fix a recurring issue surfaced by AI agent review. Make the smallest change that resolves it.',
         'The pinned review finding, the proposed change, and the original conversation are attached to this thread as context — read them first to understand exactly what was missing, then open a pull request that closes the gap.',
         recommendation
             ? `Recommended change: ${recommendation.title}\nRationale: ${recommendation.rationale}`
@@ -162,7 +162,7 @@ const buildSemanticLayerWritebackPrompt = (
         targetLines.length > 0
             ? `Target(s) to edit:\n${targetLines.join('\n')}`
             : null,
-        'Apply the change by updating field descriptions, ai_hint, or labels, or by adding a missing model, join, dimension, or metric as appropriate. Put routing and disambiguation directives — "use this field when…" steering, join recipes, and negative cross-model caveats like "NOT suitable for…, use the other model instead" — in ai_hint (model or field level), never in a description: a description defines what a field is, while an ai_hint tells the agent when to choose it over a similar one. Do not change SQL logic or unrelated fields. If the data needed to answer this is genuinely not present in the warehouse/dbt project and cannot be exposed by a semantic-layer edit, do not fabricate fields or invent data — open no pull request and report that upstream dbt modeling or ingestion is required. Otherwise open a pull request describing the change and referencing this review finding.',
+        'Apply the change by updating field descriptions, ai_hint, or labels, or by adding a missing model, join, dimension, or metric as appropriate. Put routing and disambiguation directives — "use this field when…" steering, join recipes, and negative cross-model caveats like "NOT suitable for…, use the other model instead" — in ai_hint (model or field level), never in a description: a description defines what a field is, while an ai_hint tells the agent when to choose it over a similar one. Do not change SQL logic or unrelated fields. If the data needed to answer this is genuinely not present in the warehouse or connected project and cannot be exposed by a semantic-layer edit, do not fabricate fields or invent data — open no pull request and report that upstream modeling or ingestion is required. Otherwise open a pull request describing the change and referencing this review finding.',
     ].filter((section): section is string => section !== null);
 
     return {

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -4901,24 +4901,24 @@ Parameters:
     },
   },
   {
-    "description": "Open or update a pull request that modifies the dbt project / Lightdash semantic layer for this project. Use this tool ONLY when the user asks to CHANGE something in the underlying repo — e.g. add or rename a metric, edit a dimension definition, modify a dbt model, update YAML metadata. Do NOT use this tool for read-only questions, querying data, exploring fields, or for changes that can be made inside Lightdash (use editContent for those). When a project has more than one dbt source, the prompt must name the source or its owner/repo verbatim, or you will be asked to choose one. This tool applies the change on your behalf: it runs in an isolated sandbox, edits the repo, runs \`lightdash compile\`, and opens a pull request — but the call returns immediately once the run has started, before any of that finishes (status: "pending"). Give a brief acknowledgement that you have started the change, then end your turn. Do not wait for it or call this tool again to check on it. A single conversation can open several pull requests: follow-up edits continue the most recent one, prUrl targets a specific existing one, and startNewPullRequest opens a fresh one for an unrelated change.",
+    "description": "Open or update a pull request that modifies the connected semantic layer (dbt or native Lightdash YAML). Use this tool ONLY when the user asks to CHANGE something in the underlying repo — e.g. add or rename a metric, edit a dimension definition, modify a dbt model, update YAML metadata. Do NOT use this tool for read-only questions, querying data, exploring fields, or for changes that can be made inside Lightdash (use editContent for those). When a project has more than one dbt source, the prompt must name the source or its owner/repo verbatim, or you will be asked to choose one. This tool applies the change on your behalf: it runs in an isolated sandbox, edits the repo, validates the semantic layer, and opens a pull request — but the call returns immediately once the run has started, before any of that finishes (status: "pending"). Give a brief acknowledgement that you have started the change, then end your turn. Do not wait for it or call this tool again to check on it. A single conversation can open several pull requests: follow-up edits continue the most recent one, prUrl targets a specific existing one, and startNewPullRequest opens a fresh one for an unrelated change.",
     "inputSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": false,
       "properties": {
         "prUrl": {
-          "description": "To UPDATE a specific existing pull request instead of opening a new one, put its full URL here (e.g. 'https://github.com/owner/repo/pull/123'). The PR must belong to this project's own dbt repository. Use this both for a PR the user pasted AND to target one of several pull requests this conversation has already opened (get the URL from listWorkstreams or a previous editDbtProject result). Otherwise pass null.",
+          "description": "To UPDATE a specific existing pull request instead of opening a new one, put its full URL here (e.g. 'https://github.com/owner/repo/pull/123'). The PR must belong to this project's own connected repository. Use this both for a PR the user pasted AND to target one of several pull requests this conversation has already opened (get the URL from listWorkstreams or a previous editDbtProject result). Otherwise pass null.",
           "type": [
             "string",
             "null",
           ],
         },
         "prompt": {
-          "description": "A focused, self-contained natural-language instruction describing exactly which files in the dbt project to change and how. The change is applied in a fresh sandbox that does not see this conversation, so include every detail it needs (model name, file path hints, the literal change to make). When the project has multiple dbt sources, include the source name or owner/repo verbatim. Do not include preamble or pleasantries.",
+          "description": "A focused, self-contained natural-language instruction describing exactly which files in the connected project to change and how. The change is applied in a fresh sandbox that does not see this conversation, so include every detail it needs (model name, file path hints, the literal change to make). When the project has multiple dbt sources, include the source name or owner/repo verbatim. Do not include preamble or pleasantries.",
           "type": "string",
         },
         "startNewPullRequest": {
-          "description": "Set true to open a brand-new pull request even when this conversation already has one open against this project's dbt repository — use it when the user asks for a SEPARATE, unrelated change rather than a follow-up to existing work. Leave null (the default) to continue the most recent pull request. Ignored when prUrl is set.",
+          "description": "Set true to open a brand-new pull request even when this conversation already has one open against this project's connected repository — use it when the user asks for a SEPARATE, unrelated change rather than a follow-up to existing work. Leave null (the default) to continue the most recent pull request. Ignored when prUrl is set.",
           "type": [
             "boolean",
             "null",

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
@@ -1105,7 +1105,7 @@ export const editDbtProjectToolDefinition: ToolDefinitionWithoutMcpOutput<
     typeof toolEditDbtProjectOutputSchema
 > = defineTool({
     name: 'editDbtProject',
-    title: 'Edit dbt project',
+    title: 'Edit semantic layer',
     description: TOOL_EDIT_DBT_PROJECT_DESCRIPTION,
     availability: ['agent'],
     inputSchema: toolEditDbtProjectArgsSchema,

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolEditDbtProjectArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolEditDbtProjectArgs.ts
@@ -4,11 +4,11 @@ import { makeBuiltInToolResultGuard } from './builtInToolResultGuard';
 export const AI_WRITEBACK_PENDING_GRACE_MS = 5 * 60 * 1000;
 
 export const TOOL_EDIT_DBT_PROJECT_DESCRIPTION = [
-    'Open or update a pull request that modifies the dbt project / Lightdash semantic layer for this project.',
+    'Open or update a pull request that modifies the connected semantic layer (dbt or native Lightdash YAML).',
     'Use this tool ONLY when the user asks to CHANGE something in the underlying repo — e.g. add or rename a metric, edit a dimension definition, modify a dbt model, update YAML metadata.',
     'Do NOT use this tool for read-only questions, querying data, exploring fields, or for changes that can be made inside Lightdash (use editContent for those).',
     'When a project has more than one dbt source, the prompt must name the source or its owner/repo verbatim, or you will be asked to choose one.',
-    'This tool applies the change on your behalf: it runs in an isolated sandbox, edits the repo, runs `lightdash compile`, and opens a pull request — but the call returns immediately once the run has started, before any of that finishes (status: "pending"). Give a brief acknowledgement that you have started the change, then end your turn. Do not wait for it or call this tool again to check on it.',
+    'This tool applies the change on your behalf: it runs in an isolated sandbox, edits the repo, validates the semantic layer, and opens a pull request — but the call returns immediately once the run has started, before any of that finishes (status: "pending"). Give a brief acknowledgement that you have started the change, then end your turn. Do not wait for it or call this tool again to check on it.',
     'A single conversation can open several pull requests: follow-up edits continue the most recent one, prUrl targets a specific existing one, and startNewPullRequest opens a fresh one for an unrelated change.',
 ].join(' ');
 
@@ -16,19 +16,19 @@ export const toolEditDbtProjectArgsSchema = z.object({
     prompt: z
         .string()
         .describe(
-            'A focused, self-contained natural-language instruction describing exactly which files in the dbt project to change and how. The change is applied in a fresh sandbox that does not see this conversation, so include every detail it needs (model name, file path hints, the literal change to make). When the project has multiple dbt sources, include the source name or owner/repo verbatim. Do not include preamble or pleasantries.',
+            'A focused, self-contained natural-language instruction describing exactly which files in the connected project to change and how. The change is applied in a fresh sandbox that does not see this conversation, so include every detail it needs (model name, file path hints, the literal change to make). When the project has multiple dbt sources, include the source name or owner/repo verbatim. Do not include preamble or pleasantries.',
         ),
     prUrl: z
         .string()
         .nullable()
         .describe(
-            "To UPDATE a specific existing pull request instead of opening a new one, put its full URL here (e.g. 'https://github.com/owner/repo/pull/123'). The PR must belong to this project's own dbt repository. Use this both for a PR the user pasted AND to target one of several pull requests this conversation has already opened (get the URL from listWorkstreams or a previous editDbtProject result). Otherwise pass null.",
+            "To UPDATE a specific existing pull request instead of opening a new one, put its full URL here (e.g. 'https://github.com/owner/repo/pull/123'). The PR must belong to this project's own connected repository. Use this both for a PR the user pasted AND to target one of several pull requests this conversation has already opened (get the URL from listWorkstreams or a previous editDbtProject result). Otherwise pass null.",
         ),
     startNewPullRequest: z
         .boolean()
         .nullable()
         .describe(
-            "Set true to open a brand-new pull request even when this conversation already has one open against this project's dbt repository — use it when the user asks for a SEPARATE, unrelated change rather than a follow-up to existing work. Leave null (the default) to continue the most recent pull request. Ignored when prUrl is set.",
+            "Set true to open a brand-new pull request even when this conversation already has one open against this project's connected repository — use it when the user asks for a SEPARATE, unrelated change rather than a follow-up to existing work. Leave null (the default) to continue the most recent pull request. Ignored when prUrl is set.",
         ),
 });
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewItemActions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewItemActions.tsx
@@ -200,7 +200,7 @@ export const ReviewItemActions: FC<ReviewItemActionsProps> = ({
 
                         {canCreatePr && !current.linkedPrUrl && (
                             <Tooltip
-                                label="Open a pull request against the dbt project (runs in the background, may take a few minutes)"
+                                label="Open a pull request against the connected project (runs in the background, may take a few minutes)"
                                 maw={260}
                             >
                                 <Button

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiGeneralSettingsPage.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiGeneralSettingsPage.tsx
@@ -381,7 +381,7 @@ export const AiGeneralSettingsPage = () => {
                                             recommendations. For connected
                                             projects, Lightdash can suggest pull
                                             requests that improve context and
-                                            dbt definitions.
+                                            semantic definitions.
                                             {reviewsEffectivelyOn && (
                                                 <>
                                                     {' '}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage.tsx
@@ -141,7 +141,7 @@ export const AiReviewsSettingsPage = () => {
                     description={
                         <>
                             An actionable queue of data issues from AI findings
-                            and human asks. Semantic layer fixes open a dbt pull
+                            and human asks. Semantic layer fixes open a pull
                             request; project context fixes add guidance your
                             agents read before answering.
                         </>


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-11036

### Description:

```diff
 Native Git project -> AI edit / Reviews semantic fix
- prepare dbt profiles, install dependencies, and follow dbt schema instructions
+ edit original native YAML and validate it with the shared native compiler before opening/updating a PR
```

- Keep the existing permission, conversation/resume, cancellation/finalization, GitHub attribution, PR tracking and preview paths. Fresh native runs check out the configured branch; resumed/adopted PRs retain their branch.
- Give the agent native model/context instructions and warehouse SQL guidance. Native runs need no shell execution, dbt profiles, dependencies, manifest, or installed CLI version. Runtime credentials are not included in the source snapshot.
- Validate the edited models, project config and project context on the backend before any remote branch/commit/PR mutation. Source collection stays within the connected project and is bounded to 10 MiB / 10,000 YAML files. Invalid source fails explicitly.
- Reviews semantic prompts retain original native file paths; deterministic context fixes use the existing file merge beside project config. Existing GitHub previews inherit the native format and compile the PR branch. The existing `editDbtProject` tool identifier remains compatible; its visible title, tool/input descriptions and Reviews labels cover both semantic formats. Long context IDs use a bounded branch name without changing the persisted entry or colliding on shared prefixes.
- Stack: #28818 → #28820 → #28822 → #28825 → #28828 → this PR.

Validation: 350 backend tests passed across AI write-back, providers, prompts, source collection, previews, context and Reviews planning. After the live context test exposed an overlong GitHub ref, all 22 context-service tests passed with coverage for full entry preservation and distinct bounded branches. Common/backend typechecks, common build, MCP snapshot freshness, focused lint/format and `git diff --check` passed.

AI agent contract snapshot: updated only the `editDbtProject` description entry for the intentional native YAML wording changes. All 7 agent tool contract tests passed without snapshot-update mode; `git diff --check` and commit checks passed.

Live localhost:3000 with `Spissable/lightdash-native-demo-1` and E2B:
- Created a native project and a branch preview with copied content: 8 explores each. A malformed-YAML refresh retained the cached explore; restoring source refreshed successfully.
- The browser AI conversation opened [demo PR #5](https://github.com/Spissable/lightdash-native-demo-1/pull/5), then resumed the same sandbox/PR for a follow-up. Both turns compiled native source before push and created working previews. Merging from the conversation card refreshed the project automatically.
- A deliberately invalid native field reference returned 400 with the compiler error and created no PR. Viewer AI write-back returned 403 before sandbox creation.
- Reviews opened and verified [demo PR #6](https://github.com/Spissable/lightdash-native-demo-1/pull/6), adding only the requested native metric hint, and [demo PR #7](https://github.com/Spissable/lightdash-native-demo-1/pull/7), preserving the complete project-context entry with a bounded branch name. Both native previews compiled, both PRs were merged, and both issues moved to Done. The final project refresh completed with 8 explores and no errors. Restored the original Reviews setting to off and verified it through the API.

Test definitions, projects, previews and conversations are persisted in the demo environment; no warehouse data was modified. GitLab is outside scope.

Latest rebase validation at the full-stack tip (`6b15c2d017`, based on main `21e876fa94`): backend build, backend/frontend typechecks, common build, 183 query-history/service tests, MCP snapshot freshness and `git diff --check` passed. Upstream [#28851](https://github.com/lightdash/lightdash/pull/28851) reverted the change causing the `QueryHistory.errorName` errors; both those errors and the earlier Learn UI errors are resolved. All six feature patches are unchanged by this restack. The preceding restack also passed common/CLI typechecks and 468 focused feature tests. Remote CI is rerunning.

### Risk assessment:

- [ ] This is a high-risk change

Low risk: native behavior requires explicit format selection and reuses existing authorization and PR lifecycle. The agent cannot execute shell commands in native mode. The host reads data files only, rejects escaping paths, uses no warehouse credentials for compilation, and rejects invalid source before remote Git mutation. Existing dbt behavior remains covered.
