### PR TITLE
fix(autopilot): only reprovision Anthropic resources on a 404, reuse on transient errors

### DIFF
--- a/packages/backend/src/ee/clients/ManagedAgentClient.test.ts
+++ b/packages/backend/src/ee/clients/ManagedAgentClient.test.ts
@@ -1,3 +1,4 @@
+import { NotFoundError } from '@anthropic-ai/sdk';
 import { AnyType, DEFAULT_MANAGED_AGENT_POLICY } from '@lightdash/common';
 import {
     ManagedAgentClient,
@@ -30,7 +31,8 @@ const anthropic = vi.hoisted(() => ({
     },
 }));
 
-vi.mock('@anthropic-ai/sdk', () => ({
+vi.mock('@anthropic-ai/sdk', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('@anthropic-ai/sdk')>()),
     default: class MockAnthropic {
         constructor(options: unknown) {
             anthropic.constructorOptions(options);
@@ -39,6 +41,14 @@ vi.mock('@anthropic-ai/sdk', () => ({
         beta = anthropic.beta;
     },
 }));
+
+const notFound = (message: string) =>
+    new NotFoundError(
+        404,
+        { type: 'error', error: { type: 'not_found_error', message } },
+        message,
+        new Headers(),
+    );
 
 const createClient = (anthropicApiKey = 'anthropic-api-key') =>
     new ManagedAgentClient({
@@ -171,7 +181,7 @@ describe('ManagedAgentClient.syncAgent', () => {
         );
         const vaultConfigHash = onResourcesCreated.mock.calls[0][2];
         anthropic.beta.vaults.retrieve.mockRejectedValue(
-            new Error('404 vault not found'),
+            notFound('vault vlt_x not found'),
         );
 
         await client.syncAgent(
@@ -202,7 +212,7 @@ describe('ManagedAgentClient.syncAgent', () => {
             createSessionConfig({ onAgentSynced, onResourcesCreated }),
         );
         anthropic.beta.environments.retrieve.mockRejectedValue(
-            new Error('404 environment not found'),
+            notFound('environment env_x not found'),
         );
 
         await client.syncAgent(
@@ -218,6 +228,33 @@ describe('ManagedAgentClient.syncAgent', () => {
         );
 
         expect(anthropic.beta.vaults.create).toHaveBeenCalledTimes(2);
+    });
+
+    it('reuses persisted resources when verification fails for another reason', async () => {
+        const client = createClient();
+        const onAgentSynced = vi.fn().mockResolvedValue(undefined);
+        const onResourcesCreated = vi.fn().mockResolvedValue(undefined);
+        await client.syncAgent(
+            createSessionConfig({ onAgentSynced, onResourcesCreated }),
+        );
+        anthropic.beta.vaults.retrieve.mockRejectedValue(
+            new Error('503 overloaded'),
+        );
+
+        await client.syncAgent(
+            createSessionConfig({
+                persistedAgentConfigHash: onAgentSynced.mock.calls[0][1],
+                persistedAgentVersion: 2,
+                persistedEnvironmentId: 'environment-id',
+                persistedVaultId: 'new-vault-id',
+                persistedVaultConfigHash: onResourcesCreated.mock.calls[0][2],
+                onAgentSynced,
+                onResourcesCreated,
+            }),
+        );
+
+        expect(anthropic.beta.vaults.create).toHaveBeenCalledTimes(1);
+        expect(onResourcesCreated).toHaveBeenCalledTimes(1);
     });
 
     it('reprovisions when the persisted vault is archived', async () => {

--- a/packages/backend/src/ee/clients/ManagedAgentClient.ts
+++ b/packages/backend/src/ee/clients/ManagedAgentClient.ts
@@ -1,4 +1,4 @@
-import Anthropic from '@anthropic-ai/sdk';
+import Anthropic, { NotFoundError } from '@anthropic-ai/sdk';
 import type {
     AgentCreateParams,
     AgentUpdateParams,
@@ -282,10 +282,17 @@ export class ManagedAgentClient {
 
             return true;
         } catch (error) {
+            if (error instanceof NotFoundError) {
+                Logger.warn(
+                    `[ManagedAgent] Persisted resources missing (env=${environmentId}, vault=${vaultId}), reprovisioning: ${error.message}`,
+                );
+                return false;
+            }
+            // Anything else is transient; the session call surfaces the real error.
             Logger.warn(
-                `[ManagedAgent] Persisted resources unusable (env=${environmentId}, vault=${vaultId}), reprovisioning: ${error instanceof Error ? error.message : 'Unknown'}`,
+                `[ManagedAgent] Could not verify persisted resources (env=${environmentId}, vault=${vaultId}), reusing them: ${error instanceof Error ? error.message : 'Unknown'}`,
             );
-            return false;
+            return true;
         }
     }
 


### PR DESCRIPTION
## Problem

#28829 made Autopilot verify its persisted Anthropic environment and vault before reusing them, reprovisioning when they are gone. It treated **every** error from those two verification calls as "gone". That is too broad: a rate limit, a 5xx, or a network blip would create a redundant vault, and if Anthropic were actually down, the reprovision would fail instead of the run failing the way it always has.

## Fix

Only a `NotFoundError` (404) or a vault with `archived_at` set triggers a reprovision. Any other error is logged and the persisted IDs are reused, so `sessions.create` surfaces the real error exactly as it did before #28829.

## Regression analysis

- **Behaviour on a genuinely missing or archived vault is unchanged** from #28829: still reprovisions, still self-heals on the next run.
- **Behaviour on a transient error now matches pre-#28829**: reuse the persisted IDs and let the session call fail. No vault is leaked, nothing new is created.
- The API-key-in-hash mechanism from #28829 is untouched and still forces a reprovision on key rotation on its own.
- No migration, no API surface change.

## Testing

Adds a case pinning that a non-404 verification error does **not** reprovision, and switches the two "gone" cases to throw a real `NotFoundError` (the test mock now spreads `importOriginal` so the SDK error classes are available). 9/9 pass in one test file; `pnpm -F backend typecheck`, oxlint and oxfmt clean.

Relates: #28827
Follows: #28829

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFgox6w765F7Tk3zEBsZU5
