### PR TITLE
feat(learn): record who opens the library and who starts, finishes or drops a walkthrough

### DIFF
--- a/packages/frontend/src/components/common/GuidedTour/GuidedTour.test.tsx
+++ b/packages/frontend/src/components/common/GuidedTour/GuidedTour.test.tsx
@@ -63,4 +63,39 @@ describe('GuidedTour', () => {
         await user.click(finish);
         expect(onClose).toHaveBeenCalledTimes(1);
     });
+
+    // Hosts tell Got it from Skip by onFinish having run first, and record a
+    // completion rather than a dismissal on that basis.
+    it('fires onFinish before onClose on Got it, and not on Skip', async () => {
+        const user = userEvent.setup();
+        const calls: string[] = [];
+        const onClose = vi.fn(() => calls.push('close'));
+        const onFinish = vi.fn(() => calls.push('finish'));
+        const { unmount } = renderWithProviders(
+            <GuidedTour
+                steps={steps}
+                opened
+                onClose={onClose}
+                onFinish={onFinish}
+            />,
+        );
+
+        await user.click(screen.getByRole('button', { name: 'Skip' }));
+        expect(calls).toEqual(['close']);
+        unmount();
+
+        calls.length = 0;
+        renderWithProviders(
+            <GuidedTour
+                steps={steps}
+                opened
+                onClose={onClose}
+                onFinish={onFinish}
+            />,
+        );
+        await user.click(screen.getByRole('button', { name: 'Next' }));
+        await user.click(screen.getByRole('button', { name: 'Next' }));
+        await user.click(screen.getByRole('button', { name: 'Got it' }));
+        expect(calls).toEqual(['finish', 'close']);
+    });
 });

--- a/packages/frontend/src/features/learn/LearnPage.test.tsx
+++ b/packages/frontend/src/features/learn/LearnPage.test.tsx
@@ -1,0 +1,158 @@
+import { Ability } from '@casl/ability';
+import { ProjectType } from '@lightdash/common';
+import { MantineProvider } from '@mantine/core';
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventName } from '../../types/Events';
+import { buildLearnCatalogue } from './catalogue';
+import LearnPage from './LearnPage';
+
+const { track, projectState, healthState } = vi.hoisted(() => ({
+    track: vi.fn(),
+    projectState: { current: [] as unknown[] },
+    healthState: { current: { learn: { enabled: true } } },
+}));
+
+vi.mock('react-router', () => ({
+    Navigate: () => null,
+}));
+
+vi.mock('../../providers/Tracking/useTracking', () => ({
+    default: () => ({ track }),
+}));
+
+vi.mock('../../providers/App/useApp', () => ({
+    default: () => ({
+        user: {
+            data: {
+                organizationUuid: 'org-1',
+                role: 'admin',
+                ability: new Ability([
+                    { action: 'manage', subject: 'Organization' },
+                ]),
+            },
+        },
+    }),
+}));
+
+vi.mock('../../hooks/health/useHealth', () => ({
+    default: () => ({ data: healthState.current }),
+}));
+
+vi.mock('../../hooks/useProjects', () => ({
+    useProjects: () => ({ data: projectState.current }),
+}));
+
+vi.mock('../../hooks/useProjectRoute', () => ({
+    useOptionalProjectRoute: () => undefined,
+}));
+
+// The real gates ask the licence and the AI settings; the library's own
+// counting is what is under test, so every module is open here.
+vi.mock('./availability', () => ({
+    useLearnAvailability: () => ({ isOpen: () => true }),
+}));
+
+vi.mock('./useEnableLearn', () => ({
+    useEnableLearn: () => ({ mutate: vi.fn(), isLoading: false, error: null }),
+}));
+
+vi.mock('./useStartWalkthrough', () => ({
+    useStartWalkthrough: () => ({ start: vi.fn(), opening: null }),
+}));
+
+vi.mock('./thumbnails', () => ({
+    thumbnailFor: () => undefined,
+}));
+
+const catalogue = buildLearnCatalogue();
+const scopes = catalogue.map((module) => module.scope);
+
+const renderPage = () =>
+    render(
+        <MantineProvider env="test">
+            <LearnPage />
+        </MantineProvider>,
+    );
+
+const viewEvents = () =>
+    track.mock.calls
+        .map(([event]) => event)
+        .filter((event) => event.name === EventName.LEARN_LIBRARY_VIEWED);
+
+describe('LearnPage analytics', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        track.mockClear();
+        healthState.current = { learn: { enabled: true } };
+        projectState.current = [
+            { projectUuid: 'training-1', type: ProjectType.TRAINING },
+        ];
+    });
+
+    it('records one view per mount, with the progress the learner is looking at', () => {
+        localStorage.setItem(
+            'lightdash.learn.started',
+            JSON.stringify([scopes[0], scopes[1]]),
+        );
+        localStorage.setItem(
+            'lightdash.learn.completed',
+            JSON.stringify([scopes[0]]),
+        );
+
+        const { rerender } = renderPage();
+        rerender(
+            <MantineProvider env="test">
+                <LearnPage />
+            </MantineProvider>,
+        );
+
+        expect(viewEvents()).toEqual([
+            {
+                name: EventName.LEARN_LIBRARY_VIEWED,
+                properties: {
+                    organizationUuid: 'org-1',
+                    trainingProjectUuid: 'training-1',
+                    hasTrainingProject: true,
+                    moduleCount: catalogue.length,
+                    startedCount: 2,
+                    completedCount: 1,
+                },
+            },
+        ]);
+    });
+
+    it('counts only the scopes this instance has modules for', () => {
+        localStorage.setItem(
+            'lightdash.learn.completed',
+            JSON.stringify([scopes[0], 'manage:SomethingRetired']),
+        );
+
+        renderPage();
+
+        expect(viewEvents()[0].properties).toMatchObject({
+            completedCount: 1,
+        });
+    });
+
+    it('records the call to action before an admin has enabled Learn', () => {
+        projectState.current = [
+            { projectUuid: 'other-1', type: ProjectType.DEFAULT },
+        ];
+
+        renderPage();
+
+        expect(viewEvents()[0].properties).toMatchObject({
+            trainingProjectUuid: null,
+            hasTrainingProject: false,
+        });
+    });
+
+    it('records nothing when Learn is switched off for the instance', () => {
+        healthState.current = { learn: { enabled: false } };
+
+        renderPage();
+
+        expect(viewEvents()).toEqual([]);
+    });
+});

--- a/packages/frontend/src/features/learn/LearnPage.test.tsx
+++ b/packages/frontend/src/features/learn/LearnPage.test.tsx
@@ -7,11 +7,14 @@ import { EventName } from '../../types/Events';
 import { buildLearnCatalogue } from './catalogue';
 import LearnPage from './LearnPage';
 
-const { track, projectState, healthState } = vi.hoisted(() => ({
-    track: vi.fn(),
-    projectState: { current: [] as unknown[] },
-    healthState: { current: { learn: { enabled: true } } },
-}));
+const { track, projectState, healthState, availabilityState } = vi.hoisted(
+    () => ({
+        track: vi.fn(),
+        projectState: { current: [] as unknown[] },
+        healthState: { current: { learn: { enabled: true } } },
+        availabilityState: { current: { isSettled: true } },
+    }),
+);
 
 vi.mock('react-router', () => ({
     Navigate: () => null,
@@ -48,9 +51,13 @@ vi.mock('../../hooks/useProjectRoute', () => ({
 }));
 
 // The real gates ask the licence and the AI settings; the library's own
-// counting is what is under test, so every module is open here.
+// counting is what is under test, so every module is open here, and the
+// tests decide whether the gates have answered yet.
 vi.mock('./availability', () => ({
-    useLearnAvailability: () => ({ isOpen: () => true }),
+    useLearnAvailability: () => ({
+        isOpen: () => true,
+        isSettled: availabilityState.current.isSettled,
+    }),
 }));
 
 vi.mock('./useEnableLearn', () => ({
@@ -85,6 +92,7 @@ describe('LearnPage analytics', () => {
         localStorage.clear();
         track.mockClear();
         healthState.current = { learn: { enabled: true } };
+        availabilityState.current = { isSettled: true };
         projectState.current = [
             { projectUuid: 'training-1', type: ProjectType.TRAINING },
         ];
@@ -146,6 +154,21 @@ describe('LearnPage analytics', () => {
             trainingProjectUuid: null,
             hasTrainingProject: false,
         });
+    });
+
+    it('waits for the catalogue gates to answer before counting', () => {
+        availabilityState.current = { isSettled: false };
+        const { rerender } = renderPage();
+        expect(viewEvents()).toEqual([]);
+
+        availabilityState.current = { isSettled: true };
+        rerender(
+            <MantineProvider env="test">
+                <LearnPage />
+            </MantineProvider>,
+        );
+
+        expect(viewEvents()).toHaveLength(1);
     });
 
     it('records nothing when Learn is switched off for the instance', () => {

--- a/packages/frontend/src/features/learn/LearnPage.tsx
+++ b/packages/frontend/src/features/learn/LearnPage.tsx
@@ -16,13 +16,22 @@ import {
     IconSearch,
     IconCircleCheck,
 } from '@tabler/icons-react';
-import { type FC, useEffect, useMemo, useState } from 'react';
+import {
+    type FC,
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+} from 'react';
 import { Navigate } from 'react-router';
 import MantineIcon from '../../components/common/MantineIcon';
 import useHealth from '../../hooks/health/useHealth';
 import { useOptionalProjectRoute } from '../../hooks/useProjectRoute';
 import { useProjects } from '../../hooks/useProjects';
 import useApp from '../../providers/App/useApp';
+import useTracking from '../../providers/Tracking/useTracking';
+import { EventName } from '../../types/Events';
 import { useLearnAvailability } from './availability';
 import {
     buildLearnCatalogue,
@@ -247,6 +256,51 @@ const LearnPage: FC = () => {
     const { start, opening } = useStartWalkthrough(
         trainingProject?.projectUuid,
     );
+    const startFromCard = useCallback(
+        (scope: string) => start(scope, 'card'),
+        [start],
+    );
+
+    // One view per visit to the library, once the page knows what it is
+    // showing. The redirects below are not views of it, and the call to
+    // action before an admin has enabled Learn is (hasTrainingProject
+    // false): it is the page a learner lands on.
+    const { track } = useTracking();
+    const trackedViewRef = useRef(false);
+    useEffect(() => {
+        if (trackedViewRef.current) return;
+        if (!projects || !health) return;
+        if (previewRedirect || !health.learn.enabled) return;
+        trackedViewRef.current = true;
+        track({
+            name: EventName.LEARN_LIBRARY_VIEWED,
+            properties: {
+                organizationUuid: organizationUuid ?? null,
+                trainingProjectUuid: trainingProject?.projectUuid ?? null,
+                hasTrainingProject: !!trainingProject,
+                // Counted against this instance's catalogue, so the numbers
+                // are the ones the learner sees rather than every scope the
+                // browser has ever recorded progress for.
+                moduleCount: catalogue.length,
+                startedCount: catalogue.filter((module) =>
+                    started.includes(module.scope),
+                ).length,
+                completedCount: catalogue.filter((module) =>
+                    completed.includes(module.scope),
+                ).length,
+            },
+        });
+    }, [
+        projects,
+        health,
+        previewRedirect,
+        organizationUuid,
+        trainingProject,
+        catalogue,
+        started,
+        completed,
+        track,
+    ]);
     const jumpTo = (group: LearnGroup) => {
         setActiveGroup(group);
         document
@@ -384,7 +438,7 @@ const LearnPage: FC = () => {
                                 variant="light"
                                 size="compact-md"
                                 loading={opening === resume.scope}
-                                onClick={() => start(resume.scope)}
+                                onClick={() => start(resume.scope, 'resume')}
                             >
                                 Resume module
                             </Button>
@@ -416,7 +470,9 @@ const LearnPage: FC = () => {
                                 variant="default"
                                 size="compact-md"
                                 loading={opening === recommended.scope}
-                                onClick={() => start(recommended.scope)}
+                                onClick={() =>
+                                    start(recommended.scope, 'recommended')
+                                }
                             >
                                 Start
                             </Button>
@@ -515,7 +571,7 @@ const LearnPage: FC = () => {
                                         )}
                                         heldByRole={roleHolds(role, module)}
                                         opening={opening === module.scope}
-                                        onStart={start}
+                                        onStart={startFromCard}
                                     />
                                 ))}
                         </Box>

--- a/packages/frontend/src/features/learn/LearnPage.tsx
+++ b/packages/frontend/src/features/learn/LearnPage.tsx
@@ -209,7 +209,7 @@ const LearnPage: FC = () => {
 
     // Only modules this instance can run: a walkthrough clicks the real
     // product, so a feature the instance hides has nothing to click.
-    const { isOpen } = useLearnAvailability();
+    const { isOpen, isSettled } = useLearnAvailability();
     const catalogue = useMemo(
         () => buildLearnCatalogue().filter(isOpen),
         [isOpen],
@@ -262,14 +262,17 @@ const LearnPage: FC = () => {
     );
 
     // One view per visit to the library, once the page knows what it is
-    // showing. The redirects below are not views of it, and the call to
-    // action before an admin has enabled Learn is (hasTrainingProject
-    // false): it is the page a learner lands on.
+    // showing: the projects, the instance switch, and the gates that decide
+    // which modules are in the catalogue (they answer after the projects
+    // do, and the counts below would be short without them). The redirects
+    // below are not views of it, and the call to action before an admin
+    // has enabled Learn is (hasTrainingProject false): it is the page a
+    // learner lands on.
     const { track } = useTracking();
     const trackedViewRef = useRef(false);
     useEffect(() => {
         if (trackedViewRef.current) return;
-        if (!projects || !health) return;
+        if (!projects || !health || !isSettled) return;
         if (previewRedirect || !health.learn.enabled) return;
         trackedViewRef.current = true;
         track({
@@ -293,6 +296,7 @@ const LearnPage: FC = () => {
     }, [
         projects,
         health,
+        isSettled,
         previewRedirect,
         organizationUuid,
         trainingProject,

--- a/packages/frontend/src/features/learn/availability.ts
+++ b/packages/frontend/src/features/learn/availability.ts
@@ -42,5 +42,10 @@ export const useLearnAvailability = () => {
         (module: LearnModule) => module.gate === null || open[module.gate],
         [open],
     );
-    return { isOpen };
+    // The licence rides on health, which the page already waits for; the
+    // other gates are their own requests. Until they have answered, isOpen
+    // is provisional and anything counting the catalogue should wait.
+    const isSettled =
+        !dataApps.isLoading && !copilot.isLoading && !aiSettings.isLoading;
+    return { isOpen, isSettled };
 };

--- a/packages/frontend/src/features/learn/useStartWalkthrough.test.tsx
+++ b/packages/frontend/src/features/learn/useStartWalkthrough.test.tsx
@@ -1,0 +1,97 @@
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventName } from '../../types/Events';
+import { useStartWalkthrough } from './useStartWalkthrough';
+
+const { track, openInCopy } = vi.hoisted(() => ({
+    track: vi.fn(),
+    openInCopy: vi.fn(),
+}));
+
+vi.mock('react-router', () => ({
+    useNavigate: () => vi.fn(),
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+    useMutation: () => ({ mutate: openInCopy, isLoading: false }),
+    useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+
+vi.mock('../../providers/Tracking/useTracking', () => ({
+    default: () => ({ track }),
+}));
+
+vi.mock('../../providers/App/useApp', () => ({
+    default: () => ({ user: { data: { organizationUuid: 'org-1' } } }),
+}));
+
+vi.mock('../scopeTours/trainingCopy', () => ({
+    createTrainingPreview: vi.fn(),
+    tourUrlInCopy: vi.fn(),
+}));
+
+describe('useStartWalkthrough', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        track.mockClear();
+        openInCopy.mockClear();
+    });
+
+    it('records the start, where it came from, and opens the copy', () => {
+        const { result } = renderHook(() => useStartWalkthrough('training-1'));
+
+        act(() => result.current.start('manage:PinnedItems', 'card'));
+
+        expect(track).toHaveBeenCalledTimes(1);
+        expect(track).toHaveBeenCalledWith({
+            name: EventName.LEARN_WALKTHROUGH_STARTED,
+            properties: {
+                organizationUuid: 'org-1',
+                trainingProjectUuid: 'training-1',
+                scope: 'manage:PinnedItems',
+                source: 'card',
+                isRestart: false,
+            },
+        });
+        expect(openInCopy).toHaveBeenCalledWith({
+            scope: 'manage:PinnedItems',
+        });
+    });
+
+    it.each(['resume', 'recommended'] as const)(
+        'carries the %s card as the source',
+        (source) => {
+            const { result } = renderHook(() =>
+                useStartWalkthrough('training-1'),
+            );
+
+            act(() => result.current.start('manage:Space', source));
+
+            expect(track.mock.calls[0][0].properties).toMatchObject({ source });
+        },
+    );
+
+    it('marks a walkthrough the learner has already finished as a restart', () => {
+        localStorage.setItem(
+            'lightdash.learn.completed',
+            JSON.stringify(['manage:PinnedItems']),
+        );
+        const { result } = renderHook(() => useStartWalkthrough('training-1'));
+
+        act(() => result.current.start('manage:PinnedItems', 'card'));
+
+        expect(track.mock.calls[0][0].properties).toMatchObject({
+            isRestart: true,
+        });
+    });
+
+    it('records nothing when the org has no training project', () => {
+        const { result } = renderHook(() => useStartWalkthrough(undefined));
+
+        act(() => result.current.start('manage:PinnedItems', 'card'));
+
+        expect(track).not.toHaveBeenCalled();
+        expect(openInCopy).not.toHaveBeenCalled();
+    });
+});

--- a/packages/frontend/src/features/learn/useStartWalkthrough.ts
+++ b/packages/frontend/src/features/learn/useStartWalkthrough.ts
@@ -5,11 +5,15 @@ import {
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useState } from 'react';
 import { useNavigate } from 'react-router';
+import useApp from '../../providers/App/useApp';
+import { type LearnStartSource } from '../../providers/Tracking/types';
+import useTracking from '../../providers/Tracking/useTracking';
+import { EventName } from '../../types/Events';
 import {
     createTrainingPreview,
     tourUrlInCopy,
 } from '../scopeTours/trainingCopy';
-import { markScopeStarted } from './progress';
+import { markScopeStarted, useLearnProgress } from './progress';
 
 /**
  * Start a walkthrough the way the library does: make the learner's copy
@@ -23,6 +27,9 @@ export const useStartWalkthrough = (
 ) => {
     const navigate = useNavigate();
     const queryClient = useQueryClient();
+    const { user } = useApp();
+    const { track } = useTracking();
+    const { completed } = useLearnProgress();
     const [opening, setOpening] = useState<string | null>(null);
     const { mutate: openInCopy } = useMutation<
         CreateTrainingPreviewResults,
@@ -44,12 +51,31 @@ export const useStartWalkthrough = (
         },
     });
     const start = useCallback(
-        (scope: string) => {
+        (scope: string, source: LearnStartSource) => {
             if (!trainingProjectUuid || opening) return;
+            // Recorded together: the local progress the learner sees, and
+            // the event that says who started what, and from where.
             markScopeStarted(scope);
+            track({
+                name: EventName.LEARN_WALKTHROUGH_STARTED,
+                properties: {
+                    organizationUuid: user.data?.organizationUuid ?? null,
+                    trainingProjectUuid,
+                    scope,
+                    source,
+                    isRestart: completed.includes(scope),
+                },
+            });
             openInCopy({ scope });
         },
-        [trainingProjectUuid, opening, openInCopy],
+        [
+            trainingProjectUuid,
+            opening,
+            openInCopy,
+            track,
+            user.data?.organizationUuid,
+            completed,
+        ],
     );
     return { start, opening };
 };

--- a/packages/frontend/src/features/scopeTours/ScopeTourHost.test.tsx
+++ b/packages/frontend/src/features/scopeTours/ScopeTourHost.test.tsx
@@ -1,0 +1,232 @@
+import { ProjectType } from '@lightdash/common';
+import { MantineProvider } from '@mantine/core';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventName } from '../../types/Events';
+import ScopeTourHost from './ScopeTourHost';
+
+const SCOPE = 'manage:PinnedItems';
+const NEXT_SCOPE = 'manage:Space';
+
+const { track, navigate, mutate, searchState } = vi.hoisted(() => ({
+    track: vi.fn(),
+    navigate: vi.fn().mockResolvedValue(undefined),
+    mutate: vi.fn(),
+    searchState: { current: new URLSearchParams() },
+}));
+
+vi.mock('react-router', () => ({
+    useNavigate: () => navigate,
+    useParams: () => ({ projectUuid: 'copy-1' }),
+    useSearchParams: () => [
+        searchState.current,
+        (next: URLSearchParams) => {
+            searchState.current = next;
+        },
+    ],
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+    useMutation: () => ({ mutate, isLoading: false }),
+    useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+
+vi.mock('../../providers/Tracking/useTracking', () => ({
+    default: () => ({ track }),
+}));
+
+vi.mock('../../providers/App/useApp', () => ({
+    default: () => ({ user: { data: { organizationUuid: 'org-1' } } }),
+}));
+
+vi.mock('../../hooks/useProjectRoute', () => ({
+    useOptionalProjectRoute: () => undefined,
+}));
+
+vi.mock('../../hooks/useProject', () => ({
+    useProject: () => ({
+        data: {
+            projectUuid: 'copy-1',
+            type: ProjectType.PREVIEW,
+            upstreamProjectUuid: 'training-1',
+        },
+    }),
+}));
+
+vi.mock('../../hooks/useProjects', () => ({
+    useProjects: () => ({
+        data: [{ projectUuid: 'training-1', type: ProjectType.TRAINING }],
+    }),
+}));
+
+vi.mock('./generated', () => {
+    const step = (title: string) => ({
+        target: '[data-tour-step]',
+        title,
+        body: 'body',
+        interactive: false,
+        advanceOnTargetClick: false,
+        advanceOnTargetInput: false,
+        via: [],
+    });
+    return {
+        SCOPE_TOURS: {
+            'manage:PinnedItems': {
+                scope: 'manage:PinnedItems',
+                title: 'Pin things',
+                sources: [],
+                steps: [step('one'), step('two'), step('three')],
+            },
+            'manage:Space': {
+                scope: 'manage:Space',
+                title: 'Make a space',
+                sources: [],
+                steps: [step('one')],
+            },
+        },
+    };
+});
+
+vi.mock('./trainingCopy', () => ({
+    createTrainingPreview: vi.fn(),
+    deleteTrainingPreviews: vi.fn(),
+    tourUrlInCopy: () => '/projects/copy-2/home?tour=manage:Space',
+    LEAVING_COPY_STATE: {},
+}));
+
+vi.mock('../learn/LearnDoneModal', () => ({
+    LearnDoneModal: ({ onNext }: { onNext: (scope: string) => void }) => (
+        <button type="button" onClick={() => onNext(NEXT_SCOPE)}>
+            next module
+        </button>
+    ),
+}));
+
+// Stands in for the tour card: the three things the learner can do with it,
+// with Got it firing onFinish and onClose on the one click as the real one
+// does.
+vi.mock('../../components/common/GuidedTour', () => ({
+    GuidedTour: ({
+        onClose,
+        onFinish,
+        onStepChange,
+    }: {
+        onClose: () => void;
+        onFinish?: () => void;
+        onStepChange?: (stepIndex: number, beacon: null) => void;
+    }) => (
+        <div>
+            <button type="button" onClick={() => onStepChange?.(2, null)}>
+                advance
+            </button>
+            <button
+                type="button"
+                onClick={() => {
+                    onFinish?.();
+                    onClose();
+                }}
+            >
+                got it
+            </button>
+            <button type="button" onClick={() => onClose()}>
+                skip
+            </button>
+        </div>
+    ),
+}));
+
+const renderHost = () =>
+    render(
+        <MantineProvider env="test">
+            <ScopeTourHost />
+        </MantineProvider>,
+    );
+
+const learnEvents = () =>
+    track.mock.calls
+        .map(([event]) => event)
+        .filter((event) => String(event.name).startsWith('learn_'));
+
+describe('ScopeTourHost analytics', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        sessionStorage.clear();
+        track.mockClear();
+        navigate.mockClear();
+        mutate.mockClear();
+        searchState.current = new URLSearchParams(
+            `tour=${SCOPE}&copy=true&from=learn`,
+        );
+    });
+
+    it('records a completion, and no dismissal, when the tour is finished', () => {
+        renderHost();
+
+        fireEvent.click(screen.getByText('got it'));
+
+        expect(learnEvents()).toEqual([
+            {
+                name: EventName.LEARN_WALKTHROUGH_COMPLETED,
+                properties: {
+                    organizationUuid: 'org-1',
+                    trainingProjectUuid: 'training-1',
+                    scope: SCOPE,
+                    stepCount: 3,
+                    durationSeconds: expect.any(Number),
+                },
+            },
+        ]);
+    });
+
+    it('records a dismissal at the step reached, and no completion, on skip', () => {
+        renderHost();
+
+        fireEvent.click(screen.getByText('advance'));
+        fireEvent.click(screen.getByText('skip'));
+
+        expect(learnEvents()).toEqual([
+            {
+                name: EventName.LEARN_WALKTHROUGH_DISMISSED,
+                properties: {
+                    organizationUuid: 'org-1',
+                    trainingProjectUuid: 'training-1',
+                    scope: SCOPE,
+                    stepIndex: 2,
+                    stepCount: 3,
+                    durationSeconds: expect.any(Number),
+                },
+            },
+        ]);
+    });
+
+    it('records the next module started from the completion dialog', () => {
+        renderHost();
+
+        fireEvent.click(screen.getByText('got it'));
+        fireEvent.click(screen.getByText('next module'));
+
+        expect(learnEvents()[1]).toEqual({
+            name: EventName.LEARN_WALKTHROUGH_STARTED,
+            properties: {
+                organizationUuid: 'org-1',
+                trainingProjectUuid: 'training-1',
+                scope: NEXT_SCOPE,
+                source: 'next_from_completion',
+                isRestart: false,
+            },
+        });
+    });
+
+    it('reports a walkthrough the learner has finished before as a restart', () => {
+        localStorage.setItem(
+            'lightdash.learn.completed',
+            JSON.stringify([NEXT_SCOPE]),
+        );
+        renderHost();
+
+        fireEvent.click(screen.getByText('got it'));
+        fireEvent.click(screen.getByText('next module'));
+
+        expect(learnEvents()[1].properties).toMatchObject({ isRestart: true });
+    });
+});

--- a/packages/frontend/src/features/scopeTours/ScopeTourHost.test.tsx
+++ b/packages/frontend/src/features/scopeTours/ScopeTourHost.test.tsx
@@ -217,6 +217,35 @@ describe('ScopeTourHost analytics', () => {
         });
     });
 
+    it('records a start for a tour opened by link, since nothing else did', () => {
+        searchState.current = new URLSearchParams(`tour=${SCOPE}&copy=true`);
+
+        renderHost();
+        fireEvent.click(screen.getByText('got it'));
+
+        expect(learnEvents().map((event) => event.name)).toEqual([
+            EventName.LEARN_WALKTHROUGH_STARTED,
+            EventName.LEARN_WALKTHROUGH_COMPLETED,
+        ]);
+        expect(learnEvents()[0].properties).toMatchObject({
+            scope: SCOPE,
+            source: 'deep_link',
+            trainingProjectUuid: 'training-1',
+        });
+        expect(
+            JSON.parse(localStorage.getItem('lightdash.learn.started') ?? '[]'),
+        ).toContain(SCOPE);
+    });
+
+    it('does not record a second start for a tour the library already started', () => {
+        renderHost();
+        fireEvent.click(screen.getByText('got it'));
+
+        expect(learnEvents().map((event) => event.name)).toEqual([
+            EventName.LEARN_WALKTHROUGH_COMPLETED,
+        ]);
+    });
+
     it('reports a walkthrough the learner has finished before as a restart', () => {
         localStorage.setItem(
             'lightdash.learn.completed',

--- a/packages/frontend/src/features/scopeTours/ScopeTourHost.tsx
+++ b/packages/frontend/src/features/scopeTours/ScopeTourHost.tsx
@@ -19,9 +19,16 @@ import { GuidedTour, type TourPoint } from '../../components/common/GuidedTour';
 import { useProject } from '../../hooks/useProject';
 import { useOptionalProjectRoute } from '../../hooks/useProjectRoute';
 import { useProjects } from '../../hooks/useProjects';
+import useApp from '../../providers/App/useApp';
+import useTracking from '../../providers/Tracking/useTracking';
+import { EventName } from '../../types/Events';
 import { LearnDoneModal } from '../learn/LearnDoneModal';
 import { readLearnOrigin } from '../learn/origin';
-import { markScopeCompleted, markScopeStarted } from '../learn/progress';
+import {
+    markScopeCompleted,
+    markScopeStarted,
+    useLearnProgress,
+} from '../learn/progress';
 import { SCOPE_TOURS } from './generated';
 import {
     createTrainingPreview,
@@ -46,6 +53,11 @@ type StoredTour = {
     returnTo?: ReturnTo;
     /** Where the ring collapsed to on the click that reached this step. */
     beacon?: TourPoint | null;
+    /**
+     * When the tour began, so the time a walkthrough took survives the
+     * remounts and reloads the tour itself survives.
+     */
+    startedAt?: number;
 };
 const readStoredTour = (): StoredTour | null => {
     try {
@@ -64,6 +76,10 @@ const writeStoredTour = (tour: StoredTour | null) => {
         // a remount.
     }
 };
+
+/** Whole seconds since a tour started; 0 when the start was not recorded. */
+const secondsSince = (from: number | null) =>
+    from === null ? 0 : Math.max(0, Math.round((Date.now() - from) / 1000));
 
 /**
  * Docs text keeps `**...**` around permission and control names (shown bold)
@@ -134,6 +150,15 @@ const ScopeTourHost: FC = () => {
     const [reachedStep, setReachedStep] = useState(0);
     const [reachedBeacon, setReachedBeacon] = useState<TourPoint | null>(null);
     const [returnTo, setReturnTo] = useState<ReturnTo>('home');
+    const { user } = useApp();
+    const { track } = useTracking();
+    const { completed } = useLearnProgress();
+    // The step the learner has actually reached, and when the tour began.
+    // Both are refs: they are read when a tour ends, and re-rendering on
+    // every step would hand GuidedTour a new starting step mid-tour.
+    const currentStepRef = useRef(0);
+    const startedAtRef = useRef<number | null>(null);
+    const organizationUuid = user.data?.organizationUuid ?? null;
     // A tour already under way in this project resumes where it was left,
     // once the host knows which project it is on. Read once per mount and
     // consumed on resume, so a tour that has just been closed is not picked
@@ -146,6 +171,8 @@ const ScopeTourHost: FC = () => {
         if (stored.projectUuid !== projectUuid || !SCOPE_TOURS[stored.scope])
             return;
         storedRef.current = null;
+        currentStepRef.current = stored.stepIndex;
+        startedAtRef.current = stored.startedAt ?? null;
         setReachedStep(stored.stepIndex);
         setReachedBeacon(stored.beacon ?? null);
         setReturnTo(stored.returnTo ?? 'home');
@@ -188,6 +215,10 @@ const ScopeTourHost: FC = () => {
             },
         },
     );
+    const upstream =
+        project?.type === ProjectType.PREVIEW
+            ? (project.upstreamProjectUuid ?? null)
+            : null;
     // Got it and Skip share handleClose. GuidedTour fires onFinish and then
     // onClose in the same click, so state set in onFinish would not be
     // visible yet; a ref carries the distinction across the two calls.
@@ -196,13 +227,21 @@ const ScopeTourHost: FC = () => {
     // it was pressed. The copy stays until a choice is made.
     const [finishedScope, setFinishedScope] = useState<string | null>(null);
     const handleFinish = () => {
-        if (activeScope) markScopeCompleted(activeScope);
+        if (activeScope) {
+            markScopeCompleted(activeScope);
+            track({
+                name: EventName.LEARN_WALKTHROUGH_COMPLETED,
+                properties: {
+                    organizationUuid,
+                    trainingProjectUuid: upstream,
+                    scope: activeScope,
+                    stepCount: SCOPE_TOURS[activeScope]?.steps.length ?? 0,
+                    durationSeconds: secondsSince(startedAtRef.current),
+                },
+            });
+        }
         finishedRef.current = true;
     };
-    const upstream =
-        project?.type === ProjectType.PREVIEW
-            ? (project.upstreamProjectUuid ?? null)
-            : null;
     // Where the learner goes when the copy is put away: the project the
     // library was opened from (its library, or its home), if it is still
     // theirs, else the training project. The library renders on any
@@ -231,6 +270,20 @@ const ScopeTourHost: FC = () => {
         setActiveScope(null);
         storedRef.current = null;
         writeStoredTour(null);
+        if (!finished && scope) {
+            track({
+                name: EventName.LEARN_WALKTHROUGH_DISMISSED,
+                properties: {
+                    organizationUuid,
+                    trainingProjectUuid: upstream,
+                    scope,
+                    stepIndex: currentStepRef.current,
+                    stepCount: SCOPE_TOURS[scope]?.steps.length ?? 0,
+                    durationSeconds: secondsSince(startedAtRef.current),
+                },
+            });
+        }
+        startedAtRef.current = null;
         if (!upstream) return;
         if (finished && scope) {
             setFinishedScope(scope);
@@ -300,6 +353,16 @@ const ScopeTourHost: FC = () => {
     const handleNext = (nextScope: string) => {
         if (!upstream || openingCopy) return;
         markScopeStarted(nextScope);
+        track({
+            name: EventName.LEARN_WALKTHROUGH_STARTED,
+            properties: {
+                organizationUuid,
+                trainingProjectUuid: upstream,
+                scope: nextScope,
+                source: 'next_from_completion',
+                isRestart: completed.includes(nextScope),
+            },
+        });
         startInFreshCopy({
             trainingProjectUuid: upstream,
             scope: nextScope,
@@ -342,6 +405,8 @@ const ScopeTourHost: FC = () => {
             return;
         }
         copyRequestedRef.current = false;
+        currentStepRef.current = 0;
+        startedAtRef.current = Date.now();
         setActiveScope(requested);
         setReachedStep(0);
         setReturnTo(requestedFrom);
@@ -350,6 +415,7 @@ const ScopeTourHost: FC = () => {
             projectUuid,
             stepIndex: 0,
             returnTo: requestedFrom,
+            startedAt: startedAtRef.current,
         });
         // Consume the parameters so a reload does not restart the tour.
         const next = new URLSearchParams(searchParams);
@@ -383,12 +449,14 @@ const ScopeTourHost: FC = () => {
     const handleStepChange = useCallback(
         (stepIndex: number, beacon: TourPoint | null) => {
             if (!activeScope || !projectUuid) return;
+            currentStepRef.current = stepIndex;
             writeStoredTour({
                 scope: activeScope,
                 projectUuid,
                 stepIndex,
                 beacon,
                 returnTo,
+                startedAt: startedAtRef.current ?? undefined,
             });
         },
         [activeScope, projectUuid, returnTo],

--- a/packages/frontend/src/features/scopeTours/ScopeTourHost.tsx
+++ b/packages/frontend/src/features/scopeTours/ScopeTourHost.tsx
@@ -158,6 +158,9 @@ const ScopeTourHost: FC = () => {
     // every step would hand GuidedTour a new starting step mid-tour.
     const currentStepRef = useRef(0);
     const startedAtRef = useRef<number | null>(null);
+    // The scope whose link-opened start has been recorded, so the effect
+    // below records it once however many times it settles.
+    const deepLinkTrackedRef = useRef<string | null>(null);
     const organizationUuid = user.data?.organizationUuid ?? null;
     // A tour already under way in this project resumes where it was left,
     // once the host knows which project it is on. Read once per mount and
@@ -284,6 +287,7 @@ const ScopeTourHost: FC = () => {
             });
         }
         startedAtRef.current = null;
+        deepLinkTrackedRef.current = null;
         if (!upstream) return;
         if (finished && scope) {
             setFinishedScope(scope);
@@ -405,6 +409,29 @@ const ScopeTourHost: FC = () => {
             return;
         }
         copyRequestedRef.current = false;
+        // Starts from the library and from Next were recorded where they
+        // were clicked, and arrive with from=learn. Anything else is a tour
+        // link opened directly (docs, the smoke), so this is the first
+        // anyone hears of it: record the start here, as local progress and
+        // as the event, or its completion would have nothing to pair with.
+        if (
+            requestedFrom !== 'learn' &&
+            upstream &&
+            deepLinkTrackedRef.current !== requested
+        ) {
+            deepLinkTrackedRef.current = requested;
+            markScopeStarted(requested);
+            track({
+                name: EventName.LEARN_WALKTHROUGH_STARTED,
+                properties: {
+                    organizationUuid,
+                    trainingProjectUuid: upstream,
+                    scope: requested,
+                    source: 'deep_link',
+                    isRestart: completed.includes(requested),
+                },
+            });
+        }
         currentStepRef.current = 0;
         startedAtRef.current = Date.now();
         setActiveScope(requested);
@@ -435,6 +462,10 @@ const ScopeTourHost: FC = () => {
         searchParams,
         requestedFrom,
         setSearchParams,
+        upstream,
+        track,
+        completed,
+        organizationUuid,
     ]);
 
     const steps = useMemo(() => {

--- a/packages/frontend/src/pages/Learn.tsx
+++ b/packages/frontend/src/pages/Learn.tsx
@@ -1,11 +1,15 @@
 import { type FC } from 'react';
 import Page from '../components/common/Page/Page';
 import LearnPage from '../features/learn/LearnPage';
+import { TrackPage } from '../providers/Tracking/TrackingProvider';
+import { PageName } from '../types/Events';
 
 const Learn: FC = () => (
-    <Page title="Learn" withFooter noContentPadding>
-        <LearnPage />
-    </Page>
+    <TrackPage name={PageName.LEARN}>
+        <Page title="Learn" withFooter noContentPadding>
+            <LearnPage />
+        </Page>
+    </TrackPage>
 );
 
 export default Learn;

--- a/packages/frontend/src/providers/Tracking/types.ts
+++ b/packages/frontend/src/providers/Tracking/types.ts
@@ -1020,6 +1020,63 @@ type ChartTypeForkModalOpenedEvent = {
     };
 };
 
+/** Where in the Learn library a walkthrough was started from. */
+export type LearnStartSource =
+    | 'card'
+    | 'resume'
+    | 'recommended'
+    | 'next_from_completion';
+
+type LearnLibraryViewedEvent = {
+    name: EventName.LEARN_LIBRARY_VIEWED;
+    properties: {
+        organizationUuid: string | null;
+        /** Null until an admin has enabled Learn for the organization. */
+        trainingProjectUuid: string | null;
+        hasTrainingProject: boolean;
+        /** Modules this instance can run, so the counts match the page. */
+        moduleCount: number;
+        startedCount: number;
+        completedCount: number;
+    };
+};
+
+type LearnWalkthroughStartedEvent = {
+    name: EventName.LEARN_WALKTHROUGH_STARTED;
+    properties: {
+        organizationUuid: string | null;
+        trainingProjectUuid: string;
+        scope: string;
+        source: LearnStartSource;
+        /** The learner had already finished this walkthrough. */
+        isRestart: boolean;
+    };
+};
+
+type LearnWalkthroughCompletedEvent = {
+    name: EventName.LEARN_WALKTHROUGH_COMPLETED;
+    properties: {
+        organizationUuid: string | null;
+        trainingProjectUuid: string | null;
+        scope: string;
+        stepCount: number;
+        durationSeconds: number;
+    };
+};
+
+type LearnWalkthroughDismissedEvent = {
+    name: EventName.LEARN_WALKTHROUGH_DISMISSED;
+    properties: {
+        organizationUuid: string | null;
+        trainingProjectUuid: string | null;
+        scope: string;
+        /** Furthest step reached, zero-based. */
+        stepIndex: number;
+        stepCount: number;
+        durationSeconds: number;
+    };
+};
+
 export type EventData =
     | GenericEvent
     | DashboardWorkbookEvent
@@ -1113,7 +1170,11 @@ export type EventData =
     | DashboardUiVersionToggledEvent
     | TableCalculationSaveEvent
     | FormulaTableCalculationAiGenerateClickedEvent
-    | DashboardFilterLockToggledEvent;
+    | DashboardFilterLockToggledEvent
+    | LearnLibraryViewedEvent
+    | LearnWalkthroughStartedEvent
+    | LearnWalkthroughCompletedEvent
+    | LearnWalkthroughDismissedEvent;
 
 export type IdentifyData = {
     id: string;

--- a/packages/frontend/src/providers/Tracking/types.ts
+++ b/packages/frontend/src/providers/Tracking/types.ts
@@ -1020,12 +1020,17 @@ type ChartTypeForkModalOpenedEvent = {
     };
 };
 
-/** Where in the Learn library a walkthrough was started from. */
+/**
+ * Where a walkthrough was started from: a library card, the library's
+ * Resume or Recommended card, Next on the completion dialog, or a tour
+ * link opened directly (docs, the smoke) without going through the library.
+ */
 export type LearnStartSource =
     | 'card'
     | 'resume'
     | 'recommended'
-    | 'next_from_completion';
+    | 'next_from_completion'
+    | 'deep_link';
 
 type LearnLibraryViewedEvent = {
     name: EventName.LEARN_LIBRARY_VIEWED;

--- a/packages/frontend/src/types/Events.ts
+++ b/packages/frontend/src/types/Events.ts
@@ -68,6 +68,7 @@ export enum PageName {
     METRICS_CATALOG = 'metrics_catalog',
     FUNNEL_BUILDER = 'funnel_builder',
     ROADMAP = 'roadmap',
+    LEARN = 'learn',
 }
 
 export enum CategoryName {

--- a/packages/frontend/src/types/Events.ts
+++ b/packages/frontend/src/types/Events.ts
@@ -250,4 +250,10 @@ export enum EventName {
     CHART_TYPE_DETAIL_VIEWED = 'chart_type.detail_viewed',
     CHART_TYPE_PREVIEW_IN_EXPLORER = 'chart_type.preview_in_explorer',
     CHART_TYPE_FORK_MODAL_OPENED = 'chart_type.fork_modal_opened',
+
+    // Learn: the training library and the walkthroughs started from it
+    LEARN_LIBRARY_VIEWED = 'learn_library.viewed',
+    LEARN_WALKTHROUGH_STARTED = 'learn_walkthrough.started',
+    LEARN_WALKTHROUGH_COMPLETED = 'learn_walkthrough.completed',
+    LEARN_WALKTHROUGH_DISMISSED = 'learn_walkthrough.dismissed',
 }


### PR DESCRIPTION
## Problem

Learn shipped with no user-level telemetry. There was no `track()` call anywhere in `features/learn/*` or in `ScopeTourHost`, the Learn page was not wrapped in `<TrackPage>`, and the only record of what a learner has done is `features/learn/progress.ts`, which keeps started/completed in localStorage, per browser, and never leaves the machine. The only Learn-related events that existed are the org-level `training_project.provisioned|skipped|failed`, which say Learn was switched on, not that anyone used it.

So a rollout produced no evidence of use: we could not say how many people opened Learn, which walkthroughs they started, which they finished, or at which step the rest gave up.

## Change

Learn joins the pages tracked with `<TrackPage>` (`PageName.LEARN`), so it appears in the generic page analytics alongside every other page.

On top of that, four webapp events, fired from the places that already record local progress so the two can never disagree.

| Event | Fires | Carries |
| --- | --- | --- |
| `learn_library.viewed` | once per visit to the library, after the catalogue gates have answered | module counts as rendered, `hasTrainingProject` (false on the call to action before an admin has enabled Learn) |
| `learn_walkthrough.started` | beside `markScopeStarted` | `scope`, `source` (`card`, `resume`, `recommended`, `next_from_completion`, `deep_link`), `isRestart` |
| `learn_walkthrough.completed` | beside `markScopeCompleted` | `scope`, `stepCount`, `durationSeconds` |
| `learn_walkthrough.dismissed` | on Skip | `scope`, `stepIndex` reached, `stepCount`, `durationSeconds` |

Every event carries `organizationUuid` explicitly, the way `homepage_v2.opted_in` does, so the warehouse does not have to backfill the organization from the user's group membership the way the other webapp events require.

Supporting changes:

* `useLearnAvailability` now says when its gates have settled. The data-app and AI gates answer after the projects query, and a library view counted before them was short on Enterprise instances; the view waits for them.
* A tour opened by link (docs, the smoke) had no start to pair its completion with, since nothing upstream of `ScopeTourHost` had seen it. Library and Next starts arrive with `from=learn`; anything else records a start with `source: 'deep_link'` at the point the tour begins, and marks local progress the same way.
* The tour's start time joins the stored tour in session storage, so a walkthrough's duration survives the remounts and reloads the tour itself already survives.
* The step reached is now kept in a ref. `reachedStep` only ever held the step a tour *opened* on, so it could not have answered "where did they stop".

## Decisions

* **No per-step event.** Drop-off is answered by `stepIndex` on `learn_walkthrough.dismissed`, and a `step_viewed` event would be the highest-volume thing Learn emits.
* **No new persistence and no schema change.** localStorage stays the learner-facing progress store; durable per-user progress is a separate decision.
* **No new gating.** These fire only where the Learn UI renders, which the instance switch and the training project already gate.

## Known caveats

* `durationSeconds` is wall clock with no idle detection; read medians rather than means.
* `learn_library.viewed` counts mounts. After an admin clicks Enable Learn the page swaps to the library without remounting, so that org's first library view is the call-to-action view.
* `learn_walkthrough.started` fires before the learner's copy is created; a failed copy leaves a start with no tour.

## Testing

* `features/learn/LearnPage.test.tsx`: one view per mount, counts scoped to this instance's modules, the pre-enable call to action, waiting for the gates, nothing when the instance switch is off.
* `features/learn/useStartWalkthrough.test.tsx`: the start event, its sources, restart detection, nothing recorded without a training project.
* `features/scopeTours/ScopeTourHost.test.tsx`: finishing records a completion and no dismissal, Skip records a dismissal at the step reached, Next from the completion dialog records a start, a link-opened tour records its own start, a library-started tour does not record a second one.
* `components/common/GuidedTour/GuidedTour.test.tsx`: Got it fires `onFinish` before `onClose`, Skip fires `onClose` alone. The host's completed-vs-dismissed distinction rests on that order.
* `pnpm -F frontend typecheck` and `lint` clean; 28 tests pass across the five suites.

## Verified against the preview

Driven from a local Chromium against this PR's preview environment (the guest has no egress, the browser does), capturing every request the Rudderstack SDK made to `analytics.lightdash.com`. All 35 data-plane requests returned 200. The learn events sent, in order:

```
page   learn
track  lightdash_webapp.learn_library.viewed        hasTrainingProject=true moduleCount=60 startedCount=0 completedCount=0
track  lightdash_webapp.learn_walkthrough.started    scope=manage:PinnedItems source=card isRestart=false
track  lightdash_webapp.learn_walkthrough.dismissed  scope=manage:PinnedItems stepIndex=1 stepCount=7 durationSeconds=3
track  lightdash_webapp.learn_library.viewed        startedCount=1
track  lightdash_webapp.learn_walkthrough.started    scope=view:Tags source=deep_link
track  lightdash_webapp.learn_walkthrough.dismissed  scope=view:Tags stepIndex=0 stepCount=5 durationSeconds=4
track  lightdash_webapp.learn_library.viewed        startedCount=2
track  lightdash_webapp.learn_walkthrough.started    scope=view:Space source=card
track  lightdash_webapp.learn_walkthrough.completed  scope=view:Space stepCount=5 durationSeconds=9
track  lightdash_webapp.learn_walkthrough.started    scope=view:Tags source=next_from_completion
```

Every track event carried `organizationUuid` and the user id from the SDK's identify call. An earlier run also confirmed the pre-enable view (`hasTrainingProject=false`, `trainingProjectUuid=null`). One observation outside this PR: the `<TrackPage>` page event fires twice per visit, which every page using `TrackPage` does today.

The dbt staging models and `learn_usage` mart that make these queryable live in the analytics repo and are tracked separately.

Closes: CS-268

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014noLpwSN7QMpCr3MTpkogM
