### PR TITLE
refactor: remove timezone support feature flag

### DIFF
--- a/docs/preview-feature-flags.md
+++ b/docs/preview-feature-flags.md
@@ -19,7 +19,7 @@ exclusion, with a reason, when that isn't safe. Flags are excluded when they:
   real repos),
 - are off pending a security review, or are deprecated,
 - derive their value from instance configuration (`ai-copilot`,
-  `results-cache-enabled`, `enable-timezone-support`) — these are left to their
+  `results-cache-enabled`) — these are left to their
   config handler so a preview never advertises an unconfigured backend. To test
   AI copilot in a preview, configure a provider (`AI_COPILOT_ENABLED` plus
   credentials) rather than forcing the flag. PR previews pass

--- a/docs/timezones/glitch-452-date-cast-design.md
+++ b/docs/timezones/glitch-452-date-cast-design.md
@@ -1,8 +1,8 @@
 # GLITCH-452 — Cast day-or-coarser DATE_TRUNCs to DATE at compile time
 
-> Timezone support is now always active. Feature-flag rollout and opt-out behavior described below is historical.
+> Timezone support is always active for all users.
 
-**Status:** shipped (v2 Phase 2, Done) · **Flag:** `EnableTimezoneSupport` (TimezoneV2), default ON since 1.22.0 (#26295)
+**Status:** shipped (v2 Phase 2, Done)
 **PRs:** #24231 (SQL cast) + #24251 (display / predicate collapse), stacked — ship together · design doc #24208 (merged)
 **Depends on:** GLITCH-450 (merged, #24086) — the consolidated calendar-value predicate this ticket updates.
 **Follow-ups (all resolved):** GLITCH-499 (MIN/MAX), GLITCH-503 (raw-export ISO-midnight), GLITCH-505 (Date Zoom cast consistency), GLITCH-510 (raw-base TIMESTAMP date-zoom), GLITCH-506 (raw-SQL table calcs), GLITCH-508 (per-adapter cast refactor), GLITCH-507 (process-TZ raw value), GLITCH-519 (picker affordance).
@@ -11,11 +11,9 @@
 
 Grouping a TIMESTAMP column by **day / week / month / quarter / year** currently emits a `TIMESTAMP` pinned to project-TZ midnight (a UTC instant). A downstream "format-correction layer" then shifts that instant back into the project timezone and chops the clock off so it *displays* as a calendar date. This ticket makes the warehouse emit a real `DATE` for those grains, so the warehouse type matches the metadata (`DATE`) and the correction layer can be deleted.
 
-Ships behind `EnableTimezoneSupport` (default ON since 1.22.0; disable with `LIGHTDASH_ENABLE_TIMEZONE_SUPPORT=false` or a per-org override).
-
 ## Implementation status & outcomes
 
-**Done and in review** (#24231 SQL + #24251 display, both behind `EnableTimezoneSupport`, flag-off byte-identical). Notable results vs. the original design:
+**Shipped** (#24231 SQL + #24251 display). Notable results vs. the original design:
 
 - **Per-adapter cast — BigQuery needs `DATE(expr, tz)`, not `CAST(... AS DATE)`.** Cross-warehouse execution caught a positive-offset off-by-one: BigQuery's `TIMESTAMP_TRUNC(..., tz)` returns the tz-midnight value as a *UTC instant*, so `CAST(... AS DATE)` read its UTC date (e.g. an `Asia/Tokyo` row at `15:00Z` bucketed to the previous day). Fixed: BigQuery uses `DATE(expr, '<tz>')`; every other adapter keeps `CAST(... AS DATE)`. This promotes the §1 footnote to a real, tested correction.
 - **Cross-warehouse execution: all six pass** — Postgres, Snowflake, BigQuery, Databricks, Trino, ClickHouse — for day-grain `DATE` buckets + bare `raw` + formatted display in UTC / −11 (`Pacific/Pago_Pago`) / +9 (`Asia/Tokyo`).
@@ -23,12 +21,12 @@ Ships behind `EnableTimezoneSupport` (default ON since 1.22.0; disable with `LIG
 - **`normalizeCellRawForFilter` is now inert** — the predicate collapse makes its `type === DATE` ∧ `shouldShiftItemTimezone` gates mutually exclusive; kept as a defensive guard, removal tracked separately.
 
 **Resolved design open-questions:**
-- *Date-zoom cast (§1)* — tracked as **GLITCH-505** (now resolved). The ticket's premise (date-zoom dims bypass the cast via the un-cast `getDimensionFromId` path) turned out not to match the code: standard-granularity date-zoom replaces the dim **in place** in the explore (`updateExploreWithDateZoom` → `createDimensionWithGranularity`), so it's found directly and its SELECT is recomputed by `getTimezoneAwareDimensionSql` — already cast to `DATE` under the flag. The one genuinely un-cast path was the **period-over-period range pre-filter** (see audit below). Edge case resolved in **GLITCH-510** (Done): zooming the *raw base* TIMESTAMP dim in place self-referenced in `getTimezoneAwareDimensionSql` and emitted a plain `DATE_TRUNC` (no tz wrap, no cast) — rare (axes usually carry a grain dim), fixed separately.
+- *Date-zoom cast (§1)* — tracked as **GLITCH-505** (now resolved). The ticket's premise (date-zoom dims bypass the cast via the un-cast `getDimensionFromId` path) turned out not to match the code: standard-granularity date-zoom replaces the dim **in place** in the explore (`updateExploreWithDateZoom` → `createDimensionWithGranularity`), so it's found directly and its SELECT is recomputed by `getTimezoneAwareDimensionSql` — already cast to `DATE`. The one genuinely un-cast path was the **period-over-period range pre-filter** (see audit below). Edge case resolved in **GLITCH-510** (Done): zooming the *raw base* TIMESTAMP dim in place self-referenced in `getTimezoneAwareDimensionSql` and emitted a plain `DATE_TRUNC` (no tz wrap, no cast) — rare (axes usually carry a grain dim), fixed separately.
 - *MIN/MAX (§3)* — split to **GLITCH-499**.
 - *Raw exports ISO-midnight (§4)* — XLSX/CSV "raw" mode still emits ISO-midnight (correct calendar date, not bare `YYYY-MM-DD`); tracked as **GLITCH-503**.
 - *Pre-aggregate column type (scope)* — left as-is; still a follow-up (no ticket yet).
 
-**Downstream blast-radius audit** (post-implementation, all flag-gated). Verified **inert**: custom dimensions (SQL + bin — `isField()` is false for them, so none of the three changes reach them), conditional formatting (restricted to numeric / string-dimension fields; a DATE dim can't be a target), result caching (cache key includes the compiled SQL → flag flip changes the hash → no stale-format serve), saved filters with persisted ISO values (`formatDate` → bare date, still matches the DATE LHS), view-underlying-data / drill, sorting & totals (DATE dim is always group-by, never an aggregation target). One **genuine breaking** case: raw-`sql` table calcs doing TIMESTAMP-specific math on a truncated date dim (now error on BigQuery/Snowflake, promote on Postgres/Redshift) — **GLITCH-506**. Latent/pre-existing (not introduced here): MIN/MAX-on-date in CF (`Number(date)` → NaN, GLITCH-499 territory) and the period-over-period range pre-filter's DATE-vs-TIMESTAMP coercion — **fixed in GLITCH-505.** The pre-filter LHS came from the PoP `popField`'s raw explore `compiledSql` (not the tz-aware/cast SELECT expression), so under the flag it compared an un-cast `DATE_TRUNC(...)` against the now-`DATE` min/max boundaries (superset filter → never dropped rows). Fix: the three PoP range-prefilter sites now route `popField` through `getTimezoneAwareDimensionSql`, matching the SELECT/min/max cast (flag-off returns `compiledSql` unchanged → byte-identical).
+**Downstream blast-radius audit** (post-implementation). Verified **inert**: custom dimensions (SQL + bin — `isField()` is false for them, so none of the three changes reach them), conditional formatting (restricted to numeric / string-dimension fields; a DATE dim can't be a target), result caching (cache key includes the compiled SQL → SQL changes produce a different hash → no stale-format serve), saved filters with persisted ISO values (`formatDate` → bare date, still matches the DATE LHS), view-underlying-data / drill, sorting & totals (DATE dim is always group-by, never an aggregation target). One **genuine breaking** case: raw-`sql` table calcs doing TIMESTAMP-specific math on a truncated date dim (now error on BigQuery/Snowflake, promote on Postgres/Redshift) — **GLITCH-506**. Latent/pre-existing (not introduced here): MIN/MAX-on-date in CF (`Number(date)` → NaN, GLITCH-499 territory) and the period-over-period range pre-filter's DATE-vs-TIMESTAMP coercion — **fixed in GLITCH-505.** The pre-filter LHS came from the PoP `popField`'s raw explore `compiledSql` (not the tz-aware/cast SELECT expression), so it compared an un-cast `DATE_TRUNC(...)` against the now-`DATE` min/max boundaries (superset filter → never dropped rows). Fix: the three PoP range-prefilter sites now route `popField` through `getTimezoneAwareDimensionSql`, matching the SELECT/min/max cast.
 
 ## Intuition (why this matters)
 
@@ -77,7 +75,7 @@ CAST(DATE_TRUNC('day', "orders"."order_date" AT TIME ZONE 'UTC' AT TIME ZONE 'As
 The wrap-inactive branch (UTC project / round-trip no-op) also casts the raw `DATE_TRUNC(...)` to DATE — output must be `DATE` per the AC regardless of zone.
 
 **Gating:** thread a `castDayOrCoarserToDate` boolean param (default `false`) into `getSqlForTruncatedDate`. Pass `true` from:
-- `MetricQueryBuilder.getTimezoneAwareDimensionSql` — only reached when the flag is on; covers the SELECT and the WHERE LHS (filter parity).
+- `MetricQueryBuilder.getTimezoneAwareDimensionSql` — covers the SELECT and the WHERE LHS (filter parity).
 - `QueryBuilder/utils.ts → getDimensionFromId` (date-zoom) — **not applied, and GLITCH-505 confirmed this is the wrong location.** Date-zoom dims are replaced in place in the explore and resolved directly (not through `getDimensionFromId`'s un-cast `getDateDimension` branch), so their SELECT already casts via `getTimezoneAwareDimensionSql`. GLITCH-505's real fix was routing the PoP range pre-filter's `popField` through `getTimezoneAwareDimensionSql`.
 
 Default-`false` keeps the pre-aggregate and explore-compile callers unchanged.
@@ -102,9 +100,7 @@ The WHERE LHS reuses the SELECT expression, so after the cast it's a `DATE`. The
 
 **Out of scope — split to GLITCH-499:** `MIN`/`MAX` over a DATE column or day-grain dim. The formatter's MIN/MAX branch (`value instanceof Date || isTimestampString(value)` → `formatTimestamp`, from GLITCH-485) tz-**shifts** it — the value arrives as a JS `Date` (fresh) or `…T00:00:00Z` ISO string (cached), and *both* are caught and shifted, so it's not a date-string fall-through. Rendering it unshifted needs the aggregated column's underlying type on the metric (no signal on `Metric` today), so it's its own change.
 
-**Flag-off safety (proven, not assumed):** the formatter only ever receives a timezone via `displayTimezone = enabled ? resolvedTimezone : null` (`AsyncQueryService.ts:2836`). Flag OFF → no timezone → the DATE branch never shifts regardless of the predicate. So this change is **bit-identical when the flag is off** and correct when it's on.
-
-Downstream consumers of these predicates (CSV / Excel / Google Sheets exports, `normalizeCellRawForFilter` drill) stay correct: post-452 the raw value is a real date (flag-on), and flag-off supplies no timezone.
+Downstream consumers of these predicates (CSV / Excel / Google Sheets exports, `normalizeCellRawForFilter` drill) stay correct: post-452 the raw value is a real date.
 
 ### 4. The `raw` wire value (`formatRawValue`)
 
@@ -131,11 +127,10 @@ Today the DATE branch runs `dayjs(value).utc(true).format()` and emits a full IS
 - **Casting the instant instead of the wall-clock** → wrong date. Mitigated by dropping `toUTC` + the execution tests.
 - **Per-adapter cast/DATE syntax** differences (BigQuery `DATE()`, Athena no `::`). → **Resolved:** BigQuery `DATE(expr, tz)` implemented + execution-verified across all six warehouses.
 - **Filter-literal coercion** across warehouses (DATE vs literal).
-- **Pre-aggregate** materialized column stays TIMESTAMP while the live query returns DATE — acceptable for 452, follow-up. DuckDB pre-agg caches read **both** `"...T00:00:00Z"` and `"2026-05-19"` into the same `DATE` (schema-typed read), so old caches don't break across the flag flip.
+- **Pre-aggregate** materialized column stays TIMESTAMP while the live query returns DATE — acceptable for 452, follow-up. DuckDB pre-agg caches read **both** `"...T00:00:00Z"` and `"2026-05-19"` into the same `DATE` (schema-typed read), so old caches don't break across the format change.
 - **Postgres local-midnight `Date`** parsing footgun in `formatRawValue` (see §4).
-- **Google Sheets export** is the one display path that could shift in unusual locales (it `String(value)`s the raw) — eyeball a delivery test before flipping the flag. → **Verified:** dates render correctly; written as RAW text by design (avoids locale auto-parse).
-- **API consumers that match `raw` as an exact string** (logging, dedup keys, joins) **break**; consumers that `new Date(raw)` get a *bug fix*. This is the concrete "breaking" justification for the flag gate.
-- **Corner:** `EnableTimezoneSupport` OFF + a chart-pinned non-UTC tz could still supply a display tz; pre-existing edge, document don't fix here.
+- **Google Sheets export** is the one display path that could shift in unusual locales (it `String(value)`s the raw) — eyeball a delivery test when validating the change. → **Verified:** dates render correctly; written as RAW text by design (avoids locale auto-parse).
+- **API consumers that match `raw` as an exact string** (logging, dedup keys, joins) **break**; consumers that `new Date(raw)` get a *bug fix*.
 
 ## Verified low-impact (per issue codebase scan — GLITCH-452 comment, 2026-05-19)
 
@@ -150,14 +145,10 @@ Confirmed by a code walkthrough; both `raw` formats parse identically, so these 
 
 The published setup guide (docs.lightdash.com/workspace-admin/set-project-timezone) is **consistent but doesn't explicitly document this change**: it says day-or-coarser grouping "buckets data by calendar boundaries," that `DATE` values "never shift," and its custom-SQL example ends in `::date`. It does **not** state that built-in day-grain dimensions change warehouse output type — that explicit statement lives in the internal design doc (`timezones-v2-design.md`, principle 13, `gap-date-grain-output`). No customer-doc change needed for 452.
 
-## Flag-gating invariant (hard requirement)
-
-Every behavior here is **100% gated behind `EnableTimezoneSupport`**. Flag OFF ⇒ Lightdash behaves **exactly** as before this ticket — byte-identical SELECT / WHERE / `raw` / `formatted` / exports / ECharts. This is an explicit acceptance criterion, not a nicety: the cast, the `formatRawValue` change, and the predicate collapse must all be inert when the flag is off. (Formatting half is inert because flag-off supplies no `displayTimezone`; the SQL/`raw` halves are gated by `useTimezoneAwareDateTrunc` upstream — verify both with a flag-off snapshot.)
-
 ## Docs to update
 
 `docs/timezones/timezone-handling.md` (engineer-facing current-state reference) describes the DATE_TRUNC round-trip as "returns a real UTC instant" and the `formatDate` DATE-base correction — both change here. → **Done:** updated for the cast, the removed correction layer, the inert `normalizeCellRawForFilter`, and a per-adapter callout noting BigQuery `DATE(<expr>, '<tz>')`.
 
 ## Rollout
 
-Behind `EnableTimezoneSupport`. Shipped default OFF (v2 Phase 2) with per-user enablement; the default flipped ON in 1.22.0 (#26295). The flag still gates the old path and can be disabled per instance or per org.
+Timezone support is always active for all users.

--- a/docs/timezones/glitch-452-date-cast-design.md
+++ b/docs/timezones/glitch-452-date-cast-design.md
@@ -1,5 +1,7 @@
 # GLITCH-452 — Cast day-or-coarser DATE_TRUNCs to DATE at compile time
 
+> Timezone support is now always active. Feature-flag rollout and opt-out behavior described below is historical.
+
 **Status:** shipped (v2 Phase 2, Done) · **Flag:** `EnableTimezoneSupport` (TimezoneV2), default ON since 1.22.0 (#26295)
 **PRs:** #24231 (SQL cast) + #24251 (display / predicate collapse), stacked — ship together · design doc #24208 (merged)
 **Depends on:** GLITCH-450 (merged, #24086) — the consolidated calendar-value predicate this ticket updates.

--- a/docs/timezones/naive-timestamps-gaps.md
+++ b/docs/timezones/naive-timestamps-gaps.md
@@ -161,7 +161,7 @@ At display == data timezone the equal-zones skip drops the wrap and the two agre
 
 **Gap:** `gap-snowflake-optout-aware` · **Type:** bug
 
-Snowflake normally normalizes every TIMESTAMP dim at compile time (`TO_TIMESTAMP_NTZ(CONVERT_TIMEZONE('UTC', col))` in `translator.ts`). `disableTimestampConversion: true` skips that wrap — but the flag is **warehouse-wide**, so aware `TIMESTAMP_TZ`/`LTZ` columns lose their normalization along with the naive ones the modeler meant to opt out. Two failures result, both requiring `EnableTimezoneSupport` on:
+Snowflake normally normalizes every TIMESTAMP dim at compile time (`TO_TIMESTAMP_NTZ(CONVERT_TIMEZONE('UTC', col))` in `translator.ts`). `disableTimestampConversion: true` skips that wrap — but the flag is **warehouse-wide**, so aware `TIMESTAMP_TZ`/`LTZ` columns lose their normalization along with the naive ones the modeler meant to opt out. Two failures result:
 
 **(a) Hard error on the timezone-aware wraps.** Snowflake's 3-arg `CONVERT_TIMEZONE` accepts only NTZ input. A raw `TIMESTAMP_TZ` column flowing into a truncation/extract wrap (resolved timezone ≠ source) fails the whole query:
 

--- a/docs/timezones/timestamp-domains-design.md
+++ b/docs/timezones/timestamp-domains-design.md
@@ -273,8 +273,7 @@ behaviour, not a language guarantee; the BigQuery cases in
 `packages/api-tests/tests/queryTimezone.test.ts` and the day-partitioned
 `timezone_test` fixture are the regression gate.
 
-Deliberately unchanged: everything with the flag off, projects with a UTC data
-timezone, RAW dimensions with `convert_timezone: false`, DATE dimensions,
+Deliberately unchanged: projects with a UTC data timezone, RAW dimensions with `convert_timezone: false`, DATE dimensions,
 EXTRACT-based filters, and Snowflake.
 
 ## Why this is the right approach
@@ -300,9 +299,8 @@ What the chosen design provides:
 2. Unknown means unchanged. Every safety claim reduces to this single invariant,
    and it is asserted with byte-identity tests in every slice. Projects get correct
    as they redeploy; projects that never redeploy never change.
-3. No new feature flag. Everything rides the existing EnableTimezoneSupport
-   pipeline, which stays per-org overridable as the revert lever, and all of it
-   is inert when the flag is off or no data timezone is set.
+3. Timezone support is always active. Data-timezone conversion applies when
+   a data timezone is configured; without one, the source timezone is unchanged.
 
 One accepted limitation, inherent to naive storage under any strategy: during
 the DST fall-back, one wall-clock hour happens twice, so equality on a folded

--- a/docs/timezones/timezone-handling.md
+++ b/docs/timezones/timezone-handling.md
@@ -34,7 +34,7 @@ Answers: "what timezone are my NTZ (no-timezone) timestamps actually stored in?"
 
 For TZ columns (Postgres `timestamptz`, Snowflake `TIMESTAMP_TZ`) data timezone has no effect — those are absolute instants already.
 
-The setting is gated behind `EnableTimezoneSupport`. Flag off → `dataTimezone` is `undefined` and the session TZ isn't touched (old behavior).
+The setting is always available. When no data timezone is configured, each warehouse uses the defaults listed below.
 
 ### Project timezone (`queryTimezone`)
 
@@ -114,11 +114,9 @@ flowchart LR
     Compile --> Execute --> Format --> Render
 ```
 
-> **Flag OFF → pre-timezone-work behavior.** With `EnableTimezoneSupport` off: no session TZ is set (Snowflake still defaults to `'UTC'`), DATE_TRUNC runs in UTC, filter literals stay bare, `resolvedTimezone` is omitted from the API, and formatters pass values through as UTC — identical to `main` before this work started.
-
 ### SELECT — DATE_TRUNC grouping
 
-With `useTimezoneAwareDateTrunc` on, truncation is timezone-aware. The base dimension SQL is round-tripped through the project timezone so boundaries fall on project-local wall-clock midnights:
+Query compilation uses timezone-aware truncation. The base dimension SQL is round-tripped through the project timezone so boundaries fall on project-local wall-clock midnights:
 
 1. Shift the column value from its source TZ into project wall-clock
 2. Truncate on that wall-clock
@@ -130,7 +128,7 @@ With `useTimezoneAwareDateTrunc` on, truncation is timezone-aware. The base dime
 
 The source TZ for step 1 is derived once per query at the service boundary via `getColumnTimezone(credentials)` (in `packages/common/src/types/projects.ts`) and threaded through `timeFrames.ts` as `sourceTimezone`. It returns `'UTC'` for Snowflake when the translator wrap is active, `dataTimezone` when Snowflake's `disableTimestampConversion` opts out of that wrap, and `dataTimezone` (defaulting to UTC) for every other adapter. Most warehouses ignore it because their `toProjectTz` doesn't take a source TZ; Snowflake threads it into the inner `CONVERT_TIMEZONE`.
 
-The SQL differs per warehouse (some have native TZ-aware truncation, others compose `AT TIME ZONE` / `CONVERT_TIMEZONE` / `to_utc_timestamp`), but the shape is identical everywhere. Flag off → falls back to raw `DATE_TRUNC` grouping in UTC (old behavior).
+The SQL differs per warehouse (some have native TZ-aware truncation, others compose `AT TIME ZONE` / `CONVERT_TIMEZONE` / `to_utc_timestamp`), but the shape is identical everywhere.
 
 > **DST fall-back bucketing is standardized on merge (GLITCH-509).** A DST fall-back collapses the two wall-clock-identical 1 AM hours into one `count=2` bucket on **every** warehouse, matching Lightdash's wall-clock contract (both folds are "1 AM" locally). BigQuery and ClickHouse previously split the fold into two `01:00` rows via instant-domain truncation; they now merge like the naive-domain adapters (Postgres, Snowflake, Databricks, Trino, Redshift, DuckDB, Spark). This was a deliberate product decision (`gap-dst-fold-bucketing`, GLITCH-504) made because the merge route is convergent across all adapters. See [`timezone-questions.md`](./timezone-questions.md) → "DST fall-back".
 
@@ -142,7 +140,7 @@ The SQL differs per warehouse (some have native TZ-aware truncation, others comp
 
 **Truncated intervals on a DATE base dimension skip the round-trip.** A truncated interval whose base column is a DATE (e.g. `order_date_month`) falls back to raw `DATE_TRUNC`. DATE values carry no time component — casting one into `timestamptz` for the round-trip would anchor at midnight and then cross a day boundary whenever the project timezone has a non-zero offset.
 
-**Day-or-coarser grains converge on `DATE` regardless of base type (GLITCH-452).** A DATE-base interval emits raw `DATE_TRUNC` (already a DATE); a TIMESTAMP-base interval round-trips through project wall-clock and then `CAST(... AS DATE)`. Both return a real calendar `DATE`, so the warehouse type matches the dimension metadata (`DATE`) and no display-time correction is needed. The WHERE clause for these dimensions emits **bare date literals** (no `+00:00` offset, no `::timestamptz`) to compare cleanly against the `DATE` LHS — the same literal path DATE-base dimensions already used. Only sub-day TIMESTAMP-base grains still return a UTC instant. Gated by `castDayOrCoarserToDate` threaded from `MetricQueryBuilder.getTimezoneAwareDimensionSql`, so it is inert when the flag is off.
+**Day-or-coarser grains converge on `DATE` regardless of base type (GLITCH-452).** A DATE-base interval emits raw `DATE_TRUNC` (already a DATE); a TIMESTAMP-base interval round-trips through project wall-clock and then `CAST(... AS DATE)`. Both return a real calendar `DATE`, so the warehouse type matches the dimension metadata (`DATE`) and no display-time correction is needed. The WHERE clause for these dimensions emits **bare date literals** (no `+00:00` offset, no `::timestamptz`) to compare cleanly against the `DATE` LHS — the same literal path DATE-base dimensions already used. Only sub-day TIMESTAMP-base grains still return a UTC instant. The query builder passes `castDayOrCoarserToDate` from `MetricQueryBuilder.getTimezoneAwareDimensionSql`.
 
 **A custom MIN/MAX over a day-or-coarser interval aggregates the tz-aware `DATE` (GLITCH-499).** A custom metric that takes MIN/MAX of a day-grain DATE interval (a `DATE_TRUNC` of a TIMESTAMP base) inherited the dimension's raw `compiledSql` and skipped the round-trip above, so it truncated in UTC and returned a timestamp a calendar day off from its own dimension. `getTimezoneAwareMetricSql` re-points the aggregate at the dimension's timezone-aware `compiledSql` — the same wrap the SELECT applies — so the metric and its dimension agree on the day. It fires only for a MIN/MAX whose `baseDimensionType` is a truncatable interval `DATE` over a TIMESTAMP; plain DATE columns and TIMESTAMP bases are untouched, and the substring swap is a safe no-op if the base SQL doesn't match. The base dimension is resolved through the custom metric's `baseDimensionName`, so only custom metrics are affected — model/column YAML metrics are not. Uses `useTimezoneAwareDateTrunc` in the query builder.
 
@@ -241,7 +239,7 @@ Because it is now inert, the function (and its frontend call sites) is a candida
 
 ### Filter input pickers — project-TZ wall-clock
 
-Absolute-date filter pickers (`FilterDateTimePicker`, `FilterDateTimeRangePicker`) can optionally render their wall-clock value in the project timezone instead of the browser zone. This is a per-project opt-in on top of `EnableTimezoneSupport`:
+Absolute-date filter pickers (`FilterDateTimePicker`, `FilterDateTimeRangePicker`) can optionally render their wall-clock value in the project timezone instead of the browser zone. This is a per-project opt-in:
 
 - Per-project boolean `use_project_timezone_in_filters` on `projects` (`NOT NULL DEFAULT false`)
 - Project settings exposes it as a Switch on the "Project time zone" page (page was renamed from "Query time zone")
@@ -256,7 +254,7 @@ The toggle controls picker rendering for absolute boundaries, not the chain that
 
 ### Session — Warehouse timezone
 
-Each warehouse client sets the session timezone from `dataTimezone` before running the query, when `EnableTimezoneSupport` is on.
+Each warehouse client sets the session timezone from `dataTimezone` before running the query.
 
 | Warehouse  | Session command                               | Behavior when not set                   |
 | ---------- | --------------------------------------------- | --------------------------------------- |
@@ -326,7 +324,7 @@ flowchart LR
 
 > **Known limitation — MIN/MAX with an explicit DATE format and a raw `Date` value (unknown base only).** When a MIN/MAX carries a known DATE `baseDimensionType` (GLITCH-499), `formatItemValue` renders the bare calendar date at the base grain *before* reaching `applyCustomFormat`, so an explicit date/timestamp display format no longer shifts it. The limitation now survives only for a MIN/MAX with an **unknown** base (an arbitrary-SQL metric): `applyCustomFormat` has no `item` (so no base-type or `isCalendarValueItem` access) and its by-value gate only protects date-only **strings**, so a midnight `Date` object with an explicit DATE format shifts back a day under a negative offset. This is an accepted trade-off; the safe cached-results string shape is pinned in tests.
 
-> **Operator note — bare `DATE` `raw` values depend on the backend's process timezone (GLITCH-507). Run the backend in UTC.** `formatRawValue` builds the `YYYY-MM-DD` raw value with `dayjs(value).utc(true)`, which keeps the *process-local* wall-clock. Warehouse adapters hand it the DATE differently: Postgres returns a **local-midnight** `Date` (process-tz-independent here), but BigQuery and Snowflake return a **UTC-midnight** `Date` — so under a non-UTC process timezone the bare date can shift by a day on those warehouses. **Set `TZ=UTC` on every backend process (API server, scheduler worker, headless browser);** they are separate pods and each formats independently. We deliberately do not "correct" this in the formatter: no single `Date` component-read is correct across local-midnight (Postgres) and UTC-midnight (BigQuery/Snowflake) encodings, and the formatter has no warehouse context. Instead the backend logs a startup warning when `EnableTimezoneSupport` is configured and the process is not UTC (`getProcessTimezoneWarning`, `packages/backend/src/utils/processTimezone.ts`). This is **independent of `LIGHTDASH_QUERY_TIMEZONE`**, which sets the analytical query timezone interpolated into the SQL (`… AT TIME ZONE`), not the OS/process timezone.
+> **Operator note — bare `DATE` `raw` values depend on the backend's process timezone (GLITCH-507). Run the backend in UTC.** `formatRawValue` builds the `YYYY-MM-DD` raw value with `dayjs(value).utc(true)`, which keeps the *process-local* wall-clock. Warehouse adapters hand it the DATE differently: Postgres returns a **local-midnight** `Date` (process-tz-independent here), but BigQuery and Snowflake return a **UTC-midnight** `Date` — so under a non-UTC process timezone the bare date can shift by a day on those warehouses. **Set `TZ=UTC` on every backend process (API server, scheduler worker, headless browser);** they are separate pods and each formats independently. We deliberately do not "correct" this in the formatter: no single `Date` component-read is correct across local-midnight (Postgres) and UTC-midnight (BigQuery/Snowflake) encodings, and the formatter has no warehouse context. Instead the backend logs a startup warning when the process is not UTC (`getProcessTimezoneWarning`, `packages/backend/src/utils/processTimezone.ts`). This is **independent of `LIGHTDASH_QUERY_TIMEZONE`**, which sets the analytical query timezone interpolated into the SQL (`… AT TIME ZONE`), not the OS/process timezone.
 
 **Files:** `packages/common/src/utils/formatting.ts`, `packages/common/src/visualizations/helpers/getCartesianAxisFormatterConfig.ts`, `packages/common/src/visualizations/helpers/tooltipFormatter.ts`, `packages/common/src/types/api.ts`, `packages/backend/src/utils/processTimezone.ts`
 
@@ -482,7 +480,6 @@ flowchart TD
 | MetricQueryBuilder      | `packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts`        |
 | AsyncQueryService       | `packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts` |
 | Project timezone config | `packages/backend/src/services/ProjectService/ProjectService.ts`       |
-| Feature flags           | `packages/common/src/types/featureFlags.ts`                            |
 | Warehouse credentials   | `packages/common/src/types/projects.ts` (incl. `getColumnTimezone`)    |
 | Result formatting       | `packages/common/src/utils/formatting.ts`                              |
 | Warehouse clients       | `packages/warehouses/src/warehouseClients/`                            |

--- a/docs/timezones/timezone-handling.md
+++ b/docs/timezones/timezone-handling.md
@@ -23,22 +23,7 @@ In addition, three overrides sit on top of the project timezone (the session tim
 
 Resolution order: `session (embed URL) → chart → user → project → server default ('UTC')`. A viewer with no profile preference falls through to the project. A viewer with a profile timezone sees their zone on charts that don't pin one. An embedding host can pin a single session to a zone via the `?timezone=` URL param, which outranks even the chart pin. See [User-level timezone](#user-level-timezone) below.
 
-A single flag gates timezone behavior:
-
-| Flag                    | Env var                               | Gates                                                                                                                                                  |
-| ----------------------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `EnableTimezoneSupport` | `LIGHTDASH_ENABLE_TIMEZONE_SUPPORT`   | The whole timezone feature: data-timezone warehouse field + session-TZ setup, the "filter inputs in project TZ" toggle, the user-facing timezone pickers (Profile panel, Explorer chart-level), and per-viewer (user-profile) timezone resolution |
-
-The project timezone setting itself is always available. `resolveQueryTimezone` always honors a chart pinned to `user_timezone` — falling back to the project timezone only when the viewer has no stored profile preference. The `EnableTimezoneSupport` flag gates the surrounding pipeline (warehouse session setup, timezone-aware `DATE_TRUNC`, returning `displayTimezone`), so when the flag is off the resolved zone simply isn't applied to the query.
-
-**The flag is on by default.** Resolution order (`FeatureFlagModel`):
-
-1. `LIGHTDASH_DISABLE_FEATURE_FLAGS=enable-timezone-support` — instance-wide kill switch.
-2. `LIGHTDASH_ENABLE_TIMEZONE_SUPPORT` — when set to `true`/`false` it pins the flag instance-wide and the database is not consulted.
-3. `feature_flag_overrides` in the database — per-user override, then per-organization override, then the `feature_flags.default_enabled` row. This is how a single organization is opted out.
-4. No opinion anywhere → **enabled**.
-
-A database lookup failure is swallowed (logged as a warning) and falls through to the default, so an outage leaves the flag on rather than silently changing query semantics for everyone.
+Timezone support is always active for all users. Warehouse session setup, timezone-aware `DATE_TRUNC`, result formatting, and timezone controls do not require a feature flag. Projects without a configured timezone use the server default (`UTC` unless configured otherwise). The project setting still controls whether filter inputs use the project timezone.
 
 ### Data timezone (`dataTimezone`)
 
@@ -159,7 +144,7 @@ The SQL differs per warehouse (some have native TZ-aware truncation, others comp
 
 **Day-or-coarser grains converge on `DATE` regardless of base type (GLITCH-452).** A DATE-base interval emits raw `DATE_TRUNC` (already a DATE); a TIMESTAMP-base interval round-trips through project wall-clock and then `CAST(... AS DATE)`. Both return a real calendar `DATE`, so the warehouse type matches the dimension metadata (`DATE`) and no display-time correction is needed. The WHERE clause for these dimensions emits **bare date literals** (no `+00:00` offset, no `::timestamptz`) to compare cleanly against the `DATE` LHS — the same literal path DATE-base dimensions already used. Only sub-day TIMESTAMP-base grains still return a UTC instant. Gated by `castDayOrCoarserToDate` threaded from `MetricQueryBuilder.getTimezoneAwareDimensionSql`, so it is inert when the flag is off.
 
-**A custom MIN/MAX over a day-or-coarser interval aggregates the tz-aware `DATE` (GLITCH-499).** A custom metric that takes MIN/MAX of a day-grain DATE interval (a `DATE_TRUNC` of a TIMESTAMP base) inherited the dimension's raw `compiledSql` and skipped the round-trip above, so it truncated in UTC and returned a timestamp a calendar day off from its own dimension. `getTimezoneAwareMetricSql` re-points the aggregate at the dimension's timezone-aware `compiledSql` — the same wrap the SELECT applies — so the metric and its dimension agree on the day. It fires only for a MIN/MAX whose `baseDimensionType` is a truncatable interval `DATE` over a TIMESTAMP; plain DATE columns and TIMESTAMP bases are untouched, and the substring swap is a safe no-op if the base SQL doesn't match. The base dimension is resolved through the custom metric's `baseDimensionName`, so only custom metrics are affected — model/column YAML metrics are not. Behind `useTimezoneAwareDateTrunc`, inert when the flag is off.
+**A custom MIN/MAX over a day-or-coarser interval aggregates the tz-aware `DATE` (GLITCH-499).** A custom metric that takes MIN/MAX of a day-grain DATE interval (a `DATE_TRUNC` of a TIMESTAMP base) inherited the dimension's raw `compiledSql` and skipped the round-trip above, so it truncated in UTC and returned a timestamp a calendar day off from its own dimension. `getTimezoneAwareMetricSql` re-points the aggregate at the dimension's timezone-aware `compiledSql` — the same wrap the SELECT applies — so the metric and its dimension agree on the day. It fires only for a MIN/MAX whose `baseDimensionType` is a truncatable interval `DATE` over a TIMESTAMP; plain DATE columns and TIMESTAMP bases are untouched, and the substring swap is a safe no-op if the base SQL doesn't match. The base dimension is resolved through the custom metric's `baseDimensionName`, so only custom metrics are affected — model/column YAML metrics are not. Uses `useTimezoneAwareDateTrunc` in the query builder.
 
 ### SELECT — EXTRACT-based grouping
 
@@ -233,7 +218,7 @@ const formatTimestampAsUTCNoOffset = (date: Date): string =>
 
 **Filters on a day-or-coarser truncated interval emit bare date literals.** A filter on e.g. `order_date_month` emits bare date literals — no `+00:00`, no `::timestamptz` cast. For a DATE-base interval this was always the case; post-452 a TIMESTAMP-base interval at day-or-coarser grain compiles to a `DATE` too (the cast), so its filter takes the same bare-literal path. Same reason as the SELECT-side bypass: the LHS is a calendar value, so wrapping the literal as a timestamptz would re-introduce the midnight-anchor drift we're trying to avoid.
 
-**DATE-dimension boundaries are server-timezone-independent.** DATE-dimension filter boundaries are computed and formatted in UTC (flag off) or the project timezone (flag on) — never in the server's local timezone. Previously the default formatter used `moment(date)`, which read the process timezone — on a server with a positive UTC offset, `endOf('day')` would shift into the next calendar day and produce a 2-day filter range.
+**DATE-dimension boundaries are server-timezone-independent.** DATE-dimension filter boundaries are computed and formatted in the resolved query timezone — never in the server's local timezone. Previously the default formatter used `moment(date)`, which read the process timezone — on a server with a positive UTC offset, `endOf('day')` would shift into the next calendar day and produce a 2-day filter range.
 
 **File:** `packages/common/src/compiler/filtersCompiler.ts`
 
@@ -241,7 +226,7 @@ const formatTimestampAsUTCNoOffset = (date: Date): string =>
 
 When a user clicks a result cell to filter, drill, or view underlying rows, the row's raw value is fed into a filter rule. Pre-452, a day-or-coarser TIMESTAMP-base interval (e.g. `created_at_day`, `created_at_month`) stored a UTC instant while its displayed bucket was a project-TZ wall-clock date, so the raw instant had to be shifted into the project TZ first or the filter would target the previous calendar day in a positive-offset project (e.g. Europe/Paris). 452 makes the warehouse return a real `DATE` for those grains, so the raw value is already the bucket's calendar date — no correction is needed.
 
-`normalizeCellRawForFilter` (in `@lightdash/common`) is the guard that performed that shift. It only acts when `field.type === DATE` **and** `shouldShiftItemTimezone(field)` is true — but post-452 the latter is true only for `TIMESTAMP`-typed fields, so the two conditions are mutually exclusive and the function is now an inert pass-through (also a no-op with the flag off, since no resolved timezone is supplied). Every field shape now returns the raw value unchanged:
+`normalizeCellRawForFilter` (in `@lightdash/common`) is the guard that performed that shift. It only acts when `field.type === DATE` **and** `shouldShiftItemTimezone(field)` is true — but post-452 the latter is true only for `TIMESTAMP`-typed fields, so the two conditions are mutually exclusive and the function is now an inert pass-through. Every field shape now returns the raw value unchanged:
 
 | Field shape                                       | Shifted? | Reason                                                          |
 | ------------------------------------------------- | -------- | -------------------------------------------------------------- |
@@ -312,7 +297,7 @@ Sub-day DATE_TRUNC grains produce real UTC instants whose wall-clock alignment m
 
 `formatItemValue` resolves this once and threads it through every temporal branch; the shape predicates stay exported as primitives for the value-less callers (exports, filters, pivots, sidebar, axis config).
 
-**Timestamp metrics shift like dimensions.** A MIN or MAX over a timestamp column (e.g. "last seen") now renders in the project zone everywhere a dimension does — the explore table, Big Number tiles, and cartesian tooltips/labels — whether the value arrives as a fresh `Date` or as an ISO string rehydrated from cached results, and whether or not the user applied a display format. `applyCustomFormat` takes a `timezone` and routes timestamp **strings** (which are `Number()`-NaN and would otherwise return raw) through the temporal formatters before its numeric guard. With the flag off no timezone is resolved, so the string still renders raw — unchanged.
+**Timestamp metrics shift like dimensions.** A MIN or MAX over a timestamp column (e.g. "last seen") now renders in the project zone everywhere a dimension does — the explore table, Big Number tiles, and cartesian tooltips/labels — whether the value arrives as a fresh `Date` or as an ISO string rehydrated from cached results, and whether or not the user applied a display format. `applyCustomFormat` takes a `timezone` and routes timestamp **strings** (which are `Number()`-NaN and would otherwise return raw) through the temporal formatters before its numeric guard.
 
 The resolved timezone rides on the API response (`resolvedTimezone` on `ApiExecuteAsyncQueryResultsCommon`) and is threaded into every downstream formatter:
 

--- a/docs/timezones/timezone-questions.md
+++ b/docs/timezones/timezone-questions.md
@@ -107,11 +107,11 @@ This is the same order documented in [`timezone-handling.md:23`](./timezone-hand
 
 ### Is there a user-TZ concept at all? What's the roadmap?
 
-**Yes, today.** `users.timezone` (IANA string) is settable in Profile Settings → Default timezone, gated behind the `EnableTimezoneSupport` feature flag. Stored in the database, validated server-side in `UserService.ts`, threaded through every authenticated query.
+**Yes, today.** `users.timezone` (IANA string) is settable in Profile Settings → Default timezone. Stored in the database, validated server-side in `UserService.ts`, threaded through every authenticated query.
 
 **Admin opt-in**: yes — `EnableTimezoneSupport` defaults off and can be toggled per-org via `feature_flag_overrides`.
 
-**Flag-off behavior**: turning the flag off does NOT clear stored `users.timezone` values, but they are no longer applied — when `EnableTimezoneSupport` is off, the surrounding query pipeline (warehouse session setup, timezone-aware `DATE_TRUNC`, returning `displayTimezone`) is short-circuited, so the resolved zone is not applied to the query. The stored preference is preserved (non-destructive) and re-applies when the flag is turned back on.
+Timezone support is always active; stored user preferences apply to charts pinned to `user_timezone`.
 
 ### Scheduled deliveries & embeds — which TZ wins?
 
@@ -163,8 +163,6 @@ The DATE-base bypass at `filtersCompiler.ts` is the same logic as the SELECT-sid
 
 | Configuration | Alice's SQL == Bob's SQL? |
 |---|---|
-| `EnableTimezoneSupport=off`, no chart pin | ✅ Yes — both get project TZ |
-| `EnableTimezoneSupport=off`, chart pinned to `user_timezone` | ✅ Yes — flag off, both fall back to project TZ |
 | `EnableTimezoneSupport=on`, no chart pin | ✅ Yes — both get project TZ |
 | `EnableTimezoneSupport=on`, chart pinned to `user_timezone`, neither has profile TZ | ✅ Yes — both fall through to project |
 | `EnableTimezoneSupport=on`, chart pinned to `user_timezone`, both have profile TZs | ❌ No — Alice's WHERE uses Tokyo bounds, Bob's uses LA bounds |

--- a/docs/timezones/timezone-questions.md
+++ b/docs/timezones/timezone-questions.md
@@ -101,7 +101,7 @@ This is the same order documented in [`timezone-handling.md:23`](./timezone-hand
 
 ### Per-content choice between a pinned TZ and a viewer TZ?
 
-**Partially.** The per-chart pin in Explorer (chart-level `metricQuery.timezone`) gives an **author-pinned** mode — once set, every viewer sees that zone. A chart pinned to `user_timezone` with `EnableTimezoneSupport=on` gives a **viewer-TZ** mode — each viewer's profile drives the resolution.
+**Partially.** The per-chart pin in Explorer (chart-level `metricQuery.timezone`) gives an **author-pinned** mode — once set, every viewer sees that zone. A chart pinned to `user_timezone` gives a **viewer-TZ** mode — each viewer's profile drives the resolution.
 
 **What we don't have**: an *author-saved-at-save-time* default that silently inherits the author's zone. We require the author to explicitly pin if they want viewer-stable behavior. This is more honest, slightly less ergonomic.
 
@@ -109,7 +109,7 @@ This is the same order documented in [`timezone-handling.md:23`](./timezone-hand
 
 **Yes, today.** `users.timezone` (IANA string) is settable in Profile Settings → Default timezone. Stored in the database, validated server-side in `UserService.ts`, threaded through every authenticated query.
 
-**Admin opt-in**: yes — `EnableTimezoneSupport` defaults off and can be toggled per-org via `feature_flag_overrides`.
+**Availability**: timezone support is always available. Authors choose whether a chart follows the project, a specific timezone, or each viewer's profile.
 
 Timezone support is always active; stored user preferences apply to charts pinned to `user_timezone`.
 
@@ -163,10 +163,10 @@ The DATE-base bypass at `filtersCompiler.ts` is the same logic as the SELECT-sid
 
 | Configuration | Alice's SQL == Bob's SQL? |
 |---|---|
-| `EnableTimezoneSupport=on`, no chart pin | ✅ Yes — both get project TZ |
-| `EnableTimezoneSupport=on`, chart pinned to `user_timezone`, neither has profile TZ | ✅ Yes — both fall through to project |
-| `EnableTimezoneSupport=on`, chart pinned to `user_timezone`, both have profile TZs | ❌ No — Alice's WHERE uses Tokyo bounds, Bob's uses LA bounds |
-| `EnableTimezoneSupport=on`, chart pinned to Pacific | ✅ Yes — pin wins over profile |
+| no chart pin | ✅ Yes — both get project TZ |
+| chart pinned to `user_timezone`, neither has profile TZ | ✅ Yes — both fall through to project |
+| chart pinned to `user_timezone`, both have profile TZs | ❌ No — Alice's WHERE uses Tokyo bounds, Bob's uses LA bounds |
+| chart pinned to Pacific | ✅ Yes — pin wins over profile |
 | Dashboard date filter (absolute range) | ✅ Yes — absolute filters are UTC instants regardless of viewer |
 | Dashboard date filter (relative — "last 7 days") | depends on the chart settings as above |
 
@@ -407,15 +407,13 @@ Verified on Snowflake too: `CONVERT_TIMEZONE('America/New_York', '2026-06-09 12:
 
 ### What's the declared design intent — "consistent shape" or "viewer-local"?
 
-**Both, depending on configuration.** Off the rack with `EnableTimezoneSupport=off`:
-- Every viewer sees project-TZ buckets → **consistent chart shape**.
-
-With `EnableTimezoneSupport=on`:
+**Both, depending on the chart setting.**
+- Charts using the project timezone give every viewer the same project-TZ buckets → **consistent chart shape**.
 - Charts pinned to `user_timezone` shift per viewer → **viewer-local boundaries**.
 - Charts pinned to a specific zone override per viewer → **per-content choice**.
 
 So the architectural intent is "support both, default to consistent." **This is not documented anywhere a customer can find.** Customers discover it via:
-- The Profile Settings picker appearing or not appearing (depending on flag).
+- The default timezone picker in Profile Settings.
 - The badge on the chart card showing "America/New_York" when their profile is Tokyo.
 - "Why does my dashboard look different in Singapore than in NY?" support tickets.
 
@@ -428,7 +426,6 @@ So the architectural intent is "support both, default to consistent." **This is 
 | Issue | Severity | Effort | Location |
 |---|---|---|---|
 | ~~ECharts DST shift bug~~ ✅ fixed (GLITCH-449 → 509: all grains shift via companion column) | Correctness | 1d test + 2d fix | `packages/frontend/src/hooks/echarts/timezoneShift.ts` |
-| ~~`EnableTimezoneSupport=off` doesn't gate stored profile TZs~~ ✅ fixed | Correctness | 1d | `resolveQueryTimezone.ts` |
 | Scheduled deliveries TZ interaction undocumented (GLITCH-465, v3; now in the published timezone docs: workspace-admin/set-project-timezone and personal-settings/timezone) | Docs | 0.5d | `timezone-handling.md` |
 | Per-column wall-clock TZ annotation (GLITCH-463, v3) | Feature | 2d | `translator.ts` + `getColumnTimezone` |
 | ~~BigQuery half-hour offset bare-literal hole~~ ✅ not a bug (literal is a pre-converted UTC instant) | Correctness | 1d | `filtersCompiler.ts` |

--- a/docs/timezones/timezones-v2-design.md
+++ b/docs/timezones/timezones-v2-design.md
@@ -1,6 +1,6 @@
 # Timezones v2 — Design Principles
 
-> Timezone support is now always active. Feature-flag rollout and opt-out behavior described below is historical.
+> Timezone support is always active for all users.
 
 Distilled from the [Q&A](./timezone-questions.md). Each principle is one sentence + a status line.
 
@@ -41,12 +41,11 @@ Tags combine (e.g., `bug + breaking` for a correctness fix that, shipped without
 5. **Precedence: chart pin → user profile → project → UTC.**
    ✅ Implemented in `resolveQueryTimezone.ts`.
 
-6. **User-level TZ is an admin opt-in (org-wide feature flag).**
-   ✅ `EnableTimezoneSupport` — the single timezone feature flag (the former
-   `EnableUserTimezones` flag was merged into it).
+6. **User-level TZ is available to every user.**
+   ✅ The profile timezone applies to charts pinned to `user_timezone`.
 
-7. **Disabling the user-TZ feature must actually disable it, not just hide the picker.**
-   ✅ When `EnableTimezoneSupport` is off, the surrounding query pipeline (warehouse session setup, timezone-aware `DATE_TRUNC`, returning `displayTimezone`) is short-circuited, so the resolved zone is not applied to the query. The stored `users.timezone` is preserved (non-destructive) and re-applies when the flag is turned back on.
+7. **Timezone behavior is always active.**
+   ✅ Warehouse sessions, query compilation, and formatting apply the resolved timezone.
 
 8. **Resolved TZ persists with the query record; downstream paths read it back, never re-resolve.**
    ✅ Stamped onto `metricQuery.timezone` in `executePreparedAsyncQuery`.
@@ -158,7 +157,7 @@ Minimum affordance: a distinguishing icon for TZ-immune vs TZ-sensitive dimensio
     ❌ `gap-sql-runner-raw-display` *[bug]* — separately, the output *values* are serialized as UTC ISO `Z` regardless of type: TZ-aware values collapse to the UTC instant (offset dropped) and naive values get a false `Z`, so a user's in-SQL conversion is hidden or mislabeled. (GLITCH-489, v3)
 
 31. **A customer-facing doc explains the model — pinned vs viewer-TZ trade-off, DATE vs TIMESTAMP semantics,** `dataTimezone` **vs** `queryTimezone`**.**
-    ⚠️ `gap-customer-tz-doc` *[qol]* — Phase 3, pending publish (GLITCH-457, Todo). Published 2026-06-22, now split into docs.lightdash.com/workspace-admin/set-project-timezone (setup) and docs.lightdash.com/personal-settings/timezone (daily use); flag defaulted on in 1.22.0.
+    ⚠️ `gap-customer-tz-doc` *[qol]* — Phase 3, pending publish (GLITCH-457, Todo). Published 2026-06-22, now split into docs.lightdash.com/workspace-admin/set-project-timezone (setup) and docs.lightdash.com/personal-settings/timezone (daily use).
 
 ---
 
@@ -178,7 +177,7 @@ The goal of v2 is **alignment**: every timezone interaction in Lightdash should 
 
 - *Refactor (enabling).* `gap-calendar-predicate`
 - *QoL required for the contract to be explicit and explainable.* `gap-datatz-preview`, `gap-pin-ux-toggle`, `gap-cross-viewer-indicator`, `gap-tz-sensitivity-dim-affordance`, `gap-customer-tz-doc`
-- *Bugs.* `gap-echarts-dst`, `gap-flag-off-leak`, `gap-fractional-offset-tz`, `gap-date-grain-output`, `gap-auto-pin-default`
+- *Bugs.* `gap-echarts-dst`, `gap-fractional-offset-tz`, `gap-date-grain-output`, `gap-auto-pin-default`
 
 ### Out of scope for v2
 
@@ -187,9 +186,9 @@ All `feature` items, `gap-dual-conversion` (refactor), and the two narrow QoL it
 ### Phases
 
 1. ✅ **Backstage — complete.** `gap-calendar-predicate`, `gap-datatz-preview`. No customer-visible behavior change.
-2. ✅ **Correctness behind a flag — complete.** The five bugs gated by a per-project `TimezoneV2` flag, default OFF, paired with `gap-pin-ux-toggle`, `gap-cross-viewer-indicator`, and `gap-tz-sensitivity-dim-affordance` so the UI describes either mode honestly. The phase also closed the GLITCH-452 fallout cluster (exports, Date Zoom, raw-SQL table calcs, MIN/MAX rendering, picker affordance) and the DST fall-back bucketing decision (`gap-dst-fold-bucketing` → merge, GLITCH-509). Customer docs published 2026-06-22 (now docs.lightdash.com/workspace-admin/set-project-timezone and docs.lightdash.com/personal-settings/timezone); the flag defaulted ON in 1.22.0 (#26295).
-3. ⏳ **Flip the default — in progress.** After 60 days of opt-in adoption, flip `TimezoneV2` default to ON. Publish the customer doc (`gap-customer-tz-doc`, GLITCH-457). Old behavior survives 90 days as a project-level override, then is removed.
+2. ✅ **Correctness — complete.** The five bug fixes shipped alongside `gap-pin-ux-toggle`, `gap-cross-viewer-indicator`, and `gap-tz-sensitivity-dim-affordance` so the UI describes timezone behavior. The phase also closed the GLITCH-452 fallout cluster (exports, Date Zoom, raw-SQL table calcs, MIN/MAX rendering, picker affordance) and the DST fall-back bucketing decision (`gap-dst-fold-bucketing` → merge, GLITCH-509). Customer docs published 2026-06-22 (now docs.lightdash.com/workspace-admin/set-project-timezone and docs.lightdash.com/personal-settings/timezone).
+3. ✅ **General availability — complete.** Timezone support is always active. Customer setup and personal timezone documentation are published.
 
-After Phase 3, the design doc and the customer doc describe the same Lightdash.
+The design doc and the customer doc describe the same Lightdash.
 
-> **Status (Phases 1 & 2 shipped).** All in-scope correctness and QoL gaps are closed; the only remaining v2 work is the Phase 3 rollout (publish the customer doc, flip the default, retire the old path). Every other open gap in this doc is explicitly deferred to v3. Two follow-ups surfaced in the docs are not yet ticketed: a regression test for pre-aggregate buckets frozen after a project-TZ change, and a `moment-timezone` version-pinning policy.
+> **Status (all phases shipped).** All in-scope correctness and QoL gaps are closed, and timezone support is always active. Every other open gap in this doc is explicitly deferred to v3. Two follow-ups surfaced in the docs are not yet ticketed: a regression test for pre-aggregate buckets frozen after a project-TZ change, and a `moment-timezone` version-pinning policy.

--- a/docs/timezones/timezones-v2-design.md
+++ b/docs/timezones/timezones-v2-design.md
@@ -1,5 +1,7 @@
 # Timezones v2 — Design Principles
 
+> Timezone support is now always active. Feature-flag rollout and opt-out behavior described below is historical.
+
 Distilled from the [Q&A](./timezone-questions.md). Each principle is one sentence + a status line.
 
 **Legend.** ✅ already true · ⚠️ partial — gap noted · ❌ change needed.

--- a/packages/api-tests/tests/dataTimezone.test.ts
+++ b/packages/api-tests/tests/dataTimezone.test.ts
@@ -35,7 +35,6 @@ import {
  * Expected counts by day (queryTimezone = UTC, all cases):
  *   Jan 15 = 6, Jan 16 = 4
  *
- * Requires LIGHTDASH_ENABLE_TIMEZONE_SUPPORT=true in the environment.
  */
 
 let admin: ApiClient;

--- a/packages/api-tests/tests/embedTimezone.test.ts
+++ b/packages/api-tests/tests/embedTimezone.test.ts
@@ -168,13 +168,7 @@ describe('Embed dashboard-tile session timezone (?timezone=)', () => {
         const resp = await executeTile(token, SESSION_TIMEZONE);
 
         expect(resp.status).toBe(200);
-        // resolvedTimezone is the gated display timezone — null when
-        // EnableTimezoneSupport is off. When present, it must reflect the
-        // session timezone we passed, proving it reached the resolver and
-        // won over the chart pin / project default.
-        if (resp.body.results.resolvedTimezone !== null) {
-            expect(resp.body.results.resolvedTimezone).toBe(SESSION_TIMEZONE);
-        }
+        expect(resp.body.results.resolvedTimezone).toBe(SESSION_TIMEZONE);
     });
 
     it('totals inherit the session timezone without re-passing it', async () => {
@@ -214,30 +208,14 @@ describe('Embed dashboard-tile session timezone (?timezone=)', () => {
         expect(totalsResp.body.results.resolvedTimezone).toBe(resolvedTimezone);
     });
 
-    it('rejects an invalid session timezone with a 400 when timezone support is on', async () => {
+    it('rejects an invalid session timezone with a 400', async () => {
         const token = await freshDashboardJwt();
-
-        // Probe the flag: resolvedTimezone is null when EnableTimezoneSupport
-        // is off, in which case the session timezone is gated out before
-        // resolution and never validated.
-        const probe = await executeTile(token, SESSION_TIMEZONE);
-        expect(probe.status).toBe(200);
-        const timezoneSupportEnabled =
-            probe.body.results.resolvedTimezone !== null;
 
         const resp = await executeTile(token, 'Not/AZone', {
             failOnStatusCode: false,
         });
 
-        if (timezoneSupportEnabled) {
-            // Flag on: the invalid session timezone reaches the resolver and
-            // is rejected as a ParameterError.
-            expect(resp.status).toBe(400);
-            expect(resp.body).toHaveProperty('error');
-        } else {
-            // Flag off: the session timezone is dropped at the embed boundary,
-            // so the invalid value is inert and the query runs normally.
-            expect(resp.status).toBe(200);
-        }
+        expect(resp.status).toBe(400);
+        expect(resp.body).toHaveProperty('error');
     });
 });

--- a/packages/api-tests/tests/queryTimezone.test.ts
+++ b/packages/api-tests/tests/queryTimezone.test.ts
@@ -41,7 +41,6 @@ import {
  * Expected FILTER day > Jan 15 counts:
  *   UTC: 4 | New_York: 3 | Chicago: 3 | Tokyo: 5 | Pago_Pago: 2
  *
- * Requires LIGHTDASH_ENABLE_TIMEZONE_SUPPORT=true in the environment.
  */
 
 let admin: ApiClient;

--- a/packages/api-tests/tests/queryTimezoneBoundary.test.ts
+++ b/packages/api-tests/tests/queryTimezoneBoundary.test.ts
@@ -24,7 +24,6 @@ import {
  *   #18 2024-01-31 15:00Z  (month boundary)
  *
  * Asserts the bare-date `raw` bucket (the GLITCH-452 contract).
- * Requires LIGHTDASH_ENABLE_TIMEZONE_SUPPORT=true in the environment.
  */
 
 let admin: ApiClient;

--- a/packages/api-tests/tests/userTimezone.test.ts
+++ b/packages/api-tests/tests/userTimezone.test.ts
@@ -18,8 +18,6 @@ import {
  * (+9) shifts events into Jan 15/16/17 — distinct from the UTC layout
  * (Jan 15/16), so a wrong grouping is immediately visible.
  *
- * Requires LIGHTDASH_ENABLE_TIMEZONE_SUPPORT=true in the environment —
- * `user_timezone` resolution is gated on the EnableTimezoneSupport flag.
  */
 
 const DIMENSION_KEY = 'timezone_test_event_timestamp_day';

--- a/packages/backend/src/clients/EmailClient/EmailClient.mock.ts
+++ b/packages/backend/src/clients/EmailClient/EmailClient.mock.ts
@@ -24,7 +24,6 @@ export const lightdashConfigWithNoSMTP: Pick<
         timezone: undefined,
 
         retryQueryOnTransientErrors: false,
-        enableTimezoneSupport: undefined,
     },
 };
 
@@ -63,7 +62,6 @@ export const lightdashConfigWithBasicSMTP: Pick<
         timezone: undefined,
 
         retryQueryOnTransientErrors: false,
-        enableTimezoneSupport: undefined,
     },
 };
 
@@ -89,7 +87,6 @@ export const lightdashConfigWithOauth2SMTP: Pick<
         timezone: undefined,
 
         retryQueryOnTransientErrors: false,
-        enableTimezoneSupport: undefined,
     },
 };
 
@@ -111,7 +108,6 @@ export const lightdashConfigWithSecurePortSMTP: Pick<
         timezone: undefined,
 
         retryQueryOnTransientErrors: false,
-        enableTimezoneSupport: undefined,
     },
 };
 

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -288,7 +288,6 @@ export const lightdashConfigMock: LightdashConfig = {
         csvMaxLimit: 5000000,
         timezone: undefined,
         retryQueryOnTransientErrors: true,
-        enableTimezoneSupport: undefined,
     },
     ai: {
         copilot: {

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1569,7 +1569,6 @@ export type LightdashConfig = {
         timezone: string | undefined;
         maxPageSize: number;
         retryQueryOnTransientErrors: boolean;
-        enableTimezoneSupport: boolean | undefined;
     };
     pivotTable: {
         maxColumnLimit: number;
@@ -3349,9 +3348,6 @@ export const parseConfig = (): LightdashConfig => {
                 ? process.env.LIGHTDASH_QUERY_RETRY_ON_TRANSIENT_ERRORS ===
                   'true'
                 : false,
-            enableTimezoneSupport: process.env.LIGHTDASH_ENABLE_TIMEZONE_SUPPORT
-                ? process.env.LIGHTDASH_ENABLE_TIMEZONE_SUPPORT === 'true'
-                : undefined,
         },
         dashboard: {
             maxTilesPerTab:

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.test.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.test.ts
@@ -875,7 +875,6 @@ describe('EmbedService', () => {
                             };
                         }),
                     combineParameters,
-                    isTimezoneSupportEnabled: vi.fn().mockResolvedValue(false),
                     getQueryTimezoneForProject: vi
                         .fn()
                         .mockResolvedValue('UTC'),
@@ -1166,9 +1165,6 @@ describe('EmbedService', () => {
                             staticResults: null,
                         }),
                         combineParameters,
-                        isTimezoneSupportEnabled: vi
-                            .fn()
-                            .mockResolvedValue(false),
                         getQueryTimezoneForProject: vi
                             .fn()
                             .mockResolvedValue('UTC'),

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -1074,7 +1074,6 @@ export class EmbedService extends BaseService {
         timezone,
         dateZoomGranularity,
         combinedParameters,
-        useTimezoneAwareDateTrunc,
     }: {
         projectUuid: string;
         metricQuery: MetricQuery;
@@ -1102,7 +1101,6 @@ export class EmbedService extends BaseService {
         timezone: string;
         dateZoomGranularity?: DateGranularity | string;
         combinedParameters?: ParametersValuesMap;
-        useTimezoneAwareDateTrunc: boolean;
     }) {
         const { warehouseClient, sshTunnel } = await this._getWarehouseClient(
             account,
@@ -1136,7 +1134,7 @@ export class EmbedService extends BaseService {
                     : undefined,
                 parameters: combinedParameters,
                 availableParameterDefinitions,
-                useTimezoneAwareDateTrunc,
+                useTimezoneAwareDateTrunc: true,
                 columnTimezone: getColumnTimezone(warehouseClient.credentials),
                 dataTimezone: warehouseClient.credentials.dataTimezone,
             },
@@ -1304,25 +1302,17 @@ export class EmbedService extends BaseService {
 
         // Resolve feature/permission/explore/org-context in parallel — these
         // are independent once the chart is known.
-        const [, , explore, isTimezoneSupportEnabled, projectParameters] =
-            await Promise.all([
-                this.isFeatureEnabled({ userUuid, organizationUuid }),
-                this._permissionsGetChartAndResults(
-                    { allowAllDashboards, dashboardUuids },
-                    projectUuid,
-                    chart.uuid,
-                    dashboardUuid,
-                ),
-                this.projectModel.getExploreFromCache(
-                    projectUuid,
-                    chart.tableName,
-                ),
-                this.projectService.isTimezoneSupportEnabled({
-                    userUuid,
-                    organizationUuid,
-                }),
-                this.projectService.projectParametersModel.find(projectUuid),
-            ]);
+        const [, , explore, projectParameters] = await Promise.all([
+            this.isFeatureEnabled({ userUuid, organizationUuid }),
+            this._permissionsGetChartAndResults(
+                { allowAllDashboards, dashboardUuids },
+                projectUuid,
+                chart.uuid,
+                dashboardUuid,
+            ),
+            this.projectModel.getExploreFromCache(projectUuid, chart.tableName),
+            this.projectService.projectParametersModel.find(projectUuid),
+        ]);
 
         if (isExploreError(explore)) {
             throw new ForbiddenError(
@@ -1375,9 +1365,7 @@ export class EmbedService extends BaseService {
             context: QueryExecutionContext.EMBED,
             parameters: acceptedUserParameters,
             pivotResults,
-            sessionTimezone: isTimezoneSupportEnabled
-                ? (timezone ?? null)
-                : null,
+            sessionTimezone: timezone ?? null,
         });
     }
 
@@ -1663,13 +1651,8 @@ export class EmbedService extends BaseService {
             projectTimezone,
             userTimezone: null,
         });
-        const isTimezoneSupportEnabled =
-            await this.projectService.isTimezoneSupportEnabled({
-                userUuid: user?.userUuid ?? account.user.id,
-                organizationUuid,
-            });
 
-        const displayTimezone = isTimezoneSupportEnabled ? timezone : undefined;
+        const displayTimezone = timezone;
 
         const { rows, cacheMetadata, fields } = await this._runEmbedQuery({
             projectUuid,
@@ -1689,7 +1672,6 @@ export class EmbedService extends BaseService {
             timezone,
             dateZoomGranularity,
             combinedParameters,
-            useTimezoneAwareDateTrunc: isTimezoneSupportEnabled,
         });
 
         return {
@@ -2568,20 +2550,10 @@ export class EmbedService extends BaseService {
             dashboard ? getDashboardParametersValuesMap(dashboard) : {},
         );
 
-        const useTimezoneAwareDateTrunc =
-            await this.projectService.isTimezoneSupportEnabled({
-                userUuid: user?.userUuid ?? account.user.id,
-                organizationUuid,
-            });
-
         const projectTimezone =
             await this.projectService.getQueryTimezoneForProject(projectUuid);
         const timezone = resolveQueryTimezone({
-            // Gated like the tile path: the session timezone is dropped unless
-            // timezone support is enabled, leaving the param inert.
-            sessionTimezone: useTimezoneAwareDateTrunc
-                ? (sessionTimezoneParam ?? null)
-                : null,
+            sessionTimezone: sessionTimezoneParam ?? null,
             metricQuery,
             projectTimezone,
             userTimezone: null,
@@ -2602,7 +2574,6 @@ export class EmbedService extends BaseService {
             },
             account,
             timezone,
-            useTimezoneAwareDateTrunc,
             combinedParameters,
         });
 

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -18,8 +18,6 @@ installProcessExitLogging();
 (async () => {
     try {
         const timezoneWarning = getProcessTimezoneWarning({
-            enableTimezoneSupport:
-                lightdashConfig.query.enableTimezoneSupport !== false,
             timezoneOffsetMinutes: new Date().getTimezoneOffset(),
         });
         if (timezoneWarning) {

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.test.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.test.ts
@@ -364,7 +364,7 @@ describe('FeatureFlagModel', () => {
         });
 
         it('leaves config-derived flags to their handler', async () => {
-            // ai-copilot, results-cache-enabled and enable-timezone-support are
+            // ai-copilot and results-cache-enabled are
             // excluded so previews never advertise unconfigured backends.
             const model = buildModel({
                 ...previewConfig,
@@ -577,71 +577,6 @@ describe('FeatureFlagModel', () => {
         });
     });
 
-    describe('EnableTimezoneSupport defaults to on', () => {
-        const withTimezoneSupport = (enableTimezoneSupport: boolean) => ({
-            query: { ...lightdashConfigMock.query, enableTimezoneSupport },
-        });
-
-        it('is enabled when neither config nor database has an opinion', async () => {
-            const model = buildModel({}, buildFakeDatabase({}));
-
-            const result = await model.get({
-                featureFlagId: FeatureFlags.EnableTimezoneSupport,
-                user: dbUser,
-            });
-
-            expect(result).toEqual({
-                id: FeatureFlags.EnableTimezoneSupport,
-                enabled: true,
-            });
-        });
-
-        it('is disabled by an organization override', async () => {
-            const model = buildModel(
-                {},
-                buildFakeDatabase({
-                    flag: { default_enabled: null },
-                    orgOverride: { enabled: false },
-                }),
-            );
-
-            const result = await model.get({
-                featureFlagId: FeatureFlags.EnableTimezoneSupport,
-                user: dbUser,
-            });
-
-            expect(result.enabled).toBe(false);
-        });
-
-        it('is disabled by LIGHTDASH_ENABLE_TIMEZONE_SUPPORT=false, ignoring the database', async () => {
-            const model = buildModel(
-                withTimezoneSupport(false),
-                buildFakeDatabase({ flag: { default_enabled: true } }),
-            );
-
-            const result = await model.get({
-                featureFlagId: FeatureFlags.EnableTimezoneSupport,
-                user: dbUser,
-            });
-
-            expect(result.enabled).toBe(false);
-        });
-
-        it('stays enabled when LIGHTDASH_ENABLE_TIMEZONE_SUPPORT=true, ignoring the database', async () => {
-            const model = buildModel(
-                withTimezoneSupport(true),
-                buildFakeDatabase({ orgOverride: { enabled: false } }),
-            );
-
-            const result = await model.get({
-                featureFlagId: FeatureFlags.EnableTimezoneSupport,
-                user: dbUser,
-            });
-
-            expect(result.enabled).toBe(true);
-        });
-    });
-
     describe('ensureOrganizationOverrideEnabled', () => {
         const FLAG_ID = 'homepage-builder';
         const ORG_UUID = 'org-uuid';
@@ -720,25 +655,6 @@ describe('FeatureFlagModel', () => {
 
         afterEach(() => {
             warnSpy.mockRestore();
-        });
-
-        it('does not throw when EnableTimezoneSupport DB lookup fails', async () => {
-            // Falls back to the default (on) rather than propagating.
-            const model = buildModel({}, throwingDatabase);
-
-            const result = await model.get({
-                featureFlagId: FeatureFlags.EnableTimezoneSupport,
-                user: {
-                    userUuid: 'external::not-a-uuid',
-                    organizationUuid: 'org-uuid',
-                },
-            });
-
-            expect(result).toEqual({
-                id: FeatureFlags.EnableTimezoneSupport,
-                enabled: true,
-            });
-            expect(warnSpy).toHaveBeenCalled();
         });
 
         it('does not throw when EnableDataApps DB lookup fails', async () => {

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
@@ -55,8 +55,6 @@ export class FeatureFlagModel {
         // Initialize the handlers for feature flag logic
         this.featureFlagHandlers = {
             [FeatureFlags.EditYamlInUi]: this.getEditYamlInUiEnabled.bind(this),
-            [FeatureFlags.EnableTimezoneSupport]:
-                this.getEnableTimezoneSupportEnabled.bind(this),
             [FeatureFlags.EnableDataApps]:
                 this.getEnableDataAppsEnabled.bind(this),
             [FeatureFlags.ResultsCacheEnabled]: (flagArgs, options) =>
@@ -147,22 +145,6 @@ export class FeatureFlagModel {
             id: featureFlagId,
             enabled: this.lightdashConfig.editYamlInUi.enabled,
         };
-    }
-
-    // On by default. Disable it instance-wide with
-    // LIGHTDASH_ENABLE_TIMEZONE_SUPPORT=false (or LIGHTDASH_DISABLE_FEATURE_FLAGS),
-    // or per organization/user with a `feature_flag_overrides` row.
-    private async getEnableTimezoneSupportEnabled(
-        args: FeatureFlagLogicArgs,
-        options: FeatureFlagQueryOptions = {},
-    ): Promise<FeatureFlag> {
-        if (this.lightdashConfig.query.enableTimezoneSupport !== undefined) {
-            return {
-                id: args.featureFlagId,
-                enabled: this.lightdashConfig.query.enableTimezoneSupport,
-            };
-        }
-        return this.getWithEnvFallback(args, true, options);
     }
 
     private async getEnableDataAppsEnabled(

--- a/packages/backend/src/scheduler.ts
+++ b/packages/backend/src/scheduler.ts
@@ -15,8 +15,6 @@ installProcessExitLogging();
 (async () => {
     if (process.env.CI !== 'true') {
         const timezoneWarning = getProcessTimezoneWarning({
-            enableTimezoneSupport:
-                lightdashConfig.query.enableTimezoneSupport !== false,
             timezoneOffsetMinutes: new Date().getTimezoneOffset(),
         });
         if (timezoneWarning) {

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -546,6 +546,43 @@ type JwtDashboardQueryContextTestService = {
 };
 
 describe('AsyncQueryService', () => {
+    describe('timezone resolution', () => {
+        test.each([
+            {
+                projectTimezone: undefined,
+                sessionTimezone: null,
+                expected: 'UTC',
+            },
+            {
+                projectTimezone: 'Asia/Tokyo',
+                sessionTimezone: null,
+                expected: 'Asia/Tokyo',
+            },
+            {
+                projectTimezone: 'Asia/Tokyo',
+                sessionTimezone: 'America/New_York',
+                expected: 'America/New_York',
+            },
+        ])(
+            'always applies $expected to result formatting',
+            async ({ projectTimezone, sessionTimezone, expected }) => {
+                const service = getMockedAsyncQueryService(lightdashConfigMock);
+                const context = await service['resolveTimezoneContext']({
+                    projectUuid,
+                    metricQuery: { ...metricQueryMock, timezone: undefined },
+                    sessionTimezone,
+                    userTimezone: null,
+                    preloadedProjectTimezone: projectTimezone,
+                });
+
+                expect(context).toEqual({
+                    resolvedTimezone: expected,
+                    displayTimezone: expected,
+                });
+            },
+        );
+    });
+
     describe('saved SQL chart access', () => {
         test('resolves access through the saved SQL chart target', async () => {
             const resolveAccess = vi.fn(async () => ({
@@ -1662,11 +1699,9 @@ describe('AsyncQueryService', () => {
             );
         });
 
-        // Regression: persisted metric_query.timezone must follow the gated
-        // displayTimezone, not the ungated resolvedTimezone — otherwise
-        // downstream readers (formatTimestamp, downloads, worker re-exec)
-        // apply a +TZ shift on flag-off orgs that have a project timezone.
-        test('persists displayTimezone=null when flag is off, even if a resolved timezone exists', async () => {
+        // Persist the display timezone supplied by the query composer, including
+        // null for query paths that do not format temporal results.
+        test('persists no timezone when the composer has no display timezone', async () => {
             (
                 serviceWithCache.findResultsCache as import('vitest').Mock
             ).mockResolvedValueOnce({
@@ -1694,10 +1729,8 @@ describe('AsyncQueryService', () => {
                         query_context: QueryExecutionContext.EXPLORE,
                     },
                     invalidateCache: false,
-                    // Resolved tz is set (project has query_timezone) but
-                    // the gating flag is off — SQL was built without a
-                    // timezone-aware DATE_TRUNC, so the persisted snapshot
-                    // must not carry the resolved value either.
+                    // A composer without a display timezone must not persist
+                    // its SQL compilation timezone for result formatting.
                     queryComposer: createQueryComposerMock({
                         timezone: 'Asia/Tokyo',
                         displayTimezone: null,
@@ -1720,7 +1753,7 @@ describe('AsyncQueryService', () => {
             );
         });
 
-        test('persists displayTimezone when flag is on', async () => {
+        test('persists the resolved displayTimezone', async () => {
             (
                 serviceWithCache.findResultsCache as import('vitest').Mock
             ).mockResolvedValueOnce({

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -3457,14 +3457,8 @@ export class AsyncQueryService extends ProjectService {
                 tunnelConnectMs = warehouseConnection.tunnelConnectMs;
             }
 
-            const isTimezoneSupportEnabled =
-                await this.isTimezoneSupportEnabled({
-                    userUuid,
-                    organizationUuid,
-                });
-            const resolvedDataTimezone = isTimezoneSupportEnabled
-                ? warehouseClient.credentials.dataTimezone
-                : undefined;
+            const resolvedDataTimezone =
+                warehouseClient.credentials.dataTimezone;
 
             const t0 = Date.now();
 
@@ -3841,30 +3835,24 @@ export class AsyncQueryService extends ProjectService {
 
     /**
      * Resolves both the honest `resolvedTimezone` (always a valid TZ string,
-     * used for SQL compilation + cache keys) and the flag-gated
-     * `displayTimezone` (null when timezone-aware DATE_TRUNC is off — this is
-     * what reaches API responses and the row formatter).
+     * used for SQL compilation + cache keys) and `displayTimezone`
+     * for API responses and the row formatter.
      */
     private async resolveTimezoneContext({
         projectUuid,
-        organizationUuid,
-        userUuid,
         userTimezone,
         sessionTimezone,
         metricQuery,
         preloadedProjectTimezone,
     }: {
         projectUuid: string | null;
-        organizationUuid: string;
-        userUuid: string;
         userTimezone: string | null;
         sessionTimezone: string | null;
         metricQuery: MetricQuery;
         preloadedProjectTimezone?: string;
     }): Promise<{
         resolvedTimezone: string;
-        displayTimezone: string | null;
-        enabled: boolean;
+        displayTimezone: string;
     }> {
         const projectTimezone =
             preloadedProjectTimezone ??
@@ -3877,14 +3865,9 @@ export class AsyncQueryService extends ProjectService {
             projectTimezone,
             userTimezone,
         });
-        const enabled = await this.isTimezoneSupportEnabled({
-            userUuid,
-            organizationUuid,
-        });
         return {
             resolvedTimezone,
-            displayTimezone: enabled ? resolvedTimezone : null,
-            enabled,
+            displayTimezone: resolvedTimezone,
         };
     }
 
@@ -4383,25 +4366,20 @@ export class AsyncQueryService extends ProjectService {
             preloadedProjectParameters,
         );
 
-        const {
-            resolvedTimezone,
-            displayTimezone,
-            enabled: useTimezoneAwareDateTrunc,
-        } = await this.resolveTimezoneContext({
-            projectUuid,
-            organizationUuid: account.organization.organizationUuid,
-            userUuid: account.user.id,
-            // Pre-aggregate materializations build shared tables queried by
-            // every viewer — they must compile against the project timezone,
-            // not the triggering user's profile preference.
-            userTimezone:
-                materializationRole !== undefined
-                    ? null
-                    : getAccountUserTimezone(account),
-            sessionTimezone: sessionTimezone ?? null,
-            metricQuery,
-            preloadedProjectTimezone,
-        });
+        const { resolvedTimezone, displayTimezone } =
+            await this.resolveTimezoneContext({
+                projectUuid,
+                // Pre-aggregate materializations build shared tables queried by
+                // every viewer — they must compile against the project timezone,
+                // not the triggering user's profile preference.
+                userTimezone:
+                    materializationRole !== undefined
+                        ? null
+                        : getAccountUserTimezone(account),
+                sessionTimezone: sessionTimezone ?? null,
+                metricQuery,
+                preloadedProjectTimezone,
+            });
 
         return new QueryComposer(
             { metricQuery, pivotConfiguration, totalConfiguration },
@@ -4417,7 +4395,7 @@ export class AsyncQueryService extends ProjectService {
                 dateZoom,
                 pivotDimensions: pivotDimensions ?? metricQuery.pivotDimensions,
                 skipModelRequiredFilters,
-                useTimezoneAwareDateTrunc,
+                useTimezoneAwareDateTrunc: true,
                 columnTimezone,
                 dataTimezone,
                 applyDateZoomToFilters,
@@ -4545,15 +4523,8 @@ export class AsyncQueryService extends ProjectService {
                     // Mirrors runAsyncWarehouseQuery's resolvedDataTimezone:
                     // the session (data) timezone changes results without
                     // changing the SQL text, so it is part of the cache key.
-                    const isTimezoneSupportEnabled =
-                        await this.isTimezoneSupportEnabled({
-                            userUuid: account.user.id,
-                            organizationUuid:
-                                account.organization.organizationUuid,
-                        });
-                    const resolvedDataTimezone = isTimezoneSupportEnabled
-                        ? warehouseCredentials.dataTimezone
-                        : undefined;
+                    const resolvedDataTimezone =
+                        warehouseCredentials.dataTimezone;
                     // Generate cache key from project and query identifiers
                     // Include user UUID to prevent cache sharing between users when user-specific credentials are in use
                     // Use the resolved timezone (not metricQuery.timezone) because the
@@ -10534,14 +10505,10 @@ export class AsyncQueryService extends ProjectService {
 
         // GLITCH-452: format subtotal raw values with the same resolved display
         // timezone as the main rows so DATE dimensions compare and render
-        // identically (null when the timezone flag is off → legacy ISO output).
+        // identically.
         const { displayTimezone } = await this.resolveTimezoneContext({
             projectUuid,
-            organizationUuid,
-            userUuid: account.user.id,
             userTimezone: getAccountUserTimezone(account),
-            // Only used as a presence gate for DATE raw formatting; the flag
-            // null-vs-set gating is independent of sessionTimezone.
             sessionTimezone: null,
             metricQuery,
         });

--- a/packages/backend/src/services/ProjectService/ProjectService.mock.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.mock.ts
@@ -538,7 +538,6 @@ export const lightdashConfigWithNoSMTP: Pick<
         csvMaxLimit: 5000000,
         timezone: undefined,
         retryQueryOnTransientErrors: false,
-        enableTimezoneSupport: undefined,
     },
 };
 

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -5143,19 +5143,7 @@ describe('ProjectService', () => {
             vi.useRealTimers();
         });
 
-        it('throws ForbiddenError when timezone support is disabled', async () => {
-            await expect(
-                service.previewDataTimezone(previewAccount, {
-                    mode: 'create',
-                    credentials,
-                }),
-            ).rejects.toThrowError(ForbiddenError);
-        });
-
         it('splits the preview into affected naive and unaffected aware groups (edit flow)', async () => {
-            vi.spyOn(service, 'isTimezoneSupportEnabled').mockResolvedValueOnce(
-                true,
-            );
             (
                 projectModel.getWithSensitiveFields as import('vitest').Mock
             ).mockResolvedValueOnce({
@@ -5191,9 +5179,6 @@ describe('ProjectService', () => {
         });
 
         it('rejects an edit preview when the warehouse type was switched but not saved', async () => {
-            vi.spyOn(service, 'isTimezoneSupportEnabled').mockResolvedValueOnce(
-                true,
-            );
             (
                 projectModel.getWithSensitiveFields as import('vitest').Mock
             ).mockResolvedValueOnce({
@@ -5214,9 +5199,6 @@ describe('ProjectService', () => {
         });
 
         it('throws ForbiddenError when the user cannot update the project (edit flow)', async () => {
-            vi.spyOn(service, 'isTimezoneSupportEnabled').mockResolvedValueOnce(
-                true,
-            );
             (
                 projectModel.getWithSensitiveFields as import('vitest').Mock
             ).mockResolvedValueOnce({
@@ -5237,10 +5219,6 @@ describe('ProjectService', () => {
         });
 
         it('throws ForbiddenError when the user cannot create projects (create flow)', async () => {
-            vi.spyOn(service, 'isTimezoneSupportEnabled').mockResolvedValueOnce(
-                true,
-            );
-
             await expect(
                 service.previewDataTimezone(noAccessAccount, {
                     mode: 'create',

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -4398,14 +4398,6 @@ export class ProjectService extends BaseService {
         body: DataTimezonePreviewRequest,
     ): Promise<ApiDataTimezonePreviewResults> {
         assertIsAccountWithOrg(account);
-        if (
-            !(await this.isTimezoneSupportEnabled({
-                userUuid: account.user.userUuid,
-                organizationUuid: account.organization.organizationUuid,
-            }))
-        ) {
-            throw new ForbiddenError('Timezone support is not enabled');
-        }
 
         const auditedAbility = this.createAuditedAbility(account);
 
@@ -5835,10 +5827,6 @@ export class ProjectService extends BaseService {
             projectTimezone,
             userTimezone: getAccountUserTimezone(account),
         });
-        const useTimezoneAwareDateTrunc = await this.isTimezoneSupportEnabled({
-            userUuid: account.user.id,
-            organizationUuid: account.organization.organizationUuid,
-        });
 
         const queryComposer = new QueryComposer(
             { metricQuery, pivotConfiguration, asCteBody: args.asCteBody },
@@ -5854,7 +5842,7 @@ export class ProjectService extends BaseService {
                 pivotDimensions,
                 pivotItemsMap: undefined,
                 continueOnError: true, // Return SQL even with compilation errors for debugging
-                useTimezoneAwareDateTrunc,
+                useTimezoneAwareDateTrunc: true,
                 columnTimezone: getColumnTimezone(warehouseCredentials),
                 dataTimezone: warehouseCredentials.dataTimezone,
                 applyDateZoomToFilters: undefined,
@@ -7740,12 +7728,6 @@ export class ProjectService extends BaseService {
                         projectTimezone,
                         userTimezone: getAccountUserTimezone(account),
                     });
-                    const useTimezoneAwareDateTrunc =
-                        await this.isTimezoneSupportEnabled({
-                            userUuid: account.user.id,
-                            organizationUuid:
-                                account.organization.organizationUuid,
-                        });
 
                     const fullQuery = new QueryComposer(
                         { metricQuery: metricQueryWithLimit },
@@ -7760,7 +7742,7 @@ export class ProjectService extends BaseService {
                             availableParameterDefinitions,
                             pivotDimensions:
                                 metricQueryWithLimit.pivotDimensions,
-                            useTimezoneAwareDateTrunc,
+                            useTimezoneAwareDateTrunc: true,
                             columnTimezone: getColumnTimezone(
                                 warehouseClient.credentials,
                             ),
@@ -7881,9 +7863,7 @@ export class ProjectService extends BaseService {
                         rows,
                         cacheMetadata,
                         fields: fieldsWithOverrides,
-                        displayTimezone: useTimezoneAwareDateTrunc
-                            ? timezone
-                            : undefined,
+                        displayTimezone: timezone,
                         warehouseType: warehouseClient.credentials.type,
                     };
                 } catch (e) {
@@ -8391,7 +8371,6 @@ export class ProjectService extends BaseService {
             availableParameterDefinitions,
             combinedParameters,
             projectTimezone,
-            useTimezoneAwareDateTrunc,
         ] = await Promise.all([
             this.getWarehouseCredentials({
                 projectUuid,
@@ -8402,7 +8381,6 @@ export class ProjectService extends BaseService {
             this.getAvailableParameters(projectUuid, explore),
             this.combineParameters(projectUuid, explore, parameters),
             this.getQueryTimezoneForProject(projectUuid),
-            this.isTimezoneSupportEnabled(user),
         ]);
 
         const { warehouseClient, sshTunnel } = await this._getWarehouseClient(
@@ -8438,7 +8416,7 @@ export class ProjectService extends BaseService {
                 timezone,
                 parameters: combinedParameters,
                 availableParameterDefinitions,
-                useTimezoneAwareDateTrunc,
+                useTimezoneAwareDateTrunc: true,
                 columnTimezone: getColumnTimezone(warehouseClient.credentials),
             },
         ).compile();
@@ -12094,18 +12072,6 @@ export class ProjectService extends BaseService {
             user,
         });
         return { unnestRepeatedColumns: enabled };
-    }
-
-    async isTimezoneSupportEnabled(user: {
-        userUuid: string;
-        organizationUuid?: string;
-    }): Promise<boolean> {
-        const { enabled } = await this.featureFlagModel.get({
-            featureFlagId: FeatureFlags.EnableTimezoneSupport,
-            user,
-        });
-
-        return enabled;
     }
 
     async getQueryTimezoneForProject(projectUuid: string): Promise<string> {

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -164,7 +164,7 @@ export type BuildQueryProps = {
      * so the click-filter grain matches the zoom grain (PROD-880).
      */
     dateZoomFilterTargetFieldId?: string;
-    /** Wrap DATE_TRUNC with timezone conversion. Gated behind EnableTimezoneSupport. */
+    /** Wrap DATE_TRUNC with timezone conversion. */
     useTimezoneAwareDateTrunc?: boolean;
     /** Timezone the column data is in — source for the timezone-aware wrap.
      *  Derived from warehouse credentials via `getColumnTimezone`. */

--- a/packages/backend/src/utils/QueryBuilder/QueryComposer.ts
+++ b/packages/backend/src/utils/QueryBuilder/QueryComposer.ts
@@ -71,7 +71,7 @@ export type QueryComposerContext = {
     applyDateZoomToFilters?: boolean;
     queryExecutionContext?: QueryExecutionContext;
     /**
-     * Flag-gated timezone echoed to clients and persisted with the query.
+     * Resolved timezone echoed to clients and persisted with the query.
      * Not a compile input — `timezone` drives SQL. SQL charts set it to null.
      */
     displayTimezone?: string | null;
@@ -256,7 +256,7 @@ export class QueryComposer {
         return this.context.timezone;
     }
 
-    /** Flag-gated timezone echoed to clients and persisted with the query. */
+    /** Resolved timezone echoed to clients and persisted with the query. */
     getDisplayTimezone(): string | null {
         return this.context.displayTimezone ?? null;
     }

--- a/packages/backend/src/utils/processTimezone.test.ts
+++ b/packages/backend/src/utils/processTimezone.test.ts
@@ -1,9 +1,8 @@
 import { getProcessTimezoneWarning } from './processTimezone';
 
 describe('getProcessTimezoneWarning (GLITCH-507)', () => {
-    it('warns when timezone support is on and the process is not UTC', () => {
+    it('warns when the process is not UTC', () => {
         const warning = getProcessTimezoneWarning({
-            enableTimezoneSupport: true,
             timezoneOffsetMinutes: 300, // e.g. America/New_York
         });
         expect(warning).not.toBeNull();
@@ -14,7 +13,6 @@ describe('getProcessTimezoneWarning (GLITCH-507)', () => {
     it('warns for negative offsets too (e.g. Asia/Tokyo)', () => {
         expect(
             getProcessTimezoneWarning({
-                enableTimezoneSupport: true,
                 timezoneOffsetMinutes: -540,
             }),
         ).not.toBeNull();
@@ -23,22 +21,6 @@ describe('getProcessTimezoneWarning (GLITCH-507)', () => {
     it('does not warn when the process is UTC (offset 0)', () => {
         expect(
             getProcessTimezoneWarning({
-                enableTimezoneSupport: true,
-                timezoneOffsetMinutes: 0,
-            }),
-        ).toBeNull();
-    });
-
-    it('does not warn when timezone support is off, regardless of offset', () => {
-        expect(
-            getProcessTimezoneWarning({
-                enableTimezoneSupport: false,
-                timezoneOffsetMinutes: 300,
-            }),
-        ).toBeNull();
-        expect(
-            getProcessTimezoneWarning({
-                enableTimezoneSupport: false,
                 timezoneOffsetMinutes: 0,
             }),
         ).toBeNull();

--- a/packages/backend/src/utils/processTimezone.ts
+++ b/packages/backend/src/utils/processTimezone.ts
@@ -1,5 +1,5 @@
 /**
- * GLITCH-507: with EnableTimezoneSupport on, bare DATE `raw` values are
+ * GLITCH-507: bare DATE `raw` values are
  * formatted from the process timezone, so a non-UTC backend can shift them a
  * day on BigQuery/Snowflake. We warn rather than "fix" it in the formatter (no
  * single Date-component rule works across warehouses). Run the backend in UTC.
@@ -8,15 +8,13 @@
  * @returns a warning message to log, or null when no warning is needed.
  */
 export const getProcessTimezoneWarning = ({
-    enableTimezoneSupport,
     timezoneOffsetMinutes,
 }: {
-    enableTimezoneSupport: boolean;
     timezoneOffsetMinutes: number;
 }): string | null => {
-    if (enableTimezoneSupport && timezoneOffsetMinutes !== 0) {
+    if (timezoneOffsetMinutes !== 0) {
         return (
-            `EnableTimezoneSupport is on but the backend process timezone is not UTC. ` +
+            `The backend process timezone is not UTC. ` +
             `Bare DATE values may render off by one day on BigQuery/Snowflake — ` +
             `set TZ=UTC on all backend pods. See https://docs.lightdash.com/timezones`
         );

--- a/packages/common/src/featureFlags/previewFeatureFlags.ts
+++ b/packages/common/src/featureFlags/previewFeatureFlags.ts
@@ -39,7 +39,6 @@ const PREVIEW_EXCLUDED_FEATURE_FLAGS: ReadonlySet<string> = new Set<string>([
     // scope authoritative. Opt-in only; QA enables via feature_flag_overrides.
     CommercialFeatureFlags.PatScopeAuthoritative,
     FeatureFlags.ResultsCacheEnabled,
-    FeatureFlags.EnableTimezoneSupport,
 ]);
 
 export const ALL_FEATURE_FLAG_IDS: readonly string[] = [

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -11,7 +11,6 @@ export enum FeatureFlags {
     /* Gate new timezone features: warehouse session timezone, timezone-aware
        DATE_TRUNC, per-viewer (user-profile) timezone resolution, result
        formatting, etc. Temporary — remove once stable. */
-    EnableTimezoneSupport = 'enable-timezone-support',
 
     /**
      * Enable the dynamic calculation of series color, when not manually set on the chart config.

--- a/packages/common/src/utils/resolveQueryTimezone.ts
+++ b/packages/common/src/utils/resolveQueryTimezone.ts
@@ -33,9 +33,7 @@ export function getAccountUserTimezone(account: Account): string | null {
  *     preference).
  *   - any other value → an override IANA zone, frozen regardless of viewer/project.
  *
- * Whether the resolved zone is actually applied to the query is gated by the
- * calling service (EnableTimezoneSupport). The result is validated to prevent
- * SQL injection — it is interpolated into warehouse SQL (e.g. AT TIME ZONE '...').
+ * The result is validated to prevent SQL injection — it is interpolated into warehouse SQL (e.g. AT TIME ZONE '...').
  */
 export function resolveQueryTimezone({
     sessionTimezone,

--- a/packages/frontend/src/components/DashboardTiles/TileTimezoneInfo.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileTimezoneInfo.tsx
@@ -1,5 +1,4 @@
 import {
-    FeatureFlags,
     isTimeZone,
     PROJECT_TIMEZONE_SETTING,
     USER_TIMEZONE_SETTING,
@@ -7,7 +6,6 @@ import {
 import { ActionIcon, HoverCard, Text } from '@mantine/core';
 import { IconWorld } from '@tabler/icons-react';
 import { type FC } from 'react';
-import { useServerFeatureFlag } from '../../hooks/useServerOrClientFeatureFlag';
 import { getTimezoneSourceLabel } from '../../utils/timezoneSourceLabel';
 import MantineIcon from '../common/MantineIcon';
 
@@ -19,11 +17,6 @@ type Props = {
 };
 
 const TileTimezoneInfo: FC<Props> = ({ resolvedTimezone, timezoneSetting }) => {
-    const { data: timezoneSupportFlag } = useServerFeatureFlag(
-        FeatureFlags.EnableTimezoneSupport,
-    );
-    const timezoneSupportEnabled = timezoneSupportFlag?.enabled ?? false;
-
     // Only surface the indicator when the chart opts out of the project default:
     // either following each viewer's own zone or pinned to a specific zone.
     const isUserTimezone = timezoneSetting === USER_TIMEZONE_SETTING;
@@ -35,11 +28,7 @@ const TileTimezoneInfo: FC<Props> = ({ resolvedTimezone, timezoneSetting }) => {
             : null;
     const timezone = resolvedTimezone ?? pinnedZone;
 
-    if (
-        !timezoneSupportEnabled ||
-        (!isUserTimezone && !pinnedZone) ||
-        !timezone
-    ) {
+    if ((!isUserTimezone && !pinnedZone) || !timezone) {
         return null;
     }
 

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
@@ -1,6 +1,5 @@
 import {
     DimensionType,
-    FeatureFlags,
     getItemId,
     isAdditionalMetric,
     isCompiledMetric,
@@ -49,7 +48,6 @@ import {
 } from '../../../../../features/explorer/store';
 import { useExplore } from '../../../../../hooks/useExplore';
 import { useAddFilter } from '../../../../../hooks/useFilters';
-import { useServerFeatureFlag } from '../../../../../hooks/useServerOrClientFeatureFlag';
 import { useIsModalHosted } from '../../../../../providers/Explorer/useIsModalHosted';
 import useTracking from '../../../../../providers/Tracking/useTracking';
 import { EventName } from '../../../../../types/Events';
@@ -74,13 +72,8 @@ const NavItemIcon = ({
     isMissing?: boolean;
     item: Item | AdditionalMetric;
 }) => {
-    const { data: tzSupportFlag } = useServerFeatureFlag(
-        FeatureFlags.EnableTimezoneSupport,
-    );
-    const tzSupportEnabled = tzSupportFlag?.enabled ?? false;
-
     const tzAffordance = useMemo(() => {
-        if (isMissing || !tzSupportEnabled || !isField(item)) return null;
+        if (isMissing || !isField(item)) return null;
         const isDate = item.type === DimensionType.DATE;
         const isTimestamp = item.type === DimensionType.TIMESTAMP;
         if (!isDate && !isTimestamp) return null;
@@ -105,7 +98,7 @@ const NavItemIcon = ({
                   tooltip:
                       "Timestamp shown as stored, not affected by the chart's timezone",
               };
-    }, [isMissing, tzSupportEnabled, item]);
+    }, [isMissing, item]);
 
     if (isMissing) {
         return <MantineIcon icon={IconAlertTriangle} color="ldGray.7" />;

--- a/packages/frontend/src/components/LightdashVisualization/context.ts
+++ b/packages/frontend/src/components/LightdashVisualization/context.ts
@@ -72,7 +72,7 @@ type VisualizationContext = {
     hasExplorerStore: boolean;
     // Touch device detection for tooltip positioning
     isTouchDevice: boolean;
-    // Resolved timezone for formatting (undefined when EnableTimezoneSupport flag is off)
+    // Resolved timezone for formatting (undefined when no query timezone is available)
     resolvedTimezone?: string;
     // Date-zoom granularity applied by the surface (dashboards); undefined elsewhere.
     dateZoom?: DateZoom;

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/DataTimezoneField.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/DataTimezoneField.tsx
@@ -1,7 +1,4 @@
-import {
-    FeatureFlags,
-    type CreateWarehouseCredentials,
-} from '@lightdash/common';
+import { type CreateWarehouseCredentials } from '@lightdash/common';
 import {
     Alert,
     Badge,
@@ -13,7 +10,6 @@ import {
 } from '@mantine/core';
 import { type FC, type ReactNode } from 'react';
 import { useDataTimezonePreviewMutation } from '../../../hooks/useProject';
-import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import TimeZonePicker from '../../common/TimeZonePicker';
 import { useFormContext } from '../formContext';
 import { useProjectFormContext } from '../useProjectFormContext';
@@ -47,12 +43,7 @@ const Connector: FC<{ children: ReactNode }> = ({ children }) => (
 const DataTimezoneField: FC<{ disabled: boolean }> = ({ disabled }) => {
     const form = useFormContext();
     const { savedProject } = useProjectFormContext();
-    const { data: timezoneSupportFlag } = useServerFeatureFlag(
-        FeatureFlags.EnableTimezoneSupport,
-    );
     const preview = useDataTimezonePreviewMutation();
-
-    if (!(timezoneSupportFlag?.enabled ?? false)) return null;
 
     const onPreview = () => {
         const warehouse = form.values.warehouse;

--- a/packages/frontend/src/components/RefreshButton.tsx
+++ b/packages/frontend/src/components/RefreshButton.tsx
@@ -1,4 +1,4 @@
-import { FeatureFlags, type TimezoneSetting } from '@lightdash/common';
+import { type TimezoneSetting } from '@lightdash/common';
 import {
     Box,
     Button,
@@ -22,7 +22,6 @@ import {
 import { useMergeSetup } from '../features/mergeQuery/hooks/useMergeSetup';
 import useHealth from '../hooks/health/useHealth';
 import { useExplorerQuery } from '../hooks/useExplorerQuery';
-import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
 import useTracking from '../providers/Tracking/useTracking';
 import { EventName } from '../types/Events';
 import MantineIcon from './common/MantineIcon';
@@ -42,10 +41,6 @@ export const RefreshButton: FC<{ size?: MantineSize }> = memo(({ size }) => {
     const dispatch = useExplorerDispatch();
     const preAggVisible = useExplorerSelector(selectPreAggVisible);
     const timezone = useExplorerSelector(selectTimezone);
-
-    const { data: timezoneSupportFlag } = useServerFeatureFlag(
-        FeatureFlags.EnableTimezoneSupport,
-    );
 
     const setTimeZone = useCallback(
         (newTimezone: TimezoneSetting) => {
@@ -149,7 +144,7 @@ export const RefreshButton: FC<{ size?: MantineSize }> = memo(({ size }) => {
                     onLimitChange={setRowLimit}
                     showAutoFetchSetting
                     showPreAggregateSetting={preAggVisible}
-                    showTimezoneSetting={timezoneSupportFlag?.enabled ?? false}
+                    showTimezoneSetting
                     timezone={timezone ?? undefined}
                     onTimezoneChange={setTimeZone}
                     isQueryRunning={isLoading}

--- a/packages/frontend/src/components/SettingsQueryTimezone/index.tsx
+++ b/packages/frontend/src/components/SettingsQueryTimezone/index.tsx
@@ -1,9 +1,4 @@
-import {
-    FeatureFlags,
-    getErrorMessage,
-    isApiError,
-    type Project,
-} from '@lightdash/common';
+import { getErrorMessage, isApiError, type Project } from '@lightdash/common';
 import {
     Button,
     Flex,
@@ -22,7 +17,6 @@ import {
     useProject,
     useProjectUpdateQueryTimezoneSettings,
 } from '../../hooks/useProject';
-import { useServerFeatureFlag } from '../../hooks/useServerOrClientFeatureFlag';
 import { SettingsGridCard } from '../common/Settings/SettingsCard';
 import TimeZonePicker from '../common/TimeZonePicker';
 
@@ -36,9 +30,8 @@ type QueryTimezoneFormValues = z.infer<typeof queryTimezoneSchema>;
 const QueryTimezoneForm: FC<{
     isLoading: boolean;
     project: Project;
-    showFilterInputsToggle: boolean;
     onSubmit: (data: QueryTimezoneFormValues) => void;
-}> = ({ isLoading, project, showFilterInputsToggle, onSubmit }) => {
+}> = ({ isLoading, project, onSubmit }) => {
     const form = useForm<QueryTimezoneFormValues>({
         validate: zodResolver(queryTimezoneSchema),
         initialValues: {
@@ -74,16 +67,14 @@ const QueryTimezoneForm: FC<{
                     placeholder="Server default (UTC)"
                     {...form.getInputProps('timezone')}
                 />
-                {showFilterInputsToggle && (
-                    <Switch
-                        label="Project time zone in filter inputs"
-                        description="Interpret absolute dates in the project's time zone instead of the user's browser."
-                        disabled={filterToggleDisabled}
-                        {...form.getInputProps('useProjectTimezoneInFilters', {
-                            type: 'checkbox',
-                        })}
-                    />
-                )}
+                <Switch
+                    label="Project time zone in filter inputs"
+                    description="Interpret absolute dates in the project's time zone instead of the user's browser."
+                    disabled={filterToggleDisabled}
+                    {...form.getInputProps('useProjectTimezoneInFilters', {
+                        type: 'checkbox',
+                    })}
+                />
             </Stack>
             <Flex justify="flex-end" gap="sm" mt="sm">
                 <Button
@@ -106,10 +97,6 @@ const SettingsQueryTimezone: FC<SettingsQueryTimezoneProps> = ({
     projectUuid,
 }) => {
     const { showToastError, showToastSuccess } = useToaster();
-    const { data: timezoneSupportFlag } = useServerFeatureFlag(
-        FeatureFlags.EnableTimezoneSupport,
-    );
-    const timezoneSupportEnabled = timezoneSupportFlag?.enabled === true;
     const { data: project, isLoading: isLoadingProject } =
         useProject(projectUuid);
     const projectMutation = useProjectUpdateQueryTimezoneSettings(projectUuid);
@@ -147,24 +134,9 @@ const SettingsQueryTimezone: FC<SettingsQueryTimezoneProps> = ({
                 <Stack gap="xs">
                     <Title order={5}>Time zone behavior</Title>
                     <Text c="dimmed" fz="sm">
-                        {timezoneSupportEnabled ? (
-                            <>
-                                The time zone used for date filters, time
-                                grouping, and how dates appear in charts and
-                                tables. This does not change your
-                                database&apos;s session time zone.
-                            </>
-                        ) : (
-                            <>
-                                Controls what &quot;today&quot;, &quot;this
-                                week&quot;, and other &quot;in the current&quot;
-                                date filters mean. For example, if set to
-                                US/Eastern, &quot;today&quot; means
-                                midnight-to-midnight New York time instead of
-                                UTC. This does not change your database&apos;s
-                                session time zone.
-                            </>
-                        )}
+                        The time zone used for date filters, time grouping, and
+                        how dates appear in charts and tables. This does not
+                        change your database&apos;s session time zone.
                     </Text>
                 </Stack>
                 <div>
@@ -172,7 +144,6 @@ const SettingsQueryTimezone: FC<SettingsQueryTimezoneProps> = ({
                         <QueryTimezoneForm
                             isLoading={projectMutation.isLoading}
                             project={project}
-                            showFilterInputsToggle={timezoneSupportEnabled}
                             onSubmit={handleSubmit}
                         />
                     )}

--- a/packages/frontend/src/components/UserSettings/ProfilePanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/ProfilePanel/index.tsx
@@ -1,5 +1,4 @@
 import {
-    FeatureFlags,
     getEmailSchema,
     getUserNameSchema,
     isValidTimezone,
@@ -25,7 +24,6 @@ import {
     useOneTimePassword,
 } from '../../../hooks/useEmailVerification';
 import { useUserUpdateMutation } from '../../../hooks/user/useUserUpdateMutation';
-import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import { VerifyEmailModal } from '../../../pages/VerifyEmail';
 import useApp from '../../../providers/App/useApp';
 import MantineIcon from '../../common/MantineIcon';
@@ -53,11 +51,6 @@ const ProfilePanel: FC = () => {
         health,
     } = useApp();
     const { showToastSuccess, showToastApiError } = useToaster();
-
-    const { data: timezoneSupportFlag } = useServerFeatureFlag(
-        FeatureFlags.EnableTimezoneSupport,
-    );
-    const timezoneSupportEnabled = timezoneSupportFlag?.enabled === true;
 
     const form = useForm<FormValues>({
         validate: zodResolver(validationSchema),
@@ -203,20 +196,18 @@ const ProfilePanel: FC = () => {
                     }
                 />
 
-                {timezoneSupportEnabled && (
-                    <TimeZonePicker
-                        label="Default timezone"
-                        description="Used to render query results for charts pinned to the viewer timezone. Leave empty to fall back to the project timezone."
-                        variant="default"
-                        maw="100%"
-                        size="sm"
-                        searchable
-                        clearable
-                        placeholder="Project default"
-                        disabled={isLoading}
-                        {...form.getInputProps('timezone')}
-                    />
-                )}
+                <TimeZonePicker
+                    label="Default timezone"
+                    description="Used to render query results for charts pinned to the viewer timezone. Leave empty to fall back to the project timezone."
+                    variant="default"
+                    maw="100%"
+                    size="sm"
+                    searchable
+                    clearable
+                    placeholder="Project default"
+                    disabled={isLoading}
+                    {...form.getInputProps('timezone')}
+                />
 
                 <Flex justify="flex-end" gap="sm">
                     {form.isDirty() && !isUpdatingUser && (

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateTimePicker.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateTimePicker.tsx
@@ -1,8 +1,4 @@
-import {
-    FeatureFlags,
-    getTimezoneLabel,
-    isValidTimezone,
-} from '@lightdash/common';
+import { getTimezoneLabel, isValidTimezone } from '@lightdash/common';
 import { Group, Text } from '@mantine/core';
 import {
     DateTimePicker,
@@ -14,7 +10,6 @@ import timezone from 'dayjs/plugin/timezone';
 import utc from 'dayjs/plugin/utc';
 import { useCallback, useMemo, useState, type FC } from 'react';
 import { useProject } from '../../../../hooks/useProject';
-import { useServerFeatureFlag } from '../../../../hooks/useServerOrClientFeatureFlag';
 import useFiltersContext from '../useFiltersContext';
 import styles from './FilterDateTimePicker.module.css';
 import {
@@ -67,15 +62,11 @@ const FilterDateTimePicker: FC<Props> = ({
     );
 
     const { projectUuid, metricQueryTimezone } = useFiltersContext();
-    const { data: enableTimezoneSupportFlag } = useServerFeatureFlag(
-        FeatureFlags.EnableTimezoneSupport,
-    );
     const { data: project } = useProject(projectUuid);
 
     const candidateTimezone =
         metricQueryTimezone ?? project?.queryTimezone ?? undefined;
     const projectTimezone =
-        enableTimezoneSupportFlag?.enabled &&
         project?.useProjectTimezoneInFilters &&
         candidateTimezone &&
         isValidTimezone(candidateTimezone)

--- a/packages/frontend/src/components/common/Filters/FilterInputs/mantineDatesCompatibility.test.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/mantineDatesCompatibility.test.tsx
@@ -15,17 +15,10 @@ const mocks = vi.hoisted(() => ({
         queryTimezone: undefined as string | undefined,
         useProjectTimezoneInFilters: false,
     },
-    timezoneSupportEnabled: false,
 }));
 
 vi.mock('../../../../hooks/useProject', () => ({
     useProject: () => ({ data: mocks.project }),
-}));
-
-vi.mock('../../../../hooks/useServerOrClientFeatureFlag', () => ({
-    useServerFeatureFlag: () => ({
-        data: { enabled: mocks.timezoneSupportEnabled },
-    }),
 }));
 
 vi.mock('./InvalidDateInput', () => ({
@@ -266,7 +259,6 @@ describe('Mantine Dates wrapper boundaries', () => {
     });
 
     it('preserves the project-timezone shift/string/unshift pipeline', () => {
-        mocks.timezoneSupportEnabled = true;
         mocks.project.useProjectTimezoneInFilters = true;
         const onChange = vi.fn();
 
@@ -297,7 +289,6 @@ describe('Mantine Dates wrapper boundaries', () => {
     });
 
     it('preserves datetime bounds and fractional milliseconds', () => {
-        mocks.timezoneSupportEnabled = false;
         mocks.project.useProjectTimezoneInFilters = false;
         const onChange = vi.fn();
 
@@ -323,7 +314,6 @@ describe('Mantine Dates wrapper boundaries', () => {
     });
 
     it('drops bounds the stored value violates so Mantine cannot clamp it on dropdown close', () => {
-        mocks.timezoneSupportEnabled = false;
         mocks.project.useProjectTimezoneInFilters = false;
         const onChange = vi.fn();
 
@@ -345,7 +335,6 @@ describe('Mantine Dates wrapper boundaries', () => {
     });
 
     it('keeps bounds the stored value satisfies', () => {
-        mocks.timezoneSupportEnabled = false;
         mocks.project.useProjectTimezoneInFilters = false;
         const onChange = vi.fn();
 
@@ -366,7 +355,6 @@ describe('Mantine Dates wrapper boundaries', () => {
     });
 
     it('closes invalid replacement only after a valid parsed submission', () => {
-        mocks.timezoneSupportEnabled = false;
         mocks.project.useProjectTimezoneInFilters = false;
         mocks.closeInvalidInput.mockClear();
         const onChange = vi.fn();

--- a/packages/frontend/src/components/common/Filters/FilterInputs/mantineDatesRender.test.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/mantineDatesRender.test.tsx
@@ -12,18 +12,11 @@ const mocks = vi.hoisted(() => ({
         queryTimezone: 'America/New_York',
         useProjectTimezoneInFilters: false,
     },
-    timezoneSupportEnabled: false,
 }));
 
 vi.mock('../../../../hooks/useProject', () => ({
     useProject: () => ({
         data: mocks.project,
-    }),
-}));
-
-vi.mock('../../../../hooks/useServerOrClientFeatureFlag', () => ({
-    useServerFeatureFlag: () => ({
-        data: { enabled: mocks.timezoneSupportEnabled },
     }),
 }));
 
@@ -69,7 +62,6 @@ describe('Mantine Dates runtime', () => {
     // return null and this onChange would never fire.
     it('parses the real DateTimePicker emission into a successful onChange', async () => {
         mocks.project.useProjectTimezoneInFilters = false;
-        mocks.timezoneSupportEnabled = false;
         const onChange = vi.fn();
         renderDateTimeRange(
             <FilterDateTimePicker
@@ -104,7 +96,6 @@ describe('Mantine Dates runtime', () => {
         'does not clamp a same-day datetime range when project timezone is %s',
         async (useProjectTimezone) => {
             mocks.project.useProjectTimezoneInFilters = useProjectTimezone;
-            mocks.timezoneSupportEnabled = useProjectTimezone;
             const startValue = useProjectTimezone
                 ? new Date('2025-05-14T14:00:00.000Z')
                 : new Date(2025, 4, 14, 10);

--- a/packages/frontend/src/hooks/echarts/timezoneShift.ts
+++ b/packages/frontend/src/hooks/echarts/timezoneShift.ts
@@ -151,8 +151,8 @@ export type CalendarTimeAxisField = TimezoneShiftedField;
 // label it one day early. Encoding the plotted coordinate as UTC midnight
 // keeps the calendar day fixed for every viewer.
 //
-// Gated on the response's resolvedTimezone: only flag-on results emit bare
-// calendar values (flag-off keeps full ISO strings and must stay untouched).
+// Results with a resolvedTimezone emit bare calendar values. Older results
+// without one keep full ISO strings and must stay untouched.
 // The timezone string is only the mode signal and is never applied to the
 // DATE. physicalAxisType must come from the axis actually built for the
 // field (xAxis[0], or yAxis[0] when flipped) so reference-line-forced time

--- a/packages/frontend/src/hooks/useColumns.tsx
+++ b/packages/frontend/src/hooks/useColumns.tsx
@@ -527,8 +527,8 @@ export const useColumns = (): TableColumn[] => {
     const resultsFields = mergeResults?.fields ?? query.data?.fields;
 
     const parameters = useExplorerSelector(selectParameters);
-    // Format temporal cells in the flag-gated resolved timezone (null when
-    // timezone support is off), never the chart's unresolved state timezone.
+    // Format temporal cells in the resolved query timezone, never the chart's
+    // unresolved state timezone.
     const timezone = query.data?.resolvedTimezone ?? undefined;
 
     const { data: exploreData } = useExplore(tableName, {


### PR DESCRIPTION
Timezone resolution, warehouse session setup, SQL compilation, result formatting, and timezone controls now run for everyone. Remove the timezone feature flag, environment override, and backend/frontend checks; retain the UTC fallback, project filter-input setting, and permission checks.

Update regression tests and remove obsolete internal documentation for the flag.

Validation: 480 targeted tests passed; backend, frontend, and common typechecks passed; changed-file lint and API generation passed. Live API tests were not run.

Public documentation cleanup: https://github.com/lightdash/mintlify-docs/pull/1219 (environment variable and timezone enablement notices).
