### PR TITLE
feat(cli): accept project slugs in --project and content urls

### DIFF
--- a/packages/cli/src/handlers/apps/preview.test.ts
+++ b/packages/cli/src/handlers/apps/preview.test.ts
@@ -238,7 +238,7 @@ describe('resolvePreviewTarget', () => {
         const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'ld-prev-'));
         await writeBundleToDir(dir, previewBundle);
         await expect(resolvePreviewTarget({ cwd: dir })).rejects.toThrow(
-            /Pass '--project <uuid>'/,
+            /Pass '--project <uuid or slug>'/,
         );
     });
 

--- a/packages/cli/src/handlers/apps/preview.ts
+++ b/packages/cli/src/handlers/apps/preview.ts
@@ -12,6 +12,7 @@ import { getConfig } from '../../config';
 import GlobalState from '../../globalState';
 import * as styles from '../../styles';
 import { checkLightdashVersion } from '../dbt/apiClient';
+import { resolveProjectFlag } from '../resolveProjectFlag';
 import { getAuthHeader } from '../utils';
 import { readManifestFromDir } from './appCodeFiles';
 import { startPreviewProxy } from './previewProxy';
@@ -208,7 +209,7 @@ export const resolvePreviewTarget = async (args: {
     const projectUuid = args.projectFlag ?? args.currentProjectUuid;
     if (projectUuid === undefined) {
         throw new Error(
-            `No project selected. Pass '--project <uuid>' or run 'lightdash config set-project' first.`,
+            `No project selected. Pass '--project <uuid or slug>' or run 'lightdash config set-project' first.`,
         );
     }
 
@@ -472,7 +473,9 @@ export const appsPreviewHandler = async (
 
     const target = await resolvePreviewTarget({
         pathArg,
-        projectFlag: options.project,
+        projectFlag: options.project
+            ? await resolveProjectFlag(options.project)
+            : undefined,
         currentProjectUuid: config.context?.project,
         cwd: process.cwd(),
     });

--- a/packages/cli/src/handlers/download.test.ts
+++ b/packages/cli/src/handlers/download.test.ts
@@ -1486,7 +1486,6 @@ describe('downloadHandler analytics', () => {
                     skipVirtualViews: true,
                     skipExternalConnections: true,
                     path: tmpDir,
-                    project: 'project-uuid',
                 }),
             );
 
@@ -1572,7 +1571,6 @@ describe('downloadHandler failures', () => {
                     makeDownloadHandlerOptions({
                         includeAll: true,
                         path: tmpDir,
-                        project: 'project-uuid',
                     }),
                 ),
             ).resolves.toBeUndefined();
@@ -1619,7 +1617,6 @@ describe('downloadHandler failures', () => {
             downloadHandler(
                 makeDownloadHandlerOptions({
                     agents: ['sales-agent'],
-                    project: 'project-uuid',
                 }),
             ),
         ).rejects.toBe(unavailableError);
@@ -1642,11 +1639,7 @@ describe('uploadHandler failures', () => {
         );
 
         await expect(
-            uploadHandler(
-                makeDownloadHandlerOptions({
-                    project: 'project-uuid',
-                }),
-            ),
+            uploadHandler(makeDownloadHandlerOptions({})),
         ).rejects.toBe(fatalError);
     });
 });
@@ -2625,5 +2618,39 @@ version: 99
             'Total spaces dependency skipped: 1 ',
         ]);
         summarySpy.mockRestore();
+    });
+});
+
+describe('parseContentFilters', () => {
+    const { parseContentFilters } = testHelpers;
+
+    it('passes slugs and uuids through untouched', () => {
+        expect(
+            parseContentFilters([
+                'sales-overview',
+                '00000000-0000-0000-0000-000000000001',
+            ]),
+        ).toBe('?ids=sales-overview&ids=00000000-0000-0000-0000-000000000001');
+    });
+
+    it('extracts uuids from legacy app urls', () => {
+        expect(
+            parseContentFilters([
+                'https://app.lightdash.cloud/projects/00000000-0000-0000-0000-0000000000aa/dashboards/00000000-0000-0000-0000-000000000001/view',
+                'https://app.lightdash.cloud/projects/00000000-0000-0000-0000-0000000000aa/saved/00000000-0000-0000-0000-000000000002',
+            ]),
+        ).toBe(
+            '?ids=00000000-0000-0000-0000-000000000001&ids=00000000-0000-0000-0000-000000000002',
+        );
+    });
+
+    it('extracts slugs from app urls that use project and content slugs', () => {
+        expect(
+            parseContentFilters([
+                'https://app.lightdash.cloud/projects/jaffle-shop/dashboards/daily-sales/view',
+                'https://app.lightdash.cloud/projects/jaffle-shop/saved/monthly-revenue/view?tab=1',
+                'https://app.lightdash.cloud/projects/jaffle-shop/dashboards/sales-overview/view/tabs/some-tab',
+            ]),
+        ).toBe('?ids=daily-sales&ids=monthly-revenue&ids=sales-overview');
     });
 });

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -284,10 +284,10 @@ const parseContentFilters = (items: string[]): string => {
     if (items.length === 0) return '';
 
     const parsedItems = items.map((item) => {
-        const uuidMatch = item.match(
-            /https?:\/\/.+\/(?:saved|dashboards)\/([a-f0-9-]+)/i,
+        const urlMatch = item.match(
+            /https?:\/\/.+\/(?:saved|dashboards)\/([^/?#]+)/i,
         );
-        return uuidMatch ? uuidMatch[1] : item;
+        return urlMatch ? urlMatch[1] : item;
     });
 
     return `?${new URLSearchParams(
@@ -4759,6 +4759,7 @@ export const testHelpers = {
     getDashboardAppSlugs,
     getDashboardChartSlugs,
     hasContentFilters,
+    parseContentFilters,
     isAiAgentsUnavailableError,
     isExternalConnectionsUnavailableError,
     isVirtualViewsUnavailableError,

--- a/packages/cli/src/handlers/exportChartImage.ts
+++ b/packages/cli/src/handlers/exportChartImage.ts
@@ -5,6 +5,7 @@ import { getConfig } from '../config';
 import GlobalState from '../globalState';
 import * as styles from '../styles';
 import { lightdashApi } from './dbt/apiClient';
+import { resolveProjectFlag } from './resolveProjectFlag';
 
 type ExportChartImageOptions = {
     output: string;
@@ -23,12 +24,14 @@ export const exportChartImageHandler = async (
     );
 
     const isChartUuid = isValidUuid(chartUuidOrSlug);
-    const projectUuid =
-        options.project ??
-        (!isChartUuid ? (await getConfig()).context?.project : undefined);
+    const resolveDefaultProject = async () =>
+        !isChartUuid ? (await getConfig()).context?.project : undefined;
+    const projectUuid = options.project
+        ? await resolveProjectFlag(options.project)
+        : await resolveDefaultProject();
     if (!projectUuid && !isChartUuid) {
         throw new Error(
-            'A project is required when exporting by slug. Pass --project <uuid> or select a project first.',
+            'A project is required when exporting by slug. Pass --project <uuid or slug> or select a project first.',
         );
     }
     const projectQuery = projectUuid

--- a/packages/cli/src/handlers/listProjects.ts
+++ b/packages/cli/src/handlers/listProjects.ts
@@ -39,6 +39,9 @@ export const listProjectsHandler = async (options: ListProjectsOptions) => {
             filteredProjects.forEach((project) => {
                 console.error(`  ${styles.bold(project.name)}`);
                 console.error(`    UUID: ${project.projectUuid}`);
+                if (project.slug) {
+                    console.error(`    Slug: ${project.slug}`);
+                }
                 if (project.warehouseType) {
                     console.error(`    Warehouse: ${project.warehouseType}`);
                 }

--- a/packages/cli/src/handlers/preAggregateAudit.ts
+++ b/packages/cli/src/handlers/preAggregateAudit.ts
@@ -10,6 +10,7 @@ import { getConfig } from '../config';
 import GlobalState from '../globalState';
 import * as styles from '../styles';
 import { checkLightdashVersion, lightdashApi } from './dbt/apiClient';
+import { resolveProjectFlag } from './resolveProjectFlag';
 
 type EligibleTile = TilePreAggregateAuditHit | TilePreAggregateAuditMiss;
 
@@ -33,7 +34,7 @@ type PreAggregateAuditOptions = {
 };
 
 async function resolveProjectUuid(flagValue?: string): Promise<string> {
-    if (flagValue) return flagValue;
+    if (flagValue) return resolveProjectFlag(flagValue);
     if (process.env.LIGHTDASH_PROJECT_UUID) {
         return process.env.LIGHTDASH_PROJECT_UUID;
     }
@@ -41,7 +42,7 @@ async function resolveProjectUuid(flagValue?: string): Promise<string> {
     const projectUuid = config.context?.project;
     if (!projectUuid) {
         console.error(
-            'No project selected. Pass --project <uuid>, set LIGHTDASH_PROJECT_UUID, or run `lightdash login`.',
+            'No project selected. Pass --project <uuid or slug>, set LIGHTDASH_PROJECT_UUID, or run `lightdash login`.',
         );
         process.exit(1);
     }

--- a/packages/cli/src/handlers/renameHandler.test.ts
+++ b/packages/cli/src/handlers/renameHandler.test.ts
@@ -15,7 +15,7 @@ type RenameOptions = Parameters<typeof renameHandler>[0];
 const baseOptions: RenameOptions = {
     verbose: false,
     type: RenameType.FIELD,
-    project: 'test-project-uuid',
+    project: '11111111-1111-4111-8111-111111111111',
     from: 'old_name',
     to: 'new_name',
     dryRun: false,
@@ -71,7 +71,7 @@ describe('renameHandler follow-up validation', () => {
             context: {
                 apiKey: 'test-key',
                 serverUrl: 'http://localhost',
-                project: 'test-project-uuid',
+                project: '11111111-1111-4111-8111-111111111111',
             },
         } as Awaited<ReturnType<typeof getConfig>>);
         vi.mocked(getProject).mockResolvedValue({

--- a/packages/cli/src/handlers/renameHandler.ts
+++ b/packages/cli/src/handlers/renameHandler.ts
@@ -17,6 +17,7 @@ import GlobalState from '../globalState';
 import * as styles from '../styles';
 import { checkLightdashVersion, lightdashApi } from './dbt/apiClient';
 import { getProject } from './dbt/refresh';
+import { resolveProjectFlag } from './resolveProjectFlag';
 import {
     getJobState,
     getValidation,
@@ -89,10 +90,9 @@ export const renameHandler = async (options: RenameHandlerOptions) => {
         );
     }
 
-    const projectUuid =
-        options.project ||
-        config.context.previewProject ||
-        config.context.project;
+    const projectUuid = options.project
+        ? await resolveProjectFlag(options.project)
+        : config.context.previewProject || config.context.project;
     if (!projectUuid) {
         throw new LightdashError({
             message: 'No project selected. Run lightdash config set-project',

--- a/packages/cli/src/handlers/resolveProjectFlag.test.ts
+++ b/packages/cli/src/handlers/resolveProjectFlag.test.ts
@@ -1,0 +1,73 @@
+import { ParameterError, ProjectType } from '@lightdash/common';
+import type { MockedFunction } from 'vitest';
+import { lightdashApi } from './dbt/apiClient';
+import { resolveProjectFlag } from './resolveProjectFlag';
+
+vi.mock('./dbt/apiClient', () => ({
+    lightdashApi: vi.fn(),
+}));
+
+const mockLightdashApi = lightdashApi as MockedFunction<typeof lightdashApi>;
+
+const PROJECT_UUID = '00000000-0000-0000-0000-000000000001';
+const OTHER_UUID = '00000000-0000-0000-0000-000000000002';
+
+const mockOrgProjects = (
+    projects: { projectUuid: string; slug?: string; name: string }[],
+) => {
+    mockLightdashApi.mockResolvedValueOnce(
+        projects.map((project) => ({
+            ...project,
+            type: ProjectType.DEFAULT,
+        })) as never,
+    );
+};
+
+describe('resolveProjectFlag', () => {
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns a UUID as-is without calling the API', async () => {
+        await expect(resolveProjectFlag(PROJECT_UUID)).resolves.toBe(
+            PROJECT_UUID,
+        );
+        expect(mockLightdashApi).not.toHaveBeenCalled();
+    });
+
+    it('resolves a slug to the matching project UUID', async () => {
+        mockOrgProjects([
+            { projectUuid: OTHER_UUID, slug: 'other', name: 'Other' },
+            { projectUuid: PROJECT_UUID, slug: 'jaffle-shop', name: 'Jaffle' },
+        ]);
+
+        await expect(resolveProjectFlag('jaffle-shop')).resolves.toBe(
+            PROJECT_UUID,
+        );
+        expect(mockLightdashApi).toHaveBeenCalledWith(
+            expect.objectContaining({ url: '/api/v1/org/projects' }),
+        );
+    });
+
+    it('fails with an actionable error for an unknown slug', async () => {
+        mockOrgProjects([
+            { projectUuid: PROJECT_UUID, slug: 'jaffle-shop', name: 'Jaffle' },
+            { projectUuid: OTHER_UUID, name: 'No slug' },
+        ]);
+
+        await expect(resolveProjectFlag('missing')).rejects.toThrow(
+            ParameterError,
+        );
+    });
+
+    it('fails when a slug matches more than one project', async () => {
+        mockOrgProjects([
+            { projectUuid: PROJECT_UUID, slug: 'dup', name: 'A' },
+            { projectUuid: OTHER_UUID, slug: 'dup', name: 'B' },
+        ]);
+
+        await expect(resolveProjectFlag('dup')).rejects.toThrow(
+            /more than one project/,
+        );
+    });
+});

--- a/packages/cli/src/handlers/resolveProjectFlag.ts
+++ b/packages/cli/src/handlers/resolveProjectFlag.ts
@@ -1,0 +1,49 @@
+import { OrganizationProject, ParameterError } from '@lightdash/common';
+import GlobalState from '../globalState';
+import * as styles from '../styles';
+import { lightdashApi } from './dbt/apiClient';
+
+// Same shape check the backend uses to tell uuids from slugs
+const isUuid = (value: string): boolean =>
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+        value,
+    );
+
+/**
+ * Resolves the value of a `--project` flag to a project UUID.
+ * Accepts a UUID (returned as-is) or a project slug as shown in app URLs.
+ */
+export const resolveProjectFlag = async (value: string): Promise<string> => {
+    if (isUuid(value)) {
+        return value;
+    }
+
+    const projects = await lightdashApi<OrganizationProject[]>({
+        method: 'GET',
+        url: `/api/v1/org/projects`,
+        body: undefined,
+    });
+
+    const matches = projects.filter((project) => project.slug === value);
+
+    if (matches.length === 1) {
+        GlobalState.debug(
+            `> Resolved project slug "${value}" to ${matches[0].projectUuid}`,
+        );
+        return matches[0].projectUuid;
+    }
+
+    if (matches.length > 1) {
+        throw new ParameterError(
+            `Project slug "${value}" matches more than one project. Use the project UUID instead:\n${matches
+                .map((project) => `  ${project.name}: ${project.projectUuid}`)
+                .join('\n')}`,
+        );
+    }
+
+    throw new ParameterError(
+        `No project found with UUID or slug "${value}". Run ${styles.bold(
+            'lightdash config list-projects',
+        )} to see the projects you have access to.`,
+    );
+};

--- a/packages/cli/src/handlers/selectProject.ts
+++ b/packages/cli/src/handlers/selectProject.ts
@@ -4,6 +4,7 @@ import { Config, unsetPreviewProject } from '../config';
 import GlobalState from '../globalState';
 import * as styles from '../styles';
 import { lightdashApi } from './dbt/apiClient';
+import { resolveProjectFlag } from './resolveProjectFlag';
 
 export type ProjectSelection = {
     projectUuid: string;
@@ -58,7 +59,10 @@ export const selectProject = async (
 ): Promise<ProjectSelection | undefined> => {
     // If explicit project provided via --project flag, use it
     if (explicitProject) {
-        return { projectUuid: explicitProject, isPreview: false };
+        return {
+            projectUuid: await resolveProjectFlag(explicitProject),
+            isPreview: false,
+        };
     }
 
     const mainProject = config.context?.project;

--- a/packages/cli/src/handlers/setProject.ts
+++ b/packages/cli/src/handlers/setProject.ts
@@ -14,7 +14,7 @@ type SetProjectOptions = {
 
 export const setProjectCommand = async (
     name?: string,
-    uuid?: string,
+    uuidOrSlug?: string,
 ): Promise<'selected' | 'skipped' | 'empty'> => {
     const projects = await lightdashApi<OrganizationProject[]>({
         method: 'GET',
@@ -39,9 +39,12 @@ export const setProjectCommand = async (
     let selectedProject: OrganizationProject | undefined;
 
     // --uuid or --name options
-    if (uuid !== undefined || name !== undefined) {
+    if (uuidOrSlug !== undefined || name !== undefined) {
         const matchedProject = projects.find(
-            (project) => project.name === name || project.projectUuid === uuid,
+            (project) =>
+                project.name === name ||
+                project.projectUuid === uuidOrSlug ||
+                (uuidOrSlug !== undefined && project.slug === uuidOrSlug),
         );
         if (matchedProject?.type === ProjectType.PREVIEW) {
             throw new Error(

--- a/packages/cli/src/handlers/setWarehouse.ts
+++ b/packages/cli/src/handlers/setWarehouse.ts
@@ -10,6 +10,7 @@ import * as styles from '../styles';
 import { loadWarehouseCredentialsFromProfiles } from './createProject';
 import { checkLightdashVersion, lightdashApi } from './dbt/apiClient';
 import { getFinalJobState, getProject } from './dbt/refresh';
+import { resolveProjectFlag } from './resolveProjectFlag';
 
 type SetWarehouseHandlerOptions = {
     projectDir: string;
@@ -25,12 +26,12 @@ type SetWarehouseHandlerOptions = {
 
 const resolveProjectUuid = async (projectOption?: string): Promise<string> => {
     if (projectOption) {
-        return projectOption;
+        return resolveProjectFlag(projectOption);
     }
     const config = await getConfig();
     if (!config.context?.project) {
         throw new AuthorizationError(
-            `No project selected. Run 'lightdash config set-project' first or pass '--project <uuid>'.`,
+            `No project selected. Run 'lightdash config set-project' first or pass '--project <uuid or slug>'.`,
         );
     }
     return config.context.project;

--- a/packages/cli/src/handlers/validate.test.ts
+++ b/packages/cli/src/handlers/validate.test.ts
@@ -23,7 +23,7 @@ vi.mock('./timestampConversion');
 type ValidateOptions = Parameters<typeof validateHandler>[0];
 
 const baseOptions: ValidateOptions = {
-    project: 'test-project-uuid',
+    project: '11111111-1111-4111-8111-111111111111',
     preview: false,
     only: Object.values(ValidationTarget),
     validateWarehouseColumns: false,
@@ -61,7 +61,7 @@ const chartConfigurationWarning = {
     validationUuid: 'warning-uuid',
     validationId: null,
     createdAt: new Date('2026-08-26T12:00:00Z'),
-    projectUuid: 'test-project-uuid',
+    projectUuid: '11111111-1111-4111-8111-111111111111',
     name: 'Orders over time',
     error: 'dimension is not used in the chart configuration',
     errorType: ValidationErrorType.ChartConfiguration,
@@ -77,7 +77,7 @@ const brokenChartError = {
     validationUuid: 'error-uuid',
     validationId: null,
     createdAt: new Date('2026-08-26T12:00:00Z'),
-    projectUuid: 'test-project-uuid',
+    projectUuid: '11111111-1111-4111-8111-111111111111',
     name: 'Broken chart',
     error: 'Dimension does not exist',
     errorType: ValidationErrorType.Dimension,
@@ -276,7 +276,7 @@ describe('validateHandler warehouse column validation', () => {
                         validationUuid: 'validation-uuid',
                         validationId: null,
                         createdAt: new Date('2026-08-07T09:00:00Z'),
-                        projectUuid: 'test-project-uuid',
+                        projectUuid: '11111111-1111-4111-8111-111111111111',
                         name: 'Broken data app',
                         error: 'Dimension does not exist',
                         errorType: ValidationErrorType.Dimension,

--- a/packages/cli/src/handlers/validate.ts
+++ b/packages/cli/src/handlers/validate.ts
@@ -25,6 +25,7 @@ import GlobalState from '../globalState';
 import * as styles from '../styles';
 import { compile, CompileHandlerOptions } from './compile';
 import { checkLightdashVersion, lightdashApi } from './dbt/apiClient';
+import { resolveProjectFlag } from './resolveProjectFlag';
 import { getProjectDisableTimestampConversion } from './timestampConversion';
 import {
     filterValidationsBySpace,
@@ -174,12 +175,14 @@ export const validateHandler = async (
     const selectedProject = options.preview
         ? config.context?.previewProject
         : config.context?.project;
-    const projectUuid = options.project || selectedProject;
+    const projectUuid = options.project
+        ? await resolveProjectFlag(options.project)
+        : selectedProject;
 
     if (projectUuid === undefined) {
         throw new ParameterError(
             `No project specified, select a project to validate using ${styles.bold(
-                `--project <projectUuid>`,
+                `--project <project uuid or slug>`,
             )} or create a preview environment using ${styles.bold(
                 `lightdash start-preview`,
             )} or configure your default project using ${styles.bold(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -7,7 +7,6 @@ import {
     ValidationTarget,
 } from '@lightdash/common';
 import { InvalidArgumentError, Option, program, type Command } from 'commander';
-import { validate } from 'uuid';
 import {
     DEFAULT_DBT_PROFILES_DIR as defaultProfilesDir,
     DEFAULT_DBT_PROJECT_DIR as defaultProjectDir,
@@ -105,10 +104,8 @@ function parseProjectArgument(value: string | undefined): string | undefined {
         throw new InvalidArgumentError('No project argument provided.');
     }
 
-    const isValidUuid = validate(value);
-
-    if (!isValidUuid) {
-        throw new InvalidArgumentError('Not a valid project UUID.');
+    if (value.trim() === '') {
+        throw new InvalidArgumentError('Not a valid project UUID or slug.');
     }
 
     return value;
@@ -255,8 +252,8 @@ ${styles.bold('Examples:')}
     .option('--token <token>', 'Login with an API access token', undefined)
     .addOption(
         new Option(
-            '--project <project uuid>',
-            'Select a project by UUID after login',
+            '--project <project uuid or slug>',
+            'Select a project by UUID or slug after login',
         )
             .argParser(parseProjectArgument)
             .conflicts('skipProjectSelection'),
@@ -917,8 +914,8 @@ const downloadCommand = program
         false,
     )
     .option(
-        '--project <project uuid>',
-        'specify a project UUID to download',
+        '--project <project uuid or slug>',
+        'specify a project (UUID or slug) to download from',
         parseProjectArgument,
         undefined,
     )
@@ -1071,8 +1068,8 @@ const uploadCommand = program
         undefined,
     )
     .option(
-        '--project <project uuid>',
-        'specify a project UUID to upload',
+        '--project <project uuid or slug>',
+        'specify a project (UUID or slug) to upload to',
         parseProjectArgument,
         undefined,
     )
@@ -1199,7 +1196,7 @@ appsProgram
         'Specify the Lightdash content root (default: ./lightdash)',
     )
     .option(
-        '--project <project uuid>',
+        '--project <project uuid or slug>',
         'Specify the project the app will use',
         parseProjectArgument,
         undefined,
@@ -1227,8 +1224,8 @@ appsProgram
         'Preview a downloaded data app locally against a real Lightdash instance, authenticated as you. Your credential stays in the CLI, behind a local proxy limited to data-app SDK routes.',
     )
     .option(
-        '--project <project uuid>',
-        'preview against a specific project (default: the projectUuid in lightdash-app.yml)',
+        '--project <project uuid or slug>',
+        'preview against a specific project by UUID or slug (default: the projectUuid in lightdash-app.yml)',
     )
     .option('--url <url>', 'Lightdash server URL (default: your login config)')
     .option(
@@ -1284,8 +1281,8 @@ program
     .command('deploy')
     .description('Compiles and deploys a Lightdash project')
     .option(
-        '--project <project uuid>',
-        'Project UUID to deploy to. Overrides the default project configured via `lightdash config set-project`',
+        '--project <project uuid or slug>',
+        'Project UUID or slug to deploy to. Overrides the default project configured via `lightdash config set-project`',
     )
     .option(
         '--project-dir <path>',
@@ -1429,8 +1426,8 @@ program
     .command('validate')
     .description('Validates a project')
     .option(
-        '--project <project uuid>',
-        'Project UUID to validate, if not provided, the last preview will be used',
+        '--project <project uuid or slug>',
+        'Project UUID or slug to validate, if not provided, the last preview will be used',
     )
     .option('--verbose', undefined, false)
     .option(
@@ -1616,8 +1613,8 @@ program
     .description('Rename models and fields on Lightdash content')
     .option('--verbose', undefined, false)
     .option(
-        '-p, --project <project uuid>',
-        'specify a project UUID to rename',
+        '-p, --project <project uuid or slug>',
+        'specify a project (UUID or slug) to rename in',
         parseProjectArgument,
         undefined,
     )
@@ -1640,8 +1637,8 @@ program
     .description('Rename a chart slug and update its local references')
     .option('--verbose', 'show verbose output', false)
     .option(
-        '--project <project uuid>',
-        'specify a project UUID',
+        '--project <project uuid or slug>',
+        'specify a project by UUID or slug',
         parseProjectArgument,
         undefined,
     )
@@ -1830,8 +1827,8 @@ program
     )
     .option('--all', 'Audit every dashboard in the target project', false)
     .option(
-        '--project <projectUuid>',
-        'Project UUID (defaults to LIGHTDASH_PROJECT_UUID env or config)',
+        '--project <project uuid or slug>',
+        'Project UUID or slug (defaults to LIGHTDASH_PROJECT_UUID env or config)',
     )
     .option(
         '--json',
@@ -1974,8 +1971,8 @@ program
         undefined,
     )
     .option(
-        '--project <uuid>',
-        'Lightdash project UUID to update (defaults to currently selected project)',
+        '--project <project uuid or slug>',
+        'Lightdash project UUID or slug to update (defaults to currently selected project)',
         undefined,
     )
     .option(
@@ -1995,8 +1992,8 @@ program
     .argument('<chart>', 'Chart UUID or slug')
     .requiredOption('-o, --output <file>', 'Output file path for the PNG image')
     .option(
-        '--project <uuid>',
-        'Lightdash project UUID (defaults to the currently selected project)',
+        '--project <project uuid or slug>',
+        'Lightdash project UUID or slug (defaults to the currently selected project)',
     )
     .option('--verbose', 'Show detailed output', false)
     .action(exportChartImageHandler);


### PR DESCRIPTION
## Summary

The app switched to project and content slugs in URLs (#27826), but the CLI still only accepted UUIDs. The identifier a user can copy out of the browser no longer worked with `--project`, and a dashboard URL passed to `download -d` silently downloaded nothing. This makes the CLI accept what the UI exposes, with no backend changes.

## Changes

- **`--project` accepts a slug or a UUID.** New `resolveProjectFlag` helper: a UUID passes through untouched, anything else is matched against `slug` from `GET /api/v1/org/projects`. Unknown slugs fail with a message pointing at `lightdash config list-projects`; a slug matching more than one project lists the candidates with their UUIDs. The UUID check mirrors the shape regex `CoderService.isUuid` already uses on the backend.
- **Every consumer of the flag resolves through it.** `selectProject` covers deploy, download, upload, slug-update and app create. Handlers that read the flag directly (validate, rename, export-chart-image, set-warehouse, pre-aggregate-audit, apps preview) now resolve too. `config set-project --uuid` and `login --project` match on slug as well.
- **`download -d <url>` handles slug URLs.** `parseContentFilters` captured only `[a-f0-9-]+` after `/dashboards/` or `/saved/`, so a slug like `sales-pipeline` never matched and the whole URL was sent as the id (zero results). Worse, a slug such as `daily-sales` partially matched as `da`. It now captures the whole path segment; the backend already accepts slugs or UUIDs for these ids.
- **`config list-projects` prints the slug** under each project.
- **Help text** on every `--project` option says "uuid or slug", and the commander-level `parseProjectArgument` no longer rejects non-UUIDs.

## Regression analysis

- Existing `--project <uuid>` invocations take the same path as before: the helper returns a UUID without an API call, so no extra request and no behaviour change.
- The only new network call is one `GET /api/v1/org/projects` when a non-UUID is passed, which previously would have 404'd downstream anyway.
- `parseContentFilters` still extracts UUIDs from legacy UUID URLs (covered by a test). Bare slugs and UUIDs without a URL are unchanged.
- Four existing test files passed non-UUID strings such as `test-project-uuid` as the flag; those fixtures now use UUID-shaped values, or drop the redundant flag where the config context already named the same project.

## Verification

- `pnpm -F cli typecheck`, lint, and the full CLI suite (55 files, 663 tests) pass, including new tests for `resolveProjectFlag` and `parseContentFilters`.
- Backwards compatibility with UUIDs, live with the built CLI: `--project <uuid>` with a legacy UUID URL, with a bare dashboard UUID, with a legacy URL carrying a query string, and an uppercase UUID with a bare slug all resolve to the same project and produce byte-identical dashboard files to the slug run. A UUID never triggers the org projects lookup (pinned by tests in `selectProject.test.ts` and `resolveProjectFlag.test.ts`), and the flag-level check is a superset of the old `uuid.validate`, so nothing previously accepted is rejected now.
- Live against a real instance with the built CLI: `config list-projects` shows slugs; `--project <unknown-slug>` fails with the actionable error; `download --project <slug> -d https://<host>/projects/<slug>/dashboards/<dashboard-slug>/view` resolves the project and downloads exactly one dashboard.

Closes: #27972
Relates: PROD-10532

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tz3mpZ5KKo8szM1zE71tiK

