### PR TITLE
fix(explorer): mount gallery in alternate hosts

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartEditorModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartEditorModal.tsx
@@ -35,6 +35,7 @@ import { ModalHostedContext } from '../../providers/Explorer/useIsModalHosted';
 import MantineModal from '../common/MantineModal';
 import Page from '../common/Page/Page';
 import Explorer from '../Explorer';
+import { useChartGalleryRightSidebar } from '../Explorer/ChartGallery/useChartGalleryRightSidebar';
 import RegistryImpactPreviewModal from '../Explorer/CustomMetricModal/RegistryImpactPreviewModal';
 import ExploreSideBar from '../Explorer/ExploreSideBar';
 import PageSpinner from '../PageSpinner';
@@ -46,6 +47,35 @@ type ContentProps = {
     onDirtyChange: (isDirty: boolean) => void;
     onExploreSelect: (exploreName: string) => void;
     onBackToTables: () => void;
+};
+
+const DashboardChartEditorView: FC<
+    Pick<ContentProps, 'editChart' | 'onExploreSelect' | 'onBackToTables'> & {
+        title: string;
+    }
+> = ({ editChart, onExploreSelect, onBackToTables, title }) => {
+    const rightSidebarProps = useChartGalleryRightSidebar({ enabled: true });
+
+    return (
+        <Page
+            withContainerHeight
+            title={title}
+            sidebar={
+                <ExploreSideBar
+                    onExploreClick={(explore) => onExploreSelect(explore.name)}
+                    onBackToTables={onBackToTables}
+                />
+            }
+            isSidebarOpen
+            {...rightSidebarProps}
+            withFullHeight
+            withPaddedContent
+        >
+            <MergeProvider savedMerge={editChart?.merge ?? null}>
+                <Explorer />
+            </MergeProvider>
+        </Page>
+    );
 };
 
 const DashboardChartEditorContent: FC<ContentProps> = ({
@@ -118,25 +148,12 @@ const DashboardChartEditorContent: FC<ContentProps> = ({
         <Provider store={store}>
             <ExplorerEffects />
             <UnsavedChangesBridge onDirtyChange={onDirtyChange} />
-            <Page
-                withContainerHeight
+            <DashboardChartEditorView
+                editChart={editChart}
+                onExploreSelect={onExploreSelect}
+                onBackToTables={onBackToTables}
                 title={data ? data.label : 'Tables'}
-                sidebar={
-                    <ExploreSideBar
-                        onExploreClick={(explore) =>
-                            onExploreSelect(explore.name)
-                        }
-                        onBackToTables={onBackToTables}
-                    />
-                }
-                isSidebarOpen
-                withFullHeight
-                withPaddedContent
-            >
-                <MergeProvider savedMerge={editChart?.merge ?? null}>
-                    <Explorer />
-                </MergeProvider>
-            </Page>
+            />
         </Provider>
     );
 };

--- a/packages/frontend/src/components/Explorer/ChartGallery/ExplorerAlternateHosts.test.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ExplorerAlternateHosts.test.tsx
@@ -1,0 +1,211 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createPortal } from 'react-dom';
+import { MemoryRouter } from 'react-router';
+import { describe, expect, it, vi } from 'vitest';
+import EmbedExplore from '../../../ee/features/embed/EmbedExplore/components/EmbedExplore';
+import { explorerActions } from '../../../features/explorer/store';
+import { type InfiniteQueryResults } from '../../../hooks/useQueryResults';
+import { renderWithProviders } from '../../../testing/testUtils';
+import DashboardChartEditorModal from '../../DashboardTiles/DashboardChartEditorModal';
+
+vi.mock('../../MonacoEditor', () => ({ default: () => null }));
+
+vi.mock('../VisualizationCard/VisualizationConfig', async () => {
+    const { ConfigTabs } =
+        await import('../../VisualizationConfigs/ChartConfigPanel/ConfigTabs');
+
+    return { default: ConfigTabs };
+});
+
+vi.mock('../index', async () => {
+    const { ChartType } = await import('@lightdash/common');
+    const {
+        selectIsVisualizationConfigOpen,
+        useExplorerDispatch,
+        useExplorerSelector,
+    } = await import('../../../features/explorer/store');
+    const { default: ChartColorMappingContextProvider } =
+        await import('../../../hooks/useChartColorConfig/ChartColorMappingContextProvider');
+    const { default: VisualizationProvider } =
+        await import('../../LightdashVisualization/VisualizationProvider');
+    const { default: ExplorerChartSidebar } =
+        await import('./ExplorerChartSidebar');
+    const { default: useVisualizationConfigPortalTarget } =
+        await import('../VisualizationCard/useVisualizationConfigPortalTarget');
+    const resultsData: InfiniteQueryResults & {
+        fields: Record<string, never>;
+    } = {
+        rows: [],
+        fields: {},
+        isInitialLoading: false,
+        isFetchingFirstPage: false,
+        isFetchingRows: false,
+        isFetchingAllPages: false,
+        fetchMoreRows: () => undefined,
+        refetchRows: async () => undefined,
+        setFetchAll: () => undefined,
+        fetchAll: false,
+        hasFetchedAllRows: true,
+        totalClientFetchTimeMs: undefined,
+        error: null,
+    };
+
+    const ExplorerHostProbe = () => {
+        const dispatch = useExplorerDispatch();
+        const isOpen = useExplorerSelector(selectIsVisualizationConfigOpen);
+        const target = useVisualizationConfigPortalTarget(isOpen, {
+            followHost: true,
+        });
+
+        return (
+            <ChartColorMappingContextProvider>
+                <VisualizationProvider
+                    chartConfig={{
+                        type: ChartType.CARTESIAN,
+                        config: {
+                            layout: { xField: '', yField: [] },
+                            eChartsConfig: { series: [] },
+                        },
+                    }}
+                    initialPivotDimensions={undefined}
+                    resultsData={resultsData}
+                    isLoading={false}
+                    columnOrder={[]}
+                    colorPalette={[]}
+                    isEditMode
+                >
+                    <button
+                        type="button"
+                        onClick={() =>
+                            dispatch(explorerActions.openVisualizationConfig())
+                        }
+                    >
+                        Configure
+                    </button>
+                    {target &&
+                        createPortal(
+                            <ExplorerChartSidebar
+                                chartType={ChartType.CARTESIAN}
+                                onClose={() =>
+                                    dispatch(
+                                        explorerActions.closeVisualizationConfig(),
+                                    )
+                                }
+                            />,
+                            target,
+                        )}
+                </VisualizationProvider>
+            </ChartColorMappingContextProvider>
+        );
+    };
+
+    return { default: ExplorerHostProbe };
+});
+
+vi.mock('../ExploreSideBar', () => ({
+    default: ({
+        onExploreClick,
+    }: {
+        onExploreClick?: (explore: { name: string }) => void;
+    }) => (
+        <button
+            type="button"
+            onClick={() => onExploreClick?.({ name: 'orders' })}
+        >
+            Orders
+        </button>
+    ),
+}));
+
+vi.mock('../../../hooks/useExplore', () => ({
+    useExplore: () => ({ data: undefined, error: null }),
+}));
+
+vi.mock('../../../hooks/useExplorerQueryEffects', () => ({
+    useExplorerQueryEffects: vi.fn(),
+}));
+
+vi.mock('./useIsChartGalleryEnabled', () => ({
+    useIsChartGalleryEnabled: () => true,
+}));
+
+vi.mock('../../../hooks/dashboard/useDashboardCustomMetricSeed', () => ({
+    useDashboardCustomMetricSeed: () => ({
+        seededMetrics: [],
+        dashboardMetricIds: new Set(),
+        isLoading: false,
+    }),
+}));
+
+vi.mock('../../../hooks/dashboard/useUpdateDashboardCustomMetric', () => ({
+    useDeleteDashboardCustomMetric: () => ({
+        mutate: vi.fn(),
+        isLoading: false,
+    }),
+}));
+
+vi.mock('../../../hooks/toaster/useToaster', () => ({
+    default: () => ({
+        showToastSuccess: vi.fn(),
+        showToastError: vi.fn(),
+    }),
+}));
+
+vi.mock('../../../ee/providers/Embed/useEmbed', () => ({
+    default: () => ({ projectUuid: 'project-uuid' }),
+}));
+
+describe('Explorer chart configuration in alternate hosts', () => {
+    it('opens the chart gallery and settings in the dashboard chart editor', async () => {
+        const user = userEvent.setup();
+
+        renderWithProviders(
+            <MemoryRouter>
+                <DashboardChartEditorModal
+                    opened
+                    dashboardUuid="dashboard-uuid"
+                    dashboardName="Orders dashboard"
+                    onChartSaved={vi.fn()}
+                    onRegistryMetricEdited={vi.fn()}
+                    onRegistryMetricDeleted={vi.fn()}
+                    onClose={vi.fn()}
+                />
+            </MemoryRouter>,
+        );
+
+        await user.click(screen.getByRole('button', { name: 'Orders' }));
+        expect(
+            document.getElementById('visualization-config-portal'),
+        ).not.toBeNull();
+        await user.click(screen.getByRole('button', { name: 'Configure' }));
+
+        expect(screen.getByText('Configure chart')).toBeVisible();
+        expect(screen.getByRole('tab', { name: 'Layout' })).toBeVisible();
+
+        await user.click(screen.getByRole('button', { name: 'Change' }));
+
+        expect(screen.getByText('Choose chart type')).toBeVisible();
+        expect(screen.getByRole('button', { name: 'Bar chart' })).toBeVisible();
+    });
+
+    it('opens the chart gallery and settings in Embed Explore', async () => {
+        const user = userEvent.setup();
+
+        renderWithProviders(
+            <MemoryRouter>
+                <EmbedExplore exploreId="orders" />
+            </MemoryRouter>,
+        );
+
+        await user.click(screen.getByRole('button', { name: 'Configure' }));
+
+        expect(screen.getByText('Configure chart')).toBeVisible();
+        expect(screen.getByRole('tab', { name: 'Layout' })).toBeVisible();
+
+        await user.click(screen.getByRole('button', { name: 'Change' }));
+
+        expect(screen.getByText('Choose chart type')).toBeVisible();
+        expect(screen.getByRole('button', { name: 'Bar chart' })).toBeVisible();
+    });
+});

--- a/packages/frontend/src/ee/features/embed/EmbedExplore/components/EmbedExplore.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedExplore/components/EmbedExplore.tsx
@@ -9,6 +9,7 @@ import { Provider } from 'react-redux';
 import Page from '../../../../../components/common/Page/Page';
 import SuboptimalState from '../../../../../components/common/SuboptimalState/SuboptimalState';
 import Explorer from '../../../../../components/Explorer';
+import { useChartGalleryRightSidebar } from '../../../../../components/Explorer/ChartGallery/useChartGalleryRightSidebar';
 import ExploreSideBar from '../../../../../components/Explorer/ExploreSideBar';
 import {
     buildInitialExplorerState,
@@ -37,6 +38,9 @@ const EmbedExploreView: FC<{
     chartView,
 }) => {
     const { data } = useExplore(exploreId);
+    const rightSidebarProps = useChartGalleryRightSidebar({
+        enabled: isEditMode,
+    });
 
     // Run the query effects hook
     useExplorerQueryEffects();
@@ -56,6 +60,7 @@ const EmbedExploreView: FC<{
                 />
             }
             isSidebarOpen={isEditMode}
+            {...rightSidebarProps}
             withFullHeight
             withPaddedContent
         >


### PR DESCRIPTION
Relates: [GLITCH-764](https://linear.app/lightdash/issue/GLITCH-764/decouple-the-in-dashboard-chart-editor-from-the-custom-metrics-flag)

### Description:

- Mount the chart gallery right sidebar in the dashboard chart editor modal.
- Mount it in Embed Explore while that host is in edit mode, so read-only embeds are untouched.
- Add host-level regressions that open the real Cartesian settings, click **Change**, and verify the real chart gallery in both hosts.

Base of the stack. #28833 sits on top and removes the feature flag once every Explorer host mounts the gallery.

### Risk assessment:

- [ ] This is a high-risk change

Low risk: the sidebar stays behind the existing `explorer-chart-gallery` feature flag, which `useChartGalleryRightSidebar` checks, and read-only embeds keep their current layout.

### Testing:

- `pnpm -F frontend test src/components/Explorer/ChartGallery/ExplorerAlternateHosts.test.tsx src/components/Explorer/ChartGallery/useChartGalleryRightSidebar.test.tsx src/components/Explorer/VisualizationCard/VisualizationConfigPortal.test.tsx` (3 files, 10 tests)
- `pnpm -F frontend typecheck`
- `pnpm -F frontend lint`
- Manual local verification on the stacked branch: in the embedded dashboard chart editor, **Configure** opens the real Layout settings and **Change** opens the chart gallery.

**Edit chart in dashboard modal**
<img width="2557" height="1316" alt="CleanShot 2026-09-08 at 13 53 12" src="https://github.com/user-attachments/assets/014eae99-ce68-41e5-ae20-f1e5c0268538" />

**Edit chart embed**
<img width="1680" height="1000" alt="embed-explore-edit-mode" src="https://github.com/user-attachments/assets/9ff7bb3f-d14c-427e-bb9e-3486f8d933d8" />
