### PR TITLE
feat(dashboard): split the chart editor modal onto its own feature flag

### DIFF
--- a/packages/common/src/featureFlags/previewFeatureFlags.ts
+++ b/packages/common/src/featureFlags/previewFeatureFlags.ts
@@ -30,7 +30,9 @@ const PREVIEW_EXCLUDED_FEATURE_FLAGS: ReadonlySet<string> = new Set<string>([
     FeatureFlags.ExplorerChartGallery,
     // Same reason: the dashboard E2E specs drive the navigate-away "New chart"
     // flow, which the in-dashboard modal replaces. Opt-in POC — keep previews
-    // on the shipped path until it has its own coverage.
+    // on the shipped path until it has its own coverage. The metrics layer
+    // rides inside the modal, so it must stay off with it.
+    FeatureFlags.InDashboardChartEditor,
     FeatureFlags.DashboardCustomMetrics,
     // Derived from instance configuration: left to their config handler so a
     // preview never advertises a feature whose backend isn't configured.

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -329,6 +329,11 @@ export enum FeatureFlags {
      * Off by default.
      */
     DashboardCustomMetrics = 'dashboard-custom-metrics',
+    /**
+     * Build and edit charts in a full-screen modal over the dashboard
+     * instead of navigating away. Off by default.
+     */
+    InDashboardChartEditor = 'in-dashboard-chart-editor',
 
     /**
      * AI agent battle mode: send one prompt to two models in paired threads

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartEditorModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartEditorModal.tsx
@@ -168,6 +168,8 @@ type Props = {
     dashboardUuid: string;
     dashboardName: string;
     editChart?: SavedChart;
+    /** Shared-metrics layer: seed, collect, badge, registry mutations */
+    customMetricsEnabled: boolean;
     onChartSaved: (chart: SavedChart) => void;
     onRegistryMetricEdited: (metric: AdditionalMetric) => void;
     onRegistryMetricDeleted: (metric: AdditionalMetric) => void;
@@ -183,6 +185,7 @@ const DashboardChartEditorModal: FC<Props> = ({
     dashboardUuid,
     dashboardName,
     editChart,
+    customMetricsEnabled,
     onChartSaved,
     onRegistryMetricEdited,
     onRegistryMetricDeleted,
@@ -195,7 +198,9 @@ const DashboardChartEditorModal: FC<Props> = ({
         seededMetrics,
         dashboardMetricIds,
         isLoading: isSeedLoading,
-    } = useDashboardCustomMetricSeed(exploreId);
+    } = useDashboardCustomMetricSeed(
+        customMetricsEnabled ? exploreId : undefined,
+    );
 
     const { showToastSuccess, showToastError } = useToaster();
     const deleteRegistryMetric = useDeleteDashboardCustomMetric(dashboardUuid);
@@ -276,7 +281,9 @@ const DashboardChartEditorModal: FC<Props> = ({
             isModalHosted: true,
             onChartSaved: handleChartSaved,
             dashboard: { uuid: dashboardUuid, name: dashboardName },
-            dashboardMetricIds,
+            dashboardMetricIds: customMetricsEnabled
+                ? dashboardMetricIds
+                : undefined,
             onRegistryMetricEdited,
             requestRegistryMetricDelete,
         }),
@@ -285,6 +292,7 @@ const DashboardChartEditorModal: FC<Props> = ({
             dashboardUuid,
             dashboardName,
             dashboardMetricIds,
+            customMetricsEnabled,
             onRegistryMetricEdited,
             requestRegistryMetricDelete,
         ],

--- a/packages/frontend/src/components/Explorer/ExploreTree/SelectedFieldsSection.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/SelectedFieldsSection.tsx
@@ -40,10 +40,7 @@ import {
 } from '../../../features/explorer/store';
 import { useExplore } from '../../../hooks/useExplore';
 import { useAddFilter } from '../../../hooks/useFilters';
-import {
-    useIsModalHosted,
-    useModalHostedDashboardMetricIds,
-} from '../../../providers/Explorer/useIsModalHosted';
+import { useModalHostedDashboardMetricIds } from '../../../providers/Explorer/useIsModalHosted';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
 import FieldIcon from '../../common/Filters/FieldIcon';
@@ -149,12 +146,12 @@ const SelectedFieldRow: FC<RowProps> = memo(({ row, onDeselect }) => {
 
     // Registry metrics stay frozen here too; the badge marks provenance
     const dashboardMetricIds = useModalHostedDashboardMetricIds();
-    const isModalHosted = useIsModalHosted();
     const isRegistryMetric =
         isAdditionalMetric(item) &&
         (dashboardMetricIds?.has(getItemId(item)) ?? false);
     const isDashboardMetric =
-        isRegistryMetric || (isModalHosted && isAdditionalMetric(item));
+        isRegistryMetric ||
+        (dashboardMetricIds !== undefined && isAdditionalMetric(item));
 
     const selectIsFiltered = useMemo(
         () => (state: ExplorerStoreState) =>

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
@@ -50,7 +50,6 @@ import {
 import { useExplore } from '../../../../../hooks/useExplore';
 import { useAddFilter } from '../../../../../hooks/useFilters';
 import { useServerFeatureFlag } from '../../../../../hooks/useServerOrClientFeatureFlag';
-import { useIsModalHosted } from '../../../../../providers/Explorer/useIsModalHosted';
 import useTracking from '../../../../../providers/Tracking/useTracking';
 import { EventName } from '../../../../../types/Events';
 import {
@@ -175,7 +174,6 @@ const TreeSingleNodeComponent: FC<Props> = ({ node }) => {
     const dashboardMetricIds = useTableTree(
         (context) => context.dashboardMetricIds,
     );
-    const isModalHosted = useIsModalHosted();
     const itemsAlerts = useTableTree((context) => context.itemsAlerts);
     const missingCustomDimensions = useTableTree(
         (context) => context.missingCustomDimensions,
@@ -289,9 +287,11 @@ const TreeSingleNodeComponent: FC<Props> = ({ node }) => {
     const isRegistryMetric =
         isAdditionalMetric(item) &&
         (dashboardMetricIds?.has(getItemId(item)) ?? false);
-    // The '=' badge marks provenance: dashboard-local from creation
+    // The '=' badge marks provenance: dashboard-local from creation. The ids
+    // set is only provided when the shared-metrics layer is enabled.
     const isDashboardMetric =
-        isRegistryMetric || (isModalHosted && isAdditionalMetric(item));
+        isRegistryMetric ||
+        (dashboardMetricIds !== undefined && isAdditionalMetric(item));
 
     const itemColors = getFieldColors(item);
     const alerts = itemsAlerts?.[getItemId(item)];

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -825,10 +825,17 @@ const Dashboard: FC = () => {
         (c) => c.hasTilesThatSupportFilters,
     );
 
+    // The modal editor and the shared-metrics layer roll out independently;
+    // metrics only ever activate through the modal's surfaces.
+    const chartEditorFlag = useServerFeatureFlag(
+        FeatureFlags.InDashboardChartEditor,
+    );
+    const isChartEditorEnabled = chartEditorFlag.data?.enabled === true;
     const dashboardCustomMetricsFlag = useServerFeatureFlag(
         FeatureFlags.DashboardCustomMetrics,
     );
     const isDashboardCustomMetricsEnabled =
+        isChartEditorEnabled &&
         dashboardCustomMetricsFlag.data?.enabled === true;
     const [isNewChartOpen, setIsNewChartOpen] = useState(false);
     const [chartToEdit, setChartToEdit] = useState<SavedChart | undefined>();
@@ -873,14 +880,17 @@ const Dashboard: FC = () => {
 
     const handleChartEditorSaved = useCallback(
         (chart: SavedChart) => {
-            // Only the in-dashboard builder contributes to the registry.
+            // Only the in-dashboard builder contributes to the registry, and
+            // only while the shared-metrics layer is enabled.
             const previousRegistryIds = new Set(
                 dashboardCustomMetrics.map(getItemId),
             );
-            const mergedCustomMetrics = mergeDashboardCustomMetrics(
-                dashboardCustomMetrics,
-                chart.metricQuery.additionalMetrics ?? [],
-            );
+            const mergedCustomMetrics = isDashboardCustomMetricsEnabled
+                ? mergeDashboardCustomMetrics(
+                      dashboardCustomMetrics,
+                      chart.metricQuery.additionalMetrics ?? [],
+                  )
+                : dashboardCustomMetrics;
             if (mergedCustomMetrics !== dashboardCustomMetrics) {
                 setDashboardCustomMetrics(mergedCustomMetrics);
                 setHaveCustomMetricsChanged(true);
@@ -898,23 +908,25 @@ const Dashboard: FC = () => {
                         mergedCustomMetrics.map((metric) => metric.table),
                     ).size,
                 };
-                mergedCustomMetrics.forEach((metric) => {
-                    if (!previousRegistryIds.has(getItemId(metric))) {
-                        track({
-                            name: EventName.DASHBOARD_CUSTOM_METRIC_CREATED,
-                            properties: workbookEventProperties,
-                        });
-                    }
-                });
-                // Selected metrics that were already shared = duplication avoided
-                (chart.metricQuery.metrics ?? []).forEach((metricId) => {
-                    if (previousRegistryIds.has(metricId)) {
-                        track({
-                            name: EventName.DASHBOARD_CUSTOM_METRIC_REUSED,
-                            properties: workbookEventProperties,
-                        });
-                    }
-                });
+                if (isDashboardCustomMetricsEnabled) {
+                    mergedCustomMetrics.forEach((metric) => {
+                        if (!previousRegistryIds.has(getItemId(metric))) {
+                            track({
+                                name: EventName.DASHBOARD_CUSTOM_METRIC_CREATED,
+                                properties: workbookEventProperties,
+                            });
+                        }
+                    });
+                    // Selected metrics that were already shared = duplication avoided
+                    (chart.metricQuery.metrics ?? []).forEach((metricId) => {
+                        if (previousRegistryIds.has(metricId)) {
+                            track({
+                                name: EventName.DASHBOARD_CUSTOM_METRIC_REUSED,
+                                properties: workbookEventProperties,
+                            });
+                        }
+                    });
+                }
                 track({
                     name:
                         chart.uuid !== chartToEdit?.uuid
@@ -960,6 +972,7 @@ const Dashboard: FC = () => {
             projectUuid,
             user.data?.organizationUuid,
             track,
+            isDashboardCustomMetricsEnabled,
         ],
     );
 
@@ -1091,9 +1104,7 @@ const Dashboard: FC = () => {
             hasDateZoomConfigChanged,
         onAddTiles: handleAddTiles,
         onNewChart:
-            isDashboardCustomMetricsEnabled && isEditMode
-                ? handleOpenNewChart
-                : undefined,
+            isChartEditorEnabled && isEditMode ? handleOpenNewChart : undefined,
         onSaveDashboard: () => {
             if (shouldShowVerificationSaveOptions) {
                 saveVerificationModalHandlers.open();
@@ -1217,12 +1228,15 @@ const Dashboard: FC = () => {
                 <div>
                     <DashboardHeader {...dashboardHeaderProps} />
 
-                    {isDashboardCustomMetricsEnabled && dashboard.uuid ? (
+                    {isChartEditorEnabled && dashboard.uuid ? (
                         <DashboardChartEditorModal
                             opened={isNewChartOpen || chartToEdit !== undefined}
                             dashboardUuid={dashboard.uuid}
                             dashboardName={dashboard.name}
                             editChart={chartToEdit}
+                            customMetricsEnabled={
+                                isDashboardCustomMetricsEnabled
+                            }
                             onChartSaved={handleChartEditorSaved}
                             onRegistryMetricEdited={handleRegistryMetricEdited}
                             onRegistryMetricDeleted={
@@ -1269,9 +1283,7 @@ const Dashboard: FC = () => {
                     {/* Coordinates filter chip / rules popovers across the dashboard */}
                     <DashboardChartEditContext.Provider
                         value={
-                            isDashboardCustomMetricsEnabled
-                                ? setChartToEdit
-                                : undefined
+                            isChartEditorEnabled ? setChartToEdit : undefined
                         }
                     >
                         <FilterBarPopoversProvider>
@@ -1305,8 +1317,7 @@ const Dashboard: FC = () => {
                                 setGridWidth={setGridWidth}
                                 setAddingTab={setAddingTab}
                                 onNewChart={
-                                    isDashboardCustomMetricsEnabled &&
-                                    isEditMode
+                                    isChartEditorEnabled && isEditMode
                                         ? handleOpenNewChart
                                         : undefined
                                 }


### PR DESCRIPTION
Relates: GLITCH-764

### Description:

The modal chart-building flow rolls out independently of the shared-metrics experiment.

- **`in-dashboard-chart-editor`** (new, off by default) gates the modal itself: New chart from the header, tabs and empty state; Edit chart in place; the `DashboardChartEditorModal` render.
- **`dashboard-custom-metrics`** becomes an additive layer requiring the editor flag: seeding, collection on save, the `=` badge, and registry edit/delete only activate when both are on. `isDashboardCustomMetricsEnabled` is now `editorFlag && metricsFlag`, so metrics-only is structurally inert.
- The badge's provenance condition now keys on the `dashboardMetricIds` set being *provided* (modal-hosted **and** metrics on) instead of modal-hosted alone — with metrics off, custom metrics in the modal are plain chart-local metrics with no badge and full actions.
- A registry already persisted in `dashboard.config` stays dormant with metrics off: nothing seeds or collects, and `buildDashboardConfig` still carries it through saves untouched.
- Both flags join `PREVIEW_EXCLUDED_FEATURE_FLAGS`: the editor flag replaces the navigate-away flow the dashboard E2E specs drive, and the metrics layer must not silently activate the moment QA overrides the editor flag on a preview.

Flag-combination verification (off/off, editor-only, both, metrics-only) pending local browser pass — dev stack is intentionally down; will follow up in a comment.

### Risk assessment:

- [ ] This is a high-risk change

High-risk changes require approval from a reviewer other than the author before merging.