### PR TITLE
test(cli): pin --project uuid passthrough in selectProject

### DIFF
--- a/packages/cli/src/handlers/selectProject.test.ts
+++ b/packages/cli/src/handlers/selectProject.test.ts
@@ -55,6 +55,38 @@ describe('selectProject', () => {
         });
     });
 
+    it('uses an explicit --project UUID as-is, without any API call, even when a preview is active', async () => {
+        const config: Config = {
+            context: {
+                project: MAIN_UUID,
+                previewProject: PREVIEW_UUID,
+            },
+        } as Config;
+        const explicitUuid = '00000000-0000-0000-0000-000000000003';
+
+        const selection = await selectProject(config, explicitUuid);
+
+        expect(selection).toEqual({
+            projectUuid: explicitUuid,
+            isPreview: false,
+        });
+        expect(mockLightdashApi).not.toHaveBeenCalled();
+    });
+
+    it('resolves an explicit --project slug through the org projects list', async () => {
+        const config: Config = {
+            context: { project: MAIN_UUID },
+        } as Config;
+        mockLightdashApi.mockResolvedValueOnce([
+            { projectUuid: PREVIEW_UUID, slug: 'other', name: 'Other' },
+            { projectUuid: MAIN_UUID, slug: 'jaffle-shop', name: 'Jaffle' },
+        ] as never);
+
+        const selection = await selectProject(config, 'jaffle-shop');
+
+        expect(selection).toEqual({ projectUuid: MAIN_UUID, isPreview: false });
+    });
+
     it('returns the main project when only the main project is configured', async () => {
         const config: Config = {
             context: {


### PR DESCRIPTION
## Summary

Follow-up to #28838, which made `--project` accept slugs. That change must stay additive: an existing `--project <uuid>` invocation has to keep working exactly as before, since the app UI still shows both forms.

This adds two tests to `selectProject.test.ts` that pin the contract:

- An explicit `--project` UUID is returned as-is with no API call, even when a preview project is active.
- An explicit `--project` slug is resolved through the org projects list.

## Verification

Live with the built CLI from #28838 against a real instance: `--project <uuid>` with a legacy UUID URL, with a bare dashboard UUID, with a legacy URL carrying a query string, and an uppercase UUID with a bare slug all resolve to the same project and produce byte-identical dashboard files to the slug run.

Relates: #27972
Relates: PROD-10532

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tz3mpZ5KKo8szM1zE71tiK