### PR TITLE
fix(sandboxes): run sandbox images on Node 24 so the pinned CLI can upload

### DIFF
--- a/sandboxes/agent-onboarding/e2b.Dockerfile
+++ b/sandboxes/agent-onboarding/e2b.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-bookworm-slim
+FROM node:24-bookworm-slim
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/sandboxes/ai-coding-agent/e2b.Dockerfile
+++ b/sandboxes/ai-coding-agent/e2b.Dockerfile
@@ -6,7 +6,7 @@
 # the general agent's tool allowlist (GENERAL_ALLOWED_TOOLS) has zero Bash
 # entries, and with no toolchain on the image there is nothing to build with
 # even if that ever regressed.
-FROM node:22-bookworm-slim
+FROM node:24-bookworm-slim
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/sandboxes/ai-writeback/e2b.Dockerfile
+++ b/sandboxes/ai-writeback/e2b.Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
         ca-certificates \
         build-essential \
         gnupg \
-    && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
 

--- a/sandboxes/data-apps/e2b.Dockerfile
+++ b/sandboxes/data-apps/e2b.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22
+FROM node:24
 
 # Global tooling
 RUN npm install -g pnpm@11.17.0


### PR DESCRIPTION
## Summary

Agent onboarding runs finish as `completed` without creating any charts or dashboard, so "View dashboard" on the run page 404s. Every `lightdash upload` inside the sandbox fails with `Node.js v24.0.0 or later is required for this command (current: v22.23.2)`.

This bumps the four sandbox images to Node 24: `agent-onboarding`, `ai-coding-agent` and `data-apps` move from `node:22*` to `node:24*`, and `ai-writeback` installs Node via `setup_24.x` instead of `setup_22.x`. Anything that runs the pinned CLI in a sandbox needs this, not only onboarding.

## Regression analysis

Two changes that were individually fine met only inside a sandbox at the upload step:

- #26320 (2026-07-29) moved the project to Node 24. `@lightdash/cli` now declares `engines: node >=24`, and `readCodeFiles` in the upload handler hard-fails below 24. The published `2.159.0` tarball carries that check.
- #26611 (2026-07-31) made the onboarding service pin `@lightdash/cli` to the server version at run start. npm installs it on Node 22 with only an engine warning, so nothing fails until `upload` runs.

The sandbox Dockerfiles were never touched by either, so every managed onboarding since then has deployed its semantic layer and then failed to publish content. The agent retried upload several times, wrote a handoff documenting the Node version, and reported the run complete.

## Verification

Reproduced on a fresh local instance at 2.159.0 with the Docker sandbox provider: the run completed with no dashboard, and the agent's handoff named the Node requirement. Rebuilt `lightdash-agent-onboarding:local` from the bumped Dockerfile (Node 24.20.0), reran the same project, and the run created the starter dashboard plus six charts at the expected slug.

The `post-release` E2B template job builds from these same Dockerfiles, so production picks the fix up on the next release.

## Follow-up

The run should not report `completed` when upload never happened. Either the verify stage confirms the dashboard slug exists, or the page hides "View dashboard" when the fetch 404s. Tracked in the ticket.

Closes: PROD-11058

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RHykHxXfT6vd9BHTRhTheu
