### PR TITLE
feat(agent-onboarding): overhaul the run page

### DIFF
--- a/packages/frontend/src/ee/features/agentOnboarding/AgentOnboardingActivity.tsx
+++ b/packages/frontend/src/ee/features/agentOnboarding/AgentOnboardingActivity.tsx
@@ -24,19 +24,28 @@ const getActivityLinePrefix = (message: string): string => {
     );
 };
 
+const formatEventTime = (createdAt: string): string =>
+    new Date(createdAt).toLocaleTimeString([], {
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+    });
+
 const AgentOnboardingActivity: FC<{
     events: AgentOnboardingRunEvent[];
-    isCollapsed?: boolean;
-    id?: string;
-}> = ({ events, isCollapsed = false, id }) => {
+    id: string;
+}> = ({ events, id }) => {
     const viewportRef = useRef<HTMLDivElement>(null);
     const shouldFollowRef = useRef(true);
-    const visibleEvents = isCollapsed ? events.slice(-1) : events;
 
     useEffect(() => {
-        if (!shouldFollowRef.current || !viewportRef.current) return;
-        viewportRef.current.scrollTop = viewportRef.current.scrollHeight;
-    }, [events, isCollapsed]);
+        if (!shouldFollowRef.current) return;
+        const frame = window.requestAnimationFrame(() => {
+            if (!viewportRef.current) return;
+            viewportRef.current.scrollTop = viewportRef.current.scrollHeight;
+        });
+        return () => window.cancelAnimationFrame(frame);
+    }, [events]);
 
     const handleScroll = (event: UIEvent<HTMLDivElement>) => {
         const element = event.currentTarget;
@@ -49,29 +58,16 @@ const AgentOnboardingActivity: FC<{
         <ScrollArea
             id={id}
             viewportRef={viewportRef}
-            onScrollPositionChange={() => undefined}
             className={classes.terminal}
-            data-collapsed={isCollapsed || undefined}
             viewportProps={{ onScroll: handleScroll }}
         >
-            <Stack
-                gap={isCollapsed ? 0 : 8}
-                px="md"
-                pt={isCollapsed ? 10 : 44}
-                pb={isCollapsed ? 10 : 'md'}
-                pr={isCollapsed ? 170 : 'md'}
-            >
-                {visibleEvents.length === 0 ? (
-                    <Text
-                        c="gray.5"
-                        fz="sm"
-                        ff="monospace"
-                        className={classes.terminalMessage}
-                    >
-                        Waiting for the onboarding agent to start…
+            <Stack gap={4} p="md">
+                {events.length === 0 ? (
+                    <Text c="dimmed" fz="xs" ff="monospace">
+                        Waiting for the agent to start…
                     </Text>
                 ) : (
-                    visibleEvents.map((event, index) => (
+                    events.map((event, index) => (
                         <Group
                             key={`${event.createdAt}-${index}`}
                             gap="sm"
@@ -80,23 +76,16 @@ const AgentOnboardingActivity: FC<{
                             className={classes.terminalEntry}
                         >
                             <Text
-                                c="gray.6"
+                                c="dimmed"
                                 fz="xs"
                                 ff="monospace"
                                 className={classes.terminalTime}
                             >
-                                {new Date(event.createdAt).toLocaleTimeString(
-                                    [],
-                                    {
-                                        hour: '2-digit',
-                                        minute: '2-digit',
-                                        second: '2-digit',
-                                    },
-                                )}
+                                {formatEventTime(event.createdAt)}
                             </Text>
                             <Box
                                 component="span"
-                                fz="sm"
+                                fz="xs"
                                 ff="monospace"
                                 className={classes.terminalMessage}
                                 data-line-prefix={getActivityLinePrefix(
@@ -115,41 +104,45 @@ const AgentOnboardingActivity: FC<{
 
 export const AgentOnboardingActivityPanel: FC<{
     events: AgentOnboardingRunEvent[];
-    hasGeneratedFiles: boolean;
-}> = ({ events, hasGeneratedFiles }) => {
+}> = ({ events }) => {
     const [isCollapsed, setIsCollapsed] = useState(false);
     const activityId = useId();
-
-    useEffect(() => {
-        if (hasGeneratedFiles) setIsCollapsed(true);
-    }, [hasGeneratedFiles]);
+    const lastEvent = events.at(-1);
 
     return (
-        <Box className={classes.activityPanel}>
-            <Button
-                variant="subtle"
-                color="gray"
-                size="compact-sm"
-                leftSection={
-                    <MantineIcon
-                        icon={isCollapsed ? IconChevronDown : IconChevronUp}
-                        size={14}
-                    />
-                }
-                aria-expanded={!isCollapsed}
-                aria-controls={activityId}
-                onClick={() => setIsCollapsed((value) => !value)}
-                className={classes.activityToggle}
-            >
-                {isCollapsed
-                    ? 'Expand live activity'
-                    : 'Collapse live activity'}
-            </Button>
-            <AgentOnboardingActivity
-                id={activityId}
-                events={events}
-                isCollapsed={isCollapsed}
-            />
+        <Box className={classes.activity} data-collapsed={isCollapsed}>
+            <Box className={classes.activityHeader}>
+                <Group gap="xs" wrap="nowrap" miw={0}>
+                    <Text fz="sm" fw={500}>
+                        Activity
+                    </Text>
+                    {isCollapsed && lastEvent ? (
+                        <Text c="dimmed" fz="xs" ff="monospace" truncate>
+                            {sanitizeTerminalText(lastEvent.message)}
+                        </Text>
+                    ) : (
+                        <Text c="dimmed" fz="xs">
+                            {events.length}
+                        </Text>
+                    )}
+                </Group>
+                <Button
+                    variant="subtle"
+                    size="compact-xs"
+                    rightSection={
+                        <MantineIcon
+                            icon={isCollapsed ? IconChevronUp : IconChevronDown}
+                            size={14}
+                        />
+                    }
+                    aria-expanded={!isCollapsed}
+                    aria-controls={activityId}
+                    onClick={() => setIsCollapsed((value) => !value)}
+                >
+                    {isCollapsed ? 'Show' : 'Hide'}
+                </Button>
+            </Box>
+            <AgentOnboardingActivity id={activityId} events={events} />
         </Box>
     );
 };

--- a/packages/frontend/src/ee/features/agentOnboarding/AgentOnboardingDemoOffer.tsx
+++ b/packages/frontend/src/ee/features/agentOnboarding/AgentOnboardingDemoOffer.tsx
@@ -1,12 +1,9 @@
 import { subject } from '@casl/ability';
 import { type AgentOnboardingRun } from '@lightdash/common';
-import { Button, Group, Paper, Stack, Text } from '@mantine/core';
+import { Anchor } from '@mantine/core';
 import { captureException } from '@sentry/react';
-import { IconTelescope } from '@tabler/icons-react';
 import { useCallback, useEffect, useRef, useState, type FC } from 'react';
 import { useNavigate } from 'react-router';
-import Callout from '../../../components/common/Callout';
-import MantineIcon from '../../../components/common/MantineIcon';
 import {
     getPlaygroundSetupFailure,
     isRetryablePlaygroundSetupFailure,
@@ -141,48 +138,31 @@ export const AgentOnboardingDemoOffer: FC<{ run: AgentOnboardingRun }> = ({
 
     if (offerType === null) return null;
 
+    const canRetry =
+        failure === null || isRetryablePlaygroundSetupFailure(failure);
+    const actionLabel = isProvisioning
+        ? 'setting up your demo project…'
+        : failure !== null
+          ? 'try again'
+          : offerType === 'open_existing_demo'
+            ? 'open the demo project'
+            : 'explore sample data';
+
     return (
-        <Paper radius="md" p="lg">
-            <Group justify="space-between" align="center" wrap="nowrap">
-                <Group gap="md" align="flex-start" wrap="nowrap">
-                    <MantineIcon
-                        icon={IconTelescope}
-                        size="xl"
-                        color="blue.6"
-                    />
-                    <Stack gap={4}>
-                        <Text fw={600}>
-                            Explore a demo project while you wait
-                        </Text>
-                        {failure ? (
-                            <Callout variant="warning" hideIcon>
-                                <Text size="sm">
-                                    {DEMO_OFFER_FAILURE_MESSAGES[failure]}
-                                </Text>
-                            </Callout>
-                        ) : (
-                            <Text c="dimmed" size="sm">
-                                Poke around a sample-data project — your setup
-                                keeps running in the background.
-                            </Text>
-                        )}
-                    </Stack>
-                </Group>
-                {failure === null ||
-                isRetryablePlaygroundSetupFailure(failure) ? (
-                    <Button
-                        variant="light"
-                        loading={isProvisioning}
-                        onClick={() => void openDemo(offerType)}
-                    >
-                        {failure !== null
-                            ? 'Try again'
-                            : offerType === 'open_existing_demo'
-                              ? 'Open demo project'
-                              : 'Explore sample data'}
-                    </Button>
-                ) : null}
-            </Group>
-        </Paper>
+        <>
+            {failure ? DEMO_OFFER_FAILURE_MESSAGES[failure] : 'You can also'}{' '}
+            {canRetry ? (
+                <Anchor
+                    component="button"
+                    type="button"
+                    fz="sm"
+                    disabled={isProvisioning}
+                    onClick={() => void openDemo(offerType)}
+                >
+                    {actionLabel}
+                </Anchor>
+            ) : null}
+            {failure === null ? ' while you wait.' : null}
+        </>
     );
 };

--- a/packages/frontend/src/ee/features/agentOnboarding/AgentOnboardingFileBrowser.tsx
+++ b/packages/frontend/src/ee/features/agentOnboarding/AgentOnboardingFileBrowser.tsx
@@ -2,12 +2,14 @@ import { type AgentOnboardingFile } from '@lightdash/common';
 import {
     ActionIcon,
     Box,
+    Button,
     Center,
     Group,
-    Loader,
+    Paper,
     ScrollArea,
     Stack,
     Text,
+    Tooltip,
     Tree,
     getTreeExpandedState,
     useMantineColorScheme,
@@ -20,13 +22,14 @@ import {
     IconChevronRight,
     IconFile,
     IconFolder,
-    IconGripVertical,
     IconMaximize,
+    IconPlayerPlay,
 } from '@tabler/icons-react';
 import MarkdownPreview from '@uiw/react-markdown-preview';
-import { useEffect, useMemo, useState, type FC } from 'react';
+import { useEffect, useMemo, useRef, useState, type FC } from 'react';
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 import CodeBlock from '../../../components/common/CodeBlock/CodeBlock';
+import EmptyStateLoader from '../../../components/common/EmptyStateLoader';
 import MantineIcon from '../../../components/common/MantineIcon';
 import MantineModal from '../../../components/common/MantineModal';
 import {
@@ -37,6 +40,7 @@ import classes from './AgentOnboardingRunPage.module.css';
 import { useAgentOnboardingFile } from './hooks/useAgentOnboarding';
 import {
     buildAgentOnboardingFileTree,
+    sanitizeTerminalText,
     type AgentOnboardingFileTreeNode,
 } from './utils';
 
@@ -45,6 +49,29 @@ const getPreviewLanguage = (path: string): 'json' | 'yaml' | null => {
     if (/\.ya?ml$/i.test(path)) return 'yaml';
     return null;
 };
+
+const RECENT_UPDATE_WINDOW_MS = 15_000;
+
+const getLatestUpdatedFile = (
+    files: AgentOnboardingFile[],
+): AgentOnboardingFile | undefined =>
+    files.reduce<AgentOnboardingFile | undefined>(
+        (latest, file) =>
+            !latest ||
+            Date.parse(file.updatedAt) >= Date.parse(latest.updatedAt)
+                ? file
+                : latest,
+        undefined,
+    );
+
+const getAncestorPaths = (path: string): string[] =>
+    path
+        .split('/')
+        .slice(0, -1)
+        .map((_, index, segments) => segments.slice(0, index + 1).join('/'));
+
+const isRecentlyUpdated = (file: AgentOnboardingFile): boolean =>
+    Date.now() - Date.parse(file.updatedAt) < RECENT_UPDATE_WINDOW_MS;
 
 const toTreeData = (nodes: AgentOnboardingFileTreeNode[]): TreeNodeData[] =>
     nodes.map((node) => ({
@@ -111,19 +138,30 @@ export const AgentOnboardingFileBrowser: FC<{
     projectUuid: string;
     runUuid: string;
     files: AgentOnboardingFile[];
-}> = ({ projectUuid, runUuid, files }) => {
+    isLive: boolean;
+    latestActivity: string | null;
+}> = ({ projectUuid, runUuid, files, isLive, latestActivity }) => {
     const [selectedPath, setSelectedPath] = useState<string>();
     const [isExpanded, setIsExpanded] = useState(false);
+    const [isFollowing, setIsFollowing] = useState(true);
+    const shouldFollowLatest = isLive && isFollowing;
+    // Keyed on the path set so the tree is not re-initialised on every poll
+    const pathsKey = files.map(({ path }) => path).join('\n');
     const treeData = useMemo(
         () => toTreeData(buildAgentOnboardingFileTree(files)),
-        [files],
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [pathsKey],
     );
-    const allNodesExpanded = useMemo<Record<string, boolean>>(
-        () => getTreeExpandedState(treeData, '*') as Record<string, boolean>,
-        [treeData],
+    const folderValues = useMemo(
+        () =>
+            Object.keys(getTreeExpandedState(treeData, '*')).filter((value) =>
+                files.every(({ path }) => path !== value),
+            ),
+        [files, treeData],
     );
-    const fileTree = useTree({ initialExpandedState: allNodesExpanded });
-    const { clearSelected, select, setExpandedState } = fileTree;
+    const fileTree = useTree();
+    const { clearSelected, expand, select } = fileTree;
+    const seenFoldersRef = useRef<Set<string>>(new Set());
     const selectedFile = files.find(({ path }) => path === selectedPath);
     const fileQuery = useAgentOnboardingFile(
         projectUuid,
@@ -135,26 +173,36 @@ export const AgentOnboardingFileBrowser: FC<{
         if (files.length === 0) {
             setSelectedPath(undefined);
             clearSelected();
-        } else if (!files.some(({ path }) => path === selectedPath)) {
-            const nextSelectedPath = files[0].path;
+            return;
+        }
+        const latestFile = getLatestUpdatedFile(files);
+        const nextSelectedPath = shouldFollowLatest
+            ? latestFile?.path
+            : files.some(({ path }) => path === selectedPath)
+              ? selectedPath
+              : files[0].path;
+        if (nextSelectedPath && nextSelectedPath !== selectedPath) {
             setSelectedPath(nextSelectedPath);
             select(nextSelectedPath);
+            getAncestorPaths(nextSelectedPath).forEach(expand);
         }
-    }, [clearSelected, files, select, selectedPath]);
+    }, [
+        clearSelected,
+        expand,
+        files,
+        select,
+        selectedPath,
+        shouldFollowLatest,
+    ]);
 
+    // Runs after the Tree's own initialise effect, which collapses new folders
     useEffect(() => {
-        setExpandedState((current) => {
-            let changed = false;
-            const next = { ...current };
-            Object.keys(allNodesExpanded).forEach((value) => {
-                if (!(value in current)) {
-                    next[value] = true;
-                    changed = true;
-                }
-            });
-            return changed ? next : current;
+        folderValues.forEach((value) => {
+            if (seenFoldersRef.current.has(value)) return;
+            seenFoldersRef.current.add(value);
+            expand(value);
         });
-    }, [allNodesExpanded, setExpandedState]);
+    }, [expand, folderValues]);
 
     const renderTreeNode = ({
         node,
@@ -162,44 +210,48 @@ export const AgentOnboardingFileBrowser: FC<{
         hasChildren,
         elementProps,
         tree,
-    }: RenderTreeNodePayload) => (
-        <Group
-            gap={6}
-            align="center"
-            wrap="nowrap"
-            {...elementProps}
-            onClick={(event) => {
-                elementProps.onClick(event);
-                if (!hasChildren) {
-                    tree.select(node.value);
-                    setSelectedPath(node.value);
-                }
-            }}
-        >
-            <Box className={classes.fileTreeToggle}>
-                {hasChildren && (
+    }: RenderTreeNodePayload) => {
+        const file = files.find(({ path }) => path === node.value);
+        return (
+            <Group
+                key={file ? `${file.path}-${file.updatedAt}` : node.value}
+                gap={6}
+                align="center"
+                wrap="nowrap"
+                {...elementProps}
+                data-recent={file && isRecentlyUpdated(file) ? true : undefined}
+                onClick={(event) => {
+                    elementProps.onClick(event);
+                    if (!hasChildren) {
+                        setIsFollowing(false);
+                        tree.select(node.value);
+                        setSelectedPath(node.value);
+                    }
+                }}
+            >
+                <Box className={classes.fileTreeToggle}>
+                    {hasChildren && (
+                        <MantineIcon
+                            icon={expanded ? IconChevronDown : IconChevronRight}
+                            size={14}
+                        />
+                    )}
+                </Box>
+                <Box className={classes.fileTreeIcon}>
                     <MantineIcon
-                        icon={expanded ? IconChevronDown : IconChevronRight}
-                        size={14}
+                        icon={hasChildren ? IconFolder : IconFile}
+                        size={18}
                     />
-                )}
-            </Box>
-            <Box className={classes.fileTreeIcon}>
-                <MantineIcon
-                    icon={hasChildren ? IconFolder : IconFile}
-                    size={18}
-                />
-            </Box>
-            <Text fz="sm" lh="20px" truncate>
-                {node.label}
-            </Text>
-        </Group>
-    );
+                </Box>
+                <Text fz="sm" lh="20px" truncate>
+                    {node.label}
+                </Text>
+            </Group>
+        );
+    };
 
     const preview = fileQuery.isInitialLoading ? (
-        <Center h="100%">
-            <Loader size="sm" />
-        </Center>
+        <EmptyStateLoader h="100%" />
     ) : fileQuery.isError ? (
         <Center h="100%" p="lg">
             <Text c="red" fz="sm" ta="center">
@@ -222,16 +274,41 @@ export const AgentOnboardingFileBrowser: FC<{
 
     if (files.length === 0) {
         return (
-            <Center h="100%" p="xl">
-                <Stack gap="xs" align="center">
-                    <MantineIcon icon={IconFolder} size="lg" />
-                    <Text fw={600}>Generated files will appear here</Text>
-                    <Text c="dimmed" fz="sm" ta="center">
-                        The preview refreshes as the agent creates and updates
-                        your project files.
-                    </Text>
-                </Stack>
-            </Center>
+            <Box h="100%" p="md">
+                <Paper variant="dotted" h="100%">
+                    <Center h="100%" p="xl">
+                        <Stack gap="xs" align="center">
+                            <MantineIcon
+                                icon={IconFolder}
+                                size="lg"
+                                color="dimmed"
+                            />
+                            <Text fw={500}>
+                                {isLive
+                                    ? 'Exploring your warehouse'
+                                    : 'No files were generated'}
+                            </Text>
+                            <Text c="dimmed" fz="sm" ta="center">
+                                {isLive
+                                    ? 'Your semantic layer files appear here the moment the agent starts writing them.'
+                                    : 'The run ended before any project files were written.'}
+                            </Text>
+                            {isLive && latestActivity ? (
+                                <Text
+                                    c="dimmed"
+                                    fz="xs"
+                                    ff="monospace"
+                                    ta="center"
+                                    mt="sm"
+                                    className={classes.emptyActivity}
+                                >
+                                    {sanitizeTerminalText(latestActivity)}
+                                </Text>
+                            ) : null}
+                        </Stack>
+                    </Center>
+                </Paper>
+            </Box>
         );
     }
 
@@ -258,9 +335,7 @@ export const AgentOnboardingFileBrowser: FC<{
                 <PanelResizeHandle
                     className={classes.fileResizeHandle}
                     aria-label="Resize file tree and preview"
-                >
-                    <MantineIcon icon={IconGripVertical} size={14} />
-                </PanelResizeHandle>
+                />
                 <Panel
                     id="onboarding-file-preview"
                     minSize={30}
@@ -274,17 +349,49 @@ export const AgentOnboardingFileBrowser: FC<{
                             py={6}
                             className={classes.filePreviewHeader}
                         >
-                            <Text fz="xs" ff="monospace" truncate>
+                            <Text fz="xs" ff="monospace" c="dimmed" truncate>
                                 {selectedPath}
                             </Text>
-                            <ActionIcon
-                                aria-label="Expand file preview"
-                                size="sm"
-                                onClick={() => setIsExpanded(true)}
-                                disabled={!fileQuery.data}
-                            >
-                                <MantineIcon icon={IconMaximize} size="sm" />
-                            </ActionIcon>
+                            <Group gap={4} wrap="nowrap">
+                                {isLive ? (
+                                    <Button
+                                        variant={
+                                            isFollowing ? 'light' : 'subtle'
+                                        }
+                                        color={
+                                            isFollowing ? 'indigo' : undefined
+                                        }
+                                        size="compact-xs"
+                                        leftSection={
+                                            <MantineIcon
+                                                icon={IconPlayerPlay}
+                                                size={12}
+                                            />
+                                        }
+                                        aria-pressed={isFollowing}
+                                        onClick={() =>
+                                            setIsFollowing((value) => !value)
+                                        }
+                                    >
+                                        {isFollowing
+                                            ? 'Following latest'
+                                            : 'Follow latest'}
+                                    </Button>
+                                ) : null}
+                                <Tooltip label="Expand preview">
+                                    <ActionIcon
+                                        aria-label="Expand file preview"
+                                        size="sm"
+                                        onClick={() => setIsExpanded(true)}
+                                        disabled={!fileQuery.data}
+                                    >
+                                        <MantineIcon
+                                            icon={IconMaximize}
+                                            size="sm"
+                                        />
+                                    </ActionIcon>
+                                </Tooltip>
+                            </Group>
                         </Group>
                         <Box className={classes.filePreviewScroll}>
                             {preview}

--- a/packages/frontend/src/ee/features/agentOnboarding/AgentOnboardingLaunchPanel.tsx
+++ b/packages/frontend/src/ee/features/agentOnboarding/AgentOnboardingLaunchPanel.tsx
@@ -216,7 +216,7 @@ export const AgentOnboardingLaunchPanel: FC<
                                 size={44}
                                 radius="xl"
                                 variant="light"
-                                color="violet"
+                                color="indigo"
                             >
                                 <MantineIcon icon={IconSparkles} size="lg" />
                             </ThemeIcon>

--- a/packages/frontend/src/ee/features/agentOnboarding/AgentOnboardingProgress.tsx
+++ b/packages/frontend/src/ee/features/agentOnboarding/AgentOnboardingProgress.tsx
@@ -2,7 +2,7 @@ import {
     isAgentOnboardingRunTerminal,
     type AgentOnboardingRun,
 } from '@lightdash/common';
-import { Stepper, Text, Tooltip, type StepperStepProps } from '@mantine/core';
+import { Box, Text } from '@mantine/core';
 import {
     IconChartBar,
     IconCheck,
@@ -16,49 +16,63 @@ import classes from './AgentOnboardingRunPage.module.css';
 import {
     AGENT_ONBOARDING_PROGRESS_STAGES,
     formatStageDuration,
-    getAgentOnboardingProgressStageIndex,
     getAgentOnboardingProgressStageTimings,
     type AgentOnboardingProgressStage,
+    type AgentOnboardingProgressStageTiming,
 } from './utils';
 
 const STAGE_CONFIG: Record<
     AgentOnboardingProgressStage,
-    { label: string; description: string; icon: Icon }
+    { label: string; activeLabel: string; description: string; icon: Icon }
 > = {
     explore: {
-        label: 'Explore',
-        description:
-            'Looks through your warehouse to understand your data and choose a useful starting point.',
+        label: 'Explore your warehouse',
+        activeLabel: 'Exploring your warehouse',
+        description: 'Reads your tables to find a useful starting point.',
         icon: IconDatabaseSearch,
     },
     semantic_layer: {
-        label: 'Semantic layer',
-        description:
-            'Organizes your data into clear, reusable definitions for reporting.',
+        label: 'Build the semantic layer',
+        activeLabel: 'Building the semantic layer',
+        description: 'Turns your data into reusable metrics and dimensions.',
         icon: IconLayersLinked,
     },
     dashboard: {
-        label: 'Dashboard',
-        description:
-            'Creates a starter dashboard with useful metrics, charts, filters, and details.',
+        label: 'Create a starter dashboard',
+        activeLabel: 'Creating a starter dashboard',
+        description: 'Puts the first charts and filters together for you.',
         icon: IconChartBar,
     },
     ready: {
-        label: 'Ready',
-        description:
-            'Checks that everything works and gets your new project ready to use.',
+        label: 'Verify and hand off',
+        activeLabel: 'Verifying and handing off',
+        description: 'Checks everything works and opens the project.',
         icon: IconCheck,
     },
 };
 
-const ProgressStep: FC<StepperStepProps & { tooltip: string }> = ({
-    tooltip,
-    ...stepProps
-}) => (
-    <Tooltip label={tooltip} maw={360}>
-        <Stepper.Step {...stepProps} />
-    </Tooltip>
-);
+type StageState = AgentOnboardingProgressStageTiming['state'] | 'stopped';
+
+// A cancelled or failed run leaves its last started stage unfinished
+const getStageStates = (
+    run: AgentOnboardingRun | undefined,
+    timings: AgentOnboardingProgressStageTiming[] | undefined,
+): StageState[] => {
+    if (!run || !timings) {
+        return AGENT_ONBOARDING_PROGRESS_STAGES.map(() => 'not_started');
+    }
+    if (run.status === 'completed') {
+        return AGENT_ONBOARDING_PROGRESS_STAGES.map(() => 'completed');
+    }
+    const states: StageState[] = timings.map(({ state }) => state);
+    if (run.status === 'cancelled' || run.status === 'failed') {
+        const lastStartedIndex = states.findLastIndex(
+            (state) => state !== 'not_started',
+        );
+        if (lastStartedIndex >= 0) states[lastStartedIndex] = 'stopped';
+    }
+    return states;
+};
 
 export const AgentOnboardingProgress: FC<{ run?: AgentOnboardingRun }> = ({
     run,
@@ -77,57 +91,68 @@ export const AgentOnboardingProgress: FC<{ run?: AgentOnboardingRun }> = ({
             run ? getAgentOnboardingProgressStageTimings(run, now) : undefined,
         [now, run],
     );
-    const activeStageIndex = timings?.findIndex(
-        ({ state }) => state === 'active',
-    );
-    const currentStageIndex = getAgentOnboardingProgressStageIndex(
-        run?.stage ?? null,
-    );
-    const active = !run
-        ? -1
-        : run.status === 'completed'
-          ? (timings?.length ?? 0)
-          : activeStageIndex !== undefined && activeStageIndex >= 0
-            ? activeStageIndex
-            : Math.max(currentStageIndex ?? 0, 0);
+    const states = getStageStates(run, timings);
 
     return (
-        <Stepper
-            active={active}
-            size="xs"
-            iconSize={38}
-            classNames={{
-                root: classes.progressStepper,
-                steps: classes.progressSteps,
-                step: classes.progressStep,
-                stepBody: classes.progressStepBody,
-            }}
+        <Box
+            component="ol"
+            className={classes.stages}
+            aria-label="Setup stages"
         >
-            {AGENT_ONBOARDING_PROGRESS_STAGES.map(({ stage }) => {
-                const timing = timings?.find(
-                    ({ stage: timingStage }) => timingStage === stage,
-                );
+            {AGENT_ONBOARDING_PROGRESS_STAGES.map(({ stage }, index) => {
                 const config = STAGE_CONFIG[stage];
-                const icon = <MantineIcon icon={config.icon} size="md" />;
+                const state = states[index];
+                const timing = timings?.[index];
                 return (
-                    <ProgressStep
+                    <Box
+                        component="li"
                         key={stage}
-                        tooltip={config.description}
-                        label={config.label}
-                        description={
-                            timing ? (
-                                <Text fz="xs" c="dimmed" ff="monospace">
-                                    {formatStageDuration(timing.durationMs)}
-                                </Text>
-                            ) : undefined
-                        }
-                        icon={icon}
-                        completedIcon={icon}
-                        loading={timing?.state === 'active'}
-                        allowStepSelect={false}
-                    />
+                        className={classes.stage}
+                        data-state={state}
+                        aria-current={state === 'active' ? 'step' : undefined}
+                    >
+                        <Box className={classes.stageRail}>
+                            <Box className={classes.stageGlyph}>
+                                <MantineIcon
+                                    icon={
+                                        state === 'completed'
+                                            ? IconCheck
+                                            : config.icon
+                                    }
+                                    size={14}
+                                />
+                            </Box>
+                            <Box className={classes.stageLine} />
+                        </Box>
+                        <Box className={classes.stageBody}>
+                            <Text
+                                fz="sm"
+                                fw={500}
+                                className={classes.stageLabel}
+                            >
+                                {state === 'active'
+                                    ? config.activeLabel
+                                    : config.label}
+                            </Text>
+                            <Text fz="xs" c="dimmed">
+                                {config.description}
+                            </Text>
+                        </Box>
+                        {timing && timing.durationMs !== null ? (
+                            <Text
+                                fz="xs"
+                                c="dimmed"
+                                ff="monospace"
+                                className={classes.stageDuration}
+                            >
+                                {formatStageDuration(timing.durationMs)}
+                            </Text>
+                        ) : (
+                            <span />
+                        )}
+                    </Box>
                 );
             })}
-        </Stepper>
+        </Box>
     );
 };

--- a/packages/frontend/src/ee/features/agentOnboarding/AgentOnboardingRunPage.module.css
+++ b/packages/frontend/src/ee/features/agentOnboarding/AgentOnboardingRunPage.module.css
@@ -1,83 +1,189 @@
 .page {
-    min-height: calc(100vh - var(--ld-navbar-height, 50px));
-    background:
-        radial-gradient(
-            circle at 50% 0%,
-            var(--mantine-color-blue-0),
-            transparent 34rem
-        ),
-        var(--mantine-color-gray-0);
+    display: flex;
+    flex-direction: column;
+    height: calc(100vh - var(--navbar-height));
+    background: var(--ld-color-page);
 }
 
 .content {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
     width: 100%;
-    max-width: 1440px;
+    min-height: 0;
+    max-width: var(--page-content-max-width-large, 1440px);
     margin: 0 auto;
 }
 
-.progressStepper {
-    padding: var(--mantine-spacing-md) 0;
-    overflow-x: auto;
+.statusDot {
+    flex: 0 0 auto;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--mantine-color-ldGray-4);
 }
 
-.progressSteps {
-    min-width: 720px;
+.statusDot[data-status='running'] {
+    background: var(--mantine-color-indigo-filled);
+    animation: pulse 1.6s ease-in-out infinite;
 }
 
-.progressStep {
-    min-width: 90px;
+.statusDot[data-status='completed'] {
+    background: var(--mantine-color-green-filled);
 }
 
-.progressStepBody {
-    text-align: center;
-}
-
-.progressActivityCard {
-    overflow: hidden;
-}
-
-.activityPanel {
-    position: relative;
-    border-top: 1px solid var(--mantine-color-gray-3);
-    background: #111827;
-}
-
-.activityToggle {
-    position: absolute;
-    z-index: 2;
-    top: 8px;
-    right: 12px;
-    color: var(--mantine-color-gray-3);
-    background: #1f2937;
-}
-
-.activityToggle:hover {
-    color: var(--mantine-color-white);
-    background: rgb(255 255 255 / 8%);
+.statusDot[data-status='failed'] {
+    background: var(--mantine-color-red-filled);
 }
 
 .workspace {
-    min-height: 520px;
-    height: calc(100vh - 330px);
+    display: grid;
+    flex: 1;
+    grid-template-columns: minmax(300px, 400px) minmax(0, 1fr);
+    gap: var(--mantine-spacing-md);
+    min-height: 0;
+}
+
+.panel {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
     overflow: hidden;
 }
 
-.workspacePanel {
-    display: grid;
-    grid-template-rows: 49px minmax(0, 1fr);
+.panelHeader {
+    display: flex;
+    flex: 0 0 auto;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--mantine-spacing-sm);
+    height: 44px;
+    padding: 0 var(--mantine-spacing-md);
+    border-bottom: 1px solid var(--mantine-color-default-border);
+}
+
+.panelBody {
+    flex: 1;
     min-height: 0;
-    height: 100%;
-    overflow: hidden;
+}
+
+.stages {
+    display: flex;
+    flex: 0 0 auto;
+    flex-direction: column;
+    padding: var(--mantine-spacing-sm) 0;
+}
+
+.stage {
+    display: grid;
+    grid-template-columns: 24px minmax(0, 1fr) auto;
+    column-gap: var(--mantine-spacing-sm);
+    padding: 0 var(--mantine-spacing-md);
+}
+
+.stageRail {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    align-self: stretch;
+    padding-top: 2px;
+}
+
+.stageGlyph {
+    display: flex;
+    flex: 0 0 auto;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    border: 1px solid var(--mantine-color-ldGray-3);
+    border-radius: 50%;
+    color: var(--mantine-color-ldGray-5);
+    background: var(--mantine-color-body);
+}
+
+.stageLine {
+    flex: 1;
+    width: 1px;
+    min-height: var(--mantine-spacing-sm);
+    margin: 4px 0;
+    background: var(--mantine-color-default-border);
+}
+
+.stage:last-child .stageLine {
+    visibility: hidden;
+}
+
+.stage[data-state='active'] .stageGlyph {
+    border-color: var(--mantine-color-indigo-filled);
+    color: var(--mantine-color-indigo-light-color);
+    background: var(--mantine-color-indigo-light);
+    animation: ring 1.6s ease-out infinite;
+}
+
+.stage[data-state='completed'] .stageGlyph {
+    border-color: var(--mantine-color-indigo-filled);
+    color: var(--mantine-color-white);
+    background: var(--mantine-color-indigo-filled);
+}
+
+.stage[data-state='completed'] .stageLine {
+    background: var(--mantine-color-indigo-filled);
+    opacity: 0.5;
+}
+
+.stageBody {
+    min-width: 0;
+    padding-bottom: var(--mantine-spacing-sm);
+}
+
+.stage[data-state='not_started'] .stageLabel {
+    color: var(--mantine-color-dimmed);
+}
+
+.stage[data-state='stopped'] .stageGlyph {
+    border-color: var(--mantine-color-ldGray-4);
+    color: var(--mantine-color-ldGray-6);
+    background: var(--mantine-color-ldGray-1);
+}
+
+.stageDuration {
+    padding-top: 4px;
+    font-variant-numeric: tabular-nums;
+}
+
+.activity {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    min-height: 0;
+    border-top: 1px solid var(--mantine-color-default-border);
+}
+
+.activity[data-collapsed='true'] {
+    flex: 0 0 auto;
+    margin-top: auto;
+}
+
+.activityHeader {
+    display: flex;
+    flex: 0 0 auto;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--mantine-spacing-sm);
+    height: 36px;
+    padding: 0 var(--mantine-spacing-xs) 0 var(--mantine-spacing-md);
 }
 
 .terminal {
+    flex: 1;
     min-height: 0;
-    height: 220px;
-    background: inherit;
+    border-top: 1px solid var(--mantine-color-default-border);
+    background: var(--ld-color-page);
 }
 
-.terminal[data-collapsed='true'] {
-    height: 42px;
+.activity[data-collapsed='true'] .terminal {
+    display: none;
 }
 
 .terminalEntry {
@@ -86,55 +192,40 @@
 
 .terminalTime {
     flex: 0 0 auto;
-    line-height: 1.5;
+    line-height: 1.6;
+    font-variant-numeric: tabular-nums;
 }
 
 .terminalMessage {
     min-width: 0;
-    color: var(--mantine-color-gray-3);
+    color: var(--mantine-color-text);
     white-space: pre-wrap;
     overflow-wrap: anywhere;
-    line-height: 1.5;
+    line-height: 1.6;
 }
 
-.terminalMessage[data-line-prefix='glob'] {
-    color: var(--mantine-color-green-3);
-}
-
-.terminalMessage[data-line-prefix='grep'] {
-    color: var(--mantine-color-teal-3);
-}
-
+.terminalMessage[data-line-prefix='glob'],
+.terminalMessage[data-line-prefix='grep'],
 .terminalMessage[data-line-prefix='read'] {
-    color: var(--mantine-color-cyan-3);
+    color: var(--mantine-color-teal-light-color);
 }
 
-.terminalMessage[data-line-prefix='write'] {
-    color: var(--mantine-color-blue-3);
-}
-
+.terminalMessage[data-line-prefix='write'],
 .terminalMessage[data-line-prefix='edit'] {
-    color: var(--mantine-color-violet-3);
+    color: var(--mantine-color-indigo-light-color);
 }
 
-.terminalMessage[data-line-prefix='skill'] {
-    color: var(--mantine-color-orange-3);
-}
-
+.terminalMessage[data-line-prefix='skill'],
 .terminalMessage[data-line-prefix='todowrite'] {
-    color: var(--mantine-color-yellow-3);
+    color: var(--mantine-color-orange-light-color);
 }
 
 .terminalMessage[data-line-prefix='lightdash'] {
-    color: var(--mantine-color-lime-3);
+    color: var(--mantine-color-green-light-color);
 }
 
-.terminalMessage[data-line-prefix='command'] {
-    color: var(--mantine-color-gray-3);
-}
-
-.terminal[data-collapsed='true'] .terminalEntry,
-.terminal[data-collapsed='true'] .terminalMessage {
+.emptyActivity {
+    max-width: 480px;
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
@@ -157,52 +248,45 @@
     overflow: auto;
     overscroll-behavior: contain;
     scrollbar-gutter: stable;
-    background: var(--mantine-color-gray-0);
+    background: var(--ld-color-page);
 }
 
 .fileResizeHandle {
+    position: relative;
     display: flex;
-    flex: 0 0 7px;
-    align-items: center;
-    justify-content: center;
-    width: 7px;
-    color: var(--mantine-color-gray-5);
+    flex: 0 0 1px;
+    width: 1px;
+    color: transparent;
     cursor: col-resize;
-    background: var(--mantine-color-gray-2);
+    background: var(--mantine-color-ldGray-3);
     outline: none;
-    transition:
-        color 120ms ease,
-        background-color 120ms ease;
+    transition: background-color 120ms ease;
+}
+
+/* Wider invisible hit area so a 1px line stays easy to grab */
+.fileResizeHandle::before {
+    content: '';
+    position: absolute;
+    inset: 0 -4px;
 }
 
 .fileResizeHandle[data-resize-handle-state='hover'],
 .fileResizeHandle[data-resize-handle-state='drag'],
 .fileResizeHandle:focus-visible {
-    color: var(--mantine-color-blue-7);
-    background: var(--mantine-color-blue-1);
+    background: var(--mantine-color-ldGray-5);
 }
 
 .fileTreeItem {
     display: flex;
     align-items: center;
     width: 100%;
-    min-height: 36px;
-    padding-top: 8px;
-    padding-right: 10px;
-    padding-bottom: 8px;
-    color: var(--mantine-color-gray-7);
+    min-height: 32px;
+    padding-block: 6px;
+    padding-inline-end: 10px;
+    color: var(--mantine-color-ldGray-7);
 }
 
-.fileTreeToggle {
-    display: flex;
-    flex: 0 0 20px;
-    align-items: center;
-    justify-content: center;
-    width: 20px;
-    height: 20px;
-    line-height: 0;
-}
-
+.fileTreeToggle,
 .fileTreeIcon {
     display: flex;
     flex: 0 0 20px;
@@ -211,6 +295,7 @@
     width: 20px;
     height: 20px;
     line-height: 0;
+    color: var(--mantine-color-dimmed);
 }
 
 .fileTreeToggle svg,
@@ -220,27 +305,32 @@
 }
 
 .fileTreeItem:hover {
-    background: var(--mantine-color-gray-1);
+    background: var(--mantine-color-default-hover);
+}
+
+.fileTreeItem[data-recent='true'] {
+    animation: flash 1.8s ease-out;
 }
 
 .fileTreeItem[data-selected='true'] {
-    color: var(--mantine-color-blue-8);
-    background: var(--mantine-color-blue-0);
+    color: var(--mantine-color-text);
+    font-weight: 500;
+    background: var(--mantine-color-default-hover);
 }
 
 .filePreview {
     display: grid;
-    grid-template-rows: 38px minmax(0, 1fr);
+    grid-template-rows: 36px minmax(0, 1fr);
     min-width: 0;
     min-height: 0;
     height: 100%;
-    background: var(--mantine-color-white);
+    background: var(--mantine-color-body);
 }
 
 .filePreviewHeader {
-    height: 38px;
-    border-bottom: 1px solid var(--mantine-color-gray-3);
-    background: var(--mantine-color-gray-0);
+    height: 36px;
+    border-bottom: 1px solid var(--mantine-color-default-border);
+    background: var(--ld-color-page);
 }
 
 .filePreviewScroll {
@@ -261,7 +351,7 @@
     min-height: 100%;
     padding: var(--mantine-spacing-lg);
     color: var(--mantine-color-text);
-    background: var(--mantine-color-white);
+    background: var(--mantine-color-body);
 }
 
 .markdownPreview {
@@ -280,12 +370,55 @@
     font-size: var(--mantine-font-size-xs);
 }
 
+@keyframes pulse {
+    0%,
+    100% {
+        opacity: 1;
+    }
+
+    50% {
+        opacity: 0.35;
+    }
+}
+
+@keyframes flash {
+    from {
+        background: var(--mantine-color-indigo-light);
+    }
+
+    to {
+        background: transparent;
+    }
+}
+
+@keyframes ring {
+    0% {
+        box-shadow: 0 0 0 0 var(--mantine-color-indigo-outline);
+    }
+
+    100% {
+        box-shadow: 0 0 0 6px transparent;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .statusDot[data-status='running'],
+    .stage[data-state='active'] .stageGlyph,
+    .fileTreeItem[data-recent='true'] {
+        animation: none;
+    }
+}
+
 @media (max-width: 900px) {
-    .workspace {
+    .page {
         height: auto;
     }
 
-    .workspacePanel {
+    .workspace {
+        grid-template-columns: minmax(0, 1fr);
+    }
+
+    .panel {
         height: 520px;
     }
 }

--- a/packages/frontend/src/ee/features/agentOnboarding/AgentOnboardingRunPage.tsx
+++ b/packages/frontend/src/ee/features/agentOnboarding/AgentOnboardingRunPage.tsx
@@ -6,7 +6,6 @@ import {
 } from '@lightdash/common';
 import {
     Alert,
-    Badge,
     Box,
     Button,
     Group,
@@ -44,16 +43,22 @@ import {
 } from './utils';
 import { setWatchedAgentOnboardingRun } from './watchedRunStore';
 
-const STATUS_CONFIG: Record<
-    AgentOnboardingRunStatus,
-    { label: string; color: string }
-> = {
-    queued: { label: 'Queued', color: 'gray' },
-    running: { label: 'Running', color: 'blue' },
-    completed: { label: 'Complete', color: 'green' },
-    failed: { label: 'Needs attention', color: 'red' },
-    cancelled: { label: 'Cancelled', color: 'gray' },
+const STATUS_LABELS: Record<AgentOnboardingRunStatus, string> = {
+    queued: 'Queued',
+    running: 'Running',
+    completed: 'Complete',
+    failed: 'Needs attention',
+    cancelled: 'Cancelled',
 };
+
+const RunStatus: FC<{ status: AgentOnboardingRunStatus }> = ({ status }) => (
+    <Group gap={6} wrap="nowrap" pt={4}>
+        <span className={classes.statusDot} data-status={status} />
+        <Text fz="sm" fw={500} c="dimmed">
+            {STATUS_LABELS[status]}
+        </Text>
+    </Group>
+);
 
 const getStatusMessage = (run: AgentOnboardingRun): string => {
     switch (run.status) {
@@ -96,7 +101,8 @@ const RunActions: FC<{
         return (
             <Group gap="xs">
                 <Button
-                    variant="default"
+                    variant="light"
+                    color="red"
                     leftSection={<MantineIcon icon={IconPlayerStop} />}
                     onClick={() => void onCancel()}
                     loading={isCancelling}
@@ -196,7 +202,6 @@ const AgentOnboardingRunPage: FC = () => {
     }
 
     const run = runQuery.data;
-    const statusConfig = STATUS_CONFIG[run.status];
     const openProject = () => {
         void navigate(`/projects/${run.projectUuid}`);
     };
@@ -245,25 +250,33 @@ const AgentOnboardingRunPage: FC = () => {
                 className={classes.page}
                 mx="calc(-1 * var(--mantine-spacing-md))"
                 my="calc(-1 * var(--mantine-spacing-md))"
-                p="xl"
+                p="lg"
             >
-                <Stack gap="lg" className={classes.content}>
+                <Stack gap="md" className={classes.content}>
                     <Group justify="space-between" align="flex-start">
-                        <Stack gap={6}>
-                            <Group gap="sm">
+                        <Stack gap={4}>
+                            <Group gap="sm" align="flex-start">
                                 <Title order={2}>
                                     Building your Lightdash project
                                 </Title>
-                                <Badge color={statusConfig.color}>
-                                    {statusConfig.label}
-                                </Badge>
+                                <RunStatus status={run.status} />
                             </Group>
                             {run.status !== 'failed' ? (
-                                <Text c="dimmed">
+                                <Text c="dimmed" fz="sm">
                                     {isCancellationRequested &&
                                     !isAgentOnboardingRunTerminal(run.status)
                                         ? 'Stopping the setup run…'
                                         : getStatusMessage(run)}
+                                    {!isAgentOnboardingRunTerminal(
+                                        run.status,
+                                    ) && !isCancellationRequested ? (
+                                        <>
+                                            {' '}
+                                            <AgentOnboardingDemoOffer
+                                                run={run}
+                                            />
+                                        </>
+                                    ) : null}
                                 </Text>
                             ) : null}
                         </Stack>
@@ -281,10 +294,6 @@ const AgentOnboardingRunPage: FC = () => {
                         />
                     </Group>
 
-                    {!isAgentOnboardingRunTerminal(run.status) ? (
-                        <AgentOnboardingDemoOffer run={run} />
-                    ) : null}
-
                     {run.status === 'failed' ? (
                         <Alert
                             color="red"
@@ -295,34 +304,44 @@ const AgentOnboardingRunPage: FC = () => {
                         </Alert>
                     ) : null}
 
-                    <Paper radius="md" className={classes.progressActivityCard}>
-                        <Box p="lg">
+                    <Box className={classes.workspace}>
+                        <Paper className={classes.panel}>
+                            <Box className={classes.panelHeader}>
+                                <Title order={5}>Progress</Title>
+                            </Box>
                             <AgentOnboardingProgress run={run} />
-                        </Box>
-                        <AgentOnboardingActivityPanel
-                            key={run.agentOnboardingRunUuid}
-                            events={run.events}
-                            hasGeneratedFiles={run.files.length > 0}
-                        />
-                    </Paper>
-
-                    <Paper radius="md" className={classes.workspace}>
-                        <Box className={classes.workspacePanel}>
-                            <Group h={48} px="md" justify="space-between">
-                                <Text fw={600} fz="sm">
-                                    Generated files
-                                </Text>
-                                <Text c="dimmed" fz="xs">
-                                    {run.files.length} files
-                                </Text>
-                            </Group>
-                            <AgentOnboardingFileBrowser
-                                projectUuid={run.projectUuid}
-                                runUuid={run.agentOnboardingRunUuid}
-                                files={run.files}
+                            <AgentOnboardingActivityPanel
+                                key={run.agentOnboardingRunUuid}
+                                events={run.events}
                             />
-                        </Box>
-                    </Paper>
+                        </Paper>
+
+                        <Paper className={classes.panel}>
+                            <Box className={classes.panelHeader}>
+                                <Title order={5}>Generated files</Title>
+                                <Text c="dimmed" fz="xs">
+                                    {run.files.length === 1
+                                        ? '1 file'
+                                        : `${run.files.length} files`}
+                                </Text>
+                            </Box>
+                            <Box className={classes.panelBody}>
+                                <AgentOnboardingFileBrowser
+                                    projectUuid={run.projectUuid}
+                                    runUuid={run.agentOnboardingRunUuid}
+                                    files={run.files}
+                                    isLive={
+                                        !isAgentOnboardingRunTerminal(
+                                            run.status,
+                                        )
+                                    }
+                                    latestActivity={
+                                        run.events.at(-1)?.message ?? null
+                                    }
+                                />
+                            </Box>
+                        </Paper>
+                    </Box>
                 </Stack>
             </Box>
         </Page>

--- a/packages/frontend/src/ee/features/agentOnboarding/hooks/useAgentOnboarding.ts
+++ b/packages/frontend/src/ee/features/agentOnboarding/hooks/useAgentOnboarding.ts
@@ -115,6 +115,7 @@ export const useAgentOnboardingFile = (
         ],
         queryFn: () => getFile(projectUuid!, runUuid!, file!.path),
         enabled: !!projectUuid && !!runUuid && !!file,
+        keepPreviousData: true,
     });
 
 export const useStartAgentOnboardingRun = () => {

--- a/packages/frontend/src/ee/features/agentOnboarding/utils.ts
+++ b/packages/frontend/src/ee/features/agentOnboarding/utils.ts
@@ -206,15 +206,6 @@ export const getAgentOnboardingProgressStageTimings = (
     });
 };
 
-export const getAgentOnboardingProgressStageIndex = (
-    stage: AgentOnboardingStage | null,
-): number =>
-    stage === null
-        ? -1
-        : AGENT_ONBOARDING_PROGRESS_STAGES.findIndex(({ sourceStages }) =>
-              sourceStages.some((sourceStage) => sourceStage === stage),
-          );
-
 export const formatStageDuration = (durationMs: number | null): string => {
     if (durationMs === null) return '—';
     const totalSeconds = Math.max(0, Math.floor(durationMs / 1_000));


### PR DESCRIPTION
## Summary

Reworks the managed agent onboarding run page (`/projects/:uuid/onboarding/runs/:runUuid`) so it follows the neutral theme, works in both colour schemes, and puts the files being built at the centre of the page.

- Flat page canvas and theme tokens only. The previous version hardcoded whites, greys and a hex terminal background, so dark mode did not render.
- Progress is a vertical stage list with an indigo ring on the active stage instead of Mantine's Stepper spinner. Active labels read in continuous tense ("Building the semantic layer"). Cancelled or failed runs mark the interrupted stage as stopped rather than done.
- Generated files is the hero panel next to a progress-and-activity rail instead of being stacked under the log. While the run is live the preview follows the newest written file, changed files flash in the tree, and folders open the first time they appear. Clicking a file turns following off; a "Follow latest" toggle turns it back on.
- The files empty state says what the agent is doing right now and shows its latest action.
- The demo project offer is an inline link in the subtitle rather than its own card. Cancel setup is a light red button. The file browser resize handle is a 1px line with a hidden hit area.
- The launch page reuses the same stage list, so its four stages now show their descriptions inline.

## Regression analysis

No API or data changes. Behavioural changes on the page:

- `useAgentOnboardingFile` now sets `keepPreviousData`, so a file preview no longer flashes a loader every time the agent rewrites the file it is showing.
- The activity panel no longer auto-collapses when the first file appears; that made sense when files and log shared a column and does not now.
- Mantine's `Tree` re-initialises expanded state on every `data` change and marks new folders collapsed, and its effect runs before the parent's. The tree data is now keyed on the path set, and new folders are expanded from the parent effect on first appearance. Without this the followed file's folder stayed closed.
- `getAgentOnboardingProgressStageIndex` was removed as no longer used (the pre-commit unused-exports check blocks it).

Existing tests in the feature folder pass unchanged (`AgentOnboardingStartPage`, `useAgentOnboarding`, `watchedRunStore`).

## Verification

Driven end to end on a local instance with the Docker sandbox provider, stacked on #28843 so the run actually produces a dashboard: signup, org setup, warehouse connect, "Run it for me", then watched the run through explore, semantic layer, dashboard and handoff in both light and dark. Also checked the cancelled state and the empty files state.

Closes: PROD-11060

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RHykHxXfT6vd9BHTRhTheu
