### PR TITLE
fix(merge-queries): make the active source card legible in dark mode

### DIFF
--- a/packages/frontend/src/features/mergeQuery/components/MergeQuerySidebar.module.css
+++ b/packages/frontend/src/features/mergeQuery/components/MergeQuerySidebar.module.css
@@ -41,8 +41,8 @@
 }
 
 .header[data-open='true'] {
-    background: var(--mantine-color-blue-0);
-    box-shadow: inset 3px 0 0 var(--mantine-color-blue-5);
+    background: var(--mantine-color-blue-light);
+    box-shadow: inset 3px 0 0 var(--mantine-color-blue-filled);
 }
 
 .headerButton {


### PR DESCRIPTION
## What

The active card in the Explorer's **Data sources** panel ("Choose data to combine", or the second explore once chosen) used `--mantine-color-blue-0` as its background. That palette step is a light tint in both colour schemes, so in dark mode the card's white title sat on a pale blue block and disappeared.

The card now uses `--mantine-color-blue-light` for the background and `--mantine-color-blue-filled` for the left stripe. Both resolve per scheme.

## Regression analysis

- One CSS module, one selector. No component or logic change.
- Light mode: `blue-light` is the same pale tint as before and the stripe is the same blue, verified side by side on the demo project.
- Dark mode: the card is now a translucent blue over the dark surface, title and subtitle legible.
- The other tints in the merge sidebar are `ldGray` steps, which already invert in dark mode, so nothing else needed to change.

## Verification

Captured the Explorer merge flow headlessly in both themes before and after on the demo project.

Closes: PROD-11061

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uxm1z6yGCURGZgpvUV24Aa
