### PR TITLE
fix(explores): keep a struct column's additional dimensions and metrics when unnesting is on

### DIFF
--- a/packages/common/src/compiler/translator.test.ts
+++ b/packages/common/src/compiler/translator.test.ts
@@ -3587,6 +3587,49 @@ describe('nested and repeated columns', () => {
         expect(explore.tables.ga_sessions__hits).toBeUndefined();
     });
 
+    it('keeps additional dimensions and explicit-SQL metrics declared under a struct container', async () => {
+        const jobs: DbtModelNode = {
+            ...gaSessions,
+            columns: {
+                visitId: nestedColumn('visitId'),
+                totals: nestedColumn('totals', {
+                    meta: {
+                        dimension: { type: DimensionType.STRING, hidden: true },
+                        additional_dimensions: {
+                            pageviews_bucket: {
+                                type: DimensionType.STRING,
+                                sql: "CASE WHEN ${TABLE}.totals.pageviews > 5 THEN 'many' ELSE 'few' END",
+                            },
+                        },
+                        metrics: {
+                            sessions_with_visits: {
+                                type: MetricType.COUNT,
+                                sql: '${TABLE}.totals.visits',
+                            },
+                            container_count: { type: MetricType.COUNT },
+                        },
+                    },
+                }),
+            },
+        };
+        const explore = await compile(
+            attachTypesToModels([jobs], catalog, true),
+            true,
+        );
+        const table = explore.tables.ga_sessions;
+        expect(Object.keys(table.dimensions).sort()).toEqual([
+            'pageviews_bucket',
+            'visitId',
+        ]);
+        expect(table.dimensions.pageviews_bucket.compiledSql).toEqual(
+            "CASE WHEN `ga_sessions`.totals.pageviews > 5 THEN 'many' ELSE 'few' END",
+        );
+        expect(Object.keys(table.metrics)).toEqual(['sessions_with_visits']);
+        expect(table.metrics.sessions_with_visits.compiledSql).toEqual(
+            '`ga_sessions`.totals.visits',
+        );
+    });
+
     it('unnests an array of scalars into a virtual table with a value dimension', async () => {
         const taggedSessions: DbtModelNode = {
             ...gaSessions,
@@ -3596,6 +3639,12 @@ describe('nested and repeated columns', () => {
                     description: 'Session tags',
                     meta: {
                         dimension: { label: 'Tag list' },
+                        additional_dimensions: {
+                            tag_count: {
+                                type: DimensionType.NUMBER,
+                                sql: 'ARRAY_LENGTH(${TABLE}.tags)',
+                            },
+                        },
                         metrics: {
                             last_tag: { type: MetricType.MAX },
                         },
@@ -3616,7 +3665,12 @@ describe('nested and repeated columns', () => {
         ]);
         expect(Object.keys(explore.tables.ga_sessions.dimensions)).toEqual([
             'visitId',
+            'tag_count',
         ]);
+        expect(
+            explore.tables.ga_sessions.dimensions.tag_count.compiledSql,
+        ).toEqual('ARRAY_LENGTH(`ga_sessions`.tags)');
+        expect(explore.tables.ga_sessions.metrics.last_tag).toBeUndefined();
 
         const tags = explore.tables.ga_sessions__tags;
         expect(tags.label).toEqual('Tag list');
@@ -3628,6 +3682,7 @@ describe('nested and repeated columns', () => {
             'offset',
             'value',
         ]);
+        expect(Object.keys(tags.metrics)).toEqual(['last_tag']);
         expect(tags.dimensions.value).toMatchObject({
             type: DimensionType.STRING,
             label: 'Value',

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -684,34 +684,40 @@ export const convertTable = (
         Record<string, Metric>,
     ] = Object.values(model.columns).reduce(
         ([prevDimensions, prevMetrics], column, index) => {
-            // Containers can't be selected as scalars and leaves under an
-            // array belong to the unnested table, unless custom SQL made
-            // the column scalar on purpose.
-            if (
-                unnestRepeatedColumns &&
-                !getColumnMeta(column).dimension?.sql &&
-                (column.nested_shape !== undefined ||
-                    hasRepeatedAncestor(column))
-            ) {
-                return [prevDimensions, prevMetrics];
-            }
-            const dimension = convertDimension(
-                index,
-                adapterType,
-                model,
-                tableLabel,
-                column,
-                undefined,
-                undefined,
-                startOfWeek,
-                undefined,
-                disableTimestampConversion,
-                tableWarnings,
-                granularityLabels,
-            );
-
             // Config block takes priority, then meta block
             const columnMeta = merge({}, column.meta, column.config?.meta);
+            const routedByUnnest =
+                unnestRepeatedColumns && !columnMeta.dimension?.sql;
+            // Leaves under an array belong to the unnested table, unless
+            // custom SQL made the column scalar on purpose.
+            if (routedByUnnest && hasRepeatedAncestor(column)) {
+                return [prevDimensions, prevMetrics];
+            }
+            // A struct or array can't be selected as a scalar, but the
+            // additional dimensions and explicit-SQL metrics declared under
+            // it dereference its fields and stay on the model.
+            const isContainer =
+                routedByUnnest && column.nested_shape !== undefined;
+            const isScalarArray =
+                isContainer &&
+                column.nested_shape?.repeated === true &&
+                column.nested_shape.record === false;
+            const dimension = isContainer
+                ? undefined
+                : convertDimension(
+                      index,
+                      adapterType,
+                      model,
+                      tableLabel,
+                      column,
+                      undefined,
+                      undefined,
+                      startOfWeek,
+                      undefined,
+                      disableTimestampConversion,
+                      tableWarnings,
+                      granularityLabels,
+                  );
 
             const processIntervalDimension = (
                 dim: Dimension,
@@ -871,9 +877,9 @@ export const convertTable = (
                 return {};
             };
 
-            let extraDimensions = {
-                ...processIntervalDimension(dimension, undefined),
-            };
+            let extraDimensions = dimension
+                ? { ...processIntervalDimension(dimension, undefined) }
+                : {};
 
             extraDimensions = Object.entries(
                 columnMeta.additional_dimensions || {},
@@ -915,21 +921,32 @@ export const convertTable = (
                 };
             }, extraDimensions);
 
+            // Metrics under an array of scalars aggregate its elements and
+            // live on the unnested table; a struct's metrics need explicit
+            // SQL because the container itself can't be aggregated.
             const columnMetrics = Object.fromEntries(
-                Object.entries(columnMeta.metrics || {}).map(
-                    ([name, metric]) => [
+                Object.entries(columnMeta.metrics || {})
+                    .filter(
+                        ([, metric]) =>
+                            !isScalarArray && (dimension || metric.sql),
+                    )
+                    .map(([name, metric]) => [
                         name,
                         convertColumnMetric({
                             modelName: model.name,
-                            dimensionName: dimension.name,
-                            dimensionSql: dimension.sql,
-                            dimensionType: dimension.type,
-                            dimensionTimeInterval: dimension.timeInterval,
+                            dimensionName: dimension?.name,
+                            dimensionSql:
+                                dimension?.sql ?? defaultSql(column.name),
+                            dimensionType:
+                                dimension?.type ??
+                                column.data_type ??
+                                DimensionType.STRING,
+                            dimensionTimeInterval: dimension?.timeInterval,
                             name,
                             metric,
                             tableLabel,
-                            requiredAttributes: dimension.requiredAttributes, // TODO Join dimension required_attributes with metric required_attributes
-                            anyAttributes: dimension.anyAttributes, // TODO Join dimension any_attributes with metric any_attributes
+                            requiredAttributes: dimension?.requiredAttributes, // TODO Join dimension required_attributes with metric required_attributes
+                            anyAttributes: dimension?.anyAttributes, // TODO Join dimension any_attributes with metric any_attributes
                             spotlightConfig: {
                                 ...spotlightConfig,
                                 default_visibility:
@@ -941,14 +958,13 @@ export const convertTable = (
                             defaultShowUnderlyingValues:
                                 meta.default_show_underlying_values,
                         }),
-                    ],
-                ),
+                    ]),
             );
 
             return [
                 {
                     ...prevDimensions,
-                    [column.name]: dimension,
+                    ...(dimension ? { [column.name]: dimension } : {}),
                     ...extraDimensions,
                 },
                 { ...prevMetrics, ...columnMetrics },
@@ -1205,7 +1221,11 @@ const getScalarElementColumn = (container: DbtModelColumn): DbtModelColumn => {
         config: _config,
         ...column
     } = container;
-    const { dimension, ...meta } = getColumnMeta(container);
+    const {
+        dimension,
+        additional_dimensions: _additionalDimensions,
+        ...meta
+    } = getColumnMeta(container);
     const { label: _label, ...dimensionConfig } = dimension ?? {};
     return {
         ...column,


### PR DESCRIPTION
With the unnest-repeated-columns flag on, a struct or array column documented in YAML is skipped as a container, which is right for the column itself: a struct can't be selected as a scalar. But the skip also threw away everything declared under that column. Models that already dereference struct fields the way the docs suggest, a hidden `error_result` column carrying `additional_dimensions` like `${TABLE}.error_result.reason` and a `count` metric on it, lost those dimensions and metrics on the next compile with no warning. The internal analytics project uses that exact pattern on its BigQuery jobs model, so turning the flag on for our own org would have removed its error and destination fields at the next refresh.

Additional dimensions under a container now stay on the model, since they carry their own SQL, and so do the container's metrics when they have explicit SQL (metrics without `sql` on a struct follow in #28857). Metrics under an array of scalars keep going to the unnested table, where they aggregate the elements, and additional dimensions on such a column stay on the parent rather than being copied onto the element table.

Relates: #4102
