### PR TITLE
feat: provision internal analytics previews through an admin endpoint

### DIFF
--- a/docs/development/local-analytics-project.md
+++ b/docs/development/local-analytics-project.md
@@ -1,0 +1,108 @@
+# Local usage analytics triage (PROD-11059)
+
+Development-only prototype, not the production metadata-project rollout. It
+creates a `PREVIEW` project with a backend-owned `analytics` provisioning marker
+and an invisible DuckDB `analytics` connection.
+No MotherDuck account, dbt project, or configurable connector UI is required.
+
+## Configure and provision
+
+Start an isolated development instance using the worktree runbook. Configure the
+usage-events writer's S3-compatible storage settings: `S3_ENDPOINT`,
+`USAGE_EVENTS_S3_BUCKET`, `USAGE_EVENTS_S3_ACCESS_KEY`,
+`USAGE_EVENTS_S3_SECRET_KEY`, and `USAGE_EVENTS_S3_REGION`. The reader reuses this
+server-owned configuration to issue signed GET URLs; it requires no CLI login,
+OAuth exchange, or new cloud infrastructure. Ensure the endpoint matches the
+bucket service, especially when the local instance otherwise uses MinIO.
+
+Add these values to that worktree's `.env.development.local` (never commit them):
+
+```dotenv
+LIGHTDASH_ENABLE_FEATURE_FLAGS=analytics-project
+LIGHTDASH_LOCAL_ANALYTICS_ORG_UUID=<local-organization-uuid>
+LIGHTDASH_LOCAL_ANALYTICS_SOURCE_ORG_UUID=<source-organization-uuid>
+LIGHTDASH_LOCAL_ANALYTICS_START_DATE=2026-09-07
+LIGHTDASH_LOCAL_ANALYTICS_END_DATE=2026-09-07
+```
+
+Preserve other enabled flags if needed. Explicitly disabling `analytics-project`
+takes precedence. The two org IDs are an intentional local-only binding;
+production must use the authenticated org and reviewed credential isolation.
+
+As a signed-in organization administrator, call the same-origin endpoint from
+the browser console on your assigned local frontend:
+
+```javascript
+const response = await fetch('/api/v1/org/analytics-project', { method: 'POST' });
+const body = await response.json();
+if (!response.ok) throw new Error(JSON.stringify(body));
+window.location.assign(body.results.url);
+```
+
+The endpoint accepts no configuration: organization identity comes from the
+authenticated session. After authorization, it verifies signed Parquet access
+before creating any project, then compiles both backend-owned system explores in
+memory and returns `{ projectUuid, url, created }`. Storage failures leave no new
+project. The name produces `lightdash-analytics` unless that slug is taken;
+normal collision handling chooses a unique suffix. An existing analytics project
+is found by its marker, never by a name or slug.
+
+Concurrent requests are serialized per organization using a database advisory
+lock. Re-running refreshes both models and repairs a failed model-save attempt
+without replacing the project or deleting saved charts. Analytics previews do
+not expire automatically. They are visible only to enabled org admins in the
+projects API (for slug resolution), and omitted from the normal switcher as
+previews with no upstream. No admin navigation has been added.
+
+## Read path and safeguards
+
+The backend lists `events/compacted/org_id=<uuid>/stream=<name>/dt=<date>/*.parquet`
+for `query_events` and `ai_usage` within the inclusive configured date range.
+Files and authentication are refreshed per session. DuckDB views bind exact
+HTTPS URLs; Explore SQL uses table names. Reads use HTTP ranges, with no import
+into a persistent database and no writes to the source bucket.
+
+Each query gets an isolated in-memory instance, signed GET URLs, a 256 MB
+memory limit and two threads. External access is restricted to the exact file
+manifest; disk spilling and file/metadata caches are disabled. Existing
+SELECT-only and file-function SQL validation remain enabled. Catalog queries that
+could expose signed view SQL are blocked, and native errors are sanitized. Broad
+writer keys never enter DuckDB; signed URLs are not persisted in project
+credentials or returned through the API.
+
+History, paginated results, streaming results and legacy result reads check the
+analytics flag and organization-admin access. Export and scheduled-download
+creation are unavailable for analytics previews, including for admins, so this
+slice does not issue export URLs that outlive these checks.
+
+## Before customer rollout
+
+- Replace the backend signer's write-capable source identity with dedicated
+  read-only credentials (PROD-11103). The interim signed-URL path keeps broad keys
+  out of DuckDB but still trusts the signer. Replace local source-org overrides
+  with the persisted project's org. Folder separation is not an IAM boundary.
+- Review every permissions and cached/downloaded-results surface. Finish SQL
+  Runner, scheduling, AI and model-editing exclusions. Local org-admin checks are
+  not the final metadata-project role design.
+- Production provisioning, admin navigation, and feature-flag-service integration.
+- Latest resource names, additional domain metrics, schema evolution, empty
+  streams, retention and query performance.
+- Result-cache freshness and manifest/view caching at scale. The configured
+  date range is a triage bound, not the final UX.
+- Reevaluate direct Parquet writes and optional compaction separately. This
+  slice only reads existing compacted data; the writer/nightly job is unchanged.
+
+Actual GCS reads and isolated MinIO tests verify the signed-URL path; AWS S3 and
+production multi-tenant rollout remain unverified.
+The implementation rejects production execution even with its flag enabled.
+
+## Incremental PR stack
+
+1. Internal Parquet connector, source resolver, and shared `analytics-project` flag.
+2. Signed-URL bucket access using the existing writer's backend credentials.
+3. Admin create-or-get endpoint, preview provisioning, signed-URL provider, and both
+   system models (Query Events and AI Usage). Replaces the provisioning script.
+4. Dedicated read-only credential source, deferred to PROD-11103.
+
+See [storage credential verification](analytics-storage-credentials.md) for the
+opt-in read-only cloud and isolated local security tests.

--- a/docs/development/local-analytics-project.md
+++ b/docs/development/local-analytics-project.md
@@ -21,8 +21,6 @@ Add these values to that worktree's `.env.development.local` (never commit them)
 LIGHTDASH_ENABLE_FEATURE_FLAGS=analytics-project
 LIGHTDASH_LOCAL_ANALYTICS_ORG_UUID=<local-organization-uuid>
 LIGHTDASH_LOCAL_ANALYTICS_SOURCE_ORG_UUID=<source-organization-uuid>
-LIGHTDASH_LOCAL_ANALYTICS_START_DATE=2026-09-07
-LIGHTDASH_LOCAL_ANALYTICS_END_DATE=2026-09-07
 ```
 
 Preserve other enabled flags if needed. Explicitly disabling `analytics-project`
@@ -33,7 +31,9 @@ As a signed-in organization administrator, call the same-origin endpoint from
 the browser console on your assigned local frontend:
 
 ```javascript
-const response = await fetch('/api/v1/org/analytics-project', { method: 'POST' });
+const response = await fetch('/api/v1/org/analytics-project', {
+  method: 'POST',
+});
 const body = await response.json();
 if (!response.ok) throw new Error(JSON.stringify(body));
 window.location.assign(body.results.url);
@@ -57,7 +57,9 @@ previews with no upstream. No admin navigation has been added.
 ## Read path and safeguards
 
 The backend lists `events/compacted/org_id=<uuid>/stream=<name>/dt=<date>/*.parquet`
-for `query_events` and `ai_usage` within the inclusive configured date range.
+for `query_events` and `ai_usage` across all retained dates. Filter dates in
+Explore; legacy `LIGHTDASH_LOCAL_ANALYTICS_START_DATE` and
+`LIGHTDASH_LOCAL_ANALYTICS_END_DATE` settings are no longer read.
 Files and authentication are refreshed per session. DuckDB views bind exact
 HTTPS URLs; Explore SQL uses table names. Reads use HTTP ranges, with no import
 into a persistent database and no writes to the source bucket.
@@ -87,8 +89,9 @@ slice does not issue export URLs that outlive these checks.
 - Production provisioning, admin navigation, and feature-flag-service integration.
 - Latest resource names, additional domain metrics, schema evolution, empty
   streams, retention and query performance.
-- Result-cache freshness and manifest/view caching at scale. The configured
-  date range is a triage bound, not the final UX.
+- Result-cache freshness, date-aware discovery and manifest/view caching at scale
+  (PROD-11111). All retained dates are exposed, subject to fail-closed listing/file
+  caps; large-history and concurrent query performance still need benchmarking.
 - Reevaluate direct Parquet writes and optional compaction separately. This
   slice only reads existing compacted data; the writer/nightly job is unchanged.
 

--- a/docs/development/local-analytics-project.md
+++ b/docs/development/local-analytics-project.md
@@ -8,12 +8,12 @@ No MotherDuck account, dbt project, or configurable connector UI is required.
 ## Configure and provision
 
 Start an isolated development instance using the worktree runbook. Configure the
-usage-events writer's S3-compatible storage settings: `S3_ENDPOINT`,
+usage-events writer's S3-compatible storage settings: `USAGE_EVENTS_S3_ENDPOINT`,
 `USAGE_EVENTS_S3_BUCKET`, `USAGE_EVENTS_S3_ACCESS_KEY`,
 `USAGE_EVENTS_S3_SECRET_KEY`, and `USAGE_EVENTS_S3_REGION`. The reader reuses this
 server-owned configuration to issue signed GET URLs; it requires no CLI login,
-OAuth exchange, or new cloud infrastructure. Ensure the endpoint matches the
-bucket service, especially when the local instance otherwise uses MinIO.
+OAuth exchange, or new cloud infrastructure. The usage-events endpoint defaults
+to `S3_ENDPOINT`; override it when analytics uses GCS and local storage uses MinIO.
 
 Add these values to that worktree's `.env.development.local` (never commit them):
 

--- a/packages/backend/src/analytics/systemExplores/systemStreamMetrics.ts
+++ b/packages/backend/src/analytics/systemExplores/systemStreamMetrics.ts
@@ -1,0 +1,93 @@
+import { MetricType, type Metric } from '@lightdash/common';
+
+type SystemMetricDefinition = Pick<
+    Metric,
+    'name' | 'description' | 'percentile'
+> & {
+    type: MetricType;
+    column: string;
+};
+
+export const systemStreamMetrics: Record<
+    'query_events' | 'ai_usage',
+    SystemMetricDefinition[]
+> = {
+    query_events: [
+        {
+            name: 'total_queries',
+            description: 'Total number of queries executed',
+            type: MetricType.COUNT,
+            column: 'query_id',
+        },
+        {
+            name: 'unique_users',
+            description: 'Number of distinct users',
+            type: MetricType.COUNT_DISTINCT,
+            column: 'user_id',
+        },
+        {
+            name: 'avg_warehouse_execution_time_ms',
+            description: 'Average warehouse execution time in milliseconds',
+            type: MetricType.AVERAGE,
+            column: 'warehouse_execution_time_ms',
+        },
+        {
+            name: 'p90_warehouse_execution_time_ms',
+            description:
+                '90th percentile warehouse execution time in milliseconds',
+            type: MetricType.PERCENTILE,
+            column: 'warehouse_execution_time_ms',
+            percentile: 90,
+        },
+    ],
+    ai_usage: [
+        {
+            name: 'total_ai_calls',
+            description: 'Total number of AI model calls',
+            type: MetricType.COUNT,
+            column: 'event_name',
+        },
+        {
+            name: 'unique_users',
+            description: 'Number of distinct users',
+            type: MetricType.COUNT_DISTINCT,
+            column: 'user_id',
+        },
+        {
+            name: 'total_tokens_used',
+            description: 'Total tokens used across all AI model calls',
+            type: MetricType.SUM,
+            column: 'total_tokens',
+        },
+        {
+            name: 'total_input_tokens',
+            description: 'Total input (prompt) tokens',
+            type: MetricType.SUM,
+            column: 'input_tokens',
+        },
+        {
+            name: 'total_output_tokens',
+            description: 'Total output (completion) tokens',
+            type: MetricType.SUM,
+            column: 'output_tokens',
+        },
+        {
+            name: 'total_cache_read_tokens',
+            description: 'Total cached input tokens read',
+            type: MetricType.SUM,
+            column: 'cache_read_tokens',
+        },
+        {
+            name: 'total_cache_write_tokens',
+            description: 'Total cached input tokens written',
+            type: MetricType.SUM,
+            column: 'cache_write_tokens',
+        },
+        {
+            name: 'total_reasoning_tokens',
+            description: 'Total reasoning (thinking) tokens',
+            type: MetricType.SUM,
+            column: 'reasoning_tokens',
+        },
+    ],
+};

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -23,6 +23,7 @@ import {
     getUserAttributesSetupConfig,
     parseConfig,
     parseOrganizationMemberRoleArray,
+    parseUsageEventsS3Config,
 } from './parseConfig';
 
 vi.mock('fs/promises', () => ({
@@ -37,6 +38,20 @@ beforeEach(() => {
         S3_BUCKET: 'mock_bucket',
         S3_REGION: 'mock_region',
     };
+});
+
+describe('usage events storage endpoint', () => {
+    it('inherits the base endpoint when no override is configured', () => {
+        expect(parseUsageEventsS3Config()?.endpoint).toBe('mock_endpoint');
+    });
+
+    it('supports a separate endpoint without changing base storage', () => {
+        process.env.USAGE_EVENTS_S3_ENDPOINT = 'https://storage.googleapis.com';
+        expect(parseUsageEventsS3Config()?.endpoint).toBe(
+            'https://storage.googleapis.com',
+        );
+        expect(process.env.S3_ENDPOINT).toBe('mock_endpoint');
+    });
 });
 
 describe('mobile login config', () => {

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1076,7 +1076,7 @@ export const parseUsageEventsS3Config = (): Omit<
     } = baseS3Config;
 
     return {
-        endpoint,
+        endpoint: process.env.USAGE_EVENTS_S3_ENDPOINT || endpoint,
         forcePathStyle,
         bucket: process.env.USAGE_EVENTS_S3_BUCKET || baseBucket,
         region: process.env.USAGE_EVENTS_S3_REGION || baseRegion,

--- a/packages/backend/src/controllers/organizationController.ts
+++ b/packages/backend/src/controllers/organizationController.ts
@@ -74,6 +74,27 @@ import { BaseController } from './baseController';
 @Tags('Organizations')
 export class OrganizationController extends BaseController {
     /**
+     * Create or refresh the current organization's internal analytics preview.
+     * @summary Ensure internal analytics project
+     */
+    @Middlewares([isAuthenticated, unauthorisedInDemo])
+    @Post('/analytics-project')
+    @OperationId('EnsureAnalyticsProject')
+    async ensureAnalyticsProject(
+        @Request() req: express.Request,
+    ): Promise<
+        ApiSuccess<{ projectUuid: string; url: string; created: boolean }>
+    > {
+        assertRegisteredAccount(req.account);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getProjectService()
+                .ensureAnalyticsProject(toSessionUser(req.account)),
+        };
+    }
+
+    /**
      * Get the current user's organization
      * @summary Get current organization
      * @param req express request

--- a/packages/backend/src/ee/services/ProjectService/provisionOnboardingHomepage.ts
+++ b/packages/backend/src/ee/services/ProjectService/provisionOnboardingHomepage.ts
@@ -22,7 +22,7 @@ export type ProvisionOnboardingHomepageArguments = {
     user: SessionUser;
     projectUuid: string;
     projectType: ProjectType;
-    provisioningSource?: 'playground' | 'training';
+    provisioningSource?: 'playground' | 'training' | 'analytics';
     featureFlagService: Pick<
         FeatureFlagService,
         'get' | 'ensureOrganizationOverrideEnabled'

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -260,6 +260,26 @@ type PreviewChartUuidMapping = {
 };
 
 export class ProjectModel {
+    /** Serializes create-or-get across API pods without relying on a slug. */
+    async runInAnalyticsProvisioningLock<T>(
+        organizationUuid: string,
+        callback: () => Promise<T>,
+    ): Promise<T> {
+        return this.database.transaction(async (trx) => {
+            const organization = await trx(OrganizationTableName)
+                .where('organization_uuid', organizationUuid)
+                .select('organization_id')
+                .first();
+            if (!organization)
+                throw new NotFoundError('Cannot find organization');
+            await trx.raw('SELECT pg_advisory_xact_lock(?, ?)', [
+                19350431,
+                organization.organization_id,
+            ]);
+            return callback();
+        });
+    }
+
     protected database: Knex;
 
     protected lightdashConfig: LightdashConfig;

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -2745,6 +2745,7 @@ describe('AsyncQueryService', () => {
                 status: QueryHistoryStatus.PENDING,
                 queryUuid: 'test-query-uuid',
             });
+            expect(projectModel.getSummary).toHaveBeenCalledTimes(1);
         });
 
         test('rejects embedded AI agent JWTs polling AI queries from another user', async () => {
@@ -3918,6 +3919,12 @@ describe('AsyncQueryService', () => {
                 ).rejects.toThrow(expected);
                 await expect(service.download(args)).rejects.toThrow(expected);
                 expect(service.queryHistoryModel.get).not.toHaveBeenCalled();
+                await expect(
+                    service.getAsyncQueryResults(args),
+                ).rejects.toThrow(expected);
+                expect(projectModel.getSummary).toHaveBeenLastCalledWith(
+                    projectUuid,
+                );
             },
         );
     });

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -108,6 +108,7 @@ import { OrganizationAccessService } from '../OrganizationAccessService/Organiza
 import { PermissionsService } from '../PermissionsService/PermissionsService';
 import { PersistentDownloadFileService } from '../PersistentDownloadFileService/PersistentDownloadFileService';
 import { PivotTableService } from '../PivotTableService/PivotTableService';
+import * as localAnalytics from '../ProjectService/analyticsProject/localAnalyticsProject';
 import type { ProjectService } from '../ProjectService/ProjectService';
 import {
     allExplores,
@@ -3855,6 +3856,70 @@ describe('AsyncQueryService', () => {
             expect(pivotSpy).not.toHaveBeenCalled();
             expect(flatSpy).toHaveBeenCalledTimes(1);
         });
+    });
+
+    describe('analytics cached-result boundaries', () => {
+        afterEach(() => {
+            projectModel.getSummary.mockResolvedValue(projectSummary);
+            vi.mocked(
+                localAnalytics.assertLocalAnalyticsProjectEnabled,
+            ).mockRestore();
+        });
+        test.each(['disabled', 'non-admin'] as const)(
+            'blocks every result/history/export surface for %s access',
+            async (reason) => {
+                const service = getMockedAsyncQueryService(lightdashConfigMock);
+                service.exportsStorageClient = {
+                    isEnabled: () => true,
+                } as FileStorageClient;
+                const account = buildAccount();
+                account.user.ability = new Ability<PossibleAbilities>([
+                    { action: 'view', subject: 'Project' },
+                ]);
+                vi.spyOn(projectModel, 'getSummary').mockResolvedValue({
+                    ...projectSummary,
+                    organizationUuid: account.organization.organizationUuid!,
+                    provisioningSource: 'analytics',
+                });
+                vi.spyOn(
+                    localAnalytics,
+                    'assertLocalAnalyticsProjectEnabled',
+                ).mockImplementation(() => {
+                    if (reason === 'disabled')
+                        throw new ForbiddenError('analytics disabled');
+                });
+                const args = {
+                    account,
+                    projectUuid,
+                    queryUuid: 'existing-query',
+                    type: DownloadFileType.CSV,
+                    accessMode:
+                        PersistentDownloadFileAccessMode.AUTHENTICATED_CREATOR as const,
+                };
+                const expected =
+                    reason === 'disabled'
+                        ? 'analytics disabled'
+                        : 'administration';
+                await expect(
+                    service.getAsyncQueryHistory(args),
+                ).rejects.toThrow(expected);
+                await expect(service.getResultsStream(args)).rejects.toThrow(
+                    expected,
+                );
+                await expect(
+                    service.getQueryHistoryList({
+                        ...args,
+                        filters: {},
+                        paginateArgs: { page: 1, pageSize: 10 },
+                    }),
+                ).rejects.toThrow(expected);
+                await expect(
+                    service.scheduleDownloadAsyncQueryResults(args),
+                ).rejects.toThrow(expected);
+                await expect(service.download(args)).rejects.toThrow(expected);
+                expect(service.queryHistoryModel.get).not.toHaveBeenCalled();
+            },
+        );
     });
 
     describe('getAsyncQueryHistory', () => {

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -1228,8 +1228,9 @@ export class AsyncQueryService extends ProjectService {
         filters: QueryHistoryListFilters;
         paginateArgs: KnexPaginateArgs;
     }): Promise<ApiQueryHistoryListResponse['results']> {
-        const { organizationUuid } =
-            await this.projectModel.getSummary(projectUuid);
+        const project = await this.projectModel.getSummary(projectUuid);
+        await this.assertAnalyticsProjectAccess(account, project);
+        const { organizationUuid } = project;
 
         // History is scoped to the requesting user's own runs, so an
         // anonymous (embed) account has nothing to list.
@@ -1400,6 +1401,10 @@ export class AsyncQueryService extends ProjectService {
         organizationUuid: string,
         queryHistory: QueryHistory,
     ): Promise<void> {
+        await this.assertAnalyticsProjectAccess(
+            account,
+            await this.projectModel.getSummary(projectUuid),
+        );
         const { queryUuid } = queryHistory;
         const auditedAbility = this.createAuditedAbility(account);
         const canViewProject = auditedAbility.can(
@@ -1671,8 +1676,9 @@ export class AsyncQueryService extends ProjectService {
     }): Promise<QueryHistory> {
         assertIsAccountWithOrg(account);
 
-        const { organizationUuid } =
-            await this.projectModel.getSummary(projectUuid);
+        const project = await this.projectModel.getSummary(projectUuid);
+        await this.assertAnalyticsProjectAccess(account, project);
+        const { organizationUuid } = project;
 
         const auditedAbility = this.createAuditedAbility(account);
         const canViewProject = auditedAbility.can(
@@ -1730,8 +1736,9 @@ export class AsyncQueryService extends ProjectService {
     }): Promise<Readable> {
         assertIsAccountWithOrg(account);
 
-        const { organizationUuid } =
-            await this.projectModel.getSummary(projectUuid);
+        const project = await this.projectModel.getSummary(projectUuid);
+        await this.assertAnalyticsProjectAccess(account, project);
+        const { organizationUuid } = project;
 
         const auditedAbility = this.createAuditedAbility(account);
         if (
@@ -1853,6 +1860,13 @@ export class AsyncQueryService extends ProjectService {
     ) {
         const { account, ...payload } = args;
         assertIsAccountWithOrg(account);
+        const project = await this.projectModel.getSummary(payload.projectUuid);
+        await this.assertAnalyticsProjectAccess(account, project);
+        if (project.provisioningSource === 'analytics') {
+            throw new ForbiddenError(
+                'Scheduled downloads are unavailable for internal analytics',
+            );
+        }
 
         const { organizationUuid } = account.organization;
 
@@ -2052,8 +2066,15 @@ export class AsyncQueryService extends ProjectService {
     }: DownloadAsyncQueryResultsArgs): Promise<DownloadAsyncQueryResultsInternal> {
         assertIsAccountWithOrg(account);
 
-        const { organizationUuid } =
-            await this.projectModel.getSummary(projectUuid);
+        const project = await this.projectModel.getSummary(projectUuid);
+        await this.assertAnalyticsProjectAccess(account, project);
+        // Do not issue a signed export URL that outlives the feature/admin check.
+        if (project.provisioningSource === 'analytics') {
+            throw new ForbiddenError(
+                'Downloads are unavailable for internal analytics',
+            );
+        }
+        const { organizationUuid } = project;
 
         const auditedAbility = this.createAuditedAbility(account);
         if (

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -1398,13 +1398,11 @@ export class AsyncQueryService extends ProjectService {
     private async throwIfCannotReadQueryHistory(
         account: Account,
         projectUuid: string,
-        organizationUuid: string,
+        project: Pick<Project, 'organizationUuid' | 'provisioningSource'>,
         queryHistory: QueryHistory,
     ): Promise<void> {
-        await this.assertAnalyticsProjectAccess(
-            account,
-            await this.projectModel.getSummary(projectUuid),
-        );
+        await this.assertAnalyticsProjectAccess(account, project);
+        const { organizationUuid } = project;
         const { queryUuid } = queryHistory;
         const auditedAbility = this.createAuditedAbility(account);
         const canViewProject = auditedAbility.can(
@@ -1458,15 +1456,16 @@ export class AsyncQueryService extends ProjectService {
     }: GetAsyncQueryResultsArgs): Promise<ApiGetAsyncQueryResults> {
         assertIsAccountWithOrg(account);
 
-        const [{ organizationUuid }, queryHistory] = await Promise.all([
+        const [project, queryHistory] = await Promise.all([
             this.projectModel.getSummary(projectUuid),
             this.queryHistoryModel.get(queryUuid, projectUuid, account),
         ]);
+        const { organizationUuid } = project;
 
         await this.throwIfCannotReadQueryHistory(
             account,
             projectUuid,
-            organizationUuid,
+            project,
             queryHistory,
         );
 
@@ -7412,12 +7411,10 @@ export class AsyncQueryService extends ProjectService {
     private async authorizeQueryReferences({
         account,
         projectUuid,
-        organizationUuid,
         references,
     }: {
         account: Account;
         projectUuid: string;
-        organizationUuid: string;
         references: Record<string, string>;
     }): Promise<void> {
         const validTableName = /^[a-zA-Z_][a-zA-Z0-9_]{0,62}$/;
@@ -7454,7 +7451,7 @@ export class AsyncQueryService extends ProjectService {
                 await this.throwIfCannotReadQueryHistory(
                     account,
                     projectUuid,
-                    organizationUuid,
+                    await this.projectModel.getSummary(projectUuid),
                     queryHistory,
                 );
             }),
@@ -7704,7 +7701,6 @@ export class AsyncQueryService extends ProjectService {
             await this.authorizeQueryReferences({
                 account,
                 projectUuid,
-                organizationUuid,
                 references: normalizedReferences,
             });
         }

--- a/packages/backend/src/services/OrganizationService/OrganizationService.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.ts
@@ -32,6 +32,7 @@ import {
     OrganizationMemberRole,
     OrganizationProject,
     ParameterError,
+    ProjectType,
     SaveOrganizationBrandRequest,
     SessionUser,
     TooManyRequestsError,
@@ -66,6 +67,7 @@ import {
     validateOrganizationScopesCanBeGranted,
 } from '../../utils/organizationRolePermissions';
 import { BaseService } from '../BaseService';
+import { isLocalAnalyticsProjectEnabled } from '../ProjectService/analyticsProject/localAnalyticsProject';
 
 const BRANDFETCH_API_URL = 'https://api.brandfetch.io/v2/brands';
 
@@ -664,7 +666,16 @@ export class OrganizationService extends BaseService {
             ),
         );
 
-        return projects.filter((_, index) => accessResults[index]);
+        return projects.filter(
+            (project, index) =>
+                accessResults[index] &&
+                (project.provisioningSource !== 'analytics' ||
+                    (isLocalAnalyticsProjectEnabled(organizationUuid) &&
+                        auditedAbility.can(
+                            'manage',
+                            subject('Organization', { organizationUuid }),
+                        ))),
+        );
     }
 
     async getOnboarding(user: SessionUser): Promise<OnbordingRecord> {

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -111,6 +111,7 @@ import { AdminNotificationService } from '../AdminNotificationService/AdminNotif
 import { PermissionsService } from '../PermissionsService/PermissionsService';
 import { SpacePermissionService } from '../SpaceService/SpacePermissionService';
 import { UserService } from '../UserService';
+import * as localAnalytics from './analyticsProject/localAnalyticsProject';
 import { ProjectService } from './ProjectService';
 import {
     allExplores,
@@ -208,6 +209,9 @@ vi.mock('@lightdash/warehouses', async (importOriginal) => ({
 }));
 
 const projectModel = {
+    runInAnalyticsProvisioningLock: vi.fn(
+        async (_org: string, callback: () => Promise<unknown>) => callback(),
+    ),
     getWithSensitiveFields: vi.fn(async () => projectWithSensitiveFields),
     get: vi.fn(async () => projectWithSensitiveFields),
     getAllByOrganizationUuid: vi.fn<ProjectModel['getAllByOrganizationUuid']>(),
@@ -670,6 +674,153 @@ describe('ProjectService', () => {
                 }),
             ).rejects.toThrow('Only an organization admin can enable Learn');
             expect(provisionTrainingProject).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('ensureAnalyticsProject', () => {
+        const testAnalyticsStorage = vi.fn();
+        const admin = {
+            ...user,
+            organizationUuid: 'analytics-org',
+            organizationName: 'Organization',
+            organizationCreatedAt: new Date(),
+            ability: new Ability<PossibleAbilities>([
+                {
+                    subject: 'Organization',
+                    action: 'manage',
+                    conditions: { organizationUuid: 'analytics-org' },
+                },
+            ]),
+        };
+        beforeEach(() => {
+            testAnalyticsStorage.mockResolvedValue(undefined);
+            vi.spyOn(
+                localAnalytics,
+                'createLocalAnalyticsClient',
+            ).mockReturnValue({
+                test: testAnalyticsStorage,
+            } as unknown as ReturnType<
+                typeof localAnalytics.createLocalAnalyticsClient
+            >);
+            vi.spyOn(
+                localAnalytics,
+                'assertLocalAnalyticsProjectEnabled',
+            ).mockImplementation(() => undefined);
+        });
+        afterEach(() => vi.restoreAllMocks());
+
+        test('does not create a project when storage authentication fails', async () => {
+            testAnalyticsStorage.mockRejectedValueOnce(
+                new Error('Storage unavailable'),
+            );
+            await expect(service.ensureAnalyticsProject(admin)).rejects.toThrow(
+                'Storage unavailable',
+            );
+            expect(
+                projectModel.runInAnalyticsProvisioningLock,
+            ).not.toHaveBeenCalled();
+        });
+
+        test('reuses the backend marker, refreshes both models, and returns the slug', async () => {
+            projectModel.getAllByOrganizationUuid.mockResolvedValueOnce([
+                {
+                    ...defaultProject,
+                    projectUuid: 'existing',
+                    provisioningSource: 'analytics',
+                },
+            ]);
+            projectModel.getSummary.mockResolvedValueOnce({
+                ...projectSummary,
+                slug: 'lightdash-analytics-2',
+            });
+            const result = await service.ensureAnalyticsProject(admin);
+            expect(result).toEqual({
+                projectUuid: 'existing',
+                url: '/projects/lightdash-analytics-2/tables',
+                created: false,
+            });
+            expect(
+                projectModel.runInAnalyticsProvisioningLock,
+            ).toHaveBeenCalledWith('analytics-org', expect.any(Function));
+            expect(projectModel.saveExploresToCache).toHaveBeenCalledWith(
+                'existing',
+                expect.arrayContaining([
+                    expect.objectContaining({ name: 'query_events' }),
+                    expect.objectContaining({ name: 'ai_usage' }),
+                ]),
+                true,
+            );
+            expect(
+                projectModel.createWithOptionalCredentials,
+            ).not.toHaveBeenCalled();
+        });
+
+        test('creates an internal preview, not a user-configured connection', async () => {
+            projectModel.getAllByOrganizationUuid.mockResolvedValueOnce([]);
+            const create = vi
+                .spyOn(service, 'createWithoutCompile')
+                .mockResolvedValueOnce({
+                    project: { projectUuid: 'new' },
+                } as Awaited<
+                    ReturnType<ProjectService['createWithoutCompile']>
+                >);
+            const result = await service.ensureAnalyticsProject(admin);
+            expect(result.created).toBe(true);
+            expect(create).toHaveBeenCalledWith(
+                admin,
+                expect.objectContaining({
+                    name: 'Lightdash analytics',
+                    type: ProjectType.PREVIEW,
+                    warehouseConnection: expect.objectContaining({
+                        connectionType: DuckdbConnectionType.ANALYTICS,
+                    }),
+                }),
+                RequestMethod.BACKEND,
+                { source: 'analytics' },
+            );
+        });
+
+        test('rejects non-admins before provisioning', async () => {
+            await expect(
+                service.ensureAnalyticsProject({
+                    ...admin,
+                    ability: new Ability<PossibleAbilities>([]),
+                }),
+            ).rejects.toThrow(/administration/);
+            expect(
+                projectModel.runInAnalyticsProvisioningLock,
+            ).not.toHaveBeenCalled();
+        });
+
+        test('rejects another organization even with an unrestricted ability', async () => {
+            await expect(
+                service.assertAnalyticsProjectAccess(
+                    {
+                        ...admin,
+                        ability: new Ability<PossibleAbilities>([
+                            { subject: 'all', action: 'manage' },
+                        ]),
+                    },
+                    {
+                        provisioningSource: 'analytics',
+                        organizationUuid: 'other-org',
+                    },
+                ),
+            ).rejects.toThrow(/another organization/);
+        });
+
+        test('stops before provisioning when the feature gate rejects access', async () => {
+            vi.mocked(
+                localAnalytics.assertLocalAnalyticsProjectEnabled,
+            ).mockImplementation(() => {
+                throw new ForbiddenError('disabled');
+            });
+            await expect(service.ensureAnalyticsProject(admin)).rejects.toThrow(
+                'disabled',
+            );
+            expect(
+                projectModel.runInAnalyticsProvisioningLock,
+            ).not.toHaveBeenCalled();
         });
     });
 

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -707,7 +707,10 @@ describe('ProjectService', () => {
                 'assertLocalAnalyticsProjectEnabled',
             ).mockImplementation(() => undefined);
         });
-        afterEach(() => vi.restoreAllMocks());
+        afterEach(() => {
+            vi.restoreAllMocks();
+            vi.unstubAllEnvs();
+        });
 
         test('does not create a project when storage authentication fails', async () => {
             testAnalyticsStorage.mockRejectedValueOnce(
@@ -820,6 +823,68 @@ describe('ProjectService', () => {
             );
             expect(
                 projectModel.runInAnalyticsProvisioningLock,
+            ).not.toHaveBeenCalled();
+        });
+
+        test.each([
+            { enabled: false, disabled: false },
+            { enabled: true, disabled: true },
+        ])(
+            'blocks creation and refresh before any side effects when enabled=$enabled, disabled=$disabled',
+            async ({ enabled, disabled }) => {
+                vi.mocked(
+                    localAnalytics.assertLocalAnalyticsProjectEnabled,
+                ).mockRestore();
+                vi.stubEnv('NODE_ENV', 'development');
+                vi.stubEnv(
+                    'LIGHTDASH_LOCAL_ANALYTICS_ORG_UUID',
+                    'analytics-org',
+                );
+                vi.spyOn(
+                    lightdashConfigMock.enabledFeatureFlags,
+                    'has',
+                ).mockReturnValue(enabled);
+                vi.spyOn(
+                    lightdashConfigMock.disabledFeatureFlags,
+                    'has',
+                ).mockReturnValue(disabled);
+
+                await expect(
+                    service.ensureAnalyticsProject(admin),
+                ).rejects.toThrow(/not enabled/);
+                await expect(
+                    service.assertAnalyticsProjectAccess(admin, {
+                        organizationUuid: 'analytics-org',
+                        provisioningSource: 'analytics',
+                    }),
+                ).rejects.toThrow(/not enabled/);
+
+                expect(
+                    localAnalytics.createLocalAnalyticsClient,
+                ).not.toHaveBeenCalled();
+                expect(testAnalyticsStorage).not.toHaveBeenCalled();
+                expect(
+                    projectModel.runInAnalyticsProvisioningLock,
+                ).not.toHaveBeenCalled();
+                expect(
+                    projectModel.getAllByOrganizationUuid,
+                ).not.toHaveBeenCalled();
+                expect(
+                    projectModel.createWithOptionalCredentials,
+                ).not.toHaveBeenCalled();
+                expect(projectModel.saveExploresToCache).not.toHaveBeenCalled();
+            },
+        );
+
+        test('does not apply the analytics gate to ordinary projects', async () => {
+            await expect(
+                service.assertAnalyticsProjectAccess(admin, {
+                    organizationUuid: 'analytics-org',
+                    provisioningSource: null,
+                }),
+            ).resolves.toBeUndefined();
+            expect(
+                localAnalytics.assertLocalAnalyticsProjectEnabled,
             ).not.toHaveBeenCalled();
         });
     });
@@ -3629,12 +3694,14 @@ describe('ProjectService', () => {
 
     describe('getAllExploresSummary', () => {
         test('should get all explores summary without filtering', async () => {
+            projectModel.getSummary.mockClear();
             const result = await service.getAllExploresSummary(
                 account,
                 projectUuid,
                 false,
             );
             expect(result).toEqual(expectedAllExploreSummary);
+            expect(projectModel.getSummary).toHaveBeenCalledTimes(1);
         });
         test('should get all explores summary with filtering', async () => {
             const result = await service.getAllExploresSummary(

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -372,6 +372,11 @@ import {
     getFilteredExplore,
 } from '../UserAttributesService/UserAttributeUtils';
 import { UserService } from '../UserService';
+import { createAnalyticsExplores } from './analyticsProject/createAnalyticsExplores';
+import {
+    assertLocalAnalyticsProjectEnabled,
+    createLocalAnalyticsClient,
+} from './analyticsProject/localAnalyticsProject';
 import { getFieldValuesMetricQuery } from './fieldValuesQueryBuilder';
 import { getAvailableParameterDefinitions } from './parameters';
 import { projectMergedManifest } from './projectMergedManifest';
@@ -421,7 +426,10 @@ type RefreshTokenRotationSource =
  * playground and the training project. Only these may use embedded DuckDB
  * credentials or the `TRAINING` project type.
  */
-export type InternalProvisioningSource = 'playground' | 'training';
+export type InternalProvisioningSource =
+    | 'playground'
+    | 'training'
+    | 'analytics';
 export type InternalProvisioning = { source: InternalProvisioningSource };
 
 export type ProjectServiceArguments = {
@@ -804,6 +812,71 @@ export class ProjectService extends BaseService {
         return result;
     }
 
+    async ensureAnalyticsProject(user: SessionUser): Promise<{
+        projectUuid: string;
+        url: string;
+        created: boolean;
+    }> {
+        if (!isUserWithOrg(user)) {
+            throw new ForbiddenError('User is not part of an organization');
+        }
+        const { organizationUuid } = user;
+        await this.assertAnalyticsProjectAccess(user, {
+            organizationUuid,
+            provisioningSource: 'analytics',
+        });
+        // Fail before creating a project if the signed file reads cannot authenticate.
+        await createLocalAnalyticsClient(organizationUuid).test();
+        // Both models are backend-owned. Compilation itself needs no warehouse IO.
+        const explores = createAnalyticsExplores();
+        return this.projectModel.runInAnalyticsProvisioningLock(
+            organizationUuid,
+            async () => {
+                const existing = (
+                    await this.projectModel.getAllByOrganizationUuid(
+                        organizationUuid,
+                    )
+                ).find((project) => project.provisioningSource === 'analytics');
+                const projectUuid =
+                    existing?.projectUuid ??
+                    (
+                        await this.createWithoutCompile(
+                            user,
+                            {
+                                name: 'Lightdash analytics',
+                                type: ProjectType.PREVIEW,
+                                dbtConnection: { type: DbtProjectType.NONE },
+                                dbtVersion: DefaultSupportedDbtVersion,
+                                warehouseConnection: {
+                                    type: WarehouseTypes.DUCKDB,
+                                    connectionType:
+                                        DuckdbConnectionType.ANALYTICS,
+                                    database: 'memory',
+                                    schema: 'main',
+                                },
+                            },
+                            RequestMethod.BACKEND,
+                            { source: 'analytics' },
+                        )
+                    ).project.projectUuid;
+                // Also repairs a previous attempt that created the project but
+                // failed while saving models; never delete existing content.
+                await this.projectModel.saveExploresToCache(
+                    projectUuid,
+                    explores,
+                    true,
+                );
+                this.userModel.invalidateSessionUserCache(user.userUuid);
+                const project = await this.projectModel.getSummary(projectUuid);
+                return {
+                    projectUuid,
+                    url: `/projects/${project.slug ?? projectUuid}/tables`,
+                    created: !existing,
+                };
+            },
+        );
+    }
+
     async ensurePlaygroundProject(
         user: SessionUser,
         trigger: PlaygroundProjectTrigger = 'invite_expert',
@@ -867,7 +940,10 @@ export class ProjectService extends BaseService {
         // The training project's agent comes with its seeded content (the
         // walkthroughs name it); a second, default agent would make Ask AI
         // land on either.
-        if (provisioningSource === 'training') {
+        if (
+            provisioningSource === 'training' ||
+            provisioningSource === 'analytics'
+        ) {
             return;
         }
 
@@ -923,6 +999,7 @@ export class ProjectService extends BaseService {
         projectType: ProjectType,
         provisioningSource?: InternalProvisioningSource,
     ): Promise<void> {
+        if (provisioningSource === 'analytics') return;
         await this.provisionDefaultAiAgent(
             user,
             projectUuid,
@@ -2043,6 +2120,23 @@ export class ProjectService extends BaseService {
         let userWarehouseCredentialsUuid: string | undefined;
 
         if (
+            credentials.type === WarehouseTypes.DUCKDB &&
+            credentials.connectionType === DuckdbConnectionType.ANALYTICS
+        ) {
+            if (!isRegisteredUser || isServiceAccount)
+                throw new ForbiddenError(
+                    'Local analytics requires a signed-in organization administrator',
+                );
+            const project = await this.projectModel.getSummary(projectUuid);
+            const user = await this.userModel.findSessionUserAndOrgByUuid(
+                userId,
+                project.organizationUuid,
+            );
+            await this.assertAnalyticsProjectAccess(user, project);
+            return { ...credentials, userWarehouseCredentialsUuid };
+        }
+
+        if (
             organizationWarehouseCredentialsUuid &&
             !credentials.requireUserCredentials
         ) {
@@ -2211,6 +2305,22 @@ export class ProjectService extends BaseService {
         Sentry.setTag('warehouse.type', credentials.type);
         // Setup SSH tunnel for client (user needs to close this)
         const sshTunnel = new SshTunnel(credentials);
+        if (
+            credentials.type === WarehouseTypes.DUCKDB &&
+            credentials.connectionType === DuckdbConnectionType.ANALYTICS
+        ) {
+            const project = await this.projectModel.get(projectUuid);
+            if (project.provisioningSource !== 'analytics') {
+                throw new ForbiddenError('Invalid internal analytics project');
+            }
+            return {
+                warehouseClient: createLocalAnalyticsClient(
+                    project.organizationUuid,
+                ),
+                sshTunnel,
+                tunnelConnectMs: null,
+            };
+        }
         const usedSshTunnel =
             'useSshTunnel' in credentials && !!credentials.useSshTunnel;
         const tunnelStart = performance.now();
@@ -2707,6 +2817,7 @@ export class ProjectService extends BaseService {
 
     async getProject(projectUuid: string, account: Account): Promise<Project> {
         const project = await this.projectModel.get(projectUuid);
+        await this.assertAnalyticsProjectAccess(account, project);
         const auditedAbility = this.createAuditedAbility(account);
         const projectSubject = subject('Project', {
             organizationUuid: project.organizationUuid,
@@ -2732,6 +2843,35 @@ export class ProjectService extends BaseService {
         }
 
         return project;
+    }
+
+    async assertAnalyticsProjectAccess(
+        account: Account | SessionUser,
+        project: Pick<Project, 'provisioningSource' | 'organizationUuid'>,
+    ): Promise<void> {
+        if (project.provisioningSource !== 'analytics') return;
+        const organizationUuid =
+            'organization' in account
+                ? account.organization.organizationUuid
+                : account.organizationUuid;
+        if (organizationUuid !== project.organizationUuid) {
+            throw new ForbiddenError(
+                'Analytics project belongs to another organization',
+            );
+        }
+        assertLocalAnalyticsProjectEnabled(project.organizationUuid);
+        if (
+            this.createAuditedAbility(account).cannot(
+                'manage',
+                subject('Organization', {
+                    organizationUuid: project.organizationUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'Internal analytics requires organization administration access',
+            );
+        }
     }
 
     async getMergedManifest(
@@ -2933,11 +3073,13 @@ export class ProjectService extends BaseService {
                 user.userUuid,
                 user.organizationUuid,
                 createProject,
-                await this.getPreviewExpiresAt(
-                    createProject.type,
-                    createProject.upstreamProjectUuid,
-                    createProject.expiresInHours,
-                ),
+                internalProvisioning?.source === 'analytics'
+                    ? null
+                    : await this.getPreviewExpiresAt(
+                          createProject.type,
+                          createProject.upstreamProjectUuid,
+                          createProject.expiresInHours,
+                      ),
                 internalProvisioning?.source,
             );
 
@@ -3534,6 +3676,10 @@ export class ProjectService extends BaseService {
     ): Promise<ApiDeployExploresResults> {
         const project =
             await this.projectModel.getWithSensitiveFields(projectUuid);
+        if (project.provisioningSource === 'analytics')
+            throw new ForbiddenError(
+                'Internal analytics models are managed by the backend',
+            );
 
         const auditedAbility = this.createAuditedAbility(user);
 
@@ -3646,7 +3792,8 @@ export class ProjectService extends BaseService {
     ): void {
         if (
             credentials?.type === WarehouseTypes.DUCKDB &&
-            credentials.connectionType === DuckdbConnectionType.ANALYTICS
+            credentials.connectionType === DuckdbConnectionType.ANALYTICS &&
+            internalProvisioning?.source !== 'analytics'
         ) {
             throw new ParameterError(
                 'Analytics connections can only be provisioned internally',
@@ -3775,6 +3922,10 @@ export class ProjectService extends BaseService {
         );
         const savedProject =
             await this.projectModel.getWithSensitiveFields(projectUuid);
+        if (savedProject.provisioningSource === 'analytics')
+            throw new ForbiddenError(
+                'Internal analytics configuration is managed by the backend',
+            );
         const auditedAbility = this.createAuditedAbility(account);
         if (
             auditedAbility.cannot(
@@ -3899,6 +4050,10 @@ export class ProjectService extends BaseService {
         }
 
         const project = await this.projectModel.getSummary(projectUuid);
+        if (project.provisioningSource === 'analytics')
+            throw new ForbiddenError(
+                'Internal analytics configuration is managed by the backend',
+            );
         const auditedAbility = this.createAuditedAbility(account);
         if (auditedAbility.cannot('update', subject('Project', project))) {
             throw new ForbiddenError();
@@ -3925,6 +4080,10 @@ export class ProjectService extends BaseService {
         );
         const savedProject =
             await this.projectModel.getWithSensitiveFields(projectUuid);
+        if (savedProject.provisioningSource === 'analytics')
+            throw new ForbiddenError(
+                'Internal analytics configuration is managed by the backend',
+            );
         const auditedAbility = this.createAuditedAbility(account);
         if (
             auditedAbility.cannot(
@@ -8380,8 +8539,9 @@ export class ProjectService extends BaseService {
         projectUuid: string,
         fileId: string,
     ): Promise<Readable> {
-        const { organizationUuid } =
-            await this.projectModel.getSummary(projectUuid);
+        const project = await this.projectModel.getSummary(projectUuid);
+        await this.assertAnalyticsProjectAccess(user, project);
+        const { organizationUuid } = project;
         const auditedAbility = this.createAuditedAbility(user);
         if (
             auditedAbility.cannot(
@@ -9451,6 +9611,10 @@ export class ProjectService extends BaseService {
         includeErrors: boolean = true,
         includePreAggregates: boolean = false,
     ): Promise<SummaryExplore[]> {
+        await this.assertAnalyticsProjectAccess(
+            account,
+            await this.projectModel.getSummary(projectUuid),
+        );
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
@@ -9534,6 +9698,10 @@ export class ProjectService extends BaseService {
         organizationUuid?: string,
         includeUnfilteredTables: boolean = true,
     ): Promise<{ explore: Explore; userAccessControls: UserAccessControls }> {
+        await this.assertAnalyticsProjectAccess(
+            account,
+            await this.projectModel.getSummary(projectUuid),
+        );
         return traceSpan(
             {
                 op: 'ProjectService.getExplore',
@@ -9772,6 +9940,12 @@ export class ProjectService extends BaseService {
             case WarehouseTypes.ATHENA:
                 return credentials.database; // Athena uses database as catalog name
             case WarehouseTypes.DUCKDB:
+                if (
+                    credentials.connectionType ===
+                    DuckdbConnectionType.ANALYTICS
+                ) {
+                    return 'memory';
+                }
                 if (
                     credentials.connectionType === DuckdbConnectionType.DUCKLAKE
                 ) {

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -9611,12 +9611,9 @@ export class ProjectService extends BaseService {
         includeErrors: boolean = true,
         includePreAggregates: boolean = false,
     ): Promise<SummaryExplore[]> {
-        await this.assertAnalyticsProjectAccess(
-            account,
-            await this.projectModel.getSummary(projectUuid),
-        );
-        const { organizationUuid } =
-            await this.projectModel.getSummary(projectUuid);
+        const project = await this.projectModel.getSummary(projectUuid);
+        await this.assertAnalyticsProjectAccess(account, project);
+        const { organizationUuid } = project;
 
         const auditedAbility = this.createAuditedAbility(account);
         if (

--- a/packages/backend/src/services/ProjectService/analyticsProject/createAnalyticsExplores.test.ts
+++ b/packages/backend/src/services/ProjectService/analyticsProject/createAnalyticsExplores.test.ts
@@ -1,0 +1,36 @@
+import { MetricType } from '@lightdash/common';
+import { createAnalyticsExplores } from './createAnalyticsExplores';
+
+describe('createAnalyticsExplores', () => {
+    it('compiles curated metrics and time dimensions against internal views', () => {
+        const [queries, ai] = createAnalyticsExplores();
+        expect([queries.name, ai.name]).toEqual(['query_events', 'ai_usage']);
+        expect(queries.tables.query_events.sqlTable).toBe('"query_events"');
+        expect(queries.tables.query_events.metrics.total_queries.type).toBe(
+            MetricType.COUNT,
+        );
+        expect(
+            queries.tables.query_events.metrics.p90_warehouse_execution_time_ms
+                .percentile,
+        ).toBe(90);
+        expect(
+            queries.tables.query_events.dimensions.event_ts_day,
+        ).toBeDefined();
+        expect(ai.tables.ai_usage.metrics.total_input_tokens.type).toBe(
+            MetricType.SUM,
+        );
+        expect(ai.tables.ai_usage.metrics.unique_users.type).toBe(
+            MetricType.COUNT_DISTINCT,
+        );
+    });
+
+    it('does not turn unexpected source columns into model fields or metrics', () => {
+        const [queries] = createAnalyticsExplores();
+        expect(
+            queries.tables.query_events.dimensions.extra_numeric,
+        ).toBeUndefined();
+        expect(
+            queries.tables.query_events.metrics.total_row_count_total,
+        ).toBeUndefined();
+    });
+});

--- a/packages/backend/src/services/ProjectService/analyticsProject/createAnalyticsExplores.ts
+++ b/packages/backend/src/services/ProjectService/analyticsProject/createAnalyticsExplores.ts
@@ -1,0 +1,80 @@
+import {
+    buildDimensionsFromColumns,
+    DimensionType,
+    ExploreCompiler,
+    FieldType,
+    friendlyName,
+    WarehouseTypes,
+    type Explore,
+    type Metric,
+} from '@lightdash/common';
+import { warehouseSqlBuilderFromType } from '@lightdash/warehouses';
+import { compactedStreamSchemas } from '../../../analytics/eventStream/registry';
+import type { CompactedColumnType } from '../../../analytics/eventStream/types';
+import { systemStreamMetrics } from '../../../analytics/systemExplores/systemStreamMetrics';
+
+const dimensionTypes: Record<CompactedColumnType, DimensionType> = {
+    VARCHAR: DimensionType.STRING,
+    TIMESTAMP: DimensionType.TIMESTAMP,
+    BOOLEAN: DimensionType.BOOLEAN,
+    INTEGER: DimensionType.NUMBER,
+    BIGINT: DimensionType.NUMBER,
+};
+
+/** Compile backend-owned system models without querying remote storage. */
+export const createAnalyticsExplores = (): Explore[] => {
+    const sqlBuilder = warehouseSqlBuilderFromType(WarehouseTypes.DUCKDB);
+    const compiler = new ExploreCompiler(sqlBuilder);
+    return (['query_events', 'ai_usage'] as const).map((name) => {
+        const columns = compactedStreamSchemas[name];
+        const label = friendlyName(name);
+        const base = {
+            table: name,
+            tableLabel: label,
+            fieldType: FieldType.METRIC as const,
+            hidden: false,
+        };
+        const metrics: Record<string, Metric> = Object.fromEntries(
+            systemStreamMetrics[name as keyof typeof systemStreamMetrics].map(
+                ({ column, ...definition }) => [
+                    definition.name,
+                    {
+                        ...base,
+                        ...definition,
+                        label: friendlyName(definition.name),
+                        sql: `\${${column}}`,
+                    },
+                ],
+            ),
+        );
+        return compiler.compileExplore({
+            name,
+            label,
+            tags: [],
+            baseTable: name,
+            joinedTables: [],
+            meta: {},
+            targetDatabase: sqlBuilder.getAdapterType(),
+            tables: {
+                [name]: {
+                    name,
+                    label,
+                    sqlTable: `"${name}"`,
+                    database: 'memory',
+                    schema: 'main',
+                    lineageGraph: { nodes: [], edges: [] },
+                    dimensions: buildDimensionsFromColumns({
+                        tableName: name,
+                        tableLabel: label,
+                        columns: columns.map(({ name: reference, type }) => ({
+                            reference,
+                            type: dimensionTypes[type],
+                        })),
+                        warehouseSqlBuilder: sqlBuilder,
+                    }),
+                    metrics,
+                },
+            },
+        });
+    });
+};

--- a/packages/backend/src/services/ProjectService/analyticsProject/localAnalyticsProject.test.ts
+++ b/packages/backend/src/services/ProjectService/analyticsProject/localAnalyticsProject.test.ts
@@ -1,0 +1,80 @@
+import { FeatureFlags } from '@lightdash/common';
+import { lightdashConfig } from '../../../config/lightdashConfig';
+import {
+    assertLocalAnalyticsProjectEnabled,
+    createLocalAnalyticsClient,
+} from './localAnalyticsProject';
+import { createS3AnalyticsSourceResolver } from './S3AnalyticsSource';
+
+vi.mock('./S3AnalyticsSource', () => ({
+    createS3AnalyticsSourceResolver: vi.fn(),
+}));
+
+vi.mock('../../../config/lightdashConfig', () => ({
+    lightdashConfig: {
+        enabledFeatureFlags: new Set(),
+        disabledFeatureFlags: new Set(),
+        usageEvents: { s3: null },
+    },
+}));
+
+describe('local analytics project gate', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        lightdashConfig.usageEvents.s3 = null;
+        lightdashConfig.enabledFeatureFlags.clear();
+        lightdashConfig.disabledFeatureFlags.clear();
+        lightdashConfig.enabledFeatureFlags.add(FeatureFlags.AnalyticsProject);
+        vi.stubEnv('NODE_ENV', 'development');
+        vi.stubEnv('LIGHTDASH_LOCAL_ANALYTICS_ORG_UUID', 'local-org');
+    });
+    afterEach(() => vi.unstubAllEnvs());
+    it('allows the explicitly bound local org', () => {
+        expect(() =>
+            assertLocalAnalyticsProjectEnabled('local-org'),
+        ).not.toThrow();
+    });
+    it('fails closed for another org', () => {
+        expect(() => assertLocalAnalyticsProjectEnabled('other-org')).toThrow();
+    });
+    it('cannot be enabled in production', () => {
+        vi.stubEnv('NODE_ENV', 'production');
+        expect(() => assertLocalAnalyticsProjectEnabled('local-org')).toThrow();
+    });
+    it('requires an explicit feature flag and respects an explicit disable', () => {
+        lightdashConfig.enabledFeatureFlags.clear();
+        expect(() => assertLocalAnalyticsProjectEnabled('local-org')).toThrow();
+        lightdashConfig.enabledFeatureFlags.add(FeatureFlags.AnalyticsProject);
+        lightdashConfig.disabledFeatureFlags.add(FeatureFlags.AnalyticsProject);
+        expect(() => assertLocalAnalyticsProjectEnabled('local-org')).toThrow();
+    });
+
+    it('requires configured storage rather than invoking an external login', () => {
+        expect(() => createLocalAnalyticsClient('local-org')).toThrow(
+            /storage is not configured/,
+        );
+        expect(createS3AnalyticsSourceResolver).not.toHaveBeenCalled();
+    });
+
+    it('binds the existing writer configuration to the signed-URL resolver', () => {
+        const storage = {
+            endpoint: 'https://storage.googleapis.com',
+            bucket: 'example-bucket',
+            region: 'us-east4',
+            accessKey: 'test-writer-key',
+            secretKey: 'test-writer-secret',
+            forcePathStyle: true,
+        };
+        lightdashConfig.usageEvents.s3 = storage;
+        vi.stubEnv('LIGHTDASH_LOCAL_ANALYTICS_SOURCE_ORG_UUID', 'source-org');
+        vi.stubEnv('LIGHTDASH_LOCAL_ANALYTICS_START_DATE', '2026-09-07');
+        vi.stubEnv('LIGHTDASH_LOCAL_ANALYTICS_END_DATE', '2026-09-07');
+        createLocalAnalyticsClient('local-org');
+        expect(createS3AnalyticsSourceResolver).toHaveBeenCalledWith({
+            storage,
+            organizationUuid: 'source-org',
+            startDate: '2026-09-07',
+            endDate: '2026-09-07',
+        });
+    });
+});

--- a/packages/backend/src/services/ProjectService/analyticsProject/localAnalyticsProject.test.ts
+++ b/packages/backend/src/services/ProjectService/analyticsProject/localAnalyticsProject.test.ts
@@ -56,7 +56,7 @@ describe('local analytics project gate', () => {
         expect(createS3AnalyticsSourceResolver).not.toHaveBeenCalled();
     });
 
-    it('binds the existing writer configuration to the signed-URL resolver', () => {
+    it('binds writer configuration and org without forwarding legacy date limits', () => {
         const storage = {
             endpoint: 'https://storage.googleapis.com',
             bucket: 'example-bucket',
@@ -73,8 +73,6 @@ describe('local analytics project gate', () => {
         expect(createS3AnalyticsSourceResolver).toHaveBeenCalledWith({
             storage,
             organizationUuid: 'source-org',
-            startDate: '2026-09-07',
-            endDate: '2026-09-07',
         });
     });
 });

--- a/packages/backend/src/services/ProjectService/analyticsProject/localAnalyticsProject.ts
+++ b/packages/backend/src/services/ProjectService/analyticsProject/localAnalyticsProject.ts
@@ -39,8 +39,6 @@ export const createLocalAnalyticsClient = (
         // Explicit local demo binding only; production must use the persisted org.
         organizationUuid:
             process.env.LIGHTDASH_LOCAL_ANALYTICS_SOURCE_ORG_UUID ?? '',
-        startDate: process.env.LIGHTDASH_LOCAL_ANALYTICS_START_DATE ?? '',
-        endDate: process.env.LIGHTDASH_LOCAL_ANALYTICS_END_DATE ?? '',
     });
     return new DuckdbWarehouseClient({
         type: 'duckdb_parquet',

--- a/packages/backend/src/services/ProjectService/analyticsProject/localAnalyticsProject.ts
+++ b/packages/backend/src/services/ProjectService/analyticsProject/localAnalyticsProject.ts
@@ -1,0 +1,52 @@
+import {
+    FeatureFlags,
+    ForbiddenError,
+    MissingConfigError,
+} from '@lightdash/common';
+import { DuckdbWarehouseClient } from '@lightdash/warehouses';
+import { lightdashConfig } from '../../../config/lightdashConfig';
+import { createS3AnalyticsSourceResolver } from './S3AnalyticsSource';
+
+/** Temporary local triage configuration, NOT a production credential strategy. */
+export const isLocalAnalyticsProjectEnabled = (
+    organizationUuid: string,
+): boolean =>
+    process.env.NODE_ENV === 'development' &&
+    lightdashConfig.enabledFeatureFlags.has(FeatureFlags.AnalyticsProject) &&
+    !lightdashConfig.disabledFeatureFlags.has(FeatureFlags.AnalyticsProject) &&
+    process.env.LIGHTDASH_LOCAL_ANALYTICS_ORG_UUID === organizationUuid;
+
+export const assertLocalAnalyticsProjectEnabled = (
+    organizationUuid: string,
+): void => {
+    if (!isLocalAnalyticsProjectEnabled(organizationUuid)) {
+        throw new ForbiddenError(
+            'Internal analytics projects are not enabled for this organization',
+        );
+    }
+};
+
+export const createLocalAnalyticsClient = (
+    organizationUuid: string,
+): DuckdbWarehouseClient => {
+    assertLocalAnalyticsProjectEnabled(organizationUuid);
+    const storage = lightdashConfig.usageEvents.s3;
+    if (!storage) {
+        throw new MissingConfigError('Usage events storage is not configured');
+    }
+    const resolveSource = createS3AnalyticsSourceResolver({
+        storage,
+        // Explicit local demo binding only; production must use the persisted org.
+        organizationUuid:
+            process.env.LIGHTDASH_LOCAL_ANALYTICS_SOURCE_ORG_UUID ?? '',
+        startDate: process.env.LIGHTDASH_LOCAL_ANALYTICS_START_DATE ?? '',
+        endDate: process.env.LIGHTDASH_LOCAL_ANALYTICS_END_DATE ?? '',
+    });
+    return new DuckdbWarehouseClient({
+        type: 'duckdb_parquet',
+        resolveSource: async () => {
+            assertLocalAnalyticsProjectEnabled(organizationUuid);
+            return resolveSource();
+        },
+    });
+};

--- a/packages/frontend/src/components/NavBar/switcherProjects.test.ts
+++ b/packages/frontend/src/components/NavBar/switcherProjects.test.ts
@@ -17,6 +17,15 @@ const project = (
     }) as OrganizationProject;
 
 describe('project switcher grouping', () => {
+    it('omits internal analytics projects', () => {
+        const analytics = project({
+            projectUuid: 'analytics',
+            type: ProjectType.PREVIEW,
+        });
+        expect(
+            splitSwitcherProjects([analytics], () => true).baseProjects,
+        ).toEqual([]);
+    });
     const real = project({ projectUuid: 'real' });
     const training = project({
         projectUuid: 'training',

--- a/packages/frontend/src/utils/projectUrl.test.ts
+++ b/packages/frontend/src/utils/projectUrl.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { getProjectUrlIdentifier } from './projectUrl';
+
+describe('project URL identifiers', () => {
+    it('preserves slugs for normal projects', () => {
+        expect(
+            getProjectUrlIdentifier({
+                projectUuid: 'uuid',
+                slug: 'my-project',
+            }),
+        ).toBe('my-project');
+    });
+    it('falls back to UUID when a project has no slug', () => {
+        expect(
+            getProjectUrlIdentifier({
+                projectUuid: 'uuid',
+                slug: undefined,
+            }),
+        ).toBe('uuid');
+    });
+});


### PR DESCRIPTION
## Summary

- Historical access: no fixed source date window. Legacy local start/end environment settings are ignored; Explore date filters operate over all retained supported files for the source org. Production/local-org restrictions remain unchanged.

Third slice of the internal usage analytics stack, based on the connector/flag and signed-URL credentials PRs. Replaces script-based provisioning with `POST /api/v1/org/analytics-project` and includes both Query Events and AI Usage system models together.

- Session-authenticated, org-admin-only endpoint accepts no caller-supplied org, bucket, paths, or credentials.
- Creates or reuses a backend-owned `PREVIEW` project marked `provisioning_source=analytics`. No new project-type migration. New projects prefer `lightdash-analytics`, using normal collision-safe slug allocation.
- Serializes provisioning per org with a database advisory lock; retries refresh the fixed models without replacing the project or deleting content. Analytics previews do not expire automatically.
- Verifies authenticated signed-Parquet access before creating any project, then compiles both fixed system explores in memory. Storage failures do not leave a new unusable project. Selects supported streams explicitly so adding another writer stream cannot unexpectedly expose or break models.
- Reuses the existing usage-events writer configuration to sign exact read-only file URLs. Removes the developer CLI authentication path; DuckDB receives no bucket-wide keys.
- Requires the shared flag, explicit development-org binding and org-admin access for analytics reads, query results and history. Ordinary projects return through the existing permission paths.
- Inherits public analytics create/update/connection-test rejection and regression coverage from PR1; adds only the backend-only `source: analytics` provisioning exception. Export/scheduled-download creation is unavailable for these projects, avoiding signed URLs that outlive the feature/admin checks.
- Admin-only projects API visibility supports slug resolution; the normal switcher omits previews without upstream projects. No admin navigation UI is added.

## Idempotency and slug allocation

- `POST /api/v1/org/analytics-project` is create-or-get per authenticated organization. Existing projects are identified by `provisioning_source=analytics`, not their name or slug.
- Repeated calls return the same project UUID with `created: false`. They refresh both system explores without deleting saved charts or replacing the project.
- A per-organization PostgreSQL advisory lock serializes the lookup/create sequence, including calls handled by different API pods, to prevent concurrent requests from creating duplicates.
- New projects are named `Lightdash analytics` and use the existing `generateUniqueProjectSlug` allocator: `lightdash-analytics`, then `lightdash-analytics-1`, `lightdash-analytics-2`, etc. when a slug is already reserved within the org.
- Existing analytics projects retain their current slug. A conflicting ordinary project's name or slug never makes it the analytics project.
- The response is `{ projectUuid, url, created }`; callers should redirect using the returned URL, which contains the actual assigned slug.

## Validation

- Latest opt-in standalone GCS test exceeded its existing 120-second whole-test deadline after expanding to all history; do not count it as passing on this revision. Separately, both uncached local API explores completed against the real bucket (approximately 137s Query Events, 123s AI Usage). Latency and test-budget follow-up are tracked in PROD-11111.
- All-history live API verification: concurrent create-or-get reused the existing project; anonymous and viewer access remained denied. Uncached Query Events aggregate and AI Usage grouped by event day both reached ready. Query Events took approximately 137 seconds locally, exceeding the older smoke script's 25-second wait; performance is explicitly tracked in PROD-11111, not claimed production-ready.
- All-history revision: 236 focused ProjectService/local-gate/source tests and backend typecheck passed. No new endpoint, auth bypass, or migration.
- After moving the public configuration guard into PR1 and restacking: 224 focused ProjectService/model/local-gate tests and backend typecheck passed. Final runtime source is unchanged by this move; public regression coverage is expanded in the base PR.
- Earlier full focused run: 405 backend tests passed. Latest credential integration: 390 ProjectService/AsyncQueryService/local-gate tests passed, including storage failure before provisioning, writer-config binding, flag-off and non-admin result/history/export denials.
- Latest backend typecheck, scoped lint/formatting and pre-commit checks passed. Seven frontend URL/switcher tests passed.
- Live API checks repeated after credential integration: three concurrent ensure calls returned the same existing project with `created: false`; anonymous requests returned 401, viewer provisioning/project reads returned 403, and the viewer project list excluded analytics. Uncached Query Events and AI Usage queries completed successfully; viewer query-result access was denied.
- Preserved the prototype local project UUID and saved content while converting its local record to PREVIEW.
- New credentials path verified against real GCS: native DuckDB Query Events count and AI Usage count/token aggregation passed using existing writer HMAC credentials to sign file URLs. No CLI/OAuth authentication or cloud writes. This verifies the resolver/warehouse path, not a fresh browser acceptance run.
- The developer confirmed the local flow worked in the browser. Automated verification used the API; no automated browser acceptance suite was run.
- Added `USAGE_EVENTS_S3_ENDPOINT` with fallback to `S3_ENDPOINT`, allowing GCS analytics reads while general local storage stays on MinIO. All 232 configuration tests and scoped pre-commit checks passed.
- Generated API artifacts were regenerated locally and are not committed.

## Security / deployment boundary

This remains local-only provisioning with an explicit source-org mapping; production execution is rejected even if the feature flag is enabled. Only short-lived, exact-file signed GET URLs enter DuckDB. Broad writer credentials remain inside the backend signer as an explicitly temporary compromise.

The preceding credentials PR includes live read verification and isolated signed-URL denial tests. Dedicated read-only source credentials are deferred to PROD-11103. No cloud IAM changes are included. Full production authorization/role design, canonical org binding, admin navigation, empty-stream/schema-evolution behavior, performance and cache freshness remain rollout work.

An independent bounded review found cached-result guard gaps; those paths were protected and regression tests added before submission. This is not a claim that the implementation has no vulnerabilities.

Merge in stack order. Customer enablement remains blocked pending production authorization/rollout review. The local instance was restarted for manual testing, with its existing database and saved content preserved.

Relates: [PROD-11059](https://linear.app/lightdash/issue/PROD-11059)
Relates: [PROD-8603](https://linear.app/lightdash/issue/PROD-8603)

Relates: [PROD-11111](https://linear.app/lightdash/issue/PROD-11111)
