### PR TITLE
chore(rainbow): previews do not send product analytics

### DIFF
--- a/rainbow.toml
+++ b/rainbow.toml
@@ -77,6 +77,13 @@ LIGHTDASH_PREVIEW_FEATURE_FLAGS_ENABLED = "true"
 # exist to try unreleased work, so switch it on here and let an admin press
 # Enable Learn in the environment.
 LIGHTDASH_LEARN_ENABLED = "true"
+# No product analytics from previews. The backend's config bakes in a default
+# RudderStack write key and data plane, so without this every environment
+# tracks into production analytics — and the migrate rung's node process
+# stays alive until the client gives up on that request. With the data plane
+# outside the egress list that was four TCP timeouts, 8m47s, on every fork;
+# with this set the same command takes 2.5s.
+RUDDERSTACK_ANALYTICS_DISABLED = "true"
 
 # Two seeds, in the order CONTRIBUTING gives them. First the warehouse the
 # seeded project points at: dbt loads examples/full-jaffle-shop-demo into the


### PR DESCRIPTION
Replaces #28848, whose commit carried the wrong author email.

## Why

Every Rainbow preview environment of this repo runs the backend with the config's default RudderStack write key and data plane, so previews track into production analytics. That default also made the `migrate` rung in `rainbow.toml` cost **8m47s on every PR fork**: the migrations themselves finish in about ten seconds, then the `pnpm -F backend migrate` node process stays alive while the analytics client makes four attempts at `analytics.lightdash.com`, a host the preview's egress policy does not admit. Each attempt waited out a full TCP connect timeout (127 s). Ten forks on 2026-09-08 all landed between 526 s and 528 s.

## What

`RUDDERSTACK_ANALYTICS_DISABLED = "true"` in the recipe's `[env]` table. `parseConfig.ts` already honours it by leaving `rudder.writeKey` and `dataPlaneUrl` unset, which turns `LightdashAnalytics` and the migrate script's upgrade telemetry into no-ops.

## Measured

In a fork of the current preview parent, same command, same env file:

| | `pnpm -F backend migrate` |
|---|---|
| as of this morning | 8m47.573s, four `[Rudder] error: ETIMEDOUT` |
| with this change | 2.5s |

The platform has since changed its egress deny rule from a drop to a reject, so unlisted hosts now fail in milliseconds and the same command takes 7 s even without this change. This change stands on its own: previews should not report into production analytics regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
