### PR TITLE
fix(ui): even 24px gutter on full-screen modals

### DIFF
--- a/packages/frontend/src/components/common/MantineModal/MantineModal.module.css
+++ b/packages/frontend/src/components/common/MantineModal/MantineModal.module.css
@@ -15,9 +15,12 @@
 }
 
 /* Fullscreen mode */
-.fullScreenContent {
-    height: calc(100dvh - (1rem * 2));
-    width: calc(100dvw - (1rem * 2));
+.fullScreenContent.fullScreenContent {
+    /* Mantine puts this class on the viewport-fixed inner AND the content,
+       so size both at 100% — the 24px x/yOffset provides the even gutter.
+       Doubled class beats Mantine's own auto-sizing content rule. */
+    height: 100%;
+    width: 100%;
     display: flex;
     flex-direction: column;
 }

--- a/packages/frontend/src/components/common/MantineModal/index.tsx
+++ b/packages/frontend/src/components/common/MantineModal/index.tsx
@@ -327,6 +327,8 @@ const MantineModal: React.FC<MantineModalProps> = ({
                 opened={opened}
                 onClose={handleClose}
                 size={fullScreen ? 'auto' : size}
+                yOffset={fullScreen ? 24 : undefined}
+                xOffset={fullScreen ? 24 : undefined}
                 centered
                 closeOnClickOutside={isAlertDialog ? false : undefined}
                 closeOnEscape={isAlertDialog ? false : undefined}


### PR DESCRIPTION
Relates: GLITCH-765

### Description:

The full-screen modal sheet sat 5dvh from the top, overflowed the bottom, and wasn't centered (screenshots in GLITCH-765 discussion). Three stacked causes:

1. `.fullScreenContent`'s viewport-derived sizing **lost the cascade** to Mantine's own content rule (same specificity, later order) — it has been dead CSS; the sheet was auto-sized.
2. Mantine's default `--modal-y-offset: 5dvh` / `--modal-x-offset: 5vw` padded the inner asymmetrically relative to that auto size.
3. Mantine v8 applies the `Modal.Content` className to the **viewport-fixed inner as well as the content**, so any viewport-derived size on that class shrinks the inner itself and pins everything top-left.

Fix: `fullScreen` passes `yOffset={24} xOffset={24}` (the gutter), and the class sizes **both** elements at `100%` (doubled selector to win the cascade). Verified in the browser: 24px on all four sides, perfectly centered. Applies equally to the embed chart editor — the other `fullScreen` consumer of the shared component.

First slice of the GLITCH-765 compact-UI work; the per-section density pass and stacked-sheet design come separately.

### Risk assessment:

- [ ] This is a high-risk change

High-risk changes require approval from a reviewer other than the author before merging.