### PR TITLE
chore: bring Rainbow previews up to the Okteto preview standard

### DIFF
--- a/docs/preview-feature-flags.md
+++ b/docs/preview-feature-flags.md
@@ -37,11 +37,12 @@ need an app runtime). Those surfaces render but won't work end to end.
 This is controlled by `LIGHTDASH_PREVIEW_FEATURE_FLAGS_ENABLED`, which defaults
 to `true` in PR mode. Set it to `false` for production-like flag resolution.
 
-Rainbow previews are not PR mode: they run the repo's own dev scripts, and
-`packages/backend`'s `dev` pins `LIGHTDASH_MODE=development`. They set the
-variable outright instead, in `rainbow.toml`'s `[env]` table. Anything touching
-that table or the services needs the Rainbow base image recompiled before it
-takes effect.
+Rainbow previews run in PR mode too: `rainbow.toml`'s `[env]` table sets
+`LIGHTDASH_MODE=pr`, and `packages/backend`'s `dev` script defers to a mode
+already present in the environment (it defaults to `development` only when
+nothing is set, so local development is unchanged). The table also sets this
+variable outright. Anything touching that table or the services needs the
+Rainbow base image recompiled before it takes effect.
 
 ## Managing flags at runtime
 

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -8,7 +8,7 @@
         "generate-api": "tsoa spec-and-routes --configuration tsoa.yml",
         "generate-api:build": "pnpm run generate-api && pnpm run formatter --write ./src/generated",
         "generate-api-dev": "pnpm run generate-api:build && chokidar './src/**/controllers/**/*.ts' -c 'pnpm run generate-api:build'",
-        "dev": "LIGHTDASH_MODE=development HEADLESS=true tsx watch --clear-screen=false --inspect=0.0.0.0:9229 src/index.ts",
+        "dev": "LIGHTDASH_MODE=${LIGHTDASH_MODE:-development} HEADLESS=true tsx watch --clear-screen=false --inspect=0.0.0.0:9229 src/index.ts",
         "build": "pnpm run generate-api:build && tsc --build tsconfig.json",
         "build:mcp-app": "pnpm -F @lightdash/mcp-chart-app build",
         "build-sourcemaps": "pnpm run generate-api:build && tsc --build tsconfig.sentry.json",

--- a/rainbow.toml
+++ b/rainbow.toml
@@ -40,12 +40,17 @@ mailpit = true                     # catches the mail the backend sends
 [env]
 PORT = "8080"
 NODE_ENV = "development"
-LIGHTDASH_MODE = "development"
+# PR mode is what the Okteto previews ran as: the preview flag set and its
+# management API, a fixed 000000 email passcode, the relaxed cross-origin
+# opener policy, /api/docs. Hot reload is unaffected: it belongs to the dev
+# processes, not the mode. packages/backend's dev script defers to a mode
+# already set in the environment, so this value reaches the backend.
+LIGHTDASH_MODE = "pr"
 LIGHTDASH_LOG_LEVEL = "info"
 SECURE_COOKIES = "false"
 TRUST_PROXY = "false"
-SCHEDULER_ENABLED = "false"
-ALLOW_MULTIPLE_ORGS = "false"
+SCHEDULER_ENABLED = "true"
+ALLOW_MULTIPLE_ORGS = "true"
 HEADLESS = "true"
 CI = "true"
 PGHOST = "localhost"
@@ -69,9 +74,8 @@ EMAIL_SMTP_USE_AUTH = "false"
 EMAIL_SMTP_ALLOW_INVALID_CERT = "true"
 EMAIL_SMTP_SENDER_NAME = "Lightdash"
 EMAIL_SMTP_SENDER_EMAIL = "noreply@lightdash.local"
-# Previews exercise unreleased work: enable the curated preview flag set and the
-# flag-management API (docs/preview-feature-flags.md). Okteto got this from
-# LIGHTDASH_MODE=pr; LIGHTDASH_MODE=development here, so set it outright.
+# PR mode implies this (docs/preview-feature-flags.md); kept explicit so a
+# later mode change cannot silently drop the flag-management API.
 LIGHTDASH_PREVIEW_FEATURE_FLAGS_ENABLED = "true"
 # Learn is off by default everywhere (docs/learn/architecture.md); previews
 # exist to try unreleased work, so switch it on here and let an admin press
@@ -84,6 +88,32 @@ LIGHTDASH_LEARN_ENABLED = "true"
 # outside the egress list that was four TCP timeouts, 8m47s, on every fork;
 # with this set the same command takes 2.5s.
 RUDDERSTACK_ANALYTICS_DISABLED = "true"
+
+# Parity with the Okteto previews (docker/docker-compose.preview.yml): the
+# settings that switch on the surfaces e2e and QA exercise. Values that name
+# a credential are declared under [secrets] below, not here.
+IS_PULL_REQUEST = "true"
+CUSTOM_ROLES_ENABLED = "true"
+MCP_ENABLED = "true"
+SERVICE_ACCOUNT_ENABLED = "true"       # also lights the semantic-layer connection page
+EMBEDDING_ENABLED = "true"             # the embed specs need it
+PERSISTENT_DOWNLOAD_URLS_ENABLED = "true"
+GROUPS_ENABLED = "true"
+EXTENDED_USAGE_ANALYTICS = "true"
+MICROSOFT_TEAMS_ENABLED = "true"
+APPS_RUNTIME_ENABLED = "true"          # data apps; the E2B key below makes it usable
+ALLOW_MISSING_MIGRATIONS = "true"
+# Postgres wire-protocol server for the semantic layer: setting the port
+# starts the listener and renders the project settings page. No TLS certs in
+# a preview, and the port stays private to the environment.
+PGWIRE_PORT = "5433"
+PGWIRE_SSL_MODE = "disabled"
+# Ask AI. The copilot follows instance config rather than the preview flag
+# set, so it is enabled here and made real by the Anthropic key in [secrets];
+# with no key stored it stays off.
+AI_COPILOT_ENABLED = "true"
+AI_COPILOT_REQUIRES_FEATURE_FLAG = "true"
+AI_DEFAULT_PROVIDER = "anthropic"
 
 # Two seeds, in the order CONTRIBUTING gives them. First the warehouse the
 # seeded project points at: dbt loads examples/full-jaffle-shop-demo into the
@@ -147,6 +177,29 @@ watch = ["**"]                     # Vite HMR, tsx watch and the tsc watchers no
 host = "api.keygen.sh"
 port = 443
 
+# Each integration a preview can exercise, one flow per service. A key in
+# [secrets] does nothing on its own: the connect is refused unless the host
+# is listed here.
+[[egress.allow]]
+host = "api.anthropic.com"          # Ask AI, data apps
+port = 443
+
+[[egress.allow]]
+host = "api.brandfetch.io"          # organization brand lookup
+port = 443
+
+[[egress.allow]]
+host = "api.e2b.dev"                # data-app sandboxes (control plane only; sandbox hosts are per-run)
+port = 443
+
+[[egress.allow]]
+host = "api.github.com"             # GitHub App: repo access for dbt projects
+port = 443
+
+[[egress.allow]]
+host = "github.com"                 # GitHub OAuth login
+port = 443
+
 # The browser learns its origin from one field of one response, so the ingress
 # corrects it in flight; nothing is re-execed on fork.
 [origin]
@@ -164,3 +217,13 @@ LIGHTDASH_SECRET = "app-secret"
 PGPASSWORD = "postgres-password"
 LIGHTDASH_LICENSE_KEY = "licence"
 LIGHTDASH_LICENSE_CERTIFICATE = "licence"
+# Integrations, in the order of the [[egress.allow]] list. Each is optional:
+# with no value stored the variable is absent and the feature stays off.
+ANTHROPIC_API_KEY = "api-key"
+BRANDFETCH_API_KEY = "api-key"
+E2B_API_KEY = "api-key"
+GITHUB_APP_ID = "github-app"
+GITHUB_APP_NAME = "github-app"
+GITHUB_CLIENT_ID = "github-app"
+GITHUB_CLIENT_SECRET = "github-app"
+GITHUB_PRIVATE_KEY = "github-app"


### PR DESCRIPTION
## Why

Rainbow previews are replacing the Okteto ones for QA, sharing and, next, the Cypress suite. They ran in development mode with the Okteto preview's switches off, so what a reviewer saw differed from what the e2e suite expects. This makes the dev env a preview while keeping hot reload: the mode is a backend config value, the reload loop belongs to the dev processes.

## What changes

- **`LIGHTDASH_MODE=pr`.** `packages/backend`'s `dev` script pinned the mode inline, which beat the environment. It now defers to a mode already set (`${LIGHTDASH_MODE:-development}`), so local development is unchanged. PR mode brings the preview flag set and its management API, the fixed `000000` passcode, the relaxed cross-origin opener policy and `/api/docs`.
- **The preview switches from `docker/docker-compose.preview.yml`** in `rainbow.toml`'s `[env]`: scheduler, multiple orgs, custom roles, MCP, service accounts, embedding, persistent download URLs, groups, extended usage analytics, Teams, the apps runtime, `ALLOW_MISSING_MIGRATIONS`, the PG wire listener, and the AI copilot config.
- **Integration credentials the Okteto namespace carried**, declared as names under `[secrets]`: Anthropic, Brandfetch, E2B, the GitHub App and OAuth client. Values are set on the dashboard's Secrets page; an unset name leaves that feature off.
- **One `[[egress.allow]]` flow per integration.** Rainbow envs deny outbound traffic by default, so a key alone does nothing.
- `docs/preview-feature-flags.md` updated to match.

Rudderstack is already disabled for previews on `main` (#28850), so no product analytics leave a preview and no write key is needed here.

## Not carried over

- External S3 and SMTP settings: the env has minio and mailpit, and PR mode fixes the passcode so no real inbox is needed.
- `TURBO_TOKEN`, `OKTETO_ALPHA_BUILD_COMPRESSION`, `RUDDERSTACK_WRITE_KEY`, `RUDDERSTACK_DATA_PLANE_URL`.
- Variables nothing in the codebase reads: `POSTHOG_*`, `DBT_CLOUD_BEARER_TOKEN`, `DBT_CLOUD_ENVIRONMENT_ID`, `USE_SQL_PIVOT_RESULTS`, `METRICS_CATALOG_ECHARTS_VISUALIZATION_ENABLED`.
- `LIGHTDASH_ENABLE_FEATURE_FLAGS`: the Okteto value is not visible to me; add it to `[env]` if it is still wanted.

## Verified

- The recipe parses, validates and resolves through the platform's own `ParseRepoConfig` → `Validate` → `ResolveRecipe`.
- A branch env from this ref (`preview-parity.lightdash.rainbowmachine.dev`) forks in ~35 s with no base recompile: `/api/v1/health` reports `mode: pr` and an empty `rudder` block; custom roles, service accounts, groups, Teams and extended analytics are on; the scheduler runs; the PG wire server listens on 5433; the enterprise licence validates.
- All six `[[egress.allow]]` hosts answer from inside the env; an unlisted host, analytics.lightdash.com included, is refused. The list survives a hibernate and wake, and an in-place update to a later commit re-applies it.
- The first fork showed the platform ignoring a branch's `[egress]` block (only the parent's `api.keygen.sh` was admitted). Fixed and deployed on the platform side (rainbowmachines 7d447e2) before the numbers above.
- With no Anthropic key stored yet, the backend logs `Invalid AI copilot configuration` at boot and continues; it clears once the key is stored.

## After merge

The `[env]` change is an image-class delta: the base recompiles on the first mainline build after merge. Secret values need to be stored before that build for the integrations to be live in the parent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
