### PR TITLE
fix(explores): keep count metrics declared on a struct column when unnesting is on

### DIFF
--- a/packages/common/src/compiler/translator.test.ts
+++ b/packages/common/src/compiler/translator.test.ts
@@ -3624,9 +3624,15 @@ describe('nested and repeated columns', () => {
         expect(table.dimensions.pageviews_bucket.compiledSql).toEqual(
             "CASE WHEN `ga_sessions`.totals.pageviews > 5 THEN 'many' ELSE 'few' END",
         );
-        expect(Object.keys(table.metrics)).toEqual(['sessions_with_visits']);
+        expect(Object.keys(table.metrics).sort()).toEqual([
+            'container_count',
+            'sessions_with_visits',
+        ]);
         expect(table.metrics.sessions_with_visits.compiledSql).toEqual(
             '`ga_sessions`.totals.visits',
+        );
+        expect(table.metrics.container_count.compiledSql).toEqual(
+            '`ga_sessions`.totals',
         );
     });
 

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -922,14 +922,12 @@ export const convertTable = (
             }, extraDimensions);
 
             // Metrics under an array of scalars aggregate its elements and
-            // live on the unnested table; a struct's metrics need explicit
-            // SQL because the container itself can't be aggregated.
+            // live on the unnested table. A struct's metrics stay: a count
+            // of the struct itself is valid SQL and was how errors were
+            // counted before containers stopped being dimensions.
             const columnMetrics = Object.fromEntries(
                 Object.entries(columnMeta.metrics || {})
-                    .filter(
-                        ([, metric]) =>
-                            !isScalarArray && (dimension || metric.sql),
-                    )
+                    .filter(() => !isScalarArray)
                     .map(([name, metric]) => [
                         name,
                         convertColumnMetric({


### PR DESCRIPTION
#28846 kept a struct column's additional dimensions and its metrics with explicit SQL when the unnest-repeated-columns flag is on, but still dropped metrics declared on the struct without `sql`. That was the wrong line to draw: `COUNT` of a struct column is valid BigQuery and is how the internal analytics project counts failed jobs, an `errors: count` metric on the hidden `error_result` column that the headline `error_rate` metric references. Compiling that project with the flag on lost `errors` and broke `error_rate` with a dangling reference.

Metrics declared on a struct container now all stay on the model, aggregating the column itself when they have no `sql`, exactly as they did with the flag off. Metrics on an array of scalars keep moving to the unnested table. Verified by compiling the analytics project with the flag off and on and diffing every explore: the only remaining differences are the container columns themselves and the new unnested tables.

Relates: #4102
