### PR TITLE
fix(cli): align chart type scaffolding with upload paths

### DIFF
--- a/packages/cli/src/handlers/apps/appsDownload.test.ts
+++ b/packages/cli/src/handlers/apps/appsDownload.test.ts
@@ -499,6 +499,16 @@ describe('computeUpsertedTotal', () => {
 });
 
 describe('shouldWarnAllSkipped', () => {
+    it.each(['data apps skipped', 'chart types skipped', 'data apps failed'])(
+        'does not suggest --force for %s, even with unchanged charts',
+        (key) => {
+            expect(shouldWarnAllSkipped({ [key]: 1 })).toBe(false);
+            expect(
+                shouldWarnAllSkipped({ [key]: 1, 'charts skipped': 3 }),
+            ).toBe(false);
+        },
+    );
+
     it('returns true when everything was skipped', () => {
         expect(shouldWarnAllSkipped({ 'charts skipped': 3 })).toBe(true);
     });

--- a/packages/cli/src/handlers/apps/appsDownload.ts
+++ b/packages/cli/src/handlers/apps/appsDownload.ts
@@ -303,9 +303,7 @@ export const classifyAppDownloadError = (
 };
 
 /**
- * Sums changes entries that represent actual upserts — excluding both
- * 'skipped' and 'failed' keys so that failures don't suppress the
- * "all content was skipped" warning.
+ * Sums changes entries that represent actual upserts, excluding skips and failures.
  */
 export const computeUpsertedTotal = (changes: Record<string, number>): number =>
     Object.entries(changes)
@@ -313,12 +311,22 @@ export const computeUpsertedTotal = (changes: Record<string, number>): number =>
         .reduce((sum, [, value]) => sum + value, 0);
 
 /**
- * Returns true when there is at least one skipped item and zero upserted
- * items — the condition that should display the "all skipped" warning.
+ * Show the --force hint only for unchanged content, not bundle skips or failures.
  */
 export const shouldWarnAllSkipped = (
     changes: Record<string, number>,
 ): boolean => {
+    if (
+        Object.entries(changes).some(
+            ([key, value]) =>
+                value > 0 &&
+                (key.includes('failed') ||
+                    key === 'data apps skipped' ||
+                    key === 'chart types skipped'),
+        )
+    ) {
+        return false;
+    }
     const totalSkipped = Object.entries(changes)
         .filter(([key]) => key.includes('skipped'))
         .reduce((sum, [, value]) => sum + value, 0);

--- a/packages/cli/src/handlers/apps/authoring/AGENTS.md.tmpl
+++ b/packages/cli/src/handlers/apps/authoring/AGENTS.md.tmpl
@@ -2,7 +2,9 @@
 
 Two skills in `.claude/skills/` describe how to edit this app:
 - `lightdash-data-app` — the Lightdash SDK surface (querying data, filters, downloads).
-- `developing-data-apps-locally` — the local workflow: edit `src/`, `lightdash apps validate --build`, `lightdash apps preview`, `lightdash upload --apps <slug>`; the SDK is the only data access; `.lightdash/context/` holds the project's semantic layer and theme.
+- `developing-data-apps-locally` — the local workflow: edit `src/`, `lightdash apps validate --build`, `lightdash apps preview`, `lightdash upload --apps <slug> --path ../..`; the SDK is the only data access; `.lightdash/context/` holds the project's semantic layer and theme.
+
+Run these commands from this folder under `apps/<slug>/`. The upload path `../..` selects the Lightdash content root.
 
 Edit only `src/`. Root config files are read-only reference — the server rebuilds against a trusted template.
 

--- a/packages/cli/src/handlers/apps/authoring/README.md.tmpl
+++ b/packages/cli/src/handlers/apps/authoring/README.md.tmpl
@@ -3,10 +3,12 @@
 Created or downloaded with the Lightdash CLI.
 
 ## Edit → build → upload
+Run these commands from this folder under `apps/<slug>/`. The upload path `../..` selects the Lightdash content root.
+
 1. Edit files under `src/`.
 2. Run `lightdash apps validate` to check the source, manifest, dependencies, external-connection aliases, and semantic references against the downloaded context. Use `lightdash apps validate --build` to add the Cloud-parity Vite production build; use `--live` for fresh project explores or `--format json` in CI. `lightdash apps create` installs the initial dependencies after asking permission; after `lightdash download`, run `npm install` first if `node_modules` is absent. Custom dependencies are installed from `pnpm-lock.yaml` with a frozen lockfile and lifecycle scripts disabled. A build failure is a validation error with the Vite output and a non-zero exit.
 3. Optionally, preview against real data: `lightdash apps preview` (needs a successful `npm install`).
-4. `lightdash upload --apps <slug>` (the `slug` from `lightdash-app.yml`) — Lightdash rebuilds and serves the app.
+4. `lightdash upload --apps <slug> --path ../..` (the `slug` from `lightdash-app.yml`) — Lightdash rebuilds and serves the app.
 
 Local preview uses your existing CLI login through a project- and route-restricted loopback proxy; the credential is not written into this folder or exposed to browser code. It runs local tooling as your OS user (with access to that user's files, including the existing CLI config) and shows data under your own permissions, so preview only source/dependencies you trust. Host-mediated features such as external connections and data-app-viz context still need testing after upload.
 

--- a/packages/cli/src/handlers/apps/authoring/chart-type/AGENTS.md.tmpl
+++ b/packages/cli/src/handlers/apps/authoring/chart-type/AGENTS.md.tmpl
@@ -12,9 +12,11 @@ Edit only `src/`. Root config files are read-only reference — the server rebui
 
 ## The loop
 
+Run these commands from this folder under `chart-types/<slug>/`. The upload path `../..` selects the Lightdash content root.
+
 1. Edit `src/` (and `vizSchema` in `lightdash-app.yml` when the declaration changes).
 2. `lightdash apps validate --build` — Cloud-parity Vite build; a failure is a validation error with the Vite output.
-3. `lightdash upload --chart-types <slug>` — the server rebuilds; the chart type then appears in the explorer's chart type picker for that project.
+3. `lightdash upload --chart-types <slug> --path ../..` — the server rebuilds; the chart type then appears in the explorer's chart type picker for that project.
 4. Verify in Lightdash: open any explore, run a query, pick this chart type, and map its fields.
 
 There is no local preview for a chart type: `useVizContext()` waits for the Lightdash host, so the component renders nothing standalone (`lightdash apps preview` and `npm run dev` show a blank page). Upload and verify in the explorer instead.

--- a/packages/cli/src/handlers/apps/authoring/chart-type/README.md.tmpl
+++ b/packages/cli/src/handlers/apps/authoring/chart-type/README.md.tmpl
@@ -3,9 +3,11 @@
 Created or downloaded with the Lightdash CLI. This is a **custom chart type** (a reusable visualization): one chart component that Lightdash hands data and settings to. It runs no query of its own — the same component is reused across many different queries.
 
 ## Edit → validate → upload
+Run these commands from this folder under `chart-types/<slug>/`. The upload path `../..` selects the Lightdash content root.
+
 1. Edit files under `src/`. The component's contract with Lightdash — the fields it maps and the config options viewers can change — is declared in `lightdash-app.yml` under `vizSchema` and must match what `src/App.jsx` reads (see `.claude/skills/reusable-visualization`).
 2. Run `lightdash apps validate` to check the source and manifest; `lightdash apps validate --build` adds the Cloud-parity Vite production build.
-3. `lightdash upload --chart-types <slug>` (the `slug` from `lightdash-app.yml`) — Lightdash rebuilds and serves it.
+3. `lightdash upload --chart-types <slug> --path ../..` (the `slug` from `lightdash-app.yml`) — Lightdash rebuilds and serves it.
 4. Open any explore in Lightdash, run a query, and pick this chart type in the chart type picker to see it against real data.
 
 There is no standalone preview: the component waits for the Lightdash host's data, so `npm run dev` shows a blank page. Upload and verify in the explorer.

--- a/packages/cli/src/handlers/apps/authoring/developing-chart-types-locally/SKILL.md
+++ b/packages/cli/src/handlers/apps/authoring/developing-chart-types-locally/SKILL.md
@@ -19,9 +19,11 @@ The correspondence must be exact in both directions: every key the component rea
 
 ## The edit → validate → upload → verify loop
 
+Run these commands from this folder under `chart-types/<slug>/`. The upload path `../..` selects the Lightdash content root.
+
 1. Edit files under `src/` (and `vizSchema` when the declaration changes).
 2. `lightdash apps validate` checks source and manifest (including that `vizSchema` parses); `lightdash apps validate --build` adds the Cloud-parity Vite production build. A build failure is a validation error with the Vite output.
-3. `lightdash upload --chart-types <slug>` (the `slug` from `lightdash-app.yml`) — the server rebuilds and serves it.
+3. `lightdash upload --chart-types <slug> --path ../..` (the `slug` from `lightdash-app.yml`) — the server rebuilds and serves it.
 4. Verify in Lightdash: open any explore, run a query with at least the required fields' shapes (e.g. a dimension and a metric), pick this chart type in the chart type picker, and map its fields. Check every config option you declared actually changes the chart.
 
 **There is no standalone preview.** `useVizContext()` waits for the Lightdash host to push context, so outside Lightdash the component renders nothing: `npm run dev` and `lightdash apps preview` show a blank page. Do not build a mock harness or feed the hook fake data to work around this — upload and verify in the explorer instead.

--- a/packages/cli/src/handlers/apps/authoring/developing-data-apps-locally/SKILL.md
+++ b/packages/cli/src/handlers/apps/authoring/developing-data-apps-locally/SKILL.md
@@ -27,9 +27,11 @@ You are editing a Lightdash **data app** that was created or downloaded with the
 
 ## The edit → build → upload loop
 
+Run these commands from this folder under `apps/<slug>/`. The upload path `../..` selects the Lightdash content root.
+
 1. Edit files under `src/` only.
 2. Run `lightdash apps validate` to check the source, manifest, dependencies, external-connection aliases, and semantic references against the downloaded context. Use `lightdash apps validate --build` to add the Cloud-parity Vite production build; use `--live` to check against fresh project explores or `--format json` in CI. A green run reports any call sites it could not fully analyze instead of silently claiming complete coverage.
-3. `lightdash upload --apps <slug>` (the `slug` from this folder's `lightdash-app.yml`) — the **server** rebuilds and serves the app. The server rebuild remains the final result that ships.
+3. `lightdash upload --apps <slug> --path ../..` (the `slug` from this folder's `lightdash-app.yml`) — the **server** rebuilds and serves the app. The server rebuild remains the final result that ships.
 
 ## Cloud-parity local builds
 

--- a/packages/cli/src/handlers/apps/createApp.test.ts
+++ b/packages/cli/src/handlers/apps/createApp.test.ts
@@ -279,86 +279,116 @@ describe('createAppHandler', () => {
         );
     });
 
-    it('creates a custom chart type scaffold with the viz starter and no shadcn', async () => {
-        const root = await fs.mkdtemp(path.join(os.tmpdir(), 'ld-create-app-'));
+    it.each([false, true])(
+        'creates an uploadable chart type scaffold (custom path: %s)',
+        async (customPath) => {
+            const root = await fs.mkdtemp(
+                path.join(os.tmpdir(), 'ld-create-app-'),
+            );
+            vi.spyOn(process, 'cwd').mockReturnValue(root);
+            const contentRoot = customPath
+                ? root
+                : path.join(root, 'lightdash');
 
-        await createAppHandler('Radial Gauge', {
-            description: 'A gauge with a needle',
-            path: root,
-            chartType: true,
-            verbose: false,
-        });
+            await createAppHandler('Radial Gauge', {
+                description: 'A gauge with a needle',
+                path: customPath ? root : undefined,
+                chartType: true,
+                verbose: false,
+            });
 
-        const appDir = path.join(root, 'apps', 'radial-gauge');
-        const bundle = await readBundleFromDir(appDir);
-        expect(bundle.manifest.template).toBe('data_app_viz');
-        expect(bundle.manifest.vizSchema).toEqual(
-            CHART_TYPE_STARTER_VIZ_SCHEMA,
-        );
+            const appDir = path.join(
+                contentRoot,
+                'chart-types',
+                'radial-gauge',
+            );
+            const bundle = await readBundleFromDir(appDir);
+            expect(bundle.manifest.template).toBe('data_app_viz');
+            expect(bundle.manifest.vizSchema).toEqual(
+                CHART_TYPE_STARTER_VIZ_SCHEMA,
+            );
 
-        const appSource = await fs.readFile(
-            path.join(appDir, 'src/App.jsx'),
-            'utf8',
-        );
-        expect(appSource).toContain('useVizContext');
+            const appSource = await fs.readFile(
+                path.join(appDir, 'src/App.jsx'),
+                'utf8',
+            );
+            expect(appSource).toContain('useVizContext');
 
-        // No shadcn generation: chart types ship no UI-kit source.
-        expect(execaMock).not.toHaveBeenCalledWith(
-            'npx',
-            expect.anything(),
-            expect.anything(),
-        );
+            // No shadcn generation: chart types ship no UI-kit source.
+            expect(execaMock).not.toHaveBeenCalledWith(
+                'npx',
+                expect.anything(),
+                expect.anything(),
+            );
 
-        // The viz contract + local workflow skills ship; the app-only skills
-        // do not.
-        await expect(
-            fs.access(
-                path.join(
-                    appDir,
-                    '.claude/skills/reusable-visualization/SKILL.md',
+            // The viz contract + local workflow skills ship; the app-only skills
+            // do not.
+            await expect(
+                fs.access(
+                    path.join(
+                        appDir,
+                        '.claude/skills/reusable-visualization/SKILL.md',
+                    ),
                 ),
-            ),
-        ).resolves.toBeUndefined();
-        await expect(
-            fs.access(
-                path.join(
-                    appDir,
+            ).resolves.toBeUndefined();
+            await expect(
+                fs.access(
+                    path.join(
+                        appDir,
+                        '.claude/skills/developing-chart-types-locally/SKILL.md',
+                    ),
+                ),
+            ).resolves.toBeUndefined();
+            await expect(
+                fs.access(
+                    path.join(
+                        appDir,
+                        '.claude/skills/lightdash-data-app/SKILL.md',
+                    ),
+                ),
+            ).rejects.toThrow();
+            await expect(
+                fs.access(
+                    path.join(
+                        appDir,
+                        '.claude/skills/developing-data-apps-locally/SKILL.md',
+                    ),
+                ),
+            ).rejects.toThrow();
+
+            expect(
+                await fs.readFile(path.join(appDir, 'AGENTS.md'), 'utf8'),
+            ).toContain('custom chart type');
+            expect(
+                await fs.readFile(path.join(appDir, 'README.md'), 'utf8'),
+            ).toContain('Radial Gauge');
+            const authoringDocs = await Promise.all(
+                [
+                    'README.md',
+                    'AGENTS.md',
                     '.claude/skills/developing-chart-types-locally/SKILL.md',
-                ),
-            ),
-        ).resolves.toBeUndefined();
-        await expect(
-            fs.access(
-                path.join(appDir, '.claude/skills/lightdash-data-app/SKILL.md'),
-            ),
-        ).rejects.toThrow();
-        await expect(
-            fs.access(
-                path.join(
-                    appDir,
-                    '.claude/skills/developing-data-apps-locally/SKILL.md',
-                ),
-            ),
-        ).rejects.toThrow();
+                ].map((file) => fs.readFile(path.join(appDir, file), 'utf8')),
+            );
+            for (const doc of authoringDocs) {
+                expect(doc).toContain(
+                    'upload --chart-types <slug> --path ../..',
+                );
+            }
 
-        expect(
-            await fs.readFile(path.join(appDir, 'AGENTS.md'), 'utf8'),
-        ).toContain('custom chart type');
-        expect(
-            await fs.readFile(path.join(appDir, 'README.md'), 'utf8'),
-        ).toContain('Radial Gauge');
-
-        expect(GlobalState.log).toHaveBeenCalledWith(
-            expect.stringContaining('upload --chart-types radial-gauge'),
-        );
-        expect(LightdashAnalytics.track).toHaveBeenCalledWith({
-            event: 'command.executed',
-            properties: expect.objectContaining({
-                command: 'create-chart-type',
-                success: true,
-            }),
-        });
-    });
+            expect(GlobalState.log).toHaveBeenCalledWith(
+                expect.stringContaining(
+                    `upload --chart-types radial-gauge --path ${JSON.stringify(contentRoot)}`,
+                ),
+            );
+            expect(LightdashAnalytics.track).toHaveBeenCalledWith({
+                event: 'command.executed',
+                properties: expect.objectContaining({
+                    command: 'create-chart-type',
+                    success: true,
+                }),
+            });
+        },
+    );
 
     it('requires npm before requesting app context', async () => {
         const root = await fs.mkdtemp(path.join(os.tmpdir(), 'ld-create-app-'));

--- a/packages/cli/src/handlers/apps/createApp.ts
+++ b/packages/cli/src/handlers/apps/createApp.ts
@@ -331,7 +331,12 @@ export const createAppHandler = async (
 
     try {
         const slug = resolveLocalAppSlug(name, options.slug);
-        const appDir = path.join(getDownloadFolder(options.path), 'apps', slug);
+        const contentRoot = getDownloadFolder(options.path);
+        const appDir = path.join(
+            contentRoot,
+            isChartType ? 'chart-types' : 'apps',
+            slug,
+        );
         await assertAppDirectoryAvailable(appDir);
         await assertNpmAvailable();
 
@@ -438,10 +443,10 @@ export const createAppHandler = async (
             isChartType
                 ? `\nNext:\n  cd ${JSON.stringify(
                       appDir,
-                  )}\n  lightdash apps validate --build\n  lightdash upload --chart-types ${slug}\n\nThen open any explore in Lightdash and pick "${name}" in the chart type picker.`
+                  )}\n  lightdash apps validate --build\n  lightdash upload --chart-types ${slug} --path ${JSON.stringify(contentRoot)}\n\nThen open any explore in Lightdash and pick "${name}" in the chart type picker.`
                 : `\nNext:\n  cd ${JSON.stringify(
                       appDir,
-                  )}\n  npm run build\n  lightdash upload --apps ${slug}`,
+                  )}\n  npm run build\n  lightdash upload --apps ${slug} --path ${JSON.stringify(contentRoot)}`,
         );
         success = true;
     } finally {

--- a/packages/cli/src/handlers/apps/scaffolding.test.ts
+++ b/packages/cli/src/handlers/apps/scaffolding.test.ts
@@ -1,5 +1,6 @@
 import { mkdtempSync } from 'fs';
 import { tmpdir } from 'os';
+import { parse } from 'yaml';
 import {
     buildStaticAuthoringFiles,
     firstExistingDir,
@@ -97,6 +98,14 @@ describe('buildStaticAuthoringFiles', () => {
         ).toContain('run `npm install` before');
         expect(text('.npmrc')).toContain('ignore-scripts=true');
         expect(text('.npmrc')).not.toContain('shamefully-hoist');
+    });
+
+    it('ships a release-age policy for pnpm with the SDK exemption', () => {
+        expect(parse(text('pnpm-workspace.yaml'))).toMatchObject({
+            minimumReleaseAge: 4320,
+            minimumReleaseAgeExclude: ['@lightdash/query-sdk'],
+            ignoreScripts: true,
+        });
     });
 
     it('documents Cloud-parity validation builds', () => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1217,7 +1217,7 @@ appsProgram
         )}\n  ${styles.title('⚡')}️lightdash ${styles.bold(
             'apps create "Radial gauge" --chart-type',
         )} ${styles.secondary(
-            '-- creates a custom chart type at ./lightdash/apps/radial-gauge',
+            '-- creates a custom chart type at ./lightdash/chart-types/radial-gauge',
         )}\n`,
     )
     .action(createAppHandler);

--- a/sandboxes/data-apps/template/pnpm-workspace.yaml
+++ b/sandboxes/data-apps/template/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ packages: []
 # pnpm 11 reads settings from here; the .npmrc copies remain for pnpm <=10.
 shamefullyHoist: true
 ignoreWorkspaceRootCheck: true
+minimumReleaseAge: 4320 # 3 days
 # The pinned SDK version is often <3 days old; exempt it from release-age policies
 minimumReleaseAgeExclude:
   - '@lightdash/query-sdk'


### PR DESCRIPTION
### Description

`lightdash apps create <name> --chart-type` created bundles under `lightdash/apps/`, but `upload --chart-types` only searches `lightdash/chart-types/`. Create chart types in the directory upload expects, and include the content-root `--path` in the printed next steps so upload works after changing into the scaffold directory. Update CLI help and the bundled app/chart-type authoring instructions to match.

Suppress the misleading “no local changes, use --force” hint when bundles were skipped for other reasons or uploads failed. Add the template's missing three-day pnpm `minimumReleaseAge`, preserving the SDK exemption.

Existing chart-type folders created under `apps/` still need to be moved into `chart-types/`; the upload warning already explains this.

### Validation

- 121 focused tests passed across `createApp.test.ts`, `scaffolding.test.ts`, and `appsDownload.test.ts`, including default/custom scaffold roots, upload instructions, release-age settings, and skip summaries.
- CLI lint and diff whitespace checks passed.
- CLI typecheck could not pass locally: dependencies reused from another checkout have mismatched shared-package declarations, including missing `getCatalogNestedColumnShape` and `ProjectType.TRAINING`. Reported errors are outside the changed code.

### Risk assessment

- [ ] This is a high-risk change

Low risk: corrects local scaffold paths and guidance, adjusts summary hints, and enables the existing release-age policy for template pnpm installs. No API or database changes.
