### PR TITLE
fix: let employees lift merge freezes and repair stale checks

### DIFF
--- a/.github/workflows/merge-freeze-status.yml
+++ b/.github/workflows/merge-freeze-status.yml
@@ -1,21 +1,5 @@
 name: Merge freeze status
 
-# Companion to merge-freeze.yml. That workflow stamps every PR that was already
-# open when the freeze went on; this one covers PRs opened or pushed during the
-# window, so their blocked merge names whoever froze it instead of GitHub's
-# bare "Expected - Waiting for status to be reported".
-#
-# Messaging only: the required status check on the main ruleset is what blocks
-# the merge, and `vars.MERGE_FREEZE` is a mirror the toggle maintains, so a
-# stale variable degrades the message and never the enforcement.
-#
-# Fork PRs are skipped - a pull_request run from a fork gets a read-only token
-# and cannot post a status. They stay blocked by the missing required check,
-# which is the outcome we want anyway; reaching for pull_request_target to
-# prettify that would expose secrets to fork PRs for no enforcement gain.
-#
-# SPK-985.
-
 on:
   pull_request:
     types: [opened, reopened, synchronize]
@@ -24,8 +8,9 @@ permissions:
   statuses: write
 
 concurrency:
-  group: merge-freeze-status-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  group: merge-freeze-${{ github.repository }}
+  cancel-in-progress: false
+  queue: max
 
 jobs:
   flag:
@@ -33,8 +18,7 @@ jobs:
     # Stacked PRs merging into their parent are not covered by the main ruleset
     # and are not blocked, so they are not flagged either.
     if: >-
-      vars.MERGE_FREEZE == 'true'
-      && github.event.pull_request.base.ref == github.event.repository.default_branch
+      github.event.pull_request.base.ref == github.event.repository.default_branch
       && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -48,25 +32,37 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           SHA: ${{ github.event.pull_request.head.sha }}
-          FREEZE_ACTOR: ${{ vars.MERGE_FREEZE_ACTOR }}
+          BRANCH: ${{ github.event.repository.default_branch }}
           FREEZE_URL: ${{ github.server_url }}/${{ github.repository }}/actions/workflows/merge-freeze.yml
         run: |
           set -euo pipefail
 
-          # Names the person, never the reason: this workflow's log and the
-          # statuses it writes are both public, and a freeze reason is exactly
-          # the sort of sentence that names a customer. A username carries
-          # nothing sensitive and tells the author who to go and ask.
-          if [ -n "${FREEZE_ACTOR:-}" ]; then
-            description="Merges to main are frozen by $FREEZE_ACTOR - ask Cloudy in Slack"
+          branch=$(jq -rn --arg branch "$BRANCH" '$branch | @uri')
+          rules=$(gh api --paginate --slurp "repos/$REPO/rules/branches/$branch?per_page=100")
+          frozen=$(jq -er '
+            if type == "array" and length > 0 and all(.[]; type == "array")
+            then add else error("Invalid branch rule pages") end
+            | if all(.[]; type == "object" and (.type | type == "string"))
+              then . else error("Invalid branch rules") end
+            | [.[] | select(.type == "required_status_checks")
+               | .parameters.required_status_checks
+               | if type == "array" and all(.[]; type == "object" and (.context | type == "string"))
+                 then .[] else error("Invalid required status checks") end]
+            | any(.[]; .context == "merge-freeze") | tostring
+          ' <<<"$rules")
+
+          if [ "$frozen" = "true" ]; then
+            state=failure
+            description="Merges to main are frozen - ask Cloudy in Slack"
           else
-            description="Merges to main are frozen while a release is cut"
+            state=success
+            description="Merges to main are open"
           fi
 
           gh api --method POST "repos/$REPO/statuses/$SHA" \
-            -f state=failure \
+            -f state="$state" \
             -f context=merge-freeze \
-            -f description="${description:0:140}" \
+            -f description="$description" \
             -f target_url="$FREEZE_URL" >/dev/null
 
-          echo "Flagged PR #${{ github.event.pull_request.number }} as blocked by the active merge freeze."
+          echo "$description"

--- a/.github/workflows/merge-freeze-status.yml
+++ b/.github/workflows/merge-freeze-status.yml
@@ -58,7 +58,7 @@ jobs:
           # the sort of sentence that names a customer. A username carries
           # nothing sensitive and tells the author who to go and ask.
           if [ -n "${FREEZE_ACTOR:-}" ]; then
-            description="Merges to main are frozen by $FREEZE_ACTOR - ask them in Slack"
+            description="Merges to main are frozen by $FREEZE_ACTOR - ask Cloudy in Slack"
           else
             description="Merges to main are frozen while a release is cut"
           fi

--- a/.github/workflows/merge-freeze.yml
+++ b/.github/workflows/merge-freeze.yml
@@ -228,15 +228,14 @@ jobs:
             fi
           fi
 
-          if [ "$ACTION" = "unfreeze" ] && [ "$was_required" = "true" ]; then
+          if [ "$ACTION" = "unfreeze" ] && [ "$was_required" = "true" ] && [ -z "${SLACK_ACTOR:-}" ]; then
             owner_key=$FREEZE_ACTOR
             effective_key=$effective_actor
-            if [[ "$FREEZE_ACTOR" != *:* ]] && [ -z "${SLACK_ACTOR:-}" ]; then
+            if [[ "$FREEZE_ACTOR" != *:* ]]; then
               owner_key=$(printf '%s' "$FREEZE_ACTOR" | tr '[:upper:]' '[:lower:]')
               effective_key=$actor_key
             fi
-            if { [ -n "$FREEZE_ACTOR" ] && [ "$owner_key" != "$effective_key" ]; } \
-               || { [ -z "$FREEZE_ACTOR" ] && [ -n "${SLACK_ACTOR:-}" ]; }; then
+            if [ -n "$FREEZE_ACTOR" ] && [ "$owner_key" != "$effective_key" ]; then
               echo "::error::Only the recorded freeze owner can unfreeze main. Ask the owner or a repository admin."
               exit 1
             fi
@@ -330,7 +329,7 @@ jobs:
           # than hunting the Actions tab to work out who to ask.
           if [ "$ACTION" = "freeze" ]; then
             state=failure
-            description="Merges to main are frozen by $display_owner - ask them in Slack"
+            description="Merges to main are frozen by $display_owner - ask Cloudy in Slack"
           else
             state=success
             description="Merges to main are open"
@@ -416,16 +415,12 @@ jobs:
                 echo "> Main was **already frozen** - this run only refreshed the PR statuses."
                 echo
               fi
-              if [[ "$display_owner" == T0163M87MB9:U* ]]; then
-                echo "Ask Cloudy in Slack to unfreeze merges to \`${REPO##*/}\`."
-              else
-                echo "Run this workflow again with **unfreeze** to reopen merges."
-              fi
+              echo "Any Lightdash employee can ask Cloudy in Slack to unfreeze merges to \`${REPO##*/}\`."
               echo
               if [ "$display_owner" = "an unknown owner" ]; then
-                echo "No owner is recorded. Use a direct GitHub dispatch or ask a repository admin to recover the freeze."
+                echo "No owner is recorded. A direct GitHub dispatch or repository admin can also recover the freeze."
               else
-                echo "Only **$display_owner** can do that here. If they are unavailable, a repo admin can remove the \`$CONTEXT\` check from the \`$ruleset_name\` ruleset by hand."
+                echo "Direct GitHub dispatch remains available to the recorded owner. A repo admin can remove the \`$CONTEXT\` check from the \`$ruleset_name\` ruleset by hand."
               fi
             else
               if [ "$was_required" = "false" ]; then
@@ -468,15 +463,13 @@ jobs:
           # froze main can say why in the thread if it matters.
           if [[ "$ACTOR_LOGIN" == T0163M87MB9:U* ]]; then
             actor_mention="<@${ACTOR_LOGIN#*:}>"
-            unfreeze_instructions="ask Cloudy in Slack to unfreeze merges to \`${REPO##*/}\`"
           else
             actor_mention="@$ACTOR_LOGIN"
-            unfreeze_instructions="<${WORKFLOW_URL}|Merge freeze / unfreeze>"
           fi
 
           if [ "$ACTION" = "freeze" ]; then
             text=":lock: *[merge-freeze-on]* Merges to \`main\` are frozen by ${actor_mention}."
-            text="$text"$'\n'"Your PRs will show a red \`merge-freeze\` check until it lifts. Only ${actor_mention} can lift it: ${unfreeze_instructions}. If they are unavailable, a repo admin can remove the check from the main ruleset by hand."
+            text="$text"$'\n'"Your PRs will show a red \`merge-freeze\` check until it lifts. Any Lightdash employee can ask Cloudy to unfreeze merges to \`${REPO##*/}\`. A repo admin can also remove the check from the main ruleset by hand."
           else
             text=":unlock: *[merge-freeze-off]* Merges to \`main\` are open again, lifted by ${actor_mention}."
             text="$text"$'\n'"If your PR still shows a stale \`merge-freeze\` failure, push or reopen it to clear."

--- a/.github/workflows/merge-freeze.yml
+++ b/.github/workflows/merge-freeze.yml
@@ -430,7 +430,7 @@ jobs:
                 echo "> Main was **not frozen** - this run only cleared any stale \`$CONTEXT\` statuses."
                 echo
               fi
-              echo "Merges are unblocked. Anyone whose PR still shows a stale \`$CONTEXT\` failure can push or reopen it to clear."
+              echo "Merges are open. If a PR still shows a stale \`$CONTEXT\` failure, ask Cloudy to unfreeze merges to \`${REPO##*/}\` again, then check the linked run."
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -475,7 +475,7 @@ jobs:
             text="$text"$'\n'"Your PRs will show a red \`merge-freeze\` check until it lifts. Any Lightdash employee can ask Cloudy to unfreeze merges to \`${REPO##*/}\`. A repo admin can also remove the check from the main ruleset by hand."
           else
             text=":unlock: *[merge-freeze-off]* Merges to \`main\` are open again, lifted by ${actor_mention}."
-            text="$text"$'\n'"If your PR still shows a stale \`merge-freeze\` failure, push or reopen it to clear."
+            text="$text"$'\n'"If your PR still shows a stale \`merge-freeze\` failure, ask Cloudy to unfreeze merges to \`${REPO##*/}\` again, then check the linked run."
           fi
           text="$text"$'\n'"<${RUN_URL}|View run>"
 

--- a/.github/workflows/merge-freeze.yml
+++ b/.github/workflows/merge-freeze.yml
@@ -45,6 +45,7 @@ permissions: {}
 concurrency:
   group: merge-freeze-${{ github.repository }}
   cancel-in-progress: false
+  queue: max
 
 env:
   FREEZE_CONTEXT: merge-freeze
@@ -367,10 +368,12 @@ jobs:
           # must not be told it is. Assigned before the loop so a failure to
           # list is fatal here, rather than a process substitution silently
           # yielding zero PRs to update.
-          open_prs=$(gh pr list --repo "$REPO" --state open --limit 500 \
-            --json number,headRefOid,baseRefName \
-            | jq -r --arg branch "$default_branch" \
-                '.[] | select(.baseRefName == $branch) | "\(.number)\t\(.headRefOid)"')
+          open_prs=$(gh api --paginate --slurp "repos/$REPO/pulls?state=open&per_page=100" \
+            | jq -sr --arg branch "$default_branch" '
+                if length == 1 then .[0] else error("Missing pull request pages") end
+                | if type == "array" and length > 0 and all(.[]; type == "array")
+                then .[][] else error("Invalid pull request pages") end
+                | select(.base.ref == $branch) | "\(.number)\t\(.head.sha)"')
 
           # Best-effort by design: the freeze is already in force by this point,
           # and one unpostable status must not fail the run. Fork PRs are

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,7 +196,7 @@ Never declare a break merely to make CI pass. Declaring a break advises every se
 `release.yml` fires on every push to `main`, so the release that goes out is whatever `main` contains at that moment. When something needs to reach a release on its own — a fix someone is waiting on — hold merges rather than asking people in Slack not to merge:
 
 -   **Freeze**: `gh workflow run merge-freeze.yml -f action=freeze`. This adds a `merge-freeze` required status check to the `main` ruleset. Nothing ever reports that check, so merges into `main` are blocked for everyone without a ruleset bypass.
--   **Unfreeze**: the same workflow with `action=unfreeze`. Do it as soon as the release is cut — a freeze left on blocks the whole team, and there is no auto-expiry.
+-   **Unfreeze**: the same workflow with `action=unfreeze`. Do it as soon as the release is cut — a freeze left on blocks the whole team, and there is no auto-expiry. Repeat unfreeze to refresh stale PR checks even when the ruleset is already open. In `#engineering`, ask `@Cloudy unfreeze merges to lightdash`.
 -   **Any verified Lightdash employee can unfreeze through Cloudy in Slack.** Direct Actions dispatch remains available to the recorded owner. A repo admin can remove the `merge-freeze` check from the `main` ruleset by hand.
 -   **There is no free-text reason, deliberately** — this repo is public, and a reason box invites someone to name a customer in it. Blocked PRs show who froze it so people know who to ask, and `#engineering` gets the same on both directions. Say why in Slack.
 -   **Only `main` is affected.** Stacked PRs merging into their parent branch are untouched.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,7 +197,7 @@ Never declare a break merely to make CI pass. Declaring a break advises every se
 
 -   **Freeze**: `gh workflow run merge-freeze.yml -f action=freeze`. This adds a `merge-freeze` required status check to the `main` ruleset. Nothing ever reports that check, so merges into `main` are blocked for everyone without a ruleset bypass.
 -   **Unfreeze**: the same workflow with `action=unfreeze`. Do it as soon as the release is cut — a freeze left on blocks the whole team, and there is no auto-expiry.
--   **Only the person who froze can unfreeze it** from the Actions tab. If they're unavailable, a repo admin can remove the `merge-freeze` check from the `main` ruleset by hand.
+-   **Any verified Lightdash employee can unfreeze through Cloudy in Slack.** Direct Actions dispatch remains available to the recorded owner. A repo admin can remove the `merge-freeze` check from the `main` ruleset by hand.
 -   **There is no free-text reason, deliberately** — this repo is public, and a reason box invites someone to name a customer in it. Blocked PRs show who froze it so people know who to ask, and `#engineering` gets the same on both directions. Say why in Slack.
 -   **Only `main` is affected.** Stacked PRs merging into their parent branch are untouched.
 -   **Check the current state**: the `MERGE_FREEZE` repo variable (`true`/`false`), and `MERGE_FREEZE_ACTOR` for who froze it — `gh variable list -R lightdash/lightdash`. The authority is the ruleset itself: `merge-freeze` in the `main` ruleset's required status checks (`gh api repos/lightdash/lightdash/rulesets`). The variables are a mirror, so trust the ruleset if they ever disagree.

--- a/scripts/merge-freeze-workflow.test.py
+++ b/scripts/merge-freeze-workflow.test.py
@@ -180,7 +180,7 @@ class MergeFreezeTests(unittest.TestCase):
         output, summary, _ = self.run_toggle(slack=SLACK_OTHER)
         self.assertEqual(self.state['variables']['MERGE_FREEZE_ACTOR'], SLACK_OWNER)
         self.assertIn('changed=false', output)
-        self.assertIn(f'Only **{SLACK_OWNER}**', summary)
+        self.assertIn('Any Lightdash employee can ask Cloudy', summary)
         self.assertIn(SLACK_OWNER, self.state['statuses'][0]['description'])
         self.assertFalse(any('PUT' in c for c in self.state['calls']))
         self.assertFalse(any(c[1:4] == ['variable', 'set', 'MERGE_FREEZE_ACTOR'] for c in self.state['calls']))
@@ -213,24 +213,28 @@ class MergeFreezeTests(unittest.TestCase):
                 self.assertNotIn(slack, log)
                 self.assertEqual(self.mutations(), [])
 
-    def test_other_slack_user_cannot_unfreeze(self):
+    def test_other_verified_slack_employee_can_unfreeze(self):
+        original = copy.deepcopy(self.state['ruleset'])
         self.frozen()
-        self.run_toggle(action='unfreeze', slack=SLACK_OTHER, success=False)
-        self.assertEqual(self.mutations(), [])
+        output, _, _ = self.run_toggle(action='unfreeze', slack=SLACK_OTHER)
+        self.assertEqual(self.state['ruleset'], original)
+        self.assertNotIn('MERGE_FREEZE_ACTOR', self.state['variables'])
+        self.assertIn(f'actor={SLACK_OTHER}', output)
 
     def test_github_user_cannot_unfreeze_slack_owner(self):
         self.frozen()
         self.run_toggle(action='unfreeze', actor='alice', slack='', success=False)
         self.assertEqual(self.mutations(), [])
 
-    def test_slack_cannot_unfreeze_github_or_unknown_owner(self):
+    def test_verified_slack_employee_can_unfreeze_github_or_unknown_owner(self):
         for owner in ['alice', 'cloudy[bot]', None]:
             with self.subTest(owner=owner):
                 self.state['variables'].pop('MERGE_FREEZE_ACTOR', None)
                 self.state['ruleset']['rules'][1]['parameters']['required_status_checks'] = [{'context': 'ci'}]
                 self.frozen(owner)
-                self.run_toggle(action='unfreeze', success=False)
-                self.assertEqual(self.mutations(), [])
+                self.run_toggle(action='unfreeze')
+                self.assertEqual(self.state['variables']['MERGE_FREEZE'], 'false')
+                self.assertNotIn('MERGE_FREEZE_ACTOR', self.state['variables'])
 
     def test_owner_unfreezes_and_preserves_ruleset(self):
         original = copy.deepcopy(self.state['ruleset'])
@@ -329,9 +333,9 @@ class MergeFreezeTests(unittest.TestCase):
     def test_serialized_requests_use_live_owner(self):
         self.run_toggle()
         self.run_toggle(slack=SLACK_OTHER)
-        self.run_toggle(action='unfreeze', slack=SLACK_OTHER, success=False)
         self.assertEqual(self.state['variables']['MERGE_FREEZE_ACTOR'], SLACK_OWNER)
-        self.run_toggle(action='unfreeze')
+        self.run_toggle(action='unfreeze', slack=SLACK_OTHER)
+        self.assertNotIn('MERGE_FREEZE_ACTOR', self.state['variables'])
         self.run_toggle(slack=SLACK_OTHER)
         self.assertEqual(self.state['variables']['MERGE_FREEZE_ACTOR'], SLACK_OTHER)
 
@@ -348,7 +352,8 @@ class MergeFreezeTests(unittest.TestCase):
             'WEBHOOK': 'https://example.invalid/webhook', 'WORKFLOW_URL': 'https://example.invalid/workflow',
         })
         self.assertIn('<@U0123456789>', self.state['announcements'][0]['text'])
-        self.assertNotIn('cloudy', self.state['announcements'][0]['text'])
+        self.assertIn('Any Lightdash employee can ask Cloudy', self.state['announcements'][0]['text'])
+        self.assertNotIn('Only ', self.state['announcements'][0]['text'])
 
     def two_live_shaped_rulesets(self, pin='7546338'):
         main = copy.deepcopy(self.state['ruleset'])
@@ -503,15 +508,13 @@ class MergeFreezeTests(unittest.TestCase):
         self.state['rulesets']['7546338']['conditions']['ref_name']['include'] = ['~ALL']
         self.run_toggle()
 
-    def test_pin_preserves_owner_checks(self):
+    def test_pin_allows_another_employee_and_preserves_other_rulesets(self):
         self.two_live_shaped_rulesets()
-        self.run_toggle()
         original = copy.deepcopy(self.state['rulesets'])
-        self.state['calls'] = []
-        self.run_toggle(action='unfreeze', slack=SLACK_OTHER, success=False)
-        self.assertEqual(self.mutations(), [])
+        self.run_toggle()
+        self.run_toggle(action='unfreeze', slack=SLACK_OTHER)
         self.assertEqual(self.state['rulesets'], original)
-        self.assertEqual(self.state['variables']['MERGE_FREEZE_ACTOR'], SLACK_OWNER)
+        self.assertNotIn('MERGE_FREEZE_ACTOR', self.state['variables'])
 
     def test_workflow_contract(self):
         workflow = WORKFLOW.read_text()

--- a/scripts/merge-freeze-workflow.test.py
+++ b/scripts/merge-freeze-workflow.test.py
@@ -7,6 +7,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import textwrap
 import unittest
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -48,6 +49,12 @@ def fake_command(kind, args):
             {'number': 1, 'headRefOid': 'head-main', 'baseRefName': 'main'},
             {'number': 2, 'headRefOid': 'head-stack', 'baseRefName': 'parent'},
         ]
+        if 'pull_pages' in state:
+            limit = int(args[args.index('--limit') + 1])
+            result = [
+                {'number': item['number'], 'headRefOid': item['head']['sha'], 'baseRefName': item['base']['ref']}
+                for page in state['pull_pages'] for item in page
+            ][:limit]
     elif args[0] == 'api':
         endpoint = next(a for a in args if a.startswith('repos/'))
         method = args[args.index('--method') + 1] if '--method' in args else 'GET'
@@ -60,6 +67,19 @@ def fake_command(kind, args):
             result = [{'variables': []}, {'variables': items}]
             if 'variable_response' in state:
                 result = state['variable_response']
+        elif '/pulls?' in endpoint:
+            assert '--paginate' in args and '--slurp' in args
+            if state.get('fail_pull_pages'):
+                sys.exit(1)
+            result = state.get('pull_pages', [[
+                {'number': 1, 'head': {'sha': 'head-main'}, 'base': {'ref': 'main'}},
+                {'number': 2, 'head': {'sha': 'head-stack'}, 'base': {'ref': 'parent'}},
+            ]])
+        elif '/rules/branches/' in endpoint:
+            assert '--paginate' in args and '--slurp' in args
+            if state.get('fail_branch_rules'):
+                sys.exit(1)
+            result = state.get('branch_rule_pages', [state['ruleset']['rules']])
         elif '/rulesets/' in endpoint:
             ruleset_id = endpoint.rsplit('/', 1)[1]
             rulesets = state.get('rulesets', {'7': state['ruleset']})
@@ -515,6 +535,92 @@ class MergeFreezeTests(unittest.TestCase):
         self.run_toggle(action='unfreeze', slack=SLACK_OTHER)
         self.assertEqual(self.state['rulesets'], original)
         self.assertNotIn('MERGE_FREEZE_ACTOR', self.state['variables'])
+
+    def test_unfreeze_recovers_prs_beyond_the_first_500(self):
+        self.state['pull_pages'] = [
+            [{'number': index, 'head': {'sha': f'head-{index}'}, 'base': {'ref': 'parent'}}
+             for index in range(1, 501)],
+            [{'number': 501, 'head': {'sha': 'head-501'}, 'base': {'ref': 'main'}}],
+        ]
+        self.run_toggle(action='unfreeze', slack=SLACK_OTHER)
+        writes = [call for call in self.state['calls'] if 'POST' in call]
+        self.assertEqual(len(writes), 1)
+        self.assertIn('repos/example/test/statuses/head-501', writes[0])
+        self.assertEqual(self.state['statuses'][-1]['state'], 'success')
+
+    def test_unfreeze_reports_pull_listing_failure(self):
+        self.state['fail_pull_pages'] = True
+        self.run_toggle(action='unfreeze', success=False)
+        self.assertEqual(self.state['statuses'], [])
+
+    def test_invalid_pull_pages_fail_recovery(self):
+        for response in [None, {}, [], [None]]:
+            with self.subTest(response=response):
+                self.state['pull_pages'] = response
+                self.run_toggle(action='unfreeze', success=False)
+                self.assertEqual(self.state['statuses'], [])
+
+    def run_status(self, success=True):
+        workflow = ROOT / '.github/workflows/merge-freeze-status.yml'
+        script = textwrap.dedent(workflow.read_text().split('run: |\n', 1)[1])
+        script = script.replace('${{ github.event.pull_request.number }}', '1')
+        return self.run_script(script, {
+            'SHA': 'head-main', 'BRANCH': 'main', 'FREEZE_ACTOR': SLACK_OWNER,
+            'FREEZE_URL': 'https://example.invalid/workflow',
+        }, success)
+
+    def test_delayed_status_writer_observes_completed_unfreeze(self):
+        self.frozen()
+        self.run_toggle(action='unfreeze')
+        self.run_status()
+        self.assertEqual(self.state['statuses'][-1]['state'], 'success')
+
+    def test_unfreeze_reconciles_a_status_writer_that_finishes_first(self):
+        self.frozen()
+        self.run_status()
+        self.assertEqual(self.state['statuses'][-1]['state'], 'failure')
+        self.run_toggle(action='unfreeze')
+        self.assertEqual(self.state['statuses'][-1]['state'], 'success')
+
+    def test_repeat_unfreeze_refreshes_stale_statuses(self):
+        self.state['statuses'].append({'context': 'merge-freeze', 'state': 'failure'})
+        output, _, _ = self.run_toggle(action='unfreeze', slack=SLACK_OTHER)
+        self.assertIn('changed=false', output)
+        self.assertEqual(self.state['statuses'][-1]['state'], 'success')
+        self.assertFalse(any('PUT' in call for call in self.state['calls']))
+
+    def test_status_writer_checks_every_page_of_effective_rules(self):
+        self.state['branch_rule_pages'] = [[], [{'type': 'required_status_checks', 'parameters': {
+            'required_status_checks': [{'context': 'merge-freeze', 'integration_id': 123}],
+        }}]]
+        self.run_status()
+        self.assertEqual(self.state['statuses'][-1]['state'], 'failure')
+
+    def test_status_read_failure_does_not_publish_success(self):
+        self.state['fail_branch_rules'] = True
+        self.run_status(success=False)
+        self.assertEqual(self.state['statuses'], [])
+
+    def test_malformed_rules_do_not_publish_success(self):
+        for response in [None, {}, [], [None], [[None]], [[{'type': 'required_status_checks'}]]]:
+            with self.subTest(response=response):
+                self.state['branch_rule_pages'] = response
+                self.run_status(success=False)
+                self.assertEqual(self.state['statuses'], [])
+
+    def test_status_and_toggle_share_a_non_replacing_lock(self):
+        status = (ROOT / '.github/workflows/merge-freeze-status.yml').read_text()
+        toggle = WORKFLOW.read_text()
+        for workflow in [status, toggle]:
+            concurrency = workflow.split('\nconcurrency:\n', 1)[1].split('\n\n', 1)[0]
+            self.assertIn('group: merge-freeze-${{ github.repository }}', concurrency)
+            self.assertIn('cancel-in-progress: false', concurrency)
+            self.assertIn('queue: max', concurrency)
+        self.assertNotIn('vars.MERGE_FREEZE', status)
+        self.assertNotIn('contents: write', status)
+        self.assertNotIn('MERGE_FREEZE_TOKEN', status)
+        self.assertNotIn('actions/checkout', status)
+        self.assertIn('github.event.pull_request.head.repo.full_name == github.repository', status)
 
     def test_workflow_contract(self):
         workflow = WORKFLOW.read_text()


### PR DESCRIPTION
A verified employee cannot lift another employee's merge freeze. A delayed PR status job can also restore a stale red check after unfreeze completes.

Allow verified employees to unfreeze through the configured Cloudy dispatcher. Preserve the original freeze owner for audit and record the current employee who lifts the hold. Direct GitHub dispatch keeps its existing owner checks.

Freeze toggles and PR status jobs share a queue. Status jobs read live effective branch rules before posting. Unfreeze refreshes all open default-branch PRs with paginated API requests, including PRs beyond the previous 500 limit. Repeating unfreeze repairs stale checks even when merges are already open. Completion messages give the repeat command.

Validation: all 54 workflow tests pass. They execute the workflow shell against fake GitHub and Slack services. Cases cover employee authorization, dispatcher identity, stale status writes in both orders, repeated unfreeze, PRs beyond 500, failed or malformed reads, and unrelated ruleset preservation. Workflow formatting passes. Actionlint passes with only its unsupported `concurrency.queue` field excluded; the installed version is 1.7.12. Validation does not use live freeze operations.

Rollout: land both repository workflow changes before deploying https://github.com/lightdash/lightdash-cloud-announcer/pull/308. Keep dispatcher identity and Slack workspace verification configured. Let old workflow runs drain, then repeat unfreeze to refresh their stale statuses. GitHub limits the shared queue to 100 pending runs; retry rejected requests after the queue drains.

CI note: the earlier merge-ref build failed in an unrelated frontend fixture after a required prop landed on main. SPK-1991 tracks that correction. This branch has no frontend changes.

Refs SPK-1989, SPK-1984
