### PR TITLE
fix(training): export step no longer strands the walkthrough

### DIFF
--- a/packages/frontend/src/components/ExportResults/index.test.tsx
+++ b/packages/frontend/src/components/ExportResults/index.test.tsx
@@ -1,6 +1,7 @@
 import { createConditionalFormattingConfigWithSingleColor } from '@lightdash/common';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { type ReactNode } from 'react';
 import {
     afterEach,
     beforeEach,
@@ -38,7 +39,7 @@ const getScheduledDownloadBody = async () =>
         return JSON.parse(scheduleRequest[1].body);
     });
 
-const renderExportResults = () =>
+const renderExportResults = (secondaryAction?: ReactNode) =>
     renderWithProviders(
         <ExportResults
             projectUuid={PROJECT_UUID}
@@ -46,6 +47,7 @@ const renderExportResults = () =>
             getDownloadQueryUuid={vi.fn().mockResolvedValue(QUERY_UUID)}
             conditionalFormattings={conditionalFormattings}
             hideLimitSelection
+            secondaryAction={secondaryAction}
         />,
     );
 
@@ -119,5 +121,14 @@ describe('ExportResults', () => {
         await waitFor(() =>
             expect(HTMLAnchorElement.prototype.click).toHaveBeenCalled(),
         );
+    });
+
+    it('shows a secondary action beside Download', () => {
+        renderExportResults(<button type="button">Google Sheets</button>);
+
+        expect(screen.getByTestId('chart-export-results-button')).toBeVisible();
+        expect(
+            screen.getByRole('button', { name: 'Google Sheets' }),
+        ).toBeVisible();
     });
 });

--- a/packages/frontend/src/components/ExportResults/index.tsx
+++ b/packages/frontend/src/components/ExportResults/index.tsx
@@ -68,6 +68,8 @@ export type ExportResultsProps = {
     hideLimitSelection?: boolean;
     forceShowLimitSelection?: boolean;
     renderDialogActions?: (renderProps: ExportCsvRenderProps) => ReactNode;
+    /** Another way out of the same form, shown beside Download. */
+    secondaryAction?: ReactNode;
 };
 
 const TOAST_KEY = 'exporting-results';
@@ -88,6 +90,7 @@ const ExportResults: FC<ExportResultsProps> = memo(
         hideLimitSelection = false,
         forceShowLimitSelection = false,
         renderDialogActions,
+        secondaryAction,
     }) => {
         const { showToastError, showToastInfo, showToastWarning } =
             useToaster();
@@ -476,19 +479,21 @@ const ExportResults: FC<ExportResultsProps> = memo(
                 )}
 
                 {!renderDialogActions ? (
-                    <Button
-                        loading={isExporting}
-                        size="sm"
-                        leftSection={<MantineIcon icon={IconTableExport} />}
-                        onClick={() => exportMutation()}
-                        data-testid="chart-export-results-button"
-                        // Walkthrough anchor (data-tour-then): the download.
-                        data-tour-anchor="export-download"
-                        data-tour-hint="Click Download"
-                        ml="auto"
-                    >
-                        Download
-                    </Button>
+                    <Group justify="flex-end" gap="xs">
+                        {secondaryAction}
+                        <Button
+                            loading={isExporting}
+                            size="sm"
+                            leftSection={<MantineIcon icon={IconTableExport} />}
+                            onClick={() => exportMutation()}
+                            data-testid="chart-export-results-button"
+                            // Walkthrough anchor (data-tour-then): the download.
+                            data-tour-anchor="export-download"
+                            data-tour-hint="Click Download"
+                        >
+                            Download
+                        </Button>
+                    </Group>
                 ) : (
                     <Stack gap="sm">
                         {renderDialogActions({

--- a/packages/frontend/src/components/ExportSelector/index.tsx
+++ b/packages/frontend/src/components/ExportSelector/index.tsx
@@ -1,19 +1,19 @@
 import {
-    SchedulerJobStatus,
-    type ApiDownloadCsv,
-    type ApiError,
     type ApiScheduledDownloadCsv,
     type PivotConfig,
 } from '@lightdash/common';
-import { Button, Stack } from '@mantine/core';
-import { IconArrowLeft, IconFileTypeCsv } from '@tabler/icons-react';
-import { useQuery } from '@tanstack/react-query';
-import { memo, useState, type FC } from 'react';
+import { memo, type FC } from 'react';
 import { ExportToGoogleSheet } from '../../features/export';
 import useHealth from '../../hooks/health/useHealth';
-import MantineIcon from '../common/MantineIcon';
 import ExportResults, { type ExportResultsProps } from '../ExportResults';
 
+/**
+ * The export form for a results table, with Google Sheets beside Download when
+ * the instance has Drive configured. Both ways out are on the one screen: an
+ * earlier version put the form behind a "Download data" button, which left
+ * anyone without the Google Sheets permission clicking through a chooser of
+ * one.
+ */
 const ExportSelector: FC<
     ExportResultsProps & {
         getGsheetLink?: () => Promise<ApiScheduledDownloadCsv>;
@@ -39,61 +39,6 @@ const ExportSelector: FC<
             health.data?.auth.google.oauth2ClientId !== undefined &&
             health.data?.auth.google.googleDriveApiKey !== undefined;
 
-        const [exportType, setExportType] = useState<string | undefined>();
-
-        const { data } = useQuery<ApiDownloadCsv | undefined, ApiError>({
-            queryKey: [`google-sheets`],
-            enabled: false,
-        });
-
-        const isExportingGoogleSheets =
-            data?.status === SchedulerJobStatus.STARTED;
-
-        if (exportType === 'csv') {
-            return (
-                <>
-                    <Button
-                        size="xs"
-                        mb="xs"
-                        leftSection={<MantineIcon icon={IconArrowLeft} />}
-                        variant="subtle"
-                        onClick={() => setExportType(undefined)}
-                    >
-                        Back
-                    </Button>
-                    <ExportResults
-                        totalResults={totalResults}
-                        getDownloadQueryUuid={getDownloadQueryUuid}
-                        projectUuid={projectUuid}
-                        columnOrder={columnOrder}
-                        customLabels={customLabels}
-                        hiddenFields={hiddenFields}
-                        showTableNames={showTableNames}
-                        chartName={chartName}
-                        pivotConfig={pivotConfig}
-                        conditionalFormattings={conditionalFormattings}
-                        showColumnTotals={showColumnTotals}
-                    />
-                </>
-            );
-        } else if (hasGoogleDrive && getGsheetLink) {
-            return (
-                <Stack gap="xs">
-                    <Button
-                        size="xs"
-                        variant="default"
-                        onClick={() => setExportType('csv')}
-                        leftSection={<MantineIcon icon={IconFileTypeCsv} />}
-                        disabled={isExportingGoogleSheets}
-                        data-testid="chart-export-csv-button"
-                    >
-                        Download data
-                    </Button>
-                    <ExportToGoogleSheet getGsheetLink={getGsheetLink} />
-                </Stack>
-            );
-        }
-
         return (
             <ExportResults
                 totalResults={totalResults}
@@ -107,6 +52,11 @@ const ExportSelector: FC<
                 pivotConfig={pivotConfig}
                 conditionalFormattings={conditionalFormattings}
                 showColumnTotals={showColumnTotals}
+                secondaryAction={
+                    hasGoogleDrive && getGsheetLink ? (
+                        <ExportToGoogleSheet getGsheetLink={getGsheetLink} />
+                    ) : undefined
+                }
             />
         );
     },

--- a/packages/frontend/src/components/common/GuidedTour/GuidedTour.test.tsx
+++ b/packages/frontend/src/components/common/GuidedTour/GuidedTour.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { act, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '../../../testing/testUtils';
@@ -97,5 +97,45 @@ describe('GuidedTour', () => {
         await user.click(screen.getByRole('button', { name: 'Next' }));
         await user.click(screen.getByRole('button', { name: 'Got it' }));
         expect(calls).toEqual(['finish', 'close']);
+    });
+
+    // A control the instance never shows (a screen behind a config the tour
+    // did not know about) used to leave the page blocked with no card and no
+    // Skip: the only way out was a new tab.
+    it('brings the card back when the next control never appears', async () => {
+        vi.useFakeTimers();
+        try {
+            renderWithProviders(
+                <GuidedTour
+                    steps={[
+                        { target: null, title: 'Step one', body: '' },
+                        {
+                            target: '[data-missing="true"]',
+                            title: 'Step two',
+                            body: '',
+                            interactive: true,
+                            advanceOnTargetClick: true,
+                        },
+                    ]}
+                    opened
+                    onClose={vi.fn()}
+                    initialStepIndex={1}
+                    initialBeacon={{ x: 10, y: 10 }}
+                />,
+            );
+
+            expect(screen.queryByText('Step two')).not.toBeInTheDocument();
+
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(16_000);
+            });
+
+            expect(screen.getByText('Step two')).toBeInTheDocument();
+            expect(
+                screen.getByRole('button', { name: 'Skip' }),
+            ).toBeInTheDocument();
+        } finally {
+            vi.useRealTimers();
+        }
     });
 });

--- a/packages/frontend/src/components/common/GuidedTour/GuidedTour.tsx
+++ b/packages/frontend/src/components/common/GuidedTour/GuidedTour.tsx
@@ -645,6 +645,20 @@ export const GuidedTour: FC<GuidedTourProps> = ({
         };
     }, [waiting]);
 
+    // A control that never arrives (a screen this instance does not have)
+    // would otherwise hide the card for good, leaving the page blocked with
+    // no way out but a new tab. Once patience runs out the card comes back,
+    // centred, so Skip is always within reach; the beacon keeps waiting and
+    // the card still opens at the control if it turns up.
+    useEffect(() => {
+        if (!waiting) return undefined;
+        const timeout = window.setTimeout(() => {
+            setCardRect(null);
+            setCardPhase('shown');
+        }, TARGET_PATIENCE_MS);
+        return () => window.clearTimeout(timeout);
+    }, [waiting]);
+
     // When the work finishes the ring travels to the finished surface.
     const wasBusyRef = useRef(false);
     useEffect(() => {

--- a/packages/frontend/src/features/export/components/ExportToGoogleSheet.tsx
+++ b/packages/frontend/src/features/export/components/ExportToGoogleSheet.tsx
@@ -77,7 +77,7 @@ export const ExportToGoogleSheet: FC<ExportToGoogleSheetProps> = memo(
 
         return (
             <Button
-                size="xs"
+                size="sm"
                 variant="default"
                 loading={isExporting}
                 leftSection={<MantineIcon icon={GSheetsIcon} />}


### PR DESCRIPTION
The "Download a chart's results" walkthrough waits for the Download button once the learner opens the export popover on the results table. On an instance with Google Drive configured, that popover opened on a chooser (`Download data` / `Google Sheets`) instead of the form, so the Download button never appeared. The tour kept waiting for it: the page stayed blocked, the card stayed hidden — no Skip, no way out but a new tab.

Two changes:

- `ExportSelector` now renders the export form directly, with the Google Sheets button beside Download, dropping the chooser screen and its Back button. One fewer click for everyone on Drive-enabled instances, and it also fixes the chooser-of-one a user without the Google Sheets permission used to see.
- `GuidedTour` gets an escape hatch: when a step's control has not arrived after the patience window, the card comes back centred so Skip is always reachable. Any future missing anchor degrades to a stuck step rather than a dead tab.

Verified with unit tests (the new GuidedTour test fails without the fix), plus frontend typecheck and lint. The full flow wasn't driven in a browser — no local instance available here.
