### PR TITLE
fix(explorer): call custom chart types Custom, not Project

### DIFF
--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -11,7 +11,7 @@ collisions with other contexts' or repo-wide meanings.
 ## Contexts
 
 - [Data apps](./docs/data-apps/CONTEXT.md) — AI-generated interactive apps built on the semantic layer by a coding agent in a sandbox, versioned per prompt, found and read by the AI agent
-- [Chart type registry](./docs/chart-types/CONTEXT.md) — official project chart types published as prebuilt artifacts in a public registry and installed read-only per project, with explicit fork for customization
+- [Chart type registry](./docs/chart-types/CONTEXT.md) — official custom chart types published as prebuilt artifacts in a public registry and installed read-only per project, with explicit fork for customization
 - [Pre-aggregates](./docs/pre-aggregates/CONTEXT.md) — user-defined, pre-computed summaries of explores that serve matching queries from materialized files instead of the warehouse
 - [AI agent](./docs/ai-agent/CONTEXT.md) — the in-app conversational agent (Ask AI), what users pin to its prompts, and where it opens from
 - [AI agent memory](./docs/ai-agent-memory/CONTEXT.md) — per-user, per-project knowledge the AI agent distills from a user's threads and recalls on their future threads

--- a/docs/chart-types.md
+++ b/docs/chart-types.md
@@ -3,8 +3,8 @@
 How official chart types get from the public registry into a project: the
 registry contract, listing, install, and the read-only/fork/upgrade model.
 Vocabulary is defined in [`docs/chart-types/CONTEXT.md`](./chart-types/CONTEXT.md).
-Project chart types themselves (viz schema, explorer behaviour, saved-chart
-version pinning) are data apps — see the "Project chart types" section of
+Custom chart types themselves (viz schema, explorer behaviour, saved-chart
+version pinning) are data apps — see the "Custom chart types" section of
 [`docs/data-apps.md`](./data-apps.md). The registry's own repo, publish
 pipeline, and authoring runbook are documented in
 [lightdash/lightdash-gallery](https://github.com/lightdash/lightdash-gallery).
@@ -14,7 +14,7 @@ pipeline, and authoring runbook are documented in
 ## What it is
 
 - The official registry (`lightdash/lightdash-gallery`, served from GitHub
-  Pages) publishes prebuilt project chart types. A Lightdash deployment
+  Pages) publishes prebuilt custom chart types. A Lightdash deployment
   points at one registry URL; the in-product chart type gallery gains a
   **chart type library** section to browse them and install them per
   project.
@@ -65,7 +65,7 @@ pipeline, and authoring runbook are documented in
 - The result is a project-owned app with provenance: `apps.registry_slug`
   and `apps.registry_url` identify the upstream chart, and each installed
   version records `app_versions.registry_version` (the semver it came
-  from). Once installed, the chart type behaves like any project chart type
+  from). Once installed, the chart type behaves like any custom chart type
   in the explorer.
 
 ## Read-only, fork, upgrade, uninstall

--- a/docs/chart-types/CONTEXT.md
+++ b/docs/chart-types/CONTEXT.md
@@ -1,14 +1,14 @@
 # Chart type registry
 
-Official, installable project chart types. Two halves make the feature: a
+Official, installable custom chart types. Two halves make the feature: a
 public **chart registry** that publishes prebuilt chart types as static
 artifacts, and the in-product **chart type library** that lists them and
 installs them into a project. Installed official chart types are read-only;
 making one editable is an explicit fork.
 
-Project chart types themselves — the viz schema, the explorer behaviour,
+Custom chart types themselves — the viz schema, the explorer behaviour,
 saved-chart version pinning — belong to the data apps context; use its
-vocabulary (see `docs/data-apps/CONTEXT.md`, "Project chart type") for the
+vocabulary (see `docs/data-apps/CONTEXT.md`, "Custom chart type") for the
 app/viz side and this glossary for the registry/library side.
 
 ## Language

--- a/docs/composer-viz-plan/05-viz-config-convergence.md
+++ b/docs/composer-viz-plan/05-viz-config-convergence.md
@@ -49,7 +49,7 @@ today. The copilot has no awareness of it (`getAvailableChartTypes` /
    only after parity.
 3. **Data-app vizzes bind to columns**: extend `fieldMapping` targets to
    column references so a data-app viz can sit on a composer chart; make the
-   copilot aware of project chart types.
+   copilot aware of custom chart types.
 4. **Retire the AI vocabulary**: semantic artifacts move to emitting
    `AllVizChartConfig` (step 2 did composer/SQL); `getWebAiChartConfig`
    becomes legacy-read-only.

--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -167,7 +167,7 @@ Entities, not columns:
   handle, link to its upstream app when it lives in a preview project, soft-delete markers.
 - **Version** — sequence number, verbatim prompt, status and status narration, error, attached context
   (clarifications, chart/dashboard/image/file/connection references, model and theme snapshot), viz schema for
-  project chart types, declared dependencies, generation usage, data references.
+  custom chart types, declared dependencies, generation usage, data references.
 - **Access grants** — per-app user and group access, in addition to space access.
 - **Links** — external connections linked to an app; dashboard tiles that reference an app.
 
@@ -216,9 +216,9 @@ flag-gated extension: registry-only, lockfile required, screened for malicious p
 
 ---
 
-## Project chart types
+## Custom chart types
 
-A project chart type is a data app built from a dedicated template that declares a viz schema instead of running
+A custom chart type is a data app built from a dedicated template that declares a viz schema instead of running
 queries: the explorer hands it rows and a field mapping, and it renders. They share the pipeline, storage and
 permissions of data apps but are excluded from app listings, have their own gallery and builder, and are downloaded
 as code separately.

--- a/docs/data-apps/CONTEXT.md
+++ b/docs/data-apps/CONTEXT.md
@@ -30,11 +30,12 @@ under My apps. Moving it into a space hands access over to the space
 entirely; the creator keeps no special rights.
 _Avoid_: private app, draft, unshared app
 
-**Project chart type**:
+**Custom chart type**:
 A data app that declares a viz schema and is used as a reusable chart type
 in the explorer rather than opened as an app. Excluded from data app
 listings. Named "data app viz" in code.
-_Avoid_: custom chart (that is the Vega feature), chart-type app, viz app
+_Avoid_: project chart type (the old name), custom chart (that is the Vega
+chart type), chart-type app, viz app
 
 **Template**:
 The starter flavor a data app is generated from: Dashboard, Slide show, PDF

--- a/packages/frontend/src/components/DataAppVizRenderer/index.test.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.test.tsx
@@ -438,7 +438,7 @@ describe('DataAppVizRenderer', () => {
         );
     });
 
-    it('pins an unsaved project chart type without requiring an SDK capability announcement', () => {
+    it('pins an unsaved custom chart type without requiring an SDK capability announcement', () => {
         mocks.dataAppVizVersion.current = undefined;
         mocks.vizContextOverrides.current = {
             savedChartUuid: undefined,
@@ -480,7 +480,7 @@ describe('DataAppVizRenderer', () => {
         expect(mocks.setDataAppVizVersion).toHaveBeenCalledWith(7);
     });
 
-    it('keeps an unchanged edited chart on its persisted project chart type version', () => {
+    it('keeps an unchanged edited chart on its persisted custom chart type version', () => {
         mocks.metadata.current = { ...readyMetadata(), version: 3 };
         mocks.dataAppVizVersion.current = 3;
         mocks.vizContextOverrides.current = {

--- a/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.test.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.test.tsx
@@ -137,7 +137,7 @@ describe('ChartTypeGallery', () => {
                         items: [galleryItem('Bar chart')],
                     }),
                     gallerySection({
-                        label: 'Project',
+                        label: 'Custom',
                         items: [
                             {
                                 ...galleryItem(
@@ -203,8 +203,8 @@ describe('ChartTypeGallery', () => {
                 disabledReason={null}
                 sections={[
                     gallerySection({
-                        label: 'Project',
-                        emptyMessage: 'No project chart types yet',
+                        label: 'Custom',
+                        emptyMessage: 'No custom chart types yet',
                         onCreateNew,
                     }),
                 ]}
@@ -212,7 +212,7 @@ describe('ChartTypeGallery', () => {
         );
 
         expect(
-            screen.getByText('No project chart types yet'),
+            screen.getByText('No custom chart types yet'),
         ).toBeInTheDocument();
         expect(
             screen.getByRole('button', { name: 'Create new chart type' }),
@@ -290,7 +290,7 @@ describe('ChartTypeGallery', () => {
                 sections={[
                     gallerySection({ items: [galleryItem('Bar chart')] }),
                     gallerySection({
-                        label: 'Project',
+                        label: 'Custom',
                         items: [galleryItem('Event pulse')],
                     }),
                 ]}
@@ -304,7 +304,7 @@ describe('ChartTypeGallery', () => {
             ),
         ).toBeInTheDocument();
         expect(
-            within(screen.getByRole('group', { name: 'Project' })).getByRole(
+            within(screen.getByRole('group', { name: 'Custom' })).getByRole(
                 'button',
                 { name: 'Event pulse' },
             ),
@@ -344,14 +344,14 @@ describe('ChartTypeGallery', () => {
                 disabledReason={null}
                 sections={[
                     gallerySection({
-                        errorMessage: 'Failed to load project chart types',
+                        errorMessage: 'Failed to load custom chart types',
                     }),
                 ]}
             />,
         );
 
         expect(screen.getByRole('alert')).toHaveTextContent(
-            'Failed to load project chart types',
+            'Failed to load custom chart types',
         );
     });
 
@@ -682,7 +682,7 @@ describe('ExplorerChartTypeGallery', () => {
         dataAppsEnabled.current = false;
         renderGallery();
 
-        expect(screen.queryByText('Project')).not.toBeInTheDocument();
+        expect(screen.queryByText('Custom')).not.toBeInTheDocument();
         expect(screen.getByText('Built in')).toBeInTheDocument();
         // No project shelf means no reason to ask the server for one.
         expect(mockedUseDataAppVisualizations).toHaveBeenCalledWith(
@@ -699,7 +699,7 @@ describe('ExplorerChartTypeGallery', () => {
         renderGallery();
 
         expect(
-            screen.getByText('Failed to load project chart types'),
+            screen.getByText('Failed to load custom chart types'),
         ).toBeInTheDocument();
         await userEvent.click(
             screen.getByRole('button', { name: /Vega \(JSON editor\)/ }),

--- a/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.tsx
@@ -46,7 +46,7 @@ import {
     type ChartTypeOption,
 } from './useChartTypeOptions';
 
-/** Grid slots the project section may fill before collapsing; when it does,
+/** Grid slots the custom section may fill before collapsing; when it does,
     the last slot becomes the "+N more" tile, so the collapse never trades a
     single hidden card for a tile. */
 const MAX_UNCOLLAPSED_PROJECT_TYPES = 6;
@@ -490,15 +490,15 @@ const ExplorerChartTypeGallery: FC<ExplorerChartTypeGalleryProps> = ({
         ...(dataAppsEnabled
             ? [
                   {
-                      label: 'Project',
+                      label: 'Custom',
                       items: visibleProjectItems,
                       loading: isInitialLoading,
                       errorMessage: error
-                          ? 'Failed to load project chart types'
+                          ? 'Failed to load custom chart types'
                           : null,
                       emptyMessage: debouncedSearch
-                          ? 'No project chart types match your search'
-                          : 'No project chart types yet',
+                          ? 'No custom chart types match your search'
+                          : 'No custom chart types yet',
                       onRetry: error ? () => void refetch() : null,
                       onLoadMore: collapseProjectTypes
                           ? () => setShowAllProjectTypes(true)

--- a/packages/frontend/src/components/Explorer/ChartGallery/ExplorerChartSidebar.test.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ExplorerChartSidebar.test.tsx
@@ -128,7 +128,7 @@ describe('ExplorerChartSidebar', () => {
         ).not.toBeInTheDocument();
     });
 
-    it('offers editing the selected project chart type in place', async () => {
+    it('offers editing the selected custom chart type in place', async () => {
         vizConfig.current = {
             chartType: ChartType.DATA_APP_VIZ,
             chartConfig: { dataAppVizUuid: 'viz-1' },

--- a/packages/frontend/src/components/Explorer/ChartGallery/useChartTypeOptions.test.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/useChartTypeOptions.test.tsx
@@ -40,7 +40,7 @@ const getSelectedItem = (
 };
 
 describe('getSelectedChartTypeItem', () => {
-    it('names the loaded project chart type', () => {
+    it('names the loaded custom chart type', () => {
         expect(
             getSelectedItem(ChartType.DATA_APP_VIZ, projectChartType),
         ).toMatchObject({
@@ -50,10 +50,10 @@ describe('getSelectedChartTypeItem', () => {
         });
     });
 
-    it('keeps a generic label while the project chart type loads', () => {
+    it('keeps a generic label while the custom chart type loads', () => {
         expect(getSelectedItem(ChartType.DATA_APP_VIZ, null)).toMatchObject({
             id: ChartKind.DATA_APP_VIZ,
-            label: 'Project chart type',
+            label: 'Custom chart type',
         });
     });
 

--- a/packages/frontend/src/components/Explorer/ChartGallery/useChartTypeOptions.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/useChartTypeOptions.tsx
@@ -67,14 +67,14 @@ const CUSTOM_CHART_TYPE: SelectedChartType = {
     rotatedIcon: false,
 };
 
-/** Pass `null` while the project chart type is still loading. */
+/** Pass `null` while the custom chart type is still loading. */
 export const projectChartTypeItem = (
     dataAppViz: DataAppViz | null,
 ): SelectedChartType => ({
     id: ChartKind.DATA_APP_VIZ,
     label: dataAppViz
         ? getAppDisplayName(dataAppViz.name, dataAppViz.dataAppVizUuid)
-        : 'Project chart type',
+        : 'Custom chart type',
     icon: IconPuzzle,
     rotatedIcon: false,
 });
@@ -281,13 +281,13 @@ export const useChartTypeOptions = () => {
     const isCustomChart =
         isCustomVisualizationConfig(visualizationConfig) ||
         isDataAppVizVisualizationConfig(visualizationConfig);
-    // Vega and project chart types share one "Custom" entry in the picker;
+    // Vega and custom chart types share one "Custom" entry in the picker;
     // cartesian series that do not resolve to a single entry are mixed.
     const selectedChartType: SelectedChartType = isCustomChart
         ? CUSTOM_CHART_TYPE
         : (options.find((option) => option.selected) ?? MIXED_CHART_TYPE);
 
-    // The picker collapses Vega and project chart types into a single "Custom"
+    // The picker collapses Vega and custom chart types into a single "Custom"
     // entry, so callers showing the active type resolve it by chart type.
     const getSelectedChartTypeItem = (
         chartType: ChartType,

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/CustomVisConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/CustomVisConfig.tsx
@@ -210,7 +210,7 @@ export const ConfigTabs: React.FC = memo(() => {
     );
     const isAiEnabled = aiCustomVizFlag?.enabled ?? false;
 
-    // Without data apps there are no project chart types, so Vega is the only
+    // Without data apps there are no custom chart types, so Vega is the only
     // custom chart type there is and a picker would offer a choice of one.
     const dataAppsEnabled =
         useServerFeatureFlag(FeatureFlags.EnableDataApps).data?.enabled ===

--- a/packages/frontend/src/components/VisualizationConfigs/CustomChartType/CustomChartTypePicker.test.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/CustomChartType/CustomChartTypePicker.test.tsx
@@ -104,7 +104,7 @@ describe('CustomChartTypePicker', () => {
 
         expect(screen.getByText('Built in')).toBeDefined();
         expect(screen.getByText('Vega (JSON editor)')).toBeDefined();
-        expect(screen.getByText('Project')).toBeDefined();
+        expect(screen.getByText('Custom')).toBeDefined();
         expect(screen.getByText('Bar race')).toBeDefined();
     });
 

--- a/packages/frontend/src/components/VisualizationConfigs/CustomChartType/customChartTypeOption.ts
+++ b/packages/frontend/src/components/VisualizationConfigs/CustomChartType/customChartTypeOption.ts
@@ -1,6 +1,6 @@
 /**
  * The secondary picker offers two kinds of custom chart type in one list: the
- * built-in Vega editor and the project's reusable types. They map to different
+ * built-in Vega editor and the project's custom chart types. They map to different
  * `ChartType`s, so the option value is prefixed rather than being a bare uuid.
  */
 export type CustomChartTypeOption =
@@ -30,4 +30,4 @@ export const fromOptionValue = (
 export const BUILT_IN_VEGA_LABEL = 'Vega (JSON editor)';
 export const BUILT_IN_VEGA_DESCRIPTION = 'Write Vega-Lite JSON by hand';
 export const BUILT_IN_GROUP = 'Built in';
-export const PROJECT_GROUP = 'Project';
+export const PROJECT_GROUP = 'Custom';

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizUpgradeNotice.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizUpgradeNotice.tsx
@@ -12,7 +12,7 @@ type Props = {
 };
 
 /**
- * Tells a chart editor that its project chart type moved on. The details and
+ * Tells a chart editor that its custom chart type moved on. The details and
  * the upgrade itself live behind the review modal, so the panel stays quiet.
  */
 const DataAppVizUpgradeNotice: FC<Props> = ({

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.test.ts
@@ -113,7 +113,7 @@ describe('contentMentions', () => {
             expect(url.searchParams.get('dataAppVizsFilter')).toBe('exclude');
         });
 
-        it('drops project chart type results and labels personal apps', async () => {
+        it('drops custom chart type results and labels personal apps', async () => {
             mockContentSearch([
                 dataAppResult({ uuid: 'app-1', name: 'F1 standings' }),
                 dataAppResult({ uuid: 'viz-1', template: 'data_app_viz' }),

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.tsx
@@ -450,7 +450,7 @@ const summaryContentToSuggestion = (
         };
     }
 
-    // Project chart types are data apps under the hood but not content the
+    // Custom chart types are data apps under the hood but not content the
     // agent reads, so they never show up as mentions.
     if (item.contentType === ContentType.DATA_APP) {
         if (item.template === DATA_APP_VIZ_TEMPLATE) return null;

--- a/packages/frontend/src/features/explorer/store/selectors.test.ts
+++ b/packages/frontend/src/features/explorer/store/selectors.test.ts
@@ -84,7 +84,7 @@ describe('chart type authoring selectors', () => {
 });
 
 describe('selectIsDataAppVizVersionReadyForSave', () => {
-    it('waits for an unsaved project chart type to capture its previewed version', () => {
+    it('waits for an unsaved custom chart type to capture its previewed version', () => {
         const explorer = explorerReducer(
             undefined,
             explorerActions.setChartConfig({

--- a/packages/frontend/src/hooks/useDataAppVizVisualizationConfig.test.ts
+++ b/packages/frontend/src/hooks/useDataAppVizVisualizationConfig.test.ts
@@ -24,7 +24,7 @@ describe('useDataAppVizVisualizationConfig', () => {
         });
     });
 
-    it('preserves the saved project chart type version through config edits', () => {
+    it('preserves the saved custom chart type version through config edits', () => {
         const onConfigChange = vi.fn();
         const { result } = renderHook(() =>
             useDataAppVizVisualizationConfig(
@@ -46,7 +46,7 @@ describe('useDataAppVizVisualizationConfig', () => {
         });
     });
 
-    it('pins the selected project chart type to the rendered version', () => {
+    it('pins the selected custom chart type to the rendered version', () => {
         const onConfigChange = vi.fn();
         const { result } = renderHook(() =>
             useDataAppVizVisualizationConfig(initialConfig, onConfigChange),
@@ -325,7 +325,7 @@ describe('useDataAppVizVisualizationConfig', () => {
         });
     });
 
-    it('drops the pin when the same project chart type is re-selected', () => {
+    it('drops the pin when the same custom chart type is re-selected', () => {
         const { result, rerender } = renderHook(
             ({ config }) => useDataAppVizVisualizationConfig(config),
             {

--- a/packages/frontend/src/pages/ChartTypeGallery.test.tsx
+++ b/packages/frontend/src/pages/ChartTypeGallery.test.tsx
@@ -242,7 +242,7 @@ describe('ChartTypeGallery', () => {
         });
     });
 
-    it('lists the project chart types and opens the detail modal', () => {
+    it('lists the custom chart types and opens the detail modal', () => {
         setData([
             makeDataAppViz({}),
             makeDataAppViz({ dataAppVizUuid: 'viz-2', name: 'Bar race' }),


### PR DESCRIPTION
## Summary

The Explorer's "Choose chart type" panel split chart types into **Project** and **Built in**. "Project" dates from when it sat under a "Custom chart type" heading in the secondary picker; the Explorer gallery flattened that layout, so the shelf label lost its context and nothing on screen explained it. Side by side with "Built in", the word said where the types live, not what they are.

- Rename the shelf to **Custom** in the Explorer chooser and in the secondary picker used outside the Explorer (dashboard chart editing).
- Loading, empty and error copy on both surfaces now says "custom chart types"; the Configure header fallback reads "Custom chart type".
- Glossaries: "custom chart type" is the canonical term; "project chart type" moves to the Avoid list, and the Vega chart type is named as such.

Code identifiers and persisted values are unchanged. Copy and docs only.

Also carries a one-line test fix: the dashboard chart editor modal gained a required `customMetricsEnabled` prop on main without its alternate-hosts test being updated, which fails the frontend typecheck for every PR.

## Test

- Open a saved chart in the Explorer, click Change: the shelves read **Custom** and **Built in**.
- Turn data apps off for the instance: only **Built in** shows.
- Edit a chart from a dashboard: the chart type picker groups read **Custom** and **Built in**.

Closes: PROD-11067