### PR TITLE
test(explorer): pass customMetricsEnabled in the chart editor modal test

### DIFF
--- a/packages/frontend/src/components/Explorer/ChartGallery/ExplorerAlternateHosts.test.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ExplorerAlternateHosts.test.tsx
@@ -160,6 +160,7 @@ describe('Explorer chart configuration in alternate hosts', () => {
                     opened
                     dashboardUuid="dashboard-uuid"
                     dashboardName="Orders dashboard"
+                    customMetricsEnabled={false}
                     onChartSaved={vi.fn()}
                     onRegistryMetricEdited={vi.fn()}
                     onRegistryMetricDeleted={vi.fn()}


### PR DESCRIPTION
### Description

Main fails the frontend typecheck: #28841 made `customMetricsEnabled` a required prop on `DashboardChartEditorModal`, and #28833 added a test that renders the modal without it. Each was green against its own base. This passes the prop in the test so PR checks go green again.

Verified locally: the test file passes and `pnpm -F frontend typecheck` reports no errors.

Relates: GLITCH-763
Relates: GLITCH-764