### PR TITLE
feat(apps): store a curated icon on custom chart types

### DIFF
--- a/packages/backend/src/database/entities/apps.ts
+++ b/packages/backend/src/database/entities/apps.ts
@@ -35,6 +35,10 @@ export type DbApp = {
     // in-flight old code during a deploy.
     sandbox_id: string | null;
     template: Exclude<DataAppTemplate, 'custom'> | null;
+    // Curated icon name for a custom chart type (`ChartTypeIcon`); null when
+    // no icon is chosen or the app is not a chart type. Stored as text so an
+    // icon retired from the curated set does not fail to read back.
+    icon: string | null;
     design_uuid: string | null;
     // The production app this (preview) app was promoted into. Null until the
     // app is first promoted. Lives on the preview side so a single production
@@ -66,6 +70,7 @@ export type AppsTable = Knex.CompositeTableType<
                 | 'space_uuid'
                 | 'sandbox_id'
                 | 'template'
+                | 'icon'
                 | 'design_uuid'
                 | 'upstream_app_uuid'
                 | 'registry_slug'
@@ -82,6 +87,7 @@ export type AppsTable = Knex.CompositeTableType<
             | 'slug'
             | 'space_uuid'
             | 'sandbox_id'
+            | 'icon'
             | 'design_uuid'
             | 'upstream_app_uuid'
             | 'registry_slug'

--- a/packages/backend/src/database/migrations/20260908120000_add_icon_to_apps.ts
+++ b/packages/backend/src/database/migrations/20260908120000_add_icon_to_apps.ts
@@ -1,0 +1,27 @@
+import { Knex } from 'knex';
+
+export const classification = {
+    kind: 'safe',
+    reason: 'Adds one nullable icon column to apps without reading, defaulting or rewriting existing rows',
+} as const;
+
+const AppsTableName = 'apps';
+const IconColumn = 'icon';
+const LOCK_TIMEOUT = '5s';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '${LOCK_TIMEOUT}'`);
+
+    await knex.schema.alterTable(AppsTableName, (table) => {
+        // Curated icon name for a custom chart type; null means no icon.
+        table.text(IconColumn).nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '${LOCK_TIMEOUT}'`);
+
+    await knex.schema.alterTable(AppsTableName, (table) => {
+        table.dropColumn(IconColumn);
+    });
+}

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.appMetadata.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.appMetadata.test.ts
@@ -1,0 +1,172 @@
+// Stub the e2b/ai SDKs before importing AppGenerateService so the tests never
+// reach the real sandbox or model client.
+import { generateObject } from 'ai';
+import { type z } from 'zod';
+import { AppGenerateService } from './AppGenerateService';
+
+vi.mock('e2b', () => ({
+    Sandbox: class {},
+    CommandExitError: class extends Error {},
+    ALL_TRAFFIC: '*',
+}));
+vi.mock('ai', () => ({
+    generateObject: vi.fn(),
+}));
+vi.mock('../ai/models', () => ({
+    resolveKeyManagement: vi.fn(() => 'lightdash'),
+}));
+vi.mock('../ai/utils/aiCallTelemetry', () => ({
+    getAiCallTelemetry: vi.fn(() => ({ isEnabled: false })),
+    getLanguageModelAttribution: vi.fn(() => ({})),
+}));
+
+const FAST_MODEL_OPTIONS = {
+    model: { provider: 'openai.responses', modelId: 'gpt-5.6-luna' },
+    callOptions: {},
+    providerOptions: {},
+    keyManagement: 'lightdash-managed',
+};
+
+const generateObjectMock = vi.mocked(generateObject);
+
+type MetadataResult = {
+    name: string | null;
+    description: string;
+    icon: string | null;
+};
+
+function buildService() {
+    const resolveFastModel = vi.fn().mockResolvedValue(FAST_MODEL_OPTIONS);
+    const service = new AppGenerateService({
+        lightdashConfig: { appRuntime: {} } as never,
+        analytics: { track: vi.fn() } as never,
+        analyticsModel: {} as never,
+        catalogModel: {} as never,
+        userModel: {} as never,
+        appModel: {} as never,
+        featureFlagModel: {} as never,
+        organizationDesignModel: {} as never,
+        pinnedListModel: {} as never,
+        projectModel: {} as never,
+        projectParametersModel: {} as never,
+        spaceModel: {} as never,
+        savedChartModel: {} as never,
+        schedulerClient: {} as never,
+        savedChartService: {} as never,
+        spacePermissionService: {} as never,
+        coderService: {} as never,
+        dashboardService: {} as never,
+        projectService: {} as never,
+        promoteService: {} as never,
+        externalConnectionModel: {} as never,
+        sandboxRegistryModel: {} as never,
+        orgAiCopilotConfigResolver: {
+            getCopilotConfig: vi
+                .fn()
+                .mockResolvedValue({ defaultProvider: 'openai' }),
+            resolveFastModel,
+        } as never,
+        sandboxManager: null,
+        appRuntimeS3: null,
+        chartRegistryClient: {} as never,
+    });
+    const generateMetadata = (isChartType: boolean) =>
+        (
+            service as unknown as {
+                generateAppMetadataFromPrompt: (
+                    appUuid: string,
+                    prompt: string,
+                    organizationUuid: string,
+                    projectUuid: string,
+                    userUuid: string,
+                    isChartType: boolean,
+                ) => Promise<MetadataResult>;
+            }
+        ).generateAppMetadataFromPrompt(
+            'app-1',
+            'a radial gauge',
+            'org-1',
+            'project-1',
+            'user-1',
+            isChartType,
+        );
+    return { generateMetadata, resolveFastModel };
+}
+
+/** What the metadata call actually handed to the model. */
+function sentCall() {
+    const call = generateObjectMock.mock.calls[0][0] as unknown as {
+        schema: z.ZodObject<z.ZodRawShape>;
+        messages: { role: string; content: string }[];
+    };
+    return {
+        schemaKeys: Object.keys(call.schema.shape),
+        system: call.messages.find((m) => m.role === 'system')!.content,
+    };
+}
+
+function mockObject(object: Record<string, unknown>) {
+    generateObjectMock.mockResolvedValue({ object, usage: {} } as never);
+}
+
+beforeEach(() => {
+    generateObjectMock.mockReset();
+});
+
+describe('AppGenerateService app metadata generation', () => {
+    it('asks a chart type for an icon in the same call', async () => {
+        mockObject({
+            name: 'Radial Gauge',
+            description: 'A radial gauge.',
+            icon: 'gauge',
+        });
+        const { generateMetadata } = buildService();
+
+        const result = await generateMetadata(true);
+
+        expect(generateObjectMock).toHaveBeenCalledOnce();
+        const { schemaKeys, system } = sentCall();
+        expect(schemaKeys).toContain('icon');
+        expect(system).toContain('reusable chart type');
+        expect(result).toEqual({
+            name: 'Radial Gauge',
+            description: 'A radial gauge.',
+            icon: 'gauge',
+        });
+    });
+
+    it('never asks a data app for an icon', async () => {
+        mockObject({ name: 'Revenue App', description: 'Revenue.' });
+        const { generateMetadata } = buildService();
+
+        const result = await generateMetadata(false);
+
+        const { schemaKeys, system } = sentCall();
+        expect(schemaKeys).not.toContain('icon');
+        expect(system).not.toContain('reusable chart type');
+        expect(result.icon).toBeNull();
+    });
+
+    it('drops an icon that is not in the curated set', async () => {
+        mockObject({
+            name: 'Radial Gauge',
+            description: 'A radial gauge.',
+            icon: 'skull',
+        });
+        const { generateMetadata } = buildService();
+
+        expect((await generateMetadata(true)).icon).toBeNull();
+    });
+
+    it('leaves the icon unset when no provider is configured', async () => {
+        const { generateMetadata, resolveFastModel } = buildService();
+        resolveFastModel.mockRejectedValueOnce(new Error('not configured'));
+
+        await expect(generateMetadata(true)).resolves.toEqual({
+            name: null,
+            description: '',
+            icon: null,
+        });
+        expect(generateObjectMock).not.toHaveBeenCalled();
+    });
+});

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
@@ -6,6 +6,7 @@ import {
     getUserAbilityBuilder,
     NotFoundError,
     OrganizationMemberRole,
+    ParameterError,
     type DataAppVizSchema,
 } from '@lightdash/common';
 import { verifyPreviewToken } from '../../../routers/appPreviewToken';
@@ -45,6 +46,7 @@ const makeDataAppVizRow = (overrides: Record<string, unknown> = {}) => ({
     space_uuid: null,
     sandbox_id: null,
     template: DATA_APP_VIZ_TEMPLATE,
+    icon: null,
     viz_schema: vizSchema,
     design_uuid: null,
     upstream_app_uuid: null,
@@ -231,6 +233,7 @@ describe('AppGenerateService data app vizs', () => {
                     schema: vizSchema,
                     createdAt: new Date('2026-06-30'),
                     createdByUserUuid: 'user-1',
+                    icon: null,
                 },
             ],
             pagination,
@@ -1105,6 +1108,114 @@ describe('moving a viz into a space', () => {
                 targetSpaceUuid: 'space-1',
             },
             { tx: undefined },
+        );
+    });
+});
+
+describe('choosing a chart type icon', () => {
+    const buildIconService = (app: Record<string, unknown>) => {
+        const appModel = {
+            getApp: vi.fn().mockResolvedValue(app),
+            updateApp: vi
+                .fn()
+                .mockImplementation(async (_appId, _projectUuid, update) => ({
+                    ...app,
+                    ...update,
+                })),
+        };
+        return { service: buildService(appModel), appModel };
+    };
+
+    it('rejects an icon on an app that is not a chart type', async () => {
+        const { service, appModel } = buildIconService(
+            makeDataAppVizRow({ template: null, registry_slug: null }),
+        );
+
+        await expect(
+            service.updateApp(USER, 'project-1', 'data-app-viz-1', {
+                icon: 'chart-pie',
+            }),
+        ).rejects.toThrow('Only custom chart types can have an icon');
+        expect(appModel.updateApp).not.toHaveBeenCalled();
+    });
+
+    it('rejects an icon that is not in the curated set', async () => {
+        const { service, appModel } = buildIconService(
+            makeDataAppVizRow({ registry_slug: null }),
+        );
+
+        await expect(
+            service.updateApp(USER, 'project-1', 'data-app-viz-1', {
+                icon: 'skull' as never,
+            }),
+        ).rejects.toThrow(ParameterError);
+        expect(appModel.updateApp).not.toHaveBeenCalled();
+    });
+
+    it('sets a curated icon', async () => {
+        const { service, appModel } = buildIconService(
+            makeDataAppVizRow({ registry_slug: null }),
+        );
+
+        const result = await service.updateApp(
+            USER,
+            'project-1',
+            'data-app-viz-1',
+            { icon: 'gauge' },
+        );
+
+        expect(appModel.updateApp).toHaveBeenCalledWith(
+            'data-app-viz-1',
+            'project-1',
+            { icon: 'gauge' },
+        );
+        expect(result.icon).toBe('gauge');
+    });
+
+    it('clears the icon with null', async () => {
+        const { service, appModel } = buildIconService(
+            makeDataAppVizRow({ registry_slug: null, icon: 'gauge' }),
+        );
+
+        const result = await service.updateApp(
+            USER,
+            'project-1',
+            'data-app-viz-1',
+            { icon: null },
+        );
+
+        expect(appModel.updateApp).toHaveBeenCalledWith(
+            'data-app-viz-1',
+            'project-1',
+            { icon: null },
+        );
+        expect(result.icon).toBeNull();
+    });
+
+    it('reads an icon retired from the curated set back as none', async () => {
+        const { service } = buildIconService(
+            makeDataAppVizRow({ registry_slug: null, icon: 'retired-icon' }),
+        );
+
+        const result = await service.updateApp(
+            USER,
+            'project-1',
+            'data-app-viz-1',
+            { name: 'Renamed' },
+        );
+
+        expect(result.icon).toBeNull();
+    });
+
+    it('requires at least one of name, description or icon', async () => {
+        const { service } = buildIconService(
+            makeDataAppVizRow({ registry_slug: null }),
+        );
+
+        await expect(
+            service.updateApp(USER, 'project-1', 'data-app-viz-1', {}),
+        ).rejects.toThrow(
+            'At least one of name, description or icon must be provided',
         );
     });
 });

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.registryInstall.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.registryInstall.test.ts
@@ -64,6 +64,7 @@ function makeEntry(
         tags: [],
         changelog: '',
         minLightdashVersion: null,
+        icon: null,
         vizSchema: VIZ_SCHEMA,
         thumbnail: null,
         screenshots: [],

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -18,6 +18,7 @@ import {
     assertEmbeddedAuth,
     assertUnreachable,
     ChartType,
+    chartTypeIconSchema,
     checkThemeLimits,
     compareSemverVersions,
     DATA_APP_CLAUDE_MODELS,
@@ -40,6 +41,7 @@ import {
     getEffectiveFieldAiHints,
     getErrorMessage,
     getVisibleDataAppClaudeModels,
+    isChartTypeIcon,
     isDashboardChartTileType,
     isExploreError,
     isSemverVersion,
@@ -77,6 +79,7 @@ import {
     type ChartConfig,
     type ChartReference,
     type ChartSampleData,
+    type ChartTypeIcon,
     type CompiledExploreJoin,
     type CompiledTable,
     type DashboardBlueprint,
@@ -4087,6 +4090,9 @@ export class AppGenerateService extends BaseService {
      * mirrors the clarify flow (org-resolved copilot config, BYO-key-aware
      * fast model). Returns a null name when no provider is configured or the
      * response is unusable — the app keeps its "Untitled" fallback.
+     *
+     * For a chart type the same call also suggests a curated icon, so the
+     * icon costs no extra model round trip.
      */
     private async generateAppMetadataFromPrompt(
         appUuid: string,
@@ -4094,7 +4100,12 @@ export class AppGenerateService extends BaseService {
         organizationUuid: string,
         projectUuid: string,
         userUuid: string,
-    ): Promise<{ name: string | null; description: string }> {
+        isChartType: boolean,
+    ): Promise<{
+        name: string | null;
+        description: string;
+        icon: ChartTypeIcon | null;
+    }> {
         const copilot =
             await this.orgAiCopilotConfigResolver.getCopilotConfig(
                 organizationUuid,
@@ -4110,7 +4121,7 @@ export class AppGenerateService extends BaseService {
             this.logger.info(
                 `App ${appUuid}: skipping auto-name — no LLM provider configured (${getErrorMessage(err)})`,
             );
-            return { name: null, description: '' };
+            return { name: null, description: '', icon: null };
         }
 
         const metadataSchema = z.object({
@@ -4122,6 +4133,13 @@ export class AppGenerateService extends BaseService {
             description: z
                 .string()
                 .describe('One-sentence description of what the app shows'),
+            ...(isChartType
+                ? {
+                      icon: chartTypeIconSchema.describe(
+                          'Icon from the list that best represents how the chart looks',
+                      ),
+                  }
+                : {}),
         });
 
         const METADATA_TIMEOUT_MS = 15_000;
@@ -4144,8 +4162,11 @@ export class AppGenerateService extends BaseService {
             messages: [
                 {
                     role: 'system',
-                    content:
-                        'You write display metadata for a data app that is being generated from the prompt the user provides. Respond with a short name (3-6 words, title case) and a one-sentence description of the app.',
+                    content: `You write display metadata for a data app that is being generated from the prompt the user provides. Respond with a short name (3-6 words, title case) and a one-sentence description of the app.${
+                        isChartType
+                            ? ' This app is a reusable chart type, so also pick the icon that best matches how the chart looks.'
+                            : ''
+                    }`,
                 },
                 { role: 'user', content: prompt },
             ],
@@ -4154,13 +4175,16 @@ export class AppGenerateService extends BaseService {
         const stripHtml = (s: string) => s.replace(/<[^>]*>/g, '').trim();
         const name = stripHtml(result.object.name).slice(0, 255);
         const description = stripHtml(result.object.description).slice(0, 1024);
+        const icon = isChartTypeIcon(result.object.icon)
+            ? result.object.icon
+            : null;
         if (!name) {
             this.logger.warn(
                 `App ${appUuid}: auto-name returned an empty name`,
             );
-            return { name: null, description };
+            return { name: null, description, icon };
         }
-        return { name, description };
+        return { name, description, icon };
     }
 
     private async runBuild(
@@ -4977,6 +5001,7 @@ export class AppGenerateService extends BaseService {
                 payload.organizationUuid,
                 projectUuid,
                 payload.userUuid,
+                isDataAppViz,
             )
                 .then(async (metadata) => {
                     if (metadata.name) {
@@ -4990,6 +5015,7 @@ export class AppGenerateService extends BaseService {
                                 {
                                     name: metadata.name,
                                     description: metadata.description,
+                                    icon: metadata.icon,
                                 },
                             );
                         this.logger.info(
@@ -7570,6 +7596,7 @@ export class AppGenerateService extends BaseService {
         const metadata = {
             name: sourceApp.name,
             description: sourceApp.description,
+            icon: sourceApp.icon,
             space_uuid: targetSpaceUuid,
             design_uuid: targetDesignUuid,
         };
@@ -7927,6 +7954,7 @@ export class AppGenerateService extends BaseService {
                     created_by_user_uuid: user.userUuid,
                     name: newAppName,
                     description: sourceApp.description,
+                    icon: sourceApp.icon,
                     template: sourceApp.template,
                     space_uuid: null,
                     // A fork is a plain local chart type — registry lineage
@@ -8192,6 +8220,7 @@ export class AppGenerateService extends BaseService {
                     name: sourceApp.name,
                     slug: sourceApp.slug,
                     description: sourceApp.description,
+                    icon: sourceApp.icon,
                     template: sourceApp.template,
                     space_uuid: previewSpaceUuid,
                     design_uuid: targetDesignUuid,
@@ -8407,6 +8436,7 @@ export class AppGenerateService extends BaseService {
         hasMore: boolean;
         latestReadyVersion: number | null;
         registrySlug: string | null;
+        icon: ChartTypeIcon | null;
     }> {
         await this.assertDataAppsEnabled(user);
 
@@ -8421,6 +8451,7 @@ export class AppGenerateService extends BaseService {
         const {
             name,
             description,
+            icon,
             createdByUserUuid,
             organizationUuid,
             spaceUuid,
@@ -8516,6 +8547,8 @@ export class AppGenerateService extends BaseService {
             hasMore,
             latestReadyVersion: latestReady?.version ?? null,
             registrySlug,
+            // An icon retired from the curated set reads back as no icon.
+            icon: isChartTypeIcon(icon) ? icon : null,
         };
     }
 
@@ -8597,6 +8630,8 @@ export class AppGenerateService extends BaseService {
             createdAt: app.created_at,
             createdByUserUuid: app.created_by_user_uuid,
             registrySlug: app.registry_slug,
+            // An icon retired from the curated set reads back as no icon.
+            icon: isChartTypeIcon(app.icon) ? app.icon : null,
         };
     }
 
@@ -9388,8 +9423,17 @@ export class AppGenerateService extends BaseService {
         user: SessionUser,
         projectUuid: string,
         appUuid: string,
-        update: { name?: string; description?: string },
-    ): Promise<{ appUuid: string; name: string; description: string }> {
+        update: {
+            name?: string;
+            description?: string;
+            icon?: ChartTypeIcon | null;
+        },
+    ): Promise<{
+        appUuid: string;
+        name: string;
+        description: string;
+        icon: ChartTypeIcon | null;
+    }> {
         await this.assertDataAppsEnabled(user);
         const app = await this.appModel.getApp(appUuid, projectUuid);
         await this.assertCanManageApp(
@@ -9399,8 +9443,11 @@ export class AppGenerateService extends BaseService {
         );
         AppGenerateService.assertNotRegistryManaged(app, 'renamed');
 
-        const fieldsToUpdate: Partial<{ name: string; description: string }> =
-            {};
+        const fieldsToUpdate: Partial<{
+            name: string;
+            description: string;
+            icon: string | null;
+        }> = {};
         if (update.name !== undefined) {
             const trimmedName = update.name.trim();
             if (trimmedName.length === 0) {
@@ -9422,10 +9469,23 @@ export class AppGenerateService extends BaseService {
             }
             fieldsToUpdate.description = trimmedDescription;
         }
+        if (update.icon !== undefined) {
+            if (app.template !== DATA_APP_VIZ_TEMPLATE) {
+                throw new ParameterError(
+                    'Only custom chart types can have an icon',
+                );
+            }
+            if (update.icon !== null && !isChartTypeIcon(update.icon)) {
+                throw new ParameterError(
+                    `Invalid chart type icon: ${String(update.icon)}`,
+                );
+            }
+            fieldsToUpdate.icon = update.icon;
+        }
 
         if (Object.keys(fieldsToUpdate).length === 0) {
             throw new ParameterError(
-                'At least one of name or description must be provided',
+                'At least one of name, description or icon must be provided',
             );
         }
 
@@ -9438,6 +9498,7 @@ export class AppGenerateService extends BaseService {
             appUuid: updatedApp.app_id,
             name: updatedApp.name,
             description: updatedApp.description,
+            icon: isChartTypeIcon(updatedApp.icon) ? updatedApp.icon : null,
         };
     }
 

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.vizSchemaCopy.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.vizSchemaCopy.test.ts
@@ -56,6 +56,7 @@ const sourceApp = {
     name: 'My Viz',
     slug: 'my-viz',
     description: 'A viz',
+    icon: 'gauge',
     created_by_user_uuid: USER_UUID,
     deleted_at: null,
     deleted_by_user_uuid: null,
@@ -213,7 +214,10 @@ describe('version metadata propagation on app copy paths', () => {
         await service.duplicateApp(makeUser(), PROJECT_UUID, SOURCE_APP_UUID);
 
         expect(appModel.createWithVersion).toHaveBeenCalledWith(
-            expect.objectContaining({ template: 'data_app_viz' }),
+            expect.objectContaining({
+                template: 'data_app_viz',
+                icon: 'gauge',
+            }),
             expect.anything(),
             'ready',
             expect.any(Object),
@@ -255,6 +259,7 @@ describe('version metadata propagation on app copy paths', () => {
             expect.objectContaining({
                 project_uuid: UPSTREAM_PROJECT_UUID,
                 template: 'data_app_viz',
+                icon: 'gauge',
             }),
             expect.anything(),
             'ready',
@@ -298,6 +303,10 @@ describe('version metadata propagation on app copy paths', () => {
             expect.any(Object),
             undefined, // no declared dependencies
             VIZ_SCHEMA,
+        );
+        expect(appModel.syncPromotedApp).toHaveBeenCalledWith(
+            UPSTREAM_APP_UUID,
+            expect.objectContaining({ icon: 'gauge' }),
         );
     });
 
@@ -410,6 +419,7 @@ describe('version metadata propagation on app copy paths', () => {
                 project_uuid: PREVIEW_PROJECT_UUID,
                 template: 'data_app_viz',
                 slug: 'my-viz',
+                icon: 'gauge',
             }),
             expect.anything(),
             'ready',

--- a/packages/backend/src/ee/services/AppGenerateService/testFixtures/buildChartRegistryFixture.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/testFixtures/buildChartRegistryFixture.ts
@@ -186,6 +186,7 @@ export async function buildChartRegistryFixture({
         tags: ['fixture'],
         changelog,
         minLightdashVersion: null,
+        icon: null,
         vizSchema: FIXTURE_VIZ_SCHEMA,
         thumbnail: `${relPrefix}/thumb.png`,
         screenshots: [`${relPrefix}/screenshot-1.png`],

--- a/packages/backend/src/models/AppModel.test.ts
+++ b/packages/backend/src/models/AppModel.test.ts
@@ -20,6 +20,7 @@ const appRow: DbApp = {
     space_uuid: null,
     sandbox_id: null,
     template: null,
+    icon: null,
     design_uuid: null,
     upstream_app_uuid: null,
     registry_slug: null,
@@ -163,6 +164,56 @@ describe('AppModel.setMetadataIfUnset', () => {
         expect(tracker.history.update[0].bindings).toContain(
             'sales-performance-overview-1',
         );
+    });
+
+    it('writes the suggested icon when the app has none', async () => {
+        const updatedApp = {
+            ...appRow,
+            name: 'Radial Gauge',
+            slug: 'radial-gauge',
+            icon: 'gauge',
+        };
+        tracker.on.select(AppsTableName).responseOnce(appRow);
+        tracker.on.select(AppsTableName).responseOnce([]);
+        tracker.on.update(AppsTableName).responseOnce([updatedApp]);
+
+        const result = await model.setMetadataIfUnset(appId, projectUuid, {
+            name: 'Radial Gauge',
+            description: 'A radial gauge.',
+            icon: 'gauge',
+        });
+
+        expect(result.icon).toBe('gauge');
+        expect(tracker.history.update[0].bindings).toContain('gauge');
+    });
+
+    it('does not overwrite an icon the author already chose', async () => {
+        const appWithIcon = { ...appRow, icon: 'chart-pie' };
+        tracker.on.select(AppsTableName).responseOnce(appWithIcon);
+        tracker.on.select(AppsTableName).responseOnce([]);
+        tracker.on.update(AppsTableName).responseOnce([appWithIcon]);
+
+        await model.setMetadataIfUnset(appId, projectUuid, {
+            name: 'Radial Gauge',
+            description: 'A radial gauge.',
+            icon: 'gauge',
+        });
+
+        expect(tracker.history.update[0].sql).not.toContain('"icon"');
+        expect(tracker.history.update[0].bindings).not.toContain('gauge');
+    });
+
+    it('leaves the icon alone when the metadata suggests none', async () => {
+        tracker.on.select(AppsTableName).responseOnce(appRow);
+        tracker.on.select(AppsTableName).responseOnce([]);
+        tracker.on.update(AppsTableName).responseOnce([appRow]);
+
+        await model.setMetadataIfUnset(appId, projectUuid, {
+            name: 'Sales Performance Overview',
+            description: 'A view of sales performance.',
+        });
+
+        expect(tracker.history.update[0].sql).not.toContain('"icon"');
     });
 
     it('does not change the name or slug after a user has named the app', async () => {

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -89,6 +89,7 @@ export class AppModel {
                     | 'name'
                     | 'description'
                     | 'template'
+                    | 'icon'
                     | 'space_uuid'
                     | 'design_uuid'
                     | 'registry_slug'
@@ -752,6 +753,7 @@ export class AppModel {
     ): Promise<{
         name: string;
         description: string;
+        icon: string | null;
         createdByUserUuid: string;
         organizationUuid: string;
         spaceUuid: string | null;
@@ -814,6 +816,7 @@ export class AppModel {
                 `${AppVersionsTableName}.*`,
                 `${AppsTableName}.name`,
                 `${AppsTableName}.description`,
+                `${AppsTableName}.icon`,
                 `${AppsTableName}.created_by_user_uuid`,
                 `${AppsTableName}.space_uuid`,
                 `${SpaceTableName}.name as space_name`,
@@ -841,6 +844,7 @@ export class AppModel {
         const rows: ((DbAppVersion | Record<string, null>) & {
             name: string;
             description: string;
+            icon: string | null;
             created_by_user_uuid: string;
             space_uuid: string | null;
             space_name: string | null;
@@ -864,6 +868,7 @@ export class AppModel {
         const {
             name,
             description,
+            icon,
             created_by_user_uuid: createdByUserUuid,
             space_uuid: spaceUuid,
             space_name: spaceName,
@@ -883,6 +888,7 @@ export class AppModel {
             ): r is DbAppVersion & {
                 name: string;
                 description: string;
+                icon: string | null;
                 created_by_user_uuid: string;
                 space_uuid: string | null;
                 space_name: string | null;
@@ -901,6 +907,7 @@ export class AppModel {
         return {
             name,
             description,
+            icon,
             createdByUserUuid,
             organizationUuid,
             spaceUuid,
@@ -919,7 +926,7 @@ export class AppModel {
     async updateApp(
         appId: string,
         projectUuid: string,
-        update: Partial<Pick<DbApp, 'name' | 'description'>>,
+        update: Partial<Pick<DbApp, 'name' | 'description' | 'icon'>>,
     ): Promise<DbApp> {
         const [row] = await this.database(AppsTableName)
             .where({ app_id: appId, project_uuid: projectUuid })
@@ -1336,7 +1343,7 @@ export class AppModel {
         appId: string,
         update: Pick<
             DbApp,
-            'name' | 'description' | 'space_uuid' | 'design_uuid'
+            'name' | 'description' | 'icon' | 'space_uuid' | 'design_uuid'
         >,
     ): Promise<DbApp> {
         const [row] = await this.database(AppsTableName)
@@ -1358,7 +1365,7 @@ export class AppModel {
     async setMetadataIfUnset(
         appId: string,
         projectUuid: string,
-        metadata: { name: string; description: string },
+        metadata: { name: string; description: string; icon?: string | null },
     ): Promise<DbApp> {
         return this.database.transaction(async (trx) => {
             const app = await trx(AppsTableName)
@@ -1371,13 +1378,18 @@ export class AppModel {
             }
 
             const update: Partial<
-                Pick<DbApp, 'name' | 'description' | 'slug'>
+                Pick<DbApp, 'name' | 'description' | 'slug' | 'icon'>
             > = {
                 description: trx.raw(
                     `CASE WHEN ${AppsTableName}.description = '' THEN ? ELSE ${AppsTableName}.description END`,
                     [metadata.description],
                 ) as unknown as string,
             };
+
+            // An icon the author already chose is never overwritten.
+            if (metadata.icon !== undefined && app.icon === null) {
+                update.icon = metadata.icon;
+            }
 
             if (app.name === '') {
                 const baseSlug = generateSlug(metadata.name).slice(0, 255);

--- a/packages/common/src/ee/apps/chartTypeIcons.ts
+++ b/packages/common/src/ee/apps/chartTypeIcons.ts
@@ -1,0 +1,79 @@
+import { z } from 'zod';
+
+/**
+ * Icons a custom chart type may be drawn with, as Tabler icon names. A fixed
+ * set keeps the frontend bundle flat (the full Tabler library is thousands of
+ * icons), keeps the picker scannable, and gives the model a short enum to
+ * choose from at first build. Null on a chart type means "no icon chosen"
+ * and renders the puzzle piece.
+ */
+export const CHART_TYPE_ICONS = [
+    // Bars, lines and areas
+    'chart-bar',
+    'chart-histogram',
+    'chart-line',
+    'chart-area',
+    'chart-area-line',
+    'chart-arrows',
+    'chart-arrows-vertical',
+    'chart-candle',
+    'chart-infographic',
+    // Points
+    'chart-dots',
+    'chart-dots-2',
+    'chart-bubble',
+    'chart-scatter-3d',
+    'chart-grid-dots',
+    // Parts of a whole
+    'chart-pie',
+    'chart-pie-2',
+    'chart-donut',
+    'chart-donut-2',
+    'chart-arcs',
+    'chart-circles',
+    'chart-radar',
+    'chart-treemap',
+    'chart-sankey',
+    // Structure and flow
+    'hierarchy',
+    'hierarchy-2',
+    'binary-tree',
+    'sitemap',
+    'topology-star',
+    'network',
+    'git-branch',
+    'git-merge',
+    'arrows-split',
+    // Place and time
+    'map',
+    'world',
+    'timeline',
+    'calendar',
+    'clock',
+    // Tables and values
+    'table',
+    'layout-grid',
+    'layout-kanban',
+    'list',
+    'grid-dots',
+    'number',
+    'square-number-1',
+    'percentage',
+    'trending-up',
+    'trending-down',
+    'gauge',
+    'target',
+    'activity',
+    'wave-sine',
+    'filter',
+    'stack',
+    'puzzle',
+] as const;
+
+export type ChartTypeIcon = (typeof CHART_TYPE_ICONS)[number];
+
+export const chartTypeIconSchema = z.enum(CHART_TYPE_ICONS);
+
+export const isChartTypeIcon = (value: unknown): value is ChartTypeIcon =>
+    typeof value === 'string' &&
+    (CHART_TYPE_ICONS as readonly string[]).includes(value);

--- a/packages/common/src/ee/apps/code.ts
+++ b/packages/common/src/ee/apps/code.ts
@@ -1,6 +1,7 @@
 import { parse as parseYaml } from 'yaml';
 import { type ApiSuccess } from '../../types/api/success';
 import { type ContentAsCodeDirectAccess } from '../../types/contentAsCode/directAccess';
+import { type ChartTypeIcon } from './chartTypeIcons';
 import { type DataAppTemplate, type DataAppVizSchema } from './types';
 
 export const currentDataAppCodeVersion = 1 as const;
@@ -33,6 +34,9 @@ export type DataAppManifest = {
     version: number;
     name: string;
     description: string;
+    // Curated Tabler icon name of a custom chart type. Absent for non-viz
+    // apps and bundles downloaded before this field; null clears it.
+    icon?: ChartTypeIcon | null;
     // The app's stored template flavor (includes data_app_viz); null for
     // "Custom" or apps predating template persistence.
     template: Exclude<DataAppTemplate, 'custom'> | null;

--- a/packages/common/src/ee/apps/registry.ts
+++ b/packages/common/src/ee/apps/registry.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { type ApiSuccess } from '../../types/api/success';
+import { chartTypeIconSchema, type ChartTypeIcon } from './chartTypeIcons';
 import { isValidDataAppSlug } from './code';
 import { dataAppVizSchema, type DataAppVizSchema } from './types';
 
@@ -66,6 +67,8 @@ export type ChartRegistryEntry = {
     vizSchema: DataAppVizSchema;
     thumbnail: string | null;
     screenshots: string[];
+    // Curated Tabler icon name; copied onto the app on install and upgrade.
+    icon: ChartTypeIcon | null;
     artifacts: {
         source: ChartRegistryArtifact;
         dist: ChartRegistryArtifact;
@@ -85,6 +88,7 @@ const registryEntrySchema = z.object({
     vizSchema: dataAppVizSchema,
     thumbnail: z.string().nullable().default(null),
     screenshots: z.array(z.string()).default([]),
+    icon: chartTypeIconSchema.nullable().default(null),
     artifacts: z.object({
         source: registryArtifactSchema,
         dist: registryArtifactSchema,

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -17,6 +17,7 @@ import { type ResultRow } from '../../types/results';
 import { type ChartConfig, type SavedChart } from '../../types/savedCharts';
 import assertUnreachable from '../../utils/assertUnreachable';
 import { toLlmJsonSchema } from '../../utils/zodJsonSchema';
+import { type ChartTypeIcon } from './chartTypeIcons';
 import {
     type DataAppVizConfigOption,
     type DataAppVizOptionValue,
@@ -530,17 +531,23 @@ export type ApiGetAppResponse = ApiSuccess<{
     // The registry slug it was installed from, or null for a project-authored
     // (or forked) app. Registry-installed chart types are read-only.
     registrySlug: string | null;
+    // Curated Tabler icon name of a custom chart type; null for other apps
+    // and for chart types with no icon chosen.
+    icon: ChartTypeIcon | null;
 }>;
 
 export type ApiUpdateAppRequest = {
     name?: string;
     description?: string;
+    // Custom chart types only; null clears the icon.
+    icon?: ChartTypeIcon | null;
 };
 
 export type ApiUpdateAppResponse = ApiSuccess<{
     appUuid: string;
     name: string;
     description: string;
+    icon: ChartTypeIcon | null;
 }>;
 
 export type ApiCancelAppVersionResponse = ApiSuccessEmpty;
@@ -1120,6 +1127,8 @@ export type DataAppViz = {
     projectUuid: string;
     spaceUuid: string | null;
     schema: DataAppVizSchema | null;
+    // Tabler icon name from the curated set; null renders the puzzle piece.
+    icon: ChartTypeIcon | null;
     createdAt: Date;
     createdByUserUuid: string;
     // Registry slug it was installed from, or null if project-authored (or

--- a/packages/common/src/ee/index.ts
+++ b/packages/common/src/ee/index.ts
@@ -17,6 +17,7 @@ export * from './apps/elementReference';
 export * from './apps/sdkFeatures';
 export * from './apps/dataAppVizSchemaChanges';
 export * from './apps/types';
+export * from './apps/chartTypeIcons';
 export * from './apps/code';
 export * from './apps/dataReferenceChecker';
 export * from './apps/dataReferences';

--- a/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.test.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.test.tsx
@@ -37,6 +37,7 @@ const projectChartType = {
     createdAt: new Date('2026-08-20T00:00:00Z'),
     createdByUserUuid: 'user-uuid',
     schema: { fields: [], configOptions: [], colorPalette: null },
+    icon: null,
     registrySlug: null,
 } satisfies DataAppViz;
 

--- a/packages/frontend/src/components/Explorer/ChartGallery/useChartTypeOptions.test.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/useChartTypeOptions.test.tsx
@@ -28,6 +28,7 @@ const projectChartType = {
     createdAt: new Date('2026-08-20T00:00:00Z'),
     createdByUserUuid: 'user-uuid',
     schema: { fields: [], configOptions: [], colorPalette: null },
+    icon: null,
     registrySlug: null,
 } satisfies DataAppViz;
 

--- a/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoring.test.tsx
+++ b/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoring.test.tsx
@@ -166,6 +166,7 @@ const dataAppViz = {
     },
     createdAt: new Date('2026-08-19T00:00:00Z'),
     createdByUserUuid: 'user-1',
+    icon: null,
     registrySlug: null,
 } satisfies DataAppViz;
 

--- a/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoringHeader.test.tsx
+++ b/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoringHeader.test.tsx
@@ -17,6 +17,7 @@ const app = {
     appUuid: 'viz-1',
     name: 'Revenue changes waterfall',
     description: 'By tier',
+    icon: null,
 };
 
 const renderHeader = (

--- a/packages/frontend/src/components/VisualizationConfigs/CustomChartType/CustomChartTypePicker.test.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/CustomChartType/CustomChartTypePicker.test.tsx
@@ -26,6 +26,7 @@ const makeDataAppViz = (overrides: Partial<DataAppViz>): DataAppViz => ({
     },
     createdAt: new Date('2026-06-30'),
     createdByUserUuid: 'user-1',
+    icon: null,
     registrySlug: null,
     ...overrides,
 });

--- a/packages/frontend/src/components/VisualizationConfigs/CustomChartType/useSelectProjectChartType.test.ts
+++ b/packages/frontend/src/components/VisualizationConfigs/CustomChartType/useSelectProjectChartType.test.ts
@@ -96,6 +96,7 @@ const dataAppViz = {
     },
     createdAt: new Date('2026-08-19T00:00:00Z'),
     createdByUserUuid: 'user-uuid',
+    icon: null,
     registrySlug: null,
 } satisfies DataAppViz;
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.restore.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.restore.test.tsx
@@ -42,6 +42,7 @@ const app: ApiGetAppResponse['results'] = {
     versions: [],
     hasMore: false,
     latestReadyVersion: 3,
+    icon: null,
 };
 
 const userMessage = (

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/AiDataAppBuildCard.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/AiDataAppBuildCard.test.tsx
@@ -102,6 +102,7 @@ const app = (
     hasMore: false,
     latestReadyVersion:
         versions.find((v) => v.status === 'ready')?.version ?? null,
+    icon: null,
 });
 
 const pending: ToolGenerateDataAppOutput['metadata'] = {

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/AiDataAppRestoreCard.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/AiDataAppRestoreCard.test.tsx
@@ -53,6 +53,7 @@ const app: ApiGetAppResponse['results'] = {
     versions: [readyVersion(3), readyVersion(2), readyVersion(1)],
     hasMore: false,
     latestReadyVersion: 3,
+    icon: null,
 };
 
 const item: DataAppRestoreContextItem = {

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/dataAppBuildCardState.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/dataAppBuildCardState.test.ts
@@ -51,6 +51,7 @@ const app = (
     versions,
     hasMore: false,
     latestReadyVersion: null,
+    icon: null,
 });
 
 const loaded = (versions: ApiAppVersionSummary[], name?: string) =>

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeLibrarySection.test.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeLibrarySection.test.tsx
@@ -58,6 +58,7 @@ const makeItem = (
     publishedAt: '2026-06-30T00:00:00.000Z',
     tags: [],
     changelog: '',
+    icon: null,
     minLightdashVersion: null,
     vizSchema: {
         fields: [

--- a/packages/frontend/src/pages/ChartTypeBuilder.test.tsx
+++ b/packages/frontend/src/pages/ChartTypeBuilder.test.tsx
@@ -173,6 +173,7 @@ const appMeta = (overrides: Partial<AppMeta> = {}): AppMeta =>
         hasMore: false,
         latestReadyVersion: 1,
         registrySlug: null,
+        icon: null,
         ...overrides,
     }) as AppMeta;
 

--- a/packages/frontend/src/pages/ChartTypeGallery.test.tsx
+++ b/packages/frontend/src/pages/ChartTypeGallery.test.tsx
@@ -81,6 +81,7 @@ const makeDataAppViz = (overrides: Partial<DataAppViz>): DataAppViz => ({
     },
     createdAt: new Date('2026-06-30'),
     createdByUserUuid: 'user-1',
+    icon: null,
     registrySlug: null,
     ...overrides,
 });


### PR DESCRIPTION
## Summary

Every custom chart type is drawn with the same puzzle piece, so a shelf of them in the Explorer chooser is indistinguishable until you read the names. This layer gives each chart type its own icon from a curated set of chart-related Tabler icons.

- **Contract in common**: the curated icon list (`CHART_TYPE_ICONS`), a zod enum and a type guard; `icon: ChartTypeIcon | null` on the chart type, the app detail response, the update request and response, the registry entry and the as-code manifest.
- **Storage**: a nullable `icon` text column on the app row. Null means no icon and renders the puzzle piece, so existing chart types need no backfill. The migration is additive and reversible.
- **Suggested at first build**: the existing fast-model call that writes the name and description also picks an icon, for chart types only. No extra model call. Off-list or missing answers leave it null.
- **Author control**: the update endpoint accepts `icon` (null clears). Only chart types may carry one; other apps get a 400, as does an off-list value. An icon the author already chose is never overwritten by the suggestion.
- **Fork and promotion** copy the icon with the rest of the row.

The frontend rendering and picker, and registry/as-code/CLI portability, follow in the next layers of this stack.

## Test

- Unit: model, metadata call, update validation, fork and promotion copy.
- `pnpm generate-api` resolves the new types; the migration passes the repo's SQL migration linter as safe.

Relates: PROD-11066