### PR TITLE
fix: hide period comparison dropdown for a single eligible dimension

### DIFF
--- a/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/period-over-period-reference.md
+++ b/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/period-over-period-reference.md
@@ -260,10 +260,12 @@ PoP can power the comparison value in big number charts, showing the delta from 
 1. Create the base chart in the Lightdash UI
 2. Click on a metric column header in the results table
 3. Select **Add period comparison**
-4. Choose the time dimension and offset, then save
+4. Set the offset, then click **Add comparison**. If only one eligible time dimension is available, it is selected automatically and shown as text rather than a dropdown. If multiple dimensions share the finest supported granularity, choose one from the **Time dimension** dropdown.
 5. Read the chart JSON through content tools
 6. The JSON will contain the complete `additionalMetrics` configuration
 7. Manage via `editContent` patches going forward
+
+Only dimensions at the finest supported time granularity in your results are eligible for comparison. For example, if you select both week and month, the comparison uses week. When the dropdown is shown, coarser dimensions are disabled because your results are grouped by a finer period.
 
 ## Common Patterns
 

--- a/packages/frontend/src/components/Explorer/PeriodOverPeriodComparisonModal/PeriodOverPeriodComparisonModal.test.tsx
+++ b/packages/frontend/src/components/Explorer/PeriodOverPeriodComparisonModal/PeriodOverPeriodComparisonModal.test.tsx
@@ -1,0 +1,186 @@
+import {
+    buildPopAdditionalMetric,
+    DimensionType,
+    FieldType,
+    MetricType,
+    TimeFrames,
+    type AdditionalMetric,
+    type Dimension,
+    type Metric,
+} from '@lightdash/common';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Provider } from 'react-redux';
+import {
+    createExplorerStore,
+    explorerActions,
+    selectAdditionalMetrics,
+} from '../../../features/explorer/store';
+import { renderWithProviders } from '../../../testing/testUtils';
+import { PeriodOverPeriodComparisonModal } from './PeriodOverPeriodComparisonModal';
+
+const orderWeek: Dimension = {
+    fieldType: FieldType.DIMENSION,
+    type: DimensionType.DATE,
+    table: 'orders',
+    tableLabel: 'Orders',
+    name: 'order_date_week',
+    label: 'Order date week',
+    sql: '${TABLE}.order_date',
+    hidden: false,
+    timeInterval: TimeFrames.WEEK,
+};
+
+const orderMonth: Dimension = {
+    ...orderWeek,
+    name: 'order_date_month',
+    label: 'Order date month',
+    timeInterval: TimeFrames.MONTH,
+};
+
+const metric: Metric = {
+    fieldType: FieldType.METRIC,
+    type: MetricType.COUNT,
+    table: 'orders',
+    tableLabel: 'Orders',
+    name: 'order_count',
+    label: 'Order count',
+    sql: '${TABLE}.order_id',
+    hidden: false,
+};
+
+const renderModal = (
+    dimensions: Dimension[],
+    additionalMetrics: AdditionalMetric[] = [],
+) => {
+    const store = createExplorerStore();
+    const itemsMap = Object.fromEntries(
+        dimensions.map((dimension) => [
+            `${dimension.table}_${dimension.name}`,
+            dimension,
+        ]),
+    );
+    store.dispatch(explorerActions.setDimensions(Object.keys(itemsMap)));
+    additionalMetrics.forEach((additionalMetric) =>
+        store.dispatch(explorerActions.addAdditionalMetric(additionalMetric)),
+    );
+    store.dispatch(
+        explorerActions.togglePeriodOverPeriodComparisonModal({
+            metric,
+            itemsMap,
+        }),
+    );
+    renderWithProviders(
+        <Provider store={store}>
+            <PeriodOverPeriodComparisonModal />
+        </Provider>,
+    );
+    return store;
+};
+
+describe('PeriodOverPeriodComparisonModal', () => {
+    it.each([
+        { name: 'one time dimension', dimensions: [orderWeek] },
+        { name: 'mixed grains', dimensions: [orderMonth, orderWeek] },
+    ])(
+        'automatically uses the only eligible dimension without a dropdown: $name',
+        async ({ dimensions }) => {
+            const user = userEvent.setup();
+            const store = renderModal(dimensions);
+
+            expect(
+                screen.queryByRole('textbox', { name: 'Time dimension' }),
+            ).not.toBeInTheDocument();
+            expect(screen.getByText('Order date week')).toBeVisible();
+            expect(screen.getByText('Week granularity')).toBeVisible();
+            await user.click(
+                screen.getByRole('button', { name: 'Add comparison' }),
+            );
+
+            expect(selectAdditionalMetrics(store.getState())).toEqual([
+                expect.objectContaining({
+                    timeDimensionId: 'orders_order_date_week',
+                    granularity: TimeFrames.WEEK,
+                    periodOffset: 1,
+                    baseMetricId: 'orders_order_count',
+                }),
+            ]);
+        },
+    );
+
+    it('keeps the dropdown for multiple eligible dimensions and disables coarser grains', async () => {
+        const user = userEvent.setup();
+        const store = renderModal([
+            orderMonth,
+            orderWeek,
+            { ...orderWeek, name: 'ship_date_week', label: 'Ship date week' },
+        ]);
+        const confirmButton = screen.getByRole('button', {
+            name: 'Add comparison',
+        });
+        expect(confirmButton).toBeDisabled();
+
+        await user.click(
+            screen.getByRole('textbox', { name: 'Time dimension' }),
+        );
+        await user.click(
+            screen.getByRole('option', { name: 'Order date month' }),
+        );
+        expect(confirmButton).toBeDisabled();
+        await user.click(
+            screen.getByRole('option', { name: 'Ship date week' }),
+        );
+        await user.click(confirmButton);
+
+        expect(selectAdditionalMetrics(store.getState())).toEqual([
+            expect.objectContaining({
+                timeDimensionId: 'orders_ship_date_week',
+                granularity: TimeFrames.WEEK,
+            }),
+        ]);
+    });
+
+    it('keeps comparison unavailable without an eligible time dimension', () => {
+        renderModal([]);
+
+        expect(
+            screen.getByPlaceholderText(
+                'Add a time dimension to enable comparison',
+            ),
+        ).toBeDisabled();
+        expect(
+            screen.getByRole('button', { name: 'Add comparison' }),
+        ).toBeDisabled();
+    });
+
+    it('checks duplicates for the automatic dimension and allows a different offset', async () => {
+        const user = userEvent.setup();
+        const { additionalMetric } = buildPopAdditionalMetric({
+            metric,
+            timeDimensionId: 'orders_order_date_week',
+            granularity: TimeFrames.WEEK,
+            periodOffset: 1,
+        });
+        const store = renderModal([orderWeek], [additionalMetric]);
+        const confirmButton = screen.getByRole('button', {
+            name: 'Add comparison',
+        });
+
+        expect(
+            screen.getByText('This comparison already exists'),
+        ).toBeVisible();
+        expect(confirmButton).toBeDisabled();
+        const offset = screen.getByRole('textbox', { name: 'Offset' });
+        await user.clear(offset);
+        await user.type(offset, '2');
+        await user.click(confirmButton);
+
+        expect(selectAdditionalMetrics(store.getState())).toEqual([
+            additionalMetric,
+            expect.objectContaining({
+                timeDimensionId: 'orders_order_date_week',
+                periodOffset: 2,
+            }),
+        ]);
+    });
+});

--- a/packages/frontend/src/components/Explorer/PeriodOverPeriodComparisonModal/PeriodOverPeriodComparisonModal.tsx
+++ b/packages/frontend/src/components/Explorer/PeriodOverPeriodComparisonModal/PeriodOverPeriodComparisonModal.tsx
@@ -91,9 +91,16 @@ const PeriodOverPeriodComparisonModalContent: FC<{
         return <Text size="sm">{option.label}</Text>;
     };
 
-    const [selectedTimeDimensionId, setSelectedTimeDimensionId] = useState<
+    const [chosenTimeDimensionId, setSelectedTimeDimensionId] = useState<
         string | null
     >(null);
+    const eligibleTimeDimensions = selectData.filter(
+        (option) => !option.disabled,
+    );
+    const singleTimeDimension =
+        eligibleTimeDimensions.length === 1 ? eligibleTimeDimensions[0] : null;
+    const selectedTimeDimensionId =
+        singleTimeDimension?.value ?? chosenTimeDimensionId;
     const [periodOffset, setPeriodOffset] = useState<number>(1);
 
     const selectedDimensionObj = useMemo(() => {
@@ -206,21 +213,30 @@ const PeriodOverPeriodComparisonModalContent: FC<{
                         different time dimension or offset.
                     </Callout>
                 ) : null}
-                <Select
-                    label="Time dimension"
-                    placeholder={
-                        canConfigure
-                            ? 'Select time dimension'
-                            : 'Add a time dimension to enable comparison'
-                    }
-                    data={selectData}
-                    value={selectedTimeDimensionId}
-                    onChange={setSelectedTimeDimensionId}
-                    disabled={!canConfigure}
-                    renderOption={renderSelectOption}
-                    searchable
-                    clearable
-                />
+                {singleTimeDimension ? (
+                    <Stack gap={4}>
+                        <Text size="sm" fw={500}>
+                            Time dimension
+                        </Text>
+                        <Text size="sm">{singleTimeDimension.label}</Text>
+                    </Stack>
+                ) : (
+                    <Select
+                        label="Time dimension"
+                        placeholder={
+                            canConfigure
+                                ? 'Select time dimension'
+                                : 'Add a time dimension to enable comparison'
+                        }
+                        data={selectData}
+                        value={selectedTimeDimensionId}
+                        onChange={setSelectedTimeDimensionId}
+                        disabled={!canConfigure}
+                        renderOption={renderSelectOption}
+                        searchable
+                        clearable
+                    />
+                )}
 
                 <Group gap="xs" align="center">
                     <NumberInput

--- a/skills/developing-in-lightdash/resources/period-over-period-reference.md
+++ b/skills/developing-in-lightdash/resources/period-over-period-reference.md
@@ -224,10 +224,12 @@ PoP can power the comparison value in big number charts, showing the delta from 
 1. Create the base chart in the Lightdash UI
 2. Click on a metric column header in the results table
 3. Select **Add period comparison**
-4. Choose the time dimension and offset, then save
+4. Set the offset, then click **Add comparison**. If only one eligible time dimension is available, it is selected automatically and shown as text rather than a dropdown. If multiple dimensions share the finest supported granularity, choose one from the **Time dimension** dropdown.
 5. Download with `lightdash download --charts <slug>`
 6. The YAML will contain the complete `additionalMetrics` configuration
 7. Manage as code going forward with `lightdash upload`
+
+Only dimensions at the finest supported time granularity in your results are eligible for comparison. For example, if you select both week and month, the comparison uses week. When the dropdown is shown, coarser dimensions are disabled because your results are grouped by a finer period.
 
 ## Common Patterns
 


### PR DESCRIPTION
## What changed

- fix: hide period comparison dropdown for a single eligible dimension

Co-authored-by: Jess <jess@lightdash.com>

## Verification

Rebased with `git -c user.name='Lightdash Linear Agent' -c user.email=linear-agent@lightdash.com rebase origin/main` onto 57ac641894dcc6b00d898fe74d00611fa38d5604, producing a55778e7f0. No conflicts or extra code changes.
- Inspected PR #28867 checks and Build & Test job 102503170228: TS2741 in ExplorerAlternateHosts.test.tsx (missing customMetricsEnabled). Latest main includes upstream fix 5efe85b11d.
- `pnpm -F frontend typecheck`: passed.
- `pnpm -F frontend lint`: passed, 0 warnings/errors.
- `pnpm -F frontend exec oxfmt src/components/Explorer/PeriodOverPeriodComparisonModal/PeriodOverPeriodComparisonModal{,.test}.tsx --check`: passed.
- `pnpm -F frontend exec vitest related src/components/Explorer/PeriodOverPeriodComparisonModal/PeriodOverPeriodComparisonModal{,.test}.tsx --run`: passed, 5 files / 38 tests, including ExplorerAlternateHosts.test.tsx. Non-failing source-map warnings were emitted.
- `git range-diff eb32b5f5bf..c5618df9282a4d8cb8c2a057d26483a36b18e8ab origin/main..HEAD`: original patch unchanged.
- `git diff --check origin/main...HEAD`: passed; worktree clean; latest fetched main is an ancestor of HEAD.
The full E2E/API suites were not run locally; their prior GitHub failures are not claimed resolved and require fresh CI after publication.

## Development environment

[Open the public Lightdash development environment](https://ld-runner-prod-1160-a756bf558ea0.exe.xyz) (anyone with the URL can access it)

Login: `demo@lightdash.com` / `demo_password!`

## References

Closes: [PROD-1160](https://linear.app/lightdash/issue/PROD-1160)

