### PR TITLE
fix(learn): close a menu a walkthrough opened once it points elsewhere

### DIFF
--- a/packages/frontend/src/components/common/GuidedTour/GuidedTour.test.tsx
+++ b/packages/frontend/src/components/common/GuidedTour/GuidedTour.test.tsx
@@ -1,7 +1,10 @@
+import { Popover } from '@mantine/core';
 import { act, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { type FC } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '../../../testing/testUtils';
+import MantineModal from '../MantineModal';
 import { GuidedTour, type GuidedTourStep } from './GuidedTour';
 
 const steps: GuidedTourStep[] = [
@@ -233,5 +236,117 @@ describe('GuidedTour', () => {
                 host.remove();
             }
         });
+    });
+});
+
+/** A menu the learner opened on a step, as that step would leave it. */
+const OpenMenu: FC = () => (
+    <Popover defaultOpened>
+        <Popover.Target>
+            <button type="button">Categories</button>
+        </Popover.Target>
+        <Popover.Dropdown>
+            <button type="button" data-in-menu>
+                Sales
+            </button>
+        </Popover.Dropdown>
+    </Popover>
+);
+
+// A menu a step opens survives the clicks that move the walkthrough on (the
+// tour swallows the press that would close it), so the tour puts it away
+// itself once it points somewhere else.
+describe('GuidedTour and the menus a step opens', () => {
+    it('closes a menu the step does not point into', async () => {
+        renderWithProviders(
+            <>
+                <div data-on-page>The metrics table</div>
+                <OpenMenu />
+                <GuidedTour
+                    steps={[
+                        {
+                            target: '[data-on-page]',
+                            title: 'See the result',
+                            body: '',
+                        },
+                    ]}
+                    opened
+                    onClose={vi.fn()}
+                />
+            </>,
+        );
+
+        await waitFor(() =>
+            expect(screen.queryByText('Sales')).not.toBeInTheDocument(),
+        );
+    });
+
+    it('leaves open the menu the step points into', async () => {
+        renderWithProviders(
+            <>
+                <OpenMenu />
+                <GuidedTour
+                    steps={[
+                        {
+                            target: '[data-in-menu]',
+                            title: 'Choose Sales',
+                            body: '',
+                        },
+                    ]}
+                    opened
+                    onClose={vi.fn()}
+                />
+            </>,
+        );
+
+        await screen.findByText('Choose Sales');
+        expect(screen.getByText('Sales')).toBeInTheDocument();
+    });
+
+    it('closes an open menu when the walkthrough ends', async () => {
+        const user = userEvent.setup();
+        renderWithProviders(
+            <>
+                <OpenMenu />
+                <GuidedTour
+                    steps={[
+                        {
+                            target: '[data-in-menu]',
+                            title: 'Choose Sales',
+                            body: '',
+                        },
+                    ]}
+                    opened
+                    onClose={vi.fn()}
+                />
+            </>,
+        );
+
+        expect(screen.getByText('Sales')).toBeInTheDocument();
+        await user.click(screen.getByRole('button', { name: 'Got it' }));
+        await waitFor(() =>
+            expect(screen.queryByText('Sales')).not.toBeInTheDocument(),
+        );
+    });
+
+    // Only menus: a dialog a step opened is part of what the walkthrough is
+    // teaching, and the host shows the completion dialog over it.
+    it('leaves an open dialog alone', async () => {
+        const user = userEvent.setup();
+        renderWithProviders(
+            <>
+                <MantineModal opened onClose={vi.fn()} title="Save chart">
+                    <div>Chart name</div>
+                </MantineModal>
+                <GuidedTour
+                    steps={[{ target: null, title: 'Step one', body: '' }]}
+                    opened
+                    onClose={vi.fn()}
+                />
+            </>,
+        );
+
+        await user.click(screen.getByRole('button', { name: 'Got it' }));
+        expect(screen.getByText('Chart name')).toBeInTheDocument();
     });
 });

--- a/packages/frontend/src/components/common/GuidedTour/GuidedTour.tsx
+++ b/packages/frontend/src/components/common/GuidedTour/GuidedTour.tsx
@@ -498,6 +498,31 @@ const swallowQuietly = (event: React.SyntheticEvent) => {
     event.stopPropagation();
 };
 
+/** Menus, selects and hover cards all render one of these. */
+const DROPDOWN_SELECTOR = '.mantine-Popover-dropdown';
+
+/**
+ * Put away the menus a step left open. Swallowing the presses outside the
+ * spotlight is what holds a menu open through the click that moves the
+ * walkthrough on, and nothing else will close it afterwards: it would sit
+ * over the steps that follow and over whatever the host shows when the tour
+ * ends. The one the tour is pointing inside is left alone (a comment thread
+ * stays open while its step types into it).
+ *
+ * Escape is dispatched on the dropdown and does not bubble: React still runs
+ * the dropdown's own capture handler, while the window-level listeners that
+ * close a modal or a drawer never hear it, so a dialog a step opened on
+ * purpose survives.
+ */
+const closeOpenDropdowns = (keep: Element | null) => {
+    document.querySelectorAll(DROPDOWN_SELECTOR).forEach((dropdown) => {
+        if (keep && dropdown.contains(keep)) return;
+        dropdown.dispatchEvent(
+            new KeyboardEvent('keydown', { key: 'Escape', bubbles: false }),
+        );
+    });
+};
+
 const BLOCKER_HANDLERS = {
     onPointerDown: swallow,
     onMouseDown: swallow,
@@ -714,6 +739,9 @@ export const GuidedTour: FC<GuidedTourProps> = ({
     const isLast = stepIndex === steps.length - 1;
 
     const handleClose = useCallback(() => {
+        // Whatever the walkthrough left open goes with it: the host shows the
+        // completion dialog on the page behind, and a menu floats over it.
+        closeOpenDropdowns(null);
         setStepIndex(0);
         onClose();
     }, [onClose]);
@@ -743,6 +771,33 @@ export const GuidedTour: FC<GuidedTourProps> = ({
     useEffect(() => {
         if (route) onNavigate?.(route);
     }, [route, onNavigate]);
+
+    // A step pointing outside a menu the learner opened closes that menu,
+    // once its own control is on the page: waiting for the control is what
+    // spares the menu a step is about to point into, whose items appear with
+    // it. A step pointing at nothing (a centred explainer) closes them all.
+    const stepTarget = opened ? (step?.target ?? null) : null;
+    useEffect(() => {
+        if (!opened) return undefined;
+        if (!stepTarget) {
+            closeOpenDropdowns(null);
+            return undefined;
+        }
+        // Once per step: a menu the learner opens for themselves on a
+        // hands-on step is theirs to keep.
+        let poll = 0;
+        let closed = false;
+        const tick = () => {
+            const el = document.querySelector(stepTarget);
+            if (!el) return;
+            closed = true;
+            window.clearInterval(poll);
+            closeOpenDropdowns(el);
+        };
+        tick();
+        if (!closed) poll = window.setInterval(tick, 150);
+        return () => window.clearInterval(poll);
+    }, [opened, stepIndex, stepTarget]);
 
     // "Do this" steps advance themselves when the target is clicked. The
     // target may render late (e.g. a menu item), so keep looking for it.

--- a/packages/frontend/src/testing/__mocks__/implementations/elementsFromPoint.mock.ts
+++ b/packages/frontend/src/testing/__mocks__/implementations/elementsFromPoint.mock.ts
@@ -1,0 +1,7 @@
+// jsdom has no layout, so it does not implement the hit testing that
+// elementsFromPoint does: nothing is ever on top of anything else.
+function mockElementsFromPoint() {
+    window.Document.prototype.elementsFromPoint = () => [];
+}
+
+export default mockElementsFromPoint;

--- a/packages/frontend/src/testing/vitest.setup.ts
+++ b/packages/frontend/src/testing/vitest.setup.ts
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom/vitest';
 import nock from 'nock';
 import nodeFetch from 'node-fetch';
 import { afterEach, beforeAll, beforeEach, vi } from 'vitest';
+import mockElementsFromPoint from './__mocks__/implementations/elementsFromPoint.mock';
 import mockMatchMedia from './__mocks__/implementations/matchMedia.mock';
 import mockResizeObserver from './__mocks__/implementations/resizeObserver.mock';
 import mockScrollIntoView from './__mocks__/implementations/scrollIntoView.mock';
@@ -22,6 +23,7 @@ beforeAll(() => {
     mockMatchMedia();
     mockResizeObserver();
     mockScrollIntoView();
+    mockElementsFromPoint();
 });
 
 // Disable all network requests by default


### PR DESCRIPTION
## What

A menu or popover the learner opens during a Learn walkthrough stayed open for the rest of it: it covered the step that followed and then the "Module complete" dialog. It shows up in **Find metrics by category** (`view:Tags`), where the Categories filter is left open over the last step and over the completion dialog.

`GuidedTour` deliberately stops every press outside the spotlight from reaching the document (`BLOCKER_HANDLERS`, and `swallowQuietly` on the card), so that a click moving the walkthrough on does not undo the menu a step just opened. The cost is that nothing ever closes that menu: the page cannot, and the tour did not try. A Mantine popover also sits above a modal by default, so it landed on top of the completion dialog.

## How

`GuidedTour` now puts those menus away itself, once, for every walkthrough. No generated tours and no product components change.

- When a step's own control is on the page, every open dropdown that does not contain it is closed. One that contains it is left alone: some steps act inside a popover.
- A step with no control (the centred explainer) closes them all, and so does finishing or skipping the tour, before the host swaps in the completion dialog.
- The close is a **non-bubbling** `keydown` Escape dispatched on the dropdown. `Popover.Dropdown` handles Escape in `onKeyDownCapture`, so React delivers it to that popover alone, and because it does not bubble the window-level listeners that close a modal or drawer never hear it — a dialog a step opened on purpose survives.

## Tests

Four cases in `GuidedTour.test.tsx`, against real Mantine components: a step pointing outside an open popover closes it, a step pointing inside one leaves it open, ending the walkthrough closes it, and an open modal is untouched. The two "closes" cases fail without this change.

jsdom has no hit testing, so `document.elementsFromPoint` (used by the tour's viewport check) is stubbed in `vitest.setup.ts` alongside the existing `scrollIntoView` and `ResizeObserver` stubs — without it no tour test can use a step target.

`pnpm -F frontend lint`, `pnpm -F frontend typecheck` and the GuidedTour tests pass.

## Verified in the preview environment

Run against this PR's preview env, driving the real **Find metrics by category** walkthrough end to end as an org admin, with the fix toggled off and back on in the same environment against the same data:

| | menus left open at step 5 "See the result" | menus left open over the completion dialog |
|---|---|---|
| Fix off | 1 | 1 |
| Fix on | 0 | 0 |

Closes: AE-766

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014noLpwSN7QMpCr3MTpkogM

