### PR TITLE
feat(chart-types): carry the custom chart type icon through registry, code and CLI

### DIFF
--- a/docs/chart-types.md
+++ b/docs/chart-types.md
@@ -33,7 +33,8 @@ pipeline, and authoring runbook are documented in
   helpers in `packages/common/src/ee/apps/registry.ts` validate the index
   both in the product (on fetch) and in the gallery repo's CI (on publish).
   Entries carry slug, name, description, semver version, tags, changelog,
-  `minLightdashVersion`, the viz schema, screenshots, and artifact digests.
+  `minLightdashVersion`, the viz schema, a curated icon, screenshots, and
+  artifact digests.
 - Published versions are immutable in their entirety — artifacts,
   screenshots, and metadata. Changes ship as a new semver version; the
   publish pipeline digest-verifies already-published versions and hard-fails
@@ -65,7 +66,9 @@ pipeline, and authoring runbook are documented in
 - The result is a project-owned app with provenance: `apps.registry_slug`
   and `apps.registry_url` identify the upstream chart, and each installed
   version records `app_versions.registry_version` (the semver it came
-  from). Once installed, the chart type behaves like any custom chart type
+  from). The entry's icon is copied onto the app on install and re-synced
+  from the registry on every upgrade — read-only types never drift from it.
+  Once installed, the chart type behaves like any custom chart type
   in the explorer.
 
 ## Read-only, fork, upgrade, uninstall

--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -221,7 +221,8 @@ flag-gated extension: registry-only, lockfile required, screened for malicious p
 A custom chart type is a data app built from a dedicated template that declares a viz schema instead of running
 queries: the explorer hands it rows and a field mapping, and it renders. They share the pipeline, storage and
 permissions of data apps but are excluded from app listings, have their own gallery and builder, and are downloaded
-as code separately.
+as code separately. A type can carry one icon from a curated Tabler set; the as-code manifest's `icon` field round-trips
+it (omitted for non-chart-type apps), null clears it, and an off-list value is rejected on upload.
 
 Official chart types can also be installed prebuilt from a chart registry, are read-only once installed, and are
 customized by forking — the registry, library, install and fork model is documented in

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.appCode.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.appCode.test.ts
@@ -944,11 +944,14 @@ describe('AppGenerateService.importAppCode', () => {
         code.manifest.template = 'data_app_viz';
         code.manifest.icon = 'not-a-real-icon' as never;
 
-        await expect(
-            service.importAppCode(makeUser(), PROJECT_UUID, {
-                code,
-            } as ImportAppCodeRequestBody),
-        ).rejects.toThrow(ParameterError);
+        const importPromise = service.importAppCode(makeUser(), PROJECT_UUID, {
+            code,
+        } as ImportAppCodeRequestBody);
+
+        await expect(importPromise).rejects.toThrow(ParameterError);
+        await expect(importPromise).rejects.toThrow(
+            'Invalid icon in the app manifest. Use one of the curated chart type icons, or null to clear it.',
+        );
 
         // must not create or enqueue
         expect(appModel.createWithVersion).not.toHaveBeenCalled();

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.appCode.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.appCode.test.ts
@@ -895,6 +895,195 @@ describe('AppGenerateService.importAppCode', () => {
         );
     });
 
+    it('create mode: persists a valid manifest icon for a data_app_viz upload', async () => {
+        const { service, appModel } = buildService();
+
+        appModel.findApp.mockResolvedValue(undefined);
+
+        const code = makeCode();
+        code.manifest.template = 'data_app_viz';
+        code.manifest.icon = 'chart-sankey';
+
+        await service.importAppCode(makeUser(), PROJECT_UUID, {
+            code,
+        } as ImportAppCodeRequestBody);
+
+        expect(appModel.createWithVersion).toHaveBeenCalledWith(
+            expect.objectContaining({ icon: 'chart-sankey' }),
+            { version: 1, prompt: '' },
+            'pending',
+            expect.any(Object),
+            undefined, // no declared dependencies
+            undefined, // no vizSchema in the manifest
+            { forceSlug: true },
+        );
+    });
+
+    it('create mode: ignores a manifest icon when the upload is not a data_app_viz', async () => {
+        const { service, appModel } = buildService();
+
+        appModel.findApp.mockResolvedValue(undefined);
+
+        const code = makeCode();
+        code.manifest.icon = 'chart-sankey'; // template stays null
+
+        await service.importAppCode(makeUser(), PROJECT_UUID, {
+            code,
+        } as ImportAppCodeRequestBody);
+
+        const [appArg] = appModel.createWithVersion.mock.calls[0];
+        expect(appArg).not.toHaveProperty('icon');
+    });
+
+    it('create mode: throws ParameterError when the manifest icon is off the curated list', async () => {
+        const { service, appModel, schedulerClient } = buildService();
+
+        appModel.findApp.mockResolvedValue(undefined);
+
+        const code = makeCode();
+        code.manifest.template = 'data_app_viz';
+        code.manifest.icon = 'not-a-real-icon' as never;
+
+        await expect(
+            service.importAppCode(makeUser(), PROJECT_UUID, {
+                code,
+            } as ImportAppCodeRequestBody),
+        ).rejects.toThrow(ParameterError);
+
+        // must not create or enqueue
+        expect(appModel.createWithVersion).not.toHaveBeenCalled();
+        expect(schedulerClient.appBuildFromSource).not.toHaveBeenCalled();
+    });
+
+    it('append mode: persists a valid manifest icon when the target app is a data_app_viz', async () => {
+        const { service, appModel } = buildService();
+
+        const existingApp = {
+            app_id: EXISTING_APP_UUID,
+            project_uuid: PROJECT_UUID,
+            space_uuid: null,
+            created_by_user_uuid: USER_UUID,
+            organization_uuid: PROJECT_ORG_UUID,
+            name: 'Test App',
+            description: 'A test app',
+            template: 'data_app_viz',
+            icon: null,
+            registry_slug: null,
+        };
+        appModel.findApp.mockResolvedValue(existingApp);
+        appModel.getLatestVersion.mockResolvedValue({ version: 1 });
+
+        const code = makeCode();
+        code.manifest.template = 'data_app_viz';
+        code.manifest.icon = 'chart-sankey';
+
+        await service.importAppCode(makeUser(), PROJECT_UUID, {
+            code,
+            targetAppUuid: EXISTING_APP_UUID,
+        } as ImportAppCodeRequestBody);
+
+        expect(appModel.updateApp).toHaveBeenCalledExactlyOnceWith(
+            EXISTING_APP_UUID,
+            PROJECT_UUID,
+            { icon: 'chart-sankey' },
+        );
+    });
+
+    it('append mode: clears the icon when the manifest icon is null', async () => {
+        const { service, appModel } = buildService();
+
+        const existingApp = {
+            app_id: EXISTING_APP_UUID,
+            project_uuid: PROJECT_UUID,
+            space_uuid: null,
+            created_by_user_uuid: USER_UUID,
+            organization_uuid: PROJECT_ORG_UUID,
+            name: 'Test App',
+            description: 'A test app',
+            template: 'data_app_viz',
+            icon: 'chart-sankey',
+            registry_slug: null,
+        };
+        appModel.findApp.mockResolvedValue(existingApp);
+        appModel.getLatestVersion.mockResolvedValue({ version: 1 });
+
+        const code = makeCode();
+        code.manifest.template = 'data_app_viz';
+        code.manifest.icon = null;
+
+        await service.importAppCode(makeUser(), PROJECT_UUID, {
+            code,
+            targetAppUuid: EXISTING_APP_UUID,
+        } as ImportAppCodeRequestBody);
+
+        expect(appModel.updateApp).toHaveBeenCalledExactlyOnceWith(
+            EXISTING_APP_UUID,
+            PROJECT_UUID,
+            { icon: null },
+        );
+    });
+
+    it('append mode: throws ParameterError when the manifest icon is off the curated list', async () => {
+        const { service, appModel } = buildService();
+
+        const existingApp = {
+            app_id: EXISTING_APP_UUID,
+            project_uuid: PROJECT_UUID,
+            space_uuid: null,
+            created_by_user_uuid: USER_UUID,
+            organization_uuid: PROJECT_ORG_UUID,
+            name: 'Test App',
+            description: 'A test app',
+            template: 'data_app_viz',
+            icon: null,
+            registry_slug: null,
+        };
+        appModel.findApp.mockResolvedValue(existingApp);
+        appModel.getLatestVersion.mockResolvedValue({ version: 1 });
+
+        const code = makeCode();
+        code.manifest.template = 'data_app_viz';
+        code.manifest.icon = 'not-a-real-icon' as never;
+
+        await expect(
+            service.importAppCode(makeUser(), PROJECT_UUID, {
+                code,
+                targetAppUuid: EXISTING_APP_UUID,
+            } as ImportAppCodeRequestBody),
+        ).rejects.toThrow(ParameterError);
+
+        expect(appModel.updateApp).not.toHaveBeenCalled();
+        expect(appModel.createVersion).not.toHaveBeenCalled();
+    });
+
+    it('append mode: ignores a manifest icon when the target app is not a data_app_viz', async () => {
+        const { service, appModel } = buildService();
+
+        const existingApp = {
+            app_id: EXISTING_APP_UUID,
+            project_uuid: PROJECT_UUID,
+            space_uuid: null,
+            created_by_user_uuid: USER_UUID,
+            organization_uuid: PROJECT_ORG_UUID,
+            name: 'Test App',
+            description: 'A test app',
+            registry_slug: null,
+        };
+        appModel.findApp.mockResolvedValue(existingApp);
+        appModel.getLatestVersion.mockResolvedValue({ version: 1 });
+
+        const code = makeCode();
+        code.manifest.icon = 'not-a-real-icon' as never; // template stays null
+
+        await service.importAppCode(makeUser(), PROJECT_UUID, {
+            code,
+            targetAppUuid: EXISTING_APP_UUID,
+        } as ImportAppCodeRequestBody);
+
+        // No name/description change and icon is ignored (not a chart type)
+        expect(appModel.updateApp).not.toHaveBeenCalled();
+    });
+
     it('rejects custom deps when the org flag is off', async () => {
         const { service, appModel, analytics } = buildService({
             customDependenciesOrgEnabled: false,

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.getAppCode.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.getAppCode.test.ts
@@ -453,6 +453,55 @@ describe('AppGenerateService.getAppCode', () => {
         expect(result.manifest).not.toHaveProperty('vizSchema');
     });
 
+    it('includes the app icon in the manifest for a chart type', async () => {
+        const fakeS3 = makeFakeS3(sourceTarBuffer);
+        const appModel = {
+            getAppByUuidOrSlug: vi.fn().mockResolvedValue({
+                ...fakeApp,
+                template: 'data_app_viz',
+                icon: 'chart-sankey',
+            }),
+            getLatestReadyVersion: vi.fn().mockResolvedValue(fakeAppVersion),
+        };
+
+        const svc = buildService({ appModel, s3ClientOverride: fakeS3 });
+        const result = await svc.getAppCode(fakeUser, PROJECT_UUID, APP_UUID);
+
+        expect(result.manifest.icon).toBe('chart-sankey');
+    });
+
+    it('normalizes an icon retired from the curated set to null in the manifest', async () => {
+        const fakeS3 = makeFakeS3(sourceTarBuffer);
+        const appModel = {
+            getAppByUuidOrSlug: vi.fn().mockResolvedValue({
+                ...fakeApp,
+                template: 'data_app_viz',
+                icon: 'a-retired-icon',
+            }),
+            getLatestReadyVersion: vi.fn().mockResolvedValue(fakeAppVersion),
+        };
+
+        const svc = buildService({ appModel, s3ClientOverride: fakeS3 });
+        const result = await svc.getAppCode(fakeUser, PROJECT_UUID, APP_UUID);
+
+        expect(result.manifest.icon).toBeNull();
+    });
+
+    it('omits icon from the manifest for a non-chart-type app', async () => {
+        const fakeS3 = makeFakeS3(sourceTarBuffer);
+        const appModel = {
+            getAppByUuidOrSlug: vi
+                .fn()
+                .mockResolvedValue({ ...fakeApp, icon: 'chart-sankey' }),
+            getLatestReadyVersion: vi.fn().mockResolvedValue(fakeAppVersion),
+        };
+
+        const svc = buildService({ appModel, s3ClientOverride: fakeS3 });
+        const result = await svc.getAppCode(fakeUser, PROJECT_UUID, APP_UUID);
+
+        expect(result.manifest).not.toHaveProperty('icon');
+    });
+
     it('emits app external-connection links as {alias, connectionSlug} in the manifest', async () => {
         const fakeS3 = makeFakeS3(sourceTarBuffer);
         const appModel = {

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.registryInstall.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.registryInstall.test.ts
@@ -427,6 +427,45 @@ describe('AppGenerateService.installRegistryChartType', () => {
         expect(optsArg).toEqual({ registryVersion: '1.3.0' });
     });
 
+    it('fresh install: passes the registry entry icon onto the created app', async () => {
+        const iconEntry = makeEntry({ icon: 'chart-sankey' });
+        const sourceTar = await buildTar([
+            { name: 'src/App.tsx', content: 'x' },
+        ]);
+        const distTar = await buildTar([
+            { name: 'dist/index.html', content: '<html/>' },
+        ]);
+        const fakeS3 = makeFakeS3();
+        const createWithVersion = vi.fn().mockResolvedValue(undefined);
+        const appModel = {
+            listRegistryInstalledApps: vi.fn().mockResolvedValue([]),
+            createWithVersion,
+        };
+        const chartRegistryClient = {
+            getEntry: vi.fn().mockResolvedValue(iconEntry),
+            downloadArtifact: vi
+                .fn()
+                .mockImplementation(
+                    (_entry: unknown, kind: 'source' | 'dist') =>
+                        Promise.resolve(
+                            kind === 'source' ? sourceTar : distTar,
+                        ),
+                ),
+        };
+        const svc = buildService({
+            appModel,
+            chartRegistryClient,
+            s3ClientOverride: fakeS3,
+        });
+
+        await svc.installRegistryChartType(fakeUser, PROJECT_UUID, 'sankey');
+
+        const [appArg] = createWithVersion.mock.calls[0];
+        expect(appArg).toEqual(
+            expect.objectContaining({ icon: 'chart-sankey' }),
+        );
+    });
+
     it('already installed at latest → action unchanged, no writes', async () => {
         const fakeS3 = makeFakeS3();
         const appModel = {
@@ -469,6 +508,7 @@ describe('AppGenerateService.installRegistryChartType', () => {
         ]);
         const fakeS3 = makeFakeS3();
         const createVersion = vi.fn().mockResolvedValue({ version: 3 });
+        const updateApp = vi.fn().mockResolvedValue(undefined);
         const appModel = {
             listRegistryInstalledApps: vi.fn().mockResolvedValue([
                 {
@@ -479,8 +519,11 @@ describe('AppGenerateService.installRegistryChartType', () => {
             ]),
             getLatestVersion: vi.fn().mockResolvedValue({ version: 2 }),
             createVersion,
+            updateApp,
         };
+        const iconEntry = makeEntry({ icon: 'chart-radar' });
         const chartRegistryClient = {
+            getEntry: vi.fn().mockResolvedValue(iconEntry),
             downloadArtifact: vi
                 .fn()
                 .mockImplementation(
@@ -517,6 +560,13 @@ describe('AppGenerateService.installRegistryChartType', () => {
             undefined,
             PARSED_VIZ_SCHEMA,
             { registryVersion: '1.3.0' },
+        );
+        // The registry's icon always wins on upgrade — installed types are
+        // read-only, so it can't have drifted locally.
+        expect(updateApp).toHaveBeenCalledWith(
+            'existing-app-uuid',
+            PROJECT_UUID,
+            { icon: 'chart-radar' },
         );
     });
 

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -8865,6 +8865,11 @@ export class AppGenerateService extends BaseService {
                     vizSchema,
                     { registryVersion: entry.version },
                 );
+                // Registry-installed apps are read-only, so the registry's
+                // icon always wins on upgrade.
+                await this.appModel.updateApp(appUuid, projectUuid, {
+                    icon: entry.icon,
+                });
             } else {
                 await this.appModel.createWithVersion(
                     {
@@ -8875,6 +8880,7 @@ export class AppGenerateService extends BaseService {
                         description: entry.description,
                         slug: entry.slug,
                         template: DATA_APP_VIZ_TEMPLATE,
+                        icon: entry.icon,
                         registry_slug: entry.slug,
                         registry_url: this.chartRegistryClient.getBaseUrl(),
                     },
@@ -11140,6 +11146,11 @@ export class AppGenerateService extends BaseService {
             name: app.name,
             description: app.description,
             template: app.template,
+            // Only chart types carry an icon; omit the key entirely for other
+            // apps so their manifests stay unchanged.
+            ...(app.template === DATA_APP_VIZ_TEMPLATE
+                ? { icon: isChartTypeIcon(app.icon) ? app.icon : null }
+                : {}),
             // Only viz versions carry a schema; omit the key entirely otherwise
             // so non-viz manifests stay unchanged.
             ...(versionRow?.viz_schema
@@ -11404,18 +11415,48 @@ export class AppGenerateService extends BaseService {
     }
 
     /**
-     * Applies manifest name/description to the app row when they differ.
-     * App-level metadata only — never touches versions or builds.
+     * Validates a manifest icon value: null clears it, a curated icon name
+     * passes through, anything else is rejected loudly (a hand-edited
+     * lightdash-app.yml is the only way to get a bad value here).
+     */
+    private static resolveManifestIcon(
+        manifestIcon: unknown,
+    ): ChartTypeIcon | null {
+        if (manifestIcon === null) return null;
+        if (isChartTypeIcon(manifestIcon)) return manifestIcon;
+        throw new ParameterError(
+            `Invalid icon "${String(manifestIcon)}" in the app manifest. Use one of the curated chart type icons, or null to clear it.`,
+        );
+    }
+
+    /**
+     * Applies manifest name/description/icon to the app row when they
+     * differ. App-level metadata only — never touches versions or builds.
+     * The icon is only meaningful on chart types; a manifest icon on any
+     * other app is ignored, not rejected.
      */
     private async updateAppMetadataIfChanged(
-        existingApp: Pick<DbApp, 'app_id' | 'name' | 'description'>,
+        existingApp: Pick<
+            DbApp,
+            'app_id' | 'name' | 'description' | 'template' | 'icon'
+        >,
         manifest: DataAppCode['manifest'],
         projectUuid: string,
     ): Promise<void> {
-        const update: Partial<Pick<DbApp, 'name' | 'description'>> = {};
+        const update: Partial<Pick<DbApp, 'name' | 'description' | 'icon'>> =
+            {};
         if (manifest.name !== existingApp.name) update.name = manifest.name;
         if (manifest.description !== existingApp.description)
             update.description = manifest.description;
+        if (
+            manifest.icon !== undefined &&
+            existingApp.template === DATA_APP_VIZ_TEMPLATE
+        ) {
+            const resolvedIcon = AppGenerateService.resolveManifestIcon(
+                manifest.icon,
+            );
+            if (resolvedIcon !== existingApp.icon) update.icon = resolvedIcon;
+        }
         if (Object.keys(update).length > 0) {
             await this.appModel.updateApp(
                 existingApp.app_id,
@@ -11992,6 +12033,16 @@ export class AppGenerateService extends BaseService {
                     description: code.manifest.description,
                     template: code.manifest.template,
                     space_uuid: targetSpaceUuid,
+                    // The icon is only meaningful on chart types; a manifest
+                    // icon on any other app is ignored, not rejected.
+                    ...(code.manifest.icon !== undefined &&
+                    code.manifest.template === DATA_APP_VIZ_TEMPLATE
+                        ? {
+                              icon: AppGenerateService.resolveManifestIcon(
+                                  code.manifest.icon,
+                              ),
+                          }
+                        : {}),
                     // Round-trip the manifest slug exactly; createNew and
                     // pre-slug bundles let the model generate a unique one.
                     ...(manifestSlug !== undefined && !body.createNew

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -11425,7 +11425,7 @@ export class AppGenerateService extends BaseService {
         if (manifestIcon === null) return null;
         if (isChartTypeIcon(manifestIcon)) return manifestIcon;
         throw new ParameterError(
-            `Invalid icon "${String(manifestIcon)}" in the app manifest. Use one of the curated chart type icons, or null to clear it.`,
+            'Invalid icon in the app manifest. Use one of the curated chart type icons, or null to clear it.',
         );
     }
 

--- a/packages/backend/src/ee/services/AppGenerateService/appCode.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/appCode.ts
@@ -17,6 +17,7 @@ export const buildManifest = (args: {
     name: string;
     description: string;
     template: DataAppManifest['template'];
+    icon?: DataAppManifest['icon'];
     vizSchema?: DataAppManifest['vizSchema'];
     externalConnections?: DataAppManifest['externalConnections'];
     spaceSlug?: DataAppManifest['spaceSlug'];

--- a/packages/cli/src/handlers/apps/validate.test.ts
+++ b/packages/cli/src/handlers/apps/validate.test.ts
@@ -284,6 +284,43 @@ describe('validateLocalDataApp', () => {
         );
     });
 
+    it('validates the icon from the manifest', async () => {
+        const manifest = {
+            ...defaultManifest,
+            icon: 'not-a-real-icon',
+        } as unknown as DataAppManifest;
+        const dir = await makeApp({ manifest });
+
+        const result = await validateLocalDataApp(dir, {
+            live: false,
+            loadLiveIndex: unusedLiveLoader,
+        });
+
+        expect(result.errors).toContainEqual(
+            expect.objectContaining({
+                code: 'manifest',
+                message: expect.stringContaining('Invalid icon'),
+            }),
+        );
+    });
+
+    it.each([null, 'chart-sankey'] as const)(
+        'accepts icon %s',
+        async (icon) => {
+            const manifest = { ...defaultManifest, icon };
+            const dir = await makeApp({ manifest });
+
+            const result = await validateLocalDataApp(dir, {
+                live: false,
+                loadLiveIndex: unusedLiveLoader,
+            });
+
+            expect(result.errors).not.toContainEqual(
+                expect.objectContaining({ code: 'manifest' }),
+            );
+        },
+    );
+
     it('requires a pnpm lockfile for custom dependencies', async () => {
         const dir = await makeApp({
             packageJson: JSON.stringify({

--- a/packages/cli/src/handlers/apps/validate.ts
+++ b/packages/cli/src/handlers/apps/validate.ts
@@ -7,6 +7,7 @@ import {
     dataAppVizSchema,
     extractDataAppDataReferences,
     getErrorMessage,
+    isChartTypeIcon,
     isSummaryExploreError,
     isValidDataAppSlug,
     ParameterError,
@@ -200,6 +201,17 @@ const validateManifest = (
                 issue(
                     'manifest',
                     `Invalid vizSchema in lightdash-app.yml (${details}).`,
+                ),
+            );
+        }
+    }
+
+    if (manifest.icon !== undefined && manifest.icon !== null) {
+        if (!isChartTypeIcon(manifest.icon)) {
+            errors.push(
+                issue(
+                    'manifest',
+                    `Invalid icon "${manifest.icon}" in lightdash-app.yml. Use one of the curated chart type icons, or null to clear it.`,
                 ),
             );
         }

--- a/packages/common/src/ee/apps/chartTypeIcons.test.ts
+++ b/packages/common/src/ee/apps/chartTypeIcons.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import {
+    CHART_TYPE_ICONS,
+    chartTypeIconSchema,
+    isChartTypeIcon,
+} from './chartTypeIcons';
+
+describe('isChartTypeIcon', () => {
+    it('accepts every curated icon name', () => {
+        CHART_TYPE_ICONS.forEach((icon) => {
+            expect(isChartTypeIcon(icon)).toBe(true);
+        });
+    });
+
+    it('rejects a value not in the curated set', () => {
+        expect(isChartTypeIcon('not-a-real-icon')).toBe(false);
+    });
+
+    it('rejects null, undefined and non-string values', () => {
+        expect(isChartTypeIcon(null)).toBe(false);
+        expect(isChartTypeIcon(undefined)).toBe(false);
+        expect(isChartTypeIcon(42)).toBe(false);
+    });
+});
+
+describe('chartTypeIconSchema', () => {
+    it('parses every curated icon name', () => {
+        CHART_TYPE_ICONS.forEach((icon) => {
+            expect(chartTypeIconSchema.safeParse(icon).success).toBe(true);
+        });
+    });
+
+    it('rejects a value not in the curated set', () => {
+        expect(chartTypeIconSchema.safeParse('not-a-real-icon').success).toBe(
+            false,
+        );
+    });
+});


### PR DESCRIPTION
## Summary

Top layer of the custom chart type icon stack. The icon now travels with the chart type wherever the chart type does.

- **Registry**: a fresh install copies the registry entry's icon onto the app; an upgrade re-syncs it, since registry-installed chart types are read-only. Registry entries without an icon keep the puzzle piece.
- **Chart type as code**: downloads emit `icon` for chart types only, so non-chart-type manifests are unchanged. Uploads validate it (null clears, an off-list value is rejected with a message naming it) and persist it on create and update. A manifest icon on a non-chart-type app is ignored.
- **CLI**: `validate` reports an invalid manifest icon the way it reports an invalid viz schema.
- Docs updated for the registry entry field and the manifest field.

## Test

- Unit: registry install and upgrade, download emission and normalisation, upload create/update/clear/reject, CLI validation.
- Manual: download a chart type with an icon, edit the icon in `lightdash-app.yml` to an unknown name, run `validate`, then upload with a valid one and check the chooser.

Closes: PROD-11066